### PR TITLE
Document public nanobind bindings

### DIFF
--- a/docs/source/developer_guide/python_integration.rst
+++ b/docs/source/developer_guide/python_integration.rst
@@ -323,9 +323,9 @@ Recorded divergences / gaps (the morning-summary list):
   GIL is RELEASED the instant the run loop starts; one nanobind guard covers
   the executor's complete start phase, each root evaluation cycle, and the
   complete stop phase (:doc:`python_bridge`, *GIL boundaries*). Inputs arrive
-  as plain Python VALUES (a recorded
-  divergence from Python hgraph's TimeSeries view objects); a compute
-  node's return value ticks its output (``None`` = no tick); a generator
+  as lazy, callback-scoped native ``TimeSeries`` views and convert only when
+  Python reads ``value`` or ``delta_value``; a compute node's return value
+  ticks its output (``None`` = no tick); a generator
   yields ``(datetime, value)`` pairs emitted at their absolute times. The
   bridge registers internal erased operators (``__py_compute`` /
   ``__py_sink`` / ``__py_generator``) over an immortal callable-record

--- a/docs/source/reference/python_api.rst
+++ b/docs/source/reference/python_api.rst
@@ -24,13 +24,16 @@ first access through ``hgraph.__getattr__`` and then cached:
    import hgraph as hg
 
    assert "TS" in hg.__all__
+   assert "datetime" not in hg.__all__
    assert "add_" not in hg.__all__
    assert callable(hg.add_)
    assert hg.add_ is hg.add_
 
 This distinction keeps ``from hgraph import *`` manageable without making the
 dynamic operator names private. The :doc:`python_api_inventory` combines both
-sources and is regenerated from a built wheel.
+sources and is regenerated from a built wheel. Standard-library values are not
+re-exported merely because the implementation uses them; import values such as
+``datetime`` and ``timedelta`` from their defining modules.
 
 Private boundary
 ----------------

--- a/docs/source/reference/python_api_inventory.rst
+++ b/docs/source/reference/python_api_inventory.rst
@@ -17,7 +17,7 @@ are omitted.
    * - Surface
      - Names
    * - ``hgraph.__all__``
-     - 210
+     - 206
    * - Public lazy operators
      - 212
    * - Public submodules
@@ -151,8 +151,6 @@ Top-level wildcard exports
    * - ``compute_set_delta``
    * - ``context``
    * - ``convert``
-   * - ``date``
-   * - ``datetime``
    * - ``default_path``
    * - ``delayed_binding``
    * - ``dispatch``
@@ -229,8 +227,6 @@ Top-level wildcard exports
    * - ``table_shape``
    * - ``table_shape_from_schema``
    * - ``temporal``
-   * - ``time``
-   * - ``timedelta``
    * - ``to_graph``
    * - ``try_except``
    * - ``ts_schema``

--- a/docs/source/reference/types.rst
+++ b/docs/source/reference/types.rst
@@ -81,8 +81,82 @@ execution begins.
 Node-facing runtime views
 -------------------------
 
-Inside a node, an input exposes ``value``, ``valid``, ``modified``,
-``delta_value`` and ``last_modified_time``. Collection views add structural
-access such as fields, keys and modified items. ``STATE``, ``SCHEDULER``,
-``CLOCK``, ``LOGGER`` and ``EvaluationEngineApi`` are injectable parameters,
-not time-series edges.
+Python node inputs are lazy, callback-scoped ``TimeSeries`` views over native
+runtime storage. Reading ``value`` converts the current value to Python;
+``delta_value`` converts only the current change. Use ``valid`` before relying
+on an optional input, ``modified`` to detect a tick in the current cycle, and
+``last_modified_time`` when the tick time matters. ``make_passive`` and
+``make_active`` change whether future input ticks schedule the node.
+
+Collection types add shape-specific access:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Input kind
+     - Additional runtime access
+   * - ``TSS``
+     - ``added()``, ``removed()``, membership and length
+   * - ``TSD``
+     - keys, child lookup, ``modified_items()`` and ``removed_keys()``
+   * - ``TSL`` / ``TSB``
+     - child lookup, values, and named-field access for bundles
+   * - ``TSW``
+     - ``has_removed_value`` and ``removed_value`` for window eviction
+
+Input, output, node, graph, clock and engine views expire when the callback
+returns. Do not retain them in ``STATE`` or pass them to another thread.
+
+Output and state views
+~~~~~~~~~~~~~~~~~~~~~~
+
+Returning a non-``None`` value is the ordinary way to publish a node output.
+Annotate the parameter named ``_output`` with ``TS_OUT[T]`` when the callback
+also needs its existing output or must mutate a collection output directly:
+
+.. testcode::
+
+   from hgraph import TS, TS_OUT, compute_node
+   from hgraph.test import eval_node
+
+   @compute_node
+   def change_only(value: TS[int],
+                   _output: TS_OUT[int] = None) -> TS[int]:
+       if _output.valid and _output.value == value.value:
+           return None
+       return value.value
+
+   assert eval_node(change_only, [1, 1, 2]) == [1, None, 2]
+
+``STATE`` preserves ordinary Python state for one node instance.
+``RECORDABLE_STATE[Schema]`` instead supplies a native output-backed view whose
+writes participate in record/replay. Both are distinct from graph-scoped
+``GlobalState``.
+
+Injectable parameters
+~~~~~~~~~~~~~~~~~~~~~
+
+Injectables are runtime services rather than time-series edges. Declare them
+as parameters with a ``None`` default; graph callers do not supply them.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 72
+
+   * - Annotation
+     - Callback value
+   * - ``STATE`` / ``STATE[T]``
+     - Per-node Python namespace or one lazily constructed ``T`` instance
+   * - ``SCHEDULER``
+     - Current node scheduler for absolute, relative and tagged events
+   * - ``CLOCK`` / ``EvaluationClock``
+     - Logical evaluation time and cycle timing
+   * - ``EvaluationEngineApi``
+     - Run interval, execution mode, cycle notifications and graceful stop
+   * - ``GlobalState``
+     - Guarded mapping over the graph's copied-in native state
+   * - ``LOGGER``
+     - Logger selected for this graph run
+   * - ``NODE``
+     - Current node identity, graph view and explicit notification methods

--- a/python/_hgraph_stub_patterns.txt
+++ b/python/_hgraph_stub_patterns.txt
@@ -28,6 +28,26 @@ _hgraph\.register_service_adaptor_impl$:
 # These bound declarations otherwise retain C++ implementation spellings in
 # forward references. Pattern replacements are nanobind's documented escape
 # hatch for annotations that differ from the actual C++ signature metadata.
+_hgraph\.TimeSeries\.value$:
+    @property
+    def value(self) -> object:
+        \doc
+
+_hgraph\.TimeSeries\.delta_value$:
+    @property
+    def delta_value(self) -> object:
+        \doc
+
+_hgraph\.TimeSeries\.modified$:
+    @property
+    def modified(self) -> bool:
+        \doc
+
+_hgraph\.TimeSeries\.valid$:
+    @property
+    def valid(self) -> bool:
+        \doc
+
 _hgraph\.CivilDateTime\.time$:
     @property
     def time(self) -> datetime.time: ...

--- a/python/hgraph/__init__.py
+++ b/python/hgraph/__init__.py
@@ -8,7 +8,6 @@ filter_, ...` all resolve through the C++ operator registry).
 Agreed divergences from Python hgraph are recorded in
 docs/source/developer_guide/parity_matrix.rst (e.g. REF is value-only)."""
 import _hgraph
-from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING
 
 from ._types import Series
@@ -128,7 +127,7 @@ __all__ = [
     "WiringPort", "CmpResult", "DivideByZero", "NodeError", "exception_time_series", "try_except", "lift", "lower",
     "TryExceptResult", "TryExceptTsdMapResult", "OperatorWiringNodeClass", "graph", "run_graph", "eval_node", "wire", "map_", "reduce", "mesh_", "MeshWiringPort", "get_mesh", "REMOVE", "REMOVE_IF_EXISTS", "feedback", "delayed_binding", "switch_", "passive", "compute_node", "sink_node", "generator", "STATE", "SCHEDULER", "CLOCK", "EvaluationEngineApi", "NODE", "Node", "component", "record_replay_scope", "RecordReplayEnum", "comparison_summary", "push_queue", "EvaluationMode", "context",
     "MIN_ST", "MIN_TD", "MIN_DT", "MAX_DT", "MAX_ET", "IN_MEMORY", "IN_MEMORY_DENSE", "DATA_FRAME",
-    "date", "datetime", "time", "timedelta", "default_path",
+    "default_path",
     "utc_now", "get_recorded_value", "get_recorder_api", "get_recording_label", "set_recorder_api", "set_recording_label", "EvaluationClock", "TSW_OUT", "get_context", "equal_lambdas", "is_feature_enabled",
     "GlobalContext", "GlobalState", "set_as_of", "set_table_schema_date_key", "set_table_schema_as_of_key",
     "set_pooled_compound_scalar_storage", "set_record_replay_config", "set_time_zone_provider", "frame_store_contains", "frame_store_read", "evaluate_const",

--- a/python/hgraph/_wiring/_markers.py
+++ b/python/hgraph/_wiring/_markers.py
@@ -87,13 +87,22 @@ class _StateExpr:
 
 
 class SCHEDULER:
-    """Injectable: the node scheduler - .schedule(datetime) /
-    .schedule_delta(timedelta). Annotate a parameter with SCHEDULER."""
+    """Annotation marker for injecting the current node's scheduler.
+
+    The callback receives a scheduler whose ``schedule`` method accepts an
+    absolute ``datetime`` or relative ``timedelta`` and an optional replacement
+    tag. ``reset`` cancels every outstanding schedule for the node. The object
+    is callback-scoped and must not be retained.
+    """
 
 
 class CLOCK:
-    """Injectable: the evaluation clock - .evaluation_time. Annotate a
-    parameter with CLOCK."""
+    """Annotation marker for injecting the graph evaluation clock.
+
+    The callback receives an ``EvaluationClock`` exposing logical evaluation
+    time, mode-dependent current time, cycle duration, and the earliest time
+    scheduled for the next cycle. The object is callback-scoped.
+    """
 
 
 class LOGGER:
@@ -160,7 +169,12 @@ def _tsw_kind():
 _TSW_KIND = None
 
 class _RecordableStateMarker:
-    """RECORDABLE_STATE[Schema]: a C++ hidden output-backed node state."""
+    """Persistent output-backed node state selected as RECORDABLE_STATE[Schema].
+
+    The callback receives a mutable view whose writes participate in the
+    configured record/replay model. The view is callback-scoped and must not
+    be retained.
+    """
 
     def __getitem__(self, item):
         return _RecordableStateExpr(item)
@@ -180,7 +194,13 @@ RECORDABLE_STATE = _RecordableStateMarker()
 
 
 class _TsOutMarker:
-    """TS_OUT[X]: output-backed state field, represented by TS[X]."""
+    """Annotate ``_output`` as TS_OUT[X] to inspect or mutate its native output.
+
+    The callback receives a mutable, callback-scoped output view. Returning a
+    value remains the usual publication path; the view is useful for checking
+    the existing value, suppressing duplicate ticks, and mutating collection
+    outputs in place.
+    """
 
     def __getitem__(self, item):
         from .._types import TS, _TsExpr, _GenericTsExpr

--- a/python/hgraph/_wiring/_markers.py
+++ b/python/hgraph/_wiring/_markers.py
@@ -100,8 +100,9 @@ class CLOCK:
     """Annotation marker for injecting the graph evaluation clock.
 
     The callback receives an ``EvaluationClock`` exposing logical evaluation
-    time, mode-dependent current time, cycle duration, and the earliest time
-    scheduled for the next cycle. The object is callback-scoped.
+    time, mode-dependent current time, cycle duration, and the logical time of
+    the immediately following possible evaluation cycle. The object is
+    callback-scoped.
     """
 
 

--- a/python/hgraph/_wiring/_state.py
+++ b/python/hgraph/_wiring/_state.py
@@ -94,7 +94,12 @@ class _MemoryRecording(list):
 
 
 class GlobalState:
-    """Python seed/result owner for the C++ graph GlobalState copy lifecycle."""
+    """Graph-scoped configuration copied into and back from native execution.
+
+    Use ``GlobalContext`` (or this object as a context manager) to select the
+    state while wiring and running a graph. Inside a node callback, declare a
+    ``GlobalState`` injectable instead of calling ``GlobalState.instance()``.
+    """
 
     def __init__(self, **kwargs):
         self._impl = _hgraph._GlobalState()
@@ -184,7 +189,10 @@ class GlobalState:
 
 
 class GlobalContext:
-    """Select one Python GlobalState seed for wiring and result copy-back."""
+    """Select one GlobalState seed for graph wiring and result copy-back.
+
+    Contexts cannot be nested. Entering returns the selected ``GlobalState``.
+    """
 
     def __init__(self, state=None):
         self.state = state if state is not None else GlobalState.instance()

--- a/python/py_ports.cpp
+++ b/python/py_ports.cpp
@@ -625,26 +625,34 @@ void bind_ports(nb::module_ &m) {
         WiringPortRef::structural_source(schema, std::move(children))};
   });
 
-  nb::class_<PyOpaqueRef>(m, "TimeSeriesRef")
+  nb::class_<PyOpaqueRef>(
+      m, "TimeSeriesRef",
+      "An immutable runtime reference to another time-series output.\n\n"
+      "Values of this type are produced by REF inputs. is_valid is evaluated "
+      "at the cycle in which the reference value was observed; an empty "
+      "reference has no target output.")
       .def_prop_ro("is_empty",
                    [](const PyOpaqueRef &self) {
                      return self.value.view()
                          .checked_as<TimeSeriesReference>()
                          .is_empty();
-                   })
+                   },
+                   "Whether the reference has no target.")
       .def_prop_ro("has_output",
                    [](const PyOpaqueRef &self) {
                      return self.value.view()
                          .checked_as<TimeSeriesReference>()
                          .has_output();
-                   })
+                   },
+                   "Whether the reference currently identifies an output.")
       .def_prop_ro(
           "is_valid",
           [](const PyOpaqueRef &self) {
             return self.evaluation_time != MIN_DT &&
                    self.value.view().checked_as<TimeSeriesReference>().is_valid(
                        self.evaluation_time);
-          })
+          },
+          "Whether the referenced output is valid at the observation time.")
       .def("__eq__",
            [](const PyOpaqueRef &self, nb::handle other) {
              return nb::isinstance<PyOpaqueRef>(other) &&
@@ -670,6 +678,6 @@ void bind_ports(nb::module_ &m) {
       throw std::logic_error("TimeSeriesReference meta has no canonical type");
     }
     return PyOpaqueRef{Value{type}, MIN_DT};
-  });
+  }, "Return the canonical empty time-series reference.");
 }
 } // namespace hgraph::python_bridge

--- a/python/py_state_services.cpp
+++ b/python/py_state_services.cpp
@@ -576,6 +576,8 @@ namespace hgraph::python_bridge
         .def("is_reference", &PyOutput::is_reference,
              "Return whether this is a reference-valued output.")
         .def_prop_rw("value", &PyOutput::value, &PyOutput::set_value,
+                     "The current output value. Assigning publishes a value; "
+                     "assigning None invalidates the output.",
                      nb::for_setter(nb::arg("value").none()))
         .def("can_apply_result", &PyOutput::can_apply_result,
              "Return whether the Python value can be applied to this output.")
@@ -616,11 +618,16 @@ namespace hgraph::python_bridge
         "Values written through this view participate in the configured "
         "record/replay model. The view expires when the node callback returns "
         "and must not be retained.")
-        .def_prop_ro("valid", &PyRecordableState::valid)
-        .def_prop_ro("modified", &PyRecordableState::modified)
+        .def_prop_ro("valid", &PyRecordableState::valid,
+                     "Whether the state currently has a value.")
+        .def_prop_ro("modified", &PyRecordableState::modified,
+                     "Whether the state changed in the current cycle.")
         .def_prop_rw("value", &PyRecordableState::value,
-                     &PyRecordableState::set_value)
-        .def("__getitem__", &PyRecordableState::child)
+                     &PyRecordableState::set_value,
+                     "The current persistent value. Assigning records a new "
+                     "state value through the native output.")
+        .def("__getitem__", &PyRecordableState::child,
+             "Return a statically addressed child state view.")
         .def("__getattr__",
              [](const PyRecordableState &self, const std::string &name) {
                  return self.child(nb::str(name.c_str()));
@@ -724,10 +731,15 @@ namespace hgraph::python_bridge
                   value, delta, time_zone_provider(view));
           });
     static PyGetSetDef py_ts_getset[] = {
-        {"value", &py_ts_raw_get<&PyTimeSeries::value>, nullptr, nullptr, nullptr},
-        {"delta_value", &py_ts_raw_get<&PyTimeSeries::delta_value>, nullptr, nullptr, nullptr},
-        {"modified", &py_ts_raw_get<&PyTimeSeries::modified>, nullptr, nullptr, nullptr},
-        {"valid", &py_ts_raw_get<&PyTimeSeries::valid>, nullptr, nullptr, nullptr},
+        {"value", &py_ts_raw_get<&PyTimeSeries::value>, nullptr,
+         "The current Python value, or None when the input is invalid.",
+         nullptr},
+        {"delta_value", &py_ts_raw_get<&PyTimeSeries::delta_value>, nullptr,
+         "The change observed in the current evaluation cycle.", nullptr},
+        {"modified", &py_ts_raw_get<&PyTimeSeries::modified>, nullptr,
+         "Whether the input ticked in the current evaluation cycle.", nullptr},
+        {"valid", &py_ts_raw_get<&PyTimeSeries::valid>, nullptr,
+         "Whether the input currently has a usable value.", nullptr},
         {nullptr, nullptr, nullptr, nullptr, nullptr},
     };
     static PyType_Slot py_ts_slots[] = {
@@ -742,8 +754,10 @@ namespace hgraph::python_bridge
         "Collection views expose child and change-oriented methods. The view "
         "expires when the node callback returns and must not be retained.")
         .def_prop_ro("_kind", [](const PyTimeSeries &self) { return static_cast<int>(self.kind()); })
-        .def_prop_ro("owning_node", &PyTimeSeries::owning_node)
-        .def_prop_ro("owning_graph", &PyTimeSeries::owning_graph)
+        .def_prop_ro("owning_node", &PyTimeSeries::owning_node,
+                     "The node consuming this input.")
+        .def_prop_ro("owning_graph", &PyTimeSeries::owning_graph,
+                     "The graph containing the consuming node.")
         .def("is_reference", &PyTimeSeries::is_reference,
              "Return whether this input carries a time-series reference.")
         // hgraph's runtime activity control: a node may passivate/reactivate
@@ -767,7 +781,8 @@ namespace hgraph::python_bridge
                      [](const PyTimeSeries &self) {
                          self.require_alive();
                          return self.view.active();
-                     })
+                     },
+                     "Whether ticks on this input currently schedule its node.")
         // value/delta_value/modified/valid are raw tp_getset slots above —
         // a def_prop_ro here would REPLACE the raw descriptor in the type
         // dictionary and silently restore the vectorcall path.
@@ -782,7 +797,8 @@ namespace hgraph::python_bridge
                              throw nb::attribute_error("has_removed_value");
                          }
                          return view.as_window().has_removed_value();
-                     })
+                     },
+                     "Whether a window value was evicted in the current cycle.")
         .def_prop_ro("removed_value",
                      [](const PyTimeSeries &self) -> nb::object {
                          const auto &view = self.checked();
@@ -792,7 +808,8 @@ namespace hgraph::python_bridge
                          }
                          auto window = view.as_window();
                          return window.has_removed_value() ? value_to_py(window.removed_value()) : nb::none();
-                     })
+                     },
+                     "The window value evicted in the current cycle, or None.")
         .def_prop_ro("last_modified_time", &PyTimeSeries::last_modified_time,
                      "The evaluation time of the most recent tick.")
         .def("added", &PyTimeSeries::added,
@@ -904,14 +921,17 @@ namespace hgraph::python_bridge
              "Run a callable once after the current graph evaluation cycle.")
         .def_prop_ro("evaluation_mode", [](const PyEvaluationEngineApi &self) {
             return self.checked().mode() == GraphExecutorMode::RealTime ? "real_time" : "simulation";
-        })
-        .def_prop_ro("start_time", [](const PyEvaluationEngineApi &self) { return self.checked().start_time(); })
-        .def_prop_ro("end_time", [](const PyEvaluationEngineApi &self) { return self.checked().end_time(); })
+        }, "The active execution mode: 'simulation' or 'real_time'.")
+        .def_prop_ro("start_time", [](const PyEvaluationEngineApi &self) { return self.checked().start_time(); },
+                     "The inclusive start of the configured run interval.")
+        .def_prop_ro("end_time", [](const PyEvaluationEngineApi &self) { return self.checked().end_time(); },
+                     "The exclusive end of the configured run interval.")
         .def_prop_ro("evaluation_clock", [](const PyEvaluationEngineApi &self) {
             return PyEvalClock{self.checked().evaluation_clock(), self.lease};
-        })
+        }, "The callback-scoped clock for the running graph.")
         .def_prop_ro("is_stop_requested",
-                     [](const PyEvaluationEngineApi &self) { return self.checked().stop_requested(); })
+                     [](const PyEvaluationEngineApi &self) { return self.checked().stop_requested(); },
+                     "Whether a graceful graph stop has been requested.")
         .def("request_engine_stop", [](const PyEvaluationEngineApi &self) { self.checked().request_stop(); },
              "Request a graceful stop after the current evaluation cycle.");
     nb::enum_<NodeKind>(m, "NodeType",
@@ -940,29 +960,29 @@ namespace hgraph::python_bridge
                 }
             }
             return result;
-        })
+        }, "The hierarchical numeric path identifying this graph.")
         .def_prop_ro("label", [](const PyGraph &self) {
             const GraphView graph = self.checked();
             const auto *schema = graph.schema();
             return schema != nullptr && schema->display_name != nullptr
                        ? std::string{schema->display_name}
                        : std::string{};
-        })
+        }, "The graph's diagnostic display name.")
         .def_prop_ro("started", [](const PyGraph &self) {
             return self.checked().started();
-        })
+        }, "Whether graph start has completed.")
         .def_prop_ro("evaluating", [](const PyGraph &self) {
             return self.checked().evaluating();
-        })
+        }, "Whether the graph is currently evaluating a cycle.")
         .def_prop_ro("evaluation_clock", [](const PyGraph &self) {
             return PyEvalClock{self.checked().executor().evaluation_clock(), self.lease};
-        })
+        }, "The callback-scoped clock shared by this graph's executor.")
         .def_prop_ro("parent_node", [](const PyGraph &self) -> nb::object {
             const GraphView graph = self.checked();
             if (!graph.is_nested()) { return nb::none(); }
             const NodeView parent = graph.as_nested().parent_node();
             return nb::cast(PyNode{parent.pointer(), NodeScheduler{}, self.lease});
-        })
+        }, "The node owning this nested graph, or None for the root graph.")
         .def_prop_ro("nodes", [](const PyGraph &self) {
             const GraphView graph = self.checked();
             nb::list result;
@@ -973,15 +993,17 @@ namespace hgraph::python_bridge
                     PyNode{node.pointer(), NodeScheduler{}, self.lease}));
             }
             return result;
-        });
+        }, "A snapshot list of callback-scoped views over this graph's nodes.");
     nb::class_<PyNode>(
         m, "Node",
         "A callback-scoped view of the currently running node.\n\n"
         "Inject with NODE to inspect identity or request scheduling. Runtime "
         "topology and lifecycle remain executor-owned, and this view must not "
         "be retained beyond the callback.")
-        .def_prop_ro("node_ndx", [](const PyNode &self) { return self.checked().node_index(); })
-        .def_prop_ro("node_index", [](const PyNode &self) { return self.checked().node_index(); })
+        .def_prop_ro("node_ndx", [](const PyNode &self) { return self.checked().node_index(); },
+                     "Compatibility alias for node_index.")
+        .def_prop_ro("node_index", [](const PyNode &self) { return self.checked().node_index(); },
+                     "The node's zero-based index within its graph.")
         .def_prop_ro("node_id", [](const PyNode &self) {
             const auto id = self.node_id();
             nb::tuple result = nb::steal<nb::tuple>(PyTuple_New(static_cast<Py_ssize_t>(id.size())));
@@ -994,7 +1016,7 @@ namespace hgraph::python_bridge
                 }
             }
             return result;
-        })
+        }, "The hierarchical numeric path identifying this node.")
         .def_prop_ro("owning_graph_id", [](const PyNode &self) {
             const auto id = self.node_id();
             const std::size_t size = id.empty() ? 0 : id.size() - 1;
@@ -1008,16 +1030,21 @@ namespace hgraph::python_bridge
                 }
             }
             return result;
-        })
-        .def_prop_ro("label", [](const PyNode &self) { return std::string{self.checked().label()}; })
+        }, "The hierarchical numeric path identifying the containing graph.")
+        .def_prop_ro("label", [](const PyNode &self) { return std::string{self.checked().label()}; },
+                     "The node's diagnostic display name.")
         .def_prop_ro("graph", [](const PyNode &self) {
             const GraphView graph = self.checked().graph();
             return PyGraph{graph.pointer(), self.lease};
-        })
-        .def_prop_ro("node_type", [](const PyNode &self) { return self.checked().node_kind(); })
-        .def_prop_ro("started", [](const PyNode &self) { return self.checked().started(); })
-        .def_prop_ro("has_input", [](const PyNode &self) { return self.checked().has_input(); })
-        .def_prop_ro("has_output", [](const PyNode &self) { return self.checked().has_output(); })
+        }, "The callback-scoped view of the containing graph.")
+        .def_prop_ro("node_type", [](const PyNode &self) { return self.checked().node_kind(); },
+                     "The runtime role of this node.")
+        .def_prop_ro("started", [](const PyNode &self) { return self.checked().started(); },
+                     "Whether node start has completed.")
+        .def_prop_ro("has_input", [](const PyNode &self) { return self.checked().has_input(); },
+                     "Whether the node owns an input time-series tree.")
+        .def_prop_ro("has_output", [](const PyNode &self) { return self.checked().has_output(); },
+                     "Whether the node owns an output time-series tree.")
         .def("notify", &PyNode::notify,
              "Schedule this node at the supplied evaluation time.")
         .def("notify_next_cycle", &PyNode::notify_next_cycle,
@@ -1048,7 +1075,9 @@ namespace hgraph::python_bridge
              "Cancel every outstanding schedule for this node.")
         .def("has_tag", [](const PyScheduler &self, std::string_view tag) { return self.scheduler.has_tag(tag); },
              "Return whether an event is currently scheduled under the tag.")
-        .def_prop_ro("is_scheduled", [](const PyScheduler &self) { return self.scheduler.is_scheduled(); })
-        .def_prop_ro("is_scheduled_now", [](const PyScheduler &self) { return self.scheduler.is_scheduled_now(); });
+        .def_prop_ro("is_scheduled", [](const PyScheduler &self) { return self.scheduler.is_scheduled(); },
+                     "Whether this node has any outstanding schedule.")
+        .def_prop_ro("is_scheduled_now", [](const PyScheduler &self) { return self.scheduler.is_scheduled_now(); },
+                     "Whether this node is scheduled for the current cycle.");
     }
 }  // namespace hgraph::python_bridge

--- a/python/py_state_services.cpp
+++ b/python/py_state_services.cpp
@@ -896,7 +896,8 @@ namespace hgraph::python_bridge
                      "Elapsed wall time since the current cycle began.")
         .def_prop_ro("next_cycle_evaluation_time",
                      [](const PyEvalClock &clock) { return clock.next_cycle_evaluation_time(); },
-                     "The earliest evaluation time currently scheduled for the next cycle.");
+                     "The logical time immediately following this evaluation "
+                     "cycle (evaluation_time + MIN_TD).");
     nb::class_<PyEvaluationEngineApi>(
         m, "EvaluationEngineApi",
         "A callback-scoped control view for the running graph executor.\n\n"

--- a/python/py_state_services.cpp
+++ b/python/py_state_services.cpp
@@ -552,24 +552,45 @@ namespace hgraph::python_bridge
     m.attr("MAX_DT")     = nb::cast(MAX_DT);
     m.attr("MAX_ET")     = nb::cast(MAX_ET);
 
-    nb::class_<PyOutput>(m, "OutputView")
-        .def_prop_ro("owning_node", &PyOutput::owning_node)
-        .def_prop_ro("owning_graph", &PyOutput::owning_graph)
-        .def_prop_ro("valid", &PyOutput::valid)
-        .def_prop_ro("all_valid", &PyOutput::all_valid)
-        .def_prop_ro("modified", &PyOutput::modified)
-        .def_prop_ro("last_modified_time", &PyOutput::last_modified_time)
-        .def_prop_ro("delta_value", &PyOutput::delta_value)
-        .def("is_reference", &PyOutput::is_reference)
+    nb::class_<PyOutput>(
+        m, "OutputView",
+        "A mutable, callback-scoped view of a Python node output.\n\n"
+        "OutputView is injected through TS_OUT and the collection-specific "
+        "output markers. Assign value for ordinary output, or mutate child "
+        "views for collection outputs. The view expires when the node "
+        "callback returns and must not be retained.")
+        .def_prop_ro("owning_node", &PyOutput::owning_node,
+                     "The node that owns this output view.")
+        .def_prop_ro("owning_graph", &PyOutput::owning_graph,
+                     "The graph that owns this output view.")
+        .def_prop_ro("valid", &PyOutput::valid,
+                     "Whether the output currently has a value.")
+        .def_prop_ro("all_valid", &PyOutput::all_valid,
+                     "Whether every direct child currently has a value.")
+        .def_prop_ro("modified", &PyOutput::modified,
+                     "Whether the output ticks in the current cycle.")
+        .def_prop_ro("last_modified_time", &PyOutput::last_modified_time,
+                     "The evaluation time of the most recent output tick.")
+        .def_prop_ro("delta_value", &PyOutput::delta_value,
+                     "The change published in the current cycle.")
+        .def("is_reference", &PyOutput::is_reference,
+             "Return whether this is a reference-valued output.")
         .def_prop_rw("value", &PyOutput::value, &PyOutput::set_value,
                      nb::for_setter(nb::arg("value").none()))
-        .def("can_apply_result", &PyOutput::can_apply_result)
-        .def("get_or_create", &PyOutput::get_or_create)
-        .def("clear", &PyOutput::clear)
-        .def("invalidate", &PyOutput::invalidate)
-        .def("removed_keys", &PyOutput::removed_keys)
-        .def("add", &PyOutput::add)
-        .def("remove", &PyOutput::remove)
+        .def("can_apply_result", &PyOutput::can_apply_result,
+             "Return whether the Python value can be applied to this output.")
+        .def("get_or_create", &PyOutput::get_or_create,
+             "Return the keyed child output, creating it when absent.")
+        .def("clear", &PyOutput::clear,
+             "Clear the current collection value and publish removals.")
+        .def("invalidate", &PyOutput::invalidate,
+             "Invalidate the output without assigning a replacement value.")
+        .def("removed_keys", &PyOutput::removed_keys,
+             "Return keys removed in the current cycle.")
+        .def("add", &PyOutput::add,
+             "Add a value to a set output and return whether it changed.")
+        .def("remove", &PyOutput::remove,
+             "Remove a value from a set output and return whether it changed.")
         .def("__getitem__", &PyOutput::child)
         .def("__delitem__", &PyOutput::erase)
         .def("__contains__", &PyOutput::contains)
@@ -589,7 +610,12 @@ namespace hgraph::python_bridge
                      throw nb::attribute_error(name.c_str());
                  }
              });
-    nb::class_<PyRecordableState>(m, "RecordableStateView")
+    nb::class_<PyRecordableState>(
+        m, "RecordableStateView",
+        "A mutable, callback-scoped view of persistent RECORDABLE_STATE.\n\n"
+        "Values written through this view participate in the configured "
+        "record/replay model. The view expires when the node callback returns "
+        "and must not be retained.")
         .def_prop_ro("valid", &PyRecordableState::valid)
         .def_prop_ro("modified", &PyRecordableState::modified)
         .def_prop_rw("value", &PyRecordableState::value,
@@ -599,7 +625,12 @@ namespace hgraph::python_bridge
              [](const PyRecordableState &self, const std::string &name) {
                  return self.child(nb::str(name.c_str()));
              });
-    nb::class_<PyRuntimeGlobalState>(m, "RuntimeGlobalState")
+    nb::class_<PyRuntimeGlobalState>(
+        m, "RuntimeGlobalState",
+        "A mutable, callback-scoped mapping over graph GlobalState.\n\n"
+        "The runner copies configuration into native state before execution "
+        "and copies it back afterwards. This view is valid only during the "
+        "callback in which it is supplied.")
         .def("__len__", [](const PyRuntimeGlobalState &self) { return self.checked().size(); })
         .def("__contains__", [](const PyRuntimeGlobalState &self, const std::string &key) {
             return self.checked().contains(key);
@@ -703,23 +734,32 @@ namespace hgraph::python_bridge
         {Py_tp_getset, static_cast<void *>(py_ts_getset)},
         {0, nullptr},
     };
-    nb::class_<PyTimeSeries>(m, "TimeSeries", nb::type_slots(py_ts_slots))
+    nb::class_<PyTimeSeries>(
+        m, "TimeSeries", nb::type_slots(py_ts_slots),
+        "A read-only, callback-scoped native time-series input view.\n\n"
+        "Use value for the current value, delta_value for the current change, "
+        "and modified to determine whether the input ticked this cycle. "
+        "Collection views expose child and change-oriented methods. The view "
+        "expires when the node callback returns and must not be retained.")
         .def_prop_ro("_kind", [](const PyTimeSeries &self) { return static_cast<int>(self.kind()); })
         .def_prop_ro("owning_node", &PyTimeSeries::owning_node)
         .def_prop_ro("owning_graph", &PyTimeSeries::owning_graph)
-        .def("is_reference", &PyTimeSeries::is_reference)
+        .def("is_reference", &PyTimeSeries::is_reference,
+             "Return whether this input carries a time-series reference.")
         // hgraph's runtime activity control: a node may passivate/reactivate
         // its own input subscription (the C++ In views expose the same).
         .def("make_passive",
              [](PyTimeSeries &self) {
                  self.require_alive();
                  self.view.make_passive();
-             })
+             },
+             "Stop this input from scheduling its node when it ticks.")
         .def("make_active",
              [](PyTimeSeries &self) {
                  self.require_alive();
                  self.view.make_active();
-             })
+             },
+             "Resume scheduling the node when this input ticks.")
         // The activity STATE query completing the trio (upstream parity —
         // the annotation-class ABC surface is deliberately not replicated,
         // but instance behaviour must be: ruling 2026-08-01).
@@ -731,7 +771,8 @@ namespace hgraph::python_bridge
         // value/delta_value/modified/valid are raw tp_getset slots above —
         // a def_prop_ro here would REPLACE the raw descriptor in the type
         // dictionary and silently restore the vectorcall path.
-        .def_prop_ro("all_valid", &PyTimeSeries::all_valid)
+        .def_prop_ro("all_valid", &PyTimeSeries::all_valid,
+                     "Whether every direct child currently has a value.")
         // TSW eviction surface (hgraph's removed_value pair).
         .def_prop_ro("has_removed_value",
                      [](const PyTimeSeries &self) {
@@ -752,15 +793,24 @@ namespace hgraph::python_bridge
                          auto window = view.as_window();
                          return window.has_removed_value() ? value_to_py(window.removed_value()) : nb::none();
                      })
-        .def_prop_ro("last_modified_time", &PyTimeSeries::last_modified_time)
-        .def("added", &PyTimeSeries::added)
-        .def("removed", &PyTimeSeries::removed)
-        .def("keys", &PyTimeSeries::keys)
-        .def("modified_keys", &PyTimeSeries::modified_keys)
-        .def("modified_items", &PyTimeSeries::modified_items)
-        .def("modified_values", &PyTimeSeries::modified_values)
-        .def("values", &PyTimeSeries::values)
-        .def("removed_keys", &PyTimeSeries::removed_keys)
+        .def_prop_ro("last_modified_time", &PyTimeSeries::last_modified_time,
+                     "The evaluation time of the most recent tick.")
+        .def("added", &PyTimeSeries::added,
+             "Return values added to a set in the current cycle.")
+        .def("removed", &PyTimeSeries::removed,
+             "Return values removed from a set in the current cycle.")
+        .def("keys", &PyTimeSeries::keys,
+             "Return the current keys or field names of a collection input.")
+        .def("modified_keys", &PyTimeSeries::modified_keys,
+             "Return collection keys modified in the current cycle.")
+        .def("modified_items", &PyTimeSeries::modified_items,
+             "Return key/value pairs modified in the current cycle.")
+        .def("modified_values", &PyTimeSeries::modified_values,
+             "Return collection values modified in the current cycle.")
+        .def("values", &PyTimeSeries::values,
+             "Return the current child values of a collection input.")
+        .def("removed_keys", &PyTimeSeries::removed_keys,
+             "Return dictionary keys removed in the current cycle.")
         .def("__getitem__", &PyTimeSeries::child_at)
         .def("__getattr__", [](nb::object self_obj, const std::string &name) -> nb::object {
             auto &self = nb::cast<PyTimeSeries &>(self_obj);
@@ -816,13 +866,26 @@ namespace hgraph::python_bridge
         return PyScalarValue{std::move(result)};
     });
 
-    nb::class_<PyEvalClock>(m, "EvaluationClock")
-        .def_prop_ro("evaluation_time", [](const PyEvalClock &clock) { return clock.evaluation_time(); })
-        .def_prop_ro("now", [](const PyEvalClock &clock) { return clock.now(); })
-        .def_prop_ro("cycle_time", [](const PyEvalClock &clock) { return clock.cycle_time(); })
+    nb::class_<PyEvalClock>(
+        m, "EvaluationClock",
+        "A callback-scoped view of graph evaluation time.\n\n"
+        "Inject with CLOCK or EvaluationClock. In simulation, now follows "
+        "evaluation time; in real-time mode it represents wall-clock time.")
+        .def_prop_ro("evaluation_time", [](const PyEvalClock &clock) { return clock.evaluation_time(); },
+                     "The logical time of the current evaluation cycle.")
+        .def_prop_ro("now", [](const PyEvalClock &clock) { return clock.now(); },
+                     "The clock's current time for the active evaluation mode.")
+        .def_prop_ro("cycle_time", [](const PyEvalClock &clock) { return clock.cycle_time(); },
+                     "Elapsed wall time since the current cycle began.")
         .def_prop_ro("next_cycle_evaluation_time",
-                     [](const PyEvalClock &clock) { return clock.next_cycle_evaluation_time(); });
-    nb::class_<PyEvaluationEngineApi>(m, "EvaluationEngineApi")
+                     [](const PyEvalClock &clock) { return clock.next_cycle_evaluation_time(); },
+                     "The earliest evaluation time currently scheduled for the next cycle.");
+    nb::class_<PyEvaluationEngineApi>(
+        m, "EvaluationEngineApi",
+        "A callback-scoped control view for the running graph executor.\n\n"
+        "Inject this type into a Python node to inspect the run interval, "
+        "request a graceful stop, or schedule one-shot cycle-boundary "
+        "notifications. Do not retain the view after the callback returns.")
         // One-shot cycle-boundary notifications: python sugar over the
         // C++-primary EngineControlView facility (C++-first ruling; the
         // wrapper re-acquires the GIL because drains run outside the
@@ -831,12 +894,14 @@ namespace hgraph::python_bridge
              [](PyEvaluationEngineApi &self, nb::object fn) {
                  self.checked().add_before_evaluation_notification(
                      py_notification_thunk(std::move(fn), self.lease));
-             })
+             },
+             "Run a callable once before the next graph evaluation cycle.")
         .def("add_after_evaluation_notification",
              [](PyEvaluationEngineApi &self, nb::object fn) {
                  self.checked().add_after_evaluation_notification(
                      py_notification_thunk(std::move(fn), self.lease));
-             })
+             },
+             "Run a callable once after the current graph evaluation cycle.")
         .def_prop_ro("evaluation_mode", [](const PyEvaluationEngineApi &self) {
             return self.checked().mode() == GraphExecutorMode::RealTime ? "real_time" : "simulation";
         })
@@ -847,14 +912,21 @@ namespace hgraph::python_bridge
         })
         .def_prop_ro("is_stop_requested",
                      [](const PyEvaluationEngineApi &self) { return self.checked().stop_requested(); })
-        .def("request_engine_stop", [](const PyEvaluationEngineApi &self) { self.checked().request_stop(); });
-    nb::enum_<NodeKind>(m, "NodeType")
+        .def("request_engine_stop", [](const PyEvaluationEngineApi &self) { self.checked().request_stop(); },
+             "Request a graceful stop after the current evaluation cycle.");
+    nb::enum_<NodeKind>(m, "NodeType",
+                        "The runtime role of a graph node.")
         .value("COMPUTE", NodeKind::Compute)
         .value("PUSH_SOURCE", NodeKind::PushSource)
         .value("PULL_SOURCE", NodeKind::PullSource)
         .value("SINK", NodeKind::Sink)
         .value("NESTED", NodeKind::Nested);
-    nb::class_<PyGraph>(m, "Graph")
+    nb::class_<PyGraph>(
+        m, "Graph",
+        "A read-only, callback-scoped view of a running graph.\n\n"
+        "Graph views are supplied for inspection and diagnostics. Graph "
+        "lifecycle is owned by the executor; retain identifiers rather than "
+        "retaining this view beyond its callback.")
         .def_prop_ro("graph_id", [](const PyGraph &self) {
             const auto id = self.graph_id();
             nb::tuple result = nb::steal<nb::tuple>(
@@ -902,7 +974,12 @@ namespace hgraph::python_bridge
             }
             return result;
         });
-    nb::class_<PyNode>(m, "Node")
+    nb::class_<PyNode>(
+        m, "Node",
+        "A callback-scoped view of the currently running node.\n\n"
+        "Inject with NODE to inspect identity or request scheduling. Runtime "
+        "topology and lifecycle remain executor-owned, and this view must not "
+        "be retained beyond the callback.")
         .def_prop_ro("node_ndx", [](const PyNode &self) { return self.checked().node_index(); })
         .def_prop_ro("node_index", [](const PyNode &self) { return self.checked().node_index(); })
         .def_prop_ro("node_id", [](const PyNode &self) {
@@ -941,9 +1018,15 @@ namespace hgraph::python_bridge
         .def_prop_ro("started", [](const PyNode &self) { return self.checked().started(); })
         .def_prop_ro("has_input", [](const PyNode &self) { return self.checked().has_input(); })
         .def_prop_ro("has_output", [](const PyNode &self) { return self.checked().has_output(); })
-        .def("notify", &PyNode::notify)
-        .def("notify_next_cycle", &PyNode::notify_next_cycle);
-    nb::class_<PyScheduler>(m, "Scheduler")
+        .def("notify", &PyNode::notify,
+             "Schedule this node at the supplied evaluation time.")
+        .def("notify_next_cycle", &PyNode::notify_next_cycle,
+             "Schedule this node for the next evaluation cycle.");
+    nb::class_<PyScheduler>(
+        m, "Scheduler",
+        "A callback-scoped scheduler for the current node.\n\n"
+        "Inject with SCHEDULER. A tagged schedule replaces the existing event "
+        "with the same tag; reset() cancels outstanding schedules.")
         // hgraph's SCHEDULER.schedule(when: datetime | timedelta, tag=None,
         // on_wall_clock=False). Two overloads distinguish absolute times from
         // relative deltas; a non-empty tag replaces any prior event under it.
@@ -951,15 +1034,20 @@ namespace hgraph::python_bridge
              [](const PyScheduler &self, DateTime when, std::optional<std::string> tag, bool on_wall_clock) {
                  self.scheduler.schedule(when, std::move(tag), on_wall_clock);
              },
-             nb::arg("when"), nb::arg("tag") = nb::none(), nb::arg("on_wall_clock") = false)
+             nb::arg("when"), nb::arg("tag") = nb::none(), nb::arg("on_wall_clock") = false,
+             "Schedule at an absolute evaluation time.")
         .def("schedule",
              [](const PyScheduler &self, TimeDelta delta, std::optional<std::string> tag, bool on_wall_clock) {
                  self.scheduler.schedule(delta, std::move(tag), on_wall_clock);
              },
-             nb::arg("when"), nb::arg("tag") = nb::none(), nb::arg("on_wall_clock") = false)
-        .def("schedule_delta", [](const PyScheduler &self, TimeDelta delta) { self.scheduler.schedule(delta); })
-        .def("reset", [](const PyScheduler &self) { self.scheduler.reset(); })
-        .def("has_tag", [](const PyScheduler &self, std::string_view tag) { return self.scheduler.has_tag(tag); })
+             nb::arg("when"), nb::arg("tag") = nb::none(), nb::arg("on_wall_clock") = false,
+             "Schedule after a duration relative to the current evaluation time.")
+        .def("schedule_delta", [](const PyScheduler &self, TimeDelta delta) { self.scheduler.schedule(delta); },
+             "Schedule after a duration relative to the current evaluation time.")
+        .def("reset", [](const PyScheduler &self) { self.scheduler.reset(); },
+             "Cancel every outstanding schedule for this node.")
+        .def("has_tag", [](const PyScheduler &self, std::string_view tag) { return self.scheduler.has_tag(tag); },
+             "Return whether an event is currently scheduled under the tag.")
         .def_prop_ro("is_scheduled", [](const PyScheduler &self) { return self.scheduler.is_scheduled(); })
         .def_prop_ro("is_scheduled_now", [](const PyScheduler &self) { return self.scheduler.is_scheduled_now(); });
     }

--- a/python/py_type_system.cpp
+++ b/python/py_type_system.cpp
@@ -333,9 +333,12 @@ namespace hgraph::python_bridge
             .def("overlaps", &Range::overlaps,
                  "Return whether the ranges share at least one value.")
             .def("touches", &Range::touches,
-                 "Return whether the ranges meet at an included endpoint.")
+                 "Return whether one range's finite upper endpoint equals "
+                 "the other's finite lower endpoint, regardless of boundary "
+                 "inclusion.")
             .def("adjacent", &Range::adjacent,
-                 "Return whether the ranges meet without overlapping.")
+                 "Return whether the ranges do not overlap, share an "
+                 "endpoint, and exactly one meeting boundary is closed.")
             .def("mergeable", &Range::mergeable,
                  "Return whether the ranges can be represented as one "
                  "continuous range.")

--- a/python/py_type_system.cpp
+++ b/python/py_type_system.cpp
@@ -48,24 +48,41 @@ namespace hgraph::python_bridge
 
     void bind_type_system(nb::module_ &m)
     {
-    nb::enum_<MonthEndPolicy>(m, "MonthEndPolicy")
+    nb::enum_<MonthEndPolicy>(
+        m, "MonthEndPolicy",
+        "Policy for calendar-period arithmetic when the target month does "
+        "not contain the original day.")
         .value("REJECT", MonthEndPolicy::Reject)
         .value("CLAMP", MonthEndPolicy::Clamp)
         .value("PRESERVE_END_OF_MONTH",
                MonthEndPolicy::PreserveEndOfMonth);
-    nb::enum_<AmbiguousTimePolicy>(m, "AmbiguousTimePolicy")
+    nb::enum_<AmbiguousTimePolicy>(
+        m, "AmbiguousTimePolicy",
+        "Policy for resolving a local civil time that occurs twice during "
+        "a time-zone transition.")
         .value("REJECT", AmbiguousTimePolicy::Reject)
         .value("EARLIEST", AmbiguousTimePolicy::Earliest)
         .value("LATEST", AmbiguousTimePolicy::Latest);
-    nb::enum_<NonexistentTimePolicy>(m, "NonexistentTimePolicy")
+    nb::enum_<NonexistentTimePolicy>(
+        m, "NonexistentTimePolicy",
+        "Policy for resolving a local civil time skipped by a time-zone "
+        "transition.")
         .value("REJECT", NonexistentTimePolicy::Reject)
         .value("NEXT_VALID", NonexistentTimePolicy::NextValid)
         .value("PREVIOUS_VALID", NonexistentTimePolicy::PreviousValid);
-    nb::enum_<Boundary>(m, "Boundary")
+    nb::enum_<Boundary>(
+        m, "Boundary",
+        "Whether a temporal range includes or excludes one endpoint.")
         .value("OPEN", Boundary::Open)
         .value("CLOSED", Boundary::Closed);
 
-    nb::class_<CivilDateTime>(m, "CivilDateTime")
+    nb::class_<CivilDateTime>(
+        m, "CivilDateTime",
+        "A timezone-free calendar date and wall-clock time.\n\n"
+        "CivilDateTime represents local civil time without an offset or "
+        "time zone. Use hgraph.temporal.resolve() with a ZoneId to obtain a "
+        "ZonedDateTime. Calendar Period arithmetic preserves civil-time "
+        "semantics; timedelta arithmetic uses fixed elapsed durations.")
         .def(nb::init<CivilDate, int, int, int, int>(),
              nb::arg("date"), nb::arg("hour"),
              nb::arg("minute") = 0, nb::arg("second") = 0,
@@ -88,8 +105,10 @@ namespace hgraph::python_bridge
         .def_prop_ro("minute", &CivilDateTime::minute)
         .def_prop_ro("second", &CivilDateTime::second)
         .def_prop_ro("microsecond", &CivilDateTime::microsecond)
-        .def("weekday", &CivilDateTime::weekday)
-        .def("isoweekday", &CivilDateTime::isoweekday)
+        .def("weekday", &CivilDateTime::weekday,
+             "Return the weekday as Monday=0 through Sunday=6.")
+        .def("isoweekday", &CivilDateTime::isoweekday,
+             "Return the ISO weekday as Monday=1 through Sunday=7.")
         .def_prop_ro("day_of_year", &CivilDateTime::day_of_year)
         .def("__eq__", [](const CivilDateTime &self,
                           const CivilDateTime &other) {
@@ -132,7 +151,12 @@ namespace hgraph::python_bridge
                    format_civil_datetime(self) + "')";
         });
 
-    nb::class_<Period>(m, "Period")
+    nb::class_<Period>(
+        m, "Period",
+        "A calendar-relative duration measured in years, months, and days.\n\n"
+        "Unlike datetime.timedelta, a Period depends on the starting civil "
+        "date. Applying one uses MonthEndPolicy to handle short months and "
+        "is not supported for timezone-independent instants.")
         .def(nb::init<std::int64_t, std::int64_t, std::int64_t>(),
              nb::arg("years") = 0, nb::arg("months") = 0,
              nb::arg("days") = 0)
@@ -197,7 +221,9 @@ namespace hgraph::python_bridge
             return out.str();
         });
 
-    nb::class_<ZoneId>(m, "ZoneId")
+    nb::class_<ZoneId>(
+        m, "ZoneId",
+        "An immutable IANA time-zone identifier such as 'Europe/London'.")
         .def(nb::init<std::string_view>(), nb::arg("name"))
         .def_prop_ro("name", &ZoneId::name)
         .def_prop_ro("value", &ZoneId::value)
@@ -214,13 +240,18 @@ namespace hgraph::python_bridge
             return std::hash<ZoneId>{}(self);
         });
 
-    nb::class_<ZonedDateTime>(m, "ZonedDateTime")
+    nb::class_<ZonedDateTime>(
+        m, "ZonedDateTime",
+        "An instant paired with its time zone, UTC offset, and civil time.\n\n"
+        "Equality includes the zone representation. Use same_instant() when "
+        "only the point on the UTC timeline matters.")
         .def_prop_ro("instant", &ZonedDateTime::instant)
         .def_prop_ro("zone", &ZonedDateTime::zone)
         .def_prop_ro("offset_seconds",
                      &ZonedDateTime::offset_seconds)
         .def_prop_ro("civil", &ZonedDateTime::civil)
-        .def("same_instant", &ZonedDateTime::same_instant)
+        .def("same_instant", &ZonedDateTime::same_instant,
+             "Return whether both values identify the same UTC instant.")
         .def("__eq__", [](const ZonedDateTime &self,
                           const ZonedDateTime &other) {
             return self == other;
@@ -234,15 +265,18 @@ namespace hgraph::python_bridge
             return "ZonedDateTime('" + out.str() + "')";
         });
 
-    const auto bind_range = [&]<typename Range>(const char *name) {
+    const auto bind_range = [&]<typename Range>(const char *name,
+                                                const char *doc) {
         using Endpoint = typename Range::value_type;
-        nb::class_<Range>(m, name)
+        nb::class_<Range>(m, name, doc)
             .def(nb::init<Endpoint, Endpoint, Boundary, Boundary>(),
                  nb::arg("start"), nb::arg("end"),
                  nb::arg("lower") = Boundary::Closed,
                  nb::arg("upper") = Boundary::Open)
-            .def_static("empty", &Range::make_empty)
-            .def_static("all", &Range::all)
+            .def_static("empty", &Range::make_empty,
+                        "Return the canonical empty range.")
+            .def_static("all", &Range::all,
+                        "Return the range with neither endpoint bounded.")
             .def_static("bounded",
                         [](Endpoint start, Endpoint end, Boundary lower,
                            Boundary upper) {
@@ -276,19 +310,35 @@ namespace hgraph::python_bridge
             .def_prop_ro("upper_unbounded", &Range::upper_unbounded)
             .def("contains",
                  nb::overload_cast<const Endpoint &>(
-                     &Range::contains, nb::const_))
+                     &Range::contains, nb::const_),
+                 "Return whether this range contains the value.")
             .def("contains",
                  nb::overload_cast<const Range &>(
-                     &Range::contains, nb::const_))
-            .def("intersection", &Range::intersection)
-            .def("overlaps", &Range::overlaps)
-            .def("touches", &Range::touches)
-            .def("adjacent", &Range::adjacent)
-            .def("mergeable", &Range::mergeable)
-            .def("merge", &Range::merge)
-            .def("hull", &Range::hull)
-            .def("difference", &Range::difference)
-            .def("set_union", &Range::set_union)
+                     &Range::contains, nb::const_),
+                 "Return whether this range completely contains the other "
+                 "range.")
+            .def("intersection", &Range::intersection,
+                 "Return the overlap with the other range, or an empty "
+                 "range when disjoint.")
+            .def("overlaps", &Range::overlaps,
+                 "Return whether the ranges share at least one value.")
+            .def("touches", &Range::touches,
+                 "Return whether the ranges meet at an included endpoint.")
+            .def("adjacent", &Range::adjacent,
+                 "Return whether the ranges meet without overlapping.")
+            .def("mergeable", &Range::mergeable,
+                 "Return whether the ranges can be represented as one "
+                 "continuous range.")
+            .def("merge", &Range::merge,
+                 "Return the merged range, or None when the ranges are "
+                 "disjoint.")
+            .def("hull", &Range::hull,
+                 "Return the smallest range containing both ranges.")
+            .def("difference", &Range::difference,
+                 "Return the portions of this range outside the other "
+                 "range.")
+            .def("set_union", &Range::set_union,
+                 "Return the normalized union of both ranges.")
             .def("__eq__", [](const Range &self, const Range &other) {
                 return self == other;
             })
@@ -301,12 +351,19 @@ namespace hgraph::python_bridge
                 return out.str();
             });
     };
-    bind_range.template operator()<InstantRange>("InstantRange");
-    bind_range.template operator()<CivilDateRange>("CivilDateRange");
+    bind_range.template operator()<InstantRange>(
+        "InstantRange",
+        "An immutable range of UTC instants with independently open or "
+        "closed endpoints. Unbounded and empty ranges are supported.");
+    bind_range.template operator()<CivilDateRange>(
+        "CivilDateRange",
+        "An immutable range of civil dates with independently open or "
+        "closed endpoints. Unbounded and empty ranges are supported.");
 
-    const auto bind_range_set = [&]<typename RangeSet>(const char *name) {
+    const auto bind_range_set = [&]<typename RangeSet>(const char *name,
+                                                       const char *doc) {
         using Range = typename RangeSet::value_type;
-        nb::class_<RangeSet>(m, name)
+        nb::class_<RangeSet>(m, name, doc)
             .def("__init__",
                  [](nb::pointer_and_handle<RangeSet> self,
                     nb::iterable source) {
@@ -355,9 +412,13 @@ namespace hgraph::python_bridge
             });
     };
     bind_range_set.template operator()<InstantRangeSet>(
-        "InstantRangeSet");
+        "InstantRangeSet",
+        "A normalized immutable collection of at most two disjoint instant "
+        "ranges, typically returned by range set operations.");
     bind_range_set.template operator()<CivilDateRangeSet>(
-        "CivilDateRangeSet");
+        "CivilDateRangeSet",
+        "A normalized immutable collection of at most two disjoint civil "
+        "date ranges, typically returned by range set operations.");
 
     m.def("_temporal_checked_add",
           [](Duration lhs, Duration rhs) {

--- a/python/py_type_system.cpp
+++ b/python/py_type_system.cpp
@@ -52,29 +52,39 @@ namespace hgraph::python_bridge
         m, "MonthEndPolicy",
         "Policy for calendar-period arithmetic when the target month does "
         "not contain the original day.")
-        .value("REJECT", MonthEndPolicy::Reject)
-        .value("CLAMP", MonthEndPolicy::Clamp)
+        .value("REJECT", MonthEndPolicy::Reject,
+               "Raise when the target month does not contain the source day.")
+        .value("CLAMP", MonthEndPolicy::Clamp,
+               "Clamp an invalid target day to the target month's final day.")
         .value("PRESERVE_END_OF_MONTH",
-               MonthEndPolicy::PreserveEndOfMonth);
+               MonthEndPolicy::PreserveEndOfMonth,
+               "Map a source month-end to the target month-end; otherwise "
+               "clamp only when the source day is invalid in the target month.");
     nb::enum_<AmbiguousTimePolicy>(
         m, "AmbiguousTimePolicy",
         "Policy for resolving a local civil time that occurs twice during "
         "a time-zone transition.")
-        .value("REJECT", AmbiguousTimePolicy::Reject)
-        .value("EARLIEST", AmbiguousTimePolicy::Earliest)
-        .value("LATEST", AmbiguousTimePolicy::Latest);
+        .value("REJECT", AmbiguousTimePolicy::Reject,
+               "Raise when the local civil time identifies two instants.")
+        .value("EARLIEST", AmbiguousTimePolicy::Earliest,
+               "Select the earlier of the two matching instants.")
+        .value("LATEST", AmbiguousTimePolicy::Latest,
+               "Select the later of the two matching instants.");
     nb::enum_<NonexistentTimePolicy>(
         m, "NonexistentTimePolicy",
         "Policy for resolving a local civil time skipped by a time-zone "
         "transition.")
-        .value("REJECT", NonexistentTimePolicy::Reject)
-        .value("NEXT_VALID", NonexistentTimePolicy::NextValid)
-        .value("PREVIOUS_VALID", NonexistentTimePolicy::PreviousValid);
+        .value("REJECT", NonexistentTimePolicy::Reject,
+               "Raise when the local civil time falls inside a transition gap.")
+        .value("NEXT_VALID", NonexistentTimePolicy::NextValid,
+               "Select the first valid instant after the transition gap.")
+        .value("PREVIOUS_VALID", NonexistentTimePolicy::PreviousValid,
+               "Select the final valid instant before the transition gap.");
     nb::enum_<Boundary>(
         m, "Boundary",
         "Whether a temporal range includes or excludes one endpoint.")
-        .value("OPEN", Boundary::Open)
-        .value("CLOSED", Boundary::Closed);
+        .value("OPEN", Boundary::Open, "Exclude the endpoint from the range.")
+        .value("CLOSED", Boundary::Closed, "Include the endpoint in the range.");
 
     nb::class_<CivilDateTime>(
         m, "CivilDateTime",

--- a/python/py_wiring.cpp
+++ b/python/py_wiring.cpp
@@ -843,7 +843,8 @@ namespace hgraph::python_bridge
              nb::arg("node") = true, nb::arg("graph") = true)
         .def_static("set_print_all_values", &EvaluationTrace::set_print_all_values,
                     nb::arg("value"),
-                    "Globally enable or disable full value rendering in traces.")
+                    "Globally include or omit valid input values that did not "
+                    "tick in node trace output.")
         .def_static("set_use_logger", &EvaluationTrace::set_use_logger,
                     nb::arg("value"),
                     "Globally select logging instead of direct trace output.");

--- a/python/py_wiring.cpp
+++ b/python/py_wiring.cpp
@@ -820,33 +820,55 @@ namespace hgraph::python_bridge
         return nb::cast<PyWiredFn &>(source).fn;
     };
 
-    nb::class_<PyRun>(m, "Run").def("recorded", &PyRun::recorded, nb::arg("key"), nb::arg("sparse") = false);
-    m.def("operator_names", [] { return OperatorRegistry::instance().registered_names(); });
+    nb::class_<PyRun>(
+        m, "Run",
+        "The completed result of a native graph execution.\n\n"
+        "Use recorded() to retrieve values captured through the runner's "
+        "record/replay support.")
+        .def("recorded", &PyRun::recorded, nb::arg("key"),
+             nb::arg("sparse") = false,
+             "Return values recorded under key. Sparse mode preserves only "
+             "ticks; dense mode aligns values to evaluation cycles.");
+    m.def("operator_names", [] { return OperatorRegistry::instance().registered_names(); },
+          "Return the names currently registered in the native operator registry.");
 
-    nb::class_<EvaluationTrace>(m, "EvaluationTrace")
+    nb::class_<EvaluationTrace>(
+        m, "EvaluationTrace",
+        "Configure textual tracing for graph and node lifecycle events.\n\n"
+        "Pass an instance as GraphConfiguration.trace. The optional filter "
+        "limits output to matching graph and node paths.")
         .def(nb::init<std::optional<std::string>, bool, bool, bool, bool, bool>(),
              nb::arg("filter").none() = nb::none(), nb::arg("start") = true,
              nb::arg("eval") = true, nb::arg("stop") = true,
              nb::arg("node") = true, nb::arg("graph") = true)
         .def_static("set_print_all_values", &EvaluationTrace::set_print_all_values,
-                    nb::arg("value"))
+                    nb::arg("value"),
+                    "Globally enable or disable full value rendering in traces.")
         .def_static("set_use_logger", &EvaluationTrace::set_use_logger,
-                    nb::arg("value"));
+                    nb::arg("value"),
+                    "Globally select logging instead of direct trace output.");
 
-    nb::class_<EvaluationProfilePhase>(m, "EvaluationProfilePhase")
+    nb::class_<EvaluationProfilePhase>(
+        m, "EvaluationProfilePhase",
+        "Aggregated timing and failure counts for one lifecycle phase.")
         .def_ro("count", &EvaluationProfilePhase::count)
         .def_ro("failures", &EvaluationProfilePhase::failures)
         .def_ro("total_time", &EvaluationProfilePhase::total_time)
         .def_ro("max_time", &EvaluationProfilePhase::max_time)
         .def_ro("recent_time", &EvaluationProfilePhase::recent_time);
-    nb::class_<EvaluationProfileEntry>(m, "EvaluationProfileEntry")
+    nb::class_<EvaluationProfileEntry>(
+        m, "EvaluationProfileEntry",
+        "A profiler entry for one graph or node path, split into start, "
+        "evaluation, and stop phases.")
         .def_ro("path", &EvaluationProfileEntry::path)
         .def_ro("label", &EvaluationProfileEntry::label)
         .def_ro("graph", &EvaluationProfileEntry::graph)
         .def_ro("start", &EvaluationProfileEntry::start)
         .def_ro("evaluation", &EvaluationProfileEntry::evaluation)
         .def_ro("stop", &EvaluationProfileEntry::stop);
-    nb::class_<EvaluationProfileSnapshot>(m, "EvaluationProfileSnapshot")
+    nb::class_<EvaluationProfileSnapshot>(
+        m, "EvaluationProfileSnapshot",
+        "An immutable point-in-time summary captured by EvaluationProfiler.")
         .def_ro("graph_cycles", &EvaluationProfileSnapshot::graph_cycles)
         .def_ro("wall_time", &EvaluationProfileSnapshot::wall_time)
         .def_ro("root_evaluation_time", &EvaluationProfileSnapshot::root_evaluation_time)
@@ -855,31 +877,51 @@ namespace hgraph::python_bridge
         .def_ro("scheduling_lag_samples", &EvaluationProfileSnapshot::scheduling_lag_samples)
         .def_ro("runtime_load", &EvaluationProfileSnapshot::runtime_load)
         .def_ro("entries", &EvaluationProfileSnapshot::entries);
-    nb::class_<EvaluationProfiler>(m, "EvaluationProfiler")
+    nb::class_<EvaluationProfiler>(
+        m, "EvaluationProfiler",
+        "Collect graph and node lifecycle timing without retaining runtime "
+        "objects.\n\n"
+        "Pass an instance as GraphConfiguration.profile. snapshot() is safe "
+        "after the run completes.")
         .def(nb::init<bool, bool, bool, bool, bool, std::size_t>(),
              nb::arg("start") = true, nb::arg("eval") = true,
              nb::arg("stop") = true, nb::arg("node") = true,
              nb::arg("graph") = true, nb::arg("recent_window") = 100)
-        .def("snapshot", &EvaluationProfiler::snapshot)
-        .def("reset", &EvaluationProfiler::reset);
+        .def("snapshot", &EvaluationProfiler::snapshot,
+             "Return an immutable snapshot of the currently collected metrics.")
+        .def("reset", &EvaluationProfiler::reset,
+             "Clear all collected counts and timings.");
 
-    nb::enum_<GraphDiagnosticEntityKind>(m, "GraphDiagnosticEntityKind")
+    nb::enum_<GraphDiagnosticEntityKind>(
+        m, "GraphDiagnosticEntityKind",
+        "Whether a diagnostics entry describes a graph or a node.")
         .value("GRAPH", GraphDiagnosticEntityKind::Graph)
         .value("NODE", GraphDiagnosticEntityKind::Node);
-    nb::class_<NodeStorageMetrics>(m, "NodeStorageMetrics")
+    nb::class_<NodeStorageMetrics>(
+        m, "NodeStorageMetrics",
+        "Static, nested-graph, and dynamic storage metrics for one node.")
         .def_ro("static_bytes", &NodeStorageMetrics::static_bytes)
         .def_ro("nested_graph_count", &NodeStorageMetrics::nested_graph_count)
         .def_ro("nested_graph_capacity", &NodeStorageMetrics::nested_graph_capacity)
         .def_ro("nested_graph_blocks", &NodeStorageMetrics::nested_graph_blocks)
         .def_ro("dynamic_live_bytes", &NodeStorageMetrics::dynamic_live_bytes)
         .def_ro("dynamic_reserved_bytes", &NodeStorageMetrics::dynamic_reserved_bytes);
-    nb::class_<NodeInspectionMetrics>(m, "NodeInspectionMetrics")
+    nb::class_<NodeInspectionMetrics>(
+        m, "NodeInspectionMetrics",
+        "Optional cold-path inspection metrics reported by a node.")
         .def_ro("pending_items", &NodeInspectionMetrics::pending_items);
-    nb::class_<GraphDiagnosticTarget>(m, "GraphDiagnosticTarget")
+    nb::class_<GraphDiagnosticTarget>(
+        m, "GraphDiagnosticTarget",
+        "A resolved connection from a source time-series path to a target "
+        "node input path.")
         .def_ro("source_path", &GraphDiagnosticTarget::source_path)
         .def_ro("node_id", &GraphDiagnosticTarget::node_id)
         .def_ro("target_path", &GraphDiagnosticTarget::target_path);
-    nb::class_<GraphDiagnosticValue>(m, "GraphDiagnosticValue")
+    nb::class_<GraphDiagnosticValue>(
+        m, "GraphDiagnosticValue",
+        "A serialized diagnostic view of an input, output, or scalar value.\n\n"
+        "Value capture is optional. Check available before reading json or "
+        "frame; error and table_error explain failed conversions.")
         .def_ro("available", &GraphDiagnosticValue::available)
         .def_ro("valid", &GraphDiagnosticValue::valid)
         .def_ro("last_modified", &GraphDiagnosticValue::last_modified)
@@ -898,7 +940,10 @@ namespace hgraph::python_bridge
         .def_ro("target_node_ids", &GraphDiagnosticValue::target_node_ids)
         .def_ro("targets", &GraphDiagnosticValue::targets)
         .def_ro("bound_targets", &GraphDiagnosticValue::bound_targets);
-    nb::class_<GraphDiagnosticEntry>(m, "GraphDiagnosticEntry")
+    nb::class_<GraphDiagnosticEntry>(
+        m, "GraphDiagnosticEntry",
+        "One graph or node in a GraphDiagnosticsSnapshot, including "
+        "lifecycle, storage, connection, and optional value information.")
         .def_ro("id", &GraphDiagnosticEntry::id)
         .def_ro("parent_id", &GraphDiagnosticEntry::parent_id)
         .def_ro("children", &GraphDiagnosticEntry::children)
@@ -922,7 +967,11 @@ namespace hgraph::python_bridge
         .def_ro("start", &GraphDiagnosticEntry::start)
         .def_ro("evaluation", &GraphDiagnosticEntry::evaluation)
         .def_ro("stop", &GraphDiagnosticEntry::stop);
-    nb::class_<GraphDiagnosticsSnapshot>(m, "GraphDiagnosticsSnapshot")
+    nb::class_<GraphDiagnosticsSnapshot>(
+        m, "GraphDiagnosticsSnapshot",
+        "An immutable graph-wide diagnostics snapshot.\n\n"
+        "Entries use stable numeric identifiers and do not retain live graph "
+        "or node objects, so a snapshot remains safe after execution.")
         .def_ro("graph_cycles", &GraphDiagnosticsSnapshot::graph_cycles)
         .def_ro("wall_time", &GraphDiagnosticsSnapshot::wall_time)
         .def_ro("root_evaluation_time", &GraphDiagnosticsSnapshot::root_evaluation_time)
@@ -936,7 +985,12 @@ namespace hgraph::python_bridge
         .def_ro("peak_dynamic_live_bytes", &GraphDiagnosticsSnapshot::peak_dynamic_live_bytes)
         .def_ro("peak_dynamic_reserved_bytes", &GraphDiagnosticsSnapshot::peak_dynamic_reserved_bytes)
         .def_ro("entries", &GraphDiagnosticsSnapshot::entries);
-    nb::class_<GraphDiagnostics>(m, "GraphDiagnostics")
+    nb::class_<GraphDiagnostics>(
+        m, "GraphDiagnostics",
+        "Collect graph structure, lifecycle, storage, and optional values.\n\n"
+        "Pass this observer through GraphConfiguration.life_cycle_observers. "
+        "capture_values=True serializes runtime values and may add "
+        "substantial diagnostic cost.")
         .def("__init__",
              [](nb::pointer_and_handle<GraphDiagnostics> self,
                 std::size_t recent_window, bool capture_values) {
@@ -947,9 +1001,13 @@ namespace hgraph::python_bridge
              },
              nb::arg("recent_window") = 100,
              nb::arg("capture_values") = false)
-        .def("snapshot", &GraphDiagnostics::snapshot)
-        .def("reset", &GraphDiagnostics::reset);
-    nb::class_<RuntimeRegistrySnapshot>(m, "RuntimeRegistrySnapshot")
+        .def("snapshot", &GraphDiagnostics::snapshot,
+             "Return an immutable snapshot of the collected diagnostics.")
+        .def("reset", &GraphDiagnostics::reset,
+             "Clear collected diagnostics and peak counters.");
+    nb::class_<RuntimeRegistrySnapshot>(
+        m, "RuntimeRegistrySnapshot",
+        "Process-lifetime cardinalities for native runtime registries.")
         .def_ro("node_runtime_types", &RuntimeRegistrySnapshot::node_runtime_types)
         .def_ro("graph_programs", &RuntimeRegistrySnapshot::graph_programs)
         .def_ro("graph_runtime_types", &RuntimeRegistrySnapshot::graph_runtime_types)
@@ -958,14 +1016,19 @@ namespace hgraph::python_bridge
     m.def("runtime_registry_snapshot", &runtime_registry_snapshot,
           "Capture cold-path process-lifetime runtime registry cardinalities.");
 
-    nb::class_<WiringTracer>(m, "WiringTracer")
+    nb::class_<WiringTracer>(
+        m, "WiringTracer",
+        "Capture graph and node wiring events as formatted text lines.\n\n"
+        "Supply the tracer through GraphConfiguration.wiring_observers or "
+        "trace_wiring. The optional filter matches wiring paths.")
         .def(nb::init<std::string, bool, bool>(), nb::arg("filter") = "",
              nb::arg("graph") = true, nb::arg("node") = true)
         .def_prop_ro("lines", [](const WiringTracer &tracer) {
             return std::vector<std::string>{tracer.lines().begin(),
                                             tracer.lines().end()};
         })
-        .def("clear", &WiringTracer::clear);
+        .def("clear", &WiringTracer::clear,
+             "Remove every captured wiring line.");
     nb::class_<WiringObservationScope>(m, "_WiringObservationScope")
         .def("__enter__", [](WiringObservationScope &self) -> WiringObservationScope & {
             return self;

--- a/python/tests/test_compat_exports.py
+++ b/python/tests/test_compat_exports.py
@@ -25,7 +25,12 @@ def test_optional_wiring_annotations_and_parameterized_objects_are_accepted():
 
     assert TS[Box[int]].handle.is_ts
     assert (TS[int] | None) == TS[int]
-    assert hg.datetime is not None
+
+
+def test_standard_library_datetime_types_do_not_leak_from_top_level_api():
+    for name in ("date", "datetime", "time", "timedelta"):
+        assert name not in hg.__all__
+        assert not hasattr(hg, name)
 
 
 def test_state_accepts_documentary_state_type():

--- a/python/tests/test_native_docstrings.py
+++ b/python/tests/test_native_docstrings.py
@@ -12,6 +12,7 @@ def test_native_documentation_is_available_at_runtime_and_in_the_stub():
         from pathlib import Path
 
         import _hgraph
+        import hgraph as hg
 
         types = [
             ("CivilDateTime", "timezone-free calendar date"),
@@ -45,12 +46,56 @@ def test_native_documentation_is_available_at_runtime_and_in_the_stub():
             assert documentation is not None, f"{owner}.{member}"
             assert summary in documentation, f"{owner}.{member}"
 
+        properties = [
+            ("TimeSeries", "value", "current Python value"),
+            ("TimeSeries", "active", "currently schedule its node"),
+            ("OutputView", "value", "Assigning publishes a value"),
+            ("RecordableStateView", "value", "current persistent value"),
+            ("EvaluationEngineApi", "evaluation_mode", "active execution mode"),
+            ("Graph", "nodes", "callback-scoped views"),
+            ("Node", "node_index", "zero-based index"),
+            ("Scheduler", "is_scheduled", "outstanding schedule"),
+        ]
+        for owner, member, summary in properties:
+            documentation = getdoc(getattr(getattr(_hgraph, owner), member))
+            assert documentation is not None, f"{owner}.{member}"
+            assert summary in documentation, f"{owner}.{member}"
+
+        enum_values = [
+            (_hgraph.MonthEndPolicy.PRESERVE_END_OF_MONTH, "source month-end"),
+            (_hgraph.AmbiguousTimePolicy.EARLIEST, "earlier of the two"),
+            (_hgraph.NonexistentTimePolicy.NEXT_VALID, "after the transition gap"),
+            (_hgraph.Boundary.CLOSED, "Include the endpoint"),
+        ]
+        for value, summary in enum_values:
+            documentation = getdoc(value)
+            assert documentation is not None, value
+            assert summary in documentation, value
+
+        public_types = [
+            (hg.TimeSeries, "callback-scoped native time-series input view"),
+            (hg.Graph, "callback-scoped view of a running graph"),
+            (hg.Node, "callback-scoped view of the currently running node"),
+            (hg.GlobalState, "Graph-scoped configuration"),
+            (hg.SCHEDULER, "current node's scheduler"),
+            (hg.CLOCK, "graph evaluation clock"),
+            (hg.TS_OUT, "inspect or mutate its native output"),
+            (hg.RECORDABLE_STATE, "Persistent output-backed node state"),
+        ]
+        for value, summary in public_types:
+            documentation = getdoc(value)
+            assert documentation is not None, value
+            assert summary in documentation, value
+
         stub_path = Path(_hgraph.__file__).parent / "_hgraph.pyi"
         stub = stub_path.read_text()
         assert "A calendar-relative duration measured in years" in stub
         assert "A read-only, callback-scoped native time-series input view" in stub
         assert "Collect graph and node lifecycle timing" in stub
         assert "A callback-scoped scheduler for the current node" in stub
+        assert "The current Python value, or None when the input is invalid" in stub
+        assert "The node's zero-based index within its graph" in stub
+        assert "Select the earlier of the two matching instants" in stub
         """
     )
 

--- a/python/tests/test_native_docstrings.py
+++ b/python/tests/test_native_docstrings.py
@@ -1,0 +1,64 @@
+import subprocess
+import sys
+import textwrap
+
+
+def test_native_documentation_is_available_at_runtime_and_in_the_stub():
+    """Keep module-reset tests from replacing the installed binding under test."""
+
+    check = textwrap.dedent(
+        r"""
+        from inspect import getdoc
+        from pathlib import Path
+
+        import _hgraph
+
+        types = [
+            ("CivilDateTime", "timezone-free calendar date"),
+            ("Period", "calendar-relative duration"),
+            ("TimeSeriesRef", "runtime reference"),
+            ("TimeSeries", "callback-scoped native time-series input view"),
+            ("OutputView", "callback-scoped view of a Python node output"),
+            ("EvaluationClock", "view of graph evaluation time"),
+            ("EvaluationEngineApi", "control view for the running graph executor"),
+            ("Scheduler", "scheduler for the current node"),
+            ("EvaluationProfiler", "Collect graph and node lifecycle timing"),
+            ("GraphDiagnostics", "Collect graph structure"),
+            ("WiringTracer", "Capture graph and node wiring events"),
+        ]
+        for name, summary in types:
+            documentation = getdoc(getattr(_hgraph, name))
+            assert documentation is not None, name
+            assert summary in documentation, name
+
+        methods = [
+            ("CivilDateTime", "weekday", "Monday=0"),
+            ("TimeSeries", "make_passive", "Stop this input"),
+            ("OutputView", "invalidate", "Invalidate the output"),
+            ("EvaluationEngineApi", "request_engine_stop", "graceful stop"),
+            ("EvaluationProfiler", "snapshot", "immutable snapshot"),
+            ("GraphDiagnostics", "reset", "Clear collected diagnostics"),
+            ("Scheduler", "reset", "Cancel every outstanding schedule"),
+        ]
+        for owner, member, summary in methods:
+            documentation = getdoc(getattr(getattr(_hgraph, owner), member))
+            assert documentation is not None, f"{owner}.{member}"
+            assert summary in documentation, f"{owner}.{member}"
+
+        stub_path = Path(_hgraph.__file__).parent / "_hgraph.pyi"
+        stub = stub_path.read_text()
+        assert "A calendar-relative duration measured in years" in stub
+        assert "A read-only, callback-scoped native time-series input view" in stub
+        assert "Collect graph and node lifecycle timing" in stub
+        assert "A callback-scoped scheduler for the current node" in stub
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", check],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/python/tests/test_native_docstrings.py
+++ b/python/tests/test_native_docstrings.py
@@ -36,7 +36,10 @@ def test_native_documentation_is_available_at_runtime_and_in_the_stub():
             ("CivilDateTime", "weekday", "Monday=0"),
             ("TimeSeries", "make_passive", "Stop this input"),
             ("OutputView", "invalidate", "Invalidate the output"),
+            ("InstantRange", "touches", "finite upper endpoint equals"),
+            ("InstantRange", "adjacent", "exactly one meeting boundary"),
             ("EvaluationEngineApi", "request_engine_stop", "graceful stop"),
+            ("EvaluationTrace", "set_print_all_values", "valid input values that did not tick"),
             ("EvaluationProfiler", "snapshot", "immutable snapshot"),
             ("GraphDiagnostics", "reset", "Clear collected diagnostics"),
             ("Scheduler", "reset", "Cancel every outstanding schedule"),
@@ -51,6 +54,7 @@ def test_native_documentation_is_available_at_runtime_and_in_the_stub():
             ("TimeSeries", "active", "currently schedule its node"),
             ("OutputView", "value", "Assigning publishes a value"),
             ("RecordableStateView", "value", "current persistent value"),
+            ("EvaluationClock", "next_cycle_evaluation_time", "immediately following this evaluation cycle"),
             ("EvaluationEngineApi", "evaluation_mode", "active execution mode"),
             ("Graph", "nodes", "callback-scoped views"),
             ("Node", "node_index", "zero-based index"),
@@ -86,6 +90,7 @@ def test_native_documentation_is_available_at_runtime_and_in_the_stub():
             documentation = getdoc(value)
             assert documentation is not None, value
             assert summary in documentation, value
+        assert "immediately following possible evaluation cycle" in getdoc(hg.CLOCK)
 
         stub_path = Path(_hgraph.__file__).parent / "_hgraph.pyi"
         stub = stub_path.read_text()


### PR DESCRIPTION
## Dependency

Stacked on #408. Merge #408 first, then retarget this PR to `main` if GitHub does not update the base automatically.

## Summary

- make the Python authoring API the primary documented end-user surface while retaining the C++ API for native extension authors and performance-sensitive users
- add user-facing nanobind documentation to public temporal values, policy enum members, ranges, time-series references, callback-scoped runtime views, injectables, graph state, and authoring markers
- expose complete, data-only native operator overload metadata for language tooling without exposing registry implementation objects
- generate typed Python protocols for all 201 lazy operators from 922 registered overloads across 212 public registry names; preserve the curated signatures of the 11 explicit Python helpers
- attach semantic Doxygen summaries and exact accepted native overloads to lazy operator runtime docstrings
- derive `inspect.signature` for operators whose overloads share one Python-representable call shape, while retaining an honest catch-all for structurally different overload sets
- keep standard-library `date`, `datetime`, `time`, and `timedelta` names out of the top-level runtime, wildcard, generated-inventory, and generated type-dependency surfaces
- use nanobind stub generation and stub-pattern `\doc` support for native bindings, including the optimized raw `TimeSeries` descriptors
- add regression coverage for runtime help, generated overloads, defaults and keyword-only boundaries, nanobind stubs, installed-wheel exposure, and export hygiene

## Operator signatures and documentation

The native registry now publishes a copied inspection view containing every parameter name, input/scalar kind, native type pattern, default presence, variadic and keyword-only boundary, kwargs pattern, and output pattern. `_hgraph.operator_overload_signatures()` exposes that view to the generator and runtime proxy layer.

The checked `_operator_typing.pyi` contains overload declarations rather than common `(*args, **kwargs)` placeholders. For example, `add_` exposes all 29 registered entries (24 distinct declarations after exact deduplication), including the integer, floating-point, temporal, collection, and generic forms. Native layouts with a default before a later required parameter are represented by valid positional and keyword-only Python variants.

All 212 public registry names have semantic documentation sourced from their public C++ declarations. The 201 lazy proxies combine that summary with their exact native overload list at runtime; the 11 explicit Python helpers retain their existing handwritten signatures and documentation. Generic native schema relationships remain visible in the exact pattern docs where the current non-generic `WiringPort` annotation cannot express them statically.

Generated annotation dependencies are imported under private aliases, so types used only to describe overloads do not become apparent top-level `hgraph` exports.

## Why

Python is the expected end-user authoring interface, but the native objects and lazy operators it exposes previously lacked enough editor, runtime, and API-reference guidance. Users could not reliably discover callback lifetime rules, lazy value conversion, output/state mutation behavior, injectable services, or the actual operator overloads selected during wiring.

The C++ registry remains the source of truth. Python consumes copied signature metadata and adapts it into runtime help and static declarations; it does not implement a second operator or runtime type system.

## Review follow-up

All three earlier inline review findings were answered, fixed in `3885684a4`, and resolved:

- `TimeRange.touches` and `adjacent` now use their actual endpoint and boundary semantics
- `EvaluationClock.next_cycle_evaluation_time` is documented as `evaluation_time + MIN_TD`, not as a queued-event query
- `EvaluationTrace.set_print_all_values` is documented as including valid unticked inputs

## Validation

- fresh native configure, clean build, and 1,494/1,494 C++ tests passed
- stable-ABI wheel built with Python 3.12 and installed into a fresh Python 3.14 environment
- complete non-WIP installed-wheel Python suite: 2,072 passed, 9 skipped
- installed runtime audit: 212/212 public registry names have signatures and docs; 201 lazy proxies expose exact overload docs; `add_` reports all 29 entries
- generated operator stub passes mypy; installed `hgraph.add_` resolves to its generated operator protocol and calls return `WiringPort`
- nanobind-generated `_hgraph.pyi` passes `mypy.stubtest`
- generated imports are private and runtime `dir()`, `__all__`, and the API inventory contain no leaked datetime helper names
- Sphinx HTML build passed with warnings as errors; all 64 doctests passed
- installed C++ SDK consumer configured separately, built, and passed
- API inventory freshness and `git diff --check` passed
