### PR TITLE
Preserve Kafka recovery live handoff order

### DIFF
--- a/extensions/kafka/CHANGELOG.md
+++ b/extensions/kafka/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Replay recovered records at their Kafka timestamps across all subscriptions
   instead of serializing them in shared-drain arrival order.
+- Keep real-time live records behind their subscription's queued timestamped
+  recovery tail during the recovery-to-live handoff.
 
 ## 0.8.0
 

--- a/extensions/kafka/python/tests/test_runtime.py
+++ b/extensions/kafka/python/tests/test_runtime.py
@@ -166,6 +166,84 @@ def test_multiple_python_replays_follow_record_timestamps() -> None:
     assert dict(observed) == expected
 
 
+def test_python_record_time_recovery_hands_off_before_live_records() -> None:
+    cluster = MockCluster()
+    cluster.create_topic("python-record-time-live")
+    history_time = hg.utc_now().replace(microsecond=0) + timedelta(seconds=3)
+    cluster.seed_record(
+        "python-record-time-live",
+        b"history",
+        timestamp_ms=int(history_time.replace(tzinfo=UTC).timestamp() * 1000),
+    )
+    recovery_started = threading.Event()
+    live_seeded = threading.Event()
+    observed = []
+
+    def seed_live() -> None:
+        if recovery_started.wait(5.0):
+            cluster.seed_record("python-record-time-live", b"live")
+            live_seeded.set()
+
+    @hg.sink_node
+    def capture_state(state: hg.TS[kafka.KafkaSubscriptionState]):
+        if state.value == kafka.KafkaSubscriptionState.RECOVERING:
+            recovery_started.set()
+
+    @hg.sink_node
+    def capture_record(
+        record: hg.TS[kafka.KafkaRecord],
+        _clock: hg.CLOCK = None,
+        _api: hg.EvaluationEngineApi = None,
+    ):
+        observed.append((record.value.value, _clock.evaluation_time))
+        if len(observed) == 2:
+            _api.request_engine_stop()
+
+    @hg.graph
+    def app():
+        kafka.register_kafka_service(
+            kafka.KafkaServiceConfig.from_bootstrap_servers(
+                [cluster.bootstrap_servers()],
+                client_id="python-record-time-live",
+            ),
+            path="record-time-live",
+        )
+        key = kafka.KafkaSubscriptionKey(
+            topics=("python-record-time-live",),
+            group_id="python-record-time-live",
+            assignment_mode=kafka.KafkaAssignmentMode.INDEPENDENT,
+            start_position=kafka.KafkaStartPosition.earliest(),
+            stop_position=kafka.KafkaStopPosition.unbounded(),
+            commit_mode=kafka.KafkaCommitMode.NONE,
+            recovery_clock=kafka.KafkaRecoveryClock.RECORD_TIMESTAMP,
+            merge_policy=kafka.KafkaMergePolicy.TIMESTAMP_TOPIC_PARTITION_OFFSET,
+            sharing_identity="python-record-time-live",
+        )
+        subscription = kafka.kafka_subscribe(
+            hg.const(key, tp=hg.TS[kafka.KafkaSubscriptionKey]),
+            path="record-time-live",
+        )
+        capture_state(subscription["state"])
+        capture_record(subscription["record"])
+
+    producer = threading.Thread(target=seed_live)
+    producer.start()
+    try:
+        hg.run_graph(
+            app,
+            run_mode=hg.EvaluationMode.REAL_TIME,
+            end_time=history_time + timedelta(seconds=5),
+        )
+    finally:
+        producer.join(timeout=6.0)
+
+    assert not producer.is_alive()
+    assert live_seeded.is_set()
+    assert [value for value, _ in observed] == [b"history", b"live"]
+    assert observed[0][1] == history_time
+    assert observed[1][1] > observed[0][1]
+
+
 def test_legacy_replay_surface_uses_the_same_native_history_session(monkeypatch) -> None:
     _use_mock_cluster_history_start(monkeypatch)
     cluster = MockCluster()

--- a/extensions/kafka/src/detail/service_bridge.h
+++ b/extensions/kafka/src/detail/service_bridge.h
@@ -57,6 +57,11 @@ struct OutputLimits {
 
 class ServiceBridge {
 public:
+  struct QueuedOutput {
+    Value value{};
+    std::optional<DateTime> evaluation_time{};
+  };
+
   ServiceBridge(OutputLimits subscription, OutputLimits delivery,
                 OutputLimits event, OutputLimits subscription_control = {},
                 OutputLimits delivery_control = {},
@@ -158,8 +163,8 @@ public:
     return push_impl(channel, std::move(value), retained_bytes, true);
   }
 
-  [[nodiscard]] std::optional<Value> pop(OutputChannel channel) {
-    std::optional<Value> result;
+  [[nodiscard]] std::optional<QueuedOutput> pop(OutputChannel channel) {
+    std::optional<QueuedOutput> result;
     {
       std::lock_guard lock{mutex_};
       auto &state = at(channel);
@@ -178,7 +183,7 @@ public:
         --state.payload_records;
         state.payload_bytes -= item.retained_bytes;
       }
-      result.emplace(std::move(item.value));
+      result.emplace(QueuedOutput{std::move(item.value), item.evaluation_time});
 
       if (state.values.empty()) {
         state.wake_outstanding = false;
@@ -187,13 +192,14 @@ public:
     return result;
   }
 
-  [[nodiscard]] std::optional<Value> peek(OutputChannel channel) const {
+  [[nodiscard]] std::optional<QueuedOutput> peek(OutputChannel channel) const {
     std::lock_guard lock{mutex_};
     const auto &state = at(channel);
     if (state.values.empty()) {
       return std::nullopt;
     }
-    return state.values.front().value.clone();
+    const auto &item = state.values.front();
+    return QueuedOutput{item.value.clone(), item.evaluation_time};
   }
 
   [[nodiscard]] std::size_t pending(OutputChannel channel) const {
@@ -326,6 +332,7 @@ public:
       }
       QueuedValue item{std::move(value), retained_bytes, false};
       item.evaluation_time = queued_evaluation_time(channel, item.value);
+      inherit_subscription_schedule(channel, state, item);
       const auto position = insertion_point(channel, state, item);
       const bool became_head = position == state.values.begin();
       state.values.insert(position, std::move(item));
@@ -385,6 +392,7 @@ private:
       }
       QueuedValue item{std::move(value), retained_bytes, control};
       item.evaluation_time = queued_evaluation_time(channel, item.value);
+      inherit_subscription_schedule(channel, state, item);
       const auto position = insertion_point(channel, state, item);
       const bool became_head = position == state.values.begin();
       state.values.insert(position, std::move(item));
@@ -440,6 +448,32 @@ private:
     }
     return rhs.evaluation_time.has_value() &&
            *lhs.evaluation_time < *rhs.evaluation_time;
+  }
+
+  static void inherit_subscription_schedule(OutputChannel channel,
+                                            const Channel &state,
+                                            QueuedValue &item) {
+    if (channel != OutputChannel::Subscription ||
+        item.evaluation_time.has_value()) {
+      return;
+    }
+    const auto key = item.value.view().as_bundle().at("subscription_key");
+    const auto predecessor =
+        std::find_if(state.values.rbegin(), state.values.rend(),
+                     [&](const QueuedValue &queued) {
+                       return queued.value.view()
+                           .as_bundle()
+                           .at("subscription_key")
+                           .equals(key);
+                     });
+    if (predecessor != state.values.rend() &&
+        predecessor->evaluation_time.has_value()) {
+      // A real-time consumer may resume polling while its timestamped
+      // recovery tail is still waiting on graph time. Keep later lifecycle
+      // and live values behind that per-subscription tail without delaying
+      // unrelated untimed subscriptions.
+      item.evaluation_time = *predecessor->evaluation_time + MIN_TD;
+    }
   }
 
   [[nodiscard]] static std::deque<QueuedValue>::iterator
@@ -511,14 +545,6 @@ template <typename Tag>
 struct SubscriptionDrainNode {
   static constexpr auto name = "kafka_subscription_drain";
 
-  [[nodiscard]] static std::optional<DateTime>
-  evaluation_time(const Value &envelope) {
-    const auto field = envelope.view().as_bundle().at("evaluation_time");
-    return field.data() != nullptr
-               ? std::optional<DateTime>{field.checked_as<DateTime>()}
-               : std::nullopt;
-  }
-
   static void
   eval(In<"signal", TS<Int>>, Scalar<"bridge", ServiceBridgeHandle> bridge,
        SingleShotScheduler scheduler,
@@ -527,19 +553,20 @@ struct SubscriptionDrainNode {
     if (!next.has_value()) {
       return;
     }
-    const auto batch_time = evaluation_time(*next);
-    if (batch_time.has_value() && *batch_time > scheduler.now()) {
-      scheduler.schedule(*batch_time);
+    if (next->evaluation_time.has_value() &&
+        *next->evaluation_time > scheduler.now()) {
+      scheduler.schedule(*next->evaluation_time);
       return;
     }
+    const auto batch_time = next->evaluation_time;
     auto mutation = out.begin_mutation(out.evaluation_time());
     while (true) {
-      auto envelope = bridge.value().value->pop(OutputChannel::Subscription);
-      if (!envelope.has_value()) {
+      auto queued = bridge.value().value->pop(OutputChannel::Subscription);
+      if (!queued.has_value()) {
         return;
       }
 
-      const auto fields = envelope->view().as_bundle();
+      const auto fields = queued->value.view().as_bundle();
       const auto removed = fields.at("removed");
       if (removed.data() != nullptr && removed.checked_as<Bool>()) {
         static_cast<void>(mutation.erase(fields.at("subscription_key")));
@@ -571,7 +598,7 @@ struct SubscriptionDrainNode {
       if (!next.has_value()) {
         return;
       }
-      const auto next_time = evaluation_time(*next);
+      const auto next_time = next->evaluation_time;
       if (batch_time.has_value() && next_time == batch_time) {
         // Independent subscriptions may legitimately tick at the same Kafka
         // timestamp. Apply their distinct TSD keys in one graph mutation.
@@ -598,7 +625,7 @@ struct DeliveryDrainNode {
     if (!envelope.has_value()) {
       return;
     }
-    const auto fields = envelope->view().as_bundle();
+    const auto fields = envelope->value.view().as_bundle();
     auto mutation = out.begin_mutation(out.evaluation_time());
     mutation.set(fields.at("request_id"), fields.at("report"));
     if (bridge.value().value->pending(OutputChannel::Delivery) != 0) {
@@ -618,7 +645,7 @@ struct EventDrainNode {
     if (!envelope.has_value()) {
       return;
     }
-    const auto fields = envelope->view().as_bundle();
+    const auto fields = envelope->value.view().as_bundle();
     out.apply(fields.at("event"));
     if (fields.at("stop_graph").checked_as<Bool>()) {
       engine.request_stop();

--- a/extensions/kafka/tests/test_service.cpp
+++ b/extensions/kafka/tests/test_service.cpp
@@ -184,6 +184,7 @@ inline SenderLatch subscription_commit_sender{};
 inline GenerationLatch subscription_generations{};
 inline CountLatch stale_commit_events{};
 inline CountLatch graph_lifetime_live{};
+inline CountLatch record_time_recovery_started{};
 
 inline Value service_config{};
 inline Value subscription_key{};
@@ -222,6 +223,7 @@ inline std::vector<KafkaSubscriptionState> bounded_states{};
 inline std::vector<Str> bounded_payloads{};
 inline std::vector<DateTime> bounded_evaluation_times{};
 inline std::vector<std::pair<Str, DateTime>> multi_bounded_records{};
+inline std::vector<std::pair<Str, DateTime>> recovery_live_records{};
 inline std::size_t multi_bounded_complete_count{};
 inline std::vector<Int> backlog_offsets{};
 inline std::vector<Str> backlog_events{};
@@ -475,6 +477,45 @@ struct GraphLifetimeSubscriptionGraph {
         w, subscription_key.clone());
     static_cast<void>(wire<GraphLifetimeSubscriptionCapture>(
         w, subscribe(w, path, key)));
+  }
+};
+
+struct RecordTimeRecoveryLiveCapture {
+  static constexpr auto name = "kafka_record_time_recovery_live_capture";
+
+  static void
+  eval(NodeView node,
+       In<"subscription", KafkaSubscriptionOutput, InputValidity::Unchecked>
+           subscription) {
+    auto state = subscription.template field<"state">();
+    if (state.valid() && state.modified() &&
+        state.value() == KafkaSubscriptionState::Recovering) {
+      record_time_recovery_started.publish();
+    }
+    auto record = subscription.template field<"record">();
+    if (!record.valid() || !record.modified()) {
+      return;
+    }
+    const auto fields = record.base().value().as_bundle();
+    recovery_live_records.emplace_back(
+        fields.at("value").checked_as<Bytes>().data,
+        node.graph().evaluation_time());
+    if (recovery_live_records.size() == 2) {
+      node.graph().executor().request_stop();
+    }
+  }
+};
+
+struct RecordTimeRecoveryLiveGraph {
+  static constexpr auto name = "kafka_record_time_recovery_live_test_graph";
+
+  static void compose(Wiring &w) {
+    const auto path = service::path("record-time-recovery-live");
+    register_service(w, path, production_config.clone());
+    auto key = wire<stdlib::const_, TS<KafkaSubscriptionKey>>(
+        w, subscription_key.clone());
+    static_cast<void>(
+        wire<RecordTimeRecoveryLiveCapture>(w, subscribe(w, path, key)));
   }
 };
 
@@ -1982,6 +2023,55 @@ void test_record_time_recovery_is_deterministically_merged() {
       "record-time recovery did not emit records on increasing graph times");
 }
 
+void test_record_time_recovery_hands_off_before_live_records() {
+  MockCluster cluster;
+  cluster.create_topic(Str{"typed-record-time-live"});
+  const DateTime history_time{
+      std::chrono::duration_cast<TimeDelta>(
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+              wall_now().time_since_epoch())) +
+      TimeDelta{2'000'000}};
+  cluster.seed_record(Str{"typed-record-time-live"}, Bytes{"history"},
+                      std::nullopt, {}, 0, history_time);
+
+  production_config = hgraph::kafka::service_config()
+                          .bootstrap_servers({cluster.bootstrap_servers()})
+                          .client_id(Str{"typed-record-time-live-subscriber"})
+                          .build();
+  subscription_key =
+      hgraph::kafka::subscription_key()
+          .partitions({{Str{"typed-record-time-live"}, Int{0}}})
+          .group_id(Str{"typed-record-time-live-group"})
+          .start(make_start_position(KafkaStartPositionKind::Earliest))
+          .stop(make_stop_position(KafkaStopPositionKind::Unbounded))
+          .commit_mode(KafkaCommitMode::None)
+          .recovery_clock(KafkaRecoveryClock::RecordTimestamp)
+          .merge_policy(KafkaMergePolicy::TimestampTopicPartitionOffset)
+          .sharing_identity(Str{"typed-record-time-live-subscription"})
+          .build();
+  record_time_recovery_started.reset();
+  recovery_live_records.clear();
+
+  auto executor = start_realtime(build_graph<RecordTimeRecoveryLiveGraph>(),
+                                 TimeDelta{8'000'000});
+  auto view = executor.view();
+  AsyncGraphExecutorRun runner{view};
+  require(record_time_recovery_started.await(1),
+          "record-time subscription did not enter recovery");
+  cluster.seed_record(Str{"typed-record-time-live"}, Bytes{"live"});
+  runner.join();
+
+  require(recovery_live_records.size() == 2,
+          "record-time handoff did not deliver history and live records");
+  require(recovery_live_records[0].first == Str{"history"} &&
+              recovery_live_records[1].first == Str{"live"},
+          "a live record overtook timestamped recovery");
+  require(recovery_live_records[0].second == history_time,
+          "record-time history did not retain its Kafka timestamp");
+  require(recovery_live_records[1].second > recovery_live_records[0].second,
+          "the live handoff did not follow the timestamped recovery tail");
+}
+
 void test_graph_lifetime_stop_is_bounded_in_simulation() {
   MockCluster cluster;
   cluster.create_topic(Str{"simulation-record-time"});
@@ -2236,6 +2326,7 @@ int main() {
     test_independent_assignment_reads_every_partition();
     test_commit_modes_and_monotonic_explicit_commits();
     test_record_time_recovery_is_deterministically_merged();
+    test_record_time_recovery_hands_off_before_live_records();
     test_graph_lifetime_stop_is_bounded_in_simulation();
     test_multiple_simulation_subscriptions_replay_at_record_time();
     test_real_broker_publish_subscribe_and_commit_round_trip();


### PR DESCRIPTION
## Summary

- keep untimed live and lifecycle values behind any scheduled recovery tail for the same subscription
- carry the bridge's effective schedule through peek/pop so the drain honors derived handoff barriers
- add matching native C++ and Python real-time `RecordTimestamp` regressions

## Root cause

PR #459 globally placed untimed subscription envelopes before timestamped recovery envelopes. When an unbounded `RecordTimestamp` session resumed polling before its queued history drained, a new untimed live record could move ahead of its own recovery tail and scheduled `Live` transition.

## Impact

Real-time recovery now delivers all timestamped history before later live records for that subscription, while unrelated untimed subscriptions remain immediate.

Follow-up to #459 and addresses [the P1 review thread](https://github.com/hhenson/hgraph/pull/459#discussion_r3783166309).

## Validation

- macOS complete native suite: 1584/1584 passed
- macOS Python 3.14 compatibility suite from ABI3 wheel: 2161 passed, 9 skipped
- macOS Kafka native test: passed
- macOS Kafka ABI3 Python suite: 56 passed
- Linux GCC complete native suite: 1583/1583 passed
- Linux Python 3.14 compatibility suite from ABI3 wheel: 2161 passed, 9 skipped
- Linux Kafka native test: passed
- Linux Kafka ABI3 Python suite: 56 passed
- `git diff --check` and scoped clang-format: passed
