### PR TITLE
Borrow TSD keys and TSS elements when capturing a delta

### DIFF
--- a/src/hgraph/types/time_series/ts_delta.cpp
+++ b/src/hgraph/types/time_series/ts_delta.cpp
@@ -55,6 +55,43 @@ namespace hgraph
             return result;
         }
 
+
+        /**
+         * A key or element ready to hand to a builder, borrowed where possible.
+         *
+         * The keys a ``TSD`` hands out are views into its ``KeySlotStore``, and
+         * the elements a ``TSS`` hands out are views into its own storage, so
+         * the source binding is usually already the builder's binding. In that
+         * case the builder can copy straight from that storage.
+         *
+         * Materialising unconditionally cost an allocation plus a SECOND copy
+         * of every key, every tick — the intermediate existed only to convert a
+         * binding that normally needs no conversion.
+         *
+         * The owner is an inline-storage ``ErasedOwner``, so it must outlive
+         * the returned pointer and must not be moved after the pointer is
+         * taken; callers keep it in the loop body's scope.
+         */
+        class BorrowedOperand
+        {
+          public:
+            BorrowedOperand(ValueTypeRef target, const ValueView &source, const char *fn)
+            {
+                if (target && source.binding() == target) { data_ = source.data(); return; }
+                owner_.emplace(materialize_as(target, source, fn));
+                data_ = owner_->data();
+            }
+
+            BorrowedOperand(const BorrowedOperand &)            = delete;
+            BorrowedOperand &operator=(const BorrowedOperand &) = delete;
+
+            [[nodiscard]] const void *data() const noexcept { return data_; }
+
+          private:
+            std::optional<MaterializedOwner> owner_{};
+            const void                      *data_{nullptr};
+        };
+
         [[nodiscard]] TSRoleTypeRef ts_type_for(const TSValueTypeMetaData *schema, const char *fn)
         {
             const auto type = TSDataPlanFactory::instance().data_type_for(schema);
@@ -423,14 +460,14 @@ namespace hgraph
             SetBuilder added{elem_binding};
             for (const auto &e : set.added())
             {
-                auto value = materialize_as(elem_binding, e, "capture_delta");
-                (void)added.insert_copy(value.data());
+                const BorrowedOperand borrowed{elem_binding, e, "capture_delta"};
+                (void)added.insert_copy(borrowed.data());
             }
             SetBuilder removed{elem_binding};
             for (const auto &e : set.removed())
             {
-                auto value = materialize_as(elem_binding, e, "capture_delta");
-                (void)removed.insert_copy(value.data());
+                const BorrowedOperand borrowed{elem_binding, e, "capture_delta"};
+                (void)removed.insert_copy(borrowed.data());
             }
 
             BundleBuilder bundle{binding_for(bundle_meta, "capture_delta")};
@@ -455,9 +492,8 @@ namespace hgraph
             SetBuilder removed{key_binding};
             for (const auto &key : dict.removed_keys())
             {
-                auto owned_key = materialize_as(
-                    key_binding, key, "capture_delta");
-                (void)removed.insert_copy(owned_key.data());
+                const BorrowedOperand borrowed{key_binding, key, "capture_delta"};
+                (void)removed.insert_copy(borrowed.data());
             }
 
             MapBuilder modified{key_binding, delta_binding};
@@ -468,13 +504,12 @@ namespace hgraph
                 {
                     throw std::logic_error("capture_delta_tsd resolved the wrong child TS schema");
                 }
-                auto owned_key = materialize_as(
-                    key_binding, key, "capture_delta");
+                const BorrowedOperand borrowed{key_binding, key, "capture_delta"};
                 const Value child_delta = capture_delta(child);
                 if (child_delta.binding() == delta_binding)
                 {
                     modified.set_item_copy(
-                        owned_key.data(), child_delta.view().data());
+                        borrowed.data(), child_delta.view().data());
                     continue;
                 }
                 Value stored_delta{delta_binding};
@@ -486,7 +521,7 @@ namespace hgraph
                     child_delta.binding(),
                     child_delta.view().data());
                 modified.set_item_copy(
-                    owned_key.data(), stored_delta.view().data());
+                    borrowed.data(), stored_delta.view().data());
             }
 
             // No strict removals: a capture reports what happened, and
@@ -743,9 +778,8 @@ namespace hgraph
                 const auto set = in.as_set();
                 for (const auto &value : set.values())
                 {
-                    auto owned_value = materialize_as(
-                        element, value, "capture_current_delta");
-                    static_cast<void>(added.insert_copy(owned_value.data()));
+                    const BorrowedOperand borrowed{element, value, "capture_current_delta"};
+                    static_cast<void>(added.insert_copy(borrowed.data()));
                 }
                 SetBuilder removed{element};
                 BundleBuilder bundle{
@@ -767,13 +801,12 @@ namespace hgraph
                 const auto dict = in.as_dict();
                 for (const auto &[key, child] : dict.valid_items())
                 {
-                    auto owned_key = materialize_as(
-                        key_binding, key, "capture_current_delta");
+                    const BorrowedOperand borrowed{key_binding, key, "capture_current_delta"};
                     Value child_delta = capture_current_delta(child);
                     if (child_delta.binding() == delta_binding)
                     {
                         modified.set_item_copy(
-                            owned_key.data(), child_delta.view().data());
+                            borrowed.data(), child_delta.view().data());
                         continue;
                     }
                     Value stored_delta{delta_binding};
@@ -783,7 +816,7 @@ namespace hgraph
                         child_delta.binding(),
                         child_delta.view().data());
                     modified.set_item_copy(
-                        owned_key.data(), stored_delta.view().data());
+                        borrowed.data(), stored_delta.view().data());
                 }
 
                 Value removed_delta = removed.build();


### PR DESCRIPTION
First step toward the slot-indexed observed delta: stop copying keys that never needed copying.

## What was happening

Every key and element copied into a captured delta went through `materialize_as` — an inline-storage `ErasedOwner` was constructed, the source copy-assigned into it, and the builder then copied it **again** into the map or set. So each key cost an allocation plus two copies, every tick.

The intermediate existed only to convert the source binding to the builder's binding, and that conversion is usually unnecessary: the keys a `TSD` hands out are views into its own `KeySlotStore`, and the elements a `TSS` hands out are views into its own storage, so the source binding is already the builder's.

## Change

`BorrowedOperand` keeps the materialisation for the case that genuinely needs it and borrows otherwise. Five paths: removed keys and modified items in `capture_delta_tsd`, added and removed elements in `capture_delta_tss`, and the key and element loops in `capture_current_delta`.

The owner is inline-storage, so its pointer must not be taken across a move; `BorrowedOperand` is non-copyable and scoped to the loop body using the pointer.

## Honesty about the claim

This is a **structural** saving — one allocation and one copy per key per tick, visible in the diff — **not a measured** one. There is no C++ micro-benchmark harness in the tree, so I have not benchmarked it. Adding one for delta capture is worth doing separately, since this path runs per tick per keyed structure.

1503/1503 ctest with `-DHGRAPH_WARNINGS_AS_ERRORS=ON`.

## Where this is going

Groundwork for the observed delta indexing by slot rather than key, with keys resolved by reference on demand (RFC 0017). Apply stays key-addressed, so nothing that replays into a fresh `TSD` changes; the slot-id path for image recovery comes later and is explicitly separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)