### PR TITLE
Support direct dataclass bundle schemas

### DIFF
--- a/docs/source/concepts/typing_system.rst
+++ b/docs/source/concepts/typing_system.rst
@@ -99,7 +99,15 @@ Standard-library dataclasses can also be used directly as nominal scalar schemas
 The original dataclass instance is retained as the time-series value. Its ordered fields form the schema used for
 wiring, reflection, field access, generic resolution, conversion, and dispatch. Dataclass defaults and default
 factories are honoured when constructing a value. ``TSB[Quote]`` provides the corresponding field-expanded
-time-series form.
+time-series form and is the canonical public spelling; downstream code does not need to create a peer
+``TimeSeriesSchema`` with ``TimeSeriesSchema.from_scalar_schema``.
+
+The lift from a dataclass to a bundle is deliberately conservative. Each stored dataclass field ``field: T`` becomes
+``field: TS[T]``. Collection values remain scalar values (for example, ``items: tuple[int, ...]`` becomes
+``items: TS[tuple[int, ...]]``), and a nested dataclass remains ``TS[Nested]`` rather than becoming a nested ``TSB``.
+HGraph does not infer ``TSL``, ``TSD``, ``TSS``, or another time-series topology from scalar annotations. ``ClassVar``,
+``InitVar``, and computed properties are not stored fields. An unresolved field annotation or a time-series annotation
+inside the scalar dataclass is rejected when the schema is constructed.
 
 Dataclass annotations describe the wiring schema; assigning a whole dataclass does not recursively validate or
 replace the object's fields. Frozen dataclasses are recommended because mutating a retained object in place does not

--- a/hgraph/_types/_scalar_type_meta_data.py
+++ b/hgraph/_types/_scalar_type_meta_data.py
@@ -175,15 +175,23 @@ def _dataclass_scalar_schema(tp):
             resolved_annotations.get(field.name, field.type),
             substitutions,
         )
-        field_type = (
-            HgScalarTypeVar(annotation)
-            if isinstance(annotation, TypeVar) and not annotation.__bound__ and not annotation.__constraints__
-            else HgScalarTypeMetaData.parse_type(annotation)
-        )
-        if field_type is None:
+        if isinstance(annotation, (str, typing.ForwardRef)):
+            raise ParseError(
+                f"When parsing dataclass '{origin.__qualname__}', field '{field.name}' "
+                f"has unresolved annotation {annotation!r}"
+            )
+
+        try:
+            field_type = HgTypeMetaData.parse_type(annotation)
+        except ParseError as error:
             raise ParseError(
                 f"When parsing dataclass '{origin.__qualname__}', unable to parse field "
                 f"'{field.name}' with value {annotation}"
+            ) from error
+        if not isinstance(field_type, HgScalarTypeMetaData):
+            raise ParseError(
+                f"When parsing dataclass '{origin.__qualname__}', field '{field.name}' "
+                f"must be a scalar type, not {annotation}"
             )
         schema[field.name] = field_type
 

--- a/hgraph_unit_tests/_types/test_dataclass_scalar.py
+++ b/hgraph_unit_tests/_types/test_dataclass_scalar.py
@@ -1,6 +1,7 @@
-from dataclasses import dataclass, field
+from dataclasses import InitVar, dataclass, field
 import json
-from typing import Generic, TypeVar
+from collections.abc import Mapping
+from typing import ClassVar, Generic, TypeVar
 
 import pytest
 
@@ -11,6 +12,7 @@ from hgraph import (
     ParseError,
     TS,
     TSB,
+    TimeSeriesSchema,
     combine,
     compute_node,
     convert,
@@ -79,6 +81,25 @@ class Recursive:
 class RequiredPair:
     left: int
     right: int
+
+
+@dataclass(frozen=True)
+class BundleChild:
+    value: int
+
+
+@dataclass(frozen=True)
+class ConservativeBundleShape:
+    number: int
+    values: tuple[int, ...]
+    lookup: Mapping[str, float]
+    child: BundleChild
+    constructor_only: InitVar[str] = "ignored"
+    class_value: ClassVar[int] = 1
+
+    @property
+    def computed(self) -> int:
+        return self.number * 2
 
 
 @dataclass(frozen=True)
@@ -175,6 +196,41 @@ def test_dataclass_converts_to_and_from_tsb():
     quote = Quote("ABC", 100.0, 101.0)
     assert eval_node(as_bundle, [quote]) == [{"instrument": "ABC", "bid": 100.0, "ask": 101.0, "tags": ()}]
     assert eval_node(from_bundle, ["ABC"], [100.0]) == [Quote("ABC", 100.0)]
+
+
+def test_dataclass_bundle_derivation_is_conservative_and_cached():
+    assert fields(TSB[ConservativeBundleShape]) == {
+        "number": TS[int],
+        "values": TS[tuple[int, ...]],
+        "lookup": TS[Mapping[str, float]],
+        "child": TS[BundleChild],
+    }
+
+    first_schema = TimeSeriesSchema.from_scalar_schema(ConservativeBundleShape)
+    second_schema = TimeSeriesSchema.from_scalar_schema(ConservativeBundleShape)
+    direct_meta = HgTypeMetaData.parse_type(TSB[ConservativeBundleShape])
+    explicit_meta = HgTypeMetaData.parse_type(TSB[first_schema])
+
+    assert first_schema is second_schema
+    assert direct_meta == explicit_meta
+    assert direct_meta.bundle_schema_tp.py_type is first_schema
+    assert first_schema.scalar_type() is ConservativeBundleShape
+
+
+def test_dataclass_bundle_rejects_non_scalar_and_unresolved_fields():
+    @dataclass(frozen=True)
+    class TimeSeriesField:
+        value: TS[int]
+
+    with pytest.raises(ParseError, match="field 'value' must be a scalar type"):
+        TSB[TimeSeriesField]
+
+    @dataclass(frozen=True)
+    class UnresolvedField:
+        value: "MissingBundleField"
+
+    with pytest.raises(ParseError, match="field 'value' has unresolved annotation"):
+        TSB[UnresolvedField]
 
 
 def test_dataclass_reconstruction_honours_init_false_and_post_init():


### PR DESCRIPTION
## Summary

- Make `TSB[Dataclass]` the canonical field-expanded bundle spelling.
- Derive only stored dataclass fields as exact `TS[T]` leaves while preserving scalar collections and nested dataclasses.
- Reject unresolved and time-series field annotations with a contextual `ParseError`.
- Document the conservative mapping boundary and cover helper identity and caching.

## Why

Dataclass-backed structured scalars currently require peer `TimeSeriesSchema` classes in downstream libraries. Invalid time-series annotations can also be treated as nested scalar objects, creating duplicate schemas and ambiguous topology.

## Impact

Downstream libraries can use dataclasses directly where a natural mapping exists. The mapping does not infer `TSL`, `TSD`, `TSS`, or nested `TSB` topology; invalid mappings fail during schema construction.

## Validation

- `HGRAPH_USE_CPP=0 uv run --frozen pytest hgraph_unit_tests -q` — 1,728 passed, 130 skipped, 5 xfailed, 7 xpassed.
- `HGRAPH_USE_CPP=1 uv run --frozen pytest hgraph_unit_tests -q` — 2,405 passed, 7 skipped, 5 xfailed, 7 xpassed.
- The edited typing page builds without diagnostics. The repository-wide `sphinx-build -W` remains blocked by pre-existing warnings outside this change.
- Linux VM validation was not run because the VM is unavailable in the current environment.

Closes #354

Related native implementation: https://github.com/hhenson/hg_cpp/pull/91