### PR TITLE
Install Polars for the enabled compatibility surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "frozendict>=2.4",
     "numpy>=2.0",
     "pyarrow>=25,<26",
+    "polars>=1.32",
     "pyyaml>=6",
 ]
 

--- a/python/tests/test_packaging.py
+++ b/python/tests/test_packaging.py
@@ -133,12 +133,14 @@ def test_wheel_targets_the_python_312_stable_abi():
 def test_repository_enables_polars_compatibility_without_a_cpp_switch():
     feature_config = (ROOT / "hgraph_features.yaml").read_text().splitlines()
     runtime_dependencies = load_project()["project"]["dependencies"]
-
-    assert feature_config == ["features:", "  polars_frames: true"]
-    assert "pyyaml" in {
+    runtime_dependency_names = {
         canonicalize_name(Requirement(requirement).name)
         for requirement in runtime_dependencies
     }
+
+    assert feature_config == ["features:", "  polars_frames: true"]
+    assert "polars>=1.32" in runtime_dependencies
+    assert {"polars", "pyyaml"} <= runtime_dependency_names
 
 
 def test_wheel_uses_shared_runtime_for_downstream_native_extensions():

--- a/uv.lock
+++ b/uv.lock
@@ -441,6 +441,7 @@ source = { editable = "." }
 dependencies = [
     { name = "frozendict" },
     { name = "numpy" },
+    { name = "polars" },
     { name = "pyarrow" },
     { name = "pyyaml" },
 ]
@@ -541,6 +542,7 @@ requires-dist = [
     { name = "pandas", marker = "extra == 'test'", specifier = ">=2.0" },
     { name = "perspective-python", marker = "extra == 'perspective'", specifier = ">=3.8" },
     { name = "perspective-python", marker = "extra == 'test'", specifier = ">=3.8" },
+    { name = "polars", specifier = ">=1.32" },
     { name = "polars", marker = "extra == 'dataframe'", specifier = ">=1.32" },
     { name = "polars", marker = "extra == 'delta'", specifier = ">=1.32" },
     { name = "polars", marker = "extra == 'sql'", specifier = ">=1.32" },


### PR DESCRIPTION
## What changed

- Declare `polars>=1.32` as a core runtime dependency.
- Update the lockfile so clean wheel installations receive Polars.
- Extend the packaging contract test to require both the enabled `polars_frames` configuration and its runtime dependency.

## Why

PR #399 enabled the Polars compatibility surface by default, but Polars remained an optional dependency. The release workflow's clean parity environment correctly installed only the wheel's declared dependencies, so `DataFrameStorage.read_frame()` failed with `ModuleNotFoundError: No module named 'polars'`.

An enabled-by-default user-facing surface must declare the package it imports. This fixes the packaging contract rather than suppressing parity or disabling the requested compatibility mode.

Failed job: https://github.com/hhenson/hgraph/actions/runs/31317463559/job/93255547017

## Impact

A normal `hgraph` installation now installs Polars and can use the configured compatibility surface immediately. Arrow remains the canonical internal runtime representation.

## Validation

- Packaging contract: 21 passed
- Clean base wheel installation imported Polars and enabled `polars_frames`
- `coverage-frame-recording` replay: reference and candidate matched
- Deterministic PR parity campaign: 109 attempted, 94 matched, 15 known mismatches, 0 verified mismatches
- Native C++ suite: 1,489 passed
- Installed stable-ABI wheel on Python 3.14: 2,039 passed, 9 skipped
- `uv lock --check`
- `git diff --check`
