### PR TITLE
Correct stale CI comments, and let the data-store fixture own its lifecycle

### DIFF
--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -383,11 +383,7 @@ jobs:
     if: needs.reuse-build.outputs.run-id == ''
     runs-on: ubuntu-latest
     # The C++ runtime is not yet at parity with the Python reference implementation, so its legs
-    # report without blocking.
-    #
-    # 3.14 is deliberately NOT exempted. It aborts during interpreter finalisation once the
-    # adaptors group has run, but that happens after pytest has reported, so the run step tells the
-    # two apart rather than the whole leg being made optional. A 3.14-only regression still fails.
+    # report without blocking. Every Python version blocks, 3.14 included.
     continue-on-error: ${{ matrix.runtime == 'cpp' }}
     strategy:
       fail-fast: false
@@ -451,10 +447,10 @@ jobs:
           .venv/bin/python -c "import hgraph; print('hgraph:', hgraph.__file__)"
           .venv/bin/python -c "import sys; print('python:', sys.version)"
 
-      # pytest's exit status is not usable on its own here: on 3.14 the interpreter can abort during
-      # finalisation, after the run has completed and reported, turning a green run into SIGABRT.
-      # So the verdict comes from the JUnit report, which is written before finalisation, and the
-      # process status is only consulted to catch a crash that happened *during* the run.
+      # The verdict comes from the JUnit report rather than from pytest's exit status alone. The
+      # report is written as the run finishes, so it still describes what happened even when the
+      # process dies afterwards, which a native library can cause during interpreter finalisation.
+      # The exit status is then checked as well, so a crash is never mistaken for a pass.
       - name: Run test suite
         shell: bash
         run: |


### PR DESCRIPTION
The two items raised in review of #377, which had already merged — hence a separate PR.

## 1. Two CI comments left stale by that change

Both described the situation *before* #377 and would send the next reader after the wrong thing.

**Above `continue-on-error`:**

```
# 3.14 is deliberately NOT exempted. It aborts during interpreter finalisation once the
# adaptors group has run, but ... the run step tells the two apart ...
```

Wrong on both counts, as the reviewer noted. "Once the adaptors group has run" was my superseded diagnosis — it was one test, removed in #377 along with duckdb. And "tells the two apart" described a tolerance that #377 deleted; a post-report signal death now fails. Replaced with what remains true: the C++ legs report without blocking, every Python version blocks.

**Above the run step:** it justified reading the JUnit report by the 3.14 abort specifically. Reading the report first is still right — it survives *any* post-run death, not that one incident — so the comment now describes the design rather than the bug that prompted it.

No behaviour change. Gate re-verified:

| Report | Process exit | Verdict |
|---|---|---|
| clean | 0 | pass |
| clean | 1 | **fail** |
| clean | 134 (SIGABRT) | **fail** |
| carries a failure | 0 | **fail** |

## 2. The `data_store_connection` fixture

Flagged as pre-existing and out of scope for #377; worth doing now.

The fixture returned an *unregistered* `DataConnectionStore` and relied on each test body remembering `with data_store_connection`. That matters because of how the store behaves when a test forgets — it is a process-wide singleton, and asking for it lazily registers one:

```
DataConnectionStore.instance().get_connection("sqlite")
-> ValueError: No connection found with name 'sqlite'
```

So the immediate failure points at a missing connection rather than a missing context manager. Worse, the store it auto-created is never released, and `register_instance()` raises when one already exists — so the **next** test to use the fixture fails with `RuntimeError: DataConnectionStore already registered`, in a test that did nothing wrong.

The fixture now registers and releases the store itself; the test just uses it. `release_instance()` is idempotent, so this stays correct if a test also enters the store as a context manager.

Demonstrated rather than asserted — a test that fails while holding the fixture:

| Fixture | Outcome |
|---|---|
| Owns the lifecycle (this PR) | `1 failed, 1 passed` — the failure is contained |
| Leaks the singleton | `2 failed` — second one `RuntimeError: DataConnectionStore already registered` |

The stray `print("Connection stored")` goes with it.

## Verification

| | 3.12 | 3.13 | 3.14 |
|---|---|---|---|
| `hgraph_unit_tests docs` | 1743 passed, exit 0 | 1743 passed, exit 0 | 1743 passed, exit 0 |

Plus 2420 passing under the C++ runtime.

## Also raised, and not done

The reviewer asked whether anything would catch a future reintroduction of duckdb, or dependency creep generally — "not a blocker, worth considering". I have not added a guard. Pinning the runtime dependency list in a test would make additions deliberate, and three unused runtime dependencies turning up in one sweep is some evidence it would earn its keep, but it also nags on every legitimate change. That is a policy call for you. Happy to add it if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
