### PR TITLE
Fix aggregate TSD bundle conversion

### DIFF
--- a/python/py_runtime.h
+++ b/python/py_runtime.h
@@ -1733,6 +1733,23 @@ namespace hgraph::python_bridge
                 // (peered at the true upstream output).
                 return nb::cast(python_bridge::PyOpaqueRef{Value{v.reference()}, v.evaluation_time()});
             }
+            if (schema != nullptr && schema->kind == TSTypeKind::TSD)
+            {
+                // A TSD input can expose projected structural children (for
+                // example a map_ result whose values are TSBs). Those children
+                // intentionally do not require an aggregate scalar conversion
+                // op. Assemble the public aggregate through the same child
+                // views used by values[key].value so forwarding endpoints and
+                // nested structures retain their Python representation.
+                nb::dict result;
+                auto dict = const_cast<TSInputView &>(v).as_dict();
+                for (auto &&[key, child] : dict.valid_items())
+                {
+                    nb::object py_key = value_to_py(key);
+                    result[py_key] = collection_child(std::move(child), py_key).value();
+                }
+                return result;
+            }
             if (schema != nullptr && schema->kind == TSTypeKind::TSB)
             {
                 nb::dict result;

--- a/python/tests/ported/_wiring/test_map_regressions.py
+++ b/python/tests/ported/_wiring/test_map_regressions.py
@@ -75,6 +75,37 @@ def test_map_preserves_typed_keyed_bundle_reference_and_materialization():
     assert eval_node(materialized_app, lookups, rows) == expected
 
 
+def test_map_bundle_output_exposes_aggregate_tsd_value_to_python_nodes():
+    class Status(hg.TimeSeriesSchema):
+        value: hg.TS[int]
+        ok: hg.TS[bool]
+
+    aggregate_values = []
+    individual_values = []
+
+    @hg.graph
+    def make_status(value: hg.TS[int]) -> hg.TSB[Status]:
+        return hg.combine[hg.TSB[Status]](value=value, ok=value > 0)
+
+    @hg.sink_node
+    def observe(values: hg.TSD[str, hg.TSB[Status]]):
+        individual_values.append(values["item"].value)
+        aggregate_values.append(values.value)
+
+    @hg.graph
+    def app(
+        values: hg.TSD[str, hg.TS[int]],
+    ) -> hg.TSD[str, hg.TSB[Status]]:
+        statuses = hg.map_(make_status, values)
+        observe(statuses)
+        return statuses
+
+    expected = {"item": {"value": 1, "ok": True}}
+    assert eval_node(app, [{"item": 1}]) == [expected]
+    assert individual_values == [expected["item"]]
+    assert aggregate_values == [expected]
+
+
 def test_map_removed_typed_bundle_reference_does_not_retick_with_sibling():
     class Row(hg.TimeSeriesSchema):
         value: hg.TS[int]


### PR DESCRIPTION
## What changed

- assemble Python-facing `TSD.value` from the dictionary's valid native child views
- preserve the same forwarding and structural conversion behavior used by `values[key].value`
- add a regression for a `map_` graph returning `TSD[str, TSB[Status]]`

## Root cause

`PyTimeSeries.value()` handled TSL and TSB aggregates through their child time-series views, but delegated TSD aggregates to the type-erased scalar map conversion. A mapped TSB child can be a projected structural value whose scalar binding is inspection-only, so that route raised `ValueOps::to_python is not available for this value type` even though individual child conversion worked.

## Impact

Python nodes can read the aggregate `.value` of mapped TSDs containing bundles. Invalid or removed children remain absent because the aggregate is assembled from `valid_items()`.

## Validation

- focused map regression file: 8 passed
- adjacent TSD and CompoundScalar tests: 122 passed
- clean native C++ acceptance suite: 1,582 passed
- optimized stable-ABI wheel built with Python 3.12 and complete non-WIP suite run under Python 3.14: 2,140 passed, 9 skipped
