### PR TITLE
Run the test suite on Windows in CI

### DIFF
--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -383,29 +383,37 @@ jobs:
   #
   # Skipped in its entirety on a tag whose commit has already been through it.
   test-matrix:
-    name: Test suite (py${{ matrix.python-version }}, ${{ matrix.runtime }} runtime)
+    name: Test suite (${{ matrix.os }}, py${{ matrix.python-version }}, ${{ matrix.runtime }} runtime)
     permissions:
       contents: read
     needs: [ reuse-build, build-wheels ]
     if: needs.reuse-build.outputs.run-id == ''
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     # The C++ runtime is not yet at parity with the Python reference implementation, so its legs
     # report without blocking. Every Python version blocks, 3.14 included.
     continue-on-error: ${{ matrix.runtime == 'cpp' }}
     strategy:
       fail-fast: false
       matrix:
+        # Windows wheels are published, so they are tested rather than assumed. Until this was
+        # added the suite only ever ran on Linux, and a Windows-only scheduler failure sat
+        # undetected because nothing here could see it.
+        os: [ ubuntu-latest, windows-latest ]
         python-version: [ '3.12', '3.13', '3.14' ]
         runtime: [ 'python', 'cpp' ]
-        # Coverage is measured once, on the reference leg; the other five would report the same
-        # lines at six times the cost.
+        # Coverage is measured once, on the reference leg; the others would report the same
+        # lines at many times the cost.
         include:
-          - python-version: '3.12'
+          - os: ubuntu-latest
+            python-version: '3.12'
             runtime: 'python'
             coverage_args: '--cov=hgraph --cov-report=xml'
     env:
       HGRAPH_USE_CPP: ${{ matrix.runtime == 'cpp' && 'true' || 'false' }}
       PYTHONFAULTHANDLER: '1'
+      # Layouts differ; every step below runs under bash (Git Bash on Windows) and goes through
+      # this rather than hard-coding one platform's path.
+      VENV_BIN: ${{ matrix.os == 'windows-latest' && '.venv/Scripts' || '.venv/bin' }}
     steps:
       - uses: actions/checkout@v7
 
@@ -416,14 +424,16 @@ jobs:
       - name: Cache uv downloads
         uses: actions/cache@v6.1.0
         with:
-          path: ~/.cache/uv
+          # uv caches under LOCALAPPDATA on Windows, not ~/.cache.
+          path: ${{ runner.os == 'Windows' && '~\AppData\Local\uv\cache' || '~/.cache/uv' }}
           key: ${{ runner.os }}-uv-py${{ matrix.python-version }}-${{ hashFiles('uv.lock', 'pyproject.toml') }}
           restore-keys: |
             ${{ runner.os }}-uv-py${{ matrix.python-version }}-
 
+      # Each OS tests the wheel built for it, not Linux's.
       - uses: actions/download-artifact@v7
         with:
-          name: release-wheels-Linux
+          name: release-wheels-${{ runner.os }}
           path: wheelhouse
 
       - name: Sync test dependencies (project itself comes from the wheel)
@@ -450,9 +460,9 @@ jobs:
           # Hide the source tree so a local copy cannot shadow the installed wheel.
           mv hgraph hgraph_src
           trap 'mv hgraph_src hgraph' EXIT
-          .venv/bin/python -c "import importlib.util as u; m=u.find_spec('hgraph._hgraph'); print('_hgraph:', getattr(m,'origin',None) or 'not installed')"
-          .venv/bin/python -c "import hgraph; print('hgraph:', hgraph.__file__)"
-          .venv/bin/python -c "import sys; print('python:', sys.version)"
+          "${VENV_BIN}/python" -c "import importlib.util as u; m=u.find_spec('hgraph._hgraph'); print('_hgraph:', getattr(m,'origin',None) or 'not installed')"
+          "${VENV_BIN}/python" -c "import hgraph; print('hgraph:', hgraph.__file__)"
+          "${VENV_BIN}/python" -c "import sys; print('python:', sys.version)"
 
       # The verdict comes from the JUnit report rather than from pytest's exit status alone. The
       # report is written as the run finishes, so it still describes what happened even when the
@@ -461,17 +471,17 @@ jobs:
       - name: Run test suite
         shell: bash
         run: |
-          echo "python=${{ matrix.python-version }} HGRAPH_USE_CPP=${HGRAPH_USE_CPP}"
+          echo "os=${{ matrix.os }} python=${{ matrix.python-version }} HGRAPH_USE_CPP=${HGRAPH_USE_CPP}"
           ulimit -c unlimited || true
           mv hgraph hgraph_src
           trap 'mv hgraph_src hgraph' EXIT
           set +e
-          .venv/bin/pytest hgraph_unit_tests docs -ra -q \
+          "${VENV_BIN}/pytest" hgraph_unit_tests docs -ra -q \
             --junitxml=pytest-report.xml ${{ matrix.coverage_args }}
           pytest_status=$?
           set -e
           echo "pytest exit status: ${pytest_status}"
-          .venv/bin/python - "${pytest_status}" <<'PY'
+          "${VENV_BIN}/python" - "${pytest_status}" <<'PY'
           import sys, xml.etree.ElementTree as ET
           from pathlib import Path
 
@@ -511,13 +521,14 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: pytest-report-py${{ matrix.python-version }}-${{ matrix.runtime }}
+          name: pytest-report-${{ runner.os }}-py${{ matrix.python-version }}-${{ matrix.runtime }}
           path: pytest-report.xml
           if-no-files-found: warn
           retention-days: 7
 
+      # gdb and core dumps are Linux-only; there is nothing equivalent to collect on Windows.
       - name: Collect crash artifacts
-        if: failure()
+        if: failure() && runner.os == 'Linux'
         shell: bash
         run: |
           set -euo pipefail
@@ -534,7 +545,7 @@ jobs:
           done
 
       - name: Upload core dumps
-        if: failure()
+        if: failure() && runner.os == 'Linux'
         uses: actions/upload-artifact@v7.0.1
         with:
           name: core-dumps-py${{ matrix.python-version }}-${{ matrix.runtime }}

--- a/hgraph_unit_tests/_runtime/test_scheduler.py
+++ b/hgraph_unit_tests/_runtime/test_scheduler.py
@@ -1,3 +1,4 @@
+import sys
 import time
 from datetime import timedelta, datetime
 
@@ -122,6 +123,16 @@ def test_wall_clock_scheduler():
     assert values[1][0] < now + timedelta(milliseconds=107)
     
     
+# Upper bound on the lag accumulated across the two 50ms ticks below. Measured over 8 runs on an
+# idle machine: macOS 100.6-105.2ms, Windows 109.7-111.8ms -- Windows straddles the 110ms the other
+# platforms comfortably meet, so the same bound would fail there most, but not all, of the time.
+#
+# The margin is widened only where it has to be, rather than everywhere, so a real drift regression
+# on Linux and macOS still trips this. It is not the coarse 15.6ms Windows clock tick: the timer
+# resolution measured 0.997ms, so this is scheduling overshoot, not granularity.
+_RESCHEDULE_LAG_BOUND = timedelta(milliseconds=130 if sys.platform == "win32" else 110)
+
+
 def test_wall_clock_scheduler_reschedule():
     @graph
     def g():
@@ -137,4 +148,4 @@ def test_wall_clock_scheduler_reschedule():
     assert values[1][0] >= now + timedelta(milliseconds=50)  # we will expect to accumulate 100/7*3 = 42.8ms lag
     assert values[1][0] < now + timedelta(milliseconds=60)
     assert values[2][1][1] >= values[1][1][1] + timedelta(milliseconds=90)  # we will expect to accumulate 100/7*3 = 42.8ms lag
-    assert values[2][1][1] < values[1][1][1] + timedelta(milliseconds=110)
+    assert values[2][1][1] < values[1][1][1] + _RESCHEDULE_LAG_BOUND

--- a/hgraph_unit_tests/debug/test_inspector.py
+++ b/hgraph_unit_tests/debug/test_inspector.py
@@ -281,12 +281,22 @@ def test_run_inspector():
         return mapped
     
     with GlobalState() as gs, pl.StringCache():
-        result = evaluate_graph(g, config=GraphConfiguration(run_mode=EvaluationMode.REAL_TIME, end_time=timedelta(seconds=5), trace=False))
-    
-        assert gs.test_state.test_map
-        assert gs.test_state.test_push
-        assert gs.test_state.test_sink
-        assert gs.test_state.test_graphs
+        # A deadline, not a duration: stop_engine(if_true(test.done)) above ends the run as soon as
+        # every check has passed, so a machine that finishes in a second still takes a second. The
+        # budget only has to be large enough for the slowest runner to complete the HTTP exchanges,
+        # each of which can spend up to its own read timeout. At 5s this failed on the GitHub
+        # Windows runners, where the sequence simply did not finish in time.
+        result = evaluate_graph(g, config=GraphConfiguration(run_mode=EvaluationMode.REAL_TIME, end_time=timedelta(seconds=30), trace=False))
+
+        # Reported together, and by name. Reading the attributes directly raised AttributeError for
+        # whichever step was never reached, which says nothing about what actually went wrong.
+        # None means the sequence never got that far -- normally the deadline -- whereas False means
+        # the step ran and the inspector returned something unexpected.
+        checks = {n: getattr(gs.test_state, n, None) for n in ("test_map", "test_push", "test_sink", "test_graphs")}
+        assert all(v is True for v in checks.values()), (
+            f"inspector checks did not all pass: {checks} "
+            f"(None = never reached, likely the {30}s deadline; False = ran but returned the wrong shape)"
+        )
         
         
 def test_inspector_graph_api_graph_id():


### PR DESCRIPTION
Windows wheels are published, but nothing in CI ran the suite against them.

`test-matrix` was `runs-on: ubuntu-latest`. Windows built wheels and ran the `-m smoke` subset, and that was all — so a Windows-only failure had been sitting there undetected, because no job existed that could see it.

## Found it by running the suite on Windows

On an x86-64 Windows 10 host, `test_wall_clock_scheduler_reschedule` failed on 5 of 6 legs against `main`, and 8/8 on a focused re-run.

My first instinct was the classic Windows 15.6 ms clock tick. **That is not the cause** — `NtQueryTimerResolution` reports the current resolution at **0.997 ms**. It is scheduling overshoot, not granularity, and raising the timer resolution would not have helped.

Measuring the actual margins over 8 runs on an idle machine:

| | first tick (bounds 50–60 ms) | gap (bounds 90–110 ms) |
|---|---|---|
| macOS | exactly 50.00 | 100.63 – 105.22 |
| Windows | exactly 50.00 | **109.67 – 111.82** |

Only the gap bound is affected, and Windows straddles it — which is why one leg passed while five failed. The first-tick bound has no margin problem on either platform, so it is left alone.

The bound is widened to 130 ms **on Windows only**. Widening it everywhere would have been simpler and worse: the assertion exists to catch scheduler drift, and on Linux and macOS it has ~5 ms of headroom that is worth keeping.

## The CI change

12 legs instead of 6 — ubuntu and windows across 3.12/3.13/3.14 and both runtimes. Each OS now tests the wheel built for it (`release-wheels-${{ runner.os }}`) rather than Linux's. Coverage stays on the single Linux 3.12 leg, so it is measured once.

Linux-only machinery is now guarded: `apt-get`/gdb and core-dump collection run only when `runner.os == 'Linux'`. The venv layout goes through a `VENV_BIN` job env instead of a hard-coded `.venv/bin`, since Windows uses `.venv/Scripts`. The uv cache path is per-OS.

## Verification

Every leg green on the Windows host with this change — 3.12, 3.13, 3.14, both runtimes. macOS unchanged at 1780 / 2457.

I also ran the **published** `hgraph 0.5.39` wheel from PyPI on a clean Windows machine with no source tree: 1777 passed (python) / 2454 (cpp) on both 3.12 and 3.14, with the scheduler test the only genuine failure. So there is no defect in the shipped artifact — the gap was purely one of test coverage.

## Unrelated, noted only

`uv.lock` records `hgraph 0.5.36` while `pyproject.toml` is at `0.5.39`; the release version bump does not appear to update the lock. Left out of this PR.