### PR TITLE
Coordinate Kafka recovery across independent topics

### DIFF
--- a/extensions/kafka/CHANGELOG.md
+++ b/extensions/kafka/CHANGELOG.md
@@ -8,6 +8,8 @@
   recovery tail during the recovery-to-live handoff.
 - Stage record-time recovery cohorts from independent subscriptions before
   releasing their globally ordered records into the graph.
+- Keep cohort loading independent of live-ingress watermarks, release failed
+  participants, and retain bounded lifecycle capacity through preload.
 
 ## 0.8.0
 

--- a/extensions/kafka/CHANGELOG.md
+++ b/extensions/kafka/CHANGELOG.md
@@ -6,6 +6,8 @@
   instead of serializing them in shared-drain arrival order.
 - Keep real-time live records behind their subscription's queued timestamped
   recovery tail during the recovery-to-live handoff.
+- Stage record-time recovery cohorts from independent subscriptions before
+  releasing their globally ordered records into the graph.
 
 ## 0.8.0
 

--- a/extensions/kafka/python/tests/test_runtime.py
+++ b/extensions/kafka/python/tests/test_runtime.py
@@ -244,6 +244,108 @@ def test_python_record_time_recovery_hands_off_before_live_records() -> None:
     assert observed[1][1] > observed[0][1]
 
 
+def test_python_record_time_recovery_waits_for_independent_topics() -> None:
+    cluster = MockCluster()
+    cluster.create_topic("python-recovery-cohort-early")
+    cluster.create_topic("python-recovery-cohort-late")
+    early_time = hg.utc_now().replace(microsecond=0) + timedelta(seconds=2)
+    late_time = early_time + timedelta(milliseconds=500)
+    second_early_time = early_time + timedelta(seconds=1)
+    second_late_time = early_time + timedelta(milliseconds=1500)
+    # Seed the later stream first so enqueue/poll arrival cannot be mistaken
+    # for the event-time order of the complete recovery cohort.
+    cluster.seed_record(
+        "python-recovery-cohort-late",
+        b"late-1",
+        timestamp_ms=int(late_time.replace(tzinfo=UTC).timestamp() * 1000),
+    )
+    cluster.seed_record(
+        "python-recovery-cohort-late",
+        b"late-2",
+        timestamp_ms=int(second_late_time.replace(tzinfo=UTC).timestamp() * 1000),
+    )
+    cluster.seed_record(
+        "python-recovery-cohort-early",
+        b"early-1",
+        timestamp_ms=int(early_time.replace(tzinfo=UTC).timestamp() * 1000),
+    )
+    cluster.seed_record(
+        "python-recovery-cohort-early",
+        b"early-2",
+        timestamp_ms=int(second_early_time.replace(tzinfo=UTC).timestamp() * 1000),
+    )
+    observed = []
+    completed = []
+
+    @hg.sink_node
+    def capture_record(
+        record: hg.TS[kafka.KafkaRecord],
+        _clock: hg.CLOCK = None,
+    ):
+        observed.append((record.value.value, _clock.evaluation_time))
+
+    @hg.sink_node
+    def capture_state(
+        state: hg.TS[kafka.KafkaSubscriptionState],
+        _api: hg.EvaluationEngineApi = None,
+    ):
+        if state.value == kafka.KafkaSubscriptionState.BOUNDED_COMPLETE:
+            completed.append(True)
+            if len(completed) == 2:
+                _api.request_engine_stop()
+
+    @hg.graph
+    def app():
+        kafka.register_kafka_service(
+            kafka.KafkaServiceConfig(
+                connection=kafka.KafkaConnectionConfig(
+                    (cluster.bootstrap_servers(),), "python-recovery-cohort"
+                ),
+                consumer_defaults=kafka.KafkaConsumerDefaults(
+                    ingress_record_limit=2,
+                    ingress_byte_limit=4096,
+                ),
+            ),
+            path="recovery-cohort",
+        )
+        for topic in (
+            "python-recovery-cohort-early",
+            "python-recovery-cohort-late",
+        ):
+            key = kafka.KafkaSubscriptionKey(
+                topics=(topic,),
+                group_id=topic,
+                assignment_mode=kafka.KafkaAssignmentMode.INDEPENDENT,
+                start_position=kafka.KafkaStartPosition.earliest(),
+                stop_position=kafka.KafkaStopPosition.snapshot(),
+                recovery_clock=kafka.KafkaRecoveryClock.RECORD_TIMESTAMP,
+                merge_policy=(
+                    kafka.KafkaMergePolicy.TIMESTAMP_TOPIC_PARTITION_OFFSET
+                ),
+                sharing_identity=topic,
+            )
+            subscription = kafka.kafka_subscribe(
+                hg.const(key, tp=hg.TS[kafka.KafkaSubscriptionKey]),
+                path="recovery-cohort",
+            )
+            capture_record(subscription["record"])
+            capture_state(subscription["state"])
+
+    hg.run_graph(
+        app,
+        run_mode=hg.EvaluationMode.REAL_TIME,
+        end_time=second_late_time + timedelta(seconds=2),
+    )
+
+    assert observed == [
+        (b"early-1", early_time),
+        (b"late-1", late_time),
+        (b"early-2", second_early_time),
+        (b"late-2", second_late_time),
+    ]
+    assert len(completed) == 2
+
+
 def test_legacy_replay_surface_uses_the_same_native_history_session(monkeypatch) -> None:
     _use_mock_cluster_history_start(monkeypatch)
     cluster = MockCluster()

--- a/extensions/kafka/python/tests/test_runtime.py
+++ b/extensions/kafka/python/tests/test_runtime.py
@@ -31,6 +31,7 @@ def _use_mock_cluster_history_start(monkeypatch) -> None:
 def test_python_authoring_uses_native_record_time_simulation() -> None:
     cluster = MockCluster()
     cluster.create_topic("python-simulation")
+    cluster.create_topic("python-simulation-second")
     graph_start = datetime(2026, 8, 7, 12, 0)
     record_time = graph_start + timedelta(seconds=1)
     cluster.seed_record(
@@ -40,8 +41,19 @@ def test_python_authoring_uses_native_record_time_simulation() -> None:
         headers=(("duplicate", b"one"), ("duplicate", None)),
         timestamp_ms=int(record_time.replace(tzinfo=UTC).timestamp() * 1000),
     )
+    cluster.seed_record(
+        "python-simulation-second",
+        b"second",
+        timestamp_ms=int(
+            (record_time + timedelta(milliseconds=1))
+            .replace(tzinfo=UTC)
+            .timestamp()
+            * 1000
+        ),
+    )
     records = []
     evaluation_times = []
+    completed = []
 
     @hg.sink_node
     def capture(
@@ -51,29 +63,44 @@ def test_python_authoring_uses_native_record_time_simulation() -> None:
         records.append(record.value)
         evaluation_times.append(_clock.evaluation_time)
 
+    @hg.sink_node
+    def capture_state(state: hg.TS[kafka.KafkaSubscriptionState]):
+        if state.value == kafka.KafkaSubscriptionState.BOUNDED_COMPLETE:
+            completed.append(True)
+
     @hg.graph
     def app():
         kafka.register_kafka_service(
-            kafka.KafkaServiceConfig.from_bootstrap_servers(
-                [cluster.bootstrap_servers()], client_id="python-simulation"
+            kafka.KafkaServiceConfig(
+                connection=kafka.KafkaConnectionConfig(
+                    (cluster.bootstrap_servers(),), "python-simulation"
+                ),
+                consumer_defaults=kafka.KafkaConsumerDefaults(
+                    ingress_record_limit=3,
+                    ingress_byte_limit=4096,
+                ),
             ),
             path="simulation",
         )
-        key = kafka.KafkaSubscriptionKey(
-            topics=("python-simulation",),
-            group_id="python-simulation",
-            assignment_mode=kafka.KafkaAssignmentMode.INDEPENDENT,
-            start_position=kafka.KafkaStartPosition.earliest(),
-            stop_position=kafka.KafkaStopPosition.snapshot(),
-            recovery_clock=kafka.KafkaRecoveryClock.RECORD_TIMESTAMP,
-            merge_policy=kafka.KafkaMergePolicy.TIMESTAMP_TOPIC_PARTITION_OFFSET,
-            sharing_identity="python-simulation",
-        )
-        subscription = kafka.kafka_subscribe(
-            hg.const(key, tp=hg.TS[kafka.KafkaSubscriptionKey]),
-            path="simulation",
-        )
-        capture(subscription["record"])
+        for topic in ("python-simulation", "python-simulation-second"):
+            key = kafka.KafkaSubscriptionKey(
+                topics=(topic,),
+                group_id=topic,
+                assignment_mode=kafka.KafkaAssignmentMode.INDEPENDENT,
+                start_position=kafka.KafkaStartPosition.earliest(),
+                stop_position=kafka.KafkaStopPosition.snapshot(),
+                recovery_clock=kafka.KafkaRecoveryClock.RECORD_TIMESTAMP,
+                merge_policy=(
+                    kafka.KafkaMergePolicy.TIMESTAMP_TOPIC_PARTITION_OFFSET
+                ),
+                sharing_identity=topic,
+            )
+            subscription = kafka.kafka_subscribe(
+                hg.const(key, tp=hg.TS[kafka.KafkaSubscriptionKey]),
+                path="simulation",
+            )
+            capture(subscription["record"])
+            capture_state(subscription["state"])
 
     hg.run_graph(
         app,
@@ -82,14 +109,20 @@ def test_python_authoring_uses_native_record_time_simulation() -> None:
         end_time=record_time + timedelta(seconds=1),
     )
 
-    assert len(records) == 1
-    assert records[0].value == b"payload"
-    assert records[0].key == b""
-    assert tuple((item.name, item.value) for item in records[0].headers) == (
+    assert len(records) == 2
+    records_by_value = {record.value: record for record in records}
+    assert records_by_value[b"payload"].key == b""
+    assert tuple(
+        (item.name, item.value) for item in records_by_value[b"payload"].headers
+    ) == (
         ("duplicate", b"one"),
         ("duplicate", None),
     )
-    assert evaluation_times == [record_time]
+    assert evaluation_times == [
+        record_time,
+        record_time + timedelta(milliseconds=1),
+    ]
+    assert len(completed) == 2
 
 
 def test_multiple_python_replays_follow_record_timestamps() -> None:

--- a/extensions/kafka/src/detail/service_bridge.h
+++ b/extensions/kafka/src/detail/service_bridge.h
@@ -60,6 +60,7 @@ public:
   struct QueuedOutput {
     Value value{};
     std::optional<DateTime> evaluation_time{};
+    bool recovery_blocked{};
   };
 
   ServiceBridge(OutputLimits subscription, OutputLimits delivery,
@@ -119,6 +120,68 @@ public:
     accepting_ = true;
   }
 
+  void begin_record_time_recovery(std::size_t participants) {
+    if (participants == 0) {
+      return;
+    }
+    std::lock_guard lock{mutex_};
+    auto &state = at(OutputChannel::Subscription);
+    const auto add_saturated = [](std::size_t value,
+                                  std::size_t increment) noexcept {
+      constexpr auto maximum = std::numeric_limits<std::size_t>::max();
+      return increment > maximum - value ? maximum : value + increment;
+    };
+    const auto multiply_saturated = [](std::size_t value,
+                                       std::size_t multiplier) noexcept {
+      constexpr auto maximum = std::numeric_limits<std::size_t>::max();
+      return value != 0 && multiplier > maximum / value ? maximum
+                                                        : value * multiplier;
+    };
+    if (record_time_recoveries_pending_ == 0) {
+      state.recovery_limits = OutputLimits{
+          add_saturated(state.recovery_records,
+                        multiply_saturated(state.limits.records, participants)),
+          add_saturated(state.recovery_bytes,
+                        multiply_saturated(state.limits.bytes, participants)),
+      };
+    } else {
+      state.recovery_limits.records =
+          add_saturated(state.recovery_limits.records,
+                        multiply_saturated(state.limits.records, participants));
+      state.recovery_limits.bytes =
+          add_saturated(state.recovery_limits.bytes,
+                        multiply_saturated(state.limits.bytes, participants));
+    }
+    record_time_recoveries_pending_ =
+        add_saturated(record_time_recoveries_pending_, participants);
+  }
+
+  void complete_record_time_recovery() {
+    PushSourceSender wake;
+    Int generation{};
+    {
+      std::lock_guard lock{mutex_};
+      if (record_time_recoveries_pending_ == 0) {
+        throw std::logic_error(
+            "Kafka record-time recovery participant completed twice");
+      }
+      --record_time_recoveries_pending_;
+      if (record_time_recoveries_pending_ != 0) {
+        return;
+      }
+      auto &state = at(OutputChannel::Subscription);
+      state.recovery_limits = {};
+      if (accepting_ && !state.values.empty()) {
+        state.wake_outstanding = true;
+        generation = ++state.generation;
+        wake = state.sender;
+      }
+    }
+    if (wake.valid()) {
+      wake.send(generation);
+    }
+  }
+
   void stop() noexcept {
     std::lock_guard lock{mutex_};
     accepting_ = false;
@@ -131,9 +194,13 @@ public:
       channel.control_bytes = 0;
       channel.reserved_records = 0;
       channel.reserved_bytes = 0;
+      channel.recovery_records = 0;
+      channel.recovery_bytes = 0;
+      channel.recovery_limits = {};
       channel.wake_outstanding = false;
       channel.sender = PushSourceSender{};
     }
+    record_time_recoveries_pending_ = 0;
     subscription_delivered_ = {};
   }
 
@@ -155,12 +222,17 @@ public:
 
   [[nodiscard]] bool push(OutputChannel channel, Value value,
                           std::size_t retained_bytes) {
-    return push_impl(channel, std::move(value), retained_bytes, false);
+    return push_impl(channel, std::move(value), retained_bytes, false, false);
+  }
+
+  [[nodiscard]] bool push_recovery(OutputChannel channel, Value value,
+                                   std::size_t retained_bytes) {
+    return push_impl(channel, std::move(value), retained_bytes, false, true);
   }
 
   [[nodiscard]] bool push_control(OutputChannel channel, Value value,
                                   std::size_t retained_bytes) {
-    return push_impl(channel, std::move(value), retained_bytes, true);
+    return push_impl(channel, std::move(value), retained_bytes, true, false);
   }
 
   [[nodiscard]] std::optional<QueuedOutput> pop(OutputChannel channel) {
@@ -170,6 +242,10 @@ public:
       auto &state = at(channel);
       if (state.values.empty()) {
         state.wake_outstanding = false;
+        return std::nullopt;
+      }
+      if (state.values.front().recovery &&
+          record_time_recoveries_pending_ != 0) {
         return std::nullopt;
       }
 
@@ -183,7 +259,12 @@ public:
         --state.payload_records;
         state.payload_bytes -= item.retained_bytes;
       }
-      result.emplace(QueuedOutput{std::move(item.value), item.evaluation_time});
+      if (item.recovery) {
+        --state.recovery_records;
+        state.recovery_bytes -= item.retained_bytes;
+      }
+      result.emplace(
+          QueuedOutput{std::move(item.value), item.evaluation_time, false});
 
       if (state.values.empty()) {
         state.wake_outstanding = false;
@@ -199,7 +280,8 @@ public:
       return std::nullopt;
     }
     const auto &item = state.values.front();
-    return QueuedOutput{item.value.clone(), item.evaluation_time};
+    return QueuedOutput{item.value.clone(), item.evaluation_time,
+                        item.recovery && record_time_recoveries_pending_ != 0};
   }
 
   [[nodiscard]] std::size_t pending(OutputChannel channel) const {
@@ -260,6 +342,10 @@ public:
         --state.payload_records;
         state.payload_bytes -= item->retained_bytes;
       }
+      if (item->recovery) {
+        --state.recovery_records;
+        state.recovery_bytes -= item->retained_bytes;
+      }
       item = state.values.erase(item);
     }
     if (state.values.empty()) {
@@ -291,6 +377,17 @@ public:
                state.limits.bytes -
                    std::min(state.payload_bytes + state.reserved_bytes,
                             state.limits.bytes);
+  }
+
+  [[nodiscard]] bool can_accept_recovery(OutputChannel channel,
+                                         std::size_t retained_bytes) const {
+    std::lock_guard lock{mutex_};
+    const auto &state = at(channel);
+    return accepting_ && record_time_recoveries_pending_ != 0 &&
+           state.recovery_records < state.recovery_limits.records &&
+           retained_bytes <=
+               state.recovery_limits.bytes -
+                   std::min(state.recovery_bytes, state.recovery_limits.bytes);
   }
 
   [[nodiscard]] bool reserve(OutputChannel channel,
@@ -364,7 +461,8 @@ public:
 
 private:
   [[nodiscard]] bool push_impl(OutputChannel channel, Value value,
-                               std::size_t retained_bytes, bool control) {
+                               std::size_t retained_bytes, bool control,
+                               bool recovery) {
     PushSourceSender wake;
     Int generation{};
     {
@@ -374,12 +472,22 @@ private:
       const auto records =
           control ? state.control_records : state.payload_records;
       const auto bytes = control ? state.control_bytes : state.payload_bytes;
-      if (!accepting_ || limits.records == 0 || limits.bytes == 0 ||
-          records + (control ? 0 : state.reserved_records) >= limits.records ||
-          retained_bytes >
-              limits.bytes -
-                  std::min(bytes + (control ? 0 : state.reserved_bytes),
-                           limits.bytes)) {
+      const bool recovery_full =
+          recovery &&
+          (record_time_recoveries_pending_ == 0 ||
+           state.recovery_records >= state.recovery_limits.records ||
+           retained_bytes >
+               state.recovery_limits.bytes -
+                   std::min(state.recovery_bytes, state.recovery_limits.bytes));
+      const bool ordinary_full =
+          !recovery &&
+          (limits.records == 0 || limits.bytes == 0 ||
+           records + (control ? 0 : state.reserved_records) >= limits.records ||
+           retained_bytes >
+               limits.bytes -
+                   std::min(bytes + (control ? 0 : state.reserved_bytes),
+                            limits.bytes));
+      if (!accepting_ || recovery_full || ordinary_full) {
         return false;
       }
       state.retained_bytes += retained_bytes;
@@ -390,7 +498,11 @@ private:
         ++state.payload_records;
         state.payload_bytes += retained_bytes;
       }
-      QueuedValue item{std::move(value), retained_bytes, control};
+      if (recovery) {
+        ++state.recovery_records;
+        state.recovery_bytes += retained_bytes;
+      }
+      QueuedValue item{std::move(value), retained_bytes, control, recovery};
       item.evaluation_time = queued_evaluation_time(channel, item.value);
       inherit_subscription_schedule(channel, state, item);
       const auto position = insertion_point(channel, state, item);
@@ -411,6 +523,7 @@ private:
     Value value{};
     std::size_t retained_bytes{};
     bool control{};
+    bool recovery{};
     std::optional<DateTime> evaluation_time{};
   };
 
@@ -425,6 +538,9 @@ private:
     std::size_t control_bytes{};
     std::size_t reserved_records{};
     std::size_t reserved_bytes{};
+    std::size_t recovery_records{};
+    std::size_t recovery_bytes{};
+    OutputLimits recovery_limits{};
     PushSourceSender sender{};
     Int generation{};
     bool wake_outstanding{};
@@ -500,6 +616,7 @@ private:
   mutable std::mutex mutex_{};
   std::array<Channel, static_cast<std::size_t>(OutputChannel::Count)> channels_;
   bool accepting_{};
+  std::size_t record_time_recoveries_pending_{};
   std::function<void(Value)> subscription_delivered_{};
 };
 
@@ -551,6 +668,9 @@ struct SubscriptionDrainNode {
        Out<TSD<KafkaSubscriptionKey, KafkaSubscriptionOutput>> out) {
     auto next = bridge.value().value->peek(OutputChannel::Subscription);
     if (!next.has_value()) {
+      return;
+    }
+    if (next->recovery_blocked) {
       return;
     }
     if (next->evaluation_time.has_value() &&

--- a/extensions/kafka/src/detail/service_bridge.h
+++ b/extensions/kafka/src/detail/service_bridge.h
@@ -152,8 +152,27 @@ public:
           add_saturated(state.recovery_limits.bytes,
                         multiply_saturated(state.limits.bytes, participants));
     }
+    if (record_time_recovery_controls_pending_ == 0) {
+      state.recovery_control_limits = OutputLimits{
+          add_saturated(
+              state.control_records,
+              multiply_saturated(state.control_limits.records, participants)),
+          add_saturated(
+              state.control_bytes,
+              multiply_saturated(state.control_limits.bytes, participants)),
+      };
+    } else {
+      state.recovery_control_limits.records = add_saturated(
+          state.recovery_control_limits.records,
+          multiply_saturated(state.control_limits.records, participants));
+      state.recovery_control_limits.bytes = add_saturated(
+          state.recovery_control_limits.bytes,
+          multiply_saturated(state.control_limits.bytes, participants));
+    }
     record_time_recoveries_pending_ =
         add_saturated(record_time_recoveries_pending_, participants);
+    record_time_recovery_controls_pending_ =
+        add_saturated(record_time_recovery_controls_pending_, participants);
   }
 
   void complete_record_time_recovery() {
@@ -182,6 +201,18 @@ public:
     }
   }
 
+  void finish_record_time_recovery() {
+    std::lock_guard lock{mutex_};
+    if (record_time_recovery_controls_pending_ == 0) {
+      throw std::logic_error(
+          "Kafka record-time recovery participant finished twice");
+    }
+    --record_time_recovery_controls_pending_;
+    if (record_time_recovery_controls_pending_ == 0) {
+      at(OutputChannel::Subscription).recovery_control_limits = {};
+    }
+  }
+
   void stop() noexcept {
     std::lock_guard lock{mutex_};
     accepting_ = false;
@@ -197,10 +228,12 @@ public:
       channel.recovery_records = 0;
       channel.recovery_bytes = 0;
       channel.recovery_limits = {};
+      channel.recovery_control_limits = {};
       channel.wake_outstanding = false;
       channel.sender = PushSourceSender{};
     }
     record_time_recoveries_pending_ = 0;
+    record_time_recovery_controls_pending_ = 0;
     subscription_delivered_ = {};
   }
 
@@ -468,7 +501,9 @@ private:
     {
       std::lock_guard lock{mutex_};
       auto &state = at(channel);
-      const auto limits = control ? state.control_limits : state.limits;
+      const auto limits = control && record_time_recovery_controls_pending_ != 0
+                              ? state.recovery_control_limits
+                              : (control ? state.control_limits : state.limits);
       const auto records =
           control ? state.control_records : state.payload_records;
       const auto bytes = control ? state.control_bytes : state.payload_bytes;
@@ -541,6 +576,7 @@ private:
     std::size_t recovery_records{};
     std::size_t recovery_bytes{};
     OutputLimits recovery_limits{};
+    OutputLimits recovery_control_limits{};
     PushSourceSender sender{};
     Int generation{};
     bool wake_outstanding{};
@@ -617,6 +653,7 @@ private:
   std::array<Channel, static_cast<std::size_t>(OutputChannel::Count)> channels_;
   bool accepting_{};
   std::size_t record_time_recoveries_pending_{};
+  std::size_t record_time_recovery_controls_pending_{};
   std::function<void(Value)> subscription_delivered_{};
 };
 

--- a/extensions/kafka/src/librdkafka_service.cpp
+++ b/extensions/kafka/src/librdkafka_service.cpp
@@ -7,6 +7,7 @@
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/static_node.h>
 #include <hgraph/types/value/value_builder.h>
+#include <hgraph/util/scope.h>
 
 #if defined(__GNUC__)
 #pragma GCC diagnostic push
@@ -638,6 +639,12 @@ public:
   void wait_until_preloaded();
   void stop() noexcept;
   void commit(Value cursor);
+  void coordinate_record_time_recovery() noexcept {
+    record_time_recovery_participant_ = true;
+  }
+  [[nodiscard]] bool uses_record_time_recovery() const noexcept {
+    return spec_.recovery_clock == KafkaRecoveryClock::RecordTimestamp;
+  }
   [[nodiscard]] bool matches_key(const ValueView &key) const {
     return key_.view().equals(key);
   }
@@ -692,6 +699,7 @@ private:
   void emit_state(KafkaSubscriptionState state,
                   std::optional<DateTime> evaluation_time = std::nullopt);
   void complete_preload(Str error = {});
+  void abandon_record_time_recovery() noexcept;
 
   KafkaRuntime &owner_;
   Value key_{};
@@ -717,6 +725,8 @@ private:
   std::deque<BufferedRecord> recovery_records_{};
   std::size_t recovery_bytes_{};
   std::optional<DateTime> last_recovery_evaluation_time_{};
+  bool record_time_recovery_participant_{};
+  bool record_time_recovery_arrived_{};
   std::mutex preload_mutex_{};
   std::condition_variable preload_changed_{};
   bool preload_complete_{};
@@ -780,55 +790,78 @@ public:
     bridge_.value->stop();
   }
 
-  void add_subscription(Value key) {
-    SubscriptionSpec spec = parse_subscription(key.view());
-    if (spec.stop_kind == KafkaStopPositionKind::GraphLifetime) {
-      spec.stop_kind = simulation_ ? KafkaStopPositionKind::Snapshot
-                                   : KafkaStopPositionKind::Unbounded;
+  void add_subscriptions(std::vector<Value> keys) {
+    std::vector<std::unique_ptr<ConsumerSession>> additions;
+    additions.reserve(keys.size());
+    for (auto &key : keys) {
+      SubscriptionSpec spec = parse_subscription(key.view());
+      if (spec.stop_kind == KafkaStopPositionKind::GraphLifetime) {
+        spec.stop_kind = simulation_ ? KafkaStopPositionKind::Snapshot
+                                     : KafkaStopPositionKind::Unbounded;
+      }
+      const auto identity_is_live = [&](const auto &session) {
+        return session->identity() == spec.identity;
+      };
+      if (std::ranges::any_of(sessions_, identity_is_live) ||
+          std::ranges::any_of(additions, identity_is_live)) {
+        throw std::invalid_argument("Kafka subscription identity '" +
+                                    spec.identity +
+                                    "' is already live with a different key");
+      }
+      if (simulation_ &&
+          spec.recovery_clock != KafkaRecoveryClock::RecordTimestamp) {
+        throw std::invalid_argument(
+            "Kafka simulation subscriptions require RecordTimestamp recovery");
+      }
+      if (simulation_ && spec.stop_kind == KafkaStopPositionKind::Unbounded) {
+        throw std::invalid_argument(
+            "Kafka simulation subscriptions must have a bounded stop position");
+      }
+      if (simulation_ && spec.merge_policy !=
+                             KafkaMergePolicy::TimestampTopicPartitionOffset) {
+        throw std::invalid_argument(
+            "Kafka simulation subscriptions require "
+            "TimestampTopicPartitionOffset recovery ordering");
+      }
+      if (simulation_ && spec.commit_mode == KafkaCommitMode::OnGraphDelivery) {
+        throw std::invalid_argument(
+            "Kafka simulation subscriptions cannot commit on graph delivery");
+      }
+      additions.push_back(std::make_unique<ConsumerSession>(
+          *this, std::move(key), std::move(spec)));
     }
-    if (std::ranges::any_of(sessions_, [&](const auto &session) {
-          return session->identity() == spec.identity;
-        })) {
-      throw std::invalid_argument("Kafka subscription identity '" +
-                                  spec.identity +
-                                  "' is already live with a different key");
+
+    const auto record_time_participants = static_cast<std::size_t>(
+        std::ranges::count_if(additions, [](const auto &session) {
+          return session->uses_record_time_recovery();
+        }));
+    sessions_.reserve(sessions_.size() + additions.size());
+    begin_record_time_recovery(record_time_participants);
+    for (auto &session : additions) {
+      if (session->uses_record_time_recovery()) {
+        session->coordinate_record_time_recovery();
+      }
     }
-    if (simulation_ &&
-        spec.recovery_clock != KafkaRecoveryClock::RecordTimestamp) {
-      throw std::invalid_argument(
-          "Kafka simulation subscriptions require RecordTimestamp recovery");
+
+    auto rollback = make_scope_exit<true>([&] {
+      for (auto &session : additions) {
+        if (session) {
+          session->stop();
+        }
+      }
+    });
+    for (auto &session : additions) {
+      session->start();
     }
-    if (simulation_ && spec.stop_kind == KafkaStopPositionKind::Unbounded) {
-      throw std::invalid_argument(
-          "Kafka simulation subscriptions must have a bounded stop position");
-    }
-    if (simulation_ &&
-        spec.merge_policy != KafkaMergePolicy::TimestampTopicPartitionOffset) {
-      throw std::invalid_argument(
-          "Kafka simulation subscriptions require "
-          "TimestampTopicPartitionOffset recovery ordering");
-    }
-    if (simulation_ && spec.commit_mode == KafkaCommitMode::OnGraphDelivery) {
-      throw std::invalid_argument(
-          "Kafka simulation subscriptions cannot commit on graph delivery");
-    }
-    auto session =
-        std::make_unique<ConsumerSession>(*this, key.clone(), std::move(spec));
-    if (simulation_ && sessions_.size() >= simulation_ingress_slots_) {
-      // Each session buffers at most one configured ingress window before it
-      // hands recovery to the shared bridge.  Simulation must finish that
-      // finite hand-off before graph evaluation starts, so reserve one bridge
-      // window per concurrently live session instead of letting an earlier
-      // session block every later preload behind the shared queue.
-      bridge_.value->add_capacity(OutputChannel::Subscription, config_.ingress,
-                                  subscription_control_limits(config_.ingress));
-      ++simulation_ingress_slots_;
-    }
-    session->start();
     if (simulation_) {
-      session->wait_until_preloaded();
+      for (auto &session : additions) {
+        session->wait_until_preloaded();
+      }
     }
-    sessions_.push_back(std::move(session));
+    for (auto &session : additions) {
+      sessions_.push_back(std::move(session));
+    }
+    rollback.release();
   }
 
   void remove_subscription(const ValueView &key) {
@@ -975,6 +1008,12 @@ public:
                                      retained_bytes);
   }
 
+  [[nodiscard]] bool
+  recovery_ingress_can_accept(std::size_t retained_bytes) const {
+    return bridge_.value->can_accept_recovery(OutputChannel::Subscription,
+                                              retained_bytes);
+  }
+
   bool
   emit_subscription(Value key, std::optional<Value> record,
                     std::optional<Value> cursor, KafkaSubscriptionState state,
@@ -985,6 +1024,64 @@ public:
         subscription_envelope(std::move(key), std::move(record),
                               std::move(cursor), state, evaluation_time),
         retained_bytes);
+  }
+
+  bool emit_recovery_subscription(Value key, std::optional<Value> record,
+                                  std::optional<Value> cursor,
+                                  KafkaSubscriptionState state,
+                                  std::size_t retained_bytes,
+                                  std::optional<DateTime> evaluation_time) {
+    return bridge_.value->push_recovery(
+        OutputChannel::Subscription,
+        subscription_envelope(std::move(key), std::move(record),
+                              std::move(cursor), state, evaluation_time),
+        retained_bytes);
+  }
+
+  void begin_record_time_recovery(std::size_t participants) {
+    if (participants == 0) {
+      return;
+    }
+    std::lock_guard lock{recovery_mutex_};
+    if (participants > std::numeric_limits<std::size_t>::max() -
+                           record_time_recoveries_pending_) {
+      throw std::overflow_error(
+          "Kafka record-time recovery participant count overflowed");
+    }
+    bridge_.value->begin_record_time_recovery(participants);
+    record_time_recoveries_pending_ += participants;
+  }
+
+  void record_time_recovery_ready(std::optional<DateTime> tail) {
+    std::lock_guard lock{recovery_mutex_};
+    if (record_time_recoveries_pending_ == 0) {
+      throw std::logic_error(
+          "Kafka record-time recovery participant completed twice");
+    }
+    if (tail.has_value() && (!record_time_recovery_tail_.has_value() ||
+                             *tail > *record_time_recovery_tail_)) {
+      record_time_recovery_tail_ = *tail;
+    }
+    bridge_.value->complete_record_time_recovery();
+    --record_time_recoveries_pending_;
+  }
+
+  void cancel_record_time_recovery() noexcept {
+    try {
+      std::lock_guard lock{recovery_mutex_};
+      if (record_time_recoveries_pending_ == 0) {
+        return;
+      }
+      bridge_.value->complete_record_time_recovery();
+      --record_time_recoveries_pending_;
+    } catch (...) {
+    }
+  }
+
+  [[nodiscard]] std::pair<bool, std::optional<DateTime>>
+  record_time_recovery_status() const {
+    std::lock_guard lock{recovery_mutex_};
+    return {record_time_recoveries_pending_ == 0, record_time_recovery_tail_};
   }
 
   void emit_subscription_state(
@@ -1381,9 +1478,11 @@ private:
   ServiceBridgeHandle bridge_{};
   std::int64_t graph_start_ms_{};
   bool simulation_{};
-  std::size_t simulation_ingress_slots_{1};
   std::atomic<bool> accepting_{};
   std::vector<std::unique_ptr<ConsumerSession>> sessions_{};
+  mutable std::mutex recovery_mutex_{};
+  std::size_t record_time_recoveries_pending_{};
+  std::optional<DateTime> record_time_recovery_tail_{};
   rd_kafka_t *producer_{};
   std::thread producer_thread_{};
   std::mutex producer_mutex_{};
@@ -1438,6 +1537,15 @@ void ConsumerSession::stop() noexcept {
   if (thread_.joinable()) {
     thread_.join();
   }
+  abandon_record_time_recovery();
+}
+
+void ConsumerSession::abandon_record_time_recovery() noexcept {
+  if (!record_time_recovery_participant_ || record_time_recovery_arrived_) {
+    return;
+  }
+  record_time_recovery_arrived_ = true;
+  owner_.cancel_record_time_recovery();
 }
 
 void ConsumerSession::commit(Value cursor) {
@@ -1746,12 +1854,20 @@ void ConsumerSession::configure_assignment(
              });
     };
     if (starts_reached(stop_ends_)) {
-      complete_bounded();
+      if (buffers_recovery()) {
+        prepare_recovery_flush(consumer, true);
+      } else {
+        complete_bounded();
+      }
     } else if (starts_reached(recovery_ends_)) {
-      recovering_ = false;
-      live_ = true;
-      emit_state(KafkaSubscriptionState::Live);
-      complete_preload();
+      if (buffers_recovery()) {
+        prepare_recovery_flush(consumer, false);
+      } else {
+        recovering_ = false;
+        live_ = true;
+        emit_state(KafkaSubscriptionState::Live);
+        complete_preload();
+      }
     }
     if (paused_) {
       auto *assigned = rd_kafka_topic_partition_list_copy(partitions);
@@ -2208,7 +2324,12 @@ void ConsumerSession::prepare_recovery_flush(rd_kafka_t *consumer,
 void ConsumerSession::flush_recovery_records(rd_kafka_t *consumer) {
   while (!recovery_records_.empty()) {
     auto &front = recovery_records_.front();
-    if (!owner_.ingress_can_accept(front.retained_bytes)) {
+    const bool coordinated_record_time = record_time_recovery_participant_;
+    const bool can_accept =
+        coordinated_record_time
+            ? owner_.recovery_ingress_can_accept(front.retained_bytes)
+            : owner_.ingress_can_accept(front.retained_bytes);
+    if (!can_accept) {
       return;
     }
 
@@ -2229,16 +2350,39 @@ void ConsumerSession::flush_recovery_records(rd_kafka_t *consumer) {
       evaluation_time = candidate;
     }
 
-    const bool pushed = owner_.emit_subscription(
-        key_.clone(), std::move(front.record), std::move(front.cursor),
-        KafkaSubscriptionState::Recovering, front.retained_bytes,
-        evaluation_time);
+    const bool pushed =
+        coordinated_record_time
+            ? owner_.emit_recovery_subscription(
+                  key_.clone(), std::move(front.record),
+                  std::move(front.cursor), KafkaSubscriptionState::Recovering,
+                  front.retained_bytes, evaluation_time)
+            : owner_.emit_subscription(key_.clone(), std::move(front.record),
+                                       std::move(front.cursor),
+                                       KafkaSubscriptionState::Recovering,
+                                       front.retained_bytes, evaluation_time);
     if (!pushed) {
       throw std::logic_error(
           "Kafka recovery queue capacity changed after reservation");
     }
     recovery_bytes_ -= front.retained_bytes;
     recovery_records_.erase(recovery_records_.begin());
+  }
+
+  if (record_time_recovery_participant_) {
+    if (!record_time_recovery_arrived_) {
+      owner_.record_time_recovery_ready(last_recovery_evaluation_time_);
+      record_time_recovery_arrived_ = true;
+    }
+    auto [released, recovery_tail] = owner_.record_time_recovery_status();
+    if (!released) {
+      return;
+    }
+    if (recovery_tail.has_value() &&
+        (!last_recovery_evaluation_time_.has_value() ||
+         *recovery_tail > *last_recovery_evaluation_time_)) {
+      last_recovery_evaluation_time_ = *recovery_tail;
+    }
+    record_time_recovery_participant_ = false;
   }
 
   recovery_ready_ = false;
@@ -2438,7 +2582,11 @@ void ConsumerSession::check_positions(rd_kafka_t *consumer) {
       emit_state(KafkaSubscriptionState::Live);
     }
   } else if (stop_reached) {
-    complete_bounded();
+    if (buffers_recovery()) {
+      prepare_recovery_flush(consumer, true);
+    } else {
+      complete_bounded();
+    }
   }
   rd_kafka_topic_partition_list_destroy(positions);
 }
@@ -2560,8 +2708,12 @@ struct KafkaRuntimeNode {
       for (const auto key : erased.removed()) {
         runtime->remove_subscription(key);
       }
+      std::vector<Value> additions;
       for (const auto key : erased.added()) {
-        runtime->add_subscription(key.clone());
+        additions.push_back(key.clone());
+      }
+      if (!additions.empty()) {
+        runtime->add_subscriptions(std::move(additions));
       }
     }
 

--- a/extensions/kafka/src/librdkafka_service.cpp
+++ b/extensions/kafka/src/librdkafka_service.cpp
@@ -727,6 +727,7 @@ private:
   std::optional<DateTime> last_recovery_evaluation_time_{};
   bool record_time_recovery_participant_{};
   bool record_time_recovery_arrived_{};
+  bool record_time_recovery_finished_{};
   std::mutex preload_mutex_{};
   std::condition_variable preload_changed_{};
   bool preload_complete_{};
@@ -1066,14 +1067,22 @@ public:
     --record_time_recoveries_pending_;
   }
 
-  void cancel_record_time_recovery() noexcept {
+  void finish_record_time_recovery() {
+    std::lock_guard lock{recovery_mutex_};
+    bridge_.value->finish_record_time_recovery();
+  }
+
+  void cancel_record_time_recovery(bool already_ready) noexcept {
     try {
       std::lock_guard lock{recovery_mutex_};
-      if (record_time_recoveries_pending_ == 0) {
-        return;
+      if (!already_ready) {
+        if (record_time_recoveries_pending_ == 0) {
+          return;
+        }
+        bridge_.value->complete_record_time_recovery();
+        --record_time_recoveries_pending_;
       }
-      bridge_.value->complete_record_time_recovery();
-      --record_time_recoveries_pending_;
+      bridge_.value->finish_record_time_recovery();
     } catch (...) {
     }
   }
@@ -1541,11 +1550,13 @@ void ConsumerSession::stop() noexcept {
 }
 
 void ConsumerSession::abandon_record_time_recovery() noexcept {
-  if (!record_time_recovery_participant_ || record_time_recovery_arrived_) {
+  if (!record_time_recovery_participant_ || record_time_recovery_finished_) {
     return;
   }
+  owner_.cancel_record_time_recovery(record_time_recovery_arrived_);
   record_time_recovery_arrived_ = true;
-  owner_.cancel_record_time_recovery();
+  record_time_recovery_finished_ = true;
+  record_time_recovery_participant_ = false;
 }
 
 void ConsumerSession::commit(Value cursor) {
@@ -1600,6 +1611,8 @@ void ConsumerSession::error_callback(rd_kafka_t *, int error, const char *,
 }
 
 void ConsumerSession::run() noexcept {
+  auto release_recovery_participation =
+      make_scope_exit<true>([this] { abandon_record_time_recovery(); });
   rd_kafka_t *consumer = nullptr;
   try {
     KafkaConfPtr conf{rd_kafka_conf_new()};
@@ -2368,7 +2381,8 @@ void ConsumerSession::flush_recovery_records(rd_kafka_t *consumer) {
     recovery_records_.erase(recovery_records_.begin());
   }
 
-  if (record_time_recovery_participant_) {
+  const bool coordinated_record_time = record_time_recovery_participant_;
+  if (coordinated_record_time) {
     if (!record_time_recovery_arrived_) {
       owner_.record_time_recovery_ready(last_recovery_evaluation_time_);
       record_time_recovery_arrived_ = true;
@@ -2382,7 +2396,6 @@ void ConsumerSession::flush_recovery_records(rd_kafka_t *consumer) {
          *recovery_tail > *last_recovery_evaluation_time_)) {
       last_recovery_evaluation_time_ = *recovery_tail;
     }
-    record_time_recovery_participant_ = false;
   }
 
   recovery_ready_ = false;
@@ -2411,6 +2424,11 @@ void ConsumerSession::flush_recovery_records(rd_kafka_t *consumer) {
   }
   if (bounded_after_recovery_) {
     complete_bounded();
+    if (coordinated_record_time) {
+      owner_.finish_record_time_recovery();
+      record_time_recovery_finished_ = true;
+      record_time_recovery_participant_ = false;
+    }
     return;
   }
   live_ = true;
@@ -2419,6 +2437,11 @@ void ConsumerSession::flush_recovery_records(rd_kafka_t *consumer) {
       last_recovery_evaluation_time_.has_value()
           ? std::optional<DateTime>{*last_recovery_evaluation_time_ + MIN_TD}
           : std::nullopt);
+  if (coordinated_record_time) {
+    owner_.finish_record_time_recovery();
+    record_time_recovery_finished_ = true;
+    record_time_recovery_participant_ = false;
+  }
   complete_preload();
 }
 
@@ -2492,8 +2515,15 @@ void ConsumerSession::process_commits(rd_kafka_t *consumer) {
 }
 
 void ConsumerSession::update_flow_control(rd_kafka_t *consumer) {
-  const bool should_pause =
-      !paused_ && !recovery_paused_ && owner_.ingress_at_high_watermark();
+  // A coordinated participant must reach its captured snapshot before the
+  // shared recovery drain can open. Its local recovery buffer is independently
+  // bounded, so another participant's already-staged records must not pause it
+  // behind the very barrier it is responsible for releasing.
+  const bool loading_coordinated_recovery =
+      record_time_recovery_participant_ && !recovery_ready_;
+  const bool should_pause = !loading_coordinated_recovery && !paused_ &&
+                            !recovery_paused_ &&
+                            owner_.ingress_at_high_watermark();
   const bool should_resume =
       paused_ && !recovery_ready_ && owner_.ingress_below_low_watermark();
   if (!should_pause && !should_resume) {

--- a/extensions/kafka/tests/test_service.cpp
+++ b/extensions/kafka/tests/test_service.cpp
@@ -2072,6 +2072,83 @@ void test_record_time_recovery_hands_off_before_live_records() {
           "the live handoff did not follow the timestamped recovery tail");
 }
 
+void test_record_time_recovery_waits_for_independent_subscriptions() {
+  MockCluster cluster;
+  cluster.create_topic(Str{"typed-recovery-cohort-early"});
+  cluster.create_topic(Str{"typed-recovery-cohort-late"});
+  const DateTime early_time{
+      std::chrono::duration_cast<TimeDelta>(
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+              wall_now().time_since_epoch())) +
+      TimeDelta{1'000'000}};
+  const DateTime late_time = early_time + TimeDelta{500'000};
+  const DateTime second_early_time = early_time + TimeDelta{1'000'000};
+  const DateTime second_late_time = early_time + TimeDelta{1'500'000};
+  // Seed the later stream first. Consumer sessions recover independently, so
+  // broker/poll timing must not let it enter the graph before the earlier
+  // stream has established the same recovery cohort's complete merge set.
+  cluster.seed_record(Str{"typed-recovery-cohort-late"}, Bytes{"late-1"},
+                      std::nullopt, {}, 0, late_time);
+  cluster.seed_record(Str{"typed-recovery-cohort-late"}, Bytes{"late-2"},
+                      std::nullopt, {}, 0, second_late_time);
+  cluster.seed_record(Str{"typed-recovery-cohort-early"}, Bytes{"early-1"},
+                      std::nullopt, {}, 0, early_time);
+  cluster.seed_record(Str{"typed-recovery-cohort-early"}, Bytes{"early-2"},
+                      std::nullopt, {}, 0, second_early_time);
+
+  production_config = hgraph::kafka::service_config()
+                          .bootstrap_servers({cluster.bootstrap_servers()})
+                          .client_id(Str{"typed-recovery-cohort"})
+                          .ingress_limits(Int{2}, Int{4096})
+                          .build();
+  subscription_key =
+      hgraph::kafka::subscription_key()
+          .partitions({{Str{"typed-recovery-cohort-early"}, Int{0}}})
+          .group_id(Str{"typed-recovery-cohort-early"})
+          .start(make_start_position(KafkaStartPositionKind::Earliest))
+          .stop(make_stop_position(KafkaStopPositionKind::Snapshot))
+          .recovery_clock(KafkaRecoveryClock::RecordTimestamp)
+          .merge_policy(KafkaMergePolicy::TimestampTopicPartitionOffset)
+          .sharing_identity(Str{"typed-recovery-cohort-early"})
+          .build();
+  secondary_subscription_key =
+      hgraph::kafka::subscription_key()
+          .partitions({{Str{"typed-recovery-cohort-late"}, Int{0}}})
+          .group_id(Str{"typed-recovery-cohort-late"})
+          .start(make_start_position(KafkaStartPositionKind::Earliest))
+          .stop(make_stop_position(KafkaStopPositionKind::Snapshot))
+          .recovery_clock(KafkaRecoveryClock::RecordTimestamp)
+          .merge_policy(KafkaMergePolicy::TimestampTopicPartitionOffset)
+          .sharing_identity(Str{"typed-recovery-cohort-late"})
+          .build();
+  bounded_payloads.clear();
+  multi_bounded_records.clear();
+  multi_bounded_complete_count = 0;
+
+  auto executor = start_realtime(build_graph<MultiBoundedSubscriptionGraph>(),
+                                 TimeDelta{5'000'000});
+  auto view = executor.view();
+  AsyncGraphExecutorRun runner{view};
+  runner.join();
+
+  require(bounded_payloads == std::vector<Str>{Str{"early-1"}, Str{"late-1"},
+                                               Str{"early-2"}, Str{"late-2"}},
+          "an independently recovered topic was replayed before the complete "
+          "record-time cohort was available");
+  require(multi_bounded_records ==
+              std::vector<std::pair<Str, DateTime>>{
+                  {Str{"early-1"}, early_time},
+                  {Str{"late-1"}, late_time},
+                  {Str{"early-2"}, second_early_time},
+                  {Str{"late-2"}, second_late_time}},
+          "independent recovery streams did not retain their globally merged "
+          "Kafka event times");
+  require(multi_bounded_complete_count == 2,
+          "the record-time recovery cohort did not complete both streams "
+          "(completed=" +
+              std::to_string(multi_bounded_complete_count) + ")");
+}
+
 void test_graph_lifetime_stop_is_bounded_in_simulation() {
   MockCluster cluster;
   cluster.create_topic(Str{"simulation-record-time"});
@@ -2327,6 +2404,7 @@ int main() {
     test_commit_modes_and_monotonic_explicit_commits();
     test_record_time_recovery_is_deterministically_merged();
     test_record_time_recovery_hands_off_before_live_records();
+    test_record_time_recovery_waits_for_independent_subscriptions();
     test_graph_lifetime_stop_is_bounded_in_simulation();
     test_multiple_simulation_subscriptions_replay_at_record_time();
     test_real_broker_publish_subscribe_and_commit_round_trip();

--- a/extensions/kafka/tests/test_service.cpp
+++ b/extensions/kafka/tests/test_service.cpp
@@ -225,6 +225,7 @@ inline std::vector<DateTime> bounded_evaluation_times{};
 inline std::vector<std::pair<Str, DateTime>> multi_bounded_records{};
 inline std::vector<std::pair<Str, DateTime>> recovery_live_records{};
 inline std::size_t multi_bounded_complete_count{};
+inline std::size_t multi_bounded_failed_count{};
 inline std::vector<Int> backlog_offsets{};
 inline std::vector<Str> backlog_events{};
 inline std::vector<Str> flow_control_events{};
@@ -579,12 +580,18 @@ struct MultiBoundedSubscriptionCapture {
       }
     }
     auto state = subscription.template field<"state">();
-    if (state.valid() && state.modified() &&
-        state.value() == KafkaSubscriptionState::BoundedComplete) {
+    if (!state.valid() || !state.modified()) {
+      return;
+    }
+    if (state.value() == KafkaSubscriptionState::BoundedComplete) {
       ++multi_bounded_complete_count;
-      if (multi_bounded_complete_count == 2) {
-        node.graph().executor().request_stop();
-      }
+    } else if (state.value() == KafkaSubscriptionState::Failed) {
+      ++multi_bounded_failed_count;
+    }
+    if (multi_bounded_complete_count == 2 ||
+        (multi_bounded_complete_count == 1 &&
+         multi_bounded_failed_count == 1)) {
+      node.graph().executor().request_stop();
     }
   }
 };
@@ -2124,6 +2131,7 @@ void test_record_time_recovery_waits_for_independent_subscriptions() {
   bounded_payloads.clear();
   multi_bounded_records.clear();
   multi_bounded_complete_count = 0;
+  multi_bounded_failed_count = 0;
 
   auto executor = start_realtime(build_graph<MultiBoundedSubscriptionGraph>(),
                                  TimeDelta{5'000'000});
@@ -2131,10 +2139,15 @@ void test_record_time_recovery_waits_for_independent_subscriptions() {
   AsyncGraphExecutorRun runner{view};
   runner.join();
 
+  Str observed_order;
+  for (const auto &payload : bounded_payloads) {
+    observed_order += observed_order.empty() ? payload : Str{", "} + payload;
+  }
   require(bounded_payloads == std::vector<Str>{Str{"early-1"}, Str{"late-1"},
                                                Str{"early-2"}, Str{"late-2"}},
           "an independently recovered topic was replayed before the complete "
-          "record-time cohort was available");
+          "record-time cohort was available (observed: " +
+              observed_order + ")");
   require(multi_bounded_records ==
               std::vector<std::pair<Str, DateTime>>{
                   {Str{"early-1"}, early_time},
@@ -2147,6 +2160,64 @@ void test_record_time_recovery_waits_for_independent_subscriptions() {
           "the record-time recovery cohort did not complete both streams "
           "(completed=" +
               std::to_string(multi_bounded_complete_count) + ")");
+}
+
+void test_record_time_recovery_releases_a_failed_participant() {
+  MockCluster cluster;
+  cluster.create_topic(Str{"typed-recovery-failure-a"});
+  cluster.create_topic(Str{"typed-recovery-failure-b"});
+  const DateTime record_time{
+      std::chrono::duration_cast<TimeDelta>(
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+              wall_now().time_since_epoch())) +
+      TimeDelta{1'000'000}};
+  cluster.seed_record(Str{"typed-recovery-failure-a"}, Bytes{"a"}, std::nullopt,
+                      {}, 0, record_time);
+
+  production_config = hgraph::kafka::service_config()
+                          .bootstrap_servers({cluster.bootstrap_servers()})
+                          .client_id(Str{"typed-recovery-failure"})
+                          .ingress_limits(Int{2}, Int{4096})
+                          .build();
+  subscription_key =
+      hgraph::kafka::subscription_key()
+          .partitions({{Str{"typed-recovery-failure-a"}, Int{0}}})
+          .group_id(Str{"typed-recovery-failure-a"})
+          .start(make_start_position(KafkaStartPositionKind::Earliest))
+          .stop(make_stop_position(KafkaStopPositionKind::Snapshot))
+          .recovery_clock(KafkaRecoveryClock::RecordTimestamp)
+          .merge_policy(KafkaMergePolicy::TimestampTopicPartitionOffset)
+          .sharing_identity(Str{"typed-recovery-failure-a"})
+          .build();
+  secondary_subscription_key =
+      hgraph::kafka::subscription_key()
+          .partitions({{Str{"typed-recovery-failure-b"}, Int{99}}})
+          .group_id(Str{"typed-recovery-failure-b"})
+          .start(make_start_position(KafkaStartPositionKind::Earliest))
+          .stop(make_stop_position(KafkaStopPositionKind::Snapshot))
+          .recovery_clock(KafkaRecoveryClock::RecordTimestamp)
+          .merge_policy(KafkaMergePolicy::TimestampTopicPartitionOffset)
+          .sharing_identity(Str{"typed-recovery-failure-b"})
+          .build();
+  bounded_payloads.clear();
+  multi_bounded_records.clear();
+  multi_bounded_complete_count = 0;
+  multi_bounded_failed_count = 0;
+
+  auto executor = start_realtime(build_graph<MultiBoundedSubscriptionGraph>(),
+                                 TimeDelta{5'000'000});
+  auto view = executor.view();
+  AsyncGraphExecutorRun runner{view};
+  runner.join();
+
+  require(bounded_payloads.size() == 1,
+          "the healthy recovery participant remained blocked after its peer "
+          "failed (records=" +
+              std::to_string(bounded_payloads.size()) +
+              ", complete=" + std::to_string(multi_bounded_complete_count) +
+              ", failed=" + std::to_string(multi_bounded_failed_count) + ")");
+  require(multi_bounded_complete_count == 1 && multi_bounded_failed_count == 1,
+          "the failed recovery participant did not release its cohort");
 }
 
 void test_graph_lifetime_stop_is_bounded_in_simulation() {
@@ -2202,7 +2273,7 @@ void test_multiple_simulation_subscriptions_replay_at_record_time() {
           wall_now().time_since_epoch()))};
   const DateTime record_time = graph_start + TimeDelta{1'000'000};
   std::vector<Str> expected_payloads;
-  for (Int offset = 0; offset < 8; ++offset) {
+  for (Int offset = 0; offset < 3; ++offset) {
     const Str first = Str{"first-"} + std::to_string(offset);
     const Str second = Str{"second-"} + std::to_string(offset);
     cluster.seed_record(Str{"simulation-preload-a"}, Bytes{first}, std::nullopt,
@@ -2216,7 +2287,7 @@ void test_multiple_simulation_subscriptions_replay_at_record_time() {
   production_config = hgraph::kafka::service_config()
                           .bootstrap_servers({cluster.bootstrap_servers()})
                           .client_id(Str{"simulation-multi-preload"})
-                          .ingress_limits(Int{8}, Int{8192})
+                          .ingress_limits(Int{3}, Int{4096})
                           .build();
   subscription_key =
       hgraph::kafka::subscription_key()
@@ -2241,6 +2312,7 @@ void test_multiple_simulation_subscriptions_replay_at_record_time() {
   bounded_payloads.clear();
   multi_bounded_records.clear();
   multi_bounded_complete_count = 0;
+  multi_bounded_failed_count = 0;
 
   static_cast<void>(run_graph(build_graph<MultiBoundedSubscriptionGraph>(),
                               graph_start, record_time + TimeDelta{1'000'000},
@@ -2253,7 +2325,7 @@ void test_multiple_simulation_subscriptions_replay_at_record_time() {
           "graph began draining their shared ingress queue");
   std::ranges::sort(multi_bounded_records, {},
                     &decltype(multi_bounded_records)::value_type::first);
-  require(multi_bounded_records.size() == 16,
+  require(multi_bounded_records.size() == 6,
           "multiple simulation subscriptions did not replay every "
           "timestamped record");
   for (const auto &[payload, evaluation_time] : multi_bounded_records) {
@@ -2405,6 +2477,7 @@ int main() {
     test_record_time_recovery_is_deterministically_merged();
     test_record_time_recovery_hands_off_before_live_records();
     test_record_time_recovery_waits_for_independent_subscriptions();
+    test_record_time_recovery_releases_a_failed_participant();
     test_graph_lifetime_stop_is_bounded_in_simulation();
     test_multiple_simulation_subscriptions_replay_at_record_time();
     test_real_broker_publish_subscribe_and_commit_round_trip();


### PR DESCRIPTION
## Summary

- batch record-time Kafka subscriptions from the same graph delta into one recovery cohort
- hold all timestamped recovery records until every participating subscription has staged its bounded snapshot, then release the globally ordered merge
- keep every participant paused through the barrier and align live/bounded lifecycle transitions behind the cohort's latest recovery time
- give each participant bounded recovery payload and lifecycle-control capacity so cohorts larger than the ordinary shared ingress window cannot deadlock
- release failed participants from both cohort phases on every session exit
- add matching native C++ and Python regressions for independent-topic ordering, constrained simulation ingress, and failed-participant cleanup

## Root cause

The bridge sorted only the records already present in its shared drain. Independent consumer sessions established and transferred their recovery snapshots asynchronously, so one topic's later-timestamped records could be released before another topic had supplied earlier records. Once released into graph time, that order could not be repaired.

A second cycle existed while staging the complete cohort: records from the first topic could fill the ordinary live-ingress watermark and pause another participant before it reached its captured snapshot, even though the graph drain was intentionally blocked on that participant. Failed sessions and lifecycle envelopes also needed explicit cohort-scoped release/capacity.

## Impact

RecordTimestamp subscriptions created together now establish a complete recovery merge set before any recovery payload enters the graph. Cohort loading is bounded independently of live-ingress flow control, failed sessions cannot strand healthy peers, and lifecycle signals retain capacity through preload. Cross-topic correlation is therefore ordered by Kafka event time rather than consumer/poll arrival.

Follow-up to #461 after the cross-topic recovery case exposed a second ordering boundary.

## Validation

- macOS complete native suite: 1584/1584 passed
- macOS Python 3.14 compatibility suite from ABI3 wheel: 2161 passed, 9 skipped
- macOS Kafka native test: passed
- macOS Kafka ABI3 Python suite: 57 passed
- Linux GCC complete native suite: 1583/1583 passed
- Linux Python 3.14 compatibility suite from ABI3 wheel: 2161 passed, 9 skipped
- Linux Kafka native test: passed, including 3 consecutive race-sensitive repeats
- Linux Kafka ABI3 Python suite: 57 passed
- `git diff --check`: passed
