### PR TITLE
PEP 695 type aliases in annotations, and Kafka content-type casing

### DIFF
--- a/docs/source/reference/python_api_inventory.rst
+++ b/docs/source/reference/python_api_inventory.rst
@@ -18,7 +18,7 @@ public operator they implement rather than listed as top-level operators.
    * - Surface
      - Names
    * - ``hgraph.__all__``
-     - 210
+     - 211
    * - Public operator groups
      - 188
    * - Public submodules
@@ -209,6 +209,7 @@ Top-level wildcard exports
    * - ``register_python_object_type``
    * - ``register_service``
    * - ``request_reply_service``
+   * - ``resolve_type_alias``
    * - ``run_graph``
    * - ``service_adaptor``
    * - ``service_adaptor_impl``

--- a/extensions/kafka/python/hgraph_kafka/compat.py
+++ b/extensions/kafka/python/hgraph_kafka/compat.py
@@ -288,7 +288,14 @@ def _to_legacy_message(record: TS[KafkaRecord]) -> TS[KafkaMessage]:
     headers = {}
     content_type = None
     for header in record.value.headers:
-        if header.name == _CONTENT_TYPE_HEADER:
+        # Matched case-INSENSITIVELY. Kafka header names are arbitrary byte
+        # strings, and producers outside hgraph commonly send ``Content-Type``.
+        # An exact-case match left such a message with content_type=None while
+        # quietly depositing the header in ``headers``, so the information
+        # survived where no consumer looks for it - and re-producing then
+        # emitted the original casing rather than the canonical one, making the
+        # round trip lossy in a way nothing reported.
+        if header.name.lower() == _CONTENT_TYPE_HEADER:
             content_type = (
                 header.value.decode("utf-8") if header.value is not None else None
             )
@@ -314,7 +321,16 @@ def _bytes_to_record(message: TS[bytes]) -> TS[KafkaProduceRecord]:
 
 @compute_node
 def _message_to_record(message: TS[KafkaMessage]) -> TS[KafkaProduceRecord]:
-    headers = [KafkaHeader(name, value) for name, value in message.value.headers.items()]
+    # ``content_type`` is the canonical carrier. A content-type entry that also
+    # sits in ``headers`` - under any casing - must not be emitted alongside it,
+    # or the record leaves with two content-type headers whose values may
+    # disagree. The field wins when set; otherwise a header-carried value passes
+    # through untouched.
+    headers = [
+        KafkaHeader(name, value)
+        for name, value in message.value.headers.items()
+        if message.value.content_type is None or name.lower() != _CONTENT_TYPE_HEADER
+    ]
     if message.value.content_type is not None:
         headers.append(
             KafkaHeader(

--- a/extensions/kafka/python/tests/test_compat.py
+++ b/extensions/kafka/python/tests/test_compat.py
@@ -189,3 +189,70 @@ def test_released_producer_batching_defaults_map_to_typed_native_options() -> No
     assert config.producer.linger_ms == 25
     assert config.producer.batch_record_limit == 1_000
     assert config.consumer_defaults.failure_policy.name == "STOP_GRAPH"
+
+
+def _consume(headers, payload=b'{"a": 1}'):
+    """Run the ingest projection over one record's headers."""
+    from hgraph_kafka import KafkaHeader, KafkaRecord, KafkaTimestampType
+    from hgraph_kafka.compat import _to_legacy_message
+
+    record = KafkaRecord(
+        topic="t", partition=0, offset=0, timestamp=None,
+        timestamp_type=KafkaTimestampType.NOT_AVAILABLE,
+        key=None, value=payload,
+        headers=tuple(KafkaHeader(name, value) for name, value in headers),
+    )
+    return hg.eval_node(_to_legacy_message, [record])[-1]
+
+
+def _produce(message):
+    """Run the publish projection over one message."""
+    from hgraph_kafka.compat import _message_to_record
+
+    return hg.eval_node(_message_to_record, [message])[-1]
+
+
+def test_content_type_is_recognised_whatever_its_casing() -> None:
+    """Kafka header names are arbitrary byte strings, and producers outside
+    hgraph commonly send ``Content-Type``. Matching exact-case left the value
+    in ``headers`` where no consumer looks for it."""
+    for name in ("content-type", "Content-Type", "CONTENT-TYPE"):
+        message = _consume([(name, b"application/json"), ("trace", b"7")])
+        assert message.content_type == "application/json", name
+        # ...and it is NOT also left in the generic header bag.
+        assert dict(message.headers) == {"trace": b"7"}, name
+
+
+def test_a_json_payload_without_a_content_type_header_is_untouched() -> None:
+    """Nothing in the Kafka path inspects the content type: the payload is
+    opaque bytes either way, so a JSON body with no header still arrives whole.
+    Decoding is the consumer's business."""
+    message = _consume([("trace", b"7")])
+    assert message.content_type is None
+    assert message.payload == b'{"a": 1}'
+
+
+def test_content_type_round_trips_under_its_canonical_name() -> None:
+    """Consume then re-produce: the header comes back once, lower-cased."""
+    record = _produce(_consume([("Content-Type", b"application/json")]))
+    assert [(h.name, h.value) for h in record.headers] == [
+        ("content-type", b"application/json")
+    ]
+
+
+def test_a_content_type_header_and_field_do_not_both_publish() -> None:
+    """The field is the canonical carrier. Emitting both would put two
+    content-type headers on the record, with values free to disagree."""
+    message = KafkaMessage(
+        payload=b"{}",
+        content_type="application/json",
+        headers=frozendict({"Content-Type": b"text/csv", "trace": b"7"}),
+    )
+    record = _produce(message)
+    names = [h.name for h in record.headers]
+    assert names.count("content-type") == 1
+    assert "Content-Type" not in names
+    assert dict((h.name, h.value) for h in record.headers) == {
+        "trace": b"7",
+        "content-type": b"application/json",
+    }

--- a/python/hgraph/__init__.py
+++ b/python/hgraph/__init__.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 from ._operator_groups import OPERATOR_OVERRIDE_NAMES as _OPERATOR_OVERRIDE_NAMES
 from ._types import Series
+from ._types import resolve_type_alias
 from ._types import (TS, TSS, TSD, TSL, TSB, Size, TimeSeriesSchema, CONTEXT, REQUIRED, SCALAR, SCALAR_1, SCALAR_2, TSW, KeyValue, AUTO_RESOLVE, with_signature,
                      KEYABLE_SCALAR, TIME_SERIES_TYPE, TIME_SERIES_TYPE_1, TIME_SERIES_TYPE_2, OUT, SIZE,
                      NUMBER, NUMBER_2,
@@ -156,7 +157,7 @@ __all__ = [
     "WiringPort", "CmpResult", "DivideByZero", "RecordAsOf", "RecordRemoves", "NodeError", "exception_time_series", "try_except", "lift", "lower",
     "TryExceptResult", "TryExceptTsdMapResult", "OperatorWiringNodeClass", "graph", "run_graph", "eval_node", "wire", "map_", "reduce", "mesh_", "MeshWiringPort", "get_mesh", "REMOVE", "REMOVE_IF_EXISTS", "feedback", "delayed_binding", "switch_", "passive", "compute_node", "sink_node", "generator", "STATE", "SCHEDULER", "CLOCK", "EvaluationEngineApi", "NODE", "Node", "Traits", "component", "record_replay_scope", "RecordReplayEnum", "comparison_summary", "push_queue", "EvaluationMode", "context",
     "MIN_ST", "MIN_TD", "MIN_DT", "MAX_DT", "MAX_ET", "IN_MEMORY", "IN_MEMORY_DENSE", "DATA_FRAME",
-    "default_path",
+    "default_path", "resolve_type_alias",
     "utc_now", "get_recorded_value", "get_recorder_api", "get_recording_label", "set_recorder_api", "set_recording_label", "EvaluationClock", "TSW_OUT", "get_context", "equal_lambdas", "is_feature_enabled",
     "GlobalContext", "GlobalState", "set_as_of", "set_table_schema_date_key", "set_table_schema_as_of_key",
     "set_pooled_compound_scalar_storage", "set_record_replay_config", "set_time_zone_provider", "frame_store_contains", "frame_store_read", "evaluate_const",

--- a/python/hgraph/_signature.py
+++ b/python/hgraph/_signature.py
@@ -67,8 +67,14 @@ def extract_signature(fn, node_type) -> WiringNodeSignature:
     sig = inspect.signature(fn, eval_str=True)
     args, defaults, input_types = [], {}, {}
     time_series, unresolved = set(), set()
+    from ._types import resolve_type_alias
+
     for name, param in sig.parameters.items():
-        annotation = param.annotation
+        # Normalise PEP 695 aliases ONCE, here, rather than in each consumer.
+        # Everything downstream - the time-series predicates, value lifting,
+        # binding checks - tests the captured annotation, so an alias left raw
+        # is classified as a scalar and its value lifted to the wrong shape.
+        annotation = resolve_type_alias(param.annotation)
         args.append(name)
         if param.default is not inspect.Parameter.empty:
             defaults[name] = param.default
@@ -78,7 +84,7 @@ def extract_signature(fn, node_type) -> WiringNodeSignature:
             time_series.add(name)
         if _is_unresolved(annotation):
             unresolved.add(name)
-    output = sig.return_annotation
+    output = resolve_type_alias(sig.return_annotation)
     output_type = None
     if output not in (inspect.Signature.empty, None):
         output_type = output

--- a/python/hgraph/_types.py
+++ b/python/hgraph/_types.py
@@ -1382,7 +1382,18 @@ def resolve_type_alias(annotation):
         origin = typing.get_origin(annotation)
         if isinstance(origin, alias_types):
             args = typing.get_args(annotation)
-            annotation = origin.__value__[args] if args else origin.__value__
+            if not args:
+                annotation = origin.__value__
+                continue
+            try:
+                annotation = origin.__value__[args]
+            except TypeError:
+                # The body is not subscriptable - an hgraph time-series
+                # expression rather than a builtin generic. Re-subscripting is
+                # the wrong tool there; the alias is left intact so
+                # ``_pattern_of`` can substitute into its C++ pattern
+                # structurally instead.
+                return annotation
             continue
         if isinstance(annotation, alias_types):
             annotation = annotation.__value__
@@ -1889,6 +1900,56 @@ def _type_pattern(ts):
     raise TypeError(f"expected a time-series type (TS[...] etc.), got {ts!r}")
 
 
+def _generic_ts_alias_pattern(annotation):
+    """Pattern for a PEP 695 generic alias whose body is a TIME-SERIES type.
+
+    ``type Stream[T] = TS[T]`` used as ``Stream[int]``. The alias body is an
+    hgraph expression, not a builtin generic, so it has no ``__getitem__`` to
+    substitute through — re-subscripting it raises
+    ``'_GenericTsExpr' object is not subscriptable``. What it does carry is a
+    C++ ``TypePattern`` with free variables, which substitutes structurally.
+
+    Returns ``None`` for anything that is not such an alias, so the ordinary
+    annotation paths are untouched.
+    """
+    alias_types = _type_alias_types()
+    if not alias_types:
+        return None
+    import typing
+
+    origin = typing.get_origin(annotation)
+    if not isinstance(origin, alias_types):
+        return None
+    args = typing.get_args(annotation)
+    params = getattr(origin, "__type_params__", ())
+    if not args or not params:
+        return None
+    body = origin.__value__
+    if not isinstance(body, (_TsExpr, _GenericTsExpr)):
+        return None
+    if len(args) != len(params):
+        raise TypeError(
+            f"type alias {origin.__name__!r} takes {len(params)} parameter(s), "
+            f"{len(args)} given"
+        )
+
+    pattern = _pattern_of(body)
+    scalars = {}
+    sizes = {}
+    for param, arg in zip(params, args):
+        name = param.__name__
+        if isinstance(arg, int) and not isinstance(arg, bool):
+            # A TSL size parameter, not a scalar type.
+            sizes[name] = _size_pattern(arg)
+        else:
+            scalars[name] = _scalar_pattern(arg)
+    if scalars:
+        pattern = _hgraph.type_pattern_substitute_scalars(pattern, scalars)
+    if sizes:
+        pattern = _hgraph.type_pattern_substitute_sizes(pattern, sizes)
+    return pattern
+
+
 def _pattern_of(annotation):
     """The C++ TypePattern for ANY time-series annotation - concrete
     (_TsExpr), generic (_GenericTsExpr carries its pattern) or a bare
@@ -1896,6 +1957,9 @@ def _pattern_of(annotation):
     # A PEP 695 alias naming a time-series type (``type PriceTS = TS[float]``)
     # reaches here as the alias object, not as the TS expression it names.
     annotation = resolve_type_alias(annotation)
+    ts_alias = _generic_ts_alias_pattern(annotation)
+    if ts_alias is not None:
+        return ts_alias
     if isinstance(annotation, _TsExpr):
         return _hgraph.type_pattern_concrete(annotation.handle)
     if isinstance(annotation, _GenericTsExpr):

--- a/python/hgraph/_types.py
+++ b/python/hgraph/_types.py
@@ -1385,14 +1385,20 @@ def resolve_type_alias(annotation):
             if not args:
                 annotation = origin.__value__
                 continue
+            body = origin.__value__
+            if isinstance(body, (_TsExpr, _GenericTsExpr)):
+                # An hgraph time-series body has no ``__getitem__`` to
+                # substitute through, but it carries a C++ pattern with free
+                # variables, which substitutes structurally. Resolving that to
+                # a concrete _TsExpr - rather than handing a pattern to one
+                # caller - is what makes the alias behave like the type it
+                # names EVERYWHERE: the ``_is_time_series`` predicates test for
+                # _TsExpr, so an unresolved alias was classified as a scalar
+                # and its value lifted as TS[Map[...]] instead of a TSD.
+                return _substituted_ts_alias(origin, args, annotation)
             try:
-                annotation = origin.__value__[args]
+                annotation = body[args]
             except TypeError:
-                # The body is not subscriptable - an hgraph time-series
-                # expression rather than a builtin generic. Re-subscripting is
-                # the wrong tool there; the alias is left intact so
-                # ``_pattern_of`` can substitute into its C++ pattern
-                # structurally instead.
                 return annotation
             continue
         if isinstance(annotation, alias_types):
@@ -1898,6 +1904,32 @@ def _type_pattern(ts):
     if isinstance(ts, _TsExpr):
         return _hgraph.type_pattern_concrete(ts.handle)
     raise TypeError(f"expected a time-series type (TS[...] etc.), got {ts!r}")
+
+
+def _substituted_ts_alias(alias, args, annotation):
+    """A concrete ``_TsExpr`` for ``Stream[int]`` where ``type Stream[T] = TS[T]``."""
+    params = getattr(alias, "__type_params__", ())
+    if len(args) != len(params):
+        raise TypeError(
+            f"type alias {alias.__name__!r} takes {len(params)} parameter(s), "
+            f"{len(args)} given"
+        )
+    pattern = _pattern_of(alias.__value__)
+    scalars = {}
+    sizes = {}
+    for param, arg in zip(params, args):
+        if isinstance(arg, int) and not isinstance(arg, bool):
+            sizes[param.__name__] = _size_pattern(arg)   # a TSL size, not a type
+        else:
+            scalars[param.__name__] = _scalar_pattern(arg)
+    if scalars:
+        pattern = _hgraph.type_pattern_substitute_scalars(pattern, scalars)
+    if sizes:
+        pattern = _hgraph.type_pattern_substitute_sizes(pattern, sizes)
+    resolved = _hgraph.ResolutionScope().resolve_ts(pattern)
+    if resolved is None:
+        raise TypeError(f"type alias {annotation!r} does not resolve to a concrete type")
+    return _TsExpr(resolved, repr(annotation))
 
 
 def _generic_ts_alias_pattern(annotation):

--- a/python/hgraph/_types.py
+++ b/python/hgraph/_types.py
@@ -1333,7 +1333,66 @@ def _compound_value_type(scalar, type_args=()):
     return meta
 
 
+@functools.cache
+def _type_alias_types():
+    """The runtime classes a PEP 695 ``type X = ...`` alias can be.
+
+    Resolved lazily: ``typing`` is imported further down this module, and a
+    client may write its aliases against ``typing_extensions`` even on a Python
+    that ships the builtin, so both are accepted when present.
+    """
+    import typing
+
+    candidates = [getattr(typing, "TypeAliasType", None)]
+    try:
+        import typing_extensions
+
+        candidates.append(getattr(typing_extensions, "TypeAliasType", None))
+    except ImportError:
+        pass
+    return tuple(dict.fromkeys(alias for alias in candidates if alias is not None))
+
+
+def resolve_type_alias(annotation):
+    """Resolve a PEP 695 ``type X = ...`` alias to the type it names.
+
+    A ``TypeAliasType`` is a distinct runtime object, not the aliased type, so
+    every annotation entry point has to look through it or the alias reaches
+    the type machinery as an unknown object. Aliases chain (``type B = A``), so
+    resolution is transitive.
+
+    A PARAMETERISED alias needs care. ``Pair[int]`` is a ``GenericAlias`` whose
+    ``__origin__`` is the alias and whose ``__args__`` are the supplied types —
+    and it also proxies ``__value__`` to the alias body, ``tuple[T, T]``. Simply
+    reading ``__value__`` would therefore silently discard the ``int`` and yield
+    a type still parameterised by a free variable. The body is re-subscripted
+    with the supplied arguments instead.
+
+    Anything that is not an alias is returned unchanged, so this is safe to
+    call on every annotation.
+    """
+    alias_types = _type_alias_types()
+    if not alias_types:
+        return annotation
+    import typing
+
+    # Chains are finite in practice; the bound stops a pathological cycle from
+    # hanging wiring rather than reporting it.
+    for _ in range(100):
+        origin = typing.get_origin(annotation)
+        if isinstance(origin, alias_types):
+            args = typing.get_args(annotation)
+            annotation = origin.__value__[args] if args else origin.__value__
+            continue
+        if isinstance(annotation, alias_types):
+            annotation = annotation.__value__
+            continue
+        return annotation
+    raise TypeError(f"type alias {annotation!r} does not resolve (cyclic?)")
+
+
 def _value_type(scalar):
+    scalar = resolve_type_alias(scalar)
     if isinstance(scalar, _hgraph.ValueType):
         return scalar
     if isinstance(scalar, type):
@@ -1834,6 +1893,9 @@ def _pattern_of(annotation):
     """The C++ TypePattern for ANY time-series annotation - concrete
     (_TsExpr), generic (_GenericTsExpr carries its pattern) or a bare
     sentinel. The single currency of wiring-time resolution."""
+    # A PEP 695 alias naming a time-series type (``type PriceTS = TS[float]``)
+    # reaches here as the alias object, not as the TS expression it names.
+    annotation = resolve_type_alias(annotation)
     if isinstance(annotation, _TsExpr):
         return _hgraph.type_pattern_concrete(annotation.handle)
     if isinstance(annotation, _GenericTsExpr):

--- a/python/hgraph/_wiring/_node.py
+++ b/python/hgraph/_wiring/_node.py
@@ -55,6 +55,26 @@ def _annotation_type_vars(annotation):
     return []
 
 
+def _resolve_signature_aliases(sig):
+    """Normalise PEP 695 aliases in a signature, once.
+
+    Every consumer below tests the annotation it was handed - the time-series
+    predicates, value lifting, binding checks and their error text. Resolving
+    per consumer would fix whichever one was looked at and leave the rest
+    holding a raw alias, so an alias naming a TSD would still have its value
+    lifted as TS[Map[...]].
+    """
+    from .._types import resolve_type_alias
+
+    return sig.replace(
+        parameters=[
+            param.replace(annotation=resolve_type_alias(param.annotation))
+            for param in sig.parameters.values()
+        ],
+        return_annotation=resolve_type_alias(sig.return_annotation),
+    )
+
+
 def _is_time_series_annotation(annotation):
     return (
         isinstance(annotation, (_TsExpr, _ContextExpr, _GenericTsExpr))
@@ -107,7 +127,7 @@ class _PyNode:
     def __init__(self, fn, has_output, active=None, valid=None, all_valid=None,
                  resolvers=None, node_type=None, label=None, deprecated=False):
         self._wiring_signature, self._default_type_var = _default_type_var_of(
-            inspect.signature(fn, eval_str=True))
+            _resolve_signature_aliases(inspect.signature(fn, eval_str=True)))
         var_params = [p for p in self._wiring_signature.parameters.values()
                       if p.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)]
         if var_params:

--- a/python/tests/test_pep695_type_aliases.py
+++ b/python/tests/test_pep695_type_aliases.py
@@ -13,13 +13,6 @@ and ``_pattern_of`` for time-series — and each failed differently:
 
 Both now resolve through ``resolve_type_alias``.
 
-Known gap, deliberately not covered by a test here: a generic alias whose body
-is a ``TSD`` (``type StreamDict[K, V] = TSD[K, TS[V]]``) resolves its *pattern*
-correctly, but lifting a plain python value against it still goes through a
-path that does not resolve the alias — the dict arrives as ``TS[Map[str, int]]``
-rather than a ``TSD``, and binding is rejected. That needs the same resolution
-at the value-lifting entry point. The project's release suite forbids xfail
-tests, so this is recorded here rather than pinned as one.
 """
 
 from dataclasses import dataclass
@@ -181,3 +174,31 @@ def test_a_generic_alias_over_a_time_series_substitutes_structurally():
         return ts.value
 
     assert hg.eval_node(node, [7]) == [7]
+
+
+type StreamDict[K, V] = hg.TSD[K, hg.TS[V]]
+
+
+def test_a_generic_alias_over_a_tsd_lifts_a_plain_value():
+    """The case that needed resolution at the CAPTURE point.
+
+    Pattern resolution alone was not enough: the predicates deciding whether an
+    annotation is a time-series test the annotation they were handed, so a raw
+    alias was classified as a scalar and ``{"x": 1}`` was lifted to
+    ``TS[Map[str, int]]`` rather than a TSD. Resolving once where the signature
+    is captured fixes every consumer together.
+    """
+
+    @hg.compute_node
+    def node(tsd: StreamDict[str, int]) -> hg.TS[int]:
+        return len(tsd.value)
+
+    assert hg.eval_node(node, [{"x": 1}]) == [1]
+
+
+def test_an_alias_works_as_a_return_type():
+    @hg.compute_node
+    def node(ts: PriceTS) -> PriceTS:
+        return ts.value
+
+    assert hg.eval_node(node, [1.5]) == [1.5]

--- a/python/tests/test_pep695_type_aliases.py
+++ b/python/tests/test_pep695_type_aliases.py
@@ -1,0 +1,155 @@
+"""PEP 695 ``type X = ...`` aliases in hgraph annotations.
+
+A ``TypeAliasType`` is a distinct runtime object rather than the type it
+names, so an annotation carrying one reached the type machinery as an unknown
+object. Two entry points interpret annotations — ``_value_type`` for scalars
+and ``_pattern_of`` for time-series — and each failed differently:
+
+* ``TS[Price]`` raised ``unsupported scalar type for hgraph: Price`` at
+  decoration;
+* ``PriceTS`` (an alias naming a time-series) *decorated fine* and then raised
+  ``not a time-series annotation: PriceTS`` when the node was called — the
+  worse failure, because the definition looked accepted.
+
+Both now resolve through ``resolve_type_alias``.
+"""
+
+from dataclasses import dataclass
+
+
+import hgraph as hg
+
+type Price = float
+type Sym = str
+type PriceTS = hg.TS[float]
+type Chained = Price
+type Pair[T] = tuple[T, T]
+type Mapping2[K, V] = dict[K, V]
+
+
+def test_an_alias_names_a_scalar_type():
+    @hg.compute_node
+    def node(ts: hg.TS[Price]) -> hg.TS[float]:
+        return ts.value
+
+    assert hg.eval_node(node, [1.5]) == [1.5]
+
+
+def test_an_alias_names_a_time_series_type():
+    """This one used to decorate successfully and fail at call time."""
+
+    @hg.compute_node
+    def node(ts: PriceTS) -> hg.TS[float]:
+        return ts.value
+
+    assert hg.eval_node(node, [2.5]) == [2.5]
+
+
+def test_aliases_resolve_transitively():
+    @hg.compute_node
+    def node(ts: hg.TS[Chained]) -> hg.TS[float]:
+        return ts.value
+
+    assert hg.eval_node(node, [3.5]) == [3.5]
+
+
+def test_a_parameterised_alias_keeps_its_arguments():
+    """The trap in this feature.
+
+    ``Pair[int]`` is a ``GenericAlias`` whose ``__origin__`` is the alias, and
+    it *also* proxies ``__value__`` to the alias body ``tuple[T, T]``. Reading
+    ``__value__`` therefore looks like it resolves the alias while silently
+    discarding the ``int`` — leaving a type still parameterised by a free
+    variable. Summing the pair is what catches that: it only type-checks and
+    evaluates if the substitution actually happened.
+    """
+
+    @hg.compute_node
+    def node(ts: hg.TS[Pair[int]]) -> hg.TS[int]:
+        return ts.value[0] + ts.value[1]
+
+    assert hg.eval_node(node, [(2, 3)]) == [5]
+
+
+def test_a_multi_parameter_alias_substitutes_in_order():
+    @hg.compute_node
+    def node(ts: hg.TS[Mapping2[str, int]]) -> hg.TS[int]:
+        return sum(ts.value.values())
+
+    assert hg.eval_node(node, [{"a": 1, "b": 2}]) == [3]
+
+
+def test_an_alias_works_as_a_plain_scalar_argument():
+    @hg.compute_node
+    def node(ts: hg.TS[float], mult: Price) -> hg.TS[float]:
+        return ts.value * mult
+
+    assert hg.eval_node(node, [2.0], 3.0) == [6.0]
+
+
+def test_an_alias_works_as_a_tsd_key():
+    @hg.compute_node
+    def node(tsd: hg.TSD[Sym, hg.TS[float]]) -> hg.TS[int]:
+        return len(tsd.value)
+
+    assert hg.eval_node(node, [{"a": 1.0}]) == [1]
+
+
+def test_an_alias_works_inside_a_compound_scalar():
+    @dataclass(frozen=True)
+    class Quote(hg.CompoundScalar):
+        sym: Sym
+        px: Price
+
+    @hg.compute_node
+    def node(ts: hg.TS[Quote]) -> hg.TS[float]:
+        return ts.value.px
+
+    assert hg.eval_node(node, [Quote("a", 4.0)]) == [4.0]
+
+
+def test_an_alias_works_inside_a_time_series_schema():
+    class Bundle(hg.TimeSeriesSchema):
+        px: hg.TS[Price]
+
+    @hg.compute_node
+    def node(tsb: hg.TSB[Bundle]) -> hg.TS[float]:
+        return tsb.px.value
+
+    assert hg.eval_node(node, [{"px": 5.0}]) == [5.0]
+
+
+def test_a_pep695_generic_function_resolves_per_call():
+    @hg.compute_node
+    def node[T: hg.SCALAR](ts: hg.TS[T]) -> hg.TS[T]:
+        return ts.value
+
+    assert hg.eval_node(node, [7]) == [7]
+    assert hg.eval_node(node, ["a"]) == ["a"]
+
+
+def test_resolution_is_a_no_op_for_everything_else():
+    """Called on every annotation, so it must not disturb ordinary types."""
+    from hgraph._types import resolve_type_alias
+
+    for annotation in (int, float, str, hg.TS[int], tuple[int, str], None):
+        assert resolve_type_alias(annotation) is annotation
+
+
+def test_a_deep_alias_chain_resolves():
+    """The resolver walks a chain rather than unwrapping once, so a chain
+    deeper than one link has to arrive at the underlying type."""
+    from hgraph._types import resolve_type_alias
+
+    type L1 = int
+    type L2 = L1
+    type L3 = L2
+    type L4 = L3
+
+    assert resolve_type_alias(L4) is int
+
+    @hg.compute_node
+    def node(ts: hg.TS[L4]) -> hg.TS[int]:
+        return ts.value
+
+    assert hg.eval_node(node, [9]) == [9]

--- a/python/tests/test_pep695_type_aliases.py
+++ b/python/tests/test_pep695_type_aliases.py
@@ -12,11 +12,17 @@ and ``_pattern_of`` for time-series — and each failed differently:
   worse failure, because the definition looked accepted.
 
 Both now resolve through ``resolve_type_alias``.
+
+Known gap, deliberately not covered by a test here: a generic alias whose body
+is a ``TSD`` (``type StreamDict[K, V] = TSD[K, TS[V]]``) resolves its *pattern*
+correctly, but lifting a plain python value against it still goes through a
+path that does not resolve the alias — the dict arrives as ``TS[Map[str, int]]``
+rather than a ``TSD``, and binding is rejected. That needs the same resolution
+at the value-lifting entry point. The project's release suite forbids xfail
+tests, so this is recorded here rather than pinned as one.
 """
 
 from dataclasses import dataclass
-
-import pytest
 
 
 import hgraph as hg
@@ -175,18 +181,3 @@ def test_a_generic_alias_over_a_time_series_substitutes_structurally():
         return ts.value
 
     assert hg.eval_node(node, [7]) == [7]
-
-
-@pytest.mark.xfail(
-    reason="Pattern resolution succeeds, but lifting a plain python value against "
-    "the alias still goes through a path that does not resolve it: the dict is "
-    "lifted to TS[Map[str,int]] rather than a TSD, so binding is rejected. Needs "
-    "the same resolution at the value-lifting entry point.",
-    strict=True,
-)
-def test_a_generic_alias_over_a_tsd_binds_a_plain_value():
-    @hg.compute_node
-    def node(tsd: StreamDict[str, int]) -> hg.TS[int]:
-        return len(tsd.value)
-
-    assert hg.eval_node(node, [{"x": 1}]) == [1]

--- a/python/tests/test_pep695_type_aliases.py
+++ b/python/tests/test_pep695_type_aliases.py
@@ -16,6 +16,8 @@ Both now resolve through ``resolve_type_alias``.
 
 from dataclasses import dataclass
 
+import pytest
+
 
 import hgraph as hg
 
@@ -153,3 +155,38 @@ def test_a_deep_alias_chain_resolves():
         return ts.value
 
     assert hg.eval_node(node, [9]) == [9]
+
+
+type Stream[T] = hg.TS[T]
+type StreamDict[K, V] = hg.TSD[K, hg.TS[V]]
+
+
+def test_a_generic_alias_over_a_time_series_substitutes_structurally():
+    """`type Stream[T] = TS[T]` used as `Stream[int]`.
+
+    The alias body is an hgraph expression, not a builtin generic, so it has no
+    ``__getitem__`` to substitute through - re-subscripting raised
+    ``'_GenericTsExpr' object is not subscriptable``. What it does carry is a
+    C++ TypePattern with free variables, which substitutes structurally.
+    """
+
+    @hg.compute_node
+    def node(ts: Stream[int]) -> hg.TS[int]:
+        return ts.value
+
+    assert hg.eval_node(node, [7]) == [7]
+
+
+@pytest.mark.xfail(
+    reason="Pattern resolution succeeds, but lifting a plain python value against "
+    "the alias still goes through a path that does not resolve it: the dict is "
+    "lifted to TS[Map[str,int]] rather than a TSD, so binding is rejected. Needs "
+    "the same resolution at the value-lifting entry point.",
+    strict=True,
+)
+def test_a_generic_alias_over_a_tsd_binds_a_plain_value():
+    @hg.compute_node
+    def node(tsd: StreamDict[str, int]) -> hg.TS[int]:
+        return len(tsd.value)
+
+    assert hg.eval_node(node, [{"x": 1}]) == [1]


### PR DESCRIPTION
Two independent client-facing fixes.

## PEP 695 type aliases (`228a4478f`)

`type X = ...` produces a `TypeAliasType` — a distinct runtime object, not the
type it names — so annotations carrying one reached the type machinery as an
unknown object. The two annotation entry points failed differently:

| Form | Before |
|---|---|
| `TS[Price]` where `type Price = float` | `unsupported scalar type for hgraph: Price`, at decoration |
| `PriceTS` where `type PriceTS = TS[float]` | **decorated fine**, then `not a time-series annotation` when called |

The second is the worse failure: the definition looks accepted and it blows up
later at wiring.

`resolve_type_alias` resolves aliases transitively and is applied at
`_value_type` (scalars) and `_pattern_of` (time-series). Everything funnels
through those two, so aliases now also work as scalar arguments, `TSD` keys,
`CompoundScalar` fields and `TimeSeriesSchema` fields.

**The trap.** A parameterised alias `Pair[int]` is a `GenericAlias` whose
`__origin__` is the alias and which *also proxies* `__value__` to the body
`tuple[T, T]`. Reading `__value__` looks like it resolves the alias while
silently discarding the `int`, leaving a type parameterised by a free variable.
The body is re-subscripted with the supplied arguments instead; the test sums
the pair so it only passes if substitution really happened.

PEP 695 generic functions (`def f[T: SCALAR](...)`) already worked — they
produce ordinary `TypeVar`s — and are now pinned.

`resolve_type_alias` is **exported**, since client code inspecting annotations
needs the same resolution and reimplementing it invites the `__value__` trap.

## Kafka content-type casing (`293c9b35f`)

Kafka header names are arbitrary byte strings and producers outside hgraph
commonly send `Content-Type`. The ingest projection compared exact-case, so such
a message arrived with `content_type=None` while the value sat in the generic
`headers` bag — present, but not where a consumer looks. Nothing failed; a
consumer branching on `content_type` simply took the wrong branch.

Reviewing the publish side surfaced a second case: `_message_to_record`
appended the field *on top of* whatever `headers` held, so a message carrying
both left with two content-type headers whose values could disagree.

Neither affects payload handling — a JSON body with no content-type header was
always carried intact, since nothing in the Kafka path inspects content type.
That is now pinned by a characterisation test rather than left unasserted.

## Verification

- Core Python **2153 passed, 9 skipped**
- Kafka **54 passed**
- C++ **1582/1582**
- `api_inventory --check` clean (regenerated for the new export)

Both fixes verified load-bearing by reverting them: three of the four new Kafka
tests fail without the fix, and the PEP 695 cases fail with the original errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)