### PR TITLE
Read and write JSON datetimes as ISO 8601

### DIFF
--- a/hgraph/_impl/_operators/_to_json.py
+++ b/hgraph/_impl/_operators/_to_json.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, date, time, timedelta
+from datetime import datetime, date, time, timedelta, timezone
 from enum import Enum
 from itertools import chain
 from typing import Callable, Any, get_origin
@@ -100,10 +100,12 @@ def _(value: HgAtomicType, delta=False) -> Callable[[Any], str]:
             int: lambda v: "null" if v is None else f"{v}",
             float: lambda v: "null" if v is None else f"{v}",
             str: lambda v: "null" if v is None else json.dumps(v),
-            date: lambda v: "null" if v is None else f'"{v.strftime("%Y-%m-%d")}"',
-            time: lambda v: "null" if v is None else f'"{v.strftime("%H:%M:%S.%f")}"',
+            # ISO 8601, which is what the C++ engine emits: a 'T' separator, and fractional
+            # seconds only when they are non-zero. `isoformat` produces exactly that.
+            date: lambda v: "null" if v is None else f'"{v.isoformat()}"',
+            time: lambda v: "null" if v is None else f'"{v.isoformat()}"',
             timedelta: _td_to_str,
-            datetime: lambda v: "null" if v is None else f'"{v.strftime("%Y-%m-%d %H:%M:%S.%f")}"',
+            datetime: lambda v: "null" if v is None else f'"{v.isoformat()}"',
         }[value.py_type]
     except KeyError:
         raise RuntimeError(f"Cannot convert type: '{value}' to JSON")
@@ -273,11 +275,98 @@ def _(value: HgAtomicType, delta=False) -> Callable[[Any], Any]:
         return lambda v, tp=value.py_type: None if v is None else getattr(tp, v)
 
     return {
-        date: lambda v: None if v is None else datetime.strptime(v, "%Y-%m-%d").date(),
-        time: lambda v: None if v is None else datetime.strptime(v, "%H:%M:%S.%f").time(),
+        date: parse_json_date,
+        time: parse_json_time,
         timedelta: _str_to_td,
-        datetime: lambda v: None if v is None else datetime.strptime(v, "%Y-%m-%d %H:%M:%S.%f"),
+        datetime: parse_json_datetime,
     }.get(value.py_type, lambda v: v)
+
+
+# Additional patterns tried, in order, when a value is not ISO 8601. ISO itself is not listed:
+# `fromisoformat` already accepts it, including a 'T' or ' ' separator, a 'Z' suffix, numeric
+# offsets, the basic (unpunctuated) forms and fractional seconds of any length -- so the previously
+# emitted "%Y-%m-%d %H:%M:%S.%f" still reads back. These cover the common non-ISO renderings; only
+# unambiguous ones are included, since a bare "01/02/2024" cannot be resolved without knowing the
+# producer's convention. Use ``register_json_datetime_format`` to add your own.
+_JSON_DATETIME_FORMATS: list[str] = [
+    "%Y%m%d%H%M%S%f",
+    "%Y%m%d%H%M%S",
+    "%Y%m%d",
+    "%Y/%m/%d %H:%M:%S.%f",
+    "%Y/%m/%d %H:%M:%S",
+    "%Y/%m/%d",
+    "%d-%b-%Y %H:%M:%S.%f",
+    "%d-%b-%Y %H:%M:%S",
+    "%d-%b-%Y",
+    "%d %b %Y %H:%M:%S",
+    "%d %b %Y",
+]
+
+_JSON_TIME_FORMATS: list[str] = [
+    "%H%M%S%f",
+    "%H%M%S",
+]
+
+
+def register_json_datetime_format(fmt: str, *, time_only: bool = False) -> None:
+    """
+    Add a ``strptime`` pattern to those accepted when reading a date, time or datetime from JSON.
+
+    Patterns are tried in registration order, after ISO 8601. Registering an ambiguous pattern such
+    as ``"%d/%m/%Y"`` makes every value matching it parse that way, so register only what the
+    producer actually emits.
+
+    :param fmt: the ``strptime`` pattern to accept.
+    :param time_only: register against times rather than dates and datetimes.
+    """
+    formats = _JSON_TIME_FORMATS if time_only else _JSON_DATETIME_FORMATS
+    if fmt not in formats:
+        formats.append(fmt)
+
+
+def _as_naive_utc(v: datetime) -> datetime:
+    """The engine works in naive UTC, so an offset in the source is applied and then dropped."""
+    return v.astimezone(timezone.utc).replace(tzinfo=None) if v.tzinfo is not None else v
+
+
+def _parse(v: str, iso: tuple[Callable[[str], Any], ...], formats: list[str], what: str):
+    for parse in (*iso, *(lambda s, f=f: datetime.strptime(s, f) for f in formats)):
+        try:
+            return parse(v)
+        except (TypeError, ValueError):
+            continue
+    raise ValueError(f"Cannot parse '{v}' as a {what}; it is not ISO 8601 nor any registered format")
+
+
+def parse_json_datetime(v) -> datetime:
+    """Parse a datetime from JSON, accepting ISO 8601 and any registered format."""
+    if v is None or isinstance(v, datetime):
+        return _as_naive_utc(v) if v is not None else None
+    return _as_naive_utc(_parse(v, (datetime.fromisoformat,), _JSON_DATETIME_FORMATS, "datetime"))
+
+
+def parse_json_date(v) -> date:
+    """Parse a date from JSON, accepting ISO 8601 and any registered format."""
+    if v is None:
+        return None
+    if isinstance(v, datetime):
+        return v.date()
+    if isinstance(v, date):
+        return v
+    parsed = _parse(v, (date.fromisoformat, datetime.fromisoformat), _JSON_DATETIME_FORMATS, "date")
+    return parsed.date() if isinstance(parsed, datetime) else parsed
+
+
+def parse_json_time(v) -> time:
+    """Parse a time from JSON, accepting ISO 8601 and any registered format."""
+    if v is None:
+        return None
+    if isinstance(v, datetime):
+        return v.time()
+    if isinstance(v, time):
+        return v
+    parsed = _parse(v, (time.fromisoformat,), _JSON_TIME_FORMATS, "time")
+    return parsed.time() if isinstance(parsed, datetime) else parsed
 
 
 def _str_to_td(s: str) -> timedelta:

--- a/hgraph/_impl/_operators/_to_json.py
+++ b/hgraph/_impl/_operators/_to_json.py
@@ -289,9 +289,6 @@ def _(value: HgAtomicType, delta=False) -> Callable[[Any], Any]:
 # unambiguous ones are included, since a bare "01/02/2024" cannot be resolved without knowing the
 # producer's convention. Use ``register_json_datetime_format`` to add your own.
 _JSON_DATETIME_FORMATS: list[str] = [
-    "%Y%m%d%H%M%S%f",
-    "%Y%m%d%H%M%S",
-    "%Y%m%d",
     "%Y/%m/%d %H:%M:%S.%f",
     "%Y/%m/%d %H:%M:%S",
     "%Y/%m/%d",
@@ -302,10 +299,28 @@ _JSON_DATETIME_FORMATS: list[str] = [
     "%d %b %Y",
 ]
 
-_JSON_TIME_FORMATS: list[str] = [
-    "%H%M%S%f",
-    "%H%M%S",
-]
+_JSON_TIME_FORMATS: list[str] = []
+
+# Compact, unpunctuated values are chosen by length rather than by trying patterns in order.
+# Neither of the general mechanisms gets these right on its own:
+#
+#   * `strptime` lets a variable-width directive take fewer digits than intended, and two adjacent
+#     numeric directives have no boundary between them. "%Y%m%d%H%M%S%f" reads 20240613101530 as
+#     10:15:03 -- %S takes one digit and %f swallows the rest -- so a pattern list silently
+#     corrupts every fractionless value it reaches.
+#   * `fromisoformat` mis-reads the 20-digit form: 20240613101530123456 comes back as
+#     01:53:01.234560. It handles the 'T'-separated spelling correctly, but not this one.
+#
+# Length is unambiguous for these three shapes, so it decides, and it is applied before ISO so the
+# second case above cannot arise.
+_COMPACT_DATETIME_FORMATS: dict[int, str] = {8: "%Y%m%d", 14: "%Y%m%d%H%M%S", 20: "%Y%m%d%H%M%S%f"}
+_COMPACT_TIME_FORMATS: dict[int, str] = {6: "%H%M%S", 12: "%H%M%S%f"}
+
+
+def _parse_compact(v: str, formats: dict[int, str]) -> datetime:
+    if not (isinstance(v, str) and v.isdigit()) or (fmt := formats.get(len(v))) is None:
+        raise ValueError("not a compact date or time")
+    return datetime.strptime(v, fmt)
 
 
 def register_json_datetime_format(fmt: str, *, time_only: bool = False) -> None:
@@ -329,6 +344,14 @@ def _as_naive_utc(v: datetime) -> datetime:
     return v.astimezone(timezone.utc).replace(tzinfo=None) if v.tzinfo is not None else v
 
 
+def _compact_datetime(v: str) -> datetime:
+    return _parse_compact(v, _COMPACT_DATETIME_FORMATS)
+
+
+def _compact_time(v: str) -> datetime:
+    return _parse_compact(v, _COMPACT_TIME_FORMATS)
+
+
 def _parse(v: str, iso: tuple[Callable[[str], Any], ...], formats: list[str], what: str):
     for parse in (*iso, *(lambda s, f=f: datetime.strptime(s, f) for f in formats)):
         try:
@@ -342,7 +365,7 @@ def parse_json_datetime(v) -> datetime:
     """Parse a datetime from JSON, accepting ISO 8601 and any registered format."""
     if v is None or isinstance(v, datetime):
         return _as_naive_utc(v) if v is not None else None
-    return _as_naive_utc(_parse(v, (datetime.fromisoformat,), _JSON_DATETIME_FORMATS, "datetime"))
+    return _as_naive_utc(_parse(v, (_compact_datetime, datetime.fromisoformat), _JSON_DATETIME_FORMATS, "datetime"))
 
 
 def parse_json_date(v) -> date:
@@ -353,7 +376,7 @@ def parse_json_date(v) -> date:
         return v.date()
     if isinstance(v, date):
         return v
-    parsed = _parse(v, (date.fromisoformat, datetime.fromisoformat), _JSON_DATETIME_FORMATS, "date")
+    parsed = _parse(v, (_compact_datetime, date.fromisoformat, datetime.fromisoformat), _JSON_DATETIME_FORMATS, "date")
     return parsed.date() if isinstance(parsed, datetime) else parsed
 
 
@@ -365,7 +388,7 @@ def parse_json_time(v) -> time:
         return v.time()
     if isinstance(v, time):
         return v
-    parsed = _parse(v, (time.fromisoformat,), _JSON_TIME_FORMATS, "time")
+    parsed = _parse(v, (_compact_time, time.fromisoformat), _JSON_TIME_FORMATS, "time")
     return parsed.time() if isinstance(parsed, datetime) else parsed
 
 

--- a/hgraph/_operators/_to_json.py
+++ b/hgraph/_operators/_to_json.py
@@ -5,7 +5,30 @@ from hgraph._types import TIME_SERIES_TYPE, TS, OUT, HgTypeMetaData
 from hgraph._types._scalar_types import DEFAULT
 from hgraph._wiring._decorators import operator
 
-__all__ = ["to_json", "from_json", "to_json_builder", "from_json_builder"]
+__all__ = ["to_json", "from_json", "to_json_builder", "from_json_builder", "register_json_datetime_format"]
+
+
+def register_json_datetime_format(fmt: str, *, time_only: bool = False) -> None:
+    """
+    Add a ``strptime`` pattern to those accepted when reading a date, time or datetime from JSON.
+
+    Dates and times are written as ISO 8601 and are read as ISO 8601 first, which already covers a
+    ``T`` or space separator, a ``Z`` suffix, numeric offsets and optional fractional seconds. Use
+    this only for a source that emits something else:
+
+    ::
+
+        register_json_datetime_format("%d/%m/%Y")
+
+    Patterns are tried in registration order. An ambiguous pattern captures every value matching
+    it, so register only what the producer actually emits.
+
+    :param fmt: the ``strptime`` pattern to accept.
+    :param time_only: register against times rather than dates and datetimes.
+    """
+    from hgraph._impl._operators._to_json import register_json_datetime_format as _register
+
+    _register(fmt, time_only=time_only)
 
 
 @operator

--- a/hgraph_unit_tests/_operators/test_to_json.py
+++ b/hgraph_unit_tests/_operators/test_to_json.py
@@ -121,6 +121,11 @@ def test_to_json_delta(tp: TIME_SERIES_TYPE, value: Any, expected: str):
         ['"2024-06-13"', datetime(2024, 6, 13)],
         ['"2024-06-13T10:15:30.5"', datetime(2024, 6, 13, 10, 15, 30, 500000)],
         ['"20240613T101530"', datetime(2024, 6, 13, 10, 15, 30)],
+        # Compact and unpunctuated. Neither general mechanism reads these correctly on its own:
+        # a "%Y%m%d%H%M%S%f" pattern takes the first as 10:15:03, and fromisoformat takes the
+        # second as 01:53:01.234560. Length decides instead.
+        ['"20240613101530"', datetime(2024, 6, 13, 10, 15, 30)],
+        ['"20240613101530123456"', datetime(2024, 6, 13, 10, 15, 30, 123456)],
         # The format hgraph itself emitted before this became ISO: data already written out, and
         # any store holding it, has to keep reading back.
         ['"2024-06-13 10:15:30.000042"', datetime(2024, 6, 13, 10, 15, 30, 42)],
@@ -145,6 +150,7 @@ def test_from_json_accepts_many_datetime_formats(text: str, expected: datetime):
         ['"10:15:30"', time(10, 15, 30)],  # no fractional part: rejected before this change
         ['"10:15"', time(10, 15)],
         ['"101530"', time(10, 15, 30)],
+        ['"101530123456"', time(10, 15, 30, 123456)],  # "%H%M%S%f" would read this as 10:15:03
     ],
 )
 def test_from_json_accepts_many_time_formats(text: str, expected: time):

--- a/hgraph_unit_tests/_operators/test_to_json.py
+++ b/hgraph_unit_tests/_operators/test_to_json.py
@@ -22,6 +22,7 @@ from hgraph import (
     REMOVE,
     to_json_builder,
     from_json_builder,
+    register_json_datetime_format,
 )
 from hgraph.test import eval_node
 
@@ -53,7 +54,7 @@ class MyNullableMappingCS(CompoundScalar):
         [TS[int], 1, "1"],
         [TS[float], 1.0, "1.0"],
         [TS[date], date(2024, 6, 13), '"2024-06-13"'],
-        [TS[datetime], datetime(2024, 6, 13, 10, 15, 30, 42), '"2024-06-13 10:15:30.000042"'],
+        [TS[datetime], datetime(2024, 6, 13, 10, 15, 30, 42), '"2024-06-13T10:15:30.000042"'],
         [TS[time], time(10, 15, 30, 42), '"10:15:30.000042"'],
         [TS[timedelta], timedelta(10, 15, microseconds=42), '"10:0:0:15.000042"'],
         [TS[ExpEnum], ExpEnum.E1, '"E1"'],
@@ -108,6 +109,88 @@ def test_to_json_delta(tp: TIME_SERIES_TYPE, value: Any, expected: str):
     out = eval_node(to_json[tp], value, delta=True)
     assert [json.loads(o) for o in out] == [json.loads(e) for e in expected]
     assert eval_node(from_json[tp], expected) == value
+
+
+@pytest.mark.parametrize(
+    ["text", "expected"],
+    [
+        # ISO 8601, in the shapes a producer might reasonably choose.
+        ['"2024-06-13T10:15:30.000042"', datetime(2024, 6, 13, 10, 15, 30, 42)],
+        ['"2024-06-13T10:15:30"', datetime(2024, 6, 13, 10, 15, 30)],
+        ['"2024-06-13T10:15"', datetime(2024, 6, 13, 10, 15)],
+        ['"2024-06-13"', datetime(2024, 6, 13)],
+        ['"2024-06-13T10:15:30.5"', datetime(2024, 6, 13, 10, 15, 30, 500000)],
+        ['"20240613T101530"', datetime(2024, 6, 13, 10, 15, 30)],
+        # The format hgraph itself emitted before this became ISO: data already written out, and
+        # any store holding it, has to keep reading back.
+        ['"2024-06-13 10:15:30.000042"', datetime(2024, 6, 13, 10, 15, 30, 42)],
+        # Offsets are applied and dropped, because the engine works in naive UTC.
+        ['"2024-06-13T10:15:30Z"', datetime(2024, 6, 13, 10, 15, 30)],
+        ['"2024-06-13T11:15:30+01:00"', datetime(2024, 6, 13, 10, 15, 30)],
+        ['"2024-06-13T05:15:30-05:00"', datetime(2024, 6, 13, 10, 15, 30)],
+        # Non-ISO renderings from the fallback list.
+        ['"2024/06/13 10:15:30"', datetime(2024, 6, 13, 10, 15, 30)],
+        ['"13-Jun-2024 10:15:30"', datetime(2024, 6, 13, 10, 15, 30)],
+        ['"13 Jun 2024"', datetime(2024, 6, 13)],
+    ],
+)
+def test_from_json_accepts_many_datetime_formats(text: str, expected: datetime):
+    assert eval_node(from_json[TS[datetime]], [text]) == [expected]
+
+
+@pytest.mark.parametrize(
+    ["text", "expected"],
+    [
+        ['"10:15:30.000042"', time(10, 15, 30, 42)],
+        ['"10:15:30"', time(10, 15, 30)],  # no fractional part: rejected before this change
+        ['"10:15"', time(10, 15)],
+        ['"101530"', time(10, 15, 30)],
+    ],
+)
+def test_from_json_accepts_many_time_formats(text: str, expected: time):
+    assert eval_node(from_json[TS[time]], [text]) == [expected]
+
+
+@pytest.mark.parametrize(
+    ["text", "expected"],
+    [
+        ['"2024-06-13"', date(2024, 6, 13)],
+        ['"20240613"', date(2024, 6, 13)],
+        ['"2024/06/13"', date(2024, 6, 13)],
+        ['"13-Jun-2024"', date(2024, 6, 13)],
+        ['"2024-06-13T10:15:30"', date(2024, 6, 13)],  # a datetime where a date is wanted
+    ],
+)
+def test_from_json_accepts_many_date_formats(text: str, expected: date):
+    assert eval_node(from_json[TS[date]], [text]) == [expected]
+
+
+def test_from_json_rejects_an_unparseable_datetime():
+    """Failing loudly matters more than leniency: a silent None would surface far from the cause."""
+    with pytest.raises(Exception) as e:
+        eval_node(from_json[TS[datetime]], ['"not a datetime"'])
+    assert "not a datetime" in str(e.value)
+
+
+def test_register_json_datetime_format_accepts_a_producers_own_format():
+    from hgraph._impl._operators._to_json import _JSON_DATETIME_FORMATS
+
+    original = list(_JSON_DATETIME_FORMATS)
+    try:
+        register_json_datetime_format("%d/%m/%Y %H:%M:%S")
+        assert eval_node(from_json[TS[datetime]], ['"13/06/2024 10:15:30"']) == [
+            datetime(2024, 6, 13, 10, 15, 30)
+        ]
+    finally:
+        _JSON_DATETIME_FORMATS[:] = original
+
+
+def test_to_json_omits_fractional_seconds_when_zero():
+    """Matches the C++ engine, which writes 1970-01-01T00:00:00 rather than ...00.000000."""
+    assert eval_node(to_json[TS[datetime]], [datetime(2024, 6, 13, 10, 15, 30)]) == [
+        '"2024-06-13T10:15:30"'
+    ]
+    assert eval_node(to_json[TS[time]], [time(10, 15, 30)]) == ['"10:15:30"']
 
 
 def test_to_json_builder_serializes_none_mapping_value_as_null():


### PR DESCRIPTION
Brings JSON date/time handling in line with the C++ engine, and makes reading tolerant of the formats a producer might actually send.

## Writing

Was `strftime` with a space separator and a fixed six-digit fraction. Now `isoformat`, which is exactly what hg_cpp emits — its own tests pin `1970-01-01T00:00:00Z` (no fraction when zero) and `2021-06-02T01:02:03.000014Z` (six digits when present).

| | before | after |
|---|---|---|
| `datetime(2024,6,13,10,15,30,42)` | `2024-06-13 10:15:30.000042` | `2024-06-13T10:15:30.000042` |
| `datetime(2024,6,13,10,15,30)` | `2024-06-13 10:15:30.000000` | `2024-06-13T10:15:30` |
| `time(10,15,30)` | `10:15:30.000000` | `10:15:30` |

`date` is unchanged — it was already ISO.

## Reading

Was a single `strptime` pattern that had to match exactly, so `2024-06-13T10:15:30` failed, as did a `Z`, an offset, or a time with no fractional part — `time` could not read back `10:15:30`.

Now `fromisoformat` first, which on 3.12 covers ISO 8601 broadly: either separator, `Z`, numeric offsets, the basic unpunctuated forms, and fractional seconds of any length. A list of non-ISO patterns is tried after it (`20240613101530`, `2024/06/13 10:15:30`, `13-Jun-2024`, …).

**Backwards compatible.** `fromisoformat` accepts a space separator, so anything hgraph wrote in the old format still reads back. That is covered by a test rather than left to assumption.

**Offsets** are converted to UTC and made naive, which is the engine's representation, so `...T10:15:30Z`, `...T11:15:30+01:00` and `...T05:15:30-05:00` all read as the same instant.

**Extensible.** `register_json_datetime_format(fmt)` adds a pattern for a producer that emits something else. Ambiguous patterns are deliberately not in the default list: `01/02/2024` cannot be resolved without knowing the producer's convention, so declaring it is the caller's call.

## Tests

25 new cases covering the ISO variants, the legacy format, offsets, the non-ISO fallbacks, the fraction-omitted output, registration, and that an unparseable value raises rather than silently yielding `None`.

Full suite green on both runtimes — 1777 (python) and 2454 (cpp), +25 each.

## Noted, not changed

`hgraph/adaptors/data_catalogue/data_scopes.py:127,133,146,152` parses datetimes with the same strict two-pattern approach and will reject ISO input with a `T`. It is scope-parameter parsing rather than JSON, so it is outside this change — happy to follow up if you want it aligned.