### PR TITLE
Fix the release publish: accept directory entries, and wait for the build

### DIFF
--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -40,6 +40,9 @@ jobs:
     permissions:
       actions: read          # lists previous runs and their artifacts
     runs-on: ubuntu-latest
+    # Slightly above the 45 minute wait inside the step, so the step gives up and reports rather
+    # than the job being killed mid-wait.
+    timeout-minutes: 50
     outputs:
       run-id: ${{ steps.find.outputs.run-id }}
     steps:
@@ -55,36 +58,90 @@ jobs:
               "release-sdist",
             ]);
 
+            // Tagging usually follows a push to main by seconds, long before that build has
+            // finished. Only looking at completed runs would therefore almost never find anything
+            // and every release would rebuild, which is the thing this job exists to avoid. So a
+            // run already building this commit is waited for rather than raced.
+            const WAIT_LIMIT_MS = 45 * 60 * 1000;
+            const POLL_MS = 30 * 1000;
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
             // event: "push" is load-bearing, not a tidy-up. Pull request runs take the fast build
             // path and upload wheels that are not publish-grade, under these same artifact names.
             // A rebase merge can leave main's commit sharing a SHA with the pull request head, so
             // without this filter a tag could publish an unrepaired wheel.
-            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: "release-wheels.yml",
-              event: "push",
-              head_sha: context.sha,
-              status: "success",
-              per_page: 100,
-            });
+            async function runsWithStatus(status) {
+              const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: "release-wheels.yml",
+                event: "push",
+                head_sha: context.sha,
+                status,
+                per_page: 100,
+              });
+              return runs.filter((r) => r.id !== context.runId && r.head_sha === context.sha);
+            }
 
-            for (const run of runs) {
-              if (run.id === context.runId || run.head_sha !== context.sha) continue;
-
+            async function hasAllArtifacts(runId) {
               const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                run_id: run.id,
+                run_id: runId,
                 per_page: 100,
               });
               const available = new Set(
                 artifacts.filter((a) => !a.expired).map((a) => a.name),
               );
-              if ([...required].every((name) => available.has(name))) {
-                core.notice(`Reusing distributions already built and tested by run ${run.id}`);
-                core.setOutput("run-id", String(run.id));
-                return;
+              return [...required].every((name) => available.has(name));
+            }
+
+            async function reuseIfComplete() {
+              for (const run of await runsWithStatus("success")) {
+                if (await hasAllArtifacts(run.id)) {
+                  core.notice(`Reusing distributions already built and tested by run ${run.id}`);
+                  core.setOutput("run-id", String(run.id));
+                  return true;
+                }
+              }
+              return false;
+            }
+
+            if (await reuseIfComplete()) return;
+
+            const inFlight = [...(await runsWithStatus("in_progress")), ...(await runsWithStatus("queued"))];
+            if (inFlight.length) {
+              const run = inFlight[0];
+              core.notice(
+                `Run ${run.id} is already building this commit; waiting for it rather than ` +
+                `rebuilding. Waiting up to ${WAIT_LIMIT_MS / 60000} minutes.`,
+              );
+              const deadline = Date.now() + WAIT_LIMIT_MS;
+              while (Date.now() < deadline) {
+                await sleep(POLL_MS);
+                let current;
+                try {
+                  current = await github.rest.actions.getWorkflowRun({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    run_id: run.id,
+                  });
+                } catch (error) {
+                  core.warning(`Could not read run ${run.id}: ${error.message}`);
+                  continue;
+                }
+                if (current.data.status !== "completed") continue;
+                if (current.data.conclusion === "success") {
+                  // Artifacts are uploaded by the jobs, so re-check rather than assume.
+                  if (await reuseIfComplete()) return;
+                  core.notice(`Run ${run.id} succeeded but is missing artifacts; building instead.`);
+                } else {
+                  core.notice(`Run ${run.id} finished as ${current.data.conclusion}; building instead.`);
+                }
+                break;
+              }
+              if (Date.now() >= deadline) {
+                core.notice(`Gave up waiting for run ${run.id}; building instead.`);
               }
             }
 
@@ -655,7 +712,9 @@ jobs:
           # directly is both stricter than a metadata linter and free of any added dependency.
           def verify_wheel(path: Path) -> None:
               with zipfile.ZipFile(path) as archive:
-                  names = set(archive.namelist())
+                  # RECORD lists files only. Wheels repaired by auditwheel or delocate also carry
+                  # explicit directory entries, which must not be counted against it.
+                  names = {n for n in archive.namelist() if not n.endswith("/")}
                   record_name = next(n for n in names if n.endswith(".dist-info/RECORD"))
                   listed = set()
                   for row in csv.reader(io.StringIO(archive.read(record_name).decode())):

--- a/README.md
+++ b/README.md
@@ -131,15 +131,16 @@ Prerequisites:
 
 Steps:
 ```bash
-# Push the commit you want to release to main first; that build is what gets published.
-# Once it is green, tag it:
+# Push the commit you want to release to main; that build is what gets published.
+# You can tag it straight away - the release waits for that build rather than racing it.
 
 git tag -a v_0.4.112 -m "release 0.4.112"
 git push origin v_0.4.112
 ```
 
 For a commit already built and tested on main, the workflow will:
-- Find that run and skip the build and the test matrix entirely
+- Find that run and skip the build and the test matrix entirely. If that build is still running,
+  it waits for it rather than starting a second one
 - Rewrite the version in the distribution metadata to match the tag, leaving the compiled
   extension byte-for-byte as it was built and tested
 - Validate with `twine check` and publish to PyPI (skipping files that already exist)


### PR DESCRIPTION
Two faults, both surfaced by the `v_0.5.36` release. Both are mine, from #375.

## 1. Publish failed in the restamp verification

```
AssertionError: hgraph-0.5.36-cp312-abi3-macosx_15_0_arm64.whl:
RECORD and archive disagree: {'include/', 'hgraph/', 'lib/cmake/', ...}
```

`RECORD` lists **files**. Wheels repaired by auditwheel and delocate also carry explicit **directory** entries, and I was comparing `RECORD` against the full `namelist()`, so every directory read as a file missing from `RECORD`.

The wheel I validated against locally was built by `uv` and has no directory entries, so the check passed for me and failed on the first real release. Directory entries are now excluded.

It failed safe — nothing incorrect was published — but it blocked a legitimate release, which is its own kind of broken.

Confirmed the fix does not weaken the check, by reproducing the exact failure locally (injecting 46 directory entries into a real wheel) and re-testing the cases it exists to catch:

| Case | Result |
|---|---|
| 46 directory entries, as auditwheel/delocate produce | accepted |
| METADATA bytes changed without updating RECORD | `hash mismatch for ...dist-info/METADATA` |
| Extra file present but absent from RECORD | `RECORD and archive disagree: {'hgraph/sneaky.py'}` |

## 2. Reuse never fired, so the release rebuilt everything

The whole point of #375 was that tagging skips the build. It didn't:

```
No reusable distributions for 1c9680c9; building from source.
```

| | |
|---|---|
| main run, same SHA `1c9680c9` | 12:19:29 → **12:29:11** |
| tag run's reuse lookup | ran at **12:20:09** |

The tag was pushed 37 seconds after the commit landed on main, so that build was still running, and I only considered runs with `status: "success"`. Since tagging normally follows a push by seconds, reuse would have almost never fired — the feature was close to dead on arrival, and the README's "wait until it is green, then tag" was papering over it.

A run already building the same commit is now **waited for** rather than raced, up to 45 minutes, polling every 30 seconds. If it finishes without success, or without the artifacts, the release builds from source as before. The job carries a `timeout-minutes` above the wait so it reports rather than being killed mid-wait.

The logic is exercised against a mocked GitHub API:

| Scenario | Verdict |
|---|---|
| Completed run with artifacts | REUSE |
| **Run still in flight (the failing case)** | **REUSE, after waiting** |
| In-flight run that then fails | BUILD |
| Completed but artifacts expired | BUILD |
| No runs at all for the commit | BUILD |

The embedded script is also syntax-checked, since a typo in it would otherwise only surface at release time.

README updated: you can tag straight after pushing to main now, which is what one naturally does.

## What this says about #375

Neither fault was reachable from a pull request. Reuse only does anything on a tag, and the restamp only runs on publish, so the first execution of either path was the real release. Worth knowing when reading the rest of that PR: the parts exercised by PR and main runs have now had many passes, the release-only paths had exactly one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
