### PR TITLE
Route references through state-held empty values

### DIFF
--- a/include/hgraph/lib/std/operators/impl/control_impl.h
+++ b/include/hgraph/lib/std/operators/impl/control_impl.h
@@ -569,19 +569,29 @@ namespace hgraph::stdlib
 
         static void eval(In<"condition", TS<Bool>> condition,
                          In<"ts", REF<TsVar<"S">>, InputValidity::Unchecked> ts,
+                         State<TimeSeriesReference> empty,
                          Out<output_schema> out)
         {
-            const TimeSeriesReference empty = TimeSeriesReference::empty(ts.base().schema()->referenced_ts());
-            if (condition.value())
+            // The empty reference is built once and held in node state; the
+            // per-tick path publishes by copy_value_from — no reference
+            // wrapping, no registry lookups (the 2026-07-02 lock-free
+            // ruling). Schema compatibility is wiring's guarantee: the ts
+            // input and both output fields share one TsVar.
+            if (empty.get().target_schema() == nullptr)
             {
-                out.template field<"true">().set(ts.valid() ? ts.value() : empty);
-                out.template field<"false">().set(empty);
+                empty.set(TimeSeriesReference::empty(ts.base().schema()->referenced_ts()));
             }
-            else
-            {
-                out.template field<"false">().set(ts.valid() ? ts.value() : empty);
-                out.template field<"true">().set(empty);
-            }
+            const auto publish = [](const TSOutputView &field_out, const ValueView &reference) {
+                auto mutation = field_out.begin_mutation(field_out.evaluation_time());
+                static_cast<void>(mutation.copy_value_from(reference));
+            };
+            const auto true_out   = out.template field<"true">();
+            const auto false_out  = out.template field<"false">();
+            const auto &selected   = condition.value() ? true_out : false_out;
+            const auto &deselected = condition.value() ? false_out : true_out;
+            if (ts.valid()) { publish(selected, ts.base().value()); }
+            else { publish(selected, empty.view()); }
+            publish(deselected, empty.view());
         }
     };
 
@@ -589,17 +599,24 @@ namespace hgraph::stdlib
     {
         static void eval(In<"index", TS<Int>> index,
                          In<"ts", REF<TsVar<"S">>, InputValidity::Unchecked> ts,
+                         State<TimeSeriesReference> empty,
                          Out<TSL<REF<TsVar<"S">>, SIZE<"N">>> out)
         {
-            const TimeSeriesReference empty = TimeSeriesReference::empty(ts.base().schema()->referenced_ts());
-            const Int                 selected_index = index.value();
+            // Same contract as if_ref_impl: state-held empty reference,
+            // per-tick copy_value_from only.
+            if (empty.get().target_schema() == nullptr)
+            {
+                empty.set(TimeSeriesReference::empty(ts.base().schema()->referenced_ts()));
+            }
+            const Int selected_index = index.value();
             for (std::size_t i = 0; i < out.size(); ++i)
             {
-                if (selected_index >= 0 && static_cast<std::size_t>(selected_index) == i && ts.valid())
-                {
-                    out[i].set(ts.value());
-                }
-                else { out[i].set(empty); }
+                const bool routed = selected_index >= 0 &&
+                                    static_cast<std::size_t>(selected_index) == i && ts.valid();
+                const auto element = out[i];
+                auto mutation = element.begin_mutation(element.evaluation_time());
+                if (routed) { static_cast<void>(mutation.copy_value_from(ts.base().value())); }
+                else { static_cast<void>(mutation.copy_value_from(empty.view())); }
             }
         }
     };

--- a/include/hgraph/lib/std/operators/impl/control_impl.h
+++ b/include/hgraph/lib/std/operators/impl/control_impl.h
@@ -567,20 +567,22 @@ namespace hgraph::stdlib
     {
         using output_schema = UnNamedTSB<Field<"true", REF<TsVar<"S">>>, Field<"false", REF<TsVar<"S">>>>;
 
+        static void start(In<"ts", REF<TsVar<"S">>, InputValidity::Unchecked> ts,
+                          State<TimeSeriesReference> empty)
+        {
+            // Built once at start; the per-tick path publishes by
+            // copy_value_from — no reference wrapping, no registry lookups
+            // (the 2026-07-02 lock-free ruling). Schema compatibility is
+            // wiring's guarantee: the ts input and both output fields share
+            // one TsVar.
+            empty.set(TimeSeriesReference::empty(ts.base().schema()->referenced_ts()));
+        }
+
         static void eval(In<"condition", TS<Bool>> condition,
                          In<"ts", REF<TsVar<"S">>, InputValidity::Unchecked> ts,
                          State<TimeSeriesReference> empty,
                          Out<output_schema> out)
         {
-            // The empty reference is built once and held in node state; the
-            // per-tick path publishes by copy_value_from — no reference
-            // wrapping, no registry lookups (the 2026-07-02 lock-free
-            // ruling). Schema compatibility is wiring's guarantee: the ts
-            // input and both output fields share one TsVar.
-            if (empty.get().target_schema() == nullptr)
-            {
-                empty.set(TimeSeriesReference::empty(ts.base().schema()->referenced_ts()));
-            }
             const auto publish = [](const TSOutputView &field_out, const ValueView &reference) {
                 auto mutation = field_out.begin_mutation(field_out.evaluation_time());
                 static_cast<void>(mutation.copy_value_from(reference));
@@ -597,17 +599,19 @@ namespace hgraph::stdlib
 
     struct route_by_index_ref_impl
     {
+        static void start(In<"ts", REF<TsVar<"S">>, InputValidity::Unchecked> ts,
+                          State<TimeSeriesReference> empty)
+        {
+            // Same contract as if_ref_impl: state-held empty reference,
+            // per-tick copy_value_from only.
+            empty.set(TimeSeriesReference::empty(ts.base().schema()->referenced_ts()));
+        }
+
         static void eval(In<"index", TS<Int>> index,
                          In<"ts", REF<TsVar<"S">>, InputValidity::Unchecked> ts,
                          State<TimeSeriesReference> empty,
                          Out<TSL<REF<TsVar<"S">>, SIZE<"N">>> out)
         {
-            // Same contract as if_ref_impl: state-held empty reference,
-            // per-tick copy_value_from only.
-            if (empty.get().target_schema() == nullptr)
-            {
-                empty.set(TimeSeriesReference::empty(ts.base().schema()->referenced_ts()));
-            }
             const Int selected_index = index.value();
             for (std::size_t i = 0; i < out.size(); ++i)
             {

--- a/include/hgraph/types/time_series_reference.h
+++ b/include/hgraph/types/time_series_reference.h
@@ -9,6 +9,7 @@
 #include <functional>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace hgraph
@@ -187,6 +188,20 @@ namespace hgraph
         const TSValueTypeMetaData       *target_schema_{nullptr};
         Storage                          storage_{};
     };
+
+    namespace static_schema_detail
+    {
+        template <typename T>
+        struct scalar_name;
+
+        /** Names the registered scalar so ``State<TimeSeriesReference>`` (and
+            other static-schema uses) resolve to the runtime registration. */
+        template <>
+        struct scalar_name<TimeSeriesReference>
+        {
+            static constexpr std::string_view value{"TimeSeriesReference"};
+        };
+    }  // namespace static_schema_detail
 }  // namespace hgraph
 
 namespace std

--- a/python/tests/test_registry_snapshot.py
+++ b/python/tests/test_registry_snapshot.py
@@ -6,6 +6,7 @@ from hgraph import (
     eval_node,
     generator,
     graph,
+    if_,
     map_,
     null_sink,
     register_adaptor,
@@ -133,6 +134,35 @@ def test_wired_evaluation_acquires_no_type_system_locks():
     short_graph = _dense_sink_graph(6)
     long_graph = _dense_sink_graph(24)
     # Warm every wiring/interning cache; a cold first run may intern.
+    _lock_delta_for(short_graph, 6)
+    _lock_delta_for(long_graph, 24)
+
+    short_delta = _lock_delta_for(short_graph, 6)
+    long_delta = _lock_delta_for(long_graph, 24)
+
+    assert long_delta == short_delta
+
+
+@generator
+def _int_pulse(cycles: int) -> TS[int]:
+    for i in range(cycles):
+        yield MIN_TD, i
+
+
+def _ref_route_sink_graph(cycles: int):
+    @graph
+    def _g():
+        source = _int_pulse(cycles)
+        null_sink(if_(source % 2 == 0, source).true)
+
+    return _g
+
+
+def test_reference_routing_acquires_no_type_system_locks():
+    """if_ routes references every cycle; the empty reference is state-held,
+    so steady-state routing must not touch a type-system mutex."""
+    short_graph = _ref_route_sink_graph(6)
+    long_graph = _ref_route_sink_graph(24)
     _lock_delta_for(short_graph, 6)
     _lock_delta_for(long_graph, 24)
 


### PR DESCRIPTION
## Summary

Follow-up to #475, fixing the side finding its lock counter surfaced: `if_` acquired ~10 type-system locks **per cycle**. `if_ref_impl` (and `route_by_index_ref_impl`) rebuilt an empty `TimeSeriesReference` every tick and published through `Out<REF>::set`, whose `Value{TimeSeriesReference}` wrapper resolves the scalar binding under the `TypeRegistry` mutex and whose `normalize()` re-validates schema equivalence through the locked dereference cache — per field, per tick. Pre-existing since ≤0.8.1; timing-neutral only because the mutex was uncontended.

Both routers now follow `if_then_else`'s established lock-free pattern:

- the routed branch publishes the **input's reference value view** directly (`copy_value_from`), and
- the empty reference is built **once into node `State`** (`TimeSeriesReference` gains a `static_schema_detail::scalar_name` so it can live in state), so steady-state ticks perform no type resolution — schema compatibility is wiring's guarantee, the `ts` input and routed outputs share one `TsVar`.

## Validation

- [x] C++ suite: 1603/1603 (fresh Release build)
- [x] Python suite: 2174 passed / 9 skipped, including a new `if_`-routing N-vs-2N lock-invariant test
- [x] Counter audit: `if_` graph and `type_tsb_partial_fields_std` both at **0.00 locks/cycle**
- [x] Benchmarks: `type_tsb_partial_fields_std` **0.031s → 0.022s** (x1.4 vs the pinned 0.8.1 wheel); `switch_alternating_branch_sizes_std` and `tick_std` unchanged

Remaining known per-call registry use in the REF family (out of scope, fires on reference *changes*, not per tick): `project_indexed_reference_element` in `container_impl.h`, and `Out<REF>::set`/`apply` itself for other callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)