### PR TITLE
Preserve late-loaded polymorphic event leaves

### DIFF
--- a/python/hgraph/_wiring/_runner.py
+++ b/python/hgraph/_wiring/_runner.py
@@ -265,6 +265,8 @@ def _evaluate_graph(graph_fn, config, args, kwargs):
     config._validate()
     trace = _make_evaluation_trace(config.trace)
     profiler = _make_evaluation_profiler(config.profile)
+    from .._types import _finalize_compound_scalar_types
+    _finalize_compound_scalar_types()
     state = GlobalState.instance()
     missing = object()
     previous_logger = state.get(_GRAPH_LOGGER_KEY, missing)
@@ -315,6 +317,10 @@ def _evaluate_graph(graph_fn, config, args, kwargs):
         state["__evaluation_mode__"] = config.run_mode
         config.graph_logger.debug("Wiring graph: %s", getattr(graph_fn, "__name__", graph_fn))
         out = graph_fn(*args, **kwargs)
+        # Wiring may materialize a base schema before a downstream extension
+        # class is visited. Close every now-visible hierarchy immediately
+        # before the native graph captures its immutable type realization.
+        _finalize_compound_scalar_types()
         if out is not None:
             w.wire(
                 "__harness_record",

--- a/python/tests/test_compound_scalar_hierarchy.py
+++ b/python/tests/test_compound_scalar_hierarchy.py
@@ -278,6 +278,40 @@ def test_base_annotation_closes_over_defined_python_subclasses():
     assert eval_node(is_derived, [Derived(value=1, label="one")]) == [True]
 
 
+def test_run_graph_emit_preserves_a_leaf_loaded_after_its_base_was_materialized():
+    @dataclass(frozen=True)
+    class Event(
+        CompoundScalar,
+        namespace="tests.run_graph_emit_hierarchy",
+        abstract=True,
+    ):
+        event_id: str
+
+    # Model the import order of a base package followed by an extension: the
+    # base schema is cached before the extension's transitive leaves exist.
+    _value_type(Event)
+
+    @dataclass(frozen=True)
+    class OrderEvent(Event, abstract=True):
+        order_id: str
+
+    @dataclass(frozen=True)
+    class CreateEvent(OrderEvent):
+        payload: str
+
+    created = CreateEvent(event_id="event", order_id="order", payload="created")
+
+    @compute_node
+    def create_events(trigger: TS[bool]) -> TS[tuple[Event, ...]]:
+        return (created,)
+
+    @graph
+    def app() -> TS[Event]:
+        return hg.emit(create_events(const(True)))
+
+    assert [value for _, value in hg.run_graph(app)] == [created]
+
+
 def test_closed_bundle_output_rejects_an_unrelated_compound_scalar():
     @dataclass
     class Base(CompoundScalar, namespace="tests.closed_error", abstract=True):

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -24,10 +24,12 @@
 #include <hgraph/lib/testing/record_replay.h>
 #include <hgraph/runtime/runtime.h>
 #include <hgraph/types/graph_wiring.h>
+#include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/operator_dispatch.h>
 #include <hgraph/types/static_node.h>
 #include <hgraph/types/subgraph_wiring.h>
+#include <hgraph/types/value/value_builder.h>
 #include <hgraph/util/date_time.h>
 
 #include <arrow/api.h>
@@ -45,6 +47,27 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
+
+namespace polymorphic_emit_repro
+{
+    struct Event
+    {};
+}
+
+namespace hgraph
+{
+    template <>
+    struct scalar_descriptor<polymorphic_emit_repro::Event>
+    {
+        [[nodiscard]] static constexpr bool is_concrete() noexcept { return true; }
+        [[nodiscard]] static const ValueTypeMetaData *value_meta()
+        {
+            auto &registry = TypeRegistry::instance();
+            return registry.bundle(
+                "tests.emit", "Event", {{"event_id", registry.value_type("str")}}, {}, true);
+        }
+    };
+}
 
 namespace
 {
@@ -191,6 +214,8 @@ namespace
             return wire<stdlib::convert, TS<HomogeneousTuple<Int>>>(w, ts);
         }
     };
+
+    using PolymorphicEvent = polymorphic_emit_repro::Event;
 
     struct SeriesAddGraph
     {
@@ -1369,6 +1394,46 @@ TEST_CASE("std operators: tuple subtraction accepts a native erased comparator")
                      values<Value>(int_tuple({1, 2, 3, 4, 5})), values<Int>(1),
                      value_fn<SameParity>())),
                  values<Value>(int_tuple({2, 4})));
+}
+
+TEST_CASE("std operators: emit preserves a transitive concrete Bundle leaf")
+{
+    stdlib::register_standard_operators();
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *text = registry.value_type("str");
+    const auto *event = scalar_descriptor<PolymorphicEvent>::value_meta();
+    const auto *order_event = registry.bundle(
+        "tests.emit", "OrderEvent",
+        {{"event_id", text}, {"order_id", text}}, {event}, true);
+    const auto *create_event = registry.bundle(
+        "tests.emit", "CreateEvent",
+        {{"event_id", text}, {"order_id", text}, {"payload", text}},
+        {order_event});
+
+    BundleBuilder create{ValuePlanFactory::instance().type_for(create_event)};
+    create.set("event_id", Value{Str{"event"}});
+    create.set("order_id", Value{Str{"order"}});
+    create.set("payload", Value{Str{"created"}});
+    const Value created = create.build();
+
+    const auto event_binding = value_type_for_wiring(event);
+    Value event_value{event_binding};
+    event_binding.ops_ref().copy_assign_from(
+        event_binding, event_value.begin_mutation().mutable_data(),
+        created.binding(), created.view().data());
+    ListBuilder events_builder{event_binding};
+    events_builder.push_back_copy(event_value.view().data());
+    ListStorage events_storage = events_builder.build_storage();
+    const auto *events_schema =
+        scalar_descriptor<HomogeneousTuple<PolymorphicEvent>>::value_meta();
+    const Value events{
+        compact_list_type(event_binding, *events_schema), &events_storage};
+
+    CHECK_OUTPUT(
+        (eval_node<stdlib::emit, TS<HomogeneousTuple<PolymorphicEvent>>>(
+            values<Value>(events))),
+        values<Value>(created));
 }
 
 TEST_CASE("std operators: len_ visits scalar tuple, set, and map values")


### PR DESCRIPTION
## What changed

- Finalize visible CompoundScalar and Python-owned dataclass hierarchies before production graph wiring begins.
- Finalize them again immediately before the native graph captures its immutable type-realization snapshot.
- Add a Python regression for `emit(create_events(trigger))` over `CompoundScalar -> Event -> OrderEvent -> CreateEvent`.
- Add matching native C++ coverage proving that `emit` preserves a transitive concrete Bundle leaf from a tuple-valued input.

## Why

A base schema can be materialized and cached before a downstream extension loads its concrete descendants. The `eval_node` harness already finalized those late-loaded descendants, but `run_graph` did not. Production graph execution could therefore snapshot an incomplete hierarchy, leaving an `Event` output unable to accept or preserve a concrete `CreateEvent`.

This keeps the graph snapshot closed and immutable while ensuring it contains every subclass visible when the graph is actually wired.

## User impact

Python compute nodes returning `TS[tuple[Event, ...]]` can safely feed `emit` even when concrete event leaves are loaded after the base schema was first materialized. The concrete leaf and all of its fields are retained.

## Validation

- Fresh native configure and clean rebuild using the `cpp` preset.
- `ctest --preset cpp --parallel 2`: 1,504 tests passed.
- Stable-ABI wheel built with Python 3.12 and installed into a fresh Python 3.14 environment.
- `pytest python/tests -q -m "not wip"`: 2,102 passed, 9 skipped.
- `git diff --check`.
