### PR TITLE
Let the data_store_connection fixture own the store's lifecycle

### DIFF
--- a/hgraph_unit_tests/adaptors/data_frame/test_data_frame_source.py
+++ b/hgraph_unit_tests/adaptors/data_frame/test_data_frame_source.py
@@ -103,10 +103,15 @@ def age_data(connection):
 
 @pytest.fixture(scope="function")
 def data_store_connection(connection):
+    # The store is a process-wide singleton whose register_instance() raises if one is already
+    # registered, so leaking it does not fail the test that leaked it, it fails whichever test
+    # runs next. The fixture therefore owns registration and release rather than leaving it to
+    # each test body to remember; release_instance() is idempotent, so this is safe even if a
+    # test enters the store as a context manager itself.
     dsc = DataConnectionStore()
     dsc.set_connection("sqlite", connection)
-    print("Connection stored")
-    return dsc
+    with dsc:
+        yield dsc
 
 
 def test_db_source(age_data, data_store_connection):
@@ -120,7 +125,7 @@ def test_db_source(age_data, data_store_connection):
     def main() -> TSB[ts_schema(name=TS[str], age=TS[int])]:
         return tsb_from_data_source(AgeDataSource, "date")
 
-    with data_store_connection, DataStore():
+    with DataStore():
         config = GraphConfiguration()
         result = evaluate_graph(main, config)
 


### PR DESCRIPTION
Raised in review of #377 and intended for #378, but #378 merged before this commit reached it — main still has the old fixture. Same change, re-raised.

## The problem

`data_store_connection` returned an *unregistered* `DataConnectionStore` and relied on each test body remembering `with data_store_connection`.

That matters because of how the store behaves when a test forgets. It is a process-wide singleton, and asking for it lazily registers one:

```
DataConnectionStore.instance().get_connection("sqlite")
-> ValueError: No connection found with name 'sqlite'
```

So the immediate failure points at a missing *connection* rather than a missing context manager — misleading on its own. Worse, the store it auto-created is never released, and `register_instance()` raises when one already exists, so the **next** test to use the fixture fails with:

```
RuntimeError: DataConnectionStore already registered
```

in a test that did nothing wrong.

## The change

The fixture registers and releases the store itself; the test simply uses it. `release_instance()` is idempotent, so this stays correct if a test also enters the store as a context manager.

Demonstrated rather than asserted — a test that fails while holding the fixture:

| Fixture | Outcome |
|---|---|
| Owns the lifecycle (this PR) | `1 failed, 1 passed` — the failure is contained |
| Leaks the singleton | `2 failed` — the second one `RuntimeError: DataConnectionStore already registered` |

The stray `print("Connection stored")` goes with it.

## Verification

1743 passing, exit 0, on 3.12 and 3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
