### PR TITLE
Support dataclass structured scalars

### DIFF
--- a/cpp/src/cpp/types/tsb.cpp
+++ b/cpp/src/cpp/types/tsb.cpp
@@ -190,14 +190,12 @@ namespace hgraph {
         return _schema->keys()[index];
     }
 
-    template<typename T_TS>
+    template <typename T_TS>
         requires IndexedTimeSeriesT<T_TS>
-    template<bool is_delta>
-    nb::object TimeSeriesBundle<T_TS>::py_value_with_constraint(
-const std::function < bool(const ts_type &) > &constraint)
-    const
- {
+    template <bool is_delta>
+    nb::object TimeSeriesBundle<T_TS>::py_value_with_constraint(const std::function<bool(const ts_type &)> &constraint) const {
         nb::dict out;
+        nb::dict present;
         for (size_t i = 0, l = ts_values().size(); i < l; ++i) {
             const auto &key = _schema->keys()[i];
             const auto &ts  = ts_values()[i];
@@ -208,8 +206,12 @@ const std::function < bool(const ts_type &) > &constraint)
                 } else {
                     val = ts->py_value();
                 }
-                // Only include entries that have an actual value. Some TS can be marked valid but carry no value.
-                if (val.is_valid() && !val.is_none()) { out[key.c_str()] = std::move(val); }
+                if (val.is_valid()) {
+                    present[key.c_str()] = nb::none();
+                    // Keep the existing dict representation compact, while
+                    // retaining enough information to reconstruct explicit None.
+                    if (!val.is_none()) { out[key.c_str()] = std::move(val); }
+                }
             }
         }
         // is_delta always returns dicts. For non-delta and when a scalar_type exists,
@@ -221,12 +223,15 @@ const std::function < bool(const ts_type &) > &constraint)
                 const bool python_owned{nb::hasattr(schema().scalar_type(), "__hgraph_bundle_constructor_fields__")};
                 nb::object constructor_fields{python_owned ? schema().scalar_type().attr("__hgraph_bundle_constructor_fields__")
                                                            : nb::none()};
+                nb::object required_fields{python_owned ? schema().scalar_type().attr("__hgraph_bundle_required_fields__")
+                                                        : nb::none()};
                 nb::dict   kwargs;
                 for (const auto &k : schema().keys()) {
                     if (python_owned && !nb::cast<bool>(constructor_fields.attr("__contains__")(k))) { continue; }
                     if (out.contains(k.c_str())) {
                         kwargs[k.c_str()] = out[k.c_str()];
-                    } else if (!python_owned) {
+                    } else if (!python_owned || present.contains(k.c_str()) ||
+                               nb::cast<bool>(required_fields.attr("__contains__")(k))) {
                         kwargs[k.c_str()] = nb::none();
                     }
                 }

--- a/cpp/src/cpp/types/tsb.cpp
+++ b/cpp/src/cpp/types/tsb.cpp
@@ -218,11 +218,15 @@ const std::function < bool(const ts_type &) > &constraint)
         // valid before calling us, so this still yields a fully-populated instance.
         if constexpr (!is_delta) {
             if (schema().scalar_type().is_valid() && !schema().scalar_type().is_none()) {
-                nb::dict kwargs;
+                const bool python_owned{nb::hasattr(schema().scalar_type(), "__hgraph_bundle_constructor_fields__")};
+                nb::object constructor_fields{python_owned ? schema().scalar_type().attr("__hgraph_bundle_constructor_fields__")
+                                                           : nb::none()};
+                nb::dict   kwargs;
                 for (const auto &k : schema().keys()) {
+                    if (python_owned && !nb::cast<bool>(constructor_fields.attr("__contains__")(k))) { continue; }
                     if (out.contains(k.c_str())) {
                         kwargs[k.c_str()] = out[k.c_str()];
-                    } else {
+                    } else if (!python_owned) {
                         kwargs[k.c_str()] = nb::none();
                     }
                 }

--- a/docs/source/concepts/typing_system.rst
+++ b/docs/source/concepts/typing_system.rst
@@ -105,6 +105,10 @@ Dataclass annotations describe the wiring schema; assigning a whole dataclass do
 replace the object's fields. Frozen dataclasses are recommended because mutating a retained object in place does not
 produce a new time-series tick.
 
+Schema discovery lazily attaches reserved ``__hgraph_bundle_*__`` and ``__meta_data_schema__`` metadata to the
+dataclass itself for compatibility with the Python and C++ runtimes. Defining incompatible values for these reserved
+attributes raises a type parsing error instead of being silently overwritten.
+
 Use ``CompoundScalar`` when its hgraph-specific helpers, serialisation hierarchy, or C++ field-expanded storage are
 required. Use a plain dataclass when preserving the application's Python class, constructor, properties, equality,
 and object identity is the priority. The legacy ``CS[Model]`` adaptor remains useful when a distinct

--- a/docs/source/concepts/typing_system.rst
+++ b/docs/source/concepts/typing_system.rst
@@ -60,8 +60,8 @@ Schema Based Types
 
 Besides the standard types listed above there are two special types that are derived from the ``AbstractSchema``
 type, namely: ``CompoundScalar`` and ``TimeSeriesSchema``. These types support the ability to define
-named collection types, the ``CompoundScalar`` class supports defining scalar values made up of simple types
-including ``CompoundScalar`` types.
+named collection types. ``CompoundScalar`` supports defining scalar values made up of simple types, including
+other ``CompoundScalar`` types.
 
 This is an example of it's use:
 
@@ -75,12 +75,40 @@ This is an example of it's use:
         p1: str
         p2: int
 
-This type defines it's constituents in much the same way as for a dataclass. In fact it is generally a good practice
-to wrap the class with the ``dataclass`` wrapper.
+This type defines its constituents in much the same way as a dataclass. It is generally good practice to wrap the
+class with the ``dataclass`` decorator.
 
-The reason for using this and not a standard dataclass is that this type will perform validation of the types and
-maintains the type schema that can be used to perform type-checking and for implementing useful library functions
-such as ``getattr_`` and other useful functions.
+Standard-library dataclasses can also be used directly as nominal scalar schemas without inheriting from
+``CompoundScalar``:
+
+::
+
+    from dataclasses import dataclass
+    from hgraph import TS, combine, graph
+
+    @dataclass(frozen=True)
+    class Quote:
+        instrument: str
+        bid: float
+        ask: float = 0.0
+
+    @graph
+    def make_quote(bid: TS[float]) -> TS[Quote]:
+        return combine[TS[Quote]](instrument="ABC", bid=bid)
+
+The original dataclass instance is retained as the time-series value. Its ordered fields form the schema used for
+wiring, reflection, field access, generic resolution, conversion, and dispatch. Dataclass defaults and default
+factories are honoured when constructing a value. ``TSB[Quote]`` provides the corresponding field-expanded
+time-series form.
+
+Dataclass annotations describe the wiring schema; assigning a whole dataclass does not recursively validate or
+replace the object's fields. Frozen dataclasses are recommended because mutating a retained object in place does not
+produce a new time-series tick.
+
+Use ``CompoundScalar`` when its hgraph-specific helpers, serialisation hierarchy, or C++ field-expanded storage are
+required. Use a plain dataclass when preserving the application's Python class, constructor, properties, equality,
+and object identity is the priority. The legacy ``CS[Model]`` adaptor remains useful when a distinct
+``CompoundScalar`` must be generated from a dataclass, Pydantic model, or annotated plain class.
 
 The ``TimeSeriesSchema`` is the parallel for time-series collections. In this paradigm, it's use is to define a schema
 describing a collection of named time-series values. For example:
@@ -223,4 +251,3 @@ Then prior to the use of the type the type should be registered with the type sy
 The advantage of registering the type is that it can become a fully functioning type including being able to participate
 in type resolution. This is as apposed to the python object type which has very limited ability to integrate into the
 type system.
-

--- a/hgraph/_impl/_operators/_conversion_operators/_compound_scalar_conversion_operators.py
+++ b/hgraph/_impl/_operators/_conversion_operators/_compound_scalar_conversion_operators.py
@@ -77,14 +77,16 @@ def _construct_dataclass_from_bundle(tp, bundle, strict):
     return tp(**values)
 
 
-def _structured_scalar_to_dict(value):
+def _structured_scalar_to_dict(value, *, include_none=False):
     if isinstance(value, CompoundScalar):
         return value.to_dict()
     scalar = HgScalarTypeMetaData.parse_type(type(value))
     if not isinstance(scalar, HgCompoundScalarType):
         raise TypeError(f"{type(value)} is not a structured scalar")
     return {
-        name: field_value for name in scalar.meta_data_schema if (field_value := getattr(value, name, None)) is not None
+        name: getattr(value, name, None)
+        for name in scalar.meta_data_schema
+        if include_none or getattr(value, name, None) is not None
     }
 
 
@@ -139,7 +141,7 @@ def combine_compound_scalars(orig: TS[COMPOUND_SCALAR], delta: TS[COMPOUND_SCALA
     """
     if not delta.valid:
         return orig.value
-    original_values = _structured_scalar_to_dict(o_v := orig.value)
+    original_values = _structured_scalar_to_dict(o_v := orig.value, include_none=True)
     items = [(key, value, original_values) for key, value in _structured_scalar_to_dict(delta.value).items()]
     while items:
         key, value, orig_values = items.pop()
@@ -170,7 +172,7 @@ def combine_cs_with(
     """
     if not bundle.valid:
         return orig.value
-    original_values = _structured_scalar_to_dict(o_v := orig.value)
+    original_values = _structured_scalar_to_dict(o_v := orig.value, include_none=True)
     items = [(key, value.value, original_values) for key, value in bundle.items()]
     while items:
         key, value, orig_values = items.pop()

--- a/hgraph/_impl/_operators/_conversion_operators/_compound_scalar_conversion_operators.py
+++ b/hgraph/_impl/_operators/_conversion_operators/_compound_scalar_conversion_operators.py
@@ -1,8 +1,20 @@
+from dataclasses import MISSING as DATACLASS_MISSING, fields, is_dataclass
 from typing import Type
 
 from hgraph import TimeSeriesSchema
 from hgraph._operators import combine, convert
-from hgraph._types import TS, TS_SCHEMA, TSB, DEFAULT, OUT, AUTO_RESOLVE, COMPOUND_SCALAR, CompoundScalar
+from hgraph._types import (
+    TS,
+    TS_SCHEMA,
+    TSB,
+    DEFAULT,
+    OUT,
+    AUTO_RESOLVE,
+    COMPOUND_SCALAR,
+    CompoundScalar,
+    HgCompoundScalarType,
+    HgScalarTypeMetaData,
+)
 from hgraph._wiring import compute_node
 
 __all__ = ()
@@ -11,12 +23,83 @@ __all__ = ()
 MISSING = object()
 
 
+def _dataclass_fields_by_name(tp):
+    origin = getattr(tp, "__origin__", None) or tp
+    return (
+        {field.name: field for field in fields(origin)}
+        if is_dataclass(origin) and not issubclass(origin, CompoundScalar)
+        else None
+    )
+
+
+def _field_has_default(tp, name):
+    dataclass_fields = _dataclass_fields_by_name(tp)
+    if dataclass_fields is None:
+        return getattr(tp, name, MISSING) is not MISSING
+    field = dataclass_fields[name]
+    return not field.init or field.default is not DATACLASS_MISSING or field.default_factory is not DATACLASS_MISSING
+
+
+def _constructor_values(tp, values):
+    dataclass_fields = _dataclass_fields_by_name(tp)
+    if dataclass_fields is None:
+        return values
+    return {name: value for name, value in values.items() if dataclass_fields[name].init}
+
+
+def _required_constructor_fields(tp):
+    dataclass_fields = _dataclass_fields_by_name(tp)
+    if dataclass_fields is None:
+        return ()
+    return tuple(
+        name
+        for name, field in dataclass_fields.items()
+        if field.init and field.default is DATACLASS_MISSING and field.default_factory is DATACLASS_MISSING
+    )
+
+
+def _is_python_dataclass_meta(meta):
+    return _dataclass_fields_by_name(meta.py_type) is not None
+
+
+def _construct_dataclass_from_bundle(tp, bundle, strict):
+    dataclass_fields = _dataclass_fields_by_name(tp)
+    required = _required_constructor_fields(tp)
+    if strict and any(not bundle[name].valid for name in required):
+        return None
+    values = {
+        name: value.value
+        for name, value in bundle.items()
+        if value.valid and name in dataclass_fields and dataclass_fields[name].init
+    }
+    if not strict:
+        values.update({name: None for name in required if name not in values})
+    return tp(**values)
+
+
+def _structured_scalar_to_dict(value):
+    if isinstance(value, CompoundScalar):
+        return value.to_dict()
+    scalar = HgScalarTypeMetaData.parse_type(type(value))
+    if not isinstance(scalar, HgCompoundScalarType):
+        raise TypeError(f"{type(value)} is not a structured scalar")
+    return {
+        name: field_value for name in scalar.meta_data_schema if (field_value := getattr(value, name, None)) is not None
+    }
+
+
+def _structured_scalar_from_dict(tp, values):
+    if isinstance(tp, type) and issubclass(tp, CompoundScalar):
+        return tp.from_dict(values)
+    return tp(**_constructor_values(tp, values))
+
+
 def _check_schema(scalar, bundle):
     if bundle.meta_data_schema.keys() - scalar.meta_data_schema.keys():
         return f"Extra fields: {bundle.meta_data_schema.keys() - scalar.meta_data_schema.keys()}"
     for k, t in scalar.meta_data_schema.items():
         if (kt := bundle.meta_data_schema.get(k)) is None:
-            if getattr(scalar.py_type, k, MISSING) is MISSING:
+            if not _field_has_default(scalar.py_type, k):
                 return f"Missing input: {k}"
         elif not t.matches(kt if kt.is_scalar else kt.scalar_type()):
             return f"field {k} of type {t} does not accept {kt}"
@@ -45,7 +128,7 @@ def combine_cs(
     __strict__: bool = True,
     **bundle: TSB[TS_SCHEMA],
 ) -> TS[COMPOUND_SCALAR]:
-    return tp_(**{k: v.value for k, v in bundle.items()})
+    return tp_(**_constructor_values(tp_, {k: v.value for k, v in bundle.items()}))
 
 
 @compute_node(overloads=combine, valid=("orig",))
@@ -56,8 +139,8 @@ def combine_compound_scalars(orig: TS[COMPOUND_SCALAR], delta: TS[COMPOUND_SCALA
     """
     if not delta.valid:
         return orig.value
-    original_values = (o_v := orig.value).to_dict()
-    items = [(key, value, original_values) for key, value in delta.value.to_dict().items()]
+    original_values = _structured_scalar_to_dict(o_v := orig.value)
+    items = [(key, value, original_values) for key, value in _structured_scalar_to_dict(delta.value).items()]
     while items:
         key, value, orig_values = items.pop()
         if isinstance(value, dict):
@@ -65,16 +148,17 @@ def combine_compound_scalars(orig: TS[COMPOUND_SCALAR], delta: TS[COMPOUND_SCALA
             items.extend([(k, v, values) for k, v in value.items()])
         else:
             orig_values[key] = value
-    return type(o_v).from_dict(original_values)
+    return _structured_scalar_from_dict(type(o_v), original_values)
 
 
 @compute_node(
-    overloads=combine, valid=("orig",),
+    overloads=combine,
+    valid=("orig",),
     requires=lambda m: _check_schema_nonstrict(m[COMPOUND_SCALAR], m[TS_SCHEMA]),
     all_valid=lambda m, __strict__: ("bundle",) if __strict__ else None,
-    )
+)
 def combine_cs_with(
-    orig: TS[COMPOUND_SCALAR], 
+    orig: TS[COMPOUND_SCALAR],
     tp_out_: Type[TS[COMPOUND_SCALAR]] = DEFAULT[OUT],
     tp_: Type[COMPOUND_SCALAR] = COMPOUND_SCALAR,
     __strict__: bool = True,
@@ -86,7 +170,7 @@ def combine_cs_with(
     """
     if not bundle.valid:
         return orig.value
-    original_values = (o_v := orig.value).to_dict()
+    original_values = _structured_scalar_to_dict(o_v := orig.value)
     items = [(key, value.value, original_values) for key, value in bundle.items()]
     while items:
         key, value, orig_values = items.pop()
@@ -95,23 +179,35 @@ def combine_cs_with(
             items.extend([(k, v, values) for k, v in value.items()])
         else:
             orig_values[key] = value
-    return type(o_v).from_dict(original_values)
+    return _structured_scalar_from_dict(type(o_v), original_values)
 
 
 @compute_node(
     overloads=convert,
     requires=lambda m: m[OUT].py_type == TS[CompoundScalar],
     resolvers={COMPOUND_SCALAR: lambda m: m[TS_SCHEMA].py_type.scalar_type()},
-    all_valid=lambda m, __strict__: ("bundle",) if __strict__ else None,
+    all_valid=lambda m, __strict__: (
+        ("bundle",) if __strict__ and not _is_python_dataclass_meta(m[COMPOUND_SCALAR]) else None
+    ),
 )
-def convert_cs_from_tsb(bundle: TSB[TS_SCHEMA], __strict__: bool = True) -> TS[COMPOUND_SCALAR]:
-    return bundle.value
+def convert_cs_from_tsb(
+    bundle: TSB[TS_SCHEMA],
+    __strict__: bool = True,
+    scalar_tp_: Type[COMPOUND_SCALAR] = AUTO_RESOLVE,
+) -> TS[COMPOUND_SCALAR]:
+    return (
+        _construct_dataclass_from_bundle(scalar_tp_, bundle, __strict__)
+        if _dataclass_fields_by_name(scalar_tp_) is not None
+        else bundle.value
+    )
 
 
 @compute_node(
     overloads=convert,
     requires=lambda m: m[OUT].py_type != TS[CompoundScalar],
-    all_valid=lambda m, __strict__: ("bundle",) if __strict__ else None,
+    all_valid=lambda m, __strict__: (
+        ("bundle",) if __strict__ and not _is_python_dataclass_meta(m[COMPOUND_SCALAR]) else None
+    ),
 )
 def convert_cs_from_tsb_typed(
     bundle: TSB[TS_SCHEMA],
@@ -119,9 +215,11 @@ def convert_cs_from_tsb_typed(
     tp_: Type[TS[COMPOUND_SCALAR]] = DEFAULT[OUT],
     scalar_tp_: Type[COMPOUND_SCALAR] = AUTO_RESOLVE,
 ) -> TS[COMPOUND_SCALAR]:
-    return scalar_tp_(
-        **{k: v.value if v.valid else None for k, v in bundle.items() if k in scalar_tp_.__meta_data_schema__}
-    )
+    scalar = HgScalarTypeMetaData.parse_type(scalar_tp_)
+    if _dataclass_fields_by_name(scalar_tp_) is not None:
+        return _construct_dataclass_from_bundle(scalar_tp_, bundle, __strict__)
+    values = {k: v.value for k, v in bundle.items() if k in scalar.meta_data_schema}
+    return scalar_tp_(**_constructor_values(scalar_tp_, values))
 
 
 @compute_node(
@@ -135,9 +233,5 @@ def convert_tsb_from_cs(
     tp_: type[TS_SCHEMA] = AUTO_RESOLVE,
 ) -> TSB[TS_SCHEMA]:
     value = ts.value
-    as_dict = value.to_dict()
-    return {
-        k: getattr(value, k)
-        for k, v in as_dict.items()
-        if k in tp_.__meta_data_schema__
-    }
+    as_dict = _structured_scalar_to_dict(value)
+    return {k: getattr(value, k) for k, v in as_dict.items() if k in tp_.__meta_data_schema__}

--- a/hgraph/_impl/_operators/_to_json.py
+++ b/hgraph/_impl/_operators/_to_json.py
@@ -2,7 +2,7 @@ import json
 from datetime import datetime, date, time, timedelta
 from enum import Enum
 from itertools import chain
-from typing import Callable, Any
+from typing import Callable, Any, get_origin
 
 from multimethod import multimethod
 
@@ -51,17 +51,19 @@ def to_json_converter(value: HgTypeMetaData, delta=False) -> Callable[[Any], str
 
 
 def _compound_scalar_parent_encode(value: HgCompoundScalarType, delta: bool):
-    switches = {v: to_json_converter(HgCompoundScalarType(v)) for v in value.py_type.__serialise_children__.values()}
+    tp = get_origin(value.py_type) or value.py_type
+    switches = {v: to_json_converter(HgCompoundScalarType(v)) for v in tp.__serialise_children__.values()}
     return lambda v: "null" if v is None else switches[type(v)](v)
 
 
 @to_json_converter.register
 def _(value: HgCompoundScalarType, delta=False) -> Callable[[Any], str]:
     tp = value.py_type
-    if tp.__serialise_base__:
+    origin = get_origin(tp) or tp
+    if origin.__serialise_base__:
         return _compound_scalar_parent_encode(value, delta)
     to_json = []
-    if (f := tp.__serialise_discriminator_field__) is not None and f not in tp.__meta_data_schema__:
+    if (f := origin.__serialise_discriminator_field__) is not None and f not in value.meta_data_schema:
         to_json.append(
             error_wrapper(
                 lambda v: (
@@ -237,14 +239,15 @@ def _(value: HgTSTypeMetaData, delta=False) -> Callable[[Any], Any]:
 
 def _compound_scalar_parent_decode(value: HgCompoundScalarType, delta: bool):
     tp = value.py_type
-    switches = {k: from_json_converter(HgCompoundScalarType(v)) for k, v in tp.__serialise_children__.items()}
-    discriminator = tp.__serialise_discriminator_field__
+    origin = get_origin(tp) or tp
+    switches = {k: from_json_converter(HgCompoundScalarType(v)) for k, v in origin.__serialise_children__.items()}
+    discriminator = origin.__serialise_discriminator_field__
     return lambda v, switches_=switches, d=discriminator: switches_[v.get(d)](v) if v is not None else None
 
 
 @from_json_converter.register
 def _(value: HgCompoundScalarType, delta=False) -> Callable[[Any], Any]:
-    if value.py_type.__serialise_base__:
+    if (get_origin(value.py_type) or value.py_type).__serialise_base__:
         return _compound_scalar_parent_decode(value, delta)
     fns = []
     for k, tp in value.meta_data_schema.items():

--- a/hgraph/_impl/_operators/_to_json.py
+++ b/hgraph/_impl/_operators/_to_json.py
@@ -52,7 +52,9 @@ def to_json_converter(value: HgTypeMetaData, delta=False) -> Callable[[Any], str
 
 def _compound_scalar_parent_encode(value: HgCompoundScalarType, delta: bool):
     tp = get_origin(value.py_type) or value.py_type
-    switches = {v: to_json_converter(HgCompoundScalarType(v)) for v in tp.__serialise_children__.values()}
+    switches = {
+        v: to_json_converter(HgCompoundScalarType(v)) for v in getattr(tp, "__serialise_children__", {}).values()
+    }
     return lambda v: "null" if v is None else switches[type(v)](v)
 
 
@@ -60,16 +62,15 @@ def _compound_scalar_parent_encode(value: HgCompoundScalarType, delta: bool):
 def _(value: HgCompoundScalarType, delta=False) -> Callable[[Any], str]:
     tp = value.py_type
     origin = get_origin(tp) or tp
-    if origin.__serialise_base__:
+    if getattr(origin, "__serialise_base__", False):
         return _compound_scalar_parent_encode(value, delta)
     to_json = []
-    if (f := origin.__serialise_discriminator_field__) is not None and f not in value.meta_data_schema:
+    if (
+        f := getattr(origin, "__serialise_discriminator_field__", None)
+    ) is not None and f not in value.meta_data_schema:
         to_json.append(
             error_wrapper(
-                lambda v: (
-                    f'"{v.__serialise_discriminator_field__}":'
-                    f' "{getattr(v, v.__serialise_discriminator_field__, v.__class__.__name__)}"'
-                ),
+                lambda v, f_=f: f'"{f_}": "{getattr(v, f_, v.__class__.__name__)}"',
                 f"{str(value)}: __serialise_discriminator_field__",
             )
         )
@@ -240,14 +241,17 @@ def _(value: HgTSTypeMetaData, delta=False) -> Callable[[Any], Any]:
 def _compound_scalar_parent_decode(value: HgCompoundScalarType, delta: bool):
     tp = value.py_type
     origin = get_origin(tp) or tp
-    switches = {k: from_json_converter(HgCompoundScalarType(v)) for k, v in origin.__serialise_children__.items()}
-    discriminator = origin.__serialise_discriminator_field__
+    switches = {
+        k: from_json_converter(HgCompoundScalarType(v))
+        for k, v in getattr(origin, "__serialise_children__", {}).items()
+    }
+    discriminator = getattr(origin, "__serialise_discriminator_field__", None)
     return lambda v, switches_=switches, d=discriminator: switches_[v.get(d)](v) if v is not None else None
 
 
 @from_json_converter.register
 def _(value: HgCompoundScalarType, delta=False) -> Callable[[Any], Any]:
-    if (get_origin(value.py_type) or value.py_type).__serialise_base__:
+    if getattr(get_origin(value.py_type) or value.py_type, "__serialise_base__", False):
         return _compound_scalar_parent_decode(value, delta)
     fns = []
     for k, tp in value.meta_data_schema.items():

--- a/hgraph/_impl/_types/_tsb.py
+++ b/hgraph/_impl/_types/_tsb.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, fields, is_dataclass
+from dataclasses import MISSING as DATACLASS_MISSING, dataclass, fields, is_dataclass
 from datetime import datetime
 from typing import Any, Mapping, Generic, TYPE_CHECKING, cast, Union
 
@@ -15,17 +15,27 @@ if TYPE_CHECKING:
 __all__ = ("PythonTimeSeriesBundleOutput", "PythonTimeSeriesBundleInput")
 
 
-def _python_dataclass_constructor_fields(scalar_type):
+def _python_dataclass_constructor_field_sets(scalar_type):
     origin = getattr(scalar_type, "__origin__", None) or scalar_type
     if isinstance(origin, type) and is_dataclass(origin) and not issubclass(origin, CompoundScalar):
-        return {field.name for field in fields(origin) if field.init}
+        dataclass_fields = tuple(fields(origin))
+        constructor_fields = {field.name for field in dataclass_fields if field.init}
+        required_fields = {
+            field.name
+            for field in dataclass_fields
+            if field.init and field.default is DATACLASS_MISSING and field.default_factory is DATACLASS_MISSING
+        }
+        return constructor_fields, required_fields
 
 
 def _bundle_scalar_value(schema, items):
     scalar_type = schema.scalar_type()
-    constructor_fields = _python_dataclass_constructor_fields(scalar_type)
-    if constructor_fields is not None:
-        return scalar_type(**{name: ts.value for name, ts in items if name in constructor_fields and ts.valid})
+    constructor_field_sets = _python_dataclass_constructor_field_sets(scalar_type)
+    if constructor_field_sets is not None:
+        constructor_fields, required_fields = constructor_field_sets
+        return scalar_type(**{
+            name: ts.value for name, ts in items if name in constructor_fields and (ts.valid or name in required_fields)
+        })
     return scalar_type(**{name: ts.value for name, ts in items})
 
 
@@ -161,7 +171,7 @@ class PythonTimeSeriesBundleInput(PythonBoundTimeSeriesInput, TimeSeriesBundleIn
             return super().value
         else:
             if s := self.__schema__.scalar_type():
-                if _python_dataclass_constructor_fields(s) is not None:
+                if _python_dataclass_constructor_field_sets(s) is not None:
                     return _bundle_scalar_value(self.__schema__, self.items())
                 v = {k: ts.value for k, ts in self.items() if ts.valid or getattr(s, k, None) is None}
                 return s(**v)

--- a/hgraph/_impl/_types/_tsb.py
+++ b/hgraph/_impl/_types/_tsb.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, fields, is_dataclass
 from datetime import datetime
 from typing import Any, Mapping, Generic, TYPE_CHECKING, cast, Union
 
@@ -6,12 +6,27 @@ from hgraph._runtime._constants import MIN_DT
 from hgraph._impl._types._input import PythonBoundTimeSeriesInput
 from hgraph._impl._types._output import PythonTimeSeriesOutput
 from hgraph._types._time_series_types import TimeSeriesOutput, TimeSeriesInput
+from hgraph._types._scalar_types import CompoundScalar
 from hgraph._types._tsb_type import TimeSeriesBundleInput, TS_SCHEMA, TimeSeriesBundleOutput
 
 if TYPE_CHECKING:
     from hgraph._runtime._node import Node
 
 __all__ = ("PythonTimeSeriesBundleOutput", "PythonTimeSeriesBundleInput")
+
+
+def _python_dataclass_constructor_fields(scalar_type):
+    origin = getattr(scalar_type, "__origin__", None) or scalar_type
+    if isinstance(origin, type) and is_dataclass(origin) and not issubclass(origin, CompoundScalar):
+        return {field.name for field in fields(origin) if field.init}
+
+
+def _bundle_scalar_value(schema, items):
+    scalar_type = schema.scalar_type()
+    constructor_fields = _python_dataclass_constructor_fields(scalar_type)
+    if constructor_fields is not None:
+        return scalar_type(**{name: ts.value for name, ts in items if name in constructor_fields and ts.valid})
+    return scalar_type(**{name: ts.value for name, ts in items})
 
 
 # With Bundles there are two implementation types, namely bound and un-bound.
@@ -32,7 +47,7 @@ class PythonTimeSeriesBundleOutput(PythonTimeSeriesOutput, TimeSeriesBundleOutpu
     @property
     def value(self):
         if s := self.__schema__.scalar_type():
-            return s(**{k: ts.value for k, ts in self.items()})
+            return _bundle_scalar_value(self.__schema__, self.items())
         else:
             return {k: ts.value for k, ts in self.items() if ts.valid}
 
@@ -146,6 +161,8 @@ class PythonTimeSeriesBundleInput(PythonBoundTimeSeriesInput, TimeSeriesBundleIn
             return super().value
         else:
             if s := self.__schema__.scalar_type():
+                if _python_dataclass_constructor_fields(s) is not None:
+                    return _bundle_scalar_value(self.__schema__, self.items())
                 v = {k: ts.value for k, ts in self.items() if ts.valid or getattr(s, k, None) is None}
                 return s(**v)
             else:

--- a/hgraph/_types/_scalar_type_meta_data.py
+++ b/hgraph/_types/_scalar_type_meta_data.py
@@ -4,7 +4,7 @@ import types
 import typing
 from abc import abstractmethod
 from collections.abc import Mapping, Set
-from dataclasses import fields, is_dataclass
+from dataclasses import MISSING as DATACLASS_MISSING, fields, is_dataclass
 from datetime import date, datetime, time, timedelta
 from enum import Enum
 from functools import partial
@@ -104,6 +104,7 @@ class HgScalarTypeMetaData(HgTypeMetaData):
 
 
 _DATACLASS_SCALAR_SCHEMA_CACHE = {}
+_DATACLASS_ATTRIBUTE_MISSING = object()
 
 
 def _dataclass_scalar_origin(tp):
@@ -115,6 +116,18 @@ def _dataclass_scalar_origin(tp):
 
 def _is_dataclass_scalar_type(tp) -> bool:
     return _dataclass_scalar_origin(tp) is not None
+
+
+def _set_dataclass_hgraph_attributes(origin, attributes):
+    for name, value in attributes.items():
+        existing = vars(origin).get(name, _DATACLASS_ATTRIBUTE_MISSING)
+        if existing is not _DATACLASS_ATTRIBUTE_MISSING and existing != value:
+            raise ParseError(
+                f"Dataclass '{origin.__qualname__}' defines reserved hgraph attribute '{name}' "
+                "with an incompatible value"
+            )
+    for name, value in attributes.items():
+        setattr(origin, name, value)
 
 
 def _substitute_type_vars(tp, substitutions):
@@ -175,18 +188,25 @@ def _dataclass_scalar_schema(tp):
         schema[field.name] = field_type
 
     schema = frozendict(schema)
-    _DATACLASS_SCALAR_SCHEMA_CACHE[tp] = schema
+    constructor_fields = tuple(field.name for field in fields(origin) if field.init)
+    required_fields = tuple(
+        field.name
+        for field in fields(origin)
+        if field.init and field.default is DATACLASS_MISSING and field.default_factory is DATACLASS_MISSING
+    )
 
-    # A few older integrations still inspect concrete scalar classes directly.
-    # Keep those paths working without replacing or wrapping the user's class.
-    origin.__serialise_discriminator_field__ = None
-    origin.__serialise_children__ = {}
-    origin.__serialise_base__ = False
-    origin.__cpp_native__ = False
-    origin.__hgraph_bundle_constructor_fields__ = tuple(field.name for field in fields(origin) if field.init)
+    # A few integrations inspect concrete scalar classes directly. Keep those
+    # paths working without replacing or wrapping the user's class, and reject
+    # incompatible user-defined values instead of silently overwriting them.
+    attributes = {
+        "__hgraph_bundle_constructor_fields__": constructor_fields,
+        "__hgraph_bundle_required_fields__": required_fields,
+    }
     if tp is origin:
-        origin.__meta_data_schema__ = schema
+        attributes["__meta_data_schema__"] = schema
 
+    _set_dataclass_hgraph_attributes(origin, attributes)
+    _DATACLASS_SCALAR_SCHEMA_CACHE[tp] = schema
     return schema
 
 
@@ -1251,8 +1271,8 @@ class HgCompoundScalarType(HgScalarTypeMetaData):
         # Detect recursion - for recursive compound scalars, fall back to Python handling
         if SchemaRecurseContext.is_in_context(self.py_type):
             return None
-        # Check if this CompoundScalar should use C++ field expansion
-        if getattr(self.py_type, "__cpp_native__", False):
+        # Plain dataclasses retain their Python identity and always use opaque storage.
+        if not _is_dataclass_scalar_type(self.py_type) and getattr(self.py_type, "__cpp_native__", False):
             return self._get_expanded_cpp_type()
         else:
             return self._get_opaque_cpp_type()

--- a/hgraph/_types/_scalar_type_meta_data.py
+++ b/hgraph/_types/_scalar_type_meta_data.py
@@ -1,18 +1,21 @@
 import itertools
 import logging
+import types
+import typing
 from abc import abstractmethod
 from collections.abc import Mapping, Set
+from dataclasses import fields, is_dataclass
 from datetime import date, datetime, time, timedelta
 from enum import Enum
 from functools import partial
 from statistics import fmean
 from types import GenericAlias
-from typing import TypeVar, Type, Optional, Sequence, _GenericAlias, cast, List, TYPE_CHECKING
+from typing import TypeVar, Type, Optional, Sequence, _GenericAlias, cast, List, TYPE_CHECKING, get_args, get_origin
 
 import numpy as np
 from frozendict import frozendict
 
-from hgraph._types._schema_type import SchemaRecurseContext
+from hgraph._types._schema_type import AbstractSchema, SchemaRecurseContext
 from hgraph._types._typing_utils import class_or_instance_method
 from hgraph._types._scalar_types import WindowSize
 from hgraph._types._generic_rank_util import scale_rank, combine_ranks
@@ -100,6 +103,119 @@ class HgScalarTypeMetaData(HgTypeMetaData):
         cls._parsers().insert(-1, new_parser)  # Insert before the HgObjectType which is catch-all
 
 
+_DATACLASS_SCALAR_SCHEMA_CACHE = {}
+
+
+def _dataclass_scalar_origin(tp):
+    origin = get_origin(tp) or tp
+    return (
+        origin if isinstance(origin, type) and is_dataclass(origin) and not issubclass(origin, AbstractSchema) else None
+    )
+
+
+def _is_dataclass_scalar_type(tp) -> bool:
+    return _dataclass_scalar_origin(tp) is not None
+
+
+def _substitute_type_vars(tp, substitutions):
+    if isinstance(tp, list):
+        return [_substitute_type_vars(arg, substitutions) for arg in tp]
+    try:
+        if tp in substitutions:
+            return substitutions[tp]
+    except TypeError:
+        pass
+
+    origin = get_origin(tp)
+    if origin is None:
+        return tp
+
+    args = tuple(_substitute_type_vars(arg, substitutions) for arg in get_args(tp))
+    if hasattr(tp, "copy_with"):
+        return tp.copy_with(args)
+    if origin in (typing.Union, types.UnionType):
+        return typing.Union[args]
+    try:
+        return origin[args[0] if len(args) == 1 else args]
+    except TypeError:
+        return tp
+
+
+def _dataclass_scalar_schema(tp):
+    if tp in _DATACLASS_SCALAR_SCHEMA_CACHE:
+        return _DATACLASS_SCALAR_SCHEMA_CACHE[tp]
+
+    origin = _dataclass_scalar_origin(tp)
+    if origin is None:
+        raise ParseError(f"'{tp}' is not a dataclass scalar type")
+
+    parameters = tuple(getattr(origin, "__parameters__", ()))
+    substitutions = dict(zip(parameters, get_args(tp)))
+    try:
+        resolved_annotations = typing.get_type_hints(origin)
+    except (NameError, TypeError):
+        resolved_annotations = {}
+
+    schema = {}
+    for field in fields(origin):
+        annotation = _substitute_type_vars(
+            resolved_annotations.get(field.name, field.type),
+            substitutions,
+        )
+        field_type = (
+            HgScalarTypeVar(annotation)
+            if isinstance(annotation, TypeVar) and not annotation.__bound__ and not annotation.__constraints__
+            else HgScalarTypeMetaData.parse_type(annotation)
+        )
+        if field_type is None:
+            raise ParseError(
+                f"When parsing dataclass '{origin.__qualname__}', unable to parse field "
+                f"'{field.name}' with value {annotation}"
+            )
+        schema[field.name] = field_type
+
+    schema = frozendict(schema)
+    _DATACLASS_SCALAR_SCHEMA_CACHE[tp] = schema
+
+    # A few older integrations still inspect concrete scalar classes directly.
+    # Keep those paths working without replacing or wrapping the user's class.
+    origin.__serialise_discriminator_field__ = None
+    origin.__serialise_children__ = {}
+    origin.__serialise_base__ = False
+    origin.__cpp_native__ = False
+    origin.__hgraph_bundle_constructor_fields__ = tuple(field.name for field in fields(origin) if field.init)
+    if tp is origin:
+        origin.__meta_data_schema__ = schema
+
+    return schema
+
+
+def _dataclass_scalar_is_instance(value) -> bool:
+    return not isinstance(value, type) and is_dataclass(value) and _is_dataclass_scalar_type(type(value))
+
+
+def _structured_scalar_origin_and_args(tp):
+    return get_origin(tp) or tp, get_args(tp)
+
+
+def _inherits_dataclass_specialization(candidate, target_origin, target_args):
+    candidate_origin = get_origin(candidate) or candidate
+    if candidate_origin is target_origin:
+        return get_args(candidate) == target_args
+    if not isinstance(candidate_origin, type):
+        return False
+
+    for base in getattr(candidate_origin, "__orig_bases__", ()):
+        base_origin = get_origin(base) or base
+        if base_origin is target_origin and get_args(base) == target_args:
+            return True
+        if _is_dataclass_scalar_type(base_origin) and _inherits_dataclass_specialization(
+            base, target_origin, target_args
+        ):
+            return True
+    return False
+
+
 class HgScalarTypeVar(HgScalarTypeMetaData):
     is_resolved = False
     is_generic = True
@@ -140,10 +256,13 @@ class HgScalarTypeVar(HgScalarTypeMetaData):
         if tp.is_scalar:
             # Get effective py_type for matching - unwrap CppNative wrappers
             from hgraph._types._cpp_native_meta_data import HgCppNativeScalarType
+
             effective_py_type = tp.wrapped_type.py_type if isinstance(tp, HgCppNativeScalarType) else tp.py_type
 
             for c in self.constraints():
                 if isinstance(c, HgScalarTypeMetaData) and c.matches(tp):
+                    return True
+                elif c is CompoundScalar and isinstance(tp, HgCompoundScalarType):
                     return True
                 else:
                     if issubclass(getattr(effective_py_type, "__origin__", effective_py_type), c):
@@ -180,7 +299,7 @@ class HgScalarTypeVar(HgScalarTypeMetaData):
             )
         elif self.py_type.__bound__:
             return (self.py_type.__bound__,)
-        raise RuntimeError("Unexpected item in the bagging areas")
+        return (object,)
 
     def resolve(self, resolution_dict: dict[TypeVar, "HgTypeMetaData"], weak=False) -> "HgTypeMetaData":
         if tp := resolution_dict.get(self.py_type):
@@ -213,7 +332,7 @@ class HgScalarTypeVar(HgScalarTypeMetaData):
             elif value_tp.__bound__:
                 constraints = (value_tp.__bound__,)
             else:
-                return None
+                constraints = ()
 
             from hgraph._types._time_series_types import TimeSeries
 
@@ -364,7 +483,7 @@ class HgInjectableType(HgScalarTypeMetaData):
         from hgraph._runtime._node import SCHEDULER, NODE
         from hgraph._runtime._traits import Traits
 
-        return {
+        injectables = {
             EvaluationClock: lambda: HgEvaluationClockType(),
             EvaluationClockInjector: lambda: HgEvaluationClockType(),
             EvaluationEngineApi: lambda: HgEvaluationEngineApiType(),
@@ -376,7 +495,14 @@ class HgInjectableType(HgScalarTypeMetaData):
             Traits: lambda: HgTraitsType(),
             GlobalState: lambda: HgGlobalStateType(),
             GlobalStateInjector: lambda: HgGlobalStateType(),
-        }.get(value_tp, lambda: None)()
+        }
+        try:
+            factory = injectables.get(value_tp)
+        except TypeError:
+            # Some valid typing annotations, notably Callable[[...], ...],
+            # contain a list of arguments and are therefore unhashable.
+            return None
+        return factory() if factory else None
 
     @classmethod
     def parse_value(cls, value) -> Optional["HgTypeMetaData"]:
@@ -1113,6 +1239,8 @@ class HgCompoundScalarType(HgScalarTypeMetaData):
 
     @property
     def meta_data_schema(self) -> dict[str, "HgScalarTypeMetaData"]:
+        if _is_dataclass_scalar_type(self.py_type):
+            return _dataclass_scalar_schema(self.py_type)
         return self.py_type.__meta_data_schema__
 
     def __init__(self, py_type: Type):
@@ -1124,7 +1252,7 @@ class HgCompoundScalarType(HgScalarTypeMetaData):
         if SchemaRecurseContext.is_in_context(self.py_type):
             return None
         # Check if this CompoundScalar should use C++ field expansion
-        if getattr(self.py_type, '__cpp_native__', False):
+        if getattr(self.py_type, "__cpp_native__", False):
             return self._get_expanded_cpp_type()
         else:
             return self._get_opaque_cpp_type()
@@ -1137,6 +1265,7 @@ class HgCompoundScalarType(HgScalarTypeMetaData):
         """
         try:
             import hgraph._hgraph as _hgraph
+
             # Build the fields list with (name, type_meta) pairs
             with SchemaRecurseContext(self.py_type):
                 fields = []
@@ -1147,9 +1276,7 @@ class HgCompoundScalarType(HgScalarTypeMetaData):
                         return None  # Fall back to nb::object if any field type is not supported
                     fields.append((field_name, field_cpp))
                 # Create CompoundScalar TypeMeta with Python class for reconstruction
-                return _hgraph.value.get_compound_scalar_type_meta(
-                    fields, self.py_type, self.py_type.__name__
-                )
+                return _hgraph.value.get_compound_scalar_type_meta(fields, self.py_type, self.py_type.__name__)
         except (ImportError, AttributeError):
             return None
 
@@ -1162,6 +1289,7 @@ class HgCompoundScalarType(HgScalarTypeMetaData):
         """
         try:
             import hgraph._hgraph as _hgraph
+
             return _hgraph.value.get_scalar_type_meta(object)
         except (ImportError, AttributeError):
             return None
@@ -1171,16 +1299,18 @@ class HgCompoundScalarType(HgScalarTypeMetaData):
             return True
 
         with SchemaRecurseContext(self.py_type):
-            return type(o) is HgCompoundScalarType and (
-                self.py_type is o.py_type
-                or (
-                    (issubclass(self.py_type, UnNamedCompoundScalar) or issubclass(o.py_type, UnNamedCompoundScalar))
-                    and self.py_type.__meta_data_schema__ == o.py_type.__meta_data_schema__
-                )
-            )
+            if type(o) is not HgCompoundScalarType:
+                return False
+            if self.py_type is o.py_type or self.py_type == o.py_type:
+                return True
+            if _is_dataclass_scalar_type(self.py_type) or _is_dataclass_scalar_type(o.py_type):
+                return False
+            return (
+                issubclass(self.py_type, UnNamedCompoundScalar) or issubclass(o.py_type, UnNamedCompoundScalar)
+            ) and self.meta_data_schema == o.meta_data_schema
 
     def __str__(self) -> str:
-        return f"{self.py_type.__name__}"
+        return getattr(self.py_type, "__name__", str(self.py_type))
 
     def __repr__(self) -> str:
         return f"HgCompoundScalarType({repr(self.py_type)})"
@@ -1194,7 +1324,12 @@ class HgCompoundScalarType(HgScalarTypeMetaData):
             return set()
 
         with SchemaRecurseContext(self.py_type):
-            return set().union(*(t.type_vars for t in self.py_type.__meta_data_schema__.values())) | set(
+            if _is_dataclass_scalar_type(self.py_type):
+                # Only TypeVars declared by Generic[...] can form a nominal
+                # dataclass specialization. Free TypeVars in annotations are
+                # descriptive (STATE schemas use this pattern).
+                return set(getattr(self.py_type, "__parameters__", ()))
+            return set().union(*(t.type_vars for t in self.meta_data_schema.values())) | set(
                 getattr(self.py_type, "__parameters__", ())
             )
 
@@ -1204,8 +1339,18 @@ class HgCompoundScalarType(HgScalarTypeMetaData):
             return {}
 
         with SchemaRecurseContext(self.py_type):
-            inheritance_depth = self.py_type.__mro__.index(CompoundScalar)
-            hierarchy_root = self.py_type.__mro__[inheritance_depth - 1]
+            if _is_dataclass_scalar_type(self.py_type):
+                origin = _dataclass_scalar_origin(self.py_type)
+                hierarchy = [
+                    cls
+                    for cls in origin.__mro__
+                    if cls is not object and is_dataclass(cls) and not issubclass(cls, AbstractSchema)
+                ]
+                inheritance_depth = len(hierarchy)
+                hierarchy_root = hierarchy[-1]
+            else:
+                inheritance_depth = self.py_type.__mro__.index(CompoundScalar)
+                hierarchy_root = self.py_type.__mro__[inheritance_depth - 1]
             hierarchy_rank = {hierarchy_root: 1e-10 / inheritance_depth}
 
             generic_rank = combine_ranks((HgScalarTypeVar.parse_type(tp).generic_rank for tp in self.type_vars), 0.01)
@@ -1213,7 +1358,24 @@ class HgCompoundScalarType(HgScalarTypeMetaData):
             return generic_rank | hierarchy_rank
 
     def matches(self, tp: "HgTypeMetaData") -> bool:
-        return type(tp) is HgCompoundScalarType and (issubclass(tp.py_type, self.py_type) or self.__eq__(tp))
+        if type(tp) is not HgCompoundScalarType:
+            return False
+        if self.__eq__(tp):
+            return True
+        if _is_dataclass_scalar_type(self.py_type) and _is_dataclass_scalar_type(tp.py_type):
+            self_origin, self_args = _structured_scalar_origin_and_args(self.py_type)
+            tp_origin, _ = _structured_scalar_origin_and_args(tp.py_type)
+            if self_args:
+                if any(isinstance(argument, TypeVar) for argument in self_args):
+                    return issubclass(tp_origin, self_origin) and all(
+                        field_type.matches(tp.meta_data_schema[name])
+                        for name, field_type in self.meta_data_schema.items()
+                    )
+                return _inherits_dataclass_specialization(tp.py_type, self_origin, self_args)
+            return issubclass(tp_origin, self_origin)
+        if _is_dataclass_scalar_type(self.py_type) or _is_dataclass_scalar_type(tp.py_type):
+            return False
+        return issubclass(tp.py_type, self.py_type)
 
     @property
     def is_resolved(self) -> bool:
@@ -1224,8 +1386,11 @@ class HgCompoundScalarType(HgScalarTypeMetaData):
             return True
 
         with SchemaRecurseContext(self.py_type):
-            resolved = all(tp.is_resolved for tp in self.meta_data_schema.values()) and not getattr(
-                self.py_type, "__parameters__", False
+            resolved = (
+                not getattr(self.py_type, "__parameters__", ())
+                if _is_dataclass_scalar_type(self.py_type)
+                else all(tp.is_resolved for tp in self.meta_data_schema.values())
+                and not getattr(self.py_type, "__parameters__", False)
             )
             object.__setattr__(self, "_is_resolved", resolved)
             return resolved
@@ -1234,19 +1399,34 @@ class HgCompoundScalarType(HgScalarTypeMetaData):
     def parse_type(cls, value_tp) -> Optional["HgTypeMetaData"]:
         from hgraph._types._scalar_types import CompoundScalar
 
-        if type(value_tp) is type and issubclass(value_tp, CompoundScalar):
+        if (type(value_tp) is type and issubclass(value_tp, CompoundScalar)) or _is_dataclass_scalar_type(value_tp):
             return HgCompoundScalarType(value_tp)
 
     @classmethod
     def parse_value(cls, value) -> Optional["HgTypeMetaData"]:
         from hgraph._types._scalar_types import CompoundScalar
 
-        if isinstance(value, CompoundScalar):
+        if isinstance(value, CompoundScalar) or _dataclass_scalar_is_instance(value):
             return HgCompoundScalarType(type(value))
 
     def resolve(self, resolution_dict: dict[TypeVar, "HgTypeMetaData"], weak=False) -> "HgTypeMetaData":
         if self.is_resolved:
             return self
+        elif _is_dataclass_scalar_type(self.py_type):
+            origin, current_args = _structured_scalar_origin_and_args(self.py_type)
+            parameters = tuple(getattr(origin, "__parameters__", ()))
+            if not parameters:
+                return self
+            arguments = current_args or parameters
+            resolved_arguments = []
+            for argument in arguments:
+                argument_meta = HgScalarTypeMetaData.parse_type(argument)
+                resolved = argument_meta.resolve(resolution_dict, weak)
+                resolved_arguments.append(resolved.py_type)
+            if weak and any(isinstance(argument, TypeVar) for argument in resolved_arguments):
+                return self
+            item = resolved_arguments[0] if len(resolved_arguments) == 1 else tuple(resolved_arguments)
+            return HgCompoundScalarType(origin[item])
         else:
             return HgCompoundScalarType(self.py_type._resolve(resolution_dict))
 

--- a/hgraph/_types/_scalar_types.py
+++ b/hgraph/_types/_scalar_types.py
@@ -1,4 +1,4 @@
-from dataclasses import asdict
+from dataclasses import asdict, is_dataclass
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from enum import Enum
@@ -405,6 +405,8 @@ class STATE(Generic[COMPOUND_SCALAR]):
             else:
                 raise AttributeError(item)
         else:
+            if is_dataclass(schema) and not issubclass(schema, AbstractSchema):
+                return getattr(values, item)
             if not hasattr(schema, "__meta_data_schema__") or item in schema.__meta_data_schema__:
                 return getattr(values, item)
             else:

--- a/hgraph/_types/_tsb_type.py
+++ b/hgraph/_types/_tsb_type.py
@@ -66,6 +66,8 @@ __all__ = (
     "ts_schema",
 )
 
+_DATACLASS_BUNDLE_SCHEMAS = {}
+
 
 class TimeSeriesSchema(AbstractSchema):
     """
@@ -129,7 +131,11 @@ class TimeSeriesSchema(AbstractSchema):
 
     @classmethod
     def _schema_convert_base(cls, base_py):
-        return cls.from_scalar_schema(base_py) if issubclass(base_py, CompoundScalar) else base_py
+        return (
+            cls.from_scalar_schema(base_py)
+            if isinstance(base_py, type) and issubclass(base_py, CompoundScalar)
+            else base_py
+        )
 
     @staticmethod
     def from_scalar_schema(schema: Type[AbstractSchema]) -> Type["TimeSeriesSchema"]:
@@ -137,6 +143,43 @@ class TimeSeriesSchema(AbstractSchema):
         Creates a new time-series schema from the scalar schema provided.
         This has some limitations since it is hard to distinguish between TS[frozendict] and TSD[...,...].
         """
+        from hgraph._types._scalar_type_meta_data import (
+            HgCompoundScalarType,
+            HgScalarTypeMetaData,
+            _dataclass_scalar_origin,
+            _is_dataclass_scalar_type,
+        )
+
+        if _is_dataclass_scalar_type(schema):
+            if tsc_schema := _DATACLASS_BUNDLE_SCHEMAS.get(schema):
+                return tsc_schema
+
+            scalar_meta = HgScalarTypeMetaData.parse_type(schema)
+            assert isinstance(scalar_meta, HgCompoundScalarType)
+
+            from hgraph._types._ts_type import TS
+
+            annotations = {k: TS[v.py_type] for k, v in scalar_meta.meta_data_schema.items()}
+            origin = _dataclass_scalar_origin(schema)
+            schema_name = origin.__name__
+            if schema_args := getattr(schema, "__args__", ()):
+                schema_name += "_" + "_".join(
+                    getattr(argument, "__name__", str(argument).replace(".", "_")) for argument in schema_args
+                )
+            namespace = {
+                "__annotations__": annotations,
+                "__module__": origin.__module__,
+            }
+            tsc_schema = types.new_class(
+                f"{schema_name}Bundle",
+                (TimeSeriesSchema,),
+                None,
+                lambda ns: ns.update(namespace),
+            )
+            tsc_schema.__scalar_type__ = schema
+            _DATACLASS_BUNDLE_SCHEMAS[schema] = tsc_schema
+            return tsc_schema
+
         if schema is CompoundScalar:
             return TimeSeriesSchema
 
@@ -345,7 +388,9 @@ class TimeSeriesBundle(
                 # We have a dynamic declaration of type
                 item = ts_schema(**{i.start: i.stop for i in item})
             elif HgTypeMetaData.parse_type(item).is_scalar:
-                if isinstance(item, type) and issubclass(item, CompoundScalar):
+                from hgraph._types._scalar_type_meta_data import HgCompoundScalarType
+
+                if isinstance(HgTypeMetaData.parse_type(item), HgCompoundScalarType):
                     item = TimeSeriesSchema.from_scalar_schema(item)
                 else:
                     raise ParseError(

--- a/hgraph/_use_cpp_runtime.py
+++ b/hgraph/_use_cpp_runtime.py
@@ -20,6 +20,8 @@ if is_feature_enabled("use_cpp"):
           "\n<<<<<<<<<<<<<<<<<<<")
     try:
         from datetime import date, datetime, timedelta
+        from typing import get_origin
+
         import hgraph._hgraph as _hgraph
         import hgraph
 
@@ -84,6 +86,11 @@ if is_feature_enabled("use_cpp"):
             raise NotImplementedError(f"Missing builder for {value_tp}")
 
 
+        def _cpp_scalar_type(tp):
+            """Nanobind accepts classes, while parameterised Python aliases construct through their origin."""
+            return get_origin(tp) or tp
+
+
         class HgCppFactory(hgraph.TimeSeriesBuilderFactory):
             def make_error_builder(self, value_tp):
                 return self.make_output_builder(value_tp)
@@ -104,7 +111,8 @@ if is_feature_enabled("use_cpp"):
                     ),
                     hgraph.HgTSBTypeMetaData: lambda: _hgraph.InputBuilder_TSB(
                         _hgraph.TimeSeriesSchema(
-                            keys=tuple(value_tp.bundle_schema_tp.meta_data_schema.keys()), scalar_type=tp
+                            keys=tuple(value_tp.bundle_schema_tp.meta_data_schema.keys()),
+                            scalar_type=_cpp_scalar_type(tp),
                         )
                         if (tp := value_tp.bundle_schema_tp.py_type.scalar_type())
                         else _hgraph.TimeSeriesSchema(keys=tuple(value_tp.bundle_schema_tp.meta_data_schema.keys())),
@@ -146,7 +154,8 @@ if is_feature_enabled("use_cpp"):
                     ),
                     hgraph.HgTSBTypeMetaData: lambda: _hgraph.OutputBuilder_TSB(
                         schema=_hgraph.TimeSeriesSchema(
-                            keys=tuple(value_tp.bundle_schema_tp.meta_data_schema.keys()), scalar_type=tp
+                            keys=tuple(value_tp.bundle_schema_tp.meta_data_schema.keys()),
+                            scalar_type=_cpp_scalar_type(tp),
                         )
                         if (tp := value_tp.bundle_schema_tp.py_type.scalar_type())
                         else _hgraph.TimeSeriesSchema(keys=tuple(value_tp.bundle_schema_tp.meta_data_schema.keys())),
@@ -193,7 +202,7 @@ if is_feature_enabled("use_cpp"):
                     return _hgraph.InputBuilder_TSB_Ref(
                         _hgraph.TimeSeriesSchema(
                             tuple(referenced_tp.bundle_schema_tp.meta_data_schema.keys()),
-                            tp
+                            _cpp_scalar_type(tp),
                         ) if (tp := referenced_tp.bundle_schema_tp.py_type.scalar_type()) is not None
                         else _hgraph.TimeSeriesSchema(tuple(referenced_tp.bundle_schema_tp.meta_data_schema.keys())),
                         [_make_child_ref_builder(tp) for tp in referenced_tp.bundle_schema_tp.meta_data_schema.values()]
@@ -251,7 +260,7 @@ if is_feature_enabled("use_cpp"):
                     return _hgraph.OutputBuilder_TSB_Ref(
                         _hgraph.TimeSeriesSchema(
                             tuple(referenced_tp.bundle_schema_tp.meta_data_schema.keys()),
-                            tp
+                            _cpp_scalar_type(tp),
                         ) if (tp := referenced_tp.bundle_schema_tp.py_type.scalar_type()) is not None
                         else _hgraph.TimeSeriesSchema(tuple(referenced_tp.bundle_schema_tp.meta_data_schema.keys())),
                         [_make_child_ref_builder(tp) for tp in referenced_tp.bundle_schema_tp.meta_data_schema.values()]

--- a/hgraph/_wiring/_dispatch.py
+++ b/hgraph/_wiring/_dispatch.py
@@ -9,6 +9,12 @@ from hgraph._wiring._wiring_node_class import extract_resolution_dict, PreResolv
 __all__ = ("dispatch", "dispatch_")
 
 
+def _inheritance_distance(candidate: type, target: type) -> int:
+    if candidate is target:
+        return 0
+    return 1 + min(_inheritance_distance(base, target) for base in candidate.__bases__ if issubclass(base, target))
+
+
 def dispatch(fn: Callable = None, *, on: Tuple[str, ...] = None):
     """
     Decorator that converts a graph into a single or multiple dispatch graph. See dispatch_ for more details.
@@ -202,7 +208,7 @@ def _dispatch_impl(
                 candidates = []
                 for a_key in available_keys:
                     if issubclass(key.value, a_key):
-                        candidates.append((a_key, key.value.__mro__.index(a_key)))
+                        candidates.append((a_key, _inheritance_distance(key.value, a_key)))
                 if not candidates:
                     raise RuntimeError(f"No suitable overload found for {key.value}")
                 candidates.sort(key=lambda candidate: candidate[1])
@@ -228,7 +234,9 @@ def _dispatch_impl(
                 candidates = []
                 for a_keys in available_keys:
                     if all(issubclass(k, ak) for ak, k in zip(a_keys, key.value)):
-                        candidates.append((a_keys, sum(k.__mro__.index(ak) for ak, k in zip(a_keys, key.value))))
+                        candidates.append(
+                            (a_keys, sum(_inheritance_distance(k, ak) for ak, k in zip(a_keys, key.value)))
+                        )
                 if not candidates:
                     raise RuntimeError(f"No suitable overload found for {key.value}")
                 candidates.sort(key=lambda candidate: candidate[1])

--- a/hgraph/_wiring/_dispatch.py
+++ b/hgraph/_wiring/_dispatch.py
@@ -102,7 +102,6 @@ def _dispatch_impl(
         nth,
         compute_node,
         TS,
-        CompoundScalar,
         extract_kwargs,
     )
     from hgraph import downcast_ref
@@ -130,11 +129,21 @@ def _dispatch_impl(
         o_dispatch_types = {
             k: t
             for k, t in o.signature.input_types.items()
-            if k in dispatch_args and (isinstance(t, HgTSTypeMetaData) or (isinstance(t, HgTsTypeVarTypeMetaData) and all(isinstance(i, HgTSTypeMetaData) for i in t.constraints)))
+            if k in dispatch_args
+            and (
+                isinstance(t, HgTSTypeMetaData)
+                or (
+                    isinstance(t, HgTsTypeVarTypeMetaData)
+                    and all(isinstance(i, HgTSTypeMetaData) for i in t.constraints)
+                )
+            )
         }
-        for dispatch_values in product(*((t.value_scalar_tp,) if isinstance(t, HgTSTypeMetaData) else (i.value_scalar_tp for i in t.constraints) for t in o_dispatch_types.values())):
+        for dispatch_values in product(*(
+            (t.value_scalar_tp,) if isinstance(t, HgTSTypeMetaData) else (i.value_scalar_tp for i in t.constraints)
+            for t in o_dispatch_types.values()
+        )):
             ox_dispatch_types = dict(zip(o_dispatch_types.keys(), dispatch_values))
-        
+
             if len(o_dispatch_types) != len(dispatch_args):
                 raise CustomMessageWiringError(
                     f"Cannot dispatch with signatures of different lengths:\n{dispatch_args}\n{o_dispatch_types}"
@@ -186,18 +195,17 @@ def _dispatch_impl(
     if len(dispatch_args) == 1:
 
         @compute_node
-        def adjust_dispatch_key(
-            key: TS[Type[CompoundScalar]], available_keys: Tuple[Type[CompoundScalar], ...]
-        ) -> TS[Type[CompoundScalar]]:
+        def adjust_dispatch_key(key: TS[Type[object]], available_keys: Tuple[Type[object], ...]) -> TS[Type[object]]:
             if key.value in available_keys:
                 return key.value
             else:
                 candidates = []
                 for a_key in available_keys:
                     if issubclass(key.value, a_key):
-                        candidates.append((a_key, a_key.__mro__.index(CompoundScalar)))
+                        candidates.append((a_key, key.value.__mro__.index(a_key)))
                 if not candidates:
                     raise RuntimeError(f"No suitable overload found for {key.value}")
+                candidates.sort(key=lambda candidate: candidate[1])
                 if len(candidates) > 1 and candidates[0][1] == candidates[1][1]:
                     raise RuntimeError(f"Ambiguous dispatch for {key.value}")
                 return candidates[0][0]
@@ -212,18 +220,18 @@ def _dispatch_impl(
 
         @compute_node
         def adjust_dispatch_keys(
-            key: TS[Tuple[Type[CompoundScalar], ...]], available_keys: Tuple[Tuple[Type[CompoundScalar], ...], ...]
-        ) -> TS[Tuple[Type[CompoundScalar], ...]]:
+            key: TS[Tuple[Type[object], ...]], available_keys: Tuple[Tuple[Type[object], ...], ...]
+        ) -> TS[Tuple[Type[object], ...]]:
             if key.value in available_keys:
                 return key.value
             else:
                 candidates = []
                 for a_keys in available_keys:
                     if all(issubclass(k, ak) for ak, k in zip(a_keys, key.value)):
-                        candidates.append((a_keys, sum(ak.__mro__.index(CompoundScalar) for ak in a_keys)))
+                        candidates.append((a_keys, sum(k.__mro__.index(ak) for ak, k in zip(a_keys, key.value))))
                 if not candidates:
                     raise RuntimeError(f"No suitable overload found for {key.value}")
-                candidates.sort(key=lambda x: x[1], reverse=True)
+                candidates.sort(key=lambda candidate: candidate[1])
                 if len(candidates) > 1 and candidates[0][1] == candidates[1][1]:
                     raise RuntimeError(f"Ambiguous dispatch for {key.value}")
                 return candidates[0][0]
@@ -231,7 +239,7 @@ def _dispatch_impl(
         from hgraph import type_
 
         key = adjust_dispatch_keys(
-            flatten_tsl_values[SCALAR : Type[CompoundScalar]](
+            flatten_tsl_values[SCALAR : Type[object]](
                 TSL.from_ts(*[type_(kwargs_[k]) for k in dispatch_args]), all_valid=True
             ),
             tuple(dispatch_map.keys()),

--- a/hgraph_unit_tests/_types/test_dataclass_scalar.py
+++ b/hgraph_unit_tests/_types/test_dataclass_scalar.py
@@ -1,0 +1,225 @@
+from dataclasses import dataclass, field
+import json
+from typing import Generic, TypeVar
+
+from hgraph import (
+    HgCompoundScalarType,
+    HgTypeMetaData,
+    TS,
+    TSB,
+    combine,
+    compute_node,
+    convert,
+    dispatch_,
+    from_json_builder,
+    graph,
+    operator,
+    to_json_builder,
+)
+from hgraph.reflection import fields, is_compound_scalar, scalar_type
+from hgraph.test import eval_node
+
+
+@dataclass(frozen=True)
+class Quote:
+    instrument: str
+    bid: float
+    ask: float = 0.0
+    tags: tuple[str, ...] = field(default_factory=tuple)
+
+
+VALUE = TypeVar("VALUE")
+
+
+@dataclass(frozen=True)
+class Box(Generic[VALUE]):
+    value: VALUE
+
+
+@dataclass(frozen=True)
+class LabelledBox(Box[int]):
+    label: str
+
+
+@dataclass(frozen=True)
+class Animal:
+    name: str
+
+
+@dataclass(frozen=True)
+class Dog(Animal):
+    volume: int
+
+
+@dataclass(frozen=True)
+class Computed:
+    value: int
+    doubled: int = field(init=False)
+
+    def __post_init__(self):
+        object.__setattr__(self, "doubled", self.value * 2)
+
+
+@dataclass(frozen=True)
+class ConstructorDefaults:
+    value: int
+    marker: object = field(default_factory=object, kw_only=True)
+
+
+@dataclass(frozen=True)
+class Recursive:
+    child: "Recursive"
+
+
+def test_dataclass_is_a_nominal_compound_scalar():
+    metadata = HgTypeMetaData.parse_type(TS[Quote]).value_scalar_tp
+
+    assert isinstance(metadata, HgCompoundScalarType)
+    assert metadata.py_type is Quote
+    assert fields(Quote) == {
+        "instrument": str,
+        "bid": float,
+        "ask": float,
+        "tags": tuple[str, ...],
+    }
+    assert fields(TS[Quote]) == fields(Quote)
+    assert scalar_type(TS[Quote]) is Quote
+    assert is_compound_scalar(Quote)
+    assert is_compound_scalar(TS[Quote])
+
+
+def test_dataclass_value_and_field_projection_preserve_the_object():
+    quote = Quote("ABC", 100.0, 101.0)
+
+    @compute_node
+    def identity(value: TS[Quote]) -> TS[Quote]:
+        return value.value
+
+    @graph
+    def bid(value: TS[Quote]) -> TS[float]:
+        return value.bid
+
+    assert eval_node(identity, [quote])[0] is quote
+    assert eval_node(bid, [quote]) == [100.0]
+
+
+def test_combine_constructs_dataclass_and_honours_defaults():
+    @graph
+    def make_quote(bid: TS[float]) -> TS[Quote]:
+        return combine[TS[Quote]](instrument="ABC", bid=bid)
+
+    assert eval_node(make_quote, [100.0]) == [Quote("ABC", 100.0)]
+
+
+def test_combine_calls_default_factories_and_accepts_keyword_only_fields():
+    @graph
+    def make(value: TS[int]) -> TS[ConstructorDefaults]:
+        return combine[TS[ConstructorDefaults]](value=value)
+
+    first, second = eval_node(make, [1, 2])
+
+    assert first.value == 1
+    assert second.value == 2
+    assert first.marker is not second.marker
+
+
+def test_dataclass_converts_to_and_from_tsb():
+    @graph
+    def as_bundle(value: TS[Quote]) -> TSB[Quote]:
+        return convert[TSB](value)
+
+    @graph
+    def from_bundle(instrument: TS[str], bid: TS[float]) -> TS[Quote]:
+        return convert[TS[Quote]](combine[TSB[Quote]](instrument=instrument, bid=bid))
+
+    quote = Quote("ABC", 100.0, 101.0)
+    assert eval_node(as_bundle, [quote]) == [{"instrument": "ABC", "bid": 100.0, "ask": 101.0, "tags": ()}]
+    assert eval_node(from_bundle, ["ABC"], [100.0]) == [Quote("ABC", 100.0)]
+
+
+def test_dataclass_reconstruction_honours_init_false_and_post_init():
+    @compute_node
+    def bundle_value(bundle: TSB[Computed]) -> TS[Computed]:
+        return bundle.value
+
+    @graph
+    def make(value: TS[int]) -> TS[Computed]:
+        return combine[TS[Computed]](value=value)
+
+    @graph
+    def from_bundle(value: TS[int]) -> TS[Computed]:
+        return combine[TSB[Computed]](value=value).as_scalar_ts()
+
+    @graph
+    def read_bundle(value: TS[int]) -> TS[Computed]:
+        return bundle_value(combine[TSB[Computed]](value=value))
+
+    assert eval_node(make, [3]) == [Computed(3)]
+    assert eval_node(from_bundle, [3]) == [Computed(3)]
+    assert eval_node(read_bundle, [3]) == [Computed(3)]
+
+
+def test_generic_dataclass_specializations_are_distinct_and_resolve_fields():
+    integer_box = HgTypeMetaData.parse_type(TS[Box[int]]).value_scalar_tp
+    string_box = HgTypeMetaData.parse_type(TS[Box[str]]).value_scalar_tp
+    labelled_box = HgTypeMetaData.parse_type(TS[LabelledBox]).value_scalar_tp
+
+    assert integer_box != string_box
+    assert fields(Box[int]) == {"value": int}
+    assert fields(Box[str]) == {"value": str}
+    assert integer_box.matches(labelled_box)
+    assert not integer_box.matches(string_box)
+
+    @graph
+    def unbox(value: TS[Box[int]]) -> TS[int]:
+        return value.value
+
+    assert eval_node(unbox, [Box[int](1), Box[int](2)]) == [1, 2]
+
+    @compute_node
+    def generic_unbox(value: TS[Box[VALUE]]) -> TS[VALUE]:
+        return value.value.value
+
+    assert eval_node(
+        generic_unbox,
+        [Box[int](1), Box[int](2)],
+        resolution_dict={"value": TS[Box[int]]},
+    ) == [1, 2]
+
+    @graph
+    def round_trip(value: TS[Box[int]]) -> TS[Box[int]]:
+        return convert[TS[Box[int]]](convert[TSB](value))
+
+    assert eval_node(round_trip, [Box[int](1), Box[int](2)]) == [Box[int](1), Box[int](2)]
+
+    encoded = to_json_builder(Box[int])(Box[int](3))
+    assert from_json_builder(Box[int])(json.loads(encoded)) == Box[int](3)
+
+
+def test_recursive_dataclass_schema_is_lazy():
+    assert fields(Recursive) == {"child": Recursive}
+
+
+def test_dataclass_hierarchy_supports_runtime_dispatch():
+    @operator
+    def sound(animal: TS[Animal]) -> TS[str]: ...
+
+    @compute_node(overloads=sound)
+    def dog_sound(animal: TS[Dog]) -> TS[str]:
+        return f"{animal.value.name}:{animal.value.volume}"
+
+    @graph
+    def app(animal: TS[Animal]) -> TS[str]:
+        return dispatch_(sound, animal)
+
+    assert eval_node(app, [Dog("Fido", 3)]) == ["Fido:3"]
+
+
+def test_dataclass_json_round_trip_reconstructs_the_original_class():
+    quote = Quote("ABC", 100.0, 101.0, ("firm",))
+
+    encoded = to_json_builder(Quote)(quote)
+    decoded = from_json_builder(Quote)(json.loads(encoded))
+
+    assert decoded == quote
+    assert type(decoded) is Quote

--- a/hgraph_unit_tests/_types/test_dataclass_scalar.py
+++ b/hgraph_unit_tests/_types/test_dataclass_scalar.py
@@ -2,9 +2,13 @@ from dataclasses import dataclass, field
 import json
 from typing import Generic, TypeVar
 
+import pytest
+
 from hgraph import (
     HgCompoundScalarType,
     HgTypeMetaData,
+    NodeException,
+    ParseError,
     TS,
     TSB,
     combine,
@@ -71,6 +75,38 @@ class Recursive:
     child: "Recursive"
 
 
+@dataclass(frozen=True)
+class RequiredPair:
+    left: int
+    right: int
+
+
+@dataclass(frozen=True)
+class MaybeValue:
+    label: str | None
+    count: int
+
+
+@dataclass(frozen=True)
+class DispatchRoot:
+    pass
+
+
+@dataclass(frozen=True)
+class DispatchLeft(DispatchRoot):
+    pass
+
+
+@dataclass(frozen=True)
+class DispatchRight(DispatchRoot):
+    pass
+
+
+@dataclass(frozen=True)
+class DispatchBoth(DispatchLeft, DispatchRight):
+    pass
+
+
 def test_dataclass_is_a_nominal_compound_scalar():
     metadata = HgTypeMetaData.parse_type(TS[Quote]).value_scalar_tp
 
@@ -86,6 +122,10 @@ def test_dataclass_is_a_nominal_compound_scalar():
     assert scalar_type(TS[Quote]) is Quote
     assert is_compound_scalar(Quote)
     assert is_compound_scalar(TS[Quote])
+    assert "__serialise_discriminator_field__" not in vars(Quote)
+    assert "__serialise_children__" not in vars(Quote)
+    assert "__serialise_base__" not in vars(Quote)
+    assert "__cpp_native__" not in vars(Quote)
 
 
 def test_dataclass_value_and_field_projection_preserve_the_object():
@@ -159,6 +199,41 @@ def test_dataclass_reconstruction_honours_init_false_and_post_init():
     assert eval_node(read_bundle, [3]) == [Computed(3)]
 
 
+def test_partial_dataclass_bundle_value_supplies_none_for_missing_required_fields():
+    @compute_node
+    def bundle_value(bundle: TSB[RequiredPair]) -> TS[RequiredPair]:
+        return bundle.value
+
+    @graph
+    def read_bundle(left: TS[int], right: TS[int]) -> TS[RequiredPair]:
+        return bundle_value(combine[TSB[RequiredPair]](left=left, right=right))
+
+    assert eval_node(read_bundle, [1], [None]) == [RequiredPair(1, None)]
+
+
+def test_nonstrict_dataclass_conversion_supplies_none_for_missing_required_fields():
+    @graph
+    def from_partial_bundle(right: TS[int]) -> TS[RequiredPair]:
+        bundle = combine[TSB[RequiredPair]](right=right)
+        return convert[TS[RequiredPair]](bundle, __strict__=False)
+
+    assert eval_node(from_partial_bundle, [2]) == [RequiredPair(None, 2)]
+
+
+def test_dataclass_merge_preserves_required_none_values():
+    @graph
+    def merge_values(orig: TS[MaybeValue], delta: TS[MaybeValue]) -> TS[MaybeValue]:
+        return combine(orig, delta)
+
+    @graph
+    def update_count(orig: TS[MaybeValue], count: TS[int]) -> TS[MaybeValue]:
+        return combine[TS[MaybeValue]](orig, count=count)
+
+    original = MaybeValue(None, 1)
+    assert eval_node(merge_values, [original], [MaybeValue(None, 2)]) == [MaybeValue(None, 2)]
+    assert eval_node(update_count, [original], [3]) == [MaybeValue(None, 3)]
+
+
 def test_generic_dataclass_specializations_are_distinct_and_resolve_fields():
     integer_box = HgTypeMetaData.parse_type(TS[Box[int]]).value_scalar_tp
     string_box = HgTypeMetaData.parse_type(TS[Box[str]]).value_scalar_tp
@@ -213,6 +288,37 @@ def test_dataclass_hierarchy_supports_runtime_dispatch():
         return dispatch_(sound, animal)
 
     assert eval_node(app, [Dog("Fido", 3)]) == ["Fido:3"]
+
+
+def test_dataclass_multiple_inheritance_dispatch_reports_ambiguity():
+    @operator
+    def choose(value: TS[DispatchRoot]) -> TS[str]: ...
+
+    @compute_node(overloads=choose)
+    def choose_left(value: TS[DispatchLeft]) -> TS[str]:
+        return "left"
+
+    @compute_node(overloads=choose)
+    def choose_right(value: TS[DispatchRight]) -> TS[str]:
+        return "right"
+
+    @graph
+    def app(value: TS[DispatchRoot]) -> TS[str]:
+        return dispatch_(choose, value)
+
+    with pytest.raises(NodeException, match="Ambiguous dispatch"):
+        eval_node(app, [DispatchBoth()])
+
+
+def test_dataclass_reserved_metadata_is_not_silently_overwritten():
+    @dataclass(frozen=True)
+    class ReservedMetadata:
+        value: int
+
+        __hgraph_bundle_constructor_fields__ = ("different",)
+
+    with pytest.raises(ParseError, match="reserved hgraph attribute"):
+        HgTypeMetaData.parse_type(TS[ReservedMetadata]).value_scalar_tp.meta_data_schema
 
 
 def test_dataclass_json_round_trip_reconstructs_the_original_class():


### PR DESCRIPTION
## Summary

- recognize standard-library dataclasses as nominal structured scalar schemas without requiring `CompoundScalar` inheritance
- preserve the original Python object while enabling field reflection, projection, generic resolution, inheritance, runtime dispatch, and JSON round-trips
- support `TSB[Dataclass]`, `combine`, and conversions in both directions, including defaults, default factories, keyword-only fields, `init=False`, and `__post_init__`
- update Python and C++ bundle reconstruction for Python-owned dataclasses and parameterized generic aliases
- document the behavior, tradeoffs, and continued role of `CompoundScalar` and the legacy `CS[...]` adaptor

## Why

The matching `hg_cpp` change introduces Python-owned structured scalars so application dataclasses retain their Python identity and behavior while participating in the hgraph type system. The current hgraph package treated plain dataclasses as generic Python objects, which prevented reliable schema reflection, field-expanded bundle conversion, generic resolution, and nominal dispatch.

This ports the public behavior into hgraph while retaining the existing opaque Python-object storage policy. Existing `CompoundScalar` behavior remains the reference and takes precedence for dataclasses that inherit from it.

## Impact

Users can annotate nodes directly with types such as `TS[Quote]` and `TSB[Quote]`. Target-typed generic dataclasses such as `Box[int]` retain distinct schemas and round-trip through bundles and JSON. Construction continues to use the dataclass constructor, so defaults, factories, and `__post_init__` remain authoritative.

The RFC's explicit registration API for non-dataclass classes and schema-free retention of erased generic specializations are not included in this change.

## Review follow-up

- reconstruct partial dataclass bundles with `None` for missing required fields while preserving constructor defaults
- preserve required `None` values when merging dataclass scalars
- report ambiguous runtime dispatch across equally close multiple-inheritance branches
- reduce class mutation to required compatibility metadata, reject incompatible reserved attributes, and document the behavior
- add focused strict/non-strict, merge, dispatch, and metadata-collision regressions

## Validation

- `HGRAPH_USE_CPP=1 uv run pytest -q hgraph_unit_tests`: 2,397 passed, 7 skipped, 5 xfailed, 7 xpassed
- `HGRAPH_USE_CPP=0 uv run pytest -q hgraph_unit_tests`: 1,720 passed, 130 skipped, 5 xfailed, 7 xpassed
- dataclass conformance module: 15/15 passed under each runtime
- rebuilt the C++ extension successfully with `cmake --build cmake-build-debug --parallel 4`
- standalone C++ suite: 24/24 tests passed
- Sphinx HTML documentation build succeeded (46 pre-existing warnings)
- formatting and `git diff --check` passed
