### PR TITLE
Fix the Windows build on MSVC 14.44 (VS 17.14)

### DIFF
--- a/include/hgraph/types/static_node.h
+++ b/include/hgraph/types/static_node.h
@@ -137,6 +137,17 @@ namespace hgraph
         template <fixed_string Name, typename... Fields>
         struct is_static_tsb_schema<TSB<Name, Fields...>> : std::true_type {};
 
+        /**
+         * Named so the constraint below is a concept rather than a bare
+         * ``::value`` atomic constraint: MSVC before 14.51 reports
+         * "C7607: atomic constraint should be a constant expression of type
+         * 'bool', not 'unknown'" for the latter on a constrained partial
+         * specialization, which makes the whole tree unbuildable on VS 17.14.
+         * Normalization is identical, so this is purely a portability spelling.
+         */
+        template <typename S>
+        concept static_tsb_schema = is_static_tsb_schema<S>::value;
+
         template <typename S> struct static_tsb_schema_traits;
         template <typename... Fields>
         struct static_tsb_schema_traits<UnNamedTSB<Fields...>>
@@ -939,7 +950,7 @@ namespace hgraph
      * ``field<"name">()``.
      */
     template <fixed_string Name, typename TSchema, auto... TPolicies>
-        requires static_node_detail::is_static_tsb_schema<TSchema>::value
+        requires static_node_detail::static_tsb_schema<TSchema>
     class In<Name, TSchema, TPolicies...> : public TSBInputView
     {
       public:

--- a/src/hgraph/runtime/graph_diagnostics.cpp
+++ b/src/hgraph/runtime/graph_diagnostics.cpp
@@ -126,10 +126,14 @@ namespace hgraph
                     ValueView child;
                     if (value.has_value())
                     {
-                        const ValueView &field = kind == Kind::Bundle
-                                                     ? value.as_bundle().at(index)
-                                                     : value.as_tuple().at(index);
-                        child = reborrow(field);
+                        // Assigned per branch rather than through a ternary:
+                        // MSVC does not elide the conditional operator's
+                        // composite prvalue, so the ternary form needs
+                        // ValueView's deleted copy constructor and fails to
+                        // compile there. This matches how table_impl.cpp and
+                        // the sibling case below already select a child.
+                        if (kind == Kind::Bundle) { child = reborrow(value.as_bundle().at(index)); }
+                        else { child = reborrow(value.as_tuple().at(index)); }
                     }
                     children[index].append(child, row);
                 }


### PR DESCRIPTION
hgraph does not build on Windows with the MSVC that ships in VS 17.14. Two independent causes, both pre-existing on `main`, found by building on a Windows box and confirmed against `main` before attributing anything.

CI never sees either: the GitHub runner is on **MSVC 14.51**, this box on **14.44**.

## 1. `graph_diagnostics.cpp` — a genuine portability bug

```
graph_diagnostics.cpp(130): error C2280:
  'hgraph::ValueView::ValueView(const hgraph::ValueView &)':
  attempting to reference a deleted function
```

The child-view selection used a conditional operator whose branches are prvalues from `IndexedValueView::at`. MSVC does not elide the composite prvalue the conditional produces, so it reaches for `ValueView`'s deleted copy constructor. Clang and GCC elide it, which is why only Windows notices.

Assigning per branch avoids forming a composite type at all — and matches how `table_impl.cpp` and the sibling case forty lines below already select a child, so the file gets more internally consistent as well as portable. This is the only such site: MSVC compiled every other conditional-over-views without complaint.

## 2. `static_node.h` — an MSVC bug worth spelling around

```
static_node.h(942): error C7607: atomic constraint should be a constant
  expression of type 'bool', not 'unknown'
```

MSVC before 14.51 rejects a bare `::value` atomic constraint on a constrained partial specialization. It fires once per instantiation — twenty times across the stdlib. Naming the same predicate as a concept avoids it; normalization is identical, so this is a spelling change, not a semantic one. It was the only `requires ...::value` clause in the header.

## Verification

| | before | after |
|---|---|---|
| Windows `uv sync --all-extras --all-groups` (MSVC 14.44, Ninja) | 1 × C2280, 20 × C7607 | **exit 0, zero errors** |
| Windows ported parity suite | could not run | **1193 passed, 8 skipped** |
| macOS ctest, `-DHGRAPH_WARNINGS_AS_ERRORS=ON` | 1503/1503 | 1503/1503 |

Both failures reproduce identically on `main` (same sites, same counts), so neither is a regression from recent work — they are existing breaks in a configuration CI cannot reach.

Worth considering separately: CI pins one MSVC, so this class of break is invisible until someone builds locally. A second Windows leg on an older toolchain, or a documented minimum MSVC, would catch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)