### PR TITLE
Make the inspector expansion checks decide, and say what they saw

### DIFF
--- a/hgraph_unit_tests/debug/test_inspector.py
+++ b/hgraph_unit_tests/debug/test_inspector.py
@@ -206,11 +206,19 @@ def test_run_inspector():
                     _state.map_id = i
                     return {'requests': f"expand/{i}"}
                 
+            # Each expansion check below waits for its children and then decides. The wait is
+            # `>=` rather than `==` deliberately: the table accumulates, so an exact count that
+            # is ever overshot would never match again and the check would sit unresolved until
+            # the deadline, reporting nothing about why. The count is still asserted, just as
+            # part of the verdict instead of as the trigger, and what was seen is recorded so a
+            # failure says so.
             if getattr(_state, 'test_map', None) is False:
                 f = u.filter(pl.col("id").cast(str).str.starts_with(_state.map_id + '/'))
-                if len(f) == 3:
-                    print("checking MAP", f, f['name'].cast(str).str.strip_chars().is_in(["INPUTS", "OUTPUT", "GRAPHS"]))
-                    _state.test_map = f['name'].cast(str).str.strip_chars().is_in(["INPUTS", "OUTPUT", "GRAPHS"]).all()
+                if len(f) >= 3:
+                    names = f['name'].cast(str).str.strip_chars()
+                    print("checking MAP", f, names.is_in(["INPUTS", "OUTPUT", "GRAPHS"]))
+                    _state.map_children = names.to_list()
+                    _state.test_map = len(f) == 3 and names.is_in(["INPUTS", "OUTPUT", "GRAPHS"]).all()
                     
                     f = f.filter(pl.col("name").cast(str).str.strip_chars() == "GRAPHS")
                     if len(f) > 0:
@@ -236,9 +244,11 @@ def test_run_inspector():
                 
             if getattr(_state, 'test_push', None) is False:
                 f = u.filter(pl.col("id").cast(str).str.starts_with(_state.push_id + '/'))
-                if len(f) == 1:
-                    print("checking PUSH", f, f['name'].cast(str).str.strip_chars().is_in(["OUTPUT"]))
-                    _state.test_push = f['name'].cast(str).str.strip_chars().is_in(["OUTPUT"]).all()
+                if len(f) >= 1:
+                    names = f['name'].cast(str).str.strip_chars()
+                    print("checking PUSH", f, names.is_in(["OUTPUT"]))
+                    _state.push_children = names.to_list()
+                    _state.test_push = len(f) == 1 and names.is_in(["OUTPUT"]).all()
                     
             if getattr(_state, 'test_sink', None) is None:
                 f = u.filter((pl.col("type") == "SINK") & (pl.col("name").cast(str).str.contains("debug_print")))
@@ -250,9 +260,11 @@ def test_run_inspector():
                 
             if getattr(_state, 'test_sink', None) is False:
                 f = u.filter(pl.col("id").cast(str).str.starts_with(_state.sink_id + '/'))
-                if len(f) == 2:
-                    print("checking SINK", f, f['name'].cast(str).str.strip_chars().is_in(["SCALARS", "INPUTS"]))
-                    _state.test_sink = f['name'].cast(str).str.strip_chars().is_in(["SCALARS", "INPUTS"]).all()
+                if len(f) >= 2:
+                    names = f['name'].cast(str).str.strip_chars()
+                    print("checking SINK", f, names.is_in(["SCALARS", "INPUTS"]))
+                    _state.sink_children = names.to_list()
+                    _state.test_sink = len(f) == 2 and names.is_in(["SCALARS", "INPUTS"]).all()
                     
             return {'done': 
                 getattr(_state, 'test_map', False) 
@@ -293,9 +305,15 @@ def test_run_inspector():
         # None means the sequence never got that far -- normally the deadline -- whereas False means
         # the step ran and the inspector returned something unexpected.
         checks = {n: getattr(gs.test_state, n, None) for n in ("test_map", "test_push", "test_sink", "test_graphs")}
+        # The children each expansion actually produced. Without these a False says only that a
+        # check did not pass, leaving no way to tell a wrong name from a wrong count -- and this
+        # test has failed on a CI runner in a way that has not been reproducible locally.
+        observed = {n: getattr(gs.test_state, n, None) for n in ("map_children", "push_children", "sink_children")}
         assert all(v is True for v in checks.values()), (
-            f"inspector checks did not all pass: {checks} "
-            f"(None = never reached, likely the {30}s deadline; False = ran but returned the wrong shape)"
+            f"inspector checks did not all pass: {checks}\n"
+            f"children observed: {observed}\n"
+            f"None = the expansion never produced enough rows within the 30s deadline; "
+            f"False = the rows arrived but the count or the names were not as expected"
         )
         
         


### PR DESCRIPTION
The `windows-latest, py3.12, cpp` leg failed on `release/0.5` with `test_sink` alone false:

```
{'test_map': True, 'test_push': True, 'test_sink': False, 'test_graphs': True}
```

Not the deadline this time — the run had its full 30s and used it, because `done` never goes true so `stop_engine` never fires.

## I could not reproduce it

36 runs, all passing:

| where | runs | result |
|---|---|---|
| macOS, both runtimes | 24 | all pass |
| x86-64 Windows host, both runtimes, **pinned to a single core** | 12 | all pass |

The single-core pinning was an attempt to emulate the 2-core runner, since the box is otherwise 16 idle cores. It did not bite — every run still finished in ~2s.

So changing an assertion here would be fixing a theory, not a bug. This makes the next occurrence explain itself instead.

## What changed

**The checks now decide rather than wait.** Each expansion check tested an exact child count (`== 3`, `== 1`, `== 2`) against a table that *accumulates* across updates. If a count is ever overshot it can never match again, so the check sits unresolved until the deadline and reports nothing about why. The wait is now `>=` and the exact count moved into the verdict — the same thing is asserted, but a wrong shape fails immediately and visibly rather than timing out ambiguously.

**The failure now carries evidence.** The children each expansion produced are recorded and reported:

```
inspector checks did not all pass: {'test_map': True, 'test_push': True, 'test_sink': False, 'test_graphs': True}
children observed: {'map_children': ['INPUTS', 'OUTPUT', 'GRAPHS'], 'push_children': ['OUTPUT'], 'sink_children': ['SCALARS', 'INPUTS']}
```

That separates a wrong name from a wrong count from rows that never arrived — three cases a bare `False` cannot distinguish. Verified by forcing a mismatch rather than assuming the message would be useful.

## Correction to an earlier note

When I added the previous message I wrote "False = ran but returned the wrong shape". That was imprecise: `False` is also the state set when a node is found and its expansion requested, so it covered "expanded but the children never arrived" too. The wording is now accurate about what each value means.

## Not claimed

This does not fix the flake — I never reproduced it, so I cannot say it is fixed. It makes the next failure diagnosable, which given the low rate (1 leg in 12, and the same leg passed the run before) is the honest next step.

Full suite green on both runtimes: 1780 / 2457.