### PR TITLE
Library work

### DIFF
--- a/docs/library/index.md
+++ b/docs/library/index.md
@@ -292,6 +292,15 @@ Str operators
 ### match
 `match` does regex pattern matching
 
+### replace
+`replace` replaces all occurrences of a pattern in a string with another string
+
+### split
+`split` splits a string into a tuple of strings based on a separator
+
+### join
+`join` joins a tuple of strings into a single string using the given separator
+
 ### format_
 `format` formats strings given the format spec
 

--- a/docs/library/index.md
+++ b/docs/library/index.md
@@ -317,6 +317,12 @@ never produces a tick
 ### null_sink &#10067;
 consumes a time series and does nothing
 
+### valid
+returns a bool time series that indicates if the input is valid (i.e. has a value)
+
+### last_modified_time
+returns a datetime timeseries that ticks last_modified_time of its input
+
 ### zero
 overloads of this operator provide zero value time series for the reduce_ operator
 

--- a/examples/first/trivial.py
+++ b/examples/first/trivial.py
@@ -1,0 +1,17 @@
+from hgraph import graph, TS, run_graph, EvaluationMode, str_, TIME_SERIES_TYPE, sink_node
+from hgraph.nodes import print_
+from hgraph.test import eval_node
+
+
+@graph
+def trivial_graph(a: TS[int], c: TS[int]):
+    display((a + 1) * c)
+
+
+@sink_node
+def display(ts: TIME_SERIES_TYPE):
+    print(ts.value)
+
+
+if __name__ == "__main__":
+    eval_node(trivial_graph, [None, 2, None, 4, None], [None, None, 3, None, 6], __trace__={'start': False, 'stop': False})

--- a/examples/first/trivial_tsd.py
+++ b/examples/first/trivial_tsd.py
@@ -1,0 +1,13 @@
+from hgraph import TS, TSD, graph, map_
+from hgraph.nodes import log
+from hgraph.test import eval_node
+
+
+@graph
+def trivial_tsd(ts: TSD[str, TS[int]]):
+    result = map_(lambda x: x + 1, ts).reduce(lambda x, y: x * y, 1)
+    log('result {}', result)
+
+
+if __name__ == '__main__':
+    eval_node(trivial_tsd, [{'one': 1}, {'two': 2}], __trace__={'start': False, 'stop': False, 'eval': False})

--- a/examples/web_ui/web_ui.py
+++ b/examples/web_ui/web_ui.py
@@ -9,7 +9,8 @@ from frozendict.cool import deepfreeze
 
 from hgraph import graph, TimeSeriesSchema, TSB, TSD, run_graph, EvaluationMode, TS, EvaluationClock, \
     feedback, compute_node, SCHEDULER, TSL, STATE, REMOVE_IF_EXISTS, CompoundScalar
-from hgraph.nodes import const, debug_print, merge, delay
+from hgraph.nodes import const, debug_print, delay
+from hgraph._operators._control import merge
 from hgraph.adaptors.perspective._perspective import perspective_web
 from hgraph.adaptors.perspective._perspetive_publish import publish_table
 
@@ -61,7 +62,7 @@ def host_web_server():
     initial_config = const(deepfreeze(refdata()), TSD[str, TSB[Config]])
     config_updates = feedback(TSD[str, TSB[Config]])
     debug_print('config updates', config_updates())
-    config = merge(TSL.from_ts(initial_config, config_updates()))
+    config = merge(initial_config, config_updates())
     config_updates(publish_table('config', config, editable=True, index_col_name='sensor'))
 
     publish_table('data', random_data(config, 100), index_col_name='sensor', history=sys.maxsize)

--- a/src/hgraph/_impl/_types/_tsb.py
+++ b/src/hgraph/_impl/_types/_tsb.py
@@ -30,11 +30,10 @@ class PythonTimeSeriesBundleOutput(PythonTimeSeriesOutput, TimeSeriesBundleOutpu
 
     @property
     def value(self):
-        v = {k: ts.value for k, ts in self.items() if ts.valid}
         if s := self.__schema__.scalar_type():
-            return s(**v)
+            return s(**{k: ts.value for k, ts in self.items()})
         else:
-            return v
+            return {k: ts.value for k, ts in self.items() if ts.valid}
 
     @value.setter
     def value(self, v: Mapping[str, Any] | None):

--- a/src/hgraph/_operators/__init__.py
+++ b/src/hgraph/_operators/__init__.py
@@ -1,2 +1,3 @@
 from hgraph._operators._operators import *
 from hgraph._operators._control import *
+from hgraph._operators._conversion import *

--- a/src/hgraph/_operators/__init__.py
+++ b/src/hgraph/_operators/__init__.py
@@ -1,1 +1,2 @@
 from hgraph._operators._operators import *
+from hgraph._operators._control import *

--- a/src/hgraph/_operators/_control.py
+++ b/src/hgraph/_operators/_control.py
@@ -1,4 +1,10 @@
-from hgraph import operator, TSL, TIME_SERIES_TYPE, SIZE
+from hgraph._types._scalar_types import SIZE
+from hgraph._types._tsl_type import TSL
+from hgraph._types._time_series_types import TIME_SERIES_TYPE
+from hgraph._wiring._decorators import operator
+
+
+__all__ = ("merge",)
 
 
 @operator

--- a/src/hgraph/_operators/_control.py
+++ b/src/hgraph/_operators/_control.py
@@ -1,0 +1,10 @@
+from hgraph import operator, TSL, TIME_SERIES_TYPE, SIZE
+
+
+@operator
+def merge(*tsl: TSL[TIME_SERIES_TYPE, SIZE]) -> TIME_SERIES_TYPE:
+    """
+    Selects and returns the first of the values that tick (are modified) in the list provided.
+    If more than one input is modified in the engine-cycle, it will return the first one that ticked in order of the
+    list.
+    """

--- a/src/hgraph/_operators/_conversion.py
+++ b/src/hgraph/_operators/_conversion.py
@@ -1,4 +1,5 @@
-from hgraph import TIME_SERIES_TYPE, graph, AUTO_RESOLVE, operator
+from hgraph._wiring._decorators import operator
+from hgraph._types._time_series_types import TIME_SERIES_TYPE
 from hgraph._types._scalar_types import DEFAULT
 from hgraph._types._time_series_types import OUT
 
@@ -17,7 +18,7 @@ def convert(ts: TIME_SERIES_TYPE, to: type[OUT] = DEFAULT[OUT], **kwargs) -> OUT
 
 
 @operator
-def combine(*args: TIME_SERIES_TYPE, **kwargs) -> OUT:
+def combine(*args: TIME_SERIES_TYPE, **kwargs) -> DEFAULT[OUT]:
     ...
 
 

--- a/src/hgraph/_operators/_operators.py
+++ b/src/hgraph/_operators/_operators.py
@@ -16,7 +16,7 @@ __all__ = (
     "add_", "sub_", "mul_", "div_", "floordiv_", "mod_", "divmod_", "pow_", "lshift_", "rshift_", "and_", "or_", "xor_",
     "eq_", "ne_", "lt_", "le_", "gt_", "ge_", "neg_", "pos_", "abs_", "invert_", "contains_", "not_", "getitem_",
     "getattr_", "min_", "max_", "zero", "len_", "and_op", "or_op", "union_op", "union", "union_tsl",
-    "intersection_op", "intersection", "intersection_tsl", "difference", "symmetric_difference", "is_empty", "type_"
+    "intersection_op", "intersection", "intersection_tsl", "difference", "symmetric_difference", "is_empty", "type_", "str_"
 )
 
 
@@ -832,3 +832,11 @@ def type_(ts: TIME_SERIES_TYPE) -> TS[type]:
     Returns the type of the time-series value.
     """
     return type(ts.value)
+
+
+@operator
+def str_(ts: TIME_SERIES_TYPE) -> TS[str]:
+    """
+    Returns the string representation of the time-series value.
+    """
+    return str(ts.value)

--- a/src/hgraph/_types/_context_meta_data.py
+++ b/src/hgraph/_types/_context_meta_data.py
@@ -1,6 +1,5 @@
 from types import NoneType
-from typing import Type, TypeVar, Optional, _GenericAlias
-
+from typing import Type, TypeVar, Optional, _GenericAlias, Mapping
 
 __all__ = ("HgCONTEXTTypeMetaData",)
 
@@ -99,8 +98,8 @@ class HgCONTEXTTypeMetaData(HgTimeSeriesTypeMetaData):
         return self.value_tp.typevars
 
     @property
-    def operator_rank(self) -> float:
-        return self.value_tp.operator_rank
+    def generic_rank(self) -> dict[type, float]:
+        return self.value_tp.generic_rank
 
     def __getitem__(self, item):
         return self.value_tp[item]

--- a/src/hgraph/_types/_frame_scalar_type_meta_data.py
+++ b/src/hgraph/_types/_frame_scalar_type_meta_data.py
@@ -1,6 +1,7 @@
 from types import GenericAlias
-from typing import Type, TypeVar, Generic, Optional, _GenericAlias, _SpecialGenericAlias
+from typing import Type, TypeVar, Generic, Optional, _GenericAlias, _SpecialGenericAlias, Mapping
 
+from hgraph._types._generic_rank_util import scale_rank
 from hgraph._types._type_meta_data import ParseError
 from hgraph._types._scalar_types import CompoundScalar, COMPOUND_SCALAR
 from hgraph._types._scalar_type_meta_data import HgCollectionType, HgCompoundScalarType, HgScalarTypeMetaData, \
@@ -39,8 +40,8 @@ try:
             return self.schema.typevars
 
         @property
-        def operator_rank(self) -> float:
-            return self.schema.operator_rank / 100.
+        def generic_rank(self) -> dict[type, float]:
+            return scale_rank(self.schema.generic_rank, 0.01)
 
         @property
         def is_resolved(self) -> bool:
@@ -112,8 +113,8 @@ try:
             return self.value_tp.typevars
 
         @property
-        def operator_rank(self) -> float:
-            return self.value_tp.operator_rank / 100.
+        def generic_rank(self) -> dict[type, float]:
+            return scale_rank(self.value_tp.generic_rank, 0.01)
 
         @property
         def is_resolved(self) -> bool:

--- a/src/hgraph/_types/_generic_rank_util.py
+++ b/src/hgraph/_types/_generic_rank_util.py
@@ -1,0 +1,35 @@
+from functools import reduce
+
+__all__ = ("scale_rank", "combine_ranks", "compare_ranks",)
+
+from typing import Iterable
+
+
+def scale_rank(rank: dict[type, float], scale: float) -> dict[type, float]:
+    """
+    Rank scaling happens when generic-ness in nested, for example TS[X] will scale the rank of X to produce its own
+    """
+    return {k: v * scale for k, v in rank.items()}
+
+
+def combine_ranks(ranks: Iterable[dict[type, float]], scale: float = None) -> dict[type, float]:
+    """
+    Combination of ranks is done by taking the minimum of the ranks for each type so the lower generic-ness is used
+    For example a bundle of TS[X] and TS[Tuple[X, ...]] will be generic to X to the level of Tuple[X, ...]
+    """
+    reduction = reduce(min_rank, ranks, {})
+    if scale is not None:
+        return scale_rank(reduction, scale)
+    else:
+        return reduction
+
+
+def min_rank(x, y):
+    return {k: min(x.get(k, 1.0), y.get(k, 1.0)) for k in x.keys() | y.keys()}
+
+
+def compare_ranks(rank1: dict[type, float], rank2: dict[type, float]) -> bool:
+    """
+    Comparison of ranks is done by comparing the sum of ranks by all type parameters and combining them
+    """
+    return sum(rank1.values(), 0.) < sum(rank2.values(), 0.)

--- a/src/hgraph/_types/_ref_meta_data.py
+++ b/src/hgraph/_types/_ref_meta_data.py
@@ -1,5 +1,4 @@
-from typing import Type, TypeVar, Optional, _GenericAlias
-
+from typing import Type, TypeVar, Optional, _GenericAlias, Mapping
 
 __all__ = ("HgREFTypeMetaData", "HgREFOutTypeMetaData",)
 
@@ -69,8 +68,8 @@ class HgREFTypeMetaData(HgTimeSeriesTypeMetaData):
         return self.value_tp.typevars
 
     @property
-    def operator_rank(self) -> float:
-        return self.value_tp.operator_rank
+    def generic_rank(self) -> dict[type, float]:
+        return self.value_tp.generic_rank
 
     def __getitem__(self, item):
         return self.value_tp[item]

--- a/src/hgraph/_types/_scalar_type_meta_data.py
+++ b/src/hgraph/_types/_scalar_type_meta_data.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping, Set
 from datetime import date, datetime, time, timedelta
 from enum import Enum
 from functools import reduce
+from statistics import fmean
 from types import GenericAlias
 from typing import TypeVar, Type, Optional, Sequence, _GenericAlias, cast, List
 
@@ -119,7 +120,11 @@ class HgScalarTypeVar(HgScalarTypeMetaData):
 
     @property
     def generic_rank(self) -> dict[type, float]:
-        return {self.py_type: 1.}
+        avg_constraints_rank = fmean(itertools.chain(
+            *(c.generic_rank.values() if isinstance(c, HgTypeMetaData)
+              else [1. / (c.__mro__.index(object) + 1.)] for c in self.constraints())))
+
+        return {self.py_type: 0.9 + avg_constraints_rank / 10.}
 
     def constraints(self) -> Sequence[type]:
         if self.py_type.__constraints__:

--- a/src/hgraph/_types/_scalar_type_meta_data.py
+++ b/src/hgraph/_types/_scalar_type_meta_data.py
@@ -539,7 +539,7 @@ class HgTupleCollectionScalarType(HgTupleScalarType):
 
     @property
     def typevars(self):
-        return set().union(*(t.typevars for t in self.element_type))
+        return self.element_type.typevars
 
     @property
     def generic_rank(self) -> dict[type, float]:

--- a/src/hgraph/_types/_scalar_type_meta_data.py
+++ b/src/hgraph/_types/_scalar_type_meta_data.py
@@ -529,9 +529,15 @@ class HgTupleCollectionScalarType(HgTupleScalarType):
 
     def matches(self, tp: "HgTypeMetaData") -> bool:
         tp_ = type(tp)
-        return (tp_ is HgTupleCollectionScalarType and self.element_type.matches(tp.element_type)) or (
+        if tp_ is HgTupleCollectionScalarType:
+            return self.element_type.matches(tp.element_type)
+        elif tp_ is HgTupleFixedScalarType:
+            return all(self.element_type.matches(tp_) for tp_ in tp.element_types)
+        elif tp_ is HgDictScalarType:
             # Support matching a delta value as well.
-                tp_ is HgDictScalarType and self.element_type.matches(tp.value_type) and tp.key_type.py_type is int)
+            return self.element_type.matches(tp.value_type) and tp.key_type.py_type is int
+        else:
+            return False
 
     @property
     def py_type(self) -> Type:

--- a/src/hgraph/_types/_scalar_types.py
+++ b/src/hgraph/_types/_scalar_types.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 __all__ = ("SCALAR", "UnSet", "Size", "SIZE", "COMPOUND_SCALAR", "SCALAR", "CompoundScalar", "is_keyable_scalar",
            "is_compound_scalar", "STATE", "SCALAR_1", "SCALAR_2", "NUMBER", "KEYABLE_SCALAR", "LOGGER", "REPLAY_STATE",
-           "compound_scalar", "UnNamedCompoundScalar", "COMPOUND_SCALAR_1", "COMPOUND_SCALAR_2",)
+           "compound_scalar", "UnNamedCompoundScalar", "COMPOUND_SCALAR_1", "COMPOUND_SCALAR_2", "DEFAULT")
 
 
 class _UnSet:
@@ -33,6 +33,22 @@ class _UnSet:
 
     def __repr__(self):
         return "<UnSet>"
+
+
+class Default:
+    """
+    The marker class to indicate a type parameter that is the default if provided on a generic type without a key.
+    Also doubles up as default choice in switch_
+    """
+
+    def __init__(self, tp: TypeVar):
+        self.tp = tp
+
+    def __class_getitem__(cls, item):
+        return cls(item)
+
+
+DEFAULT = Default
 
 
 __CACHED_SIZES__: dict[int, Type["Size"]] = {}

--- a/src/hgraph/_types/_ts_meta_data.py
+++ b/src/hgraph/_types/_ts_meta_data.py
@@ -2,6 +2,7 @@ from typing import Type, TypeVar, Optional, _GenericAlias
 
 __all__ = ("HgTSTypeMetaData", "HgTSOutTypeMetaData",)
 
+from hgraph._types._generic_rank_util import scale_rank
 from hgraph._types._ts_type_var_meta_data import HgTsTypeVarTypeMetaData
 from hgraph._types._type_meta_data import ParseError
 from hgraph._types._scalar_type_meta_data import HgScalarTypeMetaData
@@ -25,8 +26,8 @@ class HgTSTypeMetaData(HgTimeSeriesTypeMetaData):
         return self.value_scalar_tp.typevars
 
     @property
-    def operator_rank(self) -> float:
-        return self.value_scalar_tp.operator_rank / 100.
+    def generic_rank(self) -> dict[type, float]:
+        return scale_rank(self.value_scalar_tp.generic_rank, 0.01)
 
     @property
     def py_type(self) -> Type:

--- a/src/hgraph/_types/_tsb_meta_data.py
+++ b/src/hgraph/_types/_tsb_meta_data.py
@@ -1,9 +1,11 @@
+from functools import reduce
 from hashlib import sha1
 from itertools import chain
 from typing import Type, Optional, TypeVar, _GenericAlias, Dict
 
 from frozendict import frozendict
 
+from hgraph._types._generic_rank_util import scale_rank, combine_ranks
 from hgraph._types._typing_utils import nth
 
 from hgraph._types._scalar_type_meta_data import HgScalarTypeMetaData, HgDictScalarType
@@ -205,11 +207,11 @@ class HgTSBTypeMetaData(HgTimeSeriesTypeMetaData):
         return self.bundle_schema_tp.typevars
 
     @property
-    def operator_rank(self) -> float:
+    def generic_rank(self) -> dict[type, float]:
         if isinstance(self.bundle_schema_tp, HgTsTypeVarTypeMetaData):
-            return self.bundle_schema_tp.operator_rank / 10.
+            return scale_rank(self.bundle_schema_tp.generic_rank, 0.1)
         else:
-            return sum(t.operator_rank for t in self.bundle_schema_tp.meta_data_schema.values()) / 100.
+            return combine_ranks((t.generic_rank for t in self.bundle_schema_tp.meta_data_schema.values()), 0.01)
 
     def matches(self, tp: "HgTypeMetaData") -> bool:
         return type(tp) is HgTSBTypeMetaData and self.bundle_schema_tp.matches(tp.bundle_schema_tp)

--- a/src/hgraph/_types/_tsb_type.py
+++ b/src/hgraph/_types/_tsb_type.py
@@ -344,7 +344,8 @@ class TimeSeriesBundleInput(TimeSeriesInput, TimeSeriesBundle[TS_SCHEMA], Generi
         This does not require all values be present, but before wiring the bundle into an input, this will be a
         requirement.
         """
-        schema: TS_SCHEMA = kwargs.pop("__schema__")
+        bundle: TSB[TS_SCHEMA] = kwargs.pop("__type__", None)
+        schema: TS_SCHEMA = kwargs.pop("__schema__") or bundle.bundle_schema_tp  # remove __schema__ once `combine` is done
         fn_details = TimeSeriesBundleInput.from_ts.__code__
 
         if arg is not None:

--- a/src/hgraph/_types/_tsd_meta_data.py
+++ b/src/hgraph/_types/_tsd_meta_data.py
@@ -1,5 +1,6 @@
 from typing import Type, TypeVar, Optional, _GenericAlias, Dict
 
+from hgraph._types._generic_rank_util import combine_ranks
 from hgraph._types._tsd_type import KEY_SET_ID
 from hgraph._types._tss_meta_data import HgTSSTypeMetaData
 from hgraph._types._scalar_type_meta_data import HgScalarTypeMetaData, HgDictScalarType
@@ -83,8 +84,8 @@ class HgTSDTypeMetaData(HgTimeSeriesTypeMetaData):
         return self.key_tp.typevars | self.value_tp.typevars
 
     @property
-    def operator_rank(self) -> float:
-        return (self.key_tp.operator_rank + self.value_tp.operator_rank) / 100.
+    def generic_rank(self) -> dict[type, float]:
+        return combine_ranks((self.key_tp.generic_rank, self.value_tp.generic_rank), 0.01)
 
     def __getitem__(self, item):
         if KEY_SET_ID is item:

--- a/src/hgraph/_types/_tsl_meta_data.py
+++ b/src/hgraph/_types/_tsl_meta_data.py
@@ -1,5 +1,6 @@
 from typing import Type, TypeVar, Optional, _GenericAlias, TYPE_CHECKING, cast
 
+from hgraph._types._generic_rank_util import combine_ranks, scale_rank
 from hgraph._types._type_meta_data import ParseError
 from hgraph._types._scalar_type_meta_data import HgScalarTypeMetaData, HgTupleCollectionScalarType, \
     HgDictScalarType
@@ -108,8 +109,8 @@ class HgTSLTypeMetaData(HgTimeSeriesTypeMetaData):
         return self.value_tp.typevars
 
     @property
-    def operator_rank(self) -> float:
-        return (self.value_tp.operator_rank) / 100. + self.size_tp.operator_rank / 1e10
+    def generic_rank(self) -> dict[type, float]:
+        return combine_ranks((self.value_tp.generic_rank, scale_rank(self.size_tp.generic_rank, 1e-6)), 0.01)
 
     def __eq__(self, o: object) -> bool:
         return type(o) is HgTSLTypeMetaData and self.value_tp == o.value_tp and self.size_tp == o.size_tp

--- a/src/hgraph/_types/_tsl_meta_data.py
+++ b/src/hgraph/_types/_tsl_meta_data.py
@@ -106,7 +106,7 @@ class HgTSLTypeMetaData(HgTimeSeriesTypeMetaData):
 
     @property
     def typevars(self):
-        return self.value_tp.typevars
+        return self.value_tp.typevars | self.size_tp.typevars
 
     @property
     def generic_rank(self) -> dict[type, float]:

--- a/src/hgraph/_types/_tsl_meta_data.py
+++ b/src/hgraph/_types/_tsl_meta_data.py
@@ -85,12 +85,12 @@ class HgTSLTypeMetaData(HgTimeSeriesTypeMetaData):
             type_ = next((v.output_type for v in value if isinstance(v, WiringPort)), None)
             if not type_:
                 type_ = HgTypeMetaData.parse_value(next(i for i in value if i is not None))
-                if type_ is None:
+                if type_ is not None:
                     type_ = HgTSTypeMetaData(type_)
                 else:
                     return None
 
-            return HgTSLTypeMetaData(type_, HgScalarTypeMetaData.parse_value(Size[size]))
+            return HgTSLTypeMetaData(type_, HgScalarTypeMetaData.parse_type(Size[size]))
 
         return super().parse_value(value)
 

--- a/src/hgraph/_types/_tss_meta_data.py
+++ b/src/hgraph/_types/_tss_meta_data.py
@@ -1,5 +1,6 @@
 from typing import Type, TypeVar, Optional, _GenericAlias
 
+from hgraph._types._generic_rank_util import scale_rank
 from hgraph._types._type_meta_data import HgTypeMetaData
 from hgraph._types._scalar_type_meta_data import HgScalarTypeMetaData, HgSetScalarType
 from hgraph._types._time_series_meta_data import HgTimeSeriesTypeMetaData
@@ -28,8 +29,8 @@ class HgTSSTypeMetaData(HgTimeSeriesTypeMetaData):
         return self.value_scalar_tp.typevars
 
     @property
-    def operator_rank(self) -> float:
-        return self.value_scalar_tp.operator_rank / 100.
+    def generic_rank(self) -> dict[type, float]:
+        return scale_rank(self.value_scalar_tp.generic_rank, 0.01)
 
     @property
     def py_type(self) -> Type:

--- a/src/hgraph/_types/_type_meta_data.py
+++ b/src/hgraph/_types/_type_meta_data.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, Type, Optional
+from typing import TypeVar, Type, Optional, Mapping
 
 __all__ = ('ParseError', 'HgTypeMetaData', 'AUTO_RESOLVE')
 
@@ -92,14 +92,14 @@ class HgTypeMetaData:
         return set()
 
     @property
-    def operator_rank(self) -> float:
+    def generic_rank(self) -> dict[type, float]:
         """
-        The operator rank indicates how imprecision exists in the type. The higher the rank, the more imprecise.
+        The generic rank indicates how imprecision exists in the type. The higher the rank, the more imprecise.
         With the highest rank being 1.0 and the smallest being 0.0.
         This ranking is used to determine the best match when wiring types by summing up the ranks and picking
         the lowest sum of the inputs as the best match.
         """
-        return 1e-10
+        return {}
 
     def build_resolution_dict(self, resolution_dict: dict[TypeVar, "HgTypeMetaData"], wired_type: "HgTypeMetaData"):
         """

--- a/src/hgraph/_wiring/_dispatch.py
+++ b/src/hgraph/_wiring/_dispatch.py
@@ -117,7 +117,7 @@ def _dispatch_impl(signature: WiringNodeSignature, overloads: BaseWiringNodeClas
         from hgraph import RequirementsNotMetWiringError
         try:
             o.resolve_signature(**stub_args)
-        except RequirementsNotMetWiringError:
+        except RequirementsNotMetWiringError as e:
             continue
 
         key = tuple(t.py_type for t in o_dispatch_types.values())

--- a/src/hgraph/_wiring/_reduce.py
+++ b/src/hgraph/_wiring/_reduce.py
@@ -17,12 +17,15 @@ from hgraph._wiring._wiring_node_signature import WiringNodeSignature
 from hgraph._wiring._wiring_port import WiringPort
 from hgraph._wiring._wiring_utils import wire_nested_graph
 
-__all__ = ("reduce",)
+__all__ = ("reduce", "ZERO")
+
+
+ZERO = object()
 
 
 def reduce(func: Callable[[TIME_SERIES_TYPE, TIME_SERIES_TYPE_1], TIME_SERIES_TYPE],
            ts: TSD[K, TIME_SERIES_TYPE_1] | TSL[TIME_SERIES_TYPE_1, SIZE],
-           zero: TIME_SERIES_TYPE = None, is_associated: bool = True) -> TIME_SERIES_TYPE:
+           zero: TIME_SERIES_TYPE = ZERO, is_associated: bool = True) -> TIME_SERIES_TYPE:
     """
     Reduce the input time-series collection into a single time-series value.
     The zero must be compatible with the TIME_SERIES_TYPE value and be constructable as const(zero, TIME_SERIES_TYPE).
@@ -107,9 +110,12 @@ def _reduce_tsd(func, ts, zero):
     item_tp = tp.value_tp.py_type
 
     if not isinstance(zero, WiringPort):
-        if zero is None:
+        if zero is ZERO:
             import hgraph
             zero = hgraph._operators._operators.zero(item_tp, func)
+        elif zero is None:
+            from hgraph.nodes import nothing
+            zero = nothing(item_tp)
         else:
             from hgraph.nodes import const
             zero = const(zero, item_tp)

--- a/src/hgraph/_wiring/_switch.py
+++ b/src/hgraph/_wiring/_switch.py
@@ -4,7 +4,7 @@ from typing import Callable, Optional, cast
 
 from frozendict import frozendict
 
-from hgraph._types._scalar_types import SCALAR, STATE
+from hgraph._types._scalar_types import SCALAR, STATE, DEFAULT
 from hgraph._types._type_meta_data import HgTypeMetaData
 from hgraph._types._time_series_meta_data import HgTimeSeriesTypeMetaData
 from hgraph._types._time_series_types import TIME_SERIES_TYPE
@@ -21,10 +21,7 @@ from hgraph._wiring._wiring_node_signature import WiringNodeType
 from hgraph._wiring._wiring_utils import as_reference, wire_nested_graph
 from hgraph._wiring._wiring_port import WiringPort
 
-__all__ = ("switch_", "DEFAULT")
-
-
-DEFAULT = object()  # a marker to indicate the default option for
+__all__ = ("switch_",)
 
 
 def switch_(switches: dict[SCALAR, Callable[[...], Optional[TIME_SERIES_TYPE]]], key: TS[SCALAR], *args,

--- a/src/hgraph/_wiring/_wiring_node_class/_operator_wiring_node.py
+++ b/src/hgraph/_wiring/_wiring_node_class/_operator_wiring_node.py
@@ -1,5 +1,6 @@
 from typing import Mapping, Any, TypeVar, Callable, TYPE_CHECKING, List, Tuple
 
+from hgraph._types._generic_rank_util import scale_rank, combine_ranks
 from hgraph._wiring._wiring_utils import pretty_str_types
 from hgraph._wiring._wiring_errors import WiringError
 from hgraph._wiring._wiring_errors import WiringFailureError
@@ -108,9 +109,9 @@ class OverloadedWiringNodeHelper:
     def _calc_rank(signature: WiringNodeSignature) -> float:
         if signature.node_type == WiringNodeType.OPERATOR:
             return 1e6  # Really not a good ranking
-        return sum(t.operator_rank * (0.001 if t.is_scalar else 1)
+        return sum(combine_ranks((scale_rank(t.generic_rank, 0.001) if t.is_scalar else t.generic_rank
                    for k, t in signature.input_types.items()
-                   if signature.defaults.get(k) != AUTO_RESOLVE)
+                   if signature.defaults.get(k) != AUTO_RESOLVE)).values())
 
     def get_best_overload(self, *args, **kwargs):
         candidates = []

--- a/src/hgraph/_wiring/_wiring_node_class/_wiring_node_class.py
+++ b/src/hgraph/_wiring/_wiring_node_class/_wiring_node_class.py
@@ -325,15 +325,16 @@ def validate_and_resolve_signature(
         resolution_dict = signature.build_resolution_dict(__pre_resolved_types__, kwarg_types, kwargs)
         resolved_inputs = signature.resolve_inputs(resolution_dict)
         resolved_output = signature.resolve_output(resolution_dict, weak=not __enforce_output_type__)
-        valid_inputs, has_valid_overrides = signature.resolve_valid_inputs(**kwargs)
-        all_valid_inputs, has_all_valid_overrides = signature.resolve_all_valid_inputs(**kwargs)
+        valid_inputs, has_valid_overrides = signature.resolve_valid_inputs(resolution_dict, **kwargs)
+        all_valid_inputs, has_all_valid_overrides = signature.resolve_all_valid_inputs(resolution_dict, **kwargs)
+        active_inputs, has_active_overrides = signature.resolve_active_inputs(resolution_dict, **kwargs)
         valid_inputs, has_valid_overrides = signature.resolve_context_kwargs(kwargs, kwarg_types,
                                                                              resolved_inputs, valid_inputs,
                                                                              has_valid_overrides)
         resolved_inputs = signature.resolve_auto_resolve_kwargs(resolution_dict, kwarg_types, kwargs,
                                                                 resolved_inputs)
 
-        if signature.is_resolved and not has_valid_overrides and not has_all_valid_overrides:
+        if signature.is_resolved and not has_valid_overrides and not has_all_valid_overrides and not has_active_overrides:
             signature.resolve_auto_const_and_type_kwargs(kwarg_types, kwargs)
             signature.validate_resolved_types(kwarg_types, kwargs)
             signature.validate_requirements(resolution_dict, kwargs)
@@ -349,7 +350,7 @@ def validate_and_resolve_signature(
                 input_types=resolved_inputs,
                 output_type=resolved_output,
                 src_location=signature.src_location,
-                active_inputs=signature.active_inputs,
+                active_inputs=active_inputs,
                 valid_inputs=valid_inputs,
                 all_valid_inputs=all_valid_inputs,
                 context_inputs=signature.context_inputs,

--- a/src/hgraph/_wiring/_wiring_node_signature.py
+++ b/src/hgraph/_wiring/_wiring_node_signature.py
@@ -370,7 +370,7 @@ class WiringNodeSignature:
                     from hgraph.nodes import const
                     kwargs[arg] = const(kwargs[arg], tp=v.py_type)
                 elif not isinstance(kwargs[arg], WiringPort) and isinstance(kwargs[arg], (tuple, list, dict, frozendict)):
-                    kwargs[arg] = v.py_type.from_ts(kwargs[arg])
+                    kwargs[arg] = v.py_type.from_ts(kwargs[arg], __type__=v)
             if type(v) is HgTypeOfTypeMetaData:
                 kwargs[arg] = cast(HgTypeOfTypeMetaData, v).value_tp.py_type
 
@@ -445,7 +445,7 @@ def extract_signature(fn, wiring_node_type: WiringNodeType,
     if var_arg or var_kwarg:
         if wiring_node_type == WiringNodeType.OPERATOR:
             # Remove var_args from operators - they are decorative
-            args = tuple(a for a in args if a not in (var_arg, var_kwarg))
+            args = tuple(a for a in args if a not in (var_arg, var_kwarg) or a in annotations)
 
     if default_type_arg_name := next((k for k, v in annotations.items() if isinstance(v, DEFAULT)), None):
         tp = annotations[default_type_arg_name].tp

--- a/src/hgraph/_wiring/_wiring_node_signature.py
+++ b/src/hgraph/_wiring/_wiring_node_signature.py
@@ -157,6 +157,9 @@ class WiringNodeSignature:
         if not self.is_resolved:
             for arg, v in self.input_types.items():
                 typevars.update(v.typevars)
+            for k, v in self.defaults.items():
+                if isinstance(v, TypeVar):
+                    typevars.add(k)
             typevars.update(self.output_type.typevars)
         return frozenset(typevars)
 

--- a/src/hgraph/_wiring/_wiring_port.py
+++ b/src/hgraph/_wiring/_wiring_port.py
@@ -206,8 +206,8 @@ class TSBWiringPort(WiringPort):
         if self.__schema__.scalar_type() is None:
             raise CustomMessageWiringError("The schema does not have a scalar type")
 
-        from hgraph.nodes import cs_from_tsb
-        return cs_from_tsb(self)
+        from hgraph import convert, CompoundScalar, TS
+        return convert[TS[CompoundScalar]](self)
 
     def edges_for(self, node_map: Mapping["WiringNodeInstance", int], dst_node_ndx: int,
                   dst_path: tuple[SCALAR, ...]) -> \
@@ -248,8 +248,8 @@ class TSBREFWiringPort(WiringPort):
         if self.__schema__.scalar_type() is None:
             raise CustomMessageWiringError("The schema does not have a scalar type")
 
-        from hgraph.nodes import cs_from_tsb
-        return cs_from_tsb(self)
+        from hgraph import convert, CompoundScalar, TS
+        return convert[TS[CompoundScalar]](self)
 
     def __getattr__(self, item):
         from hgraph.nodes._tsb_operators import tsb_get_item

--- a/src/hgraph/adaptors/data_frame/_data_frame_operators.py
+++ b/src/hgraph/adaptors/data_frame/_data_frame_operators.py
@@ -75,5 +75,6 @@ def ungroup(ts: TSD[KEYABLE_SCALAR, TS[Frame[COMPOUND_SCALAR]]]) -> TS[Frame[COM
 
 
 @compute_node
-def sorted_(ts: TS[Frame[COMPOUND_SCALAR]], by: str, reverse: bool = False) -> TS[Frame[COMPOUND_SCALAR]]:
-    return ts.value.sort(by, reverse=reverse)
+def sorted_(ts: TS[Frame[COMPOUND_SCALAR]], by: str, descending: bool = False) -> TS[Frame[COMPOUND_SCALAR]]:
+    if not ts.value.is_empty():
+        return ts.value.sort(by, descending=descending)

--- a/src/hgraph/nodes/_compound_scalar_operators.py
+++ b/src/hgraph/nodes/_compound_scalar_operators.py
@@ -1,38 +1,13 @@
 from typing import Type
 
-from hgraph import compute_node, COMPOUND_SCALAR, TS, SCALAR, HgTypeMetaData, IncorrectTypeBinding, with_signature, \
-    TimeSeries, CustomMessageWiringError, TSB, TS_SCHEMA, CompoundScalar, getattr_, type_, COMPOUND_SCALAR_1
+from hgraph import compute_node, COMPOUND_SCALAR, TS, SCALAR, CompoundScalar, getattr_, type_, COMPOUND_SCALAR_1
 
-__all__ = ("getattr_cs", "cs_from_ts", "cs_from_tsb")
+__all__ = ("getattr_cs",)
 
 
 @compute_node(overloads=getattr_, resolvers={SCALAR: lambda mapping, scalars: mapping[COMPOUND_SCALAR].meta_data_schema[scalars['attr']].py_type})
 def getattr_cs(ts: TS[COMPOUND_SCALAR], attr: str) -> TS[SCALAR]:
     return getattr(ts.value, attr, None)
-
-
-def cs_from_ts(cls: Type[COMPOUND_SCALAR], **kwargs) -> TS[SCALAR]:
-    scalar_schema = cls.__meta_data_schema__
-    kwargs_schema = {k: HgTypeMetaData.parse_value(v).dereference() for k, v in kwargs.items()}
-
-    for k, t in scalar_schema.items():
-        if (kt := kwargs_schema.get(k)) is None:
-            if getattr(cls, k, None) is None:
-                raise CustomMessageWiringError(f"Missing input: {k}")
-        elif not t.matches(kt if kt.is_scalar else kt.scalar_type()):
-            raise IncorrectTypeBinding(t, kwargs_schema[k])
-
-    @compute_node
-    @with_signature(kwargs=kwargs_schema, return_annotation=TS[cls])
-    def from_ts_node(**kwargs):
-        return cls(**{k: v if not isinstance(v, TimeSeries) else v.value for k, v in kwargs.items()})
-
-    return from_ts_node(**kwargs)
-
-
-@compute_node(all_valid=('tsb',), resolvers={COMPOUND_SCALAR: lambda mapping, tsb: mapping[TS_SCHEMA].py_type.scalar_type()})
-def cs_from_tsb(tsb: TSB[TS_SCHEMA]) -> TS[COMPOUND_SCALAR]:
-    return tsb.value
 
 
 @compute_node(overloads=type_, requires=lambda m, s: COMPOUND_SCALAR not in m)

--- a/src/hgraph/nodes/_conversion_operators/__init__.py
+++ b/src/hgraph/nodes/_conversion_operators/__init__.py
@@ -1,6 +1,6 @@
-from hgraph.nodes._conversion_operators._conversion_operator_templates import *
 from hgraph.nodes._conversion_operators._ts_conversion_operators import *
 from hgraph.nodes._conversion_operators._tsb_conversion_operators import *
 from hgraph.nodes._conversion_operators._tsd_conversion_operators import *
 from hgraph.nodes._conversion_operators._tsl_conversion_operators import *
 from hgraph.nodes._conversion_operators._tss_conversion_operators import *
+from hgraph.nodes._conversion_operators._tuple_conversion_operators import *

--- a/src/hgraph/nodes/_conversion_operators/__init__.py
+++ b/src/hgraph/nodes/_conversion_operators/__init__.py
@@ -4,3 +4,4 @@ from hgraph.nodes._conversion_operators._tsd_conversion_operators import *
 from hgraph.nodes._conversion_operators._tsl_conversion_operators import *
 from hgraph.nodes._conversion_operators._tss_conversion_operators import *
 from hgraph.nodes._conversion_operators._tuple_conversion_operators import *
+from hgraph.nodes._conversion_operators._compound_scalar_conversion_operators import *

--- a/src/hgraph/nodes/_conversion_operators/_compound_scalar_conversion_operators.py
+++ b/src/hgraph/nodes/_conversion_operators/_compound_scalar_conversion_operators.py
@@ -1,0 +1,44 @@
+from typing import Type
+
+from hgraph import COMPOUND_SCALAR, TS, SCALAR, HgTypeMetaData, CustomMessageWiringError, IncorrectTypeBinding, \
+    compute_node, with_signature, TimeSeries, TS_SCHEMA, TSB, DEFAULT, OUT, combine, convert, CompoundScalar
+
+__all__ = ()
+
+
+def _check_schema(scalar, bundle):
+    if bundle.meta_data_schema.keys() - scalar.meta_data_schema.keys():
+        return f"Extra fields: {bundle.meta_data_schema.keys() - scalar.meta_data_schema.keys()}"
+    for k, t in scalar.meta_data_schema.items():
+        if (kt := bundle.meta_data_schema.get(k)) is None:
+            if getattr(scalar.py_type, k, None) is None:
+                return f"Missing input: {k}"
+        elif not t.matches(kt if kt.is_scalar else kt.scalar_type()):
+            return f"field {k} of type {t} does not accept {kt}"
+    return True
+
+
+@compute_node(overloads=combine,
+              requires=lambda m, s: _check_schema(m[COMPOUND_SCALAR], m[TS_SCHEMA]),
+              all_valid=lambda m, s: ('bundle',) if s['__strict__'] else None)
+def combine_cs(tp_out_: Type[TS[COMPOUND_SCALAR]] = DEFAULT[OUT],
+               tp_: Type[COMPOUND_SCALAR] = COMPOUND_SCALAR,
+               __strict__: bool = True,
+               **bundle: TSB[TS_SCHEMA]) -> TS[COMPOUND_SCALAR]:
+    return tp_(**{k: v.value for k, v in bundle.items()})
+
+
+@compute_node(overloads=convert,
+              requires=lambda m, s: m[OUT].py_type == TS[CompoundScalar],
+              resolvers={COMPOUND_SCALAR: lambda m, s: m[TS_SCHEMA].py_type.scalar_type()},
+              all_valid=lambda m, s: ('bundle',) if s['__strict__'] else None)
+def convert_cs_from_tsb(bundle: TSB[TS_SCHEMA], __strict__: bool = True) -> TS[COMPOUND_SCALAR]:
+    return bundle.value
+
+
+@compute_node(overloads=convert,
+              requires=lambda m, s: m[OUT].py_type != TS[CompoundScalar],
+              all_valid=lambda m, s: ('bundle',) if s['__strict__'] else None)
+def convert_cs_from_tsb_typed(bundle: TSB[TS_SCHEMA], __strict__: bool = True,
+                              tp_: Type[TS[COMPOUND_SCALAR]] = DEFAULT[OUT]) -> TS[COMPOUND_SCALAR]:
+    return bundle.value

--- a/src/hgraph/nodes/_conversion_operators/_conversion_operator_templates.py
+++ b/src/hgraph/nodes/_conversion_operators/_conversion_operator_templates.py
@@ -1,4 +1,5 @@
 from hgraph import TIME_SERIES_TYPE, graph, AUTO_RESOLVE, operator
+from hgraph._types._scalar_types import DEFAULT
 from hgraph._types._time_series_types import OUT
 
 
@@ -6,7 +7,7 @@ __all__ = ("convert", "combine", "collect", "emit")
 
 
 @operator
-def convert(ts: TIME_SERIES_TYPE, to: type[OUT], **kwargs) -> OUT:
+def convert(ts: TIME_SERIES_TYPE, to: type[OUT] = DEFAULT[OUT], **kwargs) -> OUT:
     """
     Converts the incoming time series to the desired result type. This can be called in one of two ways:
     ::

--- a/src/hgraph/nodes/_conversion_operators/_ts_conversion_operators.py
+++ b/src/hgraph/nodes/_conversion_operators/_ts_conversion_operators.py
@@ -5,7 +5,7 @@ from typing import Mapping
 from hgraph import compute_node, TS, SCALAR, STATE, CompoundScalar, SCHEDULER, MIN_TD, SCALAR_1, graph, \
     AUTO_RESOLVE, TSS, OUT
 from hgraph._types._scalar_types import DEFAULT
-from hgraph.nodes._conversion_operators._conversion_operator_templates import emit, convert
+from hgraph._operators._conversion import emit, convert
 
 __all__ = ("emit_tuple", "convert_ts_generic", "convert_ts_to_tss")
 

--- a/src/hgraph/nodes/_conversion_operators/_ts_conversion_operators.py
+++ b/src/hgraph/nodes/_conversion_operators/_ts_conversion_operators.py
@@ -22,7 +22,7 @@ def convert_ts_noop(
 
 
 @compute_node(overloads=convert)
-def convert_ts_generic(ts: TS[SCALAR], to: type[SCALAR_1] = DEFAULT[OUT], s1_type: type[SCALAR_1] = AUTO_RESOLVE) -> TS[SCALAR_1]:
+def convert_ts_generic(ts: TS[SCALAR], to: type[TS[SCALAR_1]] = DEFAULT[OUT], s1_type: type[SCALAR_1] = AUTO_RESOLVE) -> TS[SCALAR_1]:
     return s1_type(ts.value)
 
 

--- a/src/hgraph/nodes/_conversion_operators/_ts_conversion_operators.py
+++ b/src/hgraph/nodes/_conversion_operators/_ts_conversion_operators.py
@@ -3,36 +3,32 @@ from dataclasses import dataclass, field
 from typing import Mapping
 
 from hgraph import compute_node, TS, SCALAR, STATE, CompoundScalar, SCHEDULER, MIN_TD, SCALAR_1, graph, \
-    AUTO_RESOLVE, TSS
+    AUTO_RESOLVE, TSS, OUT
+from hgraph._types._scalar_types import DEFAULT
 from hgraph.nodes._conversion_operators._conversion_operator_templates import emit, convert
 
-__all__ = ("emit_tuple", "convert_ts", "convert_ts_to_tss")
+__all__ = ("emit_tuple", "convert_ts_generic", "convert_ts_to_tss")
 
 
 @graph(overloads=convert)
-def convert_ts(
+def convert_ts_noop(
         ts: TS[SCALAR],
-        to: type[TS[SCALAR_1]],
-        s_tp: type[SCALAR] = AUTO_RESOLVE,
-        s1_type: type[SCALAR_1] = AUTO_RESOLVE
-) -> TS[SCALAR_1]:
+        to: type[TS[SCALAR]] = DEFAULT[OUT],
+) -> TS[SCALAR]:
     """
-    Check types, if they are the same, then return the value.
+    if types are the same, then return the value.
     """
-    if s_tp == s1_type:
-        return ts
-    else:
-        return _convert_ts_generic(ts, s1_type)
+    return ts
 
 
-@compute_node
-def _convert_ts_generic(ts: TS[SCALAR], s1_type: type[SCALAR_1]) -> TS[SCALAR_1]:
+@compute_node(overloads=convert)
+def convert_ts_generic(ts: TS[SCALAR], to: type[SCALAR_1] = DEFAULT[OUT], s1_type: type[SCALAR_1] = AUTO_RESOLVE) -> TS[SCALAR_1]:
     return s1_type(ts.value)
 
 
 @compute_node(overloads=convert)
 def convert_ts_to_tss(ts: TS[SCALAR], to: type[TSS[SCALAR]]) -> TSS[SCALAR]:
-    return {ts.value}
+    return {ts.value}  # AB: this looks like `collect` to me
 
 
 @dataclass

--- a/src/hgraph/nodes/_conversion_operators/_tsb_conversion_operators.py
+++ b/src/hgraph/nodes/_conversion_operators/_tsb_conversion_operators.py
@@ -6,13 +6,13 @@ from hgraph import TSB, TS_SCHEMA, TS, compute_node, TSD, TIME_SERIES_TYPE, AUTO
 __all__ = ("convert_tsb_to_bool", "convert_tsb_to_tsd")
 
 
-@graph(overloads=combine)
+@graph(overloads=combine, requires=lambda m, s: OUT not in m)
 def combine_unnamed_tsb(**bundle: TSB[TS_SCHEMA]) -> TSB[TS_SCHEMA]:
     return bundle
 
 
 @graph(overloads=combine)
-def combine_named_tsb(tp_: Type[TS_SCHEMA] = DEFAULT[OUT], **bundle: TSB[TS_SCHEMA]) -> TSB[TS_SCHEMA]:
+def combine_named_tsb(tp_: Type[TSB[TS_SCHEMA]] = DEFAULT[OUT], **bundle: TSB[TS_SCHEMA]) -> TSB[TS_SCHEMA]:
     return bundle
 
 

--- a/src/hgraph/nodes/_conversion_operators/_tsb_conversion_operators.py
+++ b/src/hgraph/nodes/_conversion_operators/_tsb_conversion_operators.py
@@ -1,8 +1,19 @@
-from hgraph import TSB, TS_SCHEMA, TS, compute_node, TSD, TIME_SERIES_TYPE, TimeSeriesSchema, AUTO_RESOLVE
-from hgraph.nodes._conversion_operators._conversion_operator_templates import convert
+from typing import Type
 
+from hgraph import TSB, TS_SCHEMA, TS, compute_node, TSD, TIME_SERIES_TYPE, AUTO_RESOLVE, graph, combine, convert, \
+    DEFAULT, OUT
 
 __all__ = ("convert_tsb_to_bool", "convert_tsb_to_tsd")
+
+
+@graph(overloads=combine)
+def combine_unnamed_tsb(**bundle: TSB[TS_SCHEMA]) -> TSB[TS_SCHEMA]:
+    return bundle
+
+
+@graph(overloads=combine)
+def combine_named_tsb(tp_: Type[TS_SCHEMA] = DEFAULT[OUT], **bundle: TSB[TS_SCHEMA]) -> TSB[TS_SCHEMA]:
+    return bundle
 
 
 @compute_node(overloads=convert)
@@ -10,7 +21,7 @@ def convert_tsb_to_bool(ts: TSB[TS_SCHEMA], to: type[TS[bool]]) -> TS[bool]:
     """
     Returns True if the ts is valid or false otherwise.
     """
-    return ts.valid
+    return ts.valid  # AB: There is a 'valid' node for that, I would not see this as conversion
 
 
 def _convert_tsb_to_tsd_requirements(mapping, scalars):

--- a/src/hgraph/nodes/_conversion_operators/_tsl_conversion_operators.py
+++ b/src/hgraph/nodes/_conversion_operators/_tsl_conversion_operators.py
@@ -1,0 +1,14 @@
+from typing import Type
+
+from hgraph import graph, TSL, TIME_SERIES_TYPE, SIZE, combine, OUT, TIME_SERIES_TYPE_1, DEFAULT
+
+
+@graph(overloads=combine, requires=lambda m, s: OUT not in m or m[OUT].py_type == TSL)
+def combine_tsl(*tsl: TSL[TIME_SERIES_TYPE, SIZE]) -> TSL[TIME_SERIES_TYPE, SIZE]:
+    return tsl
+
+
+@graph(overloads=combine)
+def combine_tsl(*tsl: TSL[TIME_SERIES_TYPE, SIZE], tp_: Type[TSL[TIME_SERIES_TYPE_1, SIZE]] = DEFAULT[OUT]) \
+        -> TSL[TIME_SERIES_TYPE_1, SIZE]:
+    return tsl

--- a/src/hgraph/nodes/_conversion_operators/_tuple_conversion_operators.py
+++ b/src/hgraph/nodes/_conversion_operators/_tuple_conversion_operators.py
@@ -1,0 +1,15 @@
+from typing import Tuple, Type
+
+from hgraph import compute_node, combine, TSL, TIME_SERIES_TYPE, SIZE, TS, SCALAR, DEFAULT, OUT
+
+__all__ = ("combine_tuple",)
+
+
+@compute_node(overloads=combine, requires=lambda m, s: m[OUT].py_type == TS[Tuple], all_valid=('tsl',))
+def combine_tuple(*tsl: TSL[TS[SCALAR], SIZE]) -> TS[Tuple[SCALAR, ...]]:
+    return tuple(v.value for v in tsl)
+
+
+@compute_node(overloads=combine, requires=lambda m, s: m[OUT].py_type == TS[Tuple] and s['strict'] is False)
+def combine_tuple_relaxed(*tsl: TSL[TS[SCALAR], SIZE], strict: bool) -> TS[Tuple[SCALAR, ...]]:
+    return tuple(v.value for v in tsl)

--- a/src/hgraph/nodes/_print.py
+++ b/src/hgraph/nodes/_print.py
@@ -59,7 +59,7 @@ def print_(format_str: TS[str] | str, *args, __std_out__: bool =True, **kwargs):
     if len(args) == 0 and len(kwargs) == 0:
         return _print(format_str)
     else:
-        return _print(format_(format_str, *args, **kwargs), std_out__=__std_out__)
+        return _print(format_(format_str, *args, **kwargs), std_out=__std_out__)
 
 
 @sink_node

--- a/src/hgraph/nodes/_str_operators.py
+++ b/src/hgraph/nodes/_str_operators.py
@@ -1,8 +1,16 @@
 from typing import Tuple, Type
 
-from hgraph import compute_node, TS, TimeSeriesSchema, TSB, SCALAR, AUTO_RESOLVE, add_
+from hgraph import compute_node, TS, TimeSeriesSchema, TSB, SCALAR, AUTO_RESOLVE, add_, TIME_SERIES_TYPE, str_
 
 __all__ = ('match', 'parse', 'add_str')
+
+
+@compute_node(overloads=str_)
+def str_(ts: TIME_SERIES_TYPE) -> TS[str]:
+    """
+    Returns the string representation of the time-series value.
+    """
+    return str(ts.value)
 
 
 @compute_node(overloads=add_)

--- a/src/hgraph/nodes/_time_series_properties.py
+++ b/src/hgraph/nodes/_time_series_properties.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from hgraph import TIME_SERIES_TYPE, REF, TS, compute_node, SIGNAL
 
-__all__ = ("valid",)
+__all__ = ("valid", "last_modified_time")
 
 
 @compute_node(valid=("ts",), active=('ts',))

--- a/src/hgraph/nodes/_time_series_properties.py
+++ b/src/hgraph/nodes/_time_series_properties.py
@@ -1,5 +1,6 @@
-from hgraph import TIME_SERIES_TYPE, REF, TS, compute_node
+from datetime import datetime
 
+from hgraph import TIME_SERIES_TYPE, REF, TS, compute_node, SIGNAL
 
 __all__ = ("valid",)
 
@@ -26,3 +27,8 @@ def valid(ts: REF[TIME_SERIES_TYPE], ts_value: TIME_SERIES_TYPE = None) -> TS[bo
         return True
 
     return False
+
+
+@compute_node
+def last_modified_time(ts: SIGNAL) -> TS[datetime]:
+    return ts.last_modified_time

--- a/src/hgraph/nodes/_tsd_operators.py
+++ b/src/hgraph/nodes/_tsd_operators.py
@@ -8,7 +8,7 @@ from hgraph import TS, SCALAR, TIME_SERIES_TYPE, TSD, compute_node, REMOVE_IF_EX
     TIME_SERIES_TYPE_1
 from hgraph.nodes._analytical import sum_
 from hgraph.nodes._const import const, nothing
-from hgraph.nodes._tsl_operators import merge
+from hgraph._operators._control import merge
 
 __all__ = (
     "make_tsd", "make_tsd_scalar", "flatten_tsd", "extract_tsd", "tsd_get_item", "tsd_get_key_set", "tsd_contains",
@@ -194,7 +194,7 @@ def tsd_get_bundle_item(tsd: TSD[K, REF[TSB[TS_SCHEMA]]], key: str, _schema: Typ
             if v.value.has_peer:
                 out[k] = PythonTimeSeriesReference(v.value.output[key])
             else:
-                out[k] = PythonTimeSeriesReference(v.value[_schema._schema_index_of(key)])
+                out[k] = v.value.items[_schema._schema_index_of(key)]
         else:
             out[k] = PythonTimeSeriesReference()
 

--- a/src/hgraph/nodes/_tsd_operators.py
+++ b/src/hgraph/nodes/_tsd_operators.py
@@ -355,7 +355,7 @@ def tsd_flip_tsd(ts: TSD[K, TSD[K_1, REF[TIME_SERIES_TYPE]]], _output: TSD[K_1, 
 
 
 @compute_node(overloads=merge)
-def merge_tsds(tsl: TSL[TSD[K, REF[TIME_SERIES_TYPE]], SIZE]) -> TSD[K, REF[TIME_SERIES_TYPE]]:
+def merge_tsds(*tsl: TSL[TSD[K, REF[TIME_SERIES_TYPE]], SIZE]) -> TSD[K, REF[TIME_SERIES_TYPE]]:
     out = {}
     removals = set()
 
@@ -375,7 +375,7 @@ def merge_tsds(tsl: TSL[TSD[K, REF[TIME_SERIES_TYPE]], SIZE]) -> TSD[K, REF[TIME
 
 
 @compute_node(overloads=merge)
-def merge_nested_tsds(tsl: TSL[TSD[K, TSD[K_1, REF[TIME_SERIES_TYPE]]], SIZE]) -> TSD[
+def merge_nested_tsds(*tsl: TSL[TSD[K, TSD[K_1, REF[TIME_SERIES_TYPE]]], SIZE]) -> TSD[
     K, TSD[K_1, REF[TIME_SERIES_TYPE]]]:
     out = defaultdict(dict)
     removals = set()

--- a/src/hgraph/nodes/_tsl_operators.py
+++ b/src/hgraph/nodes/_tsl_operators.py
@@ -2,11 +2,12 @@ from typing import Type
 
 from hgraph import compute_node, TSL, TIME_SERIES_TYPE, SIZE, SCALAR, TS, graph, AUTO_RESOLVE, NUMBER, REF, TSD, \
     PythonTimeSeriesReference, len_, operator
+from hgraph._operators._control import merge
 from hgraph.nodes._analytical import sum_
 from hgraph.nodes._const import const
 
 
-__all__ = ("flatten_tsl_values", "merge", "tsl_len", "sum_tsl", "tsl_to_tsd", "tsl_get_item", "tsl_get_item_ts",
+__all__ = ("flatten_tsl_values", "tsl_len", "sum_tsl", "tsl_to_tsd", "tsl_get_item", "tsl_get_item_ts",
            "index_of")
 
 
@@ -25,17 +26,9 @@ def flatten_tsl_values(tsl: TSL[TIME_SERIES_TYPE, SIZE], all_valid: bool = False
     """
     return tsl.value if not all_valid or tsl.all_valid else None
 
-@operator
-def merge(tsl: TSL[TIME_SERIES_TYPE, SIZE]) -> TIME_SERIES_TYPE:
-    """
-    Selects and returns the first of the values that tick (are modified) in the list provided.
-    If more than one input is modified in the engine-cycle, it will return the first one that ticked in order of the
-    list.
-    """
-
 
 @compute_node(overloads=merge)
-def merge_default(tsl: TSL[TIME_SERIES_TYPE, SIZE]) -> TIME_SERIES_TYPE:
+def merge_default(*tsl: TSL[TIME_SERIES_TYPE, SIZE]) -> TIME_SERIES_TYPE:
     """
     Selects and returns the first of the values that tick (are modified) in the list provided.
     If more than one input is modified in the engine-cycle, it will return the first one that ticked in order of the

--- a/src/hgraph/test/_node_unit_tester.py
+++ b/src/hgraph/test/_node_unit_tester.py
@@ -1,4 +1,5 @@
 from contextlib import nullcontext
+from datetime import datetime
 from itertools import zip_longest
 from typing import Any
 
@@ -13,6 +14,8 @@ def eval_node(node, *args, resolution_dict: [str, Any] = None,
               __trace__: bool = False,
               __observers__: list[EvaluationLifeCycleObserver] = None,
               __elide__: bool = False,
+              __start_time__: datetime = None,
+              __end_time__: datetime = None,
               **kwargs):
     """
     Evaluates a node using the supplied arguments.
@@ -89,7 +92,7 @@ def eval_node(node, *args, resolution_dict: [str, Any] = None,
             max_count = max(max_count, len(v) if (is_list := hasattr(v, "__len__")) else 1)
         observers = [EvaluationTrace(**(__trace__ if type(__trace__) is dict else {}))] if __trace__ else []
         observers.extend(__observers__ if __observers__ else [])
-        run_graph(eval_node_graph, life_cycle_observers=observers)
+        run_graph(eval_node_graph, life_cycle_observers=observers, start_time=__start_time__, end_time=__end_time__)
 
         results = get_recorded_value() if node.signature.output_type is not None else []
         if results:

--- a/src/hgraph/test/_node_unit_tester.py
+++ b/src/hgraph/test/_node_unit_tester.py
@@ -1,4 +1,5 @@
 from contextlib import nullcontext
+from itertools import zip_longest
 from typing import Any
 
 from hgraph import graph, run_graph, GlobalState, MIN_TD, HgTypeMetaData, HgTSTypeMetaData, prepare_kwargs, MIN_ST, \
@@ -39,15 +40,23 @@ def eval_node(node, *args, resolution_dict: [str, Any] = None,
     def eval_node_graph():
         inputs = {}
         for ts_arg in time_series_inputs:
-            if kwargs_[ts_arg] is None:
+            arg_value = kwargs_.get(ts_arg)
+            if arg_value is None:
                 continue
+            if ts_arg == node.signature.var_arg and ts_arg not in kwargs:
+                # this was collected into *arg hence needs to be transposed to be correct shape for TSL replay
+                arg_value = list(zip_longest(*(a if hasattr(a, '__iter__') else [a] for a in arg_value)))
+            if ts_arg == node.signature.var_kwarg and ts_arg not in kwargs:
+                # this was collected into **kwarg hence needs to be transposed to be correct shape for TSB replay
+                arg_value = list({k: v for k, v in zip(arg_value.keys(), i)}
+                            for i in zip_longest(*(a if hasattr(a, '__iter__') else [a] for a in arg_value.values())))
             if resolution_dict is not None and ts_arg in resolution_dict:
                 ts_type = resolution_dict[ts_arg]
             else:
                 ts_type: HgTypeMetaData = node.signature.input_types[ts_arg]
                 if not ts_type.is_resolved:
                     # Attempt auto resolve
-                    v_ = kwargs_[ts_arg]
+                    v_ = arg_value
                     if not hasattr(v_, "__iter__"):  # Dealing with scalar to time-series support
                         v_ = [v_]
                     ts_type = HgTypeMetaData.parse_value(next(i for i in v_ if i is not None))
@@ -59,6 +68,8 @@ def eval_node(node, *args, resolution_dict: [str, Any] = None,
                     print(f"Auto resolved type for '{ts_arg}' to '{ts_type}'")
                 ts_type = ts_type.py_type if not ts_type.is_context_wired else ts_type.ts_type.py_type
             inputs[ts_arg] = replay(ts_arg, ts_type)
+            is_list = hasattr(arg_value, "__len__")
+            set_replay_values(ts_arg, SimpleArrayReplaySource(arg_value if is_list else [arg_value]))
         for scalar_args in node.signature.scalar_inputs.keys():
             inputs[scalar_args] = kwargs_[scalar_args]
 
@@ -76,7 +87,6 @@ def eval_node(node, *args, resolution_dict: [str, Any] = None,
                 continue
             # Dealing with scalar to time-series support
             max_count = max(max_count, len(v) if (is_list := hasattr(v, "__len__")) else 1)
-            set_replay_values(ts_arg, SimpleArrayReplaySource(v if is_list else [v]))
         observers = [EvaluationTrace(**(__trace__ if type(__trace__) is dict else {}))] if __trace__ else []
         observers.extend(__observers__ if __observers__ else [])
         run_graph(eval_node_graph, life_cycle_observers=observers)

--- a/tests/python/unit/hgraph/_wiring/test_annotation.py
+++ b/tests/python/unit/hgraph/_wiring/test_annotation.py
@@ -1,0 +1,22 @@
+from typing import Tuple
+
+from hgraph import compute_node, TS
+from hgraph.test import eval_node
+
+
+def test_valid_lambda():
+    @compute_node(valid=lambda m, s: None if s['__strict__'] else ())
+    def f(x: TS[int], y: TS[int], __strict__: bool) -> TS[Tuple[int, int]]:
+        return x.value, y.value
+
+    assert eval_node(f, [None, 2], [3, 4], __strict__=True) == [None, (2, 4)]
+    assert eval_node(f, [None, 2], [3, 4], __strict__=False) == [(None, 3), (2, 4)]
+
+
+def test_active_lambda():
+    @compute_node(active=lambda m, s: {'x'} if s['__lazy__'] else None, valid=())
+    def f(x: TS[int], y: TS[int], __lazy__: bool = False) -> TS[Tuple[int, int]]:
+        return x.value, y.value
+
+    assert eval_node(f, [1, None], [3, 4]) == [(1, 3), (1, 4)]
+    assert eval_node(f, [1, None], [3, 4], __lazy__=True) == [(1, 3), None]

--- a/tests/python/unit/hgraph/_wiring/test_arg_parsing.py
+++ b/tests/python/unit/hgraph/_wiring/test_arg_parsing.py
@@ -1,0 +1,21 @@
+import pytest
+
+from hgraph import compute_node, TS, extract_kwargs
+
+
+def test_extract_kwargs_extra_args():
+    @compute_node
+    def n(a: TS[int], b: TS[int]) -> TS[int]:
+        return a + b
+
+    with pytest.raises(SyntaxError):
+        extract_kwargs(n.signature, 'a', 'b', 'c')
+
+
+def test_extract_kwargs_extra_kwargs():
+    @compute_node
+    def n(a: TS[int], b: TS[int]) -> TS[int]:
+        return a + b
+
+    with pytest.raises(SyntaxError):
+        extract_kwargs(n.signature, a='a', b='b', c='c')

--- a/tests/python/unit/hgraph/_wiring/test_map.py
+++ b/tests/python/unit/hgraph/_wiring/test_map.py
@@ -142,7 +142,7 @@ def test_tsd_map_wiring_no_key():
 def test_tsd_map_wiring_no_key_no_kwargs():
     @graph
     def map_test(keys: TSS[str], ts1: TSD[str, TS[int]], ts2: TSD[str, TS[int]]) -> TSD[str, TS[int]]:
-        m = map_(add_ts, ts1, ts2, keys=keys)
+        m = map_(add_ts, ts1, ts2, __keys__=keys)
         return m
 
     _test_tsd_map(map_test)
@@ -151,7 +151,7 @@ def test_tsd_map_wiring_no_key_no_kwargs():
 def test_tsd_map_wiring_no_kwargs():
     @graph
     def map_test(keys: TSS[str], ts1: TSD[str, TS[int]], ts2: TSD[str, TS[int]]) -> TSD[str, TS[int]]:
-        m = map_(add_ts, ts1, ts2, keys=keys)
+        m = map_(add_ts, ts1, ts2, __keys__=keys)
         return m
 
     _test_tsd_map(map_test)

--- a/tests/python/unit/hgraph/_wiring/test_mesh.py
+++ b/tests/python/unit/hgraph/_wiring/test_mesh.py
@@ -1,7 +1,8 @@
 from typing import Tuple, Callable
 
 from hgraph import TS, TSD, switch_, graph, pass_through, mesh_, contains_, TSS, TSL, Removed, REMOVE, DEFAULT
-from hgraph.nodes import match, parse, tuple_from_ts, merge, const
+from hgraph.nodes import match, parse, tuple_from_ts, const
+from hgraph._operators._control import merge
 from hgraph.test import eval_node
 
 
@@ -58,7 +59,7 @@ def test_mesh_2():
             (False, False, True): lambda n: perform_op(n[1], mesh_(operation)[n[0]], mesh_(operation)[n[2]])
         },
             tuple_from_ts(Tuple[bool, bool, bool], number.is_match, var.is_match, expr.is_match),
-            n=merge(TSL.from_ts(number.groups, var.groups, expr.groups)))
+            n=merge(number.groups, var.groups, expr.groups))
 
     @graph
     def g(i: TSS[str], vars: TSD[str, TS[str]]) -> TSD[str, TS[float]]:

--- a/tests/python/unit/hgraph/_wiring/test_service.py
+++ b/tests/python/unit/hgraph/_wiring/test_service.py
@@ -6,7 +6,8 @@ from frozendict import frozendict
 from hgraph import reference_service, TSD, TS, service_impl, graph, register_service, default_path, \
     subscription_service, TSS, map_, TSL, SIZE, request_reply_service, contains_, NUMBER, AUTO_RESOLVE, KEYABLE_SCALAR, \
     SCALAR, SCALAR_1, TIME_SERIES_TYPE
-from hgraph.nodes import const, pass_through, merge, sample, tsd_flip, null_sink, format_, debug_print
+from hgraph.nodes import const, pass_through, sample, tsd_flip, null_sink, format_, debug_print
+from hgraph._operators._control import merge
 from hgraph.nodes._conditional import route_ref
 from hgraph.test import eval_node
 
@@ -101,7 +102,7 @@ def test_recursive_request_reply_service():
     @graph
     def _add_one_service_impl(ts: TS[int]) -> TS[int]:
         z, nz = route_ref(ts == 0, ts)
-        return merge(TSL.from_ts(sample(z, 1), add_one_service('default_path', nz - 1) + 1))
+        return merge(sample(z, 1), add_one_service('default_path', nz - 1) + 1)
 
     @service_impl(interfaces=add_one_service)
     def add_one_service_impl(ts: TSD[int, TS[int]]) -> TSD[int, TS[int]]:

--- a/tests/python/unit/hgraph/_wiring/test_var_args.py
+++ b/tests/python/unit/hgraph/_wiring/test_var_args.py
@@ -1,6 +1,7 @@
 from inspect import signature
 
-from hgraph import compute_node, TS, TIME_SERIES_TYPE, TSL, SIZE, graph, TSD, Size, with_signature, TSB, TS_SCHEMA
+from hgraph import compute_node, TS, TIME_SERIES_TYPE, TSL, SIZE, graph, TSD, Size, with_signature, TSB, TS_SCHEMA, \
+    operator
 from hgraph.test import eval_node
 
 
@@ -38,3 +39,36 @@ def test_var_args2():
         return n(a, b, c=c, d=d, e=e)
 
     assert eval_node(g, 1, 2, 3, 4, 5) == [15]
+
+
+def test_var_args3():
+    @compute_node
+    def n(a: TS[int], *b: TSL[TIME_SERIES_TYPE, SIZE], c: TS[int], **dundle: TSB[TS_SCHEMA]) -> TS[int]:
+        return a.value + sum(b_.value for b_ in b) + c.value + sum(d.value for d in dundle.values())
+
+    @graph
+    def g(a: TS[int], b: TS[int], c: TS[int], d: TS[int], e: TS[int]) -> TS[int]:
+        return n(a, 2, c=c, d=d, e=5)
+
+    assert eval_node(g, 1, 2, 3, 4, 5) == [15]
+
+
+def test_var_args4():
+    @operator
+    def n(**args: TSL[TIME_SERIES_TYPE, SIZE]) -> TS[int]:
+        pass
+
+    @compute_node(overloads=n)
+    def n_1(a: TIME_SERIES_TYPE) -> TS[int]:
+        return -a.value
+
+    @compute_node(overloads=n)
+    def n_n(a: TS[int], *b: TSL[TIME_SERIES_TYPE, SIZE]) -> TS[int]:
+        return a.value + sum(b_.value for b_ in b)
+
+    @graph
+    def g(a: TS[int], b: TS[int], c: TS[int]) -> TSL[TS[int], Size[2]]:
+        return TSL.from_ts(n(a, b, c), n(a))
+
+    assert eval_node(g, 1, 2, 3) == [{0: 6, 1: -1}]
+

--- a/tests/python/unit/hgraph/nodes/_conversion_operators/test_compound_scalar_conversion_operators.py
+++ b/tests/python/unit/hgraph/nodes/_conversion_operators/test_compound_scalar_conversion_operators.py
@@ -1,0 +1,66 @@
+from dataclasses import dataclass
+
+from hgraph import graph, TS, combine, CompoundScalar, TSB, convert
+from hgraph.test import eval_node
+
+
+def test_combine_cs():
+    @dataclass
+    class AB(CompoundScalar):
+        a: int
+        b: str = 'b'
+
+    @graph
+    def g(a: TS[int], b: TS[str]) -> TS[AB]:
+        return combine[TS[AB]](a=a, b=b)
+
+    assert eval_node(g, [None, 1], 'a') == [None, AB(a=1, b='a')]
+
+    @graph
+    def h(a: TS[int], b: TS[str]) -> TS[AB]:
+        return combine[TS[AB]](a=a, b=b, __strict__=False)
+
+    assert eval_node(h, [None, 1], 'a') == [AB(a=None, b='a'), AB(a=1, b='a')]
+
+    @graph
+    def u(a: TS[int]) -> TS[AB]:
+        return combine[TS[AB]](a=a, b='a')
+
+    assert eval_node(u, [None, 1]) == [None, AB(a=1, b='a')]
+
+    @graph
+    def v(a: TS[int]) -> TS[AB]:
+        return combine[TS[AB]](a=a)
+
+    assert eval_node(v, [None, 1]) == [None, AB(a=1, b='b')]
+
+
+def test_convert_cs():
+    @dataclass
+    class AB(CompoundScalar):
+        a: int
+        b: str
+
+    @graph
+    def g(x: TSB[AB]) -> TS[AB]:
+        return convert[TS[AB]](x)
+
+    assert eval_node(g, [dict(a=None, b='a'), dict(a=1)]) == [None, AB(a=1, b='a')]
+
+    @graph
+    def h(x: TSB[AB]) -> TS[AB]:
+        return convert[TS[CompoundScalar]](x)
+
+    assert eval_node(h, [dict(a=None, b='a'), dict(a=1)]) == [None, AB(a=1, b='a')]
+
+    @graph
+    def g1(x: TSB[AB]) -> TS[AB]:
+        return convert[TS[AB]](x, __strict__=False)
+
+    assert eval_node(g1, [dict(b='a')]) == [AB(a=None, b='a')]
+
+    @graph
+    def h1(x: TSB[AB]) -> TS[AB]:
+        return convert[TS[CompoundScalar]](x, __strict__=False)
+
+    assert eval_node(h1, [dict(b='a')]) == [AB(a=None, b='a')]

--- a/tests/python/unit/hgraph/nodes/_conversion_operators/test_ts_conversion_operators.py
+++ b/tests/python/unit/hgraph/nodes/_conversion_operators/test_ts_conversion_operators.py
@@ -3,7 +3,7 @@ from typing import Type
 import pytest
 
 from hgraph import TS, TSS, SCALAR, SCALAR_1, AUTO_RESOLVE, DEFAULT
-from hgraph.nodes import convert
+from hgraph import convert
 from hgraph.test import eval_node
 
 

--- a/tests/python/unit/hgraph/nodes/_conversion_operators/test_ts_conversion_operators.py
+++ b/tests/python/unit/hgraph/nodes/_conversion_operators/test_ts_conversion_operators.py
@@ -1,6 +1,8 @@
+from typing import Type
+
 import pytest
 
-from hgraph import TS, TSS
+from hgraph import TS, TSS, SCALAR, SCALAR_1, AUTO_RESOLVE, DEFAULT
 from hgraph.nodes import convert
 from hgraph.test import eval_node
 
@@ -28,3 +30,13 @@ from hgraph.test import eval_node
 )
 def test_convert_ts(from_, from_tp, to_tp, expected):
     assert eval_node(convert, from_, to_tp, resolution_dict=dict(ts=from_tp)) == expected
+
+
+def test_convert_wiring():
+    from hgraph import graph
+
+    @graph
+    def g(a: TS[SCALAR], to: Type[SCALAR_1] = DEFAULT[SCALAR_1]) -> TS[SCALAR_1]:
+        return convert[TS[to]](a)
+
+    assert eval_node(g[str], 1) == ['1']

--- a/tests/python/unit/hgraph/nodes/_conversion_operators/test_tsb_conversion_operators.py
+++ b/tests/python/unit/hgraph/nodes/_conversion_operators/test_tsb_conversion_operators.py
@@ -1,8 +1,7 @@
 import pytest
 from frozendict import frozendict as fd
 
-from hgraph import TimeSeriesSchema, TS, TSB, TSD, WiringError, graph
-from hgraph.nodes import convert
+from hgraph import TimeSeriesSchema, TS, TSB, TSD, WiringError, graph, TIME_SERIES_TYPE, combine, convert
 from hgraph.test import eval_node
 
 
@@ -54,3 +53,23 @@ def test_tsb_convert_to_tsd_keys():
         convert_g,
         [dict(p1=1.0)]
     ) == [fd(p1=1.0)]
+
+
+def test_combine_unnamed_tsb():
+    @graph
+    def g(a: TS[int], b: TS[str]) -> TIME_SERIES_TYPE:
+        return combine(a=a, b=b)
+
+    assert eval_node(g, 1, "a") == [dict(a=1, b="a")]
+
+
+def test_combine_named_tsb():
+    class AB(TimeSeriesSchema):
+        a: TS[int]
+        b: TS[str]
+
+    @graph
+    def g(a: TS[int], b: TS[str]) -> TSB[AB]:
+        return combine[TSB[AB]](a=a, b=b)
+
+    assert eval_node(g, 1, "a") == [dict(a=1, b="a")]

--- a/tests/python/unit/hgraph/nodes/_conversion_operators/test_tsl_conversion_operators.py
+++ b/tests/python/unit/hgraph/nodes/_conversion_operators/test_tsl_conversion_operators.py
@@ -1,0 +1,27 @@
+from hgraph import TIME_SERIES_TYPE, TS, graph, combine, TSL, Size
+from hgraph.test import eval_node
+
+
+def test_combine_tsl_implicit():
+    @graph
+    def g(a: TS[int], b: TS[int]) -> TSL[TS[int], Size[2]]:
+        return combine(a, b)
+
+    assert eval_node(g, 1, 2) == [{0: 1, 1: 2}]
+
+
+def test_combine_tsl_explicit():
+    @graph
+    def g(a: TS[int], b: TS[int]) -> TSL[TS[int], Size[2]]:
+        return combine[TSL](a, b)
+
+    assert eval_node(g, 1, 2) == [{0: 1, 1: 2}]
+
+
+def test_combine_tsl_very_explicit():
+    @graph
+    def g(a: TS[int], b: TS[int]) -> TSL[TS[int], Size[2]]:
+        return combine[TSL[TS[int], Size[2]]](a, b)
+
+    assert eval_node(g, 1, 2) == [{0: 1, 1: 2}]
+

--- a/tests/python/unit/hgraph/nodes/_conversion_operators/test_tuple_conversion_operators.py
+++ b/tests/python/unit/hgraph/nodes/_conversion_operators/test_tuple_conversion_operators.py
@@ -1,0 +1,21 @@
+from typing import Tuple
+
+from hgraph import TIME_SERIES_TYPE, combine, TS, graph, HgTypeMetaData
+from hgraph.nodes import combine_tuple
+from hgraph.test import eval_node
+
+
+def test_combine_tuple():
+    @graph
+    def g(a: TS[int], b: TS[int]) -> TIME_SERIES_TYPE:
+        return combine[TS[Tuple]](a, b)
+
+    assert eval_node(g, [None, 1], 2) == [None, (1, 2)]
+
+
+def test_combine_tuple_relaxed():
+    @graph
+    def g(a: TS[int], b: TS[int]) -> TIME_SERIES_TYPE:
+        return combine[TS[Tuple]](a, b, strict=False)
+
+    assert eval_node(g, [None, 1], 2) == [(None, 2), (1, 2)]

--- a/tests/python/unit/hgraph/nodes/analytics/test_recordable_feedback.py
+++ b/tests/python/unit/hgraph/nodes/analytics/test_recordable_feedback.py
@@ -2,7 +2,8 @@ from datetime import datetime, timedelta
 
 from hgraph import graph, TS, evaluate_graph, GraphConfiguration, MIN_TD, GlobalState, \
     compound_scalar, TSL
-from hgraph.nodes import const, merge, lag
+from hgraph.nodes import const, lag
+from hgraph._operators._control import merge
 from hgraph.nodes.analytics import recordable_feedback, register_recorder_api, PolarsRecorderAPI
 from hgraph.nodes.analytics._recorder_api import set_recording_label
 
@@ -10,7 +11,7 @@ from hgraph.nodes.analytics._recorder_api import set_recording_label
 @graph
 def g() -> TS[int]:
     fb = recordable_feedback("test", TS[int])
-    v = merge(TSL.from_ts(fb(), const(0)))
+    v = merge(fb(), const(0))
     v += 1
     fb(lag(v, period=timedelta(days=1)))
     return v

--- a/tests/python/unit/hgraph/nodes/test_compound_scalar_operators.py
+++ b/tests/python/unit/hgraph/nodes/test_compound_scalar_operators.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 
 from hgraph import CompoundScalar, graph, TS
-from hgraph.nodes import cs_from_ts
 from hgraph.test import eval_node
 
 
@@ -17,27 +16,3 @@ def test_cs_getatttr():
         return cs.a
 
     assert eval_node(g, [TestCS(a=1), TestCS(a=2)]) == [1, 2]
-
-
-def test_cs_from_ts():
-    @graph
-    def g(a: TS[int], b: TS[str]) -> TS[TestCS]:
-        return cs_from_ts(TestCS, a=a, b=b)
-
-    assert eval_node(g, a=[1, 2], b=['1', '2']) == [TestCS(a=1, b='1'), TestCS(a=2, b='2')]
-
-
-def test_cs_from_ts_scalar():
-    @graph
-    def g(a: TS[int]) -> TS[TestCS]:
-        return cs_from_ts(TestCS, a=a, b='-')
-
-    assert eval_node(g, a=[1, 2]) == [TestCS(a=1, b='-'), TestCS(a=2, b='-')]
-
-
-def test_cs_from_ts_defaults():
-    @graph
-    def g(a: TS[int]) -> TS[TestCS]:
-        return cs_from_ts(TestCS, a=a)
-
-    assert eval_node(g, a=[1, 2]) == [TestCS(a=1, b=''), TestCS(a=2, b='')]

--- a/tests/python/unit/hgraph/nodes/test_drop_dups.py
+++ b/tests/python/unit/hgraph/nodes/test_drop_dups.py
@@ -1,4 +1,4 @@
-from hgraph.nodes._drop_dups import drop_dups
+from hgraph.nodes._drop_dups import drop_dups, drop_dups_float
 from hgraph.test import eval_node
 
 
@@ -7,6 +7,6 @@ def test_drop_dups():
 
 
 def test_drop_dups_float():
-    assert eval_node(drop_dups,
+    assert eval_node(drop_dups_float,
                      [1.0, 2.0, 2.0, 3.0, 3.0 + 1e-15, 3.0, 4.0, 4.0, 4.0, 4.0, 4.00001],
                      abs_tol=1e-15) == [1.0, 2.0, None, 3.0, None, None, 4.0, None, None, None, 4.00001]

--- a/tests/python/unit/hgraph/nodes/test_time_series_properties.py
+++ b/tests/python/unit/hgraph/nodes/test_time_series_properties.py
@@ -1,8 +1,7 @@
 from datetime import datetime
 
 from hgraph import TIME_SERIES_TYPE, TS, graph, TSL, compute_node, REF, PythonTimeSeriesReference, MIN_ST, MIN_TD
-from hgraph.nodes import valid
-from hgraph.nodes._time_series_properties import last_modified_time
+from hgraph.nodes import valid, last_modified_time
 from hgraph.test import eval_node
 
 

--- a/tests/python/unit/hgraph/nodes/test_time_series_properties.py
+++ b/tests/python/unit/hgraph/nodes/test_time_series_properties.py
@@ -1,5 +1,8 @@
-from hgraph import TIME_SERIES_TYPE, TS, graph, TSL, compute_node, REF, PythonTimeSeriesReference
+from datetime import datetime
+
+from hgraph import TIME_SERIES_TYPE, TS, graph, TSL, compute_node, REF, PythonTimeSeriesReference, MIN_ST, MIN_TD
 from hgraph.nodes import valid
+from hgraph.nodes._time_series_properties import last_modified_time
 from hgraph.test import eval_node
 
 
@@ -20,3 +23,11 @@ def test_valid_1():
                      b=[None, None,    1, None, None],
                      i=[2,    1,    None,    0, None, 2]) == \
                        [False, False, True, False, True, False]
+
+
+def test_last_modified_time():
+    @graph
+    def g(a: TS[int]) -> TS[datetime]:
+        return last_modified_time(a)
+
+    assert eval_node(g, [1, None, 2]) == [MIN_ST, None, MIN_ST + 2*MIN_TD]

--- a/tests/python/unit/hgraph/nodes/test_tsd_operators.py
+++ b/tests/python/unit/hgraph/nodes/test_tsd_operators.py
@@ -173,13 +173,13 @@ def test_tsd_uncollapse_keys():
 
 def test_merge_tsd():
     assert eval_node(merge_tsds[K: int, TIME_SERIES_TYPE: TS[int], SIZE: Size[2]],
-                     [({1: 1, 2: 2}, {1: 5, 3: 6}), ({2: 4}, {3: 8}), ({1: REMOVE}, {}), ({}, {1: REMOVE})]) == [
+                     tsl=[({1: 1, 2: 2}, {1: 5, 3: 6}), ({2: 4}, {3: 8}), ({1: REMOVE}, {}), ({}, {1: REMOVE})]) == [
                {1: 1, 2: 2, 3: 6}, {2: 4, 3: 8}, {1: 5}, {1: REMOVE}]
 
 
 def test_merge_nested_tsd():
     assert eval_node(merge_nested_tsds[K: int, K_1: int, TIME_SERIES_TYPE: TS[int], SIZE: Size[2]],
-                     [({1: {1: 1}, 2: {2: 2}}, {1: {1: 5}, 3: {3: 6}}), ({2: {2: 4}}, {3: {3: 8}}), ({1: REMOVE, 2: {2: REMOVE}}, {}), ({}, {1: REMOVE})]) == [
+                     tsl=[({1: {1: 1}, 2: {2: 2}}, {1: {1: 5}, 3: {3: 6}}), ({2: {2: 4}}, {3: {3: 8}}), ({1: REMOVE, 2: {2: REMOVE}}, {}), ({}, {1: REMOVE})]) == [
         {1: {1: 1}, 2: {2: 2}, 3: {3: 6}}, {2: {2: 4}, 3: {3: 8}}, {1: {1: 5}, 2: {2: REMOVE}}, {1: REMOVE}]
 
 

--- a/tests/python/unit/hgraph/nodes/test_tsl_operators.py
+++ b/tests/python/unit/hgraph/nodes/test_tsl_operators.py
@@ -1,14 +1,14 @@
 import pytest
 
 from hgraph import Size, TS, TSL, MIN_TD, SIZE, TIME_SERIES_TYPE
-from hgraph.nodes import merge
+from hgraph._operators._control import merge
 from hgraph.nodes import lag, sum_
 from hgraph.nodes import tsl_to_tsd, index_of
 from hgraph.test import eval_node
 
 
 def test_merge():
-    assert eval_node(merge, [{1: 1}, {0: 2, 2: 3}, {1: 4, 2: 5}, None, {0: 6}],
+    assert eval_node(merge, [None, 2, None, None, 6], [1, None, 4, None, None], [None, 3, 5, None, None],
                      resolution_dict={"tsl": TSL[TS[int], Size[3]]}) == [1, 2, 4, None, 6]
 
 

--- a/tests/python/unit/hgraph/nodes/test_tuple_operator.py
+++ b/tests/python/unit/hgraph/nodes/test_tuple_operator.py
@@ -1,7 +1,21 @@
-from hgraph import SCALAR
+from typing import Tuple
+
+from hgraph import SCALAR, TS, sink_node, graph
 from hgraph.nodes._tuple_operators import unroll
 from hgraph.test import eval_node
 
 
 def test_unroll():
     assert eval_node(unroll[SCALAR: int], [(1, 2, 3), (4,), None, None, (5, 6)]) == [1, 2, 3, 4, 5, 6]
+
+
+def test_tuple_compatibility():
+    @sink_node
+    def n(x: TS[Tuple[int, ...]]):
+        ...
+
+    @graph
+    def g(i: TS[Tuple[int, int]]):
+        return n(i)
+
+    assert eval_node(g, [(1, 2), (3, 4)]) == None


### PR DESCRIPTION
Contains a few breaking changes - merge moved to the base library and uses *args so all TSL.from_ts calls have to go, many X_from_ts nodes reworked into combine and convert.

New features 
- DEFAULT[OUT] make OUT the default type parameter for `node[int]()` syntax
- lambda resolution of valid, all_valid and active annotations
