### PR TITLE
Fix configured DataFrame schema column names

### DIFF
--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -222,8 +222,9 @@ events, tick lengths, and feature pairs.  They also compare the template
 catalogue with the runtime's public operator inventory, so unsupported
 generation surface remains visible.
 
-The catalogue is deliberately targeted at the compatibility-issue classes
-production triage has actually produced (the 2026-07 batch, issues #74-#92):
+The catalogue is deliberately targeted at compatibility-issue classes found
+through production triage, starting with the 2026-07 batch (issues #74-#92)
+and extending as new regressions are identified:
 
 - ``scalar_expression`` const arguments exercise scalar auto-const overload
   selection (the #74/#78 exact-matching class);
@@ -246,7 +247,10 @@ production triage has actually produced (the 2026-07 batch, issues #74-#92):
 - ``data_frame_recording`` records through the DATA_FRAME model and emits
   the frame a ``DataFrameStorage`` hands back to user code — column names,
   **timezone presentation**, and row values — so a tz-aware engine column or
-  a changed frame surface is a trace difference (the PR #92 class);
+  a changed frame surface is a trace difference (the PR #92 class). It varies
+  between the default bitemporal names and names configured through
+  ``set_table_schema_date_key``/``set_table_schema_as_of_key`` (the #417
+  class);
 - ``postponed_annotations`` is a generation MODE on the source-built
   templates: the generated module opts into PEP 563, so string annotations
   exercise signature resolution on both distributions (the #83 class);

--- a/docs/source/user_guide/python_compatibility.rst
+++ b/docs/source/user_guide/python_compatibility.rst
@@ -194,6 +194,29 @@ The old test-only ``record_to_memory``, ``replay_from_memory`` and
 * seed focused node tests with ``hgraph.test.eval_node``; and
 * use ``Wiring.set_replay`` only in advanced custom harnesses.
 
+DataFrame bitemporal column names
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+DataFrame record/replay uses ``__date_time__`` for evaluation time and
+``__as_of__`` for revision time by default, as in 0.5. Configure both names
+before wiring or directly writing a frame when an external schema requires
+different columns:
+
+.. testcode::
+
+   import hgraph as hg
+
+   with hg.GlobalState():
+       hg.set_table_schema_date_key("event_time")
+       hg.set_table_schema_as_of_key("observed_at")
+       assert hg.get_table_schema_date_key() == "event_time"
+       assert hg.get_table_schema_as_of_key() == "observed_at"
+
+The names are scoped to the current ``GlobalState`` and are used by table
+conversion and DataFrame storage metadata. The separate ``lower()`` frame-call
+interface defaults to ``date`` and ``as_of``; pass its ``date_col`` and
+``as_of_col`` arguments when those frames use another convention.
+
 Diagnostics
 -----------
 

--- a/docs/source/user_guide/python_compatibility.rst
+++ b/docs/source/user_guide/python_compatibility.rst
@@ -213,9 +213,14 @@ different columns:
        assert hg.get_table_schema_as_of_key() == "observed_at"
 
 The names are scoped to the current ``GlobalState`` and are used by table
-conversion and DataFrame storage metadata. The separate ``lower()`` frame-call
-interface defaults to ``date`` and ``as_of``; pass its ``date_col`` and
-``as_of_col`` arguments when those frames use another convention.
+conversion and DataFrame storage metadata. Inside a Python node, declare a
+``GlobalState`` injectable and pass it as ``global_state=`` when calling
+``DataFrameStorage.write_frame`` directly; runtime code must not call
+``GlobalState.instance()``.
+
+The separate ``lower()`` frame-call interface defaults to ``date`` and
+``as_of``; pass its ``date_col`` and ``as_of_col`` arguments when those frames
+use another convention.
 
 Diagnostics
 -----------

--- a/python/hgraph/_table.py
+++ b/python/hgraph/_table.py
@@ -57,9 +57,12 @@ def _tp_key(tp):
         return repr(tp)
 
 
-def _config_keys():
+def _config_keys(global_state=None):
     # The bitemporal column names live on the C++ record_replay config
     # (set via set_table_schema_date_key/_as_of_key in _wiring).
+    if global_state is not None:
+        return _hgraph._table_schema_keys(global_state)
+
     from ._wiring import GlobalState
 
     if GlobalState.has_instance():
@@ -67,12 +70,22 @@ def _config_keys():
     return "__date_time__", "__as_of__"
 
 
-def get_table_schema_date_key() -> str:
-    return _config_keys()[0]
+def get_table_schema_date_key(global_state=None) -> str:
+    """Return the configured evaluation-time column name.
+
+    Inside a node callback, pass its ``GlobalState`` injectable rather than
+    consulting the wiring-time state.
+    """
+    return _config_keys(global_state)[0]
 
 
-def get_table_schema_as_of_key() -> str:
-    return _config_keys()[1]
+def get_table_schema_as_of_key(global_state=None) -> str:
+    """Return the configured revision-time column name.
+
+    Inside a node callback, pass its ``GlobalState`` injectable rather than
+    consulting the wiring-time state.
+    """
+    return _config_keys(global_state)[1]
 
 
 def make_table_schema(

--- a/python/hgraph/_wiring/_state.py
+++ b/python/hgraph/_wiring/_state.py
@@ -228,6 +228,10 @@ def _enter_runtime():
     _global_state_local.runtime_active = True
 
 
+def _is_runtime_active():
+    return getattr(_global_state_local, "runtime_active", False)
+
+
 def _exit_runtime():
     if getattr(_global_state_local, "runtime_active", False):
         del _global_state_local.runtime_active

--- a/python/hgraph/adaptors/data_frame/_data_frame_record_replay.py
+++ b/python/hgraph/adaptors/data_frame/_data_frame_record_replay.py
@@ -156,7 +156,9 @@ class DataFrameStorage(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def write_frame(self, path, df, mode=WriteMode.OVERWRITE, as_of=None):
+    def write_frame(
+        self, path, df, mode=WriteMode.OVERWRITE, as_of=None, global_state=None
+    ):
         raise NotImplementedError
 
     @abstractmethod
@@ -191,15 +193,27 @@ class BaseDataFrameStorage(DataFrameStorage, ABC):
         # replay normalizes back through _as_arrow.
         return as_user_frame(frame.filter(mask) if mask is not None else frame)
 
-    def write_frame(self, path, df, mode=WriteMode.OVERWRITE, as_of=None):
+    def write_frame(
+        self, path, df, mode=WriteMode.OVERWRITE, as_of=None, global_state=None
+    ):
         if mode is WriteMode.MERGE:
             raise RuntimeError("WriteMode.MERGE is not supported")
         frame = _as_arrow(df)
         if self._get_schema_info(path) == (None, None):
+            from hgraph._wiring._state import _is_runtime_active
+
+            # Preserve the original default-name runtime behavior without
+            # consulting the wiring-only GlobalState singleton. Configured
+            # runtime names come from the callback's explicit injectable.
+            if global_state is None and _is_runtime_active():
+                date_key, as_of_key = "__date_time__", "__as_of__"
+            else:
+                date_key = get_table_schema_date_key(global_state)
+                as_of_key = get_table_schema_as_of_key(global_state)
             self.set_schema_info(
                 path,
-                get_table_schema_date_key(),
-                get_table_schema_as_of_key(),
+                date_key,
+                as_of_key,
             )
         if mode is WriteMode.EXTEND and self._exists(path):
             previous = self._read(path)

--- a/python/hgraph/adaptors/data_frame/_data_frame_record_replay.py
+++ b/python/hgraph/adaptors/data_frame/_data_frame_record_replay.py
@@ -13,6 +13,8 @@ from hgraph import (
     OUT,
     Frame,
     GlobalState,
+    get_table_schema_as_of_key,
+    get_table_schema_date_key,
     graph,
     operator_function,
     table_schema,
@@ -194,7 +196,11 @@ class BaseDataFrameStorage(DataFrameStorage, ABC):
             raise RuntimeError("WriteMode.MERGE is not supported")
         frame = _as_arrow(df)
         if self._get_schema_info(path) == (None, None):
-            self.set_schema_info(path, "__date_time__", "__as_of__")
+            self.set_schema_info(
+                path,
+                get_table_schema_date_key(),
+                get_table_schema_as_of_key(),
+            )
         if mode is WriteMode.EXTEND and self._exists(path):
             previous = self._read(path)
             frame = pa.concat_tables([previous, frame], promote_options="default")

--- a/python/py_state_services.cpp
+++ b/python/py_state_services.cpp
@@ -751,6 +751,10 @@ namespace hgraph::python_bridge
             }
             return result;
         });
+    m.def("_table_schema_keys", [](const PyRuntimeGlobalState &state) {
+        const auto config = record_replay::config(state.checked());
+        return nb::make_tuple(config.date_key, config.as_of_key);
+    });
     m.def("_temporal_at_zone",
           [](GlobalState &state, Instant instant, ZoneId zone) {
               return at_zone(

--- a/python/tests/adaptors/data_frame/test_data_frame_record_replay.py
+++ b/python/tests/adaptors/data_frame/test_data_frame_record_replay.py
@@ -74,6 +74,31 @@ def test_upstream_style_storage_subclass_hooks_are_supported():
     assert storage.schemas["values"] == ("__date_time__", "__as_of__")
 
 
+def test_storage_fallback_uses_configured_bitemporal_column_names():
+    first_time = datetime(2026, 1, 1)
+    second_time = datetime(2026, 1, 2)
+    first_revision = datetime(2026, 1, 3)
+    second_revision = datetime(2026, 1, 4)
+    frame = pa.table(
+        {
+            "event_time": [first_time, second_time],
+            "observed_at": [first_revision, second_revision],
+            "value": [1, 2],
+        }
+    )
+
+    with hg.GlobalContext(hg.GlobalState()):
+        hg.set_table_schema_date_key("event_time")
+        hg.set_table_schema_as_of_key("observed_at")
+        storage = MemoryDataFrameStorage()
+        storage.write_frame("values", frame)
+
+        assert storage._get_schema_info("values") == ("event_time", "observed_at")
+        assert storage.read_frame(
+            "values", start_time=first_time, as_of=first_revision
+        ).equals(frame.slice(0, 1))
+
+
 def test_file_storage_schema_metadata_is_upstream_interoperable(tmp_path):
     storage = FileBasedDataFrameStorage(tmp_path)
     storage.set_schema_info("values", "when", "revision")

--- a/python/tests/adaptors/data_frame/test_data_frame_record_replay.py
+++ b/python/tests/adaptors/data_frame/test_data_frame_record_replay.py
@@ -99,6 +99,73 @@ def test_storage_fallback_uses_configured_bitemporal_column_names():
         ).equals(frame.slice(0, 1))
 
 
+def test_runtime_storage_write_uses_injected_schema_configuration():
+    seen_keys = []
+
+    @hg.sink_node
+    def write_frame(value: hg.TS[int], global_state: hg.GlobalState = None):
+        date_key = hg.get_table_schema_date_key(global_state)
+        as_of_key = hg.get_table_schema_as_of_key(global_state)
+        seen_keys.append((date_key, as_of_key))
+        storage = MemoryDataFrameStorage.instance(global_state)
+        storage.write_frame(
+            "runtime",
+            pa.table(
+                {
+                    date_key: [hg.MIN_ST],
+                    as_of_key: [hg.MIN_ST],
+                    "value": [value.value],
+                }
+            ),
+            global_state=global_state,
+        )
+
+    with hg.GlobalState():
+        hg.set_table_schema_date_key("event_time")
+        hg.set_table_schema_as_of_key("observed_at")
+        with MemoryDataFrameStorage() as storage:
+            assert hg.eval_node(write_frame, [7]) is None
+            assert seen_keys == [("event_time", "observed_at")]
+            assert storage.read_frame("runtime", as_of=hg.MIN_ST).equals(
+                pa.table(
+                    {
+                        "event_time": [hg.MIN_ST],
+                        "observed_at": [hg.MIN_ST],
+                        "value": [7],
+                    }
+                )
+            )
+
+
+def test_runtime_storage_write_preserves_default_names_without_state_lookup():
+    storage = MemoryDataFrameStorage()
+
+    @hg.sink_node
+    def write_frame(value: hg.TS[int]):
+        storage.write_frame(
+            "runtime-default",
+            pa.table(
+                {
+                    "__date_time__": [hg.MIN_ST],
+                    "__as_of__": [hg.MIN_ST],
+                    "value": [value.value],
+                }
+            ),
+        )
+
+    with hg.GlobalState():
+        assert hg.eval_node(write_frame, [7]) is None
+        assert storage.read_frame("runtime-default", as_of=hg.MIN_ST).equals(
+            pa.table(
+                {
+                    "__date_time__": [hg.MIN_ST],
+                    "__as_of__": [hg.MIN_ST],
+                    "value": [7],
+                }
+            )
+        )
+
+
 def test_file_storage_schema_metadata_is_upstream_interoperable(tmp_path):
     storage = FileBasedDataFrameStorage(tmp_path)
     storage.set_schema_info("values", "when", "revision")

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -1707,7 +1707,8 @@ def test_generator_covers_the_2026_07_compat_issue_classes():
     # The nightly generator must keep producing recipes in the spaces where
     # the 2026-07 compatibility issues lived: temporal accessors (#82),
     # collection sizes (#81), lifecycle signature spellings (#79), the
-    # recorded-frame surface (PR #92), and postponed annotations (#83).
+    # recorded-frame surface and configured names (PR #92 and #417), and
+    # postponed annotations (#83).
     from hypothesis import find, settings
 
     from tools.parity.generate import (
@@ -1744,6 +1745,17 @@ def test_generator_covers_the_2026_07_compat_issue_classes():
     )
     assert postponed["parameters"]["postponed_annotations"]
 
+    configured_frame = find(
+        recipe_payload_strategy(
+            min_ticks=8,
+            max_ticks=32,
+            templates=("data_frame_recording",),
+        ),
+        lambda payload: payload["parameters"].get("column_names") == "configured",
+        settings=settings(database=None, deadline=None),
+    )
+    assert "configuration:custom-table-column-names" in configured_frame["features"]
+
 
 def test_coverage_corpus_recipes_execute_on_the_candidate():
     from tools.parity.runner import run_recipe
@@ -1755,6 +1767,7 @@ def test_coverage_corpus_recipes_execute_on_the_candidate():
         "coverage-collection-sizes",
         "coverage-lifecycle-spellings",
         "coverage-frame-recording",
+        "coverage-frame-recording-custom-columns",
         "coverage-postponed-annotations",
         "coverage-nested-adaptor-pipeline",
         "coverage-nested-outer-switch",
@@ -1770,6 +1783,17 @@ def test_coverage_corpus_recipes_execute_on_the_candidate():
     frame = dict(run_recipe(raw)["trace"]["$map"])["frame"]
     columns = dict(frame["$map"])["columns"]
     assert all(dict(column["$map"])["tz"] is None for column in columns)
+
+    raw = json.loads(
+        (CORPUS / "coverage-frame-recording-custom-columns.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    frame = dict(run_recipe(raw)["trace"]["$map"])["frame"]
+    columns = dict(frame["$map"])["columns"]
+    assert [dict(column["$map"])["name"] for column in columns] == [
+        "event_time", "observed_at", "value",
+    ]
 
 
 def test_no_change_elision_relation_bounds_the_ruled_deviation():
@@ -1916,6 +1940,14 @@ def test_new_template_validators_reject_malformed_recipes():
             "parameters": {"as_of_offset": 0},
         },
         "as_of_offset",
+    )
+    rejects(
+        {
+            "template": "data_frame_recording",
+            "inputs": {"ts": [1]},
+            "parameters": {"column_names": "custom"},
+        },
+        "column_names",
     )
     rejects(
         {

--- a/tests/cpp/test_record_replay_config.cpp
+++ b/tests/cpp/test_record_replay_config.cpp
@@ -47,10 +47,13 @@ TEST_CASE("record/replay config: configuration belongs to the seeded GlobalState
 
     CHECK(config(state).model == std::string{IN_MEMORY});
     CHECK(config(state).date_key == "__date_time__");
+    CHECK(config(state).as_of_key == "__as_of__");
     CHECK(model_is(state, IN_MEMORY));
 
     set_config(state, Config{.model = "Arrow", .date_key = "dt", .as_of_key = "asof", .as_of = MIN_ST});
     CHECK(config(state).model == "Arrow");
+    CHECK(config(state).date_key == "dt");
+    CHECK(config(state).as_of_key == "asof");
     CHECK(model_is(state, "Arrow"));
     CHECK_FALSE(model_is(state, IN_MEMORY));
     CHECK(config(state).as_of == MIN_ST);

--- a/tools/parity/catalog.py
+++ b/tools/parity/catalog.py
@@ -955,8 +955,8 @@ def _nested_higher_order(hg, recipe):
 
 
 # --------------------------------------------------------------------------
-# Data-frame recording surface (issue #92 class): the frames the recorder
-# frameworks hand back to user code — column timezone presentation included.
+# Data-frame recording surface (issues #92/#417): the frames the recorder
+# frameworks hand back to user code — configured names and timezone included.
 
 
 def _validate_data_frame_recording(recipe):
@@ -966,6 +966,13 @@ def _validate_data_frame_recording(recipe):
     if (not isinstance(as_of_offset, int) or isinstance(as_of_offset, bool)
             or not 1 <= as_of_offset <= 10_000):
         raise RecipeError("data_frame_recording as_of_offset must be a bounded integer")
+    column_names = recipe.parameters.get("column_names", "default")
+    if not isinstance(column_names, str) or column_names not in {
+        "default", "configured"
+    }:
+        raise RecipeError(
+            "data_frame_recording column_names must be 'default' or 'configured'"
+        )
 
 
 def _canonical_frame_surface(frame):
@@ -1007,8 +1014,12 @@ def _data_frame_recording(hg, recipe):
     )
 
     as_of_offset = recipe.parameters.get("as_of_offset", 30)
+    column_names = recipe.parameters.get("column_names", "default")
     inputs = decoded_inputs(hg, recipe)
     with hg.GlobalState(), MemoryDataFrameStorage() as storage:
+        if column_names == "configured":
+            hg.set_table_schema_date_key("event_time")
+            hg.set_table_schema_as_of_key("observed_at")
         hg.set_record_replay_model(DATA_FRAME_RECORD_REPLAY)
         hg.set_as_of(hg.MIN_ST + hg.MIN_TD * as_of_offset)
         eval_node(hg.record[hg.TS[int]], ts=inputs["ts"], key="ts",

--- a/tools/parity/corpus/coverage-frame-recording-custom-columns.json
+++ b/tools/parity/corpus/coverage-frame-recording-custom-columns.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "id": "coverage-frame-recording-custom-columns",
+  "description": "The #417 class: DataFrame record/replay preserves bitemporal column names configured through the public schema-key setters.",
+  "template": "data_frame_recording",
+  "inputs": {
+    "ts": [1, null, 2, 3]
+  },
+  "parameters": {
+    "as_of_offset": 30,
+    "column_names": "configured"
+  },
+  "features": [
+    "shape:TS",
+    "type:int",
+    "boundary:python-owned",
+    "domain:frame-surface",
+    "topology:record-replay",
+    "configuration:custom-table-column-names"
+  ],
+  "source_issue": "https://github.com/hhenson/hgraph/issues/417"
+}

--- a/tools/parity/generate.py
+++ b/tools/parity/generate.py
@@ -822,13 +822,23 @@ def recipe_payload_strategy(*, min_ticks: int = 8, max_ticks: int = 32,
         small = st.integers(min_value=-20, max_value=20)
         values = [draw(small)] + [
             draw(st.one_of(st.none(), small)) for _ in range(count - 1)]
+        as_of_offset = draw(st.integers(min_value=1, max_value=100))
+        column_names = "configured" if as_of_offset % 2 else "default"
         return {
             "template": "data_frame_recording",
             "inputs": {"ts": values},
             "parameters": {
-                "as_of_offset": draw(st.integers(min_value=1, max_value=100)),
+                "as_of_offset": as_of_offset,
+                "column_names": column_names,
             },
-            "features": [*CATALOG["data_frame_recording"].features],
+            "features": [
+                *CATALOG["data_frame_recording"].features,
+                *(
+                    ("configuration:custom-table-column-names",)
+                    if column_names == "configured"
+                    else ()
+                ),
+            ],
         }
 
     # (name, factory) pairs for discovery. The service strategies exercise


### PR DESCRIPTION
## Summary

- use the active table-schema date and as-of keys when `BaseDataFrameStorage` creates missing schema metadata
- cover configured names through direct Python storage behavior and the matching native record/replay configuration contract
- extend the differential DataFrame recipe and fixed corpus to compare configured column names with hgraph 0.5
- document the record/replay defaults and their deliberate distinction from `lower()` frame defaults

## Root cause

The direct `BaseDataFrameStorage.write_frame()` fallback hard-coded `__date_time__` and `__as_of__`. Record-driven writes usually installed schema metadata before reaching that fallback, so ordinary record/replay tests did not expose the defect. A frame written directly after calling the public schema-key setters was therefore filtered using columns that did not exist.

## Compatibility impact

The default record/replay convention remains `__date_time__` and `__as_of__`, matching hgraph 0.5. Configured names now propagate consistently to direct storage metadata. `lower()` remains a separate interface with `date` and `as_of` defaults, and the migration guide now makes that distinction explicit.

## Validation

- fresh native configure, clean build, and CTest: 1,495/1,495 passed
- cp312 stable-ABI wheel installed under Python 3.14: 2,092 passed, 9 skipped (`not wip`)
- Sphinx HTML build with warnings as errors
- Sphinx doctest: 66 passed
- parity corpus validation: 62 recipes
- new configured-column recipe matches hgraph 0.5.41
- PR parity campaign: 110 attempted, 95 matched, 15 known mismatches, 0 new mismatches

Closes #417
