### PR TITLE
Fix omitted real-time start time

### DIFF
--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -255,6 +255,10 @@ and extending as new regressions are identified:
   accepted signature spellings — strict, bare-injectable, and unannotated
   name-match (the #79 class) — and alternates attribute and dictionary-view
   access over naked ``STATE``;
+- ``realtime_default_start`` runs a bounded real-time graph and reduces its
+  nondeterministic timestamp to whether the executor started after the
+  simulation-only ``MIN_ST`` sentinel, pinning the release/0.5 default when
+  no explicit start time is supplied;
 - ``data_frame_recording`` records through the DATA_FRAME model and emits
   the frame a ``DataFrameStorage`` hands back to user code — column names,
   **timezone presentation**, and row values — so a tz-aware engine column or

--- a/docs/source/reference/authoring_api.rst
+++ b/docs/source/reference/authoring_api.rst
@@ -199,7 +199,8 @@ Execution and testing
    :param graph: Decorated graph, node, or operator to evaluate.
    :param args: Positional wiring-time arguments passed to ``graph``.
    :param run_mode: Simulation or real-time evaluation mode.
-   :param start_time: First evaluation time.
+   :param start_time: First evaluation time. Defaults to ``MIN_ST`` in
+       simulation mode and current UTC time in real-time mode.
    :param end_time: Run bound, or a duration relative to the start.
    :param print_progress: Compatibility option; progress rendering is not
        performed by the runtime.
@@ -235,7 +236,8 @@ Execution and testing
 
    :param run_mode: ``EvaluationMode.SIMULATION`` or
        ``EvaluationMode.REAL_TIME``.
-   :param start_time: Optional first evaluation time.
+   :param start_time: Optional first evaluation time. Defaults to ``MIN_ST``
+       in simulation mode and current UTC time in real-time mode.
    :param end_time: Run bound, or a :class:`~datetime.timedelta`
        relative to the effective start time.
    :param trace: ``False``, ``True``, an ``EvaluationTrace``, or keyword

--- a/include/hgraph/runtime/executor.h
+++ b/include/hgraph/runtime/executor.h
@@ -293,6 +293,11 @@ namespace hgraph
         GraphExecutorBuilder &label(std::string label);
         GraphExecutorBuilder &graph_builder(GraphBuilder graph_builder);
         GraphExecutorBuilder &mode(GraphExecutorMode mode) noexcept;
+        /**
+         * Set the first evaluation time explicitly. When omitted, simulation
+         * starts at MIN_ST and real-time execution captures the wall clock
+         * while constructing the executor.
+         */
         GraphExecutorBuilder &start_time(DateTime start_time) noexcept;
         GraphExecutorBuilder &end_time(DateTime end_time) noexcept;
         GraphExecutorBuilder &logger(std::shared_ptr<spdlog::logger> logger);
@@ -337,6 +342,7 @@ namespace hgraph
         std::string                     label_{};
         GraphBuilder                    graph_builder_{};
         DateTime                        start_time_{MIN_ST};
+        bool                            start_time_set_{false};
         DateTime                        end_time_{MAX_ET};
         GraphExecutorMode               mode_{GraphExecutorMode::Simulation};
         std::shared_ptr<spdlog::logger>  logger_{};

--- a/python/hgraph/_wiring/_runner.py
+++ b/python/hgraph/_wiring/_runner.py
@@ -58,7 +58,8 @@ class GraphConfiguration:
 
     :param run_mode: ``EvaluationMode.SIMULATION`` or
         ``EvaluationMode.REAL_TIME``.
-    :param start_time: Optional first evaluation time.
+    :param start_time: Optional first evaluation time. Defaults to ``MIN_ST``
+        in simulation mode and current UTC time in real-time mode.
     :param end_time: Run bound, or a :class:`~datetime.timedelta`
         relative to the effective start time.
     :param trace: ``False``, ``True``, an ``EvaluationTrace``, or keyword
@@ -95,12 +96,18 @@ class GraphConfiguration:
             logger_formatter=None,
             cleanup_on_error=True):
         self.run_mode = run_mode
+        if start_time is None:
+            start_time = (
+                utc_now()
+                if run_mode == EvaluationMode.REAL_TIME
+                else _hgraph.MIN_ST
+            )
         self.start_time = start_time
         if isinstance(end_time, timedelta):
             relative_start = (
                 utc_now()
                 if run_mode == EvaluationMode.REAL_TIME
-                else start_time if start_time is not None else _hgraph.MIN_ST
+                else self.start_time
             )
             end_time = relative_start + end_time
         self.end_time = end_time
@@ -230,7 +237,8 @@ def run_graph(
     :param graph: Decorated graph, node, or operator to evaluate.
     :param args: Positional wiring-time arguments passed to ``graph``.
     :param run_mode: Simulation or real-time evaluation mode.
-    :param start_time: First evaluation time.
+    :param start_time: First evaluation time. Defaults to ``MIN_ST`` in
+        simulation mode and current UTC time in real-time mode.
     :param end_time: Run bound, or a duration relative to the start.
     :param print_progress: Compatibility option; progress rendering is not
         performed by the runtime.

--- a/python/py_wiring.h
+++ b/python/py_wiring.h
@@ -332,7 +332,6 @@ namespace hgraph::python_bridge
 
             GraphExecutorBuilder eb;
             eb.graph_builder(std::move(builder))
-                .start_time(start_time.value_or(MIN_ST))
                 .end_time(end_time.value_or(MAX_ET))
                 .mode(realtime ? GraphExecutorMode::RealTime : GraphExecutorMode::Simulation)
                 .logger(make_python_run_logger(std::move(logger), logger_level,
@@ -342,6 +341,7 @@ namespace hgraph::python_bridge
                     .capture_values = capture_values,
                 })
                 .cleanup_on_error(cleanup_on_error);
+            if (start_time.has_value()) { eb.start_time(*start_time); }
             if (requires_phase_runner)
             {
                 eb.phase_runner(&py_run_executor_phase);

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -215,6 +215,19 @@ def test_legacy_compound_scalar_json_recipe_rejects_malformed_values():
         validate_recipe(recipe)
 
 
+def test_realtime_default_start_recipe_requires_one_boolean_probe():
+    raw = {
+        "schema_version": 1,
+        "id": "test-realtime-default-start",
+        "template": "realtime_default_start",
+        "inputs": {"probe": [1]},
+        "parameters": {},
+        "features": ["execution:real-time"],
+    }
+    with pytest.raises(RecipeError, match="one boolean probe"):
+        validate_recipe(Recipe.from_dict(raw))
+
+
 def test_recipe_fingerprint_is_independent_of_json_key_order():
     first = _scalar_recipe()
     raw = first.to_dict()

--- a/python/tests/test_signature_compatibility.py
+++ b/python/tests/test_signature_compatibility.py
@@ -130,8 +130,27 @@ def test_graph_configuration_resolves_relative_end_time():
         end_time=timedelta(seconds=2),
     )
     after = hg.utc_now()
+    assert before <= real_time.start_time <= after
     assert before + timedelta(seconds=2) <= real_time.end_time
     assert real_time.end_time <= after + timedelta(seconds=2)
+
+
+def test_realtime_run_defaults_start_time_to_now():
+    @hg.graph
+    def app() -> hg.TS[int]:
+        return hg.const(1)
+
+    before = hg.utc_now()
+    result = hg.run_graph(
+        app,
+        run_mode=hg.EvaluationMode.REAL_TIME,
+        end_time=timedelta(milliseconds=50),
+    )
+    after = hg.utc_now()
+
+    assert len(result) == 1
+    assert result[0][1] == 1
+    assert before <= result[0][0] <= after
 
 
 def test_graph_configuration_applies_logger_formatter_to_python_and_native_nodes(caplog):

--- a/src/hgraph/runtime/executor.cpp
+++ b/src/hgraph/runtime/executor.cpp
@@ -64,7 +64,7 @@ namespace hgraph
                   graph(builder.graph_builder().make_root_graph(type.writable(executor_memory))),
                   start_time(builder.start_time()),
                   end_time(builder.end_time()),
-                  evaluation_time(builder.start_time()),
+                  evaluation_time(start_time),
                   cycle_wall_start(current_wall_time()),
                   error_capture_options(builder.error_capture_options()),
                   cleanup_on_error(builder.cleanup_on_error()),
@@ -114,7 +114,7 @@ namespace hgraph
                   graph(builder.graph_builder().make_root_graph(type.writable(executor_memory))),
                   start_time(builder.start_time()),
                   end_time(builder.end_time()),
-                  evaluation_time(builder.start_time()),
+                  evaluation_time(start_time),
                   error_capture_options(builder.error_capture_options()),
                   cleanup_on_error(builder.cleanup_on_error()),
                   phase_runner(builder.phase_runner()),
@@ -1327,6 +1327,7 @@ namespace hgraph
     GraphExecutorBuilder &GraphExecutorBuilder::start_time(DateTime start_time) noexcept
     {
         start_time_ = start_time;
+        start_time_set_ = true;
         return *this;
     }
 
@@ -1390,7 +1391,8 @@ namespace hgraph
 
     DateTime GraphExecutorBuilder::start_time() const noexcept
     {
-        return start_time_;
+        if (start_time_set_) { return start_time_; }
+        return mode_ == GraphExecutorMode::RealTime ? current_wall_time() : MIN_ST;
     }
 
     DateTime GraphExecutorBuilder::end_time() const noexcept

--- a/tests/cpp/test_realtime_execution.cpp
+++ b/tests/cpp/test_realtime_execution.cpp
@@ -210,6 +210,34 @@ namespace
     }
 }  // namespace
 
+TEST_CASE("real-time executor defaults an omitted start time to the wall clock")
+{
+    using namespace hgraph;
+
+    GraphBuilder graph_builder;
+    const DateTime before = hgraph::testing::wall_now();
+
+    GraphExecutorBuilder executor_builder;
+    executor_builder.graph_builder(std::move(graph_builder))
+        .mode(GraphExecutorMode::RealTime)
+        .end_time(before + TimeDelta{1'000'000});
+
+    GraphExecutorValue executor = executor_builder.make_executor();
+    const DateTime after = hgraph::testing::wall_now();
+
+    CHECK(executor.view().start_time() >= before);
+    CHECK(executor.view().start_time() <= after);
+
+    GraphExecutorBuilder explicit_builder;
+    explicit_builder.graph_builder(GraphBuilder{})
+        .mode(GraphExecutorMode::RealTime)
+        .start_time(MIN_DT)
+        .end_time(MIN_ST);
+
+    GraphExecutorValue explicit_executor = explicit_builder.make_executor();
+    CHECK(explicit_executor.view().start_time() == MIN_DT);
+}
+
 TEST_CASE("real-time executor waits for the future scheduled time")
 {
     using namespace hgraph;

--- a/tools/parity/catalog.py
+++ b/tools/parity/catalog.py
@@ -714,6 +714,43 @@ def _lifecycle_state(hg, recipe):
 
 
 # --------------------------------------------------------------------------
+# Real-time configuration: an omitted start captures wall-clock UTC rather
+# than inheriting the simulation-only MIN_ST sentinel.
+
+def _validate_realtime_default_start(recipe):
+    if recipe.parameters:
+        raise RecipeError("realtime_default_start takes no parameters")
+    probe = recipe.inputs["probe"]
+    if len(probe) != 1 or not isinstance(probe[0], bool):
+        raise RecipeError("realtime_default_start requires one boolean probe")
+
+
+def _realtime_default_start(hg, recipe):
+    from datetime import timedelta
+
+    probe = decoded_inputs(hg, recipe)["probe"][0]
+
+    @hg.compute_node
+    def started_after_simulation_sentinel(
+        value: hg.TS[bool], _api: hg.EvaluationEngineApi = None,
+    ) -> hg.TS[bool]:
+        return value.value and _api.start_time > hg.MIN_ST
+
+    @hg.graph
+    def parity_graph() -> hg.TS[bool]:
+        return started_after_simulation_sentinel(hg.const(probe))
+
+    result = hg.evaluate_graph(
+        parity_graph,
+        config=hg.GraphConfiguration(
+            run_mode=hg.EvaluationMode.REAL_TIME,
+            end_time=timedelta(milliseconds=50),
+        ),
+    )
+    return [value for _, value in result]
+
+
+# --------------------------------------------------------------------------
 # Deeply nested higher-order structures: map_/mesh_ over a CHURNING key set,
 # a per-key switch_ FLIPPING branches (nested graphs start/stop), services
 # (request-reply / subscription) and adaptors living INSIDE those branches,
@@ -2889,6 +2926,19 @@ CATALOG = {
         operators=(),
         execute=_lifecycle_state,
     ),
+    "realtime_default_start": TemplateSpec(
+        name="realtime_default_start",
+        required_inputs=("probe",),
+        features=(
+            "shape:TS",
+            "type:bool",
+            "execution:real-time",
+            "clock:wall-time",
+            "compatibility:release-0.5",
+        ),
+        operators=("const",),
+        execute=_realtime_default_start,
+    ),
     "nested_higher_order": TemplateSpec(
         name="nested_higher_order",
         required_inputs=None,
@@ -2968,6 +3018,8 @@ def validate_recipe(recipe):
         _validate_collection_size(recipe)
     elif recipe.template == "lifecycle_state":
         _validate_lifecycle_state(recipe)
+    elif recipe.template == "realtime_default_start":
+        _validate_realtime_default_start(recipe)
     elif recipe.template == "nested_higher_order":
         _validate_nested_higher_order(recipe)
     elif recipe.template == "data_frame_recording":

--- a/tools/parity/corpus/regression-realtime-default-start.json
+++ b/tools/parity/corpus/regression-realtime-default-start.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "regression-realtime-default-start",
+  "description": "A real-time run with no explicit start begins at wall-clock UTC rather than MIN_ST.",
+  "template": "realtime_default_start",
+  "inputs": {
+    "probe": [true]
+  },
+  "parameters": {},
+  "features": [
+    "shape:TS",
+    "type:bool",
+    "execution:real-time",
+    "clock:wall-time",
+    "compatibility:release-0.5"
+  ]
+}


### PR DESCRIPTION
## Summary

- make an omitted real-time start resolve to current wall-clock UTC in the native executor, matching released hgraph 0.5 behavior
- keep the simulation default at `MIN_ST` and preserve every explicit start value, including `MIN_DT`
- align Python configuration and bridge behavior, and update the generated authoring API reference
- add native, Python, and released-version parity regressions

## Root cause

The Python bridge eagerly converted a missing start time to `MIN_ST`, while the native executor builder also defaulted to `MIN_ST` without considering execution mode. That applied the simulation default to real-time runs.

## Validation

- macOS: fresh native configure, clean build, and 1,581 C++ tests passed
- macOS: installed-package C++ consumer passed
- macOS: stable-ABI wheel built with Python 3.12 and installed into a fresh Python 3.14 environment; 2,141 passed and 9 skipped
- Linux with GCC 14.3: fresh native configure, clean build, and 1,581 C++ tests passed
- Linux: stable-ABI wheel installed into a fresh Python 3.14 environment; 2,141 passed and 9 skipped
- released-hgraph-0.5 differential parity regression matched; all 86 parity recipes validate
- generated API inventory and `git diff --check` passed
