### PR TITLE
Preserve polymorphic values across owned container transfers

### DIFF
--- a/include/hgraph/lib/std/operators/impl/arithmetic_impl.h
+++ b/include/hgraph/lib/std/operators/impl/arithmetic_impl.h
@@ -12,6 +12,7 @@
 #include <hgraph/lib/std/operators/impl/tsb_itemwise_impl.h>
 #include <hgraph/lib/std/operators/impl/tsl_itemwise_impl.h>
 #include <hgraph/runtime/global_state.h>
+#include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/operator_dispatch.h>
 #include <hgraph/types/lift.h>
 #include <hgraph/types/primitive_types.h>
@@ -530,7 +531,7 @@ namespace hgraph::stdlib
 
         [[nodiscard]] inline ValueTypeRef element_binding_of(const ValueTypeMetaData *meta)
         {
-            const auto binding = ValuePlanFactory::instance().type_for(meta);
+            const auto binding = value_type_for_active_realization(meta);
             if (binding == nullptr) { throw std::logic_error("container element schema has no binding"); }
             return binding;
         }
@@ -550,11 +551,11 @@ namespace hgraph::stdlib
                              Out<TS<ScalarVar<"T">>> out)
             {
                 const auto *meta = lhs.base().value().schema();
-                ListBuilder builder{element_binding_of(meta->element_type)};
+                ListBuilder builder{element_binding_of(meta->element_type), *meta};
                 const auto lhs_values = lhs.base().value().as_list();
                 const auto rhs_values = rhs.base().value().as_list();
-                for (const ValueView &element : lhs_values) { builder.push_back_copy(element.data()); }
-                for (const ValueView &element : rhs_values) { builder.push_back_copy(element.data()); }
+                for (const ValueView &element : lhs_values) { builder.push_back(element); }
+                for (const ValueView &element : rhs_values) { builder.push_back(element); }
                 out.apply(builder.build().view());
             }
         };
@@ -591,7 +592,8 @@ namespace hgraph::stdlib
             {
                 const ValueView rhs_value = rhs.base().value();
                 const ValueCallable &predicate = cmp.value();
-                ListBuilder builder{element_binding_of(lhs.base().value().schema()->element_type)};
+                const auto *meta = lhs.base().value().schema();
+                ListBuilder builder{element_binding_of(meta->element_type), *meta};
                 const auto lhs_values = lhs.base().value().as_list();
                 for (const ValueView element : lhs_values)
                 {
@@ -608,7 +610,7 @@ namespace hgraph::stdlib
                         matches = result.view().checked_as<Bool>();
                     }
                     else { matches = element.equals(rhs_value); }
-                    if (!matches) { builder.push_back_copy(element.data()); }
+                    if (!matches) { builder.push_back(element); }
                 }
                 out.apply(builder.build().view());
             }
@@ -645,7 +647,7 @@ namespace hgraph::stdlib
                                         : Kind == SetOpKind::Intersection ? in_rhs
                                         : Kind == SetOpKind::Union        ? true
                                                                           : !in_rhs;
-                    if (keep) { (void)builder.insert_copy(element.data()); }
+                    if (keep) { (void)builder.insert(element); }
                 }
                 if constexpr (Kind == SetOpKind::Union || Kind == SetOpKind::SymmetricDifference)
                 {
@@ -653,7 +655,7 @@ namespace hgraph::stdlib
                     {
                         if (Kind == SetOpKind::Union || !lhs_set.contains(element))
                         {
-                            (void)builder.insert_copy(element.data());
+                            (void)builder.insert(element);
                         }
                     }
                 }
@@ -764,7 +766,7 @@ namespace hgraph::stdlib
                 MapBuilder  builder{element_binding_of(meta->key_type), element_binding_of(meta->element_type)};
                 for (const auto [key, item] : lhs_map)
                 {
-                    if (!rhs_map.contains(key)) { builder.set_item_copy(key.data(), item.data()); }
+                    if (!rhs_map.contains(key)) { builder.set_item(key, item); }
                 }
                 out.apply(builder.build().view());
             }
@@ -866,11 +868,11 @@ namespace hgraph::stdlib
                 const auto  rhs_map = rhs.base().value().as_map();
                 for (const auto [key, item] : lhs_map)
                 {
-                    builder.set_item_copy(key.data(), item.data());
+                    builder.set_item(key, item);
                 }
                 for (const auto [key, item] : rhs_map)
                 {
-                    builder.set_item_copy(key.data(), item.data());
+                    builder.set_item(key, item);
                 }
                 out.apply(builder.build().view());
             }

--- a/include/hgraph/lib/std/operators/impl/collection_impl.h
+++ b/include/hgraph/lib/std/operators/impl/collection_impl.h
@@ -112,8 +112,8 @@ namespace hgraph::stdlib
                 const TSDInputView &dict   = ts;
                 const auto         &erased = static_cast<const TSOutputView &>(out);
                 const auto *out_meta = erased.schema()->value_schema;
-                SetBuilder builder{ValuePlanFactory::instance().type_for(out_meta->element_type)};
-                for (const auto key : dict.keys()) { (void)builder.insert_copy(key.data()); }
+                SetBuilder builder{value_type_for_active_realization(out_meta->element_type)};
+                for (const auto key : dict.keys()) { (void)builder.insert(key); }
                 Value set = builder.build();
                 if (erased.data_view().has_current_value() && erased.value().equals(set.view())) { return; }
                 auto mutation = erased.data_view().begin_mutation(erased.evaluation_time());
@@ -143,10 +143,10 @@ namespace hgraph::stdlib
                 TSSOutputView       &erased  = out;
                 // TSS value schema = Set[element]; the element binding builds it.
                 const auto *element_meta = erased.schema()->value_schema->element_type;
-                SetBuilder union_builder{ValuePlanFactory::instance().type_for(element_meta)};
+                SetBuilder union_builder{value_type_for_active_realization(element_meta)};
                 for (auto &&[key, child] : dict.items())
                 {
-                    if (child.valid()) { (void)union_builder.insert_copy(child.value().data()); }
+                    if (child.valid()) { (void)union_builder.insert(child.value()); }
                 }
                 Value current = union_builder.build();
                 auto  current_set = current.view().as_set();
@@ -1134,7 +1134,7 @@ namespace hgraph::stdlib
                 const auto  evaluation_time = erased.evaluation_time();
                 auto        mutation = dict_out.begin_mutation(evaluation_time);
                 const auto *tuple_meta = erased.schema()->key_type();
-                const auto tuple_binding = ValuePlanFactory::instance().type_for(tuple_meta);
+                const auto tuple_binding = value_type_for_active_realization(tuple_meta);
                 const std::size_t depth = tuple_meta->field_count;
 
                 // Removed SUBTREES erase every output tuple-key with the
@@ -2098,14 +2098,14 @@ namespace hgraph::stdlib
                                                                         const ValueTypeMetaData *value)
         {
             const auto *meta = TypeRegistry::instance().map(key, value);
-            return ValuePlanFactory::instance().type_for(meta);
+            return value_type_for_active_realization(meta);
         }
 
         [[nodiscard]] inline MapBuilder make_map_builder(const ValueTypeMetaData *key,
                                                          const ValueTypeMetaData *value)
         {
-            return MapBuilder{ValuePlanFactory::instance().type_for(key),
-                              ValuePlanFactory::instance().type_for(value)};
+            return MapBuilder{value_type_for_active_realization(key),
+                              value_type_for_active_realization(value)};
         }
 
         inline void publish_value(const TSOutputView &out, Value &&value)
@@ -2142,8 +2142,8 @@ namespace hgraph::stdlib
             {
                 auto map = ts.base().value().as_map();
                 const auto *key_meta = ts.base().schema()->value_schema->key_type;
-                SetBuilder builder{ValuePlanFactory::instance().type_for(key_meta)};
-                for (const auto key : map.keys()) { builder.insert_copy(key.data()); }
+                SetBuilder builder{value_type_for_active_realization(key_meta)};
+                for (const auto key : map.keys()) { builder.insert(key); }
                 publish_value(static_cast<const TSOutputView &>(out), builder.build());
             }
         };
@@ -2172,8 +2172,11 @@ namespace hgraph::stdlib
             {
                 auto map = ts.base().value().as_map();
                 const auto *value_meta = ts.base().schema()->value_schema->element_type;
-                ListBuilder builder{ValuePlanFactory::instance().type_for(value_meta)};
-                for (const auto [key, item] : map) { builder.push_back_copy(item.data()); }
+                const auto *output_meta =
+                    static_cast<const TSOutputView &>(out).schema()->value_schema;
+                ListBuilder builder{
+                    value_type_for_active_realization(value_meta), *output_meta};
+                for (const auto [key, item] : map) { builder.push_back(item); }
                 publish_value(static_cast<const TSOutputView &>(out), builder.build());
             }
         };
@@ -2211,7 +2214,7 @@ namespace hgraph::stdlib
                 for (const auto [key, item] : data)
                 {
                     if (!mapping.contains(key)) { continue; }
-                    builder.set_item_copy(mapping.at(key).data(), item.data());
+                    builder.set_item(mapping.at(key), item);
                 }
                 publish_value(static_cast<const TSOutputView &>(out), builder.build());
             }
@@ -2242,7 +2245,7 @@ namespace hgraph::stdlib
                 auto map = ts.base().value().as_map();
                 const auto *meta = ts.base().schema()->value_schema;
                 auto builder = make_map_builder(meta->element_type, meta->key_type);
-                for (const auto [key, item] : map) { builder.set_item_copy(item.data(), key.data()); }
+                for (const auto [key, item] : map) { builder.set_item(item, key); }
                 publish_value(static_cast<const TSOutputView &>(out), builder.build());
             }
         };
@@ -2296,13 +2299,13 @@ namespace hgraph::stdlib
                                             make_map_builder(ts_meta->key_type, ts_meta->element_type));
                         group = &groups.back().second;
                     }
-                    group->set_item_copy(key.data(), item.data());
+                    group->set_item(key, item);
                 }
                 auto builder = make_map_builder(part_meta->element_type, inner_meta);
                 for (auto &[label, inner] : groups)
                 {
                     Value built = inner.build();
-                    builder.set_item_copy(label.view().data(), built.view().data());
+                    builder.set_item(label.view(), built.view());
                 }
                 publish_value(static_cast<const TSOutputView &>(out), builder.build());
             }
@@ -2362,14 +2365,14 @@ namespace hgraph::stdlib
                                                 make_map_builder(meta->key_type, inner->element_type));
                             group = &groups.back().second;
                         }
-                        group->set_item_copy(outer_key.data(), item.data());
+                        group->set_item(outer_key, item);
                     }
                 }
                 auto builder = make_map_builder(inner->key_type, flipped_inner);
                 for (auto &[label, group] : groups)
                 {
                     Value built = group.build();
-                    builder.set_item_copy(label.view().data(), built.view().data());
+                    builder.set_item(label.view(), built.view());
                 }
                 publish_value(static_cast<const TSOutputView &>(out), builder.build());
             }
@@ -2403,7 +2406,7 @@ namespace hgraph::stdlib
                 const auto *meta  = ts.base().schema()->value_schema;
                 const auto *inner = nested_map_meta(meta);
                 const auto *pair  = TypeRegistry::instance().tuple({meta->key_type, inner->key_type});
-                const auto pair_binding = ValuePlanFactory::instance().type_for(pair);
+                const auto pair_binding = value_type_for_active_realization(pair);
 
                 auto builder = make_map_builder(pair, inner->element_type);
                 const auto outer_values = ts.base().value().as_map();
@@ -2416,7 +2419,7 @@ namespace hgraph::stdlib
                         key_builder.set(0, Value{outer_key});
                         key_builder.set(1, Value{inner_key});
                         Value pair_key = key_builder.build();
-                        builder.set_item_copy(pair_key.view().data(), item.data());
+                        builder.set_item(pair_key.view(), item);
                     }
                 }
                 publish_value(static_cast<const TSOutputView &>(out), builder.build());
@@ -2470,13 +2473,13 @@ namespace hgraph::stdlib
                         groups.emplace_back(Value{outer}, make_map_builder(inner_key, meta->element_type));
                         group = &groups.back().second;
                     }
-                    group->set_item_copy(pair.at(1).data(), item.data());
+                    group->set_item(pair.at(1), item);
                 }
                 auto builder = make_map_builder(outer_meta, inner_map);
                 for (auto &[label, group] : groups)
                 {
                     Value built = group.build();
-                    builder.set_item_copy(label.view().data(), built.view().data());
+                    builder.set_item(label.view(), built.view());
                 }
                 publish_value(static_cast<const TSOutputView &>(out), builder.build());
             }
@@ -2509,7 +2512,7 @@ namespace hgraph::stdlib
                 auto key = keys.base().value();
                 auto item = values.base().value();
                 auto builder = make_map_builder(key.schema(), item.schema());
-                builder.set_item_copy(key.data(), item.data());
+                builder.set_item(key, item);
                 publish_value(static_cast<const TSOutputView &>(out), builder.build());
             }
         };
@@ -2551,7 +2554,7 @@ namespace hgraph::stdlib
                 auto builder = make_map_builder(keys_meta->element_type, values_meta->element_type);
                 for (std::size_t index = 0; index < key_list.size(); ++index)
                 {
-                    builder.set_item_copy(key_list.at(index).data(), item_list.at(index).data());
+                    builder.set_item(key_list.at(index), item_list.at(index));
                 }
                 publish_value(static_cast<const TSOutputView &>(out), builder.build());
             }
@@ -2596,7 +2599,7 @@ namespace hgraph::stdlib
                     auto key_child  = keys.base().indexed_child_at(index);
                     auto item_child = values.base().indexed_child_at(index);
                     if (!key_child.valid() || !item_child.valid()) { continue; }
-                    builder.set_item_copy(key_child.value().data(), item_child.value().data());
+                    builder.set_item(key_child.value(), item_child.value());
                 }
                 publish_value(static_cast<const TSOutputView &>(out), builder.build());
             }
@@ -2907,7 +2910,8 @@ namespace hgraph::stdlib
 
         [[nodiscard]] inline ListBuilder make_list_builder(const ValueTypeMetaData *list_meta)
         {
-            return ListBuilder{ValuePlanFactory::instance().type_for(list_meta->element_type)};
+            return ListBuilder{
+                value_type_for_active_realization(list_meta->element_type), *list_meta};
         }
 
         /** mul_(tuple, n): python tuple repetition. */
@@ -2939,7 +2943,7 @@ namespace hgraph::stdlib
                 {
                     for (std::size_t index = 0; index < items.size(); ++index)
                     {
-                        (void)builder.push_back_copy(items.at(index).data());
+                        builder.push_back(items.at(index));
                     }
                 }
                 const auto &erased = static_cast<const TSOutputView &>(out);
@@ -3207,7 +3211,7 @@ namespace hgraph::stdlib
                     auto items = value.as_indexed_view();
                     for (std::size_t index = 0; index < items.size(); ++index)
                     {
-                        (void)builder.push_back_copy(items.at(index).data());
+                        builder.push_back(items.at(index));
                     }
                 };
                 if (lhs.valid()) { push_all(lhs.base().value()); }
@@ -3246,9 +3250,9 @@ namespace hgraph::stdlib
                 auto       builder = make_list_builder(value.schema());
                 for (std::size_t index = 0; index < items.size(); ++index)
                 {
-                    (void)builder.push_back_copy(items.at(index).data());
+                    builder.push_back(items.at(index));
                 }
-                (void)builder.push_back_copy(rhs.base().value().data());
+                builder.push_back(rhs.base().value());
                 const auto &erased = static_cast<const TSOutputView &>(out);
                 auto mutation = erased.data_view().begin_mutation(erased.evaluation_time());
                 static_cast<void>(mutation.move_value_from(builder.build()));
@@ -3284,7 +3288,7 @@ namespace hgraph::stdlib
                 auto builder = make_list_builder(value.schema());
                 for (std::size_t index = 0; index < items.size(); ++index)
                 {
-                    if (!items.at(index).equals(needle)) { (void)builder.push_back_copy(items.at(index).data()); }
+                    if (!items.at(index).equals(needle)) { builder.push_back(items.at(index)); }
                 }
                 const auto &erased = static_cast<const TSOutputView &>(out);
                 auto mutation = erased.data_view().begin_mutation(erased.evaluation_time());
@@ -3766,7 +3770,7 @@ namespace hgraph::stdlib
             static Value merge(const ValueView &orig, const ValueView &delta)
             {
                 const auto *meta = orig.schema();
-                BundleBuilder builder{ValuePlanFactory::instance().type_for(meta)};
+                BundleBuilder builder{value_type_for_active_realization(meta)};
                 auto orig_fields  = orig.as_indexed_view();
                 auto delta_fields = delta.as_indexed_view();
                 for (std::size_t index = 0; index < meta->field_count; ++index)

--- a/include/hgraph/lib/std/operators/impl/container_impl.h
+++ b/include/hgraph/lib/std/operators/impl/container_impl.h
@@ -4,6 +4,7 @@
 #include <hgraph/lib/std/operators/container.h>
 #include <hgraph/lib/std/operators/conversion.h>
 #include <hgraph/lib/std/operators/impl/collection_input_semantics.h>
+#include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/operator_dispatch.h>
 #include <hgraph/types/operator_type_resolution.h>
 #include <hgraph/types/primitive_types.h>
@@ -814,22 +815,22 @@ struct getattr_ts_tuple_bundle {
     if (!index.has_value()) {
       return;
     }
-    const auto field_binding = ValuePlanFactory::instance().type_for(
+    const auto field_binding = value_type_for_active_realization(
         element_meta->fields[*index].type);
     if (field_binding == nullptr) {
       return;
     }
 
-    ListBuilder builder{field_binding};
+    ListBuilder builder{field_binding, *out.schema()->value_schema};
     auto list = value.as_indexed_view();
     for (std::size_t i = 0; i < list.size(); ++i) {
       const ValueView &element = list.at(i);
       auto fields = element.as_indexed_view();
       const ValueView &field = fields.at(*index);
       if (field.has_value()) {
-        builder.push_back_copy(field.data());
+        builder.push_back(field);
       } else if (fallback != nullptr) {
-        builder.push_back_copy(fallback->data());
+        builder.push_back(*fallback);
       } else {
         builder.push_back_unset();
       }
@@ -968,7 +969,7 @@ struct setattr_ts_bundle {
     const auto source = ts.base().value();
     const auto *meta = source.schema();
     auto fields = source.as_indexed_view();
-    BundleBuilder builder{ValuePlanFactory::instance().type_for(meta)};
+    BundleBuilder builder{value_type_for_active_realization(meta)};
     const auto target = getattr_ts_bundle::field_index(meta, attr.value());
     for (std::size_t index = 0; index < meta->field_count; ++index) {
       if (target.has_value() && index == *target) {

--- a/include/hgraph/lib/std/operators/impl/conversion_impl.h
+++ b/include/hgraph/lib/std/operators/impl/conversion_impl.h
@@ -7,6 +7,7 @@
 #include <hgraph/lib/std/operators/comparison.h>    // min_ / max_ (zero_ op mapping)
 #include <hgraph/lib/std/operators/conversion.h>    // const_ / zero_ / default_
 #include <hgraph/runtime/node_scheduler.h>          // SingleShotScheduler
+#include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/operator_dispatch.h>
 #include <hgraph/types/primitive_types.h>
@@ -609,14 +610,15 @@ namespace hgraph::stdlib
             Value       result;
             if (meta->value_kind() == ValueTypeKind::Set)
             {
-                SetBuilder builder{ValuePlanFactory::instance().type_for(meta->element_type)};
-                static_cast<void>(builder.insert_copy(value.data()));
+                SetBuilder builder{value_type_for_active_realization(meta->element_type)};
+                static_cast<void>(builder.insert(value));
                 result = builder.build();
             }
             else
             {
-                ListBuilder builder{ValuePlanFactory::instance().type_for(meta->element_type)};
-                builder.push_back_copy(value.data());
+                ListBuilder builder{
+                    value_type_for_active_realization(meta->element_type), *meta};
+                builder.push_back(value);
                 result = builder.build();
             }
             auto mutation = erased.data_view().begin_mutation(erased.evaluation_time());
@@ -648,19 +650,20 @@ namespace hgraph::stdlib
             Value       result;
             if (meta->value_kind() == ValueTypeKind::Set)
             {
-                SetBuilder builder{ValuePlanFactory::instance().type_for(meta->element_type)};
+                SetBuilder builder{value_type_for_active_realization(meta->element_type)};
                 for (std::size_t index = 0; index < items.size(); ++index)
                 {
-                    static_cast<void>(builder.insert_copy(items.at(index).data()));
+                    static_cast<void>(builder.insert(items.at(index)));
                 }
                 result = builder.build();
             }
             else
             {
-                ListBuilder builder{ValuePlanFactory::instance().type_for(meta->element_type)};
+                ListBuilder builder{
+                    value_type_for_active_realization(meta->element_type), *meta};
                 for (std::size_t index = 0; index < items.size(); ++index)
                 {
-                    builder.push_back_copy(items.at(index).data());
+                    builder.push_back(items.at(index));
                 }
                 result = builder.build();
             }
@@ -691,17 +694,17 @@ namespace hgraph::stdlib
             const auto &erased       = static_cast<const TSOutputView &>(out);
             const auto *output_meta  = erased.schema()->value_schema;
             const auto *element_meta = output_meta->element_type;
-            const auto  binding      = ValuePlanFactory::instance().type_for(element_meta);
+            const auto  binding      = value_type_for_active_realization(element_meta);
             const auto  series_value = ts.base().value();
             const auto &series       = series_value.checked_as<Series>();
 
-            ListBuilder builder{binding};
+            ListBuilder builder{binding, *output_meta};
             if (series.has_value())
             {
                 for (std::int64_t index = 0; index < series.array->length(); ++index)
                 {
                     Value value = array_cell(*series.array, element_meta, index);
-                    if (value.has_value()) { builder.push_back_copy(value.view().data()); }
+                    if (value.has_value()) { builder.push_back(value.view()); }
                     else { builder.push_back_unset(); }
                 }
             }
@@ -737,17 +740,18 @@ namespace hgraph::stdlib
             Value        result;
             if (meta->value_kind() == ValueTypeKind::Set)
             {
-                SetBuilder builder{ValuePlanFactory::instance().type_for(meta->element_type)};
+                SetBuilder builder{value_type_for_active_realization(meta->element_type)};
                 for (const ValueView &element : set.values())
                 {
-                    static_cast<void>(builder.insert_copy(element.data()));
+                    static_cast<void>(builder.insert(element));
                 }
                 result = builder.build();
             }
             else
             {
-                ListBuilder builder{ValuePlanFactory::instance().type_for(meta->element_type)};
-                for (const ValueView &element : set.values()) { builder.push_back_copy(element.data()); }
+                ListBuilder builder{
+                    value_type_for_active_realization(meta->element_type), *meta};
+                for (const ValueView &element : set.values()) { builder.push_back(element); }
                 result = builder.build();
             }
             auto mutation = erased.data_view().begin_mutation(erased.evaluation_time());
@@ -824,12 +828,12 @@ namespace hgraph::stdlib
             const auto  &erased = static_cast<const TSOutputView &>(out);
             const auto  *meta   = erased.schema()->value_schema;
             const TSDInputView dict{ts.base().borrowed_ref()};
-            MapBuilder         builder{ValuePlanFactory::instance().type_for(meta->key_type),
-                                       ValuePlanFactory::instance().type_for(meta->element_type)};
+            MapBuilder         builder{value_type_for_active_realization(meta->key_type),
+                                       value_type_for_active_realization(meta->element_type)};
             for (auto &&[key, child] : dict.items())
             {
                 if (!child.valid()) { continue; }
-                builder.set_item_copy(key.data(), child.value().data());
+                builder.set_item(key, child.value());
             }
             auto mutation = erased.data_view().begin_mutation(erased.evaluation_time());
             static_cast<void>(mutation.move_value_from(builder.build()));
@@ -1123,9 +1127,9 @@ namespace hgraph::stdlib
         {
             const auto &erased = static_cast<const TSOutputView &>(out);
             const auto *meta   = erased.schema()->value_schema;
-            MapBuilder  builder{ValuePlanFactory::instance().type_for(meta->key_type),
-                                ValuePlanFactory::instance().type_for(meta->element_type)};
-            builder.set_item_copy(key.base().value().data(), ts.base().value().data());
+            MapBuilder  builder{value_type_for_active_realization(meta->key_type),
+                                value_type_for_active_realization(meta->element_type)};
+            builder.set_item(key.base().value(), ts.base().value());
             auto mutation = erased.data_view().begin_mutation(erased.evaluation_time());
             static_cast<void>(mutation.move_value_from(builder.build()));
         }
@@ -1155,7 +1159,7 @@ namespace hgraph::stdlib
             if (meta->value_kind() == ValueTypeKind::Tuple)
             {
                 // FIXED tuple: per-slot validity survives (lenient holes).
-                BundleBuilder builder{ValuePlanFactory::instance().type_for(meta)};
+                BundleBuilder builder{value_type_for_active_realization(meta)};
                 for (std::size_t index = 0; index < tsl.schema()->fixed_size(); ++index)
                 {
                     auto child = tsl.indexed_child_at(index);
@@ -1169,11 +1173,12 @@ namespace hgraph::stdlib
                 // HOLES via element validity (unknown-size nullability - the
                 // sul-style bitset on the compact list). Strict is all-valid
                 // gated, so it never holes.
-                ListBuilder builder{ValuePlanFactory::instance().type_for(meta->element_type)};
+                ListBuilder builder{
+                    value_type_for_active_realization(meta->element_type), *meta};
                 for (std::size_t index = 0; index < tsl.schema()->fixed_size(); ++index)
                 {
                     auto child = tsl.indexed_child_at(index);
-                    if (child.valid()) { builder.push_back_copy(child.value().data()); }
+                    if (child.valid()) { builder.push_back(child.value()); }
                     else { builder.push_back_unset(); }
                 }
                 publish(erased, builder.build());
@@ -1441,12 +1446,12 @@ namespace hgraph::stdlib
             const auto *meta   = erased.schema()->value_schema;
             auto        keys   = key.base().value().as_indexed_view();
             auto        values = ts.base().value().as_indexed_view();
-            MapBuilder  builder{ValuePlanFactory::instance().type_for(meta->key_type),
-                                ValuePlanFactory::instance().type_for(meta->element_type)};
+            MapBuilder  builder{value_type_for_active_realization(meta->key_type),
+                                value_type_for_active_realization(meta->element_type)};
             const std::size_t count = std::min(keys.size(), values.size());
             for (std::size_t index = 0; index < count; ++index)
             {
-                builder.set_item_copy(keys.at(index).data(), values.at(index).data());
+                builder.set_item(keys.at(index), values.at(index));
             }
             auto mutation = erased.data_view().begin_mutation(erased.evaluation_time());
             static_cast<void>(mutation.move_value_from(builder.build()));
@@ -1475,14 +1480,14 @@ namespace hgraph::stdlib
             const auto  &erased = static_cast<const TSOutputView &>(out);
             const auto  *meta   = erased.schema()->value_schema;
             const TSInputView &tsl = ts;
-            MapBuilder   builder{ValuePlanFactory::instance().type_for(meta->key_type),
-                                 ValuePlanFactory::instance().type_for(meta->element_type)};
+            MapBuilder   builder{value_type_for_active_realization(meta->key_type),
+                                 value_type_for_active_realization(meta->element_type)};
             for (std::size_t index = 0; index < tsl.schema()->fixed_size(); ++index)
             {
                 auto child = tsl.indexed_child_at(index);
                 if (!child.valid()) { continue; }
                 Value key{static_cast<Int>(index)};
-                builder.set_item_copy(key.view().data(), child.value().data());
+                builder.set_item(key.view(), child.value());
             }
             auto mutation = erased.data_view().begin_mutation(erased.evaluation_time());
             static_cast<void>(mutation.move_value_from(builder.build()));
@@ -1523,14 +1528,14 @@ namespace hgraph::stdlib
             const auto        &erased = static_cast<const TSOutputView &>(out);
             const auto        *meta   = erased.schema()->value_schema;
             const TSInputView &bundle = ts;
-            MapBuilder         builder{ValuePlanFactory::instance().type_for(meta->key_type),
-                                       ValuePlanFactory::instance().type_for(meta->element_type)};
+            MapBuilder         builder{value_type_for_active_realization(meta->key_type),
+                                       value_type_for_active_realization(meta->element_type)};
             for (std::size_t index = 0; index < bundle.schema()->field_count(); ++index)
             {
                 auto child = bundle.indexed_child_at(index);
                 if (!child.valid()) { continue; }
                 Value key{Str{bundle.schema()->fields()[index].name}};
-                builder.set_item_copy(key.view().data(), child.value().data());
+                builder.set_item(key.view(), child.value());
             }
             auto mutation = erased.data_view().begin_mutation(erased.evaluation_time());
             static_cast<void>(mutation.move_value_from(builder.build()));
@@ -1607,12 +1612,12 @@ namespace hgraph::stdlib
             if (!fresh && !ticked) { return; }
             const auto &erased = static_cast<const TSOutputView &>(out);
             const auto *meta   = erased.schema()->value_schema;
-            MapBuilder  builder{ValuePlanFactory::instance().type_for(meta->key_type),
-                                ValuePlanFactory::instance().type_for(meta->element_type)};
+            MapBuilder  builder{value_type_for_active_realization(meta->key_type),
+                                value_type_for_active_realization(meta->element_type)};
             if (!fresh && erased.data_view().has_current_value())
             {
                 const auto current = erased.value().as_map();
-                for (const auto [k, v] : current) { builder.set_item_copy(k.data(), v.data()); }
+                for (const auto [k, v] : current) { builder.set_item(k, v); }
             }
             if (ticked)
             {
@@ -1621,7 +1626,7 @@ namespace hgraph::stdlib
                 const std::size_t count = std::min(keys.size(), values.size());
                 for (std::size_t index = 0; index < count; ++index)
                 {
-                    builder.set_item_copy(keys.at(index).data(), values.at(index).data());
+                    builder.set_item(keys.at(index), values.at(index));
                 }
             }
             auto mutation = erased.data_view().begin_mutation(erased.evaluation_time());
@@ -1641,7 +1646,7 @@ namespace hgraph::stdlib
         static void eval_impl(const TSInputView &fields, const TSOutputView &erased)
         {
             const auto *target = erased.schema()->value_schema;
-            BundleBuilder builder{ValuePlanFactory::instance().type_for(target)};
+            BundleBuilder builder{value_type_for_active_realization(target)};
             for (std::size_t index = 0; index < fields.schema()->field_count(); ++index)
             {
                 auto child = fields.indexed_child_at(index);
@@ -1924,13 +1929,14 @@ namespace hgraph::stdlib
             Value result;
             if (meta->value_kind() == ValueTypeKind::Set)
             {
-                SetBuilder builder{ValuePlanFactory::instance().type_for(meta->element_type)};
+                SetBuilder builder{value_type_for_active_realization(meta->element_type)};
                 add_all(builder);
                 result = builder.build();
             }
             else
             {
-                ListBuilder builder{ValuePlanFactory::instance().type_for(meta->element_type)};
+                ListBuilder builder{
+                    value_type_for_active_realization(meta->element_type), *meta};
                 add_all(builder);
                 result = builder.build();
             }
@@ -1941,11 +1947,11 @@ namespace hgraph::stdlib
       private:
         static void add_one(SetBuilder &builder, const ValueView &value)
         {
-            static_cast<void>(builder.insert_copy(value.data()));
+            static_cast<void>(builder.insert(value));
         }
         static void add_one(ListBuilder &builder, const ValueView &value)
         {
-            builder.push_back_copy(value.data());
+            builder.push_back(value);
         }
     };
 
@@ -1980,16 +1986,16 @@ namespace hgraph::stdlib
             const auto *meta   = erased.schema()->value_schema;
             const bool  fresh  = reset.valid() && reset.modified() && reset.value();
 
-            MapBuilder builder{ValuePlanFactory::instance().type_for(meta->key_type),
-                               ValuePlanFactory::instance().type_for(meta->element_type)};
+            MapBuilder builder{value_type_for_active_realization(meta->key_type),
+                               value_type_for_active_realization(meta->element_type)};
             if (!fresh && erased.data_view().has_current_value())
             {
                 const auto current = erased.value().as_map();
-                for (const auto [k, v] : current) { builder.set_item_copy(k.data(), v.data()); }
+                for (const auto [k, v] : current) { builder.set_item(k, v); }
             }
             if (ticked)
             {
-                builder.set_item_copy(key.base().value().data(), ts.base().value().data());
+                builder.set_item(key.base().value(), ts.base().value());
             }
             auto mutation = erased.data_view().begin_mutation(erased.evaluation_time());
             static_cast<void>(mutation.move_value_from(builder.build()));

--- a/include/hgraph/lib/std/operators/impl/stream_impl.h
+++ b/include/hgraph/lib/std/operators/impl/stream_impl.h
@@ -10,6 +10,7 @@
 #include <hgraph/lib/std/operators/conversion.h>    // const_ / default_ / cast_ (rolling_average)
 #include <hgraph/lib/std/operators/impl/tsl_itemwise_impl.h>
 #include <hgraph/types/operator_dispatch.h>
+#include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/primitive_types.h>
 #include <hgraph/types/static_node.h>
 #include <hgraph/runtime/service_node.h>
@@ -565,12 +566,11 @@ namespace hgraph::stdlib
             }
             if (added.empty() && removed.empty()) { return std::nullopt; }
 
-            auto &factory = ValuePlanFactory::instance();
-            SetBuilder added_builder{factory.type_for(element_meta)};
-            for (const Value &value : added) { static_cast<void>(added_builder.insert_copy(value.view().data())); }
-            SetBuilder removed_builder{factory.type_for(element_meta)};
-            for (const Value &value : removed) { static_cast<void>(removed_builder.insert_copy(value.view().data())); }
-            BundleBuilder bundle{factory.type_for(bundle_meta)};
+            SetBuilder added_builder{value_type_for_active_realization(element_meta)};
+            for (const Value &value : added) { static_cast<void>(added_builder.insert(value.view())); }
+            SetBuilder removed_builder{value_type_for_active_realization(element_meta)};
+            for (const Value &value : removed) { static_cast<void>(removed_builder.insert(value.view())); }
+            BundleBuilder bundle{value_type_for_active_realization(bundle_meta)};
             bundle.set("added", added_builder.build());
             bundle.set("removed", removed_builder.build());
             return bundle.build();
@@ -1349,14 +1349,22 @@ namespace hgraph::stdlib
 
     namespace stream_impl_detail
     {
-        /** The window() result meta: the named WindowResult bundle
-            {buffer: TS[tuple[T,...]], index: TS[tuple[datetime,...]]}. */
+        /** The window() result meta: a WindowResult[T] specialization with
+            {buffer: TS[tuple[T,...]], index: TS[tuple[datetime,...]]}.
+
+            TSB names are process-global nominal identities. The element type
+            therefore participates in the name: a graph may wire windows over
+            multiple value types without asking one ``WindowResult`` name to
+            describe incompatible field schemas. */
         inline const TSValueTypeMetaData *window_result_meta(const ValueTypeMetaData *element)
         {
             auto &registry = TypeRegistry::instance();
             const auto *buffer = registry.list(element, 0, true);
             const auto *index  = registry.list(scalar_descriptor<DateTime>::value_meta(), 0, true);
-            return registry.tsb("WindowResult", {{"buffer", registry.ts(buffer)}, {"index", registry.ts(index)}});
+            std::string name{"WindowResult["};
+            name.append(element->name());
+            name.push_back(']');
+            return registry.tsb(name, {{"buffer", registry.ts(buffer)}, {"index", registry.ts(index)}});
         }
 
         /** Emit the {buffer, index} bundle for the queued (time, value) entries. */
@@ -1364,16 +1372,19 @@ namespace hgraph::stdlib
                                        const std::deque<std::pair<DateTime, Value>> &entries)
         {
             const auto *meta = out.schema()->value_schema;
-            auto &factory = ValuePlanFactory::instance();
             const auto *element_meta = meta->fields[0].type->element_type;
-            ListBuilder values{factory.type_for(element_meta)};
-            ListBuilder times{factory.type_for(scalar_descriptor<DateTime>::value_meta())};
+            const auto *buffer_meta = meta->fields[0].type;
+            ListBuilder values{
+                value_type_for_active_realization(element_meta), *buffer_meta};
+            ListBuilder times{
+                value_type_for_active_realization(scalar_descriptor<DateTime>::value_meta()),
+                *meta->fields[1].type};
             for (const auto &[time, value] : entries)
             {
-                values.push_back_copy(value.view().data());
+                values.push_back(value.view());
                 times.push_back_copy(&time);
             }
-            BundleBuilder bundle{factory.type_for(meta)};
+            BundleBuilder bundle{value_type_for_active_realization(meta)};
             bundle.set("buffer", values.build());
             bundle.set("index", times.build());
             auto mutation = out.data_view().begin_mutation(out.evaluation_time());
@@ -1502,8 +1513,9 @@ namespace hgraph::stdlib
                 {
                     const auto &erased = static_cast<const TSOutputView &>(out);
                     const auto *meta   = erased.schema()->value_schema;
-                    ListBuilder builder{ValuePlanFactory::instance().type_for(meta->element_type)};
-                    for (Value &value : current.buffer) { builder.push_back_copy(value.view().data()); }
+                    ListBuilder builder{
+                        value_type_for_active_realization(meta->element_type), *meta};
+                    for (Value &value : current.buffer) { builder.push_back(value.view()); }
                     current.buffer.clear();
                     Value result   = builder.build();
                     auto  mutation = erased.data_view().begin_mutation(erased.evaluation_time());

--- a/include/hgraph/types/value/value_builder.h
+++ b/include/hgraph/types/value/value_builder.h
@@ -95,6 +95,34 @@ namespace hgraph
                 ++size_;
             }
 
+            void push_back_from(const ValueTypeRef &target, const ValueView &source)
+            {
+                if (!source.has_value())
+                {
+                    throw std::invalid_argument("container builder requires a live source value");
+                }
+                if (target.plan() != plan_)
+                {
+                    throw std::logic_error("container builder target binding does not match its accumulator plan");
+                }
+                const auto source_binding = source.binding();
+                if (!source_binding ||
+                    !target.ops_ref().accepts_source(target, source_binding))
+                {
+                    throw std::invalid_argument(
+                        "container builder target binding does not accept its source binding");
+                }
+                if (size_ == capacity_) { grow(std::max<std::size_t>(capacity_ * 2, 8)); }
+                void *destination = slot_address(size_);
+                plan_->default_construct(destination);
+                auto rollback = make_scope_exit([&]() noexcept { plan_->destroy(destination); });
+                target.ops_ref().copy_assign_from(
+                    target, destination, source_binding, source.data());
+                if (!validity_.empty()) { validity_.push_back(true); }
+                ++size_;
+                rollback.release();
+            }
+
             /** Append a default-constructed HOLE (element validity): the slot
                 is live memory but reads report it unset. The first hole sizes
                 the (otherwise-empty, dense) validity bitset. */
@@ -220,10 +248,37 @@ namespace hgraph
         {
         }
 
+        /** Build a list-shaped value with the exact declared ``result_schema``.
+            This preserves distinctions such as variadic tuple versus ordinary
+            list while allowing the element binding to use a different active
+            realization from graph-owned storage. */
+        ListBuilder(
+            const ValueTypeRef &element_binding,
+            const ValueTypeMetaData &result_schema)
+            : element_binding_{element_binding},
+              result_schema_{&result_schema},
+              accumulator_{element_binding.checked_plan()}
+        {
+            if (result_schema.try_value_kind() != ValueTypeKind::List ||
+                result_schema.element_type != element_binding.schema())
+            {
+                throw std::invalid_argument(
+                    "ListBuilder result schema does not match its element binding");
+            }
+        }
+
         void push_back_copy(const void *src)
         {
             ensure_not_built();
             accumulator_.push_back_copy(src);
+        }
+
+        /** Append ``value``, converting from its source binding into this
+            builder's element binding when their representations differ. */
+        void push_back(const ValueView &value)
+        {
+            ensure_not_built();
+            accumulator_.push_back_from(element_binding_, value);
         }
 
         /** Append an UNSET element (a hole) - element validity. */
@@ -254,7 +309,10 @@ namespace hgraph
         [[nodiscard]] Value build()
         {
             ListStorage storage = build_storage();
-            return Value{compact_list_type(element_binding_), &storage};
+            const auto binding = result_schema_ != nullptr
+                                     ? compact_list_type(element_binding_, *result_schema_)
+                                     : compact_list_type(element_binding_);
+            return Value{binding, &storage};
         }
 
       private:
@@ -264,6 +322,7 @@ namespace hgraph
         }
 
         ValueTypeRef element_binding_{nullptr};
+        const ValueTypeMetaData                 *result_schema_{nullptr};
         builder_detail::ElementAccumulator   accumulator_;
         bool                                  built_{false};
     };
@@ -310,6 +369,33 @@ namespace hgraph
                         "CyclicBufferBuilder replacement requires a copy-assignable element plan");
                 }
                 plan.copy_assign(accumulator_.at(head_), src);
+                head_ = (head_ + 1) % capacity_;
+            }
+        }
+
+        /** Append ``value``, converting it into this builder's element
+            binding. Replacement of the oldest slot uses the same binding-aware
+            assignment after the declared capacity is reached. */
+        void push_back(const ValueView &value)
+        {
+            ensure_not_built();
+            if (accumulator_.size() < capacity_)
+            {
+                accumulator_.push_back_from(element_binding_, value);
+            }
+            else
+            {
+                const auto source_binding = value.binding();
+                if (!value.has_value() || !source_binding ||
+                    !element_binding_.ops_ref().accepts_source(
+                        element_binding_, source_binding))
+                {
+                    throw std::invalid_argument(
+                        "CyclicBufferBuilder element binding does not accept its source binding");
+                }
+                element_binding_.ops_ref().copy_assign_from(
+                    element_binding_, accumulator_.at(head_), source_binding,
+                    value.data());
                 head_ = (head_ + 1) % capacity_;
             }
         }
@@ -379,6 +465,18 @@ namespace hgraph
                 throw std::overflow_error("QueueBuilder: bounded queue is full");
             }
             accumulator_.push_back_copy(src);
+        }
+
+        /** Append ``value`` after converting it into this builder's element
+            binding. */
+        void push(const ValueView &value)
+        {
+            ensure_not_built();
+            if (max_capacity_ != 0 && accumulator_.size() >= max_capacity_)
+            {
+                throw std::overflow_error("QueueBuilder: bounded queue is full");
+            }
+            accumulator_.push_back_from(element_binding_, value);
         }
 
         template <typename T>
@@ -477,6 +575,20 @@ namespace hgraph
             const auto slot = accumulator_.size();
             accumulator_.push_back_copy(src);
             auto rollback = make_scope_exit([&]() noexcept { accumulator_.pop_back(); });
+            if (!index_.insert(slot)) { throw std::logic_error("SetBuilder index rejected a unique key"); }
+            rollback.release();
+            return true;
+        }
+
+        /** Insert ``value`` after converting it into this builder's element
+            binding. Deduplication is performed on the converted value. */
+        bool insert(const ValueView &value)
+        {
+            ensure_not_built();
+            const auto slot = accumulator_.size();
+            accumulator_.push_back_from(element_binding_, value);
+            auto rollback = make_scope_exit([&]() noexcept { accumulator_.pop_back(); });
+            if (index_.contains(accumulator_.at(slot))) { return false; }
             if (!index_.insert(slot)) { throw std::logic_error("SetBuilder index rejected a unique key"); }
             rollback.release();
             return true;
@@ -624,6 +736,27 @@ namespace hgraph
             key_rollback.release();
         }
 
+        /** Set an entry after converting both views into this builder's key
+            and value bindings. Existing entries are replaced in place. */
+        void set_item(const ValueView &key, const ValueView &value)
+        {
+            ensure_not_built();
+            const auto slot = key_acc_.size();
+            key_acc_.push_back_from(key_binding_, key);
+            auto key_rollback = make_scope_exit([&]() noexcept { key_acc_.pop_back(); });
+            if (auto found = find_slot(key_acc_.at(slot)); found.has_value())
+            {
+                value_binding_.ops_ref().copy_assign_from(
+                    value_binding_, value_acc_.at(*found), value.binding(), value.data());
+                return;
+            }
+            value_acc_.push_back_from(value_binding_, value);
+            auto value_rollback = make_scope_exit([&]() noexcept { value_acc_.pop_back(); });
+            if (!index_.insert(slot)) { throw std::logic_error("MapBuilder index rejected a unique key"); }
+            value_rollback.release();
+            key_rollback.release();
+        }
+
         template <typename K, typename V>
         void set_item(const K &key, const V &value)
         {
@@ -648,6 +781,24 @@ namespace hgraph
             const auto slot = key_acc_.size();
             key_acc_.push_back_copy(key);
             auto key_rollback = make_scope_exit([&]() noexcept { key_acc_.pop_back(); });
+            value_acc_.push_back_unset();
+            auto value_rollback = make_scope_exit([&]() noexcept { value_acc_.pop_back(); });
+            if (!index_.insert(slot)) { throw std::logic_error("MapBuilder index rejected a unique key"); }
+            value_rollback.release();
+            key_rollback.release();
+        }
+
+        /** Record a converted key with an unset value. */
+        void set_item_unset(const ValueView &key)
+        {
+            ensure_not_built();
+            const auto slot = key_acc_.size();
+            key_acc_.push_back_from(key_binding_, key);
+            auto key_rollback = make_scope_exit([&]() noexcept { key_acc_.pop_back(); });
+            if (find_slot(key_acc_.at(slot)).has_value())
+            {
+                throw std::logic_error("MapBuilder::set_item_unset cannot replace an existing entry");
+            }
             value_acc_.push_back_unset();
             auto value_rollback = make_scope_exit([&]() noexcept { value_acc_.pop_back(); });
             if (!index_.insert(slot)) { throw std::logic_error("MapBuilder index rejected a unique key"); }

--- a/python/tests/test_compound_scalar_hierarchy.py
+++ b/python/tests/test_compound_scalar_hierarchy.py
@@ -2,7 +2,7 @@ import inspect
 from dataclasses import InitVar, dataclass, field
 from datetime import timedelta
 from enum import Enum
-from typing import Callable, Generic, Optional, TypeVar
+from typing import Callable, Generic, Mapping, Optional, Set, TypeVar
 
 import _hgraph
 import hgraph as hg
@@ -456,6 +456,165 @@ def test_feedback_preserves_a_transitive_concrete_leaf_with_and_without_a_defaul
             heartbeat,
             created,
         ]
+
+
+def test_polymorphic_operators_preserve_concrete_leaves_in_owned_containers():
+    @dataclass(frozen=True)
+    class Event(
+        CompoundScalar,
+        namespace="tests.polymorphic_operator_transfer",
+        abstract=True,
+        discriminator="kind",
+    ):
+        event_id: str
+
+    # Reproduce the extension import order: client leaves are registered only
+    # after the public base schema has already been materialized.
+    _value_type(Event)
+
+    @dataclass(frozen=True)
+    class HeartbeatEvent(Event):
+        pass
+
+    @dataclass(frozen=True)
+    class OrderEvent(Event, abstract=True):
+        order_id: str
+
+    @dataclass(frozen=True)
+    class CreateEvent(OrderEvent):
+        payload: str
+        details_a: str
+        details_b: str
+        details_c: str
+        details_d: str
+
+    heartbeat = HeartbeatEvent(event_id="heartbeat")
+    created = CreateEvent(
+        event_id="event",
+        order_id="order",
+        payload="created",
+        details_a="a",
+        details_b="b",
+        details_c="c",
+        details_d="d",
+    )
+
+    @graph
+    def singleton_tuple(value: TS[Event]) -> TS[tuple[Event, ...]]:
+        return hg.convert[TS[tuple[Event, ...]]](value)
+
+    @graph
+    def singleton_set(value: TS[Event]) -> TS[Set[Event]]:
+        return hg.convert[TS[Set[Event]]](value)
+
+    @graph
+    def add_tuples(
+        lhs: TS[tuple[Event, ...]], rhs: TS[tuple[Event, ...]]
+    ) -> TS[tuple[Event, ...]]:
+        return lhs + rhs
+
+    @graph
+    def singleton_mapping(
+        key: TS[str], value: TS[Event]
+    ) -> TS[Mapping[str, Event]]:
+        return hg.convert[TS[Mapping[str, Event]]](key, value)
+
+    @graph
+    def collect_mapping(
+        key: TS[str], value: TS[Event]
+    ) -> TS[Mapping[str, Event]]:
+        return hg.collect[TS[Mapping[str, Event]]](key, value)
+
+    @graph
+    def mapping_values(
+        value: TS[Mapping[str, Event]],
+    ) -> TS[tuple[Event, ...]]:
+        return hg.values_(value)
+
+    @graph
+    def batched(
+        condition: TS[bool], value: TS[Event]
+    ) -> TS[tuple[Event, ...]]:
+        return hg.batch(condition, value, hg.MIN_TD)
+
+    @graph
+    def int_window_buffer(value: TS[int]) -> TS[tuple[int, ...]]:
+        return hg.window(value, 2).buffer
+
+    @graph
+    def window_buffer(value: TS[Event]) -> TS[tuple[Event, ...]]:
+        return hg.window(value, 2).buffer
+
+    @graph
+    def events_from_json(value: TS[str]) -> TS[tuple[Event, ...]]:
+        return hg.from_json[TS[tuple[Event, ...]]](value)
+
+    def check_operator_matrix() -> None:
+        assert eval_node(singleton_tuple, [heartbeat, created]) == [
+            (heartbeat,),
+            (created,),
+        ]
+        assert eval_node(singleton_set, [heartbeat, created]) == [
+            {heartbeat},
+            {created},
+        ]
+        assert eval_node(add_tuples, [(heartbeat,)], [(created,)]) == [
+            (heartbeat, created)
+        ]
+        assert eval_node(
+            singleton_mapping,
+            ["heartbeat", "created"],
+            [heartbeat, created],
+        ) == [
+            {"heartbeat": heartbeat},
+            {"created": created},
+        ]
+        assert eval_node(
+            collect_mapping,
+            ["order", "order"],
+            [heartbeat, created],
+        ) == [
+            {"order": heartbeat},
+            {"order": created},
+        ]
+        assert eval_node(
+            mapping_values,
+            [{"heartbeat": heartbeat, "created": created}],
+        ) == [(heartbeat, created)]
+        assert eval_node(batched, [False, True], [heartbeat, created]) == [
+            None,
+            (heartbeat, created),
+        ]
+        # WindowResult is generic: using it for int first must not reserve a
+        # process-global nominal schema that rejects Event later.
+        assert eval_node(int_window_buffer, [1, 2]) == [None, (1, 2)]
+        assert eval_node(window_buffer, [heartbeat, created]) == [
+            None,
+            (heartbeat, created),
+        ]
+        assert eval_node(
+            events_from_json,
+            [
+                """[
+                    {"kind": "HeartbeatEvent", "event_id": "heartbeat"},
+                    {
+                        "kind": "CreateEvent",
+                        "event_id": "event",
+                        "order_id": "order",
+                        "payload": "created",
+                        "details_a": "a",
+                        "details_b": "b",
+                        "details_c": "c",
+                        "details_d": "d"
+                    }
+                ]"""
+            ],
+        ) == [(heartbeat, created)]
+
+    check_operator_matrix()
+    with hg.GlobalContext(hg.GlobalState()):
+        hg.set_pooled_compound_scalar_storage()
+        check_operator_matrix()
 
 
 def test_closed_bundle_output_rejects_an_unrelated_compound_scalar():

--- a/src/hgraph/types/value/compact_container_ops.cpp
+++ b/src/hgraph/types/value/compact_container_ops.cpp
@@ -10,15 +10,6 @@ namespace hgraph
     {
         namespace
         {
-            using MaterializedOwner = MemoryUtils::ErasedOwner<MemoryUtils::InlineStoragePolicy<>, TypeRecord>;
-
-            [[nodiscard]] MaterializedOwner materialize_element(ValueTypeRef target, const ValueView &source)
-            {
-                MaterializedOwner result{*target.record()};
-                target.ops_ref().copy_assign_from(target, result.data(), source.binding(), source.data());
-                return result;
-            }
-
             template <typename State>
             [[nodiscard]] const State &compact_target_state(ValueTypeRef binding, const char *what)
             {
@@ -58,8 +49,7 @@ namespace hgraph
                     builder.push_back_unset();
                     continue;
                 }
-                auto materialized = materialize_element(state.element_binding, child);
-                builder.push_back_copy(materialized.data());
+                builder.push_back(child);
             }
             *static_cast<ListStorage *>(dst) = builder.build_storage();
         }
@@ -88,8 +78,7 @@ namespace hgraph
             const ValueView source_view{source, src};
             for (const auto child : source_view.as_set())
             {
-                auto materialized = materialize_element(state.element_binding, child);
-                static_cast<void>(builder.insert_copy(materialized.data()));
+                static_cast<void>(builder.insert(child));
             }
             *static_cast<SetStorage *>(dst) = builder.build_storage();
         }
@@ -118,14 +107,12 @@ namespace hgraph
             const ValueView source_view{source, src};
             for (const auto entry : source_view.as_map())
             {
-                auto materialized_key = materialize_element(state.key_binding, entry.first);
                 if (!entry.second.has_value())
                 {
-                    builder.set_item_unset(materialized_key.data());
+                    builder.set_item_unset(entry.first);
                     continue;
                 }
-                auto materialized_value = materialize_element(state.value_binding, entry.second);
-                builder.set_item_copy(materialized_key.data(), materialized_value.data());
+                builder.set_item(entry.first, entry.second);
             }
             *static_cast<MapStorage *>(dst) = builder.build_storage();
         }
@@ -155,8 +142,7 @@ namespace hgraph
             const auto values = source_view.as_cyclic_buffer();
             for (std::size_t index = 0; index < values.size(); ++index)
             {
-                auto materialized = materialize_element(state.element_binding, values.at(index));
-                builder.push_back_copy(materialized.data());
+                builder.push_back(values.at(index));
             }
             *static_cast<CyclicBufferStorage *>(dst) = builder.build_storage();
         }
@@ -186,8 +172,7 @@ namespace hgraph
             const auto values = source_view.as_queue();
             for (std::size_t index = 0; index < values.size(); ++index)
             {
-                auto materialized = materialize_element(state.element_binding, values.at(index));
-                builder.push_copy(materialized.data());
+                builder.push(values.at(index));
             }
             *static_cast<QueueStorage *>(dst) = builder.build_storage();
         }

--- a/src/hgraph/types/value/json_codec.cpp
+++ b/src/hgraph/types/value/json_codec.cpp
@@ -1754,14 +1754,15 @@ namespace hgraph
 
         Value read_list(const JsonConverter &self, Reader &reader)
         {
-            ListBuilder builder{realized_read_binding(*self.children[0])};
+            ListBuilder builder{
+                realized_read_binding(*self.children[0]), *self.meta};
             reader.expect('[');
             if (!reader.consume_if(']'))
             {
                 while (true)
                 {
                     Value element = self.children[0]->read(reader);
-                    builder.push_back_copy(element.view().data());
+                    builder.push_back(element.view());
                     if (!reader.consume_if(',')) { break; }
                 }
                 reader.expect(']');
@@ -1778,7 +1779,7 @@ namespace hgraph
                 while (true)
                 {
                     Value element = self.children[0]->read(reader);
-                    (void)builder.insert_copy(element.view().data());
+                    (void)builder.insert(element.view());
                     if (!reader.consume_if(',')) { break; }
                 }
                 reader.expect(']');
@@ -1824,12 +1825,12 @@ namespace hgraph
                     {
                         // JSON null = an unset entry (a None-valued mapping
                         // value; element validity).
-                        builder.set_item_unset(key.view().data());
+                        builder.set_item_unset(key.view());
                     }
                     else
                     {
                         Value value = self.children[1]->read(reader);
-                        builder.set_item_copy(key.view().data(), value.view().data());
+                        builder.set_item(key.view(), value.view());
                     }
                     if (!reader.consume_if(',')) { break; }
                 }

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -280,6 +280,7 @@ hgraph_add_test_objects(hgraph_value_test_objects
     test_tsd_proxy.cpp
     test_type_registry.cpp
     test_value.cpp
+    test_value_builder.cpp
     test_value_visitor.cpp
     test_value_types.cpp
 )

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -16,6 +16,7 @@
 #include <hgraph/lib/std/std_operators.h>
 #include <hgraph/lib/std/operators/impl/arithmetic_impl.h>
 #include <hgraph/lib/std/operators/impl/collection_impl.h>
+#include <hgraph/lib/std/operators/impl/stream_impl.h>
 #include <hgraph/lib/std/operators/impl/string_impl.h>
 #include <hgraph/lib/std/standard_types.h>
 #include <hgraph/lib/std/value_util.h>
@@ -66,6 +67,27 @@ namespace hgraph
             return registry.bundle(
                 "tests.emit", "Event", {{"event_id", registry.value_type("str")}}, {}, true);
         }
+    };
+}
+
+namespace hgraph::testing
+{
+    template <>
+    struct ts_harness<TS<polymorphic_emit_repro::Event>>
+        : bundle_ts_harness<TS<polymorphic_emit_repro::Event>>
+    {
+    };
+
+    template <>
+    struct ts_harness<TS<Map<Str, polymorphic_emit_repro::Event>>>
+        : bundle_ts_harness<TS<Map<Str, polymorphic_emit_repro::Event>>>
+    {
+    };
+
+    template <>
+    struct ts_harness<TS<Set<polymorphic_emit_repro::Event>>>
+        : bundle_ts_harness<TS<Set<polymorphic_emit_repro::Event>>>
+    {
     };
 }
 
@@ -220,6 +242,13 @@ namespace
     using PolymorphicEventDict = TSD<Str, TS<PolymorphicEvent>>;
     using PolymorphicEventKeyValue =
         UnNamedTSB<Field<"key", TS<Str>>, Field<"value", TS<PolymorphicEvent>>>;
+    using PolymorphicEventTuple = TS<HomogeneousTuple<PolymorphicEvent>>;
+    using PolymorphicEventMap = TS<Map<Str, PolymorphicEvent>>;
+    using PolymorphicEventSet = TS<Set<PolymorphicEvent>>;
+    using PolymorphicEventWindow =
+        TSB<"WindowResult[tests.emit::Event]",
+            Field<"buffer", PolymorphicEventTuple>,
+            Field<"index", TS<HomogeneousTuple<DateTime>>>>;
 
     struct PolymorphicEventDictEmitGraph
     {
@@ -230,6 +259,95 @@ namespace
         {
             return wire<stdlib::emit>(w, events)
                 .as<PolymorphicEventKeyValue>();
+        }
+    };
+
+    struct PolymorphicEventSingletonTupleGraph
+    {
+        static Port<PolymorphicEventTuple> compose(
+            Wiring &w, Port<TS<PolymorphicEvent>> event)
+        {
+            return wire<stdlib::convert, PolymorphicEventTuple>(w, event);
+        }
+    };
+
+    struct PolymorphicEventTupleAddGraph
+    {
+        static Port<PolymorphicEventTuple> compose(
+            Wiring &w, Port<PolymorphicEventTuple> lhs,
+            Port<PolymorphicEventTuple> rhs)
+        {
+            return wire<stdlib::add_>(w, lhs, rhs)
+                .as<PolymorphicEventTuple>();
+        }
+    };
+
+    struct PolymorphicEventSingletonSetGraph
+    {
+        static Port<PolymorphicEventSet> compose(
+            Wiring &w, Port<TS<PolymorphicEvent>> event)
+        {
+            return wire<stdlib::convert, PolymorphicEventSet>(w, event);
+        }
+    };
+
+    struct PolymorphicEventMapGraph
+    {
+        static Port<PolymorphicEventMap> compose(
+            Wiring &w, Port<TS<Str>> key,
+            Port<TS<PolymorphicEvent>> event)
+        {
+            return wire<stdlib::convert, PolymorphicEventMap>(w, key, event);
+        }
+    };
+
+    struct PolymorphicEventMapValuesGraph
+    {
+        static Port<PolymorphicEventTuple> compose(
+            Wiring &w, Port<PolymorphicEventMap> events)
+        {
+            return wire<stdlib::values_>(w, events)
+                .as<PolymorphicEventTuple>();
+        }
+    };
+
+    struct PolymorphicEventCollectMapGraph
+    {
+        static Port<PolymorphicEventMap> compose(
+            Wiring &w, Port<TS<Str>> key,
+            Port<TS<PolymorphicEvent>> event)
+        {
+            return wire<stdlib::collect, PolymorphicEventMap>(w, key, event);
+        }
+    };
+
+    struct PolymorphicEventBatchGraph
+    {
+        static Port<PolymorphicEventTuple> compose(
+            Wiring &w, Port<TS<Bool>> condition,
+            Port<TS<PolymorphicEvent>> event)
+        {
+            return wire<stdlib::batch, PolymorphicEventTuple>(
+                w, condition, event, MIN_TD, Int{16});
+        }
+    };
+
+    struct PolymorphicEventWindowGraph
+    {
+        static Port<PolymorphicEventWindow> compose(
+            Wiring &w, Port<TS<PolymorphicEvent>> event)
+        {
+            return wire<stdlib::window, PolymorphicEventWindow>(
+                w, event, Int{2});
+        }
+    };
+
+    struct PolymorphicEventTupleFromJsonGraph
+    {
+        static Port<PolymorphicEventTuple> compose(
+            Wiring &w, Port<TS<Str>> value)
+        {
+            return wire<stdlib::from_json, PolymorphicEventTuple>(w, value);
         }
     };
 
@@ -1509,6 +1627,249 @@ TEST_CASE("std operators: keyed emit preserves a concrete Bundle leaf")
     CHECK(event_fields.at("event_id").checked_as<Str>() == Str{"event"});
     CHECK(event_fields.at("order_id").checked_as<Str>() == Str{"order"});
     CHECK(event_fields.at("payload").checked_as<Str>() == Str{"created"});
+}
+
+TEST_CASE("std operators preserve concrete Bundle leaves across owned container transfers")
+{
+    stdlib::register_standard_operators();
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *text = registry.value_type("str");
+    const auto *event = scalar_descriptor<PolymorphicEvent>::value_meta();
+    const auto *heartbeat_schema = registry.bundle(
+        "tests.emit", "HeartbeatEvent", {{"event_id", text}}, {event});
+    const auto *order_event = registry.bundle(
+        "tests.emit", "OrderEvent",
+        {{"event_id", text}, {"order_id", text}}, {event}, true);
+    const auto *create_schema = registry.bundle(
+        "tests.emit", "CreateEvent",
+        {{"event_id", text}, {"order_id", text}, {"payload", text},
+         {"details_a", text}, {"details_b", text},
+         {"details_c", text}, {"details_d", text}},
+        {order_event});
+
+    const auto exercise = [&](bool pooled) {
+        INFO("polymorphic container storage " << (pooled ? "pooled" : "inline"));
+        GlobalState graph_state;
+        if (pooled) { set_pooled_compound_scalar_storage(graph_state.view()); }
+        GlobalContext graph_context{graph_state};
+
+        const TypeRealizationOptions options{
+            .polymorphic_compound_storage =
+                pooled ? PolymorphicCompoundStoragePolicy::Pooled
+                       : PolymorphicCompoundStoragePolicy::Inline,
+        };
+        const auto realization = TypeRealizationSnapshot::capture(registry, options);
+        TypeRealizationScope realization_scope{realization.get()};
+        if (pooled)
+        {
+            REQUIRE(realization->inspect(event).representation ==
+                    GraphValueRepresentation::PooledUnion);
+        }
+
+        BundleBuilder heartbeat_builder{
+            realization->exact_type_for(heartbeat_schema)};
+        heartbeat_builder.set("event_id", Value{Str{"heartbeat"}});
+        const Value heartbeat_concrete = heartbeat_builder.build();
+
+        BundleBuilder create_builder{realization->exact_type_for(create_schema)};
+        create_builder.set("event_id", Value{Str{"event"}});
+        create_builder.set("order_id", Value{Str{"order"}});
+        create_builder.set("payload", Value{Str{"created"}});
+        create_builder.set("details_a", Value{Str{"a"}});
+        create_builder.set("details_b", Value{Str{"b"}});
+        create_builder.set("details_c", Value{Str{"c"}});
+        create_builder.set("details_d", Value{Str{"d"}});
+        const Value created_concrete = create_builder.build();
+
+        const auto event_binding = realization->type_for(event);
+        const auto realize_event = [&](const Value &concrete) {
+            Value value{event_binding};
+            event_binding.ops_ref().copy_assign_from(
+                event_binding, value.begin_mutation().mutable_data(),
+                concrete.binding(), concrete.view().data());
+            return value;
+        };
+        const Value heartbeat = realize_event(heartbeat_concrete);
+        const Value created = realize_event(created_concrete);
+
+        const auto check_event = [&](const ValueView &actual,
+                                     const ValueTypeMetaData *schema,
+                                     std::string_view event_id) {
+            const auto concrete = actual.concrete();
+            REQUIRE(concrete.schema() == schema);
+            const auto fields = concrete.as_bundle();
+            CHECK(fields.field("event_id").checked_as<Str>() == Str{event_id});
+            if (schema == create_schema)
+            {
+                CHECK(fields.field("order_id").checked_as<Str>() == Str{"order"});
+                CHECK(fields.field("payload").checked_as<Str>() == Str{"created"});
+                CHECK(fields.field("details_a").checked_as<Str>() == Str{"a"});
+                CHECK(fields.field("details_b").checked_as<Str>() == Str{"b"});
+                CHECK(fields.field("details_c").checked_as<Str>() == Str{"c"});
+                CHECK(fields.field("details_d").checked_as<Str>() == Str{"d"});
+            }
+        };
+        const auto check_events = [&](const Value &actual,
+                                      std::initializer_list<const ValueTypeMetaData *> schemas) {
+            const auto values = actual.as_list();
+            REQUIRE(values.size() == schemas.size());
+            std::size_t index = 0;
+            for (const auto *schema : schemas)
+            {
+                check_event(
+                    values.at(index++), schema,
+                    schema == heartbeat_schema ? "heartbeat" : "event");
+            }
+        };
+        const auto make_events = [&](std::initializer_list<const Value *> values) {
+            ListBuilder builder{event_binding};
+            for (const Value *value : values)
+            {
+                builder.push_back_copy(value->view().data());
+            }
+            ListStorage storage = builder.build_storage();
+            const auto *schema =
+                scalar_descriptor<HomogeneousTuple<PolymorphicEvent>>::value_meta();
+            return Value{compact_list_type(event_binding, *schema), &storage};
+        };
+        const auto make_event_map = [&]() {
+            const auto key_binding = realization->type_for(text);
+            MapBuilder builder{key_binding, event_binding};
+            const Str heartbeat_key{"heartbeat"};
+            const Str created_key{"created"};
+            builder.set_item_copy(
+                &heartbeat_key, heartbeat.view().data());
+            builder.set_item_copy(&created_key, created.view().data());
+            return builder.build();
+        };
+
+        const auto singleton = eval_node<PolymorphicEventSingletonTupleGraph>(
+            values<Value>(heartbeat, created));
+        REQUIRE(singleton.size() == 2);
+        REQUIRE(singleton[0].has_value());
+        check_events(*singleton[0], {heartbeat_schema});
+        REQUIRE(singleton[1].has_value());
+        check_events(*singleton[1], {create_schema});
+
+        const auto singleton_set = eval_node<PolymorphicEventSingletonSetGraph>(
+            values<Value>(heartbeat, created));
+        REQUIRE(singleton_set.size() == 2);
+        REQUIRE(singleton_set[0].has_value());
+        REQUIRE(singleton_set[0]->as_set().size() == 1);
+        const auto first_set_values = singleton_set[0]->as_set().values();
+        check_event(
+            *first_set_values.begin(), heartbeat_schema, "heartbeat");
+        REQUIRE(singleton_set[1].has_value());
+        REQUIRE(singleton_set[1]->as_set().size() == 1);
+        const auto second_set_values = singleton_set[1]->as_set().values();
+        check_event(
+            *second_set_values.begin(), create_schema, "event");
+
+        const Value heartbeat_tuple = make_events({&heartbeat});
+        const Value created_tuple = make_events({&created});
+        const auto added = eval_node<PolymorphicEventTupleAddGraph>(
+            values<Value>(heartbeat_tuple), values<Value>(created_tuple));
+        REQUIRE(added.size() == 1);
+        REQUIRE(added.front().has_value());
+        check_events(*added.front(), {heartbeat_schema, create_schema});
+
+        const auto converted_map = eval_node<PolymorphicEventMapGraph>(
+            values<Str>(Str{"heartbeat"}, Str{"created"}),
+            values<Value>(heartbeat, created));
+        REQUIRE(converted_map.size() == 2);
+        REQUIRE(converted_map[0].has_value());
+        check_event(
+            converted_map[0]->as_map().at(Value{Str{"heartbeat"}}.view()),
+            heartbeat_schema, "heartbeat");
+        REQUIRE(converted_map[1].has_value());
+        check_event(
+            converted_map[1]->as_map().at(Value{Str{"created"}}.view()),
+            create_schema, "event");
+
+        const auto collected_map = eval_node<PolymorphicEventCollectMapGraph>(
+            values<Str>(Str{"order"}, Str{"order"}),
+            values<Value>(heartbeat, created));
+        REQUIRE(collected_map.size() == 2);
+        REQUIRE(collected_map[0].has_value());
+        check_event(
+            collected_map[0]->as_map().at(Value{Str{"order"}}.view()),
+            heartbeat_schema, "heartbeat");
+        REQUIRE(collected_map[1].has_value());
+        check_event(
+            collected_map[1]->as_map().at(Value{Str{"order"}}.view()),
+            create_schema, "event");
+
+        const auto map_values = eval_node<PolymorphicEventMapValuesGraph>(
+            values<Value>(make_event_map()));
+        REQUIRE(map_values.size() == 1);
+        REQUIRE(map_values.front().has_value());
+        check_events(*map_values.front(), {heartbeat_schema, create_schema});
+
+        const auto batched = eval_node<PolymorphicEventBatchGraph>(
+            values<Bool>(false, true), values<Value>(heartbeat, created));
+        REQUIRE(batched.size() == 2);
+        CHECK_FALSE(batched[0].has_value());
+        REQUIRE(batched[1].has_value());
+        check_events(*batched[1], {heartbeat_schema, create_schema});
+
+        const auto windowed = eval_node<PolymorphicEventWindowGraph>(
+            values<Value>(heartbeat, created));
+        REQUIRE(windowed.size() == 2);
+        CHECK_FALSE(windowed[0].has_value());
+        REQUIRE(windowed[1].has_value());
+        const ValueView buffer =
+            windowed[1]->as_bundle().field("buffer");
+        REQUIRE(buffer.has_value());
+        const auto buffer_values = buffer.as_list();
+        REQUIRE(buffer_values.size() == 2);
+        check_event(buffer_values.at(0), heartbeat_schema, "heartbeat");
+        check_event(buffer_values.at(1), create_schema, "event");
+
+        const auto decoded = eval_node<PolymorphicEventTupleFromJsonGraph>(
+            values<Str>(Str{R"([
+                {"__type__": "HeartbeatEvent", "event_id": "heartbeat"},
+                {
+                    "__type__": "CreateEvent",
+                    "event_id": "event",
+                    "order_id": "order",
+                    "payload": "created",
+                    "details_a": "a",
+                    "details_b": "b",
+                    "details_c": "c",
+                    "details_d": "d"
+                }
+            ])"}));
+        REQUIRE(decoded.size() == 1);
+        REQUIRE(decoded.front().has_value());
+        check_events(*decoded.front(), {heartbeat_schema, create_schema});
+    };
+
+    exercise(false);
+    exercise(true);
+}
+
+TEST_CASE("window result nominal identity includes its element schema")
+{
+    const auto *integer = scalar_descriptor<Int>::value_meta();
+    const auto *event = scalar_descriptor<PolymorphicEvent>::value_meta();
+
+    const auto *integer_window =
+        stdlib::stream_impl_detail::window_result_meta(integer);
+    const auto *event_window =
+        stdlib::stream_impl_detail::window_result_meta(event);
+
+    REQUIRE(integer_window != event_window);
+    CHECK(integer_window ==
+          stdlib::stream_impl_detail::window_result_meta(integer));
+    CHECK(event_window ==
+          stdlib::stream_impl_detail::window_result_meta(event));
+    CHECK(integer_window->name() == "WindowResult[int]");
+    CHECK(event_window->name() == "WindowResult[tests.emit::Event]");
+    REQUIRE(integer_window->field_count() == 2);
+    REQUIRE(event_window->field_count() == 2);
+    CHECK(integer_window->fields()[0].type->value_schema->element_type == integer);
+    CHECK(event_window->fields()[0].type->value_schema->element_type == event);
 }
 
 TEST_CASE("std operators: len_ visits scalar tuple, set, and map values")

--- a/tests/cpp/test_value_builder.cpp
+++ b/tests/cpp/test_value_builder.cpp
@@ -1,0 +1,338 @@
+#include <hgraph/types/metadata/type_realization.h>
+#include <hgraph/types/metadata/type_registry.h>
+#include <hgraph/types/primitive_types.h>
+#include <hgraph/types/static_schema.h>
+#include <hgraph/types/value/specialized_views.h>
+#include <hgraph/types/value/value_builder.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace polymorphic_value_builder_repro
+{
+    struct Event
+    {
+    };
+}
+
+namespace hgraph
+{
+    template <>
+    struct scalar_descriptor<polymorphic_value_builder_repro::Event>
+    {
+        [[nodiscard]] static constexpr bool is_concrete() noexcept { return true; }
+        [[nodiscard]] static const ValueTypeMetaData *value_meta()
+        {
+            auto &registry = TypeRegistry::instance();
+            return registry.bundle(
+                "tests.value_builder", "Event",
+                {{"event_id", registry.value_type("str")}}, {}, true);
+        }
+    };
+}
+
+namespace
+{
+    using namespace hgraph;
+    using PolymorphicEvent = polymorphic_value_builder_repro::Event;
+
+    struct PolymorphicBuilderSchemas
+    {
+        const ValueTypeMetaData *event{nullptr};
+        const ValueTypeMetaData *heartbeat{nullptr};
+        const ValueTypeMetaData *created{nullptr};
+    };
+
+    [[nodiscard]] PolymorphicBuilderSchemas polymorphic_builder_schemas()
+    {
+        auto       &registry = TypeRegistry::instance();
+        const auto *text = registry.value_type("str");
+        const auto *event = scalar_descriptor<PolymorphicEvent>::value_meta();
+        const auto *heartbeat = registry.bundle(
+            "tests.value_builder", "HeartbeatEvent", {{"event_id", text}}, {event});
+        const auto *order = registry.bundle(
+            "tests.value_builder", "OrderEvent",
+            {{"event_id", text}, {"order_id", text}}, {event}, true);
+        const auto *created = registry.bundle(
+            "tests.value_builder", "CreateEvent",
+            {{"event_id", text}, {"order_id", text}, {"payload", text},
+             {"details_a", text}, {"details_b", text},
+             {"details_c", text}, {"details_d", text}},
+            {order});
+        return {
+            .event = event,
+            .heartbeat = heartbeat,
+            .created = created,
+        };
+    }
+
+    [[nodiscard]] Value heartbeat_value(
+        const TypeRealizationSnapshot &realization,
+        const PolymorphicBuilderSchemas &schemas)
+    {
+        BundleBuilder builder{realization.exact_type_for(schemas.heartbeat)};
+        builder.set("event_id", Value{Str{"heartbeat"}});
+        return builder.build();
+    }
+
+    [[nodiscard]] Value created_value(
+        const TypeRealizationSnapshot &realization,
+        const PolymorphicBuilderSchemas &schemas)
+    {
+        BundleBuilder builder{realization.exact_type_for(schemas.created)};
+        builder.set("event_id", Value{Str{"event"}});
+        builder.set("order_id", Value{Str{"order"}});
+        builder.set("payload", Value{Str{"created"}});
+        builder.set("details_a", Value{Str{"a"}});
+        builder.set("details_b", Value{Str{"b"}});
+        builder.set("details_c", Value{Str{"c"}});
+        builder.set("details_d", Value{Str{"d"}});
+        return builder.build();
+    }
+
+    void check_event(
+        const ValueView &actual, const ValueTypeMetaData *expected_schema,
+        std::string_view expected_id)
+    {
+        const auto concrete = actual.concrete();
+        REQUIRE(concrete.schema() == expected_schema);
+        CHECK(concrete.as_bundle().field("event_id").checked_as<Str>() ==
+              Str{expected_id});
+    }
+}
+
+TEST_CASE("value builders convert concrete Bundle leaves into a declared polymorphic binding")
+{
+    const auto schemas = polymorphic_builder_schemas();
+    for (const bool pooled : {false, true})
+    {
+        INFO("value builder polymorphic storage " << (pooled ? "pooled" : "inline"));
+        const hgraph::TypeRealizationOptions options{
+            .polymorphic_compound_storage =
+                pooled ? hgraph::PolymorphicCompoundStoragePolicy::Pooled
+                       : hgraph::PolymorphicCompoundStoragePolicy::Inline,
+        };
+        const auto realization = hgraph::TypeRealizationSnapshot::capture(
+            hgraph::TypeRegistry::instance(), options);
+        hgraph::TypeRealizationScope realization_scope{realization.get()};
+        if (pooled)
+        {
+            REQUIRE(realization->inspect(schemas.event).representation ==
+                    hgraph::GraphValueRepresentation::PooledUnion);
+        }
+
+        const hgraph::Value heartbeat = heartbeat_value(*realization, schemas);
+        const hgraph::Value created = created_value(*realization, schemas);
+        const auto event_binding = realization->type_for(schemas.event);
+        const auto *tuple_schema =
+            hgraph::scalar_descriptor<hgraph::HomogeneousTuple<PolymorphicEvent>>::value_meta();
+
+        hgraph::ListBuilder list{event_binding, *tuple_schema};
+        list.push_back(heartbeat.view());
+        list.push_back(created.view());
+        const hgraph::Value list_value = list.build();
+        REQUIRE(list_value.schema() == tuple_schema);
+        REQUIRE(list_value.as_list().size() == 2);
+        check_event(list_value.as_list().at(0), schemas.heartbeat, "heartbeat");
+        check_event(list_value.as_list().at(1), schemas.created, "event");
+
+        hgraph::SetBuilder set{event_binding};
+        CHECK(set.insert(heartbeat.view()));
+        CHECK(set.insert(created.view()));
+        CHECK_FALSE(set.insert(heartbeat.view()));
+        const hgraph::Value set_value = set.build();
+        REQUIRE(set_value.as_set().size() == 2);
+
+        hgraph::MapBuilder map{event_binding, event_binding};
+        map.set_item(heartbeat.view(), heartbeat.view());
+        map.set_item(heartbeat.view(), created.view());
+        map.set_item(created.view(), heartbeat.view());
+        const hgraph::Value map_value = map.build();
+        REQUIRE(map_value.as_map().size() == 2);
+        for (const auto [key, value] : map_value.as_map())
+        {
+            if (key.concrete().schema() == schemas.heartbeat)
+            {
+                check_event(value, schemas.created, "event");
+            }
+            else
+            {
+                check_event(key, schemas.created, "event");
+                check_event(value, schemas.heartbeat, "heartbeat");
+            }
+        }
+
+        hgraph::QueueBuilder queue{event_binding};
+        queue.push(heartbeat.view());
+        queue.push(created.view());
+        const hgraph::Value queue_value = queue.build();
+        REQUIRE(queue_value.as_queue().size() == 2);
+        check_event(queue_value.as_queue().at(0), schemas.heartbeat, "heartbeat");
+        check_event(queue_value.as_queue().at(1), schemas.created, "event");
+
+        hgraph::CyclicBufferBuilder cyclic{event_binding, 1};
+        cyclic.push_back(heartbeat.view());
+        cyclic.push_back(created.view());
+        const hgraph::Value cyclic_value = cyclic.build();
+        REQUIRE(cyclic_value.as_cyclic_buffer().size() == 1);
+        check_event(cyclic_value.as_cyclic_buffer().front(), schemas.created, "event");
+    }
+}
+
+TEST_CASE("value builders reject an incompatible view before changing their contents")
+{
+    const auto schemas = polymorphic_builder_schemas();
+    const auto realization = hgraph::TypeRealizationSnapshot::capture(
+        hgraph::TypeRegistry::instance());
+    hgraph::TypeRealizationScope realization_scope{realization.get()};
+
+    const auto event_binding = realization->type_for(schemas.event);
+    const auto string_binding = realization->type_for(
+        hgraph::scalar_descriptor<hgraph::Str>::value_meta());
+    const hgraph::Value incompatible{hgraph::Int{42}};
+    const hgraph::Value heartbeat = heartbeat_value(*realization, schemas);
+    const hgraph::Value created = created_value(*realization, schemas);
+
+    hgraph::ListBuilder list{event_binding};
+    CHECK_THROWS_AS(list.push_back(incompatible.view()),
+                    std::invalid_argument);
+    CHECK(list.empty());
+    list.push_back(heartbeat.view());
+    const hgraph::Value list_value = list.build();
+    REQUIRE(list_value.as_list().size() == 1);
+    check_event(list_value.as_list().front(), schemas.heartbeat, "heartbeat");
+
+    hgraph::SetBuilder set{event_binding};
+    CHECK_THROWS_AS(set.insert(incompatible.view()), std::invalid_argument);
+    CHECK(set.size() == 0);
+    CHECK(set.insert(heartbeat.view()));
+
+    hgraph::QueueBuilder queue{event_binding};
+    CHECK_THROWS_AS(queue.push(incompatible.view()), std::invalid_argument);
+    CHECK(queue.size() == 0);
+    queue.push(heartbeat.view());
+
+    hgraph::CyclicBufferBuilder cyclic{event_binding, 1};
+    cyclic.push_back(heartbeat.view());
+    CHECK_THROWS_AS(cyclic.push_back(incompatible.view()), std::invalid_argument);
+    const hgraph::Value cyclic_value = cyclic.build();
+    REQUIRE(cyclic_value.as_cyclic_buffer().size() == 1);
+    check_event(cyclic_value.as_cyclic_buffer().front(), schemas.heartbeat, "heartbeat");
+
+    hgraph::MapBuilder map{string_binding, event_binding};
+    const hgraph::Value key{hgraph::Str{"order"}};
+    CHECK_THROWS_AS(map.set_item(key.view(), incompatible.view()),
+                    std::invalid_argument);
+    CHECK(map.size() == 0);
+    map.set_item(key.view(), heartbeat.view());
+    CHECK_THROWS_AS(map.set_item(key.view(), incompatible.view()),
+                    std::invalid_argument);
+    CHECK(map.size() == 1);
+    map.set_item(key.view(), created.view());
+    const hgraph::Value map_value = map.build();
+    REQUIRE(map_value.as_map().size() == 1);
+    check_event(
+        map_value.as_map().at(key.view()), schemas.created, "event");
+}
+
+TEST_CASE("compact containers convert elements between polymorphic realizations")
+{
+    struct Containers
+    {
+        hgraph::Value list;
+        hgraph::Value set;
+        hgraph::Value map;
+        hgraph::Value queue;
+        hgraph::Value cyclic;
+    };
+
+    const auto schemas = polymorphic_builder_schemas();
+    const auto inline_realization = hgraph::TypeRealizationSnapshot::capture(
+        hgraph::TypeRegistry::instance());
+    const hgraph::TypeRealizationOptions pooled_options{
+        .polymorphic_compound_storage =
+            hgraph::PolymorphicCompoundStoragePolicy::Pooled,
+    };
+    const auto pooled_realization = hgraph::TypeRealizationSnapshot::capture(
+        hgraph::TypeRegistry::instance(), pooled_options);
+    REQUIRE(pooled_realization->inspect(schemas.event).representation ==
+            hgraph::GraphValueRepresentation::PooledUnion);
+
+    const auto *tuple_schema =
+        hgraph::scalar_descriptor<hgraph::HomogeneousTuple<PolymorphicEvent>>::value_meta();
+    const auto *text_schema =
+        hgraph::scalar_descriptor<hgraph::Str>::value_meta();
+    const hgraph::Value key{hgraph::Str{"order"}};
+
+    const auto make_containers = [&](const hgraph::TypeRealizationSnapshot &realization) {
+        hgraph::TypeRealizationScope scope{&realization};
+        const auto event_binding = realization.type_for(schemas.event);
+        const auto text_binding = realization.type_for(text_schema);
+        const hgraph::Value created = created_value(realization, schemas);
+
+        hgraph::ListBuilder list{event_binding, *tuple_schema};
+        list.push_back(created.view());
+        hgraph::SetBuilder set{event_binding};
+        static_cast<void>(set.insert(created.view()));
+        hgraph::MapBuilder map{text_binding, event_binding};
+        map.set_item(key.view(), created.view());
+        hgraph::QueueBuilder queue{event_binding};
+        queue.push(created.view());
+        hgraph::CyclicBufferBuilder cyclic{event_binding, 2};
+        cyclic.push_back(created.view());
+
+        return Containers{
+            .list = list.build(),
+            .set = set.build(),
+            .map = map.build(),
+            .queue = queue.build(),
+            .cyclic = cyclic.build(),
+        };
+    };
+
+    const auto inline_values = make_containers(*inline_realization);
+    const auto pooled_values = make_containers(*pooled_realization);
+
+    const auto copy_into = [](hgraph::ValueTypeRef target,
+                              const hgraph::Value &source) {
+        hgraph::Value result{target};
+        target.ops_ref().copy_assign_from(
+            target, const_cast<void *>(result.view().data()), source.binding(),
+            source.view().data());
+        return result;
+    };
+
+    const auto check_conversion = [&](const Containers &source,
+                                      const hgraph::TypeRealizationSnapshot &target_realization) {
+        hgraph::TypeRealizationScope scope{&target_realization};
+        const auto event_binding = target_realization.type_for(schemas.event);
+        const auto text_binding = target_realization.type_for(text_schema);
+
+        const hgraph::Value list = copy_into(
+            hgraph::compact_list_type(event_binding, *tuple_schema), source.list);
+        REQUIRE(list.as_list().size() == 1);
+        check_event(list.as_list().front(), schemas.created, "event");
+
+        const hgraph::Value set = copy_into(
+            hgraph::compact_set_type(event_binding), source.set);
+        REQUIRE(set.as_set().size() == 1);
+        check_event(*set.as_set().values().begin(), schemas.created, "event");
+
+        const hgraph::Value map = copy_into(
+            hgraph::compact_map_type(text_binding, event_binding), source.map);
+        REQUIRE(map.as_map().size() == 1);
+        check_event(map.as_map().at(key.view()), schemas.created, "event");
+
+        const hgraph::Value queue = copy_into(
+            hgraph::compact_queue_type(event_binding, 0), source.queue);
+        REQUIRE(queue.as_queue().size() == 1);
+        check_event(queue.as_queue().front(), schemas.created, "event");
+
+        const hgraph::Value cyclic = copy_into(
+            hgraph::compact_cyclic_buffer_type(event_binding, 2), source.cyclic);
+        REQUIRE(cyclic.as_cyclic_buffer().size() == 1);
+        check_event(cyclic.as_cyclic_buffer().front(), schemas.created, "event");
+    };
+
+    check_conversion(inline_values, *pooled_realization);
+    check_conversion(pooled_values, *inline_realization);
+}


### PR DESCRIPTION
## Summary

- add binding-aware value-builder insertion APIs so owned containers convert through the declared target binding instead of copying raw payload addresses
- migrate generic container, conversion, collection, stream, compact-storage, and JSON paths to preserve polymorphic compound-scalar leaves
- preserve exact list schemas and make `WindowResult` nominal identities element-specific
- cover transitive `Event -> OrderEvent -> CreateEvent` hierarchies, late leaf registration, inline and pooled storage, and cross-realization transfers in both C++ and Python

## Root cause

Several generic operators copied `ValueView::data()` directly into builder storage. That assumed source and destination used the same concrete representation, bypassing the target binding's conversion/copy operations. A container could therefore lock onto or reinterpret the first concrete leaf realization and reject later siblings. The generic window schema also reused one nominal `WindowResult` identity across element types.

## Validation

- macOS native acceptance suite: 1,507 passed
- macOS Python 3.14 compatibility suite from a Python 3.12 ABI3 wheel: 2,096 passed, 9 skipped
- macOS installed-SDK consumer: 1 passed
- Linux native acceptance suite: 1,507 passed
- Linux Python 3.14 compatibility suite from a Python 3.12 ABI3 wheel: 2,096 passed, 9 skipped
- Linux focused ASan polymorphic owned-container regression: passed