### PR TITLE
Dereference packed consumer values

### DIFF
--- a/docs/source/developer_guide/debugging.rst
+++ b/docs/source/developer_guide/debugging.rst
@@ -204,6 +204,18 @@ changes, into a disposable directory on that host and open a shell there:
    ssh -t hg-linux "cd '${remote_root}/repo' && exec bash"
    export REPO="$PWD"
 
+The copy intentionally excludes ``.venv``. Before running the native
+acceptance preset, recreate that repository-local environment because
+``CMakePresets.json`` selects ``.venv/bin/python`` for PyArrow discovery:
+
+.. code-block:: bash
+
+   uv venv --python 3.14 .venv
+   uv pip install --python .venv/bin/python "pyarrow>=25,<26"
+
+This bootstrap is required even when a separate disposable environment is
+created below for Python bridge or sanitizer testing.
+
 If ``hg-linux`` is unavailable, use the OrbStack VM instead. Install a current
 GCC plus Python development support there when needed. Replace the example
 checkout path below with the macOS path to the checkout; OrbStack mounts that

--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -259,6 +259,9 @@ and extending as new regressions are identified:
   nondeterministic timestamp to whether the executor started after the
   simulation-only ``MIN_ST`` sentinel, pinning the release/0.5 default when
   no explicit start time is supplied;
+- ``value_consumer_reference`` selects a live ``REF`` and passes it to a
+  runtime value callable, pinning that variadic value consumers observe the
+  referenced value rather than the reference token;
 - ``data_frame_recording`` records through the DATA_FRAME model and emits
   the frame a ``DataFrameStorage`` hands back to user code — column names,
   **timezone presentation**, and row values — so a tz-aware engine column or

--- a/include/hgraph/lib/std/operators/impl/string_impl.h
+++ b/include/hgraph/lib/std/operators/impl/string_impl.h
@@ -526,23 +526,12 @@ namespace hgraph::stdlib
                                      Scalar<"__sample__", Int> sample, Scalar<"__strict__", Bool> strict,
                                      VarKwIn<"kwargs"> kwargs)
         {
-            // format renders the referenced VALUE, never the reference
-            // itself (parity issue #72): a REF argument takes the
-            // descriptive-schema patch so input binding inserts the REF
-            // adaptation.
-            const auto dereferenced = [](WiringPortRef port) {
-                if (port.schema != nullptr && port.schema->kind == TSTypeKind::REF)
-                {
-                    port.schema = port.schema->referenced_ts();
-                }
-                return port;
-            };
-
             std::vector<std::pair<std::string, WiringPortRef>> positional_fields;
             positional_fields.reserve(args.size());
             for (std::size_t i = 0; i < args.size(); ++i)
             {
-                positional_fields.emplace_back(std::to_string(i), dereferenced(args[i]));
+                positional_fields.emplace_back(
+                    std::to_string(i), graph_wiring_detail::value_consumer_source(args[i]));
             }
 
             std::vector<std::pair<std::string, WiringPortRef>> fields;
@@ -550,7 +539,8 @@ namespace hgraph::stdlib
             fields.insert(fields.end(), positional_fields.begin(), positional_fields.end());
             for (const auto &[field_name, field_port] : kwargs)
             {
-                fields.emplace_back(field_name, dereferenced(field_port));
+                fields.emplace_back(
+                    field_name, graph_wiring_detail::value_consumer_source(field_port));
             }
 
             if (fields.empty())

--- a/include/hgraph/types/graph_wiring.h
+++ b/include/hgraph/types/graph_wiring.h
@@ -2042,6 +2042,19 @@ namespace hgraph
         [[nodiscard]] HGRAPH_EXPORT WiringPortRef adapt_source_for_input(
             Wiring &w, const TSValueTypeMetaData *input_schema, WiringPortRef source);
 
+        /**
+         * Describe a source by the value a consumer should observe rather than
+         * by any REF token used to reach that value. Variadic consumers use
+         * this before building a structural argument pack so ordinary input
+         * binding can install the same REF-transparent adaptation as a typed
+         * ``In<T>``. Dereferencing is recursive for container schemas.
+         */
+        [[nodiscard]] inline WiringPortRef value_consumer_source(WiringPortRef source)
+        {
+            source.schema = TypeRegistry::instance().dereference(source.schema);
+            return source;
+        }
+
         // ---- context scopes (see *Contexts* in services.rst) ----
         // The wiring-time context stack lives on the OperatorRegistry singleton
         // (mesh-scope precedent); these free functions keep operator_dispatch.h

--- a/python/tests/ported/_operators/test_lift_operators.py
+++ b/python/tests/ported/_operators/test_lift_operators.py
@@ -1,6 +1,6 @@
 from typing import Callable
 
-from hgraph import apply, call, graph, round_, TS
+from hgraph import apply, call, graph, if_then_else, round_, TS
 from hgraph.test import eval_node
 
 
@@ -67,6 +67,25 @@ def test_call_passes_positional_and_keyword_arguments():
 
     eval_node(g, [1, 2], ["a", "b"])
     assert seen == [("a", 1), ("b", 2)]
+
+
+def test_apply_and_call_dereference_ref_arguments():
+    seen = []
+
+    def double(value: int) -> int:
+        return value * 2
+
+    def observe(value: int):
+        seen.append(value)
+
+    @graph
+    def g(choose_rhs: TS[bool], lhs: TS[int], rhs: TS[int]) -> TS[int]:
+        selected = if_then_else(choose_rhs, rhs, lhs)
+        call(observe, selected)
+        return apply(double, selected)
+
+    assert eval_node(g, [True, False], [8, 4], [-6, 10]) == [-12, 8]
+    assert seen == [-6, 4]
 
 
 def test_apply_preserves_keyword_named_like_an_internal_positional_field():

--- a/python/tests/ported/_operators/test_print.py
+++ b/python/tests/ported/_operators/test_print.py
@@ -3,7 +3,23 @@ from contextlib import nullcontext
 
 import pytest
 
-from hgraph import LOGGER, compute_node, graph, TSL, TS, Size, debug_print, log_, print_, assert_, NodeException, DebugContext, null_sink
+from hgraph import (
+    LOGGER,
+    DebugContext,
+    NodeException,
+    Size,
+    TS,
+    TSL,
+    assert_,
+    combine,
+    compute_node,
+    debug_print,
+    graph,
+    if_then_else,
+    log_,
+    null_sink,
+    print_,
+)
 # deviation: hgraph.nodes internals are flat here
 from hgraph.nodes import tsl_to_tsd
 from hgraph.test import eval_node
@@ -145,6 +161,25 @@ def test_log_sample(caplog):
     assert "Sample output d" not in caplog.text
 
 
+def test_log_and_print_dereference_ref_arguments(caplog, capsys):
+    @graph
+    def main(choose_rhs: TS[bool], lhs: TS[int], rhs: TS[int]) -> TS[int]:
+        selected = if_then_else(choose_rhs, rhs, lhs)
+        details = combine(selected=selected)
+        log_("Selected {} details {}", selected, details, level=logging.ERROR)
+        print_("Selected {} details {}", selected, details)
+        return selected
+
+    with caplog.at_level(logging.ERROR, logger="hgraph"):
+        assert eval_node(main, [True], [8], [-6]) == [-6]
+
+    assert "Selected -6 details {selected: -6}" in caplog.text
+    assert "TimeSeriesReference" not in caplog.text
+    stdout = capsys.readouterr().out
+    assert "Selected -6 details {selected: -6}" in stdout
+    assert "TimeSeriesReference" not in stdout
+
+
 def test_debug_print_sample(capsys):
     @graph
     def main(ts: TS[int]):
@@ -162,6 +197,16 @@ def test_assert():
 
     with pytest.raises(NodeException, match="assertion 3 2"):
         eval_node(main, [True, None, False], [1, 2, 3, 4])
+
+
+def test_formatted_assert_dereferences_ref_arguments():
+    @graph
+    def main(condition: TS[bool], choose_rhs: TS[bool], lhs: TS[int], rhs: TS[int]):
+        selected = if_then_else(choose_rhs, rhs, lhs)
+        assert_(condition, "selected {}", selected)
+
+    with pytest.raises(NodeException, match="selected -6"):
+        eval_node(main, [False], [True], [8], [-6])
 
 
 def test_custom_label(capsys):

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -228,6 +228,19 @@ def test_realtime_default_start_recipe_requires_one_boolean_probe():
         validate_recipe(Recipe.from_dict(raw))
 
 
+def test_value_consumer_reference_recipe_rejects_parameters():
+    raw = {
+        "schema_version": 1,
+        "id": "test-value-consumer-reference",
+        "template": "value_consumer_reference",
+        "inputs": {"lhs": [1], "rhs": [2], "choose_rhs": [True]},
+        "parameters": {"mode": "raw-reference"},
+        "features": ["reference:REF"],
+    }
+    with pytest.raises(RecipeError, match="takes no parameters"):
+        validate_recipe(Recipe.from_dict(raw))
+
+
 def test_recipe_fingerprint_is_independent_of_json_key_order():
     first = _scalar_recipe()
     raw = first.to_dict()

--- a/src/hgraph/lib/std/operators/io_impl.cpp
+++ b/src/hgraph/lib/std/operators/io_impl.cpp
@@ -121,11 +121,13 @@ namespace hgraph::stdlib
             std::size_t index = 0;
             for (WiringPortRef &port : positional)
             {
+                port = graph_wiring_detail::value_consumer_source(std::move(port));
                 fields.emplace_back(fmt::format("${}", index++), port.schema);
                 children.push_back(std::move(port));
             }
             for (auto &[name, port] : named)
             {
+                port = graph_wiring_detail::value_consumer_source(std::move(port));
                 fields.emplace_back(name, port.schema);
                 children.push_back(std::move(port));
             }

--- a/tests/cpp/test_logger.cpp
+++ b/tests/cpp/test_logger.cpp
@@ -154,6 +154,80 @@ namespace
             return text;
         }
     };
+
+    using LoggedReferenceBundle =
+        UnNamedTSB<Field<"selected", REF<TS<Int>>>>;
+
+    struct LogReferenceArgumentsGraph
+    {
+        static constexpr auto name = "log_reference_arguments_graph";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Bool>> choose_minimum,
+                                     Port<TS<Int>> lhs, Port<TS<Int>> rhs)
+        {
+            auto minimum = wire<stdlib::min_>(w, lhs, rhs);
+            auto maximum = wire<stdlib::max_>(w, lhs, rhs);
+            auto selected = wire<stdlib::if_then_else>(w, choose_minimum,
+                                                       minimum, maximum);
+            auto bundled = stdlib::to_tsb<LoggedReferenceBundle>(w, selected);
+            wire<stdlib::log_>(w, Str{"selected {}"}, selected,
+                               arg<"level">(Int{40}));
+            wire<stdlib::log_>(w, Str{"bundled {}"}, bundled,
+                               arg<"level">(Int{40}));
+            return lhs;
+        }
+    };
+
+    struct DoubleLoggedValue
+    {
+        static constexpr auto name = "double_logged_value";
+        [[nodiscard]] static Int apply(Int value) { return value * 2; }
+    };
+
+    struct CaptureLoggedValue
+    {
+        static constexpr auto name = "capture_logged_value";
+        inline static Int captured = 0;
+
+        [[nodiscard]] static Int apply(Int value)
+        {
+            captured = value;
+            return value;
+        }
+    };
+
+    struct ApplyReferenceArgumentGraph
+    {
+        static constexpr auto name = "apply_reference_argument_graph";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Bool>> choose_minimum,
+                                     Port<TS<Int>> lhs, Port<TS<Int>> rhs)
+        {
+            auto selected = wire<stdlib::if_then_else>(
+                w, choose_minimum, wire<stdlib::min_>(w, lhs, rhs),
+                wire<stdlib::max_>(w, lhs, rhs));
+            auto callable = wire<stdlib::const_, TS<ValueCallable>>(
+                w, value_fn<DoubleLoggedValue>());
+            return wire<stdlib::apply_op, TS<Int>>(w, callable, selected);
+        }
+    };
+
+    struct CallReferenceArgumentGraph
+    {
+        static constexpr auto name = "call_reference_argument_graph";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Bool>> choose_minimum,
+                                     Port<TS<Int>> lhs, Port<TS<Int>> rhs)
+        {
+            auto selected = wire<stdlib::if_then_else>(
+                w, choose_minimum, wire<stdlib::min_>(w, lhs, rhs),
+                wire<stdlib::max_>(w, lhs, rhs));
+            auto callable = wire<stdlib::const_, TS<ValueCallable>>(
+                w, value_fn<CaptureLoggedValue>());
+            wire<stdlib::call_op>(w, callable, selected);
+            return lhs;
+        }
+    };
 }  // namespace
 
 TEST_CASE("logger: the LoggerView injectable logs from start and eval hooks")
@@ -262,6 +336,31 @@ TEST_CASE("logger: log_ sample_count emits every nth evaluation")
     CHECK_THAT(all, !Catch::Matchers::ContainsSubstring("sampled b"));
     CHECK_THAT(all, !Catch::Matchers::ContainsSubstring("sampled d"));
     CHECK_THAT(all, !Catch::Matchers::ContainsSubstring("sampled e"));
+}
+
+TEST_CASE("logger: packed value consumers dereference reference arguments")
+{
+    stdlib::register_standard_operators();
+    CapturedLog captured;
+
+    CHECK_OUTPUT(eval_node<LogReferenceArgumentsGraph>(
+                     values<Bool>(true), values<Int>(8), values<Int>(-6)),
+                 values<Int>(8));
+
+    const std::string all = captured.joined();
+    CHECK_THAT(all, Catch::Matchers::ContainsSubstring("selected -6"));
+    CHECK_THAT(all, Catch::Matchers::ContainsSubstring("bundled {selected: -6}"));
+    CHECK_THAT(all, !Catch::Matchers::ContainsSubstring("TimeSeriesReference"));
+
+    CHECK_OUTPUT(eval_node<ApplyReferenceArgumentGraph>(
+                     values<Bool>(true), values<Int>(8), values<Int>(-6)),
+                 values<Int>(-12));
+
+    CaptureLoggedValue::captured = 0;
+    CHECK_OUTPUT(eval_node<CallReferenceArgumentGraph>(
+                     values<Bool>(true), values<Int>(8), values<Int>(-6)),
+                 values<Int>(8));
+    CHECK(CaptureLoggedValue::captured == -6);
 }
 
 TEST_CASE("logger: reset_logger drops the cached logger and rebuilds the default")

--- a/tools/parity/catalog.py
+++ b/tools/parity/catalog.py
@@ -1451,6 +1451,33 @@ def _operator_pipeline(hg, recipe):
     )
 
 
+def _value_consumer_reference(hg, recipe):
+    from hgraph.test import eval_node
+
+    def double(value: int) -> int:
+        return value * 2
+
+    @hg.graph
+    def parity_graph(
+        lhs: hg.TS[int],
+        rhs: hg.TS[int],
+        choose_rhs: hg.TS[bool],
+    ) -> hg.TS[int]:
+        lhs = _via_non_peered_ref(hg, lhs)
+        rhs = _via_non_peered_ref(hg, rhs)
+        choose_rhs = _via_non_peered_ref(hg, choose_rhs)
+        selected = hg.if_then_else(choose_rhs, rhs, lhs)
+        return hg.apply(double, selected)
+
+    inputs = decoded_inputs(hg, recipe)
+    return eval_node(
+        parity_graph,
+        inputs["lhs"],
+        inputs["rhs"],
+        inputs["choose_rhs"],
+    )
+
+
 def _tsd_key_set_pipeline(hg, recipe):
     from hgraph.test import eval_node
 
@@ -2655,6 +2682,21 @@ CATALOG = {
         ),
         execute=_operator_pipeline,
     ),
+    "value_consumer_reference": TemplateSpec(
+        name="value_consumer_reference",
+        required_inputs=("lhs", "rhs", "choose_rhs"),
+        features=(
+            "shape:TS",
+            "type:int",
+            "type:bool",
+            "reference:REF",
+            "binding:non-peered",
+            "topology:operator-composition",
+            "compatibility:release-0.5",
+        ),
+        operators=("apply", "if_then_else"),
+        execute=_value_consumer_reference,
+    ),
     "tsd_key_set_pipeline": TemplateSpec(
         name="tsd_key_set_pipeline",
         required_inputs=("values", "probe"),
@@ -3082,6 +3124,9 @@ def validate_recipe(recipe):
             recipe.parameters.get("format_ref", False), bool
         ):
             raise RecipeError("operator_pipeline format_ref must be a boolean")
+    elif recipe.template == "value_consumer_reference":
+        if recipe.parameters:
+            raise RecipeError("value_consumer_reference takes no parameters")
     elif recipe.template == "tsd_key_set_pipeline":
         if not isinstance(
             recipe.parameters.get("dedup_size", True), bool

--- a/tools/parity/corpus/regression-value-consumer-reference.json
+++ b/tools/parity/corpus/regression-value-consumer-reference.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "id": "regression-value-consumer-reference",
+  "description": "A runtime value consumer receives the value selected through a REF rather than the reference token.",
+  "template": "value_consumer_reference",
+  "inputs": {
+    "lhs": [8, 4, -3],
+    "rhs": [-6, 10, 2],
+    "choose_rhs": [true, false, true]
+  },
+  "parameters": {},
+  "features": [
+    "binding:non-peered",
+    "compatibility:release-0.5",
+    "lifecycle:multi-cycle",
+    "reference:REF",
+    "shape:TS",
+    "topology:operator-composition",
+    "type:bool",
+    "type:int"
+  ]
+}


### PR DESCRIPTION
## Summary

- route packed variadic value consumers through the shared REF-transparent input adaptation
- recursively dereference direct and nested container reference schemas for `format`, `log_`, `print_`, formatted `assert_`, `apply`, and `call`
- retain explicit REF semantics for operators that consume references intentionally
- add native, Python, and released-0.5 parity regressions
- document the required repository-local `.venv` bootstrap for Linux acceptance runs

## Root cause

Typed inputs already resolve REF sources through their runtime input alternatives, but the variadic structural argument packer copied the raw REF schema. Its sinks and callables therefore read the reference token as the value. `format` had a local direct-REF workaround, while the shared I/O and callable packer had none.

The fix gives all value-consuming structural packers the schema of the recursively dereferenced source. Existing input binding then installs the normal REF-transparent runtime adaptation, including for references nested inside bundles and containers.

## Validation

- macOS fresh native acceptance: 1,584/1,584 tests passed
- macOS installed-SDK consumer: 1/1 test passed
- macOS stable-ABI wheel built with Python 3.12 and tested with Python 3.14: 2,146 passed, 9 skipped
- Linux fresh native acceptance: 1,583/1,583 tests passed
- Linux stable-ABI wheel built with Python 3.12 and tested with Python 3.14: 2,146 passed, 9 skipped
- parity recipe validation: 87 recipes
- released hgraph 0.5.41 replay matched `[-12, 8, 4]`
- PR parity campaign: 183/183 attempted, 161 matched, 22 known mismatches, 0 new mismatches, 0 quarantined
- API inventory and `git diff --check` passed
