### PR TITLE
Start wheel tests per platform and unify release tags

### DIFF
--- a/.github/workflows/release-platform-wheel.yml
+++ b/.github/workflows/release-platform-wheel.yml
@@ -1,0 +1,152 @@
+name: Build platform wheel artifacts
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: GitHub-hosted runner used to build the wheel.
+        required: true
+        type: string
+      parallel:
+        description: Maximum number of parallel CMake build jobs.
+        required: true
+        type: string
+      cmake_args:
+        description: Platform-specific CMake configuration arguments.
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+env:
+  SCCACHE_GHA_ENABLED: "true"
+
+jobs:
+  build:
+    name: Build ${{ inputs.os }} wheel
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - name: Enable shared compiler cache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        with:
+          version: v0.15.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+      - name: Configure current Clang on macOS
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          echo "CC=/usr/bin/clang" >> "$GITHUB_ENV"
+          echo "CXX=/usr/bin/clang++" >> "$GITHUB_ENV"
+          echo "MACOSX_DEPLOYMENT_TARGET=15.0" >> "$GITHUB_ENV"
+          /usr/bin/clang++ --version
+      - name: Configure MSVC toolchain for Ninja
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
+      - name: Install Ninja
+        if: runner.os == 'Windows'
+        run: >-
+          python -m pip install --only-binary=:all: "ninja==1.13.0"
+      - name: Install wheel build tools
+        run: >-
+          python -m pip install --upgrade --only-binary=:all:
+          "build==1.5.0" "abi3audit==0.0.26"
+          "scikit-build-core==1.0.3" "nanobind==2.13.0"
+          "pyarrow==24.0.0"
+      - name: Build stable ABI wheel
+        env:
+          CMAKE_GENERATOR: Ninja
+          CMAKE_ARGS: ${{ inputs.cmake_args }}
+          CMAKE_BUILD_PARALLEL_LEVEL: ${{ inputs.parallel }}
+        run: >-
+          python -m build --wheel --no-isolation --skip-dependency-check
+          "-Cbuild-dir=.ci-build/core/{wheel_tag}"
+      - name: Audit wheel contents
+        run: python tools/audit_distribution.py "dist/*.whl"
+      - name: Verify wheel ABI
+        shell: python
+        run: |
+          from pathlib import Path
+          import subprocess
+          import sys
+
+          wheels = list(Path("dist").glob("*.whl"))
+          assert len(wheels) == 1, wheels
+          wheel = wheels[0]
+          assert wheel.name.startswith("hgraph-"), wheel.name
+          assert "-cp312-abi3-" in wheel.name, wheel.name
+          if sys.platform == "darwin":
+              assert "-macosx_15_0_arm64.whl" in wheel.name, wheel.name
+          elif sys.platform == "win32":
+              assert wheel.name.endswith("-win_amd64.whl"), wheel.name
+          subprocess.check_call(["abi3audit", "--strict", str(wheel)])
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: distribution-wheel-${{ inputs.os }}
+          path: dist/*.whl
+          if-no-files-found: error
+      - name: Install the matching core SDK
+        shell: python
+        run: |
+          from pathlib import Path
+          import subprocess
+          import sys
+
+          wheels = list(Path("dist").glob("*.whl"))
+          assert len(wheels) == 1, wheels
+          subprocess.check_call([sys.executable, "-m", "pip", "install", str(wheels[0])])
+      - name: Locate the installed core SDK
+        shell: python
+        run: |
+          from importlib import metadata
+          import os
+          from pathlib import Path
+
+          distribution = metadata.distribution("hgraph")
+          sdk_prefix = Path(distribution.locate_file("")).resolve()
+          config = sdk_prefix / "lib" / "cmake" / "hgraph" / "hgraphConfig.cmake"
+          if not config.is_file():
+              raise FileNotFoundError(f"installed hgraph CMake package not found: {config}")
+
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
+              env_file.write(f"HGRAPH_KAFKA_SDK_PREFIX={sdk_prefix}\n")
+      - name: Build Kafka stable ABI wheel
+        env:
+          CMAKE_GENERATOR: Ninja
+          CMAKE_ARGS: ${{ inputs.cmake_args }}
+          CMAKE_BUILD_PARALLEL_LEVEL: ${{ inputs.parallel }}
+          CMAKE_PREFIX_PATH: ${{ env.HGRAPH_KAFKA_SDK_PREFIX }}
+        run: >-
+          python -m build --wheel --no-isolation --skip-dependency-check
+          "-Cbuild-dir=.ci-build/kafka/{wheel_tag}"
+          --outdir kafka-dist extensions/kafka
+      - name: Verify Kafka wheel ABI
+        shell: python
+        run: |
+          from pathlib import Path
+          import subprocess
+          import sys
+
+          wheels = list(Path("kafka-dist").glob("*.whl"))
+          assert len(wheels) == 1, wheels
+          wheel = wheels[0]
+          assert wheel.name.startswith("hgraph_kafka-"), wheel.name
+          assert "-cp312-abi3-" in wheel.name, wheel.name
+          if sys.platform == "darwin":
+              assert "-macosx_15_0_arm64.whl" in wheel.name, wheel.name
+          elif sys.platform == "win32":
+              assert wheel.name.endswith("-win_amd64.whl"), wheel.name
+          subprocess.check_call(["abi3audit", "--strict", str(wheel)])
+      - name: Audit Kafka wheel contents
+        run: python extensions/kafka/tools/audit_distribution.py "kafka-dist/*.whl"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: kafka-distribution-wheel-${{ inputs.os }}
+          path: kafka-dist/*.whl
+          if-no-files-found: error

--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -109,157 +109,36 @@ jobs:
             core.notice(`No reusable distributions found for commit ${context.sha}`);
             core.setOutput("run-id", "");
 
-  build-wheel:
-    name: Build ${{ matrix.os }} wheel
+  build-windows-wheel:
+    name: Build Windows wheel artifacts
     needs:
       - validate-release
       - reuse-build
     if: needs.reuse-build.outputs.run-id == ''
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # Ninja (not the Visual Studio generator): MSBuild ignores
-          # CMAKE_CXX_COMPILER_LAUNCHER, so sccache never fires under the VS
-          # generator. Debug-carrying configurations use /Z7 (embedded debug
-          # info) so they stay cacheable — sccache cannot cache /Zi's shared
-          # PDB; the Release wheel carries no debug info and no format flag.
-          - os: windows-latest
-            parallel: "4"
-            cmake_generator: Ninja
-            cmake_args: >-
-              -DHGRAPH_WARNINGS_AS_ERRORS=OFF
-              -DCMAKE_POLICY_DEFAULT_CMP0141=NEW
-              "-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>"
-          - os: macos-26
-            parallel: "1"
-            cmake_generator: Ninja
-            cmake_args: -DHGRAPH_WARNINGS_AS_ERRORS=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=15.0
+    uses: ./.github/workflows/release-platform-wheel.yml
+    with:
+      os: windows-latest
+      parallel: "4"
+      # Ninja (not the Visual Studio generator): MSBuild ignores
+      # CMAKE_CXX_COMPILER_LAUNCHER, so sccache never fires under the VS
+      # generator. /Z7 keeps debug-carrying configurations cacheable because
+      # sccache cannot cache /Zi's shared PDB.
+      cmake_args: >-
+        -DHGRAPH_WARNINGS_AS_ERRORS=OFF
+        -DCMAKE_POLICY_DEFAULT_CMP0141=NEW
+        "-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>"
 
-    steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          persist-credentials: false
-      - name: Enable shared compiler cache
-        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
-        with:
-          version: v0.15.0
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
-        with:
-          python-version: "3.12"
-      - name: Configure current Clang on macOS
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
-          echo "CC=/usr/bin/clang" >> "$GITHUB_ENV"
-          echo "CXX=/usr/bin/clang++" >> "$GITHUB_ENV"
-          echo "MACOSX_DEPLOYMENT_TARGET=15.0" >> "$GITHUB_ENV"
-          /usr/bin/clang++ --version
-      - name: Configure MSVC toolchain for Ninja
-        if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
-      - name: Install Ninja
-        if: runner.os == 'Windows'
-        run: >-
-          python -m pip install --only-binary=:all: "ninja==1.13.0"
-      - name: Install wheel build tools
-        run: >-
-          python -m pip install --upgrade --only-binary=:all:
-          "build==1.5.0" "abi3audit==0.0.26"
-          "scikit-build-core==1.0.3" "nanobind==2.13.0"
-          "pyarrow==24.0.0"
-      - name: Build stable ABI wheel
-        env:
-          CMAKE_GENERATOR: ${{ matrix.cmake_generator }}
-          CMAKE_ARGS: ${{ matrix.cmake_args }}
-          CMAKE_BUILD_PARALLEL_LEVEL: ${{ matrix.parallel }}
-        run: >-
-          python -m build --wheel --no-isolation --skip-dependency-check
-          "-Cbuild-dir=.ci-build/core/{wheel_tag}"
-      - name: Audit wheel contents
-        run: python tools/audit_distribution.py "dist/*.whl"
-      - name: Verify wheel ABI
-        shell: python
-        run: |
-          from pathlib import Path
-          import subprocess
-          import sys
-
-          wheels = list(Path("dist").glob("*.whl"))
-          assert len(wheels) == 1, wheels
-          wheel = wheels[0]
-          assert wheel.name.startswith("hgraph-"), wheel.name
-          assert "-cp312-abi3-" in wheel.name, wheel.name
-          if sys.platform == "darwin":
-              assert "-macosx_15_0_arm64.whl" in wheel.name, wheel.name
-          elif sys.platform == "win32":
-              assert wheel.name.endswith("-win_amd64.whl"), wheel.name
-          subprocess.check_call(["abi3audit", "--strict", str(wheel)])
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: distribution-wheel-${{ matrix.os }}
-          path: dist/*.whl
-          if-no-files-found: error
-      - name: Install the matching core SDK
-        shell: python
-        run: |
-          from pathlib import Path
-          import subprocess
-          import sys
-
-          wheels = list(Path("dist").glob("*.whl"))
-          assert len(wheels) == 1, wheels
-          subprocess.check_call([sys.executable, "-m", "pip", "install", str(wheels[0])])
-      - name: Locate the installed core SDK
-        shell: python
-        run: |
-          from importlib import metadata
-          import os
-          from pathlib import Path
-
-          distribution = metadata.distribution("hgraph")
-          sdk_prefix = Path(distribution.locate_file("")).resolve()
-          config = sdk_prefix / "lib" / "cmake" / "hgraph" / "hgraphConfig.cmake"
-          if not config.is_file():
-              raise FileNotFoundError(f"installed hgraph CMake package not found: {config}")
-
-          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
-              env_file.write(f"HGRAPH_KAFKA_SDK_PREFIX={sdk_prefix}\n")
-      - name: Build Kafka stable ABI wheel
-        env:
-          CMAKE_GENERATOR: ${{ matrix.cmake_generator }}
-          CMAKE_ARGS: ${{ matrix.cmake_args }}
-          CMAKE_BUILD_PARALLEL_LEVEL: ${{ matrix.parallel }}
-          CMAKE_PREFIX_PATH: ${{ env.HGRAPH_KAFKA_SDK_PREFIX }}
-        run: >-
-          python -m build --wheel --no-isolation --skip-dependency-check
-          "-Cbuild-dir=.ci-build/kafka/{wheel_tag}"
-          --outdir kafka-dist extensions/kafka
-      - name: Verify Kafka wheel ABI
-        shell: python
-        run: |
-          from pathlib import Path
-          import subprocess
-          import sys
-
-          wheels = list(Path("kafka-dist").glob("*.whl"))
-          assert len(wheels) == 1, wheels
-          wheel = wheels[0]
-          assert wheel.name.startswith("hgraph_kafka-"), wheel.name
-          assert "-cp312-abi3-" in wheel.name, wheel.name
-          if sys.platform == "darwin":
-              assert "-macosx_15_0_arm64.whl" in wheel.name, wheel.name
-          elif sys.platform == "win32":
-              assert wheel.name.endswith("-win_amd64.whl"), wheel.name
-          subprocess.check_call(["abi3audit", "--strict", str(wheel)])
-      - name: Audit Kafka wheel contents
-        run: python extensions/kafka/tools/audit_distribution.py "kafka-dist/*.whl"
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: kafka-distribution-wheel-${{ matrix.os }}
-          path: kafka-dist/*.whl
-          if-no-files-found: error
+  build-macos-wheel:
+    name: Build macOS wheel artifacts
+    needs:
+      - validate-release
+      - reuse-build
+    if: needs.reuse-build.outputs.run-id == ''
+    uses: ./.github/workflows/release-platform-wheel.yml
+    with:
+      os: macos-26
+      parallel: "1"
+      cmake_args: -DHGRAPH_WARNINGS_AS_ERRORS=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=15.0
 
   build-linux-wheel:
     name: Build manylinux 2.28 / GCC 14 wheel
@@ -467,86 +346,35 @@ jobs:
           path: kafka-dist/*.tar.gz
           if-no-files-found: error
 
-  test-wheel:
-    name: Test ${{ matrix.os }} / Python ${{ matrix.python-version }}
+  test-windows-wheel:
+    name: Test Windows wheel artifacts
     needs:
       - reuse-build
-      - build-wheel
+      - build-windows-wheel
+    if: needs.reuse-build.outputs.run-id == ''
+    uses: ./.github/workflows/test-platform-wheel.yml
+    with:
+      os: windows-latest
+
+  test-macos-wheel:
+    name: Test macOS wheel artifacts
+    needs:
+      - reuse-build
+      - build-macos-wheel
+    if: needs.reuse-build.outputs.run-id == ''
+    uses: ./.github/workflows/test-platform-wheel.yml
+    with:
+      os: macos-26
+
+  test-linux-wheel:
+    name: Test Linux wheel artifacts
+    needs:
+      - reuse-build
       - build-linux-wheel
     if: needs.reuse-build.outputs.run-id == ''
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-26
-        python-version:
-          - "3.12"
-          - "3.13"
-          - "3.14"
-
-    steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Configure GCC 14 for the installed C++ consumer
-        if: runner.os == 'Linux' && matrix.python-version == '3.12'
-        shell: bash
-        run: |
-          cc_path="$(command -v "gcc-$GCC_VERSION")"
-          cxx_path="$(command -v "g++-$GCC_VERSION")"
-          test "$("$cxx_path" -dumpfullversion -dumpversion | cut -d. -f1)" -eq "$GCC_VERSION"
-          echo "CC=$cc_path" >> "$GITHUB_ENV"
-          echo "CXX=$cxx_path" >> "$GITHUB_ENV"
-          "$cxx_path" --version
-      - name: Install uv
-        run: >-
-          python -m pip install --upgrade --only-binary=:all: "uv==0.12.3"
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
-        with:
-          name: distribution-wheel-${{ matrix.os }}
-          path: dist
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
-        with:
-          name: kafka-distribution-wheel-${{ matrix.os }}
-          path: kafka-dist
-      - name: Sync test dependencies
-        run: uv sync --frozen --all-extras --all-groups --no-install-workspace --python ${{ matrix.python-version }}
-      - name: Install wheel
-        shell: python
-        run: |
-          from pathlib import Path
-          import subprocess
-          import sys
-
-          wheels = list(Path("dist").glob("*.whl"))
-          assert len(wheels) == 1, wheels
-          venv_python = Path(".venv") / (
-              "Scripts/python.exe" if sys.platform == "win32" else "bin/python"
-          )
-          subprocess.check_call([
-              "uv", "pip", "install", "--python", str(venv_python), str(wheels[0]),
-          ])
-          kafka_wheels = list(Path("kafka-dist").glob("*.whl"))
-          assert len(kafka_wheels) == 1, kafka_wheels
-          subprocess.check_call([
-              "uv", "pip", "install", "--python", str(venv_python),
-              "--no-deps", str(kafka_wheels[0]),
-          ])
-      - name: Confirm installed distribution
-        run: uv run --no-sync python -c "import importlib.metadata as m; import _hgraph; print(m.version('hgraph'), _hgraph.__file__)"
-      - name: Run Python compatibility suite
-        run: uv run --no-sync python -m pytest python/tests -q -m "not wip"
-      - name: Run Kafka extension suite
-        run: uv run --no-sync python -m pytest extensions/kafka/python/tests -q
-      - name: Build installed Python extension consumer
-        if: matrix.python-version == '3.12'
-        run: uv run --no-sync python tests/python_extension_consumer/check.py
+    uses: ./.github/workflows/test-platform-wheel.yml
+    with:
+      os: ubuntu-latest
 
   parity-smoke:
     name: Differential parity smoke / Python 3.14
@@ -757,7 +585,9 @@ jobs:
         needs.reuse-build.outputs.run-id != '' ||
         (
           needs.build-sdist.result == 'success' &&
-          needs.test-wheel.result == 'success' &&
+          needs.test-windows-wheel.result == 'success' &&
+          needs.test-macos-wheel.result == 'success' &&
+          needs.test-linux-wheel.result == 'success' &&
           needs.native-cpp.result == 'success' &&
           needs.native-install.result == 'success'
         )
@@ -766,7 +596,9 @@ jobs:
       - validate-release
       - reuse-build
       - build-sdist
-      - test-wheel
+      - test-windows-wheel
+      - test-macos-wheel
+      - test-linux-wheel
       - native-cpp
       - native-install
       - build-linux-wheel
@@ -808,7 +640,9 @@ jobs:
         needs.reuse-build.outputs.run-id != '' ||
         (
           needs.build-sdist.result == 'success' &&
-          needs.test-wheel.result == 'success' &&
+          needs.test-windows-wheel.result == 'success' &&
+          needs.test-macos-wheel.result == 'success' &&
+          needs.test-linux-wheel.result == 'success' &&
           needs.native-cpp.result == 'success' &&
           needs.native-install.result == 'success'
         )
@@ -817,7 +651,9 @@ jobs:
       - validate-release
       - reuse-build
       - build-sdist
-      - test-wheel
+      - test-windows-wheel
+      - test-macos-wheel
+      - test-linux-wheel
       - native-cpp
       - native-install
       - build-linux-wheel

--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -5,8 +5,7 @@ on:
     branches:
       - main
     tags:
-      - "v_*.*.*"
-      - "hgraph-kafka-v_*.*.*"
+      - "*.*.*"
   pull_request:
   workflow_dispatch:
 
@@ -578,7 +577,7 @@ jobs:
     name: Publish hgraph to PyPI
     if: >-
       always() &&
-      startsWith(github.ref, 'refs/tags/v_') &&
+      github.ref_type == 'tag' &&
       needs.validate-release.result == 'success' &&
       needs.reuse-build.result == 'success' &&
       (
@@ -623,7 +622,7 @@ jobs:
       - name: Restamp distributions to the tag version
         env:
           RELEASE_TAG: ${{ github.ref_name }}
-        run: python tools/restamp_distribution.py dist "${RELEASE_TAG#v_}"
+        run: python tools/restamp_distribution.py dist "$RELEASE_TAG"
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
@@ -633,7 +632,7 @@ jobs:
     name: Publish hgraph-kafka to PyPI
     if: >-
       always() &&
-      startsWith(github.ref, 'refs/tags/hgraph-kafka-v_') &&
+      github.ref_type == 'tag' &&
       needs.validate-release.result == 'success' &&
       needs.reuse-build.result == 'success' &&
       (
@@ -678,9 +677,7 @@ jobs:
       - name: Restamp Kafka distributions to the tag version
         env:
           RELEASE_TAG: ${{ github.ref_name }}
-        run: >-
-          python tools/restamp_distribution.py dist
-          "${RELEASE_TAG#hgraph-kafka-v_}"
+        run: python tools/restamp_distribution.py dist "$RELEASE_TAG"
       - name: Publish Kafka package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:

--- a/.github/workflows/test-platform-wheel.yml
+++ b/.github/workflows/test-platform-wheel.yml
@@ -1,0 +1,88 @@
+name: Test platform wheel artifacts
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: GitHub-hosted runner matching the wheel platform.
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+env:
+  GCC_VERSION: "14"
+
+jobs:
+  test:
+    name: Test ${{ inputs.os }} / Python ${{ matrix.python-version }}
+    runs-on: ${{ inputs.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.12"
+          - "3.13"
+          - "3.14"
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Configure GCC 14 for the installed C++ consumer
+        if: runner.os == 'Linux' && matrix.python-version == '3.12'
+        shell: bash
+        run: |
+          cc_path="$(command -v "gcc-$GCC_VERSION")"
+          cxx_path="$(command -v "g++-$GCC_VERSION")"
+          test "$("$cxx_path" -dumpfullversion -dumpversion | cut -d. -f1)" -eq "$GCC_VERSION"
+          echo "CC=$cc_path" >> "$GITHUB_ENV"
+          echo "CXX=$cxx_path" >> "$GITHUB_ENV"
+          "$cxx_path" --version
+      - name: Install uv
+        run: >-
+          python -m pip install --upgrade --only-binary=:all: "uv==0.12.3"
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: distribution-wheel-${{ inputs.os }}
+          path: dist
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: kafka-distribution-wheel-${{ inputs.os }}
+          path: kafka-dist
+      - name: Sync test dependencies
+        run: uv sync --frozen --all-extras --all-groups --no-install-workspace --python ${{ matrix.python-version }}
+      - name: Install wheel
+        shell: python
+        run: |
+          from pathlib import Path
+          import subprocess
+          import sys
+
+          wheels = list(Path("dist").glob("*.whl"))
+          assert len(wheels) == 1, wheels
+          venv_python = Path(".venv") / (
+              "Scripts/python.exe" if sys.platform == "win32" else "bin/python"
+          )
+          subprocess.check_call([
+              "uv", "pip", "install", "--python", str(venv_python), str(wheels[0]),
+          ])
+          kafka_wheels = list(Path("kafka-dist").glob("*.whl"))
+          assert len(kafka_wheels) == 1, kafka_wheels
+          subprocess.check_call([
+              "uv", "pip", "install", "--python", str(venv_python),
+              "--no-deps", str(kafka_wheels[0]),
+          ])
+      - name: Confirm installed distribution
+        run: uv run --no-sync python -c "import importlib.metadata as m; import _hgraph; print(m.version('hgraph'), _hgraph.__file__)"
+      - name: Run Python compatibility suite
+        run: uv run --no-sync python -m pytest python/tests -q -m "not wip"
+      - name: Run Kafka extension suite
+        run: uv run --no-sync python -m pytest extensions/kafka/python/tests -q
+      - name: Build installed Python extension consumer
+        if: matrix.python-version == '3.12'
+        run: uv run --no-sync python tests/python_extension_consumer/check.py

--- a/.github/workflows/test-platform-wheel.yml
+++ b/.github/workflows/test-platform-wheel.yml
@@ -78,11 +78,11 @@ jobs:
               "--no-deps", str(kafka_wheels[0]),
           ])
       - name: Confirm installed distribution
-        run: uv run --no-sync python -c "import importlib.metadata as m; import _hgraph; print(m.version('hgraph'), _hgraph.__file__)"
+        run: uv run --no-sync --no-build python -c "import importlib.metadata as m; import _hgraph; print(m.version('hgraph'), _hgraph.__file__)"
       - name: Run Python compatibility suite
-        run: uv run --no-sync python -m pytest python/tests -q -m "not wip"
+        run: uv run --no-sync --no-build python -m pytest python/tests -q -m "not wip"
       - name: Run Kafka extension suite
-        run: uv run --no-sync python -m pytest extensions/kafka/python/tests -q
+        run: uv run --no-sync --no-build python -m pytest extensions/kafka/python/tests -q
       - name: Build installed Python extension consumer
         if: matrix.python-version == '3.12'
-        run: uv run --no-sync python tests/python_extension_consumer/check.py
+        run: uv run --no-sync --no-build python tests/python_extension_consumer/check.py

--- a/docs/source/developer_guide/build_system.rst
+++ b/docs/source/developer_guide/build_system.rst
@@ -61,22 +61,22 @@ compatibility oracle.
 
 ``.github/workflows/release-wheels.yml`` builds one ``cp312-abi3`` wheel for Linux x86_64,
 Windows x86_64, and Apple Silicon macOS, then installs each platform wheel under
-CPython 3.12, 3.13, and 3.14.  A tag matching ``v_x.x.x`` publishes the tested
-wheels and source distribution through PyPI trusted publishing.  The tag is the
-release version authority: the publish job restamps the metadata of artifacts
-already tested for that exact commit, rather than rebuilding them.
-For core tags, the tag's numeric version core must match CMake's
-``project(VERSION)``. This guarantees that reused wheels contain a matching
-generated ``version.h``, ``hgraphConfigVersion.cmake``, and native
-``hgraph::version()`` value. A prerelease suffix belongs to the Python
-distribution metadata; the native SDK continues to expose its numeric API
-version core.
+CPython 3.12, 3.13, and 3.14. A bare tag matching ``x.x.x`` publishes the tested
+core and Kafka wheels and source distributions through PyPI trusted publishing.
+The tag is the shared release version authority: the publish jobs restamp the
+metadata of artifacts already tested for that exact commit, rather than
+rebuilding them. The tag's numeric version core must match both CMake
+``project(VERSION)`` declarations. This guarantees that reused wheels contain
+matching generated ``version.h``, CMake package versions, and native API version
+values. A prerelease suffix belongs to the Python distribution metadata; the
+native SDKs continue to expose their numeric API version core.
 ``pyproject.toml`` therefore uses ``0.0.0`` as an explicit untagged-artifact
 sentinel; it is never the version published to PyPI.  CMake's numeric
 ``project(VERSION)`` and ``docs/source/conf.py`` track the current C++ API line
 independently.  Packaging tests enforce these relationships and the release
-workflow validates the tag syntax and rejects versions already present on
-PyPI.  The PyPI trusted publisher is bound to the ``release-wheels.yml`` workflow and
+workflow validates the tag syntax and rejects a version already present for
+either package on PyPI. The PyPI trusted publishers are bound to the
+``release-wheels.yml`` workflow and
 the GitHub ``release`` environment.
 
 The macOS build uses the current system Clang from the latest Apple Silicon
@@ -149,7 +149,7 @@ First-party extension distributions
 -----------------------------------
 
 First-party extensions live under ``extensions/`` in the same repository but
-remain independently versioned CMake and Python distributions.  The root
+remain separate CMake and Python distributions.  The root
 ``uv`` workspace makes them selectable without adding an extension dependency
 to core ``hgraph``.  With the matching installed hgraph SDK discoverable, Kafka can
 be built with::
@@ -164,13 +164,12 @@ consumer instead configures ``extensions/kafka`` against the installed
 ``hgraph`` CMake package and links ``hgraph::kafka``.
 
 Each extension owns its nested ``pyproject.toml``, CMake package configuration,
-tests, and release version.  Cross-cutting changes are tested against core at
-the same commit, while the resulting wheels remain separately publishable.
-Core releases use ``v_<version>`` tags.  Kafka releases use independent
-``hgraph-kafka-v_<version>`` tags, which publish only the tested Kafka wheel
-and source-distribution artifacts.  When both packages change, publish the
-core tag first so the Kafka source build requirement is available from PyPI,
-then tag Kafka at the same tested commit.
+and tests. Cross-cutting changes are tested against core at the same commit,
+while the resulting wheels remain separate distribution artifacts. During the
+current release line, core and Kafka are co-versioned and co-released: a bare
+``<version>`` tag such as ``0.8.1`` validates both native project versions,
+restamps both distributions, and publishes both packages. Independent
+extension tags are intentionally not part of this release workflow.
 
 The Kafka PEP 517 build requirements include ``hgraph>=0.8.0`` because its standalone
 CMake configure consumes the installed core SDK.  In-repository CI installs

--- a/docs/source/developer_guide/release_readiness.rst
+++ b/docs/source/developer_guide/release_readiness.rst
@@ -92,8 +92,9 @@ requires all of the following from a clean checkout:
 
 GitHub CI is post-push platform evidence, not a substitute for the local gates.
 Tagged releases reuse the successful distribution artifacts for the exact
-commit SHA and restamp their package metadata to the tag version. Prerelease
-tags use the same ``v_`` convention, for example ``v_0.8.1rc1``.
+commit SHA and restamp both ``hgraph`` and ``hgraph-kafka`` package metadata to
+the shared bare-version tag. For example, ``0.8.1`` publishes both packages as
+version ``0.8.1``; prereleases use the same form, such as ``0.8.1rc1``.
 
 Performance evidence
 --------------------
@@ -112,8 +113,9 @@ Release review
 
 The release reviewer should verify:
 
-- the untagged package, documentation, and CMake baseline versions agree, and
-  tagged artifacts have been restamped to the validated PEP 440 tag version;
+- the untagged packages use their sentinel versions, both native CMake baseline
+  versions agree, and all tagged artifacts have been restamped to the validated
+  shared PEP 440 tag version;
 - no public Python name relies on a private bridge-only runtime implementation;
 - the parity matrix and roadmap contain no stale implemented-as-missing rows;
 - every remaining skip has a ``deviation:`` or ``gap:`` reason and an owner or

--- a/docs/source/rfc/rfc_0005_hgraph_1_0_api.rst
+++ b/docs/source/rfc/rfc_0005_hgraph_1_0_api.rst
@@ -263,6 +263,10 @@ One CI matrix tests core plus all extensions on every change, which is the
 monorepo's payoff: a cross-cutting change lands atomically and is proven
 against every first-party consumer before anything ships.
 
+That independent extension scheme is the 1.0 target. During the 0.8 port,
+current automation deliberately co-releases core and Kafka from one bare
+version tag (for example ``0.8.1``), so both packages carry the same version.
+
 Python API contract
 -------------------
 

--- a/docs/source/rfc/rfc_0015_kafka_extension_api.rst
+++ b/docs/source/rfc/rfc_0015_kafka_extension_api.rst
@@ -1110,7 +1110,7 @@ Performance and release
 * The extension's native suite, Python 3.14 suite, real/mock broker integration
   tests, installed-SDK consumer, and Linux sanitizer gates pass.
 * The monorepo migration pull request tests core and the extension at the same
-  commit and documents independent artifact release ordering.
+  commit and documents their shared 0.8 version tag and release ordering.
 
 Implementation plan
 -------------------

--- a/extensions/kafka/CHANGELOG.md
+++ b/extensions/kafka/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.1.0
+## 0.8.0
 
 - Introduce the C++-first Kafka service implementation, native and Python APIs,
   and compatibility ownership of `hgraph.adaptors.kafka`.

--- a/extensions/kafka/CMakeLists.txt
+++ b/extensions/kafka/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.25)
 
-project(hgraph_kafka VERSION 0.1.0 LANGUAGES C CXX)
+project(hgraph_kafka VERSION 0.8.0 LANGUAGES C CXX)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)

--- a/extensions/kafka/pyproject.toml
+++ b/extensions/kafka/pyproject.toml
@@ -9,7 +9,8 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "hgraph-kafka"
-version = "0.1.0"
+# Release artifacts are restamped from the shared x.x.x tag by release-wheels.yml.
+version = "0.0.0"
 description = "C++-first Kafka services for hgraph"
 readme = "README.md"
 license = {text = "MIT"}

--- a/extensions/kafka/python/tests/test_packaging.py
+++ b/extensions/kafka/python/tests/test_packaging.py
@@ -79,19 +79,36 @@ def test_windows_wheel_statically_links_non_system_dependencies():
     ) == {"hgraph_stdlib.dll", "libcrypto-3-x64.dll"}
 
 
-def test_cmake_and_python_distribution_versions_match():
+def test_kafka_uses_the_shared_release_version_contract():
     project_version = _load(EXTENSION_ROOT / "pyproject.toml")["project"]["version"]
-    cmake = (EXTENSION_ROOT / "CMakeLists.txt").read_text()
-    match = re.search(r"project\(hgraph_kafka VERSION ([^ ]+)", cmake)
+    kafka_cmake = (EXTENSION_ROOT / "CMakeLists.txt").read_text()
+    kafka_match = re.search(r"project\(hgraph_kafka VERSION ([^ ]+)", kafka_cmake)
+    core_cmake = (REPOSITORY_ROOT / "CMakeLists.txt").read_text()
+    core_match = re.search(
+        r"project\(\s*hgraph\s+VERSION\s+(\d+\.\d+\.\d+)", core_cmake
+    )
 
-    assert match is not None
-    assert match.group(1) == project_version
+    assert project_version == "0.0.0"
+    assert kafka_match is not None
+    assert core_match is not None
+    assert kafka_match.group(1) == core_match.group(1)
 
 
 def test_ci_builds_and_tests_separate_kafka_artifacts():
-    workflow = (
+    release_workflow = (
         REPOSITORY_ROOT / ".github/workflows/release-wheels.yml"
     ).read_text()
+    workflow = "\n".join(
+        (
+            release_workflow,
+            (
+                REPOSITORY_ROOT / ".github/workflows/release-platform-wheel.yml"
+            ).read_text(),
+            (
+                REPOSITORY_ROOT / ".github/workflows/test-platform-wheel.yml"
+            ).read_text(),
+        )
+    )
 
     for artifact in (
         "kafka-distribution-sdist",
@@ -102,9 +119,12 @@ def test_ci_builds_and_tests_separate_kafka_artifacts():
         assert artifact in workflow
     assert "python -m pytest extensions/kafka/python/tests -q" in workflow
     assert "-DHGRAPH_BUILD_KAFKA_EXTENSION=ON" in workflow
-    assert '"hgraph-kafka-v_*.*.*"' in workflow
+    assert '      - "*.*.*"' in release_workflow
+    assert "hgraph-kafka-v_" not in release_workflow
     assert "pattern: kafka-distribution-*" in workflow
-    assert "python tools/restamp_distribution.py dist" in workflow
+    assert release_workflow.count(
+        'python tools/restamp_distribution.py dist "$RELEASE_TAG"'
+    ) == 2
     assert "--wheel --no-isolation" in workflow
     assert "--sdist --no-isolation" in workflow
     assert "--skip-dependency-check" in workflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "hgraph"
-# Release artifacts are restamped from the v_x.x.x tag by release-wheels.yml.
+# Release artifacts are restamped from the x.x.x tag by release-wheels.yml.
 version = "0.0.0"
 description = "C++-first functional reactive runtime for time-series processing"
 readme = "README.md"

--- a/python/tests/test_packaging.py
+++ b/python/tests/test_packaging.py
@@ -229,6 +229,7 @@ def test_release_workflow_targets_supported_platforms():
     assert '- "3.12"' in test_workflow
     assert '- "3.13"' in test_workflow
     assert '- "3.14"' in test_workflow
+    assert test_workflow.count("uv run --no-sync --no-build") == 4
 
 
 def test_platform_wheel_builds_use_stable_cacheable_paths():

--- a/python/tests/test_packaging.py
+++ b/python/tests/test_packaging.py
@@ -110,7 +110,12 @@ def test_release_metadata_uses_untagged_sentinel():
 
     workflow = (ROOT / ".github/workflows/release-wheels.yml").read_text()
     assert "Restamp distributions to the tag version" in workflow
-    assert 'python tools/restamp_distribution.py dist "${RELEASE_TAG#v_}"' in workflow
+    assert '      - "*.*.*"' in workflow
+    assert "hgraph-kafka-v_" not in workflow
+    assert "v_*.*.*" not in workflow
+    assert workflow.count(
+        'python tools/restamp_distribution.py dist "$RELEASE_TAG"'
+    ) == 2
     assert 'python tools/validate_release.py "$RELEASE_TAG"' in workflow
 
 

--- a/python/tests/test_packaging.py
+++ b/python/tests/test_packaging.py
@@ -23,6 +23,15 @@ def load_project():
     return tomllib.loads((ROOT / "pyproject.toml").read_text())
 
 
+def workflow_job(workflow, name):
+    match = re.search(
+        rf"(?ms)^  {re.escape(name)}:\n.*?(?=^  [A-Za-z0-9_-]+:\n|\Z)",
+        workflow,
+    )
+    assert match is not None, name
+    return match.group(0)
+
+
 def test_pyarrow_build_and_runtime_requirements_share_the_supported_abi():
     project = load_project()
 
@@ -163,14 +172,20 @@ def test_full_suite_gate_installs_the_wheel_test_extra():
 
 def test_release_workflow_targets_supported_platforms():
     workflow = (ROOT / ".github/workflows/release-wheels.yml").read_text()
+    platform_workflow = (
+        ROOT / ".github/workflows/release-platform-wheel.yml"
+    ).read_text()
+    test_workflow = (
+        ROOT / ".github/workflows/test-platform-wheel.yml"
+    ).read_text()
+    combined_workflow = "\n".join((workflow, platform_workflow, test_workflow))
     nightly_workflow = (
         ROOT / ".github/workflows/parity-nightly.yml"
     ).read_text()
 
-    assert "macos-15-intel" not in workflow
-    assert "          - os: macos-26" in workflow
-    assert "          - macos-26" in workflow
-    assert "CMAKE_OSX_DEPLOYMENT_TARGET=15.0" in workflow
+    assert "macos-15-intel" not in combined_workflow
+    assert "      os: macos-26" in workflow
+    assert "CMAKE_OSX_DEPLOYMENT_TARGET=15.0" in combined_workflow
     assert "quay.io/pypa/manylinux_2_28_x86_64:latest" in workflow
     assert "Build manylinux 2.28 / GCC 14 wheel" in workflow
     assert "--plat manylinux_2_28_x86_64" in workflow
@@ -181,7 +196,7 @@ def test_release_workflow_targets_supported_platforms():
     assert "--exclude libhgraph_wiring.so" in workflow
     assert "--exclude libhgraph_stdlib.so" in workflow
     assert "--exclude libnanobind-abi3.so" in workflow
-    assert "tests/python_extension_consumer/check.py" in workflow
+    assert "tests/python_extension_consumer/check.py" in combined_workflow
     assert "libarrow-acero=24" in workflow
     for linux_workflow in (workflow, nightly_workflow):
         assert 'GCC_VERSION: "14"' in linux_workflow
@@ -194,10 +209,11 @@ def test_release_workflow_targets_supported_platforms():
     # Windows builds with Ninja over cl (vcvars via msvc-dev-cmd): the
     # Visual Studio generator ignores CMAKE_CXX_COMPILER_LAUNCHER, so the
     # shared compiler cache never fires under MSBuild.
-    assert "Visual Studio 18 2026" not in workflow
+    assert "Visual Studio 18 2026" not in combined_workflow
     assert (
         "ilammy/msvc-dev-cmd@"
-        "0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1" in workflow
+        "0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1"
+        in platform_workflow
     )
     # Embedded (/Z7) debug info only for debug-carrying configurations: the
     # Release wheel emits no debug info, and sccache cannot cache /Zi.
@@ -205,29 +221,55 @@ def test_release_workflow_targets_supported_platforms():
         "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT="
         "$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>" in workflow
     )
-    assert 'python-version: "3.12"' in workflow
-    assert '- "3.13"' in workflow
-    assert '- "3.14"' in workflow
+    assert '- "3.12"' in test_workflow
+    assert '- "3.13"' in test_workflow
+    assert '- "3.14"' in test_workflow
 
 
-def test_matrix_wheel_builds_use_stable_cacheable_paths():
-    workflow = (ROOT / ".github/workflows/release-wheels.yml").read_text()
-    matrix_job = workflow.split("  build-wheel:\n", 1)[1].split(
-        "  build-linux-wheel:\n", 1
-    )[0]
+def test_platform_wheel_builds_use_stable_cacheable_paths():
+    platform_workflow = (
+        ROOT / ".github/workflows/release-platform-wheel.yml"
+    ).read_text()
 
-    assert "--wheel --no-isolation --skip-dependency-check" in matrix_job
-    assert '"-Cbuild-dir=.ci-build/core/{wheel_tag}"' in matrix_job
-    assert '"-Cbuild-dir=.ci-build/kafka/{wheel_tag}"' in matrix_job
-    assert "Install Kafka wheel build tools" not in matrix_job
+    assert "--wheel --no-isolation --skip-dependency-check" in platform_workflow
+    assert '"-Cbuild-dir=.ci-build/core/{wheel_tag}"' in platform_workflow
+    assert '"-Cbuild-dir=.ci-build/kafka/{wheel_tag}"' in platform_workflow
+    assert "Install Kafka wheel build tools" not in platform_workflow
     for dependency in (
         '"scikit-build-core==1.0.3"',
         '"nanobind==2.13.0"',
         '"pyarrow==24.0.0"',
     ):
-        assert matrix_job.index(dependency) < matrix_job.index(
+        assert platform_workflow.index(dependency) < platform_workflow.index(
             "Build stable ABI wheel"
         )
+
+
+def test_platform_wheel_tests_start_after_only_their_matching_build():
+    workflow = (ROOT / ".github/workflows/release-wheels.yml").read_text()
+    dependencies = {
+        "test-windows-wheel": "build-windows-wheel",
+        "test-macos-wheel": "build-macos-wheel",
+        "test-linux-wheel": "build-linux-wheel",
+    }
+
+    assert "  test-wheel:\n" not in workflow
+    for test_name, matching_build in dependencies.items():
+        test_job = workflow_job(workflow, test_name)
+        assert "uses: ./.github/workflows/test-platform-wheel.yml" in test_job
+        assert f"      - {matching_build}\n" in test_job
+        for other_build in set(dependencies.values()) - {matching_build}:
+            assert other_build not in test_job
+
+    for build_name in ("build-windows-wheel", "build-macos-wheel"):
+        build_job = workflow_job(workflow, build_name)
+        assert "uses: ./.github/workflows/release-platform-wheel.yml" in build_job
+
+    for publish_name in ("publish", "publish-kafka"):
+        publish_job = workflow_job(workflow, publish_name)
+        for test_name in dependencies:
+            assert f"needs.{test_name}.result == 'success'" in publish_job
+            assert f"      - {test_name}\n" in publish_job
 
 
 def test_workflow_actions_are_pinned_to_immutable_commits():
@@ -253,6 +295,9 @@ def test_release_workflow_reuses_tested_commit_artifacts():
 
 def test_release_workflow_audits_distribution_contents():
     workflow = (ROOT / ".github/workflows/release-wheels.yml").read_text()
+    workflow += (
+        ROOT / ".github/workflows/release-platform-wheel.yml"
+    ).read_text()
 
     assert workflow.count(" tools/audit_distribution.py") == 3
     assert workflow.count("extensions/kafka/tools/audit_distribution.py") == 3
@@ -264,6 +309,9 @@ def test_release_workflow_audits_distribution_contents():
 
 def test_release_workflow_locates_installed_sdk_from_distribution():
     workflow = (ROOT / ".github/workflows/release-wheels.yml").read_text()
+    workflow += (
+        ROOT / ".github/workflows/release-platform-wheel.yml"
+    ).read_text()
 
     assert 'metadata.distribution("hgraph")' in workflow
     assert 'distribution.locate_file("")' in workflow
@@ -284,7 +332,8 @@ def main():
     test_adaptor_extras_include_their_runtime_dependencies()
     test_full_suite_gate_installs_the_wheel_test_extra()
     test_release_workflow_targets_supported_platforms()
-    test_matrix_wheel_builds_use_stable_cacheable_paths()
+    test_platform_wheel_builds_use_stable_cacheable_paths()
+    test_platform_wheel_tests_start_after_only_their_matching_build()
     test_release_workflow_reuses_tested_commit_artifacts()
     test_release_workflow_audits_distribution_contents()
     test_release_workflow_locates_installed_sdk_from_distribution()
@@ -300,7 +349,8 @@ def main():
     print("PASS test_adaptor_extras_include_their_runtime_dependencies")
     print("PASS test_full_suite_gate_installs_the_wheel_test_extra")
     print("PASS test_release_workflow_targets_supported_platforms")
-    print("PASS test_matrix_wheel_builds_use_stable_cacheable_paths")
+    print("PASS test_platform_wheel_builds_use_stable_cacheable_paths")
+    print("PASS test_platform_wheel_tests_start_after_only_their_matching_build")
     print("PASS test_release_workflow_reuses_tested_commit_artifacts")
     print("PASS test_release_workflow_audits_distribution_contents")
     print("PASS test_release_workflow_locates_installed_sdk_from_distribution")

--- a/python/tests/test_release_metadata.py
+++ b/python/tests/test_release_metadata.py
@@ -5,62 +5,101 @@ import pytest
 from tools.validate_release import parse_release_tag, validate_release
 
 
-def _cmake_project(tmp_path: Path, version: str = "0.8.0") -> Path:
-    path = tmp_path / "CMakeLists.txt"
-    path.write_text(f"project(\n    hgraph\n    VERSION {version}\n)\n")
-    return path
+def _cmake_projects(
+    tmp_path: Path,
+    *,
+    core_version: str = "0.8.0",
+    kafka_version: str = "0.8.0",
+) -> tuple[Path, Path]:
+    core_path = tmp_path / "CMakeLists.txt"
+    core_path.write_text(
+        f"project(\n    hgraph\n    VERSION {core_version}\n)\n"
+    )
+    kafka_path = tmp_path / "kafka-CMakeLists.txt"
+    kafka_path.write_text(
+        f"project(hgraph_kafka VERSION {kafka_version} LANGUAGES CXX)\n"
+    )
+    return core_path, kafka_path
 
 
-def test_core_release_requires_matching_native_version(tmp_path: Path):
+def test_shared_release_requires_matching_core_native_version(tmp_path: Path):
+    core_path, kafka_path = _cmake_projects(tmp_path)
     with pytest.raises(ValueError, match="bump project\\(VERSION\\)"):
         validate_release(
-            "v_0.8.1",
-            cmake_path=_cmake_project(tmp_path),
+            "0.8.1",
+            cmake_path=core_path,
+            kafka_cmake_path=kafka_path,
             release_exists=lambda _package, _version: False,
         )
 
 
-def test_core_prerelease_uses_matching_numeric_native_core(tmp_path: Path):
+def test_shared_release_requires_matching_kafka_native_version(tmp_path: Path):
+    core_path, kafka_path = _cmake_projects(tmp_path, kafka_version="0.8.1")
+    with pytest.raises(ValueError, match="hgraph-kafka.*bump project\\(VERSION\\)"):
+        validate_release(
+            "0.8.0",
+            cmake_path=core_path,
+            kafka_cmake_path=kafka_path,
+            release_exists=lambda _package, _version: False,
+        )
+
+
+def test_shared_prerelease_uses_matching_numeric_native_core(tmp_path: Path):
+    core_path, kafka_path = _cmake_projects(tmp_path)
     release = validate_release(
-        "v_0.8.0rc1",
-        cmake_path=_cmake_project(tmp_path),
+        "0.8.0rc1",
+        cmake_path=core_path,
+        kafka_cmake_path=kafka_path,
         release_exists=lambda _package, _version: False,
     )
 
-    assert release.package == "hgraph"
+    assert release.packages == ("hgraph", "hgraph-kafka")
     assert release.version == "0.8.0rc1"
     assert release.core == (0, 8, 0)
 
 
-def test_kafka_release_has_an_independent_version(tmp_path: Path):
-    release = validate_release(
-        "hgraph-kafka-v_1.2.3",
-        cmake_path=tmp_path / "missing-CMakeLists.txt",
-        release_exists=lambda _package, _version: False,
+def test_shared_release_checks_both_pypi_packages(tmp_path: Path):
+    core_path, kafka_path = _cmake_projects(tmp_path)
+    checked: list[tuple[str, str]] = []
+
+    validate_release(
+        "0.8.0",
+        cmake_path=core_path,
+        kafka_cmake_path=kafka_path,
+        release_exists=lambda package, version: checked.append((package, version))
+        or False,
     )
 
-    assert release.package == "hgraph-kafka"
-    assert release.version == "1.2.3"
+    assert checked == [("hgraph", "0.8.0"), ("hgraph-kafka", "0.8.0")]
 
 
 def test_release_rejects_existing_pypi_version(tmp_path: Path):
-    with pytest.raises(ValueError, match="already exists on PyPI"):
+    core_path, kafka_path = _cmake_projects(tmp_path)
+    with pytest.raises(ValueError, match="hgraph-kafka 0.8.0 already exists on PyPI"):
         validate_release(
-            "v_0.8.0",
-            cmake_path=_cmake_project(tmp_path),
-            release_exists=lambda _package, _version: True,
+            "0.8.0",
+            cmake_path=core_path,
+            kafka_cmake_path=kafka_path,
+            release_exists=lambda package, _version: package == "hgraph-kafka",
         )
 
 
-@pytest.mark.parametrize("tag", ["v_0.7.9", "v0.8.0", "v_0.8", "not-a-tag"])
+@pytest.mark.parametrize(
+    "tag",
+    ["0.7.9", "v_0.8.0", "hgraph-kafka-v_0.8.0", "0.8", "not-a-tag"],
+)
 def test_invalid_or_pre_port_core_tags_are_rejected(tmp_path: Path, tag: str):
-    if tag == "v_0.7.9":
+    if tag == "0.7.9":
+        core_path, kafka_path = _cmake_projects(
+            tmp_path, core_version="0.7.9", kafka_version="0.7.9"
+        )
         with pytest.raises(ValueError, match="starts at 0.8.0"):
             validate_release(
                 tag,
-                cmake_path=_cmake_project(tmp_path, "0.7.9"),
+                cmake_path=core_path,
+                kafka_cmake_path=kafka_path,
                 release_exists=lambda _package, _version: False,
             )
     else:
-        with pytest.raises(ValueError, match="release tag must match"):
+        with pytest.raises(ValueError, match="release tag must be a bare version"):
             parse_release_tag(tag)

--- a/tools/validate_release.py
+++ b/tools/validate_release.py
@@ -11,41 +11,38 @@ from urllib.request import urlopen
 
 
 MINIMUM_CORE_VERSION = (0, 8, 0)
-_TAG_PATTERNS = (
-    (re.compile(r"v_(\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?)"), "hgraph"),
-    (
-        re.compile(r"hgraph-kafka-v_(\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?)"),
-        "hgraph-kafka",
-    ),
-)
+RELEASE_PACKAGES = ("hgraph", "hgraph-kafka")
+_TAG_PATTERN = re.compile(r"(\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?)")
 _VERSION_CORE = re.compile(r"(\d+)\.(\d+)\.(\d+)")
 _CMAKE_PROJECT_VERSION = re.compile(
-    r"project\(\s*hgraph\s+VERSION\s+(\d+)\.(\d+)\.(\d+)\b"
+    r"project\(\s*[A-Za-z_][A-Za-z0-9_]*\s+VERSION\s+"
+    r"(\d+)\.(\d+)\.(\d+)\b",
+    re.IGNORECASE,
 )
 
 
 @dataclass(frozen=True)
 class Release:
-    package: str
+    packages: tuple[str, ...]
     version: str
     core: tuple[int, int, int]
 
 
 def parse_release_tag(tag: str) -> Release:
-    for pattern, package in _TAG_PATTERNS:
-        if match := pattern.fullmatch(tag):
-            version = match.group(1)
-            core_match = _VERSION_CORE.match(version)
-            if core_match is None:  # guarded by the tag pattern
-                raise ValueError(f"release tag has no numeric version core: {tag!r}")
-            return Release(
-                package=package,
-                version=version,
-                core=tuple(map(int, core_match.groups())),
-            )
-    raise ValueError(
-        "release tag must match v_x.x.x or hgraph-kafka-v_x.x.x "
-        f"(including PEP 440 prereleases), got {tag!r}"
+    match = _TAG_PATTERN.fullmatch(tag)
+    if match is None:
+        raise ValueError(
+            "release tag must be a bare version matching x.x.x "
+            f"(including PEP 440 prereleases), got {tag!r}"
+        )
+    version = match.group(1)
+    core_match = _VERSION_CORE.match(version)
+    if core_match is None:  # guarded by the tag pattern
+        raise ValueError(f"release tag has no numeric version core: {tag!r}")
+    return Release(
+        packages=RELEASE_PACKAGES,
+        version=version,
+        core=tuple(map(int, core_match.groups())),
     )
 
 
@@ -72,24 +69,29 @@ def validate_release(
     tag: str,
     *,
     cmake_path: Path = Path("CMakeLists.txt"),
+    kafka_cmake_path: Path = Path("extensions/kafka/CMakeLists.txt"),
     release_exists: Callable[[str, str], bool] = pypi_release_exists,
 ) -> Release:
     release = parse_release_tag(tag)
-    if release.package == "hgraph":
-        if release.core < MINIMUM_CORE_VERSION:
-            raise ValueError(
-                "the C++-first hgraph release line starts at 0.8.0, "
-                f"got {release.version}"
-            )
-        native_version = native_project_version(cmake_path)
+    if release.core < MINIMUM_CORE_VERSION:
+        raise ValueError(
+            "the C++-first hgraph release line starts at 0.8.0, "
+            f"got {release.version}"
+        )
+    for package, path in (
+        ("hgraph", cmake_path),
+        ("hgraph-kafka", kafka_cmake_path),
+    ):
+        native_version = native_project_version(path)
         if release.core != native_version:
             raise ValueError(
-                f"hgraph tag {release.version} has native version core "
-                f"{release.core}, but {cmake_path} declares {native_version}; "
+                f"{package} tag {release.version} has native version core "
+                f"{release.core}, but {path} declares {native_version}; "
                 "bump project(VERSION) before building reusable release artifacts"
             )
-    if release_exists(release.package, release.version):
-        raise ValueError(f"{release.package} {release.version} already exists on PyPI")
+    for package in release.packages:
+        if release_exists(package, release.version):
+            raise ValueError(f"{package} {release.version} already exists on PyPI")
     return release
 
 
@@ -103,7 +105,8 @@ def main() -> None:
         release = validate_release(args.tag)
     except ValueError as error:
         raise SystemExit(str(error)) from error
-    print(f"Validated new {release.package} release {release.version}")
+    packages = " and ".join(release.packages)
+    print(f"Validated new {packages} release {release.version}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- split macOS and Windows wheel builds into a shared reusable workflow while keeping the Linux container build separate
- start each platform's Python 3.12/3.13/3.14 test matrix as soon as its matching wheel artifacts are available
- require all three platform test matrices before either distribution can publish
- release `hgraph` and `hgraph-kafka` together from one bare `x.y.z` tag, with matching native versions and PyPI availability validated before publication

## Local validation

- fresh native configure/build: passed
- native C++ suite: 1,488 passed
- stable-ABI wheel built with Python 3.12 and installed into a fresh Python 3.14 environment
- complete non-WIP Python compatibility suite: 2,037 passed, 9 skipped
- Kafka stable-ABI wheel built against the installed core SDK
- Kafka Python suite: 50 passed
- focused packaging/release tests: 35 passed
- strict Sphinx build: passed
- workflow YAML parsing and actionlint v1.7.10: passed
