### PR TITLE
lots of fixes and deployment related adjustments

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,11 +1,14 @@
 # hgraph issues
 
 1. __eq__ is defined on WiringNodeInstance.  This causes eq_tsds to fail because the correct __eq__ is not found on the overload. See test_tsd_operators.test_eq_tsds
-2. Empty TSDs do no tick (at least in tests). Empty TSSs appear OK.  See test_tsd_operators.test_sum_tsd_unary
+2. Empty TSSs do not tick if they are initially empty (although they do when going empty)
 3. Would be good if switch_() had the keys arg first, to make the order natural as per other languages
 4. Need a substr() operator
-5. Need a 'copy_with()' for CompoundScalar which handles expressions.  dataclasses.replace() fails with frozen dataclasses containing expressions currently
-6. Add a 'replace()' operator implemented for bundles, TSD, TS[CompoundScalar] etc
-7. dispatch/map implementation graphs fail if they have CONTEXT arguments, as do map_ nodes (and switch_?)
+7. dispatch/map_/switch_ implementation graphs fail if they have CONTEXT arguments. A workaround is to wrap the target graph in another without the CONTEXT.
 9. Add a function which silently discards errors for a node (e.g. try_(node) or discard_errors(node)). This would avoid the need to capture the exception_time_series and wrap it in a null_sink
 10. log_() should add the engine time and also output to stdout if severity info. Currently logs to stderr for everything.
+11. Add Union types to graph signatures so that (for example) dispatch branches don't have to be repeated for different subclasses
+12. Implement per-item throttle (perhaps as an arg to throttle) so that individual elements in TSBs, TSDs and TSSs are throttled independently
+13. Improve error handling for '.' operator on TS[CompoundScalar] if the attribute does not exist.  Currently a long list of overloads is quoted and the actual field in error is not reported. Similarly for combine().
+14. It is currently not possible to have a map_ over a graph/node which has default values in it, unless the lambda form is used
+15. convert() from date to datetime picks the wrong operator (should be convert_date_to_datetime but uses convert_ts_scalar_downcast). Also it is not timezone aware. Likewise datetime to date does not work.

--- a/docs_md/debug/inspector.md
+++ b/docs_md/debug/inspector.md
@@ -52,15 +52,22 @@ right end and make them smaller if you want to hide them.
 Operating inspector
 ===================
 
-- Click + to expend an element of the graph, it could be a node, graph, input, output, or a value like dict.
+- Click + to expand an element of the graph, it could be a node, graph, input, output, or a value like dict.
 - Click - to collapse an element of the graph
-- Double click on a name to expend/collapse
+- Double-click on a name to expand/collapse
 - Ctrl-click an input value to navigate to the output it is getting its value from
 - Ctrl-click an REF output value to navigate to the output that the reference points to
+- Double-click on a Frame XxY value to open the frame in a new window (the new window is static i.e. does not update)
 - Click on an item to select it (it will highlight)
 - Hitting enter expands/collapses the selected item
-- Typing '?' or '/' will open a search box over the selected item, type the name of the item you are looking for 
-and hit Enter to keep them shown, Esc to close the search box
+- Typing '?' will open a search box at the top of the grid, type the name of the item you are looking for 
+in the items already shown in the grid. THe search string will be highlighted in the items that match. Use the Up and 
+Down arrows to jump between the matching items and Enter/Escape to close the search  
+- Typing '/' when there is a highlighted item in the grid will open a search box over the selected item, allowing you to 
+search for items that are not shown on the grid that are children of the selected item up to 3 level deep. Type the name 
+of the item you are looking for and hit Enter to keep them shown, Esc to close the search box. THis type of search only 
+shows the first 10 items to avoid blocking the graph too long, narrow down the search string if the item you are looking 
+for it not shown  
 
 
 Graph performance table

--- a/docs_md/library/index.md
+++ b/docs_md/library/index.md
@@ -122,7 +122,7 @@ type arguments as it can derive the output type from the input arguments.
 #### Example
 
 ```python
-from hgraph.nodes import emit, print
+from hgraph import emit, print
 
 values = emit( (1, 2, 3) )
 print(values)

--- a/examples/web_ui/web_ui.py
+++ b/examples/web_ui/web_ui.py
@@ -122,14 +122,14 @@ def host_web_server():
 
     map_(
         lambda key, c: publish_multitable(
-            "data", key, random_values(c, 100), index_col_name="sensor", history=sys.maxsize
+            "data", key, random_values(c, 100), unique=False, index_col_name="sensor", history=sys.maxsize
         ),
         config,
     )
 
     map_(
         lambda key, c: publish_multitable(
-            "data", key, random_events(c, 100), index_col_name="sensor", history=sys.maxsize
+            "data", key, random_events(c, 100), unique=False, index_col_name="sensor", history=sys.maxsize
         ),
         config,
     )

--- a/src/hgraph/_builder/_ts_builder.py
+++ b/src/hgraph/_builder/_ts_builder.py
@@ -1,13 +1,10 @@
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from dataclasses import dataclass
 from typing import Optional, TYPE_CHECKING
 
-from _pytest.nodes import Node
-
-from hgraph._types._tsl_meta_data import HgTSLTypeMetaData
 from hgraph._builder._input_builder import InputBuilder
 from hgraph._builder._output_builder import OutputBuilder
-from hgraph._types._tsd_meta_data import HgTSDTypeMetaData
+from hgraph._runtime import Node
 
 if TYPE_CHECKING:
     from hgraph._types._scalar_type_meta_data import HgScalarTypeMetaData

--- a/src/hgraph/_impl/_operators/_conversion_operators/_tuple_conversion_operators.py
+++ b/src/hgraph/_impl/_operators/_conversion_operators/_tuple_conversion_operators.py
@@ -24,6 +24,7 @@ from hgraph import (
     convert,
     TSS,
     graph,
+    Series,
 )
 
 __all__ = ()
@@ -61,6 +62,14 @@ def convert_tss_to_tuple(ts: TSS[SCALAR], to: Type[OUT] = DEFAULT[OUT]) -> OUT:
 )
 def convert_tsl_to_tuple(ts: TSL[TS[SCALAR], SIZE], to: Type[OUT] = DEFAULT[OUT], __strict__: bool = True) -> OUT:
     return combine[to](tsl=ts, __strict__=__strict__)
+
+
+@compute_node(
+    overloads=convert,
+    requires=lambda m, s: m[OUT].py_type == TS[Tuple] or m[OUT].matches_type(TS[Tuple[m[SCALAR], ...]]),
+)
+def convert_series_to_tuple(ts: TS[Series[SCALAR]]) -> OUT:
+    return tuple(ts.value)
 
 
 @compute_node(

--- a/src/hgraph/_impl/_operators/_flow_control.py
+++ b/src/hgraph/_impl/_operators/_flow_control.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from dataclasses import dataclass, field
 
+from hgraph import TSD
 from hgraph._impl._types._ref import PythonTimeSeriesReference
 from hgraph._operators._flow_control import all_, any_, merge, index_of
 from hgraph._operators._flow_control import race, BoolResult, if_, route_by_index, if_true, if_then_else
@@ -9,9 +10,9 @@ from hgraph._runtime._constants import MAX_DT
 from hgraph._runtime._evaluation_clock import EvaluationClock
 from hgraph._types._ref_type import REF
 from hgraph._types._scalar_types import CompoundScalar, STATE
-from hgraph._types._time_series_types import OUT, TIME_SERIES_TYPE
-from hgraph._types._ts_type import TS
-from hgraph._types._tsb_type import TSB
+from hgraph._types._time_series_types import OUT, TIME_SERIES_TYPE, K
+from hgraph._types._ts_type import TS, TS_OUT
+from hgraph._types._tsb_type import TSB, TS_SCHEMA, TS_SCHEMA_1, ts_schema
 from hgraph._types._tsl_type import TSL, SIZE
 from hgraph._types._type_meta_data import AUTO_RESOLVE
 from hgraph._wiring._decorators import graph, compute_node
@@ -95,15 +96,190 @@ def race_default(
 def _tsl_ref_item_valid(tsl, i):
     if not tsl.valid:
         return False
-    if not (tsli := tsl[i]).valid:
+    return _ref_input_valid(tsl[i])
+
+
+@compute_node(overloads=race, active=("tsd",))
+def race_tsd(
+    tsd: TSD[K, REF[OUT]],
+    _values: TSD[K, OUT] = None,
+    _state: STATE[_RaceState] = None,
+    _ec: EvaluationClock = None
+) -> REF[OUT]:
+    # Keep track of the first time each input goes valid (and invalid)
+    pending_refs = {}
+
+    for k, v in tsd.modified_items():
+        if _ref_input_valid(v):
+            if k not in _state.first_valid_times:
+                _state.first_valid_times[k] = _ec.now
+        elif v.valid:  # valid reference but invalid referee
+            pending_refs[k] = v.value
+            _state.first_valid_times.pop(k, None)
+        else:
+            _state.first_valid_times.pop(k, None)
+
+    for k in tsd.removed_keys():
+        _state.first_valid_times.pop(k, None)
+
+    # Forward the input with the earliest valid time
+    winner = _state.winner
+    if winner not in _state.first_valid_times:
+        # Find a new winner - old one has gone invalid or gone altogether
+        winner = min(_state.first_valid_times.items(), default=None, key=lambda item: item[1])
+        if winner is not None:
+            _state.winner = winner[0]
+            for v in _values.valid_values():  # make all values passive and disconnect now that we have a winner
+                v.make_passive()
+                PythonTimeSeriesReference().bind_input(v)
+            return tsd[_state.winner].value
+        else:  # if no winner, track timeseries where we have reference but no value
+            for i, r in pending_refs.items():
+                if i not in _values:
+                    _values._create(i)
+                if not _values[i].active:
+                    r.bind_input(_values[i])
+                    _values[i].make_active()
+    elif tsd[_state.winner].modified:
+        # Forward the winning value
+        return tsd[_state.winner].delta_value
+
+
+def _ref_input_valid(v):
+    if not v.valid:
         return False
-    tsli_value = tsli.value
-    if (output := tsli_value.output) is not None:
+    return _ref_valid(v.value)
+
+
+def _ref_valid(value):
+    if (output := value.output) is not None:
         return output.valid
-    elif (items := getattr(tsli_value, "items", None)) is not None:
-        return items[i].valid
+    elif (items := getattr(value, "items", None)) is not None:
+        return any(i.valid for i in items if i is not None)
     else:
         return False
+
+
+@dataclass
+class _RaceTsdOfBundlesState(CompoundScalar):
+    first_valid_hashes: dict = field(default_factory=lambda: defaultdict(lambda : defaultdict(lambda: MAX_DT)))
+    first_valid_times: dict = field(default_factory=lambda: defaultdict(lambda : defaultdict(lambda: MAX_DT)))
+    winners: list[K] = None
+
+
+@compute_node(overloads=race, active=("tsd",))
+def race_tsd_of_bundles(
+    tsd: TSD[K, REF[TSB[TS_SCHEMA]]],
+    _values: TSD[K, TSB[TS_SCHEMA]] = None,
+    _state: STATE[_RaceTsdOfBundlesState] = None,
+    _ec: EvaluationClock = None,
+    _schema: type[TS_SCHEMA] = TS_SCHEMA,
+    _output: TS_OUT[REF[TSB[TS_SCHEMA]]] = None
+) -> REF[TSB[TS_SCHEMA]]:
+    # Keep track of the first time each input goes valid (and invalid)
+    pending_values = {}
+    pending_items = defaultdict(dict)
+
+    for k in tsd.removed_keys():
+        for i in _schema.__meta_data_schema__:
+            _state.first_valid_times.get(i, {}).pop(k, None)
+        _values.on_key_removed(k)
+
+    for k in tsd.valid_keys():
+        v = tsd[k]
+        if _ref_input_valid(v):
+            ref = v.value
+            if ref.output:
+                for n, r in ref.output.items():
+                    if r.valid:
+                        if _state.first_valid_hashes.get(n, {}).get(k, None) != id(r):
+                            _state.first_valid_hashes[n][k] = id(r)
+                            _state.first_valid_times[n][k] = _ec.now
+                    else:
+                        _state.first_valid_times.get(n, {}).pop(k, None)
+                        _state.first_valid_hashes.get(n, {}).pop(k, None)
+                        pending_items[n][k] = PythonTimeSeriesReference(r)
+                if k in _values:
+                    _values[k].make_passive()
+                    PythonTimeSeriesReference().bind_input(_values[k])
+            else:
+                for i, n in enumerate(_schema.__meta_data_schema__):
+                    if (r := ref.items[i]) and _ref_valid(r):
+                        if _state.first_valid_hashes.get(n, {}).get(k, None) != r:
+                            _state.first_valid_hashes[n][k] = r
+                            _state.first_valid_times[n][k] = _ec.now
+                    elif r:
+                        _state.first_valid_times.get(n, {}).pop(k, None)
+                        _state.first_valid_hashes.get(n, {}).pop(k, None)
+                        pending_items[n][k] = ref.items[i]
+                    else:
+                        _state.first_valid_times.get(n, {}).pop(k, None)
+                        _state.first_valid_hashes.get(n, {}).pop(k, None)
+        elif v.valid and v.value.output:  # valid reference but invalid referee
+            pending_values[k] = v.value
+            for n in _schema.__meta_data_schema__:
+                _state.first_valid_times.get(n, {}).pop(k, None)
+                _state.first_valid_hashes.get(n, {}).pop(k, None)
+        else:
+            for n in _schema.__meta_data_schema__:
+                _state.first_valid_times.get(n, {}).pop(k, None)
+                _state.first_valid_hashes.get(n, {}).pop(k, None)
+
+    # Forward the input with the earliest valid time
+    winners = _state.winners
+    if winners is None:
+        winners = [None] * len(_schema.__meta_data_schema__)
+
+    new_winners = [None] * len(_schema.__meta_data_schema__)
+
+    for i, n in enumerate(_schema.__meta_data_schema__):
+        if winners[i] not in _state.first_valid_times.get(n, {}):
+            # Find a new winner - old one has gone invalid or gone altogether
+            winner = min(_state.first_valid_times.get(n, {}).items(), default=None, key=lambda item: item[1])
+            if winner is not None:
+                new_winners[i] = winner[0]
+                for v in _values.valid_values():  # make all values passive and disconnect now that we have a winner
+                    if v[n].bound:
+                        v[n].make_passive()
+                        PythonTimeSeriesReference().bind_input(v[n])
+            else:  # if no winner, track timeseries where we have reference but no value
+                new_winners[i] = None
+                for k, r in pending_items.get(n, {}).items():
+                    if k not in _values:
+                        _values._create(k)
+                    if not (v := _values[k][n]).active:
+                        r.bind_input(v)
+                        v.make_active()
+        else:
+            new_winners[i] = winners[i]
+
+    if any(n is None for n in new_winners):
+        for k, v in pending_values.items():
+            if k not in _values:
+                _values._create(k)
+            if not _values[k].active:
+                v.bind_input(_values[k])
+                _values[k].make_active()
+
+    _state.winners = new_winners
+
+    ref_items = [None] * len(_schema.__meta_data_schema__)
+    for i, (n, o) in enumerate(zip(_schema.__meta_data_schema__, _state.winners)):
+        if o is not None:
+            value = tsd[o].value
+            if value.output:
+                ref_items[i] = PythonTimeSeriesReference(value.output[n])
+            else:
+                ref_items[i] = value.items[i]
+        else:
+            ref_items[i] = PythonTimeSeriesReference()
+
+    result = PythonTimeSeriesReference(from_items=ref_items)
+    if _output.valid:
+        if _output.value != result:
+            return result
+    else:
+        return result
 
 
 @compute_node(valid=("condition",), overloads=if_)

--- a/src/hgraph/_impl/_runtime/_component_node.py
+++ b/src/hgraph/_impl/_runtime/_component_node.py
@@ -101,6 +101,7 @@ class PythonComponentNodeImpl(PythonNestedNodeImpl):
         self.mark_evaluated()
         self._active_graph.evaluation_clock.reset_next_scheduled_evaluation_time()
         self._active_graph.evaluate_graph()
+        self._active_graph.evaluation_clock.reset_next_scheduled_evaluation_time()
 
     def nested_graphs(self):
         if self._active_graph:

--- a/src/hgraph/_impl/_runtime/_reduce_node.py
+++ b/src/hgraph/_impl/_runtime/_reduce_node.py
@@ -90,6 +90,7 @@ class PythonReduceNodeImpl(PythonNestedNodeImpl):
 
         self._nested_graph.evaluation_clock.reset_next_scheduled_evaluation_time()
         self._nested_graph.evaluate_graph()
+        self._nested_graph.evaluation_clock.reset_next_scheduled_evaluation_time()
 
         # Now we just need to detect the change in graph shape, so we can propagate it on.
         # The output as well as the last_output are reference time-series so this should

--- a/src/hgraph/_impl/_runtime/_service_node_impl.py
+++ b/src/hgraph/_impl/_runtime/_service_node_impl.py
@@ -41,6 +41,7 @@ class PythonServiceNodeImpl(PythonNestedNodeImpl):
         self.mark_evaluated()
         self._active_graph.evaluation_clock.reset_next_scheduled_evaluation_time()
         self._active_graph.evaluate_graph()
+        self._active_graph.evaluation_clock.reset_next_scheduled_evaluation_time()
 
     def do_stop(self):
         self._active_graph.stop()

--- a/src/hgraph/_impl/_runtime/_switch_node.py
+++ b/src/hgraph/_impl/_runtime/_switch_node.py
@@ -75,6 +75,7 @@ class PythonSwitchNodeImpl(PythonNestedNodeImpl):
         if self._active_graph:
             self._active_graph.evaluation_clock.reset_next_scheduled_evaluation_time()
             self._active_graph.evaluate_graph()
+            self._active_graph.evaluation_clock.reset_next_scheduled_evaluation_time()
 
     def nested_graphs(self):
         if self._active_graph:

--- a/src/hgraph/_impl/_runtime/_try_except_node.py
+++ b/src/hgraph/_impl/_runtime/_try_except_node.py
@@ -70,6 +70,7 @@ class PythonTryExceptNodeImpl(PythonNestedNodeImpl):
             self.mark_evaluated()
             self._active_graph.evaluation_clock.reset_next_scheduled_evaluation_time()
             self._active_graph.evaluate_graph()
+            self._active_graph.evaluation_clock.reset_next_scheduled_evaluation_time()
         except Exception as e:
             from hgraph._types._error_type import NodeError
 

--- a/src/hgraph/_impl/_types/_ref.py
+++ b/src/hgraph/_impl/_types/_ref.py
@@ -92,6 +92,19 @@ class PythonTimeSeriesReference(TimeSeriesReference):
         if reactivate:
             ts_input.make_active()
 
+    def __eq__(self, other):
+        if not isinstance(other, PythonTimeSeriesReference):
+            return False
+        if self.valid != other.valid:
+            return False
+        if self.valid:
+            if self.has_peer != other.has_peer:
+                return False
+            if self.has_peer:
+                return self.output == other.output
+            return self.items == other.items
+        return True
+
     def __str__(self) -> str:
         if self.output is not None:
             return (

--- a/src/hgraph/_operators/_stream.py
+++ b/src/hgraph/_operators/_stream.py
@@ -83,7 +83,7 @@ def filter_(condition: TS[bool], ts: TIME_SERIES_TYPE) -> TIME_SERIES_TYPE:
 
 
 @operator
-def throttle(ts: TIME_SERIES_TYPE, period: TS[timedelta]) -> TIME_SERIES_TYPE:
+def throttle(ts: TIME_SERIES_TYPE, period: TS[timedelta], delay_first_tick: bool = False) -> TIME_SERIES_TYPE:
     """
     Reduces the rate of ticks in a time series to the given period. It works like ``resample`` if the rate of ticks is
     higher than the period but unlike ``resample`` does not produce ticks when the source time series does not tick.

--- a/src/hgraph/_runtime/_graph_runner.py
+++ b/src/hgraph/_runtime/_graph_runner.py
@@ -151,6 +151,7 @@ def run_graph(
     __trace__: bool | dict = False,
     __profile__: bool | dict = False,
     __trace_wiring__: bool | dict = False,
+    __logger__: Logger = None,
     **kwargs,
 ):
     """
@@ -170,7 +171,14 @@ def run_graph(
     :param life_cycle_observers: A list of observers to register with the runtime engine prior to evaluation.
     :param kwargs: Any additional kwargs to pass to the graph.
     """
-    kwargs_ = {"run_mode": run_mode, "trace": __trace__, "profile": __profile__, "trace_wiring": __trace_wiring__}
+    kwargs_ = {"run_mode": run_mode,
+               "trace": __trace__,
+               "profile": __profile__,
+               "trace_wiring": __trace_wiring__,
+               }
+
+    if __logger__ is not None:
+        kwargs_["graph_logger"] = __logger__
     if start_time is not None:
         kwargs_["start_time"] = start_time
     if end_time is not None:

--- a/src/hgraph/_runtime/_node.py
+++ b/src/hgraph/_runtime/_node.py
@@ -412,7 +412,7 @@ class NodeScheduler(ABC):
         """
 
     @abstractmethod
-    def schedule(self, when: datetime | timedelta, tag: str = None):
+    def schedule(self, when: datetime | timedelta, tag: str = None, on_wall_clock: bool = False):
         """
         Schedule the node to be evaluated at the time specified. If tag is set, then the scheduled event will be
         associated to the tag, if a schedule is already set against the tag, it will be replaced with the new entry.

--- a/src/hgraph/_types/_schema_type.py
+++ b/src/hgraph/_types/_schema_type.py
@@ -122,7 +122,7 @@ class AbstractSchema:
     @classmethod
     def _create_resolved_class(cls, schema: dict[str, "HgTypeMetaData"]) -> Type["AbstractSchema"]:
         """Create a 'resolved' instance class and cache as appropriate"""
-        suffix = ",".join(f"{k}:{str(schema[k])}" for k in sorted(schema))
+        suffix = ",".join(f"{k}:{str(schema[k])}" for k in schema)
         root_cls = cls._root_cls()
         cls_name = f"{root_cls.__name__}_{shake_256(bytes(suffix, 'utf8')).hexdigest(6)}"
         r_cls: Type["AbstractSchema"]

--- a/src/hgraph/_wiring/_exception_handling.py
+++ b/src/hgraph/_wiring/_exception_handling.py
@@ -119,6 +119,7 @@ def try_except(
             {
                 k: kwargs_[k]
                 for k, v in resolved_signature.input_types.items()
+                if v != resolved_signature.defaults.get(k)
             },
             resolved_signature_outer,
             None,

--- a/src/hgraph/_wiring/_wiring_node_class/_service_interface_node_class.py
+++ b/src/hgraph/_wiring/_wiring_node_class/_service_interface_node_class.py
@@ -9,7 +9,9 @@ class ServiceInterfaceNodeClass(BaseWiringNodeClass):
 
     def default_path(self) -> str:
         """The default path of the service interface"""
-        return f"{self.signature.name}_default"
+        return f"{self.signature.name}_default" \
+            if (p := self.signature.defaults.get("path")) is None \
+            else p
 
     @abstractmethod
     def full_path(self, user_path: str | None) -> str:

--- a/src/hgraph/adaptors/perspective/_perspective.py
+++ b/src/hgraph/adaptors/perspective/_perspective.py
@@ -142,21 +142,29 @@ class PerspectiveTablesManager:
                             d0[k] = True
                 data = {k: v for k, v in d1.items() if k in d0}
 
-            data = pyarrow.record_batch(data)
-            sink = pyarrow.BufferOutputStream()
+            batch = pyarrow.record_batch(data)
+            stream = pyarrow.BufferOutputStream()
 
-            with pyarrow.ipc.new_stream(sink, data.schema) as writer:
-                writer.write_batch(data)
+            with pyarrow.ipc.new_stream(stream, batch.schema) as writer:
+                writer.write_batch(batch)
 
-            arrow = sink.getvalue().to_pybytes()
+            arrow = stream.getvalue().to_pybytes()
 
-            self._manager_for_table(name).call_loop(lambda: table.update(arrow))
+            def table_update(table, update, data):
+                try:
+                    table.update(update)
+                except Exception as e:
+                    print(f"Error updating table {table} with {data}: {e}")
+                    raise
+
+            self._manager_for_table(name).call_loop(lambda: table_update(table, arrow, data))
 
         if removals:
             if table.get_index() and not self.server_tables:
-                self.update_table(name + "_removes", {"i": list(removals)})
-            else:
-                self._manager_for_table(name).call_loop(lambda: table.remove(removals))
+                self.update_table(name + "_removes", {"i": list(removals)},
+                                  removals=data[table.get_index()] if data else [])
+
+            self._manager_for_table(name).call_loop(lambda: table.remove(removals))
 
         # table.update(data)
 
@@ -229,8 +237,10 @@ def _get_node_location():
     """Assuming node is installed this will retrieve the global local for npm modules"""
     import subprocess
 
-    result = subprocess.run(["npm", "root", "-g", "for", "npm"], shell=True, capture_output=True, text=True)
-    return result.stdout.rstrip()
+    result = subprocess.run(["npm", "root", "-g", "for", "npm"], shell=os.name == 'nt', capture_output=True, text=True)
+    node_path = result.stdout.rstrip()
+    print(f"NPM found at '{node_path}'")
+    return node_path
 
 
 @perspective_web.start
@@ -288,6 +298,16 @@ def perspective_web_start(
         + (
             [(
                 r"/",
+                IndexPageHandler,
+                {
+                    "mgr": perspective_manager,
+                    "layouts_path": layouts_dir,
+                    "index_template": index_template,
+                    "host": host,
+                    "port": port,
+                },
+            ),(
+                r"/versions/(.*)",
                 IndexPageHandler,
                 {
                     "mgr": perspective_manager,

--- a/src/hgraph/adaptors/perspective/_perspective_adaptor.py
+++ b/src/hgraph/adaptors/perspective/_perspective_adaptor.py
@@ -61,33 +61,32 @@ def publish_table_editable_impl(
 
 
 @service_adaptor
-def publish_multitable(path: str, key: TS[SCALAR], ts: TIME_SERIES_TYPE, index_col_name: str, history: int = None): ...
+def publish_multitable(path: str, key: TS[SCALAR], ts: TIME_SERIES_TYPE, unique: bool, index_col_name: str, history: int = None): ...
 
 
 @service_adaptor_impl(interfaces=publish_multitable)
 def publish_multitable_impl(
-    path: str, key: TSD[int, TS[SCALAR]], ts: TSD[int, TIME_SERIES_TYPE], index_col_name: str, history: int = None
+    path: str, key: TSD[int, TS[SCALAR]], ts: TSD[int, TIME_SERIES_TYPE], unique: bool, index_col_name: str, history: int = None
 ):
     _assert_unique_type_per_path(publish_multitable)
 
-    @graph
-    def merge_references(keys: TSS[int], ts: TSD[int, REF[TSB[TS_SCHEMA]]], _schema: Type[TS_SCHEMA] = TS_SCHEMA) -> TSB[TS_SCHEMA]:
-        selection = map_(lambda t: t, ts, __keys__=keys)
+    if not unique:
+        @graph
+        def merge_references(keys: TSS[int], ts: TSD[int, REF[TSB[TS_SCHEMA]]], _schema: Type[TS_SCHEMA] = TS_SCHEMA) -> TSB[TS_SCHEMA]:
+            selection = ts[keys]
+            return race(tsd=selection)
 
-        out = {}
-        for k, t in _schema.__meta_data_schema__.items():
-            out[k] = getattr(selection, k).reduce(lambda x, y: race(x, y), nothing(REF[t]))
+        @graph(overloads=merge_references)
+        def merge_references_no_tsb(keys: TSS[int], ts: TSD[int, REF[TS[SCALAR]]]) -> REF[TS[SCALAR]]:
+            assert_(len_(keys), 1, "Only bundles are allowed to be published as multi-tables with repeating keys")
+            return ts[emit(keys)]
 
-        return combine[TSB[_schema]](**out)
+        keys = flip(key, unique=False)
+        table = map_(merge_references, keys, pass_through(ts))
+        _publish_table(path, table, index_col_name=index_col_name, history=history)
 
-    @graph(overloads=merge_references)
-    def merge_references_no_tsb(keys: TSS[int], ts: TSD[int, REF[TS[SCALAR]]]) -> REF[TS[SCALAR]]:
-        assert_(len_(keys), 1, "Only bundles are allowed to be published as multi-tables with repeating keys")
-        return ts[emit(keys)]
-
-    keys = flip(key, unique=False)
-    table = map_(merge_references, keys, pass_through(ts))
-    _publish_table(path, table, index_col_name=index_col_name, history=history)
+    else:
+        _publish_table(path, rekey(ts, key), index_col_name=index_col_name, history=history)
 
 
 def _assert_unique_type_per_path(adaptor_type):

--- a/src/hgraph/adaptors/perspective/index_template.html
+++ b/src/hgraph/adaptors/perspective/index_template.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no" />
-        <link rel="stylesheet" crossorigin="anonymous" href="http://{{host}}:{{port}}/node_modules/@finos/perspective-viewer/dist/css/themes.css" />
+        <link rel="stylesheet" crossorigin="anonymous" href="/node_modules/@finos/perspective-viewer/dist/css/themes.css" />
     </head>
 
     <body>
@@ -17,21 +17,21 @@
             <tr>
                 <td>
                     {% for table in mgr.get_table_names() %}
-                        <div></div><a href="http://{{host}}:{{port}}/table/{{table}}">{{table}}</a></div>
+                        <div></div><a href="/table/{{table}}">{{table}}</a></div>
                     {% end %}
                 </td>
                 <td>
                     {% for layout in layouts %}
-                        <div></div><a href="http://{{host}}:{{port}}/workspace/{{layout}}">{{layout}}</a></div>
+                        <div></div><a href="/workspace/{{layout}}">{{layout}}</a></div>
                     {% end %}
                 </td>
                 <td>
                     {% for version in versions %}
-                        <div></div><a href="http://{{host}}:{{port}}/workspace/{{layouts[0]}}.{{version}}">{{version}}</a></div>
+                        <div></div><a href="/workspace/{{layouts[0]}}.{{version}}">{{version}}</a></div>
                     {% end %}
                     {% if not versions %}
                         {% for layout in layouts %}
-                            <div></div><a href="http://{{host}}:{{port}}/{{layout}}">{{layout}}</a></div>
+                            <div></div><a href="/versions/{{layout}}">{{layout}}</a></div>
                         {% end %}
                     {% end %}
                 </td>

--- a/src/hgraph/adaptors/perspective/table_workarounds.js
+++ b/src/hgraph/adaptors/perspective/table_workarounds.js
@@ -1,0 +1,147 @@
+
+function installTableWorkarounds(){
+    for (const g of document.querySelectorAll(
+        "perspective-viewer perspective-viewer-datagrid, perspective-viewer perspective-viewer-datagrid-norollups")) {
+
+        const table = g.shadowRoot.querySelector("regular-table")
+
+        if (!table  || table.dataset.events_set_up) continue;
+        table.dataset.events_set_up = "true";
+
+        // the built-in stylesheet limits the min-width of table cells to 52px for no apparent reason
+        // we override this so that we can have columns that are arbitrary small
+        let psp_stylesheet = g.shadowRoot.adoptedStyleSheets[0];
+        for (let i = 0; i < psp_stylesheet.cssRules.length; i++) {
+            if (psp_stylesheet.cssRules[i].selectorText === 'regular-table table tbody td') {
+                psp_stylesheet.deleteRule(i);
+                psp_stylesheet.insertRule('regular-table table tbody td { min-width: 1px !important; }');
+            }
+        }
+
+        table.addStyleListener(() => { addTooltips(table) });
+        table.addStyleListener(() => { hideColumns(table) });
+
+        if (g.tagName === "PERSPECTIVE-VIEWER-DATAGRID-NOROLLUPS") {
+            table.addStyleListener(() => {
+                noRollups(table)
+            });
+        }
+    }
+}
+
+function isOverflown(element) {
+  return element.scrollHeight > element.clientHeight || element.scrollWidth > element.clientWidth;
+}
+
+function addTooltips(table) {
+    for (const tr of table.children[0].children[0].children) {
+        for (const td of tr.children) {
+            if (isOverflown(td)) {
+                td.title = td.innerText;
+            } else {
+                td.title = "";
+            }
+            td.style.white_space = "nowrap";
+            td.style.overflow = "hidden";
+            td.style.text_overflow = "ellipsis";
+        }
+    }
+    for (const tr of table.children[0].children[1].children) {
+        for (const td of tr.children) {
+            if (isOverflown(td)) {
+                td.title = td.innerText;
+            } else {
+                td.title = "";
+            }
+            td.style.white_space = "nowrap";
+            td.style.overflow = "hidden";
+            td.style.text_overflow = "ellipsis";
+        }
+    }
+
+    table.invalidate();
+}
+
+function hideColumns(table) {
+    const hide_cols = new Set();
+    const parts = []
+
+    for (const h of table.children[0].children[0].children) {
+        if (h.id === "psp-column-titles") {
+            parts.push(h)
+            let i = 0;
+            for (const c of h.children) {
+                const metadata = table.getMeta(c);
+                if (metadata.size_key >= i) {
+                    let hide = false
+                    for (const n of metadata.column_header) {
+                        if (n.substring(n.length-7) === "-hidden")
+                            hide = true;
+                    }
+                    if (hide) {
+                        hide_cols.add(metadata.size_key);
+                    }
+                }
+                i += 1;
+            }
+        }
+        if (h.id === "psp-column-edit-buttons") {
+            parts.push(h)
+        }
+    }
+
+    const tbody = table.children[0].children[1]
+    if (hide_cols.size) {
+        for (const c of tbody.children) {
+            parts.push(c);
+        }
+    }
+
+    if (hide_cols.size) {
+        for (const tr of parts) {
+            for (const td of tr.children) {
+                const metadata = table.getMeta(td)
+                if (hide_cols.has(metadata.size_key)) {
+                    td.style.overflow = "hidden";
+                    td.style.whiteSpace = "nowrap";
+                    td.textOverflow = "clip";
+
+                    td.style.width = "0";
+                    td.style.minWidth = "0";
+                    td.style.maxWidth = "0";
+                    td.style.paddingLeft = "1px";
+                    td.style.paddingRight = "0";
+                }
+            }
+        }
+    }
+
+    table.invalidate();
+}
+
+function noRollups(table) {
+    for (const tr of table.children[0].children[1].children) {
+        for (const td of tr.children) {
+            const metadata = table.getMeta(td);
+            if (metadata.row_header[metadata.row_header.length - 1]) {
+                // keep the content
+                td.textContent = metadata.value
+                continue;
+            }
+            if (metadata.y === 0 && metadata.row_header_x === 0) {
+                // "TOTAL" header
+                td.textContent = "All";
+                continue;
+            }
+            if (metadata.row_header_x !== undefined) {
+                // header, keep the content
+                td.textContent = metadata.value;
+                continue;
+            }
+            // Delete the content
+            td.textContent = "";
+        }
+    }
+
+    table.invalidate();
+}

--- a/src/hgraph/adaptors/perspective/workspace_tables.js
+++ b/src/hgraph/adaptors/perspective/workspace_tables.js
@@ -1,0 +1,46 @@
+
+async function connectWorkspaceTables(workspace){
+    const worker = perspective.worker();
+
+    let ws = "ws"
+    if (location.protocol === 'https:'){ ws = "wss"; }
+    const websocket_ro = perspective.websocket(ws + "://" + location.host + "/websocket_readonly");
+    const websocket_rw = perspective.websocket(ws + "://" + location.host + "/websocket_editable");
+
+    //{% for table_name in mgr.get_table_names() %}
+    //{% if not table_name.endswith("_removes") %}
+    //{% if mgr.server_tables %}
+    workspace.tables.set(
+        "{{table_name}}",
+        {{"websocket_ro" if not mgr.is_table_editable(table_name) else "websocket_rw"}}.open_table("{{table_name}}")
+    );
+    //{% else %}
+    // {% set tbl = table_name.replace(" ", "_").replace("-", "_") %}
+    const table_{{tbl}} = await {{"websocket_ro" if not mgr.is_table_editable(table_name) else "websocket_rw"}}.open_table("{{table_name}}");
+    const view_{{tbl}} = await table_{{tbl}}.view();
+    // {% if mgr.get_table(table_name).get_index() %}
+    const client_{{tbl}} = await worker.table(view_{{tbl}}, {index: await table_{{tbl}}.get_index()});
+    // {% else %}
+    const client_{{tbl}} = await worker.table(view_{{tbl}});
+    // {% end %}
+    // {% if table_name + "_removes" in mgr.get_table_names() %}
+    const removes_{{tbl}} = await websocket_ro.open_table("{{table_name}}_removes");
+    const removes_view_{{tbl}} = await removes_{{tbl}}.view();
+    removes_view_{{tbl}}.on_update(
+        async (updated) => {
+            const update_table = await worker.table(updated.delta);
+            const update_view = await update_table.view();
+            const update_data = await update_view.to_columns();
+            client_{{tbl}}.remove(update_data['i']);
+        },
+        { mode: "row" }
+    );
+    // {% end %}
+    // {% end %}
+    workspace.tables.set(
+        "{{table_name}}",
+        client_{{tbl}}
+    );
+    //{% end %}
+    //{% end %}
+}

--- a/src/hgraph/adaptors/perspective/workspace_template.html
+++ b/src/hgraph/adaptors/perspective/workspace_template.html
@@ -3,15 +3,15 @@
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no" />
 
-        <script type="module" src="http://{{host}}:{{port}}/node_modules/@finos/perspective-viewer/dist/cdn/perspective-viewer.js"></script>
-        <script type="module" src="http://{{host}}:{{port}}/node_modules/@finos/perspective-workspace/dist/cdn/perspective-workspace.js"></script>
-        <script type="module" src="http://{{host}}:{{port}}/node_modules/@finos/perspective-viewer-datagrid/dist/cdn/perspective-viewer-datagrid.js"></script>
-        <script type="module" src="http://{{host}}:{{port}}/node_modules/@finos/perspective-viewer-d3fc/dist/cdn/perspective-viewer-d3fc.js"></script>
+        <script type="module" src="/node_modules/@finos/perspective-viewer/dist/cdn/perspective-viewer.js"></script>
+        <script type="module" src="/node_modules/@finos/perspective-workspace/dist/cdn/perspective-workspace.js"></script>
+        <script type="module" src="/node_modules/@finos/perspective-viewer-datagrid/dist/cdn/perspective-viewer-datagrid.js"></script>
+        <script type="module" src="/node_modules/@finos/perspective-viewer-d3fc/dist/cdn/perspective-viewer-d3fc.js"></script>
         <script type="module" src="/node_modules/perspective-viewer-datagrid-norollups/dist/cdn/perspective-viewer-datagrid-norollups.js"></script>
         <script type="module" src="/node_modules/perspective-viewer-summary/dist/cdn/perspective-viewer-summary.js"></script>
 
-        <link rel="stylesheet" crossorigin="anonymous" href="http://{{host}}:{{port}}/node_modules/@finos/perspective-viewer/dist/css/themes.css" />
-        <link rel="stylesheet" crossorigin="anonymous" href="http://{{host}}:{{port}}/node_modules/@finos/perspective-workspace/dist/css/pro-dark.css" />
+        <link rel="stylesheet" crossorigin="anonymous" href="/node_modules/@finos/perspective-viewer/dist/css/themes.css" />
+        <link rel="stylesheet" crossorigin="anonymous" href="/node_modules/@finos/perspective-workspace/dist/css/pro-dark.css" />
 
         <style>
             perspective-workspace {
@@ -39,51 +39,15 @@
         <perspective-workspace id="workspace"></perspective-workspace>
 
         <script type="module">
-            import perspective from "http://{{host}}:{{port}}/node_modules/@finos/perspective/dist/cdn/perspective.js";
+            import perspective from "/node_modules/@finos/perspective/dist/cdn/perspective.js";
+
+            //{% include table_workarounds.js %}
+            //{% include workspace_tables.js %}
 
             window.addEventListener("DOMContentLoaded", async function () {
                 const workspace = window.workspace
-                const worker = perspective.worker();
 
-                const websocket_ro = perspective.websocket("ws://{{host}}:{{port}}/websocket_readonly");
-                const websocket_rw = perspective.websocket("ws://{{host}}:{{port}}/websocket_editable");
-
-                //{% for table_name in mgr.get_table_names() %}
-                //{% if not table_name.endswith("_removes") %}
-                //{% if mgr.server_tables %}
-                workspace.tables.set(
-                    "{{table_name}}",
-                    {{"websocket_ro" if not mgr.is_table_editable(table_name) else "websocket_rw"}}.open_table("{{table_name}}")
-                );
-                //{% else %}
-                // {% set tbl = table_name.replace(" ", "_").replace("-", "_") %}
-                const table_{{tbl}} = await {{"websocket_ro" if not mgr.is_table_editable(table_name) else "websocket_rw"}}.open_table("{{table_name}}")
-                const view_{{tbl}} = await table_{{tbl}}.view()
-                // {% if mgr.get_table(table_name).get_index() %}
-                const client_{{tbl}} = await worker.table(view_{{tbl}}, {index: await table_{{tbl}}.get_index()});
-                // {% else %}
-                const client_{{tbl}} = await worker.table(view_{{tbl}});
-                // {% end %}
-                // {% if table_name + "_removes" in mgr.get_table_names() %}
-                const removes_{{tbl}} = await websocket_ro.open_table("{{table_name}}_removes")
-                const removes_view_{{tbl}} = await removes_{{tbl}}.view()
-                removes_view_{{tbl}}.on_update(
-                    async (updated) => {
-                        const update_table = await worker.table(updated.delta);
-                        const update_view = await update_table.view();
-                        const update_data = await update_view.to_columns();
-                        client_{{tbl}}.remove(update_data['i']);
-                    },
-                    { mode: "row" }
-                );
-                // {% end %}
-                // {% end %}
-                workspace.tables.set(
-                    "{{table_name}}",
-                    client_{{tbl}}
-                );
-                //{% end %}
-                //{% end %}
+                await connectWorkspaceTables(workspace);
 
                 const req = await fetch("/layout/{{url}}");
                 const json = await req.json();
@@ -91,6 +55,7 @@
 
                 window.workspace.addEventListener("workspace-layout-update", async () => {
                     await fetch("/layout/{{url}}", {method: "post", body: JSON.stringify(await window.workspace.save())});
+                    installTableWorkarounds();
                 });
             });
         </script>

--- a/src/hgraph/adaptors/tornado/_rest_handler.py
+++ b/src/hgraph/adaptors/tornado/_rest_handler.py
@@ -4,7 +4,6 @@ from enum import Enum
 from typing import Callable, Generic, TypeVar
 
 from frozendict import frozendict
-from mypy.build import json_dumps
 
 from hgraph import (
     CompoundScalar,

--- a/src/hgraph/debug/_inspector.py
+++ b/src/hgraph/debug/_inspector.py
@@ -3,6 +3,7 @@ import tempfile
 from datetime import datetime
 
 from _socket import gethostname
+import tornado.web
 
 from hgraph._wiring._decorators import sink_node
 from hgraph._types import TS, STATE
@@ -99,10 +100,31 @@ def start_inspector(port: int, publish_interval: float, start: TS[bool], _state:
                 {
                     "queue": _state.requests,
                 }
-            )
+            ),
+            (
+            r"/inspect_frame/(.*)",
+            FramePageHandler,
+            {
+                "template": os.path.join(os.path.dirname(__file__), "frame_template.html")
+            },
+        ),
+
         ]
     )
 
     print(f"Inspector running on http://{gethostname()}:{port}/inspector/view")
 
     app.start()
+
+
+class FramePageHandler(tornado.web.RequestHandler):
+    def initialize(self, template: str):
+        self.template = template
+
+    def get(self, table_name):
+        tornado.log.app_log.info(f"requesting table {table_name}")
+        self.render(
+            self.template,
+            table_name=table_name,
+        )
+

--- a/src/hgraph/debug/_inspector_item_id.py
+++ b/src/hgraph/debug/_inspector_item_id.py
@@ -10,7 +10,7 @@ from enum import Enum
 from typing import ClassVar
 
 from hgraph import Graph, Node, TimeSeriesInput, TimeSeriesOutput, TimeSeriesSet
-from hgraph.debug._inspector_util import format_name, base62
+from hgraph.debug._inspector_util import format_name, base62, inspect_item
 
 
 class InspectorItemType(Enum):
@@ -197,7 +197,7 @@ class InspectorItemId:
 
         for i in self.value_path:
             try:
-                value = value[i]
+                value = inspect_item(value, i)
             except:
                 if isinstance(value, (set, frozenset, TimeSeriesSet)):
                     if i in value:
@@ -236,8 +236,8 @@ class InspectorItemId:
     def sort_key(self):
         value_type_order = {
             NodeValueType.Inputs: "X01",
-            NodeValueType.Output: "X02",
-            NodeValueType.Graphs: "X03",
+            NodeValueType.Graphs: "X02",
+            NodeValueType.Output: "X03",
             NodeValueType.Scalars: "X04",
         }
 

--- a/src/hgraph/debug/_inspector_publish.py
+++ b/src/hgraph/debug/_inspector_publish.py
@@ -10,6 +10,15 @@ from hgraph.debug._inspector_util import format_value, format_timestamp
 def process_tick(state: InspectorState, node: Node):
     start = time.perf_counter_ns()
 
+    if item_id := state.node_subscriptions.get(node.node_id):
+        v = item_id.find_item_on_graph(node.graph)
+        str_id = item_id.to_str()
+        state.tick_data[str_id] = dict(
+            id=str_id,
+            value=format_value(v),
+            timestamp=format_timestamp(v),
+        )
+
     for item_id in state.node_item_subscriptions.get(node.node_id, ()):
         v = item_id.find_item_on_graph(node.graph)
         str_id = item_id.to_str()

--- a/src/hgraph/debug/frame_template.html
+++ b/src/hgraph/debug/frame_template.html
@@ -25,13 +25,20 @@
 
         <script type="module">
             import perspective from "/node_modules/@finos/perspective/dist/cdn/perspective.js";
+
+            const frame = async (url) => {
+                const request = fetch(url);
+                const worker = await perspective.worker();
+                const response = await request;
+                const buffer = await response.arrayBuffer();
+                return await worker.table(buffer);
+            };
+
+
             window.addEventListener("DOMContentLoaded", async function () {
                 const viewer = document.getElementById("viewer");
-                let ws = "ws"
-                if (location.protocol === 'https:'){ ws = "wss"; }
-                const websocket = perspective.websocket(ws + "://" + location.host + "/websocket{{'_readonly' if not editable else '_editable'}}");
-                const table = websocket.open_table("{{table_name}}");
-                viewer.load(table);
+
+                viewer.load(frame("/inspect/frame/{{table_name}}"));
                 viewer.toggleConfig();
             });
         </script>

--- a/src/hgraph/debug/inspector_template.html
+++ b/src/hgraph/debug/inspector_template.html
@@ -3,15 +3,15 @@
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no" />
 
-        <script type="module" src="http://{{host}}:{{port}}/node_modules/@finos/perspective-viewer/dist/cdn/perspective-viewer.js"></script>
-        <script type="module" src="http://{{host}}:{{port}}/node_modules/@finos/perspective-workspace/dist/cdn/perspective-workspace.js"></script>
-        <script type="module" src="http://{{host}}:{{port}}/node_modules/@finos/perspective-viewer-datagrid/dist/cdn/perspective-viewer-datagrid.js"></script>
-        <script type="module" src="http://{{host}}:{{port}}/node_modules/@finos/perspective-viewer-d3fc/dist/cdn/perspective-viewer-d3fc.js"></script>
+        <script type="module" src="/node_modules/@finos/perspective-viewer/dist/cdn/perspective-viewer.js"></script>
+        <script type="module" src="/node_modules/@finos/perspective-workspace/dist/cdn/perspective-workspace.js"></script>
+        <script type="module" src="/node_modules/@finos/perspective-viewer-datagrid/dist/cdn/perspective-viewer-datagrid.js"></script>
+        <script type="module" src="/node_modules/@finos/perspective-viewer-d3fc/dist/cdn/perspective-viewer-d3fc.js"></script>
         <script type="module" src="/node_modules/perspective-viewer-datagrid-norollups/dist/cdn/perspective-viewer-datagrid-norollups.js"></script>
         <script type="module" src="/node_modules/perspective-viewer-summary/dist/cdn/perspective-viewer-summary.js"></script>
 
-        <link rel="stylesheet" crossorigin="anonymous" href="http://{{host}}:{{port}}/node_modules/@finos/perspective-viewer/dist/css/themes.css" />
-        <link rel="stylesheet" crossorigin="anonymous" href="http://{{host}}:{{port}}/node_modules/@finos/perspective-workspace/dist/css/pro-dark.css" />
+        <link rel="stylesheet" crossorigin="anonymous" href="/node_modules/@finos/perspective-viewer/dist/css/themes.css" />
+        <link rel="stylesheet" crossorigin="anonymous" href="/node_modules/@finos/perspective-workspace/dist/css/pro-dark.css" />
 
         <style>
             perspective-workspace {
@@ -29,80 +29,66 @@
         <perspective-workspace id="workspace"></perspective-workspace>
 
         <script type="module">
-            import perspective from "http://{{host}}:{{port}}/node_modules/@finos/perspective/dist/cdn/perspective.js";
+            import perspective from "/node_modules/@finos/perspective/dist/cdn/perspective.js";
+
+            //{% include table_workarounds.js %}
+            //{% include workspace_tables.js %}
 
             window.addEventListener("DOMContentLoaded", async function () {
                 const workspace = window.workspace
-                const worker = perspective.worker();
 
-                const websocket_ro = perspective.websocket("ws://{{host}}:{{port}}/websocket_readonly");
-                const websocket_rw = perspective.websocket("ws://{{host}}:{{port}}/websocket_editable");
-
-                //{% for table_name in mgr.get_table_names() %}
-                //{% if not table_name.endswith("_removes") %}
-                //{% if mgr.server_tables %}
-                workspace.tables.set(
-                    "{{table_name}}",
-                    {{"websocket_ro" if not mgr.is_table_editable(table_name) else "websocket_rw"}}.open_table("{{table_name}}")
-                );
-                //{% else %}
-                // {% set tbl = table_name.replace(" ", "_").replace("-", "_") %}
-                const table_{{tbl}} = await {{"websocket_ro" if not mgr.is_table_editable(table_name) else "websocket_rw"}}.open_table("{{table_name}}")
-                const view_{{tbl}} = await table_{{tbl}}.view()
-                // {% if mgr.get_table(table_name).get_index() %}
-                const client_{{tbl}} = await worker.table(view_{{tbl}}, {index: await table_{{tbl}}.get_index()});
-                // {% else %}
-                const client_{{tbl}} = await worker.table(view_{{tbl}});
-                // {% end %}
-                // {% if table_name + "_removes" in mgr.get_table_names() %}
-                const removes_{{tbl}} = await websocket_ro.open_table("{{table_name}}_removes")
-                const removes_view_{{tbl}} = await removes_{{tbl}}.view()
-                removes_view_{{tbl}}.on_update(
-                    async (updated) => {
-                        const update_table = await worker.table(updated.delta);
-                        const update_view = await update_table.view();
-                        const update_data = await update_view.to_columns();
-                        client_{{tbl}}.remove(update_data['i']);
-                    },
-                    { mode: "row" }
-                );
-                // {% end %}
-                // {% end %}
-                workspace.tables.set(
-                    "{{table_name}}",
-                    client_{{tbl}}
-                );
-                //{% end %}
-                //{% end %}
+                await connectWorkspaceTables(workspace);
 
                 const req = await fetch("/layout/{{url}}");
                 const json = await req.json();
                 window.workspace.restore(json);
 
-                const observe = await fetch("/inspect/expand/", {cache: "no-store"});
-
                 window.workspace.addEventListener("workspace-layout-update", async () => {
                     await fetch("/layout/{{url}}", {method: "post", body: JSON.stringify(await window.workspace.save())});
 
+                    installTableWorkarounds();
+
                     for (const g of document.querySelectorAll("perspective-viewer[table='inspector'] perspective-viewer-datagrid")){
                         const table = g.shadowRoot.querySelector("regular-table")
+
+                        if (table.dataset.inspector_events_set_up) continue;
+                        table.dataset.inspector_events_set_up = true;
 
                         var sheet = new CSSStyleSheet
                         sheet.replaceSync( `.highlight { background-color: pink }`)
                         g.shadowRoot.adoptedStyleSheets.push(sheet)
 
+                        let name_col = null;
+                        function findNameCol(){
+                            if (!name_col){
+                                for (const td of table.children[0].children[1].children[0].children){
+                                    const meta = table.getMeta(td);
+                                    if (meta.column_header[0] === "name"){
+                                        name_col = meta.x;
+                                        break;
+                                    }
+                                }
+                            }
+                            return name_col
+                        }
+
                         let SELECTED_ROW = null;
+                        let SEARCH_TERM = null;
                         table.addStyleListener(function fixOverflow() {
                             for (const tr of table.children[0].children[1].children) {
                                 const meta = table.getMeta(tr.children[0]);
+
                                 if (meta.y === SELECTED_ROW) {
                                     tr.classList.add("highlight");
                                 }else{
                                     tr.classList.remove("highlight");
                                 }
 
-                                for (const td of tr.children) {
-                                    td.style.overflow = "clip";
+                                if (SEARCH_TERM){
+                                    const name = tr.children[findNameCol()];
+                                    if (name.innerText.includes(SEARCH_TERM)){
+                                        name.innerHTML = name.innerText.replace(SEARCH_TERM, "<mark>" + SEARCH_TERM + "</mark>");
+                                    }
                                 }
                             }
                         })
@@ -121,16 +107,29 @@
                             return [stuff.num_columns, stuff.num_rows]
                         }
 
+                        async function fetch_alert(url) {
+                            const reply = await fetch(url, {cache: "no-store"});
+                            if (reply.status === 200) {
+                                return await reply.text()
+                            } else {
+                                const msg = await reply.text()
+                                console.error(msg)
+                                alert(msg)
+                            }
+                        }
+
                         table.addEventListener("click", async function observerClickEventListener(event) {
+                            event.stopPropagation()
+
                             if (event.target.tagName === "TD") {
                                 const [meta, stuff, row] = await targetInfo(event.target);
 
                                 if (meta.column_header[0] === 'X'){
                                     event.target.style.cursor = "progress";
                                     if (meta.value === '+') {
-                                        await fetch("/inspect/expand/" + row.id, {cache: "no-store"});
+                                        await fetch_alert("/inspect/expand/" + row.id, {cache: "no-store"});
                                     } else {
-                                        await fetch("/inspect/collapse/" + row.id, {cache: "no-store"});
+                                        await fetch_alert("/inspect/collapse/" + row.id, {cache: "no-store"});
                                     }
                                 }
                                 if (meta.column_header[0] === 'value') {
@@ -140,14 +139,18 @@
                                         if (reply.status === 200) {
                                             const new_row = await reply.text()
                                             console.log("looking for row " + new_row)
-                                            window.setTimeout(async () => {
+                                            window.setTimeout(async function lookForRow() {
                                                 const id_col = stuff.column_headers.findIndex((c) => {
                                                     return c[0] === 'id'
                                                 })
                                                 const ids = await table._view_cache.view(id_col, 0, id_col + 1, meta.y);
                                                 let row_num = ids.metadata[0].indexOf(new_row);
-                                                table.scrollToCell(0, row_num, ids.num_columns, ids.num_rows)
-                                                SELECTED_ROW = row_num;
+                                                if (row_num === -1) {
+                                                    window.setTimeout(lookForRow, 250);
+                                                } else {
+                                                    table.scrollToCell(0, row_num - 1, ids.num_columns, row_num + 1)
+                                                    SELECTED_ROW = row_num;
+                                                }
                                             }, 250);
                                         } else {
                                             const msg = await reply.text()
@@ -158,9 +161,16 @@
                                 }
                                 if (meta.column_header[0] === 'name'){
                                     if (!event.ctrlKey && !event.altKey && !event.shiftKey) {
-                                        SELECTED_ROW = meta.y;
-                                        event.target.parentElement.classList.add("highlight");
-                                        table.draw();
+                                        const selectedRow = table.querySelector(".highlight");
+                                        if (selectedRow){
+                                            SELECTED_ROW = null;
+                                            selectedRow.classList.remove("highlight");
+                                            table.draw();
+                                        } else {
+                                            SELECTED_ROW = meta.y;
+                                            event.target.parentElement.classList.add("highlight");
+                                            table.draw();
+                                        }
                                     }
                                 }
                                 window.setTimeout(() => {
@@ -169,49 +179,125 @@
                             }
                         });
 
+                        table.addEventListener("dblclick", async function observerClickEventListener(event) {
+                            event.stopPropagation()
+
+                            if (event.target.tagName === "TD") {
+                                const [meta, stuff, row] = await targetInfo(event.target);
+
+                                if (meta.column_header[0] === 'value') {
+                                    if (row.value.startsWith("Frame")) {
+                                        event.target.style.cursor = "";
+                                        window.open("/inspect_frame/" + row.id, "_blank");
+                                    }
+                                }
+                            }
+                        });
+
                         table.addEventListener("keydown", async function observerKeydownEventListener(event) {
+                            event.stopImmediatePropagation();
+
                             if (event.key === "/" || event.key === "?") {
-                                const searchRow = table.querySelector(".highlight");
-                                if (searchRow) {
-                                    const [meta, stuff, row] = await targetInfo(searchRow.children[0]);
-                                    const search = document.createElement("input");
-                                    search.type = "text";
-                                    search.style.position = "absolute";
-                                    search.style.top = searchRow.offsetTop + "px";
-                                    search.style.left = searchRow.offsetLeft + "px";
-                                    table.appendChild(search);
-                                    search.focus()
-                                    search.addEventListener("input", async function searchEventListener(event) {
-                                        const search = event.target.value;
-                                        console.log("searching for " + search)
-                                        if (search.length > 1){
-                                            const found = await fetch("/inspect/search/" + row.id + "?" +
+                                let searchRow = table.querySelector(".highlight");
+                                let topLevelSearch = false;
+                                if (!searchRow || event.key === "?") {
+                                    topLevelSearch = true
+                                    searchRow = table.children[0].children[1].children[0]
+                                }
+                                const [meta, stuff, row] = await targetInfo(searchRow.children[0]);
+                                const search = document.createElement("input");
+                                search.type = "text";
+                                search.style.position = "absolute";
+                                search.style.top = searchRow.offsetTop + "px";
+                                search.style.left = searchRow.offsetLeft + "px";
+                                table.appendChild(search);
+                                search.focus()
+                                search.addEventListener("input", async function searchEventListener(event) {
+                                    const search = event.target.value;
+                                    console.log("searching for " + search)
+                                    if (search.length > 1){
+                                        SEARCH_TERM = search;
+                                        if (!topLevelSearch) {
+                                            const found = await fetch_alert("/inspect/search/" + row.id + "?" +
                                                 new URLSearchParams({q: search}).toString(),
                                                 {cache: "no-store"});
                                         } else {
-                                            const found = await fetch("/inspect/stopsearch/", {cache: "no-store"});
+                                            const names = await table._view_cache.view(findNameCol(), 0, findNameCol() + 1, stuff.num_rows);
+                                            for (let i = SELECTED_ROW === null ? 0: SELECTED_ROW; i < names.metadata[0].length; i++){
+                                                if (names.metadata[0][i].includes(search)){
+                                                    table.scrollToCell(0, i - 1, names.num_columns, i + 1)
+                                                    break;
+                                                }
+                                            }
                                         }
-                                    });
-                                    search.addEventListener("keydown", async function searchEventListener(event) {
+                                    } else {
+                                        SEARCH_TERM = null;
+                                        if (!topLevelSearch) {
+                                            const found = await fetch_alert("/inspect/stopsearch/", {cache: "no-store"});
+                                        }
+                                    }
+                                    table.draw();
+                                });
+                                search.addEventListener("keydown", async function searchEventListener(event) {
+                                    event.stopPropagation()
+
+                                    const search = event.target.value;
+                                    console.log("searching for " + search)
+
+                                    if (!topLevelSearch) {
                                         if (event.key === "Enter") {
                                             console.log("end searching for " + search)
                                             event.stopPropagation()
                                             event.target.remove();
-                                            await fetch("/inspect/applysearch/", {cache: "no-store"});
+                                            await fetch_alert("/inspect/applysearch/", {cache: "no-store"});
                                             table.focus();
+                                            SEARCH_TERM = null;
                                         } else if (event.key === "Escape") {
                                             console.log("cancel searching for " + search)
                                             event.stopPropagation()
                                             event.target.remove();
-                                            await fetch("/inspect/stopsearch/", {cache: "no-store"});
+                                            await fetch_alert("/inspect/stopsearch/", {cache: "no-store"});
                                             table.focus();
+                                            SELECTED_ROW = null;
                                         }
-                                    });
-                                }
+                                    } else {
+                                        if (event.key === "Enter") {
+                                            console.log("end searching for " + search)
+                                            event.stopPropagation()
+                                            event.target.remove();
+                                            table.focus();
+                                            SEARCH_TERM = null;
+                                        } else if (event.key === "Escape") {
+                                            console.log("cancel searching for " + search)
+                                            event.stopPropagation()
+                                            event.target.remove();
+                                            table.focus();
+                                            SEARCH_TERM = null;
+                                        } else if (event.key === "ArrowDown") {
+                                            const names = await table._view_cache.view(findNameCol(), 0, findNameCol() + 1, stuff.num_rows);
+                                            for (let i = SELECTED_ROW === null ? 0: SELECTED_ROW + 1; i < names.metadata[0].length; i++){
+                                                if (names.metadata[0][i].includes(search)){
+                                                    table.scrollToCell(0, i - 1, names.num_columns, i + 1)
+                                                    SELECTED_ROW = i
+                                                    break;
+                                                }
+                                            }
+                                        } else if (event.key === "ArrowUp") {
+                                            const names = await table._view_cache.view(findNameCol(), 0, findNameCol() + 1, stuff.num_rows);
+                                            for (let i = SELECTED_ROW === null ? stuff.num_rows - 1: SELECTED_ROW - 1; i >= 0; i--){
+                                                if (names.metadata[0][i].includes(search)){
+                                                    table.scrollToCell(0, i - 1, names.num_columns, i + 1)
+                                                    SELECTED_ROW = i
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                    }
+                                    table.draw();
+                                });
                             }
                             if (event.key === "ArrowDown") {
                                 if (SELECTED_ROW === null) {
-                                    SELECTED_ROW = 0;
                                 } else {
                                     if (SELECTED_ROW < table._nrows - 1){
                                         SELECTED_ROW += 1;
@@ -221,7 +307,6 @@
                             }
                             if (event.key === "ArrowUp") {
                                 if (SELECTED_ROW === null) {
-                                    SELECTED_ROW = table._nrows - 1;
                                 } else {
                                     if (SELECTED_ROW > 0) {
                                         SELECTED_ROW -= 1;
@@ -235,34 +320,38 @@
                                     const [meta, stuff, row] = await targetInfo(searchRow.children[0]);
 
                                     if (row.X === '+' || row.X === '?') {
-                                        await fetch("/inspect/expand/" + row.id, {cache: "no-store"});
+                                        await fetch_alert("/inspect/expand/" + row.id, {cache: "no-store"});
                                     } else {
-                                        await fetch("/inspect/collapse/" + row.id, {cache: "no-store"});
+                                        await fetch_alert("/inspect/collapse/" + row.id, {cache: "no-store"});
                                     }
                                 }
                             }
                         });
 
                         table.addEventListener("dblclick", async function observerClickEventListener(event) {
+                            event.stopPropagation()
+
                             if (event.target.tagName === "TD") {
                                 const [meta, stuff, row] = await targetInfo(event.target);
 
                                 if (meta.column_header[0] === 'name'){
                                     if (row.X === '+') {
                                         if (event.ctrlKey) {
-                                            await fetch("/inspect/expand/" + row.id + "?" + new URLSearchParams({all: 'true'}).toString(),
+                                            await fetch_alert("/inspect/expand/" + row.id + "?" + new URLSearchParams({all: 'true'}).toString(),
                                                 {cache: "no-store"});
                                         } else {
-                                            await fetch("/inspect/expand/" + row.id, {cache: "no-store"});
+                                            await fetch_alert("/inspect/expand/" + row.id, {cache: "no-store"});
                                         }
                                     } else {
-                                        await fetch("/inspect/collapse/" + row.id, {cache: "no-store"});
+                                        await fetch_alert("/inspect/collapse/" + row.id, {cache: "no-store"});
                                     }
                                 }
                             }
                         });
                     }
                 });
+
+                const observe = await fetch("/inspect/expand/", {cache: "no-store"});
             });
         </script>
     </body>

--- a/src/hgraph/nodes/_service_utils.py
+++ b/src/hgraph/nodes/_service_utils.py
@@ -82,7 +82,7 @@ def write_subscription_key(path: str, key: TS[SCALAR], _state: STATE = None):
     svc_node_in = GlobalState.instance().get(f"{path}/subs")
     (s := _state.tracker[(v := key.value)]).add(_state.subscription_id)
     set_delta = set()
-    if _state.previous_key:
+    if _state.previous_key and _state.previous_key != v:
         (s_old := _state.tracker[_state.previous_key]).discard(_state.subscription_id)
         if not s_old:
             set_delta.add(Removed(_state.previous_key))

--- a/tests/python/unit/hgraph/_operators/_conversion_operators/test_mapping_conversion_operators.py
+++ b/tests/python/unit/hgraph/_operators/_conversion_operators/test_mapping_conversion_operators.py
@@ -12,10 +12,10 @@ def test_convert_ts_to_mapping():
     assert eval_node(g, "a", 1) == [{"a": 1}]
 
     @graph
-    def g(k: TS[str], v: TS[int]) -> TS[Mapping[str, int]]:
-        return convert[TS[Mapping[str, int]]](k, v)
+    def g(k: TS[str], v: TS[str]) -> TS[Mapping[str, str]]:
+        return convert[TS[Mapping[str, str]]](key=k, ts=v)
 
-    assert eval_node(g, "a", 1) == [{"a": 1}]
+    assert eval_node(g, "a", "b") == [{"a": "b"}]
 
 
 def test_convert_tuples_to_mapping():

--- a/tests/python/unit/hgraph/_operators/test_frozendict_operators.py
+++ b/tests/python/unit/hgraph/_operators/test_frozendict_operators.py
@@ -5,7 +5,7 @@ import pytest
 from frozendict import frozendict
 
 from hgraph import OUT, TSS, \
-    Removed, values_, rekey, flip, partition, flip_keys, keys_, collapse_keys, uncollapse_keys
+    Removed, values_, rekey, flip, partition, flip_keys, keys_, collapse_keys, uncollapse_keys, TSD, REMOVE
 from hgraph import sub_, getitem_, TS, and_, graph, KEYABLE_SCALAR, SCALAR, or_, min_, max_, sum_, str_, WiringError, \
     mean, std, var
 from hgraph.test import eval_node

--- a/tests/python/unit/hgraph/_operators/test_stream_operators.py
+++ b/tests/python/unit/hgraph/_operators/test_stream_operators.py
@@ -208,6 +208,15 @@ def test_throttle_tsd():
                      ) == [None, {1: 1}, None, None, {1: 2, 2: 2}, None, None, {2: REMOVE, 1: 1}]
 
 
+def test_throttle_tsd_delay_first():
+    @graph
+    def g(ts: TSD[int, TS[int]], period: timedelta) -> TSD[int, TS[int]]:
+        return throttle(ts, period, delay_first_tick=True)
+
+    assert eval_node(g, [None, {1: 1}, {2: 2}, {1: 2}, None, {2: REMOVE}, {1: REMOVE}, {1: 1}], 3 * MIN_TD, __end_time__=MIN_ST + 10 * MIN_TD
+                     ) == [None, None, None, None, {1: 2, 2: 2}, None, None, {2: REMOVE, 1: 1}]
+
+
 def test_take():
     @graph
     def g(ts: TS[int], count: int) -> TS[int]:

--- a/tests/python/unit/hgraph/_wiring/test_tsb_wiring.py
+++ b/tests/python/unit/hgraph/_wiring/test_tsb_wiring.py
@@ -129,3 +129,19 @@ def test_generic_tsb():
 
     assert eval_node(g, [1, 2], ["a", "b"]) == [fd({"p1": "a"}), fd({"p1": "b"})]
 
+
+def test_tsb_order_preservation():
+    @compute_node
+    def n1(a: TS[str], b: TS[str]) -> TS[str]:
+        return a.value + b.value
+
+    @compute_node
+    def n2(b: TS[str], a: TS[str]) -> TS[str]:
+        return a.value + b.value
+
+
+    @graph
+    def g(a: TS[str], b: TS[str]) -> TS[str]:
+        return n1(a, b) + n2(a, b)
+
+    assert eval_node(g, "a", "b") == ["abba"]

--- a/tests/python/unit/hgraph/debug/test_inspector.py
+++ b/tests/python/unit/hgraph/debug/test_inspector.py
@@ -76,7 +76,7 @@ def test_inspector_sort_key():
 
     InspectorItemId.__reset__()
 
-    assert eval_node(g2, [{1: 1}]) == [{1: "001X03001001X01001"}]
+    assert eval_node(g2, [{1: 1}]) == [{1: "001X02001001X01001"}]
 
     InspectorItemId.__reset__()
 
@@ -86,7 +86,7 @@ def test_inspector_sort_key():
 
     InspectorItemId.__reset__()
 
-    assert eval_node(g3, 1) == ["001X03001001X01001"]
+    assert eval_node(g3, 1) == ["001X02001001X01001"]
 
     InspectorItemId.__reset__()
 
@@ -100,6 +100,6 @@ def test_inspector_sort_key():
 
     InspectorItemId.__reset__()
 
-    assert eval_node(g4, 1) == ["001X03000001X01001"]
+    assert eval_node(g4, 1) == ["001X02000001X01001"]
 
     InspectorItemId.__reset__()


### PR DESCRIPTION
fix state sharing in tsd_rekey, optimise scheduling, fix versions in perspective layouts UI
fix ordering of unnamed TSBs
double click on "Frame XxY" opens a new window with the value of the frame update for polars > 1.1
Fix service subscription state bug by: Simon Young <syoung@bamfunds.com>
Fix len_(tsd) not to use len(key set).  (Empty TSS does not currently tick) by: Simon Young <syoung@bamfunds.com>
Fix paths
expose logger injection
refactor js code and remove the need for patched perspective and *-norollups packages redo perspective removes, move some tests
Series to tuple conversion, by: Tope Olukemi <tolukemi@bamfunds.com>
fix tsd_flip_non_unique, more perspective js refactoring rewrite race_tsd_of_bundles, hack around perspective column width undo use of race_tsd_of_bundles
fix perspective publish regression
fix scheduler use
wall clock timer/alarm, use it in perspective and a bit more error handling extend throttle, make feedback a bit easier to use, fix publishing of node statis in the inspector race for tsd and tsd of bundles
improve inspector doc
fix web_ui and add quick search navigation to the inspector template rewrite tsd_get_items, introduce uniqueness for perspective mutlitables add race for tsd and tsd of bundles
fix inspecting mesh, deployment related fixes
make mesh items have negative ids, add tooltips to inspector, fix REF display fix url formatting
adjustments for better deployment
print npm location
relative urls in tornado templates 
fix import
client side tables, rewrite inspector
re-fix request_id
redo request ids on the graph to prevent reuse
fix broken dispatch