### PR TITLE
Build release branches, and bump the version on the branch that was tagged

### DIFF
--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -15,6 +15,12 @@ on:
   push:
     branches:
       - main
+      # Maintenance lanes build and test on push for the same reason main does: tagging reuses
+      # the artifacts the branch already built and tested, matched by commit SHA. Without a run
+      # for that commit there is nothing to reuse, so a release tag would rebuild from scratch
+      # and the reuse and restamp paths -- which no pull request can exercise -- would run for
+      # the first time during the release itself.
+      - 'release/**'
     tags:
       - 'v*'
       - 'v_*.*.*'
@@ -780,16 +786,29 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Commit version bump to default branch
+      - name: Commit version bump to the branch the tag was cut from
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REF: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          # Determine version from tag inside Python to avoid env mismatches
+          # The bump belongs on whichever branch was released, not on the default branch. While
+          # main was the only release lane the two were the same; with a maintenance lane
+          # alongside it, a 0.5.x tag cut from release/0.5 would otherwise write its version onto
+          # main. Only an exact match on a release branch head diverts it, so anything tagged
+          # elsewhere still lands on the default branch as before.
           DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
-          git checkout "$DEFAULT_BRANCH"
+          TAG_SHA="$(git rev-parse "refs/tags/${REF}^{commit}")"
+          TARGET_BRANCH="$DEFAULT_BRANCH"
+          for remote_branch in $(git for-each-ref --format='%(refname:short)' 'refs/remotes/origin/release/*'); do
+            if [ "$(git rev-parse "${remote_branch}^{commit}")" = "$TAG_SHA" ]; then
+              TARGET_BRANCH="${remote_branch#origin/}"
+              break
+            fi
+          done
+          echo "tag ${REF} (${TAG_SHA}) -> bumping version on ${TARGET_BRANCH}"
+          git checkout "$TARGET_BRANCH"
 
           python - <<PY
           import os, re, pathlib, sys
@@ -812,21 +831,43 @@ jobs:
               sys.exit(1)
           if new_s != s:
               p.write_text(new_s, encoding='utf-8')
+
+          # uv.lock carries the project's own version too. Leaving it behind meant every later
+          # 'uv sync' rewrote it and showed the tree as dirty, so the lock drifted several
+          # releases behind pyproject.
+          #
+          # The entry is edited directly rather than by running 'uv lock': re-resolving during a
+          # release could move third-party pins, which is not what a version bump should do.
+          lock = pathlib.Path('uv.lock')
+          if lock.is_file():
+              ls = lock.read_text(encoding='utf-8')
+              # Match the version line only within hgraph's own [[package]] block.
+              new_ls, ln = re.subn(
+                  r'(?ms)(\[\[package\]\]\nname = "hgraph"\nversion = ")[^"]+(")',
+                  rf'\g<1>{ver}\2',
+                  ls,
+              )
+              if ln == 0:
+                  print('WARNING: could not find hgraph version in uv.lock; leaving it unchanged', file=sys.stderr)
+              elif new_ls != ls:
+                  lock.write_text(new_ls, encoding='utf-8')
+                  print(f'Updated uv.lock to {ver}')
           PY
 
           # Commit only if changed; push to default branch
           git config --local user.name "github-actions"
           git config --local user.email "github-actions@github.com"
-          if ! git diff --quiet -- pyproject.toml; then
+          if ! git diff --quiet -- pyproject.toml uv.lock; then
             git add pyproject.toml
+            git add uv.lock 2>/dev/null || true
             # Compute version string for the commit subject from REF (supports v_#.#.# and v#.#.#)
             VER_COMMIT="$REF"
             if [[ "$VER_COMMIT" == v_* ]]; then VER_COMMIT="${VER_COMMIT#v_}"; elif [[ "$VER_COMMIT" == v* ]]; then VER_COMMIT="${VER_COMMIT#v}"; fi
-            # [skip ci]: this lands on main, which now builds release-grade wheels on every push.
-            # A version-bump commit changes no source, so rebuilding and re-testing it would cost
-            # a full matrix run to produce artifacts identical to the ones just published.
+            # [skip ci]: the target branch builds release-grade wheels on every push. A
+            # version-bump commit changes no source, so rebuilding and re-testing it would cost a
+            # full matrix run to produce artifacts identical to the ones just published.
             git commit -m "Update version to ${VER_COMMIT} based on tag [skip ci]"
-            git push origin HEAD:"$DEFAULT_BRANCH"
+            git push origin HEAD:"$TARGET_BRANCH"
           else
-            echo "No changes detected in pyproject.toml. Skipping commit and push."
+            echo "No changes detected in pyproject.toml or uv.lock. Skipping commit and push."
           fi

--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -800,13 +800,39 @@ jobs:
           # elsewhere still lands on the default branch as before.
           DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
           TAG_SHA="$(git rev-parse "refs/tags/${REF}^{commit}")"
-          TARGET_BRANCH="$DEFAULT_BRANCH"
-          for remote_branch in $(git for-each-ref --format='%(refname:short)' 'refs/remotes/origin/release/*'); do
+          RELEASE_BRANCHES="$(git for-each-ref --format='%(refname:short)' 'refs/remotes/origin/release/*')"
+          TARGET_BRANCH=""
+
+          # First choice: a release branch still sitting on the tagged commit. If the default
+          # branch happens to be on that commit too -- they are identical until the two lanes
+          # diverge -- the release branch still wins, because its head is the specific signal
+          # while the default branch coinciding is incidental.
+          for remote_branch in $RELEASE_BRANCHES; do
             if [ "$(git rev-parse "${remote_branch}^{commit}")" = "$TAG_SHA" ]; then
               TARGET_BRANCH="${remote_branch#origin/}"
               break
             fi
           done
+
+          # Second choice: a release branch that contains the tag but has moved on since. This
+          # step runs after publishing, which can be an hour after the tag was pushed, so the
+          # branch may well have advanced by now. Requiring the head to still match would send
+          # the maintenance version to the default branch -- the corruption this exists to stop.
+          #
+          # Containment alone is not enough to decide, because a commit shared with the default
+          # branch is contained by both; such a tag is genuinely ambiguous and keeps the previous
+          # behaviour of going to the default branch.
+          if [ -z "$TARGET_BRANCH" ]; then
+            for remote_branch in $RELEASE_BRANCHES; do
+              if git merge-base --is-ancestor "$TAG_SHA" "$remote_branch" 2>/dev/null &&
+                 ! git merge-base --is-ancestor "$TAG_SHA" "origin/$DEFAULT_BRANCH" 2>/dev/null; then
+                TARGET_BRANCH="${remote_branch#origin/}"
+                break
+              fi
+            done
+          fi
+
+          TARGET_BRANCH="${TARGET_BRANCH:-$DEFAULT_BRANCH}"
           echo "tag ${REF} (${TAG_SHA}) -> bumping version on ${TARGET_BRANCH}"
           git checkout "$TARGET_BRANCH"
 
@@ -820,7 +846,7 @@ jobs:
           else:
               print(f'Unexpected tag format: {ref}', file=sys.stderr)
               sys.exit(1)
-          print(f'Committing version {ver} to pyproject.toml on default branch')
+          print(f'Committing version {ver} to pyproject.toml')
           p = pathlib.Path('pyproject.toml')
           s = p.read_text(encoding='utf-8')
           new_s, n = re.subn(r'(?m)^(version\s*=\s*")[^"]+("\s*)$', rf"\g<1>{ver}\2", s)

--- a/uv.lock
+++ b/uv.lock
@@ -445,7 +445,7 @@ wheels = [
 
 [[package]]
 name = "hgraph"
-version = "0.5.36"
+version = "0.5.39"
 source = { editable = "." }
 dependencies = [
     { name = "frozendict" },


### PR DESCRIPTION
Preparation for `release/0.5` being maintained alongside main once the hg_cpp port lands.

## 1. Release branches build on push

`push.branches` covered `main` only, so a push to `release/**` produced **no run at all**. That breaks the release design: tagging reuses the artifacts the branch already built and tested, matched by commit SHA. With no run for that commit there is nothing to reuse, so a release tag would rebuild from scratch — and would run the reuse and restamp paths, which no pull request can reach, for the first time *during the release*. Two bugs shipped exactly that way in `v_0.5.36`.

`publish` is gated on `startsWith(github.ref, 'refs/tags/')`, so these pushes build and test but can never publish. I checked that before making the change.

## 2. The version bump follows the tag

This is the one that would have bitten hardest after the port. The bump was hard-coded to the **default branch**:

```bash
git push origin HEAD:"$DEFAULT_BRANCH"
```

Fine while main was the only release lane. But once `release/0.5` is maintained separately, a `v_0.5.x` tag cut from it would write its version onto **main** — which after the port is not even the same codebase.

It now resolves the target to the release branch whose head the tag matches exactly; anything else still lands on the default branch as before.

## 3. `uv.lock` tracks the bump

Only `pyproject.toml` was updated, so the lock sat several releases behind (`0.5.36` against pyproject's `0.5.39`) and every `uv sync` rewrote it and showed the tree as dirty — it produced a spurious diff three separate times while I was working today.

The entry is edited directly rather than by running `uv lock`, deliberately: re-resolving during a release could move third-party pins, which is not a version bump's job. The current drift is corrected in this PR.

## Verification

These paths are only reachable during a real release, so I exercised them directly rather than trusting review:

- **bump edits**, against the actual `pyproject.toml` and `uv.lock`: exactly **one** line of the lock changes, and comparing every package's pin before and after confirms **only hgraph's** moved.
- **branch selection**, against the real refs: a tag on `release/0.5`'s head resolves to `release/0.5`; on main's head to `main`; on an older commit to `main`.

## Not included

Reworking the workflow for hg_cpp's layout. Per the plan the repo will be stripped and hg_cpp cloned across, with the old code living only on `release/0.5`, so that work belongs with the port rather than ahead of it.