### PR TITLE
Curate hgraph.test exports: add missing __all__ to _node_unit_tester

### DIFF
--- a/hgraph/test/_node_unit_tester.py
+++ b/hgraph/test/_node_unit_tester.py
@@ -24,6 +24,8 @@ from hgraph import (
 )
 from hgraph._impl._operators._record_replay_in_memory import replay_from_memory, record_to_memory
 
+__all__ = ("eval_node",)
+
 
 def eval_node(
     node,


### PR DESCRIPTION
Four of the five `hgraph.test` submodules declare `__all__`; `_node_unit_tester` does not, so its star-import into `hgraph.test` leaks the entire import namespace — `datetime`, `nullcontext`, `zip_longest`, `GlobalState`, `MIN_ST`, `evaluate_graph`, and the `_impl` in-memory record/replay internals all become visible as `hgraph.test` attributes. The module defines exactly one public API, `eval_node`; this adds `__all__ = ("eval_node",)`.

Found by hg_cpp's API-surface parity audit (hhenson/hg_cpp#212), which diffs the public surfaces of the two packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)