### PR TITLE
Fix Kafka replay timestamp scheduling

### DIFF
--- a/extensions/kafka/CHANGELOG.md
+++ b/extensions/kafka/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Replay recovered records at their Kafka timestamps across all subscriptions
+  instead of serializing them in shared-drain arrival order.
+
 ## 0.8.0
 
 - Introduce the C++-first Kafka service implementation, native and Python APIs,

--- a/extensions/kafka/python/tests/test_runtime.py
+++ b/extensions/kafka/python/tests/test_runtime.py
@@ -92,6 +92,80 @@ def test_python_authoring_uses_native_record_time_simulation() -> None:
     assert evaluation_times == [record_time]
 
 
+def test_multiple_python_replays_follow_record_timestamps() -> None:
+    cluster = MockCluster()
+    cluster.create_topic("python-replay-a")
+    cluster.create_topic("python-replay-b")
+    graph_start = datetime(2026, 8, 7, 12, 30)
+    first_time = graph_start + timedelta(seconds=1)
+    second_time = graph_start + timedelta(seconds=2)
+    expected = {
+        b"a-first": first_time,
+        b"a-second": second_time,
+        b"b-first": first_time,
+        b"b-second": second_time,
+    }
+    for topic, prefix in (
+        ("python-replay-a", b"a"),
+        ("python-replay-b", b"b"),
+    ):
+        cluster.seed_record(
+            topic,
+            prefix + b"-first",
+            timestamp_ms=int(first_time.replace(tzinfo=UTC).timestamp() * 1000),
+        )
+        cluster.seed_record(
+            topic,
+            prefix + b"-second",
+            timestamp_ms=int(second_time.replace(tzinfo=UTC).timestamp() * 1000),
+        )
+
+    observed = []
+
+    @hg.sink_node
+    def capture(
+        record: hg.TS[kafka.KafkaRecord],
+        _clock: hg.CLOCK = None,
+    ):
+        observed.append((record.value.value, _clock.evaluation_time))
+
+    @hg.graph
+    def app():
+        kafka.register_kafka_service(
+            kafka.KafkaServiceConfig.from_bootstrap_servers(
+                [cluster.bootstrap_servers()], client_id="python-multi-replay"
+            ),
+            path="simulation",
+        )
+        for topic in ("python-replay-a", "python-replay-b"):
+            key = kafka.KafkaSubscriptionKey(
+                topics=(topic,),
+                group_id=topic,
+                assignment_mode=kafka.KafkaAssignmentMode.INDEPENDENT,
+                start_position=kafka.KafkaStartPosition.earliest(),
+                stop_position=kafka.KafkaStopPosition.snapshot(),
+                recovery_clock=kafka.KafkaRecoveryClock.RECORD_TIMESTAMP,
+                merge_policy=(
+                    kafka.KafkaMergePolicy.TIMESTAMP_TOPIC_PARTITION_OFFSET
+                ),
+                sharing_identity=topic,
+            )
+            subscription = kafka.kafka_subscribe(
+                hg.const(key, tp=hg.TS[kafka.KafkaSubscriptionKey]),
+                path="simulation",
+            )
+            capture(subscription["record"])
+
+    hg.run_graph(
+        app,
+        run_mode=hg.EvaluationMode.SIMULATION,
+        start_time=graph_start,
+        end_time=second_time + timedelta(seconds=1),
+    )
+
+    assert dict(observed) == expected
+
+
 def test_legacy_replay_surface_uses_the_same_native_history_session(monkeypatch) -> None:
     _use_mock_cluster_history_start(monkeypatch)
     cluster = MockCluster()

--- a/extensions/kafka/src/detail/service_bridge.h
+++ b/extensions/kafka/src/detail/service_bridge.h
@@ -9,6 +9,7 @@
 #include <hgraph/types/static_node.h>
 #include <hgraph/types/value/value_builder.h>
 
+#include <algorithm>
 #include <array>
 #include <compare>
 #include <cstddef>
@@ -318,18 +319,20 @@ public:
       if (retained_bytes > reserved_bytes) {
         throw std::logic_error("Kafka bridge output exceeded its reservation");
       }
-      state.values.push_back(
-          QueuedValue{std::move(value), retained_bytes, false});
       --state.reserved_records;
       state.reserved_bytes -= reserved_bytes;
       if (!accepting_) {
-        state.values.pop_back();
         return false;
       }
+      QueuedValue item{std::move(value), retained_bytes, false};
+      item.evaluation_time = queued_evaluation_time(channel, item.value);
+      const auto position = insertion_point(channel, state, item);
+      const bool became_head = position == state.values.begin();
+      state.values.insert(position, std::move(item));
       ++state.payload_records;
       state.payload_bytes += retained_bytes;
       state.retained_bytes += retained_bytes;
-      if (!state.wake_outstanding) {
+      if (!state.wake_outstanding || became_head) {
         state.wake_outstanding = true;
         generation = ++state.generation;
         wake = state.sender;
@@ -380,9 +383,12 @@ private:
         ++state.payload_records;
         state.payload_bytes += retained_bytes;
       }
-      state.values.push_back(
-          QueuedValue{std::move(value), retained_bytes, control});
-      if (!state.wake_outstanding) {
+      QueuedValue item{std::move(value), retained_bytes, control};
+      item.evaluation_time = queued_evaluation_time(channel, item.value);
+      const auto position = insertion_point(channel, state, item);
+      const bool became_head = position == state.values.begin();
+      state.values.insert(position, std::move(item));
+      if (!state.wake_outstanding || became_head) {
         state.wake_outstanding = true;
         generation = ++state.generation;
         wake = state.sender;
@@ -397,6 +403,7 @@ private:
     Value value{};
     std::size_t retained_bytes{};
     bool control{};
+    std::optional<DateTime> evaluation_time{};
   };
 
   struct Channel {
@@ -414,6 +421,39 @@ private:
     Int generation{};
     bool wake_outstanding{};
   };
+
+  [[nodiscard]] static std::optional<DateTime>
+  queued_evaluation_time(OutputChannel channel, const Value &value) {
+    if (channel != OutputChannel::Subscription) {
+      return std::nullopt;
+    }
+    const auto field = value.view().as_bundle().at("evaluation_time");
+    return field.data() != nullptr
+               ? std::optional<DateTime>{field.checked_as<DateTime>()}
+               : std::nullopt;
+  }
+
+  [[nodiscard]] static bool scheduled_before(const QueuedValue &lhs,
+                                             const QueuedValue &rhs) noexcept {
+    if (!lhs.evaluation_time.has_value()) {
+      return rhs.evaluation_time.has_value();
+    }
+    return rhs.evaluation_time.has_value() &&
+           *lhs.evaluation_time < *rhs.evaluation_time;
+  }
+
+  [[nodiscard]] static std::deque<QueuedValue>::iterator
+  insertion_point(OutputChannel channel, Channel &state,
+                  const QueuedValue &item) {
+    if (channel != OutputChannel::Subscription) {
+      return state.values.end();
+    }
+    // Recovery sessions preload independently, so enqueue order is not replay
+    // order. Untimed lifecycle/live values remain FIFO at the front; recovered
+    // values form one stable stream ordered by their graph evaluation time.
+    return std::upper_bound(state.values.begin(), state.values.end(), item,
+                            scheduled_before);
+  }
 
   [[nodiscard]] Channel &at(OutputChannel channel) {
     return channels_.at(static_cast<std::size_t>(channel));
@@ -471,6 +511,14 @@ template <typename Tag>
 struct SubscriptionDrainNode {
   static constexpr auto name = "kafka_subscription_drain";
 
+  [[nodiscard]] static std::optional<DateTime>
+  evaluation_time(const Value &envelope) {
+    const auto field = envelope.view().as_bundle().at("evaluation_time");
+    return field.data() != nullptr
+               ? std::optional<DateTime>{field.checked_as<DateTime>()}
+               : std::nullopt;
+  }
+
   static void
   eval(In<"signal", TS<Int>>, Scalar<"bridge", ServiceBridgeHandle> bridge,
        SingleShotScheduler scheduler,
@@ -479,54 +527,62 @@ struct SubscriptionDrainNode {
     if (!next.has_value()) {
       return;
     }
-    const auto next_fields = next->view().as_bundle();
-    const auto evaluation_time = next_fields.at("evaluation_time");
-    if (evaluation_time.data() != nullptr) {
-      const DateTime requested = evaluation_time.checked_as<DateTime>();
-      if (requested > scheduler.now()) {
-        scheduler.schedule(requested);
-        return;
-      }
-    }
-    auto envelope = bridge.value().value->pop(OutputChannel::Subscription);
-    if (!envelope.has_value()) {
+    const auto batch_time = evaluation_time(*next);
+    if (batch_time.has_value() && *batch_time > scheduler.now()) {
+      scheduler.schedule(*batch_time);
       return;
     }
+    auto mutation = out.begin_mutation(out.evaluation_time());
+    while (true) {
+      auto envelope = bridge.value().value->pop(OutputChannel::Subscription);
+      if (!envelope.has_value()) {
+        return;
+      }
 
-    const auto fields = envelope->view().as_bundle();
-    const auto removed = fields.at("removed");
-    if (removed.data() != nullptr && removed.checked_as<Bool>()) {
-      auto mutation = out.begin_mutation(out.evaluation_time());
-      static_cast<void>(mutation.erase(fields.at("subscription_key")));
-      if (bridge.value().value->pending(OutputChannel::Subscription) != 0) {
+      const auto fields = envelope->view().as_bundle();
+      const auto removed = fields.at("removed");
+      if (removed.data() != nullptr && removed.checked_as<Bool>()) {
+        static_cast<void>(mutation.erase(fields.at("subscription_key")));
+      } else {
+        const auto value_binding = ValuePlanFactory::instance().type_for(
+            schema_descriptor<KafkaSubscriptionOutput>::ts_meta()
+                ->value_schema);
+        BundleBuilder value{value_binding};
+        const auto record = fields.at("record");
+        const auto cursor = fields.at("cursor");
+        const auto state = fields.at("state");
+        if (record.data() != nullptr) {
+          value.set("record", record.clone());
+        }
+        if (cursor.data() != nullptr) {
+          value.set("cursor", cursor.clone());
+        }
+        if (state.data() != nullptr) {
+          value.set("state", state.clone());
+        }
+        Value update = value.build();
+        mutation.set(fields.at("subscription_key"), update.view());
+        if (cursor.data() != nullptr) {
+          bridge.value().value->subscription_delivered(cursor.clone());
+        }
+      }
+
+      next = bridge.value().value->peek(OutputChannel::Subscription);
+      if (!next.has_value()) {
+        return;
+      }
+      const auto next_time = evaluation_time(*next);
+      if (batch_time.has_value() && next_time == batch_time) {
+        // Independent subscriptions may legitimately tick at the same Kafka
+        // timestamp. Apply their distinct TSD keys in one graph mutation.
+        continue;
+      }
+      if (next_time.has_value() && *next_time > scheduler.now()) {
+        scheduler.schedule(*next_time);
+      } else {
         scheduler.schedule(MIN_TD);
       }
       return;
-    }
-    const auto value_binding = ValuePlanFactory::instance().type_for(
-        schema_descriptor<KafkaSubscriptionOutput>::ts_meta()->value_schema);
-    BundleBuilder value{value_binding};
-    const auto record = fields.at("record");
-    const auto cursor = fields.at("cursor");
-    const auto state = fields.at("state");
-    if (record.data() != nullptr) {
-      value.set("record", record.clone());
-    }
-    if (cursor.data() != nullptr) {
-      value.set("cursor", cursor.clone());
-    }
-    if (state.data() != nullptr) {
-      value.set("state", state.clone());
-    }
-    Value update = value.build();
-
-    auto mutation = out.begin_mutation(out.evaluation_time());
-    mutation.set(fields.at("subscription_key"), update.view());
-    if (cursor.data() != nullptr) {
-      bridge.value().value->subscription_delivered(cursor.clone());
-    }
-    if (bridge.value().value->pending(OutputChannel::Subscription) != 0) {
-      scheduler.schedule(MIN_TD);
     }
   }
 };

--- a/extensions/kafka/src/librdkafka_service.cpp
+++ b/extensions/kafka/src/librdkafka_service.cpp
@@ -689,7 +689,8 @@ private:
       const rd_kafka_topic_partition_list_t *positions,
       const std::vector<PositionBoundary> &boundaries) const noexcept;
   void complete_bounded();
-  void emit_state(KafkaSubscriptionState state);
+  void emit_state(KafkaSubscriptionState state,
+                  std::optional<DateTime> evaluation_time = std::nullopt);
   void complete_preload(Str error = {});
 
   KafkaRuntime &owner_;
@@ -986,13 +987,14 @@ public:
         retained_bytes);
   }
 
-  void emit_subscription_state(Value key,
-                               KafkaSubscriptionState state) noexcept {
+  void emit_subscription_state(
+      Value key, KafkaSubscriptionState state,
+      std::optional<DateTime> evaluation_time = std::nullopt) noexcept {
     try {
       if (!bridge_.value->push_control(
               OutputChannel::Subscription,
               subscription_envelope(std::move(key), std::nullopt, std::nullopt,
-                                    state, std::nullopt),
+                                    state, evaluation_time),
               512)) {
         emit_event(
             KafkaSeverity::Fatal, Str{"consumer"},
@@ -2021,7 +2023,11 @@ void ConsumerSession::complete_bounded() {
   bounded_complete_ = true;
   recovering_ = false;
   live_ = false;
-  emit_state(KafkaSubscriptionState::BoundedComplete);
+  emit_state(
+      KafkaSubscriptionState::BoundedComplete,
+      last_recovery_evaluation_time_.has_value()
+          ? std::optional<DateTime>{*last_recovery_evaluation_time_ + MIN_TD}
+          : std::nullopt);
   complete_preload();
   // BoundedComplete is queued behind any final record/cursor. Keep the
   // consumer owner alive until ordinary subscription or graph teardown
@@ -2264,7 +2270,11 @@ void ConsumerSession::flush_recovery_records(rd_kafka_t *consumer) {
     return;
   }
   live_ = true;
-  emit_state(KafkaSubscriptionState::Live);
+  emit_state(
+      KafkaSubscriptionState::Live,
+      last_recovery_evaluation_time_.has_value()
+          ? std::optional<DateTime>{*last_recovery_evaluation_time_ + MIN_TD}
+          : std::nullopt);
   complete_preload();
 }
 
@@ -2433,8 +2443,9 @@ void ConsumerSession::check_positions(rd_kafka_t *consumer) {
   rd_kafka_topic_partition_list_destroy(positions);
 }
 
-void ConsumerSession::emit_state(KafkaSubscriptionState state) {
-  owner_.emit_subscription_state(key_.clone(), state);
+void ConsumerSession::emit_state(KafkaSubscriptionState state,
+                                 std::optional<DateTime> evaluation_time) {
+  owner_.emit_subscription_state(key_.clone(), state, evaluation_time);
 }
 
 struct KafkaRuntimeHandle {

--- a/extensions/kafka/tests/test_service.cpp
+++ b/extensions/kafka/tests/test_service.cpp
@@ -221,6 +221,7 @@ inline std::vector<Int> bounded_offsets{};
 inline std::vector<KafkaSubscriptionState> bounded_states{};
 inline std::vector<Str> bounded_payloads{};
 inline std::vector<DateTime> bounded_evaluation_times{};
+inline std::vector<std::pair<Str, DateTime>> multi_bounded_records{};
 inline std::size_t multi_bounded_complete_count{};
 inline std::vector<Int> backlog_offsets{};
 inline std::vector<Str> backlog_events{};
@@ -530,7 +531,10 @@ struct MultiBoundedSubscriptionCapture {
     if (record.valid() && record.modified()) {
       const auto fields = record.base().value().as_bundle();
       if (present(fields.at("value"))) {
-        bounded_payloads.push_back(fields.at("value").checked_as<Bytes>().data);
+        const auto payload = fields.at("value").checked_as<Bytes>().data;
+        bounded_payloads.push_back(payload);
+        multi_bounded_records.emplace_back(payload,
+                                           node.graph().evaluation_time());
       }
     }
     auto state = subscription.template field<"state">();
@@ -2022,7 +2026,7 @@ void test_graph_lifetime_stop_is_bounded_in_simulation() {
       "graph-lifetime simulation did not use Kafka record time as the historical graph time");
 }
 
-void test_multiple_simulation_subscriptions_preload_before_graph_drain() {
+void test_multiple_simulation_subscriptions_replay_at_record_time() {
   MockCluster cluster;
   cluster.create_topic(Str{"simulation-preload-a"});
   cluster.create_topic(Str{"simulation-preload-b"});
@@ -2068,6 +2072,7 @@ void test_multiple_simulation_subscriptions_preload_before_graph_drain() {
           .sharing_identity(Str{"simulation-preload-b"})
           .build();
   bounded_payloads.clear();
+  multi_bounded_records.clear();
   multi_bounded_complete_count = 0;
 
   static_cast<void>(run_graph(build_graph<MultiBoundedSubscriptionGraph>(),
@@ -2079,6 +2084,21 @@ void test_multiple_simulation_subscriptions_preload_before_graph_drain() {
   require(bounded_payloads == expected_payloads,
           "multiple simulation subscriptions did not preload before the "
           "graph began draining their shared ingress queue");
+  std::ranges::sort(multi_bounded_records, {},
+                    &decltype(multi_bounded_records)::value_type::first);
+  require(multi_bounded_records.size() == 16,
+          "multiple simulation subscriptions did not replay every "
+          "timestamped record");
+  for (const auto &[payload, evaluation_time] : multi_bounded_records) {
+    const auto separator = payload.find('-');
+    require(separator != Str::npos,
+            "timestamp replay test produced an unexpected payload");
+    const auto offset =
+        static_cast<Int>(std::stoll(payload.substr(separator + 1)));
+    require(evaluation_time == record_time + offset * MIN_TD,
+            "multiple simulation subscriptions replayed '" + payload +
+                "' at drain time instead of its Kafka record timestamp");
+  }
   require(multi_bounded_complete_count == 2,
           "simulation did not complete both bounded subscriptions");
 }
@@ -2217,7 +2237,7 @@ int main() {
     test_commit_modes_and_monotonic_explicit_commits();
     test_record_time_recovery_is_deterministically_merged();
     test_graph_lifetime_stop_is_bounded_in_simulation();
-    test_multiple_simulation_subscriptions_preload_before_graph_drain();
+    test_multiple_simulation_subscriptions_replay_at_record_time();
     test_real_broker_publish_subscribe_and_commit_round_trip();
     std::cout << "hgraph-kafka service tests passed\n";
     return 0;


### PR DESCRIPTION
## Summary

- replay recovered Kafka records at their record timestamps across independent subscriptions
- batch distinct subscription keys that share a timestamp into one graph-time mutation
- keep `Live` and `BoundedComplete` transitions ordered after recovered records
- add matching native C++ and Python regression coverage

## Root cause

The native Kafka service preloaded each subscription independently into a shared FIFO drain. The drain therefore used producer arrival order and advanced by `MIN_TD` per envelope, so cross-subscription recovery ran at drain time rather than Kafka record time.

## Impact

Record-timestamp simulation and recovery now reproduce the original event timing deterministically, restoring replay/recovery semantics equivalent to the 0.5 generator path.

## Validation

- macOS native C++ suite: 1584/1584 passed
- macOS Python 3.14 compatibility suite from the stable-ABI wheel: 2161 passed, 9 skipped
- macOS Kafka native test plus Python extension suite: passed; 55 Python tests passed
- Linux GCC native C++ suite: 1583/1583 passed
- Linux Python 3.14 compatibility suite from the stable-ABI wheel: 2161 passed, 9 skipped
- Linux Kafka native test plus Python extension suite: passed; 55 Python tests passed
- `git diff --check` and scoped `git clang-format` checks passed

Kafka behavior was exercised with librdkafka's deterministic mock cluster; an external broker integration run was not required for this regression.