### PR TITLE
Build the engine at full optimization with LTO

### DIFF
--- a/cpp/src/cpp/CMakeLists.txt
+++ b/cpp/src/cpp/CMakeLists.txt
@@ -117,7 +117,13 @@ set(HGRAPH_SOURCES
 
 add_definitions(-Dhgraph_EXPORTS)
 
-nanobind_add_module(${PROJECT_NAME} STABLE_ABI ${HGRAPH_SOURCES} ${HGRAPH_INCLUDES})
+# NOMINSIZE: nanobind's default size-optimizes every module source with -Os
+# (its "bindings are glue" policy). This module contains the ENTIRE engine,
+# and target options follow the global flags (-O3 ... -Os, last wins), so
+# without NOMINSIZE the whole runtime compiles for size, not speed.
+# LTO: opt-in in nanobind; enables cross-TU inlining across the engine in
+# optimized builds (thin LTO under Clang).
+nanobind_add_module(${PROJECT_NAME} STABLE_ABI NOMINSIZE LTO ${HGRAPH_SOURCES} ${HGRAPH_INCLUDES})
 
 target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads)
 target_link_libraries(${PROJECT_NAME} PUBLIC fmt::fmt ddvisitor dynamic_bitset ${HGRAPH_NANOARROW_TARGET})


### PR DESCRIPTION
## Summary

Answers "did we enable LTO on the hgraph C++ build?" — no, and something stronger was hiding next to it.

The engine is built by a single `nanobind_add_module(${PROJECT_NAME} STABLE_ABI ${HGRAPH_SOURCES} ...)` call. Two consequences of the default parameters:

- **The entire engine has been compiling at `-Os`.** Without `NOMINSIZE`, nanobind applies its size-optimization policy (`-Os` via `nanobind_opt_size`) to *every* source in the module — reasonable for thin binding glue, but this module contains the whole C++ runtime. Target compile options follow the global flags on the command line (`-O3 … -Os`, last one wins), so optimized builds — including released wheels — have been size-optimized rather than speed-optimized. `NOMINSIZE` restores `-O3`.
- **No LTO.** `LTO` is opt-in in nanobind's CMake (`if (ARG_LTO)`); passing it enables `nanobind_lto` (thin LTO under Clang) in optimized builds for cross-TU inlining across the engine. As a monolithic module there are no cross-DSO/interposition concerns — LTO here gets the full effect.

Stacked conceptually on the `-DNDEBUG` restoration (#364): with both, the engine wheels reach a normal optimized configuration for the first time. Expect `HGRAPH_USE_CPP` benchmark baselines to improve meaningfully; worth re-running any comparative numbers after this merges.

CI is the validation gate per the current workflow (LTO can lengthen the wheel-build step somewhat; if CI time becomes a concern the `LTO` flag can be made conditional on release builds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)