### PR TITLE
Restore -DNDEBUG in the UNIX Release flags

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -14,7 +14,10 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 if (UNIX)
-    set(CMAKE_CXX_FLAGS_RELEASE "-g -O3")
+    # Overriding CMAKE_CXX_FLAGS_RELEASE replaces CMake's default Release
+    # flags (-O3 -DNDEBUG) wholesale: -DNDEBUG must be restated or every
+    # Release build (including wheels) ships with assert() live.
+    set(CMAKE_CXX_FLAGS_RELEASE "-g -O3 -DNDEBUG")
     set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g -O3 -DNDEBUG")
     set(CMAKE_CXX_FLAGS_DEBUG "-g")
     set(CMAKE_CXX_FLAGS "-Wall")


### PR DESCRIPTION
## Summary

`cpp/CMakeLists.txt` sets `CMAKE_CXX_FLAGS_RELEASE "-g -O3"` on UNIX, which *replaces* CMake's default Release flags (`-O3 -DNDEBUG`) wholesale — only RelWithDebInfo restated `-DNDEBUG`. Every UNIX Release build of the C++ engine, including released wheels, has therefore been running with `assert()` compiled in and live.

This restores `-DNDEBUG` to the Release flags (the MSVC branch already carries `/DNDEBUG`). Found while comparing Linux compiler settings across the hgraph runtimes; among other things it means published `HGRAPH_USE_CPP` benchmark numbers have been carrying assert overhead.

A quick scan found no asserts with side effects (`assert(x++)`-style), so behaviour under `NDEBUG` should be unchanged; CI is the validation gate for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)