### PR TITLE
Stabilize real-time SQL and installed SDK checks

### DIFF
--- a/include/hgraph/runtime/graph_type_ref.h
+++ b/include/hgraph/runtime/graph_type_ref.h
@@ -1,6 +1,7 @@
 #ifndef HGRAPH_RUNTIME_GRAPH_TYPE_REF_H
 #define HGRAPH_RUNTIME_GRAPH_TYPE_REF_H
 
+#include <hgraph/hgraph_export.h>
 #include <hgraph/types/metadata/type_record.h>
 #include <hgraph/types/type_pointer.h>
 
@@ -17,7 +18,7 @@ namespace hgraph
 
     inline constexpr std::uint16_t GRAPH_OPS_ABI_VERSION = 7;
 
-    class GraphTypeRef
+    class HGRAPH_EXPORT GraphTypeRef
     {
       public:
         constexpr GraphTypeRef() noexcept = default;
@@ -74,11 +75,13 @@ namespace hgraph
         const TypeRecord *record_{nullptr};
     };
 
-    [[nodiscard]] TypeCapabilities graph_type_capabilities(const MemoryUtils::StoragePlan &plan);
-    [[nodiscard]] GraphTypeRef intern_graph_type(const GraphTypeMetaData &schema,
-                                                 const MemoryUtils::StoragePlan &plan,
-                                                 const GraphOps &ops,
-                                                 std::string_view implementation_label = {});
+    [[nodiscard]] HGRAPH_EXPORT TypeCapabilities graph_type_capabilities(
+        const MemoryUtils::StoragePlan &plan);
+    [[nodiscard]] HGRAPH_EXPORT GraphTypeRef intern_graph_type(
+        const GraphTypeMetaData &schema,
+        const MemoryUtils::StoragePlan &plan,
+        const GraphOps &ops,
+        std::string_view implementation_label = {});
 
     static_assert(sizeof(GraphTypeRef) == sizeof(void *));
     static_assert(alignof(GraphTypeRef) == alignof(void *));

--- a/include/hgraph/runtime/graph_type_ref.h
+++ b/include/hgraph/runtime/graph_type_ref.h
@@ -65,8 +65,9 @@ namespace hgraph
         [[nodiscard]] friend constexpr bool operator==(GraphTypeRef, GraphTypeRef) noexcept = default;
 
       private:
-        friend GraphTypeRef intern_graph_type(const GraphTypeMetaData &, const MemoryUtils::StoragePlan &,
-                                              const GraphOps &, std::string_view);
+        friend HGRAPH_EXPORT GraphTypeRef intern_graph_type(
+            const GraphTypeMetaData &, const MemoryUtils::StoragePlan &,
+            const GraphOps &, std::string_view);
         friend class GraphView;
         friend class GraphValue;
 

--- a/include/hgraph/types/metadata/ts_data_plan_factory.h
+++ b/include/hgraph/types/metadata/ts_data_plan_factory.h
@@ -1,6 +1,7 @@
 #ifndef HGRAPH_CPP_ROOT_TS_DATA_PLAN_FACTORY_H
 #define HGRAPH_CPP_ROOT_TS_DATA_PLAN_FACTORY_H
 
+#include <hgraph/hgraph_export.h>
 #include <hgraph/types/metadata/ts_value_type_meta_data.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/time_series/ts_data.h>
@@ -43,7 +44,7 @@ namespace hgraph
      * The factory is a process-wide singleton via ``instance()``;
      * non-copyable and non-movable.
      */
-    class TSDataPlanFactory
+    class HGRAPH_EXPORT TSDataPlanFactory
     {
       public:
         /** Singleton accessor; returns a reference to the process-wide factory. */

--- a/include/hgraph/types/metadata/ts_data_plan_factory_detail.h
+++ b/include/hgraph/types/metadata/ts_data_plan_factory_detail.h
@@ -1,6 +1,7 @@
 #ifndef HGRAPH_CPP_ROOT_TS_DATA_PLAN_FACTORY_DETAIL_H
 #define HGRAPH_CPP_ROOT_TS_DATA_PLAN_FACTORY_DETAIL_H
 
+#include <hgraph/hgraph_export.h>
 #include <hgraph/types/metadata/ts_value_type_meta_data.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/time_series/ts_data.h>
@@ -124,8 +125,9 @@ namespace hgraph::ts_data_plan_factory_detail
                                                         TypeRole role,
                                                         bool embedded = false,
                                                         bool composite = false);
-    [[nodiscard]] TSRoleTypeRef tsd_value_projection_type(TSRoleTypeRef element_type,
-                                                             TypeRole role);
+    [[nodiscard]] HGRAPH_EXPORT TSRoleTypeRef tsd_value_projection_type(
+        TSRoleTypeRef element_type,
+        TypeRole role);
 
     void clear_fixed_ts_data_contexts() noexcept;
     void clear_dynamic_list_ts_data_contexts() noexcept;

--- a/include/hgraph/types/time_series/ts_data/ops.h
+++ b/include/hgraph/types/time_series/ts_data/ops.h
@@ -36,64 +36,69 @@ namespace hgraph
         /** Throw the standard missing-operation exception used by default ops thunks. */
         [[noreturn]] void missing_ts_data_op(const char *name);
 
-        [[nodiscard]] const TSDataLayout *missing_layout(const void *);
-        [[nodiscard]] const TSDataTracking *missing_tracking(const void *, const void *);
-        [[nodiscard]] TSDataTracking *missing_mutable_tracking(const void *, void *);
-        [[nodiscard]] bool missing_has_current_value(const void *, const void *);
-        [[nodiscard]] bool missing_all_valid(const void *, const void *);
-        [[nodiscard]] const void *missing_value_memory(const void *, const void *);
-        [[nodiscard]] void *missing_mutable_value_memory(const void *, void *);
-        [[nodiscard]] const void *missing_delta_memory(const void *, const void *);
-        [[nodiscard]] void *missing_mutable_delta_memory(const void *, void *);
-        void noop_reset_delta(const void *, void *);
-        void noop_record_child_modified(const void *, void *, std::size_t, DateTime);
+        // These thunks are referenced by the default member initializers of
+        // public ops tables. They are consequently part of the installed DLL
+        // SDK: downstream extensions must be able to construct an ops table.
+        [[nodiscard]] HGRAPH_EXPORT const TSDataLayout *missing_layout(const void *);
+        [[nodiscard]] HGRAPH_EXPORT const TSDataTracking *missing_tracking(const void *, const void *);
+        [[nodiscard]] HGRAPH_EXPORT TSDataTracking *missing_mutable_tracking(const void *, void *);
+        [[nodiscard]] HGRAPH_EXPORT bool missing_has_current_value(const void *, const void *);
+        [[nodiscard]] HGRAPH_EXPORT bool missing_all_valid(const void *, const void *);
+        [[nodiscard]] HGRAPH_EXPORT const void *missing_value_memory(const void *, const void *);
+        [[nodiscard]] HGRAPH_EXPORT void *missing_mutable_value_memory(const void *, void *);
+        [[nodiscard]] HGRAPH_EXPORT const void *missing_delta_memory(const void *, const void *);
+        [[nodiscard]] HGRAPH_EXPORT void *missing_mutable_delta_memory(const void *, void *);
+        HGRAPH_EXPORT void noop_reset_delta(const void *, void *);
+        HGRAPH_EXPORT void noop_record_child_modified(const void *, void *, std::size_t, DateTime);
         [[nodiscard]] inline DynamicStorageMetrics no_dynamic_storage_metrics(const void *, const void *) noexcept
         {
             return {};
         }
-        [[nodiscard]] bool missing_copy_value_from(const void *, void *, const ValueView &, DateTime);
-        [[nodiscard]] bool missing_move_value_from(const void *, void *, ValueView, DateTime);
-        [[nodiscard]] Value missing_empty_delta(const TSRoleTypeRef &);
-        [[nodiscard]] Value missing_capture_delta(const TSInputView &);
-        [[nodiscard]] bool missing_delta_has_effect(const TSOutputView &, const ValueView &);
-        void missing_apply_delta(const TSOutputView &, const ValueView &);
+        [[nodiscard]] HGRAPH_EXPORT bool missing_copy_value_from(const void *, void *, const ValueView &, DateTime);
+        [[nodiscard]] HGRAPH_EXPORT bool missing_move_value_from(const void *, void *, ValueView, DateTime);
+        [[nodiscard]] HGRAPH_EXPORT Value missing_empty_delta(const TSRoleTypeRef &);
+        [[nodiscard]] HGRAPH_EXPORT Value missing_capture_delta(const TSInputView &);
+        [[nodiscard]] HGRAPH_EXPORT bool missing_delta_has_effect(const TSOutputView &, const ValueView &);
+        HGRAPH_EXPORT void missing_apply_delta(const TSOutputView &, const ValueView &);
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
         [[nodiscard]] HGRAPH_EXPORT bool missing_from_python(const void *, void *, nb::handle, DateTime);
         [[nodiscard]] HGRAPH_EXPORT nb::object missing_to_python(const void *, const void *);
         [[nodiscard]] HGRAPH_EXPORT nb::object missing_delta_to_python(const void *, const void *, DateTime);
 #endif
-        [[nodiscard]] std::size_t missing_indexed_size(const void *, const void *);
-        [[nodiscard]] TSRoleTypeRef missing_indexed_element_binding(const void *, const void *, std::size_t);
-        [[nodiscard]] const void *missing_indexed_element_memory(const void *, const void *, std::size_t);
-        [[nodiscard]] void *missing_mutable_indexed_element_memory(const void *, void *, std::size_t);
-        [[nodiscard]] bool noop_clear_collection(const TSDataView &, DateTime) noexcept;
+        [[nodiscard]] HGRAPH_EXPORT std::size_t missing_indexed_size(const void *, const void *);
+        [[nodiscard]] HGRAPH_EXPORT TSRoleTypeRef missing_indexed_element_binding(
+            const void *, const void *, std::size_t);
+        [[nodiscard]] HGRAPH_EXPORT const void *missing_indexed_element_memory(const void *, const void *, std::size_t);
+        [[nodiscard]] HGRAPH_EXPORT void *missing_mutable_indexed_element_memory(const void *, void *, std::size_t);
+        [[nodiscard]] HGRAPH_EXPORT bool noop_clear_collection(const TSDataView &, DateTime) noexcept;
         [[nodiscard]] bool clear_tss_collection(const TSDataView &, DateTime);
         [[nodiscard]] bool clear_tsd_collection(const TSDataView &, DateTime);
-        [[nodiscard]] std::size_t missing_slot_size(const void *, const void *);
-        [[nodiscard]] std::size_t missing_slot_capacity(const void *, const void *);
-        [[nodiscard]] bool missing_slot_predicate(const void *, const void *, std::size_t);
-        [[nodiscard]] bool no_structural_delta(const void *, const void *, DateTime) noexcept;
-        [[nodiscard]] const void *missing_key_at_slot(const void *, const void *, std::size_t);
-        [[nodiscard]] bool missing_contains_key(const void *, const void *, const ValueView &);
-        [[nodiscard]] std::size_t missing_find_key_slot(const void *, const void *, const ValueView &);
-        [[nodiscard]] std::size_t missing_next_delta_slot(const void *, const void *, std::size_t);
-        [[nodiscard]] std::size_t missing_next_modified_slot(const void *, const void *, std::size_t);
-        [[nodiscard]] Range<ValueView> missing_value_range(const void *, const void *);
-        [[nodiscard]] KeyValueRange<ValueView, TSDataView> missing_ts_data_kv_range(const void *, const void *);
-        [[nodiscard]] Range<TSDataView> missing_ts_data_range(const void *, const void *);
-        [[nodiscard]] SlotTSDataMutationResult missing_insert_key(const void *, void *, const ValueView &,
-                                                                  DateTime);
-        [[nodiscard]] SlotTSDataMutationResult missing_insert_key_move(const void *, void *, const ValueView &,
-                                                                       DateTime);
-        [[nodiscard]] SlotTSDataMutationResult missing_remove_key(const void *, void *, const ValueView &,
-                                                                  DateTime);
-        [[nodiscard]] SlotTSDataMutationResult missing_remove_slot(const void *, void *, std::size_t,
-                                                                   DateTime);
-        [[nodiscard]] bool missing_touch_slots(const void *, void *, DateTime);
-        void missing_reserve_slots(const void *, void *, std::size_t);
-        void missing_subscribe_slot_observer(const void *, void *, SlotObserver *);
-        void missing_unsubscribe_slot_observer(const void *, void *, SlotObserver *);
-        [[nodiscard]] const void *missing_child_at_slot(const void *, const void *, std::size_t);
+        [[nodiscard]] HGRAPH_EXPORT std::size_t missing_slot_size(const void *, const void *);
+        [[nodiscard]] HGRAPH_EXPORT std::size_t missing_slot_capacity(const void *, const void *);
+        [[nodiscard]] HGRAPH_EXPORT bool missing_slot_predicate(const void *, const void *, std::size_t);
+        [[nodiscard]] HGRAPH_EXPORT bool no_structural_delta(const void *, const void *, DateTime) noexcept;
+        [[nodiscard]] HGRAPH_EXPORT const void *missing_key_at_slot(const void *, const void *, std::size_t);
+        [[nodiscard]] HGRAPH_EXPORT bool missing_contains_key(const void *, const void *, const ValueView &);
+        [[nodiscard]] HGRAPH_EXPORT std::size_t missing_find_key_slot(const void *, const void *, const ValueView &);
+        [[nodiscard]] HGRAPH_EXPORT std::size_t missing_next_delta_slot(const void *, const void *, std::size_t);
+        [[nodiscard]] HGRAPH_EXPORT std::size_t missing_next_modified_slot(const void *, const void *, std::size_t);
+        [[nodiscard]] HGRAPH_EXPORT Range<ValueView> missing_value_range(const void *, const void *);
+        [[nodiscard]] HGRAPH_EXPORT KeyValueRange<ValueView, TSDataView> missing_ts_data_kv_range(
+            const void *, const void *);
+        [[nodiscard]] HGRAPH_EXPORT Range<TSDataView> missing_ts_data_range(const void *, const void *);
+        [[nodiscard]] HGRAPH_EXPORT SlotTSDataMutationResult missing_insert_key(const void *, void *, const ValueView &,
+                                                                                DateTime);
+        [[nodiscard]] HGRAPH_EXPORT SlotTSDataMutationResult missing_insert_key_move(
+            const void *, void *, const ValueView &, DateTime);
+        [[nodiscard]] HGRAPH_EXPORT SlotTSDataMutationResult missing_remove_key(const void *, void *, const ValueView &,
+                                                                                DateTime);
+        [[nodiscard]] HGRAPH_EXPORT SlotTSDataMutationResult missing_remove_slot(const void *, void *, std::size_t,
+                                                                                 DateTime);
+        [[nodiscard]] HGRAPH_EXPORT bool missing_touch_slots(const void *, void *, DateTime);
+        HGRAPH_EXPORT void missing_reserve_slots(const void *, void *, std::size_t);
+        HGRAPH_EXPORT void missing_subscribe_slot_observer(const void *, void *, SlotObserver *);
+        HGRAPH_EXPORT void missing_unsubscribe_slot_observer(const void *, void *, SlotObserver *);
+        [[nodiscard]] HGRAPH_EXPORT const void *missing_child_at_slot(const void *, const void *, std::size_t);
 
         [[nodiscard]] Value empty_delta_atomic(const TSRoleTypeRef &binding);
         [[nodiscard]] Value empty_delta_tss(const TSRoleTypeRef &binding);

--- a/include/hgraph/types/time_series/ts_output.h
+++ b/include/hgraph/types/time_series/ts_output.h
@@ -1,6 +1,7 @@
 #ifndef HGRAPH_CPP_ROOT_TS_OUTPUT_H
 #define HGRAPH_CPP_ROOT_TS_OUTPUT_H
 
+#include <hgraph/hgraph_export.h>
 #include <hgraph/types/time_series/ts_data.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/time_series/endpoint_owner.h>
@@ -31,7 +32,7 @@ namespace hgraph
      * subscriptions are delegated to the root TSData observer set; child-level
      * subscriptions are registered on the projected child TSData views.
      */
-    class TSOutput : private TSDataParent
+    class HGRAPH_EXPORT TSOutput : private TSDataParent
     {
       public:
         TSOutput() noexcept;

--- a/include/hgraph/types/time_series/ts_type_ref.h
+++ b/include/hgraph/types/time_series/ts_type_ref.h
@@ -1,6 +1,7 @@
 #ifndef HGRAPH_TYPES_TIME_SERIES_TS_TYPE_REF_H
 #define HGRAPH_TYPES_TIME_SERIES_TS_TYPE_REF_H
 
+#include <hgraph/hgraph_export.h>
 #include <hgraph/types/metadata/ts_value_type_meta_data.h>
 #include <hgraph/types/type_pointer.h>
 
@@ -16,7 +17,7 @@ namespace hgraph
 
     inline constexpr std::uint16_t TS_DATA_OPS_ABI_VERSION = 9;
 
-    class TSRoleTypeRef
+    class HGRAPH_EXPORT TSRoleTypeRef
     {
       public:
         constexpr TSRoleTypeRef() noexcept = default;
@@ -161,15 +162,18 @@ namespace hgraph
     using TSInputTypeRef = BasicTSTypeRef<TypeRole::Input>;
     using TSOutputTypeRef = BasicTSTypeRef<TypeRole::Output>;
 
-    [[nodiscard]] TSRoleTypeRef intern_ts_type(const TSValueTypeMetaData &schema,
-                                               TypeRole role,
-                                               const MemoryUtils::StoragePlan &plan,
-                                               const TSDataOps &ops,
-                                               std::string_view implementation_label = {});
-    [[nodiscard]] bool is_migrated_ts_root_schema(const TSValueTypeMetaData *schema) noexcept;
-    [[nodiscard]] TypeCapabilities ts_type_capabilities(TypeRole role,
-                                                        const MemoryUtils::StoragePlan &plan,
-                                                        const TSDataOps &ops);
+    [[nodiscard]] HGRAPH_EXPORT TSRoleTypeRef intern_ts_type(
+        const TSValueTypeMetaData &schema,
+        TypeRole role,
+        const MemoryUtils::StoragePlan &plan,
+        const TSDataOps &ops,
+        std::string_view implementation_label = {});
+    [[nodiscard]] HGRAPH_EXPORT bool is_migrated_ts_root_schema(
+        const TSValueTypeMetaData *schema) noexcept;
+    [[nodiscard]] HGRAPH_EXPORT TypeCapabilities ts_type_capabilities(
+        TypeRole role,
+        const MemoryUtils::StoragePlan &plan,
+        const TSDataOps &ops);
 
     template <TypeRole Role>
     [[nodiscard]] BasicTSTypeRef<Role> checked_ts_role_type(TSRoleTypeRef type,

--- a/include/hgraph/types/time_series/ts_type_ref.h
+++ b/include/hgraph/types/time_series/ts_type_ref.h
@@ -64,9 +64,10 @@ namespace hgraph
       private:
         template <TypeRole> friend class BasicTSTypeRef;
         friend struct TSParentLink;
-        friend TSRoleTypeRef intern_ts_type(const TSValueTypeMetaData &, TypeRole,
-                                            const MemoryUtils::StoragePlan &, const TSDataOps &,
-                                            std::string_view);
+        friend HGRAPH_EXPORT TSRoleTypeRef intern_ts_type(
+            const TSValueTypeMetaData &, TypeRole,
+            const MemoryUtils::StoragePlan &, const TSDataOps &,
+            std::string_view);
         explicit constexpr TSRoleTypeRef(const TypeRecord *record) noexcept : record_(record) {}
 
         const TypeRecord *record_{nullptr};

--- a/include/hgraph/types/value/any_ops.h
+++ b/include/hgraph/types/value/any_ops.h
@@ -1,6 +1,7 @@
 #ifndef HGRAPH_CPP_ROOT_VALUE_ANY_OPS_H
 #define HGRAPH_CPP_ROOT_VALUE_ANY_OPS_H
 
+#include <hgraph/hgraph_export.h>
 #include <hgraph/types/value/value_ops.h>
 
 namespace hgraph
@@ -17,18 +18,18 @@ namespace hgraph
      * (the embedded ``Value``'s own copy/move), so no view-copy hook is
      * installed. ``allows_mutation`` is true so the box can be reassigned.
      */
-    [[nodiscard]] const ValueOps &any_ops() noexcept;
+    [[nodiscard]] HGRAPH_EXPORT const ValueOps &any_ops() noexcept;
 
     /**
      * The canonical interned ``ValueTypeRef`` for the ``Any`` schema:
      * ``(registry.any(), plan_for<Value>, any_ops())``. Use it to construct
      * a ``Value`` whose kind is ``Any``.
      */
-    [[nodiscard]] ValueTypeRef any_type();
+    [[nodiscard]] HGRAPH_EXPORT ValueTypeRef any_type();
 
     /** Meta-preserving form: a JSON-named Any schema keeps its identity
         while sharing the Any plan + ops. */
-    [[nodiscard]] ValueTypeRef any_type(const ValueTypeMetaData &meta);
+    [[nodiscard]] HGRAPH_EXPORT ValueTypeRef any_type(const ValueTypeMetaData &meta);
 }  // namespace hgraph
 
 #endif  // HGRAPH_CPP_ROOT_VALUE_ANY_OPS_H

--- a/python/tests/adaptors/sql/test_sql_adaptor.py
+++ b/python/tests/adaptors/sql/test_sql_adaptor.py
@@ -33,7 +33,8 @@ class _Row(hg.CompoundScalar):
     value: int
 
 
-def _end_time(seconds=5):
+def _end_time(seconds=30):
+    """Return a safety deadline; successful adaptor tests stop themselves."""
     return datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(seconds=seconds)
 
 
@@ -145,7 +146,7 @@ def test_sql_raw_adaptor_serves_repeated_requests_from_the_same_client(
         capture(sql_read_adaptor_raw(query(), path=target))
 
     with hg.GlobalContext(hg.GlobalState()):
-        hg.run_graph(app, run_mode=hg.EvaluationMode.REAL_TIME, end_time=_end_time(15))
+        hg.run_graph(app, run_mode=hg.EvaluationMode.REAL_TIME, end_time=_end_time())
 
     for thread in feeder_threads:
         thread.join(timeout=1.0)

--- a/python/tests/test_packaging.py
+++ b/python/tests/test_packaging.py
@@ -61,12 +61,47 @@ def test_nanobind_build_and_sdk_headers_use_one_exact_runtime_abi():
 def test_installed_sdk_exports_required_msvc_source_contract():
     cmake = (ROOT / "CMakeLists.txt").read_text()
     graph_wiring = (ROOT / "include/hgraph/types/graph_wiring.h").read_text()
+    graph_type_ref = (ROOT / "include/hgraph/runtime/graph_type_ref.h").read_text()
+    ts_type_ref = (ROOT / "include/hgraph/types/time_series/ts_type_ref.h").read_text()
+    ts_output = (ROOT / "include/hgraph/types/time_series/ts_output.h").read_text()
+    ts_data_ops = (ROOT / "include/hgraph/types/time_series/ts_data/ops.h").read_text()
+    ts_data_plan_factory = (
+        ROOT / "include/hgraph/types/metadata/ts_data_plan_factory.h"
+    ).read_text()
+    ts_data_plan_factory_detail = (
+        ROOT / "include/hgraph/types/metadata/ts_data_plan_factory_detail.h"
+    ).read_text()
+    any_ops = (ROOT / "include/hgraph/types/value/any_ops.h").read_text()
 
     assert "target_compile_options(hgraph_options INTERFACE /W4 /permissive- /utf-8)" in cmake
     assert "$<INSTALL_INTERFACE:FMT_HEADER_ONLY>" in cmake
     assert "FMT_LIB_EXPORT" not in cmake
     assert "FMT_SHARED" not in cmake
     assert "class HGRAPH_EXPORT ServiceImplementationScope" in graph_wiring
+    assert "class HGRAPH_EXPORT GraphTypeRef" in graph_type_ref
+    assert "class HGRAPH_EXPORT TSRoleTypeRef" in ts_type_ref
+    assert "class HGRAPH_EXPORT TSOutput" in ts_output
+    assert "class HGRAPH_EXPORT TSDataPlanFactory" in ts_data_plan_factory
+    assert "HGRAPH_EXPORT TSRoleTypeRef tsd_value_projection_type" in ts_data_plan_factory_detail
+    assert "HGRAPH_EXPORT ValueTypeRef any_type" in any_ops
+
+    # Public passive ops tables must remain constructible by DLL consumers.
+    default_thunks = {
+        *re.findall(r"&ts_data_detail::(missing_[a-z0-9_]+)", ts_data_ops),
+        *re.findall(r"&ts_data_detail::(noop_[a-z0-9_]+)", ts_data_ops),
+        *re.findall(r"&ts_data_detail::(no_structural_delta)", ts_data_ops),
+    }
+    for thunk in default_thunks:
+        declaration = re.search(rf"[^;]*\b{re.escape(thunk)}\([^;]*;", ts_data_ops)
+        assert declaration is not None, thunk
+        assert "HGRAPH_EXPORT" in declaration.group(0), thunk
+
+
+def test_installed_consumer_resolves_the_platform_specific_cmake_config_directory():
+    check = (ROOT / "tests/install_consumer/check.py").read_text()
+
+    assert 'package_prefix.glob("lib*/cmake/hgraph")' in check
+    assert 'f"-Dhgraph_DIR={config_dir}"' in check
 
 
 def test_windows_wheel_installs_all_linked_pyarrow_runtimes():

--- a/python/tests/test_packaging.py
+++ b/python/tests/test_packaging.py
@@ -104,6 +104,8 @@ def test_installed_consumer_resolves_the_platform_specific_cmake_config_director
 
     assert 'package_prefix.glob("lib*/cmake/hgraph")' in check
     assert 'f"-Dhgraph_DIR={config_dir}"' in check
+    assert 'cmake = cmake_tool("cmake")' in check
+    assert 'ctest = cmake_tool("ctest")' in check
 
 
 def test_windows_wheel_installs_all_linked_pyarrow_runtimes():

--- a/python/tests/test_packaging.py
+++ b/python/tests/test_packaging.py
@@ -79,7 +79,9 @@ def test_installed_sdk_exports_required_msvc_source_contract():
     assert "FMT_SHARED" not in cmake
     assert "class HGRAPH_EXPORT ServiceImplementationScope" in graph_wiring
     assert "class HGRAPH_EXPORT GraphTypeRef" in graph_type_ref
+    assert "friend HGRAPH_EXPORT GraphTypeRef intern_graph_type" in graph_type_ref
     assert "class HGRAPH_EXPORT TSRoleTypeRef" in ts_type_ref
+    assert "friend HGRAPH_EXPORT TSRoleTypeRef intern_ts_type" in ts_type_ref
     assert "class HGRAPH_EXPORT TSOutput" in ts_output
     assert "class HGRAPH_EXPORT TSDataPlanFactory" in ts_data_plan_factory
     assert "HGRAPH_EXPORT TSRoleTypeRef tsd_value_projection_type" in ts_data_plan_factory_detail

--- a/tests/install_consumer/check.py
+++ b/tests/install_consumer/check.py
@@ -13,8 +13,23 @@ import tempfile
 SOURCE_DIR = Path(__file__).resolve().parent
 
 
+def hgraph_config_dir(package_prefix: Path) -> Path:
+    candidates = sorted(
+        path
+        for path in package_prefix.glob("lib*/cmake/hgraph")
+        if (path / "hgraphConfig.cmake").is_file()
+    )
+    if len(candidates) != 1:
+        raise RuntimeError(
+            "expected exactly one installed hgraph CMake package below "
+            f"{package_prefix}, found: {candidates}"
+        )
+    return candidates[0]
+
+
 def main() -> int:
     package_prefix = Path(sysconfig.get_path("purelib")).resolve()
+    config_dir = hgraph_config_dir(package_prefix)
     with tempfile.TemporaryDirectory(prefix="hgraph-install-consumer-") as directory:
         build_dir = Path(directory)
         configure = [
@@ -24,6 +39,7 @@ def main() -> int:
             "-B",
             str(build_dir),
             "-DCMAKE_BUILD_TYPE=Release",
+            f"-Dhgraph_DIR={config_dir}",
             f"-DCMAKE_PREFIX_PATH={package_prefix}",
             f"-DPython_EXECUTABLE={sys.executable}",
         ]

--- a/tests/install_consumer/check.py
+++ b/tests/install_consumer/check.py
@@ -13,6 +13,20 @@ import tempfile
 SOURCE_DIR = Path(__file__).resolve().parent
 
 
+def cmake_tool(name: str) -> str:
+    """Return the native CMake tool, bypassing pip's Python entry-point wrapper."""
+    executable = f"{name}.exe" if sys.platform == "win32" else name
+    try:
+        from cmake import CMAKE_BIN_DIR
+    except ImportError:
+        return executable
+
+    candidate = Path(CMAKE_BIN_DIR) / executable
+    if not candidate.is_file():
+        raise RuntimeError(f"CMake package does not contain {candidate}")
+    return str(candidate)
+
+
 def hgraph_config_dir(package_prefix: Path) -> Path:
     candidates = sorted(
         path
@@ -30,10 +44,12 @@ def hgraph_config_dir(package_prefix: Path) -> Path:
 def main() -> int:
     package_prefix = Path(sysconfig.get_path("purelib")).resolve()
     config_dir = hgraph_config_dir(package_prefix)
+    cmake = cmake_tool("cmake")
+    ctest = cmake_tool("ctest")
     with tempfile.TemporaryDirectory(prefix="hgraph-install-consumer-") as directory:
         build_dir = Path(directory)
         configure = [
-            "cmake",
+            cmake,
             "-S",
             str(SOURCE_DIR),
             "-B",
@@ -49,7 +65,7 @@ def main() -> int:
             configure.extend(["-G", "Ninja"])
         subprocess.run(configure, check=True)
 
-        build = ["cmake", "--build", str(build_dir), "--parallel", "2"]
+        build = [cmake, "--build", str(build_dir), "--parallel", "2"]
         if sys.platform == "win32":
             build.extend(["--config", "Release"])
         subprocess.run(build, check=True)
@@ -69,7 +85,7 @@ def main() -> int:
             runtime_path if not existing else os.pathsep.join((runtime_path, existing))
         )
 
-        test = ["ctest", "--test-dir", str(build_dir), "--output-on-failure"]
+        test = [ctest, "--test-dir", str(build_dir), "--output-on-failure"]
         if sys.platform == "win32":
             test.extend(["--build-config", "Release"])
         subprocess.run(test, check=True, env=environment)


### PR DESCRIPTION
## Summary

- treat the SQL real-time test deadline as a safety backstop rather than a five-second performance assertion
- resolve the installed hgraph CMake package from its actual `lib*/cmake/hgraph` wheel location
- export the type references, output/factory APIs, Any helpers, projection helper, and every default thunk required to construct the public passive TS-data ops tables from a Windows DLL consumer
- enforce the public DLL export and platform-specific CMake discovery contracts in packaging tests

## Root causes

ConnectorX and Polars first-use initialization on a fresh macOS wheel installation can consume most or all of the previous five-second graph window. A valid SQL result arriving after the declared graph `end_time` is correctly discarded, which made the test fail despite correct adaptor behavior.

The later failures appeared only in Python 3.12 jobs because #470 runs its newly added installed native-consumer check only there. The Python 3.12 wheel itself is healthy. That check exposed two SDK issues:

- a site-packages prefix does not portably discover a package installed under both `lib/cmake` and `lib64/cmake`
- public passive ops-table defaults and several public SDK entry points were not exported from the Windows DLL

## Validation

- focused SQL and catalogue scheduling tests: 9 passed
- repeated-request ordering test: 25 consecutive passes
- focused packaging and distribution checks: 33 passed
- fresh native macOS build: 1,603 C++ tests passed
- newly built Python 3.12 stable-ABI wheel installed into a fresh Python 3.12 environment: native installed-SDK consumer built, linked, and passed
- the same wheel installed into a fresh Python 3.14 environment: 2,171 passed, 9 skipped
- exported-symbol inspection confirms the corrected SDK entry points in the macOS wheel

Windows and Linux validation is left to this PR's CI because the remote hosts are currently unavailable.
