### PR TITLE
Derive a generic bundle from a generic dataclass schema

### DIFF
--- a/hgraph/_types/_tsb_type.py
+++ b/hgraph/_types/_tsb_type.py
@@ -157,12 +157,22 @@ class TimeSeriesSchema(AbstractSchema):
                 return tsc_schema
 
             origin = _dataclass_scalar_origin(schema)
-            if origin is not schema and (schema_args := getattr(schema, "__args__", ())):
-                # Parameterise the origin's generic bundle rather than deriving an
-                # unrelated flat class per parameterisation. TSB[Box[int]] is then
-                # BoxBundle[int], so a node declared over TSB[Box] resolves from it.
-                # This is what the CompoundScalar path below does with _root_cls.
-                tsc_schema = TimeSeriesSchema.from_scalar_schema(origin)[schema_args]
+            free_parameters = getattr(schema, "__parameters__", ())
+            if origin is not schema and getattr(schema, "__args__", ()) and not free_parameters:
+                # A fully bound specialisation parameterises the origin's generic
+                # bundle rather than deriving an unrelated flat class. TSB[Box[int]]
+                # is then BoxBundle[int], so a node declared over TSB[Box] resolves
+                # from it. This is what the CompoundScalar path below does with
+                # _root_cls.
+                #
+                # Only when nothing is left free: a partial specialisation can repeat
+                # a variable (Pair[T, T] has __args__ (T, T) but one parameter), and
+                # handing those raw args to the origin bundle would record
+                # __parameters__ as (T, T), after which resolving with [int] takes the
+                # partial-resolution path and leaves the fields unresolved. Those fall
+                # through to the derivation below, which builds the annotations from
+                # the alias itself and is generic over its real parameters.
+                tsc_schema = TimeSeriesSchema.from_scalar_schema(origin)[schema.__args__]
                 _DATACLASS_BUNDLE_SCHEMAS[schema] = tsc_schema
                 return tsc_schema
 

--- a/hgraph/_types/_tsb_type.py
+++ b/hgraph/_types/_tsb_type.py
@@ -156,6 +156,16 @@ class TimeSeriesSchema(AbstractSchema):
             if tsc_schema := _DATACLASS_BUNDLE_SCHEMAS.get(schema):
                 return tsc_schema
 
+            origin = _dataclass_scalar_origin(schema)
+            if origin is not schema and (schema_args := getattr(schema, "__args__", ())):
+                # Parameterise the origin's generic bundle rather than deriving an
+                # unrelated flat class per parameterisation. TSB[Box[int]] is then
+                # BoxBundle[int], so a node declared over TSB[Box] resolves from it.
+                # This is what the CompoundScalar path below does with _root_cls.
+                tsc_schema = TimeSeriesSchema.from_scalar_schema(origin)[schema_args]
+                _DATACLASS_BUNDLE_SCHEMAS[schema] = tsc_schema
+                return tsc_schema
+
             scalar_meta = HgScalarTypeMetaData.parse_type(schema)
             assert isinstance(scalar_meta, HgCompoundScalarType)
 
@@ -172,9 +182,18 @@ class TimeSeriesSchema(AbstractSchema):
                 "__annotations__": annotations,
                 "__module__": origin.__module__,
             }
+            bases = (TimeSeriesSchema,)
+            if parameters := getattr(schema, "__parameters__", ()):
+                # An unparameterised generic dataclass - ``TSB[Price]`` where
+                # ``Price(Generic[NUMBER])`` - keeps its type variables in the
+                # field annotations, so the generated bundle has to be generic
+                # over the same variables. Without this it holds unresolved
+                # types while not being a generic class, which __build_schema__
+                # rejects. This mirrors what the CompoundScalar path below does.
+                bases += (Generic[parameters],)
             tsc_schema = types.new_class(
                 f"{schema_name}Bundle",
-                (TimeSeriesSchema,),
+                bases,
                 None,
                 lambda ns: ns.update(namespace),
             )

--- a/hgraph/_types/_tsb_type.py
+++ b/hgraph/_types/_tsb_type.py
@@ -140,6 +140,65 @@ class TimeSeriesSchema(AbstractSchema):
         )
 
     @staticmethod
+    def _dataclass_bundle_schema(schema) -> Type["TimeSeriesSchema"]:
+        """The derived bundle for a standard dataclass used as a nominal schema."""
+        from hgraph._types._scalar_type_meta_data import (
+            HgCompoundScalarType,
+            HgScalarTypeMetaData,
+            _dataclass_scalar_origin,
+        )
+        from hgraph._types._ts_type import TS
+
+        if tsc_schema := _DATACLASS_BUNDLE_SCHEMAS.get(schema):
+            return tsc_schema
+
+        origin = _dataclass_scalar_origin(schema)
+        parameters = getattr(schema, "__parameters__", ())
+        if origin is not schema and getattr(schema, "__args__", ()) and not parameters:
+            # A fully bound specialisation parameterises the origin's generic
+            # bundle rather than deriving an unrelated flat class. TSB[Box[int]]
+            # is then BoxBundle[int], so a node declared over TSB[Box] resolves
+            # from it. This is what the CompoundScalar path does with _root_cls.
+            #
+            # Only when nothing is left free: a partial specialisation can repeat
+            # a variable (Pair[T, T] has __args__ (T, T) but one parameter), and
+            # handing those raw args to the origin bundle would record
+            # __parameters__ as (T, T), after which resolving with [int] takes the
+            # partial-resolution path and leaves the fields unresolved. Those fall
+            # through to the derivation below, which builds the annotations from
+            # the alias itself and is generic over its real parameters.
+            tsc_schema = TimeSeriesSchema.from_scalar_schema(origin)[schema.__args__]
+            _DATACLASS_BUNDLE_SCHEMAS[schema] = tsc_schema
+            return tsc_schema
+
+        scalar_meta = HgScalarTypeMetaData.parse_type(schema)
+        assert isinstance(scalar_meta, HgCompoundScalarType)
+
+        schema_name = origin.__name__
+        if schema_args := getattr(schema, "__args__", ()):
+            schema_name += "_" + "_".join(
+                getattr(argument, "__name__", str(argument).replace(".", "_")) for argument in schema_args
+            )
+        namespace = {
+            "__annotations__": {k: TS[v.py_type] for k, v in scalar_meta.meta_data_schema.items()},
+            "__module__": origin.__module__,
+        }
+        bases = (TimeSeriesSchema,)
+        if parameters:
+            # An unparameterised generic dataclass - ``TSB[Price]`` where
+            # ``Price(Generic[NUMBER])`` - keeps its type variables in the field
+            # annotations, so the derived bundle has to be generic over the same
+            # variables. Without this it holds unresolved types while not being a
+            # generic class, which __build_schema__ rejects. This mirrors what the
+            # CompoundScalar path does.
+            bases += (Generic[parameters],)
+
+        tsc_schema = types.new_class(f"{schema_name}Bundle", bases, None, lambda ns: ns.update(namespace))
+        tsc_schema.__scalar_type__ = schema
+        _DATACLASS_BUNDLE_SCHEMAS[schema] = tsc_schema
+        return tsc_schema
+
+    @staticmethod
     def from_scalar_schema(schema: Type[AbstractSchema]) -> Type["TimeSeriesSchema"]:
         """
         Creates a new time-series schema from the scalar schema provided.
@@ -153,63 +212,7 @@ class TimeSeriesSchema(AbstractSchema):
         )
 
         if _is_dataclass_scalar_type(schema):
-            if tsc_schema := _DATACLASS_BUNDLE_SCHEMAS.get(schema):
-                return tsc_schema
-
-            origin = _dataclass_scalar_origin(schema)
-            free_parameters = getattr(schema, "__parameters__", ())
-            if origin is not schema and getattr(schema, "__args__", ()) and not free_parameters:
-                # A fully bound specialisation parameterises the origin's generic
-                # bundle rather than deriving an unrelated flat class. TSB[Box[int]]
-                # is then BoxBundle[int], so a node declared over TSB[Box] resolves
-                # from it. This is what the CompoundScalar path below does with
-                # _root_cls.
-                #
-                # Only when nothing is left free: a partial specialisation can repeat
-                # a variable (Pair[T, T] has __args__ (T, T) but one parameter), and
-                # handing those raw args to the origin bundle would record
-                # __parameters__ as (T, T), after which resolving with [int] takes the
-                # partial-resolution path and leaves the fields unresolved. Those fall
-                # through to the derivation below, which builds the annotations from
-                # the alias itself and is generic over its real parameters.
-                tsc_schema = TimeSeriesSchema.from_scalar_schema(origin)[schema.__args__]
-                _DATACLASS_BUNDLE_SCHEMAS[schema] = tsc_schema
-                return tsc_schema
-
-            scalar_meta = HgScalarTypeMetaData.parse_type(schema)
-            assert isinstance(scalar_meta, HgCompoundScalarType)
-
-            from hgraph._types._ts_type import TS
-
-            annotations = {k: TS[v.py_type] for k, v in scalar_meta.meta_data_schema.items()}
-            origin = _dataclass_scalar_origin(schema)
-            schema_name = origin.__name__
-            if schema_args := getattr(schema, "__args__", ()):
-                schema_name += "_" + "_".join(
-                    getattr(argument, "__name__", str(argument).replace(".", "_")) for argument in schema_args
-                )
-            namespace = {
-                "__annotations__": annotations,
-                "__module__": origin.__module__,
-            }
-            bases = (TimeSeriesSchema,)
-            if parameters := getattr(schema, "__parameters__", ()):
-                # An unparameterised generic dataclass - ``TSB[Price]`` where
-                # ``Price(Generic[NUMBER])`` - keeps its type variables in the
-                # field annotations, so the generated bundle has to be generic
-                # over the same variables. Without this it holds unresolved
-                # types while not being a generic class, which __build_schema__
-                # rejects. This mirrors what the CompoundScalar path below does.
-                bases += (Generic[parameters],)
-            tsc_schema = types.new_class(
-                f"{schema_name}Bundle",
-                bases,
-                None,
-                lambda ns: ns.update(namespace),
-            )
-            tsc_schema.__scalar_type__ = schema
-            _DATACLASS_BUNDLE_SCHEMAS[schema] = tsc_schema
-            return tsc_schema
+            return TimeSeriesSchema._dataclass_bundle_schema(schema)
 
         if schema is CompoundScalar:
             return TimeSeriesSchema

--- a/hgraph_unit_tests/_types/test_dataclass_scalar.py
+++ b/hgraph_unit_tests/_types/test_dataclass_scalar.py
@@ -35,6 +35,7 @@ class Quote:
 
 
 VALUE = TypeVar("VALUE")
+OTHER = TypeVar("OTHER")
 
 
 @dataclass(frozen=True)
@@ -244,6 +245,25 @@ def test_unparameterised_generic_dataclass_bundle_resolves_from_its_inputs():
         return unwrap(combine[TSB[Box[int]]](value=value))
 
     assert eval_node(g, [1, 2]) == [1, 2]
+
+
+def test_partial_specialisation_repeating_a_type_var_stays_resolvable():
+    # Pair[T, T] has __args__ (T, T) but only one parameter. Deriving the bundle
+    # from the origin with those raw args would record __parameters__ as (T, T),
+    # after which resolving with [int] takes the partial-resolution path and
+    # leaves the fields unresolved.
+    @dataclass(frozen=True)
+    class Pair(Generic[VALUE, OTHER]):
+        left: VALUE
+        right: OTHER
+
+    schema = TimeSeriesSchema.from_scalar_schema(Pair[VALUE, VALUE])
+
+    assert schema.__parameters__ == (VALUE,)
+    assert fields(TSB[schema[int]]) == {"left": TS[int], "right": TS[int]}
+
+    # A fully bound specialisation still binds each position independently.
+    assert fields(TSB[Pair[int, str]]) == {"left": TS[int], "right": TS[str]}
 
 
 def test_dataclass_bundle_rejects_non_scalar_and_unresolved_fields():

--- a/hgraph_unit_tests/_types/test_dataclass_scalar.py
+++ b/hgraph_unit_tests/_types/test_dataclass_scalar.py
@@ -217,6 +217,35 @@ def test_dataclass_bundle_derivation_is_conservative_and_cached():
     assert first_schema.scalar_type() is ConservativeBundleShape
 
 
+def test_unparameterised_generic_dataclass_derives_a_generic_bundle():
+    # TSB[Box] leaves VALUE unbound, so the derived bundle keeps a type
+    # variable in its field annotations and has to be generic over it too.
+    # Otherwise schema construction rejects it for holding unresolved types
+    # while not being a generic class.
+    schema = TimeSeriesSchema.from_scalar_schema(Box)
+
+    assert schema.__parameters__ == (VALUE,)
+    assert fields(TSB[Box]) == {"value": TS[VALUE]}
+
+    # Binding the variable still resolves to the concrete bundle.
+    assert fields(TSB[Box[int]]) == {"value": TS[int]}
+
+
+def test_unparameterised_generic_dataclass_bundle_resolves_from_its_inputs():
+    # A node declared over the unparameterised bundle resolves VALUE from the
+    # concrete bundle it is wired to. This is the shape that regressed:
+    # TSB[Box] in a signature could not be constructed at all.
+    @compute_node
+    def unwrap(value: TSB[Box]) -> TS[VALUE]:
+        return value.value.value
+
+    @graph
+    def g(value: TS[int]) -> TS[int]:
+        return unwrap(combine[TSB[Box[int]]](value=value))
+
+    assert eval_node(g, [1, 2]) == [1, 2]
+
+
 def test_dataclass_bundle_rejects_non_scalar_and_unresolved_fields():
     @dataclass(frozen=True)
     class TimeSeriesField:


### PR DESCRIPTION
Using a standard dataclass directly as a bundle schema is meant to be at parity across the 0.5 and 0.8 lines. Two generic cases were not.

Both surface from hg_oap, which supports clients on both lines:

```python
@dataclass(frozen=True)
class Price(Generic[NUMBER], ExprClass, UnitConversionContext):
    qty: NUMBER
    currency_unit: Unit
    unit: Unit

def convert_price_to_currency_units(price: TSB[Price], ...) -> TSB[Price]: ...
```

## 1. `TSB[Price]` could not be constructed

`from_scalar_schema` built the derived bundle with `(TimeSeriesSchema,)` as its only base. An *unparameterised* generic dataclass keeps its type variables in the field annotations, so the result held unresolved types while not being a generic class — which `__build_schema__` rejects:

```
ParseError: Schema '<class ...PriceBundle>' has unresolved types
while not being generic class
```

The derived bundle is now declared `Generic` over the same parameters.

## 2. `TSB[Price[float]]` did not resolve `TSB[Price]`

Each parameterisation derived its own flat class — `Box_intBundle` rather than `BoxBundle[int]` — so the two were unrelated, and a node declared over the unparameterised bundle would not accept a concrete one:

```
Argument 'value: TSB[BoxBundle]' <- 'TSB[Box_intBundle]'
```

A parameterised alias now parameterises the origin's bundle. This is exactly what the `CompoundScalar` path a few lines below already does via `_root_cls`.

## Parity checked against 0.8, not assumed

Each case was run as the same program on both lines rather than reasoned about:

| Case | 0.5.41 before | 0.8.2 | 0.5 after |
|---|---|---|---|
| `TSB[Box[float]]` | OK | OK | OK |
| `TSB[Box]` unparameterised | **ParseError** | OK | OK |
| node on `TSB[Box]` wired from `TSB[Box[int]]` | **WiringError** | OK | OK |

## Tests

Two added to `test_dataclass_scalar.py`, alongside the existing `Box(Generic[VALUE])` fixture — one for the derivation, one for the resolution behaviour.

## Downstream

| | 0.5.41 before | 0.5 after | 0.8.2 |
|---|---|---|---|
| hg_oap | 203 passed, **1 collection error** | **204 passed** | 204 passed |
| hg_systematic | 39 passed | 39 passed | 39 passed |

## Full suite

**1699 passed**, 128 skipped, 5 xfailed (adaptors excluded — the kafka optional dependency is not installed here).

`hgraph_unit_tests/_runtime/test_scheduler.py::test_wall_clock_scheduler_reschedule` fails, and fails identically on the unpatched 0.5.41 wheel, so it is pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
