### PR TITLE
Fix the differential parity smoke failing on a warm cache

### DIFF
--- a/tools/parity/environments.py
+++ b/tools/parity/environments.py
@@ -53,7 +53,15 @@ def _ensure_venv(path: Path, interpreter: Path | str) -> Path:
     python = _python_in(path)
     if not python.exists():
         path.parent.mkdir(parents=True, exist_ok=True)
-        _run(["uv", "venv", "--python", str(interpreter), str(path)])
+        # --clear because reaching here means the venv is unusable, not absent:
+        # CI restores .parity/envs from cache, and a restored venv whose
+        # interpreter symlink points at a tool-cache Python that is no longer
+        # there reads as missing (Path.exists follows symlinks) while the
+        # directory is still present. Plain `uv venv` then refuses with "a
+        # virtual environment already exists", failing every run with a warm
+        # cache. Clearing is safe precisely because we only get here when the
+        # interpreter is gone.
+        _run(["uv", "venv", "--clear", "--python", str(interpreter), str(path)])
     return python
 
 


### PR DESCRIPTION
The **Differential parity smoke** job is failing on every PR:

```
Creating virtual environment at: .parity/envs/reference-3.14-linux-x86_64
error: Failed to create virtual environment
  Caused by: A virtual environment already exists at: ...
hint: Use the `--clear` flag or set `UV_VENV_CLEAR=1` ...
```

## Cause

The workflow caches `.parity/envs/reference-*`. On a **cache hit** the directory comes back but a working interpreter does not: the venv's `bin/python` is a symlink into the hosted tool cache, and once the runner has a different Python patch release that link dangles. `Path.exists()` follows symlinks, so `_ensure_venv` reads the venv as *absent* and calls `uv venv`, while uv sees the directory and refuses.

So the failure is **cache-dependent, not change-dependent** — the first run to populate the cache passes and every run afterwards fails. That is why it surfaced on a rebase of an unrelated PR rather than on anything touching parity, and why it will keep failing until the cache expires.

## Fix

Reaching that branch means the venv is unusable rather than absent, so creating with `--clear` is safe and is what uv's own hint recommends.

## Verification

Reproduced with **uv 0.12.3**, the version CI pins. A venv with `bin/python` removed:

- plain `uv venv` → fails with the identical message
- `uv venv --clear` → succeeds, interpreter restored
- `_ensure_venv` against that state now returns a working interpreter

🤖 Generated with [Claude Code](https://claude.com/claude-code)