### PR TITLE
Fix polymorphic in-memory recording

### DIFF
--- a/include/hgraph/lib/std/operators/impl/record_replay_memory_impl.h
+++ b/include/hgraph/lib/std/operators/impl/record_replay_memory_impl.h
@@ -205,14 +205,15 @@ namespace hgraph::stdlib
             const std::string fq_key = record_replay_memory_detail::memory_recording_key(
                 traits, recordable_id.value(), key.value());
             Value delta = capture_delta(ts.base());
+            const auto delta_binding =
+                testing::recording_binding_for(ts.base().schema()->delta_value_schema);
             ValueView buffer = gs.get(fq_key);
             if (!buffer.valid())
             {
-                gs.set(fq_key, testing::make_sparse_buffer(delta.binding()));
+                gs.set(fq_key, testing::make_sparse_buffer(delta_binding));
                 buffer = gs.get(fq_key);
             }
             auto mutation = buffer.as_list().begin_mutation();
-            const auto delta_binding = delta.binding();
             Value entry = testing::make_sparse_entry(
                 delta_binding, now, std::move(delta));
             mutation.push_back(entry.view());

--- a/python/tests/test_compound_scalar_hierarchy.py
+++ b/python/tests/test_compound_scalar_hierarchy.py
@@ -360,6 +360,77 @@ def test_mapped_emit_then_outer_emit_preserves_a_transitive_concrete_leaf():
     ]
 
 
+def test_in_memory_record_replay_preserves_changing_polymorphic_event_leaves():
+    @dataclass(frozen=True)
+    class Event(
+        CompoundScalar,
+        namespace="tests.polymorphic_record_replay",
+        abstract=True,
+    ):
+        event_id: str
+
+    # Reproduce extension/client import order: the public recording type is
+    # materialized before its transitive concrete leaves are registered.
+    _value_type(Event)
+
+    @dataclass(frozen=True)
+    class HeartbeatEvent(Event):
+        pass
+
+    @dataclass(frozen=True)
+    class OrderEvent(Event, abstract=True):
+        order_id: str
+
+    @dataclass(frozen=True)
+    class CreateEvent(OrderEvent):
+        payload: str
+        details_a: str
+        details_b: str
+        details_c: str
+        details_d: str
+
+    heartbeat = HeartbeatEvent(event_id="heartbeat")
+    created = CreateEvent(
+        event_id="event",
+        order_id="order",
+        payload="created",
+        details_a="a",
+        details_b="b",
+        details_c="c",
+        details_d="d",
+    )
+
+    @hg.component
+    def recorded_events(events: TS[Event]) -> TS[Event]:
+        return events
+
+    for pooled in (False, True):
+        for expected in (
+            [heartbeat, created, heartbeat],
+            [created, heartbeat, created],
+        ):
+            with hg.GlobalState() as state:
+                hg.set_record_replay_model(hg.IN_MEMORY)
+                if pooled:
+                    hg.set_pooled_compound_scalar_storage()
+
+                with hg.RecordReplayContext(mode=hg.RecordReplayEnum.RECORD):
+                    assert eval_node(recorded_events, expected) == expected
+
+                recording = state.get(":memory:recorded_events.events")
+                assert [value for _, value in recording] == expected
+
+                replay_expected = list(expected)
+                replay_expected[0] = (
+                    created if expected[0] == heartbeat else heartbeat
+                )
+                recording[0] = recording[0][0], replay_expected[0]
+                assert state.get(":memory:recorded_events.events")[0][1] == replay_expected[0]
+
+                with hg.RecordReplayContext(mode=hg.RecordReplayEnum.REPLAY):
+                    assert eval_node(recorded_events, []) == replay_expected
+
+
 def test_feedback_preserves_a_transitive_concrete_leaf_with_and_without_a_default():
     @dataclass(frozen=True)
     class Event(

--- a/tests/cpp/test_component.cpp
+++ b/tests/cpp/test_component.cpp
@@ -3,20 +3,80 @@
 #include <hgraph/lib/testing/check_output.h>
 #include <hgraph/lib/testing/eval_node.h>
 #include <hgraph/types/graph_wiring.h>
+#include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/record_replay.h>
+#include <hgraph/types/value/value_builder.h>
 
 #include <catch2/catch_test_macros.hpp>
+
+#include <array>
+#include <cstddef>
+#include <string>
 
 // Step 5 of the record/replay/table design record: component<G> - Python's
 // @component as a wiring function over the mode scope + the record/replay
 // operators (whatever backend the active model selects).
+
+namespace polymorphic_record_replay_repro
+{
+    struct Event
+    {};
+}
+
+namespace hgraph
+{
+    template <>
+    struct scalar_descriptor<polymorphic_record_replay_repro::Event>
+    {
+        [[nodiscard]] static constexpr bool is_concrete() noexcept { return true; }
+        [[nodiscard]] static const ValueTypeMetaData *value_meta()
+        {
+            auto &registry = TypeRegistry::instance();
+            return registry.bundle(
+                "tests.record_replay", "Event",
+                {{"event_id", registry.value_type("str")}}, {}, true);
+        }
+    };
+}
+
+namespace hgraph::testing
+{
+    template <>
+    struct ts_harness<TS<polymorphic_record_replay_repro::Event>>
+        : bundle_ts_harness<TS<polymorphic_record_replay_repro::Event>>
+    {};
+}
 
 namespace
 {
     using namespace hgraph;
     using namespace hgraph::testing;
     using record_replay::Mode;
+    using PolymorphicEvent = polymorphic_record_replay_repro::Event;
+
+    struct PolymorphicEventIdentityGraph
+    {
+        [[maybe_unused]] static constexpr auto name = "polymorphic_event_identity_graph";
+
+        static Port<TS<PolymorphicEvent>> compose(
+            Wiring &, NamedPort<"events", TS<PolymorphicEvent>> events)
+        {
+            return events;
+        }
+    };
+
+    struct PolymorphicEventComponentHarness
+    {
+        [[maybe_unused]] static constexpr auto name = "polymorphic_event_component_harness";
+
+        static Port<TS<PolymorphicEvent>> compose(
+            Wiring &w, Port<TS<PolymorphicEvent>> events)
+        {
+            return stdlib::component<PolymorphicEventIdentityGraph>(
+                w, "polymorphic_events", events);
+        }
+    };
 
     struct SumGraph
     {
@@ -260,6 +320,110 @@ TEST_CASE("component: in-memory mode records timestamped values and replays them
         (void)eval_node<CompareHarness<ProductGraph>>(
             values<Int>(), values<Int>()),
         std::runtime_error);
+}
+
+TEST_CASE("component: in-memory recording preserves changing polymorphic event leaves")
+{
+    stdlib::register_standard_operators();
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *text = registry.value_type("str");
+    // Materialize the public base before registering its transitive leaves,
+    // matching extension/client import order.
+    const auto *event = scalar_descriptor<PolymorphicEvent>::value_meta();
+    const auto *heartbeat_event = registry.bundle(
+        "tests.record_replay", "HeartbeatEvent",
+        {{"event_id", text}}, {event});
+    const auto *order_event = registry.bundle(
+        "tests.record_replay", "OrderEvent",
+        {{"event_id", text}, {"order_id", text}}, {event}, true);
+    const auto *create_event = registry.bundle(
+        "tests.record_replay", "CreateEvent",
+        {{"event_id", text},
+         {"order_id", text},
+         {"payload", text},
+         {"details_a", text},
+         {"details_b", text},
+         {"details_c", text},
+         {"details_d", text}},
+        {order_event});
+
+    BundleBuilder heartbeat_builder{ValuePlanFactory::instance().type_for(heartbeat_event)};
+    heartbeat_builder.set("event_id", Value{Str{"heartbeat"}});
+    const Value heartbeat = heartbeat_builder.build();
+
+    BundleBuilder create_builder{ValuePlanFactory::instance().type_for(create_event)};
+    create_builder.set("event_id", Value{Str{"event"}});
+    create_builder.set("order_id", Value{Str{"order"}});
+    create_builder.set("payload", Value{Str{"created"}});
+    create_builder.set("details_a", Value{Str{"a"}});
+    create_builder.set("details_b", Value{Str{"b"}});
+    create_builder.set("details_c", Value{Str{"c"}});
+    create_builder.set("details_d", Value{Str{"d"}});
+    const Value created = create_builder.build();
+
+    const std::array sequences{
+        values<Value>(heartbeat, created, heartbeat),
+        values<Value>(created, heartbeat, created),
+    };
+    const std::array expected_leaves{
+        std::array{heartbeat_event, create_event, heartbeat_event},
+        std::array{create_event, heartbeat_event, create_event},
+    };
+
+    for (const bool pooled : {false, true})
+    {
+        for (std::size_t sequence_index = 0; sequence_index < sequences.size(); ++sequence_index)
+        {
+            GlobalContext context;
+            record_replay::set_config(
+                context.state().view(),
+                record_replay::Config{.model = std::string{record_replay::IN_MEMORY}});
+            if (pooled) { set_pooled_compound_scalar_storage(context.state().view()); }
+
+            {
+                record_replay::scope mode{Mode::Record};
+                const auto actual =
+                    eval_node<PolymorphicEventComponentHarness>(sequences[sequence_index]);
+                CHECK_OUTPUT(actual, sequences[sequence_index]);
+            }
+
+            const auto recording = context.state().view()
+                                       .get(":memory:polymorphic_events.events")
+                                       .as_list();
+            REQUIRE(recording.size() == sequences[sequence_index].size());
+            for (std::size_t i = 0; i < recording.size(); ++i)
+            {
+                const auto entry = recording.at(i).as_indexed_view();
+                CHECK(entry.at(1).concrete().schema() == expected_leaves[sequence_index][i]);
+            }
+
+            auto replay_expected = sequences[sequence_index];
+            const Value replacement_source =
+                sequence_index == 0 ? Value{created} : Value{heartbeat};
+            const auto *replacement_leaf =
+                sequence_index == 0 ? create_event : heartbeat_event;
+            const auto recorded_delta_binding =
+                recording.at(0).as_indexed_view().at(1).binding();
+            Value replacement_delta{recorded_delta_binding};
+            recorded_delta_binding.ops_ref().copy_assign_from(
+                recorded_delta_binding,
+                replacement_delta.begin_mutation().mutable_data(),
+                replacement_source.binding(), replacement_source.view().data());
+            Value replacement = testing::make_sparse_entry(
+                event, MIN_ST, Value{replacement_delta});
+            recording.begin_mutation().set(0, replacement.view());
+            replay_expected[0] = replacement_delta;
+            CHECK(recording.at(0).as_indexed_view().at(1).concrete().schema() ==
+                  replacement_leaf);
+
+            {
+                record_replay::scope mode{Mode::Replay};
+                const auto replayed = eval_node<PolymorphicEventComponentHarness>(values<Value>());
+                CHECK_OUTPUT(replayed, replay_expected);
+            }
+        }
+    }
 }
 
 TEST_CASE("component: Replay mode replaces live inputs with the recordings")


### PR DESCRIPTION
## Summary

- allocate sparse in-memory recording buffers from the declared time-series delta schema
- preserve changing concrete CompoundScalar leaves instead of locking storage to the first observed leaf
- cover both leaf orders, inline and pooled storage, and record/edit/replay through the public C++ and Python component APIs

## Root cause

The sparse recorder derived its persistent buffer binding from the first captured delta. For an abstract base such as Event, that delta carries the first concrete leaf binding, so a later sibling leaf is rejected by the fixed recording container. The recorder now derives storage from the declared TS[Event] delta schema while retaining the concrete leaf in each entry.

## Validation

- macOS native acceptance suite: 1,503/1,503 passed
- macOS ABI3 wheel built with Python 3.12; Python 3.14 non-WIP suite: 2,096 passed, 9 skipped
- Linux native acceptance suite: 1,503/1,503 passed
- Linux ABI3 wheel built with Python 3.12; Python 3.14 non-WIP suite: 2,096 passed, 9 skipped
- installed C++ SDK consumer: 1/1 passed