### PR TITLE
Route current-state transfer through erased TSData ops

### DIFF
--- a/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
@@ -136,10 +136,12 @@ The implementation uses the following names consistently:
     ``Output`` roles. Data and Output select mutable role-specific ops; an
     owned Input selects the corresponding physical plan under a read-only
     role, while peered positions select target-link storage and ops.
-    ``TS_DATA_OPS_ABI_VERSION`` is 5. ABI 5 adds the cold-path dynamic-storage
-    attribution hook used by GraphDiagnostics. ABI 4 represented destructive value
-    assignment sources as writable ``ValueView`` pointers rather than owning
-    ``Value&&`` objects.
+    ``TS_DATA_OPS_ABI_VERSION`` is 8. ABI 8 adds recursive source-topology
+    validation to the current-state strategy table introduced by ABI 7. ABI 6
+    added the erased Python-conversion operations. ABI 5 added the cold-path
+    dynamic-storage attribution hook used by GraphDiagnostics. ABI 4 represented
+    destructive value assignment sources as writable ``ValueView`` pointers
+    rather than owning ``Value&&`` objects.
 
 ``TSDataStorageRef<DataOps>``
     The non-owning time-series cursor. Every generic and specialised form is
@@ -456,7 +458,7 @@ runtime implementation identifier. Consequently attach,
 reparent, and invalidation cannot follow a visible TargetLink projection into
 producer-owned storage. This projection is private lifecycle infrastructure;
 it adds no storage-layout cost, and its ops-table ABI contribution is tracked by
-``TS_DATA_OPS_ABI_VERSION``, currently 5.
+``TS_DATA_OPS_ABI_VERSION``, currently 8.
 
 Fixed to-REF alternatives are the exception to the general legacy-alternative
 rule. Their allocation is owned through the canonical Data-role record. At the

--- a/include/hgraph/lib/std/operators/impl/record_replay_memory_impl.h
+++ b/include/hgraph/lib/std/operators/impl/record_replay_memory_impl.h
@@ -99,42 +99,12 @@ namespace hgraph::stdlib
                          Scalar<"sparse", Bool> sparse, Scalar<"model", Str>, GlobalStateView gs,
                          DateTime now)
         {
-            // Record every TICK, plus TICK-window TSW pre-validity ticks: a
-            // window below its min period is invalid yet its delta stream
-            // already flows (hgraph records those). Invalid structural
-            // collection unbinds are also recorded when they carry a real
-            // removal delta over a previously published key set.
             if (!ts.modified()) { return; }
-            if (!ts.valid())
-            {
-                const auto *schema = ts.base().schema();
-                const bool tick_window = schema->kind == TSTypeKind::TSW && !schema->data.tsw.is_duration_based;
-                bool structural_removal = false;
-                if (schema->kind == TSTypeKind::TSS)
-                {
-                    const auto input = ts.base().as_set();
-                    const auto removed = input.removed();
-                    structural_removal = removed.begin() != removed.end();
-                }
-                else if (schema->kind == TSTypeKind::TSD)
-                {
-                    const auto input = ts.base().as_dict();
-                    const auto removed = input.removed_keys();
-                    structural_removal = removed.begin() != removed.end();
-                }
-                if (!structural_removal && !tick_window) { return; }
-            }
             // The canonical per-tick delta, rebuilt as an owned value-layer Value (the
             // runtime's transient delta storage omits copy hooks).
             Value delta = capture_delta(ts.base());
             const auto *schema = ts.base().schema();
-            if (schema->kind == TSTypeKind::TSL && schema->fixed_size() != 0 && delta.view().as_map().empty())
-            {
-                // A fixed structural list can remain historically valid after every
-                // routed REF leaf silently unbinds. Its parent may be scheduled, but
-                // the empty map is not a tick and must remain a dense-buffer hole.
-                return;
-            }
+            if (!delta_is_observable(ts.base(), delta.view())) { return; }
             if (sparse.value())
             {
                 // SPARSE (the harness's __elide__): TYPED (time, delta)

--- a/include/hgraph/lib/std/operators/impl/stream_impl.h
+++ b/include/hgraph/lib/std/operators/impl/stream_impl.h
@@ -659,47 +659,11 @@ namespace hgraph::stdlib
                     const auto &erased = static_cast<const TSOutputView &>(out);
                     if (erased.data_view().last_modified_time() < ts.base().last_modified_time())
                     {
-                        if (erased.schema()->kind == TSTypeKind::TSD)
-                        {
-                            // Dict resync honours per-child TS-VALIDITY (a
-                            // created-but-never-ticked element - e.g. an
-                            // empty-REF map child - is NOT part of the value;
-                            // the raw value memory cannot tell).
-                            auto dict_out = erased.data_view().as_dict();
-                            auto mutation = dict_out.begin_mutation(erased.evaluation_time());
-                            auto dict_in  = ts.base().as_dict();
-                            std::vector<Value> live;
-                            for (auto &&[key, child] : dict_in.valid_items())
-                            {
-                                live.emplace_back(key);
-                                // READ-side compare first (the flip lesson):
-                                // an unchanged entry must not re-record.
-                                if (dict_out.contains(key))
-                                {
-                                    auto current = dict_out.at(key);
-                                    if (current.has_current_value() && current.value().equals(child.value()))
-                                    {
-                                        continue;
-                                    }
-                                }
-                                auto element = mutation.at(key);
-                                apply_current_value(
-                                    TSOutputView{erased.output(), element, erased.evaluation_time()},
-                                    child.value());
-                            }
-                            std::vector<Value> removals;
-                            for (const auto key : mutation.keys())
-                            {
-                                bool present = false;
-                                for (const Value &kept : live)
-                                {
-                                    if (kept.view().equals(key)) { present = true; break; }
-                                }
-                                if (!present) { removals.emplace_back(key); }
-                            }
-                            for (const Value &key : removals) { static_cast<void>(mutation.erase(key.view())); }
-                        }
-                        else { out.apply(ts.value()); }
+                        // Full resync preserves structural child validity;
+                        // the current-state policy owns each representation.
+                        reconcile_current_state(
+                            erased, ts.base(),
+                            TSCurrentReconcileOptions{TSCurrentReconcileScope::Full, false});
                     }
                 }
                 else if (ts.modified())
@@ -709,26 +673,15 @@ namespace hgraph::stdlib
                     apply_delta(out, capture_delta(ts.base()).view());
                 }
             }
-            else if (condition_true && was_true && ts.modified() && ts.base().schema() != nullptr &&
-                     (ts.base().schema()->kind == TSTypeKind::TSS ||
-                      ts.base().schema()->kind == TSTypeKind::TSD))
+            else if (condition_true && was_true && ts.modified())
             {
-                // Structural REF unbinds are invalid current values with a
-                // removal delta over the previously published key set.
-                bool has_removal = false;
-                if (ts.base().schema()->kind == TSTypeKind::TSS)
+                // Invalid structural removals and pre-valid window ticks are
+                // representation-owned observable events.
+                Value delta = capture_delta(ts.base());
+                if (delta_is_observable(ts.base(), delta.view()))
                 {
-                    const auto input = ts.base().as_set();
-                    const auto removed = input.removed();
-                    has_removal = removed.begin() != removed.end();
+                    apply_delta(out, delta.view());
                 }
-                else
-                {
-                    const auto input = ts.base().as_dict();
-                    const auto removed = input.removed_keys();
-                    has_removal = removed.begin() != removed.end();
-                }
-                if (has_removal) { apply_delta(out, capture_delta(ts.base()).view()); }
             }
             last_condition.set(condition_true);
         }

--- a/include/hgraph/types/time_series/ts_data/current_state_ops.h
+++ b/include/hgraph/types/time_series/ts_data/current_state_ops.h
@@ -1,0 +1,69 @@
+#ifndef HGRAPH_TYPES_TIME_SERIES_TS_DATA_CURRENT_STATE_OPS_H
+#define HGRAPH_TYPES_TIME_SERIES_TS_DATA_CURRENT_STATE_OPS_H
+
+#include <hgraph/hgraph_export.h>
+
+#include <cstdint>
+
+namespace hgraph
+{
+    class TSDataView;
+    class TSInputView;
+    class TSOutputView;
+    class Value;
+    class ValueView;
+    struct TSValueTypeMetaData;
+    struct ValueTypeMetaData;
+
+    /** Select how much of a source TSData tree a current-state reconciliation visits. */
+    enum class TSCurrentReconcileScope : std::uint8_t
+    {
+        /** Visit only state changed at the target view's evaluation time. */
+        Incremental,
+        /** Make the target's complete live state match the source. */
+        Full,
+    };
+
+    /** Wiring/runtime policy for copying live TSData state into a publication snapshot. */
+    struct TSCurrentReconcileOptions
+    {
+        TSCurrentReconcileScope scope{TSCurrentReconcileScope::Full};
+        /** Publish every visited live value even when its value is unchanged. */
+        bool sample_all{false};
+    };
+
+    /**
+     * Passive operations for current-state transfer through one realized TSData strategy.
+     *
+     * This table is deliberately separate from ordinary per-cycle delta operations:
+     * current values use patch semantics for partially-valid fixed structures, while an
+     * exact reconciliation must also preserve invalid children and collection removals.
+     * Concrete TSData factories select one non-null table from immutable schema/plan
+     * metadata. Generic operators dispatch here and must not recover the representation
+     * by switching on ``TSTypeKind``.
+     */
+    struct TSCurrentStateOps
+    {
+        bool (*value_schema_compatible_impl)(const TSValueTypeMetaData &schema,
+                                             const ValueTypeMetaData &value_schema);
+        Value (*capture_current_delta_impl)(const TSInputView &input);
+        void (*apply_current_value_impl)(const TSOutputView &output,
+                                         const ValueView &value);
+        bool (*delta_is_observable_impl)(const TSInputView &input,
+                                         const ValueView &delta);
+        void (*reconcile_input_impl)(const TSOutputView &target,
+                                     const TSInputView &source,
+                                     TSCurrentReconcileOptions options);
+        void (*reconcile_data_impl)(const TSOutputView &target,
+                                    const TSDataView &source,
+                                    TSCurrentReconcileOptions options);
+    };
+
+    namespace ts_current_state_detail
+    {
+        /** Canonical throwing table used by default and moved-from TSData policies. */
+        [[nodiscard]] HGRAPH_EXPORT const TSCurrentStateOps &missing_current_state_ops() noexcept;
+    }
+}  // namespace hgraph
+
+#endif  // HGRAPH_TYPES_TIME_SERIES_TS_DATA_CURRENT_STATE_OPS_H

--- a/include/hgraph/types/time_series/ts_data/current_state_ops.h
+++ b/include/hgraph/types/time_series/ts_data/current_state_ops.h
@@ -46,6 +46,14 @@ namespace hgraph
     {
         bool (*value_schema_compatible_impl)(const TSValueTypeMetaData &schema,
                                              const ValueTypeMetaData &value_schema);
+        /**
+         * True when a source TSData tree can be traversed by this target
+         * strategy. Unlike value compatibility, this preserves the complete
+         * time-series topology recursively (including collection children,
+         * fixed/dynamic list shape, window policy, and REF target shape).
+         */
+        bool (*reconcile_schema_compatible_impl)(const TSValueTypeMetaData &target,
+                                                 const TSValueTypeMetaData &source);
         Value (*capture_current_delta_impl)(const TSInputView &input);
         void (*apply_current_value_impl)(const TSOutputView &output,
                                          const ValueView &value);

--- a/include/hgraph/types/time_series/ts_data/impl/current_state_ops.h
+++ b/include/hgraph/types/time_series/ts_data/impl/current_state_ops.h
@@ -1,0 +1,13 @@
+#ifndef HGRAPH_TYPES_TIME_SERIES_TS_DATA_IMPL_CURRENT_STATE_OPS_H
+#define HGRAPH_TYPES_TIME_SERIES_TS_DATA_IMPL_CURRENT_STATE_OPS_H
+
+#include <hgraph/types/time_series/ts_data/current_state_ops.h>
+#include <hgraph/types/time_series/ts_type_ref.h>
+
+namespace hgraph::ts_current_state_detail
+{
+    /** Select the semantic current-state policy once while constructing TSData ops. */
+    [[nodiscard]] HGRAPH_EXPORT const TSCurrentStateOps &current_state_ops_for(TSTypeKind kind) noexcept;
+}
+
+#endif  // HGRAPH_TYPES_TIME_SERIES_TS_DATA_IMPL_CURRENT_STATE_OPS_H

--- a/include/hgraph/types/time_series/ts_data/ops.h
+++ b/include/hgraph/types/time_series/ts_data/ops.h
@@ -3,6 +3,7 @@
 
 #include <hgraph/hgraph_export.h>
 #include <hgraph/types/storage_metrics.h>
+#include <hgraph/types/time_series/ts_data/current_state_ops.h>
 #include <hgraph/types/time_series/ts_data/types.h>
 #include <hgraph/types/utils/slot_observer.h>
 #include <hgraph/types/value/value_range.h>
@@ -138,6 +139,11 @@ namespace hgraph
         TSTypeKind  kind{TSTypeKind::TS};
         bool        allows_mutation{false};
         const detail::TSDataOwnershipOps *ownership_ops{nullptr};
+        // Current-state transfer is a separately selected, non-null erased
+        // policy. Semantic consumers must dispatch through it rather than
+        // recover a representation from ``kind``.
+        const TSCurrentStateOps *current_state_ops{
+            &ts_current_state_detail::missing_current_state_ops()};
 
         const TSDataLayout *(*layout_impl)(const void *context) = &ts_data_detail::missing_layout;
         const TSDataTracking *(*tracking_impl)(const void *context,

--- a/include/hgraph/types/time_series/ts_delta.h
+++ b/include/hgraph/types/time_series/ts_delta.h
@@ -2,9 +2,11 @@
 #define HGRAPH_TYPES_TIME_SERIES_TS_DELTA_H
 
 #include <hgraph/hgraph_export.h>
+#include <hgraph/types/time_series/ts_data/current_state_ops.h>
 
 namespace hgraph
 {
+    class TSDataView;
     class TSInputView;
     class TSOutputView;
     struct TSValueTypeMetaData;
@@ -44,6 +46,12 @@ namespace hgraph
         composite input. */
     [[nodiscard]] HGRAPH_EXPORT Value capture_current_delta(const TSInputView &in);
 
+    /** True when a captured delta represents an externally observable tick.
+        This includes invalid structural-removal and pre-valid tick-window
+        events, while excluding scheduling-only empty structural deltas. */
+    [[nodiscard]] HGRAPH_EXPORT bool delta_is_observable(
+        const TSInputView &in, const ValueView &delta);
+
     HGRAPH_EXPORT void apply_delta(const TSOutputView &out, const ValueView &delta);
 
     /**
@@ -57,6 +65,14 @@ namespace hgraph
     [[nodiscard]] HGRAPH_EXPORT bool current_value_schema_compatible(
         const TSValueTypeMetaData &schema, const ValueTypeMetaData &value_schema);
     HGRAPH_EXPORT void apply_current_value(const TSOutputView &out, const ValueView &value);
+
+    /** Reconcile a publication/snapshot output with a live source TSData tree. */
+    HGRAPH_EXPORT void reconcile_current_state(
+        const TSOutputView &target, const TSInputView &source,
+        TSCurrentReconcileOptions options = {});
+    HGRAPH_EXPORT void reconcile_current_state(
+        const TSOutputView &target, const TSDataView &source,
+        TSCurrentReconcileOptions options = {});
 }  // namespace hgraph
 
 #endif  // HGRAPH_TYPES_TIME_SERIES_TS_DELTA_H

--- a/include/hgraph/types/time_series/ts_type_ref.h
+++ b/include/hgraph/types/time_series/ts_type_ref.h
@@ -14,7 +14,7 @@ namespace hgraph
     struct TSDataOps;
     struct TSParentLink;
 
-    inline constexpr std::uint16_t TS_DATA_OPS_ABI_VERSION = 6;
+    inline constexpr std::uint16_t TS_DATA_OPS_ABI_VERSION = 7;
 
     class TSRoleTypeRef
     {

--- a/include/hgraph/types/time_series/ts_type_ref.h
+++ b/include/hgraph/types/time_series/ts_type_ref.h
@@ -14,7 +14,7 @@ namespace hgraph
     struct TSDataOps;
     struct TSParentLink;
 
-    inline constexpr std::uint16_t TS_DATA_OPS_ABI_VERSION = 7;
+    inline constexpr std::uint16_t TS_DATA_OPS_ABI_VERSION = 8;
 
     class TSRoleTypeRef
     {

--- a/src/hgraph/runtime/mapped_key_source.h
+++ b/src/hgraph/runtime/mapped_key_source.h
@@ -2,6 +2,7 @@
 #define HGRAPH_RUNTIME_MAPPED_KEY_SOURCE_H
 
 #include <hgraph/types/metadata/value_plan_factory.h>
+#include <hgraph/types/time_series/ts_data/impl/current_state_ops.h>
 #include <hgraph/types/time_series/ts_output.h>
 #include <hgraph/types/value/value.h>
 
@@ -73,6 +74,8 @@ namespace hgraph::runtime_detail
                 .context                   = context.get(),
                 .kind                      = TSTypeKind::TS,
                 .allows_mutation           = false,
+                .current_state_ops =
+                    &ts_current_state_detail::current_state_ops_for(TSTypeKind::TS),
                 .layout_impl               = [](const void *ctx) noexcept -> const TSDataLayout * {
                     return &static_cast<const Context *>(ctx)->layout;
                 },

--- a/src/hgraph/runtime/reduce_node.cpp
+++ b/src/hgraph/runtime/reduce_node.cpp
@@ -792,16 +792,9 @@ namespace hgraph
             DateTime snapshot_time = previous_view.last_modified_time();
             if (snapshot_time == MIN_DT) { snapshot_time = evaluation_time; }
             auto snapshot_view = snapshot->view(snapshot_time);
-            if (schema->kind == TSTypeKind::TSD)
-            {
-                auto mutation = snapshot_view.as_dict().begin_mutation(snapshot_time);
-                static_cast<void>(mutation.copy_value_from(previous_view.value()));
-            }
-            else
-            {
-                auto mutation = snapshot_view.as_set().begin_mutation(snapshot_time);
-                static_cast<void>(mutation.copy_value_from(previous_view.value()));
-            }
+            reconcile_current_state(
+                snapshot_view, previous_view.data_view(),
+                TSCurrentReconcileOptions{TSCurrentReconcileScope::Full, false});
 
             // First move the forwarding endpoint to an equal, stable snapshot
             // without publishing a second transition. The snapshot is updated
@@ -815,107 +808,6 @@ namespace hgraph
             storage.publication_snapshot_active = true;
             storage.publication_full_reconcile = true;
             storage.publication_sample_all = sample_all;
-        }
-
-        void update_reduce_dict_publication(TSDOutputView snapshot, const TSOutputView &source,
-                                            DateTime evaluation_time, bool full_reconcile,
-                                            bool sample_all)
-        {
-            auto mutation = snapshot.begin_mutation(evaluation_time);
-            if (!source.valid())
-            {
-                mutation.clear();
-                return;
-            }
-
-            auto source_dict = source.as_dict();
-            if (full_reconcile)
-            {
-                std::vector<Value> removed_keys;
-                removed_keys.reserve(snapshot.size());
-                for (const ValueView &key : snapshot.keys())
-                {
-                    if (!source_dict.contains(key))
-                    {
-                        removed_keys.push_back(value_impl::graph_local_value(key));
-                    }
-                }
-                for (const Value &key : removed_keys)
-                {
-                    static_cast<void>(mutation.erase(key.view()));
-                }
-                for (auto &&[key, child] : source_dict.items())
-                {
-                    if (!child.valid()) { continue; }
-                    const bool changed = !mutation.contains(key) || !mutation.at(key).valid() ||
-                                         !mutation.at(key).value().equals(child.value());
-                    if (sample_all)
-                    {
-                        auto child_mutation = mutation.at(key).begin_mutation(evaluation_time);
-                        static_cast<void>(child_mutation.copy_value_from(child.value()));
-                        child_mutation.mark_modified();
-                    }
-                    else if (changed) { mutation.set(key, child.value()); }
-                }
-                return;
-            }
-
-            for (const ValueView &key : source_dict.removed_keys())
-            {
-                static_cast<void>(mutation.erase(key));
-            }
-            for (auto &&[key, child] : source_dict.modified_items())
-            {
-                if (!child.valid()) { continue; }
-                const bool changed = !mutation.contains(key) || !mutation.at(key).valid() ||
-                                     !mutation.at(key).value().equals(child.value());
-                if (changed) { mutation.set(key, child.value()); }
-            }
-        }
-
-        void update_reduce_set_publication(TSSOutputView snapshot, const TSOutputView &source,
-                                           DateTime evaluation_time, bool full_reconcile,
-                                           bool sample_all)
-        {
-            auto mutation = snapshot.begin_mutation(evaluation_time);
-            if (!source.valid())
-            {
-                mutation.clear();
-                return;
-            }
-
-            auto source_set = source.as_set();
-            if (full_reconcile)
-            {
-                std::vector<Value> removed_keys;
-                removed_keys.reserve(snapshot.size());
-                for (const ValueView &key : snapshot.values())
-                {
-                    if (!source_set.contains(key))
-                    {
-                        removed_keys.push_back(value_impl::graph_local_value(key));
-                    }
-                }
-                for (const Value &key : removed_keys)
-                {
-                    static_cast<void>(mutation.remove(key.view()));
-                }
-                for (const ValueView &key : source_set.values())
-                {
-                    if (!mutation.contains(key)) { static_cast<void>(mutation.add(key)); }
-                }
-                if (sample_all) { mutation.touch(); }
-                return;
-            }
-
-            for (const ValueView &key : source_set.removed())
-            {
-                static_cast<void>(mutation.remove(key));
-            }
-            for (const ValueView &key : source_set.added())
-            {
-                if (!mutation.contains(key)) { static_cast<void>(mutation.add(key)); }
-            }
         }
 
         void finish_reduce_publication(ReduceNodeStorage &storage, DateTime evaluation_time)
@@ -933,18 +825,14 @@ namespace hgraph
                                       : TSOutputView{};
 
             auto snapshot_view = snapshot->view(evaluation_time);
-            if (snapshot_view.schema()->kind == TSTypeKind::TSD)
-            {
-                update_reduce_dict_publication(snapshot_view.as_dict(), source, evaluation_time,
-                                               storage.publication_full_reconcile,
-                                               storage.publication_sample_all);
-            }
-            else
-            {
-                update_reduce_set_publication(snapshot_view.as_set(), source, evaluation_time,
-                                              storage.publication_full_reconcile,
-                                              storage.publication_sample_all);
-            }
+            reconcile_current_state(
+                snapshot_view,
+                source.bound() ? source.data_view().borrowed_ref() : TSDataView{},
+                TSCurrentReconcileOptions{
+                    storage.publication_full_reconcile
+                        ? TSCurrentReconcileScope::Full
+                        : TSCurrentReconcileScope::Incremental,
+                    storage.publication_sample_all});
             storage.publication_full_reconcile = false;
             storage.publication_sample_all = false;
         }

--- a/src/hgraph/types/metadata/ts_data_atomic_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_atomic_ops.cpp
@@ -1,5 +1,6 @@
 #include <hgraph/types/metadata/ts_data_plan_factory_detail.h>
 
+#include <hgraph/types/time_series/ts_data/impl/current_state_ops.h>
 #include <hgraph/types/utils/intern_table.h>
 #include <hgraph/types/value/value.h>
 
@@ -43,6 +44,7 @@ namespace hgraph::ts_data_plan_factory_detail
                 .context                   = &layout,
                 .kind                      = kind,
                 .allows_mutation           = true,
+                .current_state_ops         = &ts_current_state_detail::current_state_ops_for(kind),
                 .layout_impl               = &atomic_layout,
                 .tracking_impl             = &atomic_tracking,
                 .mutable_tracking_impl     = &atomic_mutable_tracking,

--- a/src/hgraph/types/metadata/ts_data_dynamic_list_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_dynamic_list_ops.cpp
@@ -1,6 +1,7 @@
 #include <hgraph/util/scope.h>
 #include <hgraph/types/metadata/ts_data_plan_factory.h>
 #include <hgraph/types/metadata/ts_data_plan_factory_detail.h>
+#include <hgraph/types/time_series/ts_data/impl/current_state_ops.h>
 
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
@@ -386,6 +387,8 @@ namespace hgraph::ts_data_plan_factory_detail
                     .kind                      = TSTypeKind::TSL,
                     .allows_mutation           = true,
                     .ownership_ops             = &ownership_ops(),
+                    .current_state_ops =
+                        &ts_current_state_detail::current_state_ops_for(TSTypeKind::TSL),
                     .layout_impl               = &dynamic_layout,
                     .tracking_impl             = &dynamic_tracking,
                     .mutable_tracking_impl     = &dynamic_mutable_tracking,

--- a/src/hgraph/types/metadata/ts_data_fixed_structured_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_fixed_structured_ops.cpp
@@ -3,6 +3,7 @@
 #include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
+#include <hgraph/types/time_series/ts_data/impl/current_state_ops.h>
 #include <hgraph/types/value/specialized_views.h>
 #include <hgraph/types/value/value.h>
 #include <hgraph/types/value/value_builder.h>
@@ -279,6 +280,8 @@ namespace hgraph::ts_data_plan_factory_detail
                 .kind                      = schema->kind,
                 .allows_mutation           = true,
                 .ownership_ops             = &ownership_ops(),
+                .current_state_ops =
+                    &ts_current_state_detail::current_state_ops_for(schema->kind),
                 .layout_impl               = &fixed_layout,
                 .tracking_impl             = &fixed_tracking,
                 .mutable_tracking_impl     = &fixed_mutable_tracking,

--- a/src/hgraph/types/metadata/ts_data_slot_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_slot_ops.cpp
@@ -6,6 +6,7 @@
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/time_series/endpoint_schema.h>
+#include <hgraph/types/time_series/ts_data/impl/current_state_ops.h>
 #include "../time_series/ts_data/ownership.h"
 #include <hgraph/types/utils/key_slot_store.h>
 #include <hgraph/types/utils/value_slot_store.h>
@@ -1137,6 +1138,8 @@ namespace hgraph::ts_data_plan_factory_detail
                     .context                   = this,
                     .kind                      = TSTypeKind::TSS,
                     .allows_mutation           = mutable_storage,
+                    .current_state_ops =
+                        &ts_current_state_detail::current_state_ops_for(TSTypeKind::TSS),
                     .layout_impl               = &tss_layout,
                     .tracking_impl             = &tss_tracking,
                     .mutable_tracking_impl     = &tss_mutable_tracking,
@@ -2113,6 +2116,8 @@ namespace hgraph::ts_data_plan_factory_detail
                 base_ops.reset_delta_impl = &tsd_reset_delta;
                 base_ops.record_child_modified_impl = &tsd_record_child_modified;
                 base_ops.copy_value_from_impl = &tsd_copy_value_from;
+                base_ops.current_state_ops =
+                    &ts_current_state_detail::current_state_ops_for(TSTypeKind::TSD);
                 base_ops.empty_delta_impl = &ts_data_detail::empty_delta_tsd;
                 base_ops.capture_delta_impl = &ts_data_detail::capture_delta_tsd;
                 base_ops.delta_has_effect_impl = &ts_data_detail::delta_has_effect_tsd;

--- a/src/hgraph/types/metadata/ts_data_window_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_window_ops.cpp
@@ -2,6 +2,7 @@
 
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
+#include <hgraph/types/time_series/ts_data/impl/current_state_ops.h>
 #include <hgraph/types/value/specialized_views.h>
 #include <hgraph/types/value/value.h>
 #include <hgraph/types/value/value_builder.h>
@@ -844,6 +845,8 @@ namespace hgraph::ts_data_plan_factory_detail
                     .context                   = this,
                     .kind                      = TSTypeKind::TSW,
                     .allows_mutation           = true,
+                    .current_state_ops =
+                        &ts_current_state_detail::current_state_ops_for(TSTypeKind::TSW),
                     .layout_impl               = &window_layout,
                     .tracking_impl             = &window_tracking,
                     .mutable_tracking_impl     = &window_mutable_tracking,

--- a/src/hgraph/types/time_series/ts_data/proxy.cpp
+++ b/src/hgraph/types/time_series/ts_data/proxy.cpp
@@ -9,6 +9,7 @@
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/metadata/ts_data_plan_factory_detail.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
+#include <hgraph/types/time_series/ts_data/impl/current_state_ops.h>
 #include <hgraph/types/utils/value_slot_store.h>
 #include <hgraph/types/value/specialized_views.h>
 #include <hgraph/types/value/value.h>
@@ -204,6 +205,8 @@ namespace hgraph
                     .context                   = this,
                     .kind                      = TSTypeKind::TSS,
                     .allows_mutation           = false,
+                    .current_state_ops =
+                        &ts_current_state_detail::current_state_ops_for(TSTypeKind::TSS),
                     .layout_impl               = &ts_layout,
                     .tracking_impl             = &key_set_tracking,
                     .mutable_tracking_impl     = &mutable_key_set_tracking,
@@ -251,6 +254,8 @@ namespace hgraph
                 dict_base.has_current_value_impl = &has_current_value;
                 dict_base.all_valid_impl = &all_valid;
                 dict_base.ownership_ops = &ownership_ops();
+                dict_base.current_state_ops =
+                    &ts_current_state_detail::current_state_ops_for(TSTypeKind::TSD);
                 dict_base.empty_delta_impl = &ts_data_detail::empty_delta_tsd;
                 dict_base.capture_delta_impl = &ts_data_detail::capture_delta_tsd;
                 dict_base.delta_has_effect_impl = &ts_data_detail::delta_has_effect_tsd;

--- a/src/hgraph/types/time_series/ts_delta.cpp
+++ b/src/hgraph/types/time_series/ts_delta.cpp
@@ -1,6 +1,5 @@
 #include <hgraph/types/time_series/ts_delta.h>
 
-
 #include <hgraph/types/metadata/ts_data_plan_factory.h>
 #include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/type_registry.h>
@@ -8,6 +7,7 @@
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/metadata/value_type_meta_data.h>
 #include <hgraph/types/time_series/ts_input.h>
+#include <hgraph/types/time_series/ts_data/impl/current_state_ops.h>
 #include <hgraph/types/time_series/ts_output.h>
 #include <hgraph/types/value/value.h>
 #include <hgraph/types/value/value_builder.h>
@@ -18,6 +18,7 @@
 
 #include <array>
 #include <cassert>
+#include <concepts>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -160,6 +161,35 @@ namespace hgraph
             }
         }
 
+        [[nodiscard]] const TSCurrentStateOps &current_state_ops(const TSRoleTypeRef &type,
+                                                                 const char *fn)
+        {
+            if (!type) { throw std::logic_error(fmt::format("{}: unresolved TSData type", fn)); }
+            const auto *ops = type.ops_ref().current_state_ops;
+            if (ops == nullptr)
+            {
+                throw std::logic_error(fmt::format("{}: TSData current-state policy is null", fn));
+            }
+            return *ops;
+        }
+
+        [[nodiscard]] const TSCurrentStateOps &current_state_ops_for_input(
+            const TSInputView &input, const char *fn)
+        {
+            if (const auto type = input.type_ref(); type)
+            {
+                return current_state_ops(type.as_role(), fn);
+            }
+            const auto &data = input.data_view();
+            if (data.valid())
+            {
+                const auto *ops = data.ops().current_state_ops;
+                if (ops != nullptr) { return *ops; }
+            }
+            static_cast<void>(require_schema(input.schema(), fn));
+            throw std::logic_error(fmt::format("{} requires a canonical input type record", fn));
+        }
+
         [[nodiscard]] bool field_name_equal(const TSFieldMetaData &ts_field,
                                             const ValueFieldMetaData &value_field) noexcept
         {
@@ -170,8 +200,9 @@ namespace hgraph
             return ts_name == value_name;
         }
 
-        [[nodiscard]] bool current_value_schema_compatible_ts(const TSValueTypeMetaData &schema,
-                                                              const ValueTypeMetaData   &value_schema) noexcept
+        [[nodiscard]] bool current_value_schema_compatible_atomic(
+            const TSValueTypeMetaData &schema,
+            const ValueTypeMetaData &value_schema) noexcept
         {
             if (schema.value_schema == &value_schema) { return true; }
             if (schema.value_schema != nullptr &&
@@ -179,7 +210,7 @@ namespace hgraph
             {
                 return true;
             }
-            // Variadic tuple vs list: distinct schema identity, ONE layout
+            // Variadic tuple vs list: distinct schema identity, one layout
             // (same element type; flags differ only by VariadicTuple).
             const auto *target = schema.value_schema;
             return target != nullptr && target->try_value_kind() == ValueTypeKind::List &&
@@ -188,37 +219,53 @@ namespace hgraph
                    target->element_type == value_schema.element_type;
         }
 
-        [[nodiscard]] bool current_value_schema_compatible_tss(const TSValueTypeMetaData &schema,
-                                                               const ValueTypeMetaData   &value_schema) noexcept
+        [[nodiscard]] bool current_value_schema_compatible_set(
+            const TSValueTypeMetaData &schema,
+            const ValueTypeMetaData &value_schema) noexcept
         {
             return schema.value_schema == &value_schema;
         }
 
-        [[nodiscard]] bool current_value_schema_compatible_tsd(const TSValueTypeMetaData &schema,
-                                                               const ValueTypeMetaData   &value_schema)
+        [[nodiscard]] bool current_value_schema_compatible_dict(
+            const TSValueTypeMetaData &schema,
+            const ValueTypeMetaData &value_schema)
         {
-            return value_schema.value_kind() == ValueTypeKind::Map &&
-                   schema.key_type() == value_schema.key_type &&
-                   schema.element_ts() != nullptr &&
-                   value_schema.element_type != nullptr &&
-                   current_value_schema_compatible(*schema.element_ts(), *value_schema.element_type);
+            if (value_schema.try_value_kind() != ValueTypeKind::Map ||
+                schema.key_type() != value_schema.key_type || schema.element_ts() == nullptr ||
+                value_schema.element_type == nullptr)
+            {
+                return false;
+            }
+            const auto *child_schema = schema.element_ts();
+            const auto &child_ops = ts_current_state_detail::current_state_ops_for(
+                child_schema->kind);
+            return child_ops.value_schema_compatible_impl(
+                *child_schema, *value_schema.element_type);
         }
 
-        [[nodiscard]] bool current_value_schema_compatible_tsl(const TSValueTypeMetaData &schema,
-                                                               const ValueTypeMetaData   &value_schema)
+        [[nodiscard]] bool current_value_schema_compatible_list(
+            const TSValueTypeMetaData &schema,
+            const ValueTypeMetaData &value_schema)
         {
-            return value_schema.value_kind() == ValueTypeKind::List &&
-                   schema.element_ts() != nullptr &&
-                   value_schema.element_type != nullptr &&
-                   (schema.fixed_size() == 0 || value_schema.fixed_size == 0 ||
-                    schema.fixed_size() == value_schema.fixed_size) &&
-                   current_value_schema_compatible(*schema.element_ts(), *value_schema.element_type);
+            if (value_schema.try_value_kind() != ValueTypeKind::List ||
+                schema.element_ts() == nullptr || value_schema.element_type == nullptr ||
+                (schema.fixed_size() != 0 && value_schema.fixed_size != 0 &&
+                 schema.fixed_size() != value_schema.fixed_size))
+            {
+                return false;
+            }
+            const auto *child_schema = schema.element_ts();
+            const auto &child_ops = ts_current_state_detail::current_state_ops_for(
+                child_schema->kind);
+            return child_ops.value_schema_compatible_impl(
+                *child_schema, *value_schema.element_type);
         }
 
-        [[nodiscard]] bool current_value_schema_compatible_tsb(const TSValueTypeMetaData &schema,
-                                                               const ValueTypeMetaData   &value_schema)
+        [[nodiscard]] bool current_value_schema_compatible_bundle(
+            const TSValueTypeMetaData &schema,
+            const ValueTypeMetaData &value_schema)
         {
-            if (value_schema.value_kind() != ValueTypeKind::Bundle ||
+            if (value_schema.try_value_kind() != ValueTypeKind::Bundle ||
                 schema.field_count() != value_schema.field_count)
             {
                 return false;
@@ -227,56 +274,20 @@ namespace hgraph
             {
                 const auto &ts_field    = schema.fields()[index];
                 const auto &value_field = value_schema.fields[index];
-                if (!field_name_equal(ts_field, value_field) ||
-                    ts_field.type == nullptr ||
-                    value_field.type == nullptr ||
-                    !current_value_schema_compatible(*ts_field.type, *value_field.type))
+                if (!field_name_equal(ts_field, value_field) || ts_field.type == nullptr ||
+                    value_field.type == nullptr)
+                {
+                    return false;
+                }
+                const auto &child_ops = ts_current_state_detail::current_state_ops_for(
+                    ts_field.type->kind);
+                if (!child_ops.value_schema_compatible_impl(
+                        *ts_field.type, *value_field.type))
                 {
                     return false;
                 }
             }
             return true;
-        }
-
-        using CurrentValueSchemaCompatibleFn = bool (*)(const TSValueTypeMetaData &, const ValueTypeMetaData &);
-
-        [[nodiscard]] constexpr std::size_t ts_kind_index(TSTypeKind kind) noexcept
-        {
-            return static_cast<std::size_t>(kind);
-        }
-
-        [[nodiscard]] CurrentValueSchemaCompatibleFn current_value_schema_compatible_for(
-            TSTypeKind kind) noexcept
-        {
-            static constexpr std::size_t kind_count = ts_kind_index(TSTypeKind::SIGNAL) + 1U;
-            static const std::array<CurrentValueSchemaCompatibleFn, kind_count> table{
-                &current_value_schema_compatible_ts,
-                &current_value_schema_compatible_tss,
-                &current_value_schema_compatible_tsd,
-                &current_value_schema_compatible_tsl,
-                &current_value_schema_compatible_ts,
-                &current_value_schema_compatible_tsb,
-                &current_value_schema_compatible_ts,
-                &current_value_schema_compatible_ts,
-            };
-
-            const auto index = ts_kind_index(kind);
-            return index < table.size() ? table[index] : &current_value_schema_compatible_ts;
-        }
-
-        [[nodiscard]] bool schema_contains_tsd(const TSValueTypeMetaData *schema) noexcept
-        {
-            if (schema == nullptr) { return false; }
-            if (schema->kind == TSTypeKind::TSD) { return true; }
-            if (schema->kind == TSTypeKind::TSL) { return schema_contains_tsd(schema->element_ts()); }
-            if (schema->kind == TSTypeKind::TSB)
-            {
-                for (std::size_t index = 0; index < schema->field_count(); ++index)
-                {
-                    if (schema_contains_tsd(schema->fields()[index].type)) { return true; }
-                }
-            }
-            return false;
         }
 
         void apply_current_value_direct(const TSOutputView &out, const ValueView &value)
@@ -285,7 +296,7 @@ namespace hgraph
             static_cast<void>(mutation.copy_value_from(value));
         }
 
-        void apply_current_value_tsd(const TSOutputView &out, const ValueView &value)
+        void apply_current_value_dict(const TSOutputView &out, const ValueView &value)
         {
             auto       dict_out   = out.as_dict();
             auto       mutation   = dict_out.begin_mutation(out.evaluation_time());
@@ -306,16 +317,13 @@ namespace hgraph
             for (const auto &key : removals) { static_cast<void>(mutation.erase(key.view())); }
         }
 
-        void apply_current_value_tsl(const TSOutputView &out, const ValueView &value)
+        void apply_current_value_list(const TSOutputView &out, const ValueView &value)
         {
             const auto *schema = out.schema();
-            if (schema == nullptr) { throw std::logic_error("apply_current_value: TSL output schema is missing"); }
-            if (value.schema() == schema->value_schema && !schema_contains_tsd(schema))
+            if (schema == nullptr)
             {
-                apply_current_value_direct(out, value);
-                return;
+                throw std::logic_error("apply_current_value: TSL output schema is missing");
             }
-
             const auto source_values = value.as_indexed_view();
             if (schema->fixed_size() != 0 && source_values.size() != schema->fixed_size())
             {
@@ -331,17 +339,20 @@ namespace hgraph
             for (std::size_t index = 0; index < source_values.size(); ++index)
             {
                 auto source_child = source_values.at(index);
-                // UNSET source children are skipped (the TSL carries the
-                // same field-validity contract as TSB).
+                // Current-value application is a patch: an UNSET structural
+                // child leaves the target child untouched.
                 if (!source_child.valid()) { continue; }
                 apply_current_value(list_out.at(index), source_child);
             }
         }
 
-        void apply_current_value_tsb(const TSOutputView &out, const ValueView &value)
+        void apply_current_value_bundle(const TSOutputView &out, const ValueView &value)
         {
             const auto *schema = out.schema();
-            if (schema == nullptr) { throw std::logic_error("apply_current_value: TSB output schema is missing"); }
+            if (schema == nullptr)
+            {
+                throw std::logic_error("apply_current_value: TSB output schema is missing");
+            }
             const auto source_values = value.as_indexed_view();
             if (source_values.size() != schema->field_count())
             {
@@ -352,34 +363,637 @@ namespace hgraph
             for (std::size_t index = 0; index < source_values.size(); ++index)
             {
                 auto source_child = source_values.at(index);
-                // UNSET source fields are skipped (Bundle field validity):
-                // applying a partially-valid value writes only its live
-                // fields - never defaults.
+                // As above, bundle field validity gives patch semantics.
                 if (!source_child.valid()) { continue; }
                 apply_current_value(bundle_out.at(index), source_child);
             }
         }
 
-        using CurrentValueApplyFn = void (*)(const TSOutputView &, const ValueView &);
-
-        [[nodiscard]] CurrentValueApplyFn current_value_apply_for(TSTypeKind kind) noexcept
+        [[nodiscard]] Value capture_current_atomic(const TSInputView &input)
         {
-            static constexpr std::size_t kind_count = ts_kind_index(TSTypeKind::SIGNAL) + 1U;
-            static const std::array<CurrentValueApplyFn, kind_count> table{
-                &apply_current_value_direct,
-                &apply_current_value_direct,
-                &apply_current_value_tsd,
-                &apply_current_value_tsl,
-                &apply_current_value_direct,
-                &apply_current_value_tsb,
-                &apply_current_value_direct,
-                &apply_current_value_direct,
-            };
+            return Value{input.value()};
+        }
 
-            const auto index = ts_kind_index(kind);
-            return index < table.size() ? table[index] : &apply_current_value_direct;
+        [[nodiscard]] Value capture_current_signal(const TSInputView &)
+        {
+            return Value{true};
+        }
+
+        [[nodiscard]] Value capture_current_set(const TSInputView &input)
+        {
+            const auto &schema = require_schema(input.schema(), "capture_current_delta");
+            const ValueTypeRef element = binding_for(
+                schema.value_schema->element_type, "capture_current_delta");
+            SetBuilder added{element};
+            const auto set = input.as_set();
+            for (const auto &value : set.values())
+            {
+                const BorrowedOperand borrowed{element, value, "capture_current_delta"};
+                static_cast<void>(added.insert_copy(borrowed.data()));
+            }
+            SetBuilder removed{element};
+            BundleBuilder bundle{binding_for(schema.delta_value_schema, "capture_current_delta")};
+            bundle.set("added", added.build());
+            bundle.set("removed", removed.build());
+            return bundle.build();
+        }
+
+        [[nodiscard]] Value capture_current_dict(const TSInputView &input)
+        {
+            const auto &schema = require_schema(input.schema(), "capture_current_delta");
+            const ValueTypeRef key_binding = binding_for(
+                schema.key_type(), "capture_current_delta");
+            const auto *element_schema = schema.element_ts();
+            const ValueTypeRef delta_binding = binding_for(
+                element_schema->delta_value_schema, "capture_current_delta");
+
+            SetBuilder removed{key_binding};
+            MapBuilder modified{key_binding, delta_binding};
+            const auto dict = input.as_dict();
+            for (const auto &[key, child] : dict.valid_items())
+            {
+                Value child_delta = capture_current_delta(child);
+                modified.set_item(key, child_delta.view());
+            }
+
+            Value removed_delta = removed.build();
+            Value modified_delta = modified.build();
+            const std::array field_bindings{
+                removed_delta.binding(), modified_delta.binding()};
+            const auto bundle_binding = ValuePlanFactory::instance().realized_composite_type_for(
+                schema.delta_value_schema, field_bindings);
+            BundleBuilder bundle{bundle_binding};
+            bundle.set("removed", std::move(removed_delta));
+            bundle.set("modified", std::move(modified_delta));
+            return bundle.build();
+        }
+
+        [[nodiscard]] Value capture_current_list(const TSInputView &input)
+        {
+            const auto &schema = require_schema(input.schema(), "capture_current_delta");
+            const ValueTypeRef key_binding = binding_for(
+                schema.delta_value_schema->key_type, "capture_current_delta");
+            const ValueTypeRef delta_binding = binding_for(
+                schema.delta_value_schema->element_type, "capture_current_delta");
+            MapBuilder builder{key_binding, delta_binding};
+            const auto list = input.as_list();
+            for (const auto &[index, child] : list.valid_items())
+            {
+                const std::int64_t key = static_cast<std::int64_t>(index);
+                Value child_delta = capture_current_delta(child);
+                builder.set_item(ValueView{key_binding, std::addressof(key)}, child_delta.view());
+            }
+            return builder.build();
+        }
+
+        [[nodiscard]] Value capture_current_bundle(const TSInputView &input)
+        {
+            const auto &schema = require_schema(input.schema(), "capture_current_delta");
+            const auto type = ts_type_for(&schema, "capture_current_delta");
+            BundleBuilder builder{binding_for(schema.delta_value_schema, "capture_current_delta")};
+            initialize_tsb_delta_defaults(type, builder);
+            auto bundle = input.as_bundle();
+            for (std::size_t index = 0; index < bundle.size(); ++index)
+            {
+                auto child = bundle.at(index);
+                if (child.valid()) { builder.set(index, capture_current_delta(child)); }
+            }
+            return builder.build();
+        }
+
+        [[nodiscard]] Value capture_current_transient(const TSInputView &input)
+        {
+            if (input.modified()) { return capture_delta(input); }
+            throw std::logic_error(
+                "capture_current_delta cannot reconstruct an unmodified TSW or REF");
+        }
+
+        [[nodiscard]] bool observable_atomic(const TSInputView &input,
+                                             const ValueView &delta)
+        {
+            return input.modified() && input.valid() && delta.has_value();
+        }
+
+        [[nodiscard]] bool observable_window(const TSInputView &input,
+                                             const ValueView &delta)
+        {
+            // Tick windows emit before they reach min-size validity.
+            return input.modified() && delta.has_value();
+        }
+
+        [[nodiscard]] bool observable_set(const TSInputView &input,
+                                          const ValueView &delta)
+        {
+            if (!input.modified() || !delta.has_value()) { return false; }
+            if (input.valid()) { return true; }
+            const auto bundle = delta.as_bundle();
+            return bundle.at(tss_delta_removed).as_indexed_view().size() != 0;
+        }
+
+        [[nodiscard]] bool observable_dict(const TSInputView &input,
+                                           const ValueView &delta)
+        {
+            if (!input.modified() || !delta.has_value()) { return false; }
+            if (input.valid()) { return true; }
+            const auto bundle = delta.as_bundle();
+            return bundle.at(tsd_delta_removed).as_indexed_view().size() != 0 ||
+                   bundle.at(tsd_delta_modified).as_map().size() != 0;
+        }
+
+        [[nodiscard]] bool observable_list(const TSInputView &input,
+                                           const ValueView &delta)
+        {
+            if (!input.modified() || !delta.has_value()) { return false; }
+            const auto &schema = require_schema(input.schema(), "delta_is_observable");
+            const bool has_children = delta.as_map().size() != 0;
+            if (schema.fixed_size() != 0) { return has_children; }
+            return input.valid() || has_children;
+        }
+
+        [[nodiscard]] bool observable_bundle(const TSInputView &input,
+                                             const ValueView &delta)
+        {
+            if (!input.modified() || !delta.has_value()) { return false; }
+            const auto bundle = delta.as_bundle();
+            auto children = input.as_bundle();
+            for (std::size_t index = 0; index < children.size(); ++index)
+            {
+                auto child = children.at(index);
+                if (!child.modified()) { continue; }
+                const auto &ops = current_state_ops_for_input(child, "delta_is_observable");
+                if (ops.delta_is_observable_impl(child, bundle.at(index))) { return true; }
+            }
+            return false;
+        }
+
+        void reconcile_current(const TSOutputView &target, const TSInputView &source,
+                               TSCurrentReconcileOptions options);
+        void reconcile_current(const TSOutputView &target, const TSDataView &source,
+                               TSCurrentReconcileOptions options);
+
+        template <typename Source>
+        [[nodiscard]] bool source_live(const Source &source)
+        {
+            if constexpr (std::same_as<Source, TSInputView>)
+            {
+                return source.valid();
+            }
+            else
+            {
+                return source.valid() && source.has_current_value();
+            }
+        }
+
+        template <typename Source>
+        [[nodiscard]] bool source_modified(const Source &source,
+                                           const TSOutputView &target)
+        {
+            if constexpr (std::same_as<Source, TSInputView>)
+            {
+                return source.modified();
+            }
+            else
+            {
+                if (!source.valid()) { return false; }
+                return source.modified(target.evaluation_time());
+            }
+        }
+
+        template <typename Source>
+        [[nodiscard]] bool should_visit_source(const Source &source,
+                                               const TSOutputView &target,
+                                               TSCurrentReconcileOptions options)
+        {
+            return options.scope == TSCurrentReconcileScope::Full || options.sample_all ||
+                   source_modified(source, target);
+        }
+
+        template <typename SourceChild>
+        [[nodiscard]] bool source_child_live(const SourceChild &child)
+        {
+            if constexpr (std::same_as<SourceChild, TSInputView>)
+            {
+                return child.valid();
+            }
+            else
+            {
+                return child.valid() && child.has_current_value();
+            }
+        }
+
+        void invalidate_target(const TSOutputView &target)
+        {
+            if (!target.data_view().has_current_value()) { return; }
+            auto mutation = target.begin_mutation(target.evaluation_time());
+            static_cast<void>(mutation.invalidate());
+        }
+
+        template <typename Source>
+        void reconcile_atomic_impl(const TSOutputView &target, const Source &source,
+                                   TSCurrentReconcileOptions options)
+        {
+            if (!should_visit_source(source, target, options)) { return; }
+            if (!source_live(source))
+            {
+                if (options.scope == TSCurrentReconcileScope::Full) { invalidate_target(target); }
+                return;
+            }
+
+            const auto source_value = source.value();
+            const bool equal = target.data_view().has_current_value() &&
+                               target.value().equals(source_value);
+            if (equal && !options.sample_all) { return; }
+            auto mutation = target.begin_mutation(target.evaluation_time());
+            static_cast<void>(mutation.copy_value_from(source_value));
+            if (options.sample_all) { mutation.mark_modified(); }
+        }
+
+        template <typename Source>
+        void reconcile_set_impl(const TSOutputView &target, const Source &source,
+                                TSCurrentReconcileOptions options)
+        {
+            if (!should_visit_source(source, target, options)) { return; }
+            auto target_set = target.as_set();
+
+            if (!source_live(source))
+            {
+                if (target.data_view().has_current_value())
+                {
+                    auto mutation = target_set.begin_mutation(target.evaluation_time());
+                    mutation.clear();
+                }
+                return;
+            }
+            auto mutation = target_set.begin_mutation(target.evaluation_time());
+            const auto source_set = source.as_set();
+
+            if (options.scope == TSCurrentReconcileScope::Full)
+            {
+                std::vector<Value> removals;
+                for (const auto key : target_set.values())
+                {
+                    if (!source_set.contains(key)) { removals.emplace_back(key); }
+                }
+                for (const auto &key : removals)
+                {
+                    static_cast<void>(mutation.remove(key.view()));
+                }
+                for (const auto key : source_set.values())
+                {
+                    if (!target_set.contains(key)) { static_cast<void>(mutation.add(key)); }
+                }
+                if (options.sample_all) { mutation.touch(); }
+                return;
+            }
+
+            for (const auto key : source_set.removed())
+            {
+                static_cast<void>(mutation.remove(key));
+            }
+            for (const auto key : source_set.added())
+            {
+                if (!target_set.contains(key)) { static_cast<void>(mutation.add(key)); }
+            }
+            if (options.sample_all) { mutation.touch(); }
+        }
+
+        template <typename Source>
+        void reconcile_dict_impl(const TSOutputView &target, const Source &source,
+                                 TSCurrentReconcileOptions options)
+        {
+            if (!should_visit_source(source, target, options)) { return; }
+            auto target_dict = target.as_dict();
+
+            if (!source_live(source))
+            {
+                if (target.data_view().has_current_value())
+                {
+                    auto mutation = target_dict.begin_mutation(target.evaluation_time());
+                    mutation.clear();
+                }
+                return;
+            }
+            auto mutation = target_dict.begin_mutation(target.evaluation_time());
+            const auto source_dict = source.as_dict();
+
+            if (options.scope == TSCurrentReconcileScope::Full)
+            {
+                std::vector<Value> removals;
+                for (const auto key : target_dict.keys())
+                {
+                    const auto source_child = source_dict.at(key);
+                    if (!source_child_live(source_child))
+                    {
+                        removals.emplace_back(key);
+                    }
+                }
+                for (const auto &key : removals)
+                {
+                    static_cast<void>(mutation.erase(key.view()));
+                }
+                for (auto &&[key, source_child] : source_dict.valid_items())
+                {
+                    auto target_child = mutation.at(key);
+                    reconcile_current(
+                        TSOutputView{target.output(), target_child, target.evaluation_time()},
+                        source_child,
+                        TSCurrentReconcileOptions{TSCurrentReconcileScope::Full,
+                                                  options.sample_all});
+                }
+                return;
+            }
+
+            const bool structure_modified = [&]() {
+                if constexpr (std::same_as<Source, TSInputView>)
+                {
+                    return source_dict.structure_modified();
+                }
+                else
+                {
+                    return source_dict.structural_delta_current(target.evaluation_time());
+                }
+            }();
+            if (structure_modified)
+            {
+                for (const auto key : source_dict.removed_keys())
+                {
+                    static_cast<void>(mutation.erase(key));
+                }
+            }
+            auto modified_items = [&]() {
+                if constexpr (std::same_as<Source, TSInputView>)
+                {
+                    return source_dict.modified_items();
+                }
+                else
+                {
+                    return source_dict.modified_items(target.evaluation_time());
+                }
+            }();
+            for (auto &&[key, source_child] : modified_items)
+            {
+                if (!source_child_live(source_child)) { continue; }
+                auto target_child = mutation.at(key);
+                reconcile_current(
+                    TSOutputView{target.output(), target_child, target.evaluation_time()},
+                    source_child,
+                    TSCurrentReconcileOptions{TSCurrentReconcileScope::Full,
+                                              options.sample_all});
+            }
+        }
+
+        template <typename Source>
+        void reconcile_indexed_impl(const TSOutputView &target, const Source &source,
+                                    TSCurrentReconcileOptions options)
+        {
+            if (!should_visit_source(source, target, options)) { return; }
+            const std::size_t source_size = [&]() {
+                if constexpr (std::same_as<Source, TSInputView>)
+                {
+                    return source.data_view().indexed_child_count();
+                }
+                else
+                {
+                    return source.indexed_child_count();
+                }
+            }();
+            const std::size_t target_size = target.data_view().indexed_child_count();
+            const bool full = options.scope == TSCurrentReconcileScope::Full;
+
+            const std::size_t visit_size = full ? source_size : source_size;
+            for (std::size_t index = 0; index < visit_size; ++index)
+            {
+                auto source_child = [&]() {
+                    if constexpr (std::same_as<Source, TSInputView>)
+                    {
+                        return source.indexed_child_at(index);
+                    }
+                    else
+                    {
+                        return source.indexed_child_at(index);
+                    }
+                }();
+                if (!full && !options.sample_all &&
+                    !source_modified(source_child, target))
+                {
+                    continue;
+                }
+                auto target_child = target.indexed_child_at(index);
+                reconcile_current(
+                    target_child, source_child,
+                    TSCurrentReconcileOptions{full ? TSCurrentReconcileScope::Full
+                                                   : TSCurrentReconcileScope::Incremental,
+                                              options.sample_all});
+            }
+
+            if (full)
+            {
+                for (std::size_t index = source_size; index < target_size; ++index)
+                {
+                    invalidate_target(target.indexed_child_at(index));
+                }
+            }
+
+            if (source_live(source) && source_size == 0 &&
+                (!target.valid() || options.sample_all))
+            {
+                auto mutation = target.begin_mutation(target.evaluation_time());
+                static_cast<void>(mutation.copy_value_from(source.value()));
+                if (options.sample_all) { mutation.mark_modified(); }
+            }
+        }
+
+        void reconcile_current(const TSOutputView &target, const TSInputView &source,
+                               TSCurrentReconcileOptions options)
+        {
+            const auto *ops = target.data_view().ops().current_state_ops;
+            if (ops == nullptr)
+            {
+                throw std::logic_error("reconcile_current_state: target policy is null");
+            }
+            ops->reconcile_input_impl(target, source, options);
+        }
+
+        void reconcile_current(const TSOutputView &target, const TSDataView &source,
+                               TSCurrentReconcileOptions options)
+        {
+            const auto *ops = target.data_view().ops().current_state_ops;
+            if (ops == nullptr)
+            {
+                throw std::logic_error("reconcile_current_state: target policy is null");
+            }
+            ops->reconcile_data_impl(target, source, options);
+        }
+
+        [[noreturn]] bool missing_schema_compatible(const TSValueTypeMetaData &,
+                                                    const ValueTypeMetaData &)
+        {
+            throw std::logic_error("TSData current-state schema compatibility is not available");
+        }
+
+        [[noreturn]] Value missing_capture_current(const TSInputView &)
+        {
+            throw std::logic_error("TSData current-state capture is not available");
+        }
+
+        [[noreturn]] void missing_apply_current(const TSOutputView &, const ValueView &)
+        {
+            throw std::logic_error("TSData current-value application is not available");
+        }
+
+        [[noreturn]] bool missing_observable_delta(const TSInputView &, const ValueView &)
+        {
+            throw std::logic_error("TSData observable-delta classification is not available");
+        }
+
+        [[noreturn]] void missing_reconcile_input(const TSOutputView &, const TSInputView &,
+                                                  TSCurrentReconcileOptions)
+        {
+            throw std::logic_error("TSData current-state reconciliation is not available");
+        }
+
+        [[noreturn]] void missing_reconcile_data(const TSOutputView &, const TSDataView &,
+                                                 TSCurrentReconcileOptions)
+        {
+            throw std::logic_error("TSData current-state reconciliation is not available");
+        }
+
+        [[nodiscard]] const TSCurrentStateOps &atomic_current_state_ops() noexcept
+        {
+            static const TSCurrentStateOps ops{
+                &current_value_schema_compatible_atomic,
+                &capture_current_atomic,
+                &apply_current_value_direct,
+                &observable_atomic,
+                &reconcile_atomic_impl<TSInputView>,
+                &reconcile_atomic_impl<TSDataView>,
+            };
+            return ops;
+        }
+
+        [[nodiscard]] const TSCurrentStateOps &signal_current_state_ops() noexcept
+        {
+            static const TSCurrentStateOps ops{
+                &current_value_schema_compatible_atomic,
+                &capture_current_signal,
+                &apply_current_value_direct,
+                &observable_atomic,
+                &reconcile_atomic_impl<TSInputView>,
+                &reconcile_atomic_impl<TSDataView>,
+            };
+            return ops;
+        }
+
+        [[nodiscard]] const TSCurrentStateOps &transient_current_state_ops() noexcept
+        {
+            static const TSCurrentStateOps ops{
+                &current_value_schema_compatible_atomic,
+                &capture_current_transient,
+                &apply_current_value_direct,
+                &observable_atomic,
+                &reconcile_atomic_impl<TSInputView>,
+                &reconcile_atomic_impl<TSDataView>,
+            };
+            return ops;
+        }
+
+        [[nodiscard]] const TSCurrentStateOps &window_current_state_ops() noexcept
+        {
+            static const TSCurrentStateOps ops{
+                &current_value_schema_compatible_atomic,
+                &capture_current_transient,
+                &apply_current_value_direct,
+                &observable_window,
+                &reconcile_atomic_impl<TSInputView>,
+                &reconcile_atomic_impl<TSDataView>,
+            };
+            return ops;
+        }
+
+        [[nodiscard]] const TSCurrentStateOps &set_current_state_ops() noexcept
+        {
+            static const TSCurrentStateOps ops{
+                &current_value_schema_compatible_set,
+                &capture_current_set,
+                &apply_current_value_direct,
+                &observable_set,
+                &reconcile_set_impl<TSInputView>,
+                &reconcile_set_impl<TSDataView>,
+            };
+            return ops;
+        }
+
+        [[nodiscard]] const TSCurrentStateOps &dict_current_state_ops() noexcept
+        {
+            static const TSCurrentStateOps ops{
+                &current_value_schema_compatible_dict,
+                &capture_current_dict,
+                &apply_current_value_dict,
+                &observable_dict,
+                &reconcile_dict_impl<TSInputView>,
+                &reconcile_dict_impl<TSDataView>,
+            };
+            return ops;
+        }
+
+        [[nodiscard]] const TSCurrentStateOps &list_current_state_ops() noexcept
+        {
+            static const TSCurrentStateOps ops{
+                &current_value_schema_compatible_list,
+                &capture_current_list,
+                &apply_current_value_list,
+                &observable_list,
+                &reconcile_indexed_impl<TSInputView>,
+                &reconcile_indexed_impl<TSDataView>,
+            };
+            return ops;
+        }
+
+        [[nodiscard]] const TSCurrentStateOps &bundle_current_state_ops() noexcept
+        {
+            static const TSCurrentStateOps ops{
+                &current_value_schema_compatible_bundle,
+                &capture_current_bundle,
+                &apply_current_value_bundle,
+                &observable_bundle,
+                &reconcile_indexed_impl<TSInputView>,
+                &reconcile_indexed_impl<TSDataView>,
+            };
+            return ops;
         }
     }  // namespace
+
+    namespace ts_current_state_detail
+    {
+        const TSCurrentStateOps &missing_current_state_ops() noexcept
+        {
+            static const TSCurrentStateOps ops{
+                &missing_schema_compatible,
+                &missing_capture_current,
+                &missing_apply_current,
+                &missing_observable_delta,
+                &missing_reconcile_input,
+                &missing_reconcile_data,
+            };
+            return ops;
+        }
+
+        const TSCurrentStateOps &current_state_ops_for(TSTypeKind kind) noexcept
+        {
+            static const std::array<const TSCurrentStateOps *, 8> table{
+                &atomic_current_state_ops(),
+                &set_current_state_ops(),
+                &dict_current_state_ops(),
+                &list_current_state_ops(),
+                &window_current_state_ops(),
+                &bundle_current_state_ops(),
+                &transient_current_state_ops(),
+                &signal_current_state_ops(),
+            };
+            const auto index = static_cast<std::size_t>(kind);
+            return index < table.size() ? *table[index] : missing_current_state_ops();
+        }
+    }  // namespace ts_current_state_detail
 
     namespace ts_data_detail
     {
@@ -460,7 +1074,19 @@ namespace hgraph
 
         Value capture_delta_ts(const TSInputView &in)
         {
-            return Value{in.value()};
+            const ValueView value = in.value();
+            if (value.type()) { return Value{value}; }
+
+            // A modified atomic endpoint may be scheduled by a reference
+            // unbind while carrying no value. Preserve the canonical delta
+            // binding as a typed null so generic consumers can classify the
+            // event without reconstructing the representation policy.
+            const auto &schema = require_schema(in.schema(), "capture_delta");
+            if (schema.delta_value_schema == nullptr)
+            {
+                throw std::logic_error("capture_delta: atomic delta schema is missing");
+            }
+            return Value{*schema.delta_value_schema};
         }
 
         Value capture_delta_signal(const TSInputView &)
@@ -804,116 +1430,20 @@ namespace hgraph
 
     Value capture_current_delta(const TSInputView &in)
     {
-        const auto &schema = require_schema(in.schema(), "capture_current_delta");
+        static_cast<void>(require_schema(in.schema(), "capture_current_delta"));
         if (!in.valid())
         {
             throw std::invalid_argument("capture_current_delta requires a valid input");
         }
+        const auto &ops = current_state_ops_for_input(in, "capture_current_delta");
+        return ops.capture_current_delta_impl(in);
+    }
 
-        switch (schema.kind)
-        {
-            case TSTypeKind::TS: return Value{in.value()};
-            case TSTypeKind::SIGNAL: return Value{true};
-            case TSTypeKind::TSS:
-            {
-                const ValueTypeRef element = binding_for(
-                    schema.value_schema->element_type, "capture_current_delta");
-                SetBuilder added{element};
-                const auto set = in.as_set();
-                for (const auto &value : set.values())
-                {
-                    const BorrowedOperand borrowed{element, value, "capture_current_delta"};
-                    static_cast<void>(added.insert_copy(borrowed.data()));
-                }
-                SetBuilder removed{element};
-                BundleBuilder bundle{
-                    binding_for(schema.delta_value_schema, "capture_current_delta")};
-                bundle.set("added", added.build());
-                bundle.set("removed", removed.build());
-                return bundle.build();
-            }
-            case TSTypeKind::TSD:
-            {
-                const ValueTypeRef key_binding = binding_for(
-                    schema.key_type(), "capture_current_delta");
-                const auto *element_schema = schema.element_ts();
-                const ValueTypeRef delta_binding = binding_for(
-                    element_schema->delta_value_schema, "capture_current_delta");
-
-                SetBuilder removed{key_binding};
-                MapBuilder modified{key_binding, delta_binding};
-                const auto dict = in.as_dict();
-                for (const auto &[key, child] : dict.valid_items())
-                {
-                    const BorrowedOperand borrowed{key_binding, key, "capture_current_delta"};
-                    Value child_delta = capture_current_delta(child);
-                    if (child_delta.binding() == delta_binding)
-                    {
-                        modified.set_item_copy(
-                            borrowed.data(), child_delta.view().data());
-                        continue;
-                    }
-                    Value stored_delta{delta_binding};
-                    delta_binding.ops_ref().copy_assign_from(
-                        delta_binding,
-                        const_cast<void *>(stored_delta.view().data()),
-                        child_delta.binding(),
-                        child_delta.view().data());
-                    modified.set_item_copy(
-                        borrowed.data(), stored_delta.view().data());
-                }
-
-                Value removed_delta = removed.build();
-                Value modified_delta = modified.build();
-                const std::array field_bindings{
-                    removed_delta.binding(), modified_delta.binding()};
-                const auto bundle_binding = ValuePlanFactory::instance().realized_composite_type_for(
-                    schema.delta_value_schema, field_bindings);
-                BundleBuilder bundle{bundle_binding};
-                bundle.set("removed", std::move(removed_delta));
-                bundle.set("modified", std::move(modified_delta));
-                return bundle.build();
-            }
-            case TSTypeKind::TSL:
-            {
-                const ValueTypeRef key_binding = binding_for(
-                    schema.delta_value_schema->key_type, "capture_current_delta");
-                const ValueTypeRef delta_binding = binding_for(
-                    schema.delta_value_schema->element_type, "capture_current_delta");
-                MapBuilder builder{key_binding, delta_binding};
-                const auto list = in.as_list();
-                for (const auto &[index, child] : list.valid_items())
-                {
-                    const std::int64_t key = static_cast<std::int64_t>(index);
-                    Value child_delta = capture_current_delta(child);
-                    builder.set_item_copy(std::addressof(key), child_delta.view().data());
-                }
-                return builder.build();
-            }
-            case TSTypeKind::TSB:
-            {
-                const auto type = ts_type_for(&schema, "capture_current_delta");
-                BundleBuilder builder{
-                    binding_for(schema.delta_value_schema, "capture_current_delta")};
-                initialize_tsb_delta_defaults(type, builder);
-                auto bundle = in.as_bundle();
-                for (std::size_t index = 0; index < bundle.size(); ++index)
-                {
-                    auto child = bundle.at(index);
-                    if (child.valid())
-                    {
-                        builder.set(index, capture_current_delta(child));
-                    }
-                }
-                return builder.build();
-            }
-            case TSTypeKind::TSW:
-            case TSTypeKind::REF:
-                if (in.modified()) { return capture_delta(in); }
-                throw std::logic_error(
-                    "capture_current_delta cannot reconstruct an unmodified TSW or REF");
-        }
-        throw std::logic_error("capture_current_delta received an unknown time-series kind");
+    bool delta_is_observable(const TSInputView &in, const ValueView &delta)
+    {
+        static_cast<void>(require_schema(in.schema(), "delta_is_observable"));
+        const auto &ops = current_state_ops_for_input(in, "delta_is_observable");
+        return ops.delta_is_observable_impl(in, delta);
     }
 
     void apply_delta(const TSOutputView &out, const ValueView &delta)
@@ -928,7 +1458,8 @@ namespace hgraph
     bool current_value_schema_compatible(const TSValueTypeMetaData &schema,
                                          const ValueTypeMetaData   &value_schema)
     {
-        return current_value_schema_compatible_for(schema.kind)(schema, value_schema);
+        const auto &ops = ts_current_state_detail::current_state_ops_for(schema.kind);
+        return ops.value_schema_compatible_impl(schema, value_schema);
     }
 
     void apply_current_value(const TSOutputView &out, const ValueView &value)
@@ -948,7 +1479,53 @@ namespace hgraph
                 static_cast<std::size_t>(schema.kind)));
         }
 
-        current_value_apply_for(schema.kind)(out, value);
+        const auto type = out.type_ref();
+        const auto &ops = current_state_ops(type.as_role(), "apply_current_value");
+        ops.apply_current_value_impl(out, value);
+    }
+
+    namespace
+    {
+        template <typename Source>
+        void validate_reconcile_source(const TSValueTypeMetaData &schema,
+                                       const Source &source)
+        {
+            if (!source.valid()) { return; }
+            const auto *source_schema = source.schema();
+            if (source_schema == nullptr || source_schema->value_schema == nullptr ||
+                !current_value_schema_compatible(schema, *source_schema->value_schema))
+            {
+                throw std::invalid_argument(
+                    "reconcile_current_state requires compatible source and target schemas");
+            }
+        }
+    }
+
+    void reconcile_current_state(const TSOutputView &target, const TSInputView &source,
+                                 TSCurrentReconcileOptions options)
+    {
+        const auto &schema = require_schema(target.schema(), "reconcile_current_state");
+        if (!target.bound())
+        {
+            throw std::invalid_argument("reconcile_current_state requires a bound target");
+        }
+        validate_reconcile_source(schema, source);
+        const auto type = target.type_ref();
+        const auto &ops = current_state_ops(type.as_role(), "reconcile_current_state");
+        ops.reconcile_input_impl(target, source, options);
+    }
+
+    void reconcile_current_state(const TSOutputView &target, const TSDataView &source,
+                                 TSCurrentReconcileOptions options)
+    {
+        const auto &schema = require_schema(target.schema(), "reconcile_current_state");
+        if (!target.bound())
+        {
+            throw std::invalid_argument("reconcile_current_state requires a bound target");
+        }
+        validate_reconcile_source(schema, source);
+        const auto type = target.type_ref();
+        const auto &ops = current_state_ops(type.as_role(), "reconcile_current_state");
+        ops.reconcile_data_impl(target, source, options);
     }
 }  // namespace hgraph
-

--- a/src/hgraph/types/time_series/ts_delta.cpp
+++ b/src/hgraph/types/time_series/ts_delta.cpp
@@ -290,6 +290,105 @@ namespace hgraph
             return true;
         }
 
+        [[nodiscard]] bool current_ts_schema_compatible(
+            const TSValueTypeMetaData &target,
+            const TSValueTypeMetaData &source);
+
+        [[nodiscard]] bool current_ts_schema_compatible_atomic(
+            const TSValueTypeMetaData &target,
+            const TSValueTypeMetaData &source)
+        {
+            return source.kind == target.kind && source.value_schema != nullptr &&
+                   current_value_schema_compatible_atomic(target, *source.value_schema);
+        }
+
+        [[nodiscard]] bool current_ts_schema_compatible_set(
+            const TSValueTypeMetaData &target,
+            const TSValueTypeMetaData &source) noexcept
+        {
+            return source.kind == target.kind && source.value_schema != nullptr &&
+                   current_value_schema_compatible_set(target, *source.value_schema);
+        }
+
+        [[nodiscard]] bool current_ts_schema_compatible_dict(
+            const TSValueTypeMetaData &target,
+            const TSValueTypeMetaData &source)
+        {
+            return source.kind == target.kind && target.key_type() == source.key_type() &&
+                   target.element_ts() != nullptr && source.element_ts() != nullptr &&
+                   current_ts_schema_compatible(*target.element_ts(), *source.element_ts());
+        }
+
+        [[nodiscard]] bool current_ts_schema_compatible_list(
+            const TSValueTypeMetaData &target,
+            const TSValueTypeMetaData &source)
+        {
+            return source.kind == target.kind && target.fixed_size() == source.fixed_size() &&
+                   target.element_ts() != nullptr && source.element_ts() != nullptr &&
+                   current_ts_schema_compatible(*target.element_ts(), *source.element_ts());
+        }
+
+        [[nodiscard]] bool current_ts_schema_compatible_bundle(
+            const TSValueTypeMetaData &target,
+            const TSValueTypeMetaData &source)
+        {
+            if (source.kind != target.kind || target.field_count() != source.field_count())
+            {
+                return false;
+            }
+            for (std::size_t index = 0; index < target.field_count(); ++index)
+            {
+                const auto &target_field = target.fields()[index];
+                const auto &source_field = source.fields()[index];
+                const std::string_view target_name =
+                    target_field.name != nullptr ? std::string_view{target_field.name}
+                                                 : std::string_view{};
+                const std::string_view source_name =
+                    source_field.name != nullptr ? std::string_view{source_field.name}
+                                                 : std::string_view{};
+                if (target_name != source_name || target_field.type == nullptr ||
+                    source_field.type == nullptr ||
+                    !current_ts_schema_compatible(*target_field.type, *source_field.type))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        [[nodiscard]] bool current_ts_schema_compatible_ref(
+            const TSValueTypeMetaData &target,
+            const TSValueTypeMetaData &source)
+        {
+            return source.kind == target.kind && target.referenced_ts() != nullptr &&
+                   source.referenced_ts() != nullptr &&
+                   current_ts_schema_compatible(*target.referenced_ts(), *source.referenced_ts());
+        }
+
+        [[nodiscard]] bool current_ts_schema_compatible_window(
+            const TSValueTypeMetaData &target,
+            const TSValueTypeMetaData &source)
+        {
+            if (!current_ts_schema_compatible_atomic(target, source) ||
+                target.is_duration_based() != source.is_duration_based())
+            {
+                return false;
+            }
+            return target.is_duration_based()
+                       ? target.time_range() == source.time_range() &&
+                             target.min_time_range() == source.min_time_range()
+                       : target.period() == source.period() &&
+                             target.min_period() == source.min_period();
+        }
+
+        [[nodiscard]] bool current_ts_schema_compatible(
+            const TSValueTypeMetaData &target,
+            const TSValueTypeMetaData &source)
+        {
+            const auto &ops = ts_current_state_detail::current_state_ops_for(target.kind);
+            return ops.reconcile_schema_compatible_impl(target, source);
+        }
+
         void apply_current_value_direct(const TSOutputView &out, const ValueView &value)
         {
             auto mutation = out.begin_mutation(out.evaluation_time());
@@ -747,6 +846,25 @@ namespace hgraph
                                     TSCurrentReconcileOptions options)
         {
             if (!should_visit_source(source, target, options)) { return; }
+            const std::size_t target_size = target.data_view().indexed_child_count();
+            const bool full = options.scope == TSCurrentReconcileScope::Full;
+
+            // A default view is the explicit "no source" sentinel used while
+            // a forwarding publication changes owners. It has no topology to
+            // traverse; a full reconciliation invalidates the current fixed
+            // or indexed state without attempting representation dispatch.
+            if (source.schema() == nullptr)
+            {
+                if (full)
+                {
+                    for (std::size_t index = 0; index < target_size; ++index)
+                    {
+                        invalidate_target(target.indexed_child_at(index));
+                    }
+                }
+                return;
+            }
+
             const std::size_t source_size = [&]() {
                 if constexpr (std::same_as<Source, TSInputView>)
                 {
@@ -757,11 +875,15 @@ namespace hgraph
                     return source.indexed_child_count();
                 }
             }();
-            const std::size_t target_size = target.data_view().indexed_child_count();
-            const bool full = options.scope == TSCurrentReconcileScope::Full;
 
-            const std::size_t visit_size = full ? source_size : source_size;
-            for (std::size_t index = 0; index < visit_size; ++index)
+            if (full && target.data_view().ops().indexed_child_growth &&
+                source_size < target_size)
+            {
+                throw std::invalid_argument(
+                    "reconcile_current_state: dynamic TSL current state cannot shrink");
+            }
+
+            for (std::size_t index = 0; index < source_size; ++index)
             {
                 auto source_child = [&]() {
                     if constexpr (std::same_as<Source, TSInputView>)
@@ -831,6 +953,14 @@ namespace hgraph
             throw std::logic_error("TSData current-state schema compatibility is not available");
         }
 
+        [[noreturn]] bool missing_reconcile_schema_compatible(
+            const TSValueTypeMetaData &,
+            const TSValueTypeMetaData &)
+        {
+            throw std::logic_error(
+                "TSData current-state topology compatibility is not available");
+        }
+
         [[noreturn]] Value missing_capture_current(const TSInputView &)
         {
             throw std::logic_error("TSData current-state capture is not available");
@@ -862,6 +992,7 @@ namespace hgraph
         {
             static const TSCurrentStateOps ops{
                 &current_value_schema_compatible_atomic,
+                &current_ts_schema_compatible_atomic,
                 &capture_current_atomic,
                 &apply_current_value_direct,
                 &observable_atomic,
@@ -875,6 +1006,7 @@ namespace hgraph
         {
             static const TSCurrentStateOps ops{
                 &current_value_schema_compatible_atomic,
+                &current_ts_schema_compatible_atomic,
                 &capture_current_signal,
                 &apply_current_value_direct,
                 &observable_atomic,
@@ -888,6 +1020,7 @@ namespace hgraph
         {
             static const TSCurrentStateOps ops{
                 &current_value_schema_compatible_atomic,
+                &current_ts_schema_compatible_ref,
                 &capture_current_transient,
                 &apply_current_value_direct,
                 &observable_atomic,
@@ -901,6 +1034,7 @@ namespace hgraph
         {
             static const TSCurrentStateOps ops{
                 &current_value_schema_compatible_atomic,
+                &current_ts_schema_compatible_window,
                 &capture_current_transient,
                 &apply_current_value_direct,
                 &observable_window,
@@ -914,6 +1048,7 @@ namespace hgraph
         {
             static const TSCurrentStateOps ops{
                 &current_value_schema_compatible_set,
+                &current_ts_schema_compatible_set,
                 &capture_current_set,
                 &apply_current_value_direct,
                 &observable_set,
@@ -927,6 +1062,7 @@ namespace hgraph
         {
             static const TSCurrentStateOps ops{
                 &current_value_schema_compatible_dict,
+                &current_ts_schema_compatible_dict,
                 &capture_current_dict,
                 &apply_current_value_dict,
                 &observable_dict,
@@ -940,6 +1076,7 @@ namespace hgraph
         {
             static const TSCurrentStateOps ops{
                 &current_value_schema_compatible_list,
+                &current_ts_schema_compatible_list,
                 &capture_current_list,
                 &apply_current_value_list,
                 &observable_list,
@@ -953,6 +1090,7 @@ namespace hgraph
         {
             static const TSCurrentStateOps ops{
                 &current_value_schema_compatible_bundle,
+                &current_ts_schema_compatible_bundle,
                 &capture_current_bundle,
                 &apply_current_value_bundle,
                 &observable_bundle,
@@ -969,6 +1107,7 @@ namespace hgraph
         {
             static const TSCurrentStateOps ops{
                 &missing_schema_compatible,
+                &missing_reconcile_schema_compatible,
                 &missing_capture_current,
                 &missing_apply_current,
                 &missing_observable_delta,
@@ -1488,15 +1627,23 @@ namespace hgraph
     {
         template <typename Source>
         void validate_reconcile_source(const TSValueTypeMetaData &schema,
+                                       const TSCurrentStateOps &ops,
                                        const Source &source)
         {
-            if (!source.valid()) { return; }
             const auto *source_schema = source.schema();
-            if (source_schema == nullptr || source_schema->value_schema == nullptr ||
-                !current_value_schema_compatible(schema, *source_schema->value_schema))
+            // A default, non-live view is the contract's explicit absent
+            // source. It carries no topology and asks the selected strategy
+            // to clear/invalidate its target state.
+            if (source_schema == nullptr && !source.valid()) { return; }
+            if (source_schema == nullptr ||
+                !ops.reconcile_schema_compatible_impl(schema, *source_schema))
             {
-                throw std::invalid_argument(
-                    "reconcile_current_state requires compatible source and target schemas");
+                throw std::invalid_argument(fmt::format(
+                    "reconcile_current_state requires compatible source and target time-series topology "
+                    "(target '{}', source '{}')",
+                    schema.name(),
+                    source_schema != nullptr ? source_schema->name()
+                                             : std::string_view{"<unbound>"}));
             }
         }
     }
@@ -1509,9 +1656,9 @@ namespace hgraph
         {
             throw std::invalid_argument("reconcile_current_state requires a bound target");
         }
-        validate_reconcile_source(schema, source);
         const auto type = target.type_ref();
         const auto &ops = current_state_ops(type.as_role(), "reconcile_current_state");
+        validate_reconcile_source(schema, ops, source);
         ops.reconcile_input_impl(target, source, options);
     }
 
@@ -1523,9 +1670,9 @@ namespace hgraph
         {
             throw std::invalid_argument("reconcile_current_state requires a bound target");
         }
-        validate_reconcile_source(schema, source);
         const auto type = target.type_ref();
         const auto &ops = current_state_ops(type.as_role(), "reconcile_current_state");
+        validate_reconcile_source(schema, ops, source);
         ops.reconcile_data_impl(target, source, options);
     }
 }  // namespace hgraph

--- a/src/hgraph/types/time_series/ts_input.cpp
+++ b/src/hgraph/types/time_series/ts_input.cpp
@@ -6,6 +6,7 @@
 #include <hgraph/runtime/graph.h>
 #include <hgraph/runtime/node.h>
 #include <hgraph/types/time_series/ts_input/detail.h>
+#include <hgraph/types/time_series/ts_data/impl/current_state_ops.h>
 
 #include <hgraph/types/metadata/ts_data_plan_factory.h>
 #include <hgraph/types/metadata/ts_data_plan_factory_detail.h>
@@ -2258,6 +2259,8 @@ namespace hgraph
                 .kind = context->schema->kind,
                 .allows_mutation = true,
                 .ownership_ops = &input_ownership_ops(),
+                .current_state_ops =
+                    &ts_current_state_detail::current_state_ops_for(context->schema->kind),
                 .layout_impl = &input_layout,
                 .tracking_impl = &input_tracking,
                 .mutable_tracking_impl = &input_mutable_tracking,

--- a/src/hgraph/types/time_series/ts_input/target_link_ops.cpp
+++ b/src/hgraph/types/time_series/ts_input/target_link_ops.cpp
@@ -1,5 +1,6 @@
 #include "target_link_ops.h"
 #include "../ts_data/ownership.h"
+#include <hgraph/types/time_series/ts_data/impl/current_state_ops.h>
 #include <hgraph/types/time_series/ts_delta.h>
 
 #include <hgraph/types/metadata/type_registry.h>
@@ -1201,6 +1202,8 @@ namespace hgraph::detail
                 .kind                      = context.schema->kind,
                 .allows_mutation           = true,
                 .ownership_ops             = &target_link_ownership_ops(),
+                .current_state_ops =
+                    &ts_current_state_detail::current_state_ops_for(context.schema->kind),
                 .layout_impl               = &target_link_layout,
                 .tracking_impl             = &target_link_tracking,
                 .mutable_tracking_impl     = &target_link_mutable_tracking,

--- a/tests/cpp/test_ts_delta.cpp
+++ b/tests/cpp/test_ts_delta.cpp
@@ -9,6 +9,7 @@
 #include <hgraph/lib/testing/record_replay.h>
 #include <hgraph/runtime/runtime.h>
 #include <hgraph/types/graph_wiring.h>
+#include <hgraph/types/metadata/ts_data_plan_factory.h>
 #include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
@@ -17,6 +18,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <array>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -166,6 +168,112 @@ template <typename Graph, typename Seed> auto run_graph(Seed seed) {
   return ex;
 }
 } // namespace
+
+TEST_CASE("TSData realizations select a non-missing current-state policy") {
+  (void)TypeRegistry::instance().register_scalar<Int>("int");
+  const std::array schemas{
+      schema_descriptor<TS<Int>>::ts_meta(),
+      schema_descriptor<TSS<Int>>::ts_meta(),
+      schema_descriptor<TSD<Int, TS<Int>>>::ts_meta(),
+      schema_descriptor<TSL<TS<Int>, 2>>::ts_meta(),
+      schema_descriptor<TSL<TS<Int>>>::ts_meta(),
+      schema_descriptor<TSW<Int, 3, 1>>::ts_meta(),
+      schema_descriptor<Quote>::ts_meta(),
+      schema_descriptor<REF<TS<Int>>>::ts_meta(),
+      schema_descriptor<SIGNAL>::ts_meta(),
+  };
+
+  for (const auto *schema : schemas) {
+    CAPTURE(schema->name());
+    const auto type = TSDataPlanFactory::instance().data_type_for(schema);
+    REQUIRE(type);
+    REQUIRE(type.ops_ref().current_state_ops != nullptr);
+    REQUIRE(type.ops_ref().current_state_ops !=
+            &ts_current_state_detail::missing_current_state_ops());
+  }
+}
+
+TEST_CASE("current-state reconciliation preserves fixed-structure child validity") {
+  (void)TypeRegistry::instance().register_scalar<Int>("int");
+  const auto *schema = schema_descriptor<Quote>::ts_meta();
+  TSOutput source{schema};
+  TSOutput target{schema};
+  TSInput input{TSInputBuilderFactory::checked_builder_for(
+      *schema, TSEndpointSchema::peered(schema))};
+  input.view(nullptr, MIN_ST).bind_output(source.view(MIN_ST));
+
+  Value first = tsb_delta<Quote>(1, std::nullopt);
+  apply_delta(source.view(MIN_ST), first.view());
+  reconcile_current_state(
+      target.view(MIN_ST), input.view(nullptr, MIN_ST),
+      TSCurrentReconcileOptions{TSCurrentReconcileScope::Full, false});
+
+  auto initial_view = target.view(MIN_ST);
+  auto initial = initial_view.as_bundle();
+  REQUIRE(initial.at(0).valid());
+  REQUIRE(initial.at(0).value().checked_as<Int>() == 1);
+  REQUIRE_FALSE(initial.at(1).valid());
+
+  const DateTime t2 = MIN_ST + MIN_TD;
+  Value second = tsb_delta<Quote>(std::nullopt, 2);
+  apply_delta(source.view(t2), second.view());
+  reconcile_current_state(
+      target.view(t2), input.view(nullptr, t2),
+      TSCurrentReconcileOptions{TSCurrentReconcileScope::Incremental, false});
+  auto updated_view = target.view(t2);
+  auto updated = updated_view.as_bundle();
+  REQUIRE(updated.at(0).value().checked_as<Int>() == 1);
+  REQUIRE(updated.at(1).value().checked_as<Int>() == 2);
+
+  const DateTime t3 = t2 + MIN_TD;
+  {
+    auto source_view = source.view(t3);
+    auto source_bundle = source_view.as_bundle();
+    auto child = source_bundle.at(0);
+    auto mutation = child.begin_mutation(t3);
+    REQUIRE(mutation.invalidate());
+  }
+  reconcile_current_state(
+      target.view(t3), input.view(nullptr, t3),
+      TSCurrentReconcileOptions{TSCurrentReconcileScope::Full, false});
+  auto invalidated_view = target.view(t3);
+  auto invalidated = invalidated_view.as_bundle();
+  REQUIRE_FALSE(invalidated.at(0).valid());
+  REQUIRE(invalidated.at(1).value().checked_as<Int>() == 2);
+
+  const DateTime t4 = t3 + MIN_TD;
+  reconcile_current_state(
+      target.view(t4), input.view(nullptr, t4),
+      TSCurrentReconcileOptions{TSCurrentReconcileScope::Full, false});
+  REQUIRE_FALSE(target.view(t4).modified());
+}
+
+TEST_CASE("observable-delta policy rejects scheduling-only fixed-list invalidation") {
+  (void)TypeRegistry::instance().register_scalar<Int>("int");
+  using One = TSL<TS<Int>, 1>;
+  const auto *schema = schema_descriptor<One>::ts_meta();
+  TSOutput source{schema};
+  TSInput input{TSInputBuilderFactory::checked_builder_for(
+      *schema, TSEndpointSchema::peered(schema))};
+  input.view(nullptr, MIN_ST).bind_output(source.view(MIN_ST));
+
+  Value first = list_delta<TS<Int>>({{0, 1}});
+  apply_delta(source.view(MIN_ST), first.view());
+
+  const DateTime t2 = MIN_ST + MIN_TD;
+  {
+    auto source_view = source.view(t2);
+    auto source_list = source_view.as_list();
+    auto child = source_list.at(0);
+    auto mutation = child.begin_mutation(t2);
+    REQUIRE(mutation.invalidate());
+  }
+  auto source_input = input.view(nullptr, t2);
+  REQUIRE(source_input.modified());
+  Value delta = capture_delta(source_input);
+  REQUIRE(delta.view().as_map().empty());
+  REQUIRE_FALSE(delta_is_observable(source_input, delta.view()));
+}
 
 TEST_CASE(
     "ts_delta: capture_delta matches ts_delta<S>::capture for a scalar TS") {
@@ -324,6 +432,13 @@ TEST_CASE("TSD output slots use the graph's closed Bundle realization") {
   const auto captured_request = modified.at(key.view()).concrete();
   REQUIRE(captured_request.schema() == leaf);
   REQUIRE(captured_request.as_bundle()["body"].checked_as<Str>() == "payload");
+
+  const Value current = capture_current_delta(input.view(nullptr, MIN_ST));
+  const auto current_modified =
+      current.view().as_bundle()["modified"].as_map();
+  const auto current_request = current_modified.at(key.view()).concrete();
+  REQUIRE(current_request.schema() == leaf);
+  REQUIRE(current_request.as_bundle()["body"].checked_as<Str>() == "payload");
 }
 
 TEST_CASE("apply_current_value accepts a concrete closed Bundle alternative") {

--- a/tests/cpp/test_ts_delta.cpp
+++ b/tests/cpp/test_ts_delta.cpp
@@ -15,6 +15,7 @@
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/static_node.h>
 #include <hgraph/types/time_series/ts_delta.h>
+#include <hgraph/types/value/value_builder.h>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -246,6 +247,67 @@ TEST_CASE("current-state reconciliation preserves fixed-structure child validity
       target.view(t4), input.view(nullptr, t4),
       TSCurrentReconcileOptions{TSCurrentReconcileScope::Full, false});
   REQUIRE_FALSE(target.view(t4).modified());
+}
+
+TEST_CASE("current-state reconciliation rejects incompatible TS topology") {
+  auto &registry = TypeRegistry::instance();
+  const auto *integer = registry.register_scalar<Int>("int");
+  const auto *text = registry.register_scalar<Str>("str");
+  const auto *list_value = registry.list(integer);
+  const auto *atomic_list = registry.ts(list_value);
+  const auto *structural_list = registry.tsl(registry.ts(integer), 0);
+
+  // These expose the same Python/current-value shape, but one is an atomic
+  // TS[List[Int]] and the other is an indexed TSL[TS[Int]]. Dispatching the
+  // target's indexed strategy over the atomic source is never valid.
+  REQUIRE(atomic_list->value_schema == structural_list->value_schema);
+  TSOutput atomic_source{atomic_list};
+  TSOutput list_target{structural_list};
+  REQUIRE_THROWS_AS(
+      reconcile_current_state(
+          list_target.view(MIN_ST), atomic_source.data_view(),
+          TSCurrentReconcileOptions{TSCurrentReconcileScope::Full, false}),
+      std::invalid_argument);
+
+  // The same distinction must be preserved recursively when the mismatched
+  // child topology is hidden below an otherwise-compatible TSD root.
+  const auto *atomic_dict = registry.tsd(text, atomic_list);
+  const auto *structural_dict = registry.tsd(text, structural_list);
+  REQUIRE(atomic_dict->value_schema == structural_dict->value_schema);
+  TSOutput nested_source{atomic_dict};
+  TSOutput nested_target{structural_dict};
+  REQUIRE_THROWS_AS(
+      reconcile_current_state(
+          nested_target.view(MIN_ST), nested_source.data_view(),
+          TSCurrentReconcileOptions{TSCurrentReconcileScope::Full, false}),
+      std::invalid_argument);
+}
+
+TEST_CASE("full current-state reconciliation rejects dynamic TSL shrink") {
+  (void)TypeRegistry::instance().register_scalar<Int>("int");
+  using DynamicList = TSL<TS<Int>>;
+  const auto *schema = schema_descriptor<DynamicList>::ts_meta();
+  TSOutput source{schema};
+  TSOutput target{schema};
+
+  Value source_delta = list_delta<TS<Int>>({{0, 1}});
+  Value target_delta = list_delta<TS<Int>>({{0, 10}, {1, 20}});
+  apply_delta(source.view(MIN_ST), source_delta.view());
+  apply_delta(target.view(MIN_ST), target_delta.view());
+
+  const DateTime next = MIN_ST + MIN_TD;
+  REQUIRE_THROWS_AS(
+      reconcile_current_state(
+          target.view(next), source.data_view(),
+          TSCurrentReconcileOptions{TSCurrentReconcileScope::Full, false}),
+      std::invalid_argument);
+
+  // Rejection happens before any child is partially reconciled.
+  auto target_view = target.view(next);
+  auto preserved = target_view.as_list();
+  REQUIRE(preserved.size() == 2);
+  REQUIRE(preserved.at(0).value().checked_as<Int>() == 10);
+  REQUIRE(preserved.at(1).value().checked_as<Int>() == 20);
 }
 
 TEST_CASE("observable-delta policy rejects scheduling-only fixed-list invalidation") {

--- a/tests/cpp/test_type_erasure_layout.cpp
+++ b/tests/cpp/test_type_erasure_layout.cpp
@@ -76,7 +76,7 @@ TEST_CASE("current type-erasure records retain their baseline layouts")
     static_assert(!HasNoArgumentRemovedValue<TSWDataView>);
     static_assert(HasNoArgumentRemovedValue<TSWInputView>);
     static_assert(sizeof(TSDataView) == sizeof(void *) * 2);
-    static_assert(TS_DATA_OPS_ABI_VERSION == 6);
+    static_assert(TS_DATA_OPS_ABI_VERSION == 7);
     static_assert(sizeof(TSRoleTypeRef) == sizeof(void *));
     static_assert(sizeof(TSDataObserverSet) == sizeof(void *));
     static_assert(sizeof(TSData) == sizeof(void *) * 3);

--- a/tests/cpp/test_type_erasure_layout.cpp
+++ b/tests/cpp/test_type_erasure_layout.cpp
@@ -76,7 +76,7 @@ TEST_CASE("current type-erasure records retain their baseline layouts")
     static_assert(!HasNoArgumentRemovedValue<TSWDataView>);
     static_assert(HasNoArgumentRemovedValue<TSWInputView>);
     static_assert(sizeof(TSDataView) == sizeof(void *) * 2);
-    static_assert(TS_DATA_OPS_ABI_VERSION == 7);
+    static_assert(TS_DATA_OPS_ABI_VERSION == 8);
     static_assert(sizeof(TSRoleTypeRef) == sizeof(void *));
     static_assert(sizeof(TSDataObserverSet) == sizeof(void *));
     static_assert(sizeof(TSData) == sizeof(void *) * 3);

--- a/tests/install_consumer/main.cpp
+++ b/tests/install_consumer/main.cpp
@@ -128,7 +128,7 @@ int main()
     static_assert(std::is_trivially_copyable_v<TypeRecord>);
     static_assert(std::is_standard_layout_v<AnyPtr>);
     static_assert(std::is_trivially_copyable_v<AnyPtr>);
-    static_assert(TS_DATA_OPS_ABI_VERSION == 6);
+    static_assert(TS_DATA_OPS_ABI_VERSION == 7);
     static_assert(sizeof(CompoundScalarStorageView) == 2 * sizeof(void *));
     static_assert(std::is_trivially_copyable_v<CompoundScalarStorageView>);
     static_assert(sizeof(PolymorphicValueType) == 2 * sizeof(void *));

--- a/tests/install_consumer/main.cpp
+++ b/tests/install_consumer/main.cpp
@@ -128,7 +128,7 @@ int main()
     static_assert(std::is_trivially_copyable_v<TypeRecord>);
     static_assert(std::is_standard_layout_v<AnyPtr>);
     static_assert(std::is_trivially_copyable_v<AnyPtr>);
-    static_assert(TS_DATA_OPS_ABI_VERSION == 7);
+    static_assert(TS_DATA_OPS_ABI_VERSION == 8);
     static_assert(sizeof(CompoundScalarStorageView) == 2 * sizeof(void *));
     static_assert(std::is_trivially_copyable_v<CompoundScalarStorageView>);
     static_assert(sizeof(PolymorphicValueType) == 2 * sizeof(void *));


### PR DESCRIPTION
## Summary

- add a non-null current-state strategy table selected with each TSData implementation
- route current capture/apply, delta observability, filter resynchronization, and reduce publication through the erased contract
- validate source time-series topology recursively before erased reconciliation dispatch
- reject unsupported dynamic TSL shrink before any target child is mutated
- preserve structural validity and polymorphic value bindings without representation-kind branches in semantic owners
- bump the TSData ops ABI to 8, document the ABI history, and cover canonical strategy selection and current-state regressions

Phase 2 of #462.

## Validation

- macOS: fresh native acceptance, 1591/1591 passed
- macOS: installed SDK consumer, 1/1 passed
- macOS: cp312-abi3 wheel installed under Python 3.14, 2170 passed, 9 skipped
- Linux (GCC 14): fresh native acceptance, 1590/1590 passed
- Linux: cp312-abi3 wheel installed under Python 3.14, 2170 passed, 9 skipped

The additional Linux installed-consumer probe reaches dependency discovery but that host does not provide an installed fmt CMake package; the installed-SDK consumer passes on macOS.