### PR TITLE
Fix dedup of initial empty TSD values

### DIFF
--- a/hgraph/_impl/_operators/_dedup.py
+++ b/hgraph/_impl/_operators/_dedup.py
@@ -50,6 +50,12 @@ def _(tp: HgTSDTypeMetaData) -> Callable[[Any, Any], Any]:
     v_builder = dedup_converter(tp.value_tp)
 
     def _fn(input_ts, output_ts):
+        if not output_ts.valid:
+            # An empty dictionary is still a valid first value. Returning the
+            # full state also avoids comparing children against an invalid
+            # paired output on the initial tick.
+            return input_ts.value
+
         out = {}
         # Handle modified items
         for k, v_in in input_ts.modified_items():

--- a/hgraph/_impl/_types/_tss.py
+++ b/hgraph/_impl/_types/_tss.py
@@ -113,9 +113,9 @@ class PythonTimeSeriesSetOutput(PythonTimeSeriesOutput, TimeSeriesSetOutput[SCAL
         elif isinstance(v, frozenset):
             # Lets make the value be v, will create an appropriate delta
             old_value = self._value
-            self._value = v
-            self._added = frozenset(v - old_value)
-            self._removed = frozenset(old_value - v)
+            self._value = set(v)
+            self._added = self._value - old_value
+            self._removed = old_value - self._value
         else:
             # Assume that the result is a set, and then we are adding all the elements that are not marked Removed
             self._added = {r for r in v if type(r) is not Removed and r not in self._value}

--- a/hgraph_unit_tests/_operators/test_stream_operators.py
+++ b/hgraph_unit_tests/_operators/test_stream_operators.py
@@ -38,6 +38,7 @@ from hgraph import (
     step,
     slice_,
     TSD,
+    len_,
     REMOVE,
     MIN_DT,
     Removed,
@@ -448,6 +449,24 @@ def test_drop_dups_tsd():
         return dedup(ts)
 
     assert eval_node(g, [{1: 1, 2: 2}, {1: 1, 2: 3}, {1: REMOVE, 2: 3}]) == [{1: 1, 2: 2}, {2: 3}, {1: REMOVE}]
+
+
+def test_drop_dups_tsd_preserves_initial_empty_value():
+    @graph
+    def g(ts: TSD[int, TS[int]]) -> TS[int]:
+        return len_(dedup(ts))
+
+    assert eval_node(g, [fd()]) == [0]
+
+
+def test_drop_dups_tsb_preserves_initial_empty_tsd_child():
+    schema = ts_schema(items=TSD[int, TS[int]], marker=TS[int])
+
+    @graph
+    def g(ts: TSB[schema]) -> TS[int]:
+        return len_(dedup(ts).items)
+
+    assert eval_node(g, [fd(items=fd(), marker=1)]) == [0]
 
 
 def test_drop_dups_tsl():

--- a/hgraph_unit_tests/ts_tests/test_tss_behavior.py
+++ b/hgraph_unit_tests/ts_tests/test_tss_behavior.py
@@ -65,6 +65,20 @@ def test_output_set_via_frozenset():
     ]
 
 
+def test_output_set_delta_after_frozenset():
+    """Test applying a delta after setting the full value via frozenset."""
+    @compute_node
+    def full_then_delta(trigger: TS[int]) -> TSS[int]:
+        if trigger.value == 1:
+            return frozenset({1})
+        return set_delta(added=frozenset({trigger.value}), removed=frozenset(), tp=int)
+
+    assert eval_node(full_then_delta, [1, 2]) == [
+        {1},
+        set_delta(frozenset({2}), frozenset(), tp=int),
+    ]
+
+
 def test_output_set_empty():
     """Test creating empty set."""
     @compute_node


### PR DESCRIPTION
## Summary

- preserve the first valid empty `TSD` value emitted through `dedup`
- keep Python `TSS` output storage mutable after accepting a full `frozenset` value
- add regression coverage for direct and nested empty `TSD` values and subsequent `TSS` deltas

## Root cause

The `TSD` dedup converter returned `out or None`, which collapsed an initial valid empty mapping into no tick. Downstream nodes therefore remained invalid and could stop making progress. While validating the real workload, a second collection-state issue surfaced: the Python `TSS` setter stored a `frozenset` directly, causing the next `SetDelta` update to fail when it attempted to mutate that value.

## Impact

Graphs using `dedup` now retain the validity of initial empty dictionaries, including empty `TSD` children inside a `TSB`. The systematic multi-index workload continues through the full evaluation period rather than stopping at the collection transition.

## Validation

- focused Python operator and TSS suites: 99 passed
- focused C++-enabled operator and TSS suites: 99 passed
- standalone empty-TSD liveness reproducer: 6 passed in both Python and C++ modes
- systematic two-month multi-index workload: 44 observations through 2019-05-31 in both modes, with identical final level `-216.907626`
- broader Python suite excluding unrelated real-time integration tests: 1,711 passed

Closes #352