### PR TITLE
Preserve polymorphic values through keyed emit

### DIFF
--- a/include/hgraph/lib/std/operators/impl/conversion_impl.h
+++ b/include/hgraph/lib/std/operators/impl/conversion_impl.h
@@ -2620,8 +2620,18 @@ namespace hgraph::stdlib
                 }
                 if (compact)
                 {
-                    // COMPACT (whole-value) bundle output: one bundle write.
-                    BundleBuilder builder{ValuePlanFactory::instance().type_for(out_schema->value_schema)};
+                    // COMPACT (whole-value) bundle output: build an owning
+                    // value with the active graph's external realization.
+                    // The canonical schema plan cannot accept a concrete
+                    // polymorphic leaf (for example Event <- CreateEvent),
+                    // while the graph-local output binding is a TS storage
+                    // view rather than the portable owning value we enqueue.
+                    const auto *snapshot = active_type_realization();
+                    const auto bundle_binding = snapshot != nullptr
+                                                    ? snapshot->type_for(out_schema->value_schema)
+                                                    : ValuePlanFactory::instance().type_for(
+                                                          out_schema->value_schema);
+                    BundleBuilder builder{bundle_binding};
                     builder.set(0, std::move(key));
                     builder.set(1, std::move(value));
                     auto mutation = erased.data_view().begin_mutation(erased.evaluation_time());

--- a/python/tests/test_compound_scalar_hierarchy.py
+++ b/python/tests/test_compound_scalar_hierarchy.py
@@ -312,6 +312,54 @@ def test_run_graph_emit_preserves_a_leaf_loaded_after_its_base_was_materialized(
     assert [value for _, value in hg.run_graph(app)] == [created]
 
 
+def test_mapped_emit_then_outer_emit_preserves_a_transitive_concrete_leaf():
+    @dataclass(frozen=True)
+    class Event(
+        CompoundScalar,
+        namespace="tests.mapped_emit_hierarchy",
+        abstract=True,
+    ):
+        event_id: str
+
+    # Reproduce the extension import order: the public base is materialized
+    # before the client defines the intermediate and concrete event types.
+    _value_type(Event)
+
+    @dataclass(frozen=True)
+    class OrderEvent(Event, abstract=True):
+        order_id: str
+
+    @dataclass(frozen=True)
+    class CreateEvent(OrderEvent):
+        payload: str
+
+    created = CreateEvent(event_id="event", order_id="order", payload="created")
+
+    @compute_node
+    def create_events(trigger: TS[bool]) -> TS[tuple[Event, ...]]:
+        return (created,) if trigger.value else ()
+
+    @graph
+    def emit_events(trigger: TS[bool]) -> TS[Event]:
+        return hg.emit(create_events(trigger))
+
+    @graph
+    def emit_keyed(events: TSD[str, TS[Event]]) -> TSB[hg.KeyValue[str, TS[Event]]]:
+        return hg.emit(events)
+
+    assert eval_node(emit_keyed, [{"order": created}]) == [
+        {"key": "order", "value": created}
+    ]
+
+    @graph
+    def app(triggers: TSD[str, TS[bool]]) -> TSB[hg.KeyValue[str, TS[Event]]]:
+        return hg.emit(hg.map_(emit_events, triggers))
+
+    assert eval_node(app, [{"order": True}]) == [
+        {"key": "order", "value": created}
+    ]
+
+
 def test_closed_bundle_output_rejects_an_unrelated_compound_scalar():
     @dataclass
     class Base(CompoundScalar, namespace="tests.closed_error", abstract=True):

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -217,6 +217,22 @@ namespace
 
     using PolymorphicEvent = polymorphic_emit_repro::Event;
 
+    using PolymorphicEventDict = TSD<Str, TS<PolymorphicEvent>>;
+    using PolymorphicEventKeyValue =
+        UnNamedTSB<Field<"key", TS<Str>>, Field<"value", TS<PolymorphicEvent>>>;
+
+    struct PolymorphicEventDictEmitGraph
+    {
+        static constexpr auto name = "polymorphic_event_dict_emit_graph";
+
+        static Port<PolymorphicEventKeyValue> compose(
+            Wiring &w, Port<PolymorphicEventDict> events)
+        {
+            return wire<stdlib::emit>(w, events)
+                .as<PolymorphicEventKeyValue>();
+        }
+    };
+
     struct SeriesAddGraph
     {
         static constexpr auto name = "series_add_graph";
@@ -1434,6 +1450,65 @@ TEST_CASE("std operators: emit preserves a transitive concrete Bundle leaf")
         (eval_node<stdlib::emit, TS<HomogeneousTuple<PolymorphicEvent>>>(
             values<Value>(events))),
         values<Value>(created));
+}
+
+TEST_CASE("std operators: keyed emit preserves a concrete Bundle leaf")
+{
+    stdlib::register_standard_operators();
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *text = registry.value_type("str");
+    const auto *event = scalar_descriptor<PolymorphicEvent>::value_meta();
+    const auto *order_event = registry.bundle(
+        "tests.emit", "OrderEvent",
+        {{"event_id", text}, {"order_id", text}}, {event}, true);
+    const auto *create_event = registry.bundle(
+        "tests.emit", "CreateEvent",
+        {{"event_id", text}, {"order_id", text}, {"payload", text}},
+        {order_event});
+
+    BundleBuilder create{ValuePlanFactory::instance().type_for(create_event)};
+    create.set("event_id", Value{Str{"event"}});
+    create.set("order_id", Value{Str{"order"}});
+    create.set("payload", Value{Str{"created"}});
+    const Value created = create.build();
+
+    const auto realization = TypeRealizationSnapshot::capture(registry);
+    TypeRealizationScope realization_scope{realization.get()};
+    const auto key_binding = realization->type_for(text);
+    const auto event_binding = realization->type_for(event);
+    Value event_value{event_binding};
+    event_binding.ops_ref().copy_assign_from(
+        event_binding, event_value.begin_mutation().mutable_data(),
+        created.binding(), created.view().data());
+
+    SetBuilder removed{key_binding};
+    MapBuilder modified{key_binding, event_binding};
+    const Str key{"order"};
+    modified.set_item_copy(&key, event_value.view().data());
+    const auto *delta_schema = ts_type<PolymorphicEventDict>()->delta_value_schema;
+    BundleBuilder delta{realization->type_for(delta_schema)};
+    delta.set("removed", removed.build());
+    delta.set("modified", modified.build());
+
+    const Value input_delta = delta.build();
+    CHECK_OUTPUT((eval_node<stdlib::len_, PolymorphicEventDict>(
+                     values<Value>(input_delta))),
+                 values<Int>(1));
+    const auto actual = eval_node<PolymorphicEventDictEmitGraph>(
+        values<Value>(input_delta));
+
+    REQUIRE(actual.size() == 1);
+    REQUIRE(actual.front().has_value());
+    const auto fields = actual.front()->view().as_indexed_view();
+    REQUIRE(fields.size() == 2);
+    CHECK(fields.at(0).checked_as<Str>() == Str{"order"});
+    const auto concrete = fields.at(1).concrete();
+    REQUIRE(concrete.schema() == create_event);
+    const auto event_fields = concrete.as_bundle();
+    CHECK(event_fields.at("event_id").checked_as<Str>() == Str{"event"});
+    CHECK(event_fields.at("order_id").checked_as<Str>() == Str{"order"});
+    CHECK(event_fields.at("payload").checked_as<Str>() == Str{"created"});
 }
 
 TEST_CASE("std operators: len_ visits scalar tuple, set, and map values")


### PR DESCRIPTION
## Summary

- build compact `KeyValue` emissions with the active graph’s external type realization
- preserve concrete `CompoundScalar` leaves when emitting a polymorphic `TSD`
- add native coverage for keyed emission and Python coverage for the client composition `emit(map_(inner_emit, ...))`

## Root cause

The compact `TSD -> KeyValue` emit path constructed its output bundle from the canonical schema plan. For a declared base such as `Event`, that plan cannot accept a graph-realized concrete leaf such as `CreateEvent`, so the outer emit failed with incompatible `ValueOps::move_assign_from` bindings. The output’s graph-local binding is not suitable either because the queued result must be a portable owning value. The builder now uses the active graph snapshot’s external value realization.

## Impact

Python compute nodes may return a tuple of base-typed polymorphic events, emit those events inside a mapped graph, and pass the resulting keyed series to an outer emit without losing the concrete leaf type.

## Validation

macOS:
- fresh C++ acceptance preset: 1,505 passed
- stable-ABI wheel built with Python 3.12 and full non-WIP suite run on Python 3.14: 2,103 passed, 9 skipped

Linux (`hg-linux`, GCC):
- fresh C++ acceptance preset: 1,505 passed
- stable-ABI wheel built with Python 3.12 and full non-WIP suite run on Python 3.14: 2,103 passed, 9 skipped