### PR TITLE
Compile runtime representation strategies

### DIFF
--- a/include/hgraph/lib/std/operators/impl/stream_impl.h
+++ b/include/hgraph/lib/std/operators/impl/stream_impl.h
@@ -491,10 +491,17 @@ namespace hgraph::stdlib
             ankerl::unordered_dense::map<Int, std::deque<Value>> cache{};
         };
 
+        struct ThrottleReleaseOps;
+        [[nodiscard]] const ThrottleReleaseOps &throttle_ordered_release_ops() noexcept;
+
         struct ThrottleState
         {
             TimeDelta period{MIN_TD};
             bool      has_period{false};
+            // Selected once at node start from the resolved output schema.
+            // Evaluation dispatches through this passive table and never
+            // reinterprets the representation kind of the output.
+            const ThrottleReleaseOps *release_ops{&throttle_ordered_release_ops()};
             // Deltas accumulated while a throttle window is open; applied in
             // arrival order on release so container deltas MERGE (dict ticks
             // within one window emit as one combined delta).
@@ -574,6 +581,44 @@ namespace hgraph::stdlib
             bundle.set("added", added_builder.build());
             bundle.set("removed", removed_builder.build());
             return bundle.build();
+        }
+
+        struct ThrottleReleaseOps
+        {
+            bool (*release)(std::deque<Value> &pending, const TSOutputView &out){nullptr};
+        };
+
+        [[nodiscard]] inline bool throttle_release_ordered(std::deque<Value> &pending,
+                                                           const TSOutputView &out)
+        {
+            for (Value &delta : pending) { apply_delta(out, delta.view()); }
+            return true;
+        }
+
+        [[nodiscard]] inline bool throttle_release_set(std::deque<Value> &pending,
+                                                       const TSOutputView &out)
+        {
+            auto net = net_set_deltas(pending);
+            if (!net.has_value()) { return false; }
+            apply_delta(out, net->view());
+            return true;
+        }
+
+        [[nodiscard]] inline const ThrottleReleaseOps &throttle_ordered_release_ops() noexcept
+        {
+            static const ThrottleReleaseOps ops{&throttle_release_ordered};
+            return ops;
+        }
+
+        [[nodiscard]] inline const ThrottleReleaseOps &throttle_set_release_ops() noexcept
+        {
+            static const ThrottleReleaseOps ops{&throttle_release_set};
+            return ops;
+        }
+
+        [[nodiscard]] inline const ThrottleReleaseOps &throttle_release_ops_for(TSTypeKind kind) noexcept
+        {
+            return kind == TSTypeKind::TSS ? throttle_set_release_ops() : throttle_ordered_release_ops();
         }
     }  // namespace stream_impl_detail
 }  // namespace hgraph::stdlib
@@ -1493,6 +1538,15 @@ namespace hgraph::stdlib
            event. Ticks inside the window accumulate; the window closing
            releases them merged. ``delay_first_tick`` buffers the tick that
            would otherwise pass straight through on a closed window. */
+        static void start(State<stream_impl_detail::ThrottleState> state,
+                          Out<TsVar<"S">> out)
+        {
+            auto current = state.get();
+            const auto &erased = static_cast<const TSOutputView &>(out);
+            current.release_ops = &stream_impl_detail::throttle_release_ops_for(erased.schema()->kind);
+            state.set(std::move(current));
+        }
+
         static void eval(In<"ts", TsVar<"S">, InputValidity::Unchecked> ts,
                          In<"period", TS<TimeDelta>, InputValidity::Unchecked> period,
                          Scalar<"delay_first_tick", Bool> delay_first_tick,
@@ -1533,19 +1587,7 @@ namespace hgraph::stdlib
             if (scheduler.is_scheduled_now() && !current.pending.empty())
             {
                 const auto &erased = static_cast<const TSOutputView &>(out);
-                bool        emitted = true;
-                if (erased.schema()->kind == TSTypeKind::TSS)
-                {
-                    // Net the window's set deltas: an add-then-remove pair
-                    // cancels; a fully-cancelled window emits nothing.
-                    auto net = stream_impl_detail::net_set_deltas(current.pending);
-                    if (net.has_value()) { apply_delta(out, net->view()); }
-                    else { emitted = false; }
-                }
-                else
-                {
-                    for (Value &delta : current.pending) { apply_delta(out, delta.view()); }
-                }
+                const bool emitted = current.release_ops->release(current.pending, erased);
                 current.pending.clear();
                 if (emitted) { scheduler.schedule(now + current.period); }
             }

--- a/src/hgraph/runtime/map_node.cpp
+++ b/src/hgraph/runtime/map_node.cpp
@@ -275,8 +275,9 @@ namespace hgraph
 
         struct MapNodeContext
         {
-            MapNodeSpec spec{};
-            std::size_t storage_offset{0};
+            MapNodeSpec                spec{};
+            runtime_detail::MappedChildAccessPlan access{};
+            std::size_t                storage_offset{0};
             MemoryUtils::StorageLayout graph_layout{};
         };
 
@@ -291,11 +292,13 @@ namespace hgraph
 
         [[nodiscard]] MapNodeContextPtr make_map_node_context(
             MapNodeSpec spec,
+            runtime_detail::MappedChildAccessPlan access,
             std::size_t storage_offset,
             MemoryUtils::StorageLayout graph_layout)
         {
             return std::make_shared<MapNodeContext>(MapNodeContext{
                 .spec           = std::move(spec),
+                .access         = std::move(access),
                 .storage_offset = storage_offset,
                 .graph_layout   = graph_layout,
             });
@@ -364,7 +367,7 @@ namespace hgraph
                                                     std::string_view stage,
                                                     std::size_t source_index)
         {
-            if (!data.valid() || data.storage_type().ops_ref().kind != TSTypeKind::TSD)
+            if (!data.valid())
             {
                 const auto *schema = data.schema();
                 const auto storage_type = data.storage_type();
@@ -435,7 +438,8 @@ namespace hgraph
         {
             if (!context.spec.child.output_binding.has_value()) { return; }
             runtime_detail::clear_mapped_output_element_binding(
-                view, evaluation_time, entry.key.view(), context.spec.output_binding_mode);
+                view, evaluation_time, entry.key.view(), context.access.output,
+                context.spec.output_binding_mode);
         }
 
         void remove_entry_at_slot(const NodeView &view, const MapNodeContext &context,
@@ -524,10 +528,10 @@ namespace hgraph
                                                 ? entry.key_source.view(evaluation_time)
                                                 : TSOutputView{};
             runtime_detail::bind_mapped_child_inputs(view, entry.graph.view(), evaluation_time,
-                                                     spec.child, spec.args, entry.key.view(), key_source,
+                                                     spec.child, context.access, entry.key.view(), key_source,
                                                      std::nullopt, false, true);
             runtime_detail::bind_mapped_child_output(view, entry.graph.view(), evaluation_time,
-                                                     spec.child.output_binding, spec.args, entry.key.view(),
+                                                     spec.child.output_binding, context.access, entry.key.view(),
                                                      key_source,
                                                      spec.output_binding_mode);
             entry.graph.view().start(evaluation_time);
@@ -840,18 +844,15 @@ namespace hgraph
             bool input_event = keys_input.modified();
             bool full_scan = storage.refresh_all_bindings || !was_primed;
 
-            for (const MapArgSource &arg : context.spec.args)
+            for (const auto &arg : context.access.args)
             {
-                if (arg.kind != MapArgSourceKind::OuterInput) { continue; }
-                auto input = root_input.indexed_child_at(arg.outer_index);
+                if (arg.source.kind != MapArgSourceKind::OuterInput) { continue; }
+                auto input = root_input.indexed_child_at(arg.source.outer_index);
                 if (input.modified())
                 {
                     input_event = true;
                     full_scan = true;
-                    const auto *schema = input.schema();
-                    if (schema != nullptr &&
-                        (schema->kind == TSTypeKind::TSB ||
-                         schema->kind == TSTypeKind::TSL))
+                    if (arg.refreshes_projected_children)
                     {
                         // A structured forwarding boundary can keep its root
                         // handle while a REF resolution changes the projected
@@ -1016,10 +1017,10 @@ namespace hgraph
                                                         ? entry->key_source.view(evaluation_time)
                                                         : TSOutputView{};
                     runtime_detail::bind_mapped_child_inputs(view, child, evaluation_time, spec.child,
-                                                             spec.args, entry->key.view(), key_source,
+                                                             context.access, entry->key.view(), key_source,
                                                              std::nullopt, silent_repoint);
                     runtime_detail::bind_mapped_child_output(view, child, evaluation_time,
-                                                             spec.child.output_binding, spec.args,
+                                                             spec.child.output_binding, context.access,
                                                              entry->key.view(), key_source,
                                                              spec.output_binding_mode, silent_repoint);
                 }
@@ -1044,6 +1045,7 @@ namespace hgraph
                     }
                     runtime_detail::finalize_mapped_child_output(
                         view, evaluation_time, spec.child.output_binding,
+                        context.access.output,
                         entry->key.view());
                 }
                 if (const DateTime next = child.next_scheduled_time(); next != MAX_DT && next > evaluation_time)
@@ -1384,6 +1386,15 @@ namespace hgraph
                 forwarding_output_endpoint_schema(meta.output_schema->element_ts()));
         }
 
+        const TSEndpointSchema *output_element_endpoint =
+            meta.output_schema != nullptr &&
+                    spec.output_binding_mode != MapOutputBindingMode::ChildTerminalWritesElement
+                ? &meta.output_endpoint_schema.child(0)
+                : nullptr;
+        auto access = runtime_detail::compile_mapped_child_access_plan(
+            spec.args, TSTypeKind::TSD, meta.input_schema, meta.output_schema,
+            output_element_endpoint);
+
         const auto *keys_schema = TypeRegistry::instance().dereference(
             meta.input_schema->fields()[*spec.keys_input_index].type);
         const ValueTypeRef key_type = ValuePlanFactory::instance().type_for(
@@ -1427,6 +1438,7 @@ namespace hgraph
         };
         MapNodeContextPtr context = make_map_node_context(
             std::move(spec),
+            std::move(access),
             descriptor.storage_plan->component(map_storage_field_name).offset,
             graph_layout);
         descriptor.ops.extended_view_context = descriptor.storage_plan;

--- a/src/hgraph/runtime/mapped_child_bindings.h
+++ b/src/hgraph/runtime/mapped_child_bindings.h
@@ -24,6 +24,61 @@ namespace hgraph::runtime_detail
         TSOutputHandle source{};
     };
 
+    struct MappedArgAccessPlan;
+    using MappedArgResolveFn = TSOutputView (*)(const MappedArgAccessPlan &, const TSInputView &,
+                                                const ValueView &, const TSOutputView &,
+                                                const std::vector<std::size_t> &);
+
+    struct MappedArgAccessOps
+    {
+        MappedArgResolveFn resolve{nullptr};
+    };
+
+    struct MappedArgAccessPlan
+    {
+        MapArgSource             source{};
+        const MappedArgAccessOps *ops{nullptr};
+        bool                     refreshes_projected_children{false};
+    };
+
+    struct MappedOutputDataPlan;
+    using MappedOutputModifiedFn = bool (*)(const MappedOutputDataPlan &, const TSDataView &, DateTime);
+
+    struct MappedOutputDataOps
+    {
+        MappedOutputModifiedFn modified{nullptr};
+    };
+
+    struct MappedOutputDataPlan
+    {
+        const MappedOutputDataOps        *ops{nullptr};
+        std::vector<MappedOutputDataPlan> children{};
+    };
+
+    struct MappedOutputAccessPlan;
+    using MappedOutputElementFn = TSOutputView (*)(const MappedOutputAccessPlan &, const NodeView &,
+                                                   DateTime, const ValueView &);
+
+    struct MappedOutputAccessOps
+    {
+        MappedOutputElementFn element{nullptr};
+    };
+
+    struct MappedOutputAccessPlan
+    {
+        const MappedOutputAccessOps *ops{nullptr};
+        MappedOutputDataPlan         data{};
+    };
+
+    struct MappedChildAccessPlan
+    {
+        // Compiled once in the owning map/mesh node context. Child lifecycle
+        // code dispatches through these passive callbacks instead of testing
+        // TSD/TSL or endpoint representation on every bind/evaluation.
+        std::vector<MappedArgAccessPlan> args{};
+        MappedOutputAccessPlan           output{};
+    };
+
     [[nodiscard]] inline std::span<const std::size_t> mapped_child_path_suffix(
         const std::vector<std::size_t> &path)
     {
@@ -47,62 +102,266 @@ namespace hgraph::runtime_detail
         return static_cast<std::size_t>(index);
     }
 
+    [[nodiscard]] inline TSOutputView mapped_key_source(
+        const MappedArgAccessPlan &,
+        const TSInputView &,
+        const ValueView &,
+        const TSOutputView &key_source,
+        const std::vector<std::size_t> &)
+    {
+        return key_source.borrowed_ref();
+    }
+
+    [[nodiscard]] inline TSOutputView mapped_dict_element_source(
+        const MappedArgAccessPlan &plan,
+        const TSInputView &root_input,
+        const ValueView &key,
+        const TSOutputView &,
+        const std::vector<std::size_t> &source_path)
+    {
+        auto mux_source = root_input.indexed_child_at(plan.source.outer_index).bound_output();
+        if (!mux_source.bound()) { return {}; }
+        auto dict = mux_source.as_dict();
+        if (!dict.contains(key)) { return {}; }
+        return walk_ts_path(dict.at(key), mapped_child_path_suffix(source_path));
+    }
+
+    [[nodiscard]] inline TSOutputView mapped_list_element_source(
+        const MappedArgAccessPlan &plan,
+        const TSInputView &root_input,
+        const ValueView &key,
+        const TSOutputView &,
+        const std::vector<std::size_t> &source_path)
+    {
+        auto mux_source = root_input.indexed_child_at(plan.source.outer_index).bound_output();
+        if (!mux_source.bound()) { return {}; }
+        auto list = mux_source.as_list();
+        const std::size_t index = mapped_list_index(key);
+        if (index >= list.size()) { return {}; }
+        return walk_ts_path(list.at(index), mapped_child_path_suffix(source_path));
+    }
+
+    [[nodiscard]] inline TSOutputView mapped_outer_input_source(
+        const MappedArgAccessPlan &plan,
+        const TSInputView &root_input,
+        const ValueView &,
+        const TSOutputView &,
+        const std::vector<std::size_t> &source_path)
+    {
+        auto outer_input = root_input.indexed_child_at(plan.source.outer_index);
+        return walk_source_to_output(std::move(outer_input), mapped_child_path_suffix(source_path));
+    }
+
     [[nodiscard]] inline TSOutputView mapped_child_input_source(
         const TSInputView &root_input,
-        const MapArgSource &arg,
+        const MappedArgAccessPlan &plan,
         const ValueView &key,
         const TSOutputView &key_source,
         const std::vector<std::size_t> &source_path)
     {
-        switch (arg.kind)
-        {
-            case MapArgSourceKind::Key:
-                return key_source.borrowed_ref();
-            case MapArgSourceKind::Element:
-            {
-                auto mux_source = root_input.indexed_child_at(arg.outer_index).bound_output();
-                if (!mux_source.bound()) { return {}; }
-                if (mux_source.schema()->kind == TSTypeKind::TSD)
-                {
-                    auto dict = mux_source.as_dict();
-                    if (!dict.contains(key)) { return {}; }
-                    return walk_ts_path(dict.at(key), mapped_child_path_suffix(source_path));
-                }
-                if (mux_source.schema()->kind == TSTypeKind::TSL)
-                {
-                    auto              list  = mux_source.as_list();
-                    const std::size_t index = mapped_list_index(key);
-                    if (index >= list.size()) { return {}; }
-                    return walk_ts_path(list.at(index), mapped_child_path_suffix(source_path));
-                }
-                throw std::invalid_argument("mapped child element source must be a TSD or TSL");
-            }
-            case MapArgSourceKind::OuterInput:
-            {
-                auto outer_input = root_input.indexed_child_at(arg.outer_index);
-                return walk_source_to_output(std::move(outer_input), mapped_child_path_suffix(source_path));
-            }
-        }
-        return {};
+        return plan.ops->resolve(plan, root_input, key, key_source, source_path);
     }
 
-    [[nodiscard]] inline TSOutputView mapped_output_element(
+    [[nodiscard]] inline TSOutputView mapped_dict_output_element(
+        const MappedOutputAccessPlan &,
         const NodeView &parent,
         DateTime evaluation_time,
         const ValueView &key)
     {
         auto output = parent.output(evaluation_time);
-        if (output.schema()->kind == TSTypeKind::TSD)
+        auto dict = output.as_dict();
+        return dict.contains(key) ? dict.at(key) : TSOutputView{};
+    }
+
+    [[nodiscard]] inline TSOutputView mapped_list_output_element(
+        const MappedOutputAccessPlan &,
+        const NodeView &parent,
+        DateTime evaluation_time,
+        const ValueView &key)
+    {
+        auto output = parent.output(evaluation_time);
+        auto list = output.as_list();
+        return list[mapped_list_index(key)];
+    }
+
+    [[nodiscard]] inline TSOutputView mapped_no_output_element(
+        const MappedOutputAccessPlan &,
+        const NodeView &,
+        DateTime,
+        const ValueView &)
+    {
+        return {};
+    }
+
+    [[nodiscard]] inline TSOutputView mapped_output_element(
+        const MappedOutputAccessPlan &plan,
+        const NodeView &parent,
+        DateTime evaluation_time,
+        const ValueView &key)
+    {
+        return plan.ops->element(plan, parent, evaluation_time, key);
+    }
+
+    [[nodiscard]] inline bool mapped_output_leaf_modified(
+        const MappedOutputDataPlan &,
+        const TSDataView &data,
+        DateTime evaluation_time)
+    {
+        return data.valid() && data.modified(evaluation_time);
+    }
+
+    [[nodiscard]] inline bool mapped_output_indexed_tree_modified(
+        const MappedOutputDataPlan &plan,
+        const TSDataView &data,
+        DateTime evaluation_time)
+    {
+        if (!data.valid()) { return false; }
+        if (data.modified(evaluation_time)) { return true; }
+        for (std::size_t index = 0; index < plan.children.size(); ++index)
         {
-            auto dict = output.as_dict();
-            return dict.contains(key) ? dict.at(key) : TSOutputView{};
+            const auto &child_plan = plan.children[index];
+            if (child_plan.ops->modified(child_plan, data.indexed_child_at(index), evaluation_time))
+            {
+                return true;
+            }
         }
-        if (output.schema()->kind == TSTypeKind::TSL)
+        return false;
+    }
+
+    [[nodiscard]] inline bool mapped_output_input_tree_modified(
+        const MappedOutputDataPlan &plan,
+        const TSDataView &data,
+        DateTime evaluation_time)
+    {
+        if (!data.valid()) { return false; }
+        if (data.modified(evaluation_time)) { return true; }
+        for (std::size_t index = 0; index < plan.children.size(); ++index)
         {
-            auto list = output.as_list();
-            return list[mapped_list_index(key)];
+            auto projection = detail::input_child_projection(data, index);
+            const auto &child_plan = plan.children[index];
+            if (child_plan.ops->modified(child_plan, projection.visible, evaluation_time))
+            {
+                return true;
+            }
         }
-        throw std::invalid_argument("mapped child output must be a TSD or TSL");
+        return false;
+    }
+
+    [[nodiscard]] inline const MappedOutputDataOps &mapped_output_leaf_ops() noexcept
+    {
+        static const MappedOutputDataOps ops{&mapped_output_leaf_modified};
+        return ops;
+    }
+
+    [[nodiscard]] inline const MappedOutputDataOps &mapped_output_indexed_ops() noexcept
+    {
+        static const MappedOutputDataOps ops{&mapped_output_indexed_tree_modified};
+        return ops;
+    }
+
+    [[nodiscard]] inline const MappedOutputDataOps &mapped_output_input_ops() noexcept
+    {
+        static const MappedOutputDataOps ops{&mapped_output_input_tree_modified};
+        return ops;
+    }
+
+    [[nodiscard]] inline MappedOutputDataPlan mapped_owned_output_data_plan(
+        const TSValueTypeMetaData *schema)
+    {
+        MappedOutputDataPlan plan{.ops = &mapped_output_leaf_ops()};
+        if (schema == nullptr) { return plan; }
+        if (schema->kind == TSTypeKind::TSB)
+        {
+            plan.ops = &mapped_output_indexed_ops();
+            plan.children.reserve(schema->field_count());
+            for (std::size_t index = 0; index < schema->field_count(); ++index)
+            {
+                plan.children.push_back(mapped_owned_output_data_plan(schema->fields()[index].type));
+            }
+        }
+        else if (schema->kind == TSTypeKind::TSL && schema->fixed_size() != 0)
+        {
+            plan.ops = &mapped_output_indexed_ops();
+            plan.children.reserve(schema->fixed_size());
+            for (std::size_t index = 0; index < schema->fixed_size(); ++index)
+            {
+                plan.children.push_back(mapped_owned_output_data_plan(schema->element_ts()));
+            }
+        }
+        return plan;
+    }
+
+    [[nodiscard]] inline MappedOutputDataPlan mapped_endpoint_output_data_plan(
+        const TSEndpointSchema &endpoint)
+    {
+        if (!endpoint.is_non_peered())
+        {
+            return MappedOutputDataPlan{.ops = &mapped_output_leaf_ops()};
+        }
+        MappedOutputDataPlan plan{.ops = &mapped_output_input_ops()};
+        plan.children.reserve(endpoint.child_count());
+        for (std::size_t index = 0; index < endpoint.child_count(); ++index)
+        {
+            plan.children.push_back(mapped_endpoint_output_data_plan(endpoint.child(index)));
+        }
+        return plan;
+    }
+
+    [[nodiscard]] inline MappedChildAccessPlan compile_mapped_child_access_plan(
+        std::span<const MapArgSource> args,
+        TSTypeKind multiplexed_kind,
+        const TSValueTypeMetaData *input_schema,
+        const TSValueTypeMetaData *output_schema,
+        const TSEndpointSchema *output_element_endpoint = nullptr)
+    {
+        static const MappedArgAccessOps key_ops{&mapped_key_source};
+        static const MappedArgAccessOps dict_element_ops{&mapped_dict_element_source};
+        static const MappedArgAccessOps list_element_ops{&mapped_list_element_source};
+        static const MappedArgAccessOps outer_ops{&mapped_outer_input_source};
+        static const MappedOutputAccessOps no_output_ops{&mapped_no_output_element};
+        static const MappedOutputAccessOps dict_output_ops{&mapped_dict_output_element};
+        static const MappedOutputAccessOps list_output_ops{&mapped_list_output_element};
+
+        MappedChildAccessPlan plan;
+        plan.args.reserve(args.size());
+        for (const auto &source : args)
+        {
+            const MappedArgAccessOps *ops = &outer_ops;
+            switch (source.kind)
+            {
+                case MapArgSourceKind::Key: ops = &key_ops; break;
+                case MapArgSourceKind::OuterInput: ops = &outer_ops; break;
+                case MapArgSourceKind::Element:
+                    ops = multiplexed_kind == TSTypeKind::TSD ? &dict_element_ops : &list_element_ops;
+                    break;
+            }
+            bool refreshes_projected_children = false;
+            if (source.kind == MapArgSourceKind::OuterInput && input_schema != nullptr &&
+                source.outer_index < input_schema->field_count())
+            {
+                const auto *schema = input_schema->fields()[source.outer_index].type;
+                refreshes_projected_children = schema != nullptr &&
+                                               (schema->kind == TSTypeKind::TSB ||
+                                                schema->kind == TSTypeKind::TSL);
+            }
+            plan.args.push_back(MappedArgAccessPlan{
+                .source = source,
+                .ops = ops,
+                .refreshes_projected_children = refreshes_projected_children,
+            });
+        }
+
+        plan.output.ops = &no_output_ops;
+        plan.output.data = MappedOutputDataPlan{.ops = &mapped_output_leaf_ops()};
+        if (output_schema != nullptr)
+        {
+            plan.output.ops = output_schema->kind == TSTypeKind::TSD ? &dict_output_ops : &list_output_ops;
+            const auto *element_schema = output_schema->element_ts();
+            plan.output.data = output_element_endpoint != nullptr
+                                   ? mapped_endpoint_output_data_plan(*output_element_endpoint)
+                                   : mapped_owned_output_data_plan(element_schema);
+        }
+        return plan;
     }
 
     inline void bind_mapped_child_inputs(
@@ -110,7 +369,7 @@ namespace hgraph::runtime_detail
         const GraphView &child,
         DateTime evaluation_time,
         const SingleNestedGraphNodeSpec &spec,
-        std::span<const MapArgSource> args,
+        const MappedChildAccessPlan &access,
         const ValueView &key,
         const TSOutputView &key_source,
         std::optional<MappedChildSourceOverride> source_override = std::nullopt,
@@ -123,11 +382,11 @@ namespace hgraph::runtime_detail
         for (const NestedGraphInputBinding &binding : spec.input_bindings)
         {
             const std::size_t source_index = binding.source_path[0];
-            if (source_index >= args.size())
+            if (source_index >= access.args.size())
             {
                 throw std::out_of_range("mapped child input binding source ordinal is out of range");
             }
-            const MapArgSource &arg = args[source_index];
+            const auto &arg = access.args[source_index];
 
             TSOutputView source{};
             if (source_override.has_value() && source_index == source_override->source_index)
@@ -147,7 +406,7 @@ namespace hgraph::runtime_detail
             {
                 throw std::invalid_argument(
                     "mapped child boundary source ordinal " + std::to_string(source_index) +
-                    " resolved through outer input " + std::to_string(arg.outer_index) +
+                    " resolved through outer input " + std::to_string(arg.source.outer_index) +
                     " as '" + std::string{source.schema()->name()} +
                     "' for child input '" + std::string{target.schema()->name()} + "'");
             }
@@ -172,7 +431,7 @@ namespace hgraph::runtime_detail
         const GraphView &child,
         DateTime evaluation_time,
         const std::optional<NestedGraphOutputBinding> &output_binding,
-        std::span<const MapArgSource> args,
+        const MappedChildAccessPlan &access,
         const ValueView &key,
         const TSOutputView &key_source,
         MapOutputBindingMode mode = MapOutputBindingMode::ChildTerminalWritesElement,
@@ -180,7 +439,7 @@ namespace hgraph::runtime_detail
     {
         if (!output_binding.has_value()) { return; }
 
-        auto element = mapped_output_element(parent, evaluation_time, key);
+        auto element = mapped_output_element(access.output, parent, evaluation_time, key);
         if (!element.bound()) { return; }
 
         if (output_binding->kind == NestedGraphOutputBinding::Kind::ParentInput)
@@ -194,13 +453,13 @@ namespace hgraph::runtime_detail
                 throw std::logic_error("mapped child parent-input output requires a source ordinal");
             }
             const std::size_t source_index = output_binding->parent_source_path[0];
-            if (source_index >= args.size())
+            if (source_index >= access.args.size())
             {
                 throw std::out_of_range("mapped child output binding source ordinal is out of range");
             }
 
             auto root_input = parent.input(evaluation_time);
-            auto source = mapped_child_input_source(root_input.borrowed_ref(), args[source_index], key,
+            auto source = mapped_child_input_source(root_input.borrowed_ref(), access.args[source_index], key,
                                                     key_source, output_binding->parent_source_path);
             auto target = silent_repoint ? element.handle().view(MIN_DT) : element.borrowed_ref();
             static_cast<void>(bind_forwarding_output_tree_to_source(std::move(target), source));
@@ -233,11 +492,12 @@ namespace hgraph::runtime_detail
         const NodeView &parent,
         DateTime evaluation_time,
         const ValueView &key,
+        const MappedOutputAccessPlan &access,
         MapOutputBindingMode mode)
     {
         if (mode == MapOutputBindingMode::ChildTerminalWritesElement) { return; }
 
-        auto element = mapped_output_element(parent, evaluation_time, key);
+        auto element = mapped_output_element(access, parent, evaluation_time, key);
         if (!element.bound()) { return; }
         static_cast<void>(clear_forwarding_output_tree(std::move(element)));
     }
@@ -250,53 +510,25 @@ namespace hgraph::runtime_detail
      * still needs to see the terminal's final validity.
      */
     [[nodiscard]] inline bool mapped_output_data_tree_modified(
+        const MappedOutputDataPlan &plan,
         const TSDataView &data,
-        const TSValueTypeMetaData *schema,
         DateTime evaluation_time)
     {
-        if (!data.valid()) { return false; }
-        if (data.modified(evaluation_time)) { return true; }
-
-        const std::size_t child_count =
-            schema != nullptr && schema->kind == TSTypeKind::TSB
-                ? schema->field_count()
-            : schema != nullptr && schema->kind == TSTypeKind::TSL
-                ? schema->fixed_size()
-                : 0;
-        for (std::size_t index = 0; index < child_count; ++index)
-        {
-            TSDataView child;
-            if (detail::has_input_children(data))
-            {
-                auto projection = detail::input_child_projection(data, index);
-                child = std::move(projection.visible);
-            }
-            else
-            {
-                child = data.indexed_child_at(index);
-            }
-            if (mapped_output_data_tree_modified(child, child.schema(),
-                                                 evaluation_time))
-            {
-                return true;
-            }
-        }
-        return false;
+        return plan.ops->modified(plan, data, evaluation_time);
     }
 
     inline void finalize_mapped_child_output(
         const NodeView &parent,
         DateTime evaluation_time,
         const std::optional<NestedGraphOutputBinding> &output_binding,
+        const MappedOutputAccessPlan &access,
         const ValueView &key)
     {
         if (!output_binding.has_value()) { return; }
 
-        auto element = mapped_output_element(parent, evaluation_time, key);
+        auto element = mapped_output_element(access, parent, evaluation_time, key);
         if (!element.bound() ||
-            !mapped_output_data_tree_modified(element.data_view(),
-                                              element.schema(),
-                                              evaluation_time))
+            !mapped_output_data_tree_modified(access.data, element.data_view(), evaluation_time))
         {
             return;
         }

--- a/src/hgraph/runtime/mesh_node.cpp
+++ b/src/hgraph/runtime/mesh_node.cpp
@@ -342,6 +342,7 @@ struct MeshNodeStorage final : SlotObserver {
 
 struct MeshNodeContext {
   MeshNodeSpec spec{};
+  runtime_detail::MappedChildAccessPlan access{};
   std::size_t storage_offset{0};
   ValueTypeRef key_binding{nullptr};
   MemoryUtils::StorageLayout graph_layout{};
@@ -383,11 +384,14 @@ mesh_node_contexts() noexcept {
 }
 
 [[nodiscard]] const MeshNodeContext &
-register_mesh_node_context(MeshNodeSpec spec, std::size_t storage_offset,
+register_mesh_node_context(MeshNodeSpec spec,
+                           runtime_detail::MappedChildAccessPlan access,
+                           std::size_t storage_offset,
                            const ValueTypeRef &key_binding,
                            MemoryUtils::StorageLayout graph_layout) {
   auto context = std::make_unique<MeshNodeContext>(MeshNodeContext{
       .spec = std::move(spec),
+      .access = std::move(access),
       .storage_offset = storage_offset,
       .key_binding = key_binding,
       .graph_layout = graph_layout,
@@ -580,17 +584,15 @@ void prepare_mesh_evaluation_candidates(const NodeView &view,
     input_event = true;
   }
 
-  for (const MapArgSource &arg : context.spec.args) {
-    if (arg.kind != MapArgSourceKind::OuterInput) {
+  for (const auto &arg : context.access.args) {
+    if (arg.source.kind != MapArgSourceKind::OuterInput) {
       continue;
     }
-    auto input = root_input.indexed_child_at(arg.outer_index);
+    auto input = root_input.indexed_child_at(arg.source.outer_index);
     if (!input.modified()) {
       continue;
     }
-    const auto *schema = input.schema();
-    if (schema != nullptr &&
-        (schema->kind == TSTypeKind::TSB || schema->kind == TSTypeKind::TSL)) {
+    if (arg.refreshes_projected_children) {
       // A structured forwarding boundary may preserve its root handle while
       // projected leaf endpoints move.
       storage.refresh_all_bindings = true;
@@ -701,7 +703,7 @@ void bind_instance_inputs(const NodeView &view, const MeshNodeContext &context,
                                       ? entry.key_source.view(evaluation_time)
                                       : TSOutputView{};
   runtime_detail::bind_mapped_child_inputs(
-      view, entry.graph.view(), evaluation_time, spec.child, spec.args,
+      view, entry.graph.view(), evaluation_time, spec.child, context.access,
       entry.key.view(), key_source, std::nullopt, false, sampled);
 }
 
@@ -713,7 +715,7 @@ void bind_instance_output(const NodeView &view, const MeshNodeContext &context,
                                       : TSOutputView{};
   runtime_detail::bind_mapped_child_output(
       view, entry.graph.view(), evaluation_time, spec.child.output_binding,
-      spec.args, entry.key.view(), key_source, spec.output_binding_mode);
+      context.access, entry.key.view(), key_source, spec.output_binding_mode);
 }
 
 void clear_instance_output_binding(const NodeView &view,
@@ -722,6 +724,7 @@ void clear_instance_output_binding(const NodeView &view,
                                    DateTime evaluation_time) {
   runtime_detail::clear_mapped_output_element_binding(
       view, evaluation_time, entry.key.view(),
+      context.access.output,
       context.spec.output_binding_mode);
 }
 
@@ -1089,6 +1092,7 @@ bool mesh_evaluate_impl(const void *, const NodeView &view,
         entry->settled_time = evaluation_time;
         runtime_detail::finalize_mapped_child_output(
             view, evaluation_time, spec.child.output_binding,
+            context.access.output,
             entry->key.view());
       } else {
         entry->paused = true;
@@ -1584,6 +1588,14 @@ NodeBuilder mesh_node(NodeTypeMetaData meta, MeshNodeSpec spec) {
         forwarding_output_endpoint_schema(meta.output_schema->element_ts()));
   }
 
+  const TSEndpointSchema *output_element_endpoint =
+      spec.output_binding_mode != MapOutputBindingMode::ChildTerminalWritesElement
+          ? &meta.output_endpoint_schema.child(0)
+          : nullptr;
+  auto access = runtime_detail::compile_mapped_child_access_plan(
+      spec.args, TSTypeKind::TSD, meta.input_schema, meta.output_schema,
+      output_element_endpoint);
+
   const auto key_binding =
       ValuePlanFactory::instance().type_for(meta.output_schema->key_type());
   if (!key_binding) {
@@ -1633,6 +1645,7 @@ NodeBuilder mesh_node(NodeTypeMetaData meta, MeshNodeSpec spec) {
   };
   descriptor.ops.extended_view_context = &register_mesh_node_context(
       std::move(spec),
+      std::move(access),
       descriptor.storage_plan->component(mesh_storage_field_name).offset,
       key_binding, graph_layout);
 

--- a/src/hgraph/runtime/reduce_node.cpp
+++ b/src/hgraph/runtime/reduce_node.cpp
@@ -181,6 +181,7 @@ namespace hgraph
 
         struct ReduceCollectionOps
         {
+            bool (*available)(const TSInputView &input);
             bool (*reconcile)(ReduceNodeStorage &storage, TSInputView &input, bool full);
             bool (*structure_modified)(const TSInputView &input, DateTime evaluation_time);
             void (*append_modified_leaves)(const ReduceNodeStorage &storage,
@@ -189,6 +190,13 @@ namespace hgraph
             TSOutputView (*leaf_output)(TSInputView &input, TSOutputView source,
                                         std::size_t leaf, const Value &key,
                                         std::size_t source_slot);
+        };
+
+        struct ReducePublicationOps
+        {
+            void (*begin)(TSOutputView output, const TSOutputView &source,
+                          ReduceNodeStorage &storage, DateTime evaluation_time,
+                          bool sample_all);
         };
 
         [[nodiscard]] bool reconcile_dict_collection(ReduceNodeStorage &storage, TSInputView &input, bool full);
@@ -211,6 +219,7 @@ namespace hgraph
             std::size_t    storage_offset{0};
             MemoryUtils::StorageLayout graph_layout{};
             const ReduceCollectionOps *collection_ops{nullptr};
+            const ReducePublicationOps *publication_ops{nullptr};
         };
 
         // Program-lifetime, intentionally-leaked context storage — same rationale
@@ -223,13 +232,14 @@ namespace hgraph
 
         [[nodiscard]] const ReduceNodeContext &register_reduce_node_context(
             ReduceNodeSpec spec, std::size_t storage_offset, MemoryUtils::StorageLayout graph_layout,
-            const ReduceCollectionOps &collection_ops)
+            const ReduceCollectionOps &collection_ops, const ReducePublicationOps &publication_ops)
         {
             auto context = std::make_unique<ReduceNodeContext>(ReduceNodeContext{
                 .spec           = std::move(spec),
                 .storage_offset = storage_offset,
                 .graph_layout   = graph_layout,
                 .collection_ops = &collection_ops,
+                .publication_ops = &publication_ops,
             });
             const auto *result = context.get();
             reduce_node_contexts().push_back(std::move(context));
@@ -730,16 +740,28 @@ namespace hgraph
             return source.bound() ? source.view(input.evaluation_time()) : TSOutputView{};
         }
 
+        [[nodiscard]] bool dict_collection_available(const TSInputView &input)
+        {
+            return input.valid();
+        }
+
+        [[nodiscard]] bool list_collection_available(const TSInputView &input)
+        {
+            return input.bound();
+        }
+
         [[nodiscard]] const ReduceCollectionOps &reduce_collection_ops_for(
             const TSValueTypeMetaData &schema)
         {
             static const ReduceCollectionOps dict_ops{
+                .available = &dict_collection_available,
                 .reconcile = &reconcile_dict_collection,
                 .structure_modified = &dict_structure_modified,
                 .append_modified_leaves = &append_modified_dict_leaves,
                 .leaf_output = &dict_leaf_output,
             };
             static const ReduceCollectionOps list_ops{
+                .available = &list_collection_available,
                 .reconcile = &reconcile_list_collection,
                 .structure_modified = &list_structure_modified,
                 .append_modified_leaves = &append_modified_list_leaves,
@@ -748,9 +770,16 @@ namespace hgraph
             return schema.kind == TSTypeKind::TSD ? dict_ops : list_ops;
         }
 
-        void begin_reduce_publication(TSOutputView output, const TSOutputView &source,
-                                      ReduceNodeStorage &storage, DateTime evaluation_time,
-                                      bool sample_all)
+        void begin_direct_reduce_publication(TSOutputView output, const TSOutputView &source,
+                                             ReduceNodeStorage &, DateTime evaluation_time,
+                                             bool)
+        {
+            bind_reduce_output(std::move(output), source, evaluation_time);
+        }
+
+        void begin_keyed_reduce_publication(TSOutputView output, const TSOutputView &source,
+                                            ReduceNodeStorage &storage, DateTime evaluation_time,
+                                            bool sample_all)
         {
             TSOutputView resolved_source = resolve_forwarding_source(source.borrowed_ref());
             if (storage.publication_snapshot_active)
@@ -770,11 +799,7 @@ namespace hgraph
                                                                  : TSOutputHandle{};
             const bool changed = output.forwarding() && previous.bound() &&
                                  (!resolved_source.bound() || !previous.same_as(resolved_source.handle()));
-            const auto *schema = output.schema();
-            const bool keyed = schema != nullptr &&
-                               (schema->kind == TSTypeKind::TSD || schema->kind == TSTypeKind::TSS);
-
-            if (!changed || !keyed)
+            if (!changed)
             {
                 bind_reduce_output(std::move(output), source, evaluation_time);
                 return;
@@ -788,6 +813,7 @@ namespace hgraph
             }
 
             auto &snapshot = storage.publication_snapshot;
+            const auto *schema = output.schema();
             snapshot.emplace(schema);
             DateTime snapshot_time = previous_view.last_modified_time();
             if (snapshot_time == MIN_DT) { snapshot_time = evaluation_time; }
@@ -808,6 +834,16 @@ namespace hgraph
             storage.publication_snapshot_active = true;
             storage.publication_full_reconcile = true;
             storage.publication_sample_all = sample_all;
+        }
+
+        [[nodiscard]] const ReducePublicationOps &reduce_publication_ops_for(
+            const TSValueTypeMetaData &schema) noexcept
+        {
+            static const ReducePublicationOps direct_ops{&begin_direct_reduce_publication};
+            static const ReducePublicationOps keyed_ops{&begin_keyed_reduce_publication};
+            return schema.kind == TSTypeKind::TSD || schema.kind == TSTypeKind::TSS
+                       ? keyed_ops
+                       : direct_ops;
         }
 
         void finish_reduce_publication(ReduceNodeStorage &storage, DateTime evaluation_time)
@@ -1038,8 +1074,8 @@ namespace hgraph
             // changed even though the new target did not write this cycle.
             const Aggregate root   = root_aggregate(context, storage);
             TSOutputView    source = aggregate_output(view, context, storage, root, evaluation_time);
-            begin_reduce_publication(view.output(evaluation_time), source, storage, evaluation_time,
-                                     bank_changed);
+            context.publication_ops->begin(view.output(evaluation_time), source, storage,
+                                           evaluation_time, bank_changed);
             storage.published = true;
 
             // Phase 3 — stop root-first, but keep the retired graph storage
@@ -1080,7 +1116,6 @@ namespace hgraph
             {
                 zero_source = effective_output_handle(root_input.indexed_child_at(1).bound_output());
             }
-            const bool list_collection = collection_input.schema()->kind == TSTypeKind::TSL;
             const bool collection_repointed = storage.source_handles_initialised &&
                                               !collection_source.same_as(storage.collection_source);
             const bool zero_repointed = context.spec.has_zero && storage.source_handles_initialised &&
@@ -1093,8 +1128,7 @@ namespace hgraph
             storage.structural_positions.clear();
             bool structural = false;
             bool full_structure = collection_repointed || !storage.published;
-            const bool collection_available = list_collection ? collection_input.bound()
-                                                              : collection_input.valid();
+            const bool collection_available = context.collection_ops->available(collection_input);
             if (collection_available)
             {
                 if (!storage.primed || collection_repointed ||
@@ -1188,7 +1222,7 @@ namespace hgraph
             // the added/removed paths does not evaluate unaffected sibling
             // paths, so include value modifications even after a rebuild.
             if (!full_scan && collection_event &&
-                (collection_input.valid() || collection_input.schema()->kind == TSTypeKind::TSL))
+                context.collection_ops->available(collection_input))
             {
                 storage.modified_leaves.clear();
                 context.collection_ops->append_modified_leaves(
@@ -1469,6 +1503,8 @@ namespace hgraph
         const MemoryUtils::StorageLayout graph_layout = spec.child.graph_builder.nested_storage_layout();
         const ReduceCollectionOps &collection_ops =
             reduce_collection_ops_for(*descriptor.schema.input_schema->fields()[0].type);
+        const ReducePublicationOps &publication_ops =
+            reduce_publication_ops_for(*descriptor.schema.output_schema);
 
         descriptor.callbacks.stop            = &reduce_node_stop;
         descriptor.ops.evaluate_impl         = &reduce_evaluate_impl;
@@ -1476,7 +1512,7 @@ namespace hgraph
         descriptor.ops.extended_view_type_id = ReduceNodeView::node_view_type_id();
         descriptor.ops.extended_view_context = &register_reduce_node_context(
             std::move(spec), descriptor.storage_plan->component(reduce_storage_field_name).offset,
-            graph_layout, collection_ops);
+            graph_layout, collection_ops, publication_ops);
 
         return NodeBuilder::from_descriptor(std::move(descriptor));
     }

--- a/src/hgraph/runtime/tsl_map_node.cpp
+++ b/src/hgraph/runtime/tsl_map_node.cpp
@@ -83,6 +83,7 @@ namespace hgraph
         struct TslMapNodeContext
         {
             TslMapNodeSpec             spec{};
+            runtime_detail::MappedChildAccessPlan access{};
             std::size_t                storage_offset{0};
             MemoryUtils::StorageLayout graph_layout{};
         };
@@ -94,10 +95,13 @@ namespace hgraph
             return *contexts;
         }
 
-        [[nodiscard]] const TslMapNodeContext &register_tsl_map_node_context(TslMapNodeSpec spec, std::size_t storage_offset,
+        [[nodiscard]] const TslMapNodeContext &register_tsl_map_node_context(TslMapNodeSpec spec,
+                                                                             runtime_detail::MappedChildAccessPlan access,
+                                                                             std::size_t storage_offset,
                                                                              MemoryUtils::StorageLayout graph_layout) {
             auto        context = std::make_unique<TslMapNodeContext>(TslMapNodeContext{
                 .spec           = std::move(spec),
+                .access         = std::move(access),
                 .storage_offset = storage_offset,
                 .graph_layout   = graph_layout,
             });
@@ -191,11 +195,11 @@ namespace hgraph
 
             const TSOutputView index_source =
                 entry.index_source.bound() ? entry.index_source.view(evaluation_time) : TSOutputView{};
-            runtime_detail::bind_mapped_child_inputs(view, entry.graph.view(), evaluation_time, spec.child, spec.args,
+            runtime_detail::bind_mapped_child_inputs(view, entry.graph.view(), evaluation_time, spec.child, context.access,
                                                      entry.index.view(), index_source,
                                                      std::nullopt, false, true);
             runtime_detail::bind_mapped_child_output(view, entry.graph.view(), evaluation_time, spec.child.output_binding,
-                                                     spec.args, entry.index.view(), index_source,
+                                                     context.access, entry.index.view(), index_source,
                                                      spec.output_binding_mode);
             entry.graph.view().start(evaluation_time);
             schedule_sampled_input_consumers(entry.graph.view(), evaluation_time, spec.child.input_bindings);
@@ -210,7 +214,8 @@ namespace hgraph
                 if (entry == nullptr || !entry->graph.has_value()) { continue; }
                 const TSOutputView index_source =
                     entry->index_source.bound() ? entry->index_source.view(evaluation_time) : TSOutputView{};
-                runtime_detail::bind_mapped_child_inputs(view, entry->graph.view(), evaluation_time, spec.child, spec.args,
+                runtime_detail::bind_mapped_child_inputs(view, entry->graph.view(), evaluation_time, spec.child,
+                                                         context.access,
                                                          entry->index.view(), index_source);
             }
         }
@@ -259,6 +264,7 @@ namespace hgraph
                         runtime_detail::finalize_mapped_child_output(
                             view, evaluation_time,
                             context.spec.child.output_binding,
+                            context.access.output,
                             entry->index.view());
                     }
                 }
@@ -425,6 +431,15 @@ namespace hgraph
                     meta.output_schema->element_ts()));
         }
 
+        const TSEndpointSchema *output_element_endpoint =
+            meta.output_schema != nullptr &&
+                    spec.output_binding_mode != MapOutputBindingMode::ChildTerminalWritesElement
+                ? &meta.output_endpoint_schema.child(0)
+                : nullptr;
+        auto access = runtime_detail::compile_mapped_child_access_plan(
+            spec.args, TSTypeKind::TSL, meta.input_schema, meta.output_schema,
+            output_element_endpoint);
+
         const GraphTypeRef child_graph_type = spec.child.graph_builder.nested_type();
         const ValueTypeRef index_type       = ValuePlanFactory::instance().type_for(scalar_descriptor<Int>::value_meta());
         if (!child_graph_type || !index_type) { throw std::logic_error("tsl_map_node could not resolve debugger child types"); }
@@ -460,7 +475,8 @@ namespace hgraph
                 descriptor.storage_plan->component(tsl_map_storage_field_name).offset + entries_offset, graph_pointer_offset, true),
         };
         descriptor.ops.extended_view_context = &register_tsl_map_node_context(
-            std::move(spec), descriptor.storage_plan->component(tsl_map_storage_field_name).offset, graph_layout);
+            std::move(spec), std::move(access),
+            descriptor.storage_plan->component(tsl_map_storage_field_name).offset, graph_layout);
 
         return NodeBuilder::from_descriptor(std::move(descriptor));
     }

--- a/src/hgraph/types/time_series/ts_output/alternative.cpp
+++ b/src/hgraph/types/time_series/ts_output/alternative.cpp
@@ -508,6 +508,40 @@ namespace hgraph::detail
             std::vector<FromRefEndpointPlan> children{};
         };
 
+        template <typename Element>
+        [[nodiscard]] DynamicStorageMetrics vector_dynamic_storage_metrics(
+            const std::vector<Element> &values) noexcept
+        {
+            return {
+                .live_bytes = values.size() * sizeof(Element),
+                .reserved_bytes = values.capacity() * sizeof(Element),
+            };
+        }
+
+        [[nodiscard]] DynamicStorageMetrics endpoint_schema_dynamic_storage_metrics(
+            const TSEndpointSchema &schema) noexcept
+        {
+            const auto &children = schema.children();
+            auto        result = vector_dynamic_storage_metrics(children);
+            for (const auto &child : children)
+            {
+                result += endpoint_schema_dynamic_storage_metrics(child);
+            }
+            return result;
+        }
+
+        [[nodiscard]] DynamicStorageMetrics from_ref_endpoint_plan_dynamic_storage_metrics(
+            const FromRefEndpointPlan &plan) noexcept
+        {
+            auto result = endpoint_schema_dynamic_storage_metrics(plan.schema);
+            result += vector_dynamic_storage_metrics(plan.children);
+            for (const auto &child : plan.children)
+            {
+                result += from_ref_endpoint_plan_dynamic_storage_metrics(child);
+            }
+            return result;
+        }
+
         void unbind_from_ref_peered(const FromRefEndpointPlan &,
                                     const TSDataView &target,
                                     DateTime modified_time,
@@ -843,6 +877,21 @@ namespace hgraph::detail
             std::optional<FromRefEndpointPlan>  endpoint{};
             std::vector<FromRefInteriorPlan>    children{};
         };
+
+        [[nodiscard]] DynamicStorageMetrics from_ref_interior_plan_dynamic_storage_metrics(
+            const FromRefInteriorPlan &plan) noexcept
+        {
+            auto result = vector_dynamic_storage_metrics(plan.children);
+            if (plan.endpoint.has_value())
+            {
+                result += from_ref_endpoint_plan_dynamic_storage_metrics(*plan.endpoint);
+            }
+            for (const auto &child : plan.children)
+            {
+                result += from_ref_interior_plan_dynamic_storage_metrics(child);
+            }
+            return result;
+        }
 
         /**
          * TSData binding for an interior from-REF alternative. A requested
@@ -1191,6 +1240,17 @@ namespace hgraph::detail
             const ToRefOps            *ops{nullptr};
             std::vector<ToRefPlan>      children{};
         };
+
+        [[nodiscard]] DynamicStorageMetrics to_ref_plan_dynamic_storage_metrics(
+            const ToRefPlan &plan) noexcept
+        {
+            auto result = vector_dynamic_storage_metrics(plan.children);
+            for (const auto &child : plan.children)
+            {
+                result += to_ref_plan_dynamic_storage_metrics(child);
+            }
+            return result;
+        }
 
         void populate_to_ref_data(const ToRefPlan &plan,
                                   const TSDataView &target,
@@ -1824,6 +1884,7 @@ namespace hgraph::detail
         to_ref_alternatives_.for_each([&](const AlternativeKey &, const ToRefAlternativeState &state) {
             result.live_bytes += sizeof(ToRefAlternativeState);
             result.reserved_bytes += sizeof(ToRefAlternativeState);
+            result += to_ref_plan_dynamic_storage_metrics(state.plan);
             const auto view = state.data.view();
             result += view.dynamic_storage_metrics();
             result += input_target_link_dynamic_storage_metrics(view);
@@ -1833,6 +1894,7 @@ namespace hgraph::detail
                                  state.reference_sources.size() * sizeof(TSOutputHandle);
             result.reserved_bytes += sizeof(RefLinkAlternativeState) +
                                      state.reference_sources.capacity() * sizeof(TSOutputHandle);
+            result += from_ref_endpoint_plan_dynamic_storage_metrics(state.plan);
             const auto view = state.data.view();
             result += view.dynamic_storage_metrics();
             result += input_target_link_dynamic_storage_metrics(view);
@@ -1841,6 +1903,7 @@ namespace hgraph::detail
             [&](const AlternativeKey &, const InteriorFromRefAlternativeState &state) {
                 result.live_bytes += sizeof(InteriorFromRefAlternativeState);
                 result.reserved_bytes += sizeof(InteriorFromRefAlternativeState);
+                result += from_ref_interior_plan_dynamic_storage_metrics(state.plan);
                 const auto view = state.data.view();
                 result += view.dynamic_storage_metrics();
                 result += input_target_link_dynamic_storage_metrics(view);

--- a/src/hgraph/types/time_series/ts_output/alternative.cpp
+++ b/src/hgraph/types/time_series/ts_output/alternative.cpp
@@ -460,104 +460,147 @@ namespace hgraph::detail
             return child;
         }
 
-        void unbind_from_ref_data(const TSDataView &target,
-                                  const TSEndpointSchema &endpoint_schema,
+        struct FromRefEndpointPlan;
+
+        void unbind_from_ref_data(const FromRefEndpointPlan &plan,
+                                  const TSDataView &target,
                                   DateTime modified_time,
                                   bool teardown = false);
 
-        void apply_output_to_from_ref_data(const TSDataView &target,
-                                           const TSEndpointSchema &endpoint_schema,
+        void apply_output_to_from_ref_data(const FromRefEndpointPlan &plan,
+                                           const TSDataView &target,
                                            const TSOutputView &output,
                                            DateTime modified_time);
 
-        void apply_reference_to_from_ref_data(const TSDataView &target,
-                                              const TSEndpointSchema &endpoint_schema,
+        void apply_reference_to_from_ref_data(const FromRefEndpointPlan &plan,
+                                              const TSDataView &target,
                                               const TimeSeriesReference &reference,
                                               DateTime modified_time);
 
-        using FromRefUnbindFn = void (*)(const TSDataView &, const TSEndpointSchema &, DateTime, bool);
-        using FromRefOutputApplyFn = void (*)(
-            const TSDataView &,
-            const TSEndpointSchema &,
-            const TSOutputView &,
-            DateTime);
-        using FromRefNonPeeredReferenceApplyFn = void (*)(
-            const TSDataView &,
-            const TSEndpointSchema &,
-            const TimeSeriesReference &,
-            DateTime);
+        using FromRefUnbindFn = void (*)(const FromRefEndpointPlan &, const TSDataView &, DateTime, bool);
+        using FromRefOutputApplyFn = void (*)(const FromRefEndpointPlan &, const TSDataView &,
+                                              const TSOutputView &, DateTime);
+        using FromRefPeeredReferenceApplyFn = void (*)(const FromRefEndpointPlan &, const TSDataView &,
+                                                       const TSOutputView &, DateTime);
+        using FromRefNonPeeredReferenceApplyFn = void (*)(const FromRefEndpointPlan &, const TSDataView &,
+                                                          const TimeSeriesReference &, DateTime);
+        using FromRefTreeUnboundFn = bool (*)(const FromRefEndpointPlan &, const TSDataView &);
+        using FromRefReferenceIdentityFn = bool (*)(const FromRefEndpointPlan &, const TSDataView &,
+                                                    const TimeSeriesReference &);
 
         struct FromRefRoleOps
         {
             FromRefUnbindFn                  unbind{nullptr};
             FromRefOutputApplyFn             apply_output{nullptr};
+            FromRefPeeredReferenceApplyFn    apply_peered_reference{nullptr};
             FromRefNonPeeredReferenceApplyFn apply_non_peered_reference{nullptr};
+            FromRefTreeUnboundFn             tree_unbound{nullptr};
+            FromRefReferenceIdentityFn       reference_identity_matches{nullptr};
         };
 
-        void unbind_from_ref_peered(const TSDataView &target,
-                                    const TSEndpointSchema &,
+        struct FromRefEndpointPlan
+        {
+            // Immutable endpoint topology compiled when the alternative is
+            // created. Refresh and teardown recurse through these callbacks;
+            // they never rediscover endpoint roles from live storage.
+            TSEndpointSchema                 schema{};
+            const FromRefRoleOps            *ops{nullptr};
+            std::vector<FromRefEndpointPlan> children{};
+        };
+
+        void unbind_from_ref_peered(const FromRefEndpointPlan &,
+                                    const TSDataView &target,
                                     DateTime modified_time,
                                     bool teardown)
         {
             unbind_target_link_at(target, modified_time, teardown);
         }
 
-        void unbind_from_ref_non_peered(const TSDataView &target,
-                                        const TSEndpointSchema &endpoint_schema,
+        void unbind_from_ref_non_peered(const FromRefEndpointPlan &plan,
+                                        const TSDataView &target,
                                         DateTime modified_time,
                                         bool teardown)
         {
-            for (std::size_t index = 0; index < endpoint_schema.child_count(); ++index)
+            for (std::size_t index = 0; index < plan.children.size(); ++index)
             {
                 auto child = endpoint_child_view(target, index);
-                unbind_from_ref_data(child, endpoint_schema.child(index), modified_time, teardown);
+                unbind_from_ref_data(plan.children[index], child, modified_time, teardown);
             }
         }
 
-        void apply_output_to_from_ref_peered(const TSDataView &target,
-                                             const TSEndpointSchema &,
+        void apply_output_to_from_ref_peered(const FromRefEndpointPlan &,
+                                             const TSDataView &target,
                                              const TSOutputView &output,
                                              DateTime modified_time)
         {
             bind_target_link_at(target, output, modified_time);
         }
 
-        void apply_output_to_from_ref_non_peered(const TSDataView &target,
-                                                 const TSEndpointSchema &endpoint_schema,
+        void apply_output_to_from_ref_non_peered(const FromRefEndpointPlan &plan,
+                                                 const TSDataView &target,
                                                  const TSOutputView &output,
                                                  DateTime modified_time)
         {
-            for (std::size_t index = 0; index < endpoint_schema.child_count(); ++index)
+            for (std::size_t index = 0; index < plan.children.size(); ++index)
             {
                 auto child = endpoint_child_view(target, index);
-                auto child_output = output_child_view(output, *endpoint_schema.schema(), index);
-                apply_output_to_from_ref_data(child, endpoint_schema.child(index), child_output, modified_time);
+                auto child_output = output_child_view(output, *plan.schema.schema(), index);
+                apply_output_to_from_ref_data(plan.children[index], child, child_output, modified_time);
             }
         }
 
-        void apply_non_peered_reference_to_peered_from_ref_data(const TSDataView &,
-                                                               const TSEndpointSchema &,
+        void apply_peered_reference_to_peered_from_ref_data(const FromRefEndpointPlan &plan,
+                                                            const TSDataView &target,
+                                                            const TSOutputView &output,
+                                                            DateTime modified_time)
+        {
+            plan.ops->apply_output(plan, target, output, modified_time);
+        }
+
+        void apply_peered_reference_to_non_peered_from_ref_data(const FromRefEndpointPlan &plan,
+                                                                const TSDataView &target,
+                                                                const TSOutputView &output,
+                                                                DateTime modified_time)
+        {
+            if (output.forwarding() && !output.forwarding_bound())
+            {
+                plan.ops->unbind(plan, target, modified_time, false);
+                return;
+            }
+            plan.ops->apply_output(plan, target, output, modified_time);
+        }
+
+        void apply_non_peered_reference_to_peered_from_ref_data(const FromRefEndpointPlan &,
+                                                               const TSDataView &,
                                                                const TimeSeriesReference &,
                                                                DateTime)
         {
             throw std::invalid_argument("TSOutput from-REF cannot apply a non-peered reference to a peered leaf");
         }
 
-        void unbind_from_ref_owned(const TSDataView &, const TSEndpointSchema &, DateTime, bool)
+        void unbind_from_ref_owned(const FromRefEndpointPlan &, const TSDataView &, DateTime, bool)
         {
             throw std::invalid_argument("TSOutput from-REF cannot target an owned endpoint leaf");
         }
 
-        void apply_output_to_from_ref_owned(const TSDataView &,
-                                            const TSEndpointSchema &,
+        void apply_output_to_from_ref_owned(const FromRefEndpointPlan &,
+                                            const TSDataView &,
                                             const TSOutputView &,
                                             DateTime)
         {
             throw std::invalid_argument("TSOutput from-REF cannot target an owned endpoint leaf");
         }
 
-        void apply_non_peered_reference_to_owned_from_ref_data(const TSDataView &,
-                                                              const TSEndpointSchema &,
+        void apply_peered_reference_to_owned_from_ref_data(const FromRefEndpointPlan &,
+                                                           const TSDataView &,
+                                                           const TSOutputView &,
+                                                           DateTime)
+        {
+            throw std::invalid_argument("TSOutput from-REF cannot target an owned endpoint leaf");
+        }
+
+        void apply_non_peered_reference_to_owned_from_ref_data(const FromRefEndpointPlan &,
+                                                              const TSDataView &,
                                                               const TimeSeriesReference &,
                                                               DateTime)
         {
@@ -565,21 +608,86 @@ namespace hgraph::detail
         }
 
         void apply_non_peered_reference_to_non_peered_from_ref_data(
+            const FromRefEndpointPlan &plan,
             const TSDataView &target,
-            const TSEndpointSchema &endpoint_schema,
             const TimeSeriesReference &reference,
             DateTime modified_time)
         {
-            if (reference.items().size() != endpoint_schema.child_count())
+            if (reference.items().size() != plan.children.size())
             {
                 throw std::invalid_argument("TSOutput from-REF non-peered reference has the wrong child count");
             }
 
-            for (std::size_t index = 0; index < endpoint_schema.child_count(); ++index)
+            for (std::size_t index = 0; index < plan.children.size(); ++index)
             {
                 auto child = endpoint_child_view(target, index);
-                apply_reference_to_from_ref_data(child, endpoint_schema.child(index), reference[index], modified_time);
+                apply_reference_to_from_ref_data(plan.children[index], child, reference[index], modified_time);
             }
+        }
+
+        [[nodiscard]] bool from_ref_peered_tree_unbound(const FromRefEndpointPlan &,
+                                                        const TSDataView &target)
+        {
+            const auto *link = target_link_storage(target);
+            return link != nullptr && !link->bound();
+        }
+
+        [[nodiscard]] bool from_ref_non_peered_tree_unbound(const FromRefEndpointPlan &plan,
+                                                            const TSDataView &target)
+        {
+            for (std::size_t index = 0; index < plan.children.size(); ++index)
+            {
+                if (!plan.children[index].ops->tree_unbound(
+                        plan.children[index], endpoint_child_view(target, index)))
+                {
+                    return false;
+                }
+            }
+            return !plan.children.empty();
+        }
+
+        [[nodiscard]] bool from_ref_owned_tree_unbound(const FromRefEndpointPlan &,
+                                                       const TSDataView &)
+        {
+            return false;
+        }
+
+        [[nodiscard]] bool from_ref_peered_reference_identity_matches(
+            const FromRefEndpointPlan &plan,
+            const TSDataView &target,
+            const TimeSeriesReference &desired)
+        {
+            if (desired.is_empty()) { return plan.ops->tree_unbound(plan, target); }
+            const auto *link = target_link_storage(target);
+            return desired.is_peered() && link != nullptr && link->bound() &&
+                   desired.target_output().same_as(link->target_output());
+        }
+
+        [[nodiscard]] bool from_ref_non_peered_reference_identity_matches(
+            const FromRefEndpointPlan &plan,
+            const TSDataView &target,
+            const TimeSeriesReference &desired)
+        {
+            if (desired.is_empty()) { return plan.ops->tree_unbound(plan, target); }
+            if (desired.is_peered() || desired.items().size() != plan.children.size()) { return false; }
+            for (std::size_t index = 0; index < plan.children.size(); ++index)
+            {
+                const auto &child_plan = plan.children[index];
+                if (!child_plan.ops->reference_identity_matches(
+                        child_plan, endpoint_child_view(target, index), desired[index]))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        [[nodiscard]] bool from_ref_owned_reference_identity_matches(
+            const FromRefEndpointPlan &,
+            const TSDataView &,
+            const TimeSeriesReference &)
+        {
+            return false;
         }
 
         [[nodiscard]] const FromRefRoleOps &from_ref_role_ops_for(TSEndpointRole role) noexcept
@@ -588,17 +696,26 @@ namespace hgraph::detail
                 {
                     &unbind_from_ref_peered,
                     &apply_output_to_from_ref_peered,
+                    &apply_peered_reference_to_peered_from_ref_data,
                     &apply_non_peered_reference_to_peered_from_ref_data,
+                    &from_ref_peered_tree_unbound,
+                    &from_ref_peered_reference_identity_matches,
                 },
                 {
                     &unbind_from_ref_non_peered,
                     &apply_output_to_from_ref_non_peered,
+                    &apply_peered_reference_to_non_peered_from_ref_data,
                     &apply_non_peered_reference_to_non_peered_from_ref_data,
+                    &from_ref_non_peered_tree_unbound,
+                    &from_ref_non_peered_reference_identity_matches,
                 },
                 {
                     &unbind_from_ref_owned,
                     &apply_output_to_from_ref_owned,
+                    &apply_peered_reference_to_owned_from_ref_data,
                     &apply_non_peered_reference_to_owned_from_ref_data,
+                    &from_ref_owned_tree_unbound,
+                    &from_ref_owned_reference_identity_matches,
                 },
             }};
 
@@ -606,30 +723,51 @@ namespace hgraph::detail
             return index < table.size() ? table[index] : table[0];
         }
 
-        void unbind_from_ref_data(const TSDataView &target,
-                                  const TSEndpointSchema &endpoint_schema,
+        [[nodiscard]] FromRefEndpointPlan make_from_ref_endpoint_plan(TSEndpointSchema schema)
+        {
+            const auto *ops = &from_ref_role_ops_for(schema.role());
+            std::vector<FromRefEndpointPlan> children;
+            children.reserve(schema.child_count());
+            for (std::size_t index = 0; index < schema.child_count(); ++index)
+            {
+                children.push_back(make_from_ref_endpoint_plan(schema.child(index)));
+            }
+            return FromRefEndpointPlan{
+                .schema = std::move(schema),
+                .ops = ops,
+                .children = std::move(children),
+            };
+        }
+
+        [[nodiscard]] FromRefEndpointPlan make_from_ref_endpoint_plan(const TSValueTypeMetaData *schema)
+        {
+            return make_from_ref_endpoint_plan(from_ref_endpoint_schema_for(schema));
+        }
+
+        void unbind_from_ref_data(const FromRefEndpointPlan &plan,
+                                  const TSDataView &target,
                                   DateTime modified_time,
                                   bool teardown)
         {
-            from_ref_role_ops_for(endpoint_schema.role()).unbind(target, endpoint_schema, modified_time, teardown);
+            plan.ops->unbind(plan, target, modified_time, teardown);
         }
 
-        void apply_output_to_from_ref_data(const TSDataView &target,
-                                           const TSEndpointSchema &endpoint_schema,
+        void apply_output_to_from_ref_data(const FromRefEndpointPlan &plan,
+                                           const TSDataView &target,
                                            const TSOutputView &output,
                                            DateTime modified_time)
         {
-            from_ref_role_ops_for(endpoint_schema.role()).apply_output(target, endpoint_schema, output, modified_time);
+            plan.ops->apply_output(plan, target, output, modified_time);
         }
 
-        void apply_reference_to_from_ref_data(const TSDataView &target,
-                                              const TSEndpointSchema &endpoint_schema,
+        void apply_reference_to_from_ref_data(const FromRefEndpointPlan &plan,
+                                              const TSDataView &target,
                                               const TimeSeriesReference &reference,
                                               DateTime modified_time)
         {
             if (reference.is_empty())
             {
-                unbind_from_ref_data(target, endpoint_schema, modified_time);
+                plan.ops->unbind(plan, target, modified_time, false);
                 return;
             }
 
@@ -637,18 +775,11 @@ namespace hgraph::detail
             {
                 const auto &output = TSOutputAlternativeStore::peered_reference_target(reference);
                 auto output_view = output.view(modified_time);
-                if (endpoint_schema.role() == TSEndpointRole::NonPeered &&
-                    output_view.forwarding() && !output_view.forwarding_bound())
-                {
-                    unbind_from_ref_data(target, endpoint_schema, modified_time);
-                    return;
-                }
-                apply_output_to_from_ref_data(target, endpoint_schema, output_view, modified_time);
+                plan.ops->apply_peered_reference(plan, target, output_view, modified_time);
                 return;
             }
 
-            from_ref_role_ops_for(endpoint_schema.role()).apply_non_peered_reference(target, endpoint_schema, reference,
-                                                                                    modified_time);
+            plan.ops->apply_non_peered_reference(plan, target, reference, modified_time);
         }
 
         void collect_forwarding_reference_sources(const TimeSeriesReference &reference,
@@ -683,6 +814,36 @@ namespace hgraph::detail
             const TSOutput *output{nullptr};
         };
 
+        struct FromRefInteriorPlan;
+
+        using FromRefInteriorApplyFn = void (*)(const FromRefInteriorPlan &, const TSDataView &,
+                                                const TSOutputView &, DateTime);
+        using FromRefInteriorIdentityFn = bool (*)(const FromRefInteriorPlan &, const TSDataView &,
+                                                   const TSOutputView &);
+        using FromRefInteriorReleaseFn = void (*)(const FromRefInteriorPlan &, const TSDataView &,
+                                                  DateTime);
+
+        struct FromRefInteriorOps
+        {
+            FromRefInteriorApplyFn    apply{nullptr};
+            FromRefInteriorIdentityFn identity_matches{nullptr};
+            FromRefInteriorReleaseFn  release{nullptr};
+            bool                      proxy_backed{false};
+        };
+
+        struct FromRefInteriorPlan
+        {
+            // The source/requested route and its representation strategy are
+            // fixed for the lifetime of one cached alternative. Child plans
+            // also provide stable proxy callback contexts.
+            const TSValueTypeMetaData          *requested_schema{nullptr};
+            const TSValueTypeMetaData          *source_schema{nullptr};
+            const FromRefBuildContext          *build_context{nullptr};
+            const FromRefInteriorOps           *ops{nullptr};
+            std::optional<FromRefEndpointPlan>  endpoint{};
+            std::vector<FromRefInteriorPlan>    children{};
+        };
+
         /**
          * TSData binding for an interior from-REF alternative. A requested
          * ``TSD`` whose source element still converts stores a ``TSDProxy``
@@ -710,208 +871,268 @@ namespace hgraph::detail
                                                     const void *);
         extern const TSDProxyValueOps from_ref_proxy_value_ops;
 
-        void apply_from_ref_interior(const TSDataView          &target,
-                                     const TSValueTypeMetaData &requested,
-                                     const TSOutputView        &source_view,
-                                     DateTime                   modified_time,
-                                     const FromRefBuildContext &build_context);
+        void apply_from_ref_interior(const FromRefInteriorPlan &plan,
+                                     const TSDataView &target,
+                                     const TSOutputView &source_view,
+                                     DateTime modified_time)
+        {
+            plan.ops->apply(plan, target, source_view, modified_time);
+        }
 
-        using FromRefInteriorApplyFn = void (*)(const TSDataView &, const TSValueTypeMetaData &,
-                                                const TSOutputView &, DateTime, const FromRefBuildContext &);
-
-        void apply_from_ref_interior_unsupported(const TSDataView &, const TSValueTypeMetaData &,
-                                                 const TSOutputView &, DateTime, const FromRefBuildContext &)
+        void apply_from_ref_interior_unsupported(const FromRefInteriorPlan &, const TSDataView &,
+                                                 const TSOutputView &, DateTime)
         {
             throw std::logic_error("TSOutput interior from-REF encountered an unsupported requested schema");
         }
 
-        void apply_from_ref_interior_dict(const TSDataView &target, const TSValueTypeMetaData &,
-                                          const TSOutputView &source_view, DateTime modified_time,
-                                          const FromRefBuildContext &build_context)
+        void apply_from_ref_interior_reference(const FromRefInteriorPlan &plan,
+                                               const TSDataView &target,
+                                               const TSOutputView &source_view,
+                                               DateTime modified_time)
+        {
+            if (!source_view.data_view().has_current_value())
+            {
+                unbind_from_ref_data(*plan.endpoint, target, modified_time);
+                return;
+            }
+            // Keep the borrowed value view alive while using the referenced payload.  In
+            // particular, do not extend a payload reference through a temporary ValueView.
+            const auto source_value = source_view.value();
+            const auto &reference   = source_value.checked_as<TimeSeriesReference>();
+            apply_reference_to_from_ref_data(*plan.endpoint, target, reference, modified_time);
+        }
+
+        void apply_from_ref_interior_equivalent(const FromRefInteriorPlan &plan,
+                                                const TSDataView &target,
+                                                const TSOutputView &source_view,
+                                                DateTime modified_time)
+        {
+            apply_output_to_from_ref_data(*plan.endpoint, target, source_view, modified_time);
+        }
+
+        void apply_from_ref_interior_dict(const FromRefInteriorPlan &plan,
+                                          const TSDataView &target,
+                                          const TSOutputView &source_view,
+                                          DateTime modified_time)
         {
             bind_tsd_proxy(target.borrowed_ref(), source_view.data_view().as_dict(), &from_ref_proxy_value_ops,
-                           &build_context, modified_time, TSDProxyChildRefresh::OnChildTick);
+                           &plan, modified_time, TSDProxyChildRefresh::OnChildTick);
         }
 
-        void apply_from_ref_interior_bundle(const TSDataView &target, const TSValueTypeMetaData &requested,
-                                            const TSOutputView &source_view, DateTime modified_time,
-                                            const FromRefBuildContext &build_context)
+        void apply_from_ref_interior_fixed(const FromRefInteriorPlan &plan,
+                                           const TSDataView &target,
+                                           const TSOutputView &source_view,
+                                           DateTime modified_time)
         {
-            const auto *source_schema = source_view.data_view().schema();
-            for (std::size_t index = 0; index < requested.field_count(); ++index)
+            for (std::size_t index = 0; index < plan.children.size(); ++index)
             {
-                apply_from_ref_interior(endpoint_child_view(target, index), *requested.fields()[index].type,
-                                        output_child_view(source_view, *source_schema, index), modified_time,
-                                        build_context);
+                apply_from_ref_interior(plan.children[index], endpoint_child_view(target, index),
+                                        output_child_view(source_view, *plan.source_schema, index),
+                                        modified_time);
             }
         }
 
-        void apply_from_ref_interior_list(const TSDataView &target, const TSValueTypeMetaData &requested,
-                                          const TSOutputView &source_view, DateTime modified_time,
-                                          const FromRefBuildContext &build_context)
+        [[nodiscard]] bool from_ref_interior_unsupported_identity(const FromRefInteriorPlan &,
+                                                                 const TSDataView &,
+                                                                 const TSOutputView &)
         {
-            const auto *source_schema = source_view.data_view().schema();
-            for (std::size_t index = 0; index < requested.fixed_size(); ++index)
-            {
-                apply_from_ref_interior(endpoint_child_view(target, index), *requested.element_ts(),
-                                        output_child_view(source_view, *source_schema, index), modified_time,
-                                        build_context);
-            }
+            return false;
         }
 
-        [[nodiscard]] FromRefInteriorApplyFn from_ref_interior_applier_for(TSTypeKind kind) noexcept
+        [[nodiscard]] bool from_ref_interior_reference_identity(const FromRefInteriorPlan &plan,
+                                                                const TSDataView &target,
+                                                                const TSOutputView &source_view)
         {
-            static constexpr std::size_t kind_count = ts_kind_index(TSTypeKind::SIGNAL) + 1U;
-            static const std::array<FromRefInteriorApplyFn, kind_count> table{
-                &apply_from_ref_interior_unsupported,
-                &apply_from_ref_interior_unsupported,
-                &apply_from_ref_interior_dict,
-                &apply_from_ref_interior_list,
-                &apply_from_ref_interior_unsupported,
-                &apply_from_ref_interior_bundle,
-                &apply_from_ref_interior_unsupported,
-                &apply_from_ref_interior_unsupported,
-            };
-
-            const auto index = ts_kind_index(kind);
-            return index < table.size() ? table[index] : &apply_from_ref_interior_unsupported;
+            if (!source_view.data_view().has_current_value())
+            {
+                return plan.endpoint->ops->tree_unbound(*plan.endpoint, target);
+            }
+            return plan.endpoint->ops->reference_identity_matches(
+                *plan.endpoint, target, source_view.value().checked_as<TimeSeriesReference>());
         }
 
-        /**
-         * Apply one source subtree into the requested-shaped target. REF
-         * positions apply their reference; a subtree already in the requested
-         * shape binds ONE whole-subtree link directly to the source child;
-         * fixed containers recurse; a converting ``TSD`` (re)binds its proxy.
-         *
-         * REFRESH-TIME temperature: this runs when the source reports key
-         * changes or a reference RETARGET (and once per slot at build) - not
-         * on ordinary value ticks, which write through the bound links.
-         */
-        void apply_from_ref_interior(const TSDataView          &target,
-                                     const TSValueTypeMetaData &requested,
-                                     const TSOutputView        &source_view,
-                                     DateTime                   modified_time,
-                                     const FromRefBuildContext &build_context)
+        [[nodiscard]] bool from_ref_interior_equivalent_identity(const FromRefInteriorPlan &,
+                                                                 const TSDataView &target,
+                                                                 const TSOutputView &source_view)
         {
-            const auto *source_schema = source_view.data_view().schema();
-            if (source_schema == nullptr)
-            {
-                throw std::logic_error("TSOutput interior from-REF requires a typed source child");
-            }
-
-            if (source_schema->kind == TSTypeKind::REF)
-            {
-                const auto endpoint = from_ref_endpoint_schema_for(&requested);
-                if (!source_view.data_view().has_current_value())
-                {
-                    unbind_from_ref_data(target, endpoint, modified_time);
-                    return;
-                }
-                const auto  source_value = source_view.value();
-                const auto &reference = source_value.checked_as<TimeSeriesReference>();
-                apply_reference_to_from_ref_data(target, endpoint, reference, modified_time);
-                return;
-            }
-
-            if (time_series_schema_equivalent(source_schema, &requested))
-            {
-                // Reference-free subtree: one link to the source child.
-                apply_output_to_from_ref_data(target, TSEndpointSchema::peered(&requested), source_view,
-                                              modified_time);
-                return;
-            }
-
-            from_ref_interior_applier_for(requested.kind)(target, requested, source_view, modified_time,
-                                                          build_context);
+            const auto *link = target_link_storage(target);
+            return link != nullptr && link->bound() && link->target_output().same_as(source_view.handle());
         }
 
-        [[nodiscard]] bool target_tree_unbound(const TSDataView &target)
-        {
-            if (const auto *link = target_link_storage(target); link != nullptr) { return !link->bound(); }
-            const auto *schema = target.schema();
-            if (schema == nullptr) { return false; }
-            const auto count = schema->kind == TSTypeKind::TSB
-                                   ? schema->field_count()
-                                   : (schema->kind == TSTypeKind::TSL ? schema->fixed_size() : 0U);
-            if (count == 0) { return false; }
-            for (std::size_t index = 0; index < count; ++index)
-            {
-                if (!target_tree_unbound(endpoint_child_view(target, index))) { return false; }
-            }
-            return true;
-        }
-
-        [[nodiscard]] bool reference_identity_matches(const TSDataView &target,
-                                                      const TimeSeriesReference &desired)
-        {
-            if (const auto *link = target_link_storage(target); link != nullptr)
-            {
-                if (desired.is_empty()) { return !link->bound(); }
-                if (!desired.is_peered() || !link->bound()) { return false; }
-                return desired.target_output().same_as(link->target_output());
-            }
-            if (desired.is_empty()) { return target_tree_unbound(target); }
-            if (desired.is_peered()) { return false; }
-
-            const auto *schema = target.schema();
-            if (schema == nullptr) { return false; }
-            const auto count = schema->kind == TSTypeKind::TSB
-                                   ? schema->field_count()
-                                   : (schema->kind == TSTypeKind::TSL ? schema->fixed_size() : 0U);
-            if (count == 0 || desired.items().size() != count) { return false; }
-            for (std::size_t index = 0; index < count; ++index)
-            {
-                if (!reference_identity_matches(endpoint_child_view(target, index), desired[index])) { return false; }
-            }
-            return true;
-        }
-
-        [[nodiscard]] bool from_ref_interior_identity_matches(const TSDataView &target,
-                                                               const TSValueTypeMetaData &requested,
-                                                               const TSOutputView &source_view,
-                                                               const FromRefBuildContext &build_context)
+        [[nodiscard]] bool from_ref_interior_dict_identity(const FromRefInteriorPlan &,
+                                                           const TSDataView &target,
+                                                           const TSOutputView &source_view)
         {
             const auto &source_data = source_view.data_view();
-            const auto *source_schema = source_data.schema();
-            if (source_schema == nullptr || build_context.output == nullptr) { return false; }
+            const auto &nested = *static_cast<const TSDProxy *>(target.data());
+            const auto actual_source = nested.source_view();
+            return actual_source.storage_type() == source_data.storage_type() &&
+                   actual_source.data() == source_data.data() && nested.source_identities_match();
+        }
 
-            if (source_schema->kind == TSTypeKind::REF)
+        [[nodiscard]] bool from_ref_interior_fixed_identity(const FromRefInteriorPlan &plan,
+                                                            const TSDataView &target,
+                                                            const TSOutputView &source_view)
+        {
+            for (std::size_t index = 0; index < plan.children.size(); ++index)
             {
-                if (!source_data.has_current_value()) { return target_tree_unbound(target); }
-                return reference_identity_matches(
-                    target, source_view.value().checked_as<TimeSeriesReference>());
-            }
-
-            if (time_series_schema_equivalent(source_schema, &requested))
-            {
-                const auto *link = target_link_storage(target);
-                return link != nullptr && link->bound() && link->target_output().same_as(source_view.handle());
-            }
-
-            if (requested.kind == TSTypeKind::TSD && source_schema->kind == TSTypeKind::TSD &&
-                target.storage_type().plan() == &MemoryUtils::plan_for<TSDProxy>())
-            {
-                const auto &nested = *static_cast<const TSDProxy *>(target.data());
-                const auto actual_source = nested.source_view();
-                return actual_source.storage_type() == source_data.storage_type() &&
-                       actual_source.data() == source_data.data() && nested.source_identities_match();
-            }
-
-            const auto count = requested.kind == TSTypeKind::TSB
-                                   ? requested.field_count()
-                                   : (requested.kind == TSTypeKind::TSL ? requested.fixed_size() : 0U);
-            if (count == 0) { return false; }
-            for (std::size_t index = 0; index < count; ++index)
-            {
-                const auto &child_requested = requested.kind == TSTypeKind::TSB
-                                                  ? *requested.fields()[index].type
-                                                  : *requested.element_ts();
-                if (!from_ref_interior_identity_matches(
-                        endpoint_child_view(target, index), child_requested,
-                        output_child_view(source_view, *source_schema, index), build_context))
+                const auto &child_plan = plan.children[index];
+                if (!child_plan.ops->identity_matches(
+                        child_plan, endpoint_child_view(target, index),
+                        output_child_view(source_view, *plan.source_schema, index)))
+                {
                     return false;
+                }
             }
             return true;
+        }
+
+        void release_from_ref_interior_unsupported(const FromRefInteriorPlan &,
+                                                   const TSDataView &,
+                                                   DateTime)
+        {
+        }
+
+        void release_from_ref_interior_endpoint(const FromRefInteriorPlan &plan,
+                                                const TSDataView &target,
+                                                DateTime release_time)
+        {
+            unbind_from_ref_data(*plan.endpoint, target, release_time, true);
+        }
+
+        void release_from_ref_interior_dict(const FromRefInteriorPlan &plan,
+                                            const TSDataView &target,
+                                            DateTime release_time)
+        {
+            auto dict = target.as_dict();
+            for (std::size_t slot = 0; slot < dict.slot_capacity(); ++slot)
+            {
+                if (!dict.slot_occupied(slot)) { continue; }
+                auto child = dict.at_slot(slot);
+                if (!child.valid()) { continue; }
+                plan.children.front().ops->release(plan.children.front(), child, release_time);
+            }
+        }
+
+        void release_from_ref_interior_fixed(const FromRefInteriorPlan &plan,
+                                             const TSDataView &target,
+                                             DateTime release_time)
+        {
+            for (std::size_t index = 0; index < plan.children.size(); ++index)
+            {
+                const auto &child_plan = plan.children[index];
+                child_plan.ops->release(child_plan, endpoint_child_view(target, index), release_time);
+            }
+        }
+
+        [[nodiscard]] const FromRefInteriorOps &from_ref_interior_reference_ops() noexcept
+        {
+            static const FromRefInteriorOps ops{
+                &apply_from_ref_interior_reference,
+                &from_ref_interior_reference_identity,
+                &release_from_ref_interior_endpoint,
+                false,
+            };
+            return ops;
+        }
+
+        [[nodiscard]] const FromRefInteriorOps &from_ref_interior_equivalent_ops() noexcept
+        {
+            static const FromRefInteriorOps ops{
+                &apply_from_ref_interior_equivalent,
+                &from_ref_interior_equivalent_identity,
+                &release_from_ref_interior_endpoint,
+                false,
+            };
+            return ops;
+        }
+
+        [[nodiscard]] const FromRefInteriorOps &from_ref_interior_dict_ops() noexcept
+        {
+            static const FromRefInteriorOps ops{
+                &apply_from_ref_interior_dict,
+                &from_ref_interior_dict_identity,
+                &release_from_ref_interior_dict,
+                true,
+            };
+            return ops;
+        }
+
+        [[nodiscard]] const FromRefInteriorOps &from_ref_interior_fixed_ops() noexcept
+        {
+            static const FromRefInteriorOps ops{
+                &apply_from_ref_interior_fixed,
+                &from_ref_interior_fixed_identity,
+                &release_from_ref_interior_fixed,
+                false,
+            };
+            return ops;
+        }
+
+        [[nodiscard]] const FromRefInteriorOps &from_ref_interior_unsupported_ops() noexcept
+        {
+            static const FromRefInteriorOps ops{
+                &apply_from_ref_interior_unsupported,
+                &from_ref_interior_unsupported_identity,
+                &release_from_ref_interior_unsupported,
+                false,
+            };
+            return ops;
+        }
+
+        [[nodiscard]] FromRefInteriorPlan make_from_ref_interior_plan(
+            const TSValueTypeMetaData &requested,
+            const TSValueTypeMetaData &source,
+            const FromRefBuildContext &build_context)
+        {
+            FromRefInteriorPlan plan{
+                .requested_schema = &requested,
+                .source_schema = &source,
+                .build_context = &build_context,
+                .ops = &from_ref_interior_unsupported_ops(),
+            };
+            if (source.kind == TSTypeKind::REF)
+            {
+                plan.ops = &from_ref_interior_reference_ops();
+                plan.endpoint = make_from_ref_endpoint_plan(&requested);
+                return plan;
+            }
+            if (time_series_schema_equivalent(&source, &requested))
+            {
+                plan.ops = &from_ref_interior_equivalent_ops();
+                plan.endpoint = make_from_ref_endpoint_plan(TSEndpointSchema::peered(&requested));
+                return plan;
+            }
+            if (requested.kind == TSTypeKind::TSD && source.kind == TSTypeKind::TSD)
+            {
+                plan.ops = &from_ref_interior_dict_ops();
+                plan.children.push_back(make_from_ref_interior_plan(
+                    *requested.element_ts(), *source.element_ts(), build_context));
+                return plan;
+            }
+            if (requested.kind == TSTypeKind::TSB && source.kind == TSTypeKind::TSB)
+            {
+                plan.ops = &from_ref_interior_fixed_ops();
+                plan.children.reserve(requested.field_count());
+                for (std::size_t index = 0; index < requested.field_count(); ++index)
+                {
+                    plan.children.push_back(make_from_ref_interior_plan(
+                        *requested.fields()[index].type, *source.fields()[index].type, build_context));
+                }
+                return plan;
+            }
+            if (requested.kind == TSTypeKind::TSL && source.kind == TSTypeKind::TSL &&
+                requested.fixed_size() != 0)
+            {
+                plan.ops = &from_ref_interior_fixed_ops();
+                plan.children.reserve(requested.fixed_size());
+                for (std::size_t index = 0; index < requested.fixed_size(); ++index)
+                {
+                    plan.children.push_back(make_from_ref_interior_plan(
+                        *requested.element_ts(), *source.element_ts(), build_context));
+                }
+            }
+            return plan;
         }
 
         bool from_ref_proxy_source_identity_matches(const TSDProxy &,
@@ -920,32 +1141,29 @@ namespace hgraph::detail
                                                     const TSDataView &source,
                                                     const void *context)
         {
-            const auto *build_context = static_cast<const FromRefBuildContext *>(context);
-            return build_context != nullptr && build_context->output != nullptr && target.schema() != nullptr &&
-                   source.valid() && from_ref_interior_identity_matches(
-                       target, *target.schema(),
-                       TSOutputView{build_context->output, source.borrowed_ref(),
-                                    source.tracking().last_modified_time},
-                       *build_context);
+            const auto *plan = static_cast<const FromRefInteriorPlan *>(context);
+            return plan != nullptr && plan->build_context != nullptr &&
+                   plan->build_context->output != nullptr && !plan->children.empty() && source.valid() &&
+                   plan->children.front().ops->identity_matches(
+                       plan->children.front(), target,
+                       TSOutputView{plan->build_context->output, source.borrowed_ref(),
+                                    source.tracking().last_modified_time});
         }
 
         void build_from_ref_proxy_value(TSDProxy &, std::size_t, const TSDataView &target,
                                         const TSDataView &source, DateTime modified_time, const void *context)
         {
-            const auto *build_context = static_cast<const FromRefBuildContext *>(context);
-            if (build_context == nullptr || build_context->output == nullptr)
+            const auto *plan = static_cast<const FromRefInteriorPlan *>(context);
+            if (plan == nullptr || plan->build_context == nullptr || plan->build_context->output == nullptr)
             {
                 throw std::logic_error("TSOutput from-REF proxy value builder requires an output context");
             }
             if (!source.valid()) { throw std::logic_error("TSOutput from-REF proxy source child is not live"); }
-            if (target.schema() == nullptr)
-            {
-                throw std::logic_error("TSOutput from-REF proxy target child is not typed");
-            }
 
-            apply_from_ref_interior(target.borrowed_ref(), *target.schema(),
-                                    TSOutputView{build_context->output, source.borrowed_ref(), modified_time},
-                                    modified_time, *build_context);
+            apply_from_ref_interior(
+                plan->children.front(), target.borrowed_ref(),
+                TSOutputView{plan->build_context->output, source.borrowed_ref(), modified_time},
+                modified_time);
         }
 
         const TSDProxyValueOps from_ref_proxy_value_ops{
@@ -954,11 +1172,33 @@ namespace hgraph::detail
         };
 
         [[nodiscard]] TSRoleTypeRef to_ref_ts_data_type_for(const TSValueTypeMetaData &schema);
-        void populate_to_ref_data(const TSDataView           &target,
-                                  const TSOutputView         &source_view,
-                                  const TSValueTypeMetaData  &target_schema,
-                                  DateTime               modified_time,
-                                  const ToRefBuildContext    &build_context);
+        struct ToRefPlan;
+        using ToRefPopulateFn = void (*)(const ToRefPlan &, const TSDataView &,
+                                         const TSOutputView &, DateTime);
+
+        struct ToRefOps
+        {
+            ToRefPopulateFn populate{nullptr};
+        };
+
+        struct ToRefPlan
+        {
+            // Fixed traversal selected from the requested schema before any
+            // refresh. TSD proxies retain the relevant child-plan address as
+            // their callback context.
+            const TSValueTypeMetaData *target_schema{nullptr};
+            const ToRefBuildContext   *build_context{nullptr};
+            const ToRefOps            *ops{nullptr};
+            std::vector<ToRefPlan>      children{};
+        };
+
+        void populate_to_ref_data(const ToRefPlan &plan,
+                                  const TSDataView &target,
+                                  const TSOutputView &source_view,
+                                  DateTime modified_time)
+        {
+            plan.ops->populate(plan, target, source_view, modified_time);
+        }
 
         void build_to_ref_proxy_value(TSDProxy      &,
                                       std::size_t,
@@ -967,8 +1207,8 @@ namespace hgraph::detail
                                       DateTime  modified_time,
                                       const void    *context)
         {
-            const auto *build_context = static_cast<const ToRefBuildContext *>(context);
-            if (build_context == nullptr || build_context->output == nullptr)
+            const auto *plan = static_cast<const ToRefPlan *>(context);
+            if (plan == nullptr || plan->build_context == nullptr || plan->build_context->output == nullptr)
             {
                 throw std::logic_error("TSOutput to-REF proxy value builder requires an output context");
             }
@@ -979,11 +1219,10 @@ namespace hgraph::detail
             }
             if (target.has_current_value()) { return; }
 
-            populate_to_ref_data(target.borrowed_ref(),
-                                 TSOutputView{build_context->output, source.borrowed_ref(), modified_time},
-                                 *target.schema(),
-                                 modified_time,
-                                 *build_context);
+            populate_to_ref_data(
+                plan->children.front(), target.borrowed_ref(),
+                TSOutputView{plan->build_context->output, source.borrowed_ref(), modified_time},
+                modified_time);
         }
 
         const TSDProxyValueOps to_ref_proxy_value_ops{
@@ -1078,35 +1317,30 @@ namespace hgraph::detail
             return output_type;
         }
 
-        void populate_to_ref_unsupported(const TSDataView &,
-                                         const TSOutputView &,
-                                         const TSValueTypeMetaData &,
-                                         DateTime,
-                                         const ToRefBuildContext &)
+        void populate_to_ref_unsupported(const ToRefPlan &, const TSDataView &,
+                                         const TSOutputView &, DateTime)
         {
             throw std::logic_error("TSOutput to-REF alternative encountered unsupported requested schema");
         }
 
-        void populate_to_ref_dict(const TSDataView           &target,
-                                  const TSOutputView         &source_view,
-                                  const TSValueTypeMetaData  &,
-                                  DateTime               modified_time,
-                                  const ToRefBuildContext    &build_context)
+        void populate_to_ref_dict(const ToRefPlan &plan,
+                                  const TSDataView &target,
+                                  const TSOutputView &source_view,
+                                  DateTime modified_time)
         {
             bind_tsd_proxy(target.borrowed_ref(),
                            source_view.data_view().as_dict(),
                            &to_ref_proxy_value_ops,
-                           &build_context,
+                           &plan,
                            modified_time);
         }
 
-        void populate_to_ref_ref(const TSDataView           &target,
-                                 const TSOutputView         &source_view,
-                                 const TSValueTypeMetaData  &target_schema,
-                                 DateTime               modified_time,
-                                 const ToRefBuildContext    &)
+        void populate_to_ref_ref(const ToRefPlan &plan,
+                                 const TSDataView &target,
+                                 const TSOutputView &source_view,
+                                 DateTime modified_time)
         {
-            auto reference = TSOutputAlternativeStore::peered_reference_as(target_schema.referenced_ts(),
+            auto reference = TSOutputAlternativeStore::peered_reference_as(plan.target_schema->referenced_ts(),
                                                                             source_view.handle());
             // SAME-REFERENCE dedup (the getitem_ lesson): boundary rebinds
             // re-populate every refresh; an unchanged reference must not
@@ -1122,74 +1356,86 @@ namespace hgraph::detail
             static_cast<void>(mutation.move_value_from(Value{std::move(reference)}));
         }
 
-        void populate_to_ref_bundle(const TSDataView           &target,
-                                    const TSOutputView         &source_view,
-                                    const TSValueTypeMetaData  &target_schema,
-                                    DateTime               modified_time,
-                                    const ToRefBuildContext    &build_context)
+        void populate_to_ref_bundle(const ToRefPlan &plan,
+                                    const TSDataView &target,
+                                    const TSOutputView &source_view,
+                                    DateTime modified_time)
         {
             auto target_bundle = target.as_bundle();
             auto source_bundle = source_view.data_view().as_bundle();
-            for (std::size_t index = 0; index < target_schema.field_count(); ++index)
+            for (std::size_t index = 0; index < plan.children.size(); ++index)
             {
                 auto target_child = target_bundle.at(index);
                 auto source_child_data = source_bundle.at(index);
                 auto source_child = source_child_view(source_view, source_child_data);
-                populate_to_ref_data(target_child, source_child, *target_schema.fields()[index].type,
-                                     modified_time, build_context);
+                populate_to_ref_data(plan.children[index], target_child, source_child, modified_time);
             }
         }
 
-        void populate_to_ref_list(const TSDataView           &target,
-                                  const TSOutputView         &source_view,
-                                  const TSValueTypeMetaData  &target_schema,
-                                  DateTime               modified_time,
-                                  const ToRefBuildContext    &build_context)
+        void populate_to_ref_list(const ToRefPlan &plan,
+                                  const TSDataView &target,
+                                  const TSOutputView &source_view,
+                                  DateTime modified_time)
         {
             auto target_list = target.as_list();
             auto source_list = source_view.data_view().as_list();
-            for (std::size_t index = 0; index < target_schema.fixed_size(); ++index)
+            for (std::size_t index = 0; index < plan.children.size(); ++index)
             {
                 auto target_child = target_list.at(index);
                 auto source_child_data = source_list.at(index);
                 auto source_child = source_child_view(source_view, source_child_data);
-                populate_to_ref_data(target_child, source_child, *target_schema.element_ts(), modified_time,
-                                     build_context);
+                populate_to_ref_data(plan.children[index], target_child, source_child, modified_time);
             }
         }
 
-        using ToRefPopulateFn = void (*)(
-            const TSDataView &,
-            const TSOutputView &,
-            const TSValueTypeMetaData &,
-            DateTime,
-            const ToRefBuildContext &);
-
-        [[nodiscard]] ToRefPopulateFn to_ref_populator_for(TSTypeKind kind) noexcept
+        [[nodiscard]] const ToRefOps &to_ref_ops_for(TSTypeKind kind) noexcept
         {
             static constexpr std::size_t kind_count = ts_kind_index(TSTypeKind::SIGNAL) + 1U;
-            static const std::array<ToRefPopulateFn, kind_count> table{
-                &populate_to_ref_unsupported,
-                &populate_to_ref_unsupported,
-                &populate_to_ref_dict,
-                &populate_to_ref_list,
-                &populate_to_ref_unsupported,
-                &populate_to_ref_bundle,
-                &populate_to_ref_ref,
-                &populate_to_ref_unsupported,
+            static const std::array<ToRefOps, kind_count> table{
+                ToRefOps{&populate_to_ref_unsupported},
+                ToRefOps{&populate_to_ref_unsupported},
+                ToRefOps{&populate_to_ref_dict},
+                ToRefOps{&populate_to_ref_list},
+                ToRefOps{&populate_to_ref_unsupported},
+                ToRefOps{&populate_to_ref_bundle},
+                ToRefOps{&populate_to_ref_ref},
+                ToRefOps{&populate_to_ref_unsupported},
             };
 
             const auto index = ts_kind_index(kind);
-            return index < table.size() ? table[index] : &populate_to_ref_unsupported;
+            return index < table.size() ? table[index] : table.front();
         }
 
-        void populate_to_ref_data(const TSDataView           &target,
-                                  const TSOutputView         &source_view,
-                                  const TSValueTypeMetaData  &target_schema,
-                                  DateTime               modified_time,
-                                  const ToRefBuildContext    &build_context)
+        [[nodiscard]] ToRefPlan make_to_ref_plan(const TSValueTypeMetaData &target_schema,
+                                                 const ToRefBuildContext &build_context)
         {
-            to_ref_populator_for(target_schema.kind)(target, source_view, target_schema, modified_time, build_context);
+            ToRefPlan plan{
+                .target_schema = &target_schema,
+                .build_context = &build_context,
+                .ops = &to_ref_ops_for(target_schema.kind),
+            };
+            if (target_schema.kind == TSTypeKind::TSD)
+            {
+                plan.children.push_back(make_to_ref_plan(*target_schema.element_ts(), build_context));
+            }
+            else if (target_schema.kind == TSTypeKind::TSB)
+            {
+                plan.children.reserve(target_schema.field_count());
+                for (std::size_t index = 0; index < target_schema.field_count(); ++index)
+                {
+                    plan.children.push_back(make_to_ref_plan(
+                        *target_schema.fields()[index].type, build_context));
+                }
+            }
+            else if (target_schema.kind == TSTypeKind::TSL)
+            {
+                plan.children.reserve(target_schema.fixed_size());
+                for (std::size_t index = 0; index < target_schema.fixed_size(); ++index)
+                {
+                    plan.children.push_back(make_to_ref_plan(*target_schema.element_ts(), build_context));
+                }
+            }
+            return plan;
         }
     }  // namespace
 
@@ -1197,6 +1443,8 @@ namespace hgraph::detail
     {
         ToRefAlternativeState(const TSValueTypeMetaData &requested_schema, const TSOutputView &source)
             : requested_schema{&requested_schema},
+              build_context{source.output()},
+              plan{make_to_ref_plan(requested_schema, build_context)},
               data{make_to_ref_data(requested_schema)}
         {
             rebind(source);
@@ -1214,9 +1462,10 @@ namespace hgraph::detail
         }
 
         const TSValueTypeMetaData *requested_schema{nullptr};
+        ToRefBuildContext          build_context{};
+        ToRefPlan                  plan{};
         TSData                     data{};
         TSOutputHandle             source{};
-        ToRefBuildContext          build_context{};
 
         [[nodiscard]] TSOutputHandle handle(const TSOutput *output)
         {
@@ -1245,7 +1494,7 @@ namespace hgraph::detail
             if (requested_schema == nullptr || !source.bound()) { return; }
             modified_time = concrete_reference_time(modified_time);
             auto target = data.view();
-            populate_to_ref_data(target, source.view(modified_time), *requested_schema, modified_time, build_context);
+            populate_to_ref_data(plan, target, source.view(modified_time), modified_time);
         }
     };
 
@@ -1268,8 +1517,8 @@ namespace hgraph::detail
 
         RefLinkAlternativeState(const TSValueTypeMetaData &requested_schema, const TSOutputView &source)
             : requested_schema{&requested_schema},
-              endpoint_schema{from_ref_endpoint_schema_for(&requested_schema)},
-              data{checked_from_ref_storage_type(endpoint_schema)},
+              plan{make_from_ref_endpoint_plan(&requested_schema)},
+              data{checked_from_ref_storage_type(plan.schema)},
               notifier{*this}
         {
             rebind(source);
@@ -1285,7 +1534,7 @@ namespace hgraph::detail
         }
 
         const TSValueTypeMetaData *requested_schema{nullptr};
-        TSEndpointSchema           endpoint_schema{};
+        FromRefEndpointPlan        plan{};
         TSData                     data{};
         TSOutputHandle             source{};
         SourceNotifier             notifier;
@@ -1321,7 +1570,7 @@ namespace hgraph::detail
             source.reset();
             static_cast<void>(fallback_on_exception(false, [&] {
                 auto target = data.view();
-                unbind_from_ref_data(target, endpoint_schema, release_time, true);
+                unbind_from_ref_data(plan, target, release_time, true);
                 return true;
             }));
         }
@@ -1380,7 +1629,7 @@ namespace hgraph::detail
             auto target = data.view();
             if (!source_view.valid())
             {
-                unbind_from_ref_data(target, endpoint_schema, modified_time);
+                unbind_from_ref_data(plan, target, modified_time);
                 replace_reference_sources({});
                 return;
             }
@@ -1389,7 +1638,7 @@ namespace hgraph::detail
             const auto &reference = source_value.checked_as<TimeSeriesReference>();
             std::vector<TSOutputHandle> next_reference_sources;
             collect_forwarding_reference_sources(reference, modified_time, next_reference_sources);
-            apply_reference_to_from_ref_data(target, endpoint_schema, reference, modified_time);
+            apply_reference_to_from_ref_data(plan, target, reference, modified_time);
             replace_reference_sources(std::move(next_reference_sources));
         }
     };
@@ -1413,6 +1662,8 @@ namespace hgraph::detail
 
         InteriorFromRefAlternativeState(const TSValueTypeMetaData &requested_schema, const TSOutputView &source)
             : requested_schema{&requested_schema},
+              build_context{source.output()},
+              plan{make_from_ref_interior_plan(requested_schema, *source.schema(), build_context)},
               data{alternative_type_for(
                   from_ref_interior_type_for(requested_schema, *source.schema()), TypeRole::Output,
                   "ts.alternative.interior-ref.output")},
@@ -1435,10 +1686,11 @@ namespace hgraph::detail
         }
 
         const TSValueTypeMetaData *requested_schema{nullptr};
+        FromRefBuildContext        build_context{};
+        FromRefInteriorPlan        plan{};
         TSData                     data{};
         TSOutputHandle             source{};
         SourceNotifier             notifier;
-        FromRefBuildContext        build_context{};
 
         [[nodiscard]] TSOutputHandle handle(const TSOutput *output) noexcept
         {
@@ -1447,7 +1699,7 @@ namespace hgraph::detail
 
         [[nodiscard]] bool proxy_backed() const noexcept
         {
-            return requested_schema != nullptr && requested_schema->kind == TSTypeKind::TSD;
+            return plan.ops->proxy_backed;
         }
 
         void rebind(const TSOutputView &new_source)
@@ -1470,8 +1722,7 @@ namespace hgraph::detail
                 // (Re)binding the proxy also performs the initial sync.
                 if (source_changed)
                 {
-                    apply_from_ref_interior(data.view(), *requested_schema, source.view(modified_time),
-                                            modified_time, build_context);
+                    apply_from_ref_interior(plan, data.view(), source.view(modified_time), modified_time);
                 }
                 return;
             }
@@ -1492,22 +1743,7 @@ namespace hgraph::detail
       private:
         void release_links(DateTime release_time)
         {
-            auto target = data.view();
-            if (proxy_backed())
-            {
-                // Unbind every materialised element's links while targets
-                // are still alive; the proxy itself unsubscribes in its dtor.
-                auto dict = target.as_dict();
-                for (std::size_t slot = 0; slot < dict.slot_capacity(); ++slot)
-                {
-                    if (!dict.slot_occupied(slot)) { continue; }
-                    auto child = dict.at_slot(slot);
-                    if (!child.valid() || child.schema() == nullptr) { continue; }
-                    unbind_from_ref_data(child, from_ref_endpoint_schema_for(child.schema()), release_time, true);
-                }
-                return;
-            }
-            unbind_from_ref_data(target, from_ref_endpoint_schema_for(requested_schema), release_time, true);
+            plan.ops->release(plan, data.view(), release_time);
         }
 
         void subscribe_source()
@@ -1531,8 +1767,7 @@ namespace hgraph::detail
         void refresh(DateTime modified_time)
         {
             if (modified_time == MIN_DT || requested_schema == nullptr || !source.bound()) { return; }
-            apply_from_ref_interior(data.view(), *requested_schema, source.view(modified_time), modified_time,
-                                    build_context);
+            apply_from_ref_interior(plan, data.view(), source.view(modified_time), modified_time);
         }
     };
 

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -2968,6 +2968,25 @@ TEST_CASE("std operators: stream operators cover sampling filtering slicing and 
                      values<Str>(Str{"1"}, Str{"2"}, Str{}, Str{"4"}, Str{}),
                      values<TimeDelta>(MIN_TD * 2, none, none, none, none)),
                  values<Str>(Str{"1"}, none, Str{}, none, Str{}));
+    // TSS selects its netting release strategy once when the node starts.
+    // Opposing changes within a window cancel, including a completely
+    // cancelled window which must not publish an empty delta.
+    CHECK_OUTPUT((eval_node<stdlib::throttle, TSS<Int>>(
+                     values<Value>(set_delta<Int>({1, 2}, {}),
+                                   set_delta<Int>({3}, {}),
+                                   set_delta<Int>({}, {2}),
+                                   set_delta<Int>({5}, {1}),
+                                   set_delta<Int>({1}, {}),
+                                   set_delta<Int>({6}, {}),
+                                   set_delta<Int>({}, {6})),
+                     values<TimeDelta>(MIN_TD * 2, none, none, none, none, none, none))),
+                 values<Value>(set_delta<Int>({1, 2}, {}),
+                               none,
+                               set_delta<Int>({3}, {2}),
+                               none,
+                               set_delta<Int>({5}, {}),
+                               none,
+                               none));
 
     CHECK_OUTPUT(eval_node<stdlib::take>(values<Int>(1, 2, 3, 4, 5), Int{3}),
                  values<Int>(1, 2, 3, none, none));

--- a/tests/cpp/test_time_series_reference.cpp
+++ b/tests/cpp/test_time_series_reference.cpp
@@ -522,6 +522,139 @@ TEST_CASE("TimeSeriesReference: output alternatives are keyed by starting view a
     REQUIRE(structural_ref_value.as<TimeSeriesReference>().target_schema() == structural_bundle);
 }
 
+TEST_CASE("TimeSeriesReference: to-REF metrics include compiled plan trees")
+{
+    using namespace hgraph;
+    constexpr std::size_t child_count = 64;
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *int_meta = registry.register_scalar<std::int32_t>("int32");
+    const auto *ts_int   = registry.ts(int_meta);
+    const auto *ref_int  = registry.ref(ts_int);
+    const auto *source_list = registry.tsl(ts_int, child_count);
+    const auto *requested_list = registry.tsl(ref_int, child_count);
+    const auto *root = registry.tsb(
+        "TimeSeriesReferenceAlternativePlanMetricsRoot",
+        {{"scalar", ts_int}, {"wide", source_list}});
+
+    TSOutput output{*root};
+    auto     source_view = output.view(MIN_ST);
+    auto     source = source_view.as_bundle();
+
+    const auto before_scalar = output.dynamic_storage_metrics();
+    const auto scalar = source.field("scalar").binding_for(*ref_int);
+    const auto after_scalar = output.dynamic_storage_metrics();
+    const auto scalar_data = scalar.data_view().dynamic_storage_metrics();
+
+    const auto before_wide = after_scalar;
+    const auto wide = source.field("wide").binding_for(*requested_list);
+    const auto after_wide = output.dynamic_storage_metrics();
+    const auto wide_data = wide.data_view().dynamic_storage_metrics();
+
+    const auto scalar_non_data_live =
+        (after_scalar.live_bytes - before_scalar.live_bytes) - scalar_data.live_bytes;
+    const auto scalar_non_data_reserved =
+        (after_scalar.reserved_bytes - before_scalar.reserved_bytes) - scalar_data.reserved_bytes;
+    const auto wide_non_data_live =
+        (after_wide.live_bytes - before_wide.live_bytes) - wide_data.live_bytes;
+    const auto wide_non_data_reserved =
+        (after_wide.reserved_bytes - before_wide.reserved_bytes) - wide_data.reserved_bytes;
+
+    // Both alternatives own the same state type. The wide alternative also
+    // owns one compiled child-plan entry per fixed-list element, which must be
+    // visible independently of the TSData storage those plans operate on.
+    CHECK(wide_non_data_live > scalar_non_data_live);
+    CHECK(wide_non_data_reserved > scalar_non_data_reserved);
+}
+
+TEST_CASE("TimeSeriesReference: from-REF metrics include endpoint plan and schema trees")
+{
+    using namespace hgraph;
+    constexpr std::size_t child_count = 64;
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *int_meta = registry.register_scalar<std::int32_t>("int32");
+    const auto *ts_int   = registry.ts(int_meta);
+    const auto *ref_int  = registry.ref(ts_int);
+    const auto *list     = registry.tsl(ts_int, child_count);
+    const auto *ref_list = registry.ref(list);
+    const auto *root = registry.tsb(
+        "TimeSeriesReferenceFromRefPlanMetricsRoot",
+        {{"scalar", ref_int}, {"wide", ref_list}});
+
+    TSOutput output{*root};
+    auto     source_view = output.view(MIN_ST);
+    auto     source = source_view.as_bundle();
+
+    const auto before_scalar = output.dynamic_storage_metrics();
+    const auto scalar = source.field("scalar").binding_for(*ts_int);
+    const auto after_scalar = output.dynamic_storage_metrics();
+    const auto scalar_data = scalar.data_view().dynamic_storage_metrics();
+
+    const auto before_wide = after_scalar;
+    const auto wide = source.field("wide").binding_for(*list);
+    const auto after_wide = output.dynamic_storage_metrics();
+    const auto wide_data = wide.data_view().dynamic_storage_metrics();
+
+    const auto scalar_non_data_live =
+        (after_scalar.live_bytes - before_scalar.live_bytes) - scalar_data.live_bytes;
+    const auto scalar_non_data_reserved =
+        (after_scalar.reserved_bytes - before_scalar.reserved_bytes) - scalar_data.reserved_bytes;
+    const auto wide_non_data_live =
+        (after_wide.live_bytes - before_wide.live_bytes) - wide_data.live_bytes;
+    const auto wide_non_data_reserved =
+        (after_wide.reserved_bytes - before_wide.reserved_bytes) - wide_data.reserved_bytes;
+
+    // Fixed structural dereferencing copies the endpoint-schema topology and
+    // compiles a matching endpoint plan. Both independently own vector trees.
+    CHECK(wide_non_data_live > scalar_non_data_live);
+    CHECK(wide_non_data_reserved > scalar_non_data_reserved);
+}
+
+TEST_CASE("TimeSeriesReference: interior from-REF metrics include compiled plan trees")
+{
+    using namespace hgraph;
+    constexpr std::size_t child_count = 64;
+
+    auto       &registry = TypeRegistry::instance();
+    const auto *int_meta = registry.register_scalar<std::int32_t>("int32");
+    const auto *ts_int   = registry.ts(int_meta);
+    const auto *ref_int  = registry.ref(ts_int);
+    const auto *narrow_source = registry.tsl(ref_int, 1);
+    const auto *narrow_requested = registry.tsl(ts_int, 1);
+    const auto *wide_source = registry.tsl(ref_int, child_count);
+    const auto *wide_requested = registry.tsl(ts_int, child_count);
+    const auto *root = registry.tsb(
+        "TimeSeriesReferenceInteriorFromRefPlanMetricsRoot",
+        {{"narrow", narrow_source}, {"wide", wide_source}});
+
+    TSOutput output{*root};
+    auto     source_view = output.view(MIN_ST);
+    auto     source = source_view.as_bundle();
+
+    const auto before_narrow = output.dynamic_storage_metrics();
+    const auto narrow = source.field("narrow").binding_for(*narrow_requested);
+    const auto after_narrow = output.dynamic_storage_metrics();
+    const auto narrow_data = narrow.data_view().dynamic_storage_metrics();
+
+    const auto before_wide = after_narrow;
+    const auto wide = source.field("wide").binding_for(*wide_requested);
+    const auto after_wide = output.dynamic_storage_metrics();
+    const auto wide_data = wide.data_view().dynamic_storage_metrics();
+
+    const auto narrow_non_data_live =
+        (after_narrow.live_bytes - before_narrow.live_bytes) - narrow_data.live_bytes;
+    const auto narrow_non_data_reserved =
+        (after_narrow.reserved_bytes - before_narrow.reserved_bytes) - narrow_data.reserved_bytes;
+    const auto wide_non_data_live =
+        (after_wide.live_bytes - before_wide.live_bytes) - wide_data.live_bytes;
+    const auto wide_non_data_reserved =
+        (after_wide.reserved_bytes - before_wide.reserved_bytes) - wide_data.reserved_bytes;
+
+    CHECK(wide_non_data_live > narrow_non_data_live);
+    CHECK(wide_non_data_reserved > narrow_non_data_reserved);
+}
+
 TEST_CASE("TimeSeriesReference: to-REF alternative stores fixed list children through TSData")
 {
     using namespace hgraph;


### PR DESCRIPTION
## Summary

- compile REF projection, nested conversion, and proxy refresh behavior into immutable passive operation plans selected from wiring metadata
- compile map, TSL-map, and mesh child access/output-modification strategies once instead of selecting representation behavior during evaluation
- select reduce collection/publication and throttle release operations once, retaining non-null no-op tables where a capability is absent
- add native coverage for TSS throttle window netting, including a fully cancelled window

This is Phase 5 of #462. It removes the audited representation-policy branches from semantic runtime owners while retaining schema validation and dynamic forwarding compatibility checks at their appropriate boundaries.

## Impact

Runtime behavior is intended to be unchanged. Representation policy is now selected once from immutable build metadata and invoked through passive operation tables on hot paths. This keeps the semantic owners independent of concrete storage strategies and preserves first-class C++ and Python authoring behavior.

This PR is stacked on #467 and should target `main` once that prerequisite is merged.

## Validation

- macOS fresh native acceptance preset: 1,596/1,596 passed
- macOS cp312-abi3 wheel installed under Python 3.14: 2,170 passed, 9 skipped
- macOS installed-SDK consumer: 1/1 passed
- native Linux fresh acceptance preset: 1,595/1,595 passed
- native Linux cp312-abi3 wheel installed under Python 3.14: 2,170 passed, 9 skipped
- `git diff --check`
