### PR TITLE
Reborrow both arms so the wheel builds under MSVC 14.44

### DIFF
--- a/src/hgraph/lib/std/operators/table_impl.cpp
+++ b/src/hgraph/lib/std/operators/table_impl.cpp
@@ -1519,9 +1519,18 @@ namespace hgraph::stdlib
 
                 static Value cell(const void *context, std::size_t row, std::size_t column)
                 {
-                    const auto     &self = *static_cast<const ValueRowSource *>(context);
-                    const ValueView row_value = self.layout->multi() ? self.value->as_list().at(row)
-                                                                     : reborrow(*self.value);
+                    const auto &self = *static_cast<const ValueRowSource *>(context);
+                    // Both arms must yield the SAME type. `at` returns a const ValueView by
+                    // value and `reborrow` a non-const one; a conditional mixing the two has
+                    // to convert one prvalue to the other's type, which needs the copy
+                    // constructor ValueView deletes. Clang, GCC and MSVC 14.51 accept it
+                    // regardless; MSVC 14.44 rejects it with C2280, so the wheel did not build
+                    // under VS 2022 17.14. Reborrowing both arms is the idiom this file
+                    // already uses for `at` results (see walk_value) and needs no constructor
+                    // at all - same-type prvalues elide.
+                    const ValueView row_value = self.layout->multi()
+                                                    ? reborrow(self.value->as_list().at(row))
+                                                    : reborrow(*self.value);
                     const ValueView item = row_value.as_tuple().at(column);
                     return item.has_value() ? Value{item} : Value{};
                 }


### PR DESCRIPTION
`main` does not build on Windows with the MSVC that VS 2022 17.14 ships, and the
CI Windows leg cannot see it.

## The error

```
table_impl.cpp(1523): error C2280:
  'hgraph::ValueView::ValueView(const hgraph::ValueView &)':
  attempting to reference a deleted function
```

`ValueRowSource::cell` picked its row with a conditional whose arms have
**different types**: `IndexedValueView::at` returns a `const ValueView` *by value*,
`reborrow` returns a non-const one. A conditional mixing the two has to convert one
prvalue to the other's type — which needs the copy constructor `ValueView` deletes.

## Why CI is green

Clang, GCC and MSVC **14.51** accept it regardless. GitHub's `windows-latest` is on
`14.51.36231`; VS 2022 17.14 ships `14.44.35207`, which rejects it. So anyone building
the wheel from source on Windows with 17.14 hits this today, and no CI leg covers it.

## The fix

Reborrow both arms. They become the same type, so no constructor is involved at all —
same-type prvalues elide — and it is the idiom this file already uses for `at()`
results (`walk_value` does it twice). `reborrow`'s own comment records why it exists:
*"the read views are move-only; `at` results are const"*.

## Scope checked

The other conditionals of this shape — the `TSOutputView`/`TSInputView` ones in
`ordered_reduce_node.cpp` and `mapped_child_bindings.h` — are safe: those `at()`
overloads return non-const, so both arms already match.

`IndexedValueView::at` is the only `at()` in the tree returning const *by value*, which
is what makes `reborrow` necessary at all. Returning a move-only type as `const` by
value blocks the move and forces the workaround. Worth revisiting, but dropping that
const is an API-shape change to the value layer rather than a build fix, so it is left
alone here.

## Verification

- macOS **1590/1590**
- Windows sweep on the branch: pending, and it is the point of the change — the same
  sweep on `main` fails at `BUILD-FAIL` with the error above.

## How it was found

The hg-windows driver was reworked to build the wheel the way CI does (build the
`cp312-abi3` wheel once, install that artifact per Python, per
`test-platform-wheel.yml`) instead of letting `uv sync` build per Python from source.
The previous arrangement silently reinstalled a **cached** wheel — uv keys its cached
build of a path dependency on `pyproject.toml`, so a C++-only change left the cache
looking fresh — which had already produced a run reporting 8 failures that did not
exist. Building properly surfaced this real one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)