### PR TITLE
Preserve structural inputs across dispatch branches

### DIFF
--- a/include/hgraph/lib/std/operators/impl/higher_order_impl.h
+++ b/include/hgraph/lib/std/operators/impl/higher_order_impl.h
@@ -2148,7 +2148,8 @@ namespace hgraph::stdlib
                 const std::size_t slot = bound_slots.ordered[ordinal];
                 const auto *schema = slot_sources[slot].schema;
                 boundary_schemas.push_back(schema);
-                WiringPortRef port = WiringPortRef::boundary_source(ordinal, {}, schema);
+                WiringPortRef port = subgraph_wiring_detail::boundary_shape(
+                    slot_sources[slot], ordinal, {});
                 for (std::size_t selected = 0; selected < dispatch_slots.size(); ++selected)
                 {
                     if (dispatch_slots[selected] != slot || case_types.empty()) { continue; }

--- a/python/tests/test_dispatch_scalar.py
+++ b/python/tests/test_dispatch_scalar.py
@@ -3,7 +3,24 @@ from typing import Type, Union
 
 import pytest
 
-from hgraph import AUTO_RESOLVE, OUT, CompoundScalar, TS, TSB, TimeSeriesSchema, compute_node, const, dispatch, dispatch_, downcast_, downcast_ref, graph, operator, switch_
+from hgraph import (
+    AUTO_RESOLVE,
+    OUT,
+    CompoundScalar,
+    TS,
+    TSB,
+    TimeSeriesSchema,
+    combine,
+    compute_node,
+    const,
+    dispatch,
+    dispatch_,
+    downcast_,
+    downcast_ref,
+    graph,
+    operator,
+    switch_,
+)
 from hgraph.test import eval_node
 
 
@@ -73,6 +90,30 @@ def test_dispatch_fn_multi():
         [None, Cat(), None, Dog(), Cat()],
         [None, Plant(), Meat(), Plant(), Meat()],
     ) == [None, False, True, True, True]
+
+
+def test_dispatch_preserves_a_structurally_combined_tsb_argument():
+    class Animal(CompoundScalar): ...
+
+    class Dog(Animal): ...
+
+    class Repository(TimeSeriesSchema):
+        lhs: TS[int]
+        rhs: TS[int]
+
+    @operator
+    def apply(animal: TS[Animal], repository: TSB[Repository]) -> TS[int]: ...
+
+    @compute_node(overloads=apply)
+    def apply_dog(animal: TS[Dog], repository: TSB[Repository]) -> TS[int]:
+        return repository.as_schema.lhs.value + repository.as_schema.rhs.value
+
+    @graph
+    def app(animal: TS[Animal], lhs: TS[int], rhs: TS[int]) -> TS[int]:
+        repository = combine[TSB[Repository]](lhs=lhs, rhs=rhs)
+        return dispatch_(apply, animal, repository)
+
+    assert eval_node(app, [Dog()], [2], [3]) == [5]
 
 
 def test_compound_scalar_dispatch_to_compute_node_overload():

--- a/tests/cpp/test_dispatch.cpp
+++ b/tests/cpp/test_dispatch.cpp
@@ -322,6 +322,10 @@ namespace
 
     using DispatchStructuralResult =
         UnNamedTSB<Field<"id", TS<Int>>, Field<"sound", TS<Str>>>;
+    using DispatchRepository =
+        TSB<"DispatchRepository",
+            Field<"lhs", TS<Int>>,
+            Field<"rhs", TS<Int>>>;
 
     struct StructuralSound
     {
@@ -350,6 +354,51 @@ namespace
                               .as<DispatchStructuralResult>();
             return wire<stdlib::getitem_>(w, result, Str{"sound"})
                 .as<TS<Str>>();
+        }
+    };
+
+    struct SumRepository
+    {
+        static constexpr auto name = "sum_dispatch_repository";
+
+        static void eval(
+            In<"repository", DispatchRepository> repository,
+            Out<TS<Int>> out)
+        {
+            const auto lhs = repository.field<"lhs">();
+            const auto rhs = repository.field<"rhs">();
+            if (lhs.valid() && rhs.valid())
+            {
+                out.set(lhs.value() + rhs.value());
+            }
+        }
+    };
+
+    struct ApplyDogToRepository
+    {
+        static constexpr auto name = "apply_dog_to_repository";
+
+        static Port<TS<Int>> compose(
+            Wiring &w, Port<void>, Port<DispatchRepository> repository)
+        {
+            return wire<SumRepository>(w, repository);
+        }
+    };
+
+    struct StructuralInputDispatchGraph
+    {
+        static constexpr auto name = "structural_input_dispatch_graph";
+
+        static Port<TS<Int>> compose(
+            Wiring &w, Port<TS<Animal>> animal, Port<TS<Int>> lhs,
+            Port<TS<Int>> rhs,
+            Scalar<"cases", stdlib::DispatchCases> cases)
+        {
+            auto repository =
+                stdlib::to_tsb<DispatchRepository>(w, lhs, rhs);
+            return wire<stdlib::dispatch_>(
+                       w, cases.value(), animal, repository)
+                .as<TS<Int>>();
         }
     };
 }
@@ -393,6 +442,23 @@ TEST_CASE("dispatch_: composed structural branch outputs retain their public sch
                                    cat_value(types, 2)),
             cases)),
         testing::values<Str>(Str{"woof"}, Str{"meow"}));
+}
+
+TEST_CASE("dispatch_: compiled branches preserve structural TSB inputs")
+{
+    using namespace hgraph;
+    stdlib::register_standard_operators();
+    const auto types = register_dispatch_types();
+    const auto cases = stdlib::dispatch_cases({
+        stdlib::dispatch_case(types.dog, fn<ApplyDogToRepository>()),
+    }).on({0});
+
+    CHECK_OUTPUT(
+        testing::eval_node<StructuralInputDispatchGraph>(
+            testing::values<Value>(dog_value(types, 1, "woof")),
+            testing::values<Int>(2), testing::values<Int>(3),
+            arg<"cases">(cases)),
+        testing::values<Int>(5));
 }
 
 TEST_CASE("dispatch_: compiled branches import an enclosing context")


### PR DESCRIPTION
## Summary

- preserve recursive structural input shape when compiling `dispatch_` branches
- cover a structurally combined TSB passed through dispatch in native C++
- cover the same `combine` to `dispatch_` path through the Python compatibility surface

## Root cause

Dispatch branch compilation recreated every boundary argument as a single peered port. That discarded the non-peered fixed structure produced by `combine`, so binding the branch's whole TSB input failed with a peered/non-peered mismatch. Dispatch now constructs its branch boundary from the source's recursive wiring shape, matching the established nested-subgraph behavior.

## Impact

A TSB assembled structurally with `combine` can be passed into a dispatched overload and consumed as a whole TSB input. The implementation remains in the native C++ wiring path, with Python adapting to that behavior.

## Validation

- `cmake --preset cpp --fresh`
- `cmake --build --preset cpp --target clean`
- `cmake --build --preset cpp --parallel`
- `ctest --preset cpp --parallel 2` — 1,509 passed
- Python 3.12 stable-ABI wheel installed into a fresh Python 3.14 environment
- `python -m pytest python/tests -q -m "not wip"` — 2,105 passed, 9 skipped