### PR TITLE
Remove list representation assumptions from table conversion

### DIFF
--- a/include/hgraph/types/value/compact_container_ops.h
+++ b/include/hgraph/types/value/compact_container_ops.h
@@ -726,11 +726,17 @@ namespace hgraph
         }
         inline const void *list_element_at(const void *, const void *memory, std::size_t index)
         {
-            return static_cast<const ListStorage *>(memory)->element_at(index);
+            const auto *storage = static_cast<const ListStorage *>(memory);
+            return storage->element_set(index) ? storage->element_at(index) : nullptr;
         }
         inline ValueTypeRef list_element_binding(const void *, const void *memory, std::size_t) noexcept
         {
             return static_cast<const ListStorage *>(memory)->element_binding();
+        }
+        inline bool list_element_valid(const void *, const void *memory,
+                                       std::size_t index) noexcept
+        {
+            return static_cast<const ListStorage *>(memory)->element_set(index);
         }
 
         // ----- CyclicBuffer -----
@@ -1091,6 +1097,7 @@ namespace hgraph
                 };
                 value.dynamic_storage_metrics_impl =
                     &compact_dynamic_storage_metrics<ListStorage>;
+                value.element_valid = &container_ops_detail::list_element_valid;
                 value.accepts_source_impl = &compact_accepts_source;
                 value.copy_assign_from_impl = &compact_list_copy_assign_from;
                 value.move_assign_from_impl = &compact_list_move_assign_from;

--- a/include/hgraph/types/value/container_ops.h
+++ b/include/hgraph/types/value/container_ops.h
@@ -94,14 +94,19 @@ namespace hgraph
          */
         Range<ValueView> (*make_range)(const void *context, const void *memory) = nullptr;
         Range<ValueView> (*make_mutable_range)(const void *context, void *memory) = nullptr;
-        /** Mutable element access (LAST member: positional initializers stay
-            valid). Null = fall back to ``element_at``. A Bundle installs one
-            that MARKS the field live (field validity, core_concepts.rst) and
-            returns real memory even when unset. */
+        /** Mutable element access. Null = fall back to ``element_at``. A
+            Bundle installs one that MARKS the field live (field validity,
+            core_concepts.rst) and returns real memory even when unset. */
         void *(*mutable_element_at)(const void *context, void *memory, std::size_t index) = nullptr;
         /** Change the logical extent of bounded indexed storage. Null for
             representations whose size is structural or fixed exactly. */
         void (*resize)(const void *context, void *memory, std::size_t size) = nullptr;
+        /** Whether the element at ``index`` is logically set. This is
+            distinct from storage lifetime: representations may keep a
+            default-constructed slot for an UNSET element. Null means
+            ``element_at(...) != nullptr``, preserving the dense default. */
+        bool (*element_valid)(const void *context, const void *memory,
+                              std::size_t index) noexcept = nullptr;
     };
 
     struct ListValueOps : IndexedValueOps

--- a/include/hgraph/types/value/mutable_container_ops.h
+++ b/include/hgraph/types/value/mutable_container_ops.h
@@ -336,6 +336,11 @@ namespace hgraph
         {
             return static_cast<const MutableListStorage *>(memory)->element_binding();
         }
+        inline bool list_element_valid(const void *, const void *memory,
+                                       std::size_t index) noexcept
+        {
+            return static_cast<const MutableListStorage *>(memory)->element_set(index);
+        }
         inline std::size_t list_hash(const void *, const void *memory)
         {
             const auto *storage = static_cast<const MutableListStorage *>(memory);
@@ -557,6 +562,7 @@ namespace hgraph
             };
             value.dynamic_storage_metrics_impl =
                 &container_ops_detail::compact_dynamic_storage_metrics<MutableListStorage>;
+            value.element_valid = &list_element_valid;
             value.accepts_source_impl = &accepts_container_source;
             value.copy_assign_from_impl = &list_copy_assign_from;
             value.move_assign_from_impl = &list_move_assign_from;

--- a/include/hgraph/types/value/specialized_views.h
+++ b/include/hgraph/types/value/specialized_views.h
@@ -191,12 +191,36 @@ namespace hgraph
             return ops_->size(ops_->context, data());
         }
 
+        /** True when the indexed element is logically set.
+
+            Storage lifetime and element validity are separate: a list may
+            retain a default-constructed slot for an UNSET element. The
+            representation supplies the answer through ``IndexedValueOps``;
+            older/dense strategies fall back to a non-null element address. */
+        [[nodiscard]] bool element_valid(std::size_t index) const
+        {
+            const auto n = ops_->size(ops_->context, data());
+            if (index >= n)
+            {
+                throw std::out_of_range(
+                    "IndexedValueView::element_valid: index out of range");
+            }
+            return ops_->element_valid != nullptr
+                       ? ops_->element_valid(ops_->context, data(), index)
+                       : ops_->element_at(ops_->context, data(), index) != nullptr;
+        }
+
         [[nodiscard]] const ValueView at(std::size_t index) const
         {
             const auto n = ops_->size(ops_->context, data());
             if (index >= n) { throw std::out_of_range("IndexedValueView::at: index out of range"); }
-            return ValueView{ops_->element_binding(ops_->context, data(), index),
-                             ops_->element_at(ops_->context, data(), index)};
+            const auto binding = ops_->element_binding(ops_->context, data(), index);
+            if (ops_->element_valid != nullptr &&
+                !ops_->element_valid(ops_->context, data(), index))
+            {
+                return ValueView{binding, nullptr};
+            }
+            return ValueView{binding, ops_->element_at(ops_->context, data(), index)};
         }
 
         [[nodiscard]] const ValueView operator[](std::size_t index) const { return at(index); }

--- a/include/hgraph/types/value/value_builder.h
+++ b/include/hgraph/types/value/value_builder.h
@@ -315,6 +315,29 @@ namespace hgraph
             return Value{binding, &storage};
         }
 
+        /** Build an owning list and materialise it in ``target_binding``.
+
+            The accumulator always produces its compact owning value first.
+            A distinct target representation receives that value through its
+            passive ``ValueOps::move_assign_from`` contract; callers must
+            never infer a concrete target layout from ``ValueOpsKind``. */
+        [[nodiscard]] Value build(const ValueTypeRef &target_binding)
+        {
+            if (!target_binding)
+            {
+                throw std::invalid_argument(
+                    "ListBuilder target binding must be bound");
+            }
+            Value source = build();
+            if (source.binding() == target_binding) { return source; }
+
+            Value result{target_binding};
+            target_binding.ops_ref().move_assign_from(
+                target_binding, const_cast<void *>(result.view().data()),
+                source.binding(), const_cast<void *>(source.view().data()));
+            return result;
+        }
+
       private:
         void ensure_not_built() const
         {

--- a/include/hgraph/types/value/value_builder.h
+++ b/include/hgraph/types/value/value_builder.h
@@ -318,9 +318,11 @@ namespace hgraph
         /** Build an owning list and materialise it in ``target_binding``.
 
             The accumulator always produces its compact owning value first.
-            A distinct target representation receives that value through its
-            passive ``ValueOps::move_assign_from`` contract; callers must
-            never infer a concrete target layout from ``ValueOpsKind``. */
+            A distinct target representation resolves its external owning
+            binding, whose passive ``ValueOps::move_assign_from`` contract
+            receives that value. Callers must never infer a concrete target
+            layout from ``ValueOpsKind`` or dispatch view operations against
+            the owner's memory. */
         [[nodiscard]] Value build(const ValueTypeRef &target_binding)
         {
             if (!target_binding)
@@ -328,12 +330,13 @@ namespace hgraph
                 throw std::invalid_argument(
                     "ListBuilder target binding must be bound");
             }
+            const auto owning_binding = value_owning_type(target_binding);
             Value source = build();
-            if (source.binding() == target_binding) { return source; }
+            if (source.binding() == owning_binding) { return source; }
 
-            Value result{target_binding};
-            target_binding.ops_ref().move_assign_from(
-                target_binding, const_cast<void *>(result.view().data()),
+            Value result{owning_binding};
+            owning_binding.ops_ref().move_assign_from(
+                owning_binding, const_cast<void *>(result.view().data()),
                 source.binding(), const_cast<void *>(source.view().data()));
             return result;
         }

--- a/include/hgraph/types/value/value_ops.h
+++ b/include/hgraph/types/value/value_ops.h
@@ -51,7 +51,7 @@ namespace hgraph
     };
 
     static_assert(sizeof(ValueOpsKind) == 1);
-    inline constexpr std::uint16_t VALUE_OPS_ABI_VERSION = 5;
+    inline constexpr std::uint16_t VALUE_OPS_ABI_VERSION = 6;
 
     struct ValueOps;
 #if HGRAPH_ENABLE_PYTHON_USER_NODES

--- a/python/tests/adaptors/data_frame/test_data_frame_record_replay.py
+++ b/python/tests/adaptors/data_frame/test_data_frame_record_replay.py
@@ -235,16 +235,16 @@ def test_raw_replay_applies_tsb_and_selects_each_tsd_partition():
     bundle_schema = hg.ts_schema(a=hg.TS[int], b=hg.TS[str])
     bundle_frame = pa.table(
         {
-            "__date_time__": [hg.MIN_ST],
-            "__as_of__": [hg.MIN_ST],
-            "a": [1],
-            "b": ["one"],
+            "__date_time__": [hg.MIN_ST, hg.MIN_ST + hg.MIN_TD],
+            "__as_of__": [hg.MIN_ST, hg.MIN_ST],
+            "a": [1, None],
+            "b": ["one", "two"],
         }
     )
     assert hg.eval_node(
         replay_data_frame[hg.TSB[bundle_schema]], bundle_frame,
         as_of_time=hg.MIN_ST
-    ) == [{"a": 1, "b": "one"}]
+    ) == [{"a": 1, "b": "one"}, {"b": "two"}]
 
     dict_frame = pa.table(
         {

--- a/src/hgraph/lib/std/operators/data_frame_impl.cpp
+++ b/src/hgraph/lib/std/operators/data_frame_impl.cpp
@@ -1,6 +1,7 @@
 #include <hgraph/lib/std/operators/impl/data_frame_impl.h>
 
 #include <hgraph/lib/std/operators/conversion.h>
+#include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/time_series/ts_input/bundle_view.h>
@@ -27,12 +28,29 @@ namespace hgraph::stdlib
             [[nodiscard]] ValueTypeRef checked_binding(const ValueTypeMetaData *meta,
                                                                   const char              *what)
             {
-                const auto binding = ValuePlanFactory::instance().type_for(meta);
+                const auto binding = value_type_for_active_realization(meta);
                 if (binding == nullptr)
                 {
                     throw std::logic_error(fmt::format("{}: schema has no value binding", what));
                 }
                 return binding;
+            }
+
+            /** Assign a cell through the selected destination strategy.
+                Compatible realized values need not have identical schemas or
+                storage plans. */
+            void assign_cell(const ValueView &destination,
+                             const ValueView &source)
+            {
+                if (!destination.has_value() || !source.has_value())
+                {
+                    throw std::invalid_argument(
+                        "data-frame cell assignment requires live values");
+                }
+                const auto target = destination.binding();
+                target.ops_ref().copy_assign_from(
+                    target, destination.mutable_data(), source.binding(),
+                    source.data());
             }
 
             [[nodiscard]] const ValueTypeMetaData *datetime_meta()
@@ -68,7 +86,7 @@ namespace hgraph::stdlib
                 ValueView root = row.view().begin_mutation();
                 auto      mut  = root.as_bundle().begin_mutation();
                 ValueView dest = mut.at(index);
-                dest.copy_from(cell);
+                assign_cell(dest, cell);
             }
 
             void set_bundle_field(Value &row, std::size_t index, const Value &cell)
@@ -349,7 +367,10 @@ namespace hgraph::stdlib
                     if (columns[column] < 0) { continue; }
                     Value cell = frame_cell_at(frame, columns[column],
                                                layout.col_metas[column], row);
-                    if (cell.has_value()) { tuple.at(column).copy_from(cell.view()); }
+                    if (cell.has_value())
+                    {
+                        assign_cell(tuple.at(column), cell.view());
+                    }
                 }
                 return value;
             }
@@ -366,16 +387,14 @@ namespace hgraph::stdlib
 
                 const auto row_binding =
                     checked_binding(layout.row_meta, "replay_data_frame");
-                ListBuilder builder{row_binding};
+                ListBuilder builder{row_binding, *layout.rows_meta};
                 for (const ReplayCandidate &candidate : candidates)
                 {
                     Value row = read_table_row(layout, frame, columns, candidate.row);
-                    builder.push_back_copy(row.view().data());
+                    builder.push_back(row.view());
                 }
-                Value rows{checked_binding(layout.rows_meta, "replay_data_frame")};
-                *static_cast<ListStorage *>(
-                    const_cast<void *>(rows.view().data())) = builder.build_storage();
-                return rows;
+                return builder.build(
+                    checked_binding(layout.rows_meta, "replay_data_frame"));
             }
         }  // namespace
 
@@ -831,7 +850,7 @@ namespace hgraph::stdlib
                         ValueView root = key.view().begin_mutation();
                         auto      mut  = root.as_tuple().begin_mutation();
                         ValueView dest = mut.at(i);
-                        dest.copy_from(cell.view());
+                        assign_cell(dest, cell.view());
                     }
                 }
                 else
@@ -840,7 +859,7 @@ namespace hgraph::stdlib
                         frame_cell(frame, plan.key_cols.front().column, plan.key_cols.front().leaf, r);
                     if (!cell.has_value()) { continue; }
                     ValueView dest = key.view().begin_mutation();
-                    dest.copy_from(cell.view());
+                    assign_cell(dest, cell.view());
                 }
 
                 auto bucket = std::find_if(buckets.begin(), buckets.end(), [&](const auto &entry) {

--- a/src/hgraph/lib/std/operators/table_impl.cpp
+++ b/src/hgraph/lib/std/operators/table_impl.cpp
@@ -1,5 +1,6 @@
 #include <hgraph/lib/std/operators/impl/table_impl.h>
 
+#include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/time_series/ts_input/bundle_view.h>
@@ -529,12 +530,31 @@ namespace hgraph::stdlib
             [[nodiscard]] ValueTypeRef checked_binding(const ValueTypeMetaData *meta,
                                                        const char              *what)
             {
-                const auto binding = ValuePlanFactory::instance().type_for(meta);
+                const auto binding = value_type_for_active_realization(meta);
                 if (binding == nullptr)
                 {
                     throw std::logic_error(fmt::format("{}: schema has no value binding", what));
                 }
                 return binding;
+            }
+
+            /** Assign a semantic cell through the selected target strategy.
+                Cell schemas may be compatible without being identical (for
+                example a concrete CompoundScalar leaf assigned to its closed
+                base realization), so ``ValueView::copy_from`` is deliberately
+                too narrow here. */
+            void assign_cell(const ValueView &destination,
+                             const ValueView &source)
+            {
+                if (!destination.has_value() || !source.has_value())
+                {
+                    throw std::invalid_argument(
+                        "table cell assignment requires live values");
+                }
+                const auto target = destination.binding();
+                target.ops_ref().copy_assign_from(
+                    target, destination.mutable_data(), source.binding(),
+                    source.data());
             }
 
             /** A fresh borrow over the same binding + memory (the read views
@@ -636,7 +656,7 @@ namespace hgraph::stdlib
                     ValueView root = value.view();
                     auto      mut = root.as_tuple().begin_mutation();
                     ValueView cell = mut.at(index);
-                    cell.copy_from(leaf);
+                    assign_cell(cell, leaf);
                 }
 
                 template <typename T>
@@ -954,15 +974,12 @@ namespace hgraph::stdlib
             {
                 const auto &row_binding = checked_binding(layout.row_meta, "to_table");
                 const auto &rows_binding = checked_binding(layout.rows_meta, "to_table");
-                ListBuilder builder{row_binding};
+                ListBuilder builder{row_binding, *layout.rows_meta};
                 for (const Value &row : rows)
                 {
-                    builder.push_back_copy(row.view().data());
+                    builder.push_back(row.view());
                 }
-                Value out{rows_binding};
-                *static_cast<ListStorage *>(const_cast<void *>(out.view().data())) =
-                    builder.build_storage();
-                return out;
+                return builder.build(rows_binding);
             }
         }  // namespace
 
@@ -1151,7 +1168,7 @@ namespace hgraph::stdlib
                 {
                     // Atomic key: the single key cell IS the key value.
                     ValueView dest = key.view().begin_mutation();
-                    dest.copy_from(row.at(level.first_key_col));
+                    assign_cell(dest, row.at(level.first_key_col));
                     return key;
                 }
                 for (std::size_t i = 0; i < level.key_paths.size(); ++i)
@@ -1161,7 +1178,10 @@ namespace hgraph::stdlib
                     {
                         continue;
                     }
-                    walk_mutable(key.view().begin_mutation(), level.key_paths[i]).copy_from(cell);
+                    assign_cell(
+                        walk_mutable(key.view().begin_mutation(),
+                                     level.key_paths[i]),
+                        cell);
                 }
                 return key;
             }
@@ -1257,7 +1277,10 @@ namespace hgraph::stdlib
                         std::vector<std::size_t> full_path = column.ts_path;
                         full_path.insert(full_path.end(), column.value_path.begin(),
                                          column.value_path.end());
-                        walk_mutable(value.view().begin_mutation(), full_path).copy_from(cell);
+                        assign_cell(
+                            walk_mutable(value.view().begin_mutation(),
+                                         full_path),
+                            cell);
                         any = true;
                     }
                     if (any)
@@ -1545,7 +1568,7 @@ namespace hgraph::stdlib
                     Value cell = source.cell(source.context, row, column);
                     if (cell.has_value())
                     {
-                        tuple.at(column).copy_from(cell.view());
+                        assign_cell(tuple.at(column), cell.view());
                     }
                 }
                 return value;

--- a/src/hgraph/types/value/compact_container_ops.cpp
+++ b/src/hgraph/types/value/compact_container_ops.cpp
@@ -39,17 +39,14 @@ namespace hgraph
             ListBuilder builder{state.element_binding};
             const ValueView source_view{source, src};
             const auto values = source_view.as_list();
-            const auto *source_storage =
-                source.ops_ref().kind == ValueOpsKind::List ? static_cast<const ListStorage *>(src) : nullptr;
             for (std::size_t index = 0; index < values.size(); ++index)
             {
-                const auto child = values.at(index);
-                if (!child.has_value() || (source_storage != nullptr && !source_storage->element_set(index)))
+                if (!values.element_valid(index))
                 {
                     builder.push_back_unset();
                     continue;
                 }
-                builder.push_back(child);
+                builder.push_back(values.at(index));
             }
             *static_cast<ListStorage *>(dst) = builder.build_storage();
         }

--- a/tests/cpp/test_record_replay_frame.cpp
+++ b/tests/cpp/test_record_replay_frame.cpp
@@ -92,7 +92,8 @@ namespace
             require_arrow(date.Append(when.time_since_epoch().count()));
             require_arrow(as_of.Append((MIN_ST + TimeDelta{10}).time_since_epoch().count()));
         }
-        require_arrow(a.AppendValues({1, 2}));
+        require_arrow(a.Append(1));
+        require_arrow(a.AppendNull());
         require_arrow(b.AppendValues({"one", "two"}));
         return Frame{arrow::Table::Make(
             arrow::schema({arrow::field("__date_time__", arrow::timestamp(arrow::TimeUnit::MICRO)),
@@ -684,7 +685,7 @@ TEST_CASE("raw frame replay uses configured as-of and applies TSB rows")
     REQUIRE(bundle.size() == 2);
     CHECK(bundle[0]->as_bundle().at(0).checked_as<Int>() == Int{1});
     CHECK(bundle[0]->as_bundle().at(1).checked_as<Str>() == Str{"one"});
-    CHECK(bundle[1]->as_bundle().at(0).checked_as<Int>() == Int{2});
+    CHECK_FALSE(bundle[1]->as_bundle().at(0).has_value());
     CHECK(bundle[1]->as_bundle().at(1).checked_as<Str>() == Str{"two"});
 }
 

--- a/tests/cpp/test_table.cpp
+++ b/tests/cpp/test_table.cpp
@@ -3,6 +3,7 @@
 #include <hgraph/lib/testing/check_output.h>
 #include <hgraph/lib/testing/eval_node.h>
 #include <hgraph/types/graph_wiring.h>
+#include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/record_replay.h>
 #include <hgraph/types/registry_reset.h>
@@ -28,6 +29,13 @@ struct ExtensionTableScalar
     bool         operator==(const ExtensionTableScalar &) const = default;
 };
 
+namespace polymorphic_table_repro
+{
+    struct Event
+    {
+    };
+}
+
 namespace hgraph::static_schema_detail
 {
     template <>
@@ -36,6 +44,31 @@ namespace hgraph::static_schema_detail
         static constexpr std::string_view value{"tests.ExtensionTableScalar"};
     };
 }  // namespace hgraph::static_schema_detail
+
+namespace hgraph
+{
+    template <>
+    struct scalar_descriptor<polymorphic_table_repro::Event>
+    {
+        [[nodiscard]] static constexpr bool is_concrete() noexcept { return true; }
+        [[nodiscard]] static const ValueTypeMetaData *value_meta()
+        {
+            auto &registry = TypeRegistry::instance();
+            return registry.bundle(
+                "tests.table", "Event",
+                {{"event_id", registry.value_type("str")}}, {}, true);
+        }
+    };
+}
+
+namespace hgraph::testing
+{
+    template <>
+    struct ts_harness<TS<polymorphic_table_repro::Event>>
+        : bundle_ts_harness<TS<polymorphic_table_repro::Event>>
+    {
+    };
+}
 
 namespace
 {
@@ -82,6 +115,44 @@ namespace
 
     const TableTypeOps extension_table_ops{&describe_extension_scalar, &emit_extension_scalar,
                                            &apply_extension_scalar};
+
+    void describe_polymorphic_event(TableLayout &layout,
+                                    const TSValueTypeMetaData *schema,
+                                    std::string, std::vector<std::size_t>,
+                                    std::size_t)
+    {
+        layout.leaf_ts = schema;
+        layout.value_col_start = layout.keys.size();
+        layout.keys.push_back("event");
+        layout.col_metas.push_back(schema->value_schema);
+        layout.value_cols.push_back(
+            TableLayout::Column{.name = "event", .leaf = schema->value_schema});
+    }
+
+    void emit_polymorphic_event(const TableLayout &layout, const TSInputView &ts,
+                                Int, DateTime now, DateTime as_of, bool,
+                                const TableRowSink &sink, bool)
+    {
+        const Value when{now};
+        const Value revision{as_of};
+        sink.cell(sink.context, 0, when.view());
+        sink.cell(sink.context, 1, revision.view());
+        sink.cell(sink.context, layout.value_col_start, ts.value());
+        sink.end_row(sink.context);
+    }
+
+    void apply_polymorphic_event(const TableLayout &layout,
+                                 const TableRowSource &source,
+                                 const TSOutputView &out)
+    {
+        const Value cell =
+            source.cell(source.context, 0, layout.value_col_start);
+        apply_current_value(out, cell.view());
+    }
+
+    const TableTypeOps polymorphic_event_table_ops{
+        &describe_polymorphic_event, &emit_polymorphic_event,
+        &apply_polymorphic_event};
 
     void describe_all_null_extension_scalar(TableLayout &layout,
                                              const TSValueTypeMetaData *schema, std::string,
@@ -452,6 +523,8 @@ namespace
     using NestedExtensionBundle =
         UnNamedTSB<Field<"custom", TS<ExtensionTableScalar>>, Field<"regular", TS<Int>>>;
     using NestedExtensionDict = TSD<Str, TS<ExtensionTableScalar>>;
+    using PolymorphicTableEvent = polymorphic_table_repro::Event;
+    using PolymorphicTableDict = TSD<Str, TS<PolymorphicTableEvent>>;
 
     template <typename Schema>
     struct NestedExtensionTableRoundTripGraph
@@ -462,6 +535,20 @@ namespace
         {
             auto rows = wire<stdlib::to_table>(w, ts);
             return wire<stdlib::from_table, Schema>(w, rows).template as<Schema>();
+        }
+    };
+
+    struct PolymorphicTableRoundTripGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "polymorphic_table_round_trip_graph";
+
+        static Port<PolymorphicTableDict>
+        compose(Wiring &w, Port<PolymorphicTableDict> ts)
+        {
+            auto rows = wire<stdlib::to_table>(w, ts);
+            return wire<stdlib::from_table, PolymorphicTableDict>(w, rows)
+                .as<PolymorphicTableDict>();
         }
     };
 
@@ -553,6 +640,85 @@ TEST_CASE("table operators: to_table -> from_table round-trips through a graph")
     stdlib::register_standard_operators();
     CHECK_OUTPUT(eval_node<TableRoundTripGraph>(values<Float>(1.5, none, -0.25)),
                  values<Float>(1.5, none, -0.25));
+}
+
+TEST_CASE("table operators materialise polymorphic row lists through the active realization")
+{
+    stdlib::register_standard_operators();
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *event = scalar_descriptor<PolymorphicTableEvent>::value_meta();
+    const auto *created = registry.bundle(
+        "tests.table", "CreateEvent",
+        {{"event_id", registry.value_type("str")},
+         {"payload", registry.value_type("str")}},
+        {event});
+    register_table_type_ops(
+        TypeRegistry::instance().ts(event), polymorphic_event_table_ops);
+
+    for (const bool pooled : {false, true})
+    {
+        INFO("table row realization " << (pooled ? "pooled" : "inline"));
+        GlobalState graph_state;
+        if (pooled)
+        {
+            set_pooled_compound_scalar_storage(graph_state.view());
+        }
+        GlobalContext graph_context{graph_state};
+
+        const TypeRealizationOptions options{
+            .polymorphic_compound_storage =
+                pooled ? PolymorphicCompoundStoragePolicy::Pooled
+                       : PolymorphicCompoundStoragePolicy::Inline,
+        };
+        const auto realization =
+            TypeRealizationSnapshot::capture(registry, options);
+        TypeRealizationScope scope{realization.get()};
+
+        BundleBuilder created_builder{
+            realization->exact_type_for(created)};
+        created_builder.set("event_id", Value{Str{"created"}});
+        created_builder.set("payload", Value{Str{"payload"}});
+        Value concrete = created_builder.build();
+
+        const auto event_binding = realization->type_for(event);
+        Value event_value{event_binding};
+        event_binding.ops_ref().copy_assign_from(
+            event_binding,
+            event_value.begin_mutation().mutable_data(),
+            concrete.binding(), concrete.view().data());
+
+        const auto key_binding =
+            realization->type_for(scalar_descriptor<Str>::value_meta());
+        SetBuilder removed{key_binding};
+        MapBuilder modified{key_binding, event_binding};
+        const Value key{Str{"order"}};
+        modified.set_item(key.view(), event_value.view());
+
+        const auto *delta_schema =
+            ts_type<PolymorphicTableDict>()->delta_value_schema;
+        BundleBuilder delta{realization->type_for(delta_schema)};
+        delta.set("removed", removed.build());
+        delta.set("modified", modified.build());
+
+        const auto actual =
+            eval_node<PolymorphicTableRoundTripGraph>(
+                values<Value>(delta.build()));
+        REQUIRE(actual.size() == 1);
+        REQUIRE(actual.front().has_value());
+        const auto output_modified =
+            actual.front()->as_bundle().field("modified").as_map();
+        REQUIRE(output_modified.size() == 1);
+        const auto round_tripped =
+            output_modified.at(key.view()).concrete();
+        REQUIRE(round_tripped.schema() == created);
+        CHECK(round_tripped.as_bundle()
+                  .field("event_id")
+                  .checked_as<Str>() == Str{"created"});
+        CHECK(round_tripped.as_bundle()
+                  .field("payload")
+                  .checked_as<Str>() == Str{"payload"});
+    }
 }
 
 TEST_CASE("table type ops: an extension supplies describe emit and apply once "

--- a/tests/cpp/test_type_erasure_layout.cpp
+++ b/tests/cpp/test_type_erasure_layout.cpp
@@ -294,7 +294,7 @@ TEST_CASE("value ops discriminator has a fixed byte ABI at offset zero")
     static_assert(sizeof(ValueOpsKind) == 1);
     static_assert(offsetof(ValueOps, kind) == 0);
     static_assert(std::is_same_v<decltype(VALUE_OPS_ABI_VERSION), const std::uint16_t>);
-    static_assert(VALUE_OPS_ABI_VERSION == 5);
+    static_assert(VALUE_OPS_ABI_VERSION == 6);
     static_assert(static_cast<std::uint8_t>(ValueOpsKind::Invalid) == 0);
     static_assert(static_cast<std::uint8_t>(ValueOpsKind::Base) == 1);
     static_assert(static_cast<std::uint8_t>(ValueOpsKind::Indexed) == 2);

--- a/tests/cpp/test_value_builder.cpp
+++ b/tests/cpp/test_value_builder.cpp
@@ -2,6 +2,7 @@
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/primitive_types.h>
 #include <hgraph/types/static_schema.h>
+#include <hgraph/types/value/mutable_container_ops.h>
 #include <hgraph/types/value/specialized_views.h>
 #include <hgraph/types/value/value_builder.h>
 
@@ -232,6 +233,56 @@ TEST_CASE("value builders reject an incompatible view before changing their cont
     REQUIRE(map_value.as_map().size() == 1);
     check_event(
         map_value.as_map().at(key.view()), schemas.created, "event");
+}
+
+TEST_CASE("list builders transfer through compatible erased realizations and preserve unset elements")
+{
+    using namespace hgraph;
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *int_meta = scalar_descriptor<Int>::value_meta();
+    const auto *list_meta = registry.list(int_meta);
+    const auto  element_binding = ValuePlanFactory::instance().type_for(int_meta);
+    const auto  compact_binding = compact_list_type(element_binding, *list_meta);
+
+    // Deliberately bind the same immutable List schema to the slot-backed list
+    // strategy. The shared schema makes it a compatible realization; its plan
+    // and storage layout remain distinct from compact ListStorage.
+    const auto slot_binding = intern_value_type(
+        *list_meta, mutable_list_plan(element_binding), mutable_list_ops());
+    REQUIRE(slot_binding != compact_binding);
+    REQUIRE(slot_binding.ops_ref().kind == ValueOpsKind::MutableList);
+
+    ListBuilder builder{element_binding, *list_meta};
+    builder.push_back(Int{10});
+    builder.push_back_unset();
+    builder.push_back(Int{30});
+    Value slot_value = builder.build(slot_binding);
+
+    const auto slot_list = slot_value.as_list();
+    REQUIRE(slot_list.size() == 3);
+    CHECK(slot_list.element_valid(0));
+    CHECK_FALSE(slot_list.element_valid(1));
+    CHECK(slot_list.element_valid(2));
+    CHECK(slot_list.at(0).checked_as<Int>() == Int{10});
+    CHECK(slot_list.at(1).bound());
+    CHECK_FALSE(slot_list.at(1).has_value());
+    CHECK(slot_list.at(2).checked_as<Int>() == Int{30});
+
+    Value compact_value{compact_binding};
+    compact_binding.ops_ref().copy_assign_from(
+        compact_binding, const_cast<void *>(compact_value.view().data()),
+        slot_value.binding(), slot_value.view().data());
+
+    const auto compact_list = compact_value.as_list();
+    REQUIRE(compact_list.size() == 3);
+    CHECK(compact_list.element_valid(0));
+    CHECK_FALSE(compact_list.element_valid(1));
+    CHECK(compact_list.element_valid(2));
+    CHECK(compact_list.at(0).checked_as<Int>() == Int{10});
+    CHECK(compact_list.at(1).bound());
+    CHECK_FALSE(compact_list.at(1).has_value());
+    CHECK(compact_list.at(2).checked_as<Int>() == Int{30});
 }
 
 TEST_CASE("compact containers convert elements between polymorphic realizations")

--- a/tests/cpp/test_value_builder.cpp
+++ b/tests/cpp/test_value_builder.cpp
@@ -2,6 +2,7 @@
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/primitive_types.h>
 #include <hgraph/types/static_schema.h>
+#include <hgraph/types/value/compound_scalar_storage.h>
 #include <hgraph/types/value/mutable_container_ops.h>
 #include <hgraph/types/value/specialized_views.h>
 #include <hgraph/types/value/value_builder.h>
@@ -283,6 +284,41 @@ TEST_CASE("list builders transfer through compatible erased realizations and pre
     CHECK(compact_list.at(1).bound());
     CHECK_FALSE(compact_list.at(1).has_value());
     CHECK(compact_list.at(2).checked_as<Int>() == Int{30});
+}
+
+TEST_CASE("list builders dispatch target transfer through the external owning binding")
+{
+    using namespace hgraph;
+
+    const auto schemas = polymorphic_builder_schemas();
+    const TypeRealizationOptions options{
+        .polymorphic_compound_storage =
+            PolymorphicCompoundStoragePolicy::Pooled,
+    };
+    const auto realization = TypeRealizationSnapshot::capture(
+        TypeRegistry::instance(), options);
+    TypeRealizationScope realization_scope{realization.get()};
+    CompoundScalarStorage pools = CompoundScalarStorage::make_default();
+    CompoundScalarStorageScope pool_scope{pools.view()};
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *list_schema = registry.list(schemas.event);
+    const auto  external_element = realization->type_for(schemas.event);
+    const auto  external_list = realization->type_for(list_schema);
+    const auto  graph_list = realization->graph_type_for(list_schema);
+    REQUIRE(graph_list != external_list);
+    REQUIRE(value_owning_type(graph_list) == external_list);
+
+    const Value created = created_value(*realization, schemas);
+    ListBuilder builder{external_element, *list_schema};
+    builder.push_back(created.view());
+    const Value result = builder.build(graph_list);
+
+    REQUIRE(result.binding() == external_list);
+    const auto values = result.as_list();
+    REQUIRE(values.size() == 1);
+    CHECK(values.at(0).binding() == external_element);
+    check_event(values.at(0), schemas.created, "event");
 }
 
 TEST_CASE("compact containers convert elements between polymorphic realizations")


### PR DESCRIPTION
## Summary

- add an erased indexed-element validity query and expose it through `IndexedValueView`
- make `ListBuilder` construct an owning compact value, resolve the requested realization's external owner, and transfer through that owner's `ValueOps`
- resolve table and data-frame row values through the active type realization and assign compatible cells through the destination ops table
- remove the `ValueOpsKind::List` implies `ListStorage` assumption from compact list transfer
- cover slot-backed and compact list realizations, unset elements, sparse frame replay, polymorphic CompoundScalar rows under inline and pooled storage, and graph-local list bindings with distinct external owners

## Why

The table and data-frame row materialisers allocated values using the active binding but then wrote `ListStorage` directly into their payloads. Compact list copy also downcast any `ValueOpsKind::List` source to `ListStorage` to inspect validity. Both paths violated the erased representation boundary and failed for compatible non-compact realizations.

The owner resolution is also required when the requested target is a graph-local or view realization: `Value` owns the external binding's memory, so assignment must dispatch through that owning binding rather than applying view operations to owner storage.

This changes the public value-ops ABI from version 5 to 6 because `IndexedValueOps` gains the optional validity operation.

## Validation

- macOS fresh native gate: 1,594 passed
- installed C++ SDK consumer: 1 passed
- macOS cp312-abi3 wheel installed under Python 3.14: 2,170 passed, 9 skipped
- Linux/GCC 14 fresh native gate: 1,593 passed
- Linux cp312-abi3 wheel installed under Python 3.14: 2,170 passed, 9 skipped
- `git diff --check`

This ready-for-review PR is stacked on #465 and contains only the Phase 3 changes relative to that branch. It advances Phase 3 of #462.
