### PR TITLE
Record why ValueView accessors return const by value, and test it

### DIFF
--- a/include/hgraph/types/value/specialized_views.h
+++ b/include/hgraph/types/value/specialized_views.h
@@ -210,6 +210,25 @@ namespace hgraph
                        : ops_->element_at(ops_->context, data(), index) != nullptr;
         }
 
+        /** Returning ``const`` BY VALUE is deliberate; do not "clean it up".
+            ``ValueView`` is one type for both read-only and mutable views, so
+            the only thing distinguishing them at an unnamed call site is the
+            cv-qualification of the prvalue. ``at`` hands back a view over the
+            ops table's ``const void *`` - always read-only - and the ``const``
+            is what steers ``at(i).as<T>()`` to the READING ``as`` overload.
+            Drop it and the non-const overload wins, routing to
+            ``checked_mutable_as<T>``, which throws "requires begin_mutation":
+            a working read becomes a runtime failure. ``begin_mutation()``
+            returns a NON-const prvalue for the same reason, so
+            ``begin_mutation().as<T>() = x`` still resolves to the mutable
+            overload (see tests/install_consumer/main.cpp).
+
+            The cost is that ``at`` results cannot be moved from, which is why
+            callers that need an owned ``ValueView`` reborrow instead. Locked in
+            by "ValueView: as<T>() on an accessor result reads, it does not
+            demand mutation" in tests/cpp/test_value.cpp. A type-level split of
+            read-only and mutable views would remove the need for this trick,
+            but that is an RFC-scale change to the value layer. */
         [[nodiscard]] const ValueView at(std::size_t index) const
         {
             const auto n = ops_->size(ops_->context, data());

--- a/src/hgraph/lib/std/operators/table_impl.cpp
+++ b/src/hgraph/lib/std/operators/table_impl.cpp
@@ -558,7 +558,12 @@ namespace hgraph::stdlib
             }
 
             /** A fresh borrow over the same binding + memory (the read views
-                are move-only; ``at`` results are const). */
+                are move-only; ``at`` results are const).
+
+                That constness is deliberate rather than incidental - see the
+                note on ``IndexedValueView::at`` - so this is the supported way
+                to get an owned ``ValueView`` out of an accessor, not a
+                workaround to be optimised away. */
             [[nodiscard]] ValueView reborrow(const ValueView &view)
             {
                 return ValueView{view.binding(), view.data()};

--- a/tests/cpp/test_value.cpp
+++ b/tests/cpp/test_value.cpp
@@ -679,3 +679,33 @@ TEST_CASE("Value: throws when a scalar type has not been registered")
     using namespace hgraph;
     REQUIRE_THROWS_AS(Value(UnregisteredScalar{}), std::logic_error);
 }
+
+TEST_CASE("ValueView: as<T>() on an accessor result reads, it does not demand mutation")
+{
+    using namespace hgraph;
+
+    // The accessors (`at`, `field`, `front`, `back`) hand back a view over the
+    // ops table's `const void *`, so the result is READ-ONLY however it is
+    // qualified. `as<T>()` has a const/non-const overload pair, and the
+    // non-const one routes to checked_mutable_as<T>, which throws without
+    // begin_mutation. Ref-qualifying the pair keeps a prvalue on the reading
+    // overload; without that, this call compiles and then throws
+    // "checked_mutable_as<T> requires begin_mutation" - a working read turned
+    // into a runtime failure, in a header shipped to downstream consumers.
+    const auto *meta = TypeRegistry::instance().array(
+        scalar_descriptor<Int>::value_meta(), 2);
+    Value list{ValuePlanFactory::instance().type_for(meta)};
+    {
+        auto output = list.as_list().begin_mutation();
+        output.resize(2);
+        Value first{Int{11}};
+        Value second{Int{22}};
+        output.at(0).copy_from(first.view());
+        output.at(1).copy_from(second.view());
+    }
+
+    CHECK(list.as_list().at(0).as<Int>() == 11);
+    CHECK(list.as_list().at(1).as<Int>() == 22);
+    CHECK(list.as_list().front().as<Int>() == 11);
+    CHECK(list.as_list().back().as<Int>() == 22);
+}


### PR DESCRIPTION
**This PR previously proposed dropping that `const`. Codex found the flaw, and chasing it
down showed the `const` is load-bearing — so the change is withdrawn and replaced by the
note and the test that were missing.**

## What I had wrong

`ValueView` is **one type** for both read-only and mutable views. At an unnamed call site
the only thing distinguishing them is the cv-qualification of the prvalue, and `as<T>()`
has a const/non-const pair:

```cpp
const T &as() const noexcept   // reads
T       &as()                  // -> checked_mutable_as<T>, throws without begin_mutation
```

`at` returns a view over the ops table's `const void *`, so its result is read-only, and
returning it as `const` is what steers `at(i).as<T>()` to the **reading** overload.
Dropping the const let the non-const overload win:

```
FAILED: CHECK( list.as_list().at(1).as<Int>() == 22 )
due to unexpected exception with message:
  checked_mutable_as<T> requires begin_mutation
```

A working read turned into a runtime throw — in a header shipped to downstream consumers.
My earlier claim that this was "source-compatible, strictly more permissive" was wrong on
both counts.

Ref-qualifying `as` doesn't rescue it either: `begin_mutation()` returns a **non-const**
prvalue on purpose, and `begin_mutation().as<T>() = x` is the published idiom — the SDK
example at `tests/install_consumer/main.cpp:252` uses it.

## Why the suite didn't catch it

Nothing in the tree writes `at(i).as<T>()`. Every call site uses `checked_as<T>()`, which
has only a const overload. So 1602/1602 stayed green while the public API was broken.

That gap is the actual deliverable here.

## What this PR now does

| | |
|---|---|
| `IndexedValueView::at` | a note explaining the `const` is deliberate, how it pairs with `begin_mutation()`, and that the cost is `at` results not being movable |
| `reborrow` | documented as the supported way to get an owned `ValueView` out of an accessor, not a workaround to optimise away |
| `test_value.cpp` | **"ValueView: `as<T>()` on an accessor result reads, it does not demand mutation"** — fails with `requires begin_mutation` if the const is removed again |

```
 include/hgraph/types/value/specialized_views.h | 19 ++++++++++++++
 src/hgraph/lib/std/operators/table_impl.cpp    |  7 +++++-
 tests/cpp/test_value.cpp                       | 30 ++++++++++++++++++++++
```

The real cleanup — splitting read-only and mutable views by **type** — would remove the
need for the trick entirely, but that is an RFC-scale change to the value layer. It is
recorded where the next person will look rather than attempted here.

#471's MSVC 14.44 build fix stands on its own and is unaffected.

## Verification

C++ **1603/1603** on current main (the new test is the +1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)