### PR TITLE
Accept RFCs 16 and 19 with persistence conformance coverage

### DIFF
--- a/.github/workflows/native-cpp.yml
+++ b/.github/workflows/native-cpp.yml
@@ -78,6 +78,36 @@ jobs:
         run: cmake --build build-native --parallel ${{ matrix.parallel }}
       - name: Run native C++ tests
         run: ctest --test-dir build-native --output-on-failure --parallel ${{ matrix.parallel }}
+      - name: Start the S3 conformance endpoint
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          docker run --detach --name hgraph-minio -p 9010:9000 \
+            -e MINIO_ROOT_USER=hgraphtest \
+            -e MINIO_ROOT_PASSWORD=hgraphtest123 \
+            quay.io/minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e \
+            server /data
+          for attempt in {1..30}; do
+            if curl --fail --silent http://127.0.0.1:9010/minio/health/live >/dev/null; then
+              break
+            fi
+            sleep 1
+          done
+          curl --fail --silent http://127.0.0.1:9010/minio/health/live >/dev/null
+          docker run --rm --network container:hgraph-minio --entrypoint /bin/sh \
+            quay.io/minio/mc@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727 \
+            -c '/usr/bin/mc alias set local http://127.0.0.1:9000 hgraphtest hgraphtest123 && /usr/bin/mc mb --ignore-existing local/hgraph-test'
+      - name: Run S3 frame-store conformance
+        if: runner.os == 'Linux'
+        env:
+          HGRAPH_S3_TEST_ENDPOINT: http://127.0.0.1:9010
+          HGRAPH_S3_TEST_BUCKET: hgraph-test
+          AWS_ACCESS_KEY_ID: hgraphtest
+          AWS_SECRET_ACCESS_KEY: hgraphtest123
+        run: ./build-native/tests/cpp/hgraph_unit_tests "[s3]"
+      - name: Stop the S3 conformance endpoint
+        if: runner.os == 'Linux' && always()
+        run: docker rm --force hgraph-minio || true
 
   native-shared-install:
     name: Native C++ / Linux shared install with IPO

--- a/docs/source/rfc/rfc_0016_object_store_frame_persistence.rst
+++ b/docs/source/rfc/rfc_0016_object_store_frame_persistence.rst
@@ -1,10 +1,10 @@
 RFC 0016: Object-Store Frame Persistence
 ========================================
 
-:Status: Proposed; reference implementation in progress
+:Status: Accepted
 :Author: Howard Henson
 :Created: 2026-08-10
-:Target: Next hgraph minor release
+:Target: 0.8.x
 
 Summary
 -------
@@ -21,10 +21,10 @@ carrying frame-level metadata, and the contract below is stated so that use is
 expressible without a private extension to it.
 
 The filesystem layer this builds on is in the ``libarrow`` hgraph already
-links. Arrow IPC is too. **Parquet is not** — it lives in a separate
-``libparquet`` that no configuration currently links, and the Conan build
-disables it outright. That is a real dependency task, not a free one, and it is
-planned below rather than assumed away.
+links. Arrow IPC is too. Parquet lives in the separate ``libparquet`` library,
+so the build discovers and links it as an explicit optional capability rather
+than assuming it accompanies Arrow. The lean Conan package keeps that optional
+dependency, and Arrow's substantially larger S3 dependency tree, disabled.
 
 Scope
 -----
@@ -162,12 +162,14 @@ checks report absence; writes fail explicitly rather than silently losing
 data. Concrete strategies and their containers are private to implementation
 files.
 
-**Registration is scoped to the graph run, not the process.** ``GlobalState``
-is already owned by one graph instance and copied into and back from that run.
-The process store in ``record_replay.cpp`` is only a fallback and cannot
-represent a graph-selected destination. The precedent is
+**Registration is scoped to ``GlobalState``, not the process.** A
+``GlobalState`` belongs to the graph instance to which it is bound and may span
+several runs of that graph. It is copied into execution and back to its caller,
+so the owning erased handle deliberately shares one store context across those
+copies and runs. The process store in ``record_replay.cpp`` is only a fallback
+and cannot represent a graph-selected destination. The precedent is
 ``set_config(GlobalStateView, ...)``; the selected store follows the same
-graph-scoped ownership.
+state-scoped ownership.
 
 .. code-block:: cpp
 
@@ -179,8 +181,8 @@ graph-scoped ownership.
 
     namespace hgraph::record_replay
     {
-        /** Register for the active run; the store is owned by GlobalState and
-            released with it. Mirrors set_config's scoping. */
+        /** Register for the GlobalState scope; the store is owned by that
+            state and released with it. Mirrors set_config's scoping. */
         HGRAPH_EXPORT void set_frame_store(
             GlobalStateView state, store::FrameStore store);
     }
@@ -241,17 +243,24 @@ Credentials are explicit about the ambient case rather than silent about it:
             std::string secret_access_key;
             std::optional<std::string> session_token{};
         };
-        /** A named profile from the shared credentials file. */
+        /** Reserved spelling. The Arrow backend rejects this directly; use
+            AWS_PROFILE with Ambient instead. */
         struct Profile { std::string name; };
-        /** Assume a role, refreshed by the SDK. */
+        /** Assume a role from the ambient source credentials, refreshed by
+            the SDK. */
         struct AssumeRole { std::string role_arn; std::optional<std::string> session_name; };
 
         std::variant<Ambient, Explicit, Profile, AssumeRole> source{Ambient{}};
     };
 
-``Ambient`` is the default, so the common deployment configures nothing. An
-application that must not read ambient credentials states another alternative
-and gets a hard failure rather than an accidental fallback.
+``Ambient`` is the default, so the common deployment configures nothing.
+``Explicit`` never consults the ambient chain. ``AssumeRole`` uses the ambient
+chain for its source credentials, which is the contract of Arrow's
+``FromAssumeRole`` provider. Arrow exposes no named-profile factory without
+requiring AWS SDK headers in hgraph's public build, so ``Profile`` is retained
+as a reserved configuration spelling but rejected explicitly; applications
+select a profile through ``AWS_PROFILE`` and ``Ambient``. No alternative
+silently falls back to a different credential mode.
 
 Python compatibility contract
 -----------------------------
@@ -351,7 +360,7 @@ format needs, verified against the repository and the bundled Arrow build:
      - Parquet
    * - Library
      - ``libarrow`` — already linked
-     - ``libparquet`` — **linked by nothing today**
+     - ``libparquet`` — linked when discovered
    * - Symbols
      - ``arrow::ipc::MakeFileWriter`` / ``RecordBatchFileReader::Open``
      - ``parquet::arrow::WriteTable`` / ``parquet::arrow::FileReader``
@@ -363,30 +372,22 @@ format needs, verified against the repository and the bundled Arrow build:
      - ``conanfile.py`` sets ``arrow.parquet = False``
 
 ``arrow::fs`` is likewise present in the pyarrow build — S3, local and the
-filesystem headers are all there, confirmed by symbol inspection — but the
-Conan configuration enables neither Parquet nor S3, so both need turning on
-there.
+filesystem headers are all there, confirmed by symbol inspection. The accepted
+build integration:
 
-Enabling Parquet therefore means, in order:
+* creates the imported ``Parquet::parquet_shared`` target beside the existing
+  ``Arrow::``/``ArrowCompute::``/``ArrowAcero::`` targets when the pyarrow
+  distribution supplies it;
+* links and exports the available format libraries through the installed SDK;
+* stages the Parquet runtime beside the Python extension on Windows and audits
+  the wheel so a missing runtime fails packaging rather than first use; and
+* enables S3 when the selected Arrow distribution exposes its filesystem
+  implementation.
 
-* flip ``arrow.parquet`` in ``conanfile.py``, and enable Arrow's S3 support in
-  the same place, so the Conan configuration can build this at all;
-* add an imported ``Parquet::parquet_shared`` target beside the existing
-  ``Arrow::``/``ArrowCompute::``/``ArrowAcero::`` ones, discovered from the same
-  pyarrow directory in the pyarrow configuration;
-* link it, and export it through ``hgraph::options`` for installed consumers as
-  the Arrow targets already are;
-* stage ``parquet.dll`` beside the extension on Windows. The build tree already
-  needs this for the Arrow DLLs — ``$<TARGET_RUNTIME_DLLS:_hgraph>`` covers a
-  newly linked library automatically, but the wheel's ``install(FILES ...)``
-  list is explicit and must gain the Parquet runtime;
-* extend ``tools/audit_distribution.py`` and the installed-SDK consumer test so
-  a wheel missing the Parquet runtime fails in CI rather than at first use.
-
-The pyarrow build now discovers and stages Parquet when it is present. Conan
-still disables it, so Parquet remains a build capability rather than a promise
-of every installation; requesting it from a build without support fails
-loudly.
+The lean Conan package deliberately keeps Arrow's optional Parquet and S3
+dependency trees disabled. Those are build capabilities rather than promises
+of every installation. Requesting an unavailable capability fails loudly
+instead of selecting another format or location.
 
 Runtime and lifecycle
 ---------------------
@@ -462,18 +463,18 @@ the endpoint differing from AWS.
 The test is a hidden Catch2 case (``[.s3]``), so it does not run, and does not
 fail, in a checkout without an endpoint; it is requested by tag. That is
 preferred to reporting skipped, because ``catch_discover_tests`` surfaces a
-skip as a CTest failure. CI can gain an S3 leg by running MinIO as a service
-container and invoking the tag.
+skip as a CTest failure. The Linux native CI job starts MinIO and invokes the
+tag explicitly, covering both formats available in that build.
 
 Compatibility and migration
 ---------------------------
 
-Selecting the ``DATA_FRAME`` model creates a graph-owned native memory store
-unless the graph already has another store. A custom C++ store supplies an
-owned context plus a static ``FrameStoreOps`` table and installs the resulting
-handle either on the graph or as the process fallback. A borrowed raw context
-is deliberately no longer accepted: the graph copy-in/copy-out lifecycle must
-not be able to outlive a store representation.
+Selecting the ``DATA_FRAME`` model creates a ``GlobalState``-owned native
+memory store unless that state already has another store. A custom C++ store
+supplies an owned context plus a static ``FrameStoreOps`` table and installs
+the resulting handle either in ``GlobalState`` or as the process fallback. A
+borrowed raw context is deliberately no longer accepted: the state
+copy-in/copy-out lifecycle must not be able to outlive a store representation.
 
 Nothing about the wire format of ``Frame`` changes. Persisted files are
 ordinary Parquet or Arrow IPC and are not versioned by hgraph beyond the RFC
@@ -588,47 +589,68 @@ Parquet store raises rather than silently changing format.
 Acceptance criteria and test plan
 ---------------------------------
 
-* The default ``DATA_FRAME`` location is a graph-owned in-memory store; the full
-  existing record/replay suite passes unchanged with no destination
-  configuration.
-* Round trip through each backend — memory, local filesystem, S3 — for both
-  formats, asserting frame equality including schema.
-* RFC 0001 metadata survives every backend/format combination, and decodes
-  back to the typed value — including a composite field carried as JSON.
+* The default ``DATA_FRAME`` location is a ``GlobalState``-owned in-memory
+  store; the full existing record/replay suite passes unchanged with no
+  destination configuration.
+* Memory retains the exact frame, and each serialising backend — local
+  filesystem and S3 — round-trips every format available in its build,
+  asserting frame equality including schema.
+* RFC 0001 metadata survives memory and every serialising backend/format
+  combination, and decodes back to the typed value — including a composite
+  field carried as JSON.
 * A write to an existing key is rejected under the default immutable setting,
   and succeeds when the store opts out.
 * A key rejected by validation is rejected identically by every backend,
   including memory.
 * A per-write compression override takes effect over the store default.
-* Credential alternatives select as declared: ``Ambient`` resolves through the
-  chain, ``Explicit``/``Profile``/``AssumeRole`` do not consult it, and a
-  missing credential fails loudly.
+* Credential alternatives select as declared: ``Ambient`` uses Arrow's
+  standard chain, ``Explicit`` uses only its supplied values, ``AssumeRole``
+  uses the ambient source provider, and ``Profile`` fails with the documented
+  ``AWS_PROFILE`` guidance rather than silently choosing another mode.
 * A failing store surfaces the error rather than degrading to memory.
 * S3 coverage runs against a local S3-compatible endpoint via
   ``endpoint_override``, so it needs no cloud account. This is what makes the
   S3 path testable in CI rather than only in deployment.
 * C++ tests for each backend, per AGENTS.md, with Python tests covering only
   the narrow compatibility bridge.
-* Two runs configured with different destinations do not disturb each other's
-  store, and a store released with its GlobalState leaves no live backend.
+* Two ``GlobalState`` scopes configured with different destinations do not
+  disturb each other's store, and a store released with its state leaves no
+  live backend.
 * The installed-SDK consumer test links and uses whichever format libraries the
   build claims to support.
 
-Implementation status
----------------------
+Reference implementation validation
+-----------------------------------
 
-Native memory and local-filesystem stores, format handling, key validation,
-immutable writes and graph-scoped ownership are implemented. S3 remains
-build-option dependent. RFC 0019 consumes this graph-scoped store; segmented
-recordings remain deferred to its step 7.
+The accepted implementation provides native memory, local-filesystem and
+build-option-dependent S3 stores; Arrow IPC and build-option-dependent Parquet;
+format-preserving RFC 0001 metadata; key validation; immutable writes;
+per-write compression overrides; and ``GlobalState``-scoped ownership. RFC
+0019 consumes this store and implements native segmented recording over its
+immutable object operations. The Python compatibility bridge remains limited
+to atomic ``store``/``load``/``has`` calls.
+
+The ordinary native suite covers memory, local persistence, both formats,
+typed metadata recovery, compression selection, state isolation and lifetime,
+failure propagation, and the installed type-erased SDK contract. The hidden
+S3 conformance case runs against MinIO in Linux CI and covers the same frame,
+schema, typed metadata, key-validation and immutability contract through the
+real Arrow S3 filesystem.
+
+Closure validation on 2026-08-14 passed all 1,582 tests from a fresh macOS
+native preset. The hidden S3 case then passed 27 assertions against MinIO,
+covering Arrow IPC and Parquet. A stable-ABI wheel built with Python 3.12 and
+installed into a fresh Python 3.14 environment passed all 2,139 non-WIP tests
+(9 skipped), and the complete Sphinx build passed with warnings treated as
+errors.
 
 References
 ----------
 
 * :doc:`rfc_0001_typed_frame_metadata` — frame-level metadata this must
   preserve.
-* :doc:`../developer_guide/record_replay_table` — the graph-scoped frame-store
-  seam and the ``DATA_FRAME`` backend.
+* :doc:`../developer_guide/record_replay_table` — the
+  ``GlobalState``-scoped frame-store seam and the ``DATA_FRAME`` backend.
 * :doc:`../developer_guide/extension_policy` — core versus extension ownership.
 * Apache Arrow C++ ``arrow::fs`` filesystem layer, and the Parquet
   ``ARROW:schema`` key-value convention.

--- a/docs/source/rfc/rfc_0019_native_table_recording.rst
+++ b/docs/source/rfc/rfc_0019_native_table_recording.rst
@@ -1,7 +1,7 @@
 RFC 0019: Native Table Recording for Partitioned Time-Series
 ============================================================
 
-:Status: Proposed; reference implementation and acceptance validation complete
+:Status: Accepted
 :Author: Howard Henson
 :Created: 2026-08-12
 :Target: Table codec, record/replay data-frame backend, and the Python data-frame adaptor
@@ -81,9 +81,10 @@ Current state
    * - ``record`` (``DATA_FRAME`` model)
      - ``record_replay_frame_impl.h``
      - Uses ``TableRecorder`` over ``TableLayout`` and writes the finished
-       frame to the graph-scoped RFC 0016 store. Partitioned frame values expand
-       to one stored row per key/frame-row pair. Optional native segmentation
-       flushes independently valid frames without changing replay semantics.
+       frame to the ``GlobalState``-scoped RFC 0016 store. Partitioned frame
+       values expand to one stored row per key/frame-row pair. Optional native
+       segmentation flushes independently valid frames without changing replay
+       semantics.
    * - Python data-frame adaptor
      - ``adaptors/data_frame``
      - A compatibility storage adapter only. It delegates complete frames
@@ -91,12 +92,11 @@ Current state
        The legacy override registry is translated to explicit native wiring
        options at the Python call boundary.
 
-The reference implementation closes that gap with an Arrow recorder driven by
+The accepted implementation closes that gap with an Arrow recorder driven by
 ``TableLayout`` rather than by a value schema. It also implements keyed frame
 expansion, native segmented flushing, and the public ``TableTypeOps`` extension
 contract described below. All eight stages and the acceptance validation are
-complete; the RFC remains Proposed until review accepts it and the pull request
-is merged.
+complete.
 
 Design
 ------
@@ -456,10 +456,11 @@ duplicated into each guard.
 Storage
 ~~~~~~~
 
-Recording writes through the graph-scoped ``store::FrameStore`` contract that
-RFC 0016 defines. The owning erased handle and its passive ops table keep the
-recorder independent of memory, filesystem, S3 and Python representations;
-none of those strategies is a public base-class implementation.
+Recording writes through the ``GlobalState``-scoped ``store::FrameStore``
+contract that RFC 0016 defines. The owning erased handle and its passive ops
+table keep the recorder independent of memory, filesystem, S3 and Python
+representations; none of those strategies is a public base-class
+implementation.
 
 ``DataFrameStorage`` is then a compatibility frame-store implementation rather
 than a parallel recording stack. The Python adaptor keeps its public surface
@@ -747,7 +748,7 @@ References
 
 * ``docs/source/developer_guide/record_replay_table.rst`` — the columnar-builder
   ruling (*I5*) this RFC finishes applying.
-* RFC 0016 — object-store frame persistence; the graph-scoped
+* RFC 0016 — object-store frame persistence; the ``GlobalState``-scoped
   ``store::FrameStore`` is the storage seam used here.
 * ``include/hgraph/types/table_type_ops.h`` — the public ``TableLayout`` and
   ``TableTypeOps`` contract.

--- a/include/hgraph/types/frame_store.h
+++ b/include/hgraph/types/frame_store.h
@@ -66,11 +66,13 @@ namespace hgraph::store
             std::string                secret_access_key{};
             std::optional<std::string> session_token{};
         };
-        /** A named profile from the shared credentials file. */
+        /** Reserved configuration spelling. The Arrow backend rejects this
+         * directly; set AWS_PROFILE and select Ambient instead. */
         struct Profile
         {
             std::string name{};
         };
+        /** Assume a role using credentials resolved from the ambient chain. */
         struct AssumeRole
         {
             std::string                role_arn{};

--- a/include/hgraph/types/record_replay.h
+++ b/include/hgraph/types/record_replay.h
@@ -153,8 +153,9 @@ namespace hgraph::record_replay
     /** The active process fallback store. */
     [[nodiscard]] HGRAPH_EXPORT const store::FrameStore &frame_store();
 
-    /** Install a configured store for one graph run. ``GlobalState`` owns a
-        copy of the erased handle and therefore shares its context. */
+    /** Install a configured store for one ``GlobalState`` scope. The state
+        owns a copy of the erased handle and therefore shares its context
+        across every graph run bound to that state. */
     HGRAPH_EXPORT void set_frame_store(GlobalStateView state, store::FrameStore frame_store);
 
     /** Remove the graph-selected store; subsequent operations use the process
@@ -169,9 +170,10 @@ namespace hgraph::record_replay
     [[nodiscard]] HGRAPH_EXPORT Frame store_read(std::string_view key);
     [[nodiscard]] HGRAPH_EXPORT bool  store_contains(std::string_view key);
 
-    /** Graph-scoped store operations. A store installed in ``state`` wins;
-        otherwise these use the process-lifetime fallback above. Runtime nodes
-        use these overloads so storage follows the graph that selected it. */
+    /** GlobalState-scoped store operations. A store installed in ``state``
+        wins; otherwise these use the process-lifetime fallback above. Runtime
+        nodes use these overloads so storage follows the graph state that
+        selected it. */
     HGRAPH_EXPORT void store_write(GlobalStateView state, std::string_view key, Frame frame);
     [[nodiscard]] HGRAPH_EXPORT Frame store_read(GlobalStateView state, std::string_view key);
     [[nodiscard]] HGRAPH_EXPORT bool  store_contains(GlobalStateView state, std::string_view key);

--- a/tests/cpp/test_frame_store.cpp
+++ b/tests/cpp/test_frame_store.cpp
@@ -6,15 +6,25 @@
 // frame, and RFC 0001 frame metadata surviving persistence and decoding back
 // to the typed value.
 
+#include <hgraph/runtime/global_state.h>
 #include <hgraph/types/frame_store.h>
 #include <hgraph/types/metadata/type_registry.h>
+#include <hgraph/types/metadata/value_plan_factory.h>
+#include <hgraph/types/record_replay.h>
+#include <hgraph/types/static_schema.h>
+#include <hgraph/types/value/value_builder.h>
 
 #include <arrow/array.h>
 #include <arrow/builder.h>
 #include <arrow/table.h>
 #include <arrow/util/key_value_metadata.h>
 
+#if defined(HGRAPH_WITH_PARQUET)
+#include <parquet/file_reader.h>
+#endif
+
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include <cstdlib>
 #include <filesystem>
@@ -26,6 +36,12 @@ using namespace hgraph::store;
 
 namespace
 {
+    using FrameStoreMetaDetails =
+        Bundle<"tests.frame_store::Details", Field<"desk", Str>>;
+    using FrameStoreMeta =
+        Bundle<"tests.frame_store::Metadata", Field<"revision", Int>,
+               Field<"details", FrameStoreMetaDetails>>;
+
     [[nodiscard]] Frame make_frame(std::int64_t first = 1)
     {
         arrow::Int64Builder builder;
@@ -35,6 +51,41 @@ namespace
         REQUIRE(builder.Finish(&array).ok());
         auto schema = arrow::schema({arrow::field("value", arrow::int64())});
         return Frame{arrow::Table::Make(schema, {array})};
+    }
+
+    [[nodiscard]] Value make_metadata()
+    {
+        BundleBuilder details{ValuePlanFactory::instance().type_for(
+            scalar_descriptor<FrameStoreMetaDetails>::value_meta())};
+        details.set(0, Value{Str{"systematic"}});
+
+        BundleBuilder metadata{ValuePlanFactory::instance().type_for(
+            scalar_descriptor<FrameStoreMeta>::value_meta())};
+        metadata.set(0, Value{Int{7}});
+        metadata.set(1, details.build());
+        return metadata.build();
+    }
+
+    [[nodiscard]] Frame make_metadata_frame()
+    {
+        return with_frame_metadata(make_frame(), make_metadata());
+    }
+
+    void check_frame_round_trip(const FrameStore &store, std::string_view key,
+                                const Frame &expected)
+    {
+        store.write(key, expected);
+        const Frame actual = store.read(key);
+        REQUIRE(actual.has_value());
+        CHECK(actual.table->Equals(*expected.table));
+        CHECK(actual.table->schema()->Equals(*expected.table->schema(), true));
+    }
+
+    void check_typed_metadata(const Frame &frame)
+    {
+        REQUIRE(frame.has_metadata());
+        CHECK(frame_metadata(frame, scalar_descriptor<FrameStoreMeta>::value_meta()) ==
+              make_metadata());
     }
 
     /** A directory that removes itself, so a failing test leaves no litter. */
@@ -181,6 +232,10 @@ TEST_CASE("frame store: memory backend round-trips and honours immutability")
 
     store.clear();
     CHECK_FALSE(store.contains("prices"));
+
+    const Frame metadata = make_metadata_frame();
+    check_frame_round_trip(store, "metadata", metadata);
+    check_typed_metadata(store.read("metadata"));
 }
 
 TEST_CASE("frame store: a local store persists frames as files")
@@ -218,15 +273,16 @@ TEST_CASE("frame store: both formats round-trip a frame")
 {
     TempDir dir{"formats"};
 
-    auto ipc = make_frame_store(local_config(dir, Format::ArrowIpc));
-    ipc.write("ipc", make_frame());
-    CHECK(ipc.read("ipc").table->num_rows() == 2);
+    const Frame expected = make_metadata_frame();
+    auto        ipc = make_frame_store(local_config(dir, Format::ArrowIpc));
+    check_frame_round_trip(ipc, "ipc", expected);
+    check_typed_metadata(ipc.read("ipc"));
 
     if (parquet_available())
     {
         auto parquet = make_frame_store(local_config(dir, Format::Parquet));
-        parquet.write("parquet", make_frame());
-        CHECK(parquet.read("parquet").table->num_rows() == 2);
+        check_frame_round_trip(parquet, "parquet", expected);
+        check_typed_metadata(parquet.read("parquet"));
     }
     else
     {
@@ -271,6 +327,61 @@ TEST_CASE("frame store: RFC 0001 frame metadata survives persistence")
     }
 }
 
+#if defined(HGRAPH_WITH_PARQUET)
+TEST_CASE("frame store: a per-write compression override wins over the store default")
+{
+    TempDir          dir{"compression"};
+    FrameStoreConfig config = local_config(dir, Format::Parquet);
+    config.compression = Compression::None;
+    auto store = make_frame_store(config);
+
+    store.write("default", make_frame());
+    store.write("override", make_frame(), Compression::Zstd);
+
+    const auto default_reader = parquet::ParquetFileReader::OpenFile(
+        (std::filesystem::path{dir.string()} / "default").string());
+    const auto override_reader = parquet::ParquetFileReader::OpenFile(
+        (std::filesystem::path{dir.string()} / "override").string());
+    REQUIRE(default_reader->metadata()->num_row_groups() == 1);
+    REQUIRE(override_reader->metadata()->num_row_groups() == 1);
+    CHECK(default_reader->metadata()->RowGroup(0)->ColumnChunk(0)->compression() ==
+          parquet::Compression::UNCOMPRESSED);
+    CHECK(override_reader->metadata()->RowGroup(0)->ColumnChunk(0)->compression() ==
+          parquet::Compression::ZSTD);
+}
+#endif
+
+TEST_CASE("frame store: GlobalState scopes independent stores and owns their lifetime")
+{
+    auto                      first_context = std::make_shared<ProbeStore>();
+    auto                      second_context = std::make_shared<ProbeStore>();
+    const std::weak_ptr<void> first_lifetime = first_context;
+    const std::weak_ptr<void> second_lifetime = second_context;
+
+    {
+        GlobalState first_state;
+        GlobalState second_state;
+        record_replay::set_frame_store(first_state.view(),
+                                       FrameStore{first_context, probe_store_ops()});
+        record_replay::set_frame_store(second_state.view(),
+                                       FrameStore{second_context, probe_store_ops()});
+        first_context.reset();
+        second_context.reset();
+
+        record_replay::store_write(first_state.view(), "value", make_frame(10));
+        record_replay::store_write(second_state.view(), "value", make_frame(20));
+        CHECK(record_replay::store_read(first_state.view(), "value")
+                  .table->column(0)->GetScalar(0).ValueOrDie()->ToString() == "10");
+        CHECK(record_replay::store_read(second_state.view(), "value")
+                  .table->column(0)->GetScalar(0).ValueOrDie()->ToString() == "20");
+        CHECK_FALSE(first_lifetime.expired());
+        CHECK_FALSE(second_lifetime.expired());
+    }
+
+    CHECK(first_lifetime.expired());
+    CHECK(second_lifetime.expired());
+}
+
 TEST_CASE("frame store: an unbuildable configuration fails rather than degrading")
 {
     // A store that quietly fell back to memory would turn a deployment error
@@ -282,6 +393,17 @@ TEST_CASE("frame store: an unbuildable configuration fails rather than degrading
     FrameStoreConfig no_bucket;
     no_bucket.location = S3Location{};
     CHECK_THROWS(make_frame_store(no_bucket));
+
+#if defined(HGRAPH_WITH_S3)
+    FrameStoreConfig named_profile;
+    S3Location      profile_location;
+    profile_location.bucket = "unused";
+    profile_location.credentials.source = Credentials::Profile{"research"};
+    named_profile.location = std::move(profile_location);
+    CHECK_THROWS_WITH(make_frame_store(named_profile),
+                      Catch::Matchers::ContainsSubstring("set AWS_PROFILE"));
+    finalize_s3();
+#endif
 }
 
 // The S3 backend runs against any S3-compatible endpoint, so it needs no cloud
@@ -324,24 +446,38 @@ TEST_CASE("frame store: an S3 store round-trips against a local endpoint", "[.s3
         location.credentials.source = Credentials::Explicit{key_id, secret, {}};
     }
 
-    FrameStoreConfig config;
-    config.location = location;
-    config.format = Format::Parquet;
+    const Frame expected = make_metadata_frame();
+    for (const auto format : {Format::ArrowIpc, Format::Parquet})
+    {
+        if (format == Format::Parquet && !parquet_available())
+        {
+            continue;
+        }
 
-    auto store = make_frame_store(config);
-    CHECK(store.supports_segmented_recordings());
+        FrameStoreConfig config;
+        config.location = location;
+        config.format = format;
 
-    store.write("run/prices", make_frame());
-    CHECK(store.contains("run/prices"));
-    CHECK(store.read("run/prices").table->num_rows() == 2);
-    CHECK_FALSE(store.contains("run/absent"));
+        auto store = make_frame_store(config);
+        CHECK(store.supports_segmented_recordings());
+        const std::string_view key =
+            format == Format::ArrowIpc ? "run/ipc" : "run/parquet";
+        check_frame_round_trip(store, key, expected);
+        check_typed_metadata(store.read(key));
+        CHECK_FALSE(store.contains("run/absent"));
+        CHECK_THROWS_AS(store.contains("../invalid"), std::invalid_argument);
 
-    // Immutability holds against a real object store, where an overwrite would
-    // usually destroy the previous version outright.
-    CHECK_THROWS(store.write("run/prices", make_frame(10)));
+        // Immutability holds against a real object store, where an overwrite
+        // would usually destroy the previous version outright.
+        CHECK_THROWS(store.write(key, make_frame(10)));
+        store.reset();
+    }
 
-    store.clear();
-    store.reset();
+    FrameStoreConfig cleanup_config;
+    cleanup_config.location = location;
+    auto cleanup = make_frame_store(cleanup_config);
+    cleanup.clear();
+    cleanup.reset();
     // The application owns S3 shutdown; see finalize_s3's contract.
     finalize_s3();
 }


### PR DESCRIPTION
## Summary

- mark RFC 0016 and RFC 0019 as accepted and align their wording with the merged implementation
- document `FrameStore` as `GlobalState`-scoped and clarify the supported Arrow credential behavior
- strengthen frame-store coverage for typed metadata, Parquet compression overrides, state isolation and lifetime, and IPC/Parquet S3 behavior
- run the hidden S3 conformance test against a pinned MinIO service in Linux native CI

## Why

The implementations behind RFCs 0016 and 0019 had been completed, but RFC 0016 still described parts of the earlier proposal and lacked direct acceptance coverage for several promises. In particular, the documentation misstated store lifetime and build capabilities, while S3, typed metadata, compression selection, and independent `GlobalState` ownership were not all exercised at the conformance boundary.

This closes those gaps before accepting both RFCs.

## Validation

- fresh native C++ preset: 1,582/1,582 tests passed
- hidden S3 conformance against MinIO: 27 assertions passed across Arrow IPC and Parquet
- stable-ABI wheel built with Python 3.12 and tested under Python 3.14: 2,139 passed, 9 skipped
- complete Sphinx build with warnings treated as errors
- workflow YAML parse and `git diff --check`

`actionlint` was not installed locally; the added MinIO workflow commands were exercised directly against Docker.