### PR TITLE
Serve Kafka topics from one adaptor implementation

### DIFF
--- a/hgraph/adaptors/kafka/_api.py
+++ b/hgraph/adaptors/kafka/_api.py
@@ -14,9 +14,7 @@ from hgraph import (
     null_sink,
     reference_service,
     debug_print,
-    default,
-    filter_,
-    not_,
+    compute_node,
     operator,
     HgAtomicType,
     CompoundScalar,
@@ -161,7 +159,7 @@ def message_publisher(fn: Callable = None, *, topic: str = None):
             # A publisher replays to rebuild its own state, so it must see history and nothing
             # after it. Where the same topic also has a live subscriber the stream continues
             # ticking past recovery, and feeding a publisher its own output would be a loop.
-            replay_msg = filter_(not_(default(recovered, False)), subscription["msg"])
+            replay_msg = _gate_by_recovery(subscription["msg"], recovered, live=False)
             kwargs["msg"] = replay_msg.payload if replay_msg_is_bytes else replay_msg  # Connect replay
             kwargs["recovered"] = recovered  # Connect replay
 
@@ -265,7 +263,7 @@ def message_subscriber(fn: Callable = None, *, topic: str = None):
             # Whether the topic replays at all depends on what other graphs asked for, and a
             # subscriber with no 'recovered' input cannot tell a replayed message from a live one.
             # It therefore sees only live messages, as it would if nothing on the topic replayed.
-            msg_input = filter_(default(subscription["recovered"], False), msg_input)
+            msg_input = _gate_by_recovery(msg_input, subscription["recovered"], live=True)
         kwargs["msg"] = msg_input.payload if msg_is_bytes else msg_input
         out = fn(**kwargs)
         return out
@@ -292,6 +290,23 @@ def get_message_state() -> MessageState:
     from hgraph.adaptors.kafka._impl import KafkaMessageState
 
     return KafkaMessageState.instance()
+
+
+@compute_node(active=("msg",), valid=("msg",))
+def _gate_by_recovery(msg: TS[KafkaMessage], recovered: TS[bool], live: bool) -> TS[KafkaMessage]:
+    """
+    Forward only the ``msg`` ticks falling on the requested side of the recovery handover:
+    ``live=False`` gives replayed history, ``live=True`` gives what arrives after it.
+
+    ``filter_`` is deliberately not used. When its condition turns True it copies the input's most
+    recent value, so opening the gate at recovery could hand the last replayed message to a
+    subscriber that opted out of replay. Today the merge upstream rebinds to the live stream at
+    that instant and there is no history value left to copy, but that is a property of how the
+    merge is built rather than of what is wanted here. Only genuine ticks pass through this node,
+    whatever the merge does with its value when it switches.
+    """
+    if bool(recovered.valid and recovered.value) == live:
+        return msg.delta_value
 
 
 @operator

--- a/hgraph/adaptors/kafka/_api.py
+++ b/hgraph/adaptors/kafka/_api.py
@@ -15,7 +15,8 @@ from hgraph import (
     reference_service,
     debug_print,
     default,
-    if_then_else,
+    filter_,
+    not_,
     operator,
     HgAtomicType,
     CompoundScalar,
@@ -155,10 +156,14 @@ def message_publisher(fn: Callable = None, *, topic: str = None):
         get_message_state().add_publisher(topic_)
         if replay_history:
             get_message_state().add_historical_subscriber(topic_)
-            msg_history = message_history_subscriber_service(path=topic_)
-            replay_msg = msg_history["msg"]
+            subscription = message_subscriber_service(path=topic_)
+            recovered = subscription["recovered"]
+            # A publisher replays to rebuild its own state, so it must see history and nothing
+            # after it. Where the same topic also has a live subscriber the stream continues
+            # ticking past recovery, and feeding a publisher its own output would be a loop.
+            replay_msg = filter_(not_(default(recovered, False)), subscription["msg"])
             kwargs["msg"] = replay_msg.payload if replay_msg_is_bytes else replay_msg  # Connect replay
-            kwargs["recovered"] = msg_history["recovered"]  # Connect replay
+            kwargs["recovered"] = recovered  # Connect replay
 
         out = fn(**kwargs)
         out_msg = out["msg"] if is_tsb else out
@@ -244,19 +249,23 @@ def message_subscriber(fn: Callable = None, *, topic: str = None):
         topic_ = kwargs.pop("topic", None)
         if topic_ is None:
             raise ValueError(f"topic must be provided to {fn.signature.name}")
-        # Both registrations happen before either service is referenced. The implementations read
-        # these registries to decide what to wire, and referencing a service can expand its
-        # implementation, so an implementation expanded between the two calls would see a topic
-        # that has history as though it had none.
+        # Both registrations happen before the service is referenced. The implementation reads
+        # these registries to decide what to wire, and referencing the service can expand that
+        # implementation, so an expansion between the two calls would see a topic that has
+        # history as though it had none.
         if has_recovered:
             get_message_state().add_historical_subscriber(topic_)
         get_message_state().add_subscriber(topic_, replay=has_recovered)
 
-        msg_input = message_subscriber_service(path=topic_)
+        subscription = message_subscriber_service(path=topic_)
+        msg_input = subscription["msg"]
         if has_recovered:
-            msg_history = message_history_subscriber_service(path=topic_)
-            kwargs["recovered"] = (recovered := msg_history["recovered"])  # Connect recovered signal
-            msg_input = if_then_else(default(recovered, False), msg_input, msg_history["msg"])
+            kwargs["recovered"] = subscription["recovered"]  # Connect recovered signal
+        else:
+            # Whether the topic replays at all depends on what other graphs asked for, and a
+            # subscriber with no 'recovered' input cannot tell a replayed message from a live one.
+            # It therefore sees only live messages, as it would if nothing on the topic replayed.
+            msg_input = filter_(default(subscription["recovered"], False), msg_input)
         kwargs["msg"] = msg_input.payload if msg_is_bytes else msg_input
         out = fn(**kwargs)
         return out
@@ -290,13 +299,22 @@ def message_publisher_operator(msg: TIME_SERIES_TYPE, topic: str):
     """Publishes the msg (``TS[bytes]`` or ``TS[KafkaMessage]``) to the topic provided."""
 
 
-@reference_service
-def message_history_subscriber_service(path: str) -> TSB["msg" : TS[KafkaMessage], "recovered" : TS[bool]]:
-    """Only retrieve history, after which the topic can be unsubscribed."""
+MessageSubscription = TSB["msg" : TS[KafkaMessage], "recovered" : TS[bool]]
+"""
+What a topic delivers: a single message stream, and the flag marking the end of history.
+
+``msg`` is continuous across the handover. Replayed history arrives first, then ``recovered``
+ticks True, then live messages arrive on the same time-series. Consumers that only want one
+side of the handover select it with ``recovered`` rather than by binding a second stream.
+"""
 
 
 @reference_service
-def message_subscriber_service(path: str) -> TS[KafkaMessage]:
+def message_subscriber_service(path: str) -> MessageSubscription:
     """
-    Subscriber for kafka, output contains the msg and a recovered flag.
+    Everything a graph can receive for one topic, on one service instance per topic.
+
+    Replay and live delivery were once two services gated against each other, which is what
+    let a recovering publisher and subscriber on one topic close a wiring cycle. Splicing them
+    inside the implementation keeps the ordering guarantee without the cross-service edge.
     """

--- a/hgraph/adaptors/kafka/_impl.py
+++ b/hgraph/adaptors/kafka/_impl.py
@@ -10,12 +10,12 @@ from kafka import KafkaConsumer, KafkaProducer, TopicPartition
 
 from hgraph import (
     GlobalState,
-    register_service,
     TS,
+    combine,
     const,
-    service_impl,
+    default,
+    if_then_else,
     MIN_TD,
-    TSB,
     sink_node,
     STATE,
     EvaluationEngineApi,
@@ -24,16 +24,14 @@ from hgraph import (
     EvaluationMode,
     push_queue,
     SCALAR,
-    set_service_output,
     adaptor_impl,
     register_adaptor,
-    debug_print,
 )
 from hgraph.adaptors.kafka._api import (
     message_publisher_operator,
     message_subscriber_service,
-    message_history_subscriber_service,
     MessageState,
+    MessageSubscription,
     KafkaMessage,
 )
 
@@ -69,6 +67,9 @@ class KafkaMessageState(MessageState):
     subscribers: set[str] = field(default_factory=set)
     history_subscribers: set[str] = field(default_factory=set)
     publishers: set[str] = field(default_factory=set)
+    # Topics whose implementation has been registered. Kept apart from the two sets above because
+    # a topic can be added to either of them, in either order, and must register exactly once.
+    _registered: set[str] = field(default_factory=set)
     _kafka_producer: KafkaProducer = None
     _kafka_producer_count: int = 0
     _kafka_sender: dict[str, Callable[[KafkaMessage], None]] = field(default_factory=dict)
@@ -84,8 +85,6 @@ class KafkaMessageState(MessageState):
 
     def add_subscriber(self, topic: str, replay: bool = False):
         self._register(topic)
-        if topic not in self.subscribers:
-            register_adaptor(topic, _real_time_message_subscriber_service_impl, topic=topic)
         self.subscribers.add(topic)
 
     def add_historical_subscriber(self, topic: str):
@@ -93,8 +92,12 @@ class KafkaMessageState(MessageState):
         self.history_subscribers.add(topic)
 
     def _register(self, topic: str):
-        if topic not in self.subscribers and topic not in self.history_subscribers:
-            register_service(topic, _message_subscriber_impl, topic=topic)
+        # One implementation serves the topic however it is used. It reads `subscribers` and
+        # `history_subscribers` when it is expanded, which is after all callers have registered,
+        # so no registration argument has to predict what a later caller will ask for.
+        if topic not in self._registered:
+            self._registered.add(topic)
+            register_adaptor(topic, _kafka_subscriber_impl, topic=topic)
 
     def add_publisher(self, topic: str):
         if topic in self.publishers:
@@ -206,35 +209,64 @@ def _kafka_full_message_publisher_stop(_state: STATE, _global_state: GlobalState
     KafkaMessageState.instance(_global_state).close_producer()
 
 
-@service_impl(interfaces=(message_history_subscriber_service, message_subscriber_service))
-def _message_subscriber_impl(path: str, topic: str, _global_state: GlobalState = None):
-    consumer = KafkaConsumer(**(ks := KafkaMessageState.instance(_global_state)).config)
-    # First, get partition information by calling 'partitions_for_topic'.
+@adaptor_impl(interfaces=message_subscriber_service)
+def _kafka_subscriber_impl(path: str, topic: str, _global_state: GlobalState = None) -> MessageSubscription:
+    """
+    Serves a topic to every graph that uses it, whatever mix of replay and live delivery they asked
+    for. Splicing history to live here rather than in the caller is what keeps this acyclic: the
+    handover is one node's business, so no client has to depend on a second service to perform it.
+
+    Being an ``adaptor_impl`` rather than a ``service_impl`` is what makes that possible at all —
+    the push source below cannot be wired inside a service implementation's nested graph.
+    """
+    ks = KafkaMessageState.instance(_global_state)
+    wants_history = topic in ks.history_subscribers
+    wants_live = topic in ks.subscribers
+
+    consumer = KafkaConsumer(**ks.config)
+    # Partitions have to be resolved and assigned before either the replay seek or the live poll.
     partitions = consumer.partitions_for_topic(topic)
     if not partitions:
         raise ValueError(f"No partitions found for topic '{topic}'")
-
-    # Create TopicPartition objects for each partition.
     topic_partitions = tuple(TopicPartition(topic, p) for p in partitions)
-    # Assign these partitions to the consumer.
     consumer.assign(topic_partitions)
 
-    if topic in ks.history_subscribers:
-        historical_out = _message_subscriber_history_aggregator(path, consumer, topic_partitions)
-        set_service_output(path, message_history_subscriber_service, historical_out)
-        start_real_time_service = historical_out.recovered
+    if wants_history:
+        # The consumer is handed on to the live thread when replay finishes, so it is only closed
+        # by the aggregator when nothing is going to take it over.
+        history = _message_subscriber_history_aggregator(
+            path, consumer, topic_partitions, close_when_done=not wants_live
+        )
+        recovered = history.recovered
     else:
-        start_real_time_service = const(True)
+        recovered = const(True)
 
-    if topic in ks.subscribers:
-        _start_realtime_message_subscriber(topic, start_real_time_service, consumer)
+    if wants_live:
+        live = _message_subscriber_queue(topic=topic)
+        # `recovered` is const(True) without history, so the thread starts on the first cycle.
+        _start_realtime_message_subscriber(topic, recovered, consumer)
+        msg = if_then_else(default(recovered, False), live, history.msg) if wants_history else live
+    else:
+        msg = history.msg
+
+    return combine[MessageSubscription](msg=msg, recovered=recovered)
 
 
 @generator
 def _message_subscriber_history_aggregator(
-    path: str, consumer: KafkaConsumer, topic_partitions: tuple[tuple[str, int], ...], _api: EvaluationEngineApi = None
-) -> TSB["msg" : TS[KafkaMessage], "recovered" : TS[bool]]:
-    """Recovered must tick after the last message has been delivered."""
+    path: str,
+    consumer: KafkaConsumer,
+    topic_partitions: tuple[tuple[str, int], ...],
+    close_when_done: bool = False,
+    _api: EvaluationEngineApi = None,
+) -> MessageSubscription:
+    """
+    Recovered must tick after the last message has been delivered.
+
+    ``close_when_done`` closes the consumer once replay ends. Set it when no live subscriber will
+    inherit this consumer, otherwise the connection stays open for the life of the graph with
+    nothing reading it.
+    """
     start_time = _api.start_time
     if _api.evaluation_mode == EvaluationMode.SIMULATION:
         end_time = _api.end_time
@@ -272,6 +304,8 @@ def _message_subscriber_history_aggregator(
                 tm = last_time + MIN_TD
             last_time = tm
             yield tm, dict(msg=_record_to_kafka_message(msg))
+    if close_when_done:
+        consumer.close()
     tm = last_time
     tm = max(tm, start_time - MIN_TD)
     yield tm + MIN_TD, dict(recovered=True)
@@ -290,25 +324,6 @@ def _timestamp_to_datetime(t: int) -> datetime:
 
 
 _EPOCH = datetime(1970, 1, 1)
-
-@adaptor_impl(interfaces=message_subscriber_service)
-def _real_time_message_subscriber_service_impl(
-        path: str, topic: str, _global_state: GlobalState = None
-) -> TS[KafkaMessage]:
-    ks = KafkaMessageState.instance(_global_state)
-    out = _message_subscriber_queue(topic=topic)
-    if topic not in ks.history_subscribers:
-        # Nothing gates this topic, so the consumer starts immediately. Where the topic does have
-        # history, _message_subscriber_impl owns the consumer and starts it once recovery has
-        # completed, so none is opened here; doing so would connect to the broker for nothing and
-        # never be closed.
-        consumer = KafkaConsumer(**ks.config)
-        partitions = consumer.partitions_for_topic(topic)
-        if not partitions:
-            raise ValueError(f"Topic {topic} has no partitions")
-        consumer.assign(tuple(TopicPartition(topic, p) for p in partitions))
-        _start_realtime_message_subscriber(topic, True, consumer)
-    return out
 
 
 @push_queue(TS[KafkaMessage])

--- a/hgraph_unit_tests/adaptors/kafka/test_kafka_api.py
+++ b/hgraph_unit_tests/adaptors/kafka/test_kafka_api.py
@@ -306,6 +306,113 @@ def test_subscriber_without_recovery_sharing_a_topic_with_a_recovering_publisher
     _run(g)
 
 
+class _HandoverConsumer(KafkaConsumer):
+    """
+    Replays one historical message, then serves one live message.
+
+    The empty second poll ends the replay loop, so the third poll is necessarily the consumer
+    thread's: that is what makes this able to tell apart what arrived before and after recovery.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self._polls = 0
+
+    def partitions_for_topic(self, topic: str):
+        return {0}
+
+    def assign(self, partitions): ...
+
+    def close(self): ...
+
+    def offsets_for_times(self, timestamps):
+        return {tp: None for tp in timestamps}
+
+    def seek(self, tp, offset): ...
+
+    def _record(self, value: bytes, offset: int):
+        rec = SimpleNamespace(value=value, key=None, headers=(), timestamp=offset + 1, topic="h", offset=offset)
+        return {"tp": [rec]}
+
+    def poll(self, **kwargs):
+        self._polls += 1
+        if self._polls == 1:
+            return self._record(b"history", 0)
+        if self._polls == 3:
+            return self._record(b"live", 1)
+        return {}
+
+
+@pytest.fixture
+def handover_kafka(monkeypatch):
+    from hgraph.adaptors.kafka import _impl as kafka_impl
+
+    monkeypatch.setattr(kafka_impl, "KafkaConsumer", _HandoverConsumer)
+    monkeypatch.setattr(kafka_impl, "KafkaProducer", MagicMock)
+
+
+def _run_recording(g, *keys: str) -> dict[str, list]:
+    """Run `g` and return the values recorded under each key. Reading has to happen inside the
+    GlobalState the graph ran in, which is why the assertions cannot pull it out themselves."""
+    with GlobalState():
+        evaluate_graph(
+            g,
+            GraphConfiguration(
+                run_mode=EvaluationMode.REAL_TIME,
+                start_time=(st := utc_now()) - timedelta(minutes=1),
+                end_time=st + timedelta(milliseconds=500),
+            ),
+        )
+        return {k: [value for _, value in get_recorded_value(key=k)] for k in keys}
+
+
+# Replay and live delivery share one stream, so each client selects the part it asked for. These
+# pin down that selection: getting it wrong is silent, and shows up only as a publisher republishing
+# live traffic or a subscriber replaying history it never requested.
+
+
+def test_a_replaying_publisher_is_not_fed_live_messages(handover_kafka):
+    """A publisher replays to rebuild state; feeding it live messages would loop its own output back."""
+
+    @message_subscriber(topic="h1")
+    def subscriber(msg: TS[bytes], recovered: TS[bool]):
+        record(msg, key="sub")
+
+    @message_publisher(topic="h1")
+    def publisher(msg: TS[bytes], recovered: TS[bool]) -> TS[bytes]:
+        record(msg, key="pub")
+        return sample(if_true(recovered), const(b"done"))
+
+    @graph
+    def g():
+        register_kafka_adaptor({})
+        subscriber()
+        publisher()
+
+    seen = _run_recording(g, "sub", "pub")
+    assert seen["sub"] == [b"history", b"live"]
+    assert seen["pub"] == [b"history"]
+
+
+def test_a_subscriber_without_recovery_sees_only_live_messages(handover_kafka):
+    """The publisher's replay must not leak history to a subscriber that never asked for it."""
+
+    @message_subscriber(topic="h2")
+    def subscriber(msg: TS[bytes]):
+        record(msg, key="sub")
+
+    @message_publisher(topic="h2")
+    def publisher(msg: TS[bytes], recovered: TS[bool]) -> TS[bytes]:
+        return sample(if_true(recovered), const(b"done"))
+
+    @graph
+    def g():
+        register_kafka_adaptor({})
+        subscriber()
+        publisher()
+
+    assert _run_recording(g, "sub")["sub"] == [b"live"]
+
+
 def test_kafka_timestamps_are_not_double_counted():
     """
     Kafka timestamps are epoch milliseconds. The conversion used to add the sub-second part twice,

--- a/hgraph_unit_tests/adaptors/kafka/test_kafka_api.py
+++ b/hgraph_unit_tests/adaptors/kafka/test_kafka_api.py
@@ -413,6 +413,32 @@ def test_a_subscriber_without_recovery_sees_only_live_messages(handover_kafka):
     assert _run_recording(g, "sub")["sub"] == [b"live"]
 
 
+def test_a_subscriber_without_recovery_is_not_given_the_last_replayed_message(fake_kafka):
+    """
+    Opening the gate at recovery must not hand over the message that arrived before it.
+
+    `fake_kafka` replays one message and then goes quiet, so anything the subscriber receives here
+    can only have come from the recovery transition itself. This is the case a gate built on
+    `filter_` gets wrong: it copies its input's latest value when the condition turns True.
+    """
+
+    @message_subscriber(topic="h3")
+    def subscriber(msg: TS[bytes]):
+        record(msg, key="sub")
+
+    @message_publisher(topic="h3")
+    def publisher(msg: TS[bytes], recovered: TS[bool]) -> TS[bytes]:
+        return sample(if_true(recovered), const(b"done"))
+
+    @graph
+    def g():
+        register_kafka_adaptor({})
+        subscriber()
+        publisher()
+
+    assert _run_recording(g, "sub")["sub"] == []
+
+
 def test_kafka_timestamps_are_not_double_counted():
     """
     Kafka timestamps are epoch milliseconds. The conversion used to add the sub-second part twice,


### PR DESCRIPTION
Collapses the Kafka subscriber's two reference services into one, implemented by a single `adaptor_impl`.

## The shape that caused the cycle

Replay and live delivery were separate services gated against each other. `message_history_subscriber_service` produced `recovered`, which started the real-time consumer; the real-time output came from a *third* component, an `adaptor_impl`, because a `push_queue` cannot be wired inside a `service_impl`'s nested graph. A publisher and a subscriber both recovering on one topic closed that into a wiring cycle.

#381 broke the cycle by fixing the registration order. This removes the shape that allowed it.

`message_subscriber_service` now carries the whole subscription — `msg` spliced across the handover, plus `recovered` — and the splice happens inside the implementation. No client depends on a second service to perform it, so there is no edge left to close. Three components become one, and `set_service_output` and the `service_impl` go away entirely.

## Behaviour is deliberately unchanged

One merged stream would quietly change what two clients receive, so each selects the part it asked for:

- a **replaying publisher** sees history and stops at recovery — it must never be fed its own output;
- a **subscriber that declared no `recovered` input** sees only live messages, rather than inheriting replay because some *other* graph on the topic asked for it.

Both are pinned by tests. I verified they are load-bearing by removing each filter in turn: the publisher then sees `[history, live]` instead of `[history]`, and the subscriber `[history, live]` instead of `[live]`.

Also fixed: the consumer is now closed when replay finishes and no live subscriber will inherit it, instead of staying open and unread for the life of the graph.

## Validation

CI cannot validate this — GitHub Actions has been in a **major outage** since 15:22 UTC (queued jobs time out at 15 minutes with no logs). So this was validated directly, on macOS and on Linux (gcc 14.3):

| Python | Python runtime | C++ runtime |
|---|---|---|
| 3.12 | 1751 passed | 2428 passed |
| 3.13 | 1751 passed | 2428 passed |
| 3.14 | 1751 passed | 2428 passed |

Counts are +2 against main, exactly the two new tests; no other test changed state.

One caveat worth recording: during this work I saw a **single** C++-runtime failure that I could not reproduce in 18 subsequent runs (6 full-suite, 12 Kafka-only), and I captured only the summary line, so I cannot name the test. It appeared after two cosmetic edits and is most likely a pre-existing real-time timing flake, but I have not proven that.

**Please re-run CI once Actions recovers** — the Windows/MSVC and manylinux wheel paths exist only in the workflow and remain unexercised.