### PR TITLE
Preserve polymorphic values through feedback

### DIFF
--- a/python/tests/test_compound_scalar_hierarchy.py
+++ b/python/tests/test_compound_scalar_hierarchy.py
@@ -360,6 +360,104 @@ def test_mapped_emit_then_outer_emit_preserves_a_transitive_concrete_leaf():
     ]
 
 
+def test_feedback_preserves_a_transitive_concrete_leaf_with_and_without_a_default():
+    @dataclass(frozen=True)
+    class Event(
+        CompoundScalar,
+        namespace="tests.polymorphic_feedback",
+        abstract=True,
+    ):
+        event_id: str
+
+    # Match extension/client import order: the public base is materialized
+    # before the intermediate and concrete event classes are registered.
+    _value_type(Event)
+
+    @dataclass(frozen=True)
+    class HeartbeatEvent(Event):
+        pass
+
+    @dataclass(frozen=True)
+    class OrderEvent(Event, abstract=True):
+        order_id: str
+
+    @dataclass(frozen=True)
+    class CreateEvent(OrderEvent):
+        payload: str
+        details_a: str
+        details_b: str
+        details_c: str
+        details_d: str
+
+    default_event = CreateEvent(
+        event_id="default-event",
+        order_id="default-order",
+        payload="default",
+        details_a="a",
+        details_b="b",
+        details_c="c",
+        details_d="d",
+    )
+    heartbeat = HeartbeatEvent(event_id="heartbeat")
+    created = CreateEvent(
+        event_id="event",
+        order_id="order",
+        payload="created",
+        details_a="a",
+        details_b="b",
+        details_c="c",
+        details_d="d",
+    )
+
+    @graph
+    def delayed(value: TS[Event]) -> TS[Event]:
+        fb = hg.feedback(TS[Event])
+        fb(value)
+        return fb()
+
+    @graph
+    def delayed_from_default(value: TS[Event]) -> TS[Event]:
+        fb = hg.feedback(TS[Event], default=default_event)
+        fb(value)
+        return fb()
+
+    @compute_node
+    def create_events(trigger: TS[bool]) -> TS[tuple[Event, ...]]:
+        return (created,) if trigger.value else ()
+
+    @graph
+    def delayed_emission(trigger: TS[bool]) -> TS[Event]:
+        fb = hg.feedback(TS[Event])
+        fb(hg.emit(create_events(trigger)))
+        return fb()
+
+    @graph
+    def mapped_delayed_emission(
+        triggers: TSD[str, TS[bool]],
+    ) -> TSD[str, TS[Event]]:
+        return hg.map_(delayed_emission, triggers)
+
+    assert eval_node(delayed, [heartbeat, created]) == [None, heartbeat, created]
+    assert eval_node(delayed_from_default, [heartbeat, created]) == [
+        default_event,
+        heartbeat,
+        created,
+    ]
+    assert eval_node(mapped_delayed_emission, [{"order": True}]) == [
+        {},
+        {"order": created},
+    ]
+
+    with hg.GlobalContext(hg.GlobalState()):
+        hg.set_pooled_compound_scalar_storage()
+        assert eval_node(delayed, [heartbeat, created]) == [None, heartbeat, created]
+        assert eval_node(delayed_from_default, [heartbeat, created]) == [
+            default_event,
+            heartbeat,
+            created,
+        ]
+
+
 def test_closed_bundle_output_rejects_an_unrelated_compound_scalar():
     @dataclass
     class Base(CompoundScalar, namespace="tests.closed_error", abstract=True):

--- a/src/hgraph/runtime/feedback_node.cpp
+++ b/src/hgraph/runtime/feedback_node.cpp
@@ -28,11 +28,31 @@ namespace hgraph
             }
         }
 
+        [[nodiscard]] bool try_copy_feedback_state(
+            const ValueView &state, const ValueView &source)
+        {
+            if (!state.can_begin_mutation() || !source.has_value()) { return false; }
+
+            const auto target_binding = state.binding();
+            const auto source_binding = source.binding();
+            if (!target_binding || !source_binding ||
+                !target_binding.ops_ref().accepts_source(
+                    target_binding, source_binding))
+            {
+                return false;
+            }
+
+            auto mutation = state.begin_mutation();
+            target_binding.ops_ref().copy_assign_from(
+                target_binding, mutation.mutable_data(),
+                source_binding, source.data());
+            return true;
+        }
+
         void start_feedback_source_with_initial_delta(const NodeView &view, DateTime start_time)
         {
             const ValueView state = view.state();
-            if (!state.can_begin_mutation() ||
-                !state.begin_mutation().try_copy_from(view.scalars()))
+            if (!try_copy_feedback_state(state, view.scalars()))
             {
                 view.replace_state(view.scalars().clone());
             }
@@ -65,17 +85,17 @@ namespace hgraph
             {
                 throw std::logic_error("feedback sink target node has no delta state");
             }
-            // Canonical TSData delta views expose owning copy hooks. Copying
-            // through the already-planned source state avoids constructing an
-            // intermediate Value on every feedback tick. A sampled rebind can
-            // expose the current-value schema instead of the delta schema, so
-            // retain capture_delta as the general fallback. That fallback may
-            // replace the planned state with immutable compact storage, in
-            // which case a later tick must capture again rather than request a
-            // mutation view.
+            // Copy through the already-planned source state when its binding
+            // accepts the observed delta. This is intentionally binding-aware:
+            // a polymorphic TS[Base] may expose a concrete Derived delta, whose
+            // schema differs while remaining a valid source for the graph's
+            // closed Base realization. A sampled rebind can expose the current-
+            // value schema instead of the delta schema, so retain capture_delta
+            // as the general fallback. That fallback may replace the planned
+            // state with immutable compact storage, in which case a later tick
+            // must capture again rather than request a mutation view.
             const ValueView state = source_node.state();
-            if (!state.can_begin_mutation() ||
-                !state.begin_mutation().try_copy_from(ts.delta_value()))
+            if (!try_copy_feedback_state(state, ts.delta_value()))
             {
                 source_node.replace_state(capture_delta(ts));
             }

--- a/src/hgraph/runtime/node.cpp
+++ b/src/hgraph/runtime/node.cpp
@@ -6,6 +6,7 @@
 #include <hgraph/runtime/graph.h>
 #include <hgraph/runtime/node_error.h>
 #include <hgraph/types/metadata/debug_descriptor.h>
+#include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/type_record_registry.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/notifiable.h>
@@ -288,7 +289,7 @@ namespace hgraph
         [[nodiscard]] ValueTypeRef state_binding_for(const ValueTypeMetaData *schema)
         {
             if (schema == nullptr) { throw std::logic_error("Node state schema is null"); }
-            const auto binding = ValuePlanFactory::instance().type_for(schema);
+            const auto binding = value_type_for_active_realization(schema);
             if (!binding)
             {
                 throw std::logic_error("Node state schema has no value binding");

--- a/tests/cpp/test_feedback.cpp
+++ b/tests/cpp/test_feedback.cpp
@@ -1,15 +1,134 @@
 #include <hgraph/lib/std/std_operators.h>
 #include <hgraph/lib/testing/check_output.h>
 #include <hgraph/lib/testing/eval_node.h>
+#include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/value/compact_container_ops.h>
 #include <hgraph/types/value/value_builder.h>
 
 #include <catch2/catch_test_macros.hpp>
 
+namespace polymorphic_feedback_repro
+{
+    struct Event
+    {
+    };
+}
+
+namespace hgraph
+{
+    template <>
+    struct scalar_descriptor<polymorphic_feedback_repro::Event>
+    {
+        [[nodiscard]] static constexpr bool is_concrete() noexcept { return true; }
+        [[nodiscard]] static const ValueTypeMetaData *value_meta()
+        {
+            auto &registry = TypeRegistry::instance();
+            return registry.bundle(
+                "tests.feedback", "Event", {{"event_id", registry.value_type("str")}}, {}, true);
+        }
+    };
+}
+
+namespace hgraph::testing
+{
+    template <>
+    struct ts_harness<TS<polymorphic_feedback_repro::Event>>
+        : bundle_ts_harness<TS<polymorphic_feedback_repro::Event>>
+    {
+    };
+}
+
 namespace
 {
     using namespace hgraph;
     using namespace hgraph::testing;
+
+    using PolymorphicEvent = polymorphic_feedback_repro::Event;
+
+    struct PolymorphicFeedbackSchemas
+    {
+        const ValueTypeMetaData *event{nullptr};
+        const ValueTypeMetaData *heartbeat_event{nullptr};
+        const ValueTypeMetaData *create_event{nullptr};
+    };
+
+    [[nodiscard]] PolymorphicFeedbackSchemas polymorphic_feedback_schemas()
+    {
+        auto       &registry = TypeRegistry::instance();
+        const auto *text = registry.value_type("str");
+        const auto *event = scalar_descriptor<PolymorphicEvent>::value_meta();
+        const auto *heartbeat_event = registry.bundle(
+            "tests.feedback", "HeartbeatEvent", {{"event_id", text}}, {event});
+        const auto *order_event = registry.bundle(
+            "tests.feedback", "OrderEvent",
+            {{"event_id", text}, {"order_id", text}}, {event}, true);
+        const auto *create_event = registry.bundle(
+            "tests.feedback", "CreateEvent",
+            {{"event_id", text}, {"order_id", text}, {"payload", text},
+             {"details_a", text}, {"details_b", text},
+             {"details_c", text}, {"details_d", text}},
+            {order_event});
+        return PolymorphicFeedbackSchemas{
+            .event = event,
+            .heartbeat_event = heartbeat_event,
+            .create_event = create_event,
+        };
+    }
+
+    [[nodiscard]] Value realize_polymorphic_event(
+        const TypeRealizationSnapshot &realization,
+        const ValueTypeMetaData        *event,
+        const Value                    &concrete)
+    {
+        const auto event_binding = realization.type_for(event);
+        Value      event_value{event_binding};
+        event_binding.ops_ref().copy_assign_from(
+            event_binding, event_value.begin_mutation().mutable_data(),
+            concrete.binding(), concrete.view().data());
+        return event_value;
+    }
+
+    [[nodiscard]] Value heartbeat_event_value(
+        const TypeRealizationSnapshot    &realization,
+        const PolymorphicFeedbackSchemas &schemas)
+    {
+        BundleBuilder heartbeat{
+            ValuePlanFactory::instance().type_for(schemas.heartbeat_event)};
+        heartbeat.set("event_id", Value{Str{"heartbeat"}});
+        const Value concrete = heartbeat.build();
+        return realize_polymorphic_event(realization, schemas.event, concrete);
+    }
+
+    [[nodiscard]] Value create_event_value(
+        const TypeRealizationSnapshot    &realization,
+        const PolymorphicFeedbackSchemas &schemas)
+    {
+        BundleBuilder create{
+            ValuePlanFactory::instance().type_for(schemas.create_event)};
+        create.set("event_id", Value{Str{"event"}});
+        create.set("order_id", Value{Str{"order"}});
+        create.set("payload", Value{Str{"created"}});
+        create.set("details_a", Value{Str{"a"}});
+        create.set("details_b", Value{Str{"b"}});
+        create.set("details_c", Value{Str{"c"}});
+        create.set("details_d", Value{Str{"d"}});
+        const Value concrete = create.build();
+        return realize_polymorphic_event(realization, schemas.event, concrete);
+    }
+
+    void check_polymorphic_event(
+        const Value &actual, const ValueTypeMetaData *expected_schema,
+        std::initializer_list<std::pair<std::string_view, std::string_view>> expected_fields)
+    {
+        const auto concrete = actual.view().concrete();
+        CHECK(concrete.schema() == expected_schema);
+        const auto bundle = concrete.as_bundle();
+        for (const auto &[name, expected] : expected_fields)
+        {
+            CAPTURE(name);
+            CHECK(bundle.field(name).checked_as<Str>() == Str{expected});
+        }
+    }
 
     [[nodiscard]] Value immutable_int_tuple()
     {
@@ -54,6 +173,30 @@ namespace
         static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>> value)
         {
             auto feedback = stdlib::feedback<TS<Int>>(w);
+            feedback(value);
+            return feedback();
+        }
+    };
+
+    struct PolymorphicFeedbackGraph
+    {
+        static Port<TS<PolymorphicEvent>> compose(
+            Wiring &w, Port<TS<PolymorphicEvent>> value)
+        {
+            auto feedback = stdlib::feedback<TS<PolymorphicEvent>>(w);
+            feedback(value);
+            return feedback();
+        }
+    };
+
+    struct PolymorphicDefaultFeedbackGraph
+    {
+        static Port<TS<PolymorphicEvent>> compose(
+            Wiring &w, Port<TS<PolymorphicEvent>> value,
+            Scalar<"initial_delta", Value> initial_delta)
+        {
+            auto feedback = stdlib::feedback<TS<PolymorphicEvent>>(
+                w, initial_delta.value().clone());
             feedback(value);
             return feedback();
         }
@@ -125,6 +268,121 @@ TEST_CASE("stdlib feedback without a default is initially silent")
     CHECK_OUTPUT(hgraph::testing::eval_node<NoDefaultFeedbackGraph>(
                      hgraph::testing::values<hgraph::Int>(7, 11)),
                  hgraph::testing::values<hgraph::Int>(hgraph::testing::none, 7, 11));
+}
+
+TEST_CASE("stdlib feedback preserves concrete Bundle alternatives")
+{
+    const auto schemas = polymorphic_feedback_schemas();
+    const auto realization = hgraph::TypeRealizationSnapshot::capture(
+        hgraph::TypeRegistry::instance());
+    hgraph::TypeRealizationScope realization_scope{realization.get()};
+    const hgraph::Value heartbeat = heartbeat_event_value(*realization, schemas);
+    const hgraph::Value created = create_event_value(*realization, schemas);
+
+    const auto actual = hgraph::testing::eval_node<PolymorphicFeedbackGraph>(
+        hgraph::testing::values<hgraph::Value>(heartbeat, created));
+
+    REQUIRE(actual.size() == 3);
+    CHECK_FALSE(actual.front().has_value());
+    REQUIRE(actual[1].has_value());
+    check_polymorphic_event(
+        *actual[1], schemas.heartbeat_event, {{"event_id", "heartbeat"}});
+    REQUIRE(actual[2].has_value());
+    check_polymorphic_event(
+        *actual[2], schemas.create_event,
+        {{"event_id", "event"}, {"order_id", "order"},
+         {"payload", "created"}, {"details_a", "a"},
+         {"details_b", "b"}, {"details_c", "c"}, {"details_d", "d"}});
+}
+
+TEST_CASE("stdlib feedback preserves concrete Bundle alternatives after its default")
+{
+    const auto schemas = polymorphic_feedback_schemas();
+    const auto realization = hgraph::TypeRealizationSnapshot::capture(
+        hgraph::TypeRegistry::instance());
+    hgraph::TypeRealizationScope realization_scope{realization.get()};
+    const hgraph::Value heartbeat = heartbeat_event_value(*realization, schemas);
+    const hgraph::Value created = create_event_value(*realization, schemas);
+
+    const auto actual = hgraph::testing::eval_node<PolymorphicDefaultFeedbackGraph>(
+        hgraph::testing::values<hgraph::Value>(heartbeat, created), created);
+
+    REQUIRE(actual.size() == 3);
+    REQUIRE(actual[0].has_value());
+    check_polymorphic_event(
+        *actual[0], schemas.create_event,
+        {{"event_id", "event"}, {"order_id", "order"},
+         {"payload", "created"}, {"details_a", "a"},
+         {"details_b", "b"}, {"details_c", "c"}, {"details_d", "d"}});
+    REQUIRE(actual[1].has_value());
+    check_polymorphic_event(
+        *actual[1], schemas.heartbeat_event, {{"event_id", "heartbeat"}});
+    REQUIRE(actual[2].has_value());
+    check_polymorphic_event(
+        *actual[2], schemas.create_event,
+        {{"event_id", "event"}, {"order_id", "order"},
+         {"payload", "created"}, {"details_a", "a"},
+         {"details_b", "b"}, {"details_c", "c"}, {"details_d", "d"}});
+}
+
+TEST_CASE("stdlib feedback preserves concrete Bundle alternatives in pooled graph storage")
+{
+    auto &registry = hgraph::TypeRegistry::instance();
+    const auto schemas = polymorphic_feedback_schemas();
+
+    const hgraph::TypeRealizationOptions options{
+        .polymorphic_compound_storage =
+            hgraph::PolymorphicCompoundStoragePolicy::Pooled,
+    };
+    const auto realization =
+        hgraph::TypeRealizationSnapshot::capture(registry, options);
+    static_cast<void>(realization->graph_type_for(schemas.event));
+    const auto inspection = realization->inspect(schemas.event);
+    INFO("feedback pooled realization size range " << inspection.minimum_leaf_size
+                                                     << ".." << inspection.maximum_leaf_size);
+    REQUIRE(inspection.representation ==
+            hgraph::GraphValueRepresentation::PooledUnion);
+
+    hgraph::GlobalState graph_state;
+    hgraph::set_pooled_compound_scalar_storage(graph_state.view());
+    hgraph::GlobalContext graph_context{graph_state};
+    hgraph::TypeRealizationScope realization_scope{realization.get()};
+    const hgraph::Value heartbeat = heartbeat_event_value(*realization, schemas);
+    const hgraph::Value created = create_event_value(*realization, schemas);
+
+    const auto delayed = hgraph::testing::eval_node<PolymorphicFeedbackGraph>(
+        hgraph::testing::values<hgraph::Value>(heartbeat, created));
+    REQUIRE(delayed.size() == 3);
+    CHECK_FALSE(delayed.front().has_value());
+    REQUIRE(delayed[1].has_value());
+    check_polymorphic_event(
+        *delayed[1], schemas.heartbeat_event, {{"event_id", "heartbeat"}});
+    REQUIRE(delayed[2].has_value());
+    check_polymorphic_event(
+        *delayed[2], schemas.create_event,
+        {{"event_id", "event"}, {"order_id", "order"},
+         {"payload", "created"}, {"details_a", "a"},
+         {"details_b", "b"}, {"details_c", "c"}, {"details_d", "d"}});
+
+    const auto from_default =
+        hgraph::testing::eval_node<PolymorphicDefaultFeedbackGraph>(
+            hgraph::testing::values<hgraph::Value>(heartbeat, created), created);
+    REQUIRE(from_default.size() == 3);
+    REQUIRE(from_default[0].has_value());
+    check_polymorphic_event(
+        *from_default[0], schemas.create_event,
+        {{"event_id", "event"}, {"order_id", "order"},
+         {"payload", "created"}, {"details_a", "a"},
+         {"details_b", "b"}, {"details_c", "c"}, {"details_d", "d"}});
+    REQUIRE(from_default[1].has_value());
+    check_polymorphic_event(
+        *from_default[1], schemas.heartbeat_event, {{"event_id", "heartbeat"}});
+    REQUIRE(from_default[2].has_value());
+    check_polymorphic_event(
+        *from_default[2], schemas.create_event,
+        {{"event_id", "event"}, {"order_id", "order"},
+         {"payload", "created"}, {"details_a", "a"},
+         {"details_b", "b"}, {"details_c", "c"}, {"details_d", "d"}});
 }
 
 TEST_CASE("stdlib feedback accepts an immutable compact initial value")


### PR DESCRIPTION
## Summary

- construct node state with the graph-local closed type realization
- copy feedback defaults and deltas through binding-aware assignment so a declared `TS[Event]` state accepts concrete derived alternatives
- add first-class C++ and Python regressions for no-default, concrete-default, stable-storage, pooled-storage, and nested `map_ -> emit -> feedback` paths

## Root cause

`feedback_source` state was planned through the canonical `ValuePlanFactory`, while graph outputs used the graph-specific closed polymorphic realization. The feedback sink's exact-binding fast path consequently rejected a valid concrete `CreateEvent` delta for the declared `Event` state. Its fallback captured the concrete delta and then failed when replacing state whose declared schema remained `Event`.

The fix keeps the state in the graph's selected realization and uses the target binding's `accepts_source`/`copy_assign_from` contract. Immutable compact values retain the existing capture-and-replace fallback.

## Validation

- macOS fresh native acceptance: 1,508 passed
- macOS stable-ABI wheel built with Python 3.12 and full non-WIP suite on Python 3.14: 2,104 passed, 9 skipped
- Linux fresh native acceptance with GCC 14: 1,508 passed
- Linux stable-ABI wheel built with Python 3.12 and full non-WIP suite on Python 3.14: 2,104 passed, 9 skipped
- Linux ASan, complete compound-scalar hierarchy module: 43 passed

This follows the polymorphic keyed-emit correction merged in #434 and covers the feedback state boundary that it exposed.
