### PR TITLE
Bigmerge 20250704

### DIFF
--- a/examples/web_ui/table_join.py
+++ b/examples/web_ui/table_join.py
@@ -50,7 +50,6 @@ from hgraph.adaptors.perspective import (
     TableEdits,
 )
 from hgraph.adaptors.perspective import perspective_web, PerspectiveTablesManager
-from hgraph.adaptors.perspective._perspective_adaptor import publish_join_table
 from hgraph.debug import trace_controller
 from hgraph.debug import inspector
 

--- a/hgraph_unit_tests/_operators/test_analytical.py
+++ b/hgraph_unit_tests/_operators/test_analytical.py
@@ -1,6 +1,6 @@
 import pytest
 
-from hgraph import TS, average, accumulate, graph, diff, count, clip, center_of_mass_to_alpha, span_to_alpha
+from hgraph import TS, NodeException, average, accumulate, graph, diff, count, clip, center_of_mass_to_alpha, span_to_alpha
 from hgraph.test import eval_node
 
 
@@ -21,7 +21,7 @@ def test_clip(values, min, max, expected):
 
 
 def test_clip_failure():
-    with pytest.raises(RuntimeError):
+    with pytest.raises(NodeException):
         assert eval_node(clip, [1.0], 1.0, -1.0) == [1.0]
 
 

--- a/hgraph_unit_tests/_operators/test_control_operators.py
+++ b/hgraph_unit_tests/_operators/test_control_operators.py
@@ -90,9 +90,9 @@ def test_any_invalid():
 
 
 def test_if_then_else():
-    expected = [None, 2, 6, 3]
+    expected = [None, 2, 6, 3, None]
 
-    assert eval_node(if_then_else, [None, True, False, True], [1, 2, 3], [4, 5, 6]) == expected
+    assert eval_node(if_then_else, [None, True, False, True, True], [1, 2, 3], [4, 5, 6]) == expected
 
 
 def test_if_cmp():

--- a/hgraph_unit_tests/_operators/test_frozendict_operators.py
+++ b/hgraph_unit_tests/_operators/test_frozendict_operators.py
@@ -16,8 +16,6 @@ from hgraph import (
     keys_,
     collapse_keys,
     uncollapse_keys,
-    TSD,
-    REMOVE,
 )
 from hgraph import (
     sub_,

--- a/hgraph_unit_tests/_operators/test_json.py
+++ b/hgraph_unit_tests/_operators/test_json.py
@@ -1,0 +1,27 @@
+from hgraph import JSON, SCHEMA, TS, TS_SCHEMA, TSB, combine, graph, json_decode, json_encode
+from hgraph.test import eval_node
+
+
+def test_json_combine_encode():
+    @graph
+    def g() -> TS[str]:
+        j1 = combine[TS[JSON]](a=1, b="test")
+        j2 = combine[TS[JSON]](c=3.14, d=[1, 2, 3])
+        j3 = combine[TS[JSON]](x=j1, y=j2)
+        return json_encode[str](j3)
+    
+    assert eval_node(g) == [
+        '{"x": {"a": 1, "b": "test"}, "y": {"c": 3.14, "d": [1, 2, 3]}}'
+    ]
+
+
+def test_json_decode():
+    @graph
+    def g() -> TSB[TS_SCHEMA]:
+        j = '{"a": 1, "b": "test", "c": 3.14, "d": [1, 2, 3]}'
+        decoded = json_decode(j)
+        return combine(a=decoded["a"].int, b=decoded["b"].str, c=decoded["c"].float, d=decoded["d"][0].int)
+    
+    assert eval_node(g) == [
+        {'a': 1, 'b': 'test', 'c': 3.14, 'd': 1}
+    ]

--- a/hgraph_unit_tests/_operators/test_print.py
+++ b/hgraph_unit_tests/_operators/test_print.py
@@ -3,7 +3,7 @@ from contextlib import nullcontext
 
 import pytest
 
-from hgraph import graph, TSL, TS, Size, debug_print, log_, print_, assert_, NodeException, DebugContext, null_sink
+from hgraph import LOGGER, compute_node, graph, TSL, TS, Size, debug_print, log_, print_, assert_, NodeException, DebugContext, null_sink
 from hgraph.nodes._tsl_operators import tsl_to_tsd
 from hgraph.test import eval_node
 
@@ -169,3 +169,14 @@ def test_assert():
 
     with pytest.raises(NodeException, match="assertion 3 2"):
         eval_node(main, [True, None, False], [1, 2, 3, 4])
+
+
+def test_custom_label(capsys):
+    @compute_node(label="custom_label {i}")
+    def g(ts: TS[str], i: str, logger_: LOGGER = None) -> TS[str]:
+        return ts.value
+
+    eval_node(g, ["Contents"], i="one", __trace__=True)
+    out = capsys.readouterr().out
+    if out:  # capture fixture is flaky, so check if out is not empty
+        assert "custom_label one:g" in out

--- a/hgraph_unit_tests/_operators/test_scalar_operators.py
+++ b/hgraph_unit_tests/_operators/test_scalar_operators.py
@@ -400,6 +400,16 @@ def test_sum_scalars(lhs, rhs, expected):
     assert eval_node(app, lhs, rhs) == expected
 
 
+def test_sum_scalars_unary():
+
+    @graph
+    def app(ts: TS[int], reset: TS[bool]) -> TS[int]:
+        return sum_(ts, reset=reset)
+
+    expected = [1, 3, 0, 3, 7]
+    assert eval_node(app, [1, 2, None, 3, 4], [None, None, True, None, None]) == expected
+
+
 def test_sum_scalars_multi():
     @graph
     def app(ts1: TS[float], ts2: TS[float], ts3: TS[float]) -> TS[float]:

--- a/hgraph_unit_tests/_operators/test_str_operators.py
+++ b/hgraph_unit_tests/_operators/test_str_operators.py
@@ -37,6 +37,7 @@ def test_match():
     assert eval_node(match_, pattern=["(a)"], s=["a"]) == [{"is_match": True, "groups": ("a",)}]
     assert eval_node(match_, pattern=["(a)"], s=["aa"]) == [{"is_match": True, "groups": ("a",)}]
     assert eval_node(match_, pattern=["(a)"], s=["aa"]) == [{"is_match": True, "groups": ("a",)}]
+    assert eval_node(match_, pattern=["a"], s=["baa"]) == [{"is_match": True, "groups": ()}]
     assert eval_node(match_, pattern=["a"], s=["b"]) == [{"is_match": False}]
 
 

--- a/hgraph_unit_tests/_operators/test_tsd_operators.py
+++ b/hgraph_unit_tests/_operators/test_tsd_operators.py
@@ -50,7 +50,7 @@ from hgraph import (
     eq_, set_delta,
 )
 from hgraph._operators._stream import filter_by
-from hgraph.nodes import keys_where_true, make_tsd, extract_tsd, flatten_tsd
+from hgraph.nodes import keys_where_true, make_tsd, extract_tsd, flatten_tsd, where_true
 from hgraph.test import eval_node
 
 
@@ -601,6 +601,12 @@ def test_keys_where_true():
     assert eval_node(
         keys_where_true[K:int], [{1: True, 2: False, 3: True}, {1: False, 2: True, 3: False}, {2: REMOVE}]
     ) == [{1, 3}, {Removed(1), 2, Removed(3)}, {Removed(2)}]
+
+
+def test_where_true():
+    assert eval_node(
+        where_true[K:int], [{1: True, 2: False, 3: True}, {1: False, 2: True, 3: False}, {2: REMOVE}]
+    ) == [{1: True, 3: True}, {1: REMOVE, 2: True, 3: REMOVE}, {2: REMOVE}]
 
 
 def test_filter_by_tsd():

--- a/hgraph_unit_tests/_operators/test_tss_operators.py
+++ b/hgraph_unit_tests/_operators/test_tss_operators.py
@@ -76,6 +76,16 @@ def test_bit_or_tsss():
     ) == [{1}, {2}, {3}, {4, 5}, None, None, {Removed(5)}]
 
 
+def test_bit_or_tsss_2():
+    @graph
+    def app(tss1: TSS[int], tss2: TSS[int]) -> TSS[int]:
+        return tss1 | tss2
+
+    assert eval_node(
+        app, [{1}, {2}, None, {4}, {5}, None, {Removed(5)}], [None, None, {3}, {5}, None, {Removed(5)}, None], __trace__=True
+    ) == [{1}, {2}, {3}, {4, 5}, None, None, {Removed(5)}]
+
+
 def test_bit_and_tsss():
     @graph
     def app(tss1: TSS[int], tss2: TSS[int]) -> TSS[int]:

--- a/hgraph_unit_tests/_wiring/test_error_handling.py
+++ b/hgraph_unit_tests/_wiring/test_error_handling.py
@@ -45,7 +45,7 @@ def test_error_not_handling_in_switch(caplog):
         run_graph(main, __capture_values__=True, __trace_back_depth__=3)
 
     assert "ZeroDivisionError" in caplog.text
-    assert "main.switch[True].<lambda>.div_numbers" in caplog.text
+    assert ".<lambda>.div_numbers" in caplog.text
 
 
 def test_error_handling():

--- a/hgraph_unit_tests/adaptors/websocket_adaptor/test_websocket_adaptor.py
+++ b/hgraph_unit_tests/adaptors/websocket_adaptor/test_websocket_adaptor.py
@@ -106,8 +106,8 @@ try:
     @pytest.mark.serial
     def test_single_websocket_request_graph():
         @websocket_server_handler(url="/test")
-        def x(request: TSB[WebSocketServerRequest]) -> TSB[WebSocketResponse]:
-            return combine[TSB[WebSocketResponse]](
+        def x(request: TSB[WebSocketServerRequest[bytes]]) -> TSB[WebSocketResponse[bytes]]:
+            return combine[TSB[WebSocketResponse[bytes]]](
                 connect_response=True,
                 message=request.messages[-1],
             )
@@ -130,7 +130,7 @@ try:
     def test_multiple_websocket_request_graph():
         @websocket_server_handler(url="/test")
         @compute_node
-        def x(request: TSD[int, TSB[WebSocketServerRequest]], _state: STATE = None) -> TSD[int, TSB[WebSocketResponse]]:
+        def x(request: TSD[int, TSB[WebSocketServerRequest[bytes]]], _state: STATE = None) -> TSD[int, TSB[WebSocketResponse[bytes]]]:
             out = defaultdict(dict)
             for i, v in request.modified_items():
                 if v.connect_request.modified:
@@ -158,8 +158,8 @@ try:
     @pytest.mark.serial
     def test_websocket_server_adaptor_graph():
         @websocket_server_handler(url="/test/(.*)")
-        def x(request: TSB[WebSocketServerRequest], b: TS[int]) -> TSB[WebSocketResponse]:
-            return combine[TSB[WebSocketResponse]](
+        def x(request: TSB[WebSocketServerRequest[bytes]], b: TS[int]) -> TSB[WebSocketResponse[bytes]]:
+            return combine[TSB[WebSocketResponse[bytes]]](
                 connect_response=True,
                 message=convert[TS[bytes]](
                     format_(
@@ -187,8 +187,8 @@ try:
     @pytest.mark.serial
     def test_single_request_graph_client():
         @websocket_server_handler(url="/test/(.*)")
-        def x(request: TSB[WebSocketServerRequest]) -> TSB[WebSocketResponse]:
-            return combine[TSB[WebSocketResponse]](
+        def x(request: TSB[WebSocketServerRequest[bytes]]) -> TSB[WebSocketResponse[bytes]]:
+            return combine[TSB[WebSocketResponse[bytes]]](
                 connect_response=True,
                 message=convert[TS[bytes]](
                     format_(
@@ -213,7 +213,7 @@ try:
             def ws_client(i: TS[tuple[WebSocketConnectRequest, tuple[bytes, ...]]]) -> TS[bytes]:
                 connected = feedback(TS[bool])
                 resp = websocket_client_adaptor(
-                    combine[TSB[WebSocketClientRequest]](connect_request=i[0], message=gate(connected(), emit(i[1])))
+                    combine[TSB[WebSocketClientRequest[bytes]]](connect_request=i[0], message=gate(connected(), emit(i[1])))
                 )
                 connected(resp.connect_response)
                 return resp.message

--- a/src/hgraph/_impl/_operators/__init__.py
+++ b/src/hgraph/_impl/_operators/__init__.py
@@ -31,3 +31,4 @@ from hgraph._impl._operators._tuple_operators import *
 from hgraph._impl._operators._type import *
 from hgraph._impl._operators._type_operators import *
 from hgraph._impl._operators._zero import *
+from hgraph._impl._operators._json import *

--- a/src/hgraph/_impl/_operators/_date_time_operators.py
+++ b/src/hgraph/_impl/_operators/_date_time_operators.py
@@ -200,7 +200,7 @@ def div_timedeltas(lhs: TS[timedelta], rhs: TS[timedelta]) -> TS[float]:
 
 
 @compute_node(overloads=floordiv_)
-def div_timedeltas(lhs: TS[timedelta], rhs: TS[timedelta]) -> TS[int]:
+def floordiv_timedeltas(lhs: TS[timedelta], rhs: TS[timedelta]) -> TS[int]:
     return lhs.value // rhs.value
 
 

--- a/src/hgraph/_impl/_operators/_flow_control.py
+++ b/src/hgraph/_impl/_operators/_flow_control.py
@@ -397,10 +397,10 @@ def if_then_else_impl(
             if false_value.valid and _output.value != false_value.value:
                 return false_value.value
 
-    if condition_value and true_value.modified:
+    if condition_value and true_value.modified and _output.value != true_value.value:
         return true_value.value
 
-    if not condition_value and false_value.modified:
+    if not condition_value and false_value.modified and _output.value != true_value.value:
         return false_value.value
 
 

--- a/src/hgraph/_impl/_operators/_json.py
+++ b/src/hgraph/_impl/_operators/_json.py
@@ -1,0 +1,72 @@
+
+import json
+from typing import overload
+from hgraph import K, OUT, TS, TS_SCHEMA, TSB, TSD, combine, compute_node, SCALAR, JSON, convert, getattr_, getitem_, json_decode, json_encode, operator, Type, DEFAULT
+
+
+@compute_node(overloads=json_decode)
+def json_decode_str(ts: TS[str]) -> TS[JSON]:
+    return JSON(json.loads(ts.value))
+
+
+@compute_node(overloads=json_decode)
+def json_decode_bytes(ts: TS[bytes]) -> TS[JSON]:
+    return JSON(json.loads(ts.value))
+
+@compute_node(overloads=json_encode)
+def json_encode_str(ts: TS[JSON], _tp: Type[str] = DEFAULT[SCALAR]) -> TS[str]:
+    return json.dumps(ts.value.json)
+
+@compute_node(overloads=json_encode)
+def json_encode_bytes(ts: TS[JSON], _tp: Type[bytes] = DEFAULT[SCALAR]) -> TS[bytes]:
+    return json.dumps(ts.value.json).encode('utf-8')
+
+@compute_node(overloads=getattr_, requires=lambda m, s: s['attr'] == 'str')
+def getattr_json_str(ts: TS[JSON], attr: str) -> TS[str]:
+    return ts.value.json
+
+@compute_node(overloads=getattr_, requires=lambda m, s: s['attr'] == 'bool')
+def getattr_json_bool(ts: TS[JSON], attr: str) -> TS[bool]:
+    return ts.value.json
+
+@compute_node(overloads=getattr_, requires=lambda m, s: s['attr'] == 'int')
+def getattr_json_int(ts: TS[JSON], attr: str) -> TS[int]:
+    return ts.value.json
+
+@compute_node(overloads=getattr_, requires=lambda m, s: s['attr'] == 'float')
+def getattr_json_float(ts: TS[JSON], attr: str) -> TS[float]:
+    return ts.value.json
+
+@compute_node(overloads=getattr_, requires=lambda m, s: s['attr'] == 'obj')
+def getattr_json_obj(ts: TS[JSON], attr: str) -> TS[object]:
+    return ts.value.json
+
+@compute_node(overloads=getitem_)
+def getitem_json_str(ts: TS[JSON], key: str) -> TS[JSON]:
+    return JSON(ts.value.json.get(key))
+
+@compute_node(overloads=getitem_)
+def getitem_json_int(ts: TS[JSON], key: int) -> TS[JSON]:
+    return JSON(ts.value.json[key])
+
+
+@compute_node(
+    overloads=combine,
+    all_valid=lambda m, s: ("bundle",) if s["__strict__"] else None,
+)
+def combine_json(
+    tp_out_: Type[TS[JSON]] = DEFAULT[OUT],
+    __strict__: bool = True,
+    **bundle: TSB[TS_SCHEMA],
+) -> TS[JSON]:
+    return JSON({k: v if type(v) is not JSON else v.json for k, v in bundle.value.items() if v is not None})
+
+
+@compute_node(
+    overloads=convert,
+    requires=lambda m, s: m[OUT].py_type == TS[JSON])
+def convert_tsd_to_json(
+    ts: TSD[K, TS[JSON]],
+    to: Type[TS[JSON]] = DEFAULT[OUT],
+) -> TS[JSON]:
+    return JSON({k: v.value.json for k, v in ts.valid_items()})

--- a/src/hgraph/_impl/_operators/_number_operators.py
+++ b/src/hgraph/_impl/_operators/_number_operators.py
@@ -200,19 +200,47 @@ def divmod_ints(lhs: TS[int], rhs: TS[int], divide_by_zero: DivideByZero = Divid
 
 
 @compute_node(overloads=pow_)
-def pow_int_float(lhs: TS[int], rhs: TS[float]) -> TS[float]:
+def pow_int_float(lhs: TS[int], rhs: TS[float], divide_by_zero: DivideByZero = DivideByZero.ERROR) -> TS[float]:
     """
     Raises an int time-series value to the power of a float time-series value
     """
-    return lhs.value ** rhs.value
+    try:
+        return lhs.value ** rhs.value
+    except ZeroDivisionError:
+        if divide_by_zero is DivideByZero.NAN:
+            return float("NaN")
+        elif divide_by_zero is DivideByZero.INF:
+            return float("inf")
+        elif divide_by_zero is DivideByZero.NONE:
+            return
+        elif divide_by_zero is DivideByZero.ZERO:
+            return 0.0
+        elif divide_by_zero is DivideByZero.ONE:
+            return 1.0
+        else:
+            raise
 
 
 @compute_node(overloads=pow_)
-def pow_float_int(lhs: TS[float], rhs: TS[int]) -> TS[float]:
+def pow_float_int(lhs: TS[float], rhs: TS[int], divide_by_zero: DivideByZero = DivideByZero.ERROR) -> TS[float]:
     """
     Raises a float time-series value to the power of an int time-series value
     """
-    return lhs.value ** rhs.value
+    try:
+        return lhs.value ** rhs.value
+    except ZeroDivisionError:
+        if divide_by_zero is DivideByZero.NAN:
+            return float("NaN")
+        elif divide_by_zero is DivideByZero.INF:
+            return float("inf")
+        elif divide_by_zero is DivideByZero.NONE:
+            return
+        elif divide_by_zero is DivideByZero.ZERO:
+            return 0.0
+        elif divide_by_zero is DivideByZero.ONE:
+            return 1.0
+        else:
+            raise
 
 
 EPSILON = 1e-10

--- a/src/hgraph/_impl/_operators/_str_operators.py
+++ b/src/hgraph/_impl/_operators/_str_operators.py
@@ -79,7 +79,7 @@ def match_default(pattern: TS[str], s: TS[str]) -> TSB[Match]:
     """
     import re
 
-    m = re.match(pattern.value, s.value)
+    m = re.search(pattern.value, s.value)
     if m:
         return {"is_match": True, "groups": m.groups()}
     else:

--- a/src/hgraph/_impl/_operators/_stream_analytical_operators.py
+++ b/src/hgraph/_impl/_operators/_stream_analytical_operators.py
@@ -1,19 +1,19 @@
 from dataclasses import dataclass
 
 from hgraph import (
-    graph,
-    TS,
     NUMBER,
-    compute_node,
+    SCALAR,
     SIGNAL,
+    STATE,
+    TS,
     TS_OUT,
     CompoundScalar,
-    STATE,
-    diff,
-    count,
     clip,
+    compute_node,
+    count,
+    diff,
     ewma,
-    SCALAR,
+    graph,
 )
 
 __all__ = tuple()
@@ -39,20 +39,18 @@ def count_impl(ts: SIGNAL, reset: SIGNAL = None, _output: TS_OUT[int] = None) ->
 
 
 @compute_node(overloads=clip)
-def clip_number(ts: TS[NUMBER], min_: NUMBER, max_: NUMBER) -> TS[NUMBER]:
+def clip_number(ts: TS[NUMBER], min_: TS[NUMBER], max_: TS[NUMBER]) -> TS[NUMBER]:
+    min_value = min_.value
+    max_value = max_.value
+    if (min_.modified or max_.modified) and (min_value > max_value):
+        raise RuntimeError(f"clip given min: {min_.value}, max: {max_.value}, but min is not < max")
+
     v = ts.value
-    if v < min_:
-        return min_
-    if v > max_:
-        return max_
+    if v < min_value:
+        return min_value
+    if v > max_value:
+        return max_value
     return v
-
-
-@clip_number.start
-def clip_number_start(min_: NUMBER, max_: NUMBER):
-    if min_ < max_:
-        return
-    raise RuntimeError(f"clip given min: {min_}, max: {max_}, but min is not < max")
 
 
 @dataclass

--- a/src/hgraph/_impl/_operators/_stream_operators.py
+++ b/src/hgraph/_impl/_operators/_stream_operators.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, field
 from datetime import timedelta, datetime
 from typing import Mapping, Generic
 
+from multimethod import multimethod
+
 from hgraph import (
     TSW,
     WINDOW_SIZE,
@@ -50,7 +52,13 @@ from hgraph import (
     TS_SCHEMA,
     AUTO_RESOLVE,
     TSS,
-    union
+    union,
+)
+
+from hgraph._impl._types import (
+    PythonTimeSeriesDictInput,
+    PythonTimeSeriesSetInput,
+    PythonTimeSeriesValueInput,
 )
 
 __all__ = ()
@@ -166,45 +174,40 @@ def resample_default(ts: TIME_SERIES_TYPE, period: timedelta) -> TIME_SERIES_TYP
     return sample(schedule(period), ts)
 
 
+@multimethod
+def dedup_item(input, output):
+    return {
+        k_new: v_new
+        for k_new, v_new in ((k, dedup_item(v, output[k])) for k, v in input.modified_items())
+        if v_new is not None
+    }
+
+@dedup_item.register
+def dedup_dicts(input: PythonTimeSeriesDictInput, output):
+    out = {
+        k_new: v_new
+        for k_new, v_new in ((k, dedup_item(v, output.get_or_create(k))) for k, v in input.modified_items())
+        if v_new is not None
+    }
+    return out | {k: REMOVE_IF_EXISTS for k in input.removed_keys()}
+
+@dedup_item.register
+def dedup_value(input: PythonTimeSeriesValueInput, output):
+    if output.valid:
+        if input.value != output.value:
+            return input.delta_value
+    else:
+        return input.value
+
+@dedup_item.register
+def dedup_value(input: PythonTimeSeriesSetInput, output):
+    return input.delta_value
+
 @compute_node(overloads=dedup)
 def dedup_default(ts: TIME_SERIES_TYPE, _output: TIME_SERIES_TYPE = None) -> TIME_SERIES_TYPE:
     """
     Drops duplicate values from a time-series.
     """
-    from multimethod import multimethod
-    from hgraph import PythonTimeSeriesValueInput
-    from hgraph import PythonTimeSeriesDictInput
-    from hgraph import PythonTimeSeriesSetInput
-
-    @multimethod
-    def dedup_item(input, output):
-        return {
-            k_new: v_new
-            for k_new, v_new in ((k, dedup_item(v, output[k])) for k, v in input.modified_items())
-            if v_new is not None
-        }
-
-    @dedup_item.register
-    def dedup_dicts(input: PythonTimeSeriesDictInput, output):
-        out = {
-            k_new: v_new
-            for k_new, v_new in ((k, dedup_item(v, output.get_or_create(k))) for k, v in input.modified_items())
-            if v_new is not None
-        }
-        return out | {k: REMOVE_IF_EXISTS for k in input.removed_keys()}
-
-    @dedup_item.register
-    def dedup_value(input: PythonTimeSeriesValueInput, output):
-        if output.valid:
-            if input.value != output.value:
-                return input.delta_value
-        else:
-            return input.value
-
-    @dedup_item.register
-    def dedup_value(input: PythonTimeSeriesSetInput, output):
-        return input.delta_value
-
     return dedup_item(ts, _output)
 
 
@@ -238,6 +241,39 @@ class _ThrottleState(CompoundScalar):
     tick: dict = field(default_factory=dict)
 
 
+@multimethod
+def collect_tick(input, out):
+    return {
+        k_new: v_new
+        for k_new, v_new in ((k, collect_tick(v, out.setdefault(k, dict()))) for k, v in input.modified_items())
+        if v_new is not None
+    }
+
+@collect_tick.register
+def collect_dict(input: PythonTimeSeriesDictInput, out):
+    out |= {
+        k_new: v_new
+        for k_new, v_new in ((k, collect_tick(v, out.setdefault(k, dict()))) for k, v in input.modified_items())
+        if v_new is not None
+    }
+    return out | {k: REMOVE_IF_EXISTS for k in input.removed_keys()}
+
+@collect_tick.register
+def collect_set(input: PythonTimeSeriesSetInput, out):
+    from hgraph import PythonSetDelta
+    if not out:
+        out = PythonSetDelta(set(), set())
+    new_added, new_removed = input.added(), input.removed()
+    added = (out.added - new_removed) | new_added
+    removed = (out.removed - new_added) | new_removed
+    return PythonSetDelta(added, removed)
+
+@collect_tick.register
+def collect_value(input: PythonTimeSeriesValueInput, out):
+    return input.value
+
+
+
 # TODO: This code will need to be re-written to support C++, it currently depends on instance checks of inputs
 # which will not work going forwards.
 @compute_node(overloads=throttle)
@@ -253,37 +289,7 @@ def throttle_default(
     from hgraph import PythonTimeSeriesValueInput
     from hgraph import PythonTimeSeriesDictInput
     from hgraph import PythonTimeSeriesSetInput
-
-    @multimethod
-    def collect_tick(input, out):
-        return {
-            k_new: v_new
-            for k_new, v_new in ((k, collect_tick(v, out.setdefault(k, dict()))) for k, v in input.modified_items())
-            if v_new is not None
-        }
-
-    @collect_tick.register
-    def collect_dict(input: PythonTimeSeriesDictInput, out):
-        out |= {
-            k_new: v_new
-            for k_new, v_new in ((k, collect_tick(v, out.setdefault(k, dict()))) for k, v in input.modified_items())
-            if v_new is not None
-        }
-        return out | {k: REMOVE_IF_EXISTS for k in input.removed_keys()}
-
-    @collect_tick.register
-    def collect_set(input: PythonTimeSeriesSetInput, out):
-        from hgraph import PythonSetDelta
-        if not out:
-            out = PythonSetDelta(set(), set())
-        new_added, new_removed = input.added(), input.removed()
-        added = (out.added - new_removed) | new_added
-        removed = (out.removed - new_added) | new_removed
-        return PythonSetDelta(added, removed)
-
-    @collect_tick.register
-    def collect_value(input: PythonTimeSeriesValueInput, out):
-        return input.value
+    from hgraph import PythonSetDelta
 
     if ts.modified:
         if _sched.is_scheduled:
@@ -326,7 +332,7 @@ class TimeState(CompoundScalar):
 
 
 @compute_node(overloads=take)
-def take_by_time(ts: TIME_SERIES_TYPE, count: timedelta = MIN_TD, state: STATE[TimeState] = None) -> TIME_SERIES_TYPE:
+def take_by_time(ts: TIME_SERIES_TYPE, count: timedelta, state: STATE[TimeState] = None) -> TIME_SERIES_TYPE:
     if state.time == MIN_DT:  # First tick
         state.time = ts.last_modified_time
 

--- a/src/hgraph/_impl/_operators/_to_table_dispatch_impl.py
+++ b/src/hgraph/_impl/_operators/_to_table_dispatch_impl.py
@@ -22,6 +22,7 @@ from hgraph._types import (
     HgREFTypeMetaData,
     STATE,
     HgDataFrameScalarTypeMetaData,
+    CompoundScalar
 )
 
 __all__ = ("PartialSchema", "extract_table_schema", "extract_table_schema_raw_type")
@@ -35,6 +36,7 @@ class PartialSchema:
     partition_keys: tuple[str, ...]
     remove_partition_keys: tuple[str, ...]
     to_table: Callable[[TIME_SERIES_TYPE], TABLE]
+    to_table_sample: Callable[[TIME_SERIES_TYPE], TABLE]
     to_table_snap: Callable[[TIME_SERIES_TYPE], TABLE]
     from_table: Callable[[Iterable], TIME_SERIES_TYPE]
 
@@ -75,6 +77,7 @@ def _(tp: HgCompoundScalarType) -> PartialSchema:
         partition_keys=tuple(),
         remove_partition_keys=tuple(),
         to_table=lambda v: tuple(i for fn in to_table for i in fn(v)),
+        to_table_sample=lambda v: tuple(i for fn in to_table for i in fn(v)),
         to_table_snap=lambda v: tuple(i for fn in to_table for i in fn(v)),
         from_table=lambda it: tp.py_type(**{k: v(it) for k, v in zip(tp.meta_data_schema.keys(), from_table)}),
     )
@@ -94,7 +97,8 @@ def _(tp: HgTSTypeMetaData) -> PartialSchema:
             to_table=lambda ts, schema=schema: (
                 schema.to_table(ts.delta_value) if ts.modified else (None,) * len(schema.keys)
             ),
-            to_table_snap=lambda ts, schema=schema: schema.to_table_snap(ts.value),
+            to_table_sample=lambda ts, schema=schema: schema.to_table_sample(ts.value) if ts.valid else (None,) * len(schema.keys),
+            to_table_snap=lambda ts, schema=schema: schema.to_table_snap(ts.value) if ts.valid else (None,) * len(schema.keys),
             from_table=schema.from_table,
         )
     else:
@@ -105,6 +109,7 @@ def _(tp: HgTSTypeMetaData) -> PartialSchema:
             partition_keys=tuple(),
             remove_partition_keys=tuple(),
             to_table=lambda v: (v.delta_value if v.modified else None,),
+            to_table_sample=lambda v: (v.value,),
             to_table_snap=lambda v: (v.value,),
             from_table=lambda iter: next(iter),
         )
@@ -129,61 +134,24 @@ def _(tp: HgREFTypeMetaData) -> PartialSchema:
         remove_partition_keys=schema.remove_partition_keys,
         to_table=lambda v, schema=schema: schema.to_table(
             v.value.output
-            if v.value.output is not None
-            else STATE(**{k: v.output for k, v in zip(schema.keys, v.value.items)})
+            if v.value.has_output
+            else STATE(**{k: i.output for k, i in zip(schema.tp.bundle_schema_tp.meta_data_schema.keys(), v.value.items)})
+            if v.value.is_valid
+            else (None,) * len(schema.keys)
+        ),
+        to_table_sample=lambda v, schema=schema: schema.to_table_sample(
+            v.value.output
+            if v.value.has_output
+            else STATE(**{k: i.output for k, i in zip(schema.tp.bundle_schema_tp.meta_data_schema.keys(), v.value.items)})
+            if v.value.is_valid
+            else (None,) * len(schema.keys)
         ),
         to_table_snap=lambda v, schema=schema: schema.to_table_snap(
             v.value.output
-            if v.value.output is not None
-            else STATE(**{k: v.output for k, v in zip(schema.keys, v.value.items)})
-        ),
-        from_table=lambda iter: next(iter),
-    )
-
-
-@extract_table_schema.register(HgREFTypeMetaData)
-def _(tp: HgREFTypeMetaData) -> PartialSchema:
-    item_tp = tp.value_tp
-    schema = extract_table_schema(item_tp)
-    return PartialSchema(
-        tp.py_type,
-        keys=schema.keys,
-        types=schema.types,
-        partition_keys=schema.partition_keys,
-        remove_partition_keys=schema.remove_partition_keys,
-        to_table=lambda v, schema=schema: schema.to_table(
-            v.value.output
-            if v.value.output is not None
-            else STATE(**{k: v.output for k, v in zip(schema.keys, v.value.items)})
-        ),
-        to_table_snap=lambda v, schema=schema: schema.to_table_snap(
-            v.value.output
-            if v.value.output is not None
-            else STATE(**{k: v.output for k, v in zip(schema.keys, v.value.items)})
-        ),
-        from_table=lambda iter: next(iter),
-    )
-
-
-@extract_table_schema.register(HgREFTypeMetaData)
-def _(tp: HgREFTypeMetaData) -> PartialSchema:
-    item_tp = tp.value_tp
-    schema = extract_table_schema(item_tp)
-    return PartialSchema(
-        tp.py_type,
-        keys=schema.keys,
-        types=schema.types,
-        partition_keys=schema.partition_keys,
-        remove_partition_keys=schema.remove_partition_keys,
-        to_table=lambda v, schema=schema: schema.to_table(
-            v.value.output
-            if v.value.output is not None
-            else STATE(**{k: v.output for k, v in zip(schema.keys, v.value.items)})
-        ),
-        to_table_snap=lambda v, schema=schema: schema.to_table_snap(
-            v.value.output
-            if v.value.output is not None
-            else STATE(**{k: v.output for k, v in zip(schema.keys, v.value.items)})
+            if v.value.has_output
+            else STATE(**{k: i.output for k, i in zip(schema.tp.bundle_schema_tp.meta_data_schema.keys(), v.value.items)})
+            if v.value.is_valid
+            else (None,) * len(schema.keys)
         ),
         from_table=lambda iter: next(iter),
     )
@@ -197,6 +165,7 @@ def _(tp: HgTSBTypeMetaData) -> PartialSchema:
     types = []
     from_table = []
     to_table = []
+    to_table_sample = []
     to_table_snap = []
     for k, v in schema.items():
         schema = extract_table_schema(v)
@@ -207,6 +176,7 @@ def _(tp: HgTSBTypeMetaData) -> PartialSchema:
             keys.append(k)
             types.append(schema.types[0])
         to_table.append(lambda value, k=k, schema=schema: schema.to_table(getattr(value, k)))
+        to_table_sample.append(lambda value, k=k, schema=schema: schema.to_table_sample(getattr(value, k)))
         to_table_snap.append(lambda value, k=k, schema=schema: schema.to_table_snap(getattr(value, k)))
         from_table.append(schema.from_table)
     return PartialSchema(
@@ -216,6 +186,7 @@ def _(tp: HgTSBTypeMetaData) -> PartialSchema:
         partition_keys=tuple(),
         remove_partition_keys=tuple(),
         to_table=lambda v: tuple(i for fn in to_table for i in fn(v)),
+        to_table_sample=lambda v: tuple(i for fn in to_table_sample for i in fn(v)),
         to_table_snap=lambda v: tuple(i for fn in to_table_snap for i in fn(v)),
         from_table=lambda it, key_s=schema_keys, f_t=from_table,: fd(
             **{k: v_ for k, v in zip(key_s, f_t) if (v_ := v(it)) is not None}
@@ -236,72 +207,107 @@ class PartitionKeyCounter:
 @extract_table_schema.register(HgTSDTypeMetaData)
 def _(tp: HgTSDTypeMetaData) -> PartialSchema:
     with PartitionKeyCounter():
-        key_name = f"__key_{PartitionKeyCounter.count}__"
-        removed_name = f"__key_{PartitionKeyCounter.count}_removed__"
         key_type = tp.key_tp.py_type
-        if key_type not in (bool, int, str, date, datetime, time, timedelta):
+        if key_type in (bool, int, str, date, datetime, time, timedelta):
+            key_names = f"__key_{PartitionKeyCounter.count}__",
+            key_schema = PartialSchema(
+                tp,
+                keys=('',),
+                types=(key_type,),
+                partition_keys=tuple(),
+                remove_partition_keys=tuple(),
+                to_table=lambda v, k=key_names[0]: (v,),
+                to_table_sample=lambda v, k=key_names[0]: (v,),
+                to_table_snap=lambda v, k=key_names[0]: (v,),
+                from_table=lambda it: next(it),
+            )
+        elif issubclass(key_type, CompoundScalar):
+            key_schema = extract_table_schema(HgTypeMetaData.parse_type(key_type))
+            key_names = tuple(f"__key_{PartitionKeyCounter.count}_{k}__" for k in key_schema.keys)
+        else:
             raise ValueError(
                 f"Cannot extract table schema from '{tp}' as {key_type} is not supported as a keyable column"
             )
+            
+
+        removed_name = f"__key_{PartitionKeyCounter.count}_removed__"
         schema = extract_table_schema(tp.value_tp)
     return PartialSchema(
         tp,
         keys=(
             removed_name,
-            key_name,
         )
+        + key_names
         + schema.keys,
         types=(
             bool,
-            key_type,
         )
+        + key_schema.types
         + schema.types,
-        partition_keys=(key_name,) + schema.partition_keys,
+        partition_keys=key_names + schema.partition_keys,
         remove_partition_keys=(removed_name,) + schema.remove_partition_keys,
-        to_table=lambda tsd, k=key_name, schema=schema: _tsd_to_table(tsd, schema),
-        to_table_snap=lambda tsd, k=key_name, schema=schema: _tsd_to_table(tsd, schema, True),
-        from_table=lambda it, schema=schema: _tsd_from_table(it, schema),
+        to_table=lambda tsd, k=key_names, key_schema=key_schema, schema=schema: _tsd_to_table(tsd, key_schema, schema),
+        to_table_sample=lambda tsd, k=key_names, key_schema=key_schema, schema=schema: _tsd_to_table(tsd, key_schema, schema, False, True),
+        to_table_snap=lambda tsd, k=key_names, key_schema=key_schema, schema=schema: _tsd_to_table(tsd, key_schema, schema, True),
+        from_table=lambda it, key_schema=key_schema, schema=schema: _tsd_from_table(it, key_schema, schema),
     )
 
 
-def _tsd_to_table(tsd: TSD[K, V], schema: PartialSchema, snap=False) -> TABLE:
+def _tsd_to_table(tsd: TSD[K, V], key_schema, schema: PartialSchema, snap=False, sample=False) -> TABLE:
     if schema.partition_keys:
         # If there are partial keys in the value, then we will potentially get multiple rows
         out = []
         for k, v in tsd.modified_items() if not snap else tsd.valid_items():
-            for row in schema.to_table(v) if not snap else schema.to_table_snap(v):
+            keys = key_schema.to_table(k)
+            if snap:
+                rows = schema.to_table_snap(v)
+            elif sample:
+                rows = schema.to_table_sample(v)
+            else:
+                rows = schema.to_table(v)
+
+            for row in rows:
                 out.append(
                     (
                         False,
-                        k,
                     )
+                    + keys
                     + row
                 )
         if not snap:
             for k in tsd.removed_keys():
-                out.append((True, k) + (None,) * len(schema.keys))
+                keys = key_schema.to_table(k)
+                out.append((True,) + keys + (None,) * len(schema.keys))
         return tuple(out)
     else:
+        if snap:
+            fn = schema.to_table_snap
+        elif sample:
+            fn = schema.to_table_sample
+        else:
+            fn = schema.to_table
+
         return tuple(
             (
                 (
                     False,
-                    k,
                 )
-                + (schema.to_table(v) if not snap else schema.to_table_snap(v))
+                + key_schema.to_table(k)
+                + fn(v)
             )
             for k, v in (tsd.modified_items() if not snap else tsd.valid_items())
-        ) + tuple(((True, k) + (None,) * len(schema.keys)) for k in (tsd.removed_keys() if not snap else ()))
+        ) + tuple(((True,) + key_schema.to_table(k) + (None,) * len(schema.keys)) for k in (tsd.removed_keys() if not snap else ()))
 
 
-def _tsd_from_table(it, schema: PartialSchema) -> fd:
+def _tsd_from_table(it, key_schema: PartialSchema, schema: PartialSchema) -> fd:
     if schema.partition_keys:
         old_k = None
         out = {}
         values = []
         for r in it:
             removed = r[0]
-            key = r[1]
+            row_values = iter(r[1:])
+            key = key_schema.from_table(row_values)
             if old_k is None:
                 old_k = key
             elif old_k != key:
@@ -311,18 +317,19 @@ def _tsd_from_table(it, schema: PartialSchema) -> fd:
             if removed:
                 out[key] = REMOVE_IF_EXISTS
                 continue
-            values.append(r[2:])
+            values.append(tuple(row_values))
         if values:
             out[key] = schema.from_table(iter(values))
     else:
         out = {}
         for r in it:
             removed = r[0]
-            key = r[1]
+            values = iter(r[1:])
+            key = key_schema.from_table(values)
             if removed:
                 out[key] = REMOVE_IF_EXISTS
             else:
-                out[key] = schema.from_table(iter(r[2:]))
+                out[key] = schema.from_table(values)
     return fd(out)
 
 
@@ -339,6 +346,7 @@ def _(tp: HgDataFrameScalarTypeMetaData) -> PartialSchema:
             partition_keys=tuple(),
             remove_partition_keys=tuple(),
             to_table=lambda v: tuple(schema.to_table(tp.schema.py_type(**i)) for i in v.rows(named=True)),
+            to_table_sample=lambda v: tuple(schema.to_table(tp.schema.py_type(**i)) for i in v.rows(named=True)),
             to_table_snap=lambda v: tuple(schema.to_table(tp.schema.py_type(**i)) for i in v.rows(named=True)),
             from_table=lambda it: pl.DataFrame(tuple(schema.from_table(iter(i)) for i in it)),
         )
@@ -350,6 +358,7 @@ def _(tp: HgDataFrameScalarTypeMetaData) -> PartialSchema:
             partition_keys=tuple(),
             remove_partition_keys=tuple(),
             to_table=lambda v: (v.value,) if v.modified else (None,),
+            to_table_sample=lambda v: (v.value,) if v.modified else (None,),
             to_table_snap=lambda v: (v.value,) if v.modified else (None,),
             from_table=lambda iter: next(iter),
         )

--- a/src/hgraph/_impl/_operators/_tsd_operators.py
+++ b/src/hgraph/_impl/_operators/_tsd_operators.py
@@ -581,7 +581,8 @@ def flip_tsd_non_unique(
     ts: TSD[K, TS[K_1]], unique: bool, _state: STATE[TsdRekeyState] = None, _output: TSD_OUT[K_1, TSS[K]] = None
 ) -> TSD[K_1, TSS[K]]:
     """
-    Flip the TSD to have the time-series as the key and the key as the time-series. Collect keys for duplicate values into TSS
+    Flip the TSD to have the time-series as the key and the key as the time-series.
+    Collect keys for duplicate values into TSS
     """
     prev = _state.prev
 

--- a/src/hgraph/_impl/_operators/_tss_operators.py
+++ b/src/hgraph/_impl/_operators/_tss_operators.py
@@ -84,9 +84,8 @@ def len_tss(ts: TSS[KEYABLE_SCALAR]) -> TS[int]:
     return len(ts.value)
 
 
-@compute_node(overloads=bit_or)
-def bit_or_tsss(lhs: TSS[KEYABLE_SCALAR], rhs: TSS[KEYABLE_SCALAR], _tp: type[KEYABLE_SCALAR] = AUTO_RESOLVE) -> TSS[
-    KEYABLE_SCALAR]:
+@compute_node(overloads=bit_or, valid=())
+def bit_or_tsss(lhs: TSS[KEYABLE_SCALAR], rhs: TSS[KEYABLE_SCALAR]) -> TSS[KEYABLE_SCALAR]:
     added = lhs.added() | rhs.added()
     lhs_value = lhs.value
     removed = lhs.removed() - rhs.value

--- a/src/hgraph/_impl/_operators/_tss_operators.py
+++ b/src/hgraph/_impl/_operators/_tss_operators.py
@@ -85,7 +85,7 @@ def len_tss(ts: TSS[KEYABLE_SCALAR]) -> TS[int]:
 
 
 @compute_node(overloads=bit_or, valid=())
-def bit_or_tsss(lhs: TSS[KEYABLE_SCALAR], rhs: TSS[KEYABLE_SCALAR]) -> TSS[KEYABLE_SCALAR]:
+def bit_or_tsss(lhs: TSS[KEYABLE_SCALAR], rhs: TSS[KEYABLE_SCALAR], _tp: type[KEYABLE_SCALAR] = AUTO_RESOLVE) -> TSS[KEYABLE_SCALAR]:
     added = lhs.added() | rhs.added()
     lhs_value = lhs.value
     removed = lhs.removed() - rhs.value

--- a/src/hgraph/_impl/_runtime/_map_node.py
+++ b/src/hgraph/_impl/_runtime/_map_node.py
@@ -72,6 +72,9 @@ class PythonTsdMapNodeImpl(PythonNestedNodeImpl):
         self._count: int = 1
         self._recordable_id: str | None = None
 
+    def tsd_output(self):
+        return self._output
+
     def do_start(self):
         super().do_start()
         if has_recordable_id_trait(self.graph.traits):
@@ -188,7 +191,7 @@ class PythonTsdMapNodeImpl(PythonNestedNodeImpl):
 
         if self.output_node_id:
             # Replace the nodes output with the map node's output for the key
-            del self.output[key]
+            del self.tsd_output()[key]
 
     def _wire_graph(self, key: K, graph: Graph):
         """Connect inputs and outputs to the nodes inputs and outputs"""
@@ -217,4 +220,4 @@ class PythonTsdMapNodeImpl(PythonNestedNodeImpl):
         if self.output_node_id:
             node: Node = graph.nodes[self.output_node_id]
             # Replace the nodes output with the map node's output for the key
-            node.output = cast(TSD_OUT[str, TIME_SERIES_TYPE], self.output).get_or_create(key)
+            node.output = cast(TSD_OUT[str, TIME_SERIES_TYPE], self.tsd_output()).get_or_create(key)

--- a/src/hgraph/_impl/_runtime/_mesh_node.py
+++ b/src/hgraph/_impl/_runtime/_mesh_node.py
@@ -102,7 +102,9 @@ class PythonMeshNodeImpl(PythonTsdMapNodeImpl):
 
         self.output["ref"].value = TimeSeriesReference.make(self.output["out"])
         GlobalState.instance()[self._full_context_path] = self.output["ref"]
-        self._output = self.output["out"]
+
+    def tsd_output(self):
+        return self._output["out"]
 
     def do_stop(self):
         del GlobalState.instance()[self._full_context_path]

--- a/src/hgraph/_operators/__init__.py
+++ b/src/hgraph/_operators/__init__.py
@@ -11,6 +11,7 @@ from hgraph._operators._stream import *
 from hgraph._operators._string import *
 from hgraph._operators._time_series_conversion import *
 from hgraph._operators._time_series_properties import *
+from hgraph._operators._json import *
 from hgraph._operators._to_json import *
 from hgraph._operators._to_table import *
 from hgraph._operators._tsd_and_mapping import *

--- a/src/hgraph/_operators/_flow_control.py
+++ b/src/hgraph/_operators/_flow_control.py
@@ -14,11 +14,16 @@ __all__ = ("merge", "all_", "any_", "race", "BoolResult", "if_", "route_by_index
 
 
 @operator
-def merge(*tsl: TSL[TIME_SERIES_TYPE, SIZE]) -> TIME_SERIES_TYPE:
+def merge(*tsl: TSL[TIME_SERIES_TYPE, SIZE], **kwargs) -> TIME_SERIES_TYPE:
     """
     Selects and returns the first of the values that tick (are modified) in the list provided.
     If more than one input is modified in the engine-cycle, it will return the first one that ticked in order of the
     list.
+    if the inputs are TSDs:
+    * If keys from multiple of the TSDs tick in the same cycle, the output will contain all the unique keys.
+    * If the ticking keys are the same, the first value is returned in order of the list.
+    * If `disjoint` is set True, the TSDs are assumed to have non-overlapping keys.  This parameter should be set
+        True to optimise performance when merging disjoint TSDs.
     """
 
 

--- a/src/hgraph/_operators/_json.py
+++ b/src/hgraph/_operators/_json.py
@@ -1,0 +1,23 @@
+from typing import Type, Union
+
+from hgraph._types import TS, SCALAR, DEFAULT
+from hgraph._wiring._decorators import operator
+
+
+class JSON:
+    def __init__(self, j):
+        self.json = j
+
+    json: Union[bool, float, str, dict, list] = None
+
+
+@operator
+def json_decode(ts: TS[SCALAR]) -> TS[JSON]:
+    pass
+
+
+@operator
+def json_encode(ts: TS[JSON], _tp: Type[SCALAR] = DEFAULT[SCALAR]) -> TS[SCALAR]:
+    pass
+
+

--- a/src/hgraph/_operators/_operators.py
+++ b/src/hgraph/_operators/_operators.py
@@ -68,14 +68,6 @@ __all__ = (
 def add_(lhs: TIME_SERIES_TYPE, rhs: TIME_SERIES_TYPE_1) -> DEFAULT[OUT]:
     """
     This represents the ``+`` operator for time series types.
-    To implement the ``add_`` operator, do:
-    ::
-
-        @compute_node(overloads=add_)
-        def my_add(lhs: TS[MyType], rhs: TS[MyType]) -> TS[MyType]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -87,14 +79,6 @@ WiringPort.__radd__ = lambda x, y: add_(y, x)
 def sub_(lhs: TIME_SERIES_TYPE, rhs: TIME_SERIES_TYPE_1) -> DEFAULT[OUT]:
     """
     This represents the ``-`` operator for time series types.
-    To implement the ``sub_`` operator, do:
-    ::
-
-        @compute_node(overloads=sub_)
-        def my_sub(lhs: TS[MyType], rhs: TS[MyType]) -> TS[MyType]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -106,14 +90,6 @@ WiringPort.__rsub__ = lambda x, y: sub_(y, x)
 def mul_(lhs: TIME_SERIES_TYPE, rhs: TIME_SERIES_TYPE) -> TIME_SERIES_TYPE:
     """
     This represents the ``*`` operator for time series types.
-    To implement the ``mul_`` operator, do:
-    ::
-
-        @compute_node(overloads=mul_)
-        def my_mul(lhs: TS[MyType], rhs: TS[MyType]) -> TS[MyType]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -136,14 +112,9 @@ class DivideByZero(Enum):
 def div_(lhs: TIME_SERIES_TYPE, rhs: TIME_SERIES_TYPE, **kwargs) -> DEFAULT[OUT]:
     """
     This represents the `/` operator for time series types.
-    To implement the ``div_`` operator, do:
-    ::
 
-        @compute_node(overloads=div_)
-        def my_div(lhs: TS[MyType], rhs: TS[MyType]) -> TS[MyType]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
+    Params:
+    * divide_by_zero: DivideByZero - controls the behaviour when dividing by zero
     """
 
 
@@ -155,14 +126,6 @@ WiringPort.__rtruediv__ = lambda x, y: div_(y, x)
 def floordiv_(lhs: TIME_SERIES_TYPE, rhs: TIME_SERIES_TYPE, **kwargs) -> TIME_SERIES_TYPE:
     """
     This represents the `//` operator for time series types.
-    To implement the ``floordiv_`` operator, do:
-    ::
-
-        @compute_node(overloads=floordiv_)
-        def my_floordiv(lhs: TS[MyType], rhs: TS[MyType]) -> TS[MyType]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -174,14 +137,6 @@ WiringPort.__rfloordiv__ = lambda x, y: floordiv_(y, x)
 def mod_(lhs: TIME_SERIES_TYPE, rhs: TIME_SERIES_TYPE) -> TIME_SERIES_TYPE:
     """
     This represents the `%` operator for time series types.
-    To implement the ``mod_`` operator, do:
-    ::
-
-        @compute_node(overloads=mod_)
-        def my_mod(lhs: TS[MyType], rhs: TS[MyType]) -> TS[MyType]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -194,14 +149,6 @@ def divmod_(lhs: TIME_SERIES_TYPE, rhs: TIME_SERIES_TYPE) -> TSL[TIME_SERIES_TYP
     """
     This represents the `divmod` operator for time series types.
     (This is defined in Python as the integer division with remainder, i.e. divmod(9, 4) == (2, 1))
-    To implement the ``divmod_`` operator, do:
-    ::
-
-        @compute_node(overloads=divmod_)
-        def my_divmod(lhs: TS[MyType], rhs: TS[MyType]) -> TSL[TS[MyType], Size[2]]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -213,14 +160,8 @@ WiringPort.__rdivmod__ = lambda x, y: divmod_(y, x)
 def pow_(lhs: TIME_SERIES_TYPE, rhs: TIME_SERIES_TYPE) -> TIME_SERIES_TYPE:
     """
     This represents the `**` operator for time series types.
-    To implement the ``pow_`` operator, do:
-    ::
-
-        @compute_node(overloads=pow_)
-        def my_pow(lhs: TS[MyType], rhs: TS[MyType]) -> TS[MyType]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
+    Params:
+    * divide_by_zero: DivideByZero - controls the behaviour when dividing by zero
     """
 
 
@@ -232,14 +173,6 @@ WiringPort.__rpow__ = lambda x, y: pow_(y, x)
 def lshift_(lhs: TIME_SERIES_TYPE, rhs: TIME_SERIES_TYPE) -> TIME_SERIES_TYPE:
     """
     This represents the ``<<`` operator for time series types.
-    To implement the ``lshift_`` operator, do:
-    ::
-
-        @compute_node(overloads=lshift_)
-        def my_lshift(lhs: TS[MyType], rhs: TS[MyType]) -> TS[MyType]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -251,14 +184,6 @@ WiringPort.__rlshift__ = lambda x, y: lshift_(y, x)
 def rshift_(lhs: TIME_SERIES_TYPE, rhs: TIME_SERIES_TYPE) -> TIME_SERIES_TYPE:
     """
     This represents the ``>>`` operator for time series types.
-    To implement the ``rshift_`` operator, do:
-    ::
-
-        @compute_node(overloads=rshift_)
-        def my_rshift(lhs: TS[MyType], rhs: TS[MyType]) -> TS[MyType]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -270,15 +195,6 @@ WiringPort.__rrshift__ = lambda x, y: rshift_(y, x)
 def bit_and(lhs: TIME_SERIES_TYPE, rhs: TIME_SERIES_TYPE) -> DEFAULT[OUT]:
     """
     This represents the ``&`` operator for time series types.
-
-    To implement the & operator, do:
-    ::
-
-        @compute_node(overloads=bit_and)
-        def my_and_op(lhs: TS[MyType], rhs: TS[MyType]) -> TS[MyType]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -293,15 +209,6 @@ def and_(lhs: TIME_SERIES_TYPE, rhs: TIME_SERIES_TYPE) -> TS[bool]:
 
     This operator does not substitute ``and`` (since that is not possible in Python), but can be used as a functional
     equivalent for ``and``.
-
-    To implement the ``and_`` operator, do:
-    ::
-
-        @compute_node(overloads=and_)
-        def my_and(lhs: TS[MyType], rhs: TS[MyType]) -> TS[bool]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -309,15 +216,6 @@ def and_(lhs: TIME_SERIES_TYPE, rhs: TIME_SERIES_TYPE) -> TS[bool]:
 def bit_or(lhs: TIME_SERIES_TYPE, rhs: TIME_SERIES_TYPE) -> TS[TIME_SERIES_TYPE_1]:
     """
     This represents the ``|`` operator for time series types.
-
-    To implement the ``or_`` operator, do:
-    ::
-
-        @compute_node(overloads=bit_or)
-        def my_or(lhs: TS[MyType], rhs: TS[MyType]) -> TS[MyType]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -332,15 +230,6 @@ def or_(lhs: TIME_SERIES_TYPE, rhs: TIME_SERIES_TYPE) -> TS[bool]:
 
     This operator does not substitute ``or`` (since that is not possible in Python), but can be used as a functional
     equivalent for ``or``.
-
-    To implement the ``or_`` operator, do:
-    ::
-
-        @compute_node(overloads=or_)
-        def my_or(lhs: TS[MyType], rhs: TS[MyType]) -> TS[bool]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -348,15 +237,6 @@ def or_(lhs: TIME_SERIES_TYPE, rhs: TIME_SERIES_TYPE) -> TS[bool]:
 def bit_xor(lhs: TIME_SERIES_TYPE, rhs: TIME_SERIES_TYPE) -> DEFAULT[OUT]:
     """
     This represents the ``^`` operator for time series types.
-
-    To implement the ``xor_`` operator, do:
-    ::
-
-        @compute_node(overloads=bit_xor)
-        def my_xor(lhs: TS[MyType], rhs: TS[MyType]) -> TS[MyType]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -368,15 +248,6 @@ WiringPort.__rxor__ = lambda x, y: bit_xor(y, x)
 def eq_(lhs: TIME_SERIES_TYPE, rhs: TIME_SERIES_TYPE) -> TS[bool]:
     """
     This represents the ``==`` operator for time series types.
-
-    To implement the ``eq_`` operator, do:
-    ::
-
-        @compute_node(overloads=eq_)
-        def my_eq(lhs: TS[MyType], rhs: TS[MyType]) -> TS[bool]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -390,15 +261,6 @@ WiringPort.__eq__ = lambda x, y: eq_(x, y)
 def ne_(lhs: TIME_SERIES_TYPE, rhs: TIME_SERIES_TYPE) -> TS[bool]:
     """
     This represents the ``!=`` operator for time series types.
-
-    To implement the ``ne_`` operator, do:
-    ::
-
-        @compute_node(overloads=ne_)
-        def my_ne(lhs: TS[MyType], rhs: TS[MyType]) -> TS[bool]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -409,14 +271,6 @@ WiringPort.__ne__ = lambda x, y: ne_(x, y)
 def lt_(lhs: TIME_SERIES_TYPE, rhs: TIME_SERIES_TYPE) -> TS[bool]:
     """
     This represents the ``<`` operator for time series types.
-    To implement the ``lt_`` operator, do:
-    ::
-
-        @compute_node(overloads=lt_)
-        def my_lt(lhs: TS[MyType], rhs: TS[MyType]) -> TS[bool]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -427,15 +281,6 @@ WiringPort.__lt__ = lambda x, y: lt_(x, y)
 def le_(lhs: TIME_SERIES_TYPE, rhs: TIME_SERIES_TYPE) -> TS[bool]:
     """
     This represents the ``<=`` operator for time series types.
-
-    To implement the ``le_`` operator, do:
-    ::
-
-        @compute_node(overloads=le_)
-        def my_le(lhs: TS[MyType], rhs: TS[MyType]) -> TS[bool]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -446,15 +291,6 @@ WiringPort.__le__ = lambda x, y: le_(x, y)
 def gt_(lhs: TIME_SERIES_TYPE, rhs: TIME_SERIES_TYPE) -> TS[bool]:
     """
     This represents the ``>`` operator for time series types.
-
-    To implement the ``gt_`` operator, do:
-    ::
-
-        @compute_node(overloads=gt_)
-        def my_gt(lhs: TS[MyType], rhs: TS[MyType]) -> TS[bool]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -465,15 +301,6 @@ WiringPort.__gt__ = lambda x, y: gt_(x, y)
 def ge_(lhs: TIME_SERIES_TYPE, rhs: TIME_SERIES_TYPE) -> TS[bool]:
     """
     This represents the ``>=`` operator for time series types.
-
-    To implement the ``ge_`` operator, do:
-    ::
-
-        @compute_node(overloads=ge_)
-        def my_ge(lhs: TS[MyType], rhs: TS[MyType]) -> TS[bool]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -484,15 +311,6 @@ WiringPort.__ge__ = lambda x, y: ge_(x, y)
 def neg_(ts: TIME_SERIES_TYPE) -> TIME_SERIES_TYPE:
     """
     This represents the unary ``-`` operator for time series types.
-
-    To implement the ``neg_`` operator, do:
-    ::
-
-        @compute_node(overloads=neg_)
-        def my_neg(ts: TS[MyType]) -> TS[MyType]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -503,15 +321,6 @@ WiringPort.__neg__ = lambda x: neg_(x)
 def pos_(ts: TIME_SERIES_TYPE) -> TIME_SERIES_TYPE:
     """
     This represents the unary ``+`` operator for time series types.
-
-    To implement the ``pos_`` operator, do:
-    ::
-
-        @compute_node(overloads=pos_)
-        def my_pos(ts: TS[MyType]) -> TS[MyType]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -522,15 +331,6 @@ WiringPort.__pos__ = lambda x: pos_(x)
 def abs_(ts: TIME_SERIES_TYPE) -> TIME_SERIES_TYPE:
     """
     This represents the ``abs`` operator for time series types.
-
-    To implement the ``abs_`` operator, do:
-    ::
-
-        @compute_node(overloads=abs_)
-        def my_abs(ts: TS[MyType]) -> TS[MyType]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -541,15 +341,6 @@ WiringPort.__abs__ = lambda x: abs_(x)
 def invert_(ts: TIME_SERIES_TYPE) -> TIME_SERIES_TYPE:
     """
     This represents the unary ``~`` operator for time series types.
-
-    To implement the ``pos_`` operator, do:
-    ::
-
-        @compute_node(overloads=pos_)
-        def my_pos(ts: TS[MyType]) -> TS[MyType]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -564,15 +355,6 @@ def contains_(ts: TIME_SERIES_TYPE, item: TS[SCALAR]) -> TS[bool]:
     ``contains_(ts, item)``.
 
     This is logically: ``item in ts``
-
-    To implement the ``contains_`` operator, do:
-    ::
-
-        @compute_node(overloads=contains_)
-        def my_contains(ts: TS[MyType], item: TS[SCALAR]) -> TS[bool]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -582,15 +364,6 @@ def not_(ts: TIME_SERIES_TYPE) -> TS[bool]:
     This represents the unary `not` operator for time series types.
 
     This must be called as ``not_(ts)`` it is not possible to overload the standard ``not`` operator.
-
-    To implement the ``not_`` operator, do:
-    ::
-
-        @compute_node(overloads=not_)
-        def my_not(ts: TS[MyType]) -> TS[MyType]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -600,15 +373,6 @@ def getitem_(ts: TIME_SERIES_TYPE, key: TS[SCALAR]) -> TIME_SERIES_TYPE_1:
     This represents the ``[]`` operator for time-series types.
 
     Use this as: ``ts[key]``
-
-    To implement the ``getitem_`` operator, do:
-    ::
-
-        @compute_node(overloads=getitem_)
-        def my_getitem(ts: TS[MyType], item: TS[SCALAR]) -> TS[SomeScalar]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -621,15 +385,6 @@ def getattr_(ts: TIME_SERIES_TYPE, attr: str, default_value: SCALAR = None) -> T
     This represents the ``.`` operator for time-series types.
 
     Use this as: ``ts.attr`` or more explicitly: ``getattr_(ts, attr)``
-
-    To implement the ``getattr_`` operator, do:
-    ::
-
-        @compute_node(overloads=getattr_)
-        def my_getattr(ts: TS[MyType], attr: str) -> TS[SomeScalar]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 
@@ -648,9 +403,10 @@ def min_(*ts: TSL[TS[SCALAR], SIZE], default_value: TS[SCALAR] = None, __strict_
     """
     This represents the ``min`` operator for time series types.
 
-    Unary implies the min over the latest TS value for collection types, or running min for non-collection types
-    Binary or multi arg implies item-wise min over all the arguments for collection types,
-    or the minimum scalar value for scalar types
+    * Unary implies the min over the latest TS value for collection types, or running min for non-collection types
+        In the case of a running sum, a 'reset' signal may be provided, which resets the sum to zero when it ticks
+    * Binary or multi arg implies item-wise min over all the arguments for collection types,
+        or the minimum scalar value for scalar types
 
     __strict__ controls whether the operator will tick if any of the arguments are missing
     """
@@ -661,22 +417,24 @@ def max_(*ts: TSL[TS[SCALAR], SIZE], default_value: TS[SCALAR] = None, __strict_
     """
     The ``max`` operator for time series types.
 
-    Unary implies the max over the latest TS value for collection types, or running max for non-collection types
-    Binary or multi arg implies item-wise max over all the arguments for collection types,
-    or the maximum scalar value for scalar types
+    * Unary implies the max over the latest TS value for collection types, or running max for non-collection types
+        In the case of a running sum, a 'reset' signal may be provided, which resets the sum to zero when it ticks
+    * Binary or multi arg implies item-wise max over all the arguments for collection types,
+        or the maximum scalar value for scalar types
 
     __strict__ controls whether the operator will tick if any of the arguments are missing
     """
 
 
 @operator
-def sum_(*ts: TSL[TS[SCALAR], SIZE]) -> DEFAULT[OUT]:
+def sum_(*ts: TSL[TS[SCALAR], SIZE], **kwargs) -> DEFAULT[OUT]:
     """
     This represents the ``sum`` operator for time series types, either as a binary or unary operator
 
-    Unary implies the sum over the latest TS value for collection types, or running sum for non-collection types
-    Binary or multi arg implies item-wise sum over all the arguments for collection types,
-    or the sum of the scalar value for scalar types
+    * Unary implies the sum over the latest TS value for collection types, or running sum for non-collection types.
+        In the case of a running sum, a 'reset' signal may be provided, which resets the sum to zero when it ticks
+    * Binary or multi arg implies item-wise sum over all the arguments for collection types,
+        or the sum of the scalar value for scalar types
     """
 
 
@@ -685,7 +443,7 @@ def mean(*ts: TSL[TIME_SERIES_TYPE, SIZE]) -> DEFAULT[OUT]:
     """
     This represents the ``mean`` operator for time series types
 
-    Unary implies the mean over the latest TS value for collection types, or running sum for non-collection types
+    Unary implies the mean over the latest TS value for collection types, or running mean for non-collection types
     Binary or multi arg implies item-wise sum over all the arguments for collection types,
     or the sum of the scalar value for scalar types
     """
@@ -726,15 +484,6 @@ def zero(tp: Type[TIME_SERIES_TYPE], op: WiringNodeClass) -> TIME_SERIES_TYPE:
 def len_(ts: TIME_SERIES_TYPE) -> TS[int]:
     """
     This represents the `len` operator for time series types.
-
-    To implement the ``len_`` operator, do:
-    ::
-
-        @compute_node(overloads=len_)
-        def my_len(ts: TS[MyType]) -> TS[int]:
-            ...
-
-    Then ensure that the code is imported before performing the operation.
     """
 
 

--- a/src/hgraph/_operators/_tsd_and_mapping.py
+++ b/src/hgraph/_operators/_tsd_and_mapping.py
@@ -44,9 +44,11 @@ def rekey(ts: TIME_SERIES_TYPE, new_keys: TIME_SERIES_TYPE_1) -> DEFAULT[OUT]:
 
 
 @operator
-def flip(ts: TIME_SERIES_TYPE) -> DEFAULT[OUT]:
+def flip(ts: TIME_SERIES_TYPE, **kwargs) -> DEFAULT[OUT]:
     """
     Flips the dictionary so that the values become the keys and the keys become the values.
+    Params:
+    * unique: bool - if False, collects multiple keys into a TSS output instead of a single TS
     """
 
 

--- a/src/hgraph/_runtime/_global_state.py
+++ b/src/hgraph/_runtime/_global_state.py
@@ -148,6 +148,15 @@ class GlobalState(object):
         else:
             return self._previous.get(key, default)
 
+    def setdefault(self, key: str, default: Any) -> Any:
+        if key in self._state:
+            return self._state[key]
+        if self._previous is not None:
+            return self._previous.setdefault(key, default)
+        else:
+            self._state[key] = default
+            return default
+
     def keys(self):
         return self._state.keys()
 

--- a/src/hgraph/_types/_tsb_meta_data.py
+++ b/src/hgraph/_types/_tsb_meta_data.py
@@ -164,7 +164,13 @@ class HgTimeSeriesSchemaTypeMetaData(HgTimeSeriesTypeMetaData):
         return super().parse_value(value)
 
     def __eq__(self, o: object) -> bool:
-        return type(o) is HgTimeSeriesSchemaTypeMetaData and self.meta_data_schema == o.meta_data_schema
+        from ._tsb_type import UnNamedTimeSeriesSchema
+        if type(o) is HgTimeSeriesSchemaTypeMetaData:
+            if self.py_type == o.py_type:
+                return True
+            elif isinstance(self.py_type, UnNamedTimeSeriesSchema) or isinstance(o.py_type, UnNamedTimeSeriesSchema):
+                return self.meta_data_schema == o.meta_data_schema
+        return False
 
     def __str__(self) -> str:
         return self.py_type.__name__

--- a/src/hgraph/_types/_tsb_type.py
+++ b/src/hgraph/_types/_tsb_type.py
@@ -451,11 +451,11 @@ class TimeSeriesBundleInput(TimeSeriesInput, TimeSeriesBundle[TS_SCHEMA], Generi
     """
 
     @staticmethod
-    def _validate_kwargs(schema: TS_SCHEMA, **kwargs):
+    def _validate_kwargs(__schema__: TS_SCHEMA, **kwargs):
         from hgraph._wiring._wiring_port import WiringPort
         from hgraph._types._type_meta_data import HgTypeMetaData
 
-        meta_data_schema: dict[str, "HgTypeMetaData"] = schema.__meta_data_schema__
+        meta_data_schema: dict[str, "HgTypeMetaData"] = __schema__.__meta_data_schema__
         if any(k not in meta_data_schema for k in kwargs.keys()):
             from hgraph._wiring._wiring_errors import InvalidArgumentsProvided
 
@@ -473,7 +473,7 @@ class TimeSeriesBundleInput(TimeSeriesInput, TimeSeriesBundle[TS_SCHEMA], Generi
                     with WiringContext(
                         current_arg=k,
                         current_signature=STATE(
-                            signature=f"TSB[{schema.__name__}].from_ts({', '.join(kwargs.keys())})"
+                            signature=f"TSB[{__schema__.__name__}].from_ts({', '.join(kwargs.keys())})"
                         ),
                     ):
                         raise IncorrectTypeBinding(expected_type=meta_data_schema[k], actual_type=v.output_type)
@@ -494,7 +494,7 @@ class TimeSeriesBundleInput(TimeSeriesInput, TimeSeriesBundle[TS_SCHEMA], Generi
 
                 with WiringContext(
                     current_arg=k,
-                    current_signature=STATE(signature=f"TSB[{schema.__name__}].from_ts({', '.join(kwargs.keys())})"),
+                    current_signature=STATE(signature=f"TSB[{__schema__.__name__}].from_ts({', '.join(kwargs.keys())})"),
                 ):
                     raise IncorrectTypeBinding(expected_type=meta_data_schema[k], actual_type=v)
 
@@ -526,7 +526,7 @@ class TimeSeriesBundleInput(TimeSeriesInput, TimeSeriesBundle[TS_SCHEMA], Generi
             else:
                 raise ParseError(f"Expected a dictionary of values, got {arg}")
 
-        kwargs = TimeSeriesBundleInput._validate_kwargs(schema, **kwargs)
+        kwargs = TimeSeriesBundleInput._validate_kwargs(__schema__=schema, **kwargs)
 
         from hgraph import (
             WiringNodeSignature,

--- a/src/hgraph/_types/_tsd_type.py
+++ b/src/hgraph/_types/_tsd_type.py
@@ -70,6 +70,9 @@ class TimeSeriesDict(TimeSeriesIterable[K, V], TimeSeriesDeltaValue[frozendict, 
             return out
         if item != (K, V):
             from hgraph._types._type_meta_data import HgTypeMetaData
+            
+            if hasattr(out, "__init_fix__"):
+                return out
 
             __key_tp__ = HgTypeMetaData.parse_type(item[0])
             __value_tp__ = HgTypeMetaData.parse_type(item[1])
@@ -89,6 +92,7 @@ class TimeSeriesDict(TimeSeriesIterable[K, V], TimeSeriesDeltaValue[frozendict, 
             out.__value_tp__ = __value_tp__
             _init = out.__init__
             out.__init__ = lambda *args, **kwargs: _init(out.__key_tp__, out.__value_tp__, *args, **kwargs)
+            out.__init_fix__ = True
         return out
 
     def __len__(self):

--- a/src/hgraph/_wiring/_decorators.py
+++ b/src/hgraph/_wiring/_decorators.py
@@ -109,6 +109,7 @@ def compute_node(
     overloads: "WiringNodeClass" | COMPUTE_NODE_SIGNATURE = None,
     resolvers: Mapping["Type", Callable] = None,
     requires: Callable[[..., ...], bool] = None,
+    label: str | None = None,
     deprecated: bool | str = False,
 ) -> COMPUTE_NODE_SIGNATURE:
     """
@@ -215,6 +216,7 @@ def compute_node(
         overloads=overloads,
         resolvers=resolvers,
         requires=requires,
+        label=label,
         deprecated=deprecated,
     )
 
@@ -225,6 +227,7 @@ def pull_source_node(
     node_impl=None,
     resolvers: Mapping["TypeVar", Callable] = None,
     requires: Callable[[..., ...], bool] = None,
+    label: str | None = None,
     deprecated: bool | str = False,
 ) -> SOURCE_NODE_SIGNATURE:
     """
@@ -234,7 +237,7 @@ def pull_source_node(
     from hgraph._wiring._wiring_node_signature import WiringNodeType
 
     return _node_decorator(
-        WiringNodeType.PULL_SOURCE_NODE, fn, node_impl, resolvers=resolvers, requires=requires, deprecated=deprecated
+        WiringNodeType.PULL_SOURCE_NODE, fn, node_impl, resolvers=resolvers, requires=requires, label=label, deprecated=deprecated
     )
 
 
@@ -244,6 +247,7 @@ def push_source_node(
     node_impl=None,
     resolvers: Mapping["TypeVar", Callable] = None,
     requires: Callable[[..., ...], bool] = None,
+    label: str | None = None,
     deprecated: bool | str = False,
 ) -> SOURCE_NODE_SIGNATURE:
     """
@@ -252,7 +256,7 @@ def push_source_node(
     from hgraph._wiring._wiring_node_signature import WiringNodeType
 
     return _node_decorator(
-        WiringNodeType.PUSH_SOURCE_NODE, fn, node_impl, resolvers=resolvers, requires=requires, deprecated=deprecated
+        WiringNodeType.PUSH_SOURCE_NODE, fn, node_impl, resolvers=resolvers, requires=requires, label=label, deprecated=deprecated
     )
 
 
@@ -266,6 +270,7 @@ def sink_node(
     overloads: "WiringNodeClass" | SINK_NODE_SIGNATURE = None,
     resolvers: Mapping["Type", Callable] = None,
     requires: Callable[[..., ...], bool] = None,
+    label: str | None = None,
     deprecated: bool | str = False,
 ) -> SINK_NODE_SIGNATURE:
     """
@@ -305,6 +310,7 @@ def sink_node(
         overloads=overloads,
         resolvers=resolvers,
         requires=requires,
+        label=label,
         deprecated=deprecated,
     )
 
@@ -314,6 +320,7 @@ def graph(
     overloads: "WiringNodeClass" | GRAPH_SIGNATURE = None,
     resolvers: Mapping["TypeVar", Callable] = None,
     requires: Callable[[..., ...], bool] = None,
+    label: str | None = None,
     deprecated: bool | str = False,
 ) -> GRAPH_SIGNATURE:
     """
@@ -357,7 +364,7 @@ def graph(
     from hgraph._wiring._wiring_node_signature import WiringNodeType
 
     return _node_decorator(
-        WiringNodeType.GRAPH, fn, overloads=overloads, resolvers=resolvers, requires=requires, deprecated=deprecated
+        WiringNodeType.GRAPH, fn, overloads=overloads, resolvers=resolvers, requires=requires, label=label, deprecated=deprecated
     )
 
 
@@ -366,6 +373,7 @@ def const_fn(
     overloads: "WiringNodeClass" | GRAPH_SIGNATURE = None,
     resolvers: Mapping["TypeVar", Callable] = None,
     requires: Callable[[..., ...], bool] = None,
+    label: str | None = None,
     deprecated: bool | str = False,
 ) -> SOURCE_NODE_SIGNATURE:
     """
@@ -401,6 +409,7 @@ def const_fn(
         node_class=PythonConstWiringNodeClass,
         resolvers=resolvers,
         requires=requires,
+        label=label,
         deprecated=deprecated,
     )
 
@@ -410,6 +419,7 @@ def generator(
     overloads: "WiringNodeClass" | GRAPH_SIGNATURE = None,
     resolvers: Mapping["TypeVar", Callable] = None,
     requires: Callable[[..., ...], bool] = None,
+    label: str | None = None,
     deprecated: bool | str = False,
 ) -> SOURCE_NODE_SIGNATURE:
     """
@@ -442,6 +452,7 @@ def generator(
         node_class=PythonGeneratorWiringNodeClass,
         resolvers=resolvers,
         requires=requires,
+        label=label,
         deprecated=deprecated,
     )
 
@@ -451,6 +462,7 @@ def push_queue(
     overloads: "WiringNodeClass" | SOURCE_NODE_SIGNATURE = None,
     resolvers: Mapping["TypeVar", Callable] = None,
     requires: Callable[[..., ...], bool] = None,
+    label: str | None = None,
     deprecated: bool | str = False,
 ):
     """
@@ -511,6 +523,7 @@ def push_queue(
                 node_type=WiringNodeType.PUSH_SOURCE_NODE,
                 deprecated=deprecated,
                 requires=requires,
+                label=label,
             ),
             impl_fn=fn,
             node_type=WiringNodeType.PUSH_SOURCE_NODE,
@@ -750,6 +763,7 @@ def service_adaptor_impl(
     *,
     interfaces: Sequence[SERVICE_DEFINITION] | SERVICE_DEFINITION = None,
     resolvers: Mapping["TypeVar", Callable] = None,
+    label: str | None = None,
     deprecated: bool | str = False,
 ):
     """
@@ -758,7 +772,7 @@ def service_adaptor_impl(
     from hgraph._wiring._wiring_node_signature import WiringNodeType
 
     return _node_decorator(
-        WiringNodeType.SERVICE_ADAPTOR_IMPL, None, interfaces=interfaces, resolvers=resolvers, deprecated=deprecated
+        WiringNodeType.SERVICE_ADAPTOR_IMPL, None, interfaces=interfaces, resolvers=resolvers, label=label, deprecated=deprecated
     )
 
 
@@ -795,6 +809,7 @@ def component(
     *,
     recordable_id: str | None = None,
     resolvers: Mapping["TypeVar", Callable] = None,
+    label: str | None = None,
     deprecated: bool | str = False,
 ) -> GRAPH_SIGNATURE:
     """
@@ -837,7 +852,7 @@ def component(
     from hgraph._wiring._wiring_node_signature import WiringNodeType
 
     return _node_decorator(
-        WiringNodeType.COMPONENT, fn, resolvers=resolvers, deprecated=deprecated, record_and_replay_id=recordable_id
+        WiringNodeType.COMPONENT, fn, resolvers=resolvers, deprecated=deprecated, record_and_replay_id=recordable_id, label=label
     )
 
 
@@ -853,6 +868,7 @@ def _node_decorator(
     interfaces=None,
     resolvers: Mapping["TypeVar", Callable] = None,
     requires: Callable[[..., ...], bool] = None,
+    label: str | None = None,
     deprecated: bool | str = False,
     record_and_replay_id: str | None = None,
     wrap_with_graph: bool = False,
@@ -871,6 +887,7 @@ def _node_decorator(
         interfaces=interfaces,
         deprecated=deprecated,
         requires=requires,
+        label=label,
         record_and_replay_id=record_and_replay_id,
         wrap_with_graph=wrap_with_graph,
     )
@@ -1001,6 +1018,7 @@ def _create_node(
     interfaces=None,
     deprecated: bool | str = False,
     requires: Callable[[..., ...], bool] = None,
+    label: str | None = None,
     record_and_replay_id: str | None = None,
     wrap_with_graph: bool = False,
 ) -> "WiringNodeClass":
@@ -1038,6 +1056,7 @@ def _create_node(
             all_valid_inputs=all_valid_inputs,
             deprecated=deprecated,
             requires=requires,
+            label=label,
             record_and_replay_id=record_and_replay_id,
         )
     )
@@ -1059,6 +1078,7 @@ def _create_node_signature(
     all_valid_inputs: frozenset[str] = None,
     defaults: dict[str, Any] = None,
     deprecated: bool | str = False,
+    label: str | None = None,
     requires: Callable[[..., ...], bool] | None = None,
 ) -> Callable:
     """
@@ -1087,6 +1107,7 @@ def _create_node_signature(
         time_series_args=frozenset(),
         injectables=extract_injectables(**kwargs),
         deprecated=deprecated,
+        label=label,
         requires=requires,
     )
     return signature

--- a/src/hgraph/_wiring/_dispatch.py
+++ b/src/hgraph/_wiring/_dispatch.py
@@ -197,6 +197,9 @@ def _dispatch_impl(
 
         from hgraph import type_
 
+        if len(dispatch_map) == 0:
+            raise RuntimeError(f"No suitable overloads found for when wiring {signature} for {kwargs}")
+
         key = adjust_dispatch_key(type_(kwargs_[nth(dispatch_args.keys(), 0)]), tuple(dispatch_map.keys()))
     else:
 

--- a/src/hgraph/_wiring/_exception_handling.py
+++ b/src/hgraph/_wiring/_exception_handling.py
@@ -109,7 +109,7 @@ def try_except(
             # We have constructed the map so that the key are is always present.
             unresolved_args=frozenset(),
             time_series_args=time_series_args,
-            label=f"try_except({resolved_signature.signature}, {', '.join(resolved_signature.args)})",
+            # label=f"try_except({resolved_signature.signature}, {', '.join(resolved_signature.args)})",
         )
         from hgraph import TryExceptWiringNodeClass
 

--- a/src/hgraph/_wiring/_mesh.py
+++ b/src/hgraph/_wiring/_mesh.py
@@ -178,7 +178,7 @@ def _create_mesh_wiring_node(
         context_inputs=None,
         unresolved_args=frozenset(),
         time_series_args=frozenset(k for k, v in input_types.items() if not v.is_scalar),
-        label=f"mesh('{resolved_signature.signature}', {', '.join(input_types.keys())})",
+        # label=f"mesh('{resolved_signature.signature}', {', '.join(input_types.keys())})",
     )
 
     try:

--- a/src/hgraph/_wiring/_nested_graph.py
+++ b/src/hgraph/_wiring/_nested_graph.py
@@ -57,7 +57,7 @@ def nested_graph(
             context_inputs=None,
             unresolved_args=frozenset(),
             time_series_args=time_series_args,
-            label=f"nested_graph({resolved_signature.signature}, {', '.join(resolved_signature.args)})",
+            # label=f"nested_graph({resolved_signature.signature}, {', '.join(resolved_signature.args)})",
         )
         from hgraph import NestedGraphWiringNodeClass
 

--- a/src/hgraph/_wiring/_reduce.py
+++ b/src/hgraph/_wiring/_reduce.py
@@ -185,7 +185,7 @@ def _reduce_tsd(func, ts, zero, is_associative=True) -> TIME_SERIES_TYPE:
         unresolved_args=resolved_signature.unresolved_args,
         time_series_args=resolved_signature.time_series_args,
         injectables=resolved_signature.injectables,
-        label=resolved_signature.label,
+        # label=resolved_signature.label,
     )
 
     if not isinstance(func, WiringNodeClass):

--- a/src/hgraph/_wiring/_switch.py
+++ b/src/hgraph/_wiring/_switch.py
@@ -141,7 +141,7 @@ def switch_(
             # We have constructed the map so that the key are is always present.
             unresolved_args=frozenset(),
             time_series_args=time_series_args,
-            label=f"switch_({{{', '.join(f'{k}: ...' for k in cases)}}}, ...)",
+            # label=f"switch_({{{', '.join(f'{k}: ...' for k in cases)}}}, ...)",
         )
 
         nested_graphs = {}

--- a/src/hgraph/_wiring/_wiring_node_class/_adaptor_impl_node_class.py
+++ b/src/hgraph/_wiring/_wiring_node_class/_adaptor_impl_node_class.py
@@ -86,15 +86,18 @@ class AdaptorImplNodeClass(GraphWiringNodeClass):
                 self.signature, *args, __pre_resolved_types__=pre_resolved_types, **(kwargs | scalars)
             )
 
-            with WiringGraphContext(node_signature=self.signature):
-                if len(self.interfaces) == 1:
+            if len(self.interfaces) == 1:
+                with WiringGraphContext(node_signature=resolved_signature):
                     from_graph = __interface__.wire_impl_inputs_stub(path, resolution_dict, **scalars)
-                    to_graph = self.implementation_graph.__call__(
-                        __pre_resolved_types__=resolution_dict, **kwargs_, **from_graph.as_dict()
-                    )
-                    if to_graph is not None:
+
+                to_graph = self.implementation_graph.__call__(
+                    __pre_resolved_types__=resolution_dict, **kwargs_, **from_graph.as_dict()
+                )
+                if to_graph is not None:
+                    with WiringGraphContext(node_signature=resolved_signature):
                         __interface__.wire_impl_out_stub(path, to_graph, resolution_dict, **scalars)
-                else:  # multiadaptor/multiservice implementations use the interface stub APIs to wire up the service
+            else:  # multiadaptor/multiservice implementations use the interface stub APIs to wire up the service
+                with WiringGraphContext(node_signature=resolved_signature):
                     self.implementation_graph.__call__(__pre_resolved_types__=resolution_dict, **kwargs_)
 
     def __eq__(self, other):

--- a/src/hgraph/_wiring/_wiring_node_class/_adaptor_node_class.py
+++ b/src/hgraph/_wiring/_wiring_node_class/_adaptor_node_class.py
@@ -39,7 +39,7 @@ class AdaptorNodeClass(ServiceInterfaceNodeClass):
                 self.signature, *args, __pre_resolved_types__=__pre_resolved_types__, **kwargs
             )
 
-            with WiringGraphContext(self.signature) as g:
+            with WiringGraphContext(resolved_signature) as g:
                 inputs = {k: v for k, v in kwargs_.items() if k in resolved_signature.time_series_inputs}
                 scalars = {k: v for k, v in kwargs_.items() if k in resolved_signature.scalar_inputs and k != "path"}
 
@@ -85,7 +85,7 @@ class AdaptorNodeClass(ServiceInterfaceNodeClass):
             )
 
             if resolved_signature.output_type:
-                with WiringGraphContext(self.signature) as g:
+                with WiringGraphContext(resolved_signature) as g:
                     scalars = {
                         k: v for k, v in kwargs_.items() if k in resolved_signature.scalar_inputs and k != "path"
                     }

--- a/src/hgraph/_wiring/_wiring_node_class/_map_wiring_node.py
+++ b/src/hgraph/_wiring/_wiring_node_class/_map_wiring_node.py
@@ -99,18 +99,22 @@ class TslMapWiringNodeClass(BaseWiringNodeClass):
 
     def _map_with_index(self, **kwargs) -> "WiringPort": ...
 
-    def _map_no_index(self, **kwargs) -> "WiringPort":
+    def _map_no_index(self, __label__=None, **kwargs) -> "WiringPort":
         """In this scenario, we can just map the nodes using the max size"""
         from hgraph._types._scalar_types import Size
         from hgraph._operators._time_series_conversion import const
         from hgraph._types._tsl_type import TSL
 
-        out = []
+        outs = []
 
         for i in range(cast(Size, self.signature.size_tp.py_type).SIZE):
             kwargs_ = {k: v[i] if k in self.signature.multiplexed_args else v for k, v in kwargs.items()}
             if self.signature.key_arg:
                 kwargs_ = {self.signature.key_arg: const(i)} | kwargs_
-            out.append(self.fn(**kwargs_))
+            outs.append(self.fn(**kwargs_))
 
-        return TSL.from_ts(*out)
+        out = TSL.from_ts(*outs)
+        if __label__ is not None:
+            out.node_instance.label = __label__
+
+        return out

--- a/src/hgraph/_wiring/_wiring_node_class/_service_adaptor_impl_node_class.py
+++ b/src/hgraph/_wiring/_wiring_node_class/_service_adaptor_impl_node_class.py
@@ -54,13 +54,16 @@ class ServiceAdaptorImplNodeClass(AdaptorImplNodeClass):
                 self.signature, *args, __pre_resolved_types__=pre_resolved_types, **(kwargs | scalars)
             )
 
-            with WiringGraphContext(node_signature=self.signature):
+            with WiringGraphContext(node_signature=resolved_signature):
                 from_graph = __interface__.wire_impl_inputs_stub(path, resolution_dict, **scalars).as_dict()
-                to_graph = self.implementation_graph.__call__(
-                    __pre_resolved_types__=resolution_dict,
-                    **{k: v for k, v in kwargs_.items() if k not in from_graph},
-                    **from_graph,
-                )
+
+            to_graph = self.implementation_graph.__call__(
+                __pre_resolved_types__=resolution_dict,
+                **{k: v for k, v in kwargs_.items() if k not in from_graph},
+                **from_graph,
+            )
+            
+            with WiringGraphContext(node_signature=resolved_signature):
                 __interface__.wire_impl_out_stub(path, to_graph, resolution_dict, **scalars)
 
     def validate_signature_vs_interfaces(

--- a/src/hgraph/_wiring/_wiring_node_class/_service_impl_node_class.py
+++ b/src/hgraph/_wiring/_wiring_node_class/_service_impl_node_class.py
@@ -345,7 +345,6 @@ def wire_request_reply_service(
 
     from hgraph._wiring._decorators import graph
 
-    @graph
     def request_reply_service():
         g = graph(fn)
         if "path" in g.signature.args:
@@ -356,7 +355,7 @@ def wire_request_reply_service(
         out = g[resolution_dict](**(requests.as_dict() | scalars))
         interface[interface_resolution_dict].wire_impl_out_stub(path, out)
 
-    with WiringNodeInstanceContext(), WiringGraphContext(wiring_signature) as context:
+    with WiringNodeInstanceContext(), WiringGraphContext() as context:
         request_reply_service()
         sink_nodes = context.pop_sink_nodes()
         reassignable = context.pop_reassignable_items()
@@ -381,7 +380,6 @@ def wire_reference_data_service(
     from hgraph._wiring._decorators import graph
     from hgraph.nodes._service_utils import capture_output_to_global_state
 
-    @graph
     def ref_svc_inner_graph():
         g = graph(fn)
         if "path" in g.signature.args:
@@ -389,9 +387,10 @@ def wire_reference_data_service(
 
         # Call the implementation graph with the scalars provided
         out = g[resolution_dict](**scalars)
-        capture_output_to_global_state(typed_full_path, out)
+        with WiringGraphContext(out.node_instance.resolved_signature):
+            capture_output_to_global_state(typed_full_path, out)
 
-    with WiringNodeInstanceContext(), WiringGraphContext(wiring_signature) as context:
+    with WiringNodeInstanceContext(), WiringGraphContext() as context:
         ref_svc_inner_graph()
         sink_nodes = context.pop_sink_nodes()
         reassignable = context.pop_reassignable_items()

--- a/src/hgraph/_wiring/_wiring_node_instance.py
+++ b/src/hgraph/_wiring/_wiring_node_instance.py
@@ -124,6 +124,9 @@ class WiringNodeInstance:
     non_input_dependencies: list["WiringNodeInstance"] = field(default_factory=list)
     ranking_alternatives: list["WiringNodeInstance"] = field(default_factory=list)
 
+    def __post_init__(self):
+        self.label = self.label or self.resolved_signature.label
+
     def __lt__(self, other: "WiringNodeInstance") -> bool:
         # The last part gives potential for inconsistent ordering, a better solution would be to
         # consider the inputs, but that may contain values which do not support ordering.

--- a/src/hgraph/_wiring/_wiring_node_signature.py
+++ b/src/hgraph/_wiring/_wiring_node_signature.py
@@ -600,6 +600,24 @@ class WiringNodeSignature:
                         if not v.dereference().matches(kwarg_types[k].dereference()):
                             raise IncorrectTypeBinding(v, kwarg_types[k])
 
+    def resolve_label(self, resolution_dict: dict[TypeVar, HgTypeMetaData], kwargs) -> str:
+        """
+        Format the label for the node, this is used to display the node in the logs/inspector UI.
+        :return: The formatted label
+        """
+        if self.label and "{" in self.label:
+            try:
+                return self.label.format(
+                    **{
+                        k: v.py_type.__name__ if isinstance(v, HgTypeMetaData) else str(v)
+                        for k, v in resolution_dict.items()
+                    },
+                    **kwargs,
+                )
+            except:
+                pass
+        return self.label
+
 
 def extract_signature(
     fn,
@@ -609,6 +627,7 @@ def extract_signature(
     all_valid_inputs: frozenset[str] | None = None,
     deprecated: bool = False,
     requires: Callable[[...], bool] | None = None,
+    label: str | None = None,
     record_and_replay_id: str | None = None,
 ) -> WiringNodeSignature:
     """
@@ -718,7 +737,7 @@ def extract_signature(
         unresolved_args=unresolved_inputs,
         time_series_args=time_series_inputs,
         injectables=injectables,
-        label=None,
+        label=label,
         record_and_replay_id=record_and_replay_id,
         deprecated=deprecated,
         requires=requires,

--- a/src/hgraph/_wiring/_wiring_port.py
+++ b/src/hgraph/_wiring/_wiring_port.py
@@ -313,7 +313,7 @@ class TSBREFWiringPort(WiringPort):
         from hgraph._operators import getitem_
 
         if item not in self.__schema__.__meta_data_schema__:
-            raise AttributeError(f"'{item}' is defined on {self.__schema__}")
+            raise AttributeError(f"'{item}' is not defined on {self.__schema__}")
         return getitem_(self, item)
 
     def __getitem__(self, item):

--- a/src/hgraph/adaptors/perspective/_perspective_adaptor.py
+++ b/src/hgraph/adaptors/perspective/_perspective_adaptor.py
@@ -63,33 +63,17 @@ def publish_table_impl(path: str, ts: TSD[K, TIME_SERIES_TYPE], index_col_name: 
 
 @adaptor
 def publish_table_editable(
-    path: str, ts: TSD[K, TIME_SERIES_TYPE], index_col_name: str, history: int = None, empty_row: bool = False
+    path: str, ts: TSD[K, TIME_SERIES_TYPE], index_col_name: str, history: int = None, edit_role: str = None, empty_row: bool = False
 ) -> TSB[TableEdits[K, TIME_SERIES_TYPE]]: ...
-
-
-@graph
-def publish_join_table(path: str, schema: Mapping[str, type], index: str, description: object):
-    _publish_join_table(path, schema, index, description, nothing(TS[bool]))
-
-
-@sink_node
-def _publish_join_table(path: str, schema: dict[str, type], index: str, description: object, _: TS[bool]): ...
-
-
-@_publish_join_table.start
-def _publish_join_table_start(path: str, schema: dict[str, type], index: str, description: object, _: TS[bool]):
-    from hgraph.adaptors.perspective import PerspectiveTablesManager
-
-    PerspectiveTablesManager.current().add_join(path, schema, index, description)
 
 
 @adaptor_impl(interfaces=publish_table_editable)
 def publish_table_editable_impl(
-    path: str, ts: TSD[K, TIME_SERIES_TYPE], index_col_name: str, history: int = None, empty_row: bool = False
+    path: str, ts: TSD[K, TIME_SERIES_TYPE], index_col_name: str, history: int = None, edit_role: str = None, empty_row: bool = False
 ) -> TSB[TableEdits[K, TIME_SERIES_TYPE]]:
     _assert_unique_type_per_path(publish_table_editable)
 
-    _publish_table(path, ts, index_col_name=index_col_name, history=history, editable=True, empty_row=empty_row)
+    _publish_table(path, ts, index_col_name=index_col_name, history=history, editable=True, empty_row=empty_row, edit_role=edit_role)
     return _receive_table_edits(
         path, tp=ts.output_type.dereference().py_type, index_col_name=index_col_name, empty_row=empty_row
     )

--- a/src/hgraph/adaptors/perspective/_perspetive_publish.py
+++ b/src/hgraph/adaptors/perspective/_perspetive_publish.py
@@ -1,12 +1,15 @@
 from collections import defaultdict
 from dataclasses import asdict
 from datetime import datetime, timedelta
-from typing import Type, Callable, Generic
+import logging
+import threading
+from typing import Any, Type, Callable, Generic
 
 from perspective import View
 
 from hgraph import (
     TIME_SERIES_TYPE,
+    GlobalState,
     sink_node,
     TSD,
     K,
@@ -31,9 +34,12 @@ from hgraph import (
 from ._perspective import PerspectiveTablesManager
 
 
+logger = logging.getLogger(__name__)
+
+
 @operator
 def _publish_table(
-    name: str, ts: TIME_SERIES_TYPE, editable: bool = False, empty_row: bool = False, history: int = None
+    name: str, ts: TIME_SERIES_TYPE, editable: bool = False, edit_role: str = None, empty_row: bool = False, history: int = None
 ): ...
 
 
@@ -45,11 +51,12 @@ def _receive_table_edits(name: str, type: Type[TIME_SERIES_TYPE]) -> TIME_SERIES
     ...
 
 
-@sink_node(overloads=_publish_table)
+@sink_node(overloads=_publish_table, label="{name}")
 def _publish_table_from_tsd(
     name: str,
     ts: TSD[K, TIME_SERIES_TYPE],
     editable: bool = False,
+    edit_role: str = None,
     empty_row: bool = False,
     index_col_name: str = None,
     history: int = None,
@@ -75,6 +82,10 @@ def _publish_table_from_tsd(
             data = [{**state.process_key(k), **row} for row in state.process_row(v)]
             if state.create_index:
                 data = [{**i, **state.create_index(i)} for i in data]
+                
+            if history is not None:
+                sample = [{**data, "time": ec.evaluation_time} for data in data]
+                state.history += sample  # multirow types do not do partial updates do data and a sample are always the same
 
             index = state.index
             updated_indices = set(i[index] for i in data)
@@ -93,12 +104,19 @@ def _publish_table_from_tsd(
             data = {**state.process_key(k), **state.process_row(v)}
             if state.create_index:
                 data = {**data, **state.create_index(data)}
+            if history is not None:
+                if state.sample_row:
+                    sample = {**state.sample_row(v), **data, "time": ec.evaluation_time}
+                    state.history.append(sample)
+                else:
+                    state.history.append({**data, "time": ec.evaluation_time})
 
-            new_index = (
-                data[state.index]
-                if not state.map_index
-                else data.setdefault("_id", state.index_to_id[data[state.index]])
-            )
+            if state.map_index:
+                with state.index_to_id_lock:
+                    row_key = state.create_row_key(data)
+                    new_index = data.setdefault("_id", state.index_to_id[row_key])
+            else:
+                new_index = data[state.index]
 
             if (old_i := state.key_tracker.get(k)) is not None and old_i != new_index:
                 state.removed.add(old_i)
@@ -114,9 +132,12 @@ def _publish_table_from_tsd(
     if sched.is_scheduled_now:
         state.manager.update_table(name, state.data, state.removed)
         if history:
-            state.manager.update_table(name + "_history", [{"time": ec.evaluation_time, **d} for d in state.data])
+            state.manager.update_table(name + "_history", state.history)
+        elif history is 0:
+            state.manager.replace_table(name + "_history", state.history)
 
         state.data = []
+        state.history = []
         state.removed = set()
 
 
@@ -126,6 +147,7 @@ def _publish_table_from_tsd_start(
     index_col_name: str,
     history: int,
     editable: bool,
+    edit_role: str,
     empty_row: bool,
     _key: Type[K],
     _schema: Type[TIME_SERIES_TYPE],
@@ -153,6 +175,7 @@ def _publish_table_from_tsd_start(
 
         state.process_key = lambda k: {index[i]: ki for i, ki in enumerate(k)}
         state.create_index = lambda v: {"index": ",".join(str(v[i]) for i in index_col_names)}
+        state.create_row_key = lambda v: tuple(v[i] for i in index_col_names)
         state.key_schema = {"index": str, **{index[i]: ks_tps[i] for i in range(ks)}}
 
         residual_index_col_names = index_col_names[ks:]
@@ -167,11 +190,13 @@ def _publish_table_from_tsd_start(
         if residual_index_col_names:
             state.process_key = lambda k: {"index": str, index: k}
             state.create_index = lambda v: {"index": ",".join(str(v[i]) for i in index_col_names)}
+            state.create_row_key = lambda v: tuple(v[i] for i in index_col_names)
             state.key_schema = state.process_key(_key.py_type)
             index_col_name = "index"
         else:
             state.process_key = lambda k: {index: k}
             state.create_index = None
+            state.create_row_key = lambda v: v[index]
             state.key_schema = state.process_key(_key.py_type)
 
     # process the value type
@@ -182,6 +207,9 @@ def _publish_table_from_tsd_start(
             state.process_row = lambda v: v.delta_value | {k: v[k].value for k in residual_index_col_names}
         else:
             state.process_row = lambda v: v.delta_value
+
+        state.sample_row = lambda v: {k: ts.value if ts.valid else None for k, ts in v.items()}
+
         state.multi_row = False
     elif isinstance(_schema, HgTSTypeMetaData):
         if isinstance(_schema.value_scalar_tp, HgCompoundScalarType):
@@ -196,6 +224,8 @@ def _publish_table_from_tsd_start(
             state.schema = {"value": _schema.value_scalar_tp.py_type}
             state.process_row = lambda v: {"value": v.value}
             state.multi_row = False
+
+        state.sample_row = False
     else:
         raise ValueError(f"Unsupported schema type '{_schema}'")
 
@@ -209,7 +239,11 @@ def _publish_table_from_tsd_start(
             state.running_id += 1
             return state.running_id
 
-        state.index_to_id = defaultdict(_new_id)
+        state.index_to_id = defaultdbldict(_new_id)
+        state.index_to_id_lock = threading.Lock()
+        index_to_id_and_lock = GlobalState.instance().setdefault(f"perspective_table_index_to_id_{name}", dict())
+        index_to_id_and_lock['mapping'] = state.index_to_id
+        index_to_id_and_lock['lock'] = state.index_to_id_lock
 
         if state.multi_row:
             raise ValueError("Empty row is not supported for multi-row tables")
@@ -219,6 +253,7 @@ def _publish_table_from_tsd_start(
             index="_id",
             name=name,
             editable=editable,
+            edit_role=edit_role
         )
         empty_values = (
             [i.py_type() for i in _key.element_types] if isinstance(_key, HgTupleFixedScalarType) else _key.py_type()
@@ -231,16 +266,18 @@ def _publish_table_from_tsd_start(
             index=state.index,
             name=name,
             editable=editable,
+            edit_role=edit_role
         )
 
     state.data = []
+    state.history = []
     state.removed = set()
     state.key_tracker = defaultdict(set) if state.multi_row else {}
 
-    if history:
+    if history is not None:
         history_table = manager.create_table(
             {"time": datetime, **state.key_schema, **{k: v for k, v in state.schema.items()}},
-            limit=min(history, 4294967295),
+            limit=min(history, 4294967295) if history > 0 else None,
             name=name + "_history",
         )
 
@@ -250,7 +287,7 @@ class TableEdits(TimeSeriesSchema, Generic[K, TIME_SERIES_TYPE]):
     removes: TSS[K]
 
 
-@push_queue(TSB[TableEdits[K, TIME_SERIES_TYPE]], overloads=_receive_table_edits)
+@push_queue(TSB[TableEdits[K, TIME_SERIES_TYPE]], overloads=_receive_table_edits, label="{name}")
 def _receive_table_edits_tsd(
     sender: Callable,
     name: str,
@@ -269,7 +306,7 @@ def _receive_table_edits_tsd(
             tp = _schema.value_scalar_tp.py_type
             tp_schema = {k: v.py_type for k, v in _schema.value_scalar_tp.meta_data_schema.items()}
             process_row = lambda row, i: tp(
-                **{k: tp_schema[k](row[k]) for k in row if k not in i and k not in ("index", "_id")}
+                **{k: tp_schema[k](row[k]) for k in row if k in tp_schema}
             )
         else:
             process_row = lambda row, i: row["value"]
@@ -285,14 +322,33 @@ def _receive_table_edits_tsd(
     else:
         index = index_col_name or "index"
 
+    # the publish node will populate the global state with the index to id mapping object and its lock to be used for lookups
+    if empty_row:
+        index_mapping = GlobalState.instance().setdefault(f"perspective_table_index_to_id_{name}", dict())
+
     def on_update(data: View):
-        print(data.to_records())
+        logger.info(f"Update from perspective: {data.to_records()}")
+
         edits = {}
         removes = set()
         for row in data.to_records():
             if empty_row:
                 _id = row.get("_id")
                 key = row[index] if type(index) is str else tuple(row[i] for i in index)
+
+                if index_mapping:
+                    with index_mapping["lock"]:
+                        mapping = index_mapping["mapping"]
+                        prev_mapped_key = mapping.reverse_get(_id)
+
+                    if prev_mapped_key is not None:
+                        if prev_mapped_key != key:
+                            # the row's key was updated, i.e one of more coluimns in the index
+                            # therefore we need to remove the old row
+                            # manager.update_table(name, data=None, removals=set((_id,)))
+                            removes.add(prev_mapped_key)  # remove the old key
+                            removes.add(Removed(key))  # undo any previous removals of the new key
+
                 if _id != 0:  # _id == 0 is for the `new row` in the editable table
                     edits[key] = process_row(row, index)
                 if (
@@ -309,6 +365,47 @@ def _receive_table_edits_tsd(
                 edits[key] = process_row(row, index)
 
         sender({"edits": edits, "removes": removes})
+        data.delete()
 
     manager = PerspectiveTablesManager.current()
     manager.subscribe_table_updates(name, on_update)
+
+
+class defaultdbldict(defaultdict):
+    """
+    A defaultdict that keeps a reverse lookup if values back to keys and assumes that mapping is 1-to-1
+    """
+    def __init__(self, default_factory: Callable):
+        super().__init__(default_factory)
+        self.key_tracker = {}
+
+    def __missing__(self, key):
+        value = super().__missing__(key)
+        self.key_tracker[value] = key
+        return value
+
+    def __setitem__(self, key: Any, value: Any) -> None:
+        r = super().__setitem__(key, value)
+        if value in self.key_tracker:
+            # If the value already exists, remove the old key
+            old_key = self.key_tracker[value]
+            if old_key != key:
+                del self.key_tracker[value]
+
+        self.key_tracker[value] = key
+        return r
+
+    def __delitem__(self, key: Any) -> None:
+        value = self.get(key, None)
+        super().__delitem__(key)
+        if value in self.key_tracker:
+            del self.key_tracker[value]
+        return value
+
+    def reverse_get(self, value):
+        """
+        Get the key for a given value
+        """
+        return self.key_tracker.get(value, None)
+
+

--- a/src/hgraph/adaptors/perspective/table_workarounds.js
+++ b/src/hgraph/adaptors/perspective/table_workarounds.js
@@ -54,6 +54,8 @@ export async function installTableWorkarounds(mode) {
             const view_config = config.viewers[viewer.slot];
             const table_config = getWorkspaceTables()[view_config.table];
 
+            if (!table_config) continue;
+            
             if (!table_config.started){
                 wait_for_table(window.workspace, view_config.table)
             }
@@ -83,14 +85,23 @@ export async function installTableWorkarounds(mode) {
 
     }
 
+    await customElements.whenDefined("perspective-viewer-datagrid");
+    await customElements.whenDefined("perspective-viewer-datagrid-norollups");
+
     for (const g of document.querySelectorAll(
         "perspective-viewer perspective-viewer-datagrid, perspective-viewer perspective-viewer-datagrid-norollups")) {
 
-        const table = g.shadowRoot.querySelector("regular-table")
+        const shadow = window.CSS?.supports && window.CSS?.supports("selector(:host-context(foo))");
+
+        const root = shadow ? g.shadowRoot : g;
+    	const table = root.querySelector("regular-table");
         const model = g.model;
         const viewer = g.parentElement;
         const view_config = config.viewers[viewer.slot];
         const table_config = getWorkspaceTables()[view_config.table];
+
+        if (!table_config)
+            continue;
 
         if (!table_config.started){
             wait_for_table(window.workspace, view_config.table)
@@ -98,7 +109,7 @@ export async function installTableWorkarounds(mode) {
 
         if (table_config && table_config.locked_columns) {
             model._column_paths.map((x, i) => {
-                if (table_config.locked_columns.includes(x) || !table_config.schema[x]) {
+                if (!table_config.editable || table_config.locked_columns.includes(x) || !table_config.schema[x]) {
                     model._is_editable[i] = false;
                 }
             })
@@ -114,18 +125,17 @@ export async function installTableWorkarounds(mode) {
 
         // the built-in stylesheet limits the min-width of table cells to 52px for no apparent reason
         // we override this so that we can have columns that are arbitrary small
-        let psp_stylesheet = g.shadowRoot.adoptedStyleSheets[0];
-        for (let i = 0; i < psp_stylesheet.cssRules.length; i++) {
-            if (psp_stylesheet.cssRules[i].selectorText === 'regular-table table tbody td') {
-                psp_stylesheet.deleteRule(i);
-                psp_stylesheet.insertRule('regular-table table tbody td { min-width: 1px !important; }');
-                psp_stylesheet.insertRule('regular-table table tbody td.invalid { color: red; }');
-                psp_stylesheet.insertRule('regular-table table tbody td.hidden { overflow: hidden; white-space: nowrap; text-overflow: clip; width: 0; min-width: 0; max-width: 0; padding-left: 1px; padding-right: 0; }');
+        for (const psp_stylesheet of (shadow ? root.adoptedStyleSheets : document.styleSheets)){
+            for (let i = 0; i < psp_stylesheet.cssRules.length; i++) {
+                if (psp_stylesheet.cssRules[i].selectorText === 'regular-table table tbody td') {
+                    psp_stylesheet.deleteRule(i);
+                    psp_stylesheet.insertRule('regular-table table tbody td { min-width: 1px !important; }');
+                    psp_stylesheet.insertRule('regular-table table tbody td.invalid { color: red; }');
+                    psp_stylesheet.insertRule('regular-table table tbody td.hidden { overflow: hidden; white-space: nowrap; text-overflow: clip; width: 0; min-width: 0; max-width: 0; padding-left: 1px; padding-right: 0; }');
+                    psp_stylesheet.insertRule( `.highlight { background-color: pink }`);
+                }
             }
         }
-        var sheet = new CSSStyleSheet
-        sheet.replaceSync( `.highlight { background-color: pink }`)
-        g.shadowRoot.adoptedStyleSheets.push(sheet)
 
         table.addStyleListener(() => {
             addTooltips(table, table_config)
@@ -362,12 +372,12 @@ async function dropdown_editor(editor, element, table_, model_, table_config_) {
             const text = ["", "\n"].includes(event.target.innerText) ? "" : event.target.innerText;
             if (option === text) {
                 option_el.style.backgroundColor = "whitesmoke";
-                option_el.hidden = "";
+                option_el.parentElement.hidden = "";
             } else if (option.includes(text)) {
                 option_el.style.backgroundColor = "";
-                option_el.hidden = "";
+                option_el.parentElement.hidden = "";
             } else {
-                option_el.hidden = true;
+                option_el.parentElement.hidden = true;
             }
         }
     })
@@ -467,6 +477,8 @@ async function focusin(event, viewer, table, model, table_config) {
 }
 
 async function refreshTimeSensitiveViews(event, viewer) {
+    if (!event.detail || !event.detail.expressions) return;
+    
     const has_now = Object.entries(event.detail.expressions)
             .map(([k, v]) => v.includes("var refresh := now()"))
             .some((x) => x);
@@ -585,32 +597,41 @@ async function fireContextActions(from, row) {
     }
 }
 
+import {WebSocketHelper} from "/workspace_code/websocket_helper.js";
+
 class tooltip_info{
     static tooltip = null;
     static view = null;
     static view_cb = null;
+    static pinned = false;
+
+    static tooltip_ws = null;
+    static tooltip_ws_cb = null;
+    static tooltip_ws_url = null;
 
     static show(table, td) {
         tooltip_info.clear();
 
+        const style = window.getComputedStyle(td.parentElement);
+        const style_2 = window.getComputedStyle(td);
         const tooltip = document.createElement("p");
-        tooltip.id = "tooltip";
+        tooltip.id = "tooltip"; 
         tooltip.className = "tooltip";
-        tooltip.style = td.style;
         tooltip.style.position = "absolute";
         tooltip.style.zIndex = "1000";
         tooltip.style.border = "1px solid grey";
         tooltip.style.padding = "5px";
+        tooltip.style.paddingRight = "25px";
         tooltip.style.whiteSpace = "normal";
-        tooltip.style.top = (td.getBoundingClientRect().bottom - table.getBoundingClientRect().top - 12) + 'px';
-        tooltip.style.left = (td.getBoundingClientRect().right - table.getBoundingClientRect().left - 12) + 'px';
+        tooltip.style.top = (td.getBoundingClientRect().bottom - 12) + 'px';
+        tooltip.style.left = (td.getBoundingClientRect().right - 12) + 'px';
         tooltip.style.overflow = "hidden";
         tooltip.style.textOverflow = "ellipsis";
         tooltip.style.backdropFilter = "blur(6px)";
         tooltip.style.boxShadow = "0 2px 5px rgba(0,0,0,0.2)";
         tooltip.style.fontSize = "12px";
 
-        const tableBackgroundColor = window.getComputedStyle(table).backgroundColor;
+        const tableBackgroundColor = style.backgroundColor;
         if (tableBackgroundColor && tableBackgroundColor !== "rgba(0, 0, 0, 0)") {
             const rgbaMatch = tableBackgroundColor.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*[\d.]+)?\)/);
             if (rgbaMatch) {
@@ -618,29 +639,139 @@ class tooltip_info{
             }
         }
 
-        table.appendChild(tooltip);
-                                    
-        const tooltipRect = tooltip.getBoundingClientRect();
-        const tableRect = table.getBoundingClientRect();
-        if (tooltipRect.right > tableRect.right) {
-            tooltip.style.left = `${tableRect.right - tooltipRect.width - table.getBoundingClientRect().left - 10}px`;
-        }
+
+        tooltip.style.color = style.color;
+        tooltip.style.font = style.font;
+        tooltip.style.fontSize = style_2.fontSize;
+        tooltip.innerHTML = "<span id='tooltip-loading'>loading...</span>";
+
+        // Add pin button container at the top-right
+        const pinContainer = document.createElement("div");
+        pinContainer.style.position = "absolute";
+        pinContainer.style.top = "2px";
+        pinContainer.style.right = "2px";
+        pinContainer.style.cursor = "pointer";
+        
+        // Create pin button
+        const pinButton = document.createElement("div");
+        pinButton.textContent = "🖈";
+        pinButton.style.background = "transparent";
+        pinButton.style.border = "none";
+        pinButton.style.cursor = "pointer";
+        pinButton.style.padding = "2px";
+        pinButton.title = "Pin tooltip";
+        pinButton.dataset.pinned = "false";
+        
+        // Pin/unpin behavior
+        pinButton.addEventListener("click", (event) => {
+            event.stopPropagation();
+            const isPinned = pinButton.dataset.pinned === "true";
+            pinButton.dataset.pinned = !isPinned;
+            tooltip_info.pinned = !isPinned;
+            pinButton.title = isPinned ? "Pin tooltip" : "Unpin tooltip";
+            pinButton.textContent = isPinned ? "🖈" : "✖";
+        });
+        
+        pinContainer.appendChild(pinButton);
+        tooltip.appendChild(pinContainer);
+        document.body.appendChild(tooltip);
 
         tooltip.addEventListener("mouseenter", () => {
             clearTimeout(tooltip_info.clear_timeout);
         });
         
         tooltip.addEventListener("mouseleave", () => {
+            if (tooltip_info.pinned) return;
             tooltip_info.clear();
         });
 
         tooltip_info.tooltip = tooltip;
+        return tooltip;
+    }
+
+    static render_json(node, json, depth = 0) {
+        for (const [key, value] of Object.entries(json)) {
+            let key_node = node.querySelector(`:scope > div[data-key="${key}"]`)
+            if (key_node === null) {
+                key_node = document.createElement("div");
+                key_node.dataset.key = key;
+                key_node.innerHTML = `<div><span data-expand style="cursor: pointer"></span>${key}: <span data-key="value"></span><div data-container="true" style="margin-left: 12px"></div></div>`;
+                node.appendChild(key_node);
+            }
+
+            if (value === null) {
+                key_node.querySelector(':scope > div > span[data-key="value"]').innerText = 'null';
+            } else if (typeof value === "object") {
+                if (Array.isArray(value)) {
+                    key_node.querySelector(':scope > div > span[data-key="value"]').innerText = `${value.length} items`;
+                } else {
+                    if (value.value !== undefined) {
+                        key_node.querySelector('[data-key="value"]').innerText = value.value;
+                    }
+                }
+                tooltip_info.render_json(key_node.querySelector('[data-container]'), value, depth + 1);
+                if (!key_node.querySelector(':scope > div > span[data-expand]').innerHTML){
+                    key_node.querySelector(':scope > div > span[data-expand]').innerHTML =  depth == 0 ? "-&nbsp;" : "+&nbsp;";
+                    key_node.querySelector(':scope > div > div[data-container]').style.display = depth == 0 ? "block" : "none";
+                }
+            } else {
+                key_node.querySelector(':scope > div > span[data-key="value"]').innerText = value;
+            }
+        }
+        for (const child of node.children) {
+            if (child.dataset.key !== undefined && !(child.dataset.key in json)) {
+                child.remove();
+            }
+        }
+        if (node === tooltip_info.tooltip) {
+            if (!node.dataset.events_set_up) {
+                node.addEventListener("click", (event) => {
+                    if (event.target.dataset.expand !== undefined) {
+                        const container = event.target.parentElement.querySelector(':scope > div[data-container]');
+                        if (container) {
+                            if (container.style.display === "none") {
+                                container.style.display = "block";
+                                event.target.innerHTML = "-&nbsp;";
+                            } else {
+                                container.style.display = "none";
+                                event.target.innerHTML = "+&nbsp;";
+                            }
+                        }
+                    }
+                });
+                node.dataset.events_set_up = "true";
+            }
+        }
+    }
+
+    static subscribe_tooltip_ws(url, msg, cb) {
+        if (tooltip_info.tooltip_ws == null || tooltip_info.tooltip_ws_url !== url) {
+            tooltip_info.tooltip_ws = new WebSocketHelper(url, (msg) => { tooltip_info.update_tooltip_ws(msg); });
+            tooltip_info.tooltip_ws.connect();
+            tooltip_info.tooltip_ws_url = url;
+        }
+        tooltip_info.tooltip_ws_cb = cb;
+        tooltip_info.tooltip_ws.send(msg);
+    }
+
+    static update_tooltip_ws(msg) {
+        if (tooltip_info.tooltip_ws_cb) {
+            tooltip_info.tooltip_ws_cb(msg);
+        }
     }
 
     static update(text) {
         if (!tooltip_info.tooltip) return;
 
-        tooltip_info.tooltip.innerHTML = text;
+        const loader = tooltip_info.tooltip.querySelector("#tooltip-loading");
+        if (loader)
+            loader.style.display = "none";
+        
+        if (typeof text === "object") { // render json
+            tooltip_info.render_json(tooltip_info.tooltip, text);
+        } else {
+            tooltip_info.tooltip.innerHTML = text;
+        }
     }
 
     static clear() {
@@ -668,6 +799,8 @@ class tooltip_info{
     }
 };
 
+const FORMAT_REGEX = /(?<!\{)\{([^\{\}]*?)\}(?!\})/g;
+
 async function enableActions(table, viewer, config, model) {
     if (!config || !config.column_actions) return;
 
@@ -694,7 +827,7 @@ async function enableActions(table, viewer, config, model) {
                             if (row){
                                     switch (action.action.type) {
                                     case 'url':
-                                        const url = action.action.url.replace(/\{(.*?)\}/g, (match, p1) => row[p1]);
+                                        const url = action.action.url.replace(FORMAT_REGEX, (match, p1) => row[p1]);
                                         btn.disabled = true;
                                         await fetch (url, {method: 'GET'});
                                         btn.disabled = false;
@@ -705,10 +838,11 @@ async function enableActions(table, viewer, config, model) {
                 }
             }
             if (action.type === 'tooltip') {
-                td.addEventListener("mouseenter", (event) => {
+                td.addEventListener("mouseenter", (event, a=action) => {
                     if (td.dataset.tooltipTimeout) return;
 
                     td.dataset.tooltipTimeout = setTimeout(async () => {
+                        const action = a;
                         tooltip_info.clear();
 
                         const id = model._ids[metadata.y - metadata.y0];
@@ -721,13 +855,17 @@ async function enableActions(table, viewer, config, model) {
                             let method = action.action;
                             let format = undefined;
                             if (action.format !== undefined) {
-                                required_cols = [...action.format.matchAll(/\{(.*?)\}/g)].map((x) => x[1]);
+                                required_cols = [...action.format.matchAll(FORMAT_REGEX)].map((x) => x[1]);
                                 format = action.format;
                                 method = "format";
                             } else if (action.url !== undefined) {
-                                required_cols = [...action.url.matchAll(/\{(.*?)\}/g)].map((x) => x[1]);
+                                required_cols = [...action.url.matchAll(FORMAT_REGEX)].map((x) => x[1]);
                                 format = action.url;
                                 method = "url";
+                            } else if (action.ws !== undefined) {
+                                required_cols = [...new Set([...action.subscribe.matchAll(FORMAT_REGEX), ...action.unsubscribe.matchAll(FORMAT_REGEX)].map((x) => x[1]))];
+                                format = action.subscribe;
+                                method = "ws";
                             }
 
                             let view;
@@ -739,25 +877,47 @@ async function enableActions(table, viewer, config, model) {
                                 const query_config = {
                                     filter: [...view_config.filter.filter((x) => !view_config.group_by.includes(x[0])), ...view_config.group_by.map((x, i) => [x, '==', id[i]])],
                                     group_by: view_config.group_by,
-                                    aggregates: {...Object.fromEntries(required_cols.map((x) => [x, 'unique'])), [index]: 'count'},
+                                    aggregates: {...Object.fromEntries(required_cols.map((x) => [x, 'unique']))},
                                     columns: [index, ...required_cols]
                                 }
                                 view = await tbl.view(query_config);
                                 get_rows = async () => {
                                     const rows = await view.to_json()
-                                    return rows.filter((x) => x[index] === 1 && x["__ROW_PATH__"].length === view_config.group_by.length);
+                                    return rows.filter((x) => x["__ROW_PATH__"].length === view_config.group_by.length && required_cols.every((col) => x["col"] !== null));
                                 }
                             } else if (view_config.group_by.length > 0) {
                             }
                             const rows = await get_rows();
                             if (rows && rows.length == 1) {
                                 const row = rows[0];
-                                const text = format.replace(/\{(.*?)\}/g, (match, p1) => row[p1]);
+                                const text = format.replace(FORMAT_REGEX, (match, p1) => row[p1]).replace('{{', '{').replace('}}', '}');
                                 if (text && text != "null"){
+                                    const tt = tooltip_info.show(table, td);
+
                                     const update_tt = async (text) => {
                                         let data = text;
                                         if (method === "url") {
-                                            data = await (await fetch(text, {method: 'GET'})).text();
+                                            const request = await fetch(text, {method: 'GET'});
+                                            if (request.headers.get('content-type') === "application/json") {
+                                                data = await request.json();
+                                            } else {
+                                                data = await request.text();
+                                            }
+                                        } else if (method === "ws") {
+                                            const request_id = `${Math.round(Math.random() * 1_000_000_000)}`;
+                                            tooltip_info.subscribe_tooltip_ws(action.ws, `{"request_id": "${request_id}", "request": ${text} }`, async (msg) => {
+                                                if (tt !== tooltip_info.tooltip) {
+                                                    return;
+                                                }
+                                                if (msg.request_id !== request_id) {
+                                                    return;
+                                                }
+                                                tooltip_info.update(msg.response);
+                                            });
+                                            return;
+                                        }
+                                        if (tt !== tooltip_info.tooltip) {
+                                            return;
                                         }
                                         if (action.line_separator) {
                                             const lines = data.split(action.line_separator).map(line => `${line}<br/>`).join('');
@@ -767,14 +927,22 @@ async function enableActions(table, viewer, config, model) {
                                         }
                                     };
 
-                                    tooltip_info.show(table, td);
                                     tooltip_info.view = view;
                                     await update_tt(text);
 
-                                    view.on_update(tooltip_info.view_cb = async () => {
+                                    let udpate_timer = undefined;
+                                    const update = async () => {
                                         const row = (await get_rows())[0];
-                                        const text = format.replace(/\{(.*?)\}/g, (match, p1) => row[p1]);
+                                        const text = format.replace(FORMAT_REGEX, (match, p1) => row[p1]).replace('{{', '{').replace('}}', '}');
                                         await update_tt(text);
+                                        udpate_timer = undefined;
+                                    };
+
+                                    view.on_update(tooltip_info.view_cb = async () => {
+                                        if (udpate_timer) {
+                                            return;
+                                        }
+                                        udpate_timer = setTimeout(update, 10000);
                                     });
                                 } else {
                                     view.delete();
@@ -813,7 +981,10 @@ async function enableAddRemove(table, viewer, config, model) {
                     td.innerHTML = "<button style='font: inherit'>Add</button>";
                     btn = td.querySelector("button");
                     btn.addEventListener("click", async () => {
-                        const data = (await (await (await viewer.getTable()).view({filter: [['_id', '==', 0]]})).to_json())[0];
+                        const id = model._ids[metadata.y - metadata.y0];
+                        if (!id) {return;}
+                        const source_tbl = await viewer.getTable();
+                        const data = (await (await (source_tbl).view({filter: [[await source_tbl.get_index(), '==', id[0]]]})).to_json())[0];
                         for (const item of td.parentElement.children) {
                             const meta = table.getMeta(item);
                             const col_name = meta.column_header[meta.column_header.length - 1];
@@ -950,7 +1121,7 @@ function addTooltips(table) {
 
 async function recordCollapseState(table, viewer, model) {
     if (viewer.dataset.config_open) return;
-    if (!model._config.group_by.length) return;    
+    if (model._config && !model._config.group_by.length) return;    
     if (viewer.dataset.collapse_state_timer) return;
 
     viewer.dataset.collapse_state_timer = setTimeout(async () => {

--- a/src/hgraph/adaptors/perspective/workspace_template.html
+++ b/src/hgraph/adaptors/perspective/workspace_template.html
@@ -5,6 +5,20 @@
 
         <title>ACE: {{url}}</title>
 
+    	<script language='javascript'>
+            const display_errors = false;
+            if (display_errors){
+                window.onerror = (errorMsg, url, lineNumber) => {
+                    document.getElementById('errors').innerText = `Error: ${errorMsg} at ${url}:${lineNumber}`;
+                    return false;
+                };
+
+                window.addEventListener("unhandledrejection", (event) => {
+                    document.getElementById('errors').innerText = `Error: ${event.reason.message} at ${event.reason.stack}`;
+                });
+            }
+        </script>
+
         <script type="module" src="/node_modules/@finos/perspective-viewer/dist/cdn/perspective-viewer.js"></script>
         <script type="module" src="/node_modules/@finos/perspective-workspace/dist/cdn/perspective-workspace.js"></script>
         <script type="module" src="/node_modules/@finos/perspective-viewer-datagrid/dist/cdn/perspective-viewer-datagrid.js"></script>
@@ -32,6 +46,42 @@
                 overflow: hidden;
                 white-space: nowrap;
                 text-overflow: clip;
+            }
+
+            .announcement-banner {
+                display: block;
+                position: fixed; /* Stay in place */
+                z-index: 9999; /* Sit on top */
+                left: 50%;
+                top: 0%;
+                transform: translate(-50%, 0%);
+                padding: 5px;
+                background-color: rgba(99, 55, 55, 0.8); /* Dark red background with opacity */
+                color: white;
+                font-family: "ui-monospace","SFMono-Regular","SF Mono","Menlo","Consolas","Liberation Mono",monospace;
+                font-size: small;
+                text-align: center;
+                justify-content: center;
+            }
+
+            .announcement-banner:empty {
+                padding: 0px;
+            }
+
+            .error-banner {
+                display: block;
+                position: fixed; /* Stay in place */
+                z-index: 9999; /* Sit on top */
+                left: 50%;
+                top: 100%;
+                transform: translate(-50%, -100%);
+                padding: 0px;
+                background-color: rgba(0, 0, 0, 0.8); /* Black background with opacity */
+                color: white;
+                font-family: "ui-monospace","SFMono-Regular","SF Mono","Menlo","Consolas","Liberation Mono",monospace;
+                font-size: small;
+                text-align: center;
+                justify-content: center;
             }
 
             .loading-banner {
@@ -123,27 +173,28 @@
             }
         </style>
     </head>
-
-    <div id="loading-banner" class="loading-banner">
-        <span id="loading-message"></span>
-        <div class="progress-indicator"></div>
-        <div>
-            <ul class="error-list"></ul>
-        </div>
-    </div>
-
-    <div id="login-dialog" class="login-dialog">
-        <h3>Login Required</h3>
-        <input type="text" id="username" placeholder="Username" />
-        <input type="password" id="password" placeholder="Password" />
-        <button id="login-button">Login</button>
-    </div>
-
     <body>
+        <div id="loading-banner" class="loading-banner">
+            <span id="loading-message">...</span>
+            <div class="progress-indicator"></div>
+            <div>
+                <ul class="error-list"></ul>
+            </div>
+        </div>
+
+        <div id="login-dialog" class="login-dialog">
+            <h3>Login Required</h3>
+            <input type="text" id="username" placeholder="Username" />
+            <input type="password" id="password" placeholder="Password" />
+            <button id="login-button">Login</button>
+        </div>
+
+        <div id="errors" class="error-banner"></div>
+        <div id="announcement" class="announcement-banner"></div>
         <perspective-workspace id="workspace"></perspective-workspace>
 
         <script type="module">
-            import {connectWorkspaceTables, wait_for_table} from "/workspace_code/workspace_tables.js";
+            import {connectWorkspaceTables, wait_for_table, DefaultMap} from "/workspace_code/workspace_tables.js";
             import {installTableWorkarounds, ensureTablesForConfig, loadLayout, saveLayout} from "/workspace_code/table_workarounds.js";
             import {setupInspectorTable} from "/workspace_code/inspector.js";
             import {WebSocketHelper} from "/workspace_code/websocket_helper.js";
@@ -223,6 +274,19 @@
                     document.getElementById('loading-message').innerText = "Logging in...";
                     await new Promise(res => setTimeout(res, 100));
 
+                    {% try %}
+                    {% if mgr.options.get('user_roles') %}
+                    const user_roles = [{{ ', '.join(f'"{r}"' for r in mgr.options.get('user_roles').get(current_user, mgr.options.get('user_roles').get("DEFAULT", []))) }}]
+                    {% else %}
+                    const user_roles = [];
+                    {% end %}
+                    {% except %}
+                    const user_roles = [];
+                    {% end %}
+
+                    {% if mgr.options.get('require_login') %}
+                    {% end %}
+
                     {% if mgr.options.get('require_login') %}
                     const token = await (await fetchWithAuth("{{mgr.options['login_url']}}")).text();
                     {% else %}
@@ -239,6 +303,41 @@
                         const errorList = document.querySelector('.error-list');
                         errorList.innerHTML += `<li>Failed to connect to management server</li>`;
                     });
+
+                    if (management_ws) {
+                        const error_stats = new DefaultMap(() => ({count: 0, last: new Date()}));
+                        function publishError(message) {
+                            const now = new Date();
+                            const stats = error_stats.get(message);
+                            if (stats.count == 0 || (now - stats.last) > 60000) {
+                                management_ws.send({type: "error", message: `${stats.count ? stats.count : 'first'} of: ${message}`});
+                                stats.last = now;
+                                stats.count = 0;
+                            }
+                            stats.count += 1;
+                        }
+
+                        const error_fn = console.error;
+                        console.error = (...args) => {
+                            error_fn(...args);
+                            const message = args.join(' ');
+                            publishError(message);
+                        };
+
+                        window.onerror = (errorMsg, url, lineNumber) => {
+                            publishError(`Error: ${errorMsg} at ${url}:${lineNumber}`);
+                            return false;
+                        }
+
+                        window.addEventListener("unhandledrejection", (event) => {
+                            publishError(`Error: ${event.reason.message} at ${event.reason.stack}`);
+                        });
+
+                        console.server = (...args) => {
+                            error_fn(...args);
+                            management_ws.send({type: "log", message: args.join(' ')});
+                        };
+                    }
                     {% else %}
                     const management_ws = undefined;
                     {% end %}
@@ -253,7 +352,7 @@
                     setTimeout(async () => {
                         document.getElementById('loading-message').innerText = "Setting up tables...";
                         const req = fetch("/layout/{{url}}");
-                        await connectWorkspaceTables(workspace, table_config, "{{'true' if mgr.is_new_api() else 'false'}}", management_ws);
+                        await connectWorkspaceTables(workspace, table_config, user_roles, "{{'true' if mgr.is_new_api() else 'false'}}", management_ws);
 
                         document.getElementById('loading-message').innerText = "Loading layout...";
                         let json = await (await req).json();
@@ -294,7 +393,7 @@
 
                         }, 1000);
 
-                    }, 5000);
+                    }, 50);
 
                     window.setTimeout(async () => {
                         window.workspace.addEventListener("workspace-layout-update", async () => {

--- a/src/hgraph/adaptors/tornado/websocket_server_adaptor.py
+++ b/src/hgraph/adaptors/tornado/websocket_server_adaptor.py
@@ -1,12 +1,15 @@
 import asyncio
 from dataclasses import dataclass
-from typing import Callable
+import logging
+from typing import Callable, Generic, Type, TypeVar
 
 import tornado.websocket
 from frozendict import frozendict
 
 from hgraph import (
+    AUTO_RESOLVE,
     CompoundScalar,
+    HgTypeMetaData,
     graph,
     push_queue,
     TSD,
@@ -31,6 +34,9 @@ from hgraph import (
 from hgraph.adaptors.tornado._tornado_web import TornadoWeb
 
 
+logger = logging.getLogger("wensocket_server_adaptor")
+
+
 @dataclass(frozen=True)
 class WebSocketConnectRequest(CompoundScalar):
     url: str
@@ -39,37 +45,43 @@ class WebSocketConnectRequest(CompoundScalar):
     cookies: dict[str, dict[str, object]] = frozendict()
 
 
+STR_OR_BYTES = TypeVar("STR_OR_BYTES", bytes, str)
+
+
 @dataclass(frozen=True)
-class WebSocketServerRequest(TimeSeriesSchema):
+class WebSocketServerRequest(TimeSeriesSchema, Generic[STR_OR_BYTES]):
     connect_request: TS[WebSocketConnectRequest]
-    messages: TS[tuple[bytes, ...]]
+    messages: TS[tuple[STR_OR_BYTES, ...]]
 
 
 @dataclass(frozen=True)
-class WebSocketClientRequest(TimeSeriesSchema):
+class WebSocketClientRequest(TimeSeriesSchema, Generic[STR_OR_BYTES]):
     connect_request: TS[WebSocketConnectRequest]
-    message: TS[bytes]
+    message: TS[STR_OR_BYTES]
 
 
 @dataclass(frozen=True)
-class WebSocketResponse(TimeSeriesSchema):
+class WebSocketResponse(TimeSeriesSchema, Generic[STR_OR_BYTES]):
     connect_response: TS[bool]
-    message: TS[bytes]
+    message: TS[STR_OR_BYTES]
 
 
 class WebSocketAdaptorManager:
     handlers: dict[str, Callable | str]
 
-    def __init__(self):
+    def __init__(self, binary):
         self.handlers = {}
         self.requests = {}
         self.message_handlers = {}
+        self.binary = binary
 
     @classmethod
-    def instance(cls):
+    def instance(cls, tp):
         if not hasattr(cls, "_instance"):
-            cls._instance = cls()
-        return cls._instance
+            cls._instance = {}
+        if tp not in cls._instance:
+            cls._instance[tp] = cls(tp == bytes)
+        return cls._instance[tp]
 
     def set_queues(self, connect_queue, message_queue):
         self.connect_queue = connect_queue
@@ -79,7 +91,7 @@ class WebSocketAdaptorManager:
         self.tornado_web = TornadoWeb.instance(port)
 
         for path in self.handlers.keys():
-            self.tornado_web.add_handler(path, WebSocketHandler, {"path": path, "mgr": self})
+            self.tornado_web.add_handler(path, WebSocketHandler, {"path": path, "binary": self.binary, "mgr": self})
 
         self.tornado_web.start()
 
@@ -117,9 +129,10 @@ class WebSocketAdaptorManager:
 
 
 class WebSocketHandler(tornado.websocket.WebSocketHandler):
-    def initialize(self, path, mgr: WebSocketAdaptorManager):
+    def initialize(self, path, binary, mgr: WebSocketAdaptorManager):
         self.path = path
         self.mgr = mgr
+        self.binary = binary
 
     async def open(self, *args):
         request_obj = object()
@@ -136,7 +149,7 @@ class WebSocketHandler(tornado.websocket.WebSocketHandler):
                     for k, v in self.request.cookies.items()
                 }),
             ),
-            lambda m: self.write_message(m, binary=True),
+            lambda m: self.write_message(m, binary=self.binary),
         )
 
         if response:
@@ -146,7 +159,10 @@ class WebSocketHandler(tornado.websocket.WebSocketHandler):
             self.close()
 
     def on_message(self, message):
-        self.enqueue_message(message if type(message) is bytes else message.encode())
+        if self.binary:
+            self.enqueue_message(message if type(message) is bytes else message.encode())
+        else:
+            self.enqueue_message(message if type(message) is str else message.decode())
 
     def on_close(self):
         self.close()
@@ -162,30 +178,70 @@ def websocket_server_handler(fn: Callable = None, *, url: str):
         fn = graph(fn)
 
     assert "request" in fn.signature.time_series_inputs.keys(), "Websocket graph must have an input named 'request'"
-    assert fn.signature.time_series_inputs["request"].matches_type(
-        TSB[WebSocketServerRequest]
-    ) or fn.signature.time_series_inputs["request"].matches_type(TSD[int, TSB[WebSocketServerRequest]]), (
-        "WebSocket graph must have a single input named 'request' of type TSB[WebSocketServerRequest] or TSD[int,"
-        " TSB[WebSocketServerRequest]]"
-    )
+
+    single_request_type = HgTypeMetaData.parse_type(TSB[WebSocketServerRequest[STR_OR_BYTES]])
+    multi_request_type = HgTypeMetaData.parse_type(TSD[int, TSB[WebSocketServerRequest[STR_OR_BYTES]]])
+
+    if single_request_type.matches(fn.signature.time_series_inputs["request"]):
+        is_single = True
+        resolution = {}
+        single_request_type.build_resolution_dict(resolution, fn.signature.time_series_inputs["request"])
+        assert STR_OR_BYTES in resolution, (
+            f"STR_OR_BYTES is expected in the resolution of the request type, but got {resolution.keys()}"
+        )
+        is_binary = resolution[STR_OR_BYTES].matches_type(bytes)
+    elif multi_request_type.matches(fn.signature.time_series_inputs["request"]):
+        is_single = False
+        resolution = {}
+        multi_request_type.build_resolution_dict(resolution, fn.signature.time_series_inputs["request"])
+        is_binary = resolution[STR_OR_BYTES].matches_type(bytes)
+    else: 
+        assert False, (
+            "WebSocket graph must have a single input named 'request' of type TSB[WebSocketServerRequest] or TSD[int,"
+            " TSB[WebSocketServerRequest]]"
+        )
 
     output_type = fn.signature.output_type
 
-    assert output_type.matches_type(TSB[WebSocketResponse]) or output_type.matches_type(
-        TSD[int, TSB[WebSocketResponse]]
-    ), "WebSocket graph must have a single output of type TSB[WebSocketResponse] or TSD[int, TSB[WebSocketResponse]]"
+    single_response_type = HgTypeMetaData.parse_type(TSB[WebSocketResponse[STR_OR_BYTES]])
+    multi_response_type = HgTypeMetaData.parse_type(TSD[int, TSB[WebSocketResponse[STR_OR_BYTES]]])
 
-    mgr = WebSocketAdaptorManager.instance()
+    if single_response_type.matches(output_type):
+        resolution = {}
+        single_response_type.build_resolution_dict(resolution, output_type)
+        assert is_binary == resolution[STR_OR_BYTES].matches_type(bytes), (
+            "WebSocket graph must have a single output of type TSB[WebSocketResponse] with the same str/binary type as the input"
+        )
+        assert is_single, (
+            "WebSocket graph must have a single output of type TSB[WebSocketResponse] when the input is TSB[WebSocketServerRequest]"
+        )
+    elif multi_response_type.matches(output_type):
+        resolution = {}
+        multi_response_type.build_resolution_dict(resolution, output_type)
+        assert is_binary == resolution[STR_OR_BYTES].matches_type(bytes), (
+            "WebSocket graph must have a single output of type TSD[int, TSB[WebSocketResponse]] with the same str/binary type as the input"
+        )
+        assert not is_single, (
+            "WebSocket graph must have a single output of type TSD[int, TSB[WebSocketResponse]] when the input is TSD[int, TSB[WebSocketServerRequest]]"
+        )
+    else:
+        assert False, (
+            "WebSocket graph must have a single output of type TSB[WebSocketResponse] or TSD[int, TSB[WebSocketResponse]]"
+        )
+
+    msg_type = bytes if is_binary else str
+    mgr = WebSocketAdaptorManager.instance(msg_type)
     # this makes the handler to be auto-wired in the http_server_adaptor
     mgr.add_handler(url, fn)
+
 
     @graph
     def websocket_server_handler_graph(**inputs: TSB[TS_SCHEMA]) -> TIME_SERIES_TYPE:
         # if however this is wired into the graph explicitly, it will be used instead of the auto-wiring the handler
         mgr.add_handler(url, None)  # prevent auto-wiring
 
-        requests = websocket_server_adaptor.to_graph(path=url, __no_ts_inputs__=True)
-        if fn.signature.time_series_inputs["request"].matches_type(TSB[WebSocketServerRequest]):
+        requests = websocket_server_adaptor[STR_OR_BYTES: msg_type].to_graph(path=url, __no_ts_inputs__=True)
+        if fn.signature.time_series_inputs["request"].matches_type(TSB[WebSocketServerRequest[msg_type]]):
             if inputs.as_dict():
                 responses = map_(lambda r, i: fn(request=r, **i.as_dict()), requests, inputs)
             else:
@@ -197,10 +253,10 @@ def websocket_server_handler(fn: Callable = None, *, url: str):
             isinstance(responses.output_type, HgTSBTypeMetaData)
             and "response" in responses.output_type.bundle_schema_tp.meta_data_schema
         ):
-            websocket_server_adaptor.from_graph(responses.response, path=url)
+            websocket_server_adaptor[STR_OR_BYTES: msg_type].from_graph(responses.response, path=url)
             return responses
         else:
-            websocket_server_adaptor.from_graph(responses, path=url)
+            websocket_server_adaptor[STR_OR_BYTES: msg_type].from_graph(responses, path=url)
             return combine()
 
     return websocket_server_handler_graph
@@ -208,8 +264,8 @@ def websocket_server_handler(fn: Callable = None, *, url: str):
 
 @adaptor
 def websocket_server_adaptor(
-    response: TSD[int, TSB[WebSocketResponse]], path: str
-) -> TSD[int, TSB[WebSocketServerRequest]]: ...
+    response: TSD[int, TSB[WebSocketResponse[STR_OR_BYTES]]], path: str
+) -> TSD[int, TSB[WebSocketServerRequest[STR_OR_BYTES]]]: ...
 
 
 @adaptor_impl(interfaces=(websocket_server_adaptor, websocket_server_adaptor))
@@ -229,7 +285,7 @@ def websocket_server_adaptor_impl(path: str, port: int):
         GlobalState.instance()[f"websocket_server_adaptor://{path}/connect_queue"] = sender
         return None
 
-    @push_queue(TSD[int, TS[tuple[bytes, ...]]])
+    @push_queue(TSD[int, TS[tuple[STR_OR_BYTES, ...]]])
     def messages_from_web(
         sender, path: str = "tornado_websocket_server_adaptor", batch: bool = True
     ) -> TSD[int, TS[tuple[bytes, ...]]]:
@@ -237,26 +293,29 @@ def websocket_server_adaptor_impl(path: str, port: int):
         return None
 
     @graph
-    def from_web(path: str) -> TSD[int, TSB[WebSocketServerRequest]]:
+    def from_web(path: str, _tp: Type[STR_OR_BYTES] = AUTO_RESOLVE) -> TSD[int, TSB[WebSocketServerRequest[STR_OR_BYTES]]]:
+        path = f"{path}[{_tp.__name__.lower()}]"
         requests = connections_from_web(path=path)
-        messages = messages_from_web(path=path)
+        messages = messages_from_web[STR_OR_BYTES: _tp](path=path)
         return map_(
-            lambda r, m: combine[TSB[WebSocketServerRequest]](connect_request=r, messages=m), requests, messages
+            lambda r, m: combine[TSB[WebSocketServerRequest[_tp]]](connect_request=r, messages=m), requests, messages
         )
 
     @sink_node
     def to_web(
-        responses: TSD[int, TSB[WebSocketResponse]],
+        responses: TSD[int, TSB[WebSocketResponse[STR_OR_BYTES]]],
         port: int,
         path: str = "tornado_websocket_server_adaptor",
+        _tp: Type[STR_OR_BYTES] = AUTO_RESOLVE,
         _state: STATE = None,
     ):
         for response_id, response in responses.modified_items():
             TornadoWeb.get_loop().add_callback(_state.mgr.complete_request, response_id, response.delta_value)
 
     @to_web.start
-    def to_web_start(port: int, path: str, _state: STATE):
-        _state.mgr = WebSocketAdaptorManager.instance()
+    def to_web_start(port: int, path: str, _tp: Type[STR_OR_BYTES] = AUTO_RESOLVE, _state: STATE = None):
+        _state.mgr = WebSocketAdaptorManager.instance(_tp)
+        path = f"{path}[{_tp.__name__.lower()}]"
         _state.mgr.set_queues(
             connect_queue=GlobalState.instance()[f"websocket_server_adaptor://{path}/connect_queue"],
             message_queue=GlobalState.instance()[f"websocket_server_adaptor://{path}/message_queue"],
@@ -267,41 +326,46 @@ def websocket_server_adaptor_impl(path: str, port: int):
     def to_web_stop(_state: STATE):
         _state.mgr.tornado_web.stop()
 
-    requests = from_web(path=path)
-    requests_by_url = partition(requests, requests.connect_request.url)
-
-    responses = {}
-    for url, handler in WebSocketAdaptorManager.instance().handlers.items():
-        if isinstance(handler, WiringNodeClass):
-            if handler.signature.time_series_inputs["request"].matches_type(TSB[WebSocketServerRequest]):
-                responses[url] = map_(handler, request=requests_by_url[url])
-            elif handler.signature.time_series_inputs["request"].matches_type(TSD[int, TSB[WebSocketServerRequest]]):
-                responses[url] = handler(request=requests_by_url[url])
-        elif handler is None:
-            pass
-        else:
-            raise ValueError(f"Invalid handler type for the websocket_ adaptor: {handler}")
-
     adaptors_dedup = set()
-    adaptors = set()
-    for handler_path, type_map, node, receive in WiringGraphContext.__stack__[0].registered_service_clients(
-        websocket_server_adaptor
-    ):
-        assert type_map == {}, "Websocket adaptor does not support type generics"
-        if (handler_path, receive) in adaptors_dedup:
-            raise ValueError(
-                f"Duplicate websocket_ adaptor client for handler_path {handler_path}: only one client is allowed"
-            )
-        adaptors_dedup.add((handler_path, receive))
-        adaptors.add(handler_path.replace("/from_graph", "").replace("/to_graph", ""))
+    for msg_type in (str, bytes):
+        if WebSocketAdaptorManager.instance(msg_type).handlers:
+            requests = from_web[STR_OR_BYTES: msg_type](path=path)
+            requests_by_url = partition(requests, requests.connect_request.url)
 
-    for handler_path in adaptors:
-        url = websocket_server_adaptor.path_from_full_path(handler_path)
+            responses = {}
+            for url, handler in WebSocketAdaptorManager.instance(msg_type).handlers.items():
+                if isinstance(handler, WiringNodeClass):
+                    logger.info("Adding WS handler: [%s] %s", url, handler.signature.signature)
+                    if handler.signature.time_series_inputs["request"].matches_type(TSB[WebSocketServerRequest]):
+                        responses[url] = map_(handler, request=requests_by_url[url])
+                    elif handler.signature.time_series_inputs["request"].matches_type(TSD[int, TSB[WebSocketServerRequest]]):
+                        responses[url] = handler(request=requests_by_url[url])
+                elif handler is None:
+                    logger.info("Pre-wired WS handler: [%s]", url)
+                else:
+                    raise ValueError(f"Invalid handler type for the websocket_ adaptor: {handler}")
 
-        mgr = WebSocketAdaptorManager.instance()
-        mgr.add_handler(url, None)
+            adaptors = set()
+            for handler_path, type_map, node, receive in WiringGraphContext.__stack__[0].registered_service_clients(
+                websocket_server_adaptor
+            ):
+                logger.info(f"Adding WS adaptor: {handler_path} for type {type_map[STR_OR_BYTES]} when msg_type is {msg_type}")
+                if type_map[STR_OR_BYTES].py_type != msg_type:
+                    continue
+                if (handler_path, receive) in adaptors_dedup:
+                    raise ValueError(
+                        f"Duplicate websocket_ adaptor client for handler_path {handler_path}: only one client is allowed"
+                    )
+                adaptors_dedup.add((handler_path, receive))
+                adaptors.add(handler_path.replace("/from_graph", "").replace("/to_graph", ""))
 
-        responses[url] = websocket_server_adaptor.wire_impl_inputs_stub(handler_path).response
-        websocket_server_adaptor.wire_impl_out_stub(handler_path, requests_by_url[url])
+            for handler_path in adaptors:
+                url = websocket_server_adaptor.path_from_full_path(handler_path)
 
-    to_web(merge(*responses.values(), disjoint=True), port, path=path)
+                mgr = WebSocketAdaptorManager.instance(msg_type)
+                mgr.add_handler(url, None)  # prevent auto-wiring the handler
+
+                responses[url] = websocket_server_adaptor[STR_OR_BYTES: msg_type].wire_impl_inputs_stub(handler_path).response
+                websocket_server_adaptor[STR_OR_BYTES: msg_type].wire_impl_out_stub(handler_path, requests_by_url[url])
+
+            to_web(merge(*responses.values(), disjoint=True), port, path=path)

--- a/src/hgraph/debug/_inspector_publish.py
+++ b/src/hgraph/debug/_inspector_publish.py
@@ -177,7 +177,7 @@ def publish_tables(state: InspectorState, include_stats=True):
 
     data = state.total_data
     if data["time"]:
-        total_time = (state.total_data["time"][-1] - state.total_data_prev.get("time", datetime.min)).total_seconds()
+        total_time = max((state.total_data["time"][-1] - state.total_data_prev.get("time", datetime.min)).total_seconds(), 1e-6)  # in case we went below system clock resolution
         total_graph_time = (data["graph_time"][-1] - state.total_data_prev.get("graph_time", 0)) / 1_000_000_000
         total_os_graph_time = data["os_graph_time"][-1] - state.total_data_prev.get("os_graph_time", 0)
         lags = [(data["time"][i] - data["evaluation_time"][i]).total_seconds() for i in range(len(data["time"]))]

--- a/src/hgraph/debug/_inspector_util.py
+++ b/src/hgraph/debug/_inspector_util.py
@@ -87,7 +87,7 @@ def format_name_node(node: "Node", key=None) -> str:
         f"{(':' + node.signature.label) if node.signature.label else ''}"
     )
 
-    if node.graph.parent_node:
+    if node.graph.parent_node and node.graph.parent_node.signature.wiring_path_name:
         return long_name.replace(node.graph.parent_node.signature.wiring_path_name + ".", "")
     else:
         return long_name
@@ -409,7 +409,7 @@ def inspect_type(value, key):
 
 @inspect_type.register
 def inspect_type_tsb(value: HgTSBTypeMetaData, key):
-    return value.meta_data_schema[key]
+    return value.bundle_schema_tp.meta_data_schema[key]
 
 
 @inspect_type.register

--- a/src/hgraph/nodes/_tsd_operators.py
+++ b/src/hgraph/nodes/_tsd_operators.py
@@ -21,6 +21,7 @@ __all__ = (
     "flatten_tsd",
     "extract_tsd",
     "keys_where_true",
+    "where_true",
 )
 
 
@@ -99,3 +100,19 @@ def keys_where_true(ts: TSD[K, TS[bool]], _tp: type[K] = AUTO_RESOLVE) -> TSS[K]
             removed.add(key)
 
     return set_delta(added, removed, _tp)
+
+
+@compute_node
+def where_true(ts: TSD[K, TS[bool]]) -> TSD[K, TS[bool]]:
+    out = {}
+
+    for key, value in ts.modified_items():
+        if value.value:
+            out[key] = value.value
+        else:
+            out[key] = REMOVE_IF_EXISTS
+
+    for key in ts.removed_keys():
+        out[key] = REMOVE_IF_EXISTS
+
+    return out

--- a/src/hgraph/test/_node_printer.py
+++ b/src/hgraph/test/_node_printer.py
@@ -83,8 +83,8 @@ class EvaluationTrace(EvaluationLifeCycleObserver):
         while graph:
             if graph.parent_node:
                 graph_str.append(
-                    f"{(graph.parent_node.signature.label + ':') if graph.parent_node.signature.label else ''}"
-                    + f"{graph.parent_node.signature.name}<{', '.join(str(i) for i in graph.graph_id)}>"
+                    f"{graph.parent_node.signature.name}<{', '.join(str(i) for i in graph.graph_id)}>" +
+                    f"{(':' + graph.parent_node.signature.label) if graph.parent_node.signature.label else ''}"
                 )
                 graph = graph.parent_node.graph
             else:


### PR DESCRIPTION
fix filtering dropdown options
    fix the case when editable field is part of the index
    node labelling changes, blank tables in perspective and other minr fixes
    improve websocket error reporting
    Fix to TSB __eq__
    add where_true operator
    fix eq, by: Simon Young <syoung@bamfunds.com>
    improve disconnect handling, add telemetry
    add reload warning and do not force reload if graph is not responding
    Support when scheme name is missing in response header, by jintang@bamfunds.com
    fix tooltips
    Fixes for mobile
    json and binary ws
    add JSON type and operators for it, make websockets generic for text  or binary types
    remove graph labels from wiring paths
    add a label decorator for nodes and graphs
    fix tss or operator
    reduce garbage generation and add sampling to to_table and perspectiv…
    force remove frame references from wiring and collect garbage once gr…
    user roles and table edit permissionss
    Add reset to unary sum_, min_, max_, by: Simon Young <syoung@bamfunds.com>
    Fix docstrings, by: Simon Young <syoung@bamfunds.com>
    Implement zero division check in pow_, by: Simon Young <syoung@bamfunds.com>
    improve if_then_else deduplication of references
    Add support for string configs to allow json templating
    Redo clip so min_ and max_ can be passed in as TS, by: Tope Olukemi <tolukemi@bamfunds.com>
    take() with no arguments should default to taking 1 by count
    handle user closing socket before we sent a reply in the http server adaptor
    Small changes to http client adaptor - prioritize negotiate over ntlm when both available; use regex to match challenge
    tooltips over http and websocket, extend to_table for complex keys
