### PR TITLE
Erase runtime context ownership

### DIFF
--- a/include/hgraph/types/utils/memory_utils.h
+++ b/include/hgraph/types/utils/memory_utils.h
@@ -220,6 +220,26 @@ namespace hgraph
         };
 
         /**
+         * Storage policy that always allocates the erased payload.
+         *
+         * Use this for implementation contexts whose address is published
+         * through passive operation tables. Moving the owner transfers the
+         * allocation and therefore cannot invalidate those published
+         * context/result pointers.
+         */
+        struct HeapOnlyStoragePolicy
+        {
+            static constexpr size_t inline_bytes = sizeof(void *);
+
+            [[nodiscard]] static constexpr size_t storage_alignment() noexcept { return alignof(void *); }
+
+            [[nodiscard]] static constexpr bool can_store_inline(StorageLayout, bool, bool) noexcept
+            {
+                return false;
+            }
+        };
+
+        /**
          * Description of one component inside a composite ``StoragePlan``.
          *
          * For tuples ``name`` is null and components are addressed by
@@ -764,6 +784,27 @@ namespace hgraph
                 return owner;
             }
 
+            /**
+             * Factory: allocate owning storage for a raw ``plan`` and let
+             * the caller construct the payload in-place.
+             *
+             * This is the explicit ownership path for non-default-
+             * constructible implementation contexts. The plan must describe
+             * the concrete object actually constructed by ``construct`` so
+             * its destruction hook remains exact after type erasure.
+             */
+            template <typename Construct>
+            [[nodiscard]] static ErasedOwner owning_constructed(
+                const StoragePlan &plan,
+                Construct &&construct,
+                const AllocatorOps &allocator = MemoryUtils::allocator())
+                requires std::is_void_v<Binding>
+            {
+                ErasedOwner owner;
+                owner.construct_owned_custom(plan, std::forward<Construct>(construct), allocator);
+                return owner;
+            }
+
             /** Factory: copy-construct an owner from ``src`` using ``binding``. */
             template <typename B = Binding>
                 requires(!std::is_void_v<B>)
@@ -1032,6 +1073,29 @@ namespace hgraph
 
                 auto rollback = ::hgraph::make_scope_exit([this]() noexcept { abandon_failed_construction(); });
                 plan.copy_construct(data(), src);
+                rollback.release();
+            }
+
+            template <typename Construct>
+            void construct_owned_custom(const StoragePlan &plan,
+                                        Construct &&construct,
+                                        const AllocatorOps &allocator)
+            {
+                if (!plan.valid()) { throw std::logic_error("MemoryUtils::ErasedOwner requires a valid plan"); }
+
+                m_identity = &plan;
+                set_allocator_state(&allocator, owning_state_for(plan));
+
+                if (storage_state() == State::OwningHeap) {
+                    m_storage.ptr = tagged_allocator()->allocate_storage(plan.layout);
+                    auto rollback = ::hgraph::make_scope_exit([this]() noexcept { abandon_failed_construction(); });
+                    std::forward<Construct>(construct)(data());
+                    rollback.release();
+                    return;
+                }
+
+                auto rollback = ::hgraph::make_scope_exit([this]() noexcept { abandon_failed_construction(); });
+                std::forward<Construct>(construct)(data());
                 rollback.release();
             }
 

--- a/src/hgraph/types/metadata/ts_data_dynamic_list_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_dynamic_list_ops.cpp
@@ -41,20 +41,8 @@ namespace hgraph::ts_data_plan_factory_detail
             return seed;
         }
 
-        struct HeapOnlyTSDataStoragePolicy
-        {
-            static constexpr std::size_t inline_bytes = sizeof(void *);
-
-            [[nodiscard]] static constexpr std::size_t storage_alignment() noexcept { return alignof(void *); }
-
-            [[nodiscard]] static constexpr bool can_store_inline(MemoryUtils::StorageLayout, bool, bool) noexcept
-            {
-                return false;
-            }
-        };
-
         using TSDataErasedOwner =
-            MemoryUtils::ErasedOwner<HeapOnlyTSDataStoragePolicy, TypeRecord>;
+            MemoryUtils::ErasedOwner<MemoryUtils::HeapOnlyStoragePolicy, TypeRecord>;
 
         struct DynamicTSLIndexEntry
         {

--- a/src/hgraph/types/metadata/ts_data_slot_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_slot_ops.cpp
@@ -997,7 +997,7 @@ namespace hgraph::ts_data_plan_factory_detail
                                            : "ts.tsd.output.root";
         }
 
-        struct SlotContextBase
+        struct SlotContextCommon
         {
             const TSValueTypeMetaData      *schema{nullptr};
             const MemoryUtils::StoragePlan *plan{nullptr};
@@ -1010,14 +1010,10 @@ namespace hgraph::ts_data_plan_factory_detail
             ValueTypeRef added_set_binding{nullptr};
             ValueTypeRef removed_set_binding{nullptr};
             TSRoleTypeRef root_type{};
-
-            virtual ~SlotContextBase() = default;
-            virtual const TSDataOps &ops_ref() const noexcept = 0;
-            virtual TSRoleTypeRef key_set_type() const noexcept { return {}; }
         };
 
         template <typename Storage>
-        struct TSSContextBase : SlotContextBase
+        struct TSSContextBase : SlotContextCommon
         {
             void initialise_tss_common(const TSValueTypeMetaData &schema_,
                                        const MemoryUtils::StoragePlan &plan_,
@@ -1053,8 +1049,6 @@ namespace hgraph::ts_data_plan_factory_detail
                 configure_tss_ops(mutable_storage);
                 bind_tss_delta_surfaces();
             }
-
-            const TSDataOps &ops_ref() const noexcept override { return set_ops; }
 
           protected:
             void configure_tss_ops(bool mutable_storage)
@@ -1936,9 +1930,6 @@ namespace hgraph::ts_data_plan_factory_detail
                 root_type = TSRoleTypeRef{intern_ts_type(
                     schema, role, plan, dict_ops, keyed_root_label(schema.kind, role, embedded, composite))};
             }
-
-            const TSDataOps &ops_ref() const noexcept override { return dict_ops; }
-            TSRoleTypeRef key_set_type() const noexcept override { return key_set_ts_type; }
 
             [[nodiscard]] static const detail::TSDataOwnershipOps &ownership_ops() noexcept
             {
@@ -3218,6 +3209,63 @@ namespace hgraph::ts_data_plan_factory_detail
 #endif
         };
 
+        using SlotContextOwner =
+            MemoryUtils::ErasedOwner<MemoryUtils::HeapOnlyStoragePolicy>;
+
+        struct SlotContextEntry
+        {
+            SlotContextOwner owner;
+            const TSDataOps *result;
+
+            SlotContextEntry(SlotContextOwner owner_, const TSDataOps &result_)
+                : owner(std::move(owner_)), result(&result_)
+            {}
+
+            SlotContextEntry(const SlotContextEntry &) = delete;
+            SlotContextEntry &operator=(const SlotContextEntry &) = delete;
+            SlotContextEntry(SlotContextEntry &&) noexcept = default;
+            SlotContextEntry &operator=(SlotContextEntry &&) noexcept = default;
+        };
+
+        template <typename Context, typename... Args>
+        [[nodiscard]] SlotContextOwner make_slot_context_owner(Args &&...args)
+        {
+            const auto &context_plan = MemoryUtils::plan_for<Context>();
+            return SlotContextOwner::owning_constructed(
+                context_plan, [&](void *memory) {
+                    std::construct_at(MemoryUtils::cast<Context>(memory),
+                                      std::forward<Args>(args)...);
+                });
+        }
+
+        [[nodiscard]] SlotContextEntry make_tss_context_entry(
+            const TSValueTypeMetaData &schema,
+            const MemoryUtils::StoragePlan &plan,
+            const ValueTypeRef &key_binding,
+            TypeRole role,
+            bool embedded)
+        {
+            auto owner = make_slot_context_owner<TSSContext>(
+                schema, plan, key_binding, role, embedded);
+            auto *context = owner.as<TSSContext>();
+            return SlotContextEntry{std::move(owner), context->set_ops};
+        }
+
+        [[nodiscard]] SlotContextEntry make_tsd_context_entry(
+            const TSValueTypeMetaData &schema,
+            const MemoryUtils::StoragePlan &plan,
+            const ValueTypeRef &key_binding,
+            TSRoleTypeRef element_type,
+            TypeRole role,
+            bool embedded,
+            bool composite)
+        {
+            auto owner = make_slot_context_owner<TSDContext>(
+                schema, plan, key_binding, element_type, role, embedded, composite);
+            auto *context = owner.as<TSDContext>();
+            return SlotContextEntry{std::move(owner), context->dict_ops};
+        }
+
         struct SlotContextKey
         {
             const TSValueTypeMetaData      *schema{nullptr};
@@ -3248,7 +3296,7 @@ namespace hgraph::ts_data_plan_factory_detail
         };
 
         using SlotContextMap =
-            std::unordered_map<SlotContextKey, std::unique_ptr<SlotContextBase>, SlotContextKeyHash>;
+            std::unordered_map<SlotContextKey, SlotContextEntry, SlotContextKeyHash>;
 
         [[nodiscard]] SlotContextMap &slot_contexts() noexcept
         {
@@ -3455,25 +3503,24 @@ namespace hgraph::ts_data_plan_factory_detail
                                                                  : TSRoleTypeRef{};
         const SlotContextKey key{
             &schema, &plan, storage_offset, key_binding, element_type, role, embedded, false};
-        if (const auto it = contexts.find(key); it != contexts.end()) { return it->second->ops_ref(); }
+        if (const auto it = contexts.find(key); it != contexts.end()) { return *it->second.result; }
 
-        std::unique_ptr<SlotContextBase> context;
-        if (schema.kind == TSTypeKind::TSS)
-        {
-            context = std::make_unique<TSSContext>(schema, plan, key_binding, role, embedded);
-        }
-        else if (schema.kind == TSTypeKind::TSD)
-        {
-            context = std::make_unique<TSDContext>(schema, plan, key_binding, element_type, role, embedded, false);
-        }
-        else
-        {
+        SlotContextEntry context = [&] {
+            if (schema.kind == TSTypeKind::TSS)
+            {
+                return make_tss_context_entry(schema, plan, key_binding, role, embedded);
+            }
+            if (schema.kind == TSTypeKind::TSD)
+            {
+                return make_tsd_context_entry(
+                    schema, plan, key_binding, element_type, role, embedded, false);
+            }
             throw std::logic_error("slot TSData ops require TSS or TSD schema");
-        }
+        }();
 
-        auto *result = context.get();
+        const auto *result = context.result;
         contexts.emplace(key, std::move(context));
-        return result->ops_ref();
+        return *result;
     }
 
     [[nodiscard]] const TSDataOps &slot_tsd_ts_data_ops(const TSValueTypeMetaData      &schema,
@@ -3514,13 +3561,13 @@ namespace hgraph::ts_data_plan_factory_detail
         auto                &contexts = slot_contexts();
         const SlotContextKey key{
             &schema, &plan, storage_offset, key_binding, element_type, storage_role, embedded, composite};
-        if (const auto it = contexts.find(key); it != contexts.end()) { return it->second->ops_ref(); }
+        if (const auto it = contexts.find(key); it != contexts.end()) { return *it->second.result; }
 
-        auto context = std::make_unique<TSDContext>(
+        auto context = make_tsd_context_entry(
             schema, plan, key_binding, element_type, storage_role, embedded, composite);
-        auto *result = context.get();
+        const auto *result = context.result;
         contexts.emplace(key, std::move(context));
-        return result->ops_ref();
+        return *result;
     }
 
     TSRoleTypeRef tsd_value_projection_type(TSRoleTypeRef element_type, TypeRole role)

--- a/src/hgraph/types/metadata/ts_data_window_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_window_ops.cpp
@@ -799,8 +799,6 @@ namespace hgraph::ts_data_plan_factory_detail
             TSWDataOps                      ops{};
             IndexedValueOps                 value_ops{};
 
-            virtual ~TSWContextCommon() = default;
-
             void bind_value_surface()
             {
                 if (schema->value_schema == nullptr)
@@ -1479,6 +1477,38 @@ namespace hgraph::ts_data_plan_factory_detail
             }
         };
 
+        using WindowContextOwner =
+            MemoryUtils::ErasedOwner<MemoryUtils::HeapOnlyStoragePolicy>;
+
+        struct WindowContextEntry
+        {
+            WindowContextOwner owner;
+            const TSWDataOps  *result;
+
+            WindowContextEntry(WindowContextOwner owner_, const TSWDataOps &result_)
+                : owner(std::move(owner_)), result(&result_)
+            {}
+
+            WindowContextEntry(const WindowContextEntry &) = delete;
+            WindowContextEntry &operator=(const WindowContextEntry &) = delete;
+            WindowContextEntry(WindowContextEntry &&) noexcept = default;
+            WindowContextEntry &operator=(WindowContextEntry &&) noexcept = default;
+        };
+
+        template <typename Context, typename... Args>
+        [[nodiscard]] WindowContextEntry make_window_context_entry(Args &&...args)
+        {
+            const auto &context_plan = MemoryUtils::plan_for<Context>();
+            auto owner = WindowContextOwner::owning_constructed(
+                context_plan, [&](void *memory) {
+                    std::construct_at(MemoryUtils::cast<Context>(memory),
+                                      std::forward<Args>(args)...);
+                });
+            auto *context = owner.template as<Context>();
+            context->bind_value_surface();
+            return WindowContextEntry{std::move(owner), context->ops};
+        }
+
         struct TSWContextKey
         {
             const TSValueTypeMetaData      *schema{nullptr};
@@ -1507,10 +1537,10 @@ namespace hgraph::ts_data_plan_factory_detail
             }
         };
 
-        [[nodiscard]] std::unordered_map<TSWContextKey, std::unique_ptr<TSWContextCommon>, TSWContextKeyHash> &
+        [[nodiscard]] std::unordered_map<TSWContextKey, WindowContextEntry, TSWContextKeyHash> &
         window_contexts() noexcept
         {
-            static std::unordered_map<TSWContextKey, std::unique_ptr<TSWContextCommon>, TSWContextKeyHash> contexts;
+            static std::unordered_map<TSWContextKey, WindowContextEntry, TSWContextKeyHash> contexts;
             return contexts;
         }
 
@@ -1639,7 +1669,7 @@ namespace hgraph::ts_data_plan_factory_detail
         auto                       &contexts = window_contexts();
         const TSWContextKey key{
             &schema, &plan, value_offset, tracking_offset, element_binding.record(), role, embedded};
-        if (const auto it = contexts.find(key); it != contexts.end()) { return it->second->ops; }
+        if (const auto it = contexts.find(key); it != contexts.end()) { return *it->second.result; }
 
         const auto *window_component = plan.find_component("window");
         if (window_component == nullptr || window_component->plan == nullptr)
@@ -1647,21 +1677,16 @@ namespace hgraph::ts_data_plan_factory_detail
             throw std::logic_error("TSDataPlanFactory: TSW TSData plan is missing window storage");
         }
 
-        std::unique_ptr<TSWContextCommon> context;
-        if (schema.is_duration_based())
-        {
-            context = std::make_unique<TimeTSWContext>(schema, *window_component->plan, time_binding,
-                                                       element_binding, value_offset, tracking_offset);
-        }
-        else
-        {
-            context = std::make_unique<SizeTSWContext>(schema, *window_component->plan, time_binding,
-                                                       element_binding, value_offset, tracking_offset);
-        }
-        auto *result = context.get();
+        WindowContextEntry context = schema.is_duration_based()
+                                         ? make_window_context_entry<TimeTSWContext>(
+                                               schema, *window_component->plan, time_binding,
+                                               element_binding, value_offset, tracking_offset)
+                                         : make_window_context_entry<SizeTSWContext>(
+                                               schema, *window_component->plan, time_binding,
+                                               element_binding, value_offset, tracking_offset);
+        const auto *result = context.result;
         contexts.emplace(key, std::move(context));
-        result->bind_value_surface();
-        return result->ops;
+        return *result;
     }
 
     void clear_window_ts_data_contexts() noexcept

--- a/src/hgraph/types/time_series/ts_input.cpp
+++ b/src/hgraph/types/time_series/ts_input.cpp
@@ -810,7 +810,8 @@ namespace hgraph
         };
 
         using TargetLinkContext = detail::TSInputTargetLinkContext;
-        using TargetLinkContextCache = std::unordered_map<std::string, std::unique_ptr<TargetLinkContext>>;
+        using TargetLinkContextOwner = detail::TSInputTargetLinkContextOwner;
+        using TargetLinkContextCache = std::unordered_map<std::string, TargetLinkContextOwner>;
         using InputBindingContextCache = std::unordered_map<std::string, std::unique_ptr<InputBindingContext>>;
         using TSInputBuilderCache = std::unordered_map<std::string, std::unique_ptr<TSInputBuilder>>;
 
@@ -1966,7 +1967,7 @@ namespace hgraph
             auto &cache = target_link_context_cache();
             if (const auto it = cache.find(key); it != cache.end())
             {
-                return *it->second->active_ops;
+                return it->second.ops();
             }
 
             const auto *schema = endpoint_schema.schema();
@@ -1985,7 +1986,7 @@ namespace hgraph
 
             auto context = detail::target_link_context_builder_for(schema->kind)(
                 *schema, root_plan, storage_offset, *regular_layout);
-            const auto *ops = context->active_ops;
+            const auto *ops = &context.ops();
             cache.emplace(key, std::move(context));
             return *ops;
         }
@@ -2335,14 +2336,14 @@ namespace hgraph
             if (const auto it = cache.find(key); it != cache.end())
             {
                 return checked_ts_role_type(
-                    intern_ts_type(*schema, TypeRole::Input, root_plan, *it->second->active_ops),
+                    intern_ts_type(*schema, TypeRole::Input, root_plan, it->second.ops()),
                     std::integral_constant<TypeRole, TypeRole::Input>{});
             }
             const auto *layout = data_type.ops_ref().layout_impl(data_type.ops_ref().context);
             if (layout == nullptr) throw std::logic_error("scalar input type requires a resolved data layout");
             auto context = detail::target_link_context_builder_for(schema->kind)(*schema, root_plan, 0, *layout);
             const auto type = checked_ts_role_type(
-                intern_ts_type(*schema, TypeRole::Input, root_plan, *context->active_ops,
+                intern_ts_type(*schema, TypeRole::Input, root_plan, context.ops(),
                                schema->kind == TSTypeKind::REF
                                    ? std::string_view{"ts.ref.input.target"}
                                    : std::string_view{}),

--- a/src/hgraph/types/time_series/ts_input/target_link_ops.cpp
+++ b/src/hgraph/types/time_series/ts_input/target_link_ops.cpp
@@ -12,6 +12,7 @@
 #endif
 
 #include <array>
+#include <memory>
 #include <stdexcept>
 #include <utility>
 
@@ -54,6 +55,28 @@ namespace hgraph::detail
             TSDDataOps    dict_ops{};
             TSSDataOps    key_set_ops{};
         };
+
+        template <typename Context>
+        [[nodiscard]] TSInputTargetLinkContextStorage make_target_link_context_storage()
+        {
+            const auto &context_plan = MemoryUtils::plan_for<Context>();
+            return TSInputTargetLinkContextStorage::owning_constructed(
+                context_plan, [](void *memory) {
+                    std::construct_at(MemoryUtils::cast<Context>(memory));
+                });
+        }
+
+        template <typename Context>
+        [[nodiscard]] TSInputTargetLinkContextOwner finish_target_link_context(
+            TSInputTargetLinkContextStorage storage, Context &context)
+        {
+            if (context.active_ops == nullptr)
+            {
+                throw std::logic_error("TSInput target-link context did not publish its operations result");
+            }
+            return TSInputTargetLinkContextOwner{
+                std::move(storage), context, *context.active_ops};
+        }
 
         [[nodiscard]] constexpr std::size_t ts_kind_index(TSTypeKind kind) noexcept
         {
@@ -1264,29 +1287,33 @@ namespace hgraph::detail
             context.storage_access = &target_link_storage_access_for(schema.kind);
         }
 
-        [[nodiscard]] std::unique_ptr<TSInputTargetLinkContext>
+        [[nodiscard]] TSInputTargetLinkContextOwner
         make_base_target_link_context(const TSValueTypeMetaData &schema,
                                       const MemoryUtils::StoragePlan &,
                                       std::size_t storage_offset,
                                       const TSDataLayout &regular_layout)
         {
-            auto context = std::make_unique<TargetLinkContextFor<TSDataLayout, TSDataOps>>();
+            using Context = TargetLinkContextFor<TSDataLayout, TSDataOps>;
+            auto storage = make_target_link_context_storage<Context>();
+            auto *context = storage.as<Context>();
             initialise_target_link_context(*context, schema, storage_offset);
             context->layout = regular_layout;
             context->layout.tracking_offset = storage_offset;
             context->ops = target_link_base_ops(*context);
             context->active_layout = &context->layout;
             context->active_ops = &context->ops;
-            return context;
+            return finish_target_link_context(std::move(storage), *context);
         }
 
-        [[nodiscard]] std::unique_ptr<TSInputTargetLinkContext>
+        [[nodiscard]] TSInputTargetLinkContextOwner
         make_set_target_link_context(const TSValueTypeMetaData &schema,
                                      const MemoryUtils::StoragePlan &,
                                      std::size_t storage_offset,
                                      const TSDataLayout &regular_layout)
         {
-            auto context = std::make_unique<TargetLinkContextFor<TSSDataLayout, TSSDataOps>>();
+            using Context = TargetLinkContextFor<TSSDataLayout, TSSDataOps>;
+            auto storage = make_target_link_context_storage<Context>();
+            auto *context = storage.as<Context>();
             initialise_target_link_context(*context, schema, storage_offset);
             context->layout = static_cast<const TSSDataLayout &>(regular_layout);
             context->layout.tracking_offset = storage_offset;
@@ -1297,16 +1324,17 @@ namespace hgraph::detail
             context->slot_access = &target_link_set_access;
             context->active_layout = &context->layout;
             context->active_ops = &context->ops;
-            return context;
+            return finish_target_link_context(std::move(storage), *context);
         }
 
-        [[nodiscard]] std::unique_ptr<TSInputTargetLinkContext>
+        [[nodiscard]] TSInputTargetLinkContextOwner
         make_dict_target_link_context(const TSValueTypeMetaData &schema,
                                       const MemoryUtils::StoragePlan &root_plan,
                                       std::size_t storage_offset,
                                       const TSDataLayout &regular_layout)
         {
-            auto context = std::make_unique<TargetLinkDictContext>();
+            auto storage = make_target_link_context_storage<TargetLinkDictContext>();
+            auto *context = storage.as<TargetLinkDictContext>();
             initialise_target_link_context(*context, schema, storage_offset);
             context->slot_access = &target_link_dict_key_access;
 
@@ -1356,10 +1384,10 @@ namespace hgraph::detail
 
             context->active_layout = &context->dict_layout;
             context->active_ops = &context->dict_ops;
-            return context;
+            return finish_target_link_context(std::move(storage), *context);
         }
 
-        [[nodiscard]] std::unique_ptr<TSInputTargetLinkContext>
+        [[nodiscard]] TSInputTargetLinkContextOwner
         make_indexed_target_link_context(const TSValueTypeMetaData &schema,
                                          const MemoryUtils::StoragePlan &,
                                          std::size_t storage_offset,
@@ -1367,7 +1395,9 @@ namespace hgraph::detail
         {
             if (schema.kind == TSTypeKind::TSB)
             {
-                auto context = std::make_unique<TargetLinkContextFor<FixedTSBDataLayout, IndexedTSDataOps>>();
+                using Context = TargetLinkContextFor<FixedTSBDataLayout, IndexedTSDataOps>;
+                auto storage = make_target_link_context_storage<Context>();
+                auto *context = storage.as<Context>();
                 initialise_target_link_context(*context, schema, storage_offset);
                 context->layout = static_cast<const FixedTSBDataLayout &>(regular_layout);
                 context->layout.tracking_offset = storage_offset;
@@ -1385,9 +1415,11 @@ namespace hgraph::detail
                 context->indexed_access = &target_link_bundle_access;
                 context->active_layout = &context->layout;
                 context->active_ops = &context->ops;
-                return context;
+                return finish_target_link_context(std::move(storage), *context);
             }
-            auto context = std::make_unique<TargetLinkContextFor<TSDataLayout, IndexedTSDataOps>>();
+            using Context = TargetLinkContextFor<TSDataLayout, IndexedTSDataOps>;
+            auto storage = make_target_link_context_storage<Context>();
+            auto *context = storage.as<Context>();
             initialise_target_link_context(*context, schema, storage_offset);
             context->layout = regular_layout;
             context->layout.tracking_offset = storage_offset;
@@ -1408,10 +1440,10 @@ namespace hgraph::detail
                                                                      : &target_link_list_access;
             context->active_layout = &context->layout;
             context->active_ops = &context->ops;
-            return context;
+            return finish_target_link_context(std::move(storage), *context);
         }
 
-        [[nodiscard]] std::unique_ptr<TSInputTargetLinkContext>
+        [[nodiscard]] TSInputTargetLinkContextOwner
         make_window_target_link_context(const TSValueTypeMetaData &schema,
                                         const MemoryUtils::StoragePlan &,
                                         std::size_t storage_offset,
@@ -1419,7 +1451,9 @@ namespace hgraph::detail
         {
             if (schema.is_duration_based())
             {
-                auto context = std::make_unique<TargetLinkContextFor<TimeTSWDataLayout, TSWDataOps>>();
+                using Context = TargetLinkContextFor<TimeTSWDataLayout, TSWDataOps>;
+                auto storage = make_target_link_context_storage<Context>();
+                auto *context = storage.as<Context>();
                 initialise_target_link_context(*context, schema, storage_offset);
                 context->layout = static_cast<const TimeTSWDataLayout &>(regular_layout);
                 context->layout.tracking_offset = storage_offset;
@@ -1434,10 +1468,12 @@ namespace hgraph::detail
                 context->ops.push_impl = &target_link_window_push;
                 context->active_layout = &context->layout;
                 context->active_ops = &context->ops;
-                return context;
+                return finish_target_link_context(std::move(storage), *context);
             }
 
-            auto context = std::make_unique<TargetLinkContextFor<SizeTSWDataLayout, TSWDataOps>>();
+            using Context = TargetLinkContextFor<SizeTSWDataLayout, TSWDataOps>;
+            auto storage = make_target_link_context_storage<Context>();
+            auto *context = storage.as<Context>();
             initialise_target_link_context(*context, schema, storage_offset);
             context->layout = static_cast<const SizeTSWDataLayout &>(regular_layout);
             context->layout.tracking_offset = storage_offset;
@@ -1452,7 +1488,7 @@ namespace hgraph::detail
             context->ops.push_impl = &target_link_window_push;
             context->active_layout = &context->layout;
             context->active_ops = &context->ops;
-            return context;
+            return finish_target_link_context(std::move(storage), *context);
         }
     }  // namespace
 

--- a/src/hgraph/types/time_series/ts_input/target_link_ops.h
+++ b/src/hgraph/types/time_series/ts_input/target_link_ops.h
@@ -6,7 +6,7 @@
 #include <hgraph/types/utils/memory_utils.h>
 
 #include <cstddef>
-#include <memory>
+#include <utility>
 
 namespace hgraph::detail
 {
@@ -15,8 +15,6 @@ namespace hgraph::detail
 
     struct TSInputTargetLinkContext
     {
-        virtual ~TSInputTargetLinkContext() = default;
-
         const TSValueTypeMetaData *schema{nullptr};
         std::size_t                storage_offset{0};
         const TSInputTargetLinkStorageAccessOps *storage_access{
@@ -27,7 +25,36 @@ namespace hgraph::detail
         const TSInputTargetLinkIndexedAccess *indexed_access{nullptr};
     };
 
-    using TSInputTargetLinkContextBuilder = std::unique_ptr<TSInputTargetLinkContext> (*)(
+    using TSInputTargetLinkContextStorage =
+        MemoryUtils::ErasedOwner<MemoryUtils::HeapOnlyStoragePolicy>;
+
+    /**
+     * Exact erased ownership plus the stable results published by a target-
+     * link context. The concrete storage plan owns destruction; consumers do
+     * not recover results by downcasting the erased payload.
+     */
+    struct TSInputTargetLinkContextOwner
+    {
+        TSInputTargetLinkContextStorage storage;
+        const TSInputTargetLinkContext *context_result;
+        const TSDataOps                 *ops_result;
+
+        TSInputTargetLinkContextOwner(TSInputTargetLinkContextStorage storage_,
+                                      const TSInputTargetLinkContext &context_,
+                                      const TSDataOps &ops_)
+            : storage(std::move(storage_)), context_result(&context_), ops_result(&ops_)
+        {}
+
+        TSInputTargetLinkContextOwner(const TSInputTargetLinkContextOwner &) = delete;
+        TSInputTargetLinkContextOwner &operator=(const TSInputTargetLinkContextOwner &) = delete;
+        TSInputTargetLinkContextOwner(TSInputTargetLinkContextOwner &&) noexcept = default;
+        TSInputTargetLinkContextOwner &operator=(TSInputTargetLinkContextOwner &&) noexcept = default;
+
+        [[nodiscard]] const TSInputTargetLinkContext &context() const noexcept { return *context_result; }
+        [[nodiscard]] const TSDataOps &ops() const noexcept { return *ops_result; }
+    };
+
+    using TSInputTargetLinkContextBuilder = TSInputTargetLinkContextOwner (*)(
         const TSValueTypeMetaData &schema,
         const MemoryUtils::StoragePlan &root_plan,
         std::size_t storage_offset,

--- a/tests/cpp/test_memory_utils.cpp
+++ b/tests/cpp/test_memory_utils.cpp
@@ -4,6 +4,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
@@ -74,6 +75,17 @@ namespace
     struct alignas(32) OverAlignedValue
     {
         std::byte storage[32]{};
+    };
+
+    struct ExplicitContext
+    {
+        static inline int destroyed{0};
+
+        int value{0};
+
+        ExplicitContext() = delete;
+        explicit ExplicitContext(int value_) : value(value_) {}
+        ~ExplicitContext() { ++destroyed; }
     };
 
     struct LifecycleRecorder
@@ -406,6 +418,35 @@ TEST_CASE("memory utils reset destroys an erased owner exactly once", "[memory u
     owner.reset();
     REQUIRE(owner.plan() == nullptr);
     REQUIRE(TrackedValue::destroyed == 1);
+}
+
+TEST_CASE("memory utils explicitly owns a non-default context at a stable address", "[memory utils]") {
+    using ContextOwner = MemoryUtils::ErasedOwner<MemoryUtils::HeapOnlyStoragePolicy>;
+
+    ExplicitContext::destroyed = 0;
+    const auto &plan = MemoryUtils::plan_for<ExplicitContext>();
+    auto owner = ContextOwner::owning_constructed(plan, [](void *memory) {
+        std::construct_at(MemoryUtils::cast<ExplicitContext>(memory), 42);
+    });
+
+    REQUIRE(owner.stores_heap());
+    auto *published = owner.as<ExplicitContext>();
+    REQUIRE(published->value == 42);
+
+    auto moved = std::move(owner);
+    REQUIRE_FALSE(owner.has_value());
+    REQUIRE(moved.as<ExplicitContext>() == published);
+    REQUIRE(ExplicitContext::destroyed == 0);
+
+    moved.reset();
+    REQUIRE(ExplicitContext::destroyed == 1);
+
+    REQUIRE_THROWS_AS(
+        ContextOwner::owning_constructed(plan, [](void *) {
+            throw std::runtime_error("construction failed");
+        }),
+        std::runtime_error);
+    REQUIRE(ExplicitContext::destroyed == 1);
 }
 
 TEST_CASE("memory utils supports custom inline policies and aligned heap ownership", "[memory utils]") {

--- a/tests/cpp/test_ts_input.cpp
+++ b/tests/cpp/test_ts_input.cpp
@@ -2,6 +2,7 @@
 #include <hgraph/types/metadata/ts_data_plan_factory.h>
 #include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/type_registry.h>
+#include <hgraph/types/registry_reset.h>
 #include <hgraph/types/time_series/ts_input.h>
 #include <hgraph/types/time_series/ts_input/detail.h>
 #include <hgraph/types/time_series/ts_input/target_link.h>
@@ -176,6 +177,111 @@ TEST_CASE("TSInput storage caching excludes endpoint trees with owned payloads")
     REQUIRE_FALSE(input_storage_type_is_realization_invariant(TSEndpointSchema::owned(root)));
     REQUIRE_FALSE(input_storage_type_is_realization_invariant(owned_leaf));
     REQUIRE_FALSE(input_storage_type_is_realization_invariant(owned_subtree));
+}
+
+TEST_CASE("erased TSData and target-link contexts rebuild after registry reset")
+{
+    using namespace hgraph;
+
+    for (int pass = 0; pass < 2; ++pass)
+    {
+        CAPTURE(pass);
+        {
+            auto       &registry = TypeRegistry::instance();
+            auto       &factory = TSDataPlanFactory::instance();
+            const auto *integer = registry.register_scalar<std::int32_t>("int32");
+            const auto *scalar = registry.ts(integer);
+            const auto *set = registry.tss(integer);
+            const auto *dict = registry.tsd(integer, scalar);
+            const auto *fixed_list = registry.tsl(scalar, 2);
+            const auto *dynamic_list = registry.tsl(scalar);
+            const auto *size_window = registry.tsw(integer, 3, 1);
+            const auto *time_window = registry.tsw_duration(
+                integer, TimeDelta{10}, TimeDelta{5});
+            const auto *bundle = registry.tsb(
+                "ErasedContextResetBundle", {{"value", scalar}, {"items", fixed_list}});
+
+            // Construct and use each concrete TSData context family before
+            // reset. The second pass proves that cache teardown destroys the
+            // exact erased context and that fresh contexts can be published.
+            TSData set_data{factory.data_type_for(set)};
+            TSData dict_data{factory.data_type_for(dict)};
+            TSData dynamic_list_data{factory.data_type_for(dynamic_list)};
+            TSData size_window_data{factory.data_type_for(size_window)};
+            TSData time_window_data{factory.data_type_for(time_window)};
+            Value  key{std::int32_t{1}};
+            Value  value{std::int32_t{42}};
+            auto   set_root = set_data.view();
+            auto   dict_root = dict_data.view();
+            auto   dynamic_list_root = dynamic_list_data.view();
+            auto   size_window_root = size_window_data.view();
+            auto   time_window_root = time_window_data.view();
+            {
+                auto mutation = set_root.as_set().begin_mutation(MIN_ST);
+                REQUIRE(mutation.add(key.view()));
+            }
+            {
+                auto mutation = dict_root.as_dict().begin_mutation(MIN_ST);
+                auto child = mutation.at(key.view());
+                auto child_mutation = child.begin_mutation(MIN_ST);
+                REQUIRE(child_mutation.copy_value_from(value.view()));
+            }
+            {
+                auto mutation = size_window_root.as_window().begin_mutation(MIN_ST);
+                mutation.push(value.view());
+            }
+            {
+                auto mutation = time_window_root.as_window().begin_mutation(MIN_ST);
+                mutation.push(value.view());
+            }
+            REQUIRE(set_root.as_set().contains(key.view()));
+            REQUIRE(dict_root.as_dict().contains(key.view()));
+            REQUIRE(dynamic_list_root.schema() == dynamic_list);
+            REQUIRE(size_window_root.as_window().back().checked_as<std::int32_t>() == 42);
+            REQUIRE(time_window_root.as_window().back().checked_as<std::int32_t>() == 42);
+
+            // Base, keyed-slot, indexed, and both window target-link
+            // strategies all publish stable pointers into their erased owners.
+            TSInput scalar_input{TSInputBuilderFactory::checked_builder_for(
+                *scalar, TSEndpointSchema::peered(scalar))};
+            TSInput set_input{TSInputBuilderFactory::checked_builder_for(
+                *set, TSEndpointSchema::peered(set))};
+            TSInput dict_input{TSInputBuilderFactory::checked_builder_for(
+                *dict, TSEndpointSchema::peered(dict))};
+            TSInput dynamic_list_input{TSInputBuilderFactory::checked_builder_for(
+                *dynamic_list, TSEndpointSchema::peered(dynamic_list))};
+            TSInput size_window_input{TSInputBuilderFactory::checked_builder_for(
+                *size_window, TSEndpointSchema::peered(size_window))};
+            TSInput time_window_input{TSInputBuilderFactory::checked_builder_for(
+                *time_window, TSEndpointSchema::peered(time_window))};
+            const auto list_endpoint = TSEndpointSchema::non_peered_list(
+                fixed_list, TSEndpointSchema::peered(scalar));
+            const auto bundle_endpoint = TSEndpointSchema::non_peered(
+                bundle, {TSEndpointSchema::peered(scalar), list_endpoint});
+            TSInput bundle_input{TSInputBuilderFactory::checked_builder_for(
+                *bundle, bundle_endpoint)};
+
+            REQUIRE(scalar_input.schema() == scalar);
+            auto set_input_root = set_input.view();
+            auto dict_input_root = dict_input.view();
+            auto dynamic_list_input_root = dynamic_list_input.view();
+            auto size_window_input_root = size_window_input.view();
+            auto time_window_input_root = time_window_input.view();
+            auto bundle_input_root = bundle_input.view();
+            REQUIRE(set_input_root.as_set().is_bindable());
+            REQUIRE(dict_input_root.as_dict().is_bindable());
+            REQUIRE(dynamic_list_input_root.as_list().is_bindable());
+            REQUIRE(size_window_input_root.as_window().is_bindable());
+            REQUIRE(time_window_input_root.as_window().is_bindable());
+            auto bundle_view = bundle_input_root.as_bundle();
+            REQUIRE(bundle_view.field("value").is_bindable());
+            auto bundle_items = bundle_view.field("items");
+            auto bundle_list = bundle_items.as_list();
+            REQUIRE(bundle_list[1].is_bindable());
+        }
+
+        if (pass == 0) { reset_all_registries(); }
+    }
 }
 
 TEST_CASE("cached TSInput builders resolve owned polymorphic storage in each graph realization")


### PR DESCRIPTION
## Summary

- add shared heap-only erased storage and raw-plan construction for context objects whose published pointers must remain stable across owner moves
- replace polymorphic slot, window, and input target-link context ownership with exact concrete storage plans, explicit erased ownership, and non-null passive operation pointers
- add registry-reset, lifetime, exception-rollback, and public behavior regressions across slot, list, window, and target-link context families

This is Phase 6 of #462. It is stacked on #468 and should target `main` once that prerequisite is merged.

## Impact

Runtime behavior is intended to be unchanged. Context lifetime and destruction now follow the concrete storage plan instead of base-class virtual destruction or base-typed ownership, while result pointers remain stable for registry cache consumers.

## Validation

- macOS fresh native acceptance preset: 1,598/1,598 passed
- macOS cp312-abi3 wheel installed under Python 3.14: 2,170 passed, 9 skipped
- macOS installed-SDK consumer: 1/1 passed
- Linux/GCC 14.3 fresh native acceptance preset: 1,597/1,597 passed
- Linux cp312-abi3 wheel installed under Python 3.14: 2,170 passed, 9 skipped
- Linux focused ASan ownership/reset coverage passed (38 assertions)
- `git diff --check`
