### PR TITLE
Use stable TypeRecord representation identity

### DIFF
--- a/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
@@ -257,7 +257,10 @@ TSData implementation families
     role records. In particular the projections are named
     ``ts.tsd.key-set.{data,input,output}`` and
     ``ts.tsd.value.{data,input,output}``, so a debugger can identify topology
-    without inferring it from an ops pointer.
+    without inferring it from an ops pointer. The implementation label is part
+    of canonical record identity, so these projections retain the exact opaque
+    ops table selected for the element realization; no derived-table copy or
+    kind-based narrowing is required.
 
     Slot lifetime follows the observer protocol. Removing a key stops its
     owned child tree and marks the slot not live, but retains the constructed

--- a/docs/source/developer_guide/data_structures/unified_type_erasure.rst
+++ b/docs/source/developer_guide/data_structures/unified_type_erasure.rst
@@ -256,9 +256,15 @@ meaning:
 
 The implementation label can be null when the semantic label is sufficient.
 The schema registry owns semantic labels and the type-record registry owns
-implementation labels.  A magic value and ABI version on each independently
-addressable common record allow a debugger to reject unrelated or incompatible
-memory instead of guessing.  The schema ABI versions the schema-header layout;
+implementation labels.  Its string content is also the stable representation
+identity used by type-record interning.  Equal labels canonicalize even when
+they originate in different caller-owned strings or shared libraries; distinct
+labels permit distinct records to share the same schema, role, plan, ops, and
+debug descriptor.  This allows topological projections to reuse an opaque ops
+table without copying it merely to obtain a different pointer.  Each
+independently addressable common record has a magic value and ABI version, so a
+debugger can reject unrelated or incompatible memory instead of guessing.  The
+schema ABI versions the schema-header layout;
 the type-record ABI versions the record layout; the ops ABI versions the table
 selected by family and role.
 
@@ -651,9 +657,11 @@ Resolution should follow one visible pipeline:
 ``TypeRecordRegistry`` is the common boundary.  It validates the schema header
 and settled family-role pair, nonzero ops ABI, known capabilities, valid plan,
 and nonnull ops pointer.  Its canonical identity key is ``(schema, role, plan,
-ops, debug descriptor)``.  The ops ABI, capabilities, and implementation label
-are immutable metadata attached to that identity: a same-key disagreement is
-rejected, and a different implementation label cannot create a second record.
+ops, debug descriptor, implementation label)``.  The label is compared by
+content and copied into registry-owned storage before the key is published.
+The ops ABI and capabilities are immutable metadata attached to that identity;
+a same-key disagreement is rejected.  Different implementation labels create
+distinct records while safely sharing an opaque plan or ops table.
 
 Family factories remain responsible for family-specific policy.  A
 time-series factory knows how TSD data uses a slot store; a node factory knows

--- a/include/hgraph/types/metadata/type_record_registry.h
+++ b/include/hgraph/types/metadata/type_record_registry.h
@@ -18,6 +18,9 @@ namespace hgraph
         const MemoryUtils::StoragePlan *plan{nullptr};
         const void *ops{nullptr};
         const DebugDescriptor *debug{nullptr};
+        /** Stable representation identity. Equality is by string content;
+            the registry owns the canonical copy. */
+        std::string_view implementation_label{};
 
         [[nodiscard]] constexpr bool operator==(const TypeRecordKey &) const noexcept = default;
     };
@@ -27,7 +30,6 @@ namespace hgraph
         TypeRecordKey key{};
         std::uint16_t ops_abi_version{INVALID_OPS_ABI_VERSION};
         TypeCapabilities capabilities{TypeCapabilities::None};
-        std::string_view implementation_label{};
     };
 
     class HGRAPH_EXPORT TypeRecordRegistry

--- a/include/hgraph/types/time_series/ts_output/alternative.h
+++ b/include/hgraph/types/time_series/ts_output/alternative.h
@@ -109,8 +109,6 @@ namespace hgraph::detail
                          InteriorFromRefAlternativeDelete, AlternativeKeyHash>
             interior_from_ref_alternatives_{};
     };
-
-    void clear_ts_output_alternative_type_cache() noexcept;
 }  // namespace hgraph::detail
 
 #endif  // HGRAPH_CPP_TS_OUTPUT_ALTERNATIVE_H

--- a/include/hgraph/types/value/compact_container_ops.h
+++ b/include/hgraph/types/value/compact_container_ops.h
@@ -726,11 +726,17 @@ namespace hgraph
         }
         inline const void *list_element_at(const void *, const void *memory, std::size_t index)
         {
-            return static_cast<const ListStorage *>(memory)->element_at(index);
+            const auto *storage = static_cast<const ListStorage *>(memory);
+            return storage->element_set(index) ? storage->element_at(index) : nullptr;
         }
         inline ValueTypeRef list_element_binding(const void *, const void *memory, std::size_t) noexcept
         {
             return static_cast<const ListStorage *>(memory)->element_binding();
+        }
+        inline bool list_element_valid(const void *, const void *memory,
+                                       std::size_t index) noexcept
+        {
+            return static_cast<const ListStorage *>(memory)->element_set(index);
         }
 
         // ----- CyclicBuffer -----
@@ -1091,6 +1097,7 @@ namespace hgraph
                 };
                 value.dynamic_storage_metrics_impl =
                     &compact_dynamic_storage_metrics<ListStorage>;
+                value.element_valid = &container_ops_detail::list_element_valid;
                 value.accepts_source_impl = &compact_accepts_source;
                 value.copy_assign_from_impl = &compact_list_copy_assign_from;
                 value.move_assign_from_impl = &compact_list_move_assign_from;

--- a/include/hgraph/types/value/container_ops.h
+++ b/include/hgraph/types/value/container_ops.h
@@ -94,14 +94,19 @@ namespace hgraph
          */
         Range<ValueView> (*make_range)(const void *context, const void *memory) = nullptr;
         Range<ValueView> (*make_mutable_range)(const void *context, void *memory) = nullptr;
-        /** Mutable element access (LAST member: positional initializers stay
-            valid). Null = fall back to ``element_at``. A Bundle installs one
-            that MARKS the field live (field validity, core_concepts.rst) and
-            returns real memory even when unset. */
+        /** Mutable element access. Null = fall back to ``element_at``. A
+            Bundle installs one that MARKS the field live (field validity,
+            core_concepts.rst) and returns real memory even when unset. */
         void *(*mutable_element_at)(const void *context, void *memory, std::size_t index) = nullptr;
         /** Change the logical extent of bounded indexed storage. Null for
             representations whose size is structural or fixed exactly. */
         void (*resize)(const void *context, void *memory, std::size_t size) = nullptr;
+        /** Whether the element at ``index`` is logically set. This is
+            distinct from storage lifetime: representations may keep a
+            default-constructed slot for an UNSET element. Null means
+            ``element_at(...) != nullptr``, preserving the dense default. */
+        bool (*element_valid)(const void *context, const void *memory,
+                              std::size_t index) noexcept = nullptr;
     };
 
     struct ListValueOps : IndexedValueOps

--- a/include/hgraph/types/value/mutable_container_ops.h
+++ b/include/hgraph/types/value/mutable_container_ops.h
@@ -336,6 +336,11 @@ namespace hgraph
         {
             return static_cast<const MutableListStorage *>(memory)->element_binding();
         }
+        inline bool list_element_valid(const void *, const void *memory,
+                                       std::size_t index) noexcept
+        {
+            return static_cast<const MutableListStorage *>(memory)->element_set(index);
+        }
         inline std::size_t list_hash(const void *, const void *memory)
         {
             const auto *storage = static_cast<const MutableListStorage *>(memory);
@@ -557,6 +562,7 @@ namespace hgraph
             };
             value.dynamic_storage_metrics_impl =
                 &container_ops_detail::compact_dynamic_storage_metrics<MutableListStorage>;
+            value.element_valid = &list_element_valid;
             value.accepts_source_impl = &accepts_container_source;
             value.copy_assign_from_impl = &list_copy_assign_from;
             value.move_assign_from_impl = &list_move_assign_from;

--- a/include/hgraph/types/value/specialized_views.h
+++ b/include/hgraph/types/value/specialized_views.h
@@ -191,12 +191,36 @@ namespace hgraph
             return ops_->size(ops_->context, data());
         }
 
+        /** True when the indexed element is logically set.
+
+            Storage lifetime and element validity are separate: a list may
+            retain a default-constructed slot for an UNSET element. The
+            representation supplies the answer through ``IndexedValueOps``;
+            older/dense strategies fall back to a non-null element address. */
+        [[nodiscard]] bool element_valid(std::size_t index) const
+        {
+            const auto n = ops_->size(ops_->context, data());
+            if (index >= n)
+            {
+                throw std::out_of_range(
+                    "IndexedValueView::element_valid: index out of range");
+            }
+            return ops_->element_valid != nullptr
+                       ? ops_->element_valid(ops_->context, data(), index)
+                       : ops_->element_at(ops_->context, data(), index) != nullptr;
+        }
+
         [[nodiscard]] const ValueView at(std::size_t index) const
         {
             const auto n = ops_->size(ops_->context, data());
             if (index >= n) { throw std::out_of_range("IndexedValueView::at: index out of range"); }
-            return ValueView{ops_->element_binding(ops_->context, data(), index),
-                             ops_->element_at(ops_->context, data(), index)};
+            const auto binding = ops_->element_binding(ops_->context, data(), index);
+            if (ops_->element_valid != nullptr &&
+                !ops_->element_valid(ops_->context, data(), index))
+            {
+                return ValueView{binding, nullptr};
+            }
+            return ValueView{binding, ops_->element_at(ops_->context, data(), index)};
         }
 
         [[nodiscard]] const ValueView operator[](std::size_t index) const { return at(index); }

--- a/include/hgraph/types/value/value_builder.h
+++ b/include/hgraph/types/value/value_builder.h
@@ -315,6 +315,29 @@ namespace hgraph
             return Value{binding, &storage};
         }
 
+        /** Build an owning list and materialise it in ``target_binding``.
+
+            The accumulator always produces its compact owning value first.
+            A distinct target representation receives that value through its
+            passive ``ValueOps::move_assign_from`` contract; callers must
+            never infer a concrete target layout from ``ValueOpsKind``. */
+        [[nodiscard]] Value build(const ValueTypeRef &target_binding)
+        {
+            if (!target_binding)
+            {
+                throw std::invalid_argument(
+                    "ListBuilder target binding must be bound");
+            }
+            Value source = build();
+            if (source.binding() == target_binding) { return source; }
+
+            Value result{target_binding};
+            target_binding.ops_ref().move_assign_from(
+                target_binding, const_cast<void *>(result.view().data()),
+                source.binding(), const_cast<void *>(source.view().data()));
+            return result;
+        }
+
       private:
         void ensure_not_built() const
         {

--- a/include/hgraph/types/value/value_builder.h
+++ b/include/hgraph/types/value/value_builder.h
@@ -318,9 +318,11 @@ namespace hgraph
         /** Build an owning list and materialise it in ``target_binding``.
 
             The accumulator always produces its compact owning value first.
-            A distinct target representation receives that value through its
-            passive ``ValueOps::move_assign_from`` contract; callers must
-            never infer a concrete target layout from ``ValueOpsKind``. */
+            A distinct target representation resolves its external owning
+            binding, whose passive ``ValueOps::move_assign_from`` contract
+            receives that value. Callers must never infer a concrete target
+            layout from ``ValueOpsKind`` or dispatch view operations against
+            the owner's memory. */
         [[nodiscard]] Value build(const ValueTypeRef &target_binding)
         {
             if (!target_binding)
@@ -328,12 +330,13 @@ namespace hgraph
                 throw std::invalid_argument(
                     "ListBuilder target binding must be bound");
             }
+            const auto owning_binding = value_owning_type(target_binding);
             Value source = build();
-            if (source.binding() == target_binding) { return source; }
+            if (source.binding() == owning_binding) { return source; }
 
-            Value result{target_binding};
-            target_binding.ops_ref().move_assign_from(
-                target_binding, const_cast<void *>(result.view().data()),
+            Value result{owning_binding};
+            owning_binding.ops_ref().move_assign_from(
+                owning_binding, const_cast<void *>(result.view().data()),
                 source.binding(), const_cast<void *>(source.view().data()));
             return result;
         }

--- a/include/hgraph/types/value/value_ops.h
+++ b/include/hgraph/types/value/value_ops.h
@@ -51,7 +51,7 @@ namespace hgraph
     };
 
     static_assert(sizeof(ValueOpsKind) == 1);
-    inline constexpr std::uint16_t VALUE_OPS_ABI_VERSION = 5;
+    inline constexpr std::uint16_t VALUE_OPS_ABI_VERSION = 6;
 
     struct ValueOps;
 #if HGRAPH_ENABLE_PYTHON_USER_NODES

--- a/python/tests/adaptors/data_frame/test_data_frame_record_replay.py
+++ b/python/tests/adaptors/data_frame/test_data_frame_record_replay.py
@@ -235,16 +235,16 @@ def test_raw_replay_applies_tsb_and_selects_each_tsd_partition():
     bundle_schema = hg.ts_schema(a=hg.TS[int], b=hg.TS[str])
     bundle_frame = pa.table(
         {
-            "__date_time__": [hg.MIN_ST],
-            "__as_of__": [hg.MIN_ST],
-            "a": [1],
-            "b": ["one"],
+            "__date_time__": [hg.MIN_ST, hg.MIN_ST + hg.MIN_TD],
+            "__as_of__": [hg.MIN_ST, hg.MIN_ST],
+            "a": [1, None],
+            "b": ["one", "two"],
         }
     )
     assert hg.eval_node(
         replay_data_frame[hg.TSB[bundle_schema]], bundle_frame,
         as_of_time=hg.MIN_ST
-    ) == [{"a": 1, "b": "one"}]
+    ) == [{"a": 1, "b": "one"}, {"b": "two"}]
 
     dict_frame = pa.table(
         {

--- a/src/hgraph/lib/std/operators/data_frame_impl.cpp
+++ b/src/hgraph/lib/std/operators/data_frame_impl.cpp
@@ -1,6 +1,7 @@
 #include <hgraph/lib/std/operators/impl/data_frame_impl.h>
 
 #include <hgraph/lib/std/operators/conversion.h>
+#include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/time_series/ts_input/bundle_view.h>
@@ -27,12 +28,29 @@ namespace hgraph::stdlib
             [[nodiscard]] ValueTypeRef checked_binding(const ValueTypeMetaData *meta,
                                                                   const char              *what)
             {
-                const auto binding = ValuePlanFactory::instance().type_for(meta);
+                const auto binding = value_type_for_active_realization(meta);
                 if (binding == nullptr)
                 {
                     throw std::logic_error(fmt::format("{}: schema has no value binding", what));
                 }
                 return binding;
+            }
+
+            /** Assign a cell through the selected destination strategy.
+                Compatible realized values need not have identical schemas or
+                storage plans. */
+            void assign_cell(const ValueView &destination,
+                             const ValueView &source)
+            {
+                if (!destination.has_value() || !source.has_value())
+                {
+                    throw std::invalid_argument(
+                        "data-frame cell assignment requires live values");
+                }
+                const auto target = destination.binding();
+                target.ops_ref().copy_assign_from(
+                    target, destination.mutable_data(), source.binding(),
+                    source.data());
             }
 
             [[nodiscard]] const ValueTypeMetaData *datetime_meta()
@@ -68,7 +86,7 @@ namespace hgraph::stdlib
                 ValueView root = row.view().begin_mutation();
                 auto      mut  = root.as_bundle().begin_mutation();
                 ValueView dest = mut.at(index);
-                dest.copy_from(cell);
+                assign_cell(dest, cell);
             }
 
             void set_bundle_field(Value &row, std::size_t index, const Value &cell)
@@ -349,7 +367,10 @@ namespace hgraph::stdlib
                     if (columns[column] < 0) { continue; }
                     Value cell = frame_cell_at(frame, columns[column],
                                                layout.col_metas[column], row);
-                    if (cell.has_value()) { tuple.at(column).copy_from(cell.view()); }
+                    if (cell.has_value())
+                    {
+                        assign_cell(tuple.at(column), cell.view());
+                    }
                 }
                 return value;
             }
@@ -366,16 +387,14 @@ namespace hgraph::stdlib
 
                 const auto row_binding =
                     checked_binding(layout.row_meta, "replay_data_frame");
-                ListBuilder builder{row_binding};
+                ListBuilder builder{row_binding, *layout.rows_meta};
                 for (const ReplayCandidate &candidate : candidates)
                 {
                     Value row = read_table_row(layout, frame, columns, candidate.row);
-                    builder.push_back_copy(row.view().data());
+                    builder.push_back(row.view());
                 }
-                Value rows{checked_binding(layout.rows_meta, "replay_data_frame")};
-                *static_cast<ListStorage *>(
-                    const_cast<void *>(rows.view().data())) = builder.build_storage();
-                return rows;
+                return builder.build(
+                    checked_binding(layout.rows_meta, "replay_data_frame"));
             }
         }  // namespace
 
@@ -831,7 +850,7 @@ namespace hgraph::stdlib
                         ValueView root = key.view().begin_mutation();
                         auto      mut  = root.as_tuple().begin_mutation();
                         ValueView dest = mut.at(i);
-                        dest.copy_from(cell.view());
+                        assign_cell(dest, cell.view());
                     }
                 }
                 else
@@ -840,7 +859,7 @@ namespace hgraph::stdlib
                         frame_cell(frame, plan.key_cols.front().column, plan.key_cols.front().leaf, r);
                     if (!cell.has_value()) { continue; }
                     ValueView dest = key.view().begin_mutation();
-                    dest.copy_from(cell.view());
+                    assign_cell(dest, cell.view());
                 }
 
                 auto bucket = std::find_if(buckets.begin(), buckets.end(), [&](const auto &entry) {

--- a/src/hgraph/lib/std/operators/table_impl.cpp
+++ b/src/hgraph/lib/std/operators/table_impl.cpp
@@ -1,5 +1,6 @@
 #include <hgraph/lib/std/operators/impl/table_impl.h>
 
+#include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/time_series/ts_input/bundle_view.h>
@@ -529,12 +530,31 @@ namespace hgraph::stdlib
             [[nodiscard]] ValueTypeRef checked_binding(const ValueTypeMetaData *meta,
                                                        const char              *what)
             {
-                const auto binding = ValuePlanFactory::instance().type_for(meta);
+                const auto binding = value_type_for_active_realization(meta);
                 if (binding == nullptr)
                 {
                     throw std::logic_error(fmt::format("{}: schema has no value binding", what));
                 }
                 return binding;
+            }
+
+            /** Assign a semantic cell through the selected target strategy.
+                Cell schemas may be compatible without being identical (for
+                example a concrete CompoundScalar leaf assigned to its closed
+                base realization), so ``ValueView::copy_from`` is deliberately
+                too narrow here. */
+            void assign_cell(const ValueView &destination,
+                             const ValueView &source)
+            {
+                if (!destination.has_value() || !source.has_value())
+                {
+                    throw std::invalid_argument(
+                        "table cell assignment requires live values");
+                }
+                const auto target = destination.binding();
+                target.ops_ref().copy_assign_from(
+                    target, destination.mutable_data(), source.binding(),
+                    source.data());
             }
 
             /** A fresh borrow over the same binding + memory (the read views
@@ -636,7 +656,7 @@ namespace hgraph::stdlib
                     ValueView root = value.view();
                     auto      mut = root.as_tuple().begin_mutation();
                     ValueView cell = mut.at(index);
-                    cell.copy_from(leaf);
+                    assign_cell(cell, leaf);
                 }
 
                 template <typename T>
@@ -954,15 +974,12 @@ namespace hgraph::stdlib
             {
                 const auto &row_binding = checked_binding(layout.row_meta, "to_table");
                 const auto &rows_binding = checked_binding(layout.rows_meta, "to_table");
-                ListBuilder builder{row_binding};
+                ListBuilder builder{row_binding, *layout.rows_meta};
                 for (const Value &row : rows)
                 {
-                    builder.push_back_copy(row.view().data());
+                    builder.push_back(row.view());
                 }
-                Value out{rows_binding};
-                *static_cast<ListStorage *>(const_cast<void *>(out.view().data())) =
-                    builder.build_storage();
-                return out;
+                return builder.build(rows_binding);
             }
         }  // namespace
 
@@ -1151,7 +1168,7 @@ namespace hgraph::stdlib
                 {
                     // Atomic key: the single key cell IS the key value.
                     ValueView dest = key.view().begin_mutation();
-                    dest.copy_from(row.at(level.first_key_col));
+                    assign_cell(dest, row.at(level.first_key_col));
                     return key;
                 }
                 for (std::size_t i = 0; i < level.key_paths.size(); ++i)
@@ -1161,7 +1178,10 @@ namespace hgraph::stdlib
                     {
                         continue;
                     }
-                    walk_mutable(key.view().begin_mutation(), level.key_paths[i]).copy_from(cell);
+                    assign_cell(
+                        walk_mutable(key.view().begin_mutation(),
+                                     level.key_paths[i]),
+                        cell);
                 }
                 return key;
             }
@@ -1257,7 +1277,10 @@ namespace hgraph::stdlib
                         std::vector<std::size_t> full_path = column.ts_path;
                         full_path.insert(full_path.end(), column.value_path.begin(),
                                          column.value_path.end());
-                        walk_mutable(value.view().begin_mutation(), full_path).copy_from(cell);
+                        assign_cell(
+                            walk_mutable(value.view().begin_mutation(),
+                                         full_path),
+                            cell);
                         any = true;
                     }
                     if (any)
@@ -1545,7 +1568,7 @@ namespace hgraph::stdlib
                     Value cell = source.cell(source.context, row, column);
                     if (cell.has_value())
                     {
-                        tuple.at(column).copy_from(cell.view());
+                        assign_cell(tuple.at(column), cell.view());
                     }
                 }
                 return value;

--- a/src/hgraph/runtime/evaluation_clock.cpp
+++ b/src/hgraph/runtime/evaluation_clock.cpp
@@ -47,10 +47,10 @@ namespace hgraph
                                  .role = TypeRole::Runtime,
                                  .plan = &plan,
                                  .ops = &ops,
-                                 .debug = nullptr},
+                                 .debug = nullptr,
+                                 .implementation_label = implementation_label},
             .ops_abi_version = CLOCK_OPS_ABI_VERSION,
             .capabilities = clock_type_capabilities(plan),
-            .implementation_label = implementation_label,
         };
         return ClockTypeRef{&TypeRecordRegistry::instance().intern(definition)};
     }

--- a/src/hgraph/runtime/executor.cpp
+++ b/src/hgraph/runtime/executor.cpp
@@ -964,10 +964,10 @@ namespace hgraph
                                  .role = TypeRole::Runtime,
                                  .plan = &plan,
                                  .ops = &ops,
-                                 .debug = nullptr},
+                                 .debug = nullptr,
+                                 .implementation_label = implementation_label},
             .ops_abi_version = EXECUTOR_OPS_ABI_VERSION,
             .capabilities = executor_type_capabilities(plan),
-            .implementation_label = implementation_label,
         };
         return ExecutorTypeRef{&TypeRecordRegistry::instance().intern(definition)};
     }

--- a/src/hgraph/runtime/graph.cpp
+++ b/src/hgraph/runtime/graph.cpp
@@ -1531,10 +1531,10 @@ GraphTypeRef intern_graph_type(const GraphTypeMetaData &schema,
                            .role = TypeRole::Runtime,
                            .plan = &plan,
                            .ops = &ops,
-                           .debug = &debug},
+                           .debug = &debug,
+                           .implementation_label = implementation_label},
       .ops_abi_version = GRAPH_OPS_ABI_VERSION,
       .capabilities = graph_type_capabilities(plan),
-      .implementation_label = implementation_label,
   };
   return GraphTypeRef{&TypeRecordRegistry::instance().intern(definition)};
 }

--- a/src/hgraph/runtime/node.cpp
+++ b/src/hgraph/runtime/node.cpp
@@ -1255,10 +1255,10 @@ namespace hgraph
                                  .role = TypeRole::Runtime,
                                  .plan = &plan,
                                  .ops = &ops,
-                                 .debug = &debug},
+                                 .debug = &debug,
+                                 .implementation_label = implementation_label},
             .ops_abi_version = NODE_OPS_ABI_VERSION,
             .capabilities = node_type_capabilities(plan),
-            .implementation_label = implementation_label,
         };
         return NodeTypeRef{&TypeRecordRegistry::instance().intern(definition)};
     }

--- a/src/hgraph/types/metadata/ts_data_plan_factory.cpp
+++ b/src/hgraph/types/metadata/ts_data_plan_factory.cpp
@@ -6,7 +6,6 @@
 
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/time_series/endpoint_schema.h>
-#include <hgraph/types/time_series/ts_output/alternative.h>
 
 #include <fmt/format.h>
 
@@ -351,7 +350,6 @@ namespace hgraph
         plan_detail::clear_window_ts_data_contexts();
         plan_detail::clear_slot_ts_data_contexts();
         clear_tsd_proxy_contexts();
-        detail::clear_ts_output_alternative_type_cache();
     }
 
     TSDataTypeRef TSDataPlanFactory::data_type_for(const TSValueTypeMetaData *schema)

--- a/src/hgraph/types/metadata/ts_data_slot_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_slot_ops.cpp
@@ -956,66 +956,6 @@ namespace hgraph::ts_data_plan_factory_detail
             Modified,
         };
 
-        struct ProjectionKey
-        {
-            const TypeRecord *type_record{nullptr};
-            const TSDataOps *source_ops{nullptr};
-            const TSValueTypeMetaData *schema{nullptr};
-            TypeRole role{TypeRole::Invalid};
-            [[nodiscard]] bool operator==(const ProjectionKey &) const noexcept = default;
-        };
-
-        struct ProjectionKeyHash
-        {
-            [[nodiscard]] std::size_t operator()(const ProjectionKey &key) const noexcept
-            {
-                auto seed = combine_hash(std::hash<const TypeRecord *>{}(key.type_record),
-                                         std::hash<const TSDataOps *>{}(key.source_ops));
-                seed = combine_hash(seed, std::hash<const TSValueTypeMetaData *>{}(key.schema));
-                return combine_hash(seed, static_cast<std::size_t>(key.role));
-            }
-        };
-
-        [[nodiscard]] std::recursive_mutex &projection_mutex() noexcept
-        {
-            static std::recursive_mutex mutex;
-            return mutex;
-        }
-
-        using OwnedProjectionOps = std::unique_ptr<TSDataOps, void (*)(TSDataOps *)>;
-
-        template <typename Ops>
-        [[nodiscard]] OwnedProjectionOps copy_projection_ops(const Ops &ops)
-        {
-            return OwnedProjectionOps{
-                new Ops{ops},
-                [](TSDataOps *value) noexcept { delete static_cast<Ops *>(value); }};
-        }
-
-        [[nodiscard]] OwnedProjectionOps copy_projection_ops(const TSDataOps &ops)
-        {
-            switch (ops.kind)
-            {
-            case TSTypeKind::TSS:
-                return copy_projection_ops(static_cast<const TSSDataOps &>(ops));
-            case TSTypeKind::TSD:
-                return copy_projection_ops(static_cast<const TSDDataOps &>(ops));
-            case TSTypeKind::TSL:
-            case TSTypeKind::TSB:
-                return copy_projection_ops(static_cast<const IndexedTSDataOps &>(ops));
-            case TSTypeKind::TSW:
-                return copy_projection_ops(static_cast<const TSWDataOps &>(ops));
-            default:
-                return copy_projection_ops<TSDataOps>(ops);
-            }
-        }
-
-        [[nodiscard]] auto &projection_ops_cache() noexcept
-        {
-            static std::unordered_map<ProjectionKey, OwnedProjectionOps, ProjectionKeyHash> cache;
-            return cache;
-        }
-
         [[nodiscard]] TSRoleTypeRef intern_tsd_value_projection_type(TSRoleTypeRef element_type,
                                                                          TypeRole role)
         {
@@ -1029,21 +969,8 @@ namespace hgraph::ts_data_plan_factory_detail
             if (const auto *record = element_type.record();
                 record != nullptr && record->role == role && record->implementation_name() == label)
                 return element_type;
-            const auto &source_ops = element_type.ops_ref();
-            const ProjectionKey key{element_type.record(), &source_ops, schema, role};
-            std::lock_guard<std::recursive_mutex> lock(projection_mutex());
-            const TSDataOps *projection_ops = nullptr;
-            auto &cache = projection_ops_cache();
-            if (const auto it = cache.find(key); it != cache.end())
-                projection_ops = it->second.get();
-            if (projection_ops == nullptr)
-            {
-                auto owned_ops = copy_projection_ops(source_ops);
-                projection_ops = owned_ops.get();
-                cache.emplace(key, std::move(owned_ops));
-            }
             return TSRoleTypeRef{intern_ts_type(
-                *schema, role, element_type.checked_plan(), *projection_ops, label)};
+                *schema, role, element_type.checked_plan(), element_type.ops_ref(), label)};
         }
 
         [[nodiscard]] std::string_view keyed_root_label(TSTypeKind kind, TypeRole role,
@@ -3610,10 +3537,6 @@ namespace hgraph::ts_data_plan_factory_detail
         {
             std::lock_guard<std::recursive_mutex> lock(slot_plan_mutex());
             custom_tsd_slot_plan_entries().clear();
-        }
-        {
-            std::lock_guard<std::recursive_mutex> lock(projection_mutex());
-            projection_ops_cache().clear();
         }
     }
 } // namespace hgraph::ts_data_plan_factory_detail

--- a/src/hgraph/types/metadata/type_record_registry.cpp
+++ b/src/hgraph/types/metadata/type_record_registry.cpp
@@ -87,7 +87,7 @@ namespace hgraph
     }
 
     TypeRecordRegistry::Entry::Entry(const TypeRecordDefinition &definition)
-        : implementation_label(definition.implementation_label),
+        : implementation_label(definition.key.implementation_label),
           record(definition.key.role, definition.ops_abi_version, definition.capabilities,
                  implementation_label.empty() ? nullptr : implementation_label.c_str(), definition.key.schema,
                  definition.key.plan, definition.key.ops, definition.key.debug)
@@ -100,7 +100,8 @@ namespace hgraph
         result = combine_hash(result, std::hash<std::uint8_t>{}(static_cast<std::uint8_t>(key.role)));
         result = combine_hash(result, std::hash<const MemoryUtils::StoragePlan *>{}(key.plan));
         result = combine_hash(result, std::hash<const void *>{}(key.ops));
-        return combine_hash(result, std::hash<const DebugDescriptor *>{}(key.debug));
+        result = combine_hash(result, std::hash<const DebugDescriptor *>{}(key.debug));
+        return combine_hash(result, std::hash<std::string_view>{}(key.implementation_label));
     }
 
     const TypeRecord &TypeRecordRegistry::intern(const TypeRecordDefinition &definition)
@@ -112,20 +113,21 @@ namespace hgraph
         {
             const Entry &entry = *found->second;
             if (entry.record.ops_abi_version != definition.ops_abi_version ||
-                entry.record.capabilities != definition.capabilities ||
-                std::string_view{entry.implementation_label} != definition.implementation_label)
+                entry.record.capabilities != definition.capabilities)
             {
                 throw std::logic_error(
                     "TypeRecordDefinition conflicts with the canonical record for its key: existing '" +
                     entry.implementation_label + "', requested '" +
-                    std::string{definition.implementation_label} + "'");
+                    std::string{definition.key.implementation_label} + "'");
             }
             return entry.record;
         }
 
         auto entry = std::make_unique<Entry>(definition);
         const TypeRecord *result = &entry->record;
-        m_entries.emplace(definition.key, std::move(entry));
+        auto owned_key = definition.key;
+        owned_key.implementation_label = entry->implementation_label;
+        m_entries.emplace(owned_key, std::move(entry));
         return *result;
     }
 

--- a/src/hgraph/types/time_series/ts_output/alternative.cpp
+++ b/src/hgraph/types/time_series/ts_output/alternative.cpp
@@ -12,10 +12,8 @@
 #include <algorithm>
 #include <array>
 #include <memory>
-#include <mutex>
 #include <stdexcept>
 #include <string_view>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -38,90 +36,14 @@ namespace hgraph::detail
             return static_cast<std::size_t>(role);
         }
 
-        struct AlternativeTypeKey
-        {
-            const TypeRecord *record{nullptr};
-            const TSDataOps *ops{nullptr};
-            const TSValueTypeMetaData *schema{nullptr};
-            TypeRole role{TypeRole::Invalid};
-            std::string_view label{};
-            [[nodiscard]] bool operator==(const AlternativeTypeKey &) const noexcept = default;
-        };
-
-        struct AlternativeTypeKeyHash
-        {
-            [[nodiscard]] std::size_t operator()(const AlternativeTypeKey &key) const noexcept
-            {
-                auto seed = std::hash<const TypeRecord *>{}(key.record);
-                seed ^= std::hash<const TSDataOps *>{}(key.ops) + 0x9e3779b97f4a7c15ULL + (seed << 6U) +
-                        (seed >> 2U);
-                seed ^= std::hash<const TSValueTypeMetaData *>{}(key.schema) + 0x9e3779b97f4a7c15ULL +
-                        (seed << 6U) + (seed >> 2U);
-                seed ^= static_cast<std::size_t>(key.role) + 0x9e3779b97f4a7c15ULL + (seed << 6U) +
-                        (seed >> 2U);
-                return seed ^ std::hash<std::string_view>{}(key.label);
-            }
-        };
-
-        [[nodiscard]] std::recursive_mutex &alternative_type_mutex() noexcept
-        {
-            static std::recursive_mutex mutex;
-            return mutex;
-        }
-
-        using OwnedAlternativeOps = std::unique_ptr<TSDataOps, void (*)(TSDataOps *)>;
-
-        template <typename Ops>
-        [[nodiscard]] OwnedAlternativeOps copy_alternative_ops(const Ops &ops)
-        {
-            return OwnedAlternativeOps{
-                new Ops{ops},
-                [](TSDataOps *value) noexcept { delete static_cast<Ops *>(value); }};
-        }
-
-        [[nodiscard]] OwnedAlternativeOps copy_alternative_ops(const TSDataOps &ops)
-        {
-            switch (ops.kind)
-            {
-            case TSTypeKind::TSS:
-                return copy_alternative_ops(static_cast<const TSSDataOps &>(ops));
-            case TSTypeKind::TSD:
-                return copy_alternative_ops(static_cast<const TSDDataOps &>(ops));
-            case TSTypeKind::TSL:
-            case TSTypeKind::TSB:
-                return copy_alternative_ops(static_cast<const IndexedTSDataOps &>(ops));
-            case TSTypeKind::TSW:
-                return copy_alternative_ops(static_cast<const TSWDataOps &>(ops));
-            default:
-                return copy_alternative_ops<TSDataOps>(ops);
-            }
-        }
-
-        [[nodiscard]] auto &alternative_type_cache() noexcept
-        {
-            static std::unordered_map<AlternativeTypeKey, OwnedAlternativeOps, AlternativeTypeKeyHash> cache;
-            return cache;
-        }
-
         [[nodiscard]] TSRoleTypeRef alternative_type_for(TSRoleTypeRef source,
                                                              TypeRole role,
                                                              std::string_view label)
         {
             const auto *schema = source.schema();
             if (schema == nullptr || !is_migrated_ts_root_schema(schema)) { return source; }
-            const auto &source_ops = source.ops_ref();
-            const AlternativeTypeKey key{source.record(), &source_ops, schema, role, label};
-            std::lock_guard<std::recursive_mutex> lock(alternative_type_mutex());
-            auto &cache = alternative_type_cache();
-            const TSDataOps *ops = nullptr;
-            if (const auto it = cache.find(key); it != cache.end()) ops = it->second.get();
-            if (ops == nullptr)
-            {
-                auto owned_ops = copy_alternative_ops(source_ops);
-                ops = owned_ops.get();
-                cache.emplace(key, std::move(owned_ops));
-            }
-            return TSRoleTypeRef{intern_ts_type(*schema, role, source.checked_plan(), *ops, label)};
+            return TSRoleTypeRef{
+                intern_ts_type(*schema, role, source.checked_plan(), source.ops_ref(), label)};
         }
 
         [[nodiscard]] DateTime concrete_reference_time(DateTime time) noexcept
@@ -1270,12 +1192,6 @@ namespace hgraph::detail
             to_ref_populator_for(target_schema.kind)(target, source_view, target_schema, modified_time, build_context);
         }
     }  // namespace
-
-    void clear_ts_output_alternative_type_cache() noexcept
-    {
-        std::lock_guard<std::recursive_mutex> lock(alternative_type_mutex());
-        alternative_type_cache().clear();
-    }
 
     struct TSOutputAlternativeStore::ToRefAlternativeState final
     {

--- a/src/hgraph/types/time_series/ts_type_ref.cpp
+++ b/src/hgraph/types/time_series/ts_type_ref.cpp
@@ -129,10 +129,14 @@ namespace hgraph
                 &ops);
         }
         const TypeRecordDefinition definition{
-            .key = TypeRecordKey{.schema = &schema.header, .role = role, .plan = &plan, .ops = &ops, .debug = debug},
+            .key = TypeRecordKey{.schema = &schema.header,
+                                 .role = role,
+                                 .plan = &plan,
+                                 .ops = &ops,
+                                 .debug = debug,
+                                 .implementation_label = implementation_label},
             .ops_abi_version = TS_DATA_OPS_ABI_VERSION,
             .capabilities = ts_type_capabilities(role, plan, ops),
-            .implementation_label = implementation_label,
         };
         return TSRoleTypeRef{&TypeRecordRegistry::instance().intern(definition)};
     }

--- a/src/hgraph/types/value/compact_container_ops.cpp
+++ b/src/hgraph/types/value/compact_container_ops.cpp
@@ -39,17 +39,14 @@ namespace hgraph
             ListBuilder builder{state.element_binding};
             const ValueView source_view{source, src};
             const auto values = source_view.as_list();
-            const auto *source_storage =
-                source.ops_ref().kind == ValueOpsKind::List ? static_cast<const ListStorage *>(src) : nullptr;
             for (std::size_t index = 0; index < values.size(); ++index)
             {
-                const auto child = values.at(index);
-                if (!child.has_value() || (source_storage != nullptr && !source_storage->element_set(index)))
+                if (!values.element_valid(index))
                 {
                     builder.push_back_unset();
                     continue;
                 }
-                builder.push_back(child);
+                builder.push_back(values.at(index));
             }
             *static_cast<ListStorage *>(dst) = builder.build_storage();
         }

--- a/src/hgraph/types/value/value_type_ref.cpp
+++ b/src/hgraph/types/value/value_type_ref.cpp
@@ -88,10 +88,10 @@ namespace hgraph
                                  .role = TypeRole::Instance,
                                  .plan = &plan,
                                  .ops = &ops,
-                                 .debug = debug},
+                                 .debug = debug,
+                                 .implementation_label = {}},
             .ops_abi_version = VALUE_OPS_ABI_VERSION,
             .capabilities = value_type_capabilities(schema, plan, ops),
-            .implementation_label = {},
         };
         return ValueTypeRef{&TypeRecordRegistry::instance().intern(definition)};
     }

--- a/tests/cpp/abi_boundary/producer.cpp
+++ b/tests/cpp/abi_boundary/producer.cpp
@@ -33,28 +33,28 @@ namespace
     const hgraph::TypeRecord &value_record()
     {
         return hgraph::TypeRecordRegistry::instance().intern(
-            {{&value_schema, hgraph::TypeRole::Instance, &hgraph::MemoryUtils::plan_for<int>(), &value_ops, nullptr},
+            {{&value_schema, hgraph::TypeRole::Instance, &hgraph::MemoryUtils::plan_for<int>(), &value_ops, nullptr,
+              "abi.fixture.value.native"},
              1,
-             hgraph::TypeCapabilities::Mutable | hgraph::TypeCapabilities::Viewable,
-             "abi.fixture.value.native"});
+             hgraph::TypeCapabilities::Mutable | hgraph::TypeCapabilities::Viewable});
     }
 
     const hgraph::TypeRecord &graph_record()
     {
         return hgraph::TypeRecordRegistry::instance().intern(
-            {{&graph_schema, hgraph::TypeRole::Runtime, &hgraph::MemoryUtils::plan_for<int>(), &graph_ops, nullptr},
+            {{&graph_schema, hgraph::TypeRole::Runtime, &hgraph::MemoryUtils::plan_for<int>(), &graph_ops, nullptr,
+              "abi.fixture.graph.native"},
              1,
-             hgraph::TypeCapabilities::Viewable,
-             "abi.fixture.graph.native"});
+             hgraph::TypeCapabilities::Viewable});
     }
 
     const hgraph::TypeRecord &ts_input_record()
     {
         return hgraph::TypeRecordRegistry::instance().intern(
-            {{&ts_schema, hgraph::TypeRole::Input, &hgraph::MemoryUtils::plan_for<int>(), &ts_input_ops, nullptr},
+            {{&ts_schema, hgraph::TypeRole::Input, &hgraph::MemoryUtils::plan_for<int>(), &ts_input_ops, nullptr,
+              "abi.fixture.ts.input"},
              1,
-             hgraph::TypeCapabilities::Viewable,
-             "abi.fixture.ts.input"});
+             hgraph::TypeCapabilities::Viewable});
     }
 }
 

--- a/tests/cpp/test_record_replay_frame.cpp
+++ b/tests/cpp/test_record_replay_frame.cpp
@@ -92,7 +92,8 @@ namespace
             require_arrow(date.Append(when.time_since_epoch().count()));
             require_arrow(as_of.Append((MIN_ST + TimeDelta{10}).time_since_epoch().count()));
         }
-        require_arrow(a.AppendValues({1, 2}));
+        require_arrow(a.Append(1));
+        require_arrow(a.AppendNull());
         require_arrow(b.AppendValues({"one", "two"}));
         return Frame{arrow::Table::Make(
             arrow::schema({arrow::field("__date_time__", arrow::timestamp(arrow::TimeUnit::MICRO)),
@@ -684,7 +685,7 @@ TEST_CASE("raw frame replay uses configured as-of and applies TSB rows")
     REQUIRE(bundle.size() == 2);
     CHECK(bundle[0]->as_bundle().at(0).checked_as<Int>() == Int{1});
     CHECK(bundle[0]->as_bundle().at(1).checked_as<Str>() == Str{"one"});
-    CHECK(bundle[1]->as_bundle().at(0).checked_as<Int>() == Int{2});
+    CHECK_FALSE(bundle[1]->as_bundle().at(0).has_value());
     CHECK(bundle[1]->as_bundle().at(1).checked_as<Str>() == Str{"two"});
 }
 

--- a/tests/cpp/test_table.cpp
+++ b/tests/cpp/test_table.cpp
@@ -3,6 +3,7 @@
 #include <hgraph/lib/testing/check_output.h>
 #include <hgraph/lib/testing/eval_node.h>
 #include <hgraph/types/graph_wiring.h>
+#include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/record_replay.h>
 #include <hgraph/types/registry_reset.h>
@@ -28,6 +29,13 @@ struct ExtensionTableScalar
     bool         operator==(const ExtensionTableScalar &) const = default;
 };
 
+namespace polymorphic_table_repro
+{
+    struct Event
+    {
+    };
+}
+
 namespace hgraph::static_schema_detail
 {
     template <>
@@ -36,6 +44,31 @@ namespace hgraph::static_schema_detail
         static constexpr std::string_view value{"tests.ExtensionTableScalar"};
     };
 }  // namespace hgraph::static_schema_detail
+
+namespace hgraph
+{
+    template <>
+    struct scalar_descriptor<polymorphic_table_repro::Event>
+    {
+        [[nodiscard]] static constexpr bool is_concrete() noexcept { return true; }
+        [[nodiscard]] static const ValueTypeMetaData *value_meta()
+        {
+            auto &registry = TypeRegistry::instance();
+            return registry.bundle(
+                "tests.table", "Event",
+                {{"event_id", registry.value_type("str")}}, {}, true);
+        }
+    };
+}
+
+namespace hgraph::testing
+{
+    template <>
+    struct ts_harness<TS<polymorphic_table_repro::Event>>
+        : bundle_ts_harness<TS<polymorphic_table_repro::Event>>
+    {
+    };
+}
 
 namespace
 {
@@ -82,6 +115,44 @@ namespace
 
     const TableTypeOps extension_table_ops{&describe_extension_scalar, &emit_extension_scalar,
                                            &apply_extension_scalar};
+
+    void describe_polymorphic_event(TableLayout &layout,
+                                    const TSValueTypeMetaData *schema,
+                                    std::string, std::vector<std::size_t>,
+                                    std::size_t)
+    {
+        layout.leaf_ts = schema;
+        layout.value_col_start = layout.keys.size();
+        layout.keys.push_back("event");
+        layout.col_metas.push_back(schema->value_schema);
+        layout.value_cols.push_back(
+            TableLayout::Column{.name = "event", .leaf = schema->value_schema});
+    }
+
+    void emit_polymorphic_event(const TableLayout &layout, const TSInputView &ts,
+                                Int, DateTime now, DateTime as_of, bool,
+                                const TableRowSink &sink, bool)
+    {
+        const Value when{now};
+        const Value revision{as_of};
+        sink.cell(sink.context, 0, when.view());
+        sink.cell(sink.context, 1, revision.view());
+        sink.cell(sink.context, layout.value_col_start, ts.value());
+        sink.end_row(sink.context);
+    }
+
+    void apply_polymorphic_event(const TableLayout &layout,
+                                 const TableRowSource &source,
+                                 const TSOutputView &out)
+    {
+        const Value cell =
+            source.cell(source.context, 0, layout.value_col_start);
+        apply_current_value(out, cell.view());
+    }
+
+    const TableTypeOps polymorphic_event_table_ops{
+        &describe_polymorphic_event, &emit_polymorphic_event,
+        &apply_polymorphic_event};
 
     void describe_all_null_extension_scalar(TableLayout &layout,
                                              const TSValueTypeMetaData *schema, std::string,
@@ -452,6 +523,8 @@ namespace
     using NestedExtensionBundle =
         UnNamedTSB<Field<"custom", TS<ExtensionTableScalar>>, Field<"regular", TS<Int>>>;
     using NestedExtensionDict = TSD<Str, TS<ExtensionTableScalar>>;
+    using PolymorphicTableEvent = polymorphic_table_repro::Event;
+    using PolymorphicTableDict = TSD<Str, TS<PolymorphicTableEvent>>;
 
     template <typename Schema>
     struct NestedExtensionTableRoundTripGraph
@@ -462,6 +535,20 @@ namespace
         {
             auto rows = wire<stdlib::to_table>(w, ts);
             return wire<stdlib::from_table, Schema>(w, rows).template as<Schema>();
+        }
+    };
+
+    struct PolymorphicTableRoundTripGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "polymorphic_table_round_trip_graph";
+
+        static Port<PolymorphicTableDict>
+        compose(Wiring &w, Port<PolymorphicTableDict> ts)
+        {
+            auto rows = wire<stdlib::to_table>(w, ts);
+            return wire<stdlib::from_table, PolymorphicTableDict>(w, rows)
+                .as<PolymorphicTableDict>();
         }
     };
 
@@ -553,6 +640,85 @@ TEST_CASE("table operators: to_table -> from_table round-trips through a graph")
     stdlib::register_standard_operators();
     CHECK_OUTPUT(eval_node<TableRoundTripGraph>(values<Float>(1.5, none, -0.25)),
                  values<Float>(1.5, none, -0.25));
+}
+
+TEST_CASE("table operators materialise polymorphic row lists through the active realization")
+{
+    stdlib::register_standard_operators();
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *event = scalar_descriptor<PolymorphicTableEvent>::value_meta();
+    const auto *created = registry.bundle(
+        "tests.table", "CreateEvent",
+        {{"event_id", registry.value_type("str")},
+         {"payload", registry.value_type("str")}},
+        {event});
+    register_table_type_ops(
+        TypeRegistry::instance().ts(event), polymorphic_event_table_ops);
+
+    for (const bool pooled : {false, true})
+    {
+        INFO("table row realization " << (pooled ? "pooled" : "inline"));
+        GlobalState graph_state;
+        if (pooled)
+        {
+            set_pooled_compound_scalar_storage(graph_state.view());
+        }
+        GlobalContext graph_context{graph_state};
+
+        const TypeRealizationOptions options{
+            .polymorphic_compound_storage =
+                pooled ? PolymorphicCompoundStoragePolicy::Pooled
+                       : PolymorphicCompoundStoragePolicy::Inline,
+        };
+        const auto realization =
+            TypeRealizationSnapshot::capture(registry, options);
+        TypeRealizationScope scope{realization.get()};
+
+        BundleBuilder created_builder{
+            realization->exact_type_for(created)};
+        created_builder.set("event_id", Value{Str{"created"}});
+        created_builder.set("payload", Value{Str{"payload"}});
+        Value concrete = created_builder.build();
+
+        const auto event_binding = realization->type_for(event);
+        Value event_value{event_binding};
+        event_binding.ops_ref().copy_assign_from(
+            event_binding,
+            event_value.begin_mutation().mutable_data(),
+            concrete.binding(), concrete.view().data());
+
+        const auto key_binding =
+            realization->type_for(scalar_descriptor<Str>::value_meta());
+        SetBuilder removed{key_binding};
+        MapBuilder modified{key_binding, event_binding};
+        const Value key{Str{"order"}};
+        modified.set_item(key.view(), event_value.view());
+
+        const auto *delta_schema =
+            ts_type<PolymorphicTableDict>()->delta_value_schema;
+        BundleBuilder delta{realization->type_for(delta_schema)};
+        delta.set("removed", removed.build());
+        delta.set("modified", modified.build());
+
+        const auto actual =
+            eval_node<PolymorphicTableRoundTripGraph>(
+                values<Value>(delta.build()));
+        REQUIRE(actual.size() == 1);
+        REQUIRE(actual.front().has_value());
+        const auto output_modified =
+            actual.front()->as_bundle().field("modified").as_map();
+        REQUIRE(output_modified.size() == 1);
+        const auto round_tripped =
+            output_modified.at(key.view()).concrete();
+        REQUIRE(round_tripped.schema() == created);
+        CHECK(round_tripped.as_bundle()
+                  .field("event_id")
+                  .checked_as<Str>() == Str{"created"});
+        CHECK(round_tripped.as_bundle()
+                  .field("payload")
+                  .checked_as<Str>() == Str{"payload"});
+    }
 }
 
 TEST_CASE("table type ops: an extension supplies describe emit and apply once "

--- a/tests/cpp/test_time_series_reference.cpp
+++ b/tests/cpp/test_time_series_reference.cpp
@@ -128,7 +128,7 @@ namespace
     };
 }
 
-TEST_CASE("TimeSeriesReference: alternative ops caches release and reseed all routes")
+TEST_CASE("TimeSeriesReference: alternative identities reseed after registry reset")
 {
     using namespace hgraph;
 
@@ -158,8 +158,14 @@ TEST_CASE("TimeSeriesReference: alternative ops caches release and reseed all ro
             ops.insert(type.record()->ops);
         };
 
-        capture(scalar_source.view(MIN_ST).binding_for(*ref));
-        capture(bundle_source.view(MIN_ST).binding_for(*requested_bundle));
+        const auto scalar_to_ref = scalar_source.view(MIN_ST).binding_for(*ref);
+        capture(scalar_to_ref);
+        REQUIRE(scalar_to_ref.type_ref().ops() ==
+                TSDataPlanFactory::instance().output_type_for(ref).ops());
+        const auto bundle_to_ref = bundle_source.view(MIN_ST).binding_for(*requested_bundle);
+        capture(bundle_to_ref);
+        REQUIRE(bundle_to_ref.type_ref().ops() ==
+                TSDataPlanFactory::instance().output_type_for(requested_bundle).ops());
         capture(scalar_ref_source.view(MIN_ST).binding_for(*ts));
         capture(dict_ref_source.view(MIN_ST).binding_for(*dict));
         capture(interior_source.view(MIN_ST).binding_for(*dict));

--- a/tests/cpp/test_ts_type_ref.cpp
+++ b/tests/cpp/test_ts_type_ref.cpp
@@ -1,4 +1,5 @@
 #include <hgraph/types/metadata/ts_data_plan_factory.h>
+#include <hgraph/types/metadata/ts_data_plan_factory_detail.h>
 #include <hgraph/types/metadata/debug_descriptor.h>
 #include <hgraph/types/metadata/type_record_registry.h>
 #include <hgraph/types/metadata/type_registry.h>
@@ -248,10 +249,10 @@ TEST_CASE("time-series role validation rejects common header kind mismatches")
             .plan = &ts_data.checked_plan(),
             .ops = &ts_data.ops_ref(),
             .debug = nullptr,
+            .implementation_label = {},
         },
         .ops_abi_version = TS_DATA_OPS_ABI_VERSION,
         .capabilities = ts_type_capabilities(TypeRole::Data, ts_data.checked_plan(), ts_data.ops_ref()),
-        .implementation_label = {},
     };
     const TypeRecord &malformed_record = TypeRecordRegistry::instance().intern(definition);
     const AnyPtr malformed_pointer = AnyPtr::typed_null(malformed_record);
@@ -802,7 +803,42 @@ TEST_CASE("keyed and reference role records preserve root input and projection t
     REQUIRE(label(proxy_output.as_role()) == "ts.tsd.proxy.output");
 }
 
-TEST_CASE("keyed projection ops caches release and reseed every role without stale records")
+TEST_CASE("TSD value projection preserves an independently supplied opaque operations table")
+{
+    using namespace hgraph;
+    auto &registry = TypeRegistry::instance();
+    auto &factory = TSDataPlanFactory::instance();
+    const auto *integer = registry.register_scalar<std::int32_t>("int32");
+    const auto *ts = registry.ts(integer);
+    const auto *bundle = registry.tsb("OpaqueProjectionBundle", {{"value", ts}});
+    const auto built_in = factory.data_type_for(bundle).as_role();
+
+    struct ExtensionIndexedOps : IndexedTSDataOps
+    {
+        std::uintptr_t extension_marker{0x48524752u};
+    };
+    ExtensionIndexedOps extension_ops;
+    static_cast<IndexedTSDataOps &>(extension_ops) =
+        static_cast<const IndexedTSDataOps &>(built_in.ops_ref());
+    // Projection must preserve this independently supplied, extended table
+    // without copying or narrowing it to a built-in table layout.
+    const auto extension = intern_ts_type(
+        *bundle, TypeRole::Data, built_in.checked_plan(), extension_ops,
+        "consumer.opaque.bundle.data");
+    const auto projected = ts_data_plan_factory_detail::tsd_value_projection_type(
+        extension, TypeRole::Output);
+    const auto repeated = ts_data_plan_factory_detail::tsd_value_projection_type(
+        extension, TypeRole::Output);
+
+    REQUIRE(extension.ops() == &extension_ops);
+    REQUIRE(projected.ops() == &extension_ops);
+    REQUIRE(projected.record() != extension.record());
+    REQUIRE(projected.record() == repeated.record());
+    REQUIRE(projected.role() == TypeRole::Output);
+    REQUIRE(projected.record()->implementation_name() == "ts.tsd.value.output");
+}
+
+TEST_CASE("keyed projection identities reseed every role without stale records")
 {
     using namespace hgraph;
 
@@ -827,6 +863,7 @@ TEST_CASE("keyed projection ops caches release and reseed every role without sta
             const auto data_element_type = data_dict.layout().element_type;
             labels.emplace_back(data_element_type.record()->implementation_name());
             REQUIRE(data_element_type.role() == TypeRole::Data);
+            REQUIRE(data_element_type.ops() == factory.data_type_for(element).ops());
 
             TSOutput output{outer};
             auto output_data = output.data_view();
@@ -834,6 +871,7 @@ TEST_CASE("keyed projection ops caches release and reseed every role without sta
             const auto output_element_type = output_dict.layout().element_type;
             labels.emplace_back(output_element_type.record()->implementation_name());
             REQUIRE(output_element_type.role() == TypeRole::Output);
+            REQUIRE(output_element_type.ops() == factory.output_type_for(element).ops());
 
             const auto endpoint = TSEndpointSchema::non_peered(
                 outer, {TSEndpointSchema::peered(element)});

--- a/tests/cpp/test_type_erasure_layout.cpp
+++ b/tests/cpp/test_type_erasure_layout.cpp
@@ -294,7 +294,7 @@ TEST_CASE("value ops discriminator has a fixed byte ABI at offset zero")
     static_assert(sizeof(ValueOpsKind) == 1);
     static_assert(offsetof(ValueOps, kind) == 0);
     static_assert(std::is_same_v<decltype(VALUE_OPS_ABI_VERSION), const std::uint16_t>);
-    static_assert(VALUE_OPS_ABI_VERSION == 5);
+    static_assert(VALUE_OPS_ABI_VERSION == 6);
     static_assert(static_cast<std::uint8_t>(ValueOpsKind::Invalid) == 0);
     static_assert(static_cast<std::uint8_t>(ValueOpsKind::Base) == 1);
     static_assert(static_cast<std::uint8_t>(ValueOpsKind::Indexed) == 2);

--- a/tests/cpp/test_type_pointer.cpp
+++ b/tests/cpp/test_type_pointer.cpp
@@ -52,7 +52,8 @@ namespace
                   const hgraph::DebugDescriptor *debug = nullptr)
     {
         return hgraph::TypeRecordRegistry::instance().intern(
-            {{&schema, role_for(schema.family), plan, &ops, debug}, 1, capabilities, implementation_label});
+            {{&schema, role_for(schema.family), plan, &ops, debug, implementation_label},
+             1, capabilities});
     }
 
     [[nodiscard]] hgraph::AnyPtr raw_pointer(const hgraph::TypeRecord *record, const void *data, std::uintptr_t tag)

--- a/tests/cpp/test_type_record.cpp
+++ b/tests/cpp/test_type_record.cpp
@@ -42,7 +42,7 @@ namespace
                    const hgraph::MemoryUtils::StoragePlan *plan = &hgraph::MemoryUtils::plan_for<std::uint32_t>(),
                    const hgraph::DebugDescriptor *debug = nullptr)
     {
-        return {{&schema, role, plan, ops, debug}, 1, capabilities, implementation_label};
+        return {{&schema, role, plan, ops, debug, implementation_label}, 1, capabilities};
     }
 
     [[nodiscard]] constexpr hgraph::TypeRole allowed_role(hgraph::TypeFamily family)
@@ -274,12 +274,13 @@ TEST_CASE("type record common layouts are fixed", "[type-erasure][type-record]")
     STATIC_REQUIRE(std::is_standard_layout_v<TypeRecordKey>);
     STATIC_REQUIRE(std::is_trivially_copyable_v<TypeRecordKey>);
     STATIC_REQUIRE(alignof(TypeRecordKey) == alignof(void *));
-    STATIC_REQUIRE(sizeof(TypeRecordKey) == 5 * sizeof(void *));
+    STATIC_REQUIRE(sizeof(TypeRecordKey) == 5 * sizeof(void *) + sizeof(std::string_view));
     STATIC_REQUIRE(offsetof(TypeRecordKey, schema) == 0);
     STATIC_REQUIRE(offsetof(TypeRecordKey, role) == sizeof(void *));
     STATIC_REQUIRE(offsetof(TypeRecordKey, plan) == 2 * sizeof(void *));
     STATIC_REQUIRE(offsetof(TypeRecordKey, ops) == 3 * sizeof(void *));
     STATIC_REQUIRE(offsetof(TypeRecordKey, debug) == 4 * sizeof(void *));
+    STATIC_REQUIRE(offsetof(TypeRecordKey, implementation_label) == 5 * sizeof(void *));
 
     STATIC_REQUIRE(std::is_standard_layout_v<MockSchema>);
     STATIC_REQUIRE(offsetof(MockSchema, header) == 0);
@@ -420,12 +421,20 @@ TEST_CASE("every type record key component participates in identity", "[type-era
     const auto *plan_a = &MemoryUtils::plan_for<std::uint32_t>();
     const auto *plan_b = &MemoryUtils::plan_for<std::uint64_t>();
 
-    const TypeRecordKey base{&schema_a, TypeRole::Instance, plan_a, &ops_a, debug_address(&debug_a)};
-    REQUIRE(base != TypeRecordKey{&schema_b, TypeRole::Instance, plan_a, &ops_a, debug_address(&debug_a)});
-    REQUIRE(base != TypeRecordKey{&schema_a, TypeRole::Data, plan_a, &ops_a, debug_address(&debug_a)});
-    REQUIRE(base != TypeRecordKey{&schema_a, TypeRole::Instance, plan_b, &ops_a, debug_address(&debug_a)});
-    REQUIRE(base != TypeRecordKey{&schema_a, TypeRole::Instance, plan_a, &ops_b, debug_address(&debug_a)});
-    REQUIRE(base != TypeRecordKey{&schema_a, TypeRole::Instance, plan_a, &ops_a, debug_address(&debug_b)});
+    const TypeRecordKey base{&schema_a, TypeRole::Instance, plan_a, &ops_a,
+                             debug_address(&debug_a), "native"};
+    REQUIRE(base != TypeRecordKey{&schema_b, TypeRole::Instance, plan_a, &ops_a,
+                                  debug_address(&debug_a), "native"});
+    REQUIRE(base != TypeRecordKey{&schema_a, TypeRole::Data, plan_a, &ops_a,
+                                  debug_address(&debug_a), "native"});
+    REQUIRE(base != TypeRecordKey{&schema_a, TypeRole::Instance, plan_b, &ops_a,
+                                  debug_address(&debug_a), "native"});
+    REQUIRE(base != TypeRecordKey{&schema_a, TypeRole::Instance, plan_a, &ops_b,
+                                  debug_address(&debug_a), "native"});
+    REQUIRE(base != TypeRecordKey{&schema_a, TypeRole::Instance, plan_a, &ops_a,
+                                  debug_address(&debug_b), "native"});
+    REQUIRE(base != TypeRecordKey{&schema_a, TypeRole::Instance, plan_a, &ops_a,
+                                  debug_address(&debug_a), "python"});
 
     auto &registry = TypeRecordRegistry::instance();
     const TypeRecord *schema_record = &registry.intern(definition_for(schema_a, TypeRole::Instance, &ops_a));
@@ -435,10 +444,13 @@ TEST_CASE("every type record key component participates in identity", "[type-era
     const TypeRecord *ops_record = &registry.intern(definition_for(schema_a, TypeRole::Instance, &ops_b));
     const TypeRecord *debug_record = &registry.intern(definition_for(
         schema_a, TypeRole::Instance, &ops_a, {}, TypeCapabilities::None, plan_a, debug_address(&debug_a)));
+    const TypeRecord *implementation_record =
+        &registry.intern(definition_for(schema_a, TypeRole::Instance, &ops_a, "native"));
     REQUIRE(schema_record != other_schema);
     REQUIRE(schema_record != plan_record);
     REQUIRE(schema_record != ops_record);
     REQUIRE(schema_record != debug_record);
+    REQUIRE(schema_record != implementation_record);
 }
 
 TEST_CASE("conflicting metadata preserves the canonical type record", "[type-erasure][type-record]")
@@ -462,17 +474,33 @@ TEST_CASE("conflicting metadata preserves the canonical type record", "[type-era
         conflict.capabilities = TypeCapabilities::Mutable;
         REQUIRE_THROWS_AS(registry.intern(conflict), std::logic_error);
     }
-    SECTION("implementation label")
-    {
-        auto conflict = original;
-        conflict.implementation_label = "python";
-        REQUIRE_THROWS_AS(registry.intern(conflict), std::logic_error);
-    }
-
     REQUIRE(registry.find(original.key) == record);
     REQUIRE(record->ops_abi_version == 1);
     REQUIRE(record->capabilities == TypeCapabilities::Viewable);
     REQUIRE(static_cast<bool>(record->implementation_name() == "native"));
+}
+
+TEST_CASE("implementation labels distinguish canonical type records by content",
+          "[type-erasure][type-record]")
+{
+    using namespace hgraph;
+    SchemaHeader schema{TypeFamily::Value, 1, "mock"};
+    MockOps ops{1};
+    auto &registry = TypeRecordRegistry::instance();
+
+    std::string native_label{"native"};
+    const TypeRecord &native = registry.intern(
+        definition_for(schema, TypeRole::Instance, &ops, native_label));
+    const TypeRecord &python = registry.intern(
+        definition_for(schema, TypeRole::Instance, &ops, "python"));
+    const TypeRecord &repeated_native = registry.intern(
+        definition_for(schema, TypeRole::Instance, &ops, std::string{"native"}));
+
+    REQUIRE(&native != &python);
+    REQUIRE(&native == &repeated_native);
+    REQUIRE(native.ops == python.ops);
+    REQUIRE(native.implementation_name() == "native");
+    REQUIRE(python.implementation_name() == "python");
 }
 
 TEST_CASE("type record owns implementation labels but borrows schema labels", "[type-erasure][type-record]")

--- a/tests/cpp/test_value.cpp
+++ b/tests/cpp/test_value.cpp
@@ -424,10 +424,10 @@ TEST_CASE("ValueTypeRef is canonical by record and narrows generic pointers safe
                              .role = TypeRole::Runtime,
                              .plan = &MemoryUtils::plan_for<std::int32_t>(),
                              .ops = &foreign_ops,
-                             .debug = nullptr},
+                             .debug = nullptr,
+                             .implementation_label = {}},
         .ops_abi_version = 1,
         .capabilities = TypeCapabilities::None,
-        .implementation_label = {},
     };
     const TypeRecord &foreign_record = TypeRecordRegistry::instance().intern(foreign_definition);
     REQUIRE_THROWS_AS(ValueTypeRef::checked(AnyPtr::read_only(foreign_record, &payload)),

--- a/tests/cpp/test_value_builder.cpp
+++ b/tests/cpp/test_value_builder.cpp
@@ -2,6 +2,7 @@
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/primitive_types.h>
 #include <hgraph/types/static_schema.h>
+#include <hgraph/types/value/mutable_container_ops.h>
 #include <hgraph/types/value/specialized_views.h>
 #include <hgraph/types/value/value_builder.h>
 
@@ -232,6 +233,56 @@ TEST_CASE("value builders reject an incompatible view before changing their cont
     REQUIRE(map_value.as_map().size() == 1);
     check_event(
         map_value.as_map().at(key.view()), schemas.created, "event");
+}
+
+TEST_CASE("list builders transfer through compatible erased realizations and preserve unset elements")
+{
+    using namespace hgraph;
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *int_meta = scalar_descriptor<Int>::value_meta();
+    const auto *list_meta = registry.list(int_meta);
+    const auto  element_binding = ValuePlanFactory::instance().type_for(int_meta);
+    const auto  compact_binding = compact_list_type(element_binding, *list_meta);
+
+    // Deliberately bind the same immutable List schema to the slot-backed list
+    // strategy. The shared schema makes it a compatible realization; its plan
+    // and storage layout remain distinct from compact ListStorage.
+    const auto slot_binding = intern_value_type(
+        *list_meta, mutable_list_plan(element_binding), mutable_list_ops());
+    REQUIRE(slot_binding != compact_binding);
+    REQUIRE(slot_binding.ops_ref().kind == ValueOpsKind::MutableList);
+
+    ListBuilder builder{element_binding, *list_meta};
+    builder.push_back(Int{10});
+    builder.push_back_unset();
+    builder.push_back(Int{30});
+    Value slot_value = builder.build(slot_binding);
+
+    const auto slot_list = slot_value.as_list();
+    REQUIRE(slot_list.size() == 3);
+    CHECK(slot_list.element_valid(0));
+    CHECK_FALSE(slot_list.element_valid(1));
+    CHECK(slot_list.element_valid(2));
+    CHECK(slot_list.at(0).checked_as<Int>() == Int{10});
+    CHECK(slot_list.at(1).bound());
+    CHECK_FALSE(slot_list.at(1).has_value());
+    CHECK(slot_list.at(2).checked_as<Int>() == Int{30});
+
+    Value compact_value{compact_binding};
+    compact_binding.ops_ref().copy_assign_from(
+        compact_binding, const_cast<void *>(compact_value.view().data()),
+        slot_value.binding(), slot_value.view().data());
+
+    const auto compact_list = compact_value.as_list();
+    REQUIRE(compact_list.size() == 3);
+    CHECK(compact_list.element_valid(0));
+    CHECK_FALSE(compact_list.element_valid(1));
+    CHECK(compact_list.element_valid(2));
+    CHECK(compact_list.at(0).checked_as<Int>() == Int{10});
+    CHECK(compact_list.at(1).bound());
+    CHECK_FALSE(compact_list.at(1).has_value());
+    CHECK(compact_list.at(2).checked_as<Int>() == Int{30});
 }
 
 TEST_CASE("compact containers convert elements between polymorphic realizations")

--- a/tests/cpp/test_value_builder.cpp
+++ b/tests/cpp/test_value_builder.cpp
@@ -2,6 +2,7 @@
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/primitive_types.h>
 #include <hgraph/types/static_schema.h>
+#include <hgraph/types/value/compound_scalar_storage.h>
 #include <hgraph/types/value/mutable_container_ops.h>
 #include <hgraph/types/value/specialized_views.h>
 #include <hgraph/types/value/value_builder.h>
@@ -283,6 +284,41 @@ TEST_CASE("list builders transfer through compatible erased realizations and pre
     CHECK(compact_list.at(1).bound());
     CHECK_FALSE(compact_list.at(1).has_value());
     CHECK(compact_list.at(2).checked_as<Int>() == Int{30});
+}
+
+TEST_CASE("list builders dispatch target transfer through the external owning binding")
+{
+    using namespace hgraph;
+
+    const auto schemas = polymorphic_builder_schemas();
+    const TypeRealizationOptions options{
+        .polymorphic_compound_storage =
+            PolymorphicCompoundStoragePolicy::Pooled,
+    };
+    const auto realization = TypeRealizationSnapshot::capture(
+        TypeRegistry::instance(), options);
+    TypeRealizationScope realization_scope{realization.get()};
+    CompoundScalarStorage pools = CompoundScalarStorage::make_default();
+    CompoundScalarStorageScope pool_scope{pools.view()};
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *list_schema = registry.list(schemas.event);
+    const auto  external_element = realization->type_for(schemas.event);
+    const auto  external_list = realization->type_for(list_schema);
+    const auto  graph_list = realization->graph_type_for(list_schema);
+    REQUIRE(graph_list != external_list);
+    REQUIRE(value_owning_type(graph_list) == external_list);
+
+    const Value created = created_value(*realization, schemas);
+    ListBuilder builder{external_element, *list_schema};
+    builder.push_back(created.view());
+    const Value result = builder.build(graph_list);
+
+    REQUIRE(result.binding() == external_list);
+    const auto values = result.as_list();
+    REQUIRE(values.size() == 1);
+    CHECK(values.at(0).binding() == external_element);
+    check_event(values.at(0), schemas.created, "event");
 }
 
 TEST_CASE("compact containers convert elements between polymorphic realizations")

--- a/tests/install_consumer/main.cpp
+++ b/tests/install_consumer/main.cpp
@@ -5,6 +5,8 @@
 #include <hgraph/runtime/registry_snapshot.h>
 #include <hgraph/types/frame.h>
 #include <hgraph/types/frame_store.h>
+#include <hgraph/types/metadata/ts_data_plan_factory.h>
+#include <hgraph/types/metadata/ts_data_plan_factory_detail.h>
 #include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/type_record.h>
 #include <hgraph/types/metadata/type_registry.h>
@@ -13,6 +15,7 @@
 #include <hgraph/types/static_schema.h>
 #include <hgraph/types/storage_metrics.h>
 #include <hgraph/types/table_type_ops.h>
+#include <hgraph/types/time_series/ts_data/ops.h>
 #include <hgraph/types/time_series/ts_output.h>
 #include <hgraph/types/time_series/visitor.h>
 #include <hgraph/types/type_pointer.h>
@@ -257,6 +260,33 @@ int main()
     if (&table_type_ops(consumer_ts) != &consumer_table_ops)
     {
         throw std::runtime_error("installed table type-ops registration is unusable");
+    }
+
+    const auto *consumer_bundle =
+        registry.tsb("consumer::OpaqueBundle", {{"value", consumer_ts}});
+    const auto built_in_bundle_type =
+        TSDataPlanFactory::instance().data_type_for(consumer_bundle).as_role();
+    struct ConsumerIndexedOps : IndexedTSDataOps
+    {
+        std::uintptr_t extension_marker{0x48524752u};
+    };
+    ConsumerIndexedOps consumer_ops;
+    static_cast<IndexedTSDataOps &>(consumer_ops) =
+        static_cast<const IndexedTSDataOps &>(built_in_bundle_type.ops_ref());
+    const auto consumer_type = intern_ts_type(
+        *consumer_bundle, TypeRole::Data, built_in_bundle_type.checked_plan(),
+        consumer_ops, "consumer.opaque.bundle.data");
+    const auto projected_consumer_type =
+        ts_data_plan_factory_detail::tsd_value_projection_type(
+            consumer_type, TypeRole::Output);
+    if (consumer_type.ops() != &consumer_ops ||
+        projected_consumer_type.ops() != &consumer_ops ||
+        projected_consumer_type.record() == consumer_type.record() ||
+        projected_consumer_type.record()->implementation_name() !=
+            "ts.tsd.value.output")
+    {
+        throw std::runtime_error(
+            "installed opaque TS operations were not projected by identity");
     }
 
     Value extension{ConsumerExtensionScalar{17}};


### PR DESCRIPTION
## Summary

- carries the already-reviewed Phase 3 commits from #466 onto `main` (that PR was merged into an already-merged stack base and was therefore not reachable from `main`)
- makes implementation-label content part of canonical `TypeRecord` identity, with registry-owned label storage
- reuses exact opaque ops tables for TSD projections and REF alternatives instead of cloning known concrete table layouts to manufacture pointer identity
- removes the projection/alternative caches, `TSTypeKind` copy switches, and derived-table narrowing
- documents representation identity and adds native, ABI-boundary, and installed-SDK extension coverage

## Root cause

`TypeRecord` interning keyed schema, role, plan, ops, and debugger metadata but treated the implementation label as non-key metadata. Topological projections that needed a distinct record therefore copied an ops table solely to obtain a new pointer. Those copies selected a known derived table from `TSTypeKind`, which sliced independently supplied extension tables and made semantic owners depend on concrete representation layouts.

The implementation label is now a stable representation identity compared by string content. Distinct records can safely share the same opaque plan and ops table, while equal labels canonicalize across caller-owned strings and shared-library boundaries.

## Validation

- macOS fresh native build and complete CTest suite: 1,596 passed
- macOS cp312 stable-ABI wheel installed under Python 3.14: 2,170 passed, 9 skipped
- `hg-linux` fresh native build and complete CTest suite: 1,595 passed
- `hg-linux` cp312 stable-ABI wheel installed under Python 3.14: 2,170 passed, 9 skipped
- installed SDK consumer: 1 passed, including a custom extended indexed-ops table
- Sphinx HTML build with warnings as errors: passed

Advances Phase 4 of #462.
