### PR TITLE
Compose nested registered table type operations

### DIFF
--- a/docs/source/developer_guide/record_replay_table.rst
+++ b/docs/source/developer_guide/record_replay_table.rst
@@ -659,6 +659,14 @@ time-series schema before wiring. The registry selects it while building the
 interned layout; evaluation performs no lookup and holds no strategy-specific
 container.
 
+Exact child strategies compose beneath built-in ``TSB`` and ``TSD`` layouts.
+The builder interns the child's own plan, projects its columns into the parent,
+and records that projection in the parent plan. Emission and application then
+delegate through the child's selected operations without another registry
+lookup. An embedded strategy must describe and emit a single row; combining a
+multi-row child with sibling structural fields has no unambiguous row product
+and is rejected while the layout is built.
+
 Direct tuple-row application and persisted Arrow replay both adapt their
 input to ``TableRowSource`` and call the selected ``apply`` function. This is
 the important inverse guarantee: an extension does not acquire a separate

--- a/docs/source/developer_guide/record_replay_table.rst
+++ b/docs/source/developer_guide/record_replay_table.rst
@@ -661,11 +661,14 @@ container.
 
 Exact child strategies compose beneath built-in ``TSB`` and ``TSD`` layouts.
 The builder interns the child's own plan, projects its columns into the parent,
-and records that projection in the parent plan. Emission and application then
-delegate through the child's selected operations without another registry
-lookup. An embedded strategy must describe and emit a single row; combining a
-multi-row child with sibling structural fields has no unambiguous row product
-and is rejected while the layout is built.
+and records that projection in the parent plan. A dedicated boolean column
+records whether the child emitted a row; presence is not inferred from payload
+nullability, so strategies with no value columns and valid all-null rows retain
+their update semantics. Emission and application then delegate through the
+child's selected operations without another registry lookup. An embedded
+strategy must describe and emit a single row; combining a multi-row child with
+sibling structural fields has no unambiguous row product and is rejected while
+the layout is built.
 
 Direct tuple-row application and persisted Arrow replay both adapt their
 input to ``TableRowSource`` and call the selected ``apply`` function. This is

--- a/docs/source/rfc/rfc_0019_native_table_recording.rst
+++ b/docs/source/rfc/rfc_0019_native_table_recording.rst
@@ -559,6 +559,14 @@ resulting Plan. The selected ops pointer is stored in that plan, so direct
 ``from_table`` and stored replay use the same ``TableRowSource`` contract.
 Default and unsupported states use a canonical non-null no-op table.
 
+When an exact registered schema is nested below a built-in ``TSB`` or ``TSD``,
+the parent plan retains the independently interned child plan and a local-to-
+parent column projection. The parent owns structural columns and row formation;
+the child owns conversion of its value columns through the same ``emit`` and
+``apply`` operations it uses at the root. Embedded multi-row strategies are
+rejected because combining their rows with sibling structural fields would
+require a separate row-product policy.
+
 Two constraints bound the design:
 
 * **Ops resolve at BUILD time into the Plan, never per tick.** The per-tick
@@ -693,7 +701,8 @@ Acceptance criteria
 * ``date_key`` and ``as_of_key`` may be renamed per recording and replayed
   through the corresponding projection without changing graph configuration.
 * A statically registered exact-schema ``TableTypeOps`` controls describe,
-  emit, direct apply, and persisted replay through one non-null passive table.
+  emit, direct apply, and persisted replay through one non-null passive table,
+  both at the root and beneath built-in ``TSB``/``TSD`` structure.
 * The installed SDK can include ``table_type_ops.h``, register an operation
   table, and consume the canonical no-op table without depending on private
   representation headers.

--- a/docs/source/rfc/rfc_0019_native_table_recording.rst
+++ b/docs/source/rfc/rfc_0019_native_table_recording.rst
@@ -563,8 +563,10 @@ When an exact registered schema is nested below a built-in ``TSB`` or ``TSD``,
 the parent plan retains the independently interned child plan and a local-to-
 parent column projection. The parent owns structural columns and row formation;
 the child owns conversion of its value columns through the same ``emit`` and
-``apply`` operations it uses at the root. Embedded multi-row strategies are
-rejected because combining their rows with sibling structural fields would
+``apply`` operations it uses at the root. Each child projection includes an
+explicit boolean presence column, since a valid emitted row may contain only
+null payload cells or no payload columns at all. Embedded multi-row strategies
+are rejected because combining their rows with sibling structural fields would
 require a separate row-product policy.
 
 Two constraints bound the design:

--- a/include/hgraph/types/table_type_ops.h
+++ b/include/hgraph/types/table_type_ops.h
@@ -64,6 +64,8 @@ namespace hgraph
             schema. ``ts_path`` locates the child below the structural leaf and
             ``columns`` maps the child's canonical column indexes into this
             layout. A ``no_column`` entry suppresses an unmapped child column.
+            ``presence_column`` records that the child emitted a row independently
+            of whether any projected payload cell has a value.
 
             This is plan data only: the selected child operations are reached
             through ``layout->ops`` and no registry lookup occurs during
@@ -73,6 +75,7 @@ namespace hgraph
             const TableLayout       *layout{nullptr};
             std::vector<std::size_t> ts_path{};
             std::vector<std::size_t> columns{};
+            std::size_t              presence_column{no_column};
         };
 
         struct Level

--- a/include/hgraph/types/table_type_ops.h
+++ b/include/hgraph/types/table_type_ops.h
@@ -46,12 +46,33 @@ namespace hgraph
     /** Interned table plan for one resolved time-series schema. */
     struct TableLayout
     {
+        static constexpr std::size_t no_column = static_cast<std::size_t>(-1);
+
         struct Column
         {
             std::string              name{};
             const ValueTypeMetaData *leaf{nullptr};
+            std::size_t              column{no_column};
             std::vector<std::size_t> ts_path{};
             std::vector<std::size_t> value_path{};
+        };
+
+        /** A registered child strategy composed into a built-in structural
+            layout.
+
+            ``layout`` is the independently interned plan for that exact child
+            schema. ``ts_path`` locates the child below the structural leaf and
+            ``columns`` maps the child's canonical column indexes into this
+            layout. A ``no_column`` entry suppresses an unmapped child column.
+
+            This is plan data only: the selected child operations are reached
+            through ``layout->ops`` and no registry lookup occurs during
+            evaluation. */
+        struct ChildPlan
+        {
+            const TableLayout       *layout{nullptr};
+            std::vector<std::size_t> ts_path{};
+            std::vector<std::size_t> columns{};
         };
 
         struct Level
@@ -67,6 +88,7 @@ namespace hgraph
         const TableTypeOps                    *ops{&empty_table_type_ops()};
         std::vector<Level>                     levels{};
         std::vector<Column>                    value_cols{};
+        std::vector<ChildPlan>                 child_plans{};
         std::size_t                            value_col_start{0};
         bool                                   is_multi_row{false};
         const TableConverter                  *frame_converter{nullptr};
@@ -123,8 +145,11 @@ namespace hgraph
         ``describe`` contributes structural/value columns and may recursively
         resolve child schemas. ``emit`` and ``apply`` are parked in the plan,
         so evaluation performs no registry lookup or kind switch. Extensions
-        can register an exact schema before wiring; the function table and its
-        referenced code must have static lifetime. */
+        can register an exact schema before wiring. When that schema appears
+        below a built-in TSB or TSD, the layout builder composes its independently
+        interned plan as a ``ChildPlan`` and evaluation delegates through the
+        same operation table. The function table and its referenced code must
+        have static lifetime. */
     struct TableTypeOps
     {
         using Describe = void (*)(TableLayout &layout, const TSValueTypeMetaData *schema,

--- a/src/hgraph/lib/std/operators/table_impl.cpp
+++ b/src/hgraph/lib/std/operators/table_impl.cpp
@@ -252,6 +252,66 @@ namespace hgraph::stdlib
                 }
             }
 
+            /** Compose an exact child override into the structural plan.
+
+                Built-in children describe directly into their parent as
+                before. A registered child is first built as its own canonical
+                layout, then its value columns are projected into the parent.
+                Evaluation can consequently invoke the already-selected child
+                ops without consulting the registry or assuming its value
+                representation. */
+            void describe_child(TableLayout &layout, const TSValueTypeMetaData *schema,
+                                std::string prefix, std::vector<std::size_t> ts_path,
+                                std::size_t level_no)
+            {
+                const TableTypeOps &selected = table_type_ops(schema);
+                const TableTypeOps &builtin = builtin_table_type_ops(schema);
+                if (&selected == &builtin)
+                {
+                    selected.describe(layout, schema, std::move(prefix), std::move(ts_path),
+                                      level_no);
+                    return;
+                }
+
+                const TsTableLayout &child =
+                    ts_table_layout(schema, layout.date_key, layout.as_of_key);
+                if (child.multi())
+                {
+                    throw std::invalid_argument(
+                        "to_table: a registered multi-row child strategy cannot be embedded "
+                        "inside a structural table layout");
+                }
+                if (child.keys.size() < 2 || child.keys.size() != child.col_metas.size())
+                {
+                    throw std::logic_error(
+                        "to_table: registered child strategy produced an invalid table layout");
+                }
+
+                begin_leaf(layout, schema);
+                TableLayout::ChildPlan child_plan{
+                    .layout = &child,
+                    .ts_path = std::move(ts_path),
+                    .columns = std::vector<std::size_t>(child.keys.size(), TableLayout::no_column),
+                };
+                // Every canonical layout starts with its bitemporal pair. They
+                // map to the parent's pair for apply, while nested emission
+                // suppresses the child's duplicate delivery.
+                child_plan.columns[0] = 0;
+                child_plan.columns[1] = 1;
+                for (std::size_t column = 2; column < child.keys.size(); ++column)
+                {
+                    const std::string &local_name = child.keys[column];
+                    const std::string name =
+                        prefix.empty()
+                            ? local_name
+                            : local_name == "value" ? prefix : prefix + "." + local_name;
+                    child_plan.columns[column] = layout.keys.size();
+                    layout.keys.push_back(name);
+                    layout.col_metas.push_back(child.col_metas[column]);
+                }
+                layout.child_plans.push_back(std::move(child_plan));
+            }
+
             void describe_tsd(TableLayout &layout, const TSValueTypeMetaData *schema, std::string,
                               std::vector<std::size_t>, std::size_t           level_no)
             {
@@ -278,7 +338,7 @@ namespace hgraph::stdlib
                               });
                 layout.levels.push_back(std::move(level));
                 const auto *child = schema->element_ts();
-                builtin_table_type_ops(child).describe(layout, child, "", {}, level_no + 1);
+                describe_child(layout, child, "", {}, level_no + 1);
             }
 
             void describe_tsb(TableLayout &layout, const TSValueTypeMetaData *schema,
@@ -296,8 +356,7 @@ namespace hgraph::stdlib
                     const std::string child_prefix =
                         prefix.empty() ? std::string{name != nullptr ? name : ""}
                                        : prefix + "." + (name != nullptr ? name : "");
-                    builtin_table_type_ops(child).describe(
-                        layout, child, child_prefix, std::move(child_path), level_no);
+                    describe_child(layout, child, child_prefix, std::move(child_path), level_no);
                 }
             }
 
@@ -311,6 +370,7 @@ namespace hgraph::stdlib
                                   TableLayout::Column entry;
                                   entry.name = suffix.empty() ? "value" : suffix;
                                   entry.leaf = leaf;
+                                  entry.column = layout.keys.size();
                                   entry.ts_path = ts_path;
                                   entry.value_path = std::move(value_path);
                                   layout.keys.push_back(entry.name);
@@ -343,6 +403,7 @@ namespace hgraph::stdlib
                     TableLayout::Column entry;
                     entry.name = column.name;
                     entry.leaf = column.leaf_meta;
+                    entry.column = layout.keys.size();
                     entry.value_path = column.path;
                     layout.keys.push_back(column.name);
                     layout.col_metas.push_back(column.leaf_meta);
@@ -622,8 +683,118 @@ namespace hgraph::stdlib
                     {
                         continue;
                     }
-                    sink.cell(sink.context, layout.value_col_start + i,
+                    sink.cell(sink.context, column.column,
                               walk_value(node.value(), column.value_path));
+                }
+            }
+
+            [[nodiscard]] TSInputView child_input(const TSInputView &root,
+                                                  std::span<const std::size_t> path)
+            {
+                TSInputView child = root.borrowed_ref();
+                for (const std::size_t index : path)
+                {
+                    auto bundle = child.as_bundle();
+                    child = bundle.at(index);
+                }
+                return child;
+            }
+
+            /** Capture one registered child's local row before projecting it
+                into its structural parent. Capturing keeps an invalid custom
+                multi-row implementation from partially mutating the parent's
+                row before the contract violation is diagnosed. */
+            struct ChildRowCapture
+            {
+                const TableLayout::ChildPlan *plan{nullptr};
+                std::vector<Value>             cells{};
+                std::vector<bool>              written{};
+                std::size_t                    rows{0};
+
+                explicit ChildRowCapture(const TableLayout::ChildPlan &plan_)
+                    : plan{&plan_}, cells(plan_.columns.size()),
+                      written(plan_.columns.size(), false)
+                {
+                }
+
+                static void cell(void *context, std::size_t column, const ValueView &value)
+                {
+                    auto &self = *static_cast<ChildRowCapture *>(context);
+                    if (self.rows != 0)
+                    {
+                        throw std::invalid_argument(
+                            "to_table: a registered child strategy emitted more than one row");
+                    }
+                    if (column >= self.cells.size())
+                    {
+                        throw std::out_of_range(
+                            "to_table: a registered child strategy emitted an unknown column");
+                    }
+                    if (column < 2)
+                    {
+                        return;  // the structural parent owns the bitemporal pair
+                    }
+                    if (self.written[column])
+                    {
+                        throw std::invalid_argument(
+                            "to_table: a registered child strategy emitted a column twice");
+                    }
+                    self.cells[column] = value.has_value() ? Value{value} : Value{};
+                    self.written[column] = true;
+                }
+
+                static void end_row(void *context)
+                {
+                    auto &self = *static_cast<ChildRowCapture *>(context);
+                    ++self.rows;
+                    if (self.rows > 1)
+                    {
+                        throw std::invalid_argument(
+                            "to_table: a registered child strategy emitted more than one row");
+                    }
+                }
+
+                [[nodiscard]] RowSink sink()
+                {
+                    return RowSink{.context = this, .cell = &cell, .end_row = &end_row};
+                }
+
+                void deliver(const RowSink &sink) const
+                {
+                    if (rows != 1)
+                    {
+                        throw std::invalid_argument(
+                            "to_table: a registered child strategy must emit exactly one row");
+                    }
+                    for (std::size_t column = 2; column < cells.size(); ++column)
+                    {
+                        const std::size_t parent_column = plan->columns[column];
+                        if (parent_column == TableLayout::no_column || !cells[column].has_value())
+                        {
+                            continue;
+                        }
+                        sink.cell(sink.context, parent_column, cells[column].view());
+                    }
+                }
+            };
+
+            void write_child_cells(const RowSink &sink, const TsTableLayout &layout,
+                                   const TSInputView &leaf, Int mode, DateTime now,
+                                   DateTime as_of, bool emit_removals,
+                                   bool reject_empty_frames)
+            {
+                for (const TableLayout::ChildPlan &plan : layout.child_plans)
+                {
+                    TSInputView child = child_input(leaf, plan.ts_path);
+                    if ((mode == kModeTick && !child.modified()) || !child.valid())
+                    {
+                        continue;
+                    }
+                    ChildRowCapture capture{plan};
+                    const RowSink   child_sink = capture.sink();
+                    plan.layout->ops->emit(*plan.layout, child, mode, now, as_of, emit_removals,
+                                           child_sink, reject_empty_frames);
+                    capture.deliver(sink);
                 }
             }
 
@@ -655,7 +826,7 @@ namespace hgraph::stdlib
                         const Value cell = frame_cell(frame, column.name, column.leaf, r);
                         if (cell.has_value())
                         {
-                            sink.cell(sink.context, layout.value_col_start + i, cell.view());
+                            sink.cell(sink.context, column.column, cell.view());
                         }
                     }
                     sink.end_row(sink.context);
@@ -681,6 +852,10 @@ namespace hgraph::stdlib
                     sink.cell(sink.context, 1, scalars.as_of.view());
                     deliver_keys(sink, scalars, chain);
                     write_value_cells(sink, layout, ts, mode);
+                    write_child_cells(sink, layout, ts, mode,
+                                      scalars.now.view().checked_as<DateTime>(),
+                                      scalars.as_of.view().checked_as<DateTime>(), emit_removals,
+                                      reject_empty_frames);
                     sink.end_row(sink.context);
                     return;
                 }
@@ -890,12 +1065,15 @@ namespace hgraph::stdlib
         namespace
         {
             void emit_plain(const TableLayout &layout, const TSInputView &ts, Int mode,
-                            DateTime now, DateTime as_of, bool, const TableRowSink &sink, bool)
+                            DateTime now, DateTime as_of, bool emit_removals,
+                            const TableRowSink &sink, bool reject_empty_frames)
             {
                 const RowScalars scalars{now, as_of};
                 sink.cell(sink.context, 0, scalars.now.view());
                 sink.cell(sink.context, 1, scalars.as_of.view());
                 write_value_cells(sink, layout, ts, mode);
+                write_child_cells(sink, layout, ts, mode, now, as_of, emit_removals,
+                                  reject_empty_frames);
                 sink.end_row(sink.context);
             }
 
@@ -977,6 +1155,74 @@ namespace hgraph::stdlib
                 return key;
             }
 
+            [[nodiscard]] TSOutputView child_output(const TSOutputView &root,
+                                                    std::span<const std::size_t> path)
+            {
+                TSOutputView child = root.borrowed_ref();
+                for (const std::size_t index : path)
+                {
+                    child = child.indexed_child_at(index);
+                }
+                return child;
+            }
+
+            struct ChildRowSource
+            {
+                const TableLayout::ChildPlan *plan{nullptr};
+                const TupleView              *row{nullptr};
+
+                static Value cell(const void *context, std::size_t row_index,
+                                  std::size_t column)
+                {
+                    const auto &self = *static_cast<const ChildRowSource *>(context);
+                    if (row_index != 0 || column >= self.plan->columns.size())
+                    {
+                        throw std::out_of_range(
+                            "from_table: registered child row or column is out of range");
+                    }
+                    const std::size_t parent_column = self.plan->columns[column];
+                    if (parent_column == TableLayout::no_column)
+                    {
+                        return {};
+                    }
+                    const ValueView value = self.row->at(parent_column);
+                    return value.has_value() ? Value{value} : Value{};
+                }
+
+                [[nodiscard]] TableRowSource source() const
+                {
+                    return TableRowSource{.context = this, .rows = 1, .cell = &cell};
+                }
+            };
+
+            void apply_child_plans(const TsTableLayout &layout, const TupleView &row,
+                                   const TSOutputView &out)
+            {
+                for (const TableLayout::ChildPlan &plan : layout.child_plans)
+                {
+                    bool has_value = false;
+                    for (std::size_t column = 2; column < plan.columns.size(); ++column)
+                    {
+                        const std::size_t parent_column = plan.columns[column];
+                        if (parent_column != TableLayout::no_column &&
+                            row.at(parent_column).has_value())
+                        {
+                            has_value = true;
+                            break;
+                        }
+                    }
+                    if (!has_value)
+                    {
+                        continue;
+                    }
+
+                    const ChildRowSource projection{.plan = &plan, .row = &row};
+                    const TableRowSource source = projection.source();
+                    TSOutputView child = child_output(out, plan.ts_path);
+                    plan.layout->ops->apply(*plan.layout, source, child);
+                }
+            }
+
             void apply_leaf_row(const TsTableLayout &layout, const TupleView &row,
                                 const TSOutputView &out)
             {
@@ -985,7 +1231,7 @@ namespace hgraph::stdlib
                     layout.value_cols.front().value_path.empty() &&
                     layout.value_cols.front().ts_path.empty())
                 {
-                    const ValueView &cell = row.at(layout.value_col_start);
+                    const ValueView &cell = row.at(layout.value_cols.front().column);
                     if (cell.has_value())
                     {
                         apply_current_value(out, cell);
@@ -995,27 +1241,30 @@ namespace hgraph::stdlib
 
                 // Compound leaf: rebuild a (possibly partial) value and apply
                 // it as the tick's delta (unset fields stay unset).
-                Value value{checked_binding(leaf_ts->value_schema, "from_table")};
-                bool  any = false;
-                for (std::size_t i = 0; i < layout.value_cols.size(); ++i)
+                if (!layout.value_cols.empty())
                 {
-                    const auto      &column = layout.value_cols[i];
-                    const ValueView &cell = row.at(layout.value_col_start + i);
-                    if (!cell.has_value())
+                    Value value{checked_binding(leaf_ts->value_schema, "from_table")};
+                    bool  any = false;
+                    for (std::size_t i = 0; i < layout.value_cols.size(); ++i)
                     {
-                        continue;
+                        const auto      &column = layout.value_cols[i];
+                        const ValueView &cell = row.at(column.column);
+                        if (!cell.has_value())
+                        {
+                            continue;
+                        }
+                        std::vector<std::size_t> full_path = column.ts_path;
+                        full_path.insert(full_path.end(), column.value_path.begin(),
+                                         column.value_path.end());
+                        walk_mutable(value.view().begin_mutation(), full_path).copy_from(cell);
+                        any = true;
                     }
-                    std::vector<std::size_t> full_path = column.ts_path;
-                    full_path.insert(full_path.end(), column.value_path.begin(),
-                                     column.value_path.end());
-                    walk_mutable(value.view().begin_mutation(), full_path).copy_from(cell);
-                    any = true;
+                    if (any)
+                    {
+                        apply_delta(out, value.view());
+                    }
                 }
-                if (!any)
-                {
-                    return;
-                }
-                apply_delta(out, value.view());
+                apply_child_plans(layout, row, out);
             }
 
             void apply_partition_row(const TsTableLayout &layout, std::size_t level_index,

--- a/src/hgraph/lib/std/operators/table_impl.cpp
+++ b/src/hgraph/lib/std/operators/table_impl.cpp
@@ -309,6 +309,15 @@ namespace hgraph::stdlib
                     layout.keys.push_back(name);
                     layout.col_metas.push_back(child.col_metas[column]);
                 }
+                // Payload nullability does not encode whether the child
+                // emitted a row: a valid strategy may have no value columns,
+                // or may deliberately emit an all-null row. Persist that
+                // distinction explicitly so nested apply observes the same
+                // row presence as root apply.
+                child_plan.presence_column = layout.keys.size();
+                layout.keys.push_back(
+                    fmt::format("__hgraph_child_{}_present__", layout.child_plans.size()));
+                layout.col_metas.push_back(TypeRegistry::instance().value_type("bool"));
                 layout.child_plans.push_back(std::move(child_plan));
             }
 
@@ -775,6 +784,8 @@ namespace hgraph::stdlib
                         }
                         sink.cell(sink.context, parent_column, cells[column].view());
                     }
+                    const Value present{Bool{true}};
+                    sink.cell(sink.context, plan->presence_column, present.view());
                 }
             };
 
@@ -1200,18 +1211,8 @@ namespace hgraph::stdlib
             {
                 for (const TableLayout::ChildPlan &plan : layout.child_plans)
                 {
-                    bool has_value = false;
-                    for (std::size_t column = 2; column < plan.columns.size(); ++column)
-                    {
-                        const std::size_t parent_column = plan.columns[column];
-                        if (parent_column != TableLayout::no_column &&
-                            row.at(parent_column).has_value())
-                        {
-                            has_value = true;
-                            break;
-                        }
-                    }
-                    if (!has_value)
+                    const ValueView &present = row.at(plan.presence_column);
+                    if (!present.has_value() || !present.checked_as<Bool>())
                     {
                         continue;
                     }

--- a/tests/cpp/test_table.cpp
+++ b/tests/cpp/test_table.cpp
@@ -83,6 +83,68 @@ namespace
     const TableTypeOps extension_table_ops{&describe_extension_scalar, &emit_extension_scalar,
                                            &apply_extension_scalar};
 
+    void describe_all_null_extension_scalar(TableLayout &layout,
+                                             const TSValueTypeMetaData *schema, std::string,
+                                             std::vector<std::size_t>, std::size_t)
+    {
+        ++extension_describes;
+        layout.leaf_ts = schema;
+        layout.value_col_start = layout.keys.size();
+        layout.keys.push_back("value");
+        layout.col_metas.push_back(scalar_descriptor<Int>::value_meta());
+    }
+
+    void describe_empty_extension_scalar(TableLayout &layout, const TSValueTypeMetaData *schema,
+                                          std::string, std::vector<std::size_t>, std::size_t)
+    {
+        ++extension_describes;
+        layout.leaf_ts = schema;
+        layout.value_col_start = layout.keys.size();
+    }
+
+    void emit_presence_only_extension_scalar(const TableLayout &, const TSInputView &, Int,
+                                              DateTime now, DateTime as_of, bool,
+                                              const TableRowSink &sink, bool)
+    {
+        ++extension_emits;
+        const Value when{now};
+        const Value revision{as_of};
+        sink.cell(sink.context, 0, when.view());
+        sink.cell(sink.context, 1, revision.view());
+        sink.end_row(sink.context);
+    }
+
+    void apply_all_null_extension_scalar(const TableLayout &, const TableRowSource &source,
+                                         const TSOutputView &out)
+    {
+        ++extension_applies;
+        if (source.rows != 1)
+        {
+            throw std::logic_error("all-null extension expected one row");
+        }
+        const Value wrapped{ExtensionTableScalar{77}};
+        apply_current_value(out, wrapped.view());
+    }
+
+    void apply_empty_extension_scalar(const TableLayout &, const TableRowSource &source,
+                                      const TSOutputView &out)
+    {
+        ++extension_applies;
+        if (source.rows != 1)
+        {
+            throw std::logic_error("empty extension expected one row");
+        }
+        const Value wrapped{ExtensionTableScalar{88}};
+        apply_current_value(out, wrapped.view());
+    }
+
+    const TableTypeOps all_null_extension_table_ops{&describe_all_null_extension_scalar,
+                                                     &emit_presence_only_extension_scalar,
+                                                     &apply_all_null_extension_scalar};
+    const TableTypeOps empty_extension_table_ops{&describe_empty_extension_scalar,
+                                                  &emit_presence_only_extension_scalar,
+                                                  &apply_empty_extension_scalar};
+
     [[nodiscard]] std::int64_t timestamp_at(const Frame &frame, const std::string &column,
                                             std::int64_t row)
     {
@@ -587,6 +649,55 @@ TEST_CASE("table type ops: a registered child records and replays beneath a TSD"
     CHECK(extension_describes == 1);
     CHECK(extension_emits == 3);
     CHECK(extension_applies == 3);
+}
+
+TEST_CASE("table type ops: a nested all-null child row survives persisted replay")
+{
+    stdlib::register_standard_operators();
+    GlobalContext context;
+    record_replay::set_config(
+        context.state().view(),
+        record_replay::Config{.model = std::string{record_replay::DATA_FRAME}});
+    const auto *child_schema =
+        TypeRegistry::instance().ts(scalar_descriptor<ExtensionTableScalar>::value_meta());
+    extension_describes = 0;
+    extension_emits = 0;
+    extension_applies = 0;
+    register_table_type_ops(child_schema, all_null_extension_table_ops);
+
+    const Value input = dict_delta<Str, TS<ExtensionTableScalar>>(
+        {{Str{"one"}, ExtensionTableScalar{1}}, {Str{"two"}, ExtensionTableScalar{2}}});
+    const Value expected = dict_delta<Str, TS<ExtensionTableScalar>>(
+        {{Str{"one"}, ExtensionTableScalar{77}}, {Str{"two"}, ExtensionTableScalar{77}}});
+
+    (void)eval_node<NestedExtensionRecordGraph<NestedExtensionDict>>(values<Value>(input));
+    CHECK_OUTPUT(eval_node<NestedExtensionReplayGraph<NestedExtensionDict>>(),
+                 values<Value>(expected));
+
+    CHECK(extension_describes == 1);
+    CHECK(extension_emits == 2);
+    CHECK(extension_applies == 2);
+}
+
+TEST_CASE("table type ops: a nested child with no value columns survives direct apply")
+{
+    stdlib::register_standard_operators();
+    const auto *child_schema =
+        TypeRegistry::instance().ts(scalar_descriptor<ExtensionTableScalar>::value_meta());
+    extension_describes = 0;
+    extension_emits = 0;
+    extension_applies = 0;
+    register_table_type_ops(child_schema, empty_extension_table_ops);
+
+    const Value input = tsb_delta<NestedExtensionBundle>(ExtensionTableScalar{1}, Int{10});
+    const Value expected = tsb_delta<NestedExtensionBundle>(ExtensionTableScalar{88}, Int{10});
+    CHECK_OUTPUT(eval_node<NestedExtensionTableRoundTripGraph<NestedExtensionBundle>>(
+                     values<Value>(input)),
+                 values<Value>(expected));
+
+    CHECK(extension_describes == 1);
+    CHECK(extension_emits == 1);
+    CHECK(extension_applies == 1);
 }
 
 TEST_CASE("table type ops: registry reset withdraws exact-schema overrides")

--- a/tests/cpp/test_table.cpp
+++ b/tests/cpp/test_table.cpp
@@ -386,6 +386,48 @@ namespace
                 .as<TS<ExtensionTableScalar>>();
         }
     };
+
+    using NestedExtensionBundle =
+        UnNamedTSB<Field<"custom", TS<ExtensionTableScalar>>, Field<"regular", TS<Int>>>;
+    using NestedExtensionDict = TSD<Str, TS<ExtensionTableScalar>>;
+
+    template <typename Schema>
+    struct NestedExtensionTableRoundTripGraph
+    {
+        [[maybe_unused]] static constexpr auto name = "nested_extension_table_round_trip_graph";
+
+        static Port<Schema> compose(Wiring &w, Port<Schema> ts)
+        {
+            auto rows = wire<stdlib::to_table>(w, ts);
+            return wire<stdlib::from_table, Schema>(w, rows).template as<Schema>();
+        }
+    };
+
+    template <typename Schema>
+    struct NestedExtensionRecordGraph
+    {
+        [[maybe_unused]] static constexpr auto name = "nested_extension_record_graph";
+
+        static Port<Schema> compose(Wiring &w, Port<Schema> ts)
+        {
+            wire<stdlib::record>(w, ts, Str{"values"},
+                                 arg<"recordable_id">(Str{"nested_extension"}));
+            return ts;
+        }
+    };
+
+    template <typename Schema>
+    struct NestedExtensionReplayGraph
+    {
+        [[maybe_unused]] static constexpr auto name = "nested_extension_replay_graph";
+
+        static Port<Schema> compose(Wiring &w)
+        {
+            return wire<stdlib::replay, Schema>(
+                       w, Str{"values"}, arg<"recordable_id">(Str{"nested_extension"}))
+                .template as<Schema>();
+        }
+    };
 }  // namespace
 
 TEST_CASE("table operators: to_table emits one bitemporal tuple row per tick")
@@ -495,6 +537,56 @@ TEST_CASE("table type ops: stored replay dispatches through the extension "
     CHECK(extension_describes == 1);
     CHECK(extension_emits == 2);
     CHECK(extension_applies == 2);
+}
+
+TEST_CASE("table type ops: a registered child composes beneath a TSB")
+{
+    stdlib::register_standard_operators();
+    const auto *child_schema =
+        TypeRegistry::instance().ts(scalar_descriptor<ExtensionTableScalar>::value_meta());
+    extension_describes = 0;
+    extension_emits = 0;
+    extension_applies = 0;
+    register_table_type_ops(child_schema, extension_table_ops);
+
+    const Value first = tsb_delta<NestedExtensionBundle>(ExtensionTableScalar{1}, Int{10});
+    const Value second = tsb_delta<NestedExtensionBundle>(ExtensionTableScalar{3}, Int{30});
+    CHECK_OUTPUT(
+        eval_node<NestedExtensionTableRoundTripGraph<NestedExtensionBundle>>(
+            values<Value>(first, none, second)),
+        values<Value>(first, none, second));
+
+    CHECK(extension_describes == 1);
+    CHECK(extension_emits == 2);
+    CHECK(extension_applies == 2);
+}
+
+TEST_CASE("table type ops: a registered child records and replays beneath a TSD")
+{
+    stdlib::register_standard_operators();
+    GlobalContext context;
+    record_replay::set_config(
+        context.state().view(),
+        record_replay::Config{.model = std::string{record_replay::DATA_FRAME}});
+    const auto *child_schema =
+        TypeRegistry::instance().ts(scalar_descriptor<ExtensionTableScalar>::value_meta());
+    extension_describes = 0;
+    extension_emits = 0;
+    extension_applies = 0;
+    register_table_type_ops(child_schema, extension_table_ops);
+
+    const Value first = dict_delta<Str, TS<ExtensionTableScalar>>(
+        {{Str{"one"}, ExtensionTableScalar{1}}, {Str{"two"}, ExtensionTableScalar{2}}});
+    const Value second = dict_delta<Str, TS<ExtensionTableScalar>>(
+        {{Str{"one"}, ExtensionTableScalar{4}}});
+    const auto expected = values<Value>(first, second);
+
+    (void)eval_node<NestedExtensionRecordGraph<NestedExtensionDict>>(expected);
+    CHECK_OUTPUT(eval_node<NestedExtensionReplayGraph<NestedExtensionDict>>(), expected);
+
+    CHECK(extension_describes == 1);
+    CHECK(extension_emits == 3);
+    CHECK(extension_applies == 3);
 }
 
 TEST_CASE("table type ops: registry reset withdraws exact-schema overrides")


### PR DESCRIPTION
## Summary

- compose exact registered `TableTypeOps` beneath built-in `TSB` and `TSD` layouts
- retain each child’s independently interned type-erased plan and local-to-parent column projection
- persist an explicit per-child row-presence column, independent of payload nullability
- delegate both emission and application through the selected child operation table without per-tick registry lookup
- add direct TSB round-trip and persisted TSD record/replay regression coverage
- document nested strategy composition and the explicit rejection of embedded multi-row strategies

## Root cause

The structural table layout builder recursively selected only built-in operations for child schemas. Exact registered operations worked at the root, but were bypassed when their schema appeared inside a TSB or TSD.

The initial nested implementation also inferred whether a child emitted a row from non-null projected payload cells. That loses valid all-null rows and strategies with no value columns. Each nested child plan now has a dedicated boolean presence column, written after a complete single-row emission and persisted through Arrow replay.

## User impact

Extension-defined table conversions now behave consistently at the root and inside supported structural time-series types. The parent retains ownership of structural keys and row formation, while the child operation table owns conversion of its projected value columns. Valid all-null and zero-value-column child rows retain their update semantics.

Embedded multi-row child strategies remain unsupported because combining their rows with sibling structural values requires an explicit row-product policy; layout construction diagnoses this rather than producing ambiguous output.

## Validation

- focused nested table-operation suite: 26 assertions across 7 cases
- macOS/Clang: 1,580/1,580 native tests passed
- macOS stable-ABI wheel: 2,139 Python 3.14 tests passed, 9 skipped
- installed-SDK consumer test passed
- Linux/GCC 14: 1,580/1,580 native tests passed
- Linux stable-ABI wheel: 2,139 Python 3.14 tests passed, 9 skipped
- Sphinx HTML build passed with warnings treated as errors
- `git diff --check` passed