### PR TITLE
Fix generic higher-order TSB resolution

### DIFF
--- a/include/hgraph/lib/std/operators/impl/higher_order_impl.h
+++ b/include/hgraph/lib/std/operators/impl/higher_order_impl.h
@@ -136,6 +136,36 @@ namespace hgraph::stdlib
             return refs;
         }
 
+        /** Nested map-like runtimes rebind broadcast arguments from one root
+            output handle. A fixed TSB/TSL assembled from child ports has no
+            such root, so materialize its structural REF once in the parent.
+            The multiplexed inputs retain their collection storage and every
+            map/mesh child shares the live broadcast reference. */
+        inline void materialize_structural_broadcast_inputs(
+            Wiring &w,
+            std::vector<WiringPortRef> &inputs,
+            std::vector<const TSValueTypeMetaData *> &schemas,
+            std::span<const std::size_t> multiplexed_inputs)
+        {
+            auto &registry = TypeRegistry::instance();
+            for (std::size_t index = 0; index < inputs.size(); ++index)
+            {
+                if (std::find(multiplexed_inputs.begin(), multiplexed_inputs.end(), index) !=
+                        multiplexed_inputs.end() ||
+                    !inputs[index].is_structural_source())
+                {
+                    continue;
+                }
+
+                const auto tag = inputs[index].arg_tag;
+                inputs[index] = graph_wiring_detail::adapt_source_for_input(
+                    w, registry.ref(inputs[index].schema),
+                    std::move(inputs[index]));
+                inputs[index].arg_tag = tag;
+                schemas[index] = inputs[index].schema;
+            }
+        }
+
         inline void bind_graph_output(ResolutionMap &resolution,
                                       const TSValueTypeMetaData *output,
                                       std::string_view legacy_var = {})
@@ -3039,6 +3069,10 @@ namespace hgraph::stdlib
             // excluded from the inference. The runtime is always keys-driven;
             // there is no in-node union scan.
             auto &registry = TypeRegistry::instance();
+            materialize_structural_broadcast_inputs(
+                w, ordered, ts_schemas,
+                {spec.multiplexed_inputs.data(),
+                 spec.multiplexed_inputs.size()});
             WiringPortRef lifecycle_keys = wire_keyed_lifecycle_keys(
                 w, std::move(keys),
                 {spec.multiplexed_inputs.data(), spec.multiplexed_inputs.size()},
@@ -3190,6 +3224,11 @@ namespace hgraph::stdlib
                 w, std::move(external_services), ts_schemas, arg_tags, ordered);
 
             auto &registry = TypeRegistry::instance();
+
+            materialize_structural_broadcast_inputs(
+                w, ordered, ts_schemas,
+                {map_spec.multiplexed_inputs.data(),
+                 map_spec.multiplexed_inputs.size()});
 
             WiringPortRef lifecycle_keys = wire_keyed_lifecycle_keys(
                 w, std::move(keys),
@@ -4091,6 +4130,11 @@ namespace hgraph::stdlib
             }
             append_external_service_inputs(
                 w, std::move(external_services), ts_schemas, arg_tags, ordered);
+
+            materialize_structural_broadcast_inputs(
+                w, ordered, ts_schemas,
+                {spec.multiplexed_inputs.data(),
+                 spec.multiplexed_inputs.size()});
 
             std::vector<std::pair<std::string, const TSValueTypeMetaData *>> fields;
             fields.reserve(ts_schemas.size());

--- a/include/hgraph/lib/std/operators/impl/higher_order_impl.h
+++ b/include/hgraph/lib/std/operators/impl/higher_order_impl.h
@@ -122,15 +122,23 @@ namespace hgraph::stdlib
         }
 
         [[nodiscard]] inline std::vector<WiringInputRef> higher_order_input_refs(
-            std::span<const WiringPortRef> inputs)
+            std::span<const WiringPortRef> inputs,
+            std::span<const std::size_t> passive_materializers = {})
         {
             std::vector<WiringInputRef> refs;
             refs.reserve(inputs.size());
-            for (const WiringPortRef &input : inputs)
+            for (std::size_t index = 0; index < inputs.size(); ++index)
             {
                 refs.push_back(WiringInputRef{
-                    .source = input,
-                    .rank_dependency = input.arg_tag != WiringPortRef::ArgTag::Passive,
+                    .source = inputs[index],
+                    // Passive transports normally omit their producer edge so
+                    // higher-order feedback can close a cycle. A synthetic
+                    // materializer is the exception: the consumer needs its
+                    // initial REF publication before the first child sample.
+                    .rank_dependency =
+                        inputs[index].arg_tag != WiringPortRef::ArgTag::Passive ||
+                        std::find(passive_materializers.begin(), passive_materializers.end(), index) !=
+                            passive_materializers.end(),
                 });
             }
             return refs;
@@ -141,13 +149,14 @@ namespace hgraph::stdlib
             such root, so materialize its structural REF once in the parent.
             The multiplexed inputs retain their collection storage and every
             map/mesh child shares the live broadcast reference. */
-        inline void materialize_structural_broadcast_inputs(
+        [[nodiscard]] inline std::vector<std::size_t> materialize_structural_broadcast_inputs(
             Wiring &w,
             std::vector<WiringPortRef> &inputs,
             std::vector<const TSValueTypeMetaData *> &schemas,
             std::span<const std::size_t> multiplexed_inputs)
         {
             auto &registry = TypeRegistry::instance();
+            std::vector<std::size_t> passive_materializers;
             for (std::size_t index = 0; index < inputs.size(); ++index)
             {
                 if (std::find(multiplexed_inputs.begin(), multiplexed_inputs.end(), index) !=
@@ -158,12 +167,18 @@ namespace hgraph::stdlib
                 }
 
                 const auto tag = inputs[index].arg_tag;
+                inputs[index].arg_tag = WiringPortRef::ArgTag::None;
                 inputs[index] = graph_wiring_detail::adapt_source_for_input(
                     w, registry.ref(inputs[index].schema),
                     std::move(inputs[index]));
                 inputs[index].arg_tag = tag;
                 schemas[index] = inputs[index].schema;
+                if (tag == WiringPortRef::ArgTag::Passive)
+                {
+                    passive_materializers.push_back(index);
+                }
             }
+            return passive_materializers;
         }
 
         inline void bind_graph_output(ResolutionMap &resolution,
@@ -3069,7 +3084,7 @@ namespace hgraph::stdlib
             // excluded from the inference. The runtime is always keys-driven;
             // there is no in-node union scan.
             auto &registry = TypeRegistry::instance();
-            materialize_structural_broadcast_inputs(
+            const auto passive_materializers = materialize_structural_broadcast_inputs(
                 w, ordered, ts_schemas,
                 {spec.multiplexed_inputs.data(),
                  spec.multiplexed_inputs.size()});
@@ -3106,7 +3121,8 @@ namespace hgraph::stdlib
             // the scalar at the point of use.
             (void)scalar_descriptor<MapCallConfig>::value_meta();
             const auto input_refs = higher_order_input_refs(
-                std::span<const WiringPortRef>{inputs.data(), inputs.size()});
+                std::span<const WiringPortRef>{inputs.data(), inputs.size()},
+                {passive_materializers.data(), passive_materializers.size()});
             WiringPortRef out = w.add_node(
                 std::type_index(typeid(map_node_tag)), node_schema,
                 std::span<const WiringInputRef>{input_refs.data(), input_refs.size()},
@@ -3225,7 +3241,7 @@ namespace hgraph::stdlib
 
             auto &registry = TypeRegistry::instance();
 
-            materialize_structural_broadcast_inputs(
+            const auto passive_materializers = materialize_structural_broadcast_inputs(
                 w, ordered, ts_schemas,
                 {map_spec.multiplexed_inputs.data(),
                  map_spec.multiplexed_inputs.size()});
@@ -3269,7 +3285,8 @@ namespace hgraph::stdlib
 
             (void)scalar_descriptor<MapCallConfig>::value_meta();
             const auto input_refs = higher_order_input_refs(
-                std::span<const WiringPortRef>{inputs.data(), inputs.size()});
+                std::span<const WiringPortRef>{inputs.data(), inputs.size()},
+                {passive_materializers.data(), passive_materializers.size()});
             WiringPortRef out = w.add_node(
                 std::type_index(typeid(mesh_node_tag)), node_schema,
                 std::span<const WiringInputRef>{input_refs.data(), input_refs.size()},
@@ -4131,7 +4148,7 @@ namespace hgraph::stdlib
             append_external_service_inputs(
                 w, std::move(external_services), ts_schemas, arg_tags, ordered);
 
-            materialize_structural_broadcast_inputs(
+            const auto passive_materializers = materialize_structural_broadcast_inputs(
                 w, ordered, ts_schemas,
                 {spec.multiplexed_inputs.data(),
                  spec.multiplexed_inputs.size()});
@@ -4147,7 +4164,8 @@ namespace hgraph::stdlib
 
             (void)scalar_descriptor<MapCallConfig>::value_meta();
             const auto input_refs = higher_order_input_refs(
-                std::span<const WiringPortRef>{ordered.data(), ordered.size()});
+                std::span<const WiringPortRef>{ordered.data(), ordered.size()},
+                {passive_materializers.data(), passive_materializers.size()});
             return w.add_node(std::type_index(typeid(dynamic_tsl_map_node_tag)), node_schema,
                               std::span<const WiringInputRef>{input_refs.data(), input_refs.size()},
                               Value{MapCallConfig{func, Str{key_arg}, Str{}, arg_tags}}, [&]() {

--- a/include/hgraph/runtime/nested_bindings.h
+++ b/include/hgraph/runtime/nested_bindings.h
@@ -378,8 +378,10 @@ inline bool bind_forwarding_output_tree_to_source(TSOutputView target,
   if (!effective_source.bound()) {
     return clear_forwarding_output_tree(std::move(target), sampled);
   }
-  if (!time_series_schema_equivalent(target.schema(),
-                                     effective_source.schema())) {
+  auto &registry = TypeRegistry::instance();
+  if (!time_series_schema_equivalent(
+          registry.dereference(target.schema()),
+          registry.dereference(effective_source.schema()))) {
     throw std::logic_error("Forwarding output tree source schema '" +
                            (effective_source.schema() != nullptr
                                 ? std::string{effective_source.schema()->name()}

--- a/python/hgraph/_wiring/_graph.py
+++ b/python/hgraph/_wiring/_graph.py
@@ -1,6 +1,7 @@
 """_GraphFn/@graph, graph-fn wrapping (the borrowed-wiring re-entry),
 signature auto-resolution and @component."""
 import inspect
+from collections.abc import Mapping
 
 import _hgraph
 
@@ -8,7 +9,7 @@ from .._types import (_ContextExpr, _GenericTsExpr, _TsExpr,
                       _TypeVarSentinel, _pattern_of, _type_var_name)
 from ._core import (ParseError, WiringError, WiringPort, _current_wiring,
                     _resolve_context, _unwrap, _wiring_stack, wire)
-from ._markers import _INJECTABLE_MARKERS
+from ._markers import _INJECTABLE_MARKERS, _annotation_ts_kind
 from ._node import (_PyNode, _is_time_series_annotation,
                     _lift_time_series_argument, _warn_deprecated)
 from ._operator import _register_overload, _run_requires
@@ -152,6 +153,12 @@ def _prepare_higher_order_call(func, args, kwargs, *, default_key_arg):
         if _is_time_series_annotation(parameter.annotation):
             input_names.append(parameter.name)
             if value is not inspect.Parameter.empty:
+                if (not isinstance(value, WiringPort)
+                        and isinstance(value, Mapping)
+                        and _annotation_ts_kind(parameter.annotation)
+                        == _hgraph.TS_KIND_TSB):
+                    value = _lift_time_series_argument(
+                        value, parameter.annotation)
                 prepared_args.append(value)
             continue
         if parameter.annotation is inspect.Parameter.empty:

--- a/python/hgraph/_wiring/_node.py
+++ b/python/hgraph/_wiring/_node.py
@@ -3,6 +3,7 @@ normalisation), @compute_node/@sink_node, lift, @generator, push_queue."""
 import inspect
 import typing
 import warnings
+from collections.abc import Mapping
 from copy import copy
 
 import _hgraph
@@ -68,6 +69,23 @@ def _lift_time_series_argument(value, annotation):
     """Lift a plain Python value to the time-series shape declared by a
     graph or node parameter, retaining nominal CompoundScalar schemas when
     the annotation itself is generic."""
+    if (_annotation_ts_kind(annotation) == _hgraph.TS_KIND_TSB
+            and isinstance(value, Mapping)):
+        if not all(isinstance(name, str) for name in value):
+            raise TypeError("TSB field names must be strings")
+        if isinstance(annotation, _TsExpr):
+            return annotation.from_ts(**value)
+
+        lifted = {}
+        for name, field_value in value.items():
+            if not isinstance(field_value, WiringPort):
+                field_value = wire("const", field_value)
+            lifted[name] = _unwrap(field_value)
+
+        tsb_type = _hgraph.un_named_tsb_type(
+            [(name, port.ts_type) for name, port in lifted.items()])
+        return WiringPort(_hgraph.tsb_port(tsb_type, lifted))
+
     if isinstance(annotation, _TsExpr):
         return wire("const", value, output_type=annotation)
 

--- a/python/tests/ported/_wiring/test_map_regressions.py
+++ b/python/tests/ported/_wiring/test_map_regressions.py
@@ -183,6 +183,42 @@ def test_map_generic_bundle_parameter_accepts_keyword_mapping():
     ]
 
 
+def test_map_passive_structural_bundle_materializes_before_child_binding():
+    class Params(hg.TimeSeriesSchema):
+        flag: hg.TS[bool]
+        limit: hg.TS[int]
+
+    @hg.graph
+    def child(
+        value: hg.TS[int], params: hg.TSB[hg.TS_SCHEMA],
+    ) -> hg.TS[int]:
+        resolved = hg.dereference(params)
+        return hg.if_then_else(
+            resolved.flag, value + resolved.limit, value - resolved.limit,
+        )
+
+    @hg.graph
+    def app(
+        values: hg.TSD[str, hg.TS[int]],
+        flag: hg.TS[bool],
+        limit: hg.TS[int],
+    ) -> hg.TSD[str, hg.TS[int]]:
+        params = hg.passive(hg.TSB[Params].from_ts(flag=flag, limit=limit))
+        return hg.map_(
+            child, value=values, params=params, __keys__=values.key_set,
+        )
+
+    assert eval_node(
+        app,
+        [{"a": 2, "b": 3}, {"a": 4, "b": 5}],
+        [True, False],
+        [10, 5],
+    ) == [
+        {"a": 12, "b": 13},
+        {"a": -1, "b": 0},
+    ]
+
+
 def test_key_only_map_combines_captured_reference_fields():
     @hg.graph
     def app(

--- a/python/tests/ported/_wiring/test_map_regressions.py
+++ b/python/tests/ported/_wiring/test_map_regressions.py
@@ -145,6 +145,44 @@ def test_map_generic_bundle_child_can_dereference_its_element():
     ]
 
 
+def test_map_generic_bundle_parameter_accepts_keyword_mapping():
+    @hg.graph
+    def handler(
+        value: hg.TS[int], flag: hg.TS[bool], limit: hg.TS[int],
+    ) -> hg.TS[int]:
+        return hg.if_then_else(flag, value + limit, value - limit)
+
+    @hg.graph
+    def child(
+        value: hg.TS[int], params: hg.TSB[hg.TS_SCHEMA],
+    ) -> hg.TS[int]:
+        resolved = hg.dereference(params)
+        return handler(value=value, **resolved)
+
+    @hg.graph
+    def app(
+        values: hg.TSD[str, hg.TS[int]],
+        flag: hg.TS[bool],
+        limit: hg.TS[int],
+    ) -> hg.TSD[str, hg.TS[int]]:
+        return hg.map_(
+            child,
+            value=values,
+            params={"flag": flag, "limit": limit},
+            __keys__=values.key_set,
+        )
+
+    assert eval_node(
+        app,
+        [{"a": 2, "b": 3}, None],
+        [True, False],
+        [10, 5],
+    ) == [
+        {"a": 12, "b": 13},
+        {"a": -3, "b": -2},
+    ]
+
+
 def test_key_only_map_combines_captured_reference_fields():
     @hg.graph
     def app(

--- a/python/tests/ported/_wiring/test_reduce.py
+++ b/python/tests/ported/_wiring/test_reduce.py
@@ -7,12 +7,16 @@ from hgraph import (
     REMOVE_IF_EXISTS,
     Size,
     TS,
+    TSB,
     TSD,
+    TS_SCHEMA,
     TSL,
+    TimeSeriesSchema,
     add_,
     compute_node,
     const,
     default,
+    dereference,
     graph,
     map_,
     reduce,
@@ -184,6 +188,27 @@ def test_tsl_reduce_uses_the_same_zero_cardinality_rules():
 
 def test_tsd_reduce_preserves_explicit_none_as_an_unset_zero():
     assert eval_node(_sum_with_none_zero, [None, {"a": 1, "b": 2}]) == [None, 3]
+
+
+def test_tsd_reduce_accepts_generic_bundle_combiner_reference_fields():
+    class Params(TimeSeriesSchema):
+        value: TS[int]
+
+    @graph
+    def keep_lhs(
+        lhs: TSB[TS_SCHEMA], rhs: TSB[TS_SCHEMA],
+    ) -> TSB[TS_SCHEMA]:
+        del rhs
+        return dereference(lhs)
+
+    @graph
+    def app(values: TSD[str, TSB[Params]]) -> TSB[Params]:
+        return reduce(keep_lhs, values)
+
+    assert eval_node(
+        app,
+        [{"a": {"value": 7}, "b": {"value": 7}}],
+    ) == [{"value": 7}]
 
 
 def test_tsd_reduce_wires_three_argument_map_inside_combiner():

--- a/python/tests/test_mesh_map_classification.py
+++ b/python/tests/test_mesh_map_classification.py
@@ -9,6 +9,7 @@ from hgraph import (
     TSD,
     TS_SCHEMA,
     TSS,
+    TimeSeriesSchema,
     WiringError,
     compute_node,
     dereference,
@@ -17,6 +18,7 @@ from hgraph import (
     len_,
     mesh_,
     no_key,
+    passive,
     pass_through,
 )
 from hgraph.test import eval_node
@@ -158,6 +160,38 @@ def test_mesh_generic_bundle_parameter_accepts_keyword_mapping():
     ) == [
         {"a": 12, "b": 13},
         {"a": -3, "b": -2},
+    ]
+
+
+def test_mesh_passive_structural_bundle_materializes_before_child_binding():
+    class Params(TimeSeriesSchema):
+        flag: TS[bool]
+        limit: TS[int]
+
+    @graph
+    def child(value: TS[int], params: TSB[TS_SCHEMA]) -> TS[int]:
+        resolved = dereference(params)
+        return if_then_else(
+            resolved.flag, value + resolved.limit, value - resolved.limit,
+        )
+
+    @graph
+    def g(
+        values: TSD[str, TS[int]], flag: TS[bool], limit: TS[int],
+    ) -> TSD[str, TS[int]]:
+        params = passive(TSB[Params].from_ts(flag=flag, limit=limit))
+        return mesh_(
+            child, value=values, params=params, __keys__=values.key_set,
+        )
+
+    assert eval_node(
+        g,
+        [{"a": 2, "b": 3}, {"a": 4, "b": 5}],
+        [True, False],
+        [10, 5],
+    ) == [
+        {"a": 12, "b": 13},
+        {"a": -1, "b": 0},
     ]
 
 

--- a/python/tests/test_mesh_map_classification.py
+++ b/python/tests/test_mesh_map_classification.py
@@ -5,11 +5,15 @@ import pytest
 from hgraph import (
     TIME_SERIES_TYPE,
     TS,
+    TSB,
     TSD,
+    TS_SCHEMA,
     TSS,
     WiringError,
     compute_node,
+    dereference,
     graph,
+    if_then_else,
     len_,
     mesh_,
     no_key,
@@ -121,6 +125,40 @@ def test_mesh_non_tsd_generic_input_is_direct():
         [{"a": 1, "b": 2}, None],
         [10, 20],
     ) == [{"a": 11, "b": 12}, {"a": 21, "b": 22}]
+
+
+def test_mesh_generic_bundle_parameter_accepts_keyword_mapping():
+    @graph
+    def handler(
+        value: TS[int], flag: TS[bool], limit: TS[int],
+    ) -> TS[int]:
+        return if_then_else(flag, value + limit, value - limit)
+
+    @graph
+    def child(value: TS[int], params: TSB[TS_SCHEMA]) -> TS[int]:
+        resolved = dereference(params)
+        return handler(value=value, **resolved)
+
+    @graph
+    def g(
+        values: TSD[str, TS[int]], flag: TS[bool], limit: TS[int],
+    ) -> TSD[str, TS[int]]:
+        return mesh_(
+            child,
+            value=values,
+            params={"flag": flag, "limit": limit},
+            __keys__=values.key_set,
+        )
+
+    assert eval_node(
+        g,
+        [{"a": 2, "b": 3}, None],
+        [True, False],
+        [10, 5],
+    ) == [
+        {"a": 12, "b": 13},
+        {"a": -3, "b": -2},
+    ]
 
 
 def test_mesh_concrete_tsd_before_first_multiplexed_input_is_direct():

--- a/tests/cpp/test_map.cpp
+++ b/tests/cpp/test_map.cpp
@@ -247,6 +247,51 @@ namespace
         }
     };
 
+    using MappedKeywordParams =
+        UnNamedTSB<Field<"flag", TS<Bool>>, Field<"limit", TS<Int>>>;
+    using MappedKeywordParamRefs =
+        UnNamedTSB<Field<"flag", REF<TS<Bool>>>,
+                     Field<"limit", REF<TS<Int>>>>;
+
+    struct MappedKeywordParamsChildG
+    {
+        static constexpr auto name = "mapped_keyword_params_child_g";
+
+        static Port<TS<Int>> compose(
+            Wiring &w, NamedPort<"value", TS<Int>> value,
+            NamedPort<"params", MappedKeywordParams> params)
+        {
+            using namespace hgraph::stdlib::syntax;
+            auto resolved = wire<stdlib::dereference>(w, params)
+                                .as<MappedKeywordParamRefs>();
+            auto flag = wire<stdlib::getattr_>(w, resolved, Str{"flag"})
+                            .as<REF<TS<Bool>>>();
+            auto limit = wire<stdlib::getattr_>(w, resolved, Str{"limit"})
+                             .as<REF<TS<Int>>>();
+            auto accepted = (value + limit).as<TS<Int>>();
+            auto rejected = (value - limit).as<TS<Int>>();
+            return wire<stdlib::if_then_else>(w, flag, accepted, rejected)
+                .as<TS<Int>>();
+        }
+    };
+
+    struct MapBundledKeywordParamsG
+    {
+        static constexpr auto name = "map_bundled_keyword_params_g";
+
+        static Port<TSD<Str, TS<Int>>> compose(
+            Wiring &w, Port<TSD<Str, TS<Int>>> values,
+            Port<TS<Bool>> flag, Port<TS<Int>> limit, Port<TSS<Str>> keys)
+        {
+            auto params = stdlib::to_tsb<MappedKeywordParams>(w, flag, limit);
+            return wire<stdlib::map_>(
+                       w, fn<MappedKeywordParamsChildG>(),
+                       arg<"value">(values), arg<"params">(params),
+                       arg<"__keys__">(keys))
+                .as<TSD<Str, TS<Int>>>();
+        }
+    };
+
     using CapturedMapReferenceBundle =
         UnNamedTSB<Field<"status", REF<TS<Bool>>>,
                      Field<"rejected", REF<TS<Bool>>>>;
@@ -1582,6 +1627,22 @@ TEST_CASE("map_: a direct TSB child boundary can be dereferenced")
                 {{"right"s,
                   tsb_delta<DereferencedMappedBundle>(Int{3})}}),
             dict_delta<Str, DereferencedMappedBundle>({}, {"left"s})));
+}
+
+TEST_CASE("map_: a structural TSB broadcast binds through a named child parameter")
+{
+    using namespace hgraph;
+    stdlib::register_standard_operators();
+
+    CHECK_OUTPUT(
+        eval_node<MapBundledKeywordParamsG>(
+            values<Value>(
+                dict_delta<Str, TS<Int>>({{"a"s, 2}, {"b"s, 3}}), none),
+            values<Bool>(true, false), values<Int>(10, 5),
+            values<Value>(set_delta<Str>({"a"s, "b"s}, {}), none)),
+        values<Value>(
+            dict_delta<Str, TS<Int>>({{"a"s, 12}, {"b"s, 13}}),
+            dict_delta<Str, TS<Int>>({{"a"s, -3}, {"b"s, -2}})));
 }
 
 TEST_CASE("map_: a structural child preserves captured REF fields")

--- a/tests/cpp/test_map.cpp
+++ b/tests/cpp/test_map.cpp
@@ -292,6 +292,24 @@ namespace
         }
     };
 
+    struct MapPassiveBundledKeywordParamsG
+    {
+        static constexpr auto name = "map_passive_bundled_keyword_params_g";
+
+        static Port<TSD<Str, TS<Int>>> compose(
+            Wiring &w, Port<TSD<Str, TS<Int>>> values,
+            Port<TS<Bool>> flag, Port<TS<Int>> limit, Port<TSS<Str>> keys)
+        {
+            auto params = passive(
+                stdlib::to_tsb<MappedKeywordParams>(w, flag, limit));
+            return wire<stdlib::map_>(
+                       w, fn<MappedKeywordParamsChildG>(),
+                       arg<"value">(values), arg<"params">(params),
+                       arg<"__keys__">(keys))
+                .as<TSD<Str, TS<Int>>>();
+        }
+    };
+
     using CapturedMapReferenceBundle =
         UnNamedTSB<Field<"status", REF<TS<Bool>>>,
                      Field<"rejected", REF<TS<Bool>>>>;
@@ -1643,6 +1661,23 @@ TEST_CASE("map_: a structural TSB broadcast binds through a named child paramete
         values<Value>(
             dict_delta<Str, TS<Int>>({{"a"s, 12}, {"b"s, 13}}),
             dict_delta<Str, TS<Int>>({{"a"s, -3}, {"b"s, -2}})));
+}
+
+TEST_CASE("map_: a passive structural TSB broadcast materializes before child binding")
+{
+    using namespace hgraph;
+    stdlib::register_standard_operators();
+
+    CHECK_OUTPUT(
+        eval_node<MapPassiveBundledKeywordParamsG>(
+            values<Value>(
+                dict_delta<Str, TS<Int>>({{"a"s, 2}, {"b"s, 3}}),
+                dict_delta<Str, TS<Int>>({{"a"s, 4}, {"b"s, 5}})),
+            values<Bool>(true, false), values<Int>(10, 5),
+            values<Value>(set_delta<Str>({"a"s, "b"s}, {}), none)),
+        values<Value>(
+            dict_delta<Str, TS<Int>>({{"a"s, 12}, {"b"s, 13}}),
+            dict_delta<Str, TS<Int>>({{"a"s, -1}, {"b"s, 0}})));
 }
 
 TEST_CASE("map_: a structural child preserves captured REF fields")

--- a/tests/cpp/test_mesh.cpp
+++ b/tests/cpp/test_mesh.cpp
@@ -214,6 +214,22 @@ struct MeshBundledKeywordParamsG {
   }
 };
 
+struct MeshPassiveBundledKeywordParamsG {
+  static constexpr auto name = "mesh_passive_bundled_keyword_params_g";
+
+  static Port<TSD<Str, TS<Int>>>
+  compose(Wiring &w, Port<TSD<Str, TS<Int>>> values,
+          Port<TS<Bool>> flag, Port<TS<Int>> limit,
+          Port<TSS<Str>> keys) {
+    auto params = passive(stdlib::to_tsb<MeshKeywordParams>(w, flag, limit));
+    return wire<stdlib::mesh_>(w, fn<MeshKeywordParamsChildG>(),
+                               arg<"value">(values),
+                               arg<"params">(params),
+                               arg<"__keys__">(keys))
+        .as<TSD<Str, TS<Int>>>();
+  }
+};
+
 struct ConcreteDictSizeG {
   static constexpr auto name = "mesh_concrete_dict_size_g";
   static Port<TS<Int>> compose(Wiring &w,
@@ -696,6 +712,22 @@ TEST_CASE("mesh_: a structural TSB broadcast binds through a named child paramet
       values<Value>(
           dict_delta<Str, TS<Int>>({{"a"s, 12}, {"b"s, 13}}),
           dict_delta<Str, TS<Int>>({{"a"s, -3}, {"b"s, -2}})));
+}
+
+TEST_CASE("mesh_: a passive structural TSB broadcast materializes before child binding") {
+  using namespace hgraph;
+  stdlib::register_standard_operators();
+
+  CHECK_OUTPUT(
+      eval_node<MeshPassiveBundledKeywordParamsG>(
+          values<Value>(
+              dict_delta<Str, TS<Int>>({{"a"s, 2}, {"b"s, 3}}),
+              dict_delta<Str, TS<Int>>({{"a"s, 4}, {"b"s, 5}})),
+          values<Bool>(true, false), values<Int>(10, 5),
+          values<Value>(set_delta<Str>({"a"s, "b"s}, {}), none)),
+      values<Value>(
+          dict_delta<Str, TS<Int>>({{"a"s, 12}, {"b"s, 13}}),
+          dict_delta<Str, TS<Int>>({{"a"s, -1}, {"b"s, 0}})));
 }
 
 TEST_CASE(

--- a/tests/cpp/test_mesh.cpp
+++ b/tests/cpp/test_mesh.cpp
@@ -172,6 +172,48 @@ struct MeshGenericOffsetG {
   }
 };
 
+using MeshKeywordParams =
+    UnNamedTSB<Field<"flag", TS<Bool>>, Field<"limit", TS<Int>>>;
+using MeshKeywordParamRefs =
+    UnNamedTSB<Field<"flag", REF<TS<Bool>>>,
+               Field<"limit", REF<TS<Int>>>>;
+
+struct MeshKeywordParamsChildG {
+  static constexpr auto name = "mesh_keyword_params_child_g";
+
+  static Port<TS<Int>>
+  compose(Wiring &w, NamedPort<"value", TS<Int>> value,
+          NamedPort<"params", MeshKeywordParams> params) {
+    using namespace hgraph::stdlib::syntax;
+    auto resolved = wire<stdlib::dereference>(w, params)
+                        .as<MeshKeywordParamRefs>();
+    auto flag = wire<stdlib::getattr_>(w, resolved, Str{"flag"})
+                    .as<REF<TS<Bool>>>();
+    auto limit = wire<stdlib::getattr_>(w, resolved, Str{"limit"})
+                     .as<REF<TS<Int>>>();
+    auto accepted = (value + limit).as<TS<Int>>();
+    auto rejected = (value - limit).as<TS<Int>>();
+    return wire<stdlib::if_then_else>(w, flag, accepted, rejected)
+        .as<TS<Int>>();
+  }
+};
+
+struct MeshBundledKeywordParamsG {
+  static constexpr auto name = "mesh_bundled_keyword_params_g";
+
+  static Port<TSD<Str, TS<Int>>>
+  compose(Wiring &w, Port<TSD<Str, TS<Int>>> values,
+          Port<TS<Bool>> flag, Port<TS<Int>> limit,
+          Port<TSS<Str>> keys) {
+    auto params = stdlib::to_tsb<MeshKeywordParams>(w, flag, limit);
+    return wire<stdlib::mesh_>(w, fn<MeshKeywordParamsChildG>(),
+                               arg<"value">(values),
+                               arg<"params">(params),
+                               arg<"__keys__">(keys))
+        .as<TSD<Str, TS<Int>>>();
+  }
+};
+
 struct ConcreteDictSizeG {
   static constexpr auto name = "mesh_concrete_dict_size_g";
   static Port<TS<Int>> compose(Wiring &w,
@@ -639,6 +681,21 @@ TEST_CASE("mesh_: a non-TSD passed to a generic child parameter is direct") {
           values<Int>(10, 20))),
       values<Value>(dict_delta<Str, TS<Int>>({{"a"s, 11}, {"b"s, 12}}),
                     dict_delta<Str, TS<Int>>({{"a"s, 21}, {"b"s, 22}})));
+}
+
+TEST_CASE("mesh_: a structural TSB broadcast binds through a named child parameter") {
+  using namespace hgraph;
+  stdlib::register_standard_operators();
+
+  CHECK_OUTPUT(
+      eval_node<MeshBundledKeywordParamsG>(
+          values<Value>(
+              dict_delta<Str, TS<Int>>({{"a"s, 2}, {"b"s, 3}}), none),
+          values<Bool>(true, false), values<Int>(10, 5),
+          values<Value>(set_delta<Str>({"a"s, "b"s}, {}), none)),
+      values<Value>(
+          dict_delta<Str, TS<Int>>({{"a"s, 12}, {"b"s, 13}}),
+          dict_delta<Str, TS<Int>>({{"a"s, -3}, {"b"s, -2}})));
 }
 
 TEST_CASE(

--- a/tests/cpp/test_reduce.cpp
+++ b/tests/cpp/test_reduce.cpp
@@ -222,6 +222,34 @@ namespace
         }
     };
 
+    using ReduceReferenceBundle = UnNamedTSB<Field<"value", TS<Int>>>;
+
+    struct KeepLeftReferencedBundleG
+    {
+        static constexpr auto name = "keep_left_referenced_bundle_g";
+
+        static Port<ReduceReferenceBundle> compose(
+            Wiring &w, Port<ReduceReferenceBundle> lhs,
+            Port<ReduceReferenceBundle>)
+        {
+            return wire<stdlib::dereference>(w, lhs)
+                .as<ReduceReferenceBundle>();
+        }
+    };
+
+    struct ReduceReferencedBundleG
+    {
+        static constexpr auto name = "reduce_referenced_bundle_g";
+
+        static Port<ReduceReferenceBundle> compose(
+            Wiring &w, Port<TSD<Str, ReduceReferenceBundle>> values)
+        {
+            return wire<stdlib::reduce_>(
+                       w, fn<KeepLeftReferencedBundleG>(), values)
+                .as<ReduceReferenceBundle>();
+        }
+    };
+
     // Specialised reduce overload: concrete TSL<TS<Int>, 2>, gated on the wired
     // function's identity — selected over the generic default by requires_.
     struct ReduceFirstTimes100
@@ -911,6 +939,20 @@ TEST_CASE("reduce over TSD: fixed composite results remain projectable and follo
                       tsb_delta<ReduceBundle>(Int{1}, Int{2}),
                       tsb_delta<ReduceBundle>(Int{4}, Int{6}),
                       tsb_delta<ReduceBundle>(Int{3}, Int{4})));
+}
+
+TEST_CASE("reduce over TSD: generic bundle reference fields forward through the result")
+{
+    using namespace hgraph;
+    using namespace std::string_literals;
+    stdlib::register_standard_operators();
+
+    CHECK_OUTPUT(
+        eval_node<ReduceReferencedBundleG>(
+            values<Value>(dict_delta<Str, ReduceReferenceBundle>(
+                {{"a"s, tsb_delta<ReduceReferenceBundle>(Int{7})},
+                 {"b"s, tsb_delta<ReduceReferenceBundle>(Int{7})}}))),
+        values<Value>(tsb_delta<ReduceReferenceBundle>(Int{7})));
 }
 
 TEST_CASE("reduce over TSD: keys added over time grow the tree")


### PR DESCRIPTION
## Summary

- lift mapping-shaped arguments as structural TSB inputs when a graph or higher-order child declares `TSB[TS_SCHEMA]`
- materialize non-peered structural broadcast inputs through one native helper shared by keyed `map_`, `mesh_`, and dynamic-TSL `map_`
- compare recursively dereferenced schemas in the shared nested-output forwarding path, allowing logically identical `REF[TSB]` and `TSB` results in reduce and other nested graphs
- add equivalent public C++ and Python regressions for map, mesh, and reduce

## Root cause

Python wiring treated a dictionary of time-series ports as a scalar mapping before generic TSB resolution. Once represented structurally, map-like runtimes still assumed every broadcast input had a single peered root output, which an assembled TSB does not have.

Separately, nested result forwarding compared the decorated source schema directly with the endpoint schema. A combiner returning a bundle whose fields were references therefore failed even when recursively dereferencing both schemas produced the same logical bundle.

## Impact

Generic bundled keyword parameters such as:

```python
map_(
    child,
    value=values,
    params={"flag": flag, "limit": limit},
    __keys__=values.key_set,
)
```

now resolve and execute consistently. The native structural broadcast fix is shared by map, mesh, and dynamic-list map. The forwarding compatibility fix is shared by reduce and other nested-output users.

This is a follow-up to #448, which is already merged.

## Validation

- macOS clean native configure/build: passed
- macOS C++ suite: 1,523 passed
- macOS Python 3.14 non-WIP suite using a Python 3.12-built stable-ABI wheel: 2,094 passed, 9 skipped
- Linux GCC clean native configure/build: passed
- Linux C++ suite: 1,523 passed
- Linux Python 3.14 non-WIP suite using a Python 3.12-built stable-ABI wheel: 2,094 passed, 9 skipped
- differential parity PR campaign: 181 attempted, zero new mismatches or quarantines
- focused Python files: 27 passed
- `git diff --check`: passed