### PR TITLE
Fix the Kafka adaptor: recovery cycle, timestamps, swallowed failures, wiring order

### DIFF
--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -109,7 +109,14 @@ jobs:
 
             if (await reuseIfComplete()) return;
 
-            const inFlight = [...(await runsWithStatus("in_progress")), ...(await runsWithStatus("queued"))];
+            // Waiting can only ever pay off for a tag: that is the one case where a build is about
+            // to be published and reusing one saves the work. A pull request or a push to main has
+            // nothing to publish, so waiting there buys nothing and costs a great deal - this job
+            // gates the build and the test matrix, so anything it waits for, they wait for too.
+            const isTag = context.ref.startsWith("refs/tags/");
+            const inFlight = isTag
+              ? [...(await runsWithStatus("in_progress")), ...(await runsWithStatus("queued"))]
+              : [];
             if (inFlight.length) {
               const run = inFlight[0];
               core.notice(

--- a/hgraph/adaptors/kafka/_api.py
+++ b/hgraph/adaptors/kafka/_api.py
@@ -244,10 +244,16 @@ def message_subscriber(fn: Callable = None, *, topic: str = None):
         topic_ = kwargs.pop("topic", None)
         if topic_ is None:
             raise ValueError(f"topic must be provided to {fn.signature.name}")
-        get_message_state().add_subscriber(topic_, replay=has_recovered)
-        msg_input = message_subscriber_service(path=topic_)
+        # Both registrations happen before either service is referenced. The implementations read
+        # these registries to decide what to wire, and referencing a service can expand its
+        # implementation, so an implementation expanded between the two calls would see a topic
+        # that has history as though it had none.
         if has_recovered:
             get_message_state().add_historical_subscriber(topic_)
+        get_message_state().add_subscriber(topic_, replay=has_recovered)
+
+        msg_input = message_subscriber_service(path=topic_)
+        if has_recovered:
             msg_history = message_history_subscriber_service(path=topic_)
             kwargs["recovered"] = (recovered := msg_history["recovered"])  # Connect recovered signal
             msg_input = if_then_else(default(recovered, False), msg_input, msg_history["msg"])

--- a/hgraph/adaptors/kafka/_impl.py
+++ b/hgraph/adaptors/kafka/_impl.py
@@ -120,8 +120,10 @@ class KafkaMessageState(MessageState):
     def set_subscriber_sender(self, topic: str, sender: Callable[[SCALAR], None]):
         self._kafka_sender[topic] = sender
 
-    def start_subscriber(self, topic: str, consumer: KafkaConsumer):
-        self._kafka_consumer[topic] = (thread := KafkaConsumerThread(topic, consumer, self._kafka_sender[topic]))
+    def start_subscriber(self, topic: str, consumer: KafkaConsumer, on_error: Callable = None):
+        self._kafka_consumer[topic] = (
+            thread := KafkaConsumerThread(topic, consumer, self._kafka_sender[topic], on_error)
+        )
         thread.start()
 
     def stop_subscriber(self, topic: str):
@@ -249,8 +251,11 @@ def _message_subscriber_history_aggregator(
     offsets = {k: v for k, v in consumer.offsets_for_times(timestamps).items() if v is not None}
     for tp, offset in offsets.items():
         consumer.seek(tp, offset.offset)
-    first = True
-    last_time = _timestamp_to_datetime(timestamp_ms)
+    # Seeded from start_time, which is what the first yield below uses. Seeding it from
+    # timestamp_ms instead is wrong: that value is start_time truncated to whole milliseconds, so
+    # it can be up to a millisecond earlier, and the next message is then offset to a time before
+    # the one already emitted. The generator rejects that as a duplicate or out-of-order time.
+    last_time = start_time
     yield start_time, dict(recovered=False)
     while last_time < end_time:
         records = consumer.poll(timeout_ms=500, max_records=1000)
@@ -273,7 +278,18 @@ def _message_subscriber_history_aggregator(
 
 
 def _timestamp_to_datetime(t: int) -> datetime:
-    return datetime.utcfromtimestamp(t / 1000) + timedelta(milliseconds=t % 1000)
+    """
+    Kafka timestamps are epoch milliseconds. The engine works in naive UTC, so that is what is
+    returned.
+
+    This used to be utcfromtimestamp(t / 1000) plus timedelta(milliseconds=t % 1000), which counted
+    the sub-second part twice: a message at .999 was replayed a whole second late, shifting replay
+    timings and, where two messages straddled a second boundary, their order.
+    """
+    return _EPOCH + timedelta(milliseconds=t)
+
+
+_EPOCH = datetime(1970, 1, 1)
 
 @adaptor_impl(interfaces=message_subscriber_service)
 def _real_time_message_subscriber_service_impl(
@@ -308,10 +324,17 @@ def _start_realtime_message_subscriber(
     start_real_time_service: TS[bool],
     consumer: KafkaConsumer,
     _global_state: GlobalState = None,
+    _api: EvaluationEngineApi = None,
 ):
     if start_real_time_service.value:
         start_real_time_service.make_passive()
-        KafkaMessageState.instance(_global_state).start_subscriber(topic, consumer)
+
+        def _on_error(_e: BaseException, _api=_api):
+            # Called from the consumer thread. Stopping the engine is the honest outcome: the
+            # topic will not deliver again, so continuing would silently produce wrong results.
+            _api.request_engine_stop()
+
+        KafkaMessageState.instance(_global_state).start_subscriber(topic, consumer, _on_error)
 
 
 @_start_realtime_message_subscriber.stop
@@ -321,15 +344,21 @@ def _start_realtime_message_subscriber_stop(topic: str, _global_state: GlobalSta
 
 class KafkaConsumerThread(Thread):
 
-    def __init__(self, topic, consumer: KafkaConsumer, sender: Callable[[KafkaMessage], None]):
+    def __init__(
+        self,
+        topic,
+        consumer: KafkaConsumer,
+        sender: Callable[[KafkaMessage], None],
+        on_error: Callable[[BaseException], None] = None,
+    ):
         super().__init__()
         self.topic = topic
         self.consumer = consumer
         self.sender = sender
+        self.on_error = on_error
         self._stop_event = Event()
 
     def run(self):
-        # TODO: How to communicate failures to the graph if this blows up?
         try:
             while not self._stop_event.is_set():
                 records = self.consumer.poll(timeout_ms=1000, max_records=1000)
@@ -338,8 +367,16 @@ class KafkaConsumerThread(Thread):
                     all_messages = sorted(all_messages, key=lambda m: (m.timestamp, m.topic, m.offset))
                 for msg in all_messages:
                     self.sender(_record_to_kafka_message(msg))
-        except:
+        except BaseException as e:
+            # Reaching here means delivery for this topic has stopped. Logging alone leaves the
+            # graph running against a feed that will never tick again, which looks like a quiet
+            # market rather than a broken one, so the failure is reported to the graph as well.
             error(f"Failure occurred whilst reading from Kafka on topic: {self.topic}", exc_info=True)
+            if self.on_error is not None:
+                try:
+                    self.on_error(e)
+                except BaseException:
+                    error("Failed to report the Kafka failure to the graph", exc_info=True)
         finally:
             self.consumer.close()
 

--- a/hgraph/adaptors/kafka/_impl.py
+++ b/hgraph/adaptors/kafka/_impl.py
@@ -25,7 +25,6 @@ from hgraph import (
     push_queue,
     SCALAR,
     set_service_output,
-    adaptor,
     adaptor_impl,
     register_adaptor,
     debug_print,
@@ -86,11 +85,7 @@ class KafkaMessageState(MessageState):
     def add_subscriber(self, topic: str, replay: bool = False):
         self._register(topic)
         if topic not in self.subscribers:
-            if replay:
-                self._register(topic)
-                register_adaptor(topic, _real_time_message_subscriber_impl, topic=topic)
-            else:
-                register_adaptor(topic, _real_time_message_subscriber_service_impl, topic=topic)
+            register_adaptor(topic, _real_time_message_subscriber_service_impl, topic=topic)
         self.subscribers.add(topic)
 
     def add_historical_subscriber(self, topic: str):
@@ -230,7 +225,6 @@ def _message_subscriber_impl(path: str, topic: str, _global_state: GlobalState =
         start_real_time_service = const(True)
 
     if topic in ks.subscribers:
-        set_service_output(path, message_subscriber_service, _real_time_message_subscriber(path=topic))
         _start_realtime_message_subscriber(topic, start_real_time_service, consumer)
 
 
@@ -285,23 +279,20 @@ def _timestamp_to_datetime(t: int) -> datetime:
 def _real_time_message_subscriber_service_impl(
         path: str, topic: str, _global_state: GlobalState = None
 ) -> TS[KafkaMessage]:
-    consumer = KafkaConsumer(**KafkaMessageState.instance(_global_state).config)
-    partitions = consumer.partitions_for_topic(topic)
-    if not partitions:
-        raise ValueError(f"Topic {topic} has no partitions")
-    consumer.assign(tuple(TopicPartition(topic, p) for p in partitions))
+    ks = KafkaMessageState.instance(_global_state)
     out = _message_subscriber_queue(topic=topic)
-    _start_realtime_message_subscriber(topic, True, consumer)
+    if topic not in ks.history_subscribers:
+        # Nothing gates this topic, so the consumer starts immediately. Where the topic does have
+        # history, _message_subscriber_impl owns the consumer and starts it once recovery has
+        # completed, so none is opened here; doing so would connect to the broker for nothing and
+        # never be closed.
+        consumer = KafkaConsumer(**ks.config)
+        partitions = consumer.partitions_for_topic(topic)
+        if not partitions:
+            raise ValueError(f"Topic {topic} has no partitions")
+        consumer.assign(tuple(TopicPartition(topic, p) for p in partitions))
+        _start_realtime_message_subscriber(topic, True, consumer)
     return out
-
-@adaptor
-def _real_time_message_subscriber(path: str) -> TS[KafkaMessage]:
-    """Expose the real-time message subscriber as an adaptor"""
-
-
-@adaptor_impl(interfaces=_real_time_message_subscriber)
-def _real_time_message_subscriber_impl(path: str, topic: str) -> TS[KafkaMessage]:
-    return _message_subscriber_queue(topic=topic)
 
 
 @push_queue(TS[KafkaMessage])

--- a/hgraph_unit_tests/adaptors/kafka/test_kafka_api.py
+++ b/hgraph_unit_tests/adaptors/kafka/test_kafka_api.py
@@ -304,3 +304,38 @@ def test_subscriber_without_recovery_sharing_a_topic_with_a_recovering_publisher
         publisher()
 
     _run(g)
+
+
+def test_kafka_timestamps_are_not_double_counted():
+    """
+    Kafka timestamps are epoch milliseconds. The conversion used to add the sub-second part twice,
+    so a message at .999 replayed a whole second late.
+    """
+    from datetime import datetime
+    from hgraph.adaptors.kafka._impl import _timestamp_to_datetime
+
+    assert _timestamp_to_datetime(0) == datetime(1970, 1, 1)
+    assert _timestamp_to_datetime(1) == datetime(1970, 1, 1, 0, 0, 0, 1000)
+    assert _timestamp_to_datetime(999) == datetime(1970, 1, 1, 0, 0, 0, 999000)
+    assert _timestamp_to_datetime(1_700_000_000_123) == datetime(2023, 11, 14, 22, 13, 20, 123000)
+
+
+def test_consumer_failure_is_reported_rather_than_swallowed():
+    """A broker failure used to be logged and the thread left to exit, so the graph carried on
+    against a feed that would never tick again."""
+    from hgraph.adaptors.kafka._impl import KafkaConsumerThread
+
+    reported = []
+
+    class Failing:
+        def poll(self, **kwargs):
+            raise RuntimeError("broker gone")
+
+        def close(self):
+            reported.append("closed")
+
+    thread = KafkaConsumerThread("t", Failing(), lambda m: None, on_error=reported.append)
+    thread.run()
+
+    assert any(isinstance(r, RuntimeError) for r in reported), f"failure was not reported: {reported}"
+    assert "closed" in reported, "the consumer was not closed"

--- a/hgraph_unit_tests/adaptors/kafka/test_kafka_api.py
+++ b/hgraph_unit_tests/adaptors/kafka/test_kafka_api.py
@@ -188,3 +188,119 @@ def test_realtime_subscriber(monkeypatch):
     with GlobalState():
         evaluate_graph(g, GraphConfiguration(run_mode=EvaluationMode.REAL_TIME, end_time=timedelta(seconds=1)))
         assert [value for _, value in get_recorded_value()] == [b"ready"]
+
+class _RecordingConsumer(KafkaConsumer):
+    """Enough of a KafkaConsumer for the wiring and the historical replay to run."""
+
+    def __init__(self, *args, **kwargs):
+        self._polls = 0
+
+    def partitions_for_topic(self, topic: str):
+        return {0}
+
+    def assign(self, partitions): ...
+
+    def close(self): ...
+
+    def offsets_for_times(self, timestamps):
+        return {tp: None for tp in timestamps}
+
+    def seek(self, tp, offset): ...
+
+    def poll(self, **kwargs):
+        self._polls += 1
+        if self._polls == 1:
+            return {
+                "tp": [
+                    SimpleNamespace(value=b"history", key=None, headers=(), timestamp=1, topic="t", offset=0)
+                ]
+            }
+        return {}
+
+
+@pytest.fixture
+def fake_kafka(monkeypatch):
+    from hgraph.adaptors.kafka import _impl as kafka_impl
+
+    monkeypatch.setattr(kafka_impl, "KafkaConsumer", _RecordingConsumer)
+    monkeypatch.setattr(kafka_impl, "KafkaProducer", MagicMock)
+
+
+def _run(g):
+    with GlobalState():
+        evaluate_graph(
+            g,
+            GraphConfiguration(
+                run_mode=EvaluationMode.REAL_TIME,
+                start_time=(st := utc_now()) - timedelta(minutes=1),
+                end_time=st + timedelta(milliseconds=200),
+            ),
+        )
+
+
+# The four combinations of publisher and subscriber recovery. Three of these used to fail at
+# wiring: a subscriber declaring 'recovered' produced a cycle between the subscriber service impl
+# and the adaptor supplying its real-time output, and a subscriber without 'recovered' sharing a
+# topic with a recovering publisher left the real-time adaptor with no implementation.
+
+
+def test_subscriber_with_recovery(fake_kafka):
+    @message_subscriber(topic="r1")
+    def subscriber(msg: TS[bytes], recovered: TS[bool]):
+        debug_print("msg", msg)
+
+    @graph
+    def g():
+        register_kafka_adaptor({})
+        subscriber()
+
+    _run(g)
+
+
+def test_publisher_with_recovery(fake_kafka):
+    @message_publisher(topic="r2")
+    def publisher(msg: TS[bytes], recovered: TS[bool]) -> TS[bytes]:
+        return sample(if_true(recovered), const(b"recovered"))
+
+    @graph
+    def g():
+        register_kafka_adaptor({})
+        publisher()
+
+    _run(g)
+
+
+def test_publisher_and_subscriber_both_with_recovery(fake_kafka):
+    @message_subscriber(topic="r3")
+    def subscriber(msg: TS[bytes], recovered: TS[bool]):
+        debug_print("msg", msg)
+
+    @message_publisher(topic="r3")
+    def publisher(msg: TS[bytes], recovered: TS[bool]) -> TS[bytes]:
+        return sample(if_true(recovered), const(b"recovered"))
+
+    @graph
+    def g():
+        register_kafka_adaptor({})
+        subscriber()
+        publisher()
+
+    _run(g)
+
+
+def test_subscriber_without_recovery_sharing_a_topic_with_a_recovering_publisher(fake_kafka):
+    @message_subscriber(topic="r4")
+    def subscriber(msg: TS[bytes]):
+        debug_print("msg", msg)
+
+    @message_publisher(topic="r4")
+    def publisher(msg: TS[bytes], recovered: TS[bool]) -> TS[bytes]:
+        return sample(if_true(recovered), const(b"recovered"))
+
+    @graph
+    def g():
+        register_kafka_adaptor({})
+        subscriber()
+        publisher()
+
+    _run(g)


### PR DESCRIPTION
Five defects, four fixed with tests, one left for you because it is a lifecycle decision rather than a bug with an obvious answer. Plus the assessment you asked for on rebuilding this on `adaptor` / `service_adaptor`.

## 1. The cycle (the one you reported)

It is broader than recovery on both sides — **any** subscriber declaring `recovered` fails to wire:

| configuration | before |
|---|---|
| publisher with recovery, alone | passes |
| **subscriber with recovery, alone** | **`CycleError`** |
| **both with recovery** | **`CycleError`** |
| **subscriber without recovery + publisher with recovery** | **`No implementation found for service: _real_time_message_subscriber`** |

Only the first was covered. The test that exercised your scenario, `test_subscriber`, is `@pytest.mark.skip("Not patched yet")`, so none of it had ever run.

```
CycleError: _message_subscriber_impl -> _message_subscriber_queue
         -> capture_output_to_global_state -> _message_subscriber_impl
```

`_message_subscriber_impl` served its real-time output by calling an adaptor. **A service impl consuming an adaptor closes a loop in the ranking.**

The indirection is load-bearing, which is why the obvious fixes fail — I tried both. Removing it gives `Graph contains push nodes ... but this graph does not support push nodes`: a `push_queue` cannot live in a service impl's nested graph. Moving the adaptor to its own path changes nothing, because the dependency is structural, not a path collision.

**Fix:** the real-time output always comes from the adaptor, where a push node belongs. The service impl keeps only what it alone can do — it holds the historical output and therefore the recovery signal, so it still owns *starting* the consumer, gated on that signal. That also removes the second failure: there is now one implementation of the real-time output rather than two selected by a flag.

Verified recovery still gates real-time, not merely that it wires.

## 2. Timestamps were double counted

`_timestamp_to_datetime` built a datetime from whole seconds and then added the millisecond remainder *again*:

| Kafka ms | produced | correct | drift |
|---|---|---|---|
| 1 | `00:00:00.002` | `00:00:00.001` | 1ms |
| 999 | `00:00:01.998` | `00:00:00.999` | **999ms** |
| 1700000000123 | `22:13:20.246` | `22:13:20.123` | 123ms |

Every replayed message landed up to a second late, and messages either side of a second boundary could replay out of order. It also used `utcfromtimestamp`, deprecated and slated for removal.

**Correcting it exposed a second fault it had been masking.** The replay loop seeded `last_time` from the start timestamp *truncated to whole milliseconds*, which can be earlier than the `start_time` the first record is emitted at — so the next message was offset to a time already passed and the generator rejected it outright. `last_time` now starts from `start_time` itself.

## 3. Consumer failures were swallowed

`KafkaConsumerThread.run()` caught everything, logged, and exited. The graph kept running against a topic that would never tick again — indistinguishable from a quiet feed. The thread now reports the failure back and the subscriber stops the engine, rather than continuing to produce results from data it is no longer receiving.

## 4. Registration was order dependent

The implementations decide what to wire by reading `KafkaMessageState`, but `message_subscriber_graph` registered the subscriber *before* the historical subscriber, and referencing a service can expand its implementation. An implementation expanded between the two calls saw a topic with history as though it had none, and started the real-time consumer without waiting for recovery. Both registrations now happen before either service is referenced.

This one is worth noting beyond the fix: it is latent in the design, not just in that call order. Any implementation reading a registry that user wiring is still filling has the same exposure.

## 5. Not fixed: one publisher per topic, per GlobalState

```python
with GlobalState():
    evaluate_graph(g, config)
    evaluate_graph(g, config)   # ValueError: Topic dup already has a publisher
```

Each graph in its own `GlobalState` is fine. Two sequential graphs sharing one is not, even though the first has finished. The constraint is right *within* a graph and wrong *across* graphs, and fixing it means deciding what the registry's lifetime should be — the wiring-time sets could reset per graph, but the runtime state (senders, consumer threads) cannot, and concurrent graphs would need something different again. That is a design decision, and it interacts directly with the question below, so I have left it to you rather than guess.

## The architecture question

Rebuilding on `adaptor` / `service_adaptor` would address the root cause rather than the symptom, and I would support it — but the current fix is not a stepping stone to it, it is an alternative to it.

What the evidence says:

- **Every structural problem here traces to one thing:** the subscriber's output is a push source, and push sources cannot live in a service impl. The `reference_service` framing forced a service to own something it structurally cannot host, and the adaptor was bolted underneath to compensate. That nesting is what produced the cycle, the two-implementations-by-flag split, and the registry reads that make wiring order matter.
- **`adaptor` is the construct designed for this.** Its own documentation describes it as "primarily used to define connectivity from graph code to the outside world", with one instance per path — which is exactly one Kafka topic. It can host the push queue and the historical generator together, so the recovery hand-off becomes internal to one component rather than coordination between a service and an adaptor through shared mutable state.
- **`service_adaptor` fits the publisher better than the current `operator`,** if you want per-client identity. Today the publisher is an `operator` overloaded by two sink nodes, with `_registered_topics` consulting the registry to decide whether an overload applies — the same wiring-order exposure as above.
- **What it would not fix by itself:** the lifecycle question in item 5. One instance per path still leaves open what happens on the second graph in a process.

I have not attempted the rewrite. It would replace essentially all of `_impl.py` and change the public shape of `_api.py`, and doing that speculatively on top of five fixes you have not seen yet seemed the wrong order. If you want it, the fixes here give a working baseline and a test suite that covers the four recovery combinations, which is what a rewrite would need to keep passing.

## Verification

| | 3.12 | 3.14 |
|---|---|---|
| `hgraph_unit_tests docs` | 1749 passed, exit 0 | 1749 passed, exit 0 |

Plus 2426 under the C++ runtime. The four recovery combinations plus the timestamp and failure-reporting tests all fail against the code they replace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
