### PR TITLE
Index canonical delta fields instead of scanning for them by name

### DIFF
--- a/src/hgraph/types/time_series/ts_delta.cpp
+++ b/src/hgraph/types/time_series/ts_delta.cpp
@@ -17,6 +17,7 @@
 #include <fmt/format.h>
 
 #include <array>
+#include <cassert>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -55,6 +56,40 @@ namespace hgraph
             return result;
         }
 
+
+        /**
+         * Canonical delta field layouts. ``type_registry.cpp`` builds these in
+         * one place, so the apply path indexes them directly:
+         *
+         *   TSS           {added, removed}
+         *   TSD observed  {removed, modified}
+         *   TSD authored  {removed, modified, removed_strict}
+         *
+         * ``BundleView::field`` looks a field up by scanning the schema and
+         * comparing field-name strings. That is the wrong algorithm here - it
+         * runs on every tick, for every keyed structure, to find a field whose
+         * position is fixed and known at compile time.
+         *
+         * ``delta_field_is`` re-checks the assumption under ``assert`` so a
+         * reordered schema fails loudly in a debug build instead of silently
+         * reading the wrong field; release builds pay nothing.
+         */
+        inline constexpr std::size_t tss_delta_added           = 0;
+        inline constexpr std::size_t tss_delta_removed         = 1;
+        inline constexpr std::size_t tsd_delta_removed         = 0;
+        inline constexpr std::size_t tsd_delta_modified        = 1;
+        inline constexpr std::size_t tsd_delta_removed_strict  = 2;
+        /** An authored TSD delta has the third field; an observed one does not. */
+        inline constexpr std::size_t tsd_authored_delta_fields = 3;
+
+        [[maybe_unused]] [[nodiscard]] inline bool delta_field_is(const ValueView &bundle, std::size_t index,
+                                                 std::string_view name) noexcept
+        {
+            const auto *schema = bundle.binding() ? bundle.binding().schema() : nullptr;
+            if (schema == nullptr || index >= schema->field_count) { return false; }
+            const char *field = schema->fields[index].name;
+            return field != nullptr && name == field;
+        }
 
         /**
          * A key or element ready to hand to a builder, borrowed where possible.
@@ -589,8 +624,10 @@ namespace hgraph
         {
             if (!delta.has_value()) { return false; }
             const auto bundle = delta.as_bundle();
-            if (bundle.field("added").as_indexed_view().size() != 0 ||
-                bundle.field("removed").as_indexed_view().size() != 0)
+            assert(delta_field_is(delta, tss_delta_added, "added"));
+            assert(delta_field_is(delta, tss_delta_removed, "removed"));
+            if (bundle.at(tss_delta_added).as_indexed_view().size() != 0 ||
+                bundle.at(tss_delta_removed).as_indexed_view().size() != 0)
             {
                 return true;
             }
@@ -604,17 +641,19 @@ namespace hgraph
         {
             if (!delta.has_value()) { return false; }
             const auto bundle = delta.as_bundle();
-            const auto modified       = bundle.field("modified").as_map();
+            assert(delta_field_is(delta, tsd_delta_modified, "modified"));
+            const auto modified = bundle.at(tsd_delta_modified).as_map();
             if (modified.size() != 0) { return true; }
             // Only an AUTHORED delta carries strict removals; an observed one
             // has no such field.
-            if (bundle.has_field("removed_strict") &&
-                bundle.field("removed_strict").as_indexed_view().size() != 0)
+            if (bundle.size() == tsd_authored_delta_fields &&
+                bundle.at(tsd_delta_removed_strict).as_indexed_view().size() != 0)
             {
                 return true;
             }
 
-            const auto removed = bundle.field("removed").as_indexed_view();
+            assert(delta_field_is(delta, tsd_delta_removed, "removed"));
+            const auto removed = bundle.at(tsd_delta_removed).as_indexed_view();
             if (removed.size() != 0)
             {
                 const auto dict_out = out.as_dict();
@@ -678,9 +717,11 @@ namespace hgraph
             const auto bundle  = delta.as_bundle();
             auto       set_out = out.as_set();
             auto       mutation = set_out.begin_mutation(out.evaluation_time());
-            const auto removed = bundle.field("removed").as_indexed_view();
+            assert(delta_field_is(delta, tss_delta_added, "added"));
+            assert(delta_field_is(delta, tss_delta_removed, "removed"));
+            const auto removed = bundle.at(tss_delta_removed).as_indexed_view();
             for (std::size_t i = 0; i < removed.size(); ++i) { (void)mutation.remove(removed.at(i)); }
-            const auto added = bundle.field("added").as_indexed_view();
+            const auto added = bundle.at(tss_delta_added).as_indexed_view();
             for (std::size_t i = 0; i < added.size(); ++i) { (void)mutation.add(added.at(i)); }
             // Touch LAST: the once-per-time notification rides the FIRST
             // record and must carry the real changes; the trailing touch
@@ -698,16 +739,18 @@ namespace hgraph
             // Applying a removal is ALWAYS lenient, whatever it meant to its
             // producer: a captured removal is a fact about the source, and the
             // target being replayed or replicated into need not hold the key.
-            const auto removed = bundle.field("removed").as_indexed_view();
+            assert(delta_field_is(delta, tsd_delta_removed, "removed"));
+            const auto removed = bundle.at(tsd_delta_removed).as_indexed_view();
             for (std::size_t i = 0; i < removed.size(); ++i) { (void)mutation.erase(removed.at(i)); }
 
             // The one exception, and the only strictness in the model: keys a
             // USER authored as REMOVE, asserting the target holds them. Present
             // only on an AUTHORED delta (``authored_delta_schema``); apply
             // accepts either shape.
-            if (bundle.has_field("removed_strict"))
+            if (bundle.size() == tsd_authored_delta_fields)
             {
-                const auto removed_strict = bundle.field("removed_strict").as_indexed_view();
+                assert(delta_field_is(delta, tsd_delta_removed_strict, "removed_strict"));
+                const auto removed_strict = bundle.at(tsd_delta_removed_strict).as_indexed_view();
                 for (std::size_t i = 0; i < removed_strict.size(); ++i)
                 {
                     if (!mutation.erase(removed_strict.at(i)))
@@ -718,7 +761,8 @@ namespace hgraph
                 }
             }
 
-            const auto modified = bundle.field("modified").as_map();
+            assert(delta_field_is(delta, tsd_delta_modified, "modified"));
+            const auto modified = bundle.at(tsd_delta_modified).as_map();
             for (const auto &[key, child_delta] : modified)
             {
                 auto child = mutation.at(key);


### PR DESCRIPTION
Re-raise of work that was lost: this commit was pushed to `perf/tsd-delta-key-borrow` **after** #432 had already merged, so it never reached `main`. #432 landed only the key-borrow half.

## The problem

Applying a delta looked every field up with `BundleView::field`, which scans the schema comparing field-name strings. That is the wrong algorithm for this path — it runs on every tick, for every keyed structure, to find fields whose position is fixed and known at compile time. Eleven such lookups sat on the TSS and TSD apply and has-effect paths, and the `removed_strict` test added a twelfth by calling `has_field` and then `field`, scanning twice for one answer.

## The change

`type_registry.cpp` builds the layouts in one place, so they become named constants and the path indexes directly:

```
TSS           {added, removed}
TSD observed  {removed, modified}
TSD authored  {removed, modified, removed_strict}
```

The authored/observed test becomes a field-count comparison rather than a name scan, which is also a truer statement of the distinction.

`delta_field_is` re-checks each assumption under `assert`, so a reordered schema fails loudly in a debug build rather than silently reading the wrong field; release builds pay nothing.

## Verification

- 1505/1505 ctest in **Release** with `-DHGRAPH_WARNINGS_AS_ERRORS=ON`.
- 1503/1503 in **Debug** on the original branch, so the assertions actually executed against the real schemas rather than compiling away.

## On evidence

This is **not** visible in the benchmark pack: services and adaptor scenarios measure the same before and after, and the small adaptor gap against 0.8.1 that prompted the investigation is the same magnitude as the run-to-run variation of the 0.8.1 wheel itself. The change stands on the algorithm being wrong, not on a measurement — a needless per-tick string scan should not survive because a benchmark is too coarse to see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)