### PR TITLE
Expose the complete Python time-series runtime API

### DIFF
--- a/docs/source/developer_guide/python_integration.rst
+++ b/docs/source/developer_guide/python_integration.rst
@@ -549,14 +549,16 @@ Recorded divergences / gaps (the morning-summary list):
   ``.all_valid`` / ``.last_modified_time`` / ``.owning_node`` /
   ``.owning_graph`` / ``.is_reference()``. Mutable ``_output`` views expose
   the same generic interrogation properties while retaining their native
-  mutation API. Kind-dispatched: TSS
-  ``added()``/``removed()``; TSD ``[]``/``keys()``/``modified_keys()``/
-  ``modified_items()``/``removed_keys()``/``in``; TSL ``[i]``/``len``;
-  TSB ``.field`` / ``[]``. Child access returns child views sharing the
-  parent's lifetime guard: a view stored past its node's evaluation
-  raises rather than dangling. ``delta_value`` builds hgraph's friendly
-  shapes natively from the dict/set views (no canonical-delta
-  intermediate). Python does not reproduce the old engine's endpoint topology
+  mutation API. Kind-dispatched: TSS exposes current/add/remove set views and
+  membership; TSD exposes complete, modified, valid, added and removed
+  key/value/item ranges plus its zero-copy ``key_set``; TSL and TSB expose
+  complete, modified and valid ranges plus ``key_from_value``; TSW exposes its
+  configured bounds, current occupancy, eviction state, and NumPy-compatible
+  value/time buffers. Child access returns child views sharing the parent's
+  lifetime guard: a view stored past its node's evaluation raises rather than
+  dangling. ``delta_value`` builds hgraph's friendly shapes natively from the
+  dict/set views (no canonical-delta intermediate). Python does not reproduce
+  the old engine's endpoint topology
   mutation hooks: ``bind_output`` / ``un_bind_output``, their ``do_*``
   implementation hooks, ``re_parent``, direct parent/bound-output traversal,
   and subscription management remain native runtime responsibilities.

--- a/docs/source/reference/python_api.rst
+++ b/docs/source/reference/python_api.rst
@@ -58,7 +58,12 @@ for native values, and generated declarations for lazy operators. Nanobind
 reads structured binding signatures (including captured binding docstrings)
 rather than parsing rendered ``__doc__`` text. HGraph augments that result with
 the native operator registry because lazy operators are Python proxy objects,
-not nanobind functions.
+not nanobind functions. The native declaration describes the guarded
+``TimeSeries`` and ``OutputView`` contracts as well: keyed lookup returns a
+child view or ``None``, collection ranges identify their child-view types, and
+``TSW.value_times`` is declared as ``numpy.ndarray``. The runtime value and
+time buffers are NumPy-compatible one-dimensional arrays; window times use
+``datetime64[us]``.
 
 Operator overload selection still happens while the graph is wired, but the
 typing declarations are not reduced to a common ``(*args, **kwargs)`` shape.

--- a/docs/source/reference/types.rst
+++ b/docs/source/reference/types.rst
@@ -35,6 +35,9 @@ stores and updates it.
    * - ``REF[V]``
      - Reference value naming another time-series output
      - ``TimeSeriesReference``
+   * - ``SIGNAL``
+     - A tick notification whose source value is intentionally ignored
+     - ``True`` when the signal ticks
 
 ``Size`` and ``WindowSize`` carry values that ordinary Python generic syntax
 cannot express directly. ``Frame`` and ``Array`` are native scalar schemas for
@@ -86,7 +89,9 @@ runtime storage. Reading ``value`` converts the current value to Python;
 ``delta_value`` converts only the current change. Use ``valid`` before relying
 on an optional input, ``modified`` to detect a tick in the current cycle, and
 ``last_modified_time`` when the tick time matters. ``make_passive`` and
-``make_active`` change whether future input ticks schedule the node.
+``make_active`` change whether future input ticks schedule the node. Every
+input also exposes ``all_valid``, ``owning_node``, ``owning_graph`` and
+``is_reference()``. These are live views, not copies of the runtime endpoint.
 
 Collection types add shape-specific access:
 
@@ -97,13 +102,58 @@ Collection types add shape-specific access:
    * - Input kind
      - Additional runtime access
    * - ``TSS``
-     - ``added()``, ``removed()``, membership and length
+     - ``values()``, ``added()``, ``removed()``, ``was_added(value)``,
+       ``was_removed(value)``, iteration, membership and length
    * - ``TSD``
-     - keys, child lookup, ``modified_items()`` and ``removed_keys()``
+     - ``keys()``/``values()``/``items()``; corresponding ``modified_*``,
+       ``valid_*``, ``added_*`` and ``removed_*`` views; ``get(key)``, child
+       lookup, ``key_from_value(child)``, ``key_set``, iteration, membership
+       and length
    * - ``TSL`` / ``TSB``
-     - child lookup, values, and named-field access for bundles
+     - ``keys()``/``values()``/``items()`` and the ``modified_*`` and
+       ``valid_*`` forms; child lookup, ``key_from_value(child)``, iteration
+       and length. Bundles also provide named-field access and ``as_schema``
    * - ``TSW``
-     - ``has_removed_value`` and ``removed_value`` for window eviction
+     - configured ``size`` and ``min_size``; current occupancy through
+       ``len(window)``; NumPy-compatible ``value`` and ``value_times``
+       buffers; ``first_modified_time``, ``has_removed_value`` and
+       ``removed_value``
+   * - ``REF``
+     - the common input API; ``value`` is the current reference token
+   * - ``SIGNAL``
+     - the common input API; ``value`` and ``delta_value`` are ``True`` on a
+       signal tick
+
+For a ``TSW``, ``size`` and ``min_size`` describe configuration rather than
+current occupancy. They are integers for tick-count windows and
+``datetime.timedelta`` values for duration windows. ``value`` is a one-
+dimensional NumPy array of retained values, and ``value_times`` is a matching
+``datetime64[us]`` array in the same oldest-to-newest order:
+
+.. testcode::
+
+   import numpy as np
+   from hgraph import MIN_ST, TS, TSW, WindowSize, compute_node, graph, to_window
+   from hgraph.test import eval_node
+
+   observations = []
+
+   @compute_node
+   def inspect_window(window: TSW[int, WindowSize[3], WindowSize[1]]) -> TS[int]:
+       assert isinstance(window.value, np.ndarray)
+       assert isinstance(window.value_times, np.ndarray)
+       assert window.value_times.dtype == np.dtype("datetime64[us]")
+       assert len(window.value) == len(window.value_times) == len(window)
+       observations.append((window.value.copy(), window.value_times.copy()))
+       return int(window.value[-1])
+
+   @graph
+   def window_example(value: TS[int]) -> TS[int]:
+       return inspect_window(to_window(value, 3, 1))
+
+   assert eval_node(window_example, [1, 2, 3, 4]) == [1, 2, 3, 4]
+   assert observations[-1][0].tolist() == [2, 3, 4]
+   assert observations[-1][1].tolist()[0] > MIN_ST
 
 Input, output, node, graph, clock and engine views expire when the callback
 returns. Do not retain them in ``STATE`` or pass them to another thread.
@@ -128,6 +178,13 @@ also needs its existing output or must mutate a collection output directly:
        return value.value
 
    assert eval_node(change_only, [1, 1, 2]) == [1, None, 2]
+
+Output views expose the same observational collection and window methods as
+inputs. They additionally provide native mutation: assign ``value``, call
+``invalidate()`` or ``clear()``, use ``add()``/``remove()`` for ``TSS``, and
+use ``get_or_create(key)``, item assignment/deletion or ``pop(key)`` for
+``TSD``. Mutating a child view publishes through the same C++ output; it does
+not build a second Python-side time-series implementation.
 
 ``STATE`` preserves ordinary Python state for one node instance.
 ``RECORDABLE_STATE[Schema]`` instead supplies a native output-backed view whose

--- a/docs/source/user_guide/python_compatibility.rst
+++ b/docs/source/user_guide/python_compatibility.rst
@@ -12,8 +12,8 @@ What remains supported
 
 The following authoring patterns remain part of the public Python surface:
 
-* ``TS``, ``TSS``, ``TSD``, ``TSL``, ``TSB``, ``TSW`` and ``REF`` type
-  expressions;
+* ``TS``, ``TSS``, ``TSD``, ``TSL``, ``TSB``, ``TSW``, ``REF`` and
+  ``SIGNAL`` type expressions;
 * ``graph``, ``compute_node``, ``sink_node``, ``generator`` and ``push_queue``;
 * operator syntax, subscripted type resolution, ``map_``, ``reduce``, ``mesh_``
   and ``switch_``;

--- a/include/hgraph/types/time_series/ts_data/set_view.h
+++ b/include/hgraph/types/time_series/ts_data/set_view.h
@@ -10,7 +10,7 @@
 namespace hgraph
 {
     /** Read view over set-shaped TSData. */
-    class TSSDataView
+    class HGRAPH_EXPORT TSSDataView
     {
       public:
         explicit TSSDataView(TSDataView view);

--- a/include/hgraph/types/time_series/ts_data/window_view.h
+++ b/include/hgraph/types/time_series/ts_data/window_view.h
@@ -9,7 +9,7 @@
 namespace hgraph
 {
     /** Read view over window-shaped TSData. */
-    class TSWDataView
+    class HGRAPH_EXPORT TSWDataView
     {
       public:
         explicit TSWDataView(TSDataView view);
@@ -102,7 +102,7 @@ namespace hgraph
     };
 
     /** Mutation view over window-shaped TSData. */
-    class TSWDataMutationView : public TSWDataView
+    class HGRAPH_EXPORT TSWDataMutationView : public TSWDataView
     {
       public:
         TSWDataMutationView(TSDataView view, DateTime evaluation_time);

--- a/include/hgraph/types/time_series/ts_output/window_view.h
+++ b/include/hgraph/types/time_series/ts_output/window_view.h
@@ -14,7 +14,7 @@ namespace hgraph
     class TSDOutputView;
     class TSWOutputView;
 
-    class TSWOutputView : public TSOutputTypedView<TSWOutputView>
+    class HGRAPH_EXPORT TSWOutputView : public TSOutputTypedView<TSWOutputView>
     {
       public:
         explicit TSWOutputView(TSOutputView view);

--- a/python/_hgraph_stub_patterns.txt
+++ b/python/_hgraph_stub_patterns.txt
@@ -48,6 +48,125 @@ _hgraph\.TimeSeries\.valid$:
     def valid(self) -> bool:
         \doc
 
+# TimeSeries is one native runtime-view class whose collection/window surface
+# dispatches by the schema kind.  Describe the public Python contract rather
+# than leaking nanobind's erased ``object`` return types into editor support.
+_hgraph\.TimeSeries\.(size|min_size)$:
+    @property
+    def \1(self) -> int | datetime.timedelta:
+        \doc
+
+_hgraph\.TimeSeries\.value_times$:
+    \import numpy
+    @property
+    def value_times(self) -> numpy.ndarray:
+        \doc
+
+_hgraph\.TimeSeries\.(keys|modified_keys|valid_keys|added_keys|removed_keys)$:
+    def \1(self) -> list[object]:
+        \doc
+
+_hgraph\.TimeSeries\.values$:
+    def values(self) -> list[TimeSeries | object]:
+        \doc
+
+_hgraph\.TimeSeries\.(modified_values|valid_values|added_values|removed_values)$:
+    def \1(self) -> list[TimeSeries]:
+        \doc
+
+_hgraph\.TimeSeries\.(items|modified_items|valid_items|added_items|removed_items)$:
+    def \1(self) -> list[tuple[object, TimeSeries]]:
+        \doc
+
+_hgraph\.TimeSeries\.(added|removed)$:
+    def \1(self) -> frozenset[object]:
+        \doc
+
+_hgraph\.TimeSeries\.get$:
+    def get(self, key: object) -> TimeSeries | None:
+        \doc
+
+_hgraph\.TimeSeries\.key_from_value$:
+    def key_from_value(self, value: TimeSeries) -> object | None:
+        \doc
+
+_hgraph\.TimeSeries\.__getitem__$:
+    def __getitem__(self, key: object) -> TimeSeries: ...
+
+_hgraph\.TimeSeries\.__iter__$:
+    def __iter__(self) -> Iterator[object]: ...
+
+_hgraph\.TimeSeries\.as_schema$:
+    @property
+    def as_schema(self) -> TimeSeries:
+        \doc
+
+_hgraph\.TimeSeries\.__getattr__$:
+    def __getattr__(self, name: str) -> TimeSeries: ...
+
+_hgraph\.OutputView\.(size|min_size)$:
+    @property
+    def \1(self) -> int | datetime.timedelta:
+        \doc
+
+_hgraph\.OutputView\.value_times$:
+    \import numpy
+    @property
+    def value_times(self) -> numpy.ndarray:
+        \doc
+
+_hgraph\.OutputView\.(keys|modified_keys|valid_keys|added_keys|removed_keys)$:
+    def \1(self) -> list[object]:
+        \doc
+
+_hgraph\.OutputView\.values$:
+    def values(self) -> list[OutputView | object]:
+        \doc
+
+_hgraph\.OutputView\.(modified_values|valid_values|added_values|removed_values)$:
+    def \1(self) -> list[OutputView]:
+        \doc
+
+_hgraph\.OutputView\.(items|modified_items|valid_items|added_items|removed_items)$:
+    def \1(self) -> list[tuple[object, OutputView]]:
+        \doc
+
+_hgraph\.OutputView\.(added|removed)$:
+    def \1(self) -> frozenset[object]:
+        \doc
+
+_hgraph\.OutputView\.get$:
+    def get(self, key: object) -> OutputView | None:
+        \doc
+
+_hgraph\.OutputView\.pop$:
+    def pop(self, key: object) -> OutputView | None:
+        \doc
+
+_hgraph\.OutputView\.key_from_value$:
+    def key_from_value(self, value: OutputView) -> object | None:
+        \doc
+
+_hgraph\.OutputView\.__getitem__$:
+    def __getitem__(self, key: object) -> OutputView: ...
+
+_hgraph\.OutputView\.__setitem__$:
+    def __setitem__(self, key: object, value: object) -> None: ...
+
+_hgraph\.OutputView\.__delitem__$:
+    def __delitem__(self, key: object) -> None: ...
+
+_hgraph\.OutputView\.__iter__$:
+    def __iter__(self) -> Iterator[object]: ...
+
+_hgraph\.OutputView\.as_schema$:
+    @property
+    def as_schema(self) -> OutputView:
+        \doc
+
+_hgraph\.OutputView\.__getattr__$:
+    def __getattr__(self, name: str) -> OutputView: ...
+
 _hgraph\.CivilDateTime\.time$:
     @property
     def time(self) -> datetime.time: ...

--- a/python/py_runtime.h
+++ b/python/py_runtime.h
@@ -79,6 +79,23 @@ namespace hgraph::python_bridge
         return result;
     }
 
+    /** Copy a window's evaluation timestamps into the value layer's standard
+        NumPy-compatible one-dimensional buffer.  The scalar binding owns the
+        dtype conversion (DateTime -> datetime64[us]); the window remains the
+        C++ source of ordering and contents. */
+    [[nodiscard]] inline nb::object materialize_window_times(TSWDataView &window)
+    {
+        const ValueTypeRef binding = window.layout().time_binding;
+        const ValueArraySource source{
+            .owner = &window,
+            .size = window.size(),
+            .element_at = [](const void *owner, std::size_t index) -> const void * {
+                return static_cast<const TSWDataView *>(owner)->time_value_at(index).data();
+            },
+        };
+        return binding.ops_ref().to_python_buffer(binding, source);
+    }
+
     /**
      * ONE compute/sink operator for ANY arity (Howard's review: per-arity
      * stubs do not scale): the argument ports pack into a STRUCTURAL
@@ -464,11 +481,25 @@ namespace hgraph::python_bridge
         DateTime       now{};
         NodeScheduler  scheduler;
         PyTsLease      lease;
+        /** Parent-relative identity retained for ``key_from_value`` when an
+            invalid structural output child has no resolved data pointer. */
+        nb::object     collection_key{};
+        const void    *collection_identity{nullptr};
 
         [[nodiscard]] TSOutputView checked() const
         {
             lease.require_alive("an output view was accessed outside its node's evaluation");
             return handle.view(now);
+        }
+
+        [[nodiscard]] PyOutput collection_child(TSOutputHandle child,
+                                                nb::object key) const
+        {
+            PyOutput result{
+                std::move(child), now, scheduler, lease};
+            result.collection_key      = std::move(key);
+            result.collection_identity = checked().data_view().data();
+            return result;
         }
 
         [[nodiscard]] bool valid() const
@@ -560,19 +591,27 @@ namespace hgraph::python_bridge
                     {
                         throw nb::key_error("output key not found");
                     }
-                    return PyOutput{dict.at(key_value.view()).handle(), now, scheduler, lease};
+                    return collection_child(
+                        dict.at(key_value.view()).handle(),
+                        nb::borrow<nb::object>(key));
                 }
                 case TSTypeKind::TSL: {
                     auto list = view.as_list();
-                    return PyOutput{
-                        list.at(nb::cast<std::size_t>(key)).handle(), now, scheduler, lease};
+                    const auto index = nb::cast<std::size_t>(key);
+                    return collection_child(list.at(index).handle(), nb::cast(index));
                 }
                 case TSTypeKind::TSB: {
                     auto bundle = view.as_bundle();
-                    TSOutputView result = nb::isinstance<nb::str>(key)
-                                              ? bundle.field(nb::cast<std::string>(key))
-                                              : bundle.at(nb::cast<std::size_t>(key));
-                    return PyOutput{result.handle(), now, scheduler, lease};
+                    if (nb::isinstance<nb::str>(key))
+                    {
+                        return collection_child(
+                            bundle.field(nb::cast<std::string>(key)).handle(),
+                            nb::borrow<nb::object>(key));
+                    }
+                    const auto index = nb::cast<std::size_t>(key);
+                    const auto &field = view.schema()->fields()[index];
+                    return collection_child(
+                        bundle.at(index).handle(), nb::str(field.name));
                 }
                 default: throw nb::type_error("this output kind has no children");
             }
@@ -588,8 +627,8 @@ namespace hgraph::python_bridge
             Value key_value = py_to_value_as(key, view.schema()->key_type());
             auto  mutation  = view.as_dict().begin_mutation(now);
             auto  child     = mutation.at(key_value.view());
-            return PyOutput{
-                TSOutputHandle{view.output(), child}, now, scheduler, lease};
+            return collection_child(
+                TSOutputHandle{view.output(), child}, nb::borrow<nb::object>(key));
         }
 
         void erase(nb::handle key) const
@@ -601,6 +640,28 @@ namespace hgraph::python_bridge
             }
             Value key_value = py_to_value_as(key, view.schema()->key_type());
             static_cast<void>(view.as_dict().begin_mutation(now).erase(key_value.view()));
+        }
+
+        void set_child_value(nb::handle key, nb::object value) const
+        {
+            child(key).set_value(std::move(value));
+        }
+
+        [[nodiscard]] nb::object pop(nb::handle key) const
+        {
+            auto view = checked();
+            if (view.schema()->kind != TSTypeKind::TSD)
+            {
+                throw nb::type_error("pop(): not a keyed output");
+            }
+            Value key_value = py_to_value_as(key, view.schema()->key_type());
+            auto  dict      = view.as_dict();
+            if (!dict.contains(key_value.view())) { return nb::none(); }
+            PyOutput removed = collection_child(
+                TSOutputHandle{dict.at(key_value.view())},
+                nb::borrow<nb::object>(key));
+            static_cast<void>(dict.begin_mutation(now).erase(key_value.view()));
+            return nb::cast(std::move(removed));
         }
 
         void clear() const
@@ -644,8 +705,306 @@ namespace hgraph::python_bridge
                 case TSTypeKind::TSS: return view.as_set().size();
                 case TSTypeKind::TSL: return view.as_list().size();
                 case TSTypeKind::TSB: return view.as_bundle().size();
+                case TSTypeKind::TSW: return view.as_window().size();
                 default: throw nb::type_error("this output kind has no size");
             }
+        }
+
+        [[nodiscard]] nb::object get(nb::handle key) const
+        {
+            auto view = checked();
+            if (view.schema()->kind != TSTypeKind::TSD)
+            {
+                throw nb::type_error("get(): not a keyed output");
+            }
+            Value key_value = py_to_value_as(key, view.schema()->key_type());
+            auto  dict      = view.as_dict();
+            return dict.contains(key_value.view())
+                       ? nb::cast(collection_child(
+                             TSOutputHandle{dict.at(key_value.view())},
+                             nb::borrow<nb::object>(key)))
+                       : nb::none();
+        }
+
+        [[nodiscard]] PyOutput key_set() const
+        {
+            auto view = checked();
+            if (view.schema()->kind != TSTypeKind::TSD)
+            {
+                throw nb::attribute_error("key_set");
+            }
+            return PyOutput{
+                TSOutputHandle{view.as_dict().key_set()}, now, scheduler, lease};
+        }
+
+        [[nodiscard]] nb::list keys() const
+        {
+            nb::list result;
+            auto view = checked();
+            switch (view.schema()->kind)
+            {
+                case TSTypeKind::TSD: {
+                    for (const ValueView &key : view.as_dict().keys())
+                    {
+                        result.append(value_to_py(key));
+                    }
+                    return result;
+                }
+                case TSTypeKind::TSL: {
+                    const auto length = view.as_list().size();
+                    for (std::size_t index = 0; index < length; ++index) { result.append(index); }
+                    return result;
+                }
+                case TSTypeKind::TSB: {
+                    auto bundle = view.as_bundle();
+                    for (std::string_view key : bundle.keys())
+                    {
+                        result.append(nb::str(key.data(), key.size()));
+                    }
+                    return result;
+                }
+                default: throw nb::type_error("keys(): not an indexed output");
+            }
+        }
+
+        [[nodiscard]] nb::list values() const
+        {
+            nb::list result;
+            auto view = checked();
+            switch (view.schema()->kind)
+            {
+                case TSTypeKind::TSD: {
+                    auto dict = view.as_dict();
+                    for (auto &&[key, child] : dict.items())
+                    {
+                        result.append(collection_child(
+                            TSOutputHandle{std::move(child)}, value_to_py(key)));
+                    }
+                    return result;
+                }
+                case TSTypeKind::TSL: {
+                    auto list = view.as_list();
+                    for (auto &&[index, child] : list.items())
+                    {
+                        result.append(collection_child(
+                            TSOutputHandle{std::move(child)}, nb::cast(index)));
+                    }
+                    return result;
+                }
+                case TSTypeKind::TSB: {
+                    auto bundle = view.as_bundle();
+                    for (auto &&[key, child] : bundle.items())
+                    {
+                        result.append(collection_child(
+                            TSOutputHandle{std::move(child)},
+                            nb::str(key.data(), key.size())));
+                    }
+                    return result;
+                }
+                case TSTypeKind::TSS: {
+                    auto set = view.as_set();
+                    for (const ValueView &element : set.values())
+                    {
+                        result.append(value_to_py(element));
+                    }
+                    return result;
+                }
+                default: throw nb::type_error("values(): not a collection output");
+            }
+        }
+
+        [[nodiscard]] nb::list items() const
+        {
+            nb::list result;
+            auto view = checked();
+            switch (view.schema()->kind)
+            {
+                case TSTypeKind::TSD: {
+                    auto dict = view.as_dict();
+                    for (auto &&[key, child] : dict.items())
+                    {
+                        nb::object py_key = value_to_py(key);
+                        result.append(nb::make_tuple(
+                            py_key,
+                            collection_child(TSOutputHandle{std::move(child)}, py_key)));
+                    }
+                    return result;
+                }
+                case TSTypeKind::TSL: {
+                    auto list = view.as_list();
+                    for (auto &&[index, child] : list.items())
+                    {
+                        result.append(nb::make_tuple(
+                            index,
+                            collection_child(
+                                TSOutputHandle{std::move(child)}, nb::cast(index))));
+                    }
+                    return result;
+                }
+                case TSTypeKind::TSB: {
+                    auto bundle = view.as_bundle();
+                    for (auto &&[key, child] : bundle.items())
+                    {
+                        nb::object py_key = nb::str(key.data(), key.size());
+                        result.append(nb::make_tuple(
+                            py_key,
+                            collection_child(TSOutputHandle{std::move(child)}, py_key)));
+                    }
+                    return result;
+                }
+                default: throw nb::type_error("items(): not an indexed output");
+            }
+        }
+
+        [[nodiscard]] nb::list modified_keys() const
+        {
+            nb::list result;
+            for (nb::handle item : modified_items()) { result.append(item[0]); }
+            return result;
+        }
+
+        [[nodiscard]] nb::list modified_values() const
+        {
+            nb::list result;
+            for (nb::handle item : modified_items()) { result.append(item[1]); }
+            return result;
+        }
+
+        [[nodiscard]] nb::list modified_items() const
+        {
+            nb::list result;
+            auto view = checked();
+            switch (view.schema()->kind)
+            {
+                case TSTypeKind::TSD: {
+                    auto dict = view.as_dict();
+                    for (auto &&[key, child] : dict.modified_items())
+                    {
+                        nb::object py_key = value_to_py(key);
+                        result.append(nb::make_tuple(
+                            py_key,
+                            collection_child(TSOutputHandle{std::move(child)}, py_key)));
+                    }
+                    return result;
+                }
+                case TSTypeKind::TSL: {
+                    auto list = view.as_list();
+                    for (auto &&[index, child] : list.modified_items())
+                    {
+                        result.append(nb::make_tuple(
+                            index,
+                            collection_child(
+                                TSOutputHandle{std::move(child)}, nb::cast(index))));
+                    }
+                    return result;
+                }
+                case TSTypeKind::TSB: {
+                    auto bundle = view.as_bundle();
+                    for (auto &&[key, child] : bundle.modified_items())
+                    {
+                        nb::object py_key = nb::str(key.data(), key.size());
+                        result.append(nb::make_tuple(
+                            py_key,
+                            collection_child(TSOutputHandle{std::move(child)}, py_key)));
+                    }
+                    return result;
+                }
+                default: throw nb::type_error("modified_items(): not an indexed output");
+            }
+        }
+
+        [[nodiscard]] nb::list valid_keys() const
+        {
+            nb::list result;
+            for (nb::handle item : valid_items()) { result.append(item[0]); }
+            return result;
+        }
+
+        [[nodiscard]] nb::list valid_values() const
+        {
+            nb::list result;
+            for (nb::handle item : valid_items()) { result.append(item[1]); }
+            return result;
+        }
+
+        [[nodiscard]] nb::list valid_items() const
+        {
+            nb::list result;
+            auto view = checked();
+            switch (view.schema()->kind)
+            {
+                case TSTypeKind::TSD: {
+                    auto dict = view.as_dict();
+                    for (auto &&[key, child] : dict.valid_items())
+                    {
+                        nb::object py_key = value_to_py(key);
+                        result.append(nb::make_tuple(
+                            py_key,
+                            collection_child(TSOutputHandle{std::move(child)}, py_key)));
+                    }
+                    return result;
+                }
+                case TSTypeKind::TSL: {
+                    auto list = view.as_list();
+                    for (auto &&[index, child] : list.valid_items())
+                    {
+                        result.append(nb::make_tuple(
+                            index,
+                            collection_child(
+                                TSOutputHandle{std::move(child)}, nb::cast(index))));
+                    }
+                    return result;
+                }
+                case TSTypeKind::TSB: {
+                    auto bundle = view.as_bundle();
+                    for (auto &&[key, child] : bundle.valid_items())
+                    {
+                        nb::object py_key = nb::str(key.data(), key.size());
+                        result.append(nb::make_tuple(
+                            py_key,
+                            collection_child(TSOutputHandle{std::move(child)}, py_key)));
+                    }
+                    return result;
+                }
+                default: throw nb::type_error("valid_items(): not an indexed output");
+            }
+        }
+
+        [[nodiscard]] nb::list added_keys() const
+        {
+            nb::list result;
+            auto view = checked();
+            auto dict = view.as_dict();
+            for (const ValueView &key : dict.added_keys()) { result.append(value_to_py(key)); }
+            return result;
+        }
+
+        [[nodiscard]] nb::list added_values() const
+        {
+            nb::list result;
+            auto view = checked();
+            auto dict = view.as_dict();
+            for (auto &&[key, child] : dict.added_items())
+            {
+                result.append(collection_child(
+                    TSOutputHandle{std::move(child)}, value_to_py(key)));
+            }
+            return result;
+        }
+
+        [[nodiscard]] nb::list added_items() const
+        {
+            nb::list result;
+            auto view = checked();
+            auto dict = view.as_dict();
+            for (auto &&[key, child] : dict.added_items())
+            {
+                nb::object py_key = value_to_py(key);
+                result.append(nb::make_tuple(
+                    py_key,
+                    collection_child(TSOutputHandle{std::move(child)}, py_key)));
+            }
+            return result;
         }
 
         [[nodiscard]] nb::list removed_keys() const
@@ -655,6 +1014,186 @@ namespace hgraph::python_bridge
             auto     dict = view.as_dict();
             for (const ValueView &key : dict.removed_keys()) { result.append(value_to_py(key)); }
             return result;
+        }
+
+        [[nodiscard]] nb::list removed_values() const
+        {
+            nb::list result;
+            auto view = checked();
+            auto dict = view.as_dict();
+            for (auto &&[key, child] : dict.removed_items())
+            {
+                result.append(collection_child(
+                    TSOutputHandle{std::move(child)}, value_to_py(key)));
+            }
+            return result;
+        }
+
+        [[nodiscard]] nb::list removed_items() const
+        {
+            nb::list result;
+            auto view = checked();
+            auto dict = view.as_dict();
+            for (auto &&[key, child] : dict.removed_items())
+            {
+                nb::object py_key = value_to_py(key);
+                result.append(nb::make_tuple(
+                    py_key,
+                    collection_child(TSOutputHandle{std::move(child)}, py_key)));
+            }
+            return result;
+        }
+
+        [[nodiscard]] nb::object set_added() const
+        {
+            nb::list items;
+            auto view = checked();
+            auto set  = view.as_set();
+            for (const ValueView &element : set.added())
+            {
+                items.append(value_to_py(element));
+            }
+            return nb::steal(PyFrozenSet_New(items.ptr()));
+        }
+
+        [[nodiscard]] nb::object set_removed() const
+        {
+            nb::list items;
+            auto view = checked();
+            auto set  = view.as_set();
+            for (const ValueView &element : set.removed())
+            {
+                items.append(value_to_py(element));
+            }
+            return nb::steal(PyFrozenSet_New(items.ptr()));
+        }
+
+        [[nodiscard]] bool was_added(nb::handle item) const
+        {
+            nb::object changes = set_added();
+            const int result = PySequence_Contains(changes.ptr(), item.ptr());
+            if (result < 0) { nb::raise_python_error(); }
+            return result != 0;
+        }
+
+        [[nodiscard]] bool was_removed(nb::handle item) const
+        {
+            nb::object changes = set_removed();
+            const int result = PySequence_Contains(changes.ptr(), item.ptr());
+            if (result < 0) { nb::raise_python_error(); }
+            return result != 0;
+        }
+
+        [[nodiscard]] nb::object key_from_value(const PyOutput &value) const
+        {
+            const auto identity = checked().data_view().data();
+            if (value.collection_identity == identity &&
+                value.collection_key.is_valid())
+            {
+                return nb::borrow<nb::object>(value.collection_key);
+            }
+            const auto target = value.checked().data_view().data();
+            auto view = checked();
+            if (view.schema()->kind == TSTypeKind::TSL)
+            {
+                auto list = view.as_list();
+                for (std::size_t index = 0; index < list.size(); ++index)
+                {
+                    if (list[index].data_view().data() == target) { return nb::cast(index); }
+                }
+                return nb::none();
+            }
+            if (view.schema()->kind == TSTypeKind::TSB)
+            {
+                auto bundle = view.as_bundle();
+                for (auto &&[key, child] : bundle.items())
+                {
+                    if (child.data_view().data() == target)
+                    {
+                        return nb::str(key.data(), key.size());
+                    }
+                }
+                return nb::none();
+            }
+            if (view.schema()->kind == TSTypeKind::TSD)
+            {
+                auto dict = view.as_dict();
+                for (auto &&[key, child] : dict.items())
+                {
+                    if (child.data_view().data() == target) { return value_to_py(key); }
+                }
+                return nb::none();
+            }
+            throw nb::type_error("key_from_value(): not an indexed output");
+        }
+
+        [[nodiscard]] nb::object window_size() const
+        {
+            auto view   = checked();
+            if (view.schema()->kind != TSTypeKind::TSW)
+            {
+                throw nb::attribute_error("size");
+            }
+            auto window = view.as_window();
+            return window.duration_based() ? nb::cast(window.time_range())
+                                           : nb::cast(window.period());
+        }
+
+        [[nodiscard]] nb::object window_min_size() const
+        {
+            auto view   = checked();
+            if (view.schema()->kind != TSTypeKind::TSW)
+            {
+                throw nb::attribute_error("min_size");
+            }
+            auto window = view.as_window();
+            return window.duration_based() ? nb::cast(window.min_time_range())
+                                           : nb::cast(window.min_period());
+        }
+
+        [[nodiscard]] nb::object value_times() const
+        {
+            auto view   = checked();
+            if (view.schema()->kind != TSTypeKind::TSW)
+            {
+                throw nb::attribute_error("value_times");
+            }
+            auto window = view.as_window().data_view();
+            return materialize_window_times(window);
+        }
+
+        [[nodiscard]] DateTime first_modified_time() const
+        {
+            auto view   = checked();
+            if (view.schema()->kind != TSTypeKind::TSW)
+            {
+                throw nb::attribute_error("first_modified_time");
+            }
+            auto window = view.as_window();
+            return window.first_modified_time();
+        }
+
+        [[nodiscard]] bool has_removed_value() const
+        {
+            auto view   = checked();
+            if (view.schema()->kind != TSTypeKind::TSW)
+            {
+                throw nb::attribute_error("has_removed_value");
+            }
+            auto window = view.as_window().data_view();
+            return window.has_removed_value(now);
+        }
+
+        [[nodiscard]] nb::object removed_value() const
+        {
+            auto view   = checked();
+            if (view.schema()->kind != TSTypeKind::TSW)
+            {
+                throw nb::attribute_error("removed_value");
+            }
+            auto window = view.as_window().data_view();
+            return window.has_removed_value(now) ? value_to_py(window.removed_value(now))
+                                                 : nb::none();
         }
 
         [[nodiscard]] bool add(nb::handle value) const
@@ -761,6 +1300,16 @@ namespace hgraph::python_bridge
         PyTsLease         lease;
         TSDataStorageRef<> evaluation_data{};
         const TSDataOps   *python_value_ops{nullptr};
+        /** ``TSD.key_set`` is a zero-copy observational projection over the
+            parent input.  Keeping the parent TSInputView preserves ownership,
+            sampled-transition and callback-lifetime behaviour while the
+            public kind and set methods dispatch to its native key-set view. */
+        bool               key_set_projection{false};
+        /** Parent-relative identity retained for ``key_from_value`` even when
+            a structural child is currently invalid and therefore has no
+            resolved target-data pointer. */
+        nb::object         collection_key{};
+        const void        *collection_identity{nullptr};
 
         void refresh_evaluation_data(TSDataStorageRef<> storage,
                                      bool has_current_value)
@@ -787,9 +1336,39 @@ namespace hgraph::python_bridge
             return view;
         }
 
-        [[nodiscard]] TSTypeKind kind() const { return checked().schema()->kind; }
+        [[nodiscard]] TSTypeKind kind() const
+        {
+            return key_set_projection ? TSTypeKind::TSS : checked().schema()->kind;
+        }
 
-        [[nodiscard]] bool is_reference() const { return checked().is_reference(); }
+        [[nodiscard]] bool is_reference() const
+        {
+            return !key_set_projection && checked().is_reference();
+        }
+
+        [[nodiscard]] TSDInputView projected_dict() const
+        {
+            if (!key_set_projection)
+            {
+                throw nb::type_error("this time-series is not a dictionary key-set projection");
+            }
+            return checked().as_dict();
+        }
+
+        [[nodiscard]] static nb::object python_set(nb::list items, bool frozen)
+        {
+            return frozen ? nb::steal(PyFrozenSet_New(items.ptr()))
+                          : nb::steal(PySet_New(items.ptr()));
+        }
+
+        [[nodiscard]] PyTimeSeries collection_child(TSInputView child,
+                                                    nb::object key) const
+        {
+            PyTimeSeries result{std::move(child), lease};
+            result.collection_key      = std::move(key);
+            result.collection_identity = checked().data_view().data();
+            return result;
+        }
 
         [[nodiscard]] nb::object owning_node() const
         {
@@ -814,6 +1393,16 @@ namespace hgraph::python_bridge
 
         [[nodiscard]] nb::object value() const
         {
+            if (key_set_projection)
+            {
+                nb::list items;
+                auto dict = projected_dict();
+                for (const ValueView &key : dict.keys())
+                {
+                    items.append(value_to_py(key));
+                }
+                return python_set(std::move(items), false);
+            }
             if (python_value_ops != nullptr)
             {
                 // The argument assembler already proved that this atomic TS
@@ -895,6 +1484,14 @@ namespace hgraph::python_bridge
 
         [[nodiscard]] nb::object delta_value() const
         {
+            if (key_set_projection)
+            {
+                nb::dict canonical;
+                canonical["added"]   = added();
+                canonical["removed"] = removed();
+                nb::object &shape = delta_shaper_slot();
+                return shape.is_valid() ? shape(canonical) : std::move(canonical);
+            }
             const auto &ts = checked();
             if (ts.schema() != nullptr && ts.schema()->kind == TSTypeKind::REF)
             {
@@ -915,26 +1512,80 @@ namespace hgraph::python_bridge
             return shape.is_valid() ? shape(delta) : delta;
         }
 
-        [[nodiscard]] bool modified() const { return checked().modified(); }
-        [[nodiscard]] bool valid() const { return checked().valid(); }
-        [[nodiscard]] bool all_valid() const { return checked().all_valid(); }
-        [[nodiscard]] DateTime last_modified_time() const { return checked().last_modified_time(); }
+        [[nodiscard]] bool modified() const
+        {
+            return key_set_projection ? projected_dict().structure_modified()
+                                      : checked().modified();
+        }
+        [[nodiscard]] bool valid() const
+        {
+            if (!key_set_projection) { return checked().valid(); }
+            auto data = projected_dict().data_view().key_set().base();
+            return data.has_current_value();
+        }
+        [[nodiscard]] bool all_valid() const
+        {
+            return key_set_projection ? valid() : checked().all_valid();
+        }
+        [[nodiscard]] DateTime last_modified_time() const
+        {
+            if (!key_set_projection) { return checked().last_modified_time(); }
+            return projected_dict().data_view().key_set().base().last_modified_time();
+        }
 
         // --- TSS ---
         [[nodiscard]] nb::object added() const
         {
             nb::list items;
-            auto set = checked().as_set();
-            for (const ValueView &element : set.added()) { items.append(value_to_py(element)); }
-            return nb::steal(PyFrozenSet_New(nb::list(items).ptr()));
+            if (key_set_projection)
+            {
+                auto dict = projected_dict();
+                for (const ValueView &element : dict.added_keys())
+                {
+                    items.append(value_to_py(element));
+                }
+            }
+            else
+            {
+                auto set = checked().as_set();
+                for (const ValueView &element : set.added()) { items.append(value_to_py(element)); }
+            }
+            return python_set(std::move(items), true);
         }
 
         [[nodiscard]] nb::object removed() const
         {
             nb::list items;
-            auto set = checked().as_set();
-            for (const ValueView &element : set.removed()) { items.append(value_to_py(element)); }
-            return nb::steal(PyFrozenSet_New(nb::list(items).ptr()));
+            if (key_set_projection)
+            {
+                auto dict = projected_dict();
+                for (const ValueView &element : dict.removed_keys())
+                {
+                    items.append(value_to_py(element));
+                }
+            }
+            else
+            {
+                auto set = checked().as_set();
+                for (const ValueView &element : set.removed()) { items.append(value_to_py(element)); }
+            }
+            return python_set(std::move(items), true);
+        }
+
+        [[nodiscard]] bool was_added(nb::handle item) const
+        {
+            nb::object changes = added();
+            const int result = PySequence_Contains(changes.ptr(), item.ptr());
+            if (result < 0) { nb::raise_python_error(); }
+            return result != 0;
+        }
+
+        [[nodiscard]] bool was_removed(nb::handle item) const
+        {
+            nb::object changes = removed();
+            const int result = PySequence_Contains(changes.ptr(), item.ptr());
+            if (result < 0) { nb::raise_python_error(); }
+            return result != 0;
         }
 
         // --- TSD / TSL / TSB children (share the guard) ---
@@ -945,27 +1596,64 @@ namespace hgraph::python_bridge
             {
                 case TSTypeKind::TSD: {
                     Value key_value = py_to_value_as(key, ts.schema()->key_type());
-                    return PyTimeSeries{ts.as_dict().at(key_value.view()), lease};
+                    auto dict = ts.as_dict();
+                    if (!dict.contains(key_value.view()))
+                    {
+                        throw nb::key_error("time-series key not found");
+                    }
+                    return collection_child(
+                        dict.at(key_value.view()), nb::borrow<nb::object>(key));
                 }
                 case TSTypeKind::TSL: {
                     auto list = ts.as_list();
-                    return PyTimeSeries{list[nb::cast<std::size_t>(key)], lease};
+                    const auto index = nb::cast<std::size_t>(key);
+                    return collection_child(list[index], nb::cast(index));
                 }
                 case TSTypeKind::TSB: {
                     auto bundle = ts.as_bundle();
                     if (nb::isinstance<nb::str>(key))
                     {
-                        return PyTimeSeries{
-                            bundle.field(nb::cast<std::string>(key)), lease};
+                        return collection_child(
+                            bundle.field(nb::cast<std::string>(key)),
+                            nb::borrow<nb::object>(key));
                     }
-                    return PyTimeSeries{bundle[nb::cast<std::size_t>(key)], lease};
+                    const auto index = nb::cast<std::size_t>(key);
+                    const auto &field = ts.schema()->fields()[index];
+                    return collection_child(
+                        bundle[index], nb::str(field.name));
                 }
                 default: throw nb::type_error("this time-series kind has no children");
             }
         }
 
+        [[nodiscard]] nb::object get(nb::handle key) const
+        {
+            const auto &ts = checked();
+            if (ts.schema()->kind != TSTypeKind::TSD)
+            {
+                throw nb::type_error("get(): not a keyed time-series");
+            }
+            Value key_value = py_to_value_as(key, ts.schema()->key_type());
+            auto  dict      = ts.as_dict();
+            return dict.contains(key_value.view())
+                       ? nb::cast(collection_child(
+                             dict.at(key_value.view()), nb::borrow<nb::object>(key)))
+                       : nb::none();
+        }
+
+        [[nodiscard]] PyTimeSeries key_set() const
+        {
+            const auto &ts = checked();
+            if (ts.schema()->kind != TSTypeKind::TSD)
+            {
+                throw nb::attribute_error("key_set");
+            }
+            return PyTimeSeries{ts.borrowed_ref(), lease, {}, nullptr, true};
+        }
+
         [[nodiscard]] std::size_t size() const
         {
+            if (key_set_projection) { return projected_dict().size(); }
             const auto &ts = checked();
             switch (ts.schema()->kind)
             {
@@ -973,6 +1661,7 @@ namespace hgraph::python_bridge
                 case TSTypeKind::TSL: return ts.as_list().size();
                 case TSTypeKind::TSB: return ts.as_bundle().size();
                 case TSTypeKind::TSS: return ts.as_set().size();
+                case TSTypeKind::TSW: return ts.as_window().size();
                 default: throw nb::type_error("this time-series kind has no size");
             }
         }
@@ -980,47 +1669,151 @@ namespace hgraph::python_bridge
         [[nodiscard]] nb::list keys() const
         {
             nb::list result;
-            auto dict = checked().as_dict();
-            for (const ValueView &key : dict.keys()) { result.append(value_to_py(key)); }
-            return result;
+            const auto &ts = checked();
+            switch (ts.schema()->kind)
+            {
+                case TSTypeKind::TSD: {
+                    auto dict = ts.as_dict();
+                    for (const ValueView &key : dict.keys()) { result.append(value_to_py(key)); }
+                    return result;
+                }
+                case TSTypeKind::TSL: {
+                    const auto length = ts.as_list().size();
+                    for (std::size_t index = 0; index < length; ++index) { result.append(index); }
+                    return result;
+                }
+                case TSTypeKind::TSB: {
+                    auto bundle = ts.as_bundle();
+                    for (std::string_view key : bundle.keys()) { result.append(nb::str(key.data(), key.size())); }
+                    return result;
+                }
+                default: throw nb::type_error("keys(): not an indexed time-series");
+            }
         }
 
         [[nodiscard]] nb::list modified_keys() const
         {
             nb::list result;
-            auto dict = checked().as_dict();
-            for (const auto &[key, child] : dict.modified_items()) { result.append(value_to_py(key)); }
-            return result;
+            const auto &ts = checked();
+            switch (ts.schema()->kind)
+            {
+                case TSTypeKind::TSD: {
+                    auto dict = ts.as_dict();
+                    for (const ValueView &key : dict.modified_keys()) { result.append(value_to_py(key)); }
+                    return result;
+                }
+                case TSTypeKind::TSL: {
+                    auto list = ts.as_list();
+                    for (auto &&[index, child] : list.modified_items())
+                    {
+                        static_cast<void>(child);
+                        result.append(index);
+                    }
+                    return result;
+                }
+                case TSTypeKind::TSB: {
+                    auto bundle = ts.as_bundle();
+                    for (auto &&[key, child] : bundle.modified_items())
+                    {
+                        static_cast<void>(child);
+                        result.append(nb::str(key.data(), key.size()));
+                    }
+                    return result;
+                }
+                default: throw nb::type_error("modified_keys(): not an indexed time-series");
+            }
         }
 
         [[nodiscard]] nb::list modified_items() const
         {
             nb::list result;
-            auto dict = checked().as_dict();
-            for (auto &&[key, child] : dict.modified_items())
+            const auto &ts = checked();
+            switch (ts.schema()->kind)
             {
-                result.append(nb::make_tuple(
-                    value_to_py(key), PyTimeSeries{std::move(child), lease}));
+                case TSTypeKind::TSD: {
+                    auto dict = ts.as_dict();
+                    for (auto &&[key, child] : dict.modified_items())
+                    {
+                        result.append(nb::make_tuple(
+                            value_to_py(key),
+                            collection_child(std::move(child), value_to_py(key))));
+                    }
+                    return result;
+                }
+                case TSTypeKind::TSL: {
+                    auto list = ts.as_list();
+                    for (auto &&[index, child] : list.modified_items())
+                    {
+                        result.append(nb::make_tuple(
+                            index, collection_child(std::move(child), nb::cast(index))));
+                    }
+                    return result;
+                }
+                case TSTypeKind::TSB: {
+                    auto bundle = ts.as_bundle();
+                    for (auto &&[key, child] : bundle.modified_items())
+                    {
+                        nb::object py_key = nb::str(key.data(), key.size());
+                        result.append(nb::make_tuple(
+                            py_key,
+                            collection_child(std::move(child), py_key)));
+                    }
+                    return result;
+                }
+                default: throw nb::type_error("modified_items(): not an indexed time-series");
             }
-            return result;
         }
 
         [[nodiscard]] nb::list modified_values() const
         {
             nb::list result;
-            auto dict = checked().as_dict();
-            for (auto &&[key, child] : dict.modified_items())
+            const auto &ts = checked();
+            switch (ts.schema()->kind)
             {
-                static_cast<void>(key);
-                result.append(PyTimeSeries{std::move(child), lease});
+                case TSTypeKind::TSD: {
+                    auto dict = ts.as_dict();
+                    for (auto &&[key, child] : dict.modified_items())
+                    {
+                        result.append(collection_child(
+                            std::move(child), value_to_py(key)));
+                    }
+                    return result;
+                }
+                case TSTypeKind::TSL: {
+                    auto list = ts.as_list();
+                    for (auto &&[index, child] : list.modified_items())
+                    {
+                        result.append(collection_child(
+                            std::move(child), nb::cast(index)));
+                    }
+                    return result;
+                }
+                case TSTypeKind::TSB: {
+                    auto bundle = ts.as_bundle();
+                    for (auto &&[key, child] : bundle.modified_items())
+                    {
+                        result.append(collection_child(
+                            std::move(child), nb::str(key.data(), key.size())));
+                    }
+                    return result;
+                }
+                default: throw nb::type_error("modified_values(): not an indexed time-series");
             }
-            return result;
         }
 
         /** Child views in order (TSB fields / TSD entries / TSL elements). */
         [[nodiscard]] nb::list values() const
         {
             nb::list    result;
+            if (key_set_projection)
+            {
+                auto dict = projected_dict();
+                for (const ValueView &key : dict.keys())
+                {
+                    result.append(value_to_py(key));
+                }
+                return result;
+            }
             const auto &ts = checked();
             switch (ts.schema()->kind)
             {
@@ -1028,7 +1821,7 @@ namespace hgraph::python_bridge
                     auto dict = ts.as_dict();
                     for (const ValueView &key : dict.keys())
                     {
-                        result.append(nb::cast(PyTimeSeries{dict.at(key), lease}));
+                        result.append(collection_child(dict.at(key), value_to_py(key)));
                     }
                     return result;
                 }
@@ -1036,7 +1829,8 @@ namespace hgraph::python_bridge
                     auto bundle = ts.as_bundle();
                     for (std::size_t index = 0; index < bundle.size(); ++index)
                     {
-                        result.append(nb::cast(PyTimeSeries{bundle[index], lease}));
+                        result.append(collection_child(
+                            bundle[index], nb::str(ts.schema()->fields()[index].name)));
                     }
                     return result;
                 }
@@ -1044,12 +1838,203 @@ namespace hgraph::python_bridge
                     auto list = ts.as_list();
                     for (std::size_t index = 0; index < list.size(); ++index)
                     {
-                        result.append(nb::cast(PyTimeSeries{list[index], lease}));
+                        result.append(collection_child(list[index], nb::cast(index)));
+                    }
+                    return result;
+                }
+                case TSTypeKind::TSS: {
+                    auto set = ts.as_set();
+                    for (const ValueView &element : set.values())
+                    {
+                        result.append(value_to_py(element));
                     }
                     return result;
                 }
                 default: throw nb::type_error("values(): not a container time-series");
             }
+        }
+
+        [[nodiscard]] nb::list items() const
+        {
+            nb::list result;
+            const auto &ts = checked();
+            switch (ts.schema()->kind)
+            {
+                case TSTypeKind::TSD: {
+                    auto dict = ts.as_dict();
+                    for (auto &&[key, child] : dict.items())
+                    {
+                        nb::object py_key = value_to_py(key);
+                        result.append(nb::make_tuple(
+                            py_key,
+                            collection_child(std::move(child), py_key)));
+                    }
+                    return result;
+                }
+                case TSTypeKind::TSL: {
+                    auto list = ts.as_list();
+                    for (auto &&[index, child] : list.items())
+                    {
+                        result.append(nb::make_tuple(
+                            index, collection_child(std::move(child), nb::cast(index))));
+                    }
+                    return result;
+                }
+                case TSTypeKind::TSB: {
+                    auto bundle = ts.as_bundle();
+                    for (auto &&[key, child] : bundle.items())
+                    {
+                        nb::object py_key = nb::str(key.data(), key.size());
+                        result.append(nb::make_tuple(
+                            py_key,
+                            collection_child(std::move(child), py_key)));
+                    }
+                    return result;
+                }
+                default: throw nb::type_error("items(): not an indexed time-series");
+            }
+        }
+
+        [[nodiscard]] nb::list valid_keys() const
+        {
+            nb::list result;
+            const auto &ts = checked();
+            switch (ts.schema()->kind)
+            {
+                case TSTypeKind::TSD: {
+                    auto dict = ts.as_dict();
+                    for (const ValueView &key : dict.valid_keys()) { result.append(value_to_py(key)); }
+                    return result;
+                }
+                case TSTypeKind::TSL: {
+                    auto list = ts.as_list();
+                    for (auto &&[index, child] : list.valid_items())
+                    {
+                        static_cast<void>(child);
+                        result.append(index);
+                    }
+                    return result;
+                }
+                case TSTypeKind::TSB: {
+                    auto bundle = ts.as_bundle();
+                    for (auto &&[key, child] : bundle.valid_items())
+                    {
+                        static_cast<void>(child);
+                        result.append(nb::str(key.data(), key.size()));
+                    }
+                    return result;
+                }
+                default: throw nb::type_error("valid_keys(): not an indexed time-series");
+            }
+        }
+
+        [[nodiscard]] nb::list valid_values() const
+        {
+            nb::list result;
+            const auto &ts = checked();
+            switch (ts.schema()->kind)
+            {
+                case TSTypeKind::TSD: {
+                    auto dict = ts.as_dict();
+                    for (auto &&[key, child] : dict.valid_items())
+                    {
+                        result.append(collection_child(
+                            std::move(child), value_to_py(key)));
+                    }
+                    return result;
+                }
+                case TSTypeKind::TSL: {
+                    auto list = ts.as_list();
+                    for (auto &&[index, child] : list.valid_items())
+                    {
+                        result.append(collection_child(
+                            std::move(child), nb::cast(index)));
+                    }
+                    return result;
+                }
+                case TSTypeKind::TSB: {
+                    auto bundle = ts.as_bundle();
+                    for (auto &&[key, child] : bundle.valid_items())
+                    {
+                        result.append(collection_child(
+                            std::move(child), nb::str(key.data(), key.size())));
+                    }
+                    return result;
+                }
+                default: throw nb::type_error("valid_values(): not an indexed time-series");
+            }
+        }
+
+        [[nodiscard]] nb::list valid_items() const
+        {
+            nb::list result;
+            const auto &ts = checked();
+            switch (ts.schema()->kind)
+            {
+                case TSTypeKind::TSD: {
+                    auto dict = ts.as_dict();
+                    for (auto &&[key, child] : dict.valid_items())
+                    {
+                        nb::object py_key = value_to_py(key);
+                        result.append(nb::make_tuple(
+                            py_key,
+                            collection_child(std::move(child), py_key)));
+                    }
+                    return result;
+                }
+                case TSTypeKind::TSL: {
+                    auto list = ts.as_list();
+                    for (auto &&[index, child] : list.valid_items())
+                    {
+                        result.append(nb::make_tuple(
+                            index, collection_child(std::move(child), nb::cast(index))));
+                    }
+                    return result;
+                }
+                case TSTypeKind::TSB: {
+                    auto bundle = ts.as_bundle();
+                    for (auto &&[key, child] : bundle.valid_items())
+                    {
+                        nb::object py_key = nb::str(key.data(), key.size());
+                        result.append(nb::make_tuple(
+                            py_key,
+                            collection_child(std::move(child), py_key)));
+                    }
+                    return result;
+                }
+                default: throw nb::type_error("valid_items(): not an indexed time-series");
+            }
+        }
+
+        [[nodiscard]] nb::list added_keys() const
+        {
+            nb::list result;
+            auto dict = checked().as_dict();
+            for (const ValueView &key : dict.added_keys()) { result.append(value_to_py(key)); }
+            return result;
+        }
+
+        [[nodiscard]] nb::list added_values() const
+        {
+            nb::list result;
+            auto dict = checked().as_dict();
+            for (auto &&child : dict.added_values())
+            {
+                result.append(PyTimeSeries{std::move(child), lease});
+            }
+            return result;
+        }
+
+        [[nodiscard]] nb::list added_items() const
+        {
+            nb::list result;
+            auto dict = checked().as_dict();
+            for (auto &&[key, child] : dict.added_items())
+            {
+                result.append(nb::make_tuple(
+                    value_to_py(key), PyTimeSeries{std::move(child), lease}));
+            }
+            return result;
         }
 
         [[nodiscard]] nb::list removed_keys() const
@@ -1060,13 +2045,155 @@ namespace hgraph::python_bridge
             return result;
         }
 
+        [[nodiscard]] nb::list removed_values() const
+        {
+            nb::list result;
+            auto dict = checked().as_dict();
+            for (auto &&child : dict.removed_values())
+            {
+                result.append(PyTimeSeries{std::move(child), lease});
+            }
+            return result;
+        }
+
+        [[nodiscard]] nb::list removed_items() const
+        {
+            nb::list result;
+            auto dict = checked().as_dict();
+            for (auto &&[key, child] : dict.removed_items())
+            {
+                result.append(nb::make_tuple(
+                    value_to_py(key), PyTimeSeries{std::move(child), lease}));
+            }
+            return result;
+        }
+
+        [[nodiscard]] nb::object key_from_value(const PyTimeSeries &value) const
+        {
+            const auto identity = checked().data_view().data();
+            if (value.collection_identity == identity &&
+                value.collection_key.is_valid())
+            {
+                return nb::borrow<nb::object>(value.collection_key);
+            }
+            const auto target = value.checked().data_view().data();
+            const auto &ts = checked();
+            if (ts.schema()->kind == TSTypeKind::TSL)
+            {
+                auto list = ts.as_list();
+                for (std::size_t index = 0; index < list.size(); ++index)
+                {
+                    if (list[index].data_view().data() == target) { return nb::cast(index); }
+                }
+                return nb::none();
+            }
+            if (ts.schema()->kind == TSTypeKind::TSB)
+            {
+                auto bundle = ts.as_bundle();
+                for (auto &&[key, child] : bundle.items())
+                {
+                    if (child.data_view().data() == target)
+                    {
+                        return nb::str(key.data(), key.size());
+                    }
+                }
+                return nb::none();
+            }
+            if (ts.schema()->kind == TSTypeKind::TSD)
+            {
+                auto dict = ts.as_dict();
+                for (auto &&[key, child] : dict.items())
+                {
+                    if (child.data_view().data() == target) { return value_to_py(key); }
+                }
+                return nb::none();
+            }
+            throw nb::type_error("key_from_value(): not an indexed time-series");
+        }
+
+        [[nodiscard]] nb::object window_size() const
+        {
+            const auto &ts = checked();
+            if (ts.schema()->kind != TSTypeKind::TSW)
+            {
+                throw nb::attribute_error("size");
+            }
+            auto window = ts.as_window();
+            return window.duration_based() ? nb::cast(window.time_range())
+                                           : nb::cast(window.period());
+        }
+
+        [[nodiscard]] nb::object window_min_size() const
+        {
+            const auto &ts = checked();
+            if (ts.schema()->kind != TSTypeKind::TSW)
+            {
+                throw nb::attribute_error("min_size");
+            }
+            auto window = ts.as_window();
+            return window.duration_based() ? nb::cast(window.min_time_range())
+                                           : nb::cast(window.min_period());
+        }
+
+        [[nodiscard]] nb::object value_times() const
+        {
+            const auto &ts = checked();
+            if (ts.schema()->kind != TSTypeKind::TSW)
+            {
+                throw nb::attribute_error("value_times");
+            }
+            auto window = ts.as_window().data_view();
+            return materialize_window_times(window);
+        }
+
+        [[nodiscard]] DateTime first_modified_time() const
+        {
+            const auto &ts = checked();
+            if (ts.schema()->kind != TSTypeKind::TSW)
+            {
+                throw nb::attribute_error("first_modified_time");
+            }
+            return ts.as_window().first_modified_time();
+        }
+
+        [[nodiscard]] bool has_removed_value() const
+        {
+            const auto &ts = checked();
+            if (ts.schema()->kind != TSTypeKind::TSW)
+            {
+                throw nb::attribute_error("has_removed_value");
+            }
+            return ts.as_window().has_removed_value();
+        }
+
+        [[nodiscard]] nb::object removed_value() const
+        {
+            const auto &ts = checked();
+            if (ts.schema()->kind != TSTypeKind::TSW)
+            {
+                throw nb::attribute_error("removed_value");
+            }
+            auto window = ts.as_window();
+            return window.has_removed_value() ? value_to_py(window.removed_value()) : nb::none();
+        }
+
         [[nodiscard]] bool contains(nb::handle key) const
         {
+            if (key_set_projection)
+            {
+                Value key_value = py_to_value_as(key, checked().schema()->key_type());
+                return projected_dict().contains(key_value.view());
+            }
             const auto &ts = checked();
             if (ts.schema()->kind == TSTypeKind::TSD)
             {
                 Value key_value = py_to_value_as(key, ts.schema()->key_type());
                 return ts.as_dict().contains(key_value.view());
+            }
+            if (ts.schema()->kind == TSTypeKind::TSS)
+            {
+                Value element = py_to_value_as(key, ts.schema()->value_schema->element_type);
+                return ts.as_set().contains(element.view());
             }
             throw nb::type_error("contains: not a keyed time-series");
         }

--- a/python/py_runtime.h
+++ b/python/py_runtime.h
@@ -644,6 +644,11 @@ namespace hgraph::python_bridge
 
         void set_child_value(nb::handle key, nb::object value) const
         {
+            if (checked().schema()->kind == TSTypeKind::TSD)
+            {
+                get_or_create(key).set_value(std::move(value));
+                return;
+            }
             child(key).set_value(std::move(value));
         }
 
@@ -744,7 +749,8 @@ namespace hgraph::python_bridge
             switch (view.schema()->kind)
             {
                 case TSTypeKind::TSD: {
-                    for (const ValueView &key : view.as_dict().keys())
+                    auto dict = view.as_dict();
+                    for (const ValueView &key : dict.keys())
                     {
                         result.append(value_to_py(key));
                     }
@@ -1093,6 +1099,7 @@ namespace hgraph::python_bridge
                 return nb::borrow<nb::object>(value.collection_key);
             }
             const auto target = value.checked().data_view().data();
+            if (target == nullptr) { return nb::none(); }
             auto view = checked();
             if (view.schema()->kind == TSTypeKind::TSL)
             {
@@ -2018,9 +2025,10 @@ namespace hgraph::python_bridge
         {
             nb::list result;
             auto dict = checked().as_dict();
-            for (auto &&child : dict.added_values())
+            for (auto &&[key, child] : dict.added_items())
             {
-                result.append(PyTimeSeries{std::move(child), lease});
+                result.append(collection_child(
+                    std::move(child), value_to_py(key)));
             }
             return result;
         }
@@ -2031,8 +2039,9 @@ namespace hgraph::python_bridge
             auto dict = checked().as_dict();
             for (auto &&[key, child] : dict.added_items())
             {
+                nb::object py_key = value_to_py(key);
                 result.append(nb::make_tuple(
-                    value_to_py(key), PyTimeSeries{std::move(child), lease}));
+                    py_key, collection_child(std::move(child), py_key)));
             }
             return result;
         }
@@ -2049,9 +2058,10 @@ namespace hgraph::python_bridge
         {
             nb::list result;
             auto dict = checked().as_dict();
-            for (auto &&child : dict.removed_values())
+            for (auto &&[key, child] : dict.removed_items())
             {
-                result.append(PyTimeSeries{std::move(child), lease});
+                result.append(collection_child(
+                    std::move(child), value_to_py(key)));
             }
             return result;
         }
@@ -2062,8 +2072,9 @@ namespace hgraph::python_bridge
             auto dict = checked().as_dict();
             for (auto &&[key, child] : dict.removed_items())
             {
+                nb::object py_key = value_to_py(key);
                 result.append(nb::make_tuple(
-                    value_to_py(key), PyTimeSeries{std::move(child), lease}));
+                    py_key, collection_child(std::move(child), py_key)));
             }
             return result;
         }
@@ -2077,6 +2088,7 @@ namespace hgraph::python_bridge
                 return nb::borrow<nb::object>(value.collection_key);
             }
             const auto target = value.checked().data_view().data();
+            if (target == nullptr) { return nb::none(); }
             const auto &ts = checked();
             if (ts.schema()->kind == TSTypeKind::TSL)
             {

--- a/python/py_state_services.cpp
+++ b/python/py_state_services.cpp
@@ -571,6 +571,18 @@ namespace hgraph::python_bridge
                      "Whether the output ticks in the current cycle.")
         .def_prop_ro("last_modified_time", &PyOutput::last_modified_time,
                      "The evaluation time of the most recent output tick.")
+        .def_prop_ro("size", &PyOutput::window_size,
+                     "The configured tick count or duration of a window output.")
+        .def_prop_ro("min_size", &PyOutput::window_min_size,
+                     "The configured minimum tick count or duration of a window output.")
+        .def_prop_ro("value_times", &PyOutput::value_times,
+                     "A NumPy-compatible datetime64 buffer containing window evaluation times.")
+        .def_prop_ro("first_modified_time", &PyOutput::first_modified_time,
+                     "The evaluation time of the oldest value retained by a window output.")
+        .def_prop_ro("has_removed_value", &PyOutput::has_removed_value,
+                     "Whether a window value was evicted in the current cycle.")
+        .def_prop_ro("removed_value", &PyOutput::removed_value,
+                     "The window value evicted in the current cycle, or None.")
         .def_prop_ro("delta_value", &PyOutput::delta_value,
                      "The change published in the current cycle.")
         .def("is_reference", &PyOutput::is_reference,
@@ -579,24 +591,93 @@ namespace hgraph::python_bridge
                      "The current output value. Assigning publishes a value; "
                      "assigning None invalidates the output.",
                      nb::for_setter(nb::arg("value").none()))
-        .def("can_apply_result", &PyOutput::can_apply_result,
+        .def("can_apply_result", &PyOutput::can_apply_result, nb::arg("result"),
              "Return whether the Python value can be applied to this output.")
-        .def("get_or_create", &PyOutput::get_or_create,
+        .def("get_or_create", &PyOutput::get_or_create, nb::arg("key"),
              "Return the keyed child output, creating it when absent.")
+        .def("get", &PyOutput::get, nb::arg("key"),
+             "Return a keyed child output, or None when the key is absent.")
+        .def("pop", &PyOutput::pop, nb::arg("key"),
+             "Remove a dictionary child output and return it, or None when absent.")
+        .def_prop_ro("key_set", &PyOutput::key_set,
+                     "A zero-copy set output over the keys of a dictionary output.")
+        .def("keys", &PyOutput::keys,
+             "Return collection indices, keys, or bundle field names.")
+        .def("values", &PyOutput::values,
+             "Return current child outputs, or scalar values for a set output.")
+        .def("items", &PyOutput::items,
+             "Return current collection key/child-output pairs.")
+        .def("modified_keys", &PyOutput::modified_keys,
+             "Return collection keys modified in the current cycle.")
+        .def("modified_values", &PyOutput::modified_values,
+             "Return child outputs modified in the current cycle.")
+        .def("modified_items", &PyOutput::modified_items,
+             "Return collection key/child-output pairs modified in the current cycle.")
+        .def("valid_keys", &PyOutput::valid_keys,
+             "Return collection keys whose child outputs are valid.")
+        .def("valid_values", &PyOutput::valid_values,
+             "Return valid child outputs.")
+        .def("valid_items", &PyOutput::valid_items,
+             "Return collection key/child-output pairs whose children are valid.")
+        .def("added_keys", &PyOutput::added_keys,
+             "Return dictionary keys added in the current cycle.")
+        .def("added_values", &PyOutput::added_values,
+             "Return dictionary child outputs added in the current cycle.")
+        .def("added_items", &PyOutput::added_items,
+             "Return dictionary key/child-output pairs added in the current cycle.")
         .def("clear", &PyOutput::clear,
              "Clear the current collection value and publish removals.")
         .def("invalidate", &PyOutput::invalidate,
              "Invalidate the output without assigning a replacement value.")
         .def("removed_keys", &PyOutput::removed_keys,
              "Return keys removed in the current cycle.")
-        .def("add", &PyOutput::add,
+        .def("removed_values", &PyOutput::removed_values,
+             "Return dictionary child outputs removed in the current cycle.")
+        .def("removed_items", &PyOutput::removed_items,
+             "Return dictionary key/child-output pairs removed in the current cycle.")
+        .def("added", &PyOutput::set_added,
+             "Return values added to a set output in the current cycle.")
+        .def("removed", &PyOutput::set_removed,
+             "Return values removed from a set output in the current cycle.")
+        .def("was_added", &PyOutput::was_added, nb::arg("item"),
+             "Return whether a set value was added in the current cycle.")
+        .def("was_removed", &PyOutput::was_removed, nb::arg("item"),
+             "Return whether a set value was removed in the current cycle.")
+        .def("key_from_value", &PyOutput::key_from_value, nb::arg("value"),
+             "Return the dictionary key, list index, or bundle field name for a child output.")
+        .def("add", &PyOutput::add, nb::arg("value"),
              "Add a value to a set output and return whether it changed.")
-        .def("remove", &PyOutput::remove,
+        .def("remove", &PyOutput::remove, nb::arg("value"),
              "Remove a value from a set output and return whether it changed.")
-        .def("__getitem__", &PyOutput::child)
-        .def("__delitem__", &PyOutput::erase)
-        .def("__contains__", &PyOutput::contains)
+        .def("__getitem__", &PyOutput::child, nb::arg("key"))
+        .def("__setitem__", &PyOutput::set_child_value,
+             nb::arg("key"), nb::arg("value"))
+        .def("__delitem__", &PyOutput::erase, nb::arg("key"))
+        .def("__contains__", &PyOutput::contains, nb::arg("key"))
         .def("__len__", &PyOutput::size)
+        .def("__iter__", [](const PyOutput &self) -> nb::object {
+            auto view = self.checked();
+            nb::object source;
+            switch (view.schema()->kind)
+            {
+                case TSTypeKind::TSD: source = self.keys(); break;
+                case TSTypeKind::TSL:
+                case TSTypeKind::TSB:
+                case TSTypeKind::TSS: source = self.values(); break;
+                default: throw nb::type_error("this output kind is not iterable");
+            }
+            PyObject *iterator = PyObject_GetIter(source.ptr());
+            if (iterator == nullptr) { nb::raise_python_error(); }
+            return nb::steal(iterator);
+        })
+        .def_prop_ro("as_schema", [](nb::object self_obj) -> nb::object {
+            auto &self = nb::cast<PyOutput &>(self_obj);
+            if (self.checked().schema()->kind != TSTypeKind::TSB)
+            {
+                throw nb::attribute_error("as_schema");
+            }
+            return self_obj;
+        }, "The same bundle output viewed through its declared schema.")
         .def("__getattr__",
              [](const PyOutput &self, const std::string &name) -> PyOutput {
                  if (self.checked().schema()->kind != TSTypeKind::TSB)
@@ -788,27 +869,17 @@ namespace hgraph::python_bridge
         // dictionary and silently restore the vectorcall path.
         .def_prop_ro("all_valid", &PyTimeSeries::all_valid,
                      "Whether every direct child currently has a value.")
-        // TSW eviction surface (hgraph's removed_value pair).
-        .def_prop_ro("has_removed_value",
-                     [](const PyTimeSeries &self) {
-                         const auto &view = self.checked();
-                         if (view.schema()->kind != TSTypeKind::TSW)
-                         {
-                             throw nb::attribute_error("has_removed_value");
-                         }
-                         return view.as_window().has_removed_value();
-                     },
+        .def_prop_ro("size", &PyTimeSeries::window_size,
+                     "The configured tick count or duration of a window input.")
+        .def_prop_ro("min_size", &PyTimeSeries::window_min_size,
+                     "The configured minimum tick count or duration of a window input.")
+        .def_prop_ro("value_times", &PyTimeSeries::value_times,
+                     "A NumPy-compatible datetime64 buffer containing window evaluation times.")
+        .def_prop_ro("first_modified_time", &PyTimeSeries::first_modified_time,
+                     "The evaluation time of the oldest value retained by a window input.")
+        .def_prop_ro("has_removed_value", &PyTimeSeries::has_removed_value,
                      "Whether a window value was evicted in the current cycle.")
-        .def_prop_ro("removed_value",
-                     [](const PyTimeSeries &self) -> nb::object {
-                         const auto &view = self.checked();
-                         if (view.schema()->kind != TSTypeKind::TSW)
-                         {
-                             throw nb::attribute_error("removed_value");
-                         }
-                         auto window = view.as_window();
-                         return window.has_removed_value() ? value_to_py(window.removed_value()) : nb::none();
-                     },
+        .def_prop_ro("removed_value", &PyTimeSeries::removed_value,
                      "The window value evicted in the current cycle, or None.")
         .def_prop_ro("last_modified_time", &PyTimeSeries::last_modified_time,
                      "The evaluation time of the most recent tick.")
@@ -816,19 +887,55 @@ namespace hgraph::python_bridge
              "Return values added to a set in the current cycle.")
         .def("removed", &PyTimeSeries::removed,
              "Return values removed from a set in the current cycle.")
+        .def("was_added", &PyTimeSeries::was_added, nb::arg("item"),
+             "Return whether a set value was added in the current cycle.")
+        .def("was_removed", &PyTimeSeries::was_removed, nb::arg("item"),
+             "Return whether a set value was removed in the current cycle.")
         .def("keys", &PyTimeSeries::keys,
              "Return the current keys or field names of a collection input.")
+        .def("items", &PyTimeSeries::items,
+             "Return the current key/child-input pairs of a collection input.")
         .def("modified_keys", &PyTimeSeries::modified_keys,
              "Return collection keys modified in the current cycle.")
         .def("modified_items", &PyTimeSeries::modified_items,
              "Return key/value pairs modified in the current cycle.")
         .def("modified_values", &PyTimeSeries::modified_values,
              "Return collection values modified in the current cycle.")
+        .def("valid_keys", &PyTimeSeries::valid_keys,
+             "Return collection keys whose child inputs are valid.")
+        .def("valid_items", &PyTimeSeries::valid_items,
+             "Return collection key/child-input pairs whose children are valid.")
+        .def("valid_values", &PyTimeSeries::valid_values,
+             "Return valid collection child inputs.")
+        .def("added_keys", &PyTimeSeries::added_keys,
+             "Return dictionary keys added in the current cycle.")
+        .def("added_items", &PyTimeSeries::added_items,
+             "Return dictionary key/child-input pairs added in the current cycle.")
+        .def("added_values", &PyTimeSeries::added_values,
+             "Return dictionary child inputs added in the current cycle.")
         .def("values", &PyTimeSeries::values,
              "Return the current child values of a collection input.")
         .def("removed_keys", &PyTimeSeries::removed_keys,
              "Return dictionary keys removed in the current cycle.")
-        .def("__getitem__", &PyTimeSeries::child_at)
+        .def("removed_items", &PyTimeSeries::removed_items,
+             "Return dictionary key/child-input pairs removed in the current cycle.")
+        .def("removed_values", &PyTimeSeries::removed_values,
+             "Return dictionary child inputs removed in the current cycle.")
+        .def("get", &PyTimeSeries::get, nb::arg("key"),
+             "Return a dictionary child input, or None when the key is absent.")
+        .def_prop_ro("key_set", &PyTimeSeries::key_set,
+                     "A zero-copy set view over the keys of a dictionary input.")
+        .def("key_from_value", &PyTimeSeries::key_from_value, nb::arg("value"),
+             "Return the dictionary key, list index, or bundle field name for a child input.")
+        .def("__getitem__", &PyTimeSeries::child_at, nb::arg("key"))
+        .def_prop_ro("as_schema", [](nb::object self_obj) -> nb::object {
+            auto &self = nb::cast<PyTimeSeries &>(self_obj);
+            if (self.kind() != TSTypeKind::TSB)
+            {
+                throw nb::attribute_error("as_schema");
+            }
+            return self_obj;
+        }, "The same bundle input viewed through its declared schema.")
         .def("__getattr__", [](nb::object self_obj, const std::string &name) -> nb::object {
             auto &self = nb::cast<PyTimeSeries &>(self_obj);
             if (self.kind() != TSTypeKind::TSB) { throw nb::attribute_error(name.c_str()); }
@@ -845,8 +952,22 @@ namespace hgraph::python_bridge
                 throw nb::attribute_error(name.c_str());
             }
         })
-        .def("__contains__", &PyTimeSeries::contains)
+        .def("__contains__", &PyTimeSeries::contains, nb::arg("key"))
         .def("__len__", &PyTimeSeries::size)
+        .def("__iter__", [](const PyTimeSeries &self) -> nb::object {
+            nb::object source;
+            switch (self.kind())
+            {
+                case TSTypeKind::TSD: source = self.keys(); break;
+                case TSTypeKind::TSL:
+                case TSTypeKind::TSB:
+                case TSTypeKind::TSS: source = self.values(); break;
+                default: throw nb::type_error("this time-series kind is not iterable");
+            }
+            PyObject *iterator = PyObject_GetIter(source.ptr());
+            if (iterator == nullptr) { nb::raise_python_error(); }
+            return nb::steal(iterator);
+        })
         .def("__str__", [](const PyTimeSeries &self) { return nb::str(self.value()); })
         .def("__repr__", [](const PyTimeSeries &self) { return nb::str("TimeSeries({})").format(self.value()); });
     m.def("_set_cmp_result_enum", [](nb::object enum_class) { cmp_result_enum_slot() = std::move(enum_class); });

--- a/python/tests/test_time_series_api_contract.py
+++ b/python/tests/test_time_series_api_contract.py
@@ -273,7 +273,7 @@ def test_mutable_tsd_and_key_set_output_views_report_exact_native_changes():
         command: TS[int], _output: TSD_OUT[str, TS[int]] = None
     ) -> TSD[str, TS[int]]:
         if command.value == 1:
-            _output.get_or_create("a").value = 10
+            _output["a"] = 10
             popped = None
         elif command.value == 2:
             _output["a"] = 20
@@ -506,6 +506,18 @@ def test_tsd_input_views_distinguish_added_modified_valid_and_removed_items():
                 "removed_values": tuple(
                     child.value for child in value.removed_values()
                 ),
+                "removed_value_keys": tuple(
+                    sorted(
+                        value.key_from_value(child)
+                        for child in value.removed_values()
+                    )
+                ),
+                "removed_item_value_keys": tuple(
+                    sorted(
+                        value.key_from_value(child)
+                        for _, child in value.removed_items()
+                    )
+                ),
                 "get": value.get("a").value if value.get("a") is not None else None,
                 "missing": value.get("missing"),
                 "key_set": (
@@ -553,6 +565,8 @@ def test_tsd_input_views_distinguish_added_modified_valid_and_removed_items():
     assert remove["modified_keys"] == ()
     assert remove["removed_keys"] == ("a",)
     assert tuple(key for key, *_ in remove["removed"]) == ("a",)
+    assert remove["removed_value_keys"] == ("a",)
+    assert remove["removed_item_value_keys"] == ("a",)
     assert remove["get"] is None
     assert remove["keys_from_children"] == ("b",)
     assert remove["missing"] is None
@@ -632,6 +646,29 @@ def test_tsb_input_views_expose_named_complete_modified_and_valid_ranges():
     assert observations[0]["schema"]
     assert observations[1]["modified_keys"] == ("right",)
     assert observations[1]["valid_keys"] == ("left", "right")
+
+
+def test_key_from_value_rejects_foreign_unresolved_structural_children():
+    @compute_node(valid=())
+    def inspect(
+        left_list: TSL[TS[int], Size[2]],
+        right_list: TSL[TS[int], Size[2]],
+        left_bundle: TSB[_ApiContractPair],
+        right_bundle: TSB[_ApiContractPair],
+    ) -> TS[bool]:
+        assert left_list.key_from_value(left_list[1]) == 1
+        assert left_bundle.key_from_value(left_bundle.right) == "right"
+        assert left_list.key_from_value(right_list[1]) is None
+        assert left_bundle.key_from_value(right_bundle.right) is None
+        return True
+
+    assert eval_node(
+        inspect,
+        [{0: 1}],
+        [{0: 2}],
+        [{"left": 3}],
+        [{"left": 4}],
+    ) == [True]
 
 
 def test_tss_input_views_expose_membership_and_exact_change_classification():

--- a/python/tests/test_time_series_api_contract.py
+++ b/python/tests/test_time_series_api_contract.py
@@ -1,0 +1,826 @@
+"""Python runtime-view compatibility contract for every time-series kind.
+
+The release/0.5 runtime exposed a common observational API plus specialised
+collection/window views.  These tests deliberately exercise the methods from
+inside Python node callbacks: a method present only in C++, or present in a
+stub but absent on the live callback object, does not satisfy this contract.
+
+Endpoint-topology and runtime-implementation hooks (binding, parenting,
+subscription and direct output traversal) are intentionally excluded.  They
+remain native runtime responsibilities, as documented in the compatibility
+deviations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import _hgraph
+import numpy as np
+
+from hgraph import (
+    MIN_ST,
+    MIN_TD,
+    REF,
+    REMOVE,
+    Removed,
+    SIGNAL,
+    Size,
+    TS,
+    TSB,
+    TSB_OUT,
+    TSD,
+    TSD_OUT,
+    TSL,
+    TSS,
+    TSS_OUT,
+    TSW,
+    TSW_OUT,
+    TS_OUT,
+    TimeSeriesSchema,
+    WindowSize,
+    compute_node,
+    graph,
+    to_window,
+)
+from hgraph.test import eval_node
+
+
+BASE_INPUT_API = {
+    "active",
+    "all_valid",
+    "delta_value",
+    "is_reference",
+    "last_modified_time",
+    "make_active",
+    "make_passive",
+    "modified",
+    "owning_graph",
+    "owning_node",
+    "valid",
+    "value",
+}
+
+ITERABLE_API = {
+    "items",
+    "key_from_value",
+    "keys",
+    "modified_items",
+    "modified_keys",
+    "modified_values",
+    "valid_items",
+    "valid_keys",
+    "valid_values",
+    "values",
+}
+
+TSD_API = {
+    "added_items",
+    "added_keys",
+    "added_values",
+    "get",
+    "items",
+    "key_set",
+    "key_from_value",
+    "keys",
+    "modified_items",
+    "modified_keys",
+    "modified_values",
+    "removed_items",
+    "removed_keys",
+    "removed_values",
+    "valid_items",
+    "valid_keys",
+    "valid_values",
+    "values",
+}
+
+TSS_API = {"added", "removed", "values", "was_added", "was_removed"}
+
+TSW_API = {
+    "first_modified_time",
+    "has_removed_value",
+    "min_size",
+    "removed_value",
+    "size",
+    "value_times",
+}
+
+BASE_OUTPUT_API = {
+    "all_valid",
+    "can_apply_result",
+    "clear",
+    "delta_value",
+    "invalidate",
+    "is_reference",
+    "last_modified_time",
+    "modified",
+    "owning_graph",
+    "owning_node",
+    "valid",
+    "value",
+}
+
+
+def _assert_api(value, expected):
+    missing = sorted(expected.difference(dir(value)))
+    assert not missing, f"{type(value).__name__} is missing {missing}"
+
+
+@dataclass
+class _ApiContractPair(TimeSeriesSchema):
+    left: TS[int]
+    right: TS[str]
+
+
+def test_live_input_views_expose_the_complete_supported_api_inventory():
+    @compute_node(valid=())
+    def inspect_ts(value: TS[int]) -> TS[bool]:
+        _assert_api(value, BASE_INPUT_API)
+        assert not hasattr(value, "key_set")
+        assert not hasattr(value, "size")
+        assert not hasattr(value, "value_times")
+        return True
+
+    @compute_node(valid=())
+    def inspect_ref(value: REF[TS[int]]) -> TS[bool]:
+        _assert_api(value, BASE_INPUT_API)
+        return True
+
+    @compute_node(valid=())
+    def inspect_signal(value: SIGNAL) -> TS[bool]:
+        _assert_api(value, BASE_INPUT_API)
+        assert value.value is True
+        assert value.delta_value is True
+        return True
+
+    @compute_node(valid=())
+    def inspect_tss(value: TSS[int]) -> TS[bool]:
+        _assert_api(value, BASE_INPUT_API | TSS_API)
+        return True
+
+    @compute_node(valid=())
+    def inspect_tsd(value: TSD[str, TS[int]]) -> TS[bool]:
+        _assert_api(value, BASE_INPUT_API | TSD_API)
+        return True
+
+    @compute_node(valid=())
+    def inspect_tsl(value: TSL[TS[int], Size[2]]) -> TS[bool]:
+        _assert_api(value, BASE_INPUT_API | ITERABLE_API)
+        return True
+
+    @compute_node(valid=())
+    def inspect_tsb(value: TSB[_ApiContractPair]) -> TS[bool]:
+        _assert_api(value, BASE_INPUT_API | ITERABLE_API | {"as_schema"})
+        return True
+
+    @compute_node(valid=())
+    def inspect_tsw(value: TSW[int, WindowSize[2], WindowSize[1]]) -> TS[bool]:
+        _assert_api(value, BASE_INPUT_API | TSW_API)
+        return True
+
+    @graph
+    def inspect_window(value: TS[int]) -> TS[bool]:
+        return inspect_tsw(to_window(value, 2, 1))
+
+    assert eval_node(inspect_ts, [1]) == [True]
+    assert eval_node(inspect_ref, [1]) == [True]
+    assert eval_node(inspect_signal, [True]) == [True]
+    assert eval_node(inspect_tss, [{1}]) == [True]
+    assert eval_node(inspect_tsd, [{"a": 1}]) == [True]
+    assert eval_node(inspect_tsl, [{0: 1}]) == [True]
+    assert eval_node(inspect_tsb, [{"left": 1}]) == [True]
+    assert eval_node(inspect_window, [1]) == [True]
+
+
+def test_live_output_views_expose_the_complete_supported_api_inventory():
+    @compute_node
+    def inspect_ts(value: TS[int], _output: TS_OUT[int] = None) -> TS[int]:
+        _assert_api(_output, BASE_OUTPUT_API)
+        assert not hasattr(_output, "key_set")
+        assert not hasattr(_output, "size")
+        assert not hasattr(_output, "value_times")
+        return value.value
+
+    @compute_node
+    def inspect_ref(
+        value: REF[TS[int]], _output: REF[TS[int]] = None
+    ) -> REF[TS[int]]:
+        _assert_api(_output, BASE_OUTPUT_API)
+        return value.value
+
+    @compute_node
+    def inspect_signal(value: SIGNAL, _output: SIGNAL = None) -> SIGNAL:
+        _assert_api(_output, BASE_OUTPUT_API)
+        return value.value
+
+    @compute_node
+    def inspect_tss(value: TS[int], _output: TSS_OUT[int] = None) -> TSS[int]:
+        _assert_api(_output, BASE_OUTPUT_API | TSS_API | {"add", "remove"})
+        return {value.value}
+
+    @compute_node
+    def inspect_tsd(
+        value: TS[int], _output: TSD_OUT[str, TS[int]] = None
+    ) -> TSD[str, TS[int]]:
+        _assert_api(
+            _output,
+            BASE_OUTPUT_API
+            | TSD_API
+            | {"get_or_create"},
+        )
+        return {"value": value.value}
+
+    @compute_node
+    def inspect_tsl(
+        value: TSL[TS[int], Size[2]],
+        _output: TS_OUT[TSL[TS[int], Size[2]]] = None,
+    ) -> TSL[TS[int], Size[2]]:
+        _assert_api(_output, BASE_OUTPUT_API | ITERABLE_API)
+        return value.delta_value
+
+    @compute_node
+    def inspect_tsb(
+        value: TSB[_ApiContractPair], _output: TSB_OUT[_ApiContractPair] = None
+    ) -> TSB[_ApiContractPair]:
+        _assert_api(_output, BASE_OUTPUT_API | ITERABLE_API | {"as_schema"})
+        return value.delta_value
+
+    @compute_node
+    def inspect_tsw(
+        value: TS[int],
+        _output: TSW_OUT[int, WindowSize[2], WindowSize[1]] = None,
+    ) -> TSW[int, WindowSize[2], WindowSize[1]]:
+        _assert_api(_output, BASE_OUTPUT_API | TSW_API)
+        return value.value
+
+    assert eval_node(inspect_ts, [1]) == [1]
+    assert eval_node(inspect_ref, [1]) == [1]
+    assert eval_node(inspect_signal, [True]) == [True]
+    assert eval_node(inspect_tss, [1]) == [{1}]
+    assert eval_node(inspect_tsd, [1]) == [{"value": 1}]
+    assert eval_node(inspect_tsl, [{0: 1}]) == [{0: 1}]
+    assert eval_node(inspect_tsb, [{"left": 1}]) == [{"left": 1}]
+    assert eval_node(inspect_tsw, [1]) == [1]
+
+
+def test_mutable_tsd_and_key_set_output_views_report_exact_native_changes():
+    observations = []
+
+    @compute_node
+    def mutate(
+        command: TS[int], _output: TSD_OUT[str, TS[int]] = None
+    ) -> TSD[str, TS[int]]:
+        if command.value == 1:
+            _output.get_or_create("a").value = 10
+            popped = None
+        elif command.value == 2:
+            _output["a"] = 20
+            _output.get_or_create("b").value = 30
+            popped = None
+        else:
+            popped = _output.pop("a")
+            assert _output.pop("missing") is None
+
+        key_set = _output.key_set
+        current_a = _output.get("a")
+        observations.append(
+            {
+                "keys": tuple(sorted(_output.keys())),
+                "values": tuple(sorted(child.value for child in _output.values())),
+                "items": _child_snapshot(sorted(_output.items())),
+                "modified_keys": tuple(sorted(_output.modified_keys())),
+                "valid_keys": tuple(sorted(_output.valid_keys())),
+                "added_keys": tuple(sorted(_output.added_keys())),
+                "removed_keys": tuple(sorted(_output.removed_keys())),
+                "keys_from_children": tuple(
+                    sorted(
+                        _output.key_from_value(child)
+                        for child in _output.values()
+                    )
+                ),
+                "get": current_a.value if current_a is not None else None,
+                "missing": _output.get("missing"),
+                "popped_key": (
+                    _output.key_from_value(popped) if popped is not None else None
+                ),
+                "key_set": (
+                    tuple(sorted(key_set.values())),
+                    tuple(sorted(key_set.added())),
+                    tuple(sorted(key_set.removed())),
+                ),
+            }
+        )
+
+    assert eval_node(mutate, [1, 2, 3]) == [
+        {"a": 10},
+        {"a": 20, "b": 30},
+        {"a": REMOVE},
+    ]
+    first, update, remove = observations
+    assert first["added_keys"] == first["modified_keys"] == ("a",)
+    assert first["valid_keys"] == ("a",)
+    assert first["keys_from_children"] == ("a",)
+    assert first["key_set"] == (("a",), ("a",), ())
+    assert update["added_keys"] == ("b",)
+    assert update["modified_keys"] == ("a", "b")
+    assert update["valid_keys"] == ("a", "b")
+    assert update["keys_from_children"] == ("a", "b")
+    assert update["key_set"] == (("a", "b"), ("b",), ())
+    assert remove["keys"] == ("b",)
+    assert remove["modified_keys"] == ()
+    assert remove["removed_keys"] == ("a",)
+    assert remove["keys_from_children"] == ("b",)
+    assert remove["popped_key"] == "a"
+    assert remove["get"] is None
+    assert remove["missing"] is None
+    assert remove["key_set"] == (("b",), (), ("a",))
+
+
+def test_mutable_tss_output_views_report_membership_and_exact_changes():
+    observations = []
+
+    @compute_node
+    def mutate(command: TS[int], _output: TSS_OUT[int] = None) -> TSS[int]:
+        if command.value == 1:
+            assert _output.add(1)
+            assert _output.add(2)
+            assert not _output.add(2)
+        else:
+            assert _output.remove(1)
+            assert _output.add(3)
+
+        observations.append(
+            (
+                tuple(sorted(_output)),
+                tuple(sorted(_output.values())),
+                tuple(sorted(_output.added())),
+                tuple(sorted(_output.removed())),
+                _output.was_added(3),
+                _output.was_removed(1),
+                2 in _output,
+                len(_output),
+            )
+        )
+
+    assert eval_node(mutate, [1, 2]) == [{1, 2}, {Removed(1), 3}]
+    assert observations == [
+        ((1, 2), (1, 2), (1, 2), (), False, False, True, 2),
+        ((2, 3), (2, 3), (3,), (1,), True, True, True, 2),
+    ]
+
+
+def test_mutable_structural_outputs_expose_complete_child_ranges():
+    list_observations = []
+    bundle_observations = []
+
+    @compute_node
+    def mutate_list(
+        command: TS[int],
+        _output: TS_OUT[TSL[TS[int], Size[2]]] = None,
+    ) -> TSL[TS[int], Size[2]]:
+        _output[0].value = command.value
+        if command.value == 2:
+            _output[1].value = 20
+        list_observations.append(
+            {
+                "keys": tuple(_output.keys()),
+                "values": tuple(child.value for child in _output.values()),
+                "modified_keys": tuple(_output.modified_keys()),
+                "valid_keys": tuple(_output.valid_keys()),
+                "key_from_values": tuple(
+                    _output.key_from_value(child) for child in _output.values()
+                ),
+                "key_from_items": tuple(
+                    _output.key_from_value(child) for _, child in _output.items()
+                ),
+            }
+        )
+
+    @compute_node
+    def mutate_bundle(
+        command: TS[int], _output: TSB_OUT[_ApiContractPair] = None
+    ) -> TSB[_ApiContractPair]:
+        _output.left.value = command.value
+        if command.value == 2:
+            _output.right.value = "two"
+        bundle_observations.append(
+            {
+                "keys": tuple(_output.keys()),
+                "values": tuple(child.value for child in _output.values()),
+                "modified_keys": tuple(_output.modified_keys()),
+                "valid_keys": tuple(_output.valid_keys()),
+                "key_from_values": tuple(
+                    _output.key_from_value(child) for child in _output.values()
+                ),
+                "key_from_items": tuple(
+                    _output.key_from_value(child) for _, child in _output.items()
+                ),
+                "schema": _output.as_schema is _output,
+            }
+        )
+
+    assert eval_node(mutate_list, [1, 2]) == [{0: 1}, {0: 2, 1: 20}]
+    assert list_observations == [
+        {
+            "keys": (0, 1),
+            "values": (1, None),
+            "modified_keys": (0,),
+            "valid_keys": (0,),
+            "key_from_values": (0, 1),
+            "key_from_items": (0, 1),
+        },
+        {
+            "keys": (0, 1),
+            "values": (2, 20),
+            "modified_keys": (0, 1),
+            "valid_keys": (0, 1),
+            "key_from_values": (0, 1),
+            "key_from_items": (0, 1),
+        },
+    ]
+
+    assert eval_node(mutate_bundle, [1, 2]) == [
+        {"left": 1},
+        {"left": 2, "right": "two"},
+    ]
+    assert bundle_observations == [
+        {
+            "keys": ("left", "right"),
+            "values": (1, None),
+            "modified_keys": ("left",),
+            "valid_keys": ("left",),
+            "key_from_values": ("left", "right"),
+            "key_from_items": ("left", "right"),
+            "schema": True,
+        },
+        {
+            "keys": ("left", "right"),
+            "values": (2, "two"),
+            "modified_keys": ("left", "right"),
+            "valid_keys": ("left", "right"),
+            "key_from_values": ("left", "right"),
+            "key_from_items": ("left", "right"),
+            "schema": True,
+        },
+    ]
+
+
+def _child_snapshot(items):
+    return tuple(
+        (key, child.value, child.valid, child.modified)
+        for key, child in items
+    )
+
+
+def test_tsd_input_views_distinguish_added_modified_valid_and_removed_items():
+    observations = []
+
+    @compute_node(valid=())
+    def inspect(value: TSD[str, TS[int]]) -> TS[int]:
+        key_set = value.key_set
+        observations.append(
+            {
+                "iter": tuple(sorted(value)),
+                "keys": tuple(sorted(value.keys())),
+                "values": tuple(sorted(child.value for child in value.values())),
+                "items": _child_snapshot(sorted(value.items())),
+                "modified": _child_snapshot(sorted(value.modified_items())),
+                "modified_keys": tuple(sorted(value.modified_keys())),
+                "modified_values": tuple(
+                    sorted(child.value for child in value.modified_values())
+                ),
+                "valid": _child_snapshot(sorted(value.valid_items())),
+                "valid_keys": tuple(sorted(value.valid_keys())),
+                "valid_values": tuple(
+                    sorted(child.value for child in value.valid_values())
+                ),
+                "added": _child_snapshot(sorted(value.added_items())),
+                "added_keys": tuple(sorted(value.added_keys())),
+                "added_values": tuple(
+                    sorted(child.value for child in value.added_values())
+                ),
+                "removed": _child_snapshot(sorted(value.removed_items())),
+                "removed_keys": tuple(sorted(value.removed_keys())),
+                "removed_values": tuple(
+                    child.value for child in value.removed_values()
+                ),
+                "get": value.get("a").value if value.get("a") is not None else None,
+                "missing": value.get("missing"),
+                "key_set": (
+                    tuple(sorted(key_set.values())),
+                    tuple(sorted(key_set.added())),
+                    tuple(sorted(key_set.removed())),
+                ),
+                "keys_from_children": tuple(
+                    sorted(
+                        value.key_from_value(child) for child in value.values()
+                    )
+                ),
+            }
+        )
+        return len(value)
+
+    assert eval_node(
+        inspect,
+        [
+            {"a": 1},
+            {"a": 2, "b": 3},
+            {"a": REMOVE},
+            {"a": 4},
+        ],
+    ) == [1, 2, 1, 2]
+
+    first, update, remove, readd = observations
+    assert first["added_keys"] == ("a",)
+    assert first["modified_keys"] == ("a",)
+    assert first["added"] == first["modified"]
+    assert first["keys_from_children"] == ("a",)
+    assert first["key_set"] == (("a",), ("a",), ())
+
+    assert update["keys"] == ("a", "b")
+    assert update["added_keys"] == ("b",)
+    assert update["modified_keys"] == ("a", "b")
+    assert update["added_values"] == (3,)
+    assert update["modified_values"] == (2, 3)
+    assert update["keys_from_children"] == ("a", "b")
+    assert update["valid_keys"] == ("a", "b")
+    assert update["key_set"] == (("a", "b"), ("b",), ())
+
+    assert remove["keys"] == ("b",)
+    assert remove["added_keys"] == ()
+    assert remove["modified_keys"] == ()
+    assert remove["removed_keys"] == ("a",)
+    assert tuple(key for key, *_ in remove["removed"]) == ("a",)
+    assert remove["get"] is None
+    assert remove["keys_from_children"] == ("b",)
+    assert remove["missing"] is None
+    assert remove["key_set"] == (("b",), (), ("a",))
+
+    assert readd["added_keys"] == ("a",)
+    assert readd["modified_keys"] == ("a",)
+    assert readd["removed_keys"] == ()
+
+
+def test_tsl_input_views_expose_ordered_complete_modified_and_valid_ranges():
+    observations = []
+
+    @compute_node(valid=())
+    def inspect(value: TSL[TS[int], Size[3]]) -> TS[int]:
+        observations.append(
+            {
+                "iter": tuple(child.value for child in value),
+                "keys": tuple(value.keys()),
+                "items": _child_snapshot(value.items()),
+                "modified": _child_snapshot(value.modified_items()),
+                "modified_keys": tuple(value.modified_keys()),
+                "modified_values": tuple(child.value for child in value.modified_values()),
+                "valid": _child_snapshot(value.valid_items()),
+                "valid_keys": tuple(value.valid_keys()),
+                "valid_values": tuple(child.value for child in value.valid_values()),
+                "keys_from_children": (
+                    value.key_from_value(value[1]),
+                    value.key_from_value(value.values()[1]),
+                    value.key_from_value(dict(value.items())[1]),
+                ),
+            }
+        )
+        return len(value)
+
+    assert eval_node(inspect, [{0: 1}, {1: 2}, {0: 3}]) == [3, 3, 3]
+    assert observations[0]["keys"] == (0, 1, 2)
+    assert observations[0]["iter"] == (1, None, None)
+    assert observations[0]["modified_keys"] == (0,)
+    assert observations[0]["valid_keys"] == (0,)
+    assert observations[0]["keys_from_children"] == (1, 1, 1)
+    assert observations[1]["modified_keys"] == (1,)
+    assert observations[1]["valid_keys"] == (0, 1)
+    assert observations[2]["modified_values"] == (3,)
+
+
+def test_tsb_input_views_expose_named_complete_modified_and_valid_ranges():
+    observations = []
+
+    @compute_node(valid=())
+    def inspect(value: TSB[_ApiContractPair]) -> TS[int]:
+        observations.append(
+            {
+                "keys": tuple(value.keys()),
+                "items": _child_snapshot(value.items()),
+                "modified": _child_snapshot(value.modified_items()),
+                "modified_keys": tuple(value.modified_keys()),
+                "modified_values": tuple(child.value for child in value.modified_values()),
+                "valid": _child_snapshot(value.valid_items()),
+                "valid_keys": tuple(value.valid_keys()),
+                "valid_values": tuple(child.value for child in value.valid_values()),
+                "keys_from_children": (
+                    value.key_from_value(value.right),
+                    value.key_from_value(value.values()[1]),
+                    value.key_from_value(dict(value.items())["right"]),
+                ),
+                "schema": value.as_schema is value,
+            }
+        )
+        return len(value)
+
+    assert eval_node(inspect, [{"left": 1}, {"right": "two"}]) == [2, 2]
+    assert observations[0]["keys"] == ("left", "right")
+    assert observations[0]["modified_keys"] == ("left",)
+    assert observations[0]["valid_keys"] == ("left",)
+    assert observations[0]["keys_from_children"] == ("right", "right", "right")
+    assert observations[0]["schema"]
+    assert observations[1]["modified_keys"] == ("right",)
+    assert observations[1]["valid_keys"] == ("left", "right")
+
+
+def test_tss_input_views_expose_membership_and_exact_change_classification():
+    observations = []
+
+    @compute_node(valid=())
+    def inspect(value: TSS[int]) -> TS[int]:
+        observations.append(
+            (
+                tuple(sorted(value)),
+                tuple(sorted(value.values())),
+                tuple(sorted(value.added())),
+                tuple(sorted(value.removed())),
+                value.was_added(1),
+                value.was_added(3),
+                value.was_removed(1),
+                2 in value,
+                len(value),
+            )
+        )
+        return len(value)
+
+    assert eval_node(inspect, [{1, 2}, {Removed(1), 3}]) == [2, 2]
+    assert observations == [
+        ((1, 2), (1, 2), (1, 2), (), True, False, False, True, 2),
+        ((2, 3), (2, 3), (3,), (1,), False, True, True, True, 2),
+    ]
+
+
+def test_tsw_input_views_expose_configuration_population_and_time_metadata():
+    observations = []
+
+    @compute_node
+    def inspect(value: TSW[int, WindowSize[3], WindowSize[2]]) -> TS[int]:
+        observations.append(
+            {
+                "size": value.size,
+                "min_size": value.min_size,
+                "length": len(value),
+                "values": value.value,
+                "times": value.value_times,
+                "first_modified_time": value.first_modified_time,
+                "has_removed_value": value.has_removed_value,
+                "removed_value": value.removed_value,
+            }
+        )
+        return len(value)
+
+    @graph
+    def app(value: TS[int]) -> TS[int]:
+        return inspect(to_window(value, 3, 2))
+
+    assert eval_node(app, [1, 2, 3, 4]) == [1, 2, 3, 3]
+    assert [
+        (item["size"], item["min_size"], item["length"])
+        for item in observations
+    ] == [
+        (3, 2, 1),
+        (3, 2, 2),
+        (3, 2, 3),
+        (3, 2, 3),
+    ]
+    assert all(isinstance(item["values"], np.ndarray) for item in observations)
+    assert all(isinstance(item["times"], np.ndarray) for item in observations)
+    assert all(
+        item["times"].dtype == np.dtype("datetime64[us]")
+        for item in observations
+    )
+    assert observations[0]["values"].tolist() == [1]
+    assert observations[2]["values"].tolist() == [1, 2, 3]
+    assert observations[3]["values"].tolist() == [2, 3, 4]
+    assert observations[0]["times"].tolist() == [MIN_ST]
+    assert observations[2]["times"].tolist() == [
+        MIN_ST,
+        MIN_ST + MIN_TD,
+        MIN_ST + 2 * MIN_TD,
+    ]
+    assert observations[3]["times"].tolist() == [
+        MIN_ST + MIN_TD,
+        MIN_ST + 2 * MIN_TD,
+        MIN_ST + 3 * MIN_TD,
+    ]
+    assert observations[0]["first_modified_time"] == MIN_ST
+    assert observations[3]["first_modified_time"] == MIN_ST + MIN_TD
+    assert observations[3]["has_removed_value"]
+    assert observations[3]["removed_value"] == 1
+
+
+def test_tsw_output_views_expose_numpy_compatible_value_and_time_buffers():
+    observations = []
+
+    @compute_node
+    def mutate(
+        value: TS[int],
+        _output: TSW_OUT[int, WindowSize[3], WindowSize[2]] = None,
+    ) -> TSW[int, WindowSize[3], WindowSize[2]]:
+        _output.value = value.value
+        observations.append(
+            {
+                "size": _output.size,
+                "min_size": _output.min_size,
+                "length": len(_output),
+                "values": _output.value,
+                "times": _output.value_times,
+                "first_modified_time": _output.first_modified_time,
+                "has_removed_value": _output.has_removed_value,
+                "removed_value": _output.removed_value,
+            }
+        )
+
+    assert eval_node(mutate, [1, 2, 3, 4]) == [1, 2, 3, 4]
+    assert all(isinstance(item["values"], np.ndarray) for item in observations)
+    assert all(isinstance(item["times"], np.ndarray) for item in observations)
+    assert all(
+        item["times"].dtype == np.dtype("datetime64[us]")
+        for item in observations
+    )
+    assert observations[0]["values"].tolist() == [1]
+    assert observations[3]["values"].tolist() == [2, 3, 4]
+    assert observations[3]["times"].tolist() == [
+        MIN_ST + MIN_TD,
+        MIN_ST + 2 * MIN_TD,
+        MIN_ST + 3 * MIN_TD,
+    ]
+    assert observations[3]["size"] == 3
+    assert observations[3]["min_size"] == 2
+    assert observations[3]["length"] == 3
+    assert observations[3]["first_modified_time"] == MIN_ST + MIN_TD
+    assert observations[3]["has_removed_value"]
+    assert observations[3]["removed_value"] == 1
+
+
+def test_duration_tsw_exposes_timedelta_configuration():
+    period = 3 * MIN_TD
+    minimum = MIN_TD
+    observations = []
+
+    @compute_node
+    def inspect(
+        value: TSW[int, WindowSize[MIN_TD * 3], WindowSize[MIN_TD]],
+    ) -> TS[int]:
+        observations.append((value.size, value.min_size))
+        return len(value)
+
+    @graph
+    def app(value: TS[int]) -> TS[int]:
+        return inspect(to_window(value, period, minimum))
+
+    assert eval_node(app, [1, 2]) == [1, 2]
+    assert observations == [(period, minimum), (period, minimum)]
+
+
+def test_runtime_stub_declares_the_supported_time_series_contract():
+    source = Path(_hgraph.__file__).with_name("_hgraph.pyi").read_text(
+        encoding="utf-8"
+    )
+
+    def class_declaration(name):
+        match = re.search(
+            rf"^class {name}:.*?(?=^class |\Z)",
+            source,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        assert match is not None, name
+        return match.group(0)
+
+    input_declaration = class_declaration("TimeSeries")
+    output_declaration = class_declaration("OutputView")
+    for name in sorted(BASE_INPUT_API | ITERABLE_API | TSD_API | TSS_API | TSW_API):
+        assert f"def {name}(" in input_declaration, name
+    for name in sorted(
+        BASE_OUTPUT_API
+        | ITERABLE_API
+        | TSD_API
+        | TSS_API
+        | TSW_API
+        | {"get_or_create", "pop", "add", "remove"}
+    ):
+        assert f"def {name}(" in output_declaration, name
+
+    assert "def size(self) -> int | datetime.timedelta:" in source
+    assert "def min_size(self) -> int | datetime.timedelta:" in source
+    assert "def value_times(self) -> numpy.ndarray:" in source
+    assert "def get(self, key: object) -> TimeSeries | None:" in source
+    assert "def get(self, key: object) -> OutputView | None:" in source
+    assert "def get_or_create(self, key: object) -> OutputView:" in source
+    assert "def pop(self, key: object) -> OutputView | None:" in source
+    assert "def add(self, value: object) -> bool:" in source
+    assert "def remove(self, value: object) -> bool:" in source
+    assert "def key_from_value(self, value: TimeSeries) -> object | None:" in source
+    assert "def key_from_value(self, value: OutputView) -> object | None:" in source
+    assert "def __setitem__(self, key: object, value: object) -> None:" in source

--- a/src/hgraph/types/time_series/ts_output/bundle_view.cpp
+++ b/src/hgraph/types/time_series/ts_output/bundle_view.cpp
@@ -37,6 +37,15 @@ namespace hgraph
             return static_cast<const TSBOutputView *>(context)->at(index).valid();
         }
 
+        [[nodiscard]] std::string_view tsb_output_project_key(
+            const void *context,
+            const void *,
+            std::size_t index)
+        {
+            const auto *view = static_cast<const TSBOutputView *>(context);
+            return field_name_at(view->schema(), index);
+        }
+
         [[nodiscard]] bool tsb_output_modified_child(const void *context, const void *, std::size_t index)
         {
             return static_cast<const TSBOutputView *>(context)->at(index).modified();
@@ -86,7 +95,14 @@ namespace hgraph
 
     Range<std::string_view> TSBOutputView::keys() const
     {
-        return data_view().keys();
+        // The returned range retains its context.  Do not delegate through a
+        // temporary TSBDataView here: that would leave the range pointing at a
+        // destroyed view as soon as keys() returned.
+        return Range<std::string_view>{.context = this,
+                                       .memory = nullptr,
+                                       .limit = size(),
+                                       .predicate = nullptr,
+                                       .projector = &tsb_output_project_key};
     }
 
     Range<TSOutputView> TSBOutputView::values() const

--- a/tests/cpp/test_ts_output.cpp
+++ b/tests/cpp/test_ts_output.cpp
@@ -1191,6 +1191,26 @@ TEST_CASE("TSOutputView all_valid recurses through fixed bundle children")
     REQUIRE(fully_valid_bundle.field("b").value().checked_as<std::int32_t>() == 2);
 }
 
+TEST_CASE("TSBOutputView keys range retains the output view as its context")
+{
+    using namespace hgraph;
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *int_meta = registry.register_scalar<std::int32_t>("int32");
+    const auto *ts_int   = registry.ts(int_meta);
+    const auto *tsb      = registry.tsb(
+        "TSOutputKeysBundle", {{"left", ts_int}, {"right", ts_int}});
+
+    TSOutput output{*tsb};
+    auto     root   = output.view(MIN_ST);
+    auto     bundle = root.as_bundle();
+
+    std::vector<std::string> keys;
+    for (std::string_view key : bundle.keys()) { keys.emplace_back(key); }
+
+    REQUIRE(keys == std::vector<std::string>{"left", "right"});
+}
+
 TEST_CASE("TSData observers notify at the modified level and bubble to parents")
 {
     using namespace hgraph;


### PR DESCRIPTION
## Summary

- add an explicit Python runtime-view API contract for TS, REF, SIGNAL, TSS, TSD, TSL, TSB, and TSW inputs and outputs
- expose the supported native-backed collection, change-tracking, lookup, membership, iteration, key-projection, and output-mutation operations
- return NumPy-compatible arrays from both TSW `.value` and `.value_times`, with timestamps represented as matching `datetime64[us]` buffers
- generate accurate `.pyi` signatures for the expanded surface
- document the complete Python-first runtime API, including TSW configuration, occupancy, ordering, and buffer behaviour
- fix a native `TSBOutputView::keys()` range-lifetime defect uncovered by the new contract pack

## Motivation

Python is the expected end-user authoring interface, but several runtime-view methods present in the 0.5 API contract were either absent from the native bridge, incompletely typed, or undocumented. The new test pack makes the supported public surface explicit and verifies that it is visible and usable from Python without promoting endpoint-internal runtime mechanics.

The TSW contract now guarantees that retained values and their timestamps are exposed as corresponding NumPy-compatible buffers in oldest-to-newest order.

## Validation

- macOS native acceptance suite: 1,495 passed
- macOS Python 3.14 non-WIP compatibility suite from a fresh stable-ABI wheel: 2,090 passed, 9 skipped
- Linux/GCC native acceptance suite: 1,495 passed
- Linux Python 3.14 non-WIP compatibility suite from a fresh stable-ABI wheel: 2,090 passed, 9 skipped
- Sphinx HTML build with warnings treated as errors
- documentation doctests
- focused runtime API, Python authoring, and generated-stub tests
- `git diff --check`
