### PR TITLE
Fix dataclass public scalar paths

### DIFF
--- a/hgraph/_impl/_types/_tsb.py
+++ b/hgraph/_impl/_types/_tsb.py
@@ -1,6 +1,6 @@
 from dataclasses import MISSING as DATACLASS_MISSING, dataclass, fields, is_dataclass
 from datetime import datetime
-from typing import Any, Mapping, Generic, TYPE_CHECKING, cast, Union
+from typing import Any, Mapping, Generic, TYPE_CHECKING, cast, Union, get_origin
 
 from hgraph._runtime._constants import MIN_DT
 from hgraph._impl._types._input import PythonBoundTimeSeriesInput
@@ -39,6 +39,10 @@ def _bundle_scalar_value(schema, items):
     return scalar_type(**{name: ts.value for name, ts in items})
 
 
+def _is_bundle_scalar_value(value, scalar_type) -> bool:
+    return type(value) is (get_origin(scalar_type) or scalar_type)
+
+
 # With Bundles there are two implementation types, namely bound and un-bound.
 # Bound bundles are those that are bound to a specific output, and un-bound bundles are those that are not.
 # A bound bundle has a peer output of the same shape that this bundle can map directly to. A bound bundle
@@ -66,7 +70,7 @@ class PythonTimeSeriesBundleOutput(PythonTimeSeriesOutput, TimeSeriesBundleOutpu
         if v is None:
             self.invalidate()
         else:
-            if type(v) is self.__schema__.scalar_type():
+            if _is_bundle_scalar_value(v, self.__schema__.scalar_type()):
                 for k in self.__schema__._schema_keys():
                     if (i := getattr(v, k, None)) is not None:
                         cast(TimeSeriesOutput, self[k]).value = i
@@ -93,7 +97,7 @@ class PythonTimeSeriesBundleOutput(PythonTimeSeriesOutput, TimeSeriesBundleOutpu
         if result is None:
             return True
         else:
-            if type(result) is self.__schema__.scalar_type():
+            if _is_bundle_scalar_value(result, self.__schema__.scalar_type()):
                 return self.modified
             else:
                 for k, v_ in result.items():

--- a/hgraph/_types/_scalar_types.py
+++ b/hgraph/_types/_scalar_types.py
@@ -201,7 +201,7 @@ class CompoundScalar(AbstractSchema):
         super().__init_subclass__(**kwargs)
         if cpp_native is CompoundScalar._CPP_NATIVE_NOT_SET:
             # Not explicitly set - inherit from parent class
-            cls.__cpp_native__ = getattr(cls, '__cpp_native__', False)
+            cls.__cpp_native__ = getattr(cls, "__cpp_native__", False)
         else:
             # Explicitly set - use the provided value
             cls.__cpp_native__ = cpp_native
@@ -448,7 +448,7 @@ class STATE(Generic[COMPOUND_SCALAR]):
 
     def __delattr__(self, key):
         if key in ["_value", "__schema__", "_updated"]:
-            pass # can't remove those
+            pass  # can't remove those
         else:
             value_ = self.__dict__["_value"]
             schema = self.__dict__["__schema__"]
@@ -484,7 +484,8 @@ def is_keyable_scalar(value) -> bool:
     This is not a substitute for HgScalarType.parse.
     """
     return (
-        isinstance(
+        (is_dataclass(value) and (value if isinstance(value, type) else type(value)).__hash__ is not None)
+        or isinstance(
             value,
             (
                 bool,

--- a/hgraph/_types/_schema_type.py
+++ b/hgraph/_types/_schema_type.py
@@ -19,6 +19,7 @@ from typing import (
     ClassVar,
     Generic,
     Mapping,
+    get_origin,
 )
 
 from frozendict import frozendict
@@ -235,7 +236,9 @@ class AbstractSchema:
                 suffix_map = b.__parameters_meta_data__
             elif issubclass(b, cls._root_cls()):
                 arg_map = {k: cls._parse_type(v) for k, v in zip(suffix_map.keys(), b.__args__)}
-                suffix_map = {k: cls._parse_type(v).resolve(arg_map, weak=True).py_type for k, v in root_suffix_map.items()}
+                suffix_map = {
+                    k: cls._parse_type(v).resolve(arg_map, weak=True).py_type for k, v in root_suffix_map.items()
+                }
 
         suffix_map = {k: cls._parse_type(v).resolve(resolution_dict, weak=True).py_type for k, v in suffix_map.items()}
         if all(k is v for k, v in suffix_map.items()):
@@ -261,10 +264,16 @@ class AbstractSchema:
                 base = cls._parse_type(base_py)
                 if (base := base.resolve(resolution_dict, weak=True)).is_resolved:
                     base_py = cls._schema_convert_base(base.py_type)
-                    cls = base_py._schema_convert_base(cls)
-                    bases = (cls, base_py)
-                    type_dict["__base_meta_data_schema__"] = base_py.__meta_data_schema__
-                    type_dict["__base_resolution_meta__"] = cls._parse_type(base_py)
+                    base_origin = get_origin(base_py) or base_py
+                    if isinstance(base_origin, type) and issubclass(base_origin, AbstractSchema):
+                        cls = base_py._schema_convert_base(cls)
+                        bases = (cls, base_py)
+                        type_dict["__base_meta_data_schema__"] = base_py.__meta_data_schema__
+                        type_dict["__base_resolution_meta__"] = cls._parse_type(base_py)
+                    else:
+                        bases = (cls, base_origin)
+                        type_dict["__base_meta_data_schema__"] = base.meta_data_schema
+                        type_dict["__base_resolution_meta__"] = base
                 else:
                     type_dict["__base_typevar_meta__"] = base
                     type_dict["__base_typevar__"] = base.py_type
@@ -276,6 +285,18 @@ class AbstractSchema:
                     parameters.extend(r.type_vars)
 
             r_cls = type(cls_name, bases, type_dict)
+            if base_schema := type_dict.get("__base_meta_data_schema__"):
+                from hgraph._types._type_meta_data import ParseError
+
+                for key, field_type in base_schema.items():
+                    if (existing := r_cls.__meta_data_schema__.get(key)) is not None and not existing.matches(
+                        field_type
+                    ):
+                        raise ParseError(
+                            f"Attribute: '{key}' in '{r_cls}' is already defined as '{existing}' "
+                            f"but attempted to be redefined as '{field_type}'"
+                        )
+                r_cls.__meta_data_schema__ = frozendict(r_cls.__meta_data_schema__ | base_schema)
             r_cls.__root__ = cls._root_cls()
             r_cls.__parameters__ = tuple(parameters)
             r_cls.__parameters_meta_data__ = {p: cls._parse_type(p) for p in parameters}
@@ -364,15 +385,25 @@ class Base:
             if len(item) != 1:
                 raise TypeError(f"Base accepts only a single type parameter, got {len(item)}: {item}")
             item = item[0]
-            
+
         if cls is Base and isinstance(item, TypeVar):
             assert item.__bound__ is not None
             return cls(item)
-        elif isinstance(item, type) and item._root_cls() is not item and item.__args__:  # Base[C[int]] is a resolution of Base[C]
+        elif (
+            isinstance(item, type)
+            and issubclass(item, AbstractSchema)
+            and item._root_cls() is not item
+            and item.__args__
+        ):  # Base[C[int]] is a resolution of Base[C]
             from hgraph._types._type_meta_data import HgTypeMetaData
-            return super().__class_getitem__(item._root_cls())._resolve(
-                {k: HgTypeMetaData.parse_type(v) for k, v in zip(item._root_cls().__parameters__, item.__args__)}
-            )    
+
+            return (
+                super()
+                .__class_getitem__(item._root_cls())
+                ._resolve(
+                    {k: HgTypeMetaData.parse_type(v) for k, v in zip(item._root_cls().__parameters__, item.__args__)}
+                )
+            )
         else:
             return super().__class_getitem__(item)
 

--- a/hgraph/_types/_tsb_type.py
+++ b/hgraph/_types/_tsb_type.py
@@ -131,9 +131,11 @@ class TimeSeriesSchema(AbstractSchema):
 
     @classmethod
     def _schema_convert_base(cls, base_py):
+        from hgraph._types._scalar_type_meta_data import _is_dataclass_scalar_type
+
         return (
             cls.from_scalar_schema(base_py)
-            if isinstance(base_py, type) and issubclass(base_py, CompoundScalar)
+            if _is_dataclass_scalar_type(base_py) or (isinstance(base_py, type) and issubclass(base_py, CompoundScalar))
             else base_py
         )
 

--- a/hgraph_unit_tests/_types/test_dataclass_scalar.py
+++ b/hgraph_unit_tests/_types/test_dataclass_scalar.py
@@ -271,6 +271,14 @@ def test_generic_dataclass_specializations_are_distinct_and_resolve_fields():
     assert from_json_builder(Box[int])(json.loads(encoded)) == Box[int](3)
 
 
+def test_parameterized_dataclass_can_be_assigned_to_bundle_output():
+    @compute_node
+    def echo(box: TSB[Box[int]]) -> TSB[Box[int]]:
+        return box.value
+
+    assert eval_node(echo, [Box(1), Box(2)]) == [{"value": 1}, {"value": 2}]
+
+
 def test_recursive_dataclass_schema_is_lazy():
     assert fields(Recursive) == {"child": Recursive}
 

--- a/hgraph_unit_tests/_types/test_schema_base.py
+++ b/hgraph_unit_tests/_types/test_schema_base.py
@@ -9,12 +9,20 @@ from hgraph import (
     HgTypeMetaData,
     TimeSeriesSchema,
     TS,
+    TSB,
     HgCompoundScalarType,
     from_json_builder,
 )
 from hgraph._impl._operators._to_json import to_json_converter, from_json_converter
 from hgraph._types._scalar_types import COMPOUND_SCALAR_1
+from hgraph.reflection import fields
+from hgraph.stream import Stream, StreamStatus
 from frozendict import frozendict as fd
+
+
+@dataclass(frozen=True)
+class PlainDataclassPayload:
+    value: int
 
 
 def test_schema_base():
@@ -32,6 +40,21 @@ def test_schema_base():
     assert "p2" in tp.__meta_data_schema__
     assert issubclass(tp, SimpleCompoundScalar)
     assert issubclass(tp, GenericallyDerivedCompoundScalar)
+
+
+def test_schema_base_supports_plain_dataclasses():
+    stream = Stream[PlainDataclassPayload]
+
+    assert fields(stream) == {
+        "status": StreamStatus,
+        "status_msg": str,
+        "value": int,
+    }
+    assert fields(TSB[stream]) == {
+        "status": TS[StreamStatus],
+        "status_msg": TS[str],
+        "value": TS[int],
+    }
 
 
 def test_schema_base_generic():
@@ -103,7 +126,7 @@ def test_schema_base_generic():
     meta6 = meta4.resolve(resolution_dict)
     assert meta6 == meta5
     assert meta6.scalar_type() == meta5.scalar_type()
-    
+
     assert meta4.matches(meta6)
 
 

--- a/hgraph_unit_tests/_wiring/test_service.py
+++ b/hgraph_unit_tests/_wiring/test_service.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Type
 
 from frozendict import frozendict
@@ -42,6 +43,7 @@ from hgraph.test import eval_node
 
 
 import pytest
+
 pytestmark = pytest.mark.smoke
 
 
@@ -98,6 +100,32 @@ def test_subscription_service():
             "subscription_topic1",
         ],
     ) == [None, {0: "subscription_topic1", 1: "subscription_topic2"}, {2: "subscription_topic1"}]
+
+
+def test_subscription_service_accepts_frozen_dataclass_keys():
+    @dataclass(frozen=True)
+    class Request:
+        instrument: str
+
+    @subscription_service
+    def request_service(request: TS[Request], path: str) -> TS[str]:
+        """A service keyed by a frozen Python dataclass."""
+
+    @graph
+    def subscription_instance(request: TS[Request]) -> TS[str]:
+        return request.instrument
+
+    @service_impl(interfaces=request_service)
+    def request_service_impl(request: TSS[Request]) -> TSD[Request, TS[str]]:
+        return map_(subscription_instance, __keys__=request, __key_arg__="request")
+
+    @graph
+    def main(request: TS[Request]) -> TS[str]:
+        register_service(default_path, request_service_impl)
+        return pass_through_node(request_service(request, default_path))
+
+    request = Request("ABC")
+    assert eval_node(main, [request, None]) == [None, "ABC"]
 
 
 def test_request_reply_service():


### PR DESCRIPTION
## Summary

- allow plain and parameterized dataclass schemas to participate in `Base[...]` types such as `Stream[Payload]`
- treat hashable dataclasses as keyable scalar types so frozen dataclasses can key subscription services
- normalize parameterized dataclass aliases to their runtime origin when assigning values to Python `TSB` outputs
- add public-boundary regressions for stream reflection, an end-to-end subscription service, and generic bundle output assignment

## Root cause

The dataclass structured-scalar support added the core metadata and bundle conversion paths, but three older integrations still assumed either a concrete `CompoundScalar` subclass or exact equality between a runtime class and a parameterized typing alias. `Base[...]` also expected every resolved scalar base to expose `AbstractSchema` internals, while subscription validation used a fixed list of keyable scalar classes.

## Impact

Frozen Python dataclasses now behave consistently across the affected public APIs. Downstream packages no longer need a generated stream schema, tuple transport key, or non-generic boundary type for these cases.

Fixes #349

## Validation

- `HGRAPH_USE_CPP=0 uv run --frozen pytest -q hgraph_unit_tests`: 1,723 passed, 130 skipped, 5 xfailed, 7 xpassed
- `HGRAPH_USE_CPP=1 uv run --frozen pytest -q hgraph_unit_tests`: 2,400 passed, 7 skipped, 5 xfailed, 7 xpassed
- focused schema/dataclass/service suite: 45/45 passed under both runtimes
- Black formatting check passed
- `git diff --check` passed
