### PR TITLE
Support Python dataclass feedback defaults

### DIFF
--- a/python/tests/test_hgraph_api.py
+++ b/python/tests/test_hgraph_api.py
@@ -342,6 +342,24 @@ def test_feedback_active_consumption_with_explicit_end():
     check(out == [1, 3, 6, 9], f"feedback: {out}")
 
 
+def test_feedback_accepts_a_python_dataclass_default():
+    @dataclass(frozen=True)
+    class FeedbackState:
+        count: int
+
+    @graph
+    def delayed(value: TS[FeedbackState]) -> TS[FeedbackState]:
+        fb = hg.feedback(TS[FeedbackState], default=FeedbackState(0))
+        fb(value)
+        return fb()
+
+    out = eval_node(delayed, [FeedbackState(1), FeedbackState(2)])
+    check(
+        out == [FeedbackState(0), FeedbackState(1), FeedbackState(2)],
+        f"dataclass feedback: {out}",
+    )
+
+
 def test_python_graph_fns_in_higher_order_operators():
     # Python @graph callables erase into WiredFn values (the type-erased
     # context+ops backend): map_/switch_ COMPILE them as C++ sub-graphs,

--- a/src/hgraph/runtime/feedback_node.cpp
+++ b/src/hgraph/runtime/feedback_node.cpp
@@ -30,8 +30,12 @@ namespace hgraph
 
         void start_feedback_source_with_initial_delta(const NodeView &view, DateTime start_time)
         {
-            auto state = view.state().begin_mutation();
-            state.copy_from(view.scalars());
+            const ValueView state = view.state();
+            if (!state.can_begin_mutation() ||
+                !state.begin_mutation().try_copy_from(view.scalars()))
+            {
+                view.replace_state(view.scalars().clone());
+            }
 
             if (GraphValue *graph = view.graph_value(); graph != nullptr)
             {

--- a/tests/cpp/test_feedback.cpp
+++ b/tests/cpp/test_feedback.cpp
@@ -1,6 +1,8 @@
 #include <hgraph/lib/std/std_operators.h>
 #include <hgraph/lib/testing/check_output.h>
 #include <hgraph/lib/testing/eval_node.h>
+#include <hgraph/types/value/compact_container_ops.h>
+#include <hgraph/types/value/value_builder.h>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -8,6 +10,18 @@ namespace
 {
     using namespace hgraph;
     using namespace hgraph::testing;
+
+    [[nodiscard]] Value immutable_int_tuple()
+    {
+        const auto *meta = scalar_descriptor<HomogeneousTuple<Int>>::value_meta();
+        const auto binding =
+            ValuePlanFactory::instance().type_for(scalar_descriptor<Int>::value_meta());
+        ListBuilder builder{binding};
+        builder.push_back(Int{1});
+        builder.push_back(Int{2});
+        ListStorage storage = builder.build_storage();
+        return Value{compact_list_type(binding, *meta), &storage};
+    }
 
     struct AddInts
     {
@@ -41,6 +55,16 @@ namespace
         {
             auto feedback = stdlib::feedback<TS<Int>>(w);
             feedback(value);
+            return feedback();
+        }
+    };
+
+    struct ImmutableDefaultFeedbackGraph
+    {
+        static Port<TS<HomogeneousTuple<Int>>> compose(Wiring &w)
+        {
+            auto feedback = stdlib::feedback<TS<HomogeneousTuple<Int>>>(
+                w, immutable_int_tuple());
             return feedback();
         }
     };
@@ -101,6 +125,13 @@ TEST_CASE("stdlib feedback without a default is initially silent")
     CHECK_OUTPUT(hgraph::testing::eval_node<NoDefaultFeedbackGraph>(
                      hgraph::testing::values<hgraph::Int>(7, 11)),
                  hgraph::testing::values<hgraph::Int>(hgraph::testing::none, 7, 11));
+}
+
+TEST_CASE("stdlib feedback accepts an immutable compact initial value")
+{
+    CHECK_OUTPUT(hgraph::testing::eval_node<ImmutableDefaultFeedbackGraph>(),
+                 hgraph::testing::values<hgraph::Value>(
+                     immutable_int_tuple()));
 }
 
 TEST_CASE("stdlib feedback supports canonical Fibonacci-style wiring")


### PR DESCRIPTION
## Summary

- allow native feedback source initialization to fall back to owned cloned state when the planned state cannot be mutated in place
- retain the in-place copy path for mutable planned state
- add a public Python regression for `feedback(TS[Dataclass], default=instance)`
- add equivalent native coverage using immutable compact initial storage

## Root cause

Feedback startup assumed every initial delta could be copied into a mutable planned state. Python dataclass defaults are represented by immutable compact value storage, so `begin_mutation()` raised before the first feedback tick. The source now mirrors the existing feedback update behavior: use in-place mutation when supported, otherwise replace state with an owned clone.

## User impact

A Python dataclass instance can now be used as a typed feedback default, and the first tick emits that default before subsequent feedback values.

## Validation

- fresh native configure, clean build, and full CTest suite: 1,503 passed
- stable-ABI wheel built with Python 3.12 and full non-WIP suite run from a fresh Python 3.14 environment: 2,100 passed, 9 skipped
- direct reproduction confirmed the expected sequence for a frozen Python dataclass default