### PR TITLE
Preserve Arrow and mapped structural output types

### DIFF
--- a/include/hgraph/lib/std/operators/impl/higher_order_impl.h
+++ b/include/hgraph/lib/std/operators/impl/higher_order_impl.h
@@ -2462,6 +2462,30 @@ namespace hgraph::stdlib
             bool whole_variable{false};
         };
 
+        /** Schema a keyed/dynamic-list container must allocate for one child.
+            A synthetic structural adapter remains an implementation detail,
+            while an operator-authored REF terminal is the endpoint that the
+            container actually forwards to and must therefore be retained. */
+        [[nodiscard]] inline const TSValueTypeMetaData *mapped_element_schema(
+            const CompiledSubGraph &compiled)
+        {
+            const auto *logical = compiled.output_schema;
+            const auto *terminal = compiled.terminal_output_schema;
+            if (logical == nullptr || terminal == nullptr ||
+                compiled.terminal_is_structural_adapter ||
+                terminal->kind != TSTypeKind::REF)
+            {
+                return logical;
+            }
+
+            auto &registry = TypeRegistry::instance();
+            return time_series_schema_equivalent(
+                       registry.dereference(logical),
+                       registry.dereference(terminal))
+                       ? terminal
+                       : logical;
+        }
+
         /** Configure a whole child terminal against one public container
             element. A terminal with endpoint topology of its own, including
             the synthetic REF used for composed fixed structures, stays owned
@@ -2786,6 +2810,11 @@ namespace hgraph::stdlib
                         // switch_ remains the child's public output identity.
                         element_schema = declared;
                     }
+                }
+                if (const auto *physical = mapped_element_schema(compiled);
+                    physical != compiled.output_schema)
+                {
+                    element_schema = physical;
                 }
                 // TSD / dynamic-TSL elements embed since the storage-stability
                 // ruling (938a125): slot-backed TSData is construct-only in
@@ -3398,33 +3427,12 @@ namespace hgraph::stdlib
             auto ordered = ordered_map_schemas(context, "key");
             if (!ordered.has_value()) { return; }
 
-            if (const TSValueTypeMetaData *element = func->output_schema())
-            {
-                const MapArgClassification classified = classify_map_args(
-                    *func, ordered->takes_key,
-                    {ordered->schemas.data(), ordered->schemas.size()},
-                    {ordered->arg_tags.data(), ordered->arg_tags.size()},
-                    keys_kwarg_element(context));
-                std::size_t parameter = 0;
-                const auto accepts = [&](const TSValueTypeMetaData *actual) {
-                    const TSValueTypeMetaData *expected = func->input_schema(parameter++);
-                    return expected == nullptr ||
-                           graph_wiring_detail::input_accepts_output_schema(expected, actual);
-                };
-                const bool key_accepted =
-                    !ordered->takes_key || accepts(TypeRegistry::instance().ts(classified.key_meta));
-                const bool inputs_accepted = key_accepted &&
-                    std::ranges::all_of(classified.child_schemas, accepts);
-                const auto *output_schema = inputs_accepted
-                                                ? TypeRegistry::instance().tsd(classified.key_meta, element)
-                                                : nullptr;
-                if (output_schema != nullptr)
-                {
-                    bind_graph_output(resolution, output_schema, "O");
-                    return;
-                }
-            }
-
+            // A graph's declared return schema is only its public contract.
+            // Its compiled terminal can be transparently compatible but more
+            // precise, most notably REF[TSB] from a keyed TSD lookup exposed as
+            // TSB.  Compile the child before allocating the map output so the
+            // outer TSD retains that terminal schema instead of incorrectly
+            // allocating owned TSB storage.
             auto output_schema = try_resolve_map_output_schema(
                 *func, {ordered->schemas.data(), ordered->schemas.size()},
                 {ordered->arg_tags.data(), ordered->arg_tags.size()}, keys_kwarg_element(context));
@@ -4008,12 +4016,13 @@ namespace hgraph::stdlib
                     throw std::invalid_argument("map_: dynamic TSL function output node is out of range");
                 }
 
+                const auto *element_schema = mapped_element_schema(compiled);
                 NodeBuilder &terminal =
                     spec.child.graph_builder.node_at(binding.source.node);
                 spec.output_binding_mode = configure_mapped_child_terminal(
-                    terminal, compiled.output_schema,
+                    terminal, element_schema,
                     compiled.terminal_output_schema, "map_");
-                output_schema = registry.tsl(compiled.output_schema, 0);
+                output_schema = registry.tsl(element_schema, 0);
             } else {
                 output_schema = nullptr;
             }

--- a/include/hgraph/types/subgraph_wiring.h
+++ b/include/hgraph/types/subgraph_wiring.h
@@ -70,9 +70,14 @@ namespace hgraph
         /** Physical schema of the endpoint named by ``output_binding``.
             This differs from ``output_schema`` only when compilation adds an
             internal terminal (for example REF<TSB/TSL> for a newly composed
-            fixed structural result). Consumers expose ``output_schema`` and
-            use this field only when configuring the child terminal itself. */
+            fixed structural result). Consumers normally expose
+            ``output_schema``; container owners also use this to retain an
+            operator-authored REF endpoint in their element allocation. */
         const TSValueTypeMetaData               *terminal_output_schema{nullptr};
+        /** The physical REF terminal was synthesized solely to give a newly
+            composed fixed structure one endpoint. Unlike an operator-authored
+            REF result, this adapter is not part of the callable's result. */
+        bool terminal_is_structural_adapter{false};
         /**
          * Outer-port CAPTURES (nested_graphs.rst): OUTER-wiring ports the
          * compose body referenced (closure capture). One per boundary index

--- a/python/hgraph/arrow/_arrow.py
+++ b/python/hgraph/arrow/_arrow.py
@@ -401,11 +401,6 @@ def convert_pairs_to_tuples(ts: TIME_SERIES_TYPE) -> TS[object]:
 convert_pairs_to_delta_tuples = convert_pairs_to_tuples  # full-value dialect (see module docstring)
 
 
-@compute_node
-def _record_probe(ts: TIME_SERIES_TYPE) -> TS[object]:
-    return ts.value
-
-
 # ---------------------------------------------------------------------------
 # eval_
 # ---------------------------------------------------------------------------
@@ -438,39 +433,21 @@ class _EvalArrowInput:
             values = _build_inputs(self.first, self.second, self.type_map)
             out = other(values)
             if out is not None:
-                flat_value = _to_value_port(out)
-                w.wire("__harness_record", (_unwrap(flat_value), "arrow::out"),
+                # Record the actual, typed output.  Pair-to-tuple conversion
+                # is a presentation concern for eval_ and must not insert an
+                # object-valued node into the graph: doing so erases enum,
+                # CompoundScalar, and structural projection types.
+                w.wire("__harness_record", (_unwrap(out), "arrow::out"),
                        {"sparse": True})
             run = w.run()
         finally:
             _wiring_stack.pop()
         if out is None:
             return []
-        return [v for _, v in run.recorded("arrow::out", sparse=True)]
-
-
-def _to_value_port(out):
-    """A TS[object] port carrying the (tuple-converted) full value of out."""
-    shape = _pair_shape(out)
-    if shape is None:
-        return _record_probe(out)
-    return convert_pairs_to_tuples(_pair_value_port(out))
-
-
-def _pair_value_port(x):
-    """Build a TS[object] of nested-dict full values from a pair port so a
-    single probe records tuple-shaped output."""
-    elements = _pair_elements(x)
-    if elements is None:
-        return _record_probe(x)
-    return _combine_pair_values(_pair_value_port(elements[0]),
-                                _pair_value_port(elements[1]))
-
-
-@compute_node(valid=())
-def _combine_pair_values(first: TS[object], second: TS[object]) -> TS[object]:
-    return {"first": first.value if first.valid else None,
-            "second": second.value if second.valid else None}
+        return [
+            _value_to_tuples(value)
+            for _, value in run.recorded("arrow::out", sparse=True)
+        ]
 
 
 _REPLAY_COUNTER = 0

--- a/python/hgraph/arrow/_test_operators.py
+++ b/python/hgraph/arrow/_test_operators.py
@@ -4,11 +4,10 @@ Dialect: STATE here is hg_cpp's attribute-namespace injectable (upstream's
 ``STATE[Schema]`` subscript form does not exist in this runtime)."""
 import string
 
-import hgraph as hg
-from hgraph import CLOCK, STATE, TIME_SERIES_TYPE, TS
+from hgraph import CLOCK, STATE, TIME_SERIES_TYPE
 
 from .._wiring import compute_node
-from ._arrow import _pair_shape, _pair_value_port, _value_to_tuples, arrow
+from ._arrow import _value_to_tuples, arrow
 
 __all__ = ("assert_", "debug_", "d")
 
@@ -19,8 +18,10 @@ def assert_(*args, message: str = None):
     message = "" if message is None else f": ({message})"
     expected_values = args
 
-    @compute_node
-    def _assert(ts: TIME_SERIES_TYPE, _state: STATE = None) -> TS[object]:
+    @compute_node(valid=())
+    def _assert(
+        ts: TIME_SERIES_TYPE, _state: STATE = None
+    ) -> TIME_SERIES_TYPE:
         c = getattr(_state, "count", 0)
         if c >= (l := len(expected_values)):
             _state.failed = True
@@ -33,7 +34,7 @@ def assert_(*args, message: str = None):
             _state.failed = True
             raise AssertionError(
                 f"Expected '{expected}' but got '{value}' on tick count: {_state.count}{message}")
-        return ts.value
+        return ts.delta_value
 
     @_assert.stop
     def _assert_stop(_state: STATE = None):
@@ -43,38 +44,53 @@ def assert_(*args, message: str = None):
             raise AssertionError(f"Expected {l} values but got {count} results{message}")
 
     def _wrapper(x):
-        # Feed the assert from a tuple-shaped TS[object] view of x, but pass
-        # the ORIGINAL port through so chains continue with typed values.
-        value_port = _pair_value_port(x) if _pair_shape(x) is not None else x
-        checked = _assert(value_port)
-        hg.null_sink(checked)
-        return x
+        checked = _assert(x)
+        return checked
 
     return arrow(_wrapper, __name__=f"assert_{expected_values}",
                  __has_side_effects__=True)
 
 
-def debug_(fmt_str: str = None, delta_value: bool = False):
-    """Print the (tuple-shaped) value of the stream and pass it through."""
+@compute_node(valid=())
+def _debug(
+    ts: TIME_SERIES_TYPE,
+    fmt: str,
+    use_delta: bool,
+    _clock: CLOCK = None,
+) -> TIME_SERIES_TYPE:
+    """Typed runtime half of the Arrow diagnostic pass-through."""
+    msg = _value_to_tuples(ts.delta_value if use_delta else ts.value)
+    if fmt:
+        _, parsed, _, _ = next(string.Formatter().parse(fmt), (None,) * 4)
+        msg = f"{fmt}: {msg}" if parsed is None else fmt.format(msg)
+    when = _clock.evaluation_time if _clock is not None else ""
+    print(f"[DEBUG][{when}] {msg}")
+    return ts.delta_value
 
-    @compute_node
-    def _debug(ts: TIME_SERIES_TYPE, fmt: str, use_delta: bool,
-               _clock: CLOCK = None) -> TS[object]:
-        msg = _value_to_tuples(ts.delta_value if use_delta else ts.value)
-        if fmt:
-            _, parsed, _, _ = next(string.Formatter().parse(fmt), (None,) * 4)
-            msg = f"{fmt}: {msg}" if parsed is None else fmt.format(msg)
-        when = _clock.evaluation_time if _clock is not None else ""
-        print(f"[DEBUG][{when}] {msg}")
-        return ts.value
 
-    def _wrapper(x):
-        value_port = _pair_value_port(x) if _pair_shape(x) is not None else x
-        hg.null_sink(_debug(value_port, fmt_str or "", delta_value))
-        return x
+def _debug_arrow(*args, fmt_str: str = None, delta_value: bool = False):
+    """Apply bound diagnostic options to the final Arrow input port."""
+    if not args:
+        raise TypeError("debug_ requires an Arrow input when it is evaluated")
+    ts = args[-1]
+    options = args[:-1]
+    if len(options) > 2:
+        raise TypeError("debug_ accepts at most a format string and delta_value")
+    if options:
+        if fmt_str is not None:
+            raise TypeError("debug_ received fmt_str both positionally and by keyword")
+        fmt_str = options[0]
+    if len(options) == 2:
+        if delta_value is not False:
+            raise TypeError("debug_ received delta_value both positionally and by keyword")
+        delta_value = options[1]
+    return _debug(ts, fmt_str or "", delta_value)
 
-    return arrow(_wrapper, __name__=f"debug_({fmt_str})",
-                 __has_side_effects__=True)
+
+# ``debug_`` is itself an Arrow, as in release/0.5.  It can therefore be
+# placed directly in a chain, while calls bind its optional configuration:
+# ``... >> debug_ >> ...`` and ``... >> debug_("value {}") >> ...``.
+debug_ = arrow(_debug_arrow, __name__="debug_", __has_side_effects__=True)
 
 
 d = debug_

--- a/python/tests/ported/_wiring/test_map_regressions.py
+++ b/python/tests/ported/_wiring/test_map_regressions.py
@@ -19,3 +19,57 @@ def test_map_invalid_reference_bundle_field_output():
         return hg.map_(child, values, condition)
 
     assert eval_node(app, [{"x": 1}], [False]) == [{}]
+
+
+def test_map_preserves_typed_keyed_bundle_reference_and_materialization():
+    class Row(hg.TimeSeriesSchema):
+        value: hg.TS[int]
+        label: hg.TS[str]
+
+    class Projection(hg.TimeSeriesSchema):
+        value: hg.TS[int]
+        label: hg.TS[str]
+
+    @hg.graph
+    def keyed_lookup(
+        lookup: hg.TS[str], rows: hg.TSD[str, hg.TSB[Row]],
+    ) -> hg.TSB[Row]:
+        # A dynamic lookup is physically REF[TSB[Row]], even though the typed
+        # graph presents its dereferenced TSB contract to callers.
+        return rows[lookup]
+
+    @hg.graph
+    def materialize_lookup(
+        lookup: hg.TS[str], rows: hg.TSD[str, hg.TSB[Row]],
+    ) -> hg.TSB[Projection]:
+        selected = rows[lookup]
+        return hg.combine[hg.TSB[Projection]](
+            value=selected.value, label=selected.label,
+        )
+
+    @hg.graph
+    def reference_app(
+        lookups: hg.TSD[str, hg.TS[str]],
+        rows: hg.TSD[str, hg.TSB[Row]],
+    ) -> hg.TSD[str, hg.REF[hg.TSB[Row]]]:
+        return hg.map_(keyed_lookup, lookups, hg.pass_through(rows))
+
+    @hg.graph
+    def materialized_app(
+        lookups: hg.TSD[str, hg.TS[str]],
+        rows: hg.TSD[str, hg.TSB[Row]],
+    ) -> hg.TSD[str, hg.TSB[Projection]]:
+        return hg.map_(materialize_lookup, lookups, hg.pass_through(rows))
+
+    lookups = [{"left": "a", "right": "b"}]
+    rows = [{
+        "a": {"value": 1, "label": "one"},
+        "b": {"value": 2, "label": "two"},
+    }]
+    expected = [{
+        "left": {"value": 1, "label": "one"},
+        "right": {"value": 2, "label": "two"},
+    }]
+
+    assert eval_node(reference_app, lookups, rows) == expected
+    assert eval_node(materialized_app, lookups, rows) == expected

--- a/python/tests/ported/arrow/test_arrow.py
+++ b/python/tests/ported/arrow/test_arrow.py
@@ -8,6 +8,9 @@
 #  - test_side_effects: converted - hg_cpp retains explicitly wired nodes, so
 #    an un-flagged side-effect node evaluates even when its output is unused
 #    (upstream discards nodes unreachable from a sink).
+from dataclasses import dataclass
+from enum import Enum
+
 import pytest
 from frozendict import frozendict as fd
 
@@ -300,6 +303,49 @@ def test_reduce():
 
 def test_debug_():
     eval_([1, 2], [1, None, 2]) | debug_("Test value {}") >> assert_((1, 1), (2, 1), (2, 2))
+
+
+def test_debug_is_a_direct_typed_arrow_for_enum_and_compound_scalar(capsys):
+    class Side(Enum):
+        BUY = "BUY"
+        SELL = "SELL"
+
+    @dataclass(frozen=True)
+    class Event(hgraph.CompoundScalar):
+        event_id: str
+
+    @compute_node
+    def render(side: TS[Side], event: TS[Event]) -> TS[str]:
+        return f"{side.value.value}:{event.value.event_id}"
+
+    @graph
+    def app(side: TS[Side], event: TS[Event]) -> TS[str]:
+        # release/0.5 exposed debug_ itself as an Arrow.  Its pass-through
+        # output must retain the pair's concrete field projections so this
+        # typed consumer receives TS[Side] and TS[Event], not TS[object].
+        return arrow(side, event) | debug_ >> render
+
+    buy = Event("one")
+    sell = Event("two")
+    assert eval_node(app, [Side.BUY, Side.SELL], [buy, sell]) == [
+        "BUY:one",
+        "SELL:two",
+    ]
+    output = capsys.readouterr().out
+    assert "<Side.BUY: 'BUY'>" in output and "Event(event_id='one')" in output
+    assert "<Side.SELL: 'SELL'>" in output and "Event(event_id='two')" in output
+
+    # eval_ records the typed pair and converts it to the presentation tuple
+    # only after execution; no object-valued _combine_pair_values node is
+    # inserted into the graph.
+    assert (
+        eval_(
+            [Side.BUY, Side.SELL],
+            [buy, sell],
+            type_map=(TS[Side], TS[Event]),
+        )
+        | i
+    ) == [(Side.BUY, buy), (Side.SELL, sell)]
 
 
 def test_side_effects():

--- a/src/hgraph/types/graph_wiring.cpp
+++ b/src/hgraph/types/graph_wiring.cpp
@@ -2790,6 +2790,9 @@ CompiledSubGraph Wiring::finish_subgraph(
           }
           if (output->peered_path().empty()) {
             compiled.terminal_output_schema = terminal_meta->output_schema;
+            compiled.terminal_is_structural_adapter =
+                output->peered_node()->definition ==
+                std::type_index(typeid(StructuralRefNodeTag));
           }
           compiled.output_binding = NestedGraphOutputBinding{
               .source = NestedGraphEndpoint{.node = it->second,

--- a/tests/cpp/test_map.cpp
+++ b/tests/cpp/test_map.cpp
@@ -214,6 +214,48 @@ namespace
         static Port<TSS<Int>> compose(Wiring &, Port<TSS<Int>> ts) { return ts; }
     };
 
+    using LookupMappedBundle =
+        UnNamedTSB<Field<"value", TS<Int>>, Field<"label", TS<Str>>>;
+
+    /** A typed graph whose public C++ return type is TSB, while its actual
+        terminal is the REF[TSB] produced by a dynamic TSD lookup. */
+    struct LookupMappedBundleG
+    {
+        static constexpr auto name = "lookup_mapped_bundle_g";
+
+        static Port<LookupMappedBundle> compose(
+            Wiring &w, Port<TS<Str>> lookup,
+            Port<TSD<Str, LookupMappedBundle>> values)
+        {
+            return wire<stdlib::getitem_>(w, values, lookup)
+                .as<LookupMappedBundle>();
+        }
+    };
+
+    struct MapLookupMappedBundleG
+    {
+        static constexpr auto name = "map_lookup_mapped_bundle_g";
+
+        static Port<TS<Int>> compose(
+            Wiring &w, Port<TSD<Str, TS<Str>>> lookups,
+            Port<TSD<Str, LookupMappedBundle>> values)
+        {
+            auto mapped = wire<stdlib::map_>(
+                w, fn<LookupMappedBundleG>(), lookups,
+                stdlib::pass_through(values));
+            if (mapped.erased().schema !=
+                ts_type<TSD<Str, REF<LookupMappedBundle>>>())
+            {
+                throw std::logic_error(
+                    "map_ erased the typed graph's REF[TSB] terminal");
+            }
+            auto selected = wire<stdlib::getitem_>(w, mapped, Str{"left"})
+                                .as<REF<LookupMappedBundle>>();
+            return wire<stdlib::getattr_>(w, selected, Str{"value"})
+                .as<TS<Int>>();
+        }
+    };
+
     struct ExplicitKeySetMapG
     {
         static constexpr auto name = "explicit_key_set_map_g";
@@ -1393,6 +1435,21 @@ TEST_CASE("map_: keyed lookup follows a child that becomes valid after its slot 
         values<Int>(none, 42));
 }
 
+TEST_CASE("map_: a typed graph preserves its keyed REF[TSB] terminal")
+{
+    using namespace hgraph;
+    stdlib::register_standard_operators();
+
+    CHECK_OUTPUT(
+        eval_node<MapLookupMappedBundleG>(
+            values<Value>(dict_delta<Str, TS<Str>>(
+                {{"left"s, "a"s}, {"right"s, "b"s}})),
+            values<Value>(dict_delta<Str, LookupMappedBundle>(
+                {{"a"s, tsb_delta<LookupMappedBundle>(Int{1}, Str{"one"})},
+                 {"b"s, tsb_delta<LookupMappedBundle>(Int{2}, Str{"two"})}}))),
+        values<Int>(1));
+}
+
 TEST_CASE("map_: a downstream map binds when an upstream phantom slot becomes valid")
 {
     using namespace hgraph;
@@ -2182,6 +2239,27 @@ namespace
         }
     };
 
+    struct MapDynamicLookupMappedBundleG
+    {
+        static constexpr auto name = "map_dynamic_lookup_mapped_bundle_g";
+
+        static Port<TSL<TS<Str>>> compose(
+            Wiring &w, Port<TSL<TS<Str>>> lookups,
+            Port<TSD<Str, LookupMappedBundle>> values)
+        {
+            auto mapped = wire<stdlib::map_>(
+                w, fn<LookupMappedBundleG>(), lookups,
+                stdlib::pass_through(values));
+            if (mapped.erased().schema !=
+                ts_type<TSL<REF<LookupMappedBundle>>>())
+            {
+                throw std::logic_error(
+                    "dynamic TSL map_ erased the child REF[TSB] terminal");
+            }
+            return lookups;
+        }
+    };
+
     struct MapDynamicCounterG
     {
         static constexpr auto name = "map_dynamic_counter_g";
@@ -2686,6 +2764,19 @@ TEST_CASE("map_ over dynamic TSL: composed structural child results retain their
                 {{1, tsb_delta<DynamicStructuralPair>(Int{2}, Int{102})}}),
             list_delta<DynamicStructuralPair>(
                 {{0, tsb_delta<DynamicStructuralPair>(Int{3}, Int{103})}})));
+}
+
+TEST_CASE("map_ over dynamic TSL: a typed graph preserves its keyed REF[TSB] terminal")
+{
+    using namespace hgraph;
+    stdlib::register_standard_operators();
+
+    CHECK_OUTPUT(
+        (eval_node<MapDynamicLookupMappedBundleG>(
+            values<Value>(list_delta<TS<Str>>({{0, Str{"a"}}})),
+            values<Value>(dict_delta<Str, LookupMappedBundle>(
+                {{"a"s, tsb_delta<LookupMappedBundle>(Int{1}, Str{"one"})}})))),
+        values<Value>(list_delta<TS<Str>>({{0, Str{"a"}}})));
 }
 
 TEST_CASE("map_ over dynamic TSL: each index preserves isolated child state") {

--- a/tests/cpp/test_nested_wiring.cpp
+++ b/tests/cpp/test_nested_wiring.cpp
@@ -521,11 +521,13 @@ TEST_CASE("nested wiring: compiled structural results keep logical and terminal 
     CHECK(bundle.output_schema == bundle_schema);
     CHECK(bundle.terminal_output_schema ==
           TypeRegistry::instance().ref(bundle_schema));
+    CHECK(bundle.terminal_is_structural_adapter);
 
     const auto *list_schema = schema_descriptor<IntPair>::ts_meta();
     const CompiledSubGraph list = compile_subgraph<StructuralListSubGraph>();
     CHECK(list.output_schema == list_schema);
     CHECK(list.terminal_output_schema == TypeRegistry::instance().ref(list_schema));
+    CHECK(list.terminal_is_structural_adapter);
 
     const auto *plain_schema = schema_descriptor<TS<Int>>::ts_meta();
     const CompiledSubGraph dereferenced_ref =
@@ -533,6 +535,7 @@ TEST_CASE("nested wiring: compiled structural results keep logical and terminal 
     CHECK(dereferenced_ref.output_schema == plain_schema);
     CHECK(dereferenced_ref.terminal_output_schema ==
           TypeRegistry::instance().ref(plain_schema));
+    CHECK_FALSE(dereferenced_ref.terminal_is_structural_adapter);
 }
 
 TEST_CASE("nested wiring: newly composed fixed structural results retain their public schemas")


### PR DESCRIPTION
## Summary

- preserve concrete Arrow projection types through evaluation and recording
- restore direct `debug_` use while retaining configured `debug_()` calls
- allocate mapped structural outputs from the child operator's physical terminal schema
- cover both keyed `TSD` mapping and dynamic `TSL` mapping with native and Python regressions

## Root cause

Arrow evaluation inserted an object-typed conversion node before recording, which erased enum and `CompoundScalar` projection types. The debug Arrow had also changed from a direct typed operator into a factory-only form.

Separately, `map_` allocated its result from the typed graph's declared output. A typed graph may publicly declare `TSB[...]` while its actual child terminal is an operator-authored `REF[TSB[...]]`, such as a keyed lookup. Treating that physical reference as an owned bundle produced a mismatch between the parent collection and mapped children.

## Implementation

- record the typed Arrow output and convert values only after evaluation for presentation
- make `assert_` and `debug_` generic typed Arrow operators again
- retain terminal provenance in `CompiledSubGraph` so synthetic structural adapters can be distinguished from genuine operator-authored references
- use the physical mapped-element schema for genuine `REF` terminals without exposing synthetic adapter references
- apply the same output selection to keyed `TSD` and dynamic `TSL` mapping

## Validation

- macOS native suite: 1,510 passed
- macOS Python 3.14 installed-wheel suite: 2,099 passed, 9 skipped
- Linux native suite: 1,510 passed
- Linux Python 3.14 installed-wheel suite: 2,099 passed, 9 skipped
- installed-wheel extension consumer passed
- focused Arrow and map regression suites passed
- `git diff --check` passed
