### PR TITLE
Pin multimethod below 2.1 to unblock CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,10 @@ dependencies = [
     "sqlalchemy",
     "duckdb",
     "pyarrow>=16.1.0",
-    "multimethod",
+    # <2.1: multimethod 2.1 (2026-07-29) raises "metaclass conflict" when a
+    # Union[...] overload is registered against the C++-engine's bound types
+    # (hgraph.debug._inspector_util's format_value); unpin once adapted.
+    "multimethod<2.1",
     "psutil",
     "typing-extensions",
     "pycurl",

--- a/uv.lock
+++ b/uv.lock
@@ -539,7 +539,7 @@ requires-dist = [
     { name = "frozendict", specifier = ">=2.3.10" },
     { name = "kafka-python", marker = "extra == 'messaging'", specifier = ">=2.1.5" },
     { name = "matplotlib", marker = "extra == 'notebook'" },
-    { name = "multimethod" },
+    { name = "multimethod", specifier = "<2.1" },
     { name = "mypy", marker = "extra == 'test'" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=2.0.0" },
     { name = "nanobind", marker = "extra == 'dev'", specifier = "==2.13.0" },


### PR DESCRIPTION
## Summary

CI has been red on every platform since this morning — including on `main` itself — failing test collection in the ABI3 smoke step with `TypeError: metaclass conflict` importing `hgraph.debug._inspector_util`.

Root cause: **multimethod 2.1 released 2026-07-29**, and the dependency is unpinned, so the smoke environments picked it up immediately (last green runs were Jul 27, pre-release; a full package diff between the green and red runs shows multimethod as the only meaningful change). `_inspector_util.format_value` is a `@multimethod` with a `Union[TimeSeriesReferenceOutput, TimeSeriesReferenceInput]` overload — under 2.1 that registration raises the metaclass conflict against the C++ engine's bound types. The pure-python engine imports cleanly on both 2.0.2 and 2.1, which is why the failure appears only in the wheel smoke step.

This pins `multimethod<2.1` (pyproject + lock) to unblock CI; adapting the registration to 2.1 can follow as its own change. Note PR #364's identical failures were this, not the NDEBUG change — it should go green on re-run once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)