### PR TITLE
Allow tag-driven patch releases

### DIFF
--- a/docs/source/developer_guide/build_system.rst
+++ b/docs/source/developer_guide/build_system.rst
@@ -65,11 +65,13 @@ CPython 3.12, 3.13, and 3.14. A bare tag matching ``x.x.x`` publishes the tested
 core and Kafka wheels and source distributions through PyPI trusted publishing.
 The tag is the shared release version authority: the publish jobs restamp the
 metadata of artifacts already tested for that exact commit, rather than
-rebuilding them. The tag's numeric version core must match both CMake
-``project(VERSION)`` declarations. This guarantees that reused wheels contain
-matching generated ``version.h``, CMake package versions, and native API version
-values. A prerelease suffix belongs to the Python distribution metadata; the
-native SDKs continue to expose their numeric API version core.
+rebuilding them. The CMake ``project(VERSION)`` declarations identify the native
+API line and are intentionally independent of the shared Python distribution
+version. Reused wheels therefore retain the native API version they were built
+and tested with; a patch release tag does not require a source commit that only
+bumps CMake metadata. The release's numeric core may not predate either native
+API version. A prerelease suffix likewise belongs only to the Python distribution
+metadata.
 ``pyproject.toml`` therefore uses ``0.0.0`` as an explicit untagged-artifact
 sentinel; it is never the version published to PyPI.  CMake's numeric
 ``project(VERSION)`` and ``docs/source/conf.py`` track the current C++ API line
@@ -167,8 +169,8 @@ Each extension owns its nested ``pyproject.toml``, CMake package configuration,
 and tests. Cross-cutting changes are tested against core at the same commit,
 while the resulting wheels remain separate distribution artifacts. During the
 current release line, core and Kafka are co-versioned and co-released: a bare
-``<version>`` tag such as ``0.8.1`` validates both native project versions,
-restamps both distributions, and publishes both packages. Independent
+``<version>`` tag such as ``0.8.1`` validates that the version is new for both
+packages, restamps both distributions, and publishes both packages. Independent
 extension tags are intentionally not part of this release workflow.
 
 The Kafka PEP 517 build requirements include ``hgraph>=0.8.0`` because its standalone

--- a/docs/source/developer_guide/build_system.rst
+++ b/docs/source/developer_guide/build_system.rst
@@ -169,9 +169,9 @@ Each extension owns its nested ``pyproject.toml``, CMake package configuration,
 and tests. Cross-cutting changes are tested against core at the same commit,
 while the resulting wheels remain separate distribution artifacts. During the
 current release line, core and Kafka are co-versioned and co-released: a bare
-``<version>`` tag such as ``0.8.1`` validates that the version is new for both
-packages, restamps both distributions, and publishes both packages. Independent
-extension tags are intentionally not part of this release workflow.
+``<version>`` tag validates that the version is new for both packages, restamps
+both distributions, and publishes both packages. Independent extension tags are
+intentionally not part of this release workflow.
 
 The Kafka PEP 517 build requirements include ``hgraph>=0.8.0`` because its standalone
 CMake configure consumes the installed core SDK.  In-repository CI installs

--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -693,9 +693,11 @@ The following are intentional unless separately re-opened:
   feature flag ``polars_frames`` / ``HGRAPH_POLARS_FRAMES``) flips the
   OUTBOUND boundary only: ``Frame``/``Series`` values surface as
   ``polars.DataFrame``/``polars.Series`` (``pl.from_arrow``, zero-copy) to
-  reduce migration cost for polars-era user code.  Default off; polars stays
-  a lazy optional dependency (a clear error if the switch is on without it);
-  the runtime substrate and record/replay artifacts remain Arrow either way.
+  reduce migration cost for polars-era user code.  The feature mechanism
+  defaults off, while this repository's ``hgraph_features.yaml`` enables it
+  for source-tree use during the migration period. Polars stays a lazy optional
+  dependency (a clear error if the switch is on without it); the runtime
+  substrate and record/replay artifacts remain Arrow either way.
   The same boundary presents **naive UTC timestamps** (upstream parity — the
   Python convention is tz-free datetimes throughout): version-2 Instant
   columns (``timestamp[us, UTC]``) strip their timezone on the way out and

--- a/hgraph_features.yaml
+++ b/hgraph_features.yaml
@@ -1,0 +1,2 @@
+features:
+  polars_frames: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "frozendict>=2.4",
     "numpy>=2.0",
     "pyarrow>=25,<26",
+    "pyyaml>=6",
 ]
 
 [project.optional-dependencies]

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Canonical suite configuration.
+
+The repository enables the Polars compatibility boundary for normal source-tree
+use. Most tests assert the canonical Arrow representation directly, so collect
+them with that compatibility veneer disabled. Dedicated Polars tests enable it
+explicitly and separately verify the repository default in a clean subprocess.
+"""
+
+import os
+
+
+os.environ["HGRAPH_POLARS_FRAMES"] = "false"

--- a/python/tests/test_packaging.py
+++ b/python/tests/test_packaging.py
@@ -130,6 +130,17 @@ def test_wheel_targets_the_python_312_stable_abi():
     assert scikit_build["wheel"]["py-api"] == STABLE_ABI_TAG
 
 
+def test_repository_enables_polars_compatibility_without_a_cpp_switch():
+    feature_config = (ROOT / "hgraph_features.yaml").read_text().splitlines()
+    runtime_dependencies = load_project()["project"]["dependencies"]
+
+    assert feature_config == ["features:", "  polars_frames: true"]
+    assert "pyyaml" in {
+        canonicalize_name(Requirement(requirement).name)
+        for requirement in runtime_dependencies
+    }
+
+
 def test_wheel_uses_shared_runtime_for_downstream_native_extensions():
     cmake_defines = load_project()["tool"]["scikit-build"]["cmake"]["define"]
 
@@ -337,6 +348,7 @@ def main():
     test_pypi_classifiers_are_valid()
     test_release_metadata_uses_untagged_sentinel()
     test_wheel_targets_the_python_312_stable_abi()
+    test_repository_enables_polars_compatibility_without_a_cpp_switch()
     test_wheel_uses_shared_runtime_for_downstream_native_extensions()
     test_source_distribution_excludes_private_release_evidence()
     test_full_suite_dependencies_include_the_dataframe_runtime()
@@ -354,6 +366,7 @@ def main():
     print("PASS test_pypi_classifiers_are_valid")
     print("PASS test_release_metadata_uses_untagged_sentinel")
     print("PASS test_wheel_targets_the_python_312_stable_abi")
+    print("PASS test_repository_enables_polars_compatibility_without_a_cpp_switch")
     print("PASS test_wheel_uses_shared_runtime_for_downstream_native_extensions")
     print("PASS test_source_distribution_excludes_private_release_evidence")
     print("PASS test_full_suite_dependencies_include_the_dataframe_runtime")

--- a/python/tests/test_polars_frames.py
+++ b/python/tests/test_polars_frames.py
@@ -8,8 +8,11 @@ Inbound polars is accepted regardless of the switch (anything exposing
 runtime substrate; the switch is a Python-boundary veneer only.
 """
 
+import os
+import subprocess
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 
 import pyarrow as pa
 import pytest
@@ -29,25 +32,32 @@ class PriceRow(CompoundScalar):
 
 @pytest.fixture
 def polars_frames():
+    previous = _hgraph.polars_frames()
     _hgraph.set_polars_frames(True)
     try:
         yield
     finally:
-        _hgraph.set_polars_frames(False)
+        _hgraph.set_polars_frames(previous)
 
 
 def _price_table():
     return pa.table({"instrument": ["A", "B"], "value": [101.5, 7.25]})
 
 
-def test_switch_defaults_off_and_frames_stay_pyarrow():
-    assert _hgraph.polars_frames() is False
-    result = eval_node(
-        pass_through,
-        [_price_table()],
-        resolution_dict={"tsd": TS[Frame[PriceRow]]},
-    )[0]
-    assert isinstance(result, pa.Table)
+def test_repository_config_enables_polars_compatibility():
+    environment = os.environ.copy()
+    environment.pop("HGRAPH_POLARS_FRAMES", None)
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import _hgraph; import hgraph; assert _hgraph.polars_frames() is True",
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        env=environment,
+        check=True,
+        timeout=30,
+    )
 
 
 def test_frames_surface_as_polars_dataframes(polars_frames):

--- a/python/tests/test_release_metadata.py
+++ b/python/tests/test_release_metadata.py
@@ -22,24 +22,40 @@ def _cmake_projects(
     return core_path, kafka_path
 
 
+def _next_patch(version: str) -> str:
+    major, minor, patch = map(int, version.split("."))
+    return f"{major}.{minor}.{patch + 1}"
+
+
 def test_shared_release_can_advance_without_bumping_native_api_version(tmp_path: Path):
-    core_path, kafka_path = _cmake_projects(tmp_path)
+    native_version = "1.2.3"
+    release_version = _next_patch(native_version)
+    core_path, kafka_path = _cmake_projects(
+        tmp_path,
+        core_version=native_version,
+        kafka_version=native_version,
+    )
     release = validate_release(
-        "0.8.1",
+        release_version,
         cmake_path=core_path,
         kafka_cmake_path=kafka_path,
         release_exists=lambda _package, _version: False,
     )
 
-    assert release.version == "0.8.1"
+    assert release.version == release_version
 
 
 def test_shared_release_cannot_predate_native_api_version(tmp_path: Path):
-    core_path, kafka_path = _cmake_projects(tmp_path, kafka_version="0.8.2")
+    release_version = "1.2.3"
+    core_path, kafka_path = _cmake_projects(
+        tmp_path,
+        core_version=release_version,
+        kafka_version=_next_patch(release_version),
+    )
 
     with pytest.raises(ValueError, match="hgraph-kafka.*predates native API version"):
         validate_release(
-            "0.8.1",
+            release_version,
             cmake_path=core_path,
             kafka_cmake_path=kafka_path,
             release_exists=lambda _package, _version: False,

--- a/python/tests/test_release_metadata.py
+++ b/python/tests/test_release_metadata.py
@@ -22,9 +22,22 @@ def _cmake_projects(
     return core_path, kafka_path
 
 
-def test_shared_release_requires_matching_core_native_version(tmp_path: Path):
+def test_shared_release_can_advance_without_bumping_native_api_version(tmp_path: Path):
     core_path, kafka_path = _cmake_projects(tmp_path)
-    with pytest.raises(ValueError, match="bump project\\(VERSION\\)"):
+    release = validate_release(
+        "0.8.1",
+        cmake_path=core_path,
+        kafka_cmake_path=kafka_path,
+        release_exists=lambda _package, _version: False,
+    )
+
+    assert release.version == "0.8.1"
+
+
+def test_shared_release_cannot_predate_native_api_version(tmp_path: Path):
+    core_path, kafka_path = _cmake_projects(tmp_path, kafka_version="0.8.2")
+
+    with pytest.raises(ValueError, match="hgraph-kafka.*predates native API version"):
         validate_release(
             "0.8.1",
             cmake_path=core_path,
@@ -33,23 +46,9 @@ def test_shared_release_requires_matching_core_native_version(tmp_path: Path):
         )
 
 
-def test_shared_release_requires_matching_kafka_native_version(tmp_path: Path):
-    core_path, kafka_path = _cmake_projects(tmp_path, kafka_version="0.8.1")
-    with pytest.raises(ValueError, match="hgraph-kafka.*bump project\\(VERSION\\)"):
-        validate_release(
-            "0.8.0",
-            cmake_path=core_path,
-            kafka_cmake_path=kafka_path,
-            release_exists=lambda _package, _version: False,
-        )
-
-
-def test_shared_prerelease_uses_matching_numeric_native_core(tmp_path: Path):
-    core_path, kafka_path = _cmake_projects(tmp_path)
+def test_shared_prerelease_uses_numeric_release_core():
     release = validate_release(
         "0.8.0rc1",
-        cmake_path=core_path,
-        kafka_cmake_path=kafka_path,
         release_exists=lambda _package, _version: False,
     )
 
@@ -58,14 +57,11 @@ def test_shared_prerelease_uses_matching_numeric_native_core(tmp_path: Path):
     assert release.core == (0, 8, 0)
 
 
-def test_shared_release_checks_both_pypi_packages(tmp_path: Path):
-    core_path, kafka_path = _cmake_projects(tmp_path)
+def test_shared_release_checks_both_pypi_packages():
     checked: list[tuple[str, str]] = []
 
     validate_release(
         "0.8.0",
-        cmake_path=core_path,
-        kafka_cmake_path=kafka_path,
         release_exists=lambda package, version: checked.append((package, version))
         or False,
     )
@@ -73,13 +69,10 @@ def test_shared_release_checks_both_pypi_packages(tmp_path: Path):
     assert checked == [("hgraph", "0.8.0"), ("hgraph-kafka", "0.8.0")]
 
 
-def test_release_rejects_existing_pypi_version(tmp_path: Path):
-    core_path, kafka_path = _cmake_projects(tmp_path)
+def test_release_rejects_existing_pypi_version():
     with pytest.raises(ValueError, match="hgraph-kafka 0.8.0 already exists on PyPI"):
         validate_release(
             "0.8.0",
-            cmake_path=core_path,
-            kafka_cmake_path=kafka_path,
             release_exists=lambda package, _version: package == "hgraph-kafka",
         )
 
@@ -88,16 +81,11 @@ def test_release_rejects_existing_pypi_version(tmp_path: Path):
     "tag",
     ["0.7.9", "v_0.8.0", "hgraph-kafka-v_0.8.0", "0.8", "not-a-tag"],
 )
-def test_invalid_or_pre_port_core_tags_are_rejected(tmp_path: Path, tag: str):
+def test_invalid_or_pre_port_core_tags_are_rejected(tag: str):
     if tag == "0.7.9":
-        core_path, kafka_path = _cmake_projects(
-            tmp_path, core_version="0.7.9", kafka_version="0.7.9"
-        )
         with pytest.raises(ValueError, match="starts at 0.8.0"):
             validate_release(
                 tag,
-                cmake_path=core_path,
-                kafka_cmake_path=kafka_path,
                 release_exists=lambda _package, _version: False,
             )
     else:

--- a/tools/validate_release.py
+++ b/tools/validate_release.py
@@ -1,4 +1,4 @@
-"""Validate release tags against package and native SDK version invariants."""
+"""Validate shared release tags against package and native API invariants."""
 
 from __future__ import annotations
 
@@ -46,13 +46,6 @@ def parse_release_tag(tag: str) -> Release:
     )
 
 
-def native_project_version(cmake_path: Path) -> tuple[int, int, int]:
-    match = _CMAKE_PROJECT_VERSION.search(cmake_path.read_text())
-    if match is None:
-        raise ValueError(f"could not read hgraph project version from {cmake_path}")
-    return tuple(map(int, match.groups()))
-
-
 def pypi_release_exists(package: str, version: str) -> bool:
     try:
         with urlopen(
@@ -63,6 +56,13 @@ def pypi_release_exists(package: str, version: str) -> bool:
         if error.code == 404:
             return False
         raise
+
+
+def native_project_version(cmake_path: Path) -> tuple[int, int, int]:
+    match = _CMAKE_PROJECT_VERSION.search(cmake_path.read_text())
+    if match is None:
+        raise ValueError(f"could not read hgraph project version from {cmake_path}")
+    return tuple(map(int, match.groups()))
 
 
 def validate_release(
@@ -83,11 +83,10 @@ def validate_release(
         ("hgraph-kafka", kafka_cmake_path),
     ):
         native_version = native_project_version(path)
-        if release.core != native_version:
+        if release.core < native_version:
             raise ValueError(
-                f"{package} tag {release.version} has native version core "
-                f"{release.core}, but {path} declares {native_version}; "
-                "bump project(VERSION) before building reusable release artifacts"
+                f"{package} tag {release.version} predates native API version "
+                f"{native_version} declared by {path}"
             )
     for package in release.packages:
         if release_exists(package, release.version):

--- a/uv.lock
+++ b/uv.lock
@@ -442,6 +442,7 @@ dependencies = [
     { name = "frozendict" },
     { name = "numpy" },
     { name = "pyarrow" },
+    { name = "pyyaml" },
 ]
 
 [package.optional-dependencies]
@@ -549,6 +550,7 @@ requires-dist = [
     { name = "pyarrow", specifier = ">=25,<26" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
+    { name = "pyyaml", specifier = ">=6" },
     { name = "scikit-build-core", marker = "extra == 'dev'", specifier = ">=0.12" },
     { name = "sphinx", marker = "extra == 'dev'", specifier = ">=7.4" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7.4" },


### PR DESCRIPTION
## What changed

- Treat the CMake project versions as native API floors instead of requiring an exact match with every shared package release tag.
- Keep rejecting release tags that predate either the core or Kafka native API version.
- Enable the `polars_frames` compatibility boundary in `hgraph_features.yaml` and remove the obsolete `use_cpp` feature-switch model.
- Add PyYAML as the runtime dependency required for YAML feature configuration to work in clean wheel installations.
- Run canonical Arrow representation tests with the Polars compatibility veneer disabled, while dedicated tests verify the repository configuration enables Polars behavior.
- Update the release and compatibility documentation.

## Why

The release validator conflated the Python distribution version with the native API line. As a result, tagging `0.8.1` failed while CMake correctly remained on native API version `0.8.0`, forcing a metadata-only source bump before each reusable release.

A package release may advance beyond the native API version without changing that API. The corrected comparison preserves the useful guard—package versions cannot predate the native API—without requiring exact equality.

## Impact

A bare `0.8.1` tag now validates and can publish reusable artifacts built with native API version `0.8.0`. Source-tree usage defaults to the Polars compatibility surface during migration, while Arrow remains the canonical runtime representation.

The existing `0.8.1` tag predates this change and will need to be recreated on the merged commit, or replaced with a new release tag.

## Validation

- `python tools/validate_release.py 0.8.1`
- Release metadata tests: 10 passed
- Standalone packaging contract checks: passed
- Native C++ suite: 1,489 passed
- Installed stable-ABI wheel on Python 3.14: 2,038 passed, 9 skipped
- Clean-wheel import verified PyYAML installation and `polars_frames` activation
- Strict Sphinx build with warnings as errors: passed
- `git diff --check`
