### PR TITLE
Dereference generic time-series arguments where they are bound

### DIFF
--- a/docs/source/developer_guide/writing_nodes.rst
+++ b/docs/source/developer_guide/writing_nodes.rst
@@ -128,15 +128,25 @@ explicit request. Dereferencing there would strip it and leave output resolution
 describing a reference the implementation never receives — the rule's own
 failure mode, inverted.
 
-.. note::
+**If you replace ``OperatorImpl::wire``, you own the rule.** An overload may
+substitute a hand-written wire closure for the generated one — ``apply_`` does,
+because the resolved output schema has to reach the packed runtime node. That
+closure receives the raw ``WiringArg`` span, so ``operator_dispatch`` never
+binds its arguments and nothing applies the rule for it. Call
+``operator_dispatch_detail::value_argument`` on what the signature it stands in
+for declares:
 
-   ``log_`` / ``print_`` and ``format_`` still call
-   ``graph_wiring_detail::value_consumer_source`` explicitly, and removing
-   those calls fails ``logger: packed value consumers dereference reference
-   arguments``. They declare the same ``VarIn`` / ``VarKwIn`` selectors the
-   rule covers, so *why* the rule does not reach them is not yet established —
-   do not assume it is a separate binding path until that is traced. Until it
-   is understood, a consumer that packs ports itself must dereference them.
+.. code-block:: cpp
+
+   // apply_value_callable_signature declares VarIn<"args", TsVar<"S">>.
+   using apply_args = VarIn<"args", TsVar<"S">>;
+   positional.push_back(
+       operator_dispatch_detail::value_argument<apply_args::schema_type>(as_port(args[index])));
+
+This is the only category of exemption. ``log_`` / ``print_`` / ``format_``
+declare ordinary ``VarIn`` / ``VarKwIn`` selectors and are covered — they each
+used to dereference by hand, and those calls were removed once the rule was
+structural.
 
 Structure-preserving packing is different: ``tsb_itemwise`` and the
 ``map_`` / ``switch_`` / ``mesh_`` machinery pass references deliberately —

--- a/docs/source/developer_guide/writing_nodes.rst
+++ b/docs/source/developer_guide/writing_nodes.rst
@@ -112,21 +112,31 @@ where the value belonged. Nothing raises, and the output looks like data.
 consumer:
 
 * ordinary inputs — ``adapt_source_for_input`` installs the adaptation;
-* variadic tails and ``**kwargs`` — ``operator_dispatch_detail::value_argument``
-  dereferences unless the declared schema is ``REF<...>``.
+* variadic tails — ``operator_dispatch_detail::value_argument`` dereferences
+  unless the declared schema is ``REF<...>``;
+* an UNTYPED ``VarKwIn<Name>`` — nothing in a bare collector could ask for a
+  reference, so every collected port is dereferenced.
 
 Putting it there is what keeps it from being rediscovered one operator at a
 time. Two consumers had already been fixed individually before the rule was
 made structural, and a third (``combine[TS[JSON]]``) was still wrong.
+
+A **typed** ``VarKwIn<Name, Schema>`` is the exception, and for the same reason
+the rule exists: the declaration wins. Its pack schema has already been matched
+at dispatch against the supplied keywords, so a ``REF`` field in that pack is an
+explicit request. Dereferencing there would strip it and leave output resolution
+describing a reference the implementation never receives — the rule's own
+failure mode, inverted.
 
 .. note::
 
    ``log_`` / ``print_`` and ``format_`` still call
    ``graph_wiring_detail::value_consumer_source`` explicitly, and removing
    those calls fails ``logger: packed value consumers dereference reference
-   arguments``. They reach their arguments through a binding path the rule
-   above does not cover. That second path should be brought under the same
-   rule; until it is, a consumer that packs ports itself must dereference them.
+   arguments``. They declare the same ``VarIn`` / ``VarKwIn`` selectors the
+   rule covers, so *why* the rule does not reach them is not yet established —
+   do not assume it is a separate binding path until that is traced. Until it
+   is understood, a consumer that packs ports itself must dereference them.
 
 Structure-preserving packing is different: ``tsb_itemwise`` and the
 ``map_`` / ``switch_`` / ``mesh_`` machinery pass references deliberately —

--- a/docs/source/developer_guide/writing_nodes.rst
+++ b/docs/source/developer_guide/writing_nodes.rst
@@ -88,6 +88,51 @@ build the real empty container:
    // tuple[str, ...] meaning "rename nothing".
    arg<"partition_names">(empty_names())
 
+A generic time-series parameter binds the DEREFERENCED type
+-------------------------------------------------------------
+
+``REF`` is always explicit. A parameter declared as a generic time-series —
+``TIME_SERIES_TYPE``, ``TsVar<"S">``, or an unconstrained ``**kwargs`` — binds
+the type with every reference followed, recursively through container schemas.
+A consumer that wants the reference token itself says so: ``REF[TS[int]]``,
+``REF[TIME_SERIES_TYPE]``.
+
+.. code-block:: cpp
+
+   In<"ts", TsVar<"S">>        // the VALUE, however many refs reach it
+   In<"ts", REF<TsVar<"S">>>   // the reference token
+
+**Why.** A reference is a routing detail — how a value is reached, not what it
+is. An operator that consumes values (formats, serialises, compares, records)
+and is handed a ref token produces *plausible nonsense* rather than failing:
+``log_`` printed the token, and ``combine[TS[JSON]]`` serialised ``"<ref>"``
+where the value belonged. Nothing raises, and the output looks like data.
+
+**Where the rule is applied.** At the point arguments are BOUND, not in each
+consumer:
+
+* ordinary inputs — ``adapt_source_for_input`` installs the adaptation;
+* variadic tails and ``**kwargs`` — ``operator_dispatch_detail::value_argument``
+  dereferences unless the declared schema is ``REF<...>``.
+
+Putting it there is what keeps it from being rediscovered one operator at a
+time. Two consumers had already been fixed individually before the rule was
+made structural, and a third (``combine[TS[JSON]]``) was still wrong.
+
+.. note::
+
+   ``log_`` / ``print_`` and ``format_`` still call
+   ``graph_wiring_detail::value_consumer_source`` explicitly, and removing
+   those calls fails ``logger: packed value consumers dereference reference
+   arguments``. They reach their arguments through a binding path the rule
+   above does not cover. That second path should be brought under the same
+   rule; until it is, a consumer that packs ports itself must dereference them.
+
+Structure-preserving packing is different: ``tsb_itemwise`` and the
+``map_`` / ``switch_`` / ``mesh_`` machinery pass references deliberately —
+they route values rather than consuming them — so they are *not* covered by
+this rule.
+
 Guard overloads through one resolution point
 --------------------------------------------
 

--- a/include/hgraph/lib/std/operators/impl/string_impl.h
+++ b/include/hgraph/lib/std/operators/impl/string_impl.h
@@ -531,7 +531,7 @@ namespace hgraph::stdlib
             for (std::size_t i = 0; i < args.size(); ++i)
             {
                 positional_fields.emplace_back(
-                    std::to_string(i), graph_wiring_detail::value_consumer_source(args[i]));
+                    std::to_string(i), args[i]);
             }
 
             std::vector<std::pair<std::string, WiringPortRef>> fields;
@@ -539,8 +539,7 @@ namespace hgraph::stdlib
             fields.insert(fields.end(), positional_fields.begin(), positional_fields.end());
             for (const auto &[field_name, field_port] : kwargs)
             {
-                fields.emplace_back(
-                    field_name, graph_wiring_detail::value_consumer_source(field_port));
+                fields.emplace_back(field_name, field_port);
             }
 
             if (fields.empty())

--- a/include/hgraph/types/graph_wiring.h
+++ b/include/hgraph/types/graph_wiring.h
@@ -2044,10 +2044,16 @@ namespace hgraph
 
         /**
          * Describe a source by the value a consumer should observe rather than
-         * by any REF token used to reach that value. Variadic consumers use
-         * this before building a structural argument pack so ordinary input
-         * binding can install the same REF-transparent adaptation as a typed
-         * ``In<T>``. Dereferencing is recursive for container schemas.
+         * by any REF token used to reach that value, so ordinary input binding
+         * installs the same REF-transparent adaptation as a typed ``In<T>``.
+         * Dereferencing is recursive for container schemas.
+         *
+         * Do NOT call this from an operator implementation: whether a given
+         * argument wants the value or the reference is decided by its
+         * declaration, in ``operator_dispatch_detail::value_argument``, which
+         * is the sole caller. A consumer that dereferences by hand is deciding
+         * a question its declaration has already answered — that is how the
+         * rule came to be applied inconsistently in the first place.
          */
         [[nodiscard]] inline WiringPortRef value_consumer_source(WiringPortRef source)
         {

--- a/include/hgraph/types/operator_dispatch.h
+++ b/include/hgraph/types/operator_dispatch.h
@@ -122,6 +122,33 @@ namespace hgraph
         struct is_var_in<VarIn<N, S>> : std::true_type
         {
         };
+
+        /** Whether a declared schema asks for a REFERENCE rather than a value.
+            ``REF`` must be explicit: a generic time-series parameter binds the
+            DEREFERENCED type, so a consumer never silently receives a ref
+            token in place of the value it names. */
+        template <typename S>
+        struct declares_reference : std::false_type
+        {
+        };
+        template <typename S>
+        struct declares_reference<REF<S>> : std::true_type
+        {
+        };
+
+        /** The port a value consumer should observe: the ref is followed
+            (recursively, for container schemas) unless the parameter asked for
+            a reference. */
+        template <typename S>
+        [[nodiscard]] inline WiringPortRef value_argument(WiringPortRef port)
+        {
+            if constexpr (declares_reference<S>::value) { return port; }
+            else
+            {
+                port.schema = TypeRegistry::instance().dereference(port.schema);
+                return port;
+            }
+        }
     }  // namespace operator_dispatch_detail
 
     /**
@@ -1594,7 +1621,17 @@ namespace hgraph
                         {
                             using KW = std::tuple_element_t<lay::total - 1, params_tuple>;
                             KW collected{};
-                            collected.ports.assign(kwargs.begin(), kwargs.end());
+                            // Keyword arguments carry no declared schema, so
+                            // there is nothing that could ask for a reference:
+                            // a consumer of **kwargs always wants the values.
+                            collected.ports.reserve(kwargs.size());
+                            for (const auto &entry : kwargs)
+                            {
+                                auto value = entry;
+                                value.second.schema =
+                                    TypeRegistry::instance().dereference(value.second.schema);
+                                collected.ports.push_back(std::move(value));
+                            }
                             return invoke(std::forward<decltype(tail_args)>(tail_args)..., std::move(collected));
                         }
                         else { return invoke(std::forward<decltype(tail_args)>(tail_args)...); }
@@ -1614,12 +1651,17 @@ namespace hgraph
                     tail.ports.reserve(args.size() - tail_start);
                     for (std::size_t i = tail_start; i < args.size(); ++i)
                     {
+                        using tail_schema = typename V::schema_type;
                         if (args[i].kind == WiringArg::Kind::TimeSeries)
                         {
-                            tail.ports.push_back(args[i].port);
+                            // The variadic tail is bound HERE for every
+                            // operator, so the deref rule belongs here rather
+                            // than in each consumer that packs its arguments.
+                            tail.ports.push_back(
+                                operator_dispatch_detail::value_argument<tail_schema>(
+                                    args[i].port));
                             continue;
                         }
-                        using tail_schema = typename V::schema_type;
                         const TSValueTypeMetaData *target = nullptr;
                         if constexpr (schema_descriptor<tail_schema>::is_concrete())
                         {

--- a/include/hgraph/types/operator_dispatch.h
+++ b/include/hgraph/types/operator_dispatch.h
@@ -138,16 +138,18 @@ namespace hgraph
 
         /** The port a value consumer should observe: the ref is followed
             (recursively, for container schemas) unless the parameter asked for
-            a reference. */
+            a reference. ``S = void`` is an argument that declares nothing at
+            all - a bare ``**kwargs`` entry - which by the rule is a value.
+
+            This is the ONE place the rule is decided. Everything that binds
+            arguments routes through it rather than dereferencing by hand, so
+            there is a single answer to change rather than a set to keep in
+            step. */
         template <typename S>
         [[nodiscard]] inline WiringPortRef value_argument(WiringPortRef port)
         {
             if constexpr (declares_reference<S>::value) { return port; }
-            else
-            {
-                port.schema = TypeRegistry::instance().dereference(port.schema);
-                return port;
-            }
+            else { return graph_wiring_detail::value_consumer_source(std::move(port)); }
         }
     }  // namespace operator_dispatch_detail
 

--- a/include/hgraph/types/operator_dispatch.h
+++ b/include/hgraph/types/operator_dispatch.h
@@ -1621,16 +1621,29 @@ namespace hgraph
                         {
                             using KW = std::tuple_element_t<lay::total - 1, params_tuple>;
                             KW collected{};
-                            // Keyword arguments carry no declared schema, so
-                            // there is nothing that could ask for a reference:
-                            // a consumer of **kwargs always wants the values.
-                            collected.ports.reserve(kwargs.size());
-                            for (const auto &entry : kwargs)
+                            if constexpr (std::is_void_v<typename KW::pack_schema>)
                             {
-                                auto value = entry;
-                                value.second.schema =
-                                    TypeRegistry::instance().dereference(value.second.schema);
-                                collected.ports.push_back(std::move(value));
+                                // An UNTYPED collector declares no schema, so
+                                // nothing in it could ask for a reference: a
+                                // consumer of bare **kwargs wants the values.
+                                collected.ports.reserve(kwargs.size());
+                                for (const auto &entry : kwargs)
+                                {
+                                    auto value          = entry;
+                                    value.second.schema = TypeRegistry::instance().dereference(value.second.schema);
+                                    collected.ports.push_back(std::move(value));
+                                }
+                            }
+                            else
+                            {
+                                // A TYPED collector's pack schema is the
+                                // declaration, and dispatch has already matched
+                                // it against the supplied schemas. Rewriting the
+                                // ports here would violate it — a REF field in
+                                // the pack would be silently stripped, leaving
+                                // output resolution describing a reference the
+                                // implementation never receives.
+                                collected.ports.assign(kwargs.begin(), kwargs.end());
                             }
                             return invoke(std::forward<decltype(tail_args)>(tail_args)..., std::move(collected));
                         }

--- a/python/tests/ported/_operators/test_json.py
+++ b/python/tests/ported/_operators/test_json.py
@@ -27,3 +27,22 @@ def test_json_decode():
     assert eval_node(g) == [
         {'a': 1, 'b': 'test', 'c': 3.14, 'd': 1}
     ]
+
+
+def test_combine_json_dereferences_reference_arguments():
+    """A JSON object serialises the VALUES it is given.
+
+    ``if_then_else`` publishes a REFERENCE, and ``combine[TS[JSON]]`` packs its
+    keyword arguments into a structural bundle. Before the deref rule was
+    applied where variadic and keyword arguments are BOUND, the ref token
+    reached the encoder and serialised as ``"<ref>"`` instead of the value it
+    names - the same defect as the logging one, in a different consumer.
+    """
+    from hgraph import TS, JSON, combine, graph, if_then_else
+    from hgraph.test import eval_node
+
+    @graph
+    def g(choose: TS[bool], lhs: TS[int], rhs: TS[int]) -> TS[JSON]:
+        return combine[TS[JSON]](v=if_then_else(choose, lhs, rhs))
+
+    assert eval_node(g, [True], [8], [-6]) == [{"v": 8}]

--- a/src/hgraph/lib/std/operators/io_impl.cpp
+++ b/src/hgraph/lib/std/operators/io_impl.cpp
@@ -26,17 +26,31 @@ namespace hgraph::stdlib
                 return operator_dispatch_detail::wire_scalar_const(w, arg, schema);
             };
 
+            // This closure REPLACES the generated one, so it is also where the
+            // deref rule has to be applied by hand - operator_dispatch never
+            // sees these arguments. The declarations it stands in for are
+            // apply_value_callable_signature's: VarIn<"args", TsVar<"S">> and
+            // an untyped VarKwIn<"kwargs">, neither of which asks for a
+            // reference. `fn` is left alone: it is passed on as an ordinary
+            // named input below, where input adaptation handles it.
+            using apply_args = VarIn<"args", TsVar<"S">>;
+
             WiringPortRef fn = as_port(args.front());
             std::vector<WiringPortRef> positional;
             positional.reserve(args.size() - 1);
             for (std::size_t index = 1; index < args.size(); ++index)
             {
-                positional.push_back(as_port(args[index]));
+                positional.push_back(
+                    operator_dispatch_detail::value_argument<apply_args::schema_type>(as_port(args[index])));
+            }
+            std::vector<std::pair<std::string, WiringPortRef>> named{kwargs.begin(), kwargs.end()};
+            for (auto &[name, port] : named)
+            {
+                static_cast<void>(name);
+                port = operator_dispatch_detail::value_argument<void>(port);
             }
             const auto positional_count = static_cast<Int>(positional.size());
-            WiringPortRef packed = io_impl_detail::pack_format_args(
-                std::move(positional),
-                std::vector<std::pair<std::string, WiringPortRef>>{kwargs.begin(), kwargs.end()});
+            WiringPortRef packed = io_impl_detail::pack_format_args(std::move(positional), std::move(named));
 
             const auto *output = ts_pattern_resolve(output_pattern, resolution);
             if (output == nullptr) { throw std::logic_error("apply output type is unresolved"); }
@@ -121,13 +135,11 @@ namespace hgraph::stdlib
             std::size_t index = 0;
             for (WiringPortRef &port : positional)
             {
-                port = graph_wiring_detail::value_consumer_source(std::move(port));
                 fields.emplace_back(fmt::format("${}", index++), port.schema);
                 children.push_back(std::move(port));
             }
             for (auto &[name, port] : named)
             {
-                port = graph_wiring_detail::value_consumer_source(std::move(port));
                 fields.emplace_back(name, port.schema);
                 children.push_back(std::move(port));
             }

--- a/tests/cpp/test_json.cpp
+++ b/tests/cpp/test_json.cpp
@@ -457,6 +457,23 @@ namespace
             return wire<stdlib::cmp_>(w, decoded, eager).as<TS<stdlib::CmpResult>>();
         }
     };
+
+    // if_then_else publishes a REFERENCE, and combine_json packs its keyword
+    // arguments into a structural bundle it then serializes. Wired natively,
+    // so the deref rule is exercised through C++ dispatch rather than only
+    // through the Python bridge.
+    struct CombineJsonReferenceGraph
+    {
+        [[maybe_unused]] static constexpr auto name = "combine_json_reference_graph";
+
+        static Port<TS<Str>> compose(Wiring &w, Port<TS<Bool>> choose_lhs, Port<TS<Int>> lhs,
+                                     Port<TS<Int>> rhs)
+        {
+            auto selected = wire<stdlib::if_then_else>(w, choose_lhs, lhs, rhs);
+            auto combined = wire<stdlib::combine_json>(w, arg<"v">(selected));
+            return wire<stdlib::json_encode, TS<Str>>(w, combined).as<TS<Str>>();
+        }
+    };
 }  // namespace
 
 TEST_CASE("json operators: to_json serializes per tick")
@@ -520,6 +537,20 @@ TEST_CASE("dynamic json operators: equality is semantic not raw string equality"
                      values<Str>(Str{"{\"a\":1,\"b\":[2,3]}"}),
                      values<Str>(Str{"{ \"b\" : [2, 3], \"a\" : 1 }"})),
                  values<Bool>(true));
+}
+
+TEST_CASE("dynamic json operators: combine serializes the value behind a reference")
+{
+    stdlib::register_standard_operators();
+    // Without the deref rule the ref token reaches the encoder: natively that
+    // raises "JSON tree: unsupported node content", while the same graph
+    // through the Python bridge silently serialized "<ref>" (see
+    // python/tests/ported/_operators/test_json.py). Same defect, and only one
+    // of the two ends up looking like data - which is why both are covered.
+    CHECK_OUTPUT(eval_node<CombineJsonReferenceGraph>(values<Bool>(true), values<Int>(8), values<Int>(-6)),
+                 values<Str>(Str{"{\"v\": 8}"}));
+    CHECK_OUTPUT(eval_node<CombineJsonReferenceGraph>(values<Bool>(false), values<Int>(8), values<Int>(-6)),
+                 values<Str>(Str{"{\"v\": -6}"}));
 }
 
 TEST_CASE("dynamic json operators: equality is independent of lazy or eager storage")

--- a/tests/cpp/test_operators.cpp
+++ b/tests/cpp/test_operators.cpp
@@ -1342,6 +1342,76 @@ namespace
         }
     };
 
+    // Whether a port still carries a REF, using only the public registry.
+    [[nodiscard]] inline bool is_reference_port(const WiringPortRef &port)
+    {
+        return port.schema != TypeRegistry::instance().dereference(port.schema);
+    }
+
+    // A TYPED **kwargs collector declares a pack schema, and a REF field in
+    // that pack is an explicit request for the reference token. The deref rule
+    // applies to what carries no such declaration, so it must not overrule one.
+    struct ref_kw_ : Operator<"ref_kw",
+                              VarKwIn<"kwargs", UnNamedTSB<Field<"x", REF<TS<Int>>>>>,
+                              Out<TS<Int>>>
+    {
+    };
+    struct ref_kw_impl
+    {
+        static constexpr auto name             = "ref_kw_impl";
+        inline static bool    saw_reference    = false;
+        static Port<TS<Int>>  compose(Wiring &w,
+                                      VarKwIn<"kwargs", UnNamedTSB<Field<"x", REF<TS<Int>>>>> rest)
+        {
+            REQUIRE(rest.size() == 1);
+            saw_reference = is_reference_port(rest[0].second);
+            return Port<TS<Int>>{w, rest[0].second};
+        }
+    };
+
+    // The untyped counterpart over the same source: nothing declares a
+    // reference, so the collector receives the value.
+    struct plain_kw_ : Operator<"plain_kw", VarKwIn<"kwargs">, Out<TS<Int>>>
+    {
+    };
+    struct plain_kw_impl
+    {
+        static constexpr auto name          = "plain_kw_impl";
+        inline static bool    saw_reference = true;
+        static Port<TS<Int>>  compose(Wiring &w, VarKwIn<"kwargs"> rest)
+        {
+            REQUIRE(rest.size() == 1);
+            saw_reference = is_reference_port(rest[0].second);
+            return Port<TS<Int>>{w, rest[0].second};
+        }
+    };
+
+    // if_then_else publishes a reference; each collector sees it per its own
+    // declaration.
+    struct RefKwGraph
+    {
+        [[maybe_unused]] static constexpr auto name = "ref_kw_graph";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Bool>> choose_lhs, Port<TS<Int>> lhs,
+                                     Port<TS<Int>> rhs)
+        {
+            auto selected = wire<stdlib::if_then_else>(w, choose_lhs, lhs, rhs);
+            return wire<ref_kw_>(w, arg<"x">(selected)).as<TS<Int>>();
+        }
+    };
+
+    struct PlainKwGraph
+    {
+        [[maybe_unused]] static constexpr auto name = "plain_kw_graph";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Bool>> choose_lhs, Port<TS<Int>> lhs,
+                                     Port<TS<Int>> rhs)
+        {
+            auto selected = wire<stdlib::if_then_else>(w, choose_lhs, lhs, rhs);
+            return wire<plain_kw_>(w, arg<"x">(selected)).as<TS<Int>>();
+        }
+    };
+
     [[nodiscard]] inline WiringArg scalar_arg(Value value)
     {
         WiringArg arg;
@@ -1552,6 +1622,31 @@ TEST_CASE("operators: a typed **kwargs collector gates candidates on its pack pa
         OperatorRegistry::instance().resolve("typed_kw",
                                              std::span<const WiringArg>{mismatched}),
         Catch::Matchers::ContainsSubstring("**kwargs pattern"));
+}
+
+TEST_CASE("operators: a typed **kwargs pack schema decides whether REF survives")
+{
+    using namespace hgraph;
+    (void)TypeRegistry::instance().register_scalar<Int>("int");
+    stdlib::register_standard_operators();
+    register_graph_overload<ref_kw_, ref_kw_impl>();
+    register_graph_overload<plain_kw_, plain_kw_impl>();
+
+    // The declared pack asks for REF<TS<Int>>, so the reference reaches the
+    // implementation intact - dispatch matched against that schema, and
+    // rewriting the port here would leave output resolution describing a
+    // reference the implementation never receives.
+    ref_kw_impl::saw_reference = false;
+    CHECK_OUTPUT(eval_node<RefKwGraph>(values<Bool>(true), values<Int>(8), values<Int>(-6)),
+                 values<Int>(8));
+    CHECK(ref_kw_impl::saw_reference);
+
+    // Nothing in a bare **kwargs can ask for a reference, so the same source
+    // arrives dereferenced.
+    plain_kw_impl::saw_reference = true;
+    CHECK_OUTPUT(eval_node<PlainKwGraph>(values<Bool>(true), values<Int>(8), values<Int>(-6)),
+                 values<Int>(8));
+    CHECK(!plain_kw_impl::saw_reference);
 }
 
 TEST_CASE("operators: arg<\"name\">(...) flows named arguments through wire<Op>")


### PR DESCRIPTION
Follow-up to #458. That fix was one instance of a wider rule, not the whole of it.

## The rule

A generic time-series parameter binds the **dereferenced** type, recursively.
`REF` is always explicit:

```cpp
In<"ts", TsVar<"S">>        // the VALUE, however many refs reach it
In<"ts", REF<TsVar<"S">>>   // the reference token
```

A reference is *how* a value is reached, not *what it is*. A consumer handed a
ref token produces plausible nonsense rather than failing — nothing raises, and
the output looks like data.

## Still-live instance

`combine[TS[JSON]]` over an `if_then_else` source serialised `{'v': <ref>}`
instead of `{'v': 8}`. Same defect as the logging one, different consumer.

## Applied structurally, not per consumer

The rule is applied where arguments are **bound**, in `operator_dispatch`:

- `operator_dispatch_detail::value_argument` dereferences a variadic tail unless
  the declared schema is `REF<...>`;
- an **untyped** `VarKwIn<Name>` declares nothing that could ask for a
  reference, so its ports are dereferenced;
- a **typed** `VarKwIn<Name, Schema>` is left alone. Its pack schema has already
  been matched at dispatch, so a `REF` field in it is an explicit request —
  stripping it would leave output resolution describing a reference the
  implementation never receives.

`value_argument` is the single decision point; `value_consumer_source` is now
its only implementation detail, with one caller.

## One mechanism, not several

All four hand-rolled dereferences are gone — two in `pack_format_args`, two in
`format_graph_impl`, plus the one already removed from `json_impl`.

The first version of this PR asserted that `log_`/`print_`/`format_` "reach
their arguments through a different binding path." **That was wrong**, and
tracing it rather than inferring it found the real gap: removing
`pack_format_args`' dereference leaves `log_` and `print_` passing and fails
`apply_`, with `checked_as<T> type mismatch`.

`apply_` substitutes a hand-written `OperatorImpl::wire` closure for the
generated one (the resolved output schema has to reach the packed runtime
node). That closure receives the raw `WiringArg` span, so `operator_dispatch`
never binds its arguments. It now applies the rule itself, against what
`apply_value_callable_signature` declares. Replacing `OperatorImpl::wire` is the
only category of exemption, and `writing_nodes.rst` now says so.

## Deliberately excluded

`tsb_itemwise` and the `map_`/`switch_`/`mesh_` machinery pack references on
purpose — they route values rather than consume them.

## Verification

- C++ **1585/1585**, Python **2162 passed, 9 skipped**, `api_inventory --check` clean
- Native `eval_node` coverage for the JSON case and for typed-vs-untyped
  collectors over a reference source, alongside the Python regression test.
  Worth both ends: natively the ref token *raises*
  (`JSON tree: unsupported node content`), while through the bridge it silently
  serialised `"<ref>"` — only one of the two looks like data.
- Every fix confirmed load-bearing by probe: reverting the typed-pack gate fails
  the `REF` half, removing the deref entirely fails the untyped half and the
  JSON test, and reverting the `apply_` closure reproduces the `checked_as`
  mismatch.

Not run on this branch: the Linux and Windows boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)