### PR TITLE
Add HGraph node and graph authoring skills

### DIFF
--- a/.agents/skills/hgraph-compute-sink-node/SKILL.md
+++ b/.agents/skills/hgraph-compute-sink-node/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: hgraph-compute-sink-node
+description: Implement or review C++ hgraph compute nodes, sink nodes, algorithms, and concrete operator-node specializations. Use when adding or changing a static node `eval`, lifecycle hooks, local or recordable state, REF usage, incremental or windowed algorithms, operator strategy selection or overload registration, type-erased node strategy, node naming, complexity documentation, or native/Python behavioral tests for a compute or sink node.
+---
+
+# HGraph Compute and Sink Nodes
+
+Build C++-first nodes whose per-tick path is small, whose lifecycle and state
+semantics are explicit, and whose names and tests fit the operator system.
+
+## Start from the existing contract
+
+1. Read the repository `AGENTS.md` and the relevant operator definition,
+   implementation, registration, and tests before editing.
+2. Read the applicable parts of
+   `docs/source/user_guide/cpp/authoring_nodes.rst`. Use
+   `tests/cpp/test_static_node.cpp` as the compact executable reference for
+   lifecycle hooks, `State`, and `RecordableState`.
+3. Classify the work before choosing a type:
+   - Use a compute node for time-series input plus an output.
+   - Use a sink node for time-series input and a side effect with no output.
+   - Implement an operator specialization when the behavior belongs to an
+     existing abstract operator or valid implementations may vary by type or
+     algorithm.
+   - Introduce a standalone node only when the behavior is not an operator and
+     cannot be expressed clearly as a graph.
+
+Keep static node implementation structs empty. Put instance data in the
+appropriate selector or plan rather than in members.
+
+Keep the node's per-tick implementation logic in `eval`. Extract a helper only
+when it is a well-defined operation with its own clear contract or is genuinely
+shared by multiple callers. Do not scatter one node's implementation across
+single-use helper functions. Keep one-off lifecycle work in `start` and `stop`
+as described below.
+
+## Design the hot path first
+
+Treat `eval` as the hot path. Leave only work that depends on the current tick.
+
+- Prefer typed `In`, `Out`, `State`, and `RecordableState` access.
+- Avoid schema discovery, registry lookup, overload selection, RTTI, string
+  construction, parsing, policy selection, and representation selection in
+  `eval`.
+- Avoid avoidable allocation, container growth, reference counting, locking,
+  and Python conversion in `eval`. Reuse pre-sized storage when the algorithm
+  requires scratch space.
+- Resolve wiring-time scalar policies to a concrete overload or plan. Do not
+  branch on a policy string every tick.
+- Read each input view only as often as needed. Use modified/delta access when
+  full-value traversal is unnecessary.
+- Emit no output when the contract calls for no tick; do not manufacture an
+  unchanged value merely to simplify control flow.
+
+If expensive work appears unavoidable, state why, inspect neighboring hot-path
+code, and add focused performance evidence for a material regression risk.
+
+## Use REF deliberately
+
+Treat `REF` as a semantic indirection with significant memory overhead, not as
+the default way to connect nodes. Input bindings to non-`REF` outputs are
+lightweight C++ structures.
+
+- Use a normal binding when the consumer only needs to read an output.
+- Use `REF` when indirection prevents a value from being copied from an input
+  to an output. Selection and routing operators such as `if_then` and `route`
+  are the primary pattern: capture the selected source output and direct that
+  source instead of copying its current value.
+- Use `REF` when dynamic source identity is part of the operator contract.
+- Before adding `REF`, state which copy or dynamic binding it avoids and verify
+  that plain input binding cannot express the behavior.
+
+Do not reject `REF` merely because it is expensive. Use it whenever the
+indirection is required, and pay its overhead intentionally.
+
+## Place one-off work in lifecycle hooks
+
+Use `start` for work performed once per node lifetime, including:
+
+- initializing `State`, or seeding `RecordableState` only when it is invalid;
+  never overwrite recordable state restored for replay;
+- initializing sequences, cursors, buffers, or cached plans associated with
+  that state;
+- acquiring run-scoped resources or establishing subscriptions;
+- scheduling the initial evaluation when declarative `schedule_on_start` is
+  insufficient.
+
+Use `stop` to flush, finalize, unsubscribe, or release what `start` acquired.
+Keep teardown safe for partial lifecycle progress and follow existing scope
+guard patterns where rollback is required.
+
+Request only the selectors each hook needs. When lifecycle-only arguments are
+required, use the established explicit `signature_args` pattern rather than
+polluting `eval`.
+
+## Choose state by semantics
+
+- Use no state for a pure transformation or side effect.
+- Use `State<T>` for private, ephemeral implementation state that does not
+  participate in record/replay.
+- Use `RecordableState<TSchema>` when a tick updates state that affects later
+  ticks: this is loopback or feedback state and should be observable and
+  restorable by record/replay.
+- Do not combine `State` and `RecordableState` in one static node.
+- Keep recordable state structured and typed. Update only the fields modified
+  by the current tick.
+
+Do not replace semantic loopback state with an opaque cache merely because the
+cache is easier to implement.
+
+## Implement algorithms incrementally
+
+Prefer an incremental algorithm that consumes the current tick or delta and
+updates only the sufficient statistics needed for the result. Do not retain an
+entire history or window in private state when an online formulation exists.
+Minimal sufficient statistics are algorithmic state; they are preferable to
+capturing the input history.
+
+- Put incremental state that affects later ticks in `RecordableState`.
+- When an exact result intrinsically requires the window contents, use `TSW`
+  as the semantic window rather than copying the window into private state.
+  Exact median is the standard example.
+- Do not maintain a private duplicate of a `TSW` merely to simplify the
+  implementation.
+- Test an incremental implementation against a simple full-recomputation
+  reference over multiple ticks, including removals and boundary conditions.
+
+Document algorithmic cost beside the implementation and public operator:
+
+- state the worst-case or amortized time cost per tick;
+- state retained-memory cost;
+- for `TSW`, express both costs in terms of window size `W` and document the
+  supported window semantics.
+
+## Exploit concrete C++ types
+
+Use type erasure at boundaries that genuinely need to accept independently
+realized types. Once wiring or plan construction selects a concrete strategy,
+make the per-tick implementation typed.
+
+- Template an implementation when its scalar or time-series types vary, and
+  use those template parameters to remove runtime conversion and dispatch.
+- Prefer a concrete typed overload over inspecting `TSTypeKind` or a schema in
+  `eval`.
+- Select erased representation operations once from immutable wiring or plan
+  metadata, then dispatch through the installed ops table.
+- Follow the repository passive ops-table plus explicit erased-ownership
+  pattern for a reusable erased contract. Do not add a facade `std::variant`
+  or scatter strategy branches through semantic node code.
+- Preserve native C++ authoring as the primary path. Adapt Python values and
+  callables to the same node rather than implementing separate Python runtime
+  semantics.
+
+## Name operator implementations consistently
+
+Name a concrete operator node from the operator plus a concise specialization
+suffix, using lower snake case.
+
+- If the operator name ends in `_`, append the suffix directly:
+  `add_` + `float` becomes `add_float`.
+- Otherwise insert `_` as the separator:
+  `debug_print` + `tsb` becomes `debug_print_tsb`.
+- Describe the specialization by the distinguishing type, shape, policy, or
+  direction. Avoid generic suffixes such as `impl` when a precise name exists.
+- Apply the same rule to the implementation type and any explicit diagnostic
+  `name` unless a nearby registration convention requires a different label.
+
+Keep the abstract operator in its operator header, the concrete node under the
+existing `impl` boundary, and register it through the neighboring operator
+registration mechanism.
+
+Use the operator as the public abstraction whenever implementation selection
+may vary by type or algorithm. Keep concrete node choices behind overload
+resolution or the operator's wiring contract.
+
+When an operator offers meaningful algorithmic trade-offs, expose a strongly
+typed enum as a wiring-time scalar policy:
+
+- Give each enum value a name that describes the accepted property or risk.
+- Document accuracy, overflow, numerical stability, time, and memory trade-offs
+  that differ between values.
+- Select the concrete overload or immutable plan before execution; do not
+  switch on the enum in `eval`.
+- Use a graph-level switch only when the policy is genuinely time-varying.
+
+For example, average may offer sum divided by count, with overflow risk, and an
+online recurrence based on the previous average, count, and next value, with
+different floating-point accuracy behavior. Test every exposed strategy.
+
+## Document standalone nodes
+
+For a node that is not an operator, add documentation beside its public or
+implementation declaration that states:
+
+- why a primitive node is required instead of a graph or existing operator;
+- its input activation and validity behavior;
+- its output or side-effect contract;
+- its lifecycle and state semantics;
+- any intentional hot-path cost or external-resource behavior.
+
+Add user-facing documentation when the standalone node is public. Do not add
+domain-specific behavior to core merely because the algorithm is generic.
+
+## Test through public wiring
+
+1. Add native C++ behavior coverage using a concrete minimal graph and
+   `eval_node`. Cover sink side effects without driving runtime internals
+   directly.
+2. Cover multiple ticks for stateful nodes, including initialization, update,
+   no-tick behavior, and teardown where relevant.
+3. Prove recordable loopback state through its public recordable-state behavior.
+4. Add equivalent Python authoring/bridge coverage for every Python-visible
+   behavior; keep the semantic implementation in C++.
+5. Test invalid input, passive/active behavior, and lifecycle failure in
+   proportion to the risk.
+6. Run focused tests while iterating, then every acceptance gate required by
+   the current repository `AGENTS.md`. Add an installed-SDK consumer check for
+   public-header changes and cross-platform validation for large runtime or
+   type-erasure changes.
+
+Before handing off, review the final diff specifically for work that can move
+out of `eval`, unnecessary `REF`, retained history that can become incremental,
+state that should be recordable, undocumented per-tick or window cost, policy
+branches that should select an overload, per-tick erased dispatch that can
+become typed, and names that do not identify their operator specialization.

--- a/.agents/skills/hgraph-compute-sink-node/agents/openai.yaml
+++ b/.agents/skills/hgraph-compute-sink-node/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "HGraph Compute and Sink Nodes"
+  short_description: "Build efficient C++ compute and sink nodes"
+  default_prompt: "Use $hgraph-compute-sink-node to implement or review this HGraph C++ compute or sink node."

--- a/.agents/skills/hgraph-write-graphs/SKILL.md
+++ b/.agents/skills/hgraph-write-graphs/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: hgraph-write-graphs
+description: Implement or review composable C++ hgraph graphs and Python `@graph` functions. Use when adding or changing graph composition, wiring-time type or scalar decisions, graph overloads and polymorphism, `GlobalState` or `LOGGER` graph injection, conditional wiring, graph documentation, or native/Python graph behavior tests.
+---
+
+# Write HGraph Graphs
+
+Build behavior by composing small typed nodes and graphs at wiring time. Prefer
+graphs as the ordinary unit of reuse; reserve new nodes for genuine runtime
+primitives or demonstrated performance needs.
+
+## Start from the existing contract
+
+1. Read the repository `AGENTS.md`, the relevant operator and graph code, and
+   nearby tests before editing.
+2. Read the applicable parts of:
+   - `docs/source/user_guide/cpp/authoring_graphs.rst`;
+   - `docs/source/user_guide/python/tutorial/graph.rst`;
+   - `docs/source/developer_guide/graph_wiring.rst`.
+3. Identify the existing nodes, operators and graphs that already provide the
+   required primitives. Compose them before creating a new primitive.
+4. Preserve equivalent first-class C++ wiring and Python authoring behavior
+   for every public cross-language feature.
+
+Apply all repository documentation and type-system rules. A graph is not a
+shortcut around signature validation, generic resolution or operator dispatch.
+
+## Prefer a graph to a node
+
+Start new behavior as a graph. A graph combines small, purpose-specific,
+efficient and well-tested nodes into more complicated behavior, reducing the
+new runtime code and validation surface.
+
+Create a node only when the behavior requires a new per-tick primitive, side
+effect, lifecycle service, runtime state transition, or a measured performance
+improvement that composition cannot provide. Document that reason. Apply
+`$hgraph-compute-sink-node` when implementing or reviewing the node.
+
+Keep the trade-off explicit:
+
+- Prefer composition and reuse by default.
+- Measure before replacing a clear graph with a fused node for performance.
+- Keep a justified fused node narrow and expose it through the same operator or
+  graph contract where practical.
+
+## Keep graph work at wiring time
+
+A C++ graph's `compose` method and a Python `@graph` function execute once while
+the graph is wired. Graphs flatten into their nodes and do not exist as runtime
+evaluation objects.
+
+Keep the graph's wiring implementation in `compose` or the decorated graph
+function. Extract a helper only when it is a well-defined operation with its
+own clear contract or is genuinely shared by multiple callers. Do not scatter
+one graph's composition across single-use helper functions.
+
+- Treat ports as typed wiring handles, never as current values.
+- Inspect scalars, resolved types and wiring metadata only to choose topology.
+- Do not retain runtime state or expect the graph body to run on a tick.
+- Do not perform runtime side effects in a graph body.
+- Move lifecycle and tick-dependent behavior into nodes.
+
+The topology, overloads, bindings and policies selected by the graph are fixed
+when graph composition returns.
+
+## Compose for reuse and polymorphism
+
+Use graphs as the primary workers for reusable behavior:
+
+- Factor repeated compositions into small graphs with precise typed
+  signatures.
+- Compose graphs from other graphs; do not duplicate their internal nodes.
+- Use generic graph signatures for type-safe reuse across compatible schemas.
+- Use operator overloads when callers need polymorphic selection by type,
+  shape or wiring-time algorithm policy.
+- Use higher-order graph parameters when the caller should supply behavior.
+- Keep wiring-time policy selection out of every node's `eval` path.
+
+Prefer an operator contract over exposing one concrete graph when multiple
+valid graph or node implementations may exist.
+
+## Limit graph injectables
+
+Graphs support only `GlobalState` and `LOGGER` as injectables.
+
+- In Python, declare either injectable with a `None` default and never supply
+  it from a graph call.
+- Use `GlobalState` for graph-scoped wiring configuration and values that seed
+  the built graph. Runtime reads or writes still belong in nodes.
+- Use `LOGGER` to report wiring choices, resolved types and selected policies.
+  It is the logger selected for graph wiring, not a per-tick node view.
+- In C++, access the equivalent services through `Wiring::global_state()` and
+  `Wiring::logger()`.
+- Do not inject `STATE`, `RECORDABLE_STATE`, `SCHEDULER`, `CLOCK`,
+  `EvaluationEngineApi`, `Traits` or `NODE` into a graph. Put behavior that
+  needs a runtime service in a node.
+
+Use a node `LoggerView` or the logging operator for runtime values. A graph
+logger cannot observe ticks because the graph body has already finished.
+
+## Make wiring choices explicit
+
+A graph may inspect resolved type information, scalar configuration and wiring
+metadata; perform ordinary conditional logic; select overloads; and log why it
+made a choice.
+
+- Base Python type decisions on resolved annotations, `AUTO_RESOLVE` values and
+  supported metadata APIs.
+- Base C++ decisions on concrete template types and wiring-time scalar values.
+- Log a material type, policy or implementation choice when it helps explain
+  the built topology.
+- Use runtime control-flow operators such as selection, switching, mapping and
+  mesh when a time-series value must change behavior after wiring.
+
+Never read a time-series value to choose topology. Never imply that a logged
+wiring choice can change later in the run.
+
+## Preserve documentation and type rules
+
+- Give every graph a complete input and output signature.
+- Keep generic variables linked consistently across inputs, outputs and scalar
+  resolution parameters.
+- Return the declared time-series shape and preserve the established `REF`,
+  dereference and structural binding rules.
+- Keep scalar policies at wiring time and use enums where several named
+  trade-offs are supported.
+- Document public behavior, wiring-time choices, supported types, error cases
+  and any measured reason for choosing a node over a graph.
+- Update authoritative operator and type documentation with the implementation.
+
+## Test through public wiring
+
+1. Test graph behavior through `eval_node` with concrete public signatures.
+2. Add equivalent native C++ and Python coverage for Python-visible behavior.
+3. Cover every conditional wiring branch, generic type specialization and
+   exposed algorithm policy.
+4. Assert invalid types and unsupported graph injectables fail during wiring.
+5. Test wiring-time logging without confusing it with runtime log output.
+6. Prefer behavior assertions over internal node-count or index assumptions,
+   except when topology itself is the contract.
+7. Run focused tests while iterating, then every acceptance gate required by
+   the current repository `AGENTS.md`.
+
+Before handing off, review the final diff for runtime work left in the graph
+body, a new node that could be a composition, time-series-dependent wiring,
+unsupported injectables, unresolved type variables, and wiring decisions that
+are not documented or tested.

--- a/.agents/skills/hgraph-write-graphs/agents/openai.yaml
+++ b/.agents/skills/hgraph-write-graphs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "HGraph Graph Authoring"
+  short_description: "Compose typed HGraph behavior at wiring time"
+  default_prompt: "Use $hgraph-write-graphs to implement or review this HGraph graph composition."

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@
 /docs/_build/
 /REVIEW.md
 
-.claude/
+.claude/*
+!.claude/skills
 benchmarks/.venv-upstream*/
 benchmarks/.venv-hg-cpp*/
 benchmarks/.venv-release*/

--- a/docs/source/reference/types.rst
+++ b/docs/source/reference/types.rst
@@ -216,6 +216,10 @@ Injectable parameters
 Injectables are runtime services rather than time-series edges. Declare them
 as parameters with a ``None`` default; graph callers do not supply them.
 
+Python ``@graph`` functions are the wiring-time exception: they support only
+``GlobalState`` and ``LOGGER``. The other injectables below are available only
+to node callbacks because graphs do not exist at runtime.
+
 .. list-table::
    :header-rows: 1
    :widths: 28 72

--- a/docs/source/user_guide/cpp/authoring_graphs.rst
+++ b/docs/source/user_guide/cpp/authoring_graphs.rst
@@ -1358,6 +1358,25 @@ Each built graph gets its own copy seeded with the wiring-time entries, so the
 builder stays reusable. Values are heterogeneous (a mutable ``Map<string, Any>``
 under the hood). This is the store the testing toolkit's replay/record use.
 
+Wiring-time logging
+~~~~~~~~~~~~~~~~~~~
+
+A ``compose`` body may log type resolution, policy selection and other wiring
+choices through ``Wiring::logger()``. These messages are emitted while the
+graph is being built and must describe decisions that are fixed when
+``compose`` returns:
+
+.. code-block:: cpp
+
+   static void compose(Wiring &w)
+   {
+       w.logger().info("selected compact quote graph");
+       // wire the selected nodes and sub-graphs...
+   }
+
+Use a node ``LoggerView`` injectable or the ``log_`` operator for runtime
+values. A graph never executes again to observe ticks.
+
 Opt-in polymorphic compound-scalar pooling
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/user_guide/python/tutorial/graph.rst
+++ b/docs/source/user_guide/python/tutorial/graph.rst
@@ -32,8 +32,16 @@ In this example we are using the :func:`add_ <hgraph.add_>` library node. This d
 Note, the signature structure is the same for nodes, this allows for nodes and graph to be interchanged, that is the
 user may start with a node based implementation of some logic and then re-factor the logic into a graph, or vice-versa.
 
-The graph signature does not support property injection, that is the use of injectables (such as loggers, state, etc.)
-are not supported in the graph signature. These are only for use in nodes.
+Graph functions run only at wiring time. Their signatures therefore support
+only the two wiring-time injectables: ``GlobalState`` and ``LOGGER``. Both must
+default to ``None`` and callers must not supply them. ``LOGGER`` is the graph
+logger selected by ``GraphConfiguration`` and is useful for describing wiring
+choices. ``GlobalState`` exposes graph-scoped wiring configuration and seed
+values.
+
+Runtime injectables such as ``STATE``, ``SCHEDULER``, ``CLOCK``,
+``EvaluationEngineApi``, ``Traits`` and ``NODE`` are node-only. Put behavior
+that needs those services in a node and compose that node from the graph.
 
 Composition
 -----------
@@ -151,4 +159,3 @@ function, make use of it in the graph and write logic that can be extended by th
 
 .. note:: It is not possible to pass a time-series function (or make use of one) inside of a node decorated
           function. Only graph decorated functions can accept time-series functions as inputs.
-

--- a/include/hgraph/types/graph_wiring.h
+++ b/include/hgraph/types/graph_wiring.h
@@ -2,6 +2,7 @@
 #define HGRAPH_CPP_ROOT_GRAPH_WIRING_H
 
 #include <hgraph/runtime/graph.h>                       // GraphBuilder, GraphEdge
+#include <hgraph/runtime/logger.h>                      // wiring-time LoggerView
 #include <hgraph/runtime/node.h>                        // NodeBuilder, NodeTypeRef
 #include <hgraph/types/call_args.h>                     // NamedArg / arg<"name">(...)
 #include <hgraph/types/metadata/type_realization.h>     // graph-scoped closed-union value bindings
@@ -1123,6 +1124,12 @@ namespace hgraph
         [[nodiscard]] GlobalStateView global_state() noexcept;
         /** State visible to operator resolution; sub-graphs read the active root seed. */
         [[nodiscard]] GlobalStateView operator_state() noexcept;
+        /**
+         * Wiring-time logger for graph composition diagnostics. The returned
+         * view has no node context; runtime value logging belongs in a node or
+         * logging operator.
+         */
+        [[nodiscard]] LoggerView logger() const;
 
         /** Add a borrowed wiring observer. It must outlive this wiring and its children. */
         void add_wiring_observer(WiringObserver *observer);

--- a/python/hgraph/_wiring/_graph.py
+++ b/python/hgraph/_wiring/_graph.py
@@ -1,6 +1,7 @@
 """_GraphFn/@graph, graph-fn wrapping (the borrowed-wiring re-entry),
 signature auto-resolution and @component."""
 import inspect
+import logging
 from collections.abc import Mapping
 
 import _hgraph
@@ -9,12 +10,22 @@ from .._types import (_ContextExpr, _GenericTsExpr, _TsExpr,
                       _TypeVarSentinel, _pattern_of, _type_var_name)
 from ._core import (ParseError, WiringError, WiringPort, _current_wiring,
                     _resolve_context, _unwrap, _wiring_stack, wire)
-from ._markers import _INJECTABLE_MARKERS, _annotation_ts_kind
+from ._markers import (LOGGER, _INJECTABLE_MARKERS, _RecordableStateExpr,
+                       _StateExpr, _annotation_ts_kind)
 from ._node import (_PyNode, _is_time_series_annotation,
                     _lift_time_series_argument, _warn_deprecated)
 from ._operator import _register_overload, _run_requires
 from ._resolution import _apply_resolvers
-from ._state import GlobalState
+from ._state import GlobalState, _GRAPH_LOGGER_KEY
+
+
+_GRAPH_INJECTABLES = frozenset((GlobalState, LOGGER))
+
+
+def _is_injectable_annotation(annotation):
+    return (annotation in _INJECTABLE_MARKERS or
+            isinstance(annotation, (_StateExpr, _RecordableStateExpr)))
+
 
 def _wrap_graph_fn(gfn, *, input_names=None, scalar_bindings=None):
     """Erase a Python @graph function into a WiredFn: the wrapper runs the
@@ -394,6 +405,17 @@ class _GraphFn:
         self._label = label
         self._deprecated = deprecated
         self._wired_fn_cache = {}
+        for param in self._signature.parameters.values():
+            if not _is_injectable_annotation(param.annotation):
+                continue
+            if param.annotation not in _GRAPH_INJECTABLES:
+                raise TypeError(
+                    f"@graph '{self.__name__}' supports only GlobalState and LOGGER "
+                    f"injectables; '{param.name}' uses {param.annotation!r}")
+            if param.default is not None:
+                raise TypeError(
+                    f"injectable parameter '{param.name}' of '{self.__name__}' "
+                    "must default to None")
         out = self._signature.return_annotation
         if isinstance(out, type):
             from .._types import TimeSeriesSchema
@@ -486,8 +508,16 @@ class _GraphFn:
         bound = self._signature.bind_partial(*args, **kwargs)
         context_scope = _hgraph.ResolutionScope()
         for param in self._signature.parameters.values():
-            if param.annotation is GlobalState and param.name not in bound.arguments:
-                bound.arguments[param.name] = GlobalState.instance()
+            if param.annotation in _GRAPH_INJECTABLES:
+                if param.name in bound.arguments:
+                    raise TypeError(
+                        f"{self.__name__}: injectable '{param.name}' cannot be supplied")
+                if param.annotation is GlobalState:
+                    bound.arguments[param.name] = GlobalState.instance()
+                else:
+                    logger = GlobalState.instance().get(_GRAPH_LOGGER_KEY)
+                    bound.arguments[param.name] = (
+                        logger if logger is not None else logging.getLogger("hgraph"))
             value = bound.arguments.get(param.name)
             if isinstance(param.annotation, _ContextExpr):
                 requirement = value if param.name in bound.arguments else param.default

--- a/python/tests/ported/_wiring/test_injectables.py
+++ b/python/tests/ported/_wiring/test_injectables.py
@@ -1,4 +1,6 @@
 # Ported from release/0.5:hgraph_unit_tests/_wiring/test_injectables.py
+import logging
+
 import pytest
 
 from hgraph import (
@@ -83,6 +85,54 @@ def test_global_state_injectable_for_graph():
         result = evaluate_graph(read_from_state, GraphConfiguration())
 
     assert [v for _, v in result] == [42]
+
+
+def test_logger_injectable_for_graph(caplog):
+    selected = []
+    logger = logging.getLogger("hgraph.test.graph-injectable")
+
+    @graph
+    def log_wiring_choice(_logger: LOGGER = None) -> TS[int]:
+        selected.append(_logger)
+        _logger.info("selected graph wiring strategy: compact")
+        return const(42)
+
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        result = evaluate_graph(
+            log_wiring_choice,
+            GraphConfiguration(graph_logger=logger, default_log_level=logging.INFO),
+        )
+
+    assert selected == [logger]
+    assert [v for _, v in result] == [42]
+    assert "selected graph wiring strategy: compact" in caplog.text
+
+
+def test_graph_rejects_runtime_injectables():
+    with pytest.raises(TypeError, match="supports only GlobalState and LOGGER"):
+        @graph
+        def invalid_graph(engine: EvaluationEngineApi = None) -> TS[int]:
+            return const(1)
+
+
+def test_graph_injectables_must_default_to_none():
+    with pytest.raises(TypeError, match="must default to None"):
+        @graph
+        def invalid_graph(_logger: LOGGER) -> TS[int]:
+            return const(1)
+
+
+def test_graph_injectables_cannot_be_supplied():
+    @graph
+    def inner(_logger: LOGGER = None) -> TS[int]:
+        return const(1)
+
+    @graph
+    def outer() -> TS[int]:
+        return inner(logging.getLogger("not-an-injected-logger"))
+
+    with pytest.raises(TypeError, match="injectable '_logger' cannot be supplied"):
+        evaluate_graph(outer, GraphConfiguration())
 
 
 def test_node_self_injectable_is_native_and_call_scoped():

--- a/src/hgraph/types/graph_wiring.cpp
+++ b/src/hgraph/types/graph_wiring.cpp
@@ -2454,6 +2454,8 @@ GlobalStateView Wiring::operator_state() noexcept {
   return global_state();
 }
 
+LoggerView Wiring::logger() const { return LoggerView{&log::logger()}; }
+
 void Wiring::apply_service_rank_dependencies() {
   for (const auto &client : impl_->service_client_ranks) {
     auto anchor_it = impl_->service_rank_anchors.find(client.path);

--- a/tests/cpp/test_logger.cpp
+++ b/tests/cpp/test_logger.cpp
@@ -67,6 +67,16 @@ namespace
         }
     };
 
+    struct WiringLoggingGraph
+    {
+        static constexpr auto name = "wiring_logging_graph";
+
+        static void compose(Wiring &w)
+        {
+            w.logger().info("selected wiring strategy {}", "typed");
+        }
+    };
+
     class CapturedContextLogger final : public spdlog::logger
     {
       public:
@@ -262,6 +272,16 @@ TEST_CASE("logger: the LoggerView injectable logs from start and eval hooks")
     CHECK_THAT(all, Catch::Matchers::ContainsSubstring("logging node started"));
     CHECK_THAT(all, Catch::Matchers::ContainsSubstring("tick value 7"));
     CHECK_THAT(all, Catch::Matchers::ContainsSubstring("tick value 9"));
+}
+
+TEST_CASE("logger: graphs log wiring-time choices through Wiring")
+{
+    CapturedLog captured;
+
+    static_cast<void>(build_graph<WiringLoggingGraph>());
+
+    CHECK_THAT(captured.joined(),
+               Catch::Matchers::ContainsSubstring("selected wiring strategy typed"));
 }
 
 TEST_CASE("logger: an executor-owned logger is inherited by root and nested graphs")


### PR DESCRIPTION
## Summary

- add repository-local skills for efficient C++ compute/sink nodes and composable C++/Python graphs
- keep node logic in `eval` and graph logic in `compose`, with helpers reserved for well-defined or shared behavior
- expose wiring-time logging through C++ `Wiring::logger()`
- support only `GlobalState` and `LOGGER` injection in Python `@graph` functions, rejecting runtime-only injectables
- make the canonical `.agents/skills` directory available to Claude through `.claude/skills`
- document the graph injectable and wiring-time logging contract

## Why

Graph authoring guidance was not captured in a reusable repository skill, and the existing compute/sink guidance needed an explicit implementation-locality rule. The Python graph wrapper injected `GlobalState` but did not resolve `LOGGER`, while unsupported runtime injectables were accepted until later wiring behavior. C++ graph composition likewise had no explicit wiring-time logger accessor.

## Validation

- native C++ acceptance preset: 1,605 tests passed
- stable-ABI wheel built with Python 3.12
- wheel installed into fresh Python 3.14.7 environment: 2,177 passed, 9 skipped
- installed-SDK CMake consumer: passed
- strict Sphinx build with warnings as errors: passed
- focused injectable tests: 11 passed, 1 skipped
- both skills validated through `.agents/skills` and the Claude symlink
- `git diff --check`: passed