### PR TITLE
Route Python structural values through type-erased ops

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,12 @@ the edited documentation, commands, links, or configuration directly.
 - Publish explicit data-only inspection views when debugger metadata needs
   representation details. Debuggers must not infer private implementation
   member layouts or decode standard-library containers.
+- Public Python scalar representation policy belongs in the concrete
+  `ValueOps` strategy. For example, compact Set values export `frozenset`
+  directly from their erased `to_python` operation; atomic TS storage,
+  synthetic mapped-key sources, and structural collection strategies consume
+  that result without re-normalizing it. Collection-specific shapes such as a
+  TSS value or delta remain the responsibility of their `TSDataOps` strategy.
 - Python time-series value and delta export must dispatch through the live
   endpoint's `TSDataOps` table. Python-facing wrappers must not branch on
   `TSTypeKind` to assemble TSD, TSL, TSB, or other runtime value shapes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,18 @@ the edited documentation, commands, links, or configuration directly.
 - Publish explicit data-only inspection views when debugger metadata needs
   representation details. Debuggers must not infer private implementation
   member layouts or decode standard-library containers.
+- Python time-series value and delta export must dispatch through the live
+  endpoint's `TSDataOps` table. Python-facing wrappers must not branch on
+  `TSTypeKind` to assemble TSD, TSL, TSB, or other runtime value shapes.
+  Representation-specific recursion and Python shaping belong in the concrete
+  TSData strategy that installs the erased operation. Synthetic bridge-only
+  projections must likewise have one explicitly documented erased strategy,
+  not an accumulating chain of facade special cases.
+- Every TSData representation that can reach a Python-authored node must
+  install working `to_python_impl` and `delta_to_python_impl` operations and
+  recursively invoke child `TSDataOps` for structural children. Tests must
+  exercise aggregate `.value` and `.delta_value`, not only individual child
+  access, including nested projected structures and CompoundScalar-backed TSBs.
 
 ## Test Guidelines
 

--- a/include/hgraph/python/bridge_state.h
+++ b/include/hgraph/python/bridge_state.h
@@ -14,6 +14,7 @@
 
 namespace hgraph {
 struct ValueTypeMetaData;
+struct TSValueTypeMetaData;
 class ValueTypeRef;
 } // namespace hgraph
 
@@ -118,6 +119,17 @@ struct HGRAPH_LOCAL NB_EXPORT_SHARED PyBundleClassInfo {
  */
 [[nodiscard]] HGRAPH_EXPORT std::unordered_map<const void *, const void *> &
 tsb_compound_value_registry();
+
+/**
+ * Restore the public Python value for a structural TSB snapshot.
+ *
+ * Concrete TSData conversion strategies call this after recursively exporting
+ * their children through child TSDataOps. Keeping the class lookup here lets
+ * the erased TSData strategy preserve CompoundScalar identity without making
+ * Python-facing TimeSeries wrappers understand TSB representation details.
+ */
+[[nodiscard]] HGRAPH_EXPORT nb::object
+materialize_tsb_python_value(const TSValueTypeMetaData *schema, nb::dict value);
 
 /**
  * Install a Python-owned canonical binding for a nominal Bundle schema.

--- a/include/hgraph/types/time_series/ts_data/base_view.h
+++ b/include/hgraph/types/time_series/ts_data/base_view.h
@@ -206,10 +206,23 @@ namespace hgraph
         [[nodiscard]] ValueView delta_value(DateTime evaluation_time) const;
 
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
-        /** Current value converted by the TSData binding's type-erased Python export op. */
+        /**
+         * Export the current value through this live representation's
+         * type-erased TSDataOps table.
+         *
+         * Structural implementations must recursively invoke child TSDataOps
+         * and produce the complete public Python shape. Callers must not
+         * switch on TSTypeKind and reconstruct that shape themselves.
+         */
         [[nodiscard]] nb::object value_to_python() const;
 
-        /** Delta value for ``evaluation_time`` converted by the TSData binding's type-erased Python export op. */
+        /**
+         * Export the delta for ``evaluation_time`` through this live
+         * representation's type-erased TSDataOps table.
+         *
+         * As with value_to_python(), recursive shape conversion belongs to
+         * the concrete TSData strategy, not its Python-facing caller.
+         */
         [[nodiscard]] nb::object delta_value_to_python(DateTime evaluation_time) const;
 #endif
 

--- a/include/hgraph/types/time_series/ts_data/ops.h
+++ b/include/hgraph/types/time_series/ts_data/ops.h
@@ -194,6 +194,9 @@ namespace hgraph
             std::size_t index) = &ts_data_detail::missing_mutable_indexed_element_memory;
         bool indexed_child_growth{false};
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
+        // Required for every representation that can reach a Python-authored
+        // node. Structural strategies recurse through each child's TSDataOps;
+        // Python facades must never reconstruct shapes by switching on kind.
         bool (*from_python_impl)(const void *context, void *memory, nb::handle source,
                                  DateTime modified_time) = &ts_data_detail::missing_from_python;
         nb::object (*to_python_impl)(const void *context,

--- a/include/hgraph/types/time_series/ts_input/base_view.h
+++ b/include/hgraph/types/time_series/ts_input/base_view.h
@@ -118,6 +118,24 @@ namespace hgraph
         [[nodiscard]] ValueView value() const;
         [[nodiscard]] ValueView delta_value() const;
 
+#if HGRAPH_ENABLE_PYTHON_USER_NODES
+        /**
+         * Export the current input value through the resolved endpoint's
+         * type-erased TSDataOps.
+         *
+         * Python facades must call this operation rather than inspect
+         * TSTypeKind and rebuild structural values themselves. Concrete
+         * storage/input strategies own recursive child conversion.
+         */
+        [[nodiscard]] nb::object value_to_python() const;
+
+        /**
+         * Export this input's current delta through type-erased TSDataOps,
+         * preserving sampled-rebind semantics owned by TSInputView.
+         */
+        [[nodiscard]] nb::object delta_value_to_python() const;
+#endif
+
         /** Dynamic storage owned by this view's complete input endpoint. */
         [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept;
 

--- a/include/hgraph/types/value/compact_container_ops.h
+++ b/include/hgraph/types/value/compact_container_ops.h
@@ -568,12 +568,18 @@ namespace hgraph
             }
             const auto element_binding = storage->element_binding();
             const auto &ops = element_binding.ops_ref();
-            nb::set result;
+            nb::list items;
             for (std::size_t i = 0; i < storage->size(); ++i)
             {
-                result.add(ops.to_python(storage->element_at(i)));
+                items.append(ops.to_python(storage->element_at(i)));
             }
-            return result;
+            // A compact Set is the value-layer realization of Python's
+            // immutable frozenset scalar. This concrete ValueOps strategy must
+            // establish that public representation itself; TSData strategies
+            // and Python facades consume the erased result unchanged. Slot-
+            // backed TSS collections install different ValueOps and retain
+            // their collection-specific mutable set surface.
+            return nb::steal(PyFrozenSet_New(items.ptr()));
         }
 
         void set_from_python(const void *, const ValueTypeRef &binding, void *memory, nb::handle source);

--- a/python/py_nodes.cpp
+++ b/python/py_nodes.cpp
@@ -81,7 +81,7 @@ void apply_py_result(nb::handle result, Out<TsVar<"O">> &out) {
   const bool tss = erased.schema()->kind == TSTypeKind::TSS;
   const bool has_value = tss && erased.data_view().has_current_value();
   nb::object current = tss && has_value
-                           ? value_to_py(erased.data_view().value())
+                           ? erased.data_view().value_to_python()
                            : nb::steal(PyFrozenSet_New(nullptr));
   nb::object frozenset_added;
   nb::object frozenset_removed;
@@ -1671,7 +1671,9 @@ struct type_py_node {
 
   static void eval(In<"ts", TsVar<"S">> ts, Out<TS<AnyValue>> out) {
     translate_python_error([&] {
-      nb::object value = value_to_py(ts.value());
+      // Projected structures may use non-owning ValueOps; the input's TSData
+      // conversion contract is the authoritative Python value surface.
+      nb::object value = ts.base().value_to_python();
       out.set(Value{PyObj{nb::borrow(value.type())}});
     });
   }

--- a/python/py_runtime.h
+++ b/python/py_runtime.h
@@ -27,58 +27,6 @@ namespace hgraph::python_bridge
         py_nodes.cpp. */
     void apply_py_result(nb::handle result, Out<TsVar<"O">> &out);
 
-    [[nodiscard]] inline nb::object materialize_tsb_value(
-        const TSValueTypeMetaData *schema,
-        nb::dict value)
-    {
-        const auto mapped = tsb_compound_value_registry().find(schema);
-        if (mapped == tsb_compound_value_registry().end()) { return value; }
-
-        const auto info = bundle_class_info_registry().find(mapped->second);
-        if (info == bundle_class_info_registry().end() || !info->second.type.is_valid())
-        {
-            throw std::logic_error("TSB CompoundScalar class registration is incomplete");
-        }
-
-        const auto &class_info = info->second;
-        nb::dict constructor_arguments;
-        nb::object result;
-        if (!class_info.requires_constructor)
-        {
-            result = nb::steal(class_info.allocator(
-                reinterpret_cast<PyTypeObject *>(class_info.type.ptr()), 0));
-            if (!result.is_valid()) { nb::raise_python_error(); }
-        }
-        for (std::size_t index = 0; index < class_info.field_names.size(); ++index)
-        {
-            const nb::handle key = class_info.field_names[index];
-            nb::object field_value = nb::borrow<nb::object>(value[key]);
-            if (class_info.requires_constructor)
-            {
-                if (class_info.constructor_fields[index])
-                {
-                    constructor_arguments[key] = field_value;
-                }
-            }
-            else if (class_info.field_overrides[index].is_valid())
-            {
-                class_info.field_overrides[index](result, field_value);
-            }
-            else if (PyObject_GenericSetAttr(result.ptr(), key.ptr(), field_value.ptr()) != 0)
-            {
-                nb::raise_python_error();
-            }
-        }
-        if (class_info.requires_constructor)
-        {
-            nb::tuple positional = nb::steal<nb::tuple>(PyTuple_New(0));
-            result = nb::steal(PyObject_Call(
-                class_info.type.ptr(), positional.ptr(), constructor_arguments.ptr()));
-            if (!result.is_valid()) { nb::raise_python_error(); }
-        }
-        return result;
-    }
-
     /** Copy a window's evaluation timestamps into the value layer's standard
         NumPy-compatible one-dimensional buffer.  The scalar binding owns the
         dtype conversion (DateTime -> datetime64[us]); the window remains the
@@ -583,21 +531,9 @@ namespace hgraph::python_bridge
         [[nodiscard]] nb::object value() const
         {
             auto view = checked();
-            if (!view.valid() || !view.data_view().has_current_value()) { return nb::none(); }
-            if (view.schema() != nullptr && view.schema()->kind == TSTypeKind::TSB)
-            {
-                nb::dict value;
-                auto bundle = view.as_bundle();
-                for (std::size_t index = 0; index < view.schema()->field_count(); ++index)
-                {
-                    const auto &field = view.schema()->fields()[index];
-                    auto child = bundle.at(index);
-                    value[nb::str{field.name}] =
-                        PyOutput{TSOutputHandle{child}, now, scheduler, lease}.value();
-                }
-                return materialize_tsb_value(view.schema(), std::move(value));
-            }
-            return value_to_py(view.data_view().value());
+            // Do not add TSTypeKind branches here. Every output storage
+            // representation owns Python shaping through its TSDataOps table.
+            return !view.valid() ? nb::none() : view.data_view().value_to_python();
         }
 
         void set_value(nb::object value) const
@@ -1477,6 +1413,9 @@ namespace hgraph::python_bridge
         [[nodiscard]] nb::object value() const
         {
             auto view = checked();
+            // Recordable-state TSBs use a conventional child named "value"
+            // as their editable payload view. This is navigation, not Python
+            // value shaping; all ordinary snapshots still use TSDataOps.
             if (view.schema()->kind == TSTypeKind::TSB)
             {
                 auto bundle = view.as_bundle();
@@ -1486,9 +1425,7 @@ namespace hgraph::python_bridge
                     return nb::cast(PyRecordableState{child.handle(), now, lease});
                 }
             }
-            return view.valid() && view.data_view().has_current_value()
-                       ? value_to_py(view.data_view().value())
-                       : nb::none();
+            return view.valid() ? view.data_view().value_to_python() : nb::none();
         }
 
         void set_value(nb::handle value) const
@@ -1662,13 +1599,7 @@ namespace hgraph::python_bridge
         {
             if (key_set_projection)
             {
-                nb::list items;
-                auto dict = projected_dict();
-                for (const ValueView &key : dict.keys())
-                {
-                    items.append(value_to_py(key));
-                }
-                return python_set(std::move(items), false);
+                return projected_dict().data_view().key_set().base().value_to_python();
             }
             if (python_value_ops != nullptr)
             {
@@ -1677,55 +1608,11 @@ namespace hgraph::python_bridge
                 // its common ``ts.value`` read avoids both a schema lookup and
                 // a duplicate has-current-value dispatch.
                 require_alive();
-                nb::object result = python_value_ops->to_python_impl(
+                return python_value_ops->to_python_impl(
                     python_value_ops->context, evaluation_data.data());
-                if (PySet_CheckExact(result.ptr()))
-                {
-                    return nb::steal(PyFrozenSet_New(result.ptr()));
-                }
-                return result;
             }
             const auto &v = checked();
             const auto *schema = v.schema();
-            if (schema != nullptr && schema->kind == TSTypeKind::TS)
-            {
-                // HOT PATH: atomic scalars dominate python-node reads.
-                // value_to_python() folds the has_current_value check into
-                // one ops dispatch; the invalid/None read falls out of it.
-                TSDataView data = evaluation_data.has_value()
-                                      ? TSDataView{evaluation_data}
-                                      : v.data_view().borrowed_ref();
-                if (!data.valid()) { return nb::none(); }
-                nb::object result = data.value_to_python();
-                if (PySet_CheckExact(result.ptr()))
-                {
-                    // hgraph parity: a scalar set is a FROZENSET (TSS values
-                    // stay mutable sets) - returning it to a TSS output means
-                    // replace.
-                    return nb::steal(PyFrozenSet_New(result.ptr()));
-                }
-                return result;
-            }
-            TSDataView data = evaluation_data.has_value()
-                                  ? TSDataView{evaluation_data}
-                                  : v.data_view().borrowed_ref();
-            if (!data.valid() || !data.has_current_value())
-            {
-                return nb::none();   // hgraph: invalid reads as None
-            }
-            if (schema != nullptr && schema->kind == TSTypeKind::TSL)
-            {
-                // hgraph parity: a TSL's value is a tuple of child values
-                // (invalid children read as None).
-                auto list = const_cast<TSInputView &>(v).as_list();
-                nb::list out;
-                for (auto &&[index, child] : list.items())
-                {
-                    static_cast<void>(index);
-                    out.append(child.valid() ? value_to_py(child.value()) : nb::none());
-                }
-                return nb::tuple(out);
-            }
             if (schema != nullptr && schema->kind == TSTypeKind::REF)
             {
                 // A REF input's value is the REFERENCE - TSInputView::
@@ -1733,46 +1620,17 @@ namespace hgraph::python_bridge
                 // (peered at the true upstream output).
                 return nb::cast(python_bridge::PyOpaqueRef{Value{v.reference()}, v.evaluation_time()});
             }
-            if (schema != nullptr && schema->kind == TSTypeKind::TSD)
-            {
-                // A TSD input can expose projected structural children (for
-                // example a map_ result whose values are TSBs). Those children
-                // intentionally do not require an aggregate scalar conversion
-                // op. Assemble the public aggregate through the same child
-                // views used by values[key].value so forwarding endpoints and
-                // nested structures retain their Python representation.
-                nb::dict result;
-                auto dict = const_cast<TSInputView &>(v).as_dict();
-                for (auto &&[key, child] : dict.valid_items())
-                {
-                    nb::object py_key = value_to_py(key);
-                    result[py_key] = collection_child(std::move(child), py_key).value();
-                }
-                return result;
-            }
-            if (schema != nullptr && schema->kind == TSTypeKind::TSB)
-            {
-                nb::dict result;
-                auto bundle = const_cast<TSInputView &>(v).as_bundle();
-                for (std::size_t index = 0; index < schema->field_count(); ++index)
-                {
-                    const auto &field = schema->fields()[index];
-                    auto child = bundle.at(index);
-                    result[nb::str{field.name}] =
-                        PyTimeSeries{std::move(child), lease}.value();
-                }
-                return materialize_tsb_value(schema, std::move(result));
-            }
-            return data.value_to_python();   // TS handled on the hot path above
+            // Structural shape is entirely a TSDataOps concern. The facade
+            // has one erased operation regardless of TSD/TSL/TSB nesting.
+            return v.value_to_python();
         }
 
         [[nodiscard]] nb::object delta_value() const
         {
             if (key_set_projection)
             {
-                nb::dict canonical;
-                canonical["added"]   = added();
-                canonical["removed"] = removed();
+                nb::object canonical = projected_dict().data_view().key_set().base()
+                                           .delta_value_to_python(checked().evaluation_time());
                 nb::object &shape = delta_shaper_slot();
                 return shape.is_valid() ? shape(canonical) : std::move(canonical);
             }
@@ -1791,7 +1649,9 @@ namespace hgraph::python_bridge
             // already-valid target is bound this cycle, its current value is
             // the input delta even though the target itself last ticked in an
             // earlier cycle.
-            nb::object delta = value_to_py(ts.delta_value());
+            // As with value(), representation-specific delta recursion is an
+            // erased TSData operation owned below the Python facade.
+            nb::object delta = ts.delta_value_to_python();
             nb::object &shape = delta_shaper_slot();
             return shape.is_valid() ? shape(delta) : delta;
         }

--- a/python/tests/ported/_wiring/test_map_regressions.py
+++ b/python/tests/ported/_wiring/test_map_regressions.py
@@ -1,5 +1,7 @@
 # Public regression from hgraph 275215c5. The C++ runtime represents the same
 # shape directly; no private Python builder behavior is part of this test.
+from dataclasses import dataclass
+
 import hgraph as hg
 from hgraph.test import eval_node
 
@@ -81,6 +83,9 @@ def test_map_bundle_output_exposes_aggregate_tsd_value_to_python_nodes():
         ok: hg.TS[bool]
 
     aggregate_values = []
+    aggregate_deltas = []
+    bound_output_values = []
+    bound_output_deltas = []
     individual_values = []
 
     @hg.graph
@@ -91,6 +96,9 @@ def test_map_bundle_output_exposes_aggregate_tsd_value_to_python_nodes():
     def observe(values: hg.TSD[str, hg.TSB[Status]]):
         individual_values.append(values["item"].value)
         aggregate_values.append(values.value)
+        aggregate_deltas.append(values.delta_value)
+        bound_output_values.append(values.output.value)
+        bound_output_deltas.append(values.output.delta_value)
 
     @hg.graph
     def app(
@@ -104,6 +112,248 @@ def test_map_bundle_output_exposes_aggregate_tsd_value_to_python_nodes():
     assert eval_node(app, [{"item": 1}]) == [expected]
     assert individual_values == [expected["item"]]
     assert aggregate_values == [expected]
+    assert aggregate_deltas == [expected]
+    assert bound_output_values == [expected]
+    assert bound_output_deltas == [expected]
+
+
+def test_map_bundle_output_exposes_aggregate_fixed_tsl_value_and_delta():
+    class Status(hg.TimeSeriesSchema):
+        value: hg.TS[int]
+        ok: hg.TS[bool]
+
+    aggregate_values = []
+    aggregate_deltas = []
+
+    @hg.graph
+    def make_status(value: hg.TS[int]) -> hg.TSB[Status]:
+        return hg.combine[hg.TSB[Status]](value=value, ok=value > 0)
+
+    @hg.sink_node
+    def observe(values: hg.TSL[hg.TSB[Status], hg.Size[2]]):
+        aggregate_values.append(values.value)
+        aggregate_deltas.append(values.delta_value)
+
+    @hg.graph
+    def app(
+        values: hg.TSL[hg.TS[int], hg.Size[2]],
+    ) -> hg.TSL[hg.TSB[Status], hg.Size[2]]:
+        statuses = hg.map_(make_status, values)
+        observe(statuses)
+        return statuses
+
+    first = {"value": 1, "ok": True}
+    second = {"value": 2, "ok": True}
+    assert eval_node(app, [(1, 2)]) == [{0: first, 1: second}]
+    assert aggregate_values == [(first, second)]
+    assert aggregate_deltas == [{0: first, 1: second}]
+
+
+def test_map_bundle_output_exposes_dynamic_tsl_bound_output_aggregates():
+    class Status(hg.TimeSeriesSchema):
+        value: hg.TS[int]
+        ok: hg.TS[bool]
+
+    aggregate_values = []
+    aggregate_deltas = []
+    bound_output_values = []
+    bound_output_deltas = []
+
+    @hg.graph
+    def make_status(value: hg.TS[int]) -> hg.TSB[Status]:
+        return hg.combine[hg.TSB[Status]](value=value, ok=value > 0)
+
+    @hg.sink_node
+    def observe(values: hg.TSL[hg.TSB[Status], hg.Size[0]]):
+        aggregate_values.append(values.value)
+        aggregate_deltas.append(values.delta_value)
+        bound_output_values.append(values.output.value)
+        bound_output_deltas.append(values.output.delta_value)
+
+    @hg.graph
+    def app(
+        values: hg.TSL[hg.TS[int], hg.Size[0]],
+    ) -> hg.TSL[hg.TSB[Status], hg.Size[0]]:
+        statuses = hg.map_(make_status, values)
+        observe(statuses)
+        return statuses
+
+    status = {"value": 1, "ok": True}
+    expected_delta = {0: status}
+    assert eval_node(app, [{0: 1}]) == [expected_delta]
+    assert aggregate_values == [(status,)]
+    assert aggregate_deltas == [expected_delta]
+    assert bound_output_values == [(status,)]
+    assert bound_output_deltas == [expected_delta]
+
+
+def test_type_operator_supports_projected_structural_values():
+    class Status(hg.TimeSeriesSchema):
+        value: hg.TS[int]
+        ok: hg.TS[bool]
+
+    @hg.graph
+    def make_status(value: hg.TS[int]) -> hg.TSB[Status]:
+        return hg.combine[hg.TSB[Status]](value=value, ok=value > 0)
+
+    @hg.graph
+    def bundle_type(value: hg.TS[int]) -> hg.TS[type]:
+        return hg.type_(make_status(value))
+
+    @hg.graph
+    def dict_type(values: hg.TSD[str, hg.TS[int]]) -> hg.TS[type]:
+        return hg.type_(hg.map_(make_status, values))
+
+    @hg.graph
+    def list_type(
+        values: hg.TSL[hg.TS[int], hg.Size[2]],
+    ) -> hg.TS[type]:
+        return hg.type_(hg.map_(make_status, values))
+
+    assert eval_node(bundle_type, [1]) == [dict]
+    assert eval_node(dict_type, [{"item": 1}]) == [dict]
+    assert eval_node(list_type, [(1, 2)]) == [tuple]
+
+
+def test_map_compound_scalar_bundle_preserves_aggregate_python_values():
+    @dataclass(frozen=True)
+    class Status(hg.CompoundScalar):
+        value: int
+        ok: bool
+
+    aggregate_values = []
+    bound_output_values = []
+
+    @hg.graph
+    def make_status(value: hg.TS[int]) -> hg.TSB[Status]:
+        return hg.combine[hg.TSB[Status]](value=value, ok=value > 0)
+
+    @hg.sink_node
+    def observe(values: hg.TSD[str, hg.TSB[Status]]):
+        aggregate_values.append(values.value)
+        bound_output_values.append(values.output.value)
+
+    @hg.graph
+    def app(values: hg.TSD[str, hg.TS[int]]) -> hg.TSD[str, hg.TSB[Status]]:
+        statuses = hg.map_(make_status, values)
+        observe(statuses)
+        return statuses
+
+    expected = {"item": Status(value=1, ok=True)}
+    assert eval_node(app, [{"item": 1}]) == [{"item": {"value": 1, "ok": True}}]
+    assert aggregate_values == [expected]
+    assert bound_output_values == [expected]
+
+
+def test_map_nested_fixed_tsl_bundle_preserves_aggregate_python_values():
+    class Status(hg.TimeSeriesSchema):
+        value: hg.TS[int]
+
+    aggregate_values = []
+    aggregate_deltas = []
+
+    @hg.graph
+    def make_status(value: hg.TS[int]) -> hg.TSB[Status]:
+        return hg.combine[hg.TSB[Status]](value=value)
+
+    @hg.graph
+    def make_pair(value: hg.TS[int]) -> hg.TSL[hg.TSB[Status], hg.Size[2]]:
+        return hg.combine[hg.TSL[hg.TSB[Status], hg.Size[2]]](
+            make_status(value), make_status(value + 1)
+        )
+
+    @hg.sink_node
+    def observe(values: hg.TSD[str, hg.TSL[hg.TSB[Status], hg.Size[2]]]):
+        aggregate_values.append(values.value)
+        aggregate_deltas.append(values.delta_value)
+
+    @hg.graph
+    def app(
+        values: hg.TSD[str, hg.TS[int]],
+    ) -> hg.TSD[str, hg.TSL[hg.TSB[Status], hg.Size[2]]]:
+        pairs = hg.map_(make_pair, values)
+        observe(pairs)
+        return pairs
+
+    pair = ({"value": 1}, {"value": 2})
+    assert eval_node(app, [{"item": 1}]) == [{"item": {0: pair[0], 1: pair[1]}}]
+    assert aggregate_values == [{"item": pair}]
+    assert aggregate_deltas == [{"item": {0: pair[0], 1: pair[1]}}]
+
+
+def test_proxy_lag_of_mapped_bundle_uses_erased_aggregate_conversion():
+    class Status(hg.TimeSeriesSchema):
+        value: hg.TS[int]
+        ok: hg.TS[bool]
+
+    aggregate_values = []
+    aggregate_deltas = []
+    bound_output_values = []
+    bound_output_deltas = []
+
+    @hg.graph
+    def make_status(value: hg.TS[int]) -> hg.TSB[Status]:
+        return hg.combine[hg.TSB[Status]](value=value, ok=value > 0)
+
+    @hg.sink_node
+    def observe(values: hg.TSD[str, hg.TSB[Status]]):
+        aggregate_values.append(values.value)
+        aggregate_deltas.append(values.delta_value)
+        bound_output_values.append(values.output.value)
+        bound_output_deltas.append(values.output.delta_value)
+
+    @hg.graph
+    def app(
+        values: hg.TSD[str, hg.TS[int]], proxy: hg.TS[bool]
+    ) -> hg.TSD[str, hg.TSB[Status]]:
+        delayed = hg.lag(hg.map_(make_status, values), 1, proxy)
+        observe(delayed)
+        return delayed
+
+    first = {"value": 1, "ok": True}
+    second = {"value": 2, "ok": True}
+    assert eval_node(
+        app, [{"item": 1}, {"item": 2}], [True, True, True]
+    ) == [{}, {"item": first}, {"item": second}]
+    expected = [{}, {"item": first}, {"item": second}]
+    assert aggregate_values == expected
+    assert aggregate_deltas == expected
+    assert bound_output_values == expected
+    assert bound_output_deltas == expected
+
+
+def test_bundle_with_nested_tsd_and_tsl_uses_child_conversion_strategies():
+    class Nested(hg.TimeSeriesSchema):
+        keyed: hg.TSD[str, hg.TS[int]]
+        listed: hg.TSL[hg.TS[int], hg.Size[2]]
+
+    aggregate_values = []
+    aggregate_deltas = []
+    bound_output_values = []
+    bound_output_deltas = []
+
+    @hg.sink_node
+    def observe(values: hg.TSB[Nested]):
+        aggregate_values.append(values.value)
+        aggregate_deltas.append(values.delta_value)
+        bound_output_values.append(values.output.value)
+        bound_output_deltas.append(values.output.delta_value)
+
+    @hg.graph
+    def app(values: hg.TSB[Nested]) -> hg.TSB[Nested]:
+        observe(values)
+        return values
+
+    sample = {"keyed": {"item": 1}, "listed": (2, 3)}
+    assert eval_node(app, [sample]) == [
+        {"keyed": {"item": 1}, "listed": {0: 2, 1: 3}}
+    ]
+    expected_value = {"keyed": {"item": 1}, "listed": (2, 3)}
+    expected_delta = {"keyed": {"item": 1}, "listed": {0: 2, 1: 3}}
+    assert aggregate_values == [expected_value]
+    assert aggregate_deltas == [expected_delta]
+    assert bound_output_values == [expected_value]
+    assert bound_output_deltas == [expected_delta]
 
 
 def test_map_removed_typed_bundle_reference_does_not_retick_with_sibling():

--- a/python/tests/test_python_authoring.py
+++ b/python/tests/test_python_authoring.py
@@ -823,6 +823,34 @@ def test_python_sink_nodes_work_as_native_keyed_map_children():
     check(lifecycle.count("stop") == 3, f"sink map stops: {lifecycle}")
 
 
+def test_python_mapped_key_source_preserves_frozenset_scalar_values():
+    observed = []
+
+    @hg.compute_node
+    def inspect_key(key: TS[frozenset[int]], value: TS[int]) -> TS[bool]:
+        mapped_key = key.value
+        observed.append(mapped_key)
+        return type(mapped_key) is frozenset and hash(mapped_key) == hash(frozenset(mapped_key))
+
+    @graph
+    def app(values: TSD[frozenset[int], TS[int]]) -> TSD[frozenset[int], TS[bool]]:
+        return hg.map_(inspect_key, values)
+
+    first = frozenset({1, 2})
+    second = frozenset({3})
+    check(
+        eval_node(app, [{first: 10, second: 20}, {first: hg.REMOVE}]) == [
+            {first: True, second: True},
+            {first: hg.REMOVE},
+        ],
+        "mapped frozenset key values remain immutable and hashable",
+    )
+    check(
+        len(observed) == 2 and all(type(value) is frozenset for value in observed),
+        f"mapped key Python values: {observed}",
+    )
+
+
 def test_python_key_only_sink_map_uses_explicit_keys():
     seen = []
 

--- a/src/hgraph/python/bridge_state.cpp
+++ b/src/hgraph/python/bridge_state.cpp
@@ -676,6 +676,55 @@ std::unordered_map<const void *, const void *> &tsb_compound_value_registry() {
   return *registry;
 }
 
+nb::object materialize_tsb_python_value(const TSValueTypeMetaData *schema,
+                                        nb::dict value) {
+  const auto mapped = tsb_compound_value_registry().find(schema);
+  if (mapped == tsb_compound_value_registry().end()) {
+    return value;
+  }
+
+  const auto info = bundle_class_info_registry().find(mapped->second);
+  if (info == bundle_class_info_registry().end() ||
+      !info->second.type.is_valid()) {
+    throw std::logic_error(
+        "TSB CompoundScalar class registration is incomplete");
+  }
+
+  const auto &class_info = info->second;
+  nb::dict constructor_arguments;
+  nb::object result;
+  if (!class_info.requires_constructor) {
+    result = nb::steal(class_info.allocator(
+        reinterpret_cast<PyTypeObject *>(class_info.type.ptr()), 0));
+    if (!result.is_valid()) {
+      nb::raise_python_error();
+    }
+  }
+  for (std::size_t index = 0; index < class_info.field_names.size(); ++index) {
+    const nb::handle key = class_info.field_names[index];
+    nb::object field_value = nb::borrow<nb::object>(value[key]);
+    if (class_info.requires_constructor) {
+      if (class_info.constructor_fields[index]) {
+        constructor_arguments[key] = field_value;
+      }
+    } else if (class_info.field_overrides[index].is_valid()) {
+      class_info.field_overrides[index](result, field_value);
+    } else if (PyObject_GenericSetAttr(result.ptr(), key.ptr(),
+                                       field_value.ptr()) != 0) {
+      nb::raise_python_error();
+    }
+  }
+  if (class_info.requires_constructor) {
+    nb::tuple positional = nb::steal<nb::tuple>(PyTuple_New(0));
+    result = nb::steal(PyObject_Call(class_info.type.ptr(), positional.ptr(),
+                                     constructor_arguments.ptr()));
+    if (!result.is_valid()) {
+      nb::raise_python_error();
+    }
+  }
+  return result;
+}
+
 void register_python_bundle_binding(const ValueTypeMetaData *schema) {
   if (schema == nullptr || !schema->is_named_bundle()) {
     throw std::invalid_argument(

--- a/src/hgraph/runtime/mapped_key_source.h
+++ b/src/hgraph/runtime/mapped_key_source.h
@@ -119,7 +119,12 @@ namespace hgraph::runtime_detail
                     {
                         return nb::none();
                     }
-                    return context->layout.value_binding.ops_ref().to_python(storage->key->view().data());
+                    // This synthetic TSData strategy must preserve the scalar
+                    // ValueOps result unchanged. Representation policy (for
+                    // example compact Set -> frozenset) belongs to ValueOps,
+                    // never to this source or a Python facade.
+                    return context->layout.value_binding.ops_ref().to_python(
+                        storage->key->view().data());
                 },
                 .delta_to_python_impl      = [](const void *ctx, const void *memory, DateTime evaluation_time) -> nb::object {
                     const auto *context = static_cast<const Context *>(ctx);
@@ -129,7 +134,8 @@ namespace hgraph::runtime_detail
                     {
                         return nb::none();
                     }
-                    return context->layout.delta_binding.ops_ref().to_python(storage->key->view().data());
+                    return context->layout.delta_binding.ops_ref().to_python(
+                        storage->key->view().data());
                 },
 #endif
             };

--- a/src/hgraph/types/metadata/ts_data_atomic_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_atomic_ops.cpp
@@ -379,10 +379,11 @@ namespace hgraph::ts_data_plan_factory_detail
             const void *context, const void *memory)
         {
             const auto *layout = atomic_layout(context);
+            nb::object converted;
             if constexpr (Storage !=
                           ValueStorageVariant::NativeWithPythonCache)
             {
-                return layout->value_binding.ops_ref().to_python(
+                converted = layout->value_binding.ops_ref().to_python(
                     atomic_value_memory(context, memory));
             }
             else
@@ -390,19 +391,28 @@ namespace hgraph::ts_data_plan_factory_detail
                 if (const auto *retained = python_value(context, memory);
                     retained != nullptr && retained->has_value())
                 {
-                    return retained->get();
+                    converted = retained->get();
                 }
-                nb::object converted =
-                    layout->value_binding.ops_ref().to_python(
-                        atomic_value_memory(context, memory));
-                if (auto *cached =
-                        python_value(context, const_cast<void *>(memory));
-                    cached != nullptr)
+                else
                 {
-                    cached->set(converted);
+                    converted = layout->value_binding.ops_ref().to_python(
+                        atomic_value_memory(context, memory));
+                    if (auto *cached =
+                            python_value(context, const_cast<void *>(memory));
+                        cached != nullptr)
+                    {
+                        cached->set(converted);
+                    }
                 }
-                return converted;
             }
+            // TS[set-like] is the immutable scalar value surface; TSS owns
+            // the mutable set/delta surface. This representation choice is
+            // installed once in the atomic TSData strategy, never in a
+            // Python TimeSeries facade.
+            return entry(context).ops.kind == TSTypeKind::TS &&
+                           PySet_CheckExact(converted.ptr())
+                       ? nb::steal(PyFrozenSet_New(converted.ptr()))
+                       : std::move(converted);
         }
 
         template <ValueStorageVariant Storage>
@@ -414,8 +424,12 @@ namespace hgraph::ts_data_plan_factory_detail
             if constexpr (Storage == ValueStorageVariant::Native)
             {
                 const auto *layout = atomic_layout(context);
-                return layout->delta_binding.ops_ref().to_python(
+                nb::object converted = layout->delta_binding.ops_ref().to_python(
                     atomic_delta_memory(context, memory));
+                return entry(context).ops.kind == TSTypeKind::TS &&
+                               PySet_CheckExact(converted.ptr())
+                           ? nb::steal(PyFrozenSet_New(converted.ptr()))
+                           : std::move(converted);
             }
             else
             {

--- a/src/hgraph/types/metadata/ts_data_atomic_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_atomic_ops.cpp
@@ -405,14 +405,10 @@ namespace hgraph::ts_data_plan_factory_detail
                     }
                 }
             }
-            // TS[set-like] is the immutable scalar value surface; TSS owns
-            // the mutable set/delta surface. This representation choice is
-            // installed once in the atomic TSData strategy, never in a
-            // Python TimeSeries facade.
-            return entry(context).ops.kind == TSTypeKind::TS &&
-                           PySet_CheckExact(converted.ptr())
-                       ? nb::steal(PyFrozenSet_New(converted.ptr()))
-                       : std::move(converted);
+            // Scalar Python representation is already owned by the selected
+            // ValueOps strategy (notably compact Set -> frozenset). Atomic
+            // TSData forwards that erased result without re-normalizing it.
+            return converted;
         }
 
         template <ValueStorageVariant Storage>
@@ -426,10 +422,7 @@ namespace hgraph::ts_data_plan_factory_detail
                 const auto *layout = atomic_layout(context);
                 nb::object converted = layout->delta_binding.ops_ref().to_python(
                     atomic_delta_memory(context, memory));
-                return entry(context).ops.kind == TSTypeKind::TS &&
-                               PySet_CheckExact(converted.ptr())
-                           ? nb::steal(PyFrozenSet_New(converted.ptr()))
-                           : std::move(converted);
+                return converted;
             }
             else
             {

--- a/src/hgraph/types/metadata/ts_data_dynamic_list_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_dynamic_list_ops.cpp
@@ -404,6 +404,10 @@ namespace hgraph::ts_data_plan_factory_detail
                     .indexed_child_memory_impl = &dynamic_indexed_element_memory,
                     .mutable_indexed_child_memory_impl = &dynamic_mutable_indexed_element_memory,
                     .indexed_child_growth      = true,
+#if HGRAPH_ENABLE_PYTHON_USER_NODES
+                    .to_python_impl            = &dynamic_to_python,
+                    .delta_to_python_impl      = &dynamic_delta_to_python,
+#endif
                 };
                 ops.size_impl                   = &dynamic_indexed_size;
                 ops.modified_index_count_impl   = &dynamic_modified_index_count;
@@ -418,7 +422,12 @@ namespace hgraph::ts_data_plan_factory_detail
                 value_list_ops = IndexedValueOps{
                     {ValueOpsKind::Indexed, this, false, &dynamic_value_hash, &dynamic_value_equals,
                      &dynamic_value_compare,
-                     &dynamic_value_to_string},
+                     &dynamic_value_to_string
+#if HGRAPH_ENABLE_PYTHON_USER_NODES
+                     ,
+                     &dynamic_value_projection_to_python
+#endif
+                    },
                     &dynamic_value_size,
                     &dynamic_value_element_at,
                     &dynamic_value_element_binding,
@@ -433,7 +442,12 @@ namespace hgraph::ts_data_plan_factory_detail
                 delta_map_ops = MapValueOps{
                     {{ValueOpsKind::Map, this, false, &dynamic_delta_map_hash, &dynamic_delta_map_equals,
                       &dynamic_delta_map_compare,
-                      &dynamic_delta_map_to_string},
+                      &dynamic_delta_map_to_string
+#if HGRAPH_ENABLE_PYTHON_USER_NODES
+                      ,
+                      &dynamic_delta_projection_to_python
+#endif
+                     },
                      &dynamic_delta_map_size,
                      &dynamic_delta_map_key_at_index,
                      &dynamic_delta_map_key_binding,
@@ -454,7 +468,12 @@ namespace hgraph::ts_data_plan_factory_detail
 
                 delta_key_set_ops = SetValueOps{
                     {{ValueOpsKind::Set, this, false, &dynamic_delta_key_set_hash, &dynamic_delta_key_set_equals,
-                      &dynamic_delta_key_set_compare, &dynamic_delta_key_set_to_string},
+                      &dynamic_delta_key_set_compare, &dynamic_delta_key_set_to_string
+#if HGRAPH_ENABLE_PYTHON_USER_NODES
+                      ,
+                      &dynamic_delta_key_set_projection_to_python
+#endif
+                     },
                      &dynamic_delta_map_size,
                      &dynamic_delta_map_key_at_index,
                      &dynamic_delta_map_key_binding,
@@ -471,6 +490,71 @@ namespace hgraph::ts_data_plan_factory_detail
             {
                 return static_cast<const DynamicTSLContext *>(context);
             }
+
+#if HGRAPH_ENABLE_PYTHON_USER_NODES
+            [[nodiscard]] static nb::object dynamic_value_projection_to_python(
+                const void *context, const void *memory)
+            {
+                const auto *state = ctx(context);
+                return Value{ValueView{state->list_layout.value_binding, memory}}.to_python();
+            }
+
+            [[nodiscard]] static nb::object dynamic_delta_projection_to_python(
+                const void *context, const void *memory)
+            {
+                const auto *state = ctx(context);
+                return Value{ValueView{state->list_layout.delta_binding, memory}}.to_python();
+            }
+
+            [[nodiscard]] static nb::object dynamic_delta_key_set_projection_to_python(
+                const void *context, const void *memory)
+            {
+                const auto *state = ctx(context);
+                return Value{ValueView{state->delta_key_set_binding, memory}}.to_python();
+            }
+
+            /** Dynamic TSL Python export is a TSData strategy. It deliberately
+                recurses through child TSDataOps; the public facade must never
+                infer this representation from TSTypeKind. */
+            [[nodiscard]] static nb::object dynamic_to_python(const void *context,
+                                                               const void *memory)
+            {
+                const auto *state = ctx(context);
+                const auto &store = storage(memory);
+                const auto &ops = child_ops(state->element_type);
+                nb::list result;
+                for (std::size_t index = 0; index < store.size(); ++index)
+                {
+                    const auto *child = store.child_memory(index);
+                    result.append(ops.has_current_value_impl(ops.context, child)
+                                      ? ops.to_python_impl(ops.context, child)
+                                      : nb::none());
+                }
+                return nb::tuple(result);
+            }
+
+            [[nodiscard]] static nb::object dynamic_delta_to_python(
+                const void *context, const void *memory, DateTime evaluation_time)
+            {
+                const auto *state = ctx(context);
+                const auto &store = storage(memory);
+                if (store.tracking().last_modified_time != evaluation_time)
+                {
+                    return nb::none();
+                }
+                const auto &ops = child_ops(state->element_type);
+                nb::dict result;
+                for (std::size_t ordinal = 0; ordinal < store.modified_index_count(); ++ordinal)
+                {
+                    const auto index = store.modified_index_at(ordinal);
+                    const auto *child = store.child_memory(index);
+                    nb::object value = ops.delta_to_python_impl(
+                        ops.context, child, evaluation_time);
+                    if (!value.is_none()) { result[nb::int_{index}] = std::move(value); }
+                }
+                return result;
+            }
+#endif
 
             [[nodiscard]] static const TSDataLayout *dynamic_layout(const void *context) noexcept
             {

--- a/src/hgraph/types/metadata/ts_data_fixed_structured_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_fixed_structured_ops.cpp
@@ -8,6 +8,10 @@
 #include <hgraph/types/value/value_builder.h>
 #include <hgraph/util/scope.h>
 
+#if HGRAPH_ENABLE_PYTHON_USER_NODES
+#include <hgraph/python/bridge_state.h>
+#endif
+
 #include "../time_series/ts_data/ownership.h"
 
 #include <fmt/format.h>
@@ -844,26 +848,10 @@ namespace hgraph::ts_data_plan_factory_detail
         [[nodiscard]] static nb::object fixed_value_to_python(const void *context, const void *memory)
         {
             const auto *state = ctx(context);
-            if (state->schema->kind == TSTypeKind::TSB)
-            {
-                nb::dict result;
-                for (std::size_t index = 0; index < state->element_count(); ++index)
-                {
-                    const char *name = state->schema->fields()[index].name;
-                    if (name == nullptr || *name == '\0') { continue; }
-                    auto child_view = child_value_view(state, memory, index);
-                    if (!child_view.has_value()) { continue; }
-                    result[nb::str{name}] = child_view.to_python();
-                }
-                return result;
-            }
-
-            nb::list result;
-            for (std::size_t index = 0; index < state->element_count(); ++index)
-            {
-                result.append(child_value_view(state, memory, index).to_python());
-            }
-            return result;
+            // This is a VALUE projection, not the TSData Python surface.
+            // Materialise through the erased owning-type/copy contract so a
+            // projected child never needs ad-hoc recursive shape knowledge.
+            return Value{ValueView{state->layout_ptr()->value_binding, memory}}.to_python();
         }
 #endif
 
@@ -930,15 +918,7 @@ namespace hgraph::ts_data_plan_factory_detail
         [[nodiscard]] static nb::object fixed_delta_bundle_to_python(const void *context, const void *memory)
         {
             const auto *state = ctx(context);
-            nb::dict    result;
-            for (std::size_t index = 0; index < state->element_count(); ++index)
-            {
-                if (!child_modified_for_parent_time(state, memory, index)) { continue; }
-                const char *name = state->schema->fields()[index].name;
-                if (name == nullptr || *name == '\0') { continue; }
-                result[nb::str{name}] = child_delta_view(state, memory, index).to_python();
-            }
-            return result;
+            return Value{ValueView{state->layout_ptr()->delta_binding, memory}}.to_python();
         }
 #endif
 
@@ -1238,13 +1218,7 @@ namespace hgraph::ts_data_plan_factory_detail
         [[nodiscard]] static nb::object fixed_delta_map_to_python(const void *context, const void *memory)
         {
             const auto *state = ctx(context);
-            nb::dict    result;
-            for (std::size_t index = 0; index < state->element_count(); ++index)
-            {
-                if (!child_modified_for_parent_time(state, memory, index)) { continue; }
-                result[nb::int_{state->ordinal_keys[index]}] = child_delta_view(state, memory, index).to_python();
-            }
-            return result;
+            return Value{ValueView{state->layout_ptr()->delta_binding, memory}}.to_python();
         }
 #endif
 
@@ -1570,7 +1544,36 @@ namespace hgraph::ts_data_plan_factory_detail
         [[nodiscard]] static nb::object fixed_to_python(const void *context, const void *memory)
         {
             const auto *state = ctx(context);
-            return state->layout_ptr()->value_binding.ops_ref().to_python(fixed_value_memory(context, memory));
+            // Python TimeSeries.value is a TSData operation. Recurse through
+            // each child's TSDataOps so nested TSL/TSD/TSB representations
+            // retain their own public Python semantics.
+            if (state->schema->kind == TSTypeKind::TSB)
+            {
+                nb::dict result;
+                for (std::size_t index = 0; index < state->element_count(); ++index)
+                {
+                    const char *name = state->schema->fields()[index].name;
+                    if (name == nullptr || *name == '\0') { continue; }
+                    const auto &ops = child_ops(state->element_type(index));
+                    const auto *child = child_data(state, memory, index);
+                    result[nb::str{name}] = ops.has_current_value_impl(ops.context, child)
+                                                ? ops.to_python_impl(ops.context, child)
+                                                : nb::none();
+                }
+                return python_bridge::materialize_tsb_python_value(
+                    state->schema, std::move(result));
+            }
+
+            nb::list result;
+            for (std::size_t index = 0; index < state->element_count(); ++index)
+            {
+                const auto &ops = child_ops(state->element_type(index));
+                const auto *child = child_data(state, memory, index);
+                result.append(ops.has_current_value_impl(ops.context, child)
+                                  ? ops.to_python_impl(ops.context, child)
+                                  : nb::none());
+            }
+            return nb::tuple(result);
         }
 
         [[nodiscard]] static nb::object fixed_delta_to_python(const void *context,
@@ -1579,7 +1582,29 @@ namespace hgraph::ts_data_plan_factory_detail
         {
             const auto *state = ctx(context);
             if (fixed_tracking(state, memory)->last_modified_time != evaluation_time) { return nb::none(); }
-            return state->layout_ptr()->delta_binding.ops_ref().to_python(fixed_delta_memory(context, memory));
+            nb::dict result;
+            for (std::size_t index = 0; index < state->element_count(); ++index)
+            {
+                if (!child_modified_for_parent_time(state, memory, index)) { continue; }
+                const auto &ops = child_ops(state->element_type(index));
+                const auto *child = child_data(state, memory, index);
+                nb::object value = ops.delta_to_python_impl(
+                    ops.context, child, evaluation_time);
+                if (value.is_none()) { continue; }
+                if (state->schema->kind == TSTypeKind::TSB)
+                {
+                    const char *name = state->schema->fields()[index].name;
+                    if (name != nullptr && *name != '\0')
+                    {
+                        result[nb::str{name}] = std::move(value);
+                    }
+                }
+                else
+                {
+                    result[nb::int_{index}] = std::move(value);
+                }
+            }
+            return result;
         }
 
         [[nodiscard]] static bool is_python_sequence(nb::handle source)

--- a/src/hgraph/types/metadata/ts_data_slot_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_slot_ops.cpp
@@ -2502,7 +2502,19 @@ namespace hgraph::ts_data_plan_factory_detail
             [[nodiscard]] static nb::object tsd_to_python(const void *context, const void *memory)
             {
                 const auto *state = ctxd(context);
-                return state->dict_layout.value_binding.ops_ref().to_python(memory);
+                const auto &store = storage<TSDSlotStorage>(memory);
+                const auto &key_ops = state->dict_layout.key_binding.ops_ref();
+                const auto &child_ops = state->dict_layout.element_type.ops_ref();
+                nb::dict result;
+                for (std::size_t slot = 0; slot < store.slot_capacity(); ++slot)
+                {
+                    if (!map_slot_in_surface<SlotMapSurface::Live>(store, slot)) { continue; }
+                    const auto *child = store.child_at_slot(slot);
+                    if (!child_ops.has_current_value_impl(child_ops.context, child)) { continue; }
+                    result[key_ops.to_python(store.key_at_slot(slot))] =
+                        child_ops.to_python_impl(child_ops.context, child);
+                }
+                return result;
             }
 
             [[nodiscard]] static nb::object tsd_delta_to_python(const void *context,
@@ -2514,7 +2526,25 @@ namespace hgraph::ts_data_plan_factory_detail
                 {
                     return nb::none();
                 }
-                return state->dict_layout.delta_binding.ops_ref().to_python(memory);
+                const auto &store = storage<TSDSlotStorage>(memory);
+                const auto &key_ops = state->dict_layout.key_binding.ops_ref();
+                const auto &child_ops = state->dict_layout.element_type.ops_ref();
+                nb::dict modified;
+                for (std::size_t slot = 0; slot < store.slot_capacity(); ++slot)
+                {
+                    if (!map_slot_in_surface<SlotMapSurface::Modified>(store, slot)) { continue; }
+                    const auto *child = store.child_at_slot(slot);
+                    nb::object delta = child_ops.delta_to_python_impl(
+                        child_ops.context, child, evaluation_time);
+                    if (!delta.is_none())
+                    {
+                        modified[key_ops.to_python(store.key_at_slot(slot))] = std::move(delta);
+                    }
+                }
+                nb::dict result;
+                result[nb::str{"removed"}] = state->removed_set_binding.ops_ref().to_python(memory);
+                result[nb::str{"modified"}] = std::move(modified);
+                return result;
             }
 
             [[nodiscard]] static bool tsd_from_python(const void *context,

--- a/src/hgraph/types/time_series/ts_data/proxy.cpp
+++ b/src/hgraph/types/time_series/ts_data/proxy.cpp
@@ -179,7 +179,12 @@ namespace hgraph
                 modified_map_ops      = map_value_ops_for<TSDProxyMapSurface::Modified>();
                 delta_bundle_ops      = IndexedValueOps{
                     {ValueOpsKind::Indexed, this, false, &delta_hash, &delta_equals, &delta_compare,
-                     &delta_to_string},
+                     &delta_to_string
+#if HGRAPH_ENABLE_PYTHON_USER_NODES
+                     ,
+                     &delta_projection_to_python
+#endif
+                    },
                     &delta_size,
                     &delta_element_at,
                     &delta_element_binding,
@@ -213,6 +218,10 @@ namespace hgraph
                     .capture_delta_impl        = &ts_data_detail::capture_delta_tss,
                     .delta_has_effect_impl     = &ts_data_detail::delta_has_effect_tss,
                     .apply_delta_impl          = &ts_data_detail::apply_delta_tss,
+#if HGRAPH_ENABLE_PYTHON_USER_NODES
+                    .to_python_impl            = &key_set_to_python,
+                    .delta_to_python_impl      = &key_set_delta_to_python,
+#endif
                 };
                 key_set_ts_ops.size_impl                      = &set_size<TSDProxySetSurface::Live>;
                 key_set_ts_ops.slot_capacity_impl             = &slot_capacity;
@@ -246,6 +255,10 @@ namespace hgraph
                 dict_base.capture_delta_impl = &ts_data_detail::capture_delta_tsd;
                 dict_base.delta_has_effect_impl = &ts_data_detail::delta_has_effect_tsd;
                 dict_base.apply_delta_impl = &ts_data_detail::apply_delta_tsd;
+#if HGRAPH_ENABLE_PYTHON_USER_NODES
+                dict_base.to_python_impl = &dict_to_python;
+                dict_base.delta_to_python_impl = &dict_delta_to_python;
+#endif
                 dict_ops.structural_delta_current_impl = &structural_delta_current;
                 dict_ops.child_at_slot_impl = &tsd_child_at_slot;
                 dict_ops.slot_modified_impl = &slot_modified;
@@ -371,6 +384,97 @@ namespace hgraph
                 }
                 return binding;
             }
+
+#if HGRAPH_ENABLE_PYTHON_USER_NODES
+            [[nodiscard]] static nb::object delta_projection_to_python(
+                const void *context, const void *memory)
+            {
+                const auto *state = ctx(context);
+                return Value{ValueView{state->layout.delta_binding, memory}}.to_python();
+            }
+
+            [[nodiscard]] static nb::object key_set_to_python(
+                const void *context, const void *memory)
+            {
+                const auto *state = ctx(context);
+                nb::set result;
+                for (const auto key : set_range<TSDProxySetSurface::Live>(context, memory))
+                {
+                    result.add(state->layout.key_binding.ops_ref().to_python(key.data()));
+                }
+                return result;
+            }
+
+            [[nodiscard]] static nb::object key_set_delta_to_python(
+                const void *context, const void *memory, DateTime evaluation_time)
+            {
+                const auto &proxy = proxy_storage(memory);
+                if (proxy.key_set_tracking().last_modified_time != evaluation_time)
+                {
+                    return nb::none();
+                }
+                nb::dict result;
+                result[nb::str{"added"}] =
+                    set_surface_to_python<TSDProxySetSurface::Added>(context, memory);
+                result[nb::str{"removed"}] =
+                    set_surface_to_python<TSDProxySetSurface::Removed>(context, memory);
+                return result;
+            }
+
+            /** TSDProxy is a concrete TSData representation. Python export
+                therefore lives here and follows each child through its own
+                erased TSDataOps instead of leaking proxy layout to a facade. */
+            [[nodiscard]] static nb::object dict_to_python(
+                const void *context, const void *memory)
+            {
+                const auto *state = ctx(context);
+                const auto &proxy = proxy_storage(memory);
+                const auto dict = source_dict(memory);
+                const auto &child_ops = state->element_type.ops_ref();
+                nb::dict result;
+                for (std::size_t slot = 0; slot < dict.slot_capacity(); ++slot)
+                {
+                    if (!dict.slot_live(slot) || !proxy.has_child(slot)) { continue; }
+                    const auto key = dict.key_at_slot(slot);
+                    const auto *child = proxy.child_at_slot(slot);
+                    if (!child_ops.has_current_value_impl(child_ops.context, child)) { continue; }
+                    result[key.binding().ops_ref().to_python(key.data())] =
+                        child_ops.to_python_impl(child_ops.context, child);
+                }
+                return result;
+            }
+
+            [[nodiscard]] static nb::object dict_delta_to_python(
+                const void *context, const void *memory, DateTime evaluation_time)
+            {
+                const auto *state = ctx(context);
+                const auto &proxy = proxy_storage(memory);
+                if (proxy.tracking().last_modified_time != evaluation_time)
+                {
+                    return nb::none();
+                }
+                const auto dict = source_dict(memory);
+                const auto &child_ops = state->element_type.ops_ref();
+                nb::dict modified;
+                for (std::size_t slot = 0; slot < dict.slot_capacity(); ++slot)
+                {
+                    if (!slot_modified(context, memory, slot) || !proxy.has_child(slot)) { continue; }
+                    const auto key = dict.key_at_slot(slot);
+                    const auto *child = proxy.child_at_slot(slot);
+                    nb::object delta = child_ops.delta_to_python_impl(
+                        child_ops.context, child, evaluation_time);
+                    if (!delta.is_none())
+                    {
+                        modified[key.binding().ops_ref().to_python(key.data())] = std::move(delta);
+                    }
+                }
+                nb::dict result;
+                result[nb::str{"removed"}] =
+                    set_surface_to_python<TSDProxySetSurface::Removed>(context, memory);
+                result[nb::str{"modified"}] = std::move(modified);
+                return result;
+            }
+#endif
 
             static void delta_copy_construct_view(const void *context,
                                                   const ValueTypeRef &binding,

--- a/src/hgraph/types/time_series/ts_input.cpp
+++ b/src/hgraph/types/time_series/ts_input.cpp
@@ -18,6 +18,10 @@
 #include <hgraph/types/value/value_builder.h>
 #include <hgraph/util/scope.h>
 
+#if HGRAPH_ENABLE_PYTHON_USER_NODES
+#include <hgraph/python/bridge_state.h>
+#endif
+
 #include <algorithm>
 #include <array>
 #include <cstdint>
@@ -1812,28 +1816,23 @@ namespace hgraph
         [[nodiscard]] nb::object input_delta_bundle_value_to_python(const void *context, const void *memory)
         {
             const auto *state = static_cast<const InputBindingContext *>(context);
-            nb::dict result;
-            for (std::size_t index = 0; index < state->children.size(); ++index)
-            {
-                if (!input_child_modified_for_parent_time(context, memory, index)) { continue; }
-                const auto *name = state->schema->fields()[index].name;
-                if (name == nullptr || *name == '\0') { continue; }
-                result[nb::str{name}] = input_child_delta_view(context, memory, index).to_python();
-            }
-            return result;
+            return Value{ValueView{state->delta_binding, memory}}.to_python();
         }
 
         [[nodiscard]] nb::object input_delta_map_value_to_python(const void *context, const void *memory)
         {
             const auto *state = static_cast<const InputBindingContext *>(context);
-            const auto &delta = state->delta.list();
-            nb::dict result;
-            for (std::size_t index = 0; index < state->children.size(); ++index)
-            {
-                if (!input_child_modified_for_parent_time(context, memory, index)) { continue; }
-                result[nb::int_{delta.ordinal_keys[index]}] = input_child_delta_view(context, memory, index).to_python();
-            }
-            return result;
+            return Value{ValueView{state->delta_binding, memory}}.to_python();
+        }
+
+        [[nodiscard]] nb::object input_value_projection_to_python(const void *context,
+                                                                   const void *memory)
+        {
+            const auto *state = static_cast<const InputBindingContext *>(context);
+            // Projection storage is materialised exclusively through its
+            // erased owning-type and copy hooks. This keeps ValueOps complete
+            // without teaching the caller which structural endpoint produced it.
+            return Value{ValueView{state->value_binding, memory}}.to_python();
         }
 
         [[nodiscard]] nb::object input_delta_key_set_to_python(const void *context, const void *memory)
@@ -1882,7 +1881,8 @@ namespace hgraph
                     child_value_to_python(input_value_storage_type(context, memory, index),
                                           input_element_memory(context, memory, index));
             }
-            return result;
+            return python_bridge::materialize_tsb_python_value(
+                state->schema, std::move(result));
         }
 
         [[nodiscard]] nb::object input_tsl_to_python(const void *context, const void *memory)
@@ -1894,7 +1894,7 @@ namespace hgraph
                 result.append(child_value_to_python(input_value_storage_type(context, memory, index),
                                                     input_element_memory(context, memory, index)));
             }
-            return result;
+            return nb::tuple(result);
         }
 
         [[nodiscard]] nb::object input_to_python(const void *context, const void *memory)
@@ -2140,7 +2140,12 @@ namespace hgraph
             context->value_ops = IndexedValueOps{
                 {ValueOpsKind::Indexed, context.get(), false, &input_value_hash, &input_value_equals,
                  &input_value_compare,
-                 &input_value_to_string},
+                 &input_value_to_string
+#if HGRAPH_ENABLE_PYTHON_USER_NODES
+                 ,
+                 &input_value_projection_to_python
+#endif
+                },
                 &input_indexed_size,
                 &input_value_element_at,
                 &input_value_element_binding,

--- a/src/hgraph/types/time_series/ts_input/base_view.cpp
+++ b/src/hgraph/types/time_series/ts_input/base_view.cpp
@@ -495,6 +495,42 @@ namespace hgraph
         throw std::logic_error("TSInputView::delta_value requires a live input view");
     }
 
+#if HGRAPH_ENABLE_PYTHON_USER_NODES
+    nb::object TSInputView::value_to_python() const
+    {
+        const auto &data = data_view();
+        return data.valid() ? data.value_to_python() : nb::none();
+    }
+
+    nb::object TSInputView::delta_value_to_python() const
+    {
+        const auto &data = data_view();
+        if (!data.valid()) { return nb::none(); }
+
+        // Sampled target rebinds carry the modification on the input link,
+        // not on the already-valid target. In that case the input delta is
+        // the target's current value, exported by the target TSData strategy.
+        if (is_target_position())
+        {
+            const auto *link = detail::target_link_storage(data_.raw_data);
+            if (link != nullptr && link->tracking.last_modified_time > data.last_modified_time())
+            {
+                return data.value_to_python();
+            }
+        }
+
+        nb::object delta = data.delta_value_to_python(evaluation_time_);
+        if (!delta.is_none()) { return delta; }
+
+        const auto *view_schema = schema();
+        if (view_schema != nullptr && view_schema->kind == TSTypeKind::TS && modified())
+        {
+            return data.value_to_python();
+        }
+        return nb::none();
+    }
+#endif
+
     DynamicStorageMetrics TSInputView::dynamic_storage_metrics() const noexcept
     {
         return input_ != nullptr ? input_->dynamic_storage_metrics() : DynamicStorageMetrics{};


### PR DESCRIPTION
## Summary

- route Python time-series `.value` and `.delta_value` reads through the live `TSDataOps` type-erased contract
- implement erased Python conversion in fixed and dynamic structures, slot-backed TSDs, TSD proxies, and non-peered inputs
- preserve CompoundScalar-backed TSB materialization below the Python façade
- make compact Set `ValueOps` own the immutable `frozenset` Python representation, including mapped and aggregate TSD keys
- codify the architectural invariant in `AGENTS.md` and directly on the relevant conversion methods
- add realistic aggregate, nested projection, proxy, dynamic-list, CompoundScalar, and mapped-key regression coverage

## Context

#455 restored aggregate TSD `.value` compatibility using Python façade type switches. This PR replaces that temporary workaround with the intended passive ops-table and erased-ownership design. Structural representations now own their recursive conversion; the façade no longer reconstructs TSB, TSL, or TSD values by switching on `TSTypeKind`.

REF remains an intentional façade exception because its Python value is an observation-time-stamped reference token, not a structural snapshot.

Review feedback also exposed that compact Set values were returning mutable Python sets and relying on façade normalization. Compact Set `ValueOps` now returns `frozenset` directly, so atomic TS storage, synthetic mapped-key sources, TSD/proxy keys, and other erased consumers preserve the correct scalar representation without local repair logic.

## Validation

- macOS native C++: 1,583/1,583 passed
- macOS stable-ABI wheel on fresh Python 3.14: 2,165 passed, 9 skipped
- Linux native C++ (GCC 14.3): 1,582/1,582 passed
- Linux stable-ABI wheel on fresh Python 3.14: 2,165 passed, 9 skipped
- focused structural regression pack: 42 passed
- focused mapped-`frozenset` regression: passed
- `git diff --check`: clean
