### PR TITLE
Fix InputsKey equality leaking NotImplemented; test on 3.12, 3.13 and 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
             ${{ runner.os }}-uvpip-
 
       # Build the ABI3 wheel against the 3.12 stable ABI baseline.
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
         with:
           python-version: '3.12'
 
@@ -223,7 +223,7 @@ jobs:
 
       # Pinned, and matching the build job, rather than `pip install --upgrade uv`, which resolves
       # to an unverified version at run time.
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,18 +195,15 @@ jobs:
     name: Test suite (py${{ matrix.python-version }}, ${{ matrix.runtime }} runtime)
     needs: build-test
     runs-on: ubuntu-latest
-    # Two categories report without blocking:
+    # The C++ runtime is not yet at parity with the Python reference implementation, so its legs
+    # report without blocking. This matches the behaviour of the steps this job replaces.
     #
-    #  - cpp: the C++ runtime is not yet at parity with the Python reference implementation. This
-    #    matches the behaviour of the step this job replaces.
-    #  - 3.14: every test passes, but the interpreter aborts during finalisation
-    #    ("Fatal Python error: gilstate_tss_set", SIGABRT/134) once the hgraph_unit_tests/adaptors
-    #    group has run. No single adaptor sub-directory triggers it, and it reproduces with this
-    #    change reverted, so it is a pre-existing native-extension teardown problem rather than a
-    #    test failure. Observed on macOS; it may not occur on the Linux runner. Drop the
-    #    python-version clause below once a green 3.14 run confirms it does not, or once the
-    #    teardown issue is fixed.
-    continue-on-error: ${{ matrix.runtime == 'cpp' || matrix.python-version == '3.14' }}
+    # Note that 3.14 is NOT exempted here. It aborts during interpreter finalisation
+    # ("Fatal Python error: gilstate_tss_set", SIGABRT/134) once the hgraph_unit_tests/adaptors
+    # group has run, but that happens after pytest has reported, so the run step distinguishes it
+    # from a genuine test failure rather than the whole leg being made optional. A 3.14-only
+    # regression still fails CI.
+    continue-on-error: ${{ matrix.runtime == 'cpp' }}
     strategy:
       fail-fast: false
       matrix:
@@ -224,12 +221,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v6
+      # Pinned, and matching the build job, rather than `pip install --upgrade uv`, which resolves
+      # to an unverified version at run time.
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Install uv
-        run: python -m pip install --upgrade uv
 
       - uses: actions/download-artifact@v7
         with:
@@ -261,15 +257,67 @@ jobs:
           .venv/bin/python -c "import hgraph; print('hgraph:', hgraph.__file__)"
           .venv/bin/python -c "import sys; print('python:', sys.version)"
 
+      # pytest's exit status is not usable on its own here: on 3.14 the interpreter can abort during
+      # finalisation, after the run has completed and reported, turning a green run into SIGABRT.
+      # So the verdict comes from the JUnit report, which is written before finalisation, and the
+      # process status is only consulted to catch a crash that happened *during* the run.
       - name: Run test suite
         shell: bash
         run: |
-          set -euo pipefail
           echo "python=${{ matrix.python-version }} HGRAPH_USE_CPP=${HGRAPH_USE_CPP}"
           ulimit -c unlimited || true
           mv hgraph hgraph_src
           trap 'mv hgraph_src hgraph' EXIT
-          .venv/bin/pytest hgraph_unit_tests docs -ra -q ${{ matrix.coverage_args }}
+          set +e
+          .venv/bin/pytest hgraph_unit_tests docs -ra -q \
+            --junitxml=pytest-report.xml ${{ matrix.coverage_args }}
+          pytest_status=$?
+          set -e
+          echo "pytest exit status: ${pytest_status}"
+          .venv/bin/python - "${pytest_status}" <<'PY'
+          import sys, xml.etree.ElementTree as ET
+          from pathlib import Path
+
+          status = int(sys.argv[1])
+          report = Path("pytest-report.xml")
+
+          if not report.is_file():
+              sys.exit(f"FAIL: pytest produced no report; it died before finishing (status {status}).")
+
+          suites = ET.parse(report).getroot().iter("testsuite")
+          totals = {k: 0 for k in ("tests", "failures", "errors", "skipped")}
+          for suite in suites:
+              for k in totals:
+                  totals[k] += int(suite.get(k, 0))
+          print("report:", ", ".join(f"{k}={v}" for k, v in totals.items()))
+
+          if totals["failures"] or totals["errors"]:
+              sys.exit("FAIL: the run reported test failures or errors.")
+          if totals["tests"] == 0:
+              sys.exit("FAIL: the report contains no tests; collection probably failed.")
+          if status == 0:
+              print("PASS")
+              sys.exit(0)
+          # Every test passed but the process still died. Tolerated only for the known
+          # post-run finalisation abort; anything else is a real crash during the run.
+          if status > 128:
+              print(
+                  f"PASS (with warning): all tests passed but the process exited on signal "
+                  f"{status - 128} after reporting. This is the known interpreter-finalisation "
+                  f"abort; see the crash artifacts for detail."
+              )
+              sys.exit(0)
+          sys.exit(f"FAIL: tests reported clean but pytest exited {status}.")
+          PY
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: pytest-report-py${{ matrix.python-version }}-${{ matrix.runtime }}
+          path: pytest-report.xml
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Collect crash artifacts
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,45 +186,93 @@ jobs:
             done
           done
 
-      - name: Run tests (Linux only) [Python runtime]
-        if: runner.os == 'Linux'
-        env:
-          HGRAPH_USE_CPP: 'false'
-          PYTHONFAULTHANDLER: '1'
+  # The full suite, run against the built wheel on every supported Python.
+  #
+  # The wheel is abi3, built once against the 3.12 stable ABI, so the same artifact is exercised on
+  # 3.13 and 3.14 rather than rebuilt per version. Splitting this out of build-test means a failure
+  # names the version and runtime it belongs to, instead of hiding inside the Linux build leg.
+  test-matrix:
+    name: Test suite (py${{ matrix.python-version }}, ${{ matrix.runtime }} runtime)
+    needs: build-test
+    runs-on: ubuntu-latest
+    # Two categories report without blocking:
+    #
+    #  - cpp: the C++ runtime is not yet at parity with the Python reference implementation. This
+    #    matches the behaviour of the step this job replaces.
+    #  - 3.14: every test passes, but the interpreter aborts during finalisation
+    #    ("Fatal Python error: gilstate_tss_set", SIGABRT/134) once the hgraph_unit_tests/adaptors
+    #    group has run. No single adaptor sub-directory triggers it, and it reproduces with this
+    #    change reverted, so it is a pre-existing native-extension teardown problem rather than a
+    #    test failure. Observed on macOS; it may not occur on the Linux runner. Drop the
+    #    python-version clause below once a green 3.14 run confirms it does not, or once the
+    #    teardown issue is fixed.
+    continue-on-error: ${{ matrix.runtime == 'cpp' || matrix.python-version == '3.14' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ '3.12', '3.13', '3.14' ]
+        runtime: [ 'python', 'cpp' ]
+        # Coverage is measured once, on the reference leg; the other five would report the same
+        # lines at six times the cost. Undefined for every other combination, expanding to nothing.
+        include:
+          - python-version: '3.12'
+            runtime: 'python'
+            coverage_args: '--cov=hgraph --cov-report=xml'
+    env:
+      HGRAPH_USE_CPP: ${{ matrix.runtime == 'cpp' && 'true' || 'false' }}
+      PYTHONFAULTHANDLER: '1'
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        run: python -m pip install --upgrade uv
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: wheels-linux-manylinux
+          path: dist
+
+      - name: Sync test dependencies (project itself comes from the wheel)
+        run: uv sync --frozen --all-extras --all-groups --no-install-project --python ${{ matrix.python-version }}
+
+      - name: Install built wheel
+        shell: python
+        run: |
+          import subprocess, sys
+          from pathlib import Path
+
+          wheels = sorted(Path("dist").glob("*.whl"))
+          assert len(wheels) == 1, f"expected exactly one wheel, found {wheels}"
+          venv_python = Path(".venv") / ("Scripts/python.exe" if sys.platform == "win32" else "bin/python")
+          subprocess.check_call(["uv", "pip", "install", "--python", str(venv_python), str(wheels[0])])
+
+      - name: Confirm the wheel is what gets imported
+        shell: bash
         run: |
           set -euo pipefail
-          echo "HGRAPH_USE_CPP=$HGRAPH_USE_CPP"
-          ulimit -c unlimited || true
-          # Temporarily hide local hgraph/ to force use of installed wheel
+          # Hide the source tree so a stale local copy cannot shadow the installed wheel.
           mv hgraph hgraph_src
-          echo "Discovering extension paths..."
-          .venv/bin/python -c "import importlib.util as u, sys; m=u.find_spec('hgraph._hgraph'); print('_hgraph:', getattr(m,'origin',None) or 'not installed')"
+          trap 'mv hgraph_src hgraph' EXIT
+          .venv/bin/python -c "import importlib.util as u; m=u.find_spec('hgraph._hgraph'); print('_hgraph:', getattr(m,'origin',None) or 'not installed')"
           .venv/bin/python -c "import hgraph; print('hgraph:', hgraph.__file__)"
-          .venv/bin/pytest hgraph_unit_tests docs -ra -q --cov=hgraph --cov-report=xml || status=$?
-          mv hgraph_src hgraph
-          exit ${status:-0}
+          .venv/bin/python -c "import sys; print('python:', sys.version)"
 
-      - name: Run tests (Linux only) [C++ runtime]
-        if: runner.os == 'Linux'
-        continue-on-error: true
-        env:
-          HGRAPH_USE_CPP: 'true'
-          PYTHONFAULTHANDLER: '1'
+      - name: Run test suite
+        shell: bash
         run: |
           set -euo pipefail
-          echo "HGRAPH_USE_CPP=$HGRAPH_USE_CPP"
+          echo "python=${{ matrix.python-version }} HGRAPH_USE_CPP=${HGRAPH_USE_CPP}"
           ulimit -c unlimited || true
-          # Temporarily hide local hgraph/ to force use of installed wheel
           mv hgraph hgraph_src
-          echo "Discovering extension paths..."
-          .venv/bin/python -c "import importlib.util as u, sys; m=u.find_spec('hgraph._hgraph'); print('_hgraph:', getattr(m,'origin',None) or 'not installed')"
-          .venv/bin/python -c "import hgraph; print('hgraph:', hgraph.__file__)"
-          .venv/bin/pytest hgraph_unit_tests docs -ra -q --cov=hgraph --cov-report=xml || status=$?
-          mv hgraph_src hgraph
-          exit ${status:-0}
+          trap 'mv hgraph_src hgraph' EXIT
+          .venv/bin/pytest hgraph_unit_tests docs -ra -q ${{ matrix.coverage_args }}
 
-      - name: Collect crash artifacts (Linux only)
-        if: failure() && runner.os == 'Linux'
+      - name: Collect crash artifacts
+        if: failure()
         shell: bash
         run: |
           set -euo pipefail
@@ -237,15 +285,14 @@ jobs:
           for c in "${CORES[@]}"; do
             echo "==> Core file: $c"
             file "$c" || true
-            which python || true
             gdb -q -n -batch -ex "set pagination off" -ex "thread apply all bt full" -ex "quit" "$(which python)" "$c" || true
           done
 
-      - name: Upload core dumps (Linux only)
-        if: failure() && runner.os == 'Linux'
+      - name: Upload core dumps
+        if: failure()
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: linux-core-dumps
+          name: core-dumps-py${{ matrix.python-version }}-${{ matrix.runtime }}
           path: |
             core*
             /var/crash/*.crash

--- a/hgraph/_wiring/_wiring_node_instance.py
+++ b/hgraph/_wiring/_wiring_node_instance.py
@@ -36,13 +36,45 @@ class InputsKey:
             self._hash = hash(tuple((k, _safe_hash(v)) for k, v in self._inputs.items()))
 
     def __eq__(self, other: Any) -> bool:
-        return all(
-            v.__orig_eq__(other._inputs[k]) if hasattr(v, "__orig_eq__") else v == other._inputs[k]
-            for k, v in self._inputs.items()
-        )
+        if other is self:
+            return True
+        if not isinstance(other, InputsKey):
+            return NotImplemented
+        other_inputs = other._inputs
+        if self._inputs.keys() != other_inputs.keys():
+            return False
+        return all(_eq(v, other_inputs[k]) for k, v in self._inputs.items())
 
     def __hash__(self) -> int:
         return self._hash
+
+
+def _eq(lhs: Any, rhs: Any) -> bool:
+    """
+    Compare two wiring inputs.
+
+    ``WiringPort`` replaces ``__eq__`` so that ``a == b`` wires an ``eq_`` node rather than comparing,
+    stashing the real implementation on ``__orig_eq__``. We therefore have to call that directly, which
+    bypasses the interpreter's handling of ``NotImplemented``, so this reproduces it: try the reflected
+    operation, then fall back to identity.
+
+    Getting this wrong is not academic. ``WiringPort`` is declared ``eq=False``, so ``__orig_eq__`` is
+    ``object.__eq__``, which returns ``NotImplemented`` for any two distinct objects. Returning that from
+    here would make every non-identical pair of ports compare *equal* (``NotImplemented`` is truthy), and
+    from Python 3.14 using it in a boolean context raises ``TypeError``.
+    """
+    if lhs is rhs:
+        return True
+    orig_eq = getattr(type(lhs), "__orig_eq__", None)
+    if orig_eq is None:
+        return bool(lhs == rhs)
+    result = orig_eq(lhs, rhs)
+    if result is NotImplemented:
+        reflected_eq = getattr(type(rhs), "__orig_eq__", None)
+        result = reflected_eq(rhs, lhs) if reflected_eq is not None else NotImplemented
+        if result is NotImplemented:
+            return False  # lhs is rhs was already ruled out above
+    return bool(result)
 
 
 def _safe_hash(v):

--- a/hgraph/_wiring/_wiring_node_instance.py
+++ b/hgraph/_wiring/_wiring_node_instance.py
@@ -49,29 +49,39 @@ class InputsKey:
         return self._hash
 
 
+def _real_eq(obj: Any):
+    """
+    The comparison to use for ``obj``: the stashed original where ``__eq__`` has been replaced.
+
+    ``WiringPort`` replaces ``__eq__`` so that ``a == b`` wires an ``eq_`` node rather than comparing,
+    keeping the real implementation on ``__orig_eq__``. Reaching that replacement from here would build
+    graph nodes as a side effect of a dictionary lookup, so it must never be called.
+    """
+    tp = type(obj)
+    return getattr(tp, "__orig_eq__", None) or tp.__eq__
+
+
 def _eq(lhs: Any, rhs: Any) -> bool:
     """
     Compare two wiring inputs.
 
-    ``WiringPort`` replaces ``__eq__`` so that ``a == b`` wires an ``eq_`` node rather than comparing,
-    stashing the real implementation on ``__orig_eq__``. We therefore have to call that directly, which
-    bypasses the interpreter's handling of ``NotImplemented``, so this reproduces it: try the reflected
-    operation, then fall back to identity.
+    Because the comparison has to be invoked directly rather than through ``==``, the interpreter's
+    handling of ``NotImplemented`` is bypassed, so this reproduces it: try the left operand, then the
+    reflected operation, then fall back to identity.
 
     Getting this wrong is not academic. ``WiringPort`` is declared ``eq=False``, so ``__orig_eq__`` is
     ``object.__eq__``, which returns ``NotImplemented`` for any two distinct objects. Returning that from
     here would make every non-identical pair of ports compare *equal* (``NotImplemented`` is truthy), and
     from Python 3.14 using it in a boolean context raises ``TypeError``.
+
+    Both operands are resolved through :func:`_real_eq`, so a plain value on one side and a port on the
+    other cannot reflect into the ``eq_``-wiring ``__eq__`` and quietly add a node to the graph.
     """
     if lhs is rhs:
         return True
-    orig_eq = getattr(type(lhs), "__orig_eq__", None)
-    if orig_eq is None:
-        return bool(lhs == rhs)
-    result = orig_eq(lhs, rhs)
+    result = _real_eq(lhs)(lhs, rhs)
     if result is NotImplemented:
-        reflected_eq = getattr(type(rhs), "__orig_eq__", None)
-        result = reflected_eq(rhs, lhs) if reflected_eq is not None else NotImplemented
+        result = _real_eq(rhs)(rhs, lhs)
         if result is NotImplemented:
             return False  # lhs is rhs was already ruled out above
     return bool(result)

--- a/hgraph_unit_tests/_wiring/test_inputs_key.py
+++ b/hgraph_unit_tests/_wiring/test_inputs_key.py
@@ -95,6 +95,18 @@ def test_unhashable_input_degrades_to_best_effort_hash():
     assert key == InputsKey(frozendict(a=value))
 
 
+def test_mixed_scalar_and_port_does_not_wire_a_node():
+    """
+    A plain value on one side and a port on the other must not reach the ``eq_``-wiring ``__eq__``.
+
+    ``==`` would reflect into it when the left operand returns NotImplemented, which would build a
+    graph node as a side effect of a dictionary lookup, and outside a wiring context that raises.
+    """
+    port = _port()
+    assert InputsKey(frozendict(a=1)) != InputsKey(frozendict(a=port))
+    assert InputsKey(frozendict(a=port)) != InputsKey(frozendict(a=1))
+
+
 def test_wiring_port_orig_eq_is_identity_based():
     """Documents the premise: __orig_eq__ is object.__eq__, so it yields NotImplemented for distinct objects."""
     assert WiringPort.__orig_eq__ is object.__eq__

--- a/hgraph_unit_tests/_wiring/test_inputs_key.py
+++ b/hgraph_unit_tests/_wiring/test_inputs_key.py
@@ -1,0 +1,122 @@
+"""
+Tests for ``InputsKey``, the cache key used to de-dup wiring node instances.
+
+``WiringPort`` replaces ``__eq__`` so that ``a == b`` wires an ``eq_`` node, stashing the real
+implementation on ``__orig_eq__``. ``InputsKey`` has to call that stashed implementation directly,
+which bypasses the interpreter's handling of ``NotImplemented``. ``WiringPort`` is declared
+``eq=False``, so ``__orig_eq__`` is ``object.__eq__``, which returns ``NotImplemented`` for any two
+distinct objects.
+
+Mishandling that has two consequences: every non-identical pair of ports compares *equal*, because
+``NotImplemented`` is truthy, and from Python 3.14 using it in a boolean context raises
+``TypeError``.
+"""
+
+import warnings
+
+import pytest
+from frozendict import frozendict
+
+from hgraph._wiring._wiring_node_instance import InputsKey
+from hgraph._wiring._wiring_port import TSLWiringPort, WiringPort
+
+
+def _port(path=(0,)):
+    """A wiring port that hashes by field value (``unsafe_hash=True``), so distinct instances collide."""
+    return TSLWiringPort(node_instance=None, path=path)
+
+
+def test_identical_inputs_are_equal():
+    port = _port()
+    assert InputsKey(frozendict(a=port)) == InputsKey(frozendict(a=port))
+
+
+def test_distinct_ports_are_not_equal():
+    """Two distinct ports are not equal, per ``object.__eq__``, even when their fields match."""
+    assert InputsKey(frozendict(a=_port())) != InputsKey(frozendict(a=_port()))
+
+
+def test_different_ports_are_not_equal():
+    """Regression: this returned True, because ``object.__eq__`` gave NotImplemented, which is truthy."""
+    assert InputsKey(frozendict(a=_port(path=(0,)))) != InputsKey(frozendict(a=_port(path=(9,))))
+
+
+def test_field_equal_ports_hash_alike_so_eq_is_reached():
+    """Guards the premise of the tests above: these ports collide, so __eq__ is actually exercised."""
+    assert hash(_port()) == hash(_port())
+    assert hash(InputsKey(frozendict(a=_port()))) == hash(InputsKey(frozendict(a=_port())))
+
+
+def test_comparison_does_not_leak_not_implemented():
+    """``__eq__`` must return a bool for ports, never the ``NotImplemented`` singleton."""
+    result = InputsKey(frozendict(a=_port())).__eq__(InputsKey(frozendict(a=_port())))
+    assert result is False
+
+
+def test_no_deprecation_warning_from_not_implemented():
+    """On 3.12/3.13 this warns; on 3.14 the same code path raises TypeError."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        assert InputsKey(frozendict(a=_port())) != InputsKey(frozendict(a=_port()))
+
+
+def test_differing_key_sets_are_not_equal():
+    """Must not raise KeyError, and a subset of matching entries must not count as equal."""
+    port = _port()
+    assert InputsKey(frozendict(a=port)) != InputsKey(frozendict(a=port, b=port))
+    assert InputsKey(frozendict(a=port, b=port)) != InputsKey(frozendict(a=port))
+
+
+def test_disjoint_key_sets_are_not_equal():
+    port = _port()
+    assert InputsKey(frozendict(a=port)) != InputsKey(frozendict(b=port))
+
+
+def test_non_inputs_key_is_not_equal():
+    """Comparing against an unrelated type must defer rather than blow up."""
+    key = InputsKey(frozendict(a=_port()))
+    assert key.__eq__(object()) is NotImplemented
+    assert key != object()
+    assert key != 42
+    assert key is not None
+
+
+def test_scalar_inputs_compare_by_value():
+    """Non-port inputs keep ordinary value semantics."""
+    assert InputsKey(frozendict(a=1, b="x")) == InputsKey(frozendict(a=1, b="x"))
+    assert InputsKey(frozendict(a=1, b="x")) != InputsKey(frozendict(a=2, b="x"))
+
+
+def test_unhashable_input_degrades_to_best_effort_hash():
+    """Logically immutable but unhashable values must not break key construction."""
+    value = [1, 2, 3]
+    key = InputsKey(frozendict(a=value))
+    assert isinstance(hash(key), int)
+    assert key == InputsKey(frozendict(a=value))
+
+
+def test_wiring_port_orig_eq_is_identity_based():
+    """Documents the premise: __orig_eq__ is object.__eq__, so it yields NotImplemented for distinct objects."""
+    assert WiringPort.__orig_eq__ is object.__eq__
+    assert _port().__orig_eq__(_port()) is NotImplemented
+
+
+@pytest.mark.smoke
+def test_node_instance_cache_lookup_survives_port_comparison():
+    """
+    End-to-end: wiring must not raise while probing the node-instance cache.
+
+    Marked smoke so it runs in the cross-version CI matrix, where a NotImplemented
+    leak would surface as a TypeError on Python 3.14.
+    """
+    from hgraph import graph, const, debug_print, wire_graph
+    from hgraph._wiring._wiring_node_instance import WiringNodeInstanceContext
+
+    @graph
+    def main():
+        c = const(1)
+        d = const(1)
+        debug_print("sum", c + d)
+
+    with WiringNodeInstanceContext():
+        assert wire_graph(main) is not None


### PR DESCRIPTION
Reported: hgraph calls some inputs' original `__eq__` directly, which can return `NotImplemented`, and Python 3.14 rejects that. Confirmed, with a broader impact than the report suggests.

## The defect

`InputsKey.__eq__` called `v.__orig_eq__(other._inputs[k])` directly. Calling a dunder that way bypasses the interpreter's handling of `NotImplemented`.

`WiringPort` replaces `__eq__` so `a == b` wires an `eq_` node, stashing the real one on `__orig_eq__`. But `WiringPort` is declared `eq=False`, so what got stashed is `object.__eq__` — which returns `NotImplemented` for **any two distinct objects**.

`NotImplemented` is truthy, so the consequences split by version:

| Python | Behaviour |
|---|---|
| 3.12 / 3.13 | Every non-identical pair of inputs compares **equal**, with a `DeprecationWarning` |
| 3.14 | `TypeError: NotImplemented should not be used in a boolean context` |

So this is not only a 3.14 break. On 3.12 today, two `InputsKey`s holding genuinely different wiring ports compare equal:

```python
k1 = InputsKey(frozendict(a=TSLWiringPort(node_instance=None, path=(0,))))
k3 = InputsKey(frozendict(a=TSLWiringPort(node_instance=None, path=(9,))))
k1 == k3   # True on 3.12  <- wrong;  TypeError on 3.14
```

Three further gaps in the same method:

- No `isinstance` guard, so comparing against an unrelated type raised rather than deferring.
- No key-set check before indexing `other._inputs[k]`, so disjoint keys raised `KeyError` and a subset of matching entries compared equal.
- An asymmetric fallback: with a plain value on the left and a port on the right, `lhs == rhs` reflected into the `eq_`-wiring `__eq__`, building a graph node as a side effect of a dictionary lookup. Outside a wiring context that recurses to `RecursionError`. Raised in review; both operands now resolve through `_real_eq`, so the replacement is never reachable.

## The fix

The comparison now reproduces what the interpreter does for `==`: try the left operand, then the reflected operation, then fall back to identity. Identity is what `__orig_eq__` literally is here, so this preserves existing conflation semantics exactly while removing the wrong answers.

## How exposed is this?

Worth being precise, because it affects how urgent this is. Instrumenting the full suite: `InputsKey.__eq__` is called **1494 times and never once produces `NotImplemented`** — every one of those comparisons is between the same object, so `object.__eq__` returns `True` honestly.

Triggering it needs two distinct but hash-equal inputs. The `unsafe_hash=True` `WiringPort` subclasses (`TSLWiringPort`, `TSBWiringPort`, and others) hash by field, so field-equal distinct ports do collide and reach `__eq__`. The new tests construct that directly. I tried and **could not** find a trigger through the public graph API — duplicated `tsl[0]`, TSB field access, `map_`, `const` all failed to reach it.

So: latent rather than actively breaking today's graphs, but it fails closed on 3.14 and silently gives wrong answers before that. The whole suite passes on 3.14 both before and after this change.

## Tests

`hgraph_unit_tests/_wiring/test_inputs_key.py`, 14 tests. Reverting the fix fails 7 of them. They cover identity equality, distinct-but-field-equal ports, genuinely different ports, `NotImplemented` never escaping, no `DeprecationWarning`, differing and disjoint key sets, non-`InputsKey` operands, mixed scalar/port operands, scalar value semantics, and the unhashable-input fallback. One is marked `smoke` so it runs in the cross-version matrix.

## CI matrix

The full suite previously ran on Linux/3.12 only; 3.13 and 3.14 got smoke tests. A `test-matrix` job — modelled on the `test-wheel` job in `hg_cpp`, as suggested — now runs it across 3.12/3.13/3.14 against both runtimes, six legs. The abi3 wheel is built once and reused rather than rebuilt per version, and the now-redundant Linux-only steps are removed. Coverage is measured on the reference leg only.

Verified locally that `uv sync --frozen --all-extras --all-groups` resolves cleanly on both 3.13 and 3.14, and ran the complete suite on all three.

### 3.14 failures block

On 3.14 the interpreter aborts during finalisation — `Fatal Python error: gilstate_tss_set`, SIGABRT/134 — once the `hgraph_unit_tests/adaptors` group has run. No single adaptor sub-directory triggers it; it needs the group. It reproduces with this change reverted, so it is a pre-existing native-extension teardown problem, not a test failure and not related to `InputsKey`.

The first version of this PR handled that by marking the whole 3.14 leg `continue-on-error`. Review correctly pointed out that this lets a genuine 3.14-only regression merge green, defeating the point of adding 3.14. The two signals are now separated instead: the abort happens *after* pytest has reported, so the verdict comes from the JUnit report and the process status is only consulted to catch a crash *during* the run.

| Situation | Verdict |
|---|---|
| Report shows failures or errors | **fail** |
| Report missing (died before finishing) | **fail** |
| Report has zero tests (collection broke) | **fail** |
| Clean report, exit 0 | **pass** |
| Clean report, killed by a signal after reporting | **pass, with warning** |
| Clean report, ordinary non-zero exit | **fail** |

All six paths verified locally. The decisive one injects a real failure into a 3.14 run: it exits 134, exactly like the benign abort, but the gate reads `failures=1` and fails the job.

`continue-on-error` therefore applies only to the C++ runtime legs, matching the behaviour of the steps this job replaces.

## Verification

| | Result |
|---|---|
| 3.12, C++ runtime | 2419 passed |
| 3.12, Python runtime | 1742 passed |
| 3.13 | 1742 passed |
| 3.14 | 1742 passed |

Also noted while testing, and not addressed here: `test_wall_clock_scheduler_reschedule` and `test_inspector.py::test_run_inspector` are both timing-flaky, each failing once then passing on repeat, on 3.12 as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
