### PR TITLE
Support naked STATE mapping compatibility

### DIFF
--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -241,7 +241,8 @@ production triage has actually produced (the 2026-07 batch, issues #74-#92):
   relation in ``known_divergences.json``;
 - ``lifecycle_state`` generates start/stop lifecycle functions across the
   accepted signature spellings — strict, bare-injectable, and unannotated
-  name-match (the #79 class);
+  name-match (the #79 class) — and alternates attribute and dictionary-view
+  access over naked ``STATE``;
 - ``data_frame_recording`` records through the DATA_FRAME model and emits
   the frame a ``DataFrameStorage`` hands back to user code — column names,
   **timezone presentation**, and row values — so a tz-aware engine column or

--- a/python/hgraph/_wiring/_markers.py
+++ b/python/hgraph/_wiring/_markers.py
@@ -10,11 +10,68 @@ from .._types import _GenericTsExpr, _TsExpr
 from ._state import GlobalState
 
 class STATE:
-    """Injectable per-node state. ``STATE`` supplies a mutable namespace;
-    ``STATE[T]`` constructs and preserves one ``T`` instance."""
+    """Injectable per-node state.
+
+    Naked ``STATE`` stores values in an attribute dictionary, with attribute
+    access mirrored through ``state[name]`` and ``keys`` / ``items`` /
+    ``values`` views. ``STATE[T]`` constructs and preserves one ``T``
+    instance instead.
+    """
+
+    def __init__(self, **kwargs):
+        self.__dict__["__schema__"] = None
+        self.__dict__["_updated"] = False
+        self.__dict__["_value"] = dict(kwargs)
 
     def __class_getitem__(cls, item):
         return _StateExpr(item)
+
+    @property
+    def as_schema(self):
+        return self.__dict__["_value"]
+
+    def __getattr__(self, name):
+        values = self.__dict__.get("_value")
+        if values is not None and name in values:
+            return values[name]
+        raise AttributeError(name)
+
+    def __getitem__(self, name):
+        return getattr(self, name)
+
+    def keys(self):
+        return self.__dict__["_value"].keys()
+
+    def items(self):
+        return self.__dict__["_value"].items()
+
+    def values(self):
+        return self.__dict__["_value"].values()
+
+    def __setattr__(self, name, value):
+        if name in ("__schema__", "_updated", "_value"):
+            self.__dict__[name] = value
+            return
+        self.__dict__["_updated"] = True
+        self.__dict__["_value"][name] = value
+
+    def __delattr__(self, name):
+        if name in ("__schema__", "_updated", "_value"):
+            return
+        self.__dict__["_updated"] = True
+        del self.__dict__["_value"][name]
+
+    def reset_updated(self):
+        self.__dict__["_updated"] = False
+
+    def is_updated(self):
+        return self.__dict__["_updated"]
+
+    def __repr__(self):
+        values = ", ".join(
+            f"{name}={value!r}" for name, value in self.__dict__["_value"].items()
+        )
+        return f"SCALAR({values})"
 
 
 class _StateExpr:

--- a/python/py_runtime.h
+++ b/python/py_runtime.h
@@ -94,7 +94,7 @@ namespace hgraph::python_bridge
 
     struct PyStateRef
     {
-        PyObject         *ns{nullptr};   ///< a SimpleNamespace, lazily created (per-node python STATE)
+        PyObject         *ns{nullptr};   ///< the lazily created per-node Python state value
         PyCallLeaseState *call_lease{nullptr};
         friend bool operator==(const PyStateRef &, const PyStateRef &) noexcept = default;
     };
@@ -104,30 +104,8 @@ namespace hgraph::python_bridge
         NodeScheduler scheduler;
     };
 
-    [[nodiscard]] inline nb::object py_state_namespace(State<PyStateRef> &state)
-    {
-        PyStateRef ref = state.get();
-        if (ref.ns == nullptr)
-        {
-            nb::object ns = nb::module_::import_("types").attr("SimpleNamespace")();
-            ref.ns        = ns.release().ptr();
-            state.set(ref);
-        }
-        return nb::borrow(nb::handle(ref.ns));
-    }
-
-    [[nodiscard]] inline nb::object py_state_namespace(PyStateRef &state)
-    {
-        if (state.ns == nullptr)
-        {
-            nb::object ns = nb::module_::import_("types").attr("SimpleNamespace")();
-            state.ns = ns.release().ptr();
-        }
-        return nb::borrow(nb::handle(state.ns));
-    }
-
-    [[nodiscard]] inline nb::object py_typed_state(PyStateRef &state,
-                                                    nb::handle factory)
+    [[nodiscard]] inline nb::object py_state_value(PyStateRef &state,
+                                                   nb::handle factory)
     {
         if (state.ns == nullptr)
         {
@@ -137,13 +115,45 @@ namespace hgraph::python_bridge
         return nb::borrow(nb::handle(state.ns));
     }
 
+    [[nodiscard]] inline nb::object py_state_value(State<PyStateRef> &state,
+                                                   nb::handle factory)
+    {
+        PyStateRef ref = state.get();
+        const bool created = ref.ns == nullptr;
+        nb::object value = py_state_value(ref, factory);
+        if (created) { state.set(ref); }
+        return value;
+    }
+
+    [[nodiscard]] inline nb::object py_state_namespace(PyStateRef &state)
+    {
+        if (state.ns == nullptr)
+        {
+            nb::object factory = nb::module_::import_("hgraph._wiring._markers").attr("STATE");
+            return py_state_value(state, factory);
+        }
+        return nb::borrow(nb::handle(state.ns));
+    }
+
+    [[nodiscard]] inline nb::object py_state_namespace(State<PyStateRef> &state)
+    {
+        PyStateRef ref = state.get();
+        const bool created = ref.ns == nullptr;
+        nb::object value = py_state_namespace(ref);
+        if (created) { state.set(ref); }
+        return value;
+    }
+
+    [[nodiscard]] inline nb::object py_typed_state(PyStateRef &state,
+                                                    nb::handle factory)
+    {
+        return py_state_value(state, factory);
+    }
+
     [[nodiscard]] inline nb::object py_typed_state(State<PyStateRef> &state,
                                                     nb::handle factory)
     {
-        PyStateRef ref = state.get();
-        nb::object value = py_typed_state(ref, factory);
-        state.set(ref);
-        return value;
+        return py_state_value(state, factory);
     }
 
     /** Call-scope lifetime guard: python must not use a view after its eval. */

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -1900,6 +1900,17 @@ def test_new_template_validators_reject_malformed_recipes():
     )
     rejects(
         {
+            "template": "lifecycle_state",
+            "inputs": {"value": [1]},
+            "parameters": {
+                "start_spelling": "default",
+                "state_access": "sequence",
+            },
+        },
+        "state_access",
+    )
+    rejects(
+        {
             "template": "data_frame_recording",
             "inputs": {"ts": [1]},
             "parameters": {"as_of_offset": 0},

--- a/python/tests/test_python_authoring.py
+++ b/python/tests/test_python_authoring.py
@@ -131,11 +131,12 @@ def test_python_generator_stop_hook_receives_state_and_scalars():
     @hg.generator
     def source(label: str, state: hg.STATE = None) -> TS[int]:
         state.value = 7
-        yield hg.MIN_ST, state.value
+        check(isinstance(state, hg.STATE), "generator receives the public STATE wrapper")
+        yield hg.MIN_ST, state["value"]
 
     @source.stop
     def stop(label: str, state: hg.STATE = None):
-        stopped.append((label, state.value))
+        stopped.append((label, state["value"]))
 
     @graph
     def app() -> TS[int]:
@@ -143,6 +144,50 @@ def test_python_generator_stop_hook_receives_state_and_scalars():
 
     check(eval_node(app) == [7], "generator output")
     check(stopped == [("generator", 7)], f"generator stop hook: {stopped}")
+
+
+def test_naked_state_matches_attribute_dictionary_compatibility_surface():
+    lifecycle = []
+
+    @hg.compute_node
+    def accumulate(value: TS[int], state: hg.STATE = None) -> TS[int]:
+        check(not state.is_updated(), "dirty state is reset between observations")
+        state.total = state["total"] + value.value
+        check(state.is_updated(), "attribute assignment marks state updated")
+        check(state.total == state["total"], "attribute and item reads agree")
+        check(list(state.keys()) == ["total"], "state keys view")
+        check(list(state.items()) == [("total", state.total)], "state items view")
+        check(list(state.values()) == [state.total], "state values view")
+        result = state["total"]
+        state.reset_updated()
+        return result
+
+    @accumulate.start
+    def start(state: hg.STATE = None):
+        check(isinstance(state, hg.STATE), "naked injection returns STATE")
+        check(repr(state) == "SCALAR()", "empty state repr")
+        check(state.as_schema == {}, "empty backing dictionary")
+        check(not state.is_updated(), "new state is clean")
+        expect_raises(AttributeError, lambda: state.missing)
+        expect_raises(AttributeError, lambda: state["missing"])
+        expect_raises(AttributeError, lambda: state.__setitem__("total", 10))
+        state.total = 10
+        check(state["total"] == 10, "attribute writes feed item reads")
+        check(repr(state) == "SCALAR(total=10)", "populated state repr")
+        check(state.as_schema == {"total": 10}, "backing dictionary exposes values")
+        check(state.is_updated(), "start mutation marks state updated")
+        state.reset_updated()
+        lifecycle.append(("start", state["total"]))
+
+    @accumulate.stop
+    def stop(state: hg.STATE = None):
+        lifecycle.append(("stop", state["total"]))
+        del state.total
+        check(state.is_updated(), "attribute deletion marks state updated")
+        check(list(state.items()) == [], "attribute deletion removes the item")
+
+    check(eval_node(accumulate, [1, 2, 3]) == [11, 13, 16], "naked state mapping")
+    check(lifecycle == [("start", 10), ("stop", 16)], f"state lifecycle: {lifecycle}")
 
 
 def test_python_compute_consumes_and_produces_dynamic_tsl():

--- a/tests/cpp/test_static_node.cpp
+++ b/tests/cpp/test_static_node.cpp
@@ -142,6 +142,20 @@ namespace
         }
     };
 
+    struct RunningTotal
+    {
+        static constexpr auto name = "running_total";
+
+        static void start(State<Int> state) { state.set(Int{0}); }
+
+        static void eval(In<"value", TS<Int>> value, State<Int> state, Out<TS<Int>> out)
+        {
+            const Int total = state.get() + value.value();
+            state.set(total);
+            out.set(total);
+        }
+    };
+
     using LastSeenState = TSB<"LastSeenState", Field<"last", TS<Int>>>;
 
     using ClockSnapshot = TSB<"ClockSnapshot",
@@ -576,6 +590,13 @@ TEST_CASE("static node: State<Int> is constructed and mutated across evaluations
     node.view().evaluate(t2);
     CHECK(node.view().state().checked_as<Int>() == 2);
     CHECK(node.view().output(t2).value().checked_as<Int>() == 2);
+}
+
+TEST_CASE("static node: State<Int> persists through public eval_node wiring")
+{
+    using namespace hgraph;
+
+    CHECK_OUTPUT(testing::eval_node<RunningTotal>({1, 2, 3}), {1, 3, 6});
 }
 
 TEST_CASE("static node: EvaluationClockView is injected as a read-only clock view")

--- a/tools/parity/catalog.py
+++ b/tools/parity/catalog.py
@@ -642,6 +642,8 @@ def _validate_lifecycle_state(recipe):
     seed = parameters.get("seed", 0)
     if not isinstance(seed, int) or isinstance(seed, bool) or not -100 <= seed <= 100:
         raise RecipeError("lifecycle_state seed must be a bounded integer")
+    if parameters.get("state_access", "attribute") not in ("attribute", "mapping"):
+        raise RecipeError("lifecycle_state state_access must be 'attribute' or 'mapping'")
     if set(recipe.inputs) != {"value"}:
         raise RecipeError("lifecycle_state requires the value input")
 
@@ -651,23 +653,54 @@ def _lifecycle_state(hg, recipe):
 
     parameters = recipe.parameters
     seed = parameters.get("seed", 0)
+    state_access = parameters.get("state_access", "attribute")
     start_signature = _LIFECYCLE_SPELLINGS[parameters["start_spelling"]]
     stop_spelling = parameters.get("stop_spelling")
+    if state_access == "mapping":
+        eval_body = (
+            "    if _state.is_updated():\n"
+            "        raise AssertionError('state unexpectedly dirty before evaluation')\n"
+            "    _state.total = _state['total'] + value.value\n"
+            "    expected = [('total', _state['total'])]\n"
+            "    if list(_state.keys()) != ['total'] or list(_state.items()) != expected:\n"
+            "        raise AssertionError('state mapping views disagree')\n"
+            "    if list(_state.values()) != [_state.total]:\n"
+            "        raise AssertionError('state values view disagrees')\n"
+            "    result = _state['total']\n"
+            "    _state.reset_updated()\n"
+            "    return result\n"
+        )
+        start_body = (
+            f"    _state.total = {seed}\n"
+            "    if not isinstance(_state, hg.STATE) or _state['total'] != _state.total:\n"
+            "        raise AssertionError('naked STATE mapping surface unavailable')\n"
+            "    _state.reset_updated()\n"
+        )
+        stop_body = (
+            "    if _state['total'] != _state.total:\n"
+            "        raise AssertionError('naked STATE did not persist through stop')\n"
+        )
+    else:
+        eval_body = (
+            "    _state.total = _state.total + value.value\n"
+            "    return _state.total\n"
+        )
+        start_body = f"    _state.total = {seed}\n"
+        stop_body = "    pass\n"
     stop_block = ""
     if stop_spelling is not None:
         stop_block = (
             "@lifecycle_node.stop\n"
             f"def lifecycle_stop({_LIFECYCLE_SPELLINGS[stop_spelling]}):\n"
-            "    pass\n"
+            f"{stop_body}"
         )
     source = (
         "@hg.compute_node\n"
         "def lifecycle_node(value: hg.TS[int], _state: hg.STATE = None) -> hg.TS[int]:\n"
-        "    _state.total = _state.total + value.value\n"
-        "    return _state.total\n"
+        f"{eval_body}"
         "@lifecycle_node.start\n"
         f"def lifecycle_start({start_signature}):\n"
-        f"    _state.total = {seed}\n"
+        f"{start_body}"
         f"{stop_block}"
         "@hg.graph\n"
         "def parity_graph(value: hg.TS[int]) -> hg.TS[int]:\n"

--- a/tools/parity/corpus/coverage-naked-state-mapping.json
+++ b/tools/parity/corpus/coverage-naked-state-mapping.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "id": "coverage-naked-state-mapping",
+  "description": "Naked STATE preserves the Python 0.5 attribute dictionary surface through start, evaluation, and stop.",
+  "template": "lifecycle_state",
+  "inputs": {
+    "value": [1, null, 2, 3]
+  },
+  "parameters": {
+    "start_spelling": "default",
+    "stop_spelling": "default",
+    "seed": 10,
+    "state_access": "mapping"
+  },
+  "features": [
+    "shape:TS",
+    "type:int",
+    "boundary:python-owned",
+    "domain:lifecycle-signature",
+    "lifecycle:start-default",
+    "lifecycle:stop-default",
+    "state-access:mapping"
+  ]
+}

--- a/tools/parity/generate.py
+++ b/tools/parity/generate.py
@@ -724,6 +724,7 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
             "start_spelling": draw(st.sampled_from(spellings)),
             "stop_spelling": draw(st.sampled_from((None,) + spellings)),
             "seed": draw(st.integers(min_value=-50, max_value=50)),
+            "state_access": draw(st.sampled_from(("attribute", "mapping"))),
         }
         return {
             "template": "lifecycle_state",
@@ -733,6 +734,7 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
                 *CATALOG["lifecycle_state"].features,
                 f"lifecycle:start-{parameters['start_spelling']}",
                 f"lifecycle:stop-{parameters['stop_spelling'] or 'absent'}",
+                f"state-access:{parameters['state_access']}",
             ],
         }
 


### PR DESCRIPTION
## Summary

- expose naked Python `STATE` as the public compatibility wrapper instead of a `SimpleNamespace`
- preserve attribute assignment while adding the released hgraph item reads, dictionary views, dirty tracking, deletion, and representation
- centralize lazy Python state construction in the native bridge while leaving typed `STATE[T]` on the same shared path
- add public C++ `eval_node`, Python lifecycle, and differential parity coverage

## Validation

- `cmake --preset cpp --fresh`
- `cmake --build --preset cpp --target clean`
- `cmake --build --preset cpp --parallel`
- `ctest --preset cpp --parallel 2` — 1,489 passed
- stable-ABI wheel built with Python 3.12 and installed into a fresh Python 3.14 environment
- `python -m pytest python/tests -q -m "not wip"` — 2,038 passed, 9 skipped
- focused Python authoring and parity harness tests — 44 passed
- parity corpus validation — 61 recipes
- PR differential campaign — 109 attempted, 94 matched, 15 known mismatches, 0 new mismatches, 0 quarantined

## Scope

The coordinated PyArrow ABI 25 dependency update is intentionally excluded and can follow independently.
