### PR TITLE
Separate native validation from wheel releases

### DIFF
--- a/.github/workflows/native-cpp.yml
+++ b/.github/workflows/native-cpp.yml
@@ -1,0 +1,183 @@
+name: Native C++ validation
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  GCC_VERSION: "14"
+  SCCACHE_GHA_ENABLED: "true"
+
+jobs:
+  native-cpp:
+    name: Native C++ / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            parallel: "2"
+          - os: macos-26
+            parallel: "1"
+
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - name: Enable shared compiler cache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        with:
+          version: v0.15.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+      - name: Configure current Clang on macOS
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          echo "CC=/usr/bin/clang" >> "$GITHUB_ENV"
+          echo "CXX=/usr/bin/clang++" >> "$GITHUB_ENV"
+          /usr/bin/clang++ --version
+      - name: Configure GCC 14 on Linux
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          cc_path="$(command -v "gcc-$GCC_VERSION")"
+          cxx_path="$(command -v "g++-$GCC_VERSION")"
+          test "$("$cxx_path" -dumpfullversion -dumpversion | cut -d. -f1)" -eq "$GCC_VERSION"
+          echo "CC=$cc_path" >> "$GITHUB_ENV"
+          echo "CXX=$cxx_path" >> "$GITHUB_ENV"
+          "$cxx_path" --version
+      - name: Install native build dependencies
+        run: >-
+          python -m pip install --upgrade --only-binary=:all:
+          "cmake==4.4.2" "ninja==1.13.0" "pyarrow==25.0.0"
+      - name: Expose Arrow runtime libraries
+        shell: python
+        run: |
+          import os
+          from pathlib import Path
+          import pyarrow
+
+          with open(os.environ["GITHUB_PATH"], "a", encoding="utf-8") as path_file:
+              path_file.write(str(Path(pyarrow.__file__).resolve().parent) + "\n")
+      - name: Configure native C++ tests
+        run: cmake -S . -B build-native -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DHGRAPH_BUILD_PYTHON_BINDINGS=OFF -DHGRAPH_ENABLE_PYTHON_USER_NODES=OFF -DHGRAPH_ENABLE_IDE_PYTHON_HEADER_HINTS=OFF -DHGRAPH_USE_PYARROW_ARROW=ON -DHGRAPH_FETCH_SIMDJSON=ON -DHGRAPH_FETCH_DATE=ON -DHGRAPH_ENABLE_DEBUGGER_SMOKE_TESTS=ON -DHGRAPH_WARNINGS_AS_ERRORS=ON -DHGRAPH_BUILD_KAFKA_EXTENSION=ON -DHGRAPH_KAFKA_FORCE_FETCH_LIBRDKAFKA=ON -DHGRAPH_BUILD_ANALYTICS_EXTENSION=ON
+      - name: Build native C++ tests
+        run: cmake --build build-native --parallel ${{ matrix.parallel }}
+      - name: Run native C++ tests
+        run: ctest --test-dir build-native --output-on-failure --parallel ${{ matrix.parallel }}
+
+  native-shared-install:
+    name: Native C++ / Linux shared install with IPO
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - name: Enable shared compiler cache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        with:
+          version: v0.15.0
+      - name: Configure GCC 14
+        shell: bash
+        run: |
+          cc_path="$(command -v "gcc-$GCC_VERSION")"
+          cxx_path="$(command -v "g++-$GCC_VERSION")"
+          test "$("$cxx_path" -dumpfullversion -dumpversion | cut -d. -f1)" -eq "$GCC_VERSION"
+          echo "CC=$cc_path" >> "$GITHUB_ENV"
+          echo "CXX=$cxx_path" >> "$GITHUB_ENV"
+          "$cxx_path" --version
+      - uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3
+        with:
+          environment-name: hgraph-native
+          cache-environment: true
+          create-args: >-
+            cmake>=3.26
+            ninja
+            libarrow=25
+            libarrow-compute=25
+            libarrow-acero=25
+            fmt
+            spdlog>=1.15
+            simdjson>=4.5
+      - name: Configure optimized shared C++ tests
+        shell: micromamba-shell {0}
+        run: >-
+          cmake -S . -B build-shared -G Ninja
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          -DCMAKE_PREFIX_PATH="$CONDA_PREFIX"
+          -DBUILD_TESTING=ON
+          -DHGRAPH_BUILD_SHARED=ON
+          -DHGRAPH_BUILD_PYTHON_BINDINGS=OFF
+          -DHGRAPH_ENABLE_PYTHON_USER_NODES=OFF
+          -DHGRAPH_ENABLE_IDE_PYTHON_HEADER_HINTS=OFF
+          -DHGRAPH_FETCH_DATE=ON
+          -DHGRAPH_ENABLE_DEBUGGER_SMOKE_TESTS=ON
+          -DHGRAPH_WARNINGS_AS_ERRORS=ON
+          -DHGRAPH_BUILD_KAFKA_EXTENSION=ON
+          -DHGRAPH_KAFKA_FORCE_FETCH_LIBRDKAFKA=ON
+          -DHGRAPH_BUILD_ANALYTICS_EXTENSION=ON
+      - name: Verify IPO is enabled
+        shell: micromamba-shell {0}
+        run: >-
+          grep -Eq -- '"command":.*-flto(=auto)?.*/src/hgraph/'
+          build-shared/compile_commands.json
+      - name: Build optimized shared C++ tests
+        shell: micromamba-shell {0}
+        run: cmake --build build-shared --parallel 2
+      - name: Run optimized shared C++ tests
+        shell: micromamba-shell {0}
+        run: ctest --test-dir build-shared --output-on-failure --parallel 2
+      - name: Install optimized shared C++ package
+        shell: micromamba-shell {0}
+        run: cmake --install build-shared --prefix "$GITHUB_WORKSPACE/install-shared"
+      - name: Configure installed-package consumer
+        shell: micromamba-shell {0}
+        run: >-
+          cmake -S tests/install_consumer -B build-consumer -G Ninja
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/install-shared;$CONDA_PREFIX"
+      - name: Build and test installed-package consumer
+        shell: micromamba-shell {0}
+        run: |
+          cmake --build build-consumer --parallel 2
+          LD_LIBRARY_PATH="$CONDA_PREFIX/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+            ctest --test-dir build-consumer --output-on-failure
+      - name: Configure installed Kafka consumer
+        shell: micromamba-shell {0}
+        run: >-
+          cmake -S extensions/kafka/test_package -B build-kafka-consumer -G Ninja
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/install-shared;$CONDA_PREFIX"
+      - name: Build and test installed Kafka consumer
+        shell: micromamba-shell {0}
+        run: |
+          cmake --build build-kafka-consumer --parallel 2
+          LD_LIBRARY_PATH="$GITHUB_WORKSPACE/install-shared/lib:$CONDA_PREFIX/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+            ctest --test-dir build-kafka-consumer --output-on-failure
+      - name: Configure installed analytics consumer
+        shell: micromamba-shell {0}
+        run: >-
+          cmake -S extensions/analytics/test_package
+          -B build-analytics-consumer -G Ninja
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/install-shared;$CONDA_PREFIX"
+      - name: Build and test installed analytics consumer
+        shell: micromamba-shell {0}
+        run: |
+          cmake --build build-analytics-consumer --parallel 2
+          LD_LIBRARY_PATH="$GITHUB_WORKSPACE/install-shared/lib:$CONDA_PREFIX/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+            ctest --test-dir build-analytics-consumer --output-on-failure

--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -514,171 +514,6 @@ jobs:
           path: parity-results
           if-no-files-found: error
 
-  native-cpp:
-    name: Native C++ / ${{ matrix.os }}
-    needs:
-      - validate-release
-      - reuse-build
-    if: needs.reuse-build.outputs.run-id == ''
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-24.04
-            parallel: "2"
-          - os: macos-26
-            parallel: "1"
-
-    steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          persist-credentials: false
-      - name: Enable shared compiler cache
-        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
-        with:
-          version: v0.15.0
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
-        with:
-          python-version: "3.12"
-      - name: Configure current Clang on macOS
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
-          echo "CC=/usr/bin/clang" >> "$GITHUB_ENV"
-          echo "CXX=/usr/bin/clang++" >> "$GITHUB_ENV"
-          /usr/bin/clang++ --version
-      - name: Configure GCC 14 on Linux
-        if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          cc_path="$(command -v "gcc-$GCC_VERSION")"
-          cxx_path="$(command -v "g++-$GCC_VERSION")"
-          test "$("$cxx_path" -dumpfullversion -dumpversion | cut -d. -f1)" -eq "$GCC_VERSION"
-          echo "CC=$cc_path" >> "$GITHUB_ENV"
-          echo "CXX=$cxx_path" >> "$GITHUB_ENV"
-          "$cxx_path" --version
-      - name: Install native build dependencies
-        run: >-
-          python -m pip install --upgrade --only-binary=:all:
-          "cmake==4.4.2" "ninja==1.13.0" "pyarrow==25.0.0"
-      - name: Expose Arrow runtime libraries
-        shell: python
-        run: |
-          import os
-          from pathlib import Path
-          import pyarrow
-
-          with open(os.environ["GITHUB_PATH"], "a", encoding="utf-8") as path_file:
-              path_file.write(str(Path(pyarrow.__file__).resolve().parent) + "\n")
-      - name: Configure native C++ tests
-        run: cmake -S . -B build-native -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DHGRAPH_BUILD_PYTHON_BINDINGS=OFF -DHGRAPH_ENABLE_PYTHON_USER_NODES=OFF -DHGRAPH_ENABLE_IDE_PYTHON_HEADER_HINTS=OFF -DHGRAPH_USE_PYARROW_ARROW=ON -DHGRAPH_FETCH_SIMDJSON=ON -DHGRAPH_FETCH_DATE=ON -DHGRAPH_ENABLE_DEBUGGER_SMOKE_TESTS=ON -DHGRAPH_WARNINGS_AS_ERRORS=ON -DHGRAPH_BUILD_KAFKA_EXTENSION=ON -DHGRAPH_KAFKA_FORCE_FETCH_LIBRDKAFKA=ON -DHGRAPH_BUILD_ANALYTICS_EXTENSION=ON
-      - name: Build native C++ tests
-        run: cmake --build build-native --parallel ${{ matrix.parallel }}
-      - name: Run native C++ tests
-        run: ctest --test-dir build-native --output-on-failure --parallel ${{ matrix.parallel }}
-
-  native-install:
-    name: Native C++ / Linux shared install
-    needs:
-      - validate-release
-      - reuse-build
-    if: needs.reuse-build.outputs.run-id == ''
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          persist-credentials: false
-      - name: Enable shared compiler cache
-        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
-        with:
-          version: v0.15.0
-      - name: Configure GCC 14
-        shell: bash
-        run: |
-          cc_path="$(command -v "gcc-$GCC_VERSION")"
-          cxx_path="$(command -v "g++-$GCC_VERSION")"
-          test "$("$cxx_path" -dumpfullversion -dumpversion | cut -d. -f1)" -eq "$GCC_VERSION"
-          echo "CC=$cc_path" >> "$GITHUB_ENV"
-          echo "CXX=$cxx_path" >> "$GITHUB_ENV"
-          "$cxx_path" --version
-      - uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3
-        with:
-          environment-name: hgraph-native
-          cache-environment: true
-          create-args: >-
-            cmake>=3.26
-            ninja
-            libarrow=25
-            libarrow-compute=25
-            libarrow-acero=25
-            fmt
-            spdlog>=1.15
-            simdjson>=4.5
-      - name: Configure shared C++ tests
-        shell: micromamba-shell {0}
-        run: >-
-          cmake -S . -B build-shared -G Ninja
-          -DCMAKE_BUILD_TYPE=Release
-          -DCMAKE_PREFIX_PATH="$CONDA_PREFIX"
-          -DBUILD_TESTING=ON
-          -DHGRAPH_BUILD_SHARED=ON
-          -DHGRAPH_BUILD_PYTHON_BINDINGS=OFF
-          -DHGRAPH_ENABLE_PYTHON_USER_NODES=OFF
-          -DHGRAPH_ENABLE_IDE_PYTHON_HEADER_HINTS=OFF
-          -DHGRAPH_FETCH_DATE=ON
-          -DHGRAPH_ENABLE_DEBUGGER_SMOKE_TESTS=ON
-          -DHGRAPH_WARNINGS_AS_ERRORS=ON
-          -DHGRAPH_BUILD_KAFKA_EXTENSION=ON
-          -DHGRAPH_KAFKA_FORCE_FETCH_LIBRDKAFKA=ON
-          -DHGRAPH_BUILD_ANALYTICS_EXTENSION=ON
-      - name: Build shared C++ tests
-        shell: micromamba-shell {0}
-        run: cmake --build build-shared --parallel 2
-      - name: Run shared C++ tests
-        shell: micromamba-shell {0}
-        run: ctest --test-dir build-shared --output-on-failure --parallel 2
-      - name: Install shared C++ package
-        shell: micromamba-shell {0}
-        run: cmake --install build-shared --prefix "$GITHUB_WORKSPACE/install-shared"
-      - name: Configure installed-package consumer
-        shell: micromamba-shell {0}
-        run: >-
-          cmake -S tests/install_consumer -B build-consumer -G Ninja
-          -DCMAKE_BUILD_TYPE=Release
-          -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/install-shared;$CONDA_PREFIX"
-      - name: Build and test installed-package consumer
-        shell: micromamba-shell {0}
-        run: |
-          cmake --build build-consumer --parallel 2
-          LD_LIBRARY_PATH="$CONDA_PREFIX/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
-            ctest --test-dir build-consumer --output-on-failure
-      - name: Configure installed Kafka consumer
-        shell: micromamba-shell {0}
-        run: >-
-          cmake -S extensions/kafka/test_package -B build-kafka-consumer -G Ninja
-          -DCMAKE_BUILD_TYPE=Release
-          -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/install-shared;$CONDA_PREFIX"
-      - name: Build and test installed Kafka consumer
-        shell: micromamba-shell {0}
-        run: |
-          cmake --build build-kafka-consumer --parallel 2
-          LD_LIBRARY_PATH="$GITHUB_WORKSPACE/install-shared/lib:$CONDA_PREFIX/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
-            ctest --test-dir build-kafka-consumer --output-on-failure
-      - name: Configure installed analytics consumer
-        shell: micromamba-shell {0}
-        run: >-
-          cmake -S extensions/analytics/test_package
-          -B build-analytics-consumer -G Ninja
-          -DCMAKE_BUILD_TYPE=Release
-          -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/install-shared;$CONDA_PREFIX"
-      - name: Build and test installed analytics consumer
-        shell: micromamba-shell {0}
-        run: |
-          cmake --build build-analytics-consumer --parallel 2
-          LD_LIBRARY_PATH="$GITHUB_WORKSPACE/install-shared/lib:$CONDA_PREFIX/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
-            ctest --test-dir build-analytics-consumer --output-on-failure
-
   publish:
     name: Publish hgraph to PyPI
     if: >-
@@ -692,9 +527,7 @@ jobs:
           needs.build-sdist.result == 'success' &&
           needs.test-windows-wheel.result == 'success' &&
           needs.test-macos-wheel.result == 'success' &&
-          needs.test-linux-wheel.result == 'success' &&
-          needs.native-cpp.result == 'success' &&
-          needs.native-install.result == 'success'
+          needs.test-linux-wheel.result == 'success'
         )
       )
     needs:
@@ -704,8 +537,6 @@ jobs:
       - test-windows-wheel
       - test-macos-wheel
       - test-linux-wheel
-      - native-cpp
-      - native-install
       - build-linux-wheel
     runs-on: ubuntu-latest
     environment:
@@ -747,9 +578,7 @@ jobs:
           needs.build-sdist.result == 'success' &&
           needs.test-windows-wheel.result == 'success' &&
           needs.test-macos-wheel.result == 'success' &&
-          needs.test-linux-wheel.result == 'success' &&
-          needs.native-cpp.result == 'success' &&
-          needs.native-install.result == 'success'
+          needs.test-linux-wheel.result == 'success'
         )
       )
     needs:
@@ -759,8 +588,6 @@ jobs:
       - test-windows-wheel
       - test-macos-wheel
       - test-linux-wheel
-      - native-cpp
-      - native-install
       - build-linux-wheel
     runs-on: ubuntu-latest
     environment:
@@ -802,9 +629,7 @@ jobs:
           needs.build-sdist.result == 'success' &&
           needs.test-windows-wheel.result == 'success' &&
           needs.test-macos-wheel.result == 'success' &&
-          needs.test-linux-wheel.result == 'success' &&
-          needs.native-cpp.result == 'success' &&
-          needs.native-install.result == 'success'
+          needs.test-linux-wheel.result == 'success'
         )
       )
     needs:
@@ -814,8 +639,6 @@ jobs:
       - test-windows-wheel
       - test-macos-wheel
       - test-linux-wheel
-      - native-cpp
-      - native-install
       - build-linux-wheel
     runs-on: ubuntu-latest
     environment:

--- a/docs/source/developer_guide/build_system.rst
+++ b/docs/source/developer_guide/build_system.rst
@@ -64,6 +64,12 @@ Windows x86_64, and Apple Silicon macOS, then installs each platform wheel under
 CPython 3.12, 3.13, and 3.14. A bare tag matching ``x.x.x`` publishes the tested
 core, Kafka, and analytics wheels and source distributions through PyPI trusted
 publishing.
+Standalone C++ validation runs independently in
+``.github/workflows/native-cpp.yml``. It covers native Linux and macOS builds,
+plus a fully optimized Linux shared-library build with IPO, the complete native
+test suite, installation, and downstream core, Kafka, and analytics SDK
+consumers. This deliberately expensive validation remains visible on pull
+requests and ``main`` without delaying or gating publication of wheel artifacts.
 The tag is the shared release version authority: the publish jobs restamp the
 metadata of artifacts already tested for that exact commit, rather than
 rebuilding them. The CMake ``project(VERSION)`` declarations identify the native

--- a/extensions/kafka/python/tests/test_packaging.py
+++ b/extensions/kafka/python/tests/test_packaging.py
@@ -105,7 +105,7 @@ def test_ci_builds_and_tests_separate_kafka_artifacts():
     release_workflow = (
         REPOSITORY_ROOT / ".github/workflows/release-wheels.yml"
     ).read_text()
-    workflow = "\n".join(
+    wheel_workflows = "\n".join(
         (
             release_workflow,
             (
@@ -116,6 +116,9 @@ def test_ci_builds_and_tests_separate_kafka_artifacts():
             ).read_text(),
         )
     )
+    native_workflow = (
+        REPOSITORY_ROOT / ".github/workflows/native-cpp.yml"
+    ).read_text()
 
     for artifact in (
         "kafka-distribution-sdist",
@@ -123,24 +126,25 @@ def test_ci_builds_and_tests_separate_kafka_artifacts():
         "kafka-distribution-wheel-ubuntu-latest",
         "kafka-distribution-wheel-windows-latest",
     ):
-        assert artifact in workflow
-    assert "python -m pytest extensions/kafka/python/tests -q" in workflow
-    assert "-DHGRAPH_BUILD_KAFKA_EXTENSION=ON" in workflow
+        assert artifact in wheel_workflows
+    assert "python -m pytest extensions/kafka/python/tests -q" in wheel_workflows
+    assert "-DHGRAPH_BUILD_KAFKA_EXTENSION=ON" in native_workflow
+    assert "Build and test installed Kafka consumer" in native_workflow
     assert '      - "*.*.*"' in release_workflow
     assert "hgraph-kafka-v_" not in release_workflow
-    assert "pattern: kafka-distribution-*" in workflow
+    assert "pattern: kafka-distribution-*" in wheel_workflows
     assert release_workflow.count(
         'python tools/restamp_distribution.py dist "$RELEASE_TAG"'
     ) == 3
-    assert "--wheel --no-isolation" in workflow
-    assert "--sdist --no-isolation" in workflow
-    assert "--skip-dependency-check" in workflow
+    assert "--wheel --no-isolation" in wheel_workflows
+    assert "--sdist --no-isolation" in wheel_workflows
+    assert "--skip-dependency-check" in wheel_workflows
     for dependency in (
         '"scikit-build-core==1.0.3"',
         '"nanobind==2.13.0"',
         '"ninja==1.13.0"',
         '"pyarrow==25.0.0"',
     ):
-        assert dependency in workflow
-    assert '"scikit-build-core>=0.11"' not in workflow
-    assert '"pyarrow>=25,<26"' not in workflow
+        assert dependency in wheel_workflows
+    assert '"scikit-build-core>=0.11"' not in wheel_workflows
+    assert '"pyarrow>=25,<26"' not in wheel_workflows

--- a/python/tests/test_packaging.py
+++ b/python/tests/test_packaging.py
@@ -215,7 +215,10 @@ def test_release_workflow_targets_supported_platforms():
     test_workflow = (
         ROOT / ".github/workflows/test-platform-wheel.yml"
     ).read_text()
-    combined_workflow = "\n".join((workflow, platform_workflow, test_workflow))
+    native_workflow = (ROOT / ".github/workflows/native-cpp.yml").read_text()
+    combined_workflow = "\n".join(
+        (workflow, platform_workflow, test_workflow, native_workflow)
+    )
     nightly_workflow = (
         ROOT / ".github/workflows/parity-nightly.yml"
     ).read_text()
@@ -234,8 +237,8 @@ def test_release_workflow_targets_supported_platforms():
     assert "--exclude libhgraph_stdlib.so" in workflow
     assert "--exclude libnanobind-abi3.so" in workflow
     assert "tests/python_extension_consumer/check.py" in combined_workflow
-    assert "libarrow-acero=25" in workflow
-    for linux_workflow in (workflow, nightly_workflow):
+    assert "libarrow-acero=25" in native_workflow
+    for linux_workflow in (nightly_workflow, native_workflow):
         assert 'GCC_VERSION: "14"' in linux_workflow
         assert 'command -v "gcc-$GCC_VERSION"' in linux_workflow
         assert 'command -v "g++-$GCC_VERSION"' in linux_workflow
@@ -308,6 +311,33 @@ def test_platform_wheel_tests_start_after_only_their_matching_build():
         for test_name in dependencies:
             assert f"needs.{test_name}.result == 'success'" in publish_job
             assert f"      - {test_name}\n" in publish_job
+
+
+def test_native_cpp_validation_is_independent_of_wheel_publication():
+    release_workflow = (ROOT / ".github/workflows/release-wheels.yml").read_text()
+    native_workflow = (ROOT / ".github/workflows/native-cpp.yml").read_text()
+
+    assert "  native-cpp:\n" not in release_workflow
+    assert "  native-install:\n" not in release_workflow
+    assert "needs.native-cpp.result" not in release_workflow
+    assert "needs.native-install.result" not in release_workflow
+    assert "  native-cpp:\n" in native_workflow
+    assert "  native-shared-install:\n" in native_workflow
+
+    shared_job = workflow_job(native_workflow, "native-shared-install")
+    assert "-DHGRAPH_BUILD_SHARED=ON" in shared_job
+    assert "Verify IPO is enabled" in shared_job
+    assert "-flto(=auto)?" in shared_job
+    assert "Run optimized shared C++ tests" in shared_job
+    assert "Build and test installed-package consumer" in shared_job
+    assert "Build and test installed Kafka consumer" in shared_job
+    assert "Build and test installed analytics consumer" in shared_job
+
+    for publish_name in ("publish", "publish-kafka", "publish-analytics"):
+        publish_job = workflow_job(release_workflow, publish_name)
+        assert "native-cpp" not in publish_job
+        assert "native-install" not in publish_job
+        assert "native-shared-install" not in publish_job
 
 
 def test_workflow_actions_are_pinned_to_immutable_commits():


### PR DESCRIPTION
## Summary

- move native Linux/macOS builds and the Linux shared-library install test into an independent `Native C++ validation` workflow
- retain the complete optimized shared build, native suite, installation, and core/Kafka/analytics installed-SDK consumer tests
- explicitly verify that the shared validation compiles hgraph with IPO/LTO enabled
- remove native jobs from all three PyPI publication dependency chains
- document and enforce the workflow separation through packaging contract tests

## Why

The shared Linux validation is intentionally expensive because release-mode shared libraries enable IPO/LTO. Recent runs spent roughly 14 minutes in the build step, with most of the tail in LTO linking, while tests and installed consumers completed in under a minute.

Those standalone libraries are validation artifacts and are discarded after the job. Wheel builds already exercise the optimized release artifacts that are actually published, so wheel publication should not wait for the separate standalone SDK validation.

## Behavior after this change

- `release-wheels.yml` builds, tests, and publishes the fully optimized platform wheels
- `native-cpp.yml` runs independently on pull requests and `main`
- the standalone Linux shared build retains full IPO/LTO so optimization-induced problems remain detectable
- the independent native workflow still tests Linux, macOS, the full shared native suite, installation, and all installed SDK consumers

## Validation

- packaging workflow contract tests: 23 passed
- all workflow YAML files parsed successfully
- Sphinx HTML build with warnings treated as errors
- `git diff --check`
