### PR TITLE
Ops catalogue and erasure-doc reconciliation

### DIFF
--- a/docs/source/developer_guide/data_structures/core_concepts.rst
+++ b/docs/source/developer_guide/data_structures/core_concepts.rst
@@ -106,11 +106,11 @@ Data Group
 Interning
 ~~~~~~~~~
 
-Plans, Schemas, Ops tables, Bindings, and reusable Builders are *interned*:
+Plans, Schemas, Ops tables, TypeRecords, and reusable Builders are *interned*:
 there is only ever one true instance of each, kept alive by an intern table
 that returns stable references for structurally equivalent inputs. Any
 consumer—a View, a Builder, a node, a graph—holds a borrowed pointer to its
-Plan, Schema, Ops, Binding, or reusable Builder for the artifact's whole
+Plan, Schema, Ops, TypeRecord, or reusable Builder for the artifact's whole
 lifetime without managing ownership.
 
 The generic vehicle is ``InternTable<Key, Value>``, which guarantees stable

--- a/docs/source/developer_guide/data_structures/plans_and_ops/erased_types.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/erased_types.rst
@@ -53,12 +53,17 @@ debug descriptor for one implementation:
 .. code-block:: cpp
 
    struct TypeRecord {
+       std::uint32_t                   magic;
+       std::uint16_t                   abi_version;
        TypeRole                        role;
+       std::uint16_t                   ops_abi_version;
        TypeCapabilities                capabilities;
+       const char*                     implementation_label;
        const SchemaHeader*             schema;
        const MemoryUtils::StoragePlan* plan;
        const void*                     ops;
        const DebugDescriptor*          debug;
+       mutable const TypeRecord*       external_value_owner;
    };
 
    class ValueTypeRef {
@@ -68,6 +73,8 @@ debug descriptor for one implementation:
 A ``ValueTypeRef`` is a one-word, trivially-copyable typed reference to a
 value-family ``Instance`` record. ``Value``, ``ValueView``, and builders use
 it to reach schema, plan, lifecycle, capabilities, and ``ValueOps``.
+:doc:`ops_catalogue` is the current-state reference for all six record
+families, their ops tables, and their ABI versions.
 
 ``intern_value_type`` interns one record per ``(schema header, Instance role,
 plan, ops)`` key in ``TypeRecordRegistry``. ``ValuePlanFactory`` caches
@@ -379,10 +386,8 @@ currently support explicit mutation when their ops table allows
 ``begin_mutation()``. The compact (build-once) container storage ops do
 not allow it. Structural mutation is supported for **mutable** container
 schemas (``ValueTypeFlags::Mutable``), which bind to slot-store-backed
-storage and install a structural-mutation ops surface — the mutable list
-is implemented (below); the mutable map follows; the remaining structural
-methods are still design/API targets for the slot-store-backed
-time-series layer.
+storage and install a structural-mutation ops surface — the mutable
+list, set, and map are all implemented (below).
 
 ``MutableTupleView``
     Adds mutable child access by index. ``set(index, value)`` is a

--- a/docs/source/developer_guide/data_structures/plans_and_ops/index.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/index.rst
@@ -89,6 +89,7 @@ and is described in *Refinement Topics*.
    :maxdepth: 2
 
    erased_types
+   ops_catalogue
    scalar
    time_series
    proxy_state_management

--- a/docs/source/developer_guide/data_structures/plans_and_ops/ops_catalogue.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/ops_catalogue.rst
@@ -199,10 +199,13 @@ argument** to every slot. Groups of slots:
      - **throw**
    * - copy / assign
      - ``copy_construct_view`` · ``copy_assign_view`` ·
-       ``accepts_source`` · ``copy_assign_from`` · ``move_assign_from`` ·
-       ``can_materialize_source``
-     - fall back to the **plan's** ``LifecycleOps``;
-       ``accepts_source`` defaults to same-plan
+       ``copy_assign_from`` · ``move_assign_from``
+     - fall back to the **plan's** ``LifecycleOps``
+   * - source gating
+     - ``accepts_source`` · ``can_materialize_source``
+     - ``accepts_source`` defaults to same-plan;
+       ``can_materialize_source`` defaults to **false** — an incomplete
+       indexed source is rejected, never materialised
    * - projection
      - ``owning_type`` · ``concrete_type`` · ``concrete_memory`` ·
        ``mutable_concrete_memory`` · ``writable_concrete_memory``

--- a/docs/source/developer_guide/data_structures/plans_and_ops/ops_catalogue.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/ops_catalogue.rst
@@ -1,0 +1,537 @@
+Ops Catalogue
+=============
+
+.. admonition:: Status
+
+   Authoritative **current-state reference** for every erased ops family in
+   the runtime: which tables exist, how they relate, and which concrete
+   implementation installs which table. The *rationale* for this shape is
+   recorded in :doc:`../unified_type_erasure`; the pre-migration snapshot is
+   preserved in :doc:`../type_erasure_inventory` (historical). When code and
+   this page disagree, one of them is wrong — fix it in the same change.
+
+This page answers three questions the rest of the chapter assumes:
+
+1. What ops tables exist, per family, and what anchors them?
+2. Which implementation specialisation installs which table?
+3. What are the dispatch chains a read or write actually walks?
+
+The anchor: ``TypeRecord``
+--------------------------
+
+Every erased type in the runtime — value, time-series, node, graph,
+executor, clock — is identified by one interned, immutable
+``TypeRecord`` (``include/hgraph/types/metadata/type_record.h``):
+
+.. code-block:: cpp
+
+   struct TypeRecord
+   {
+       std::uint32_t          magic;                // TYPE_RECORD_MAGIC
+       std::uint16_t          abi_version;          // record layout ABI
+       TypeRole               role;                 // Instance/Data/Runtime/Input/Output
+       std::uint16_t          ops_abi_version;      // family ops-table ABI (ledger below)
+       TypeCapabilities       capabilities;         // derived once at interning
+       const char            *implementation_label; // participates in identity
+       const SchemaHeader    *schema;               // family + kind + introspection
+       const MemoryUtils::StoragePlan *plan;        // layout + LifecycleOps
+       const void            *ops;                  // family-specific ops table
+       const DebugDescriptor *debug;                // cold-path descriptor
+       mutable const TypeRecord *external_value_owner; // published once via CAS
+   };
+
+Records are interned in the process-wide ``TypeRecordRegistry`` keyed by
+``(schema, role, plan, ops, debug, implementation_label)``; interning the
+same key with conflicting capabilities or ABI versions throws. Registry
+storage never relocates, so a ``TypeRecord*`` is process-stable.
+
+Each family wraps the record pointer in a one-word, role-checked *TypeRef*
+(``ValueTypeRef``, ``BasicTSTypeRef<TypeRole>`` and its aliases
+``TSDataTypeRef`` / ``TSInputTypeRef`` / ``TSOutputTypeRef``,
+``NodeTypeRef``, ``GraphTypeRef``, ``ExecutorTypeRef``, ``ClockTypeRef``),
+and each views live memory through a two-word typed pointer
+(``ValuePtr``, ``TSDataPtr``, …) whose low two bits of the record pointer
+carry the :ref:`access mode <ops-catalogue-access-modes>`.
+
+.. mermaid::
+
+   flowchart LR
+      subgraph interned["Interned (TypeRecordRegistry, process-stable)"]
+         TR["TypeRecord<br/>role · capabilities · ops_abi_version<br/>implementation_label"]
+         SH["SchemaHeader<br/>family · kind · label"]
+         SP["StoragePlan<br/>size · align · offsets<br/>LifecycleOps"]
+         OPS["family ops table<br/>(ValueOps / TSDataOps / NodeOps / …)"]
+         DBG["DebugDescriptor<br/>cold-path fields"]
+         TR --> SH
+         TR --> SP
+         TR --> OPS
+         TR --> DBG
+      end
+      REF["family TypeRef<br/>(one word: TypeRecord*)"] --> TR
+      PTR["typed pointer<br/>(two words: tagged TypeRecord* + data*)"] --> TR
+      PTR --> MEM["live instance memory<br/>(NOT interned)"]
+      VIEW["family View<br/>(wraps the typed pointer)"] --> PTR
+
+The six families
+----------------
+
+``TypeFamily`` enumerates ``Value``, ``TimeSeries``, ``Node``, ``Graph``,
+``Executor``, ``Clock``. ``TypeRole`` distinguishes ``Instance``,
+``Data``, ``Runtime``, ``Input``, ``Output`` — the TimeSeries family is
+the only one interning the same schema under three roles (Data, Input,
+Output).
+
+.. list-table::
+   :header-rows: 1
+   :widths: 12 22 18 24 24
+
+   * - Family
+     - Ops struct (root)
+     - TypeRef
+     - Schema type behind ``SchemaHeader``
+     - Primary factory / intern site
+   * - Value
+     - ``ValueOps``
+     - ``ValueTypeRef``
+     - ``ValueTypeMetaData``
+     - ``ValuePlanFactory::synthesise_type`` → ``intern_value_type``
+   * - TimeSeries
+     - ``TSDataOps``
+     - ``BasicTSTypeRef<Role>``
+     - ``TSValueTypeMetaData``
+     - ``TSDataPlanFactory`` per-kind factories → ``intern_ts_type``
+   * - Node
+     - ``NodeOps``
+     - ``NodeTypeRef``
+     - node runtime schema (``runtime/node.h``)
+     - node runtime-type interning (``runtime/node_type_ref.h``)
+   * - Graph
+     - ``GraphOps``
+     - ``GraphTypeRef``
+     - graph runtime schema (``runtime/graph.h``)
+     - graph runtime-type interning (``runtime/graph_type_ref.h``)
+   * - Executor
+     - ``GraphExecutorOps``
+     - ``ExecutorTypeRef``
+     - executor schema (``runtime/executor.h``)
+     - executor interning (``runtime/executor_type_ref.h``)
+   * - Clock
+     - ``EvaluationClockOps``
+     - ``ClockTypeRef``
+     - clock schema
+     - clock interning (``runtime/clock_type_ref.h``)
+
+Ops-ABI ledger
+--------------
+
+Every record stamps the ABI version of the ops table it points at;
+record validation rejects mismatches at interning time. Bump the
+constant when the ops struct layout changes.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 12 58
+
+   * - Constant
+     - Value
+     - Declared in
+   * - ``VALUE_OPS_ABI_VERSION``
+     - 6
+     - ``include/hgraph/types/value/value_ops.h``
+   * - ``TS_DATA_OPS_ABI_VERSION``
+     - 9
+     - ``include/hgraph/types/time_series/ts_type_ref.h``
+   * - ``NODE_OPS_ABI_VERSION``
+     - 4
+     - ``include/hgraph/runtime/node_type_ref.h``
+   * - ``GRAPH_OPS_ABI_VERSION``
+     - 7
+     - ``include/hgraph/runtime/graph_type_ref.h``
+   * - ``EXECUTOR_OPS_ABI_VERSION``
+     - 5
+     - ``include/hgraph/runtime/executor_type_ref.h``
+   * - ``CLOCK_OPS_ABI_VERSION``
+     - 1
+     - ``include/hgraph/runtime/clock_type_ref.h``
+
+.. _ops-catalogue-access-modes:
+
+Access modes
+------------
+
+The two tag bits on every typed pointer encode
+``ReadOnly`` / ``Writable`` / ``Mutation``. The transitions are checked:
+
+- ``begin_mutation`` requires a Writable or Mutation pointer **and**
+  the record capability ``Mutable``; on ``ValueView`` it additionally
+  requires the ops table to opt in (``allows_mutation``).
+- ``mutable_data`` / ``mutable_payload`` / ``try_mutable_as`` require
+  ``Mutation`` — a merely Writable pointer refuses them. Constructing a
+  view over raw memory yields Writable, so **typed in-place fast paths
+  must perform the explicit** ``begin_mutation()`` **re-tag or they
+  silently never engage** (this was the PR #479 review finding; the
+  engagement probe in ``tests/cpp/test_audit_behavior.cpp`` pins it).
+
+Value-layer ops
+---------------
+
+``ValueOps`` (``include/hgraph/types/value/value_ops.h``) is a passive
+struct of function pointers. The first member is the ``ValueOpsKind``
+discriminant; ``context`` comes next and is passed as the **first
+argument** to every slot. Groups of slots:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 50 28
+
+   * - Group
+     - Slots
+     - Default when null
+   * - compare / hash
+     - ``hash`` · ``equals`` · ``compare``
+     - ``hash`` **throws**; ``equals`` degrades to pointer identity;
+       ``compare`` degrades to null-ordering
+   * - render
+     - ``to_string`` · ``format_string``
+     - empty string; ``format_string`` falls back to ``to_string``
+   * - python bridge
+     - ``to_python`` · ``from_python`` · ``to_python_buffer``
+     - **throw**
+   * - copy / assign
+     - ``copy_construct_view`` · ``copy_assign_view`` ·
+       ``accepts_source`` · ``copy_assign_from`` · ``move_assign_from`` ·
+       ``can_materialize_source``
+     - fall back to the **plan's** ``LifecycleOps``;
+       ``accepts_source`` defaults to same-plan
+   * - projection
+     - ``owning_type`` · ``concrete_type`` · ``concrete_memory`` ·
+       ``mutable_concrete_memory`` · ``writable_concrete_memory``
+     - identity
+   * - metrics
+     - ``dynamic_storage_metrics``
+     - empty metrics
+
+.. note::
+
+   The null-slot policy is deliberately per-slot (a missing ``hash`` is
+   an error, a missing ``equals`` is a semantic default). When adding a
+   slot, record its default in the table above.
+
+Container ops derive from ``ValueOps`` by struct inheritance; the
+``ValueOpsKind`` discriminant makes narrowing safe.
+``try_value_ops<Ops>`` / ``checked_value_ops<Ops>`` validate the kind
+against the compatibility lattice before the downcast:
+
+.. mermaid::
+
+   classDiagram
+      ValueOps <|-- IndexedValueOps
+      IndexedValueOps <|-- ListValueOps
+      IndexedValueOps <|-- CyclicBufferValueOps
+      IndexedValueOps <|-- QueueValueOps
+      IndexedValueOps <|-- SetValueOps
+      IndexedValueOps <|-- MapValueOps
+      ListValueOps <|-- MutableListValueOps
+      SetValueOps <|-- MutableSetValueOps
+      MapValueOps <|-- MutableMapValueOps
+      class ValueOps {
+        kind · context · allows_mutation
+        hash / equals / compare
+        to_string · python hooks
+        copy/assign · projection
+      }
+      class IndexedValueOps {
+        size · element_at · element_binding
+        make_range · resize · element_valid
+      }
+      class MutableListValueOps {
+        push_back · set_element · erase
+        pop_back · clear · push_back_unset
+      }
+      class SetValueOps { contains }
+      class MutableSetValueOps { add · remove · clear }
+      class MapValueOps {
+        contains · value_at · value_binding
+        keys/values/kv ranges · key_set
+      }
+      class MutableMapValueOps {
+        insert · erase · clear · value_or_emplace
+      }
+
+.. note::
+
+   ``ValueOpsKind`` is an **ops-shape** tag, not a value-kind tag:
+   tuples, bundles, fixed lists, ``Owned[T]`` and polymorphic unions all
+   report ``Indexed``. Consult ``schema()->value_kind()`` for the
+   semantic kind.
+
+Value specialisation matrix
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``ValuePlanFactory::synthesise_type``
+(``src/hgraph/types/metadata/value_plan_factory.cpp``) is the single
+switch mapping schema kind × flags (owned, mutable, fixed-size, shaped
+array, storage variant) to a concrete plan + ops pair:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 26 26 26
+
+   * - Value kind
+     - Storage
+     - Ops installed
+     - Installer
+   * - atomic scalar
+     - raw ``T``
+     - ``ops_for<T>()`` (kind Base)
+     - ``TypeRegistry::register_scalar<T>``
+   * - enum
+     - ``Int``
+     - ``enum_ops_for(meta)`` (member-aware)
+     - ``type_registry.cpp``
+   * - tuple / bundle (fixed)
+     - flat composite bytes + hidden validity words
+     - ``composite_indexed_ops`` (per schema)
+     - ``value_plan_factory.cpp``
+   * - list, fixed
+     - array plan (stride × count)
+     - ``array_indexed_ops``
+     - ``value_plan_factory.cpp``
+   * - list / set / map / cyclic-buffer / queue, compact
+     - ``ListStorage`` … ``QueueStorage``
+       (``compact_storage.h``)
+     - ``compact_*_ops`` statics
+     - ``compact_container_ops.h``
+   * - list / set / map, mutable
+     - ``Mutable*Storage`` (slot stores)
+     - ``mutable_*_ops`` statics
+     - ``mutable_container_ops.h``
+   * - map key-set adapter
+     - *reuses the map's storage and plan*
+     - ``*_map_key_set_ops`` (read-only Set surface)
+     - ``compact_container_ops.cpp``
+   * - ``Any``
+     - embedded owning ``Value``
+     - ``any_ops()`` (kind Base)
+     - ``any_ops.cpp``
+   * - ``Owned[T]`` indirection
+     - one-word ``OwnedAllocation*``
+     - per-entry ``IndexedValueOps``
+     - ``value_plan_factory.cpp``
+   * - polymorphic union (inline / pooled)
+     - tag + max payload, or one-word pooled handle
+     - per-entry ``IndexedValueOps``
+     - ``type_realization.cpp`` /
+       ``pooled_polymorphic_value_type.cpp``
+   * - python-retained / python-owned bundle
+     - ``PythonValueHolder`` / ``PythonBundleValue``
+     - per-entry ops (GIL-taking)
+     - ``value_plan_factory.cpp`` / ``bridge_state.cpp``
+
+TS-layer ops
+------------
+
+``TSDataOps`` (``include/hgraph/types/time_series/ts_data/ops.h``) is
+the root table for every time-series payload+delta structure. Its
+context is the interned per-shape layout/context object; generic policy
+(validity checks, parent stamping, modification recording) lives on
+``TSDataView`` / ``TSDataMutationView``, never in the table.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 76
+
+   * - Group
+     - Members
+   * - identity / policy
+     - ``kind`` · ``context`` · ``allows_mutation`` ·
+       ``indexed_child_growth`` · ``direct_native_value``
+   * - sub-tables
+     - ``ownership_ops`` (nullable) · ``inspection_ops`` ·
+       ``current_state_ops`` · ``python_ops``
+   * - layout / tracking
+     - ``layout`` · ``tracking`` · ``mutable_tracking``
+   * - validity
+     - ``has_current_value`` · ``all_valid``
+   * - value / delta read
+     - ``value_view`` (nullable override) · ``delta_view`` (nullable) ·
+       ``value_memory`` · ``mutable_value_memory`` · ``delta_memory`` ·
+       ``mutable_delta_memory``
+   * - mutation
+     - ``copy_value_from`` · ``move_value_from`` (bool =
+       *first-for-time*, not success)
+   * - delta capture / apply
+     - ``empty_delta`` · ``capture_delta`` · ``delta_has_effect`` ·
+       ``apply_delta`` · ``clear_collection`` · ``reset_delta`` ·
+       ``record_child_modified``
+   * - children
+     - ``indexed_child_count`` · ``indexed_child_binding`` ·
+       ``indexed_child_memory`` · ``mutable_indexed_child_memory``
+   * - python (opt-in build)
+     - ``from_python`` · ``to_python`` · ``delta_to_python``
+
+``direct_native_value`` is the **typed fast-path gate**: set only by
+pure-native atomic storages (never for python-cached or python-only
+variants), it lets ``TSDataMutationView::mutable_value()`` hand out a
+Mutation-tagged ``ValueView`` over the raw payload so callers such as
+``Out<TS<T>>::set`` can assign in place and commit with
+``mark_modified()``, skipping the erased copy pipeline.
+
+Derived tables and sub-tables:
+
+.. mermaid::
+
+   classDiagram
+      TSDataOps <|-- TSSDataOps
+      TSSDataOps <|-- TSDDataOps
+      TSDataOps <|-- IndexedTSDataOps
+      TSDataOps <|-- TSWDataOps
+      TSDataOps ..> TSDataOwnershipOps : ownership_ops (nullable)
+      TSDataOps ..> TSDataInspectionOps : inspection_ops
+      TSDataOps ..> TSCurrentStateOps : current_state_ops (per kind)
+      TSDataOps ..> PythonTSDataOps : python_ops (per kind)
+      class TSSDataOps {
+        slot surface: size · occupied · added/removed
+        insert/remove key · touch · ranges
+        slot observers
+      }
+      class TSDDataOps {
+        child_at_slot · slot_modified
+        structural delta · 12 range makers
+      }
+      class IndexedTSDataOps {
+        size · element access
+        dense modified-index (nullable)
+      }
+      class TSWDataOps {
+        window: push · element/time_at
+        capacity · evicted/cleared
+      }
+
+The four sub-tables each answer one concern:
+
+- ``TSCurrentStateOps`` — record/replay reconciliation: eight per-kind
+  singleton tables selected once at factory time
+  (``src/hgraph/types/time_series/ts_delta.cpp``).
+- ``python_bridge::PythonTSDataOps`` — delta conversion and node-result
+  application per kind, plus a target-link alias table that
+  canonicalises through the bound target.
+- ``detail::TSDataOwnershipOps`` — owned-child enumeration used by the
+  parent-attachment / stop / invalidate tree walkers.
+- ``TSDataInspectionOps`` — cold-path field metadata consumed when
+  interning debug descriptors; only fixed bundles install a real table.
+
+TS specialisation matrix
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 16 22 20 42
+
+   * - TS kind
+     - Ops struct
+     - Context object
+     - Notes
+   * - ``TS`` / ``SIGNAL`` / ``REF``
+     - ``TSDataOps``
+     - ``AtomicTSDataOpsEntry``
+       (``ts_data_atomic_ops.cpp``)
+     - delta memory aliases value memory; storage-variant selection
+       (Native / NativeWithPythonCache / PythonOnly) happens here;
+       ``direct_native_value`` true only for Native
+   * - ``TSB`` / fixed ``TSL``
+     - ``IndexedTSDataOps``
+     - ``FixedTSDataContext``
+       (``ts_data_fixed_structured_ops.cpp``)
+     - children at planned offsets; recursion interns per-child records
+   * - dynamic ``TSL``
+     - ``IndexedTSDataOps``
+     - ``DynamicTSLContext``
+       (``ts_data_dynamic_list_ops.cpp``)
+     - grow-only child slots; sole user of ``indexed_child_growth``
+   * - ``TSS``
+     - ``TSSDataOps``
+     - ``TSSContext``
+       (``ts_data_slot_ops.cpp``)
+     - slot store + added/removed bitsets; lazy delta-window roll
+   * - ``TSD``
+     - ``TSDDataOps``
+     - ``TSDContext``
+       (``ts_data_slot_ops.cpp``)
+     - inherits the TSS key surface; owns child TSData slots; exposes a
+       read-only key-set projection with dedicated tracking
+   * - ``TSW`` (tick / duration)
+     - ``TSWDataOps``
+     - ``SizeTSWContext`` / ``TimeTSWContext``
+       (``ts_data_window_ops.cpp``)
+     - ring storage; validity policy differs per strategy
+   * - target-link alias (input side, every kind)
+     - matching derived struct
+     - ``TSInputTargetLinkContext``
+       (``ts_input/target_link_ops.cpp``)
+     - no owned payload — forwards to the bound target; the only tables
+       installing ``value_view`` / ``delta_view`` overrides
+   * - ``TSD`` proxy (REF adaptation)
+     - ``TSDDataOps`` (read-only)
+     - ``TSDProxyContext`` (``ts_data/proxy.cpp``)
+     - mirrors a source TSD through reference adaptation
+
+Every context object is interned in a per-family, mutex-guarded map
+(counted ``TypeSystemMutex`` — build-time only, per the 2026-07-02
+lock-free ruling). Contexts also intern the **value-layer** ops whose
+records become ``layout.value_binding`` / ``delta_binding`` — the TS
+layer manufactures ``ValueTypeRef`` s that project live TSData as plain
+value views.
+
+Dispatch chains
+---------------
+
+The typed write path (``Out<TS<T>>::set``):
+
+.. mermaid::
+
+   flowchart TD
+      SET["Out&lt;TS&lt;T&gt;&gt;::set(value)"] --> BM["TSOutputView::begin_mutation(et)<br/>re-tags pointer Writable → Mutation"]
+      BM --> MV["TSDataMutationView::mutable_value()"]
+      MV --> GATE{"ops.direct_native_value<br/>and value ops allow mutation?"}
+      GATE -- yes --> TRY{"try_mutable_as&lt;T&gt;()"}
+      TRY -- match --> FAST["assign in place<br/>mark_modified()"]
+      GATE -- no --> ERASED["erased path:<br/>copy_value_from → value-layer copy_assign_from"]
+      TRY -- mismatch --> ERASED
+      FAST --> REC["record_modified_local<br/>observers.notify"]
+      ERASED --> FFT{"first for time?"}
+      FFT -- yes --> REC
+      REC --> PARENT["notify_parent_modified<br/>TSParentLink bubble to endpoint"]
+
+The read path (``In<TS<Int>>::value()``, active peered slot):
+
+.. mermaid::
+
+   flowchart TD
+      VAL["In&lt;TS&lt;Int&gt;&gt;::value()"] --> CUR["InputDataCursor::resolved_value_data()"]
+      CUR --> TRUST{"route bound · locally active ·<br/>value observation · target bound?"}
+      TRUST -- yes --> DV["observed.data_view()<br/>(handle resolved at subscribe time)"]
+      TRUST -- no --> SLOW["target_link_resolve<br/>full path projection"]
+      DV --> TSV["TSDataView::value()"]
+      SLOW --> TSV
+      TSV --> OPS["ops.layout / ops.value_memory<br/>(fn-ptr hops)"]
+      OPS --> VV["ValueView · concrete()"]
+      VV --> CA["checked_as&lt;Int&gt;<br/>(atomicity + ops-address identity checks)"]
+      CA --> LOAD["load the Int"]
+
+Terminology notes
+-----------------
+
+- The parent-link type is ``TSParentLink`` (kinds in
+  ``TSParentLinkKind``; terminal interface ``TSDataParent``). Older doc
+  revisions used the name *TSDataParentLink*, which never existed in
+  code.
+- ``TSDataTypeRef`` / ``TSInputTypeRef`` / ``TSOutputTypeRef`` are
+  aliases of ``BasicTSTypeRef<TypeRole>``, not distinct classes.
+- The word *binding* survives only in the runtime-connection sense
+  (``TSOutputView::binding_for`` negotiates output representation for a
+  binding input). As **type metadata** the term is retired — the anchor
+  is the ``TypeRecord`` and its TypeRefs
+  (:doc:`../unified_type_erasure`).
+- ``TSState`` remains conceptual vocabulary only; no such C++ type
+  exists.

--- a/docs/source/developer_guide/data_structures/plans_and_ops/scalar.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/scalar.rst
@@ -80,9 +80,9 @@ cached by value against the schema.
   *Container Storage Shapes* below. ``plan_for`` synthesises the
   matching plan on first request, attaching a per-instantiation
   ``*State`` struct as the ``StoragePlan::lifecycle_context`` so the
-  lifecycle hooks know how to construct the storage. ``binding_for``
-  is replaced by ``type_for``, which pairs the plan with the compact
-  kind-specific ops table in the common type-record registry.
+  lifecycle hooks know how to construct the storage. ``type_for``
+  pairs the plan with the compact kind-specific ops table in the
+  common type-record registry.
 
 The time-series layer has the matching ``TSDataPlanFactory`` for the
 payload/delta component inside a time-series endpoint. Atomic TSData

--- a/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
@@ -44,7 +44,7 @@ The implementation uses the following names consistently:
        ``TSState`` is a *conceptual grouping*, not a distinct runtime type in
        the current code. The state it names is realised inside ``TSData`` —
        chiefly the per-level ``TSDataTracking`` record (``last_modified_time``,
-       ``TSDataParentLink``) and ``TSDataObserverSet`` — together with
+       ``TSParentLink``) and ``TSDataObserverSet`` — together with
        endpoint-local state on ``TSOutput`` / ``TSInput``. Use the name when
        discussing the *role*; do not expect a ``TSState`` class to exist.
 
@@ -405,7 +405,7 @@ Views are not stored in TargetLink state. Endpoint views materialize
 transient ``TSDataView`` cursors from the stored ``TSOutputHandle`` when
 they need to navigate or read the target. They also avoid storing
 input and target path vectors. Non-peered positions derive their
-logical input path from ``TSDataParentLink`` only when activation needs
+logical input path from ``TSParentLink`` only when activation needs
 to touch the root active trie. Positions below a TargetLink carry a
 pointer into the link's descendant trie; that node records the
 input-to-output transition identity, while the projected output
@@ -627,7 +627,7 @@ bindings and memory offsets needed by the concrete implementation:
   value;
 - ``tracking`` — the common ``TSDataTracking`` record. Every TSData
   shape, including compact atomic TSData, has one. It stores
-  ``last_modified_time`` and the optional ``TSDataParentLink`` used
+  ``last_modified_time`` and the optional ``TSParentLink`` used
   when the data is projected as a child.
 
 The diagrams below are conceptual. ``StoragePlan`` still owns the
@@ -785,7 +785,7 @@ subobject when the child is selected. The child storage type is the canonical
 embedded role record over the independent child plan; slot, dynamic-list, and
 window ops still receive a pointer to their own storage object and do not know
 about the parent's root allocation. Parent notification uses the existing
-``TSDataParentLink`` installed by child view projection.
+``TSParentLink`` installed by child view projection.
 
 When a fixed parent contains projected child storage, its ``value()`` and
 delta surfaces are projected from child views instead of exposing a stale
@@ -851,7 +851,7 @@ fixed ``TSL`` it exposes the documented map-shaped delta
 ``Map<int, child.delta>`` and iterates only child indices modified at
 ``t``.
 
-Projecting a child stores a ``TSDataParentLink`` in the child node's
+Projecting a child stores a ``TSParentLink`` in the child node's
 tracking region. The link records the immediate parent storage-type/data
 identity (a canonical role record) and the parent-local field/index
 id. It does not point at the
@@ -976,7 +976,7 @@ transient parent view that created it:
       Type["TSRoleTypeRef<br/>canonical TypeRecord"]
       Data["TSData storage allocation<br/>value + optional delta + tracking"]
       Tracking["TSDataTracking<br/>last_modified_time<br/>parent<br/>observers"]
-      Link["TSDataParentLink<br/>tagged parent identity<br/>payload union<br/>child_id"]
+      Link["TSParentLink<br/>tagged parent identity<br/>payload union<br/>child_id"]
       Observers["TSDataObserverSet<br/>null / single / vector"]
       ParentData["parent TSData storage"]
       Endpoint["terminal endpoint<br/>TSOutput / TSInput"]
@@ -993,7 +993,7 @@ transient parent view that created it:
 The parent identity is tagged so the link carries exactly one parent
 kind. For a TSData parent it stores ``TypeRecord + data``; for an endpoint
 parent it stores the endpoint pointer in the same payload slot. Because
-each TSData parent also stores its own ``TSDataParentLink``, a child link
+each TSData parent also stores its own ``TSParentLink``, a child link
 can walk back to the root TSData without retaining transient views. The
 walk stops at the endpoint link. The same walk produces the
 root-to-child navigation path as integer field/index/slot ids.
@@ -1026,7 +1026,7 @@ Modification handling is deliberately split into three responsibilities.
 ``TSData`` tracks local modification state and per-level observers;
 projecting child data records the immediate parent binding/data identity
 and parent-relative child id into the child's tracking region; and child
-mutations notify their parent only through ``TSDataParentLink``. The link
+mutations notify their parent only through ``TSParentLink``. The link
 hides the parent-specific details by invoking the parent's
 ``record_child_modified(parent_data, child_id)`` hook before marking the
 parent modified. Marking a TSData level modified updates
@@ -1167,14 +1167,14 @@ the parent bitset is the parent's delta surface, not a duplicate
 timestamp store.
 
 The bubble-up path uses the slot id carried by the child's
-``TSDataParentLink``:
+``TSParentLink``:
 
 .. mermaid::
 
    flowchart TD
       ChildMutation["child TSDataMutationView"]
       Mark["mark_modified() / copy_value_from()"]
-      ParentLink["child tracking<br/>TSDataParentLink(parent, s)"]
+      ParentLink["child tracking<br/>TSParentLink(parent, s)"]
       ParentHook["parent ops<br/>record_child_modified(parent_data, s)"]
       ModifiedBit["parent modified bitset[s] = 1"]
       ParentTime["parent last_modified_time<br/>= current evaluation time"]
@@ -1372,7 +1372,7 @@ slot ids for the current evaluation time so the layer can publish
 
 These structural slot observers are internal synchronisation hooks, not
 the public change-notification surface. Per-level change propagation
-uses the ``TSDataParentLink`` stored in child tracking plus the
+uses the ``TSParentLink`` stored in child tracking plus the
 ``record_child_modified`` hook on the parent ops table. The parent link
 owns the child id because that id is a parent-local slot/path
 identifier. It can also resolve the root ``TSDataView`` and the

--- a/docs/source/developer_guide/data_structures/type_erasure_inventory.rst
+++ b/docs/source/developer_guide/data_structures/type_erasure_inventory.rst
@@ -61,7 +61,7 @@ but it is an exception to the desired two-word pointer model.
 The complete current-layout baseline is enforced by
 ``tests/cpp/test_type_erasure_layout.cpp``:
 
-.. list-table:: Current erased layout baseline
+.. list-table:: Milestone-0 erased layout baseline
    :header-rows: 1
    :widths: 42 18 40
 
@@ -136,7 +136,7 @@ Only value and time-series schemas currently share ``TypeMetaData`` and its
 unrelated C++ types.  Every family has a narrow ops ABI; there is no common ops
 prefix and no runtime family discriminator on a binding.
 
-.. list-table:: Current schema and ops families
+.. list-table:: Milestone-0 schema and ops families
    :header-rows: 1
    :widths: 13 22 25 24 16
 
@@ -239,7 +239,7 @@ Binding Specializations
 Pointers, Views, Owners, And Builders
 -------------------------------------
 
-.. list-table:: Current object classification and ownership
+.. list-table:: Milestone-0 object classification and ownership
    :header-rows: 1
    :widths: 24 15 26 35
 
@@ -309,7 +309,7 @@ must not be mechanically renamed without preserving their endpoint semantics.
 Factories, Registries, And Reset
 --------------------------------
 
-.. list-table:: Current interning and factory layers
+.. list-table:: Milestone-0 interning and factory layers
    :header-rows: 1
    :widths: 25 38 37
 

--- a/docs/source/developer_guide/data_structures/unified_type_erasure.rst
+++ b/docs/source/developer_guide/data_structures/unified_type_erasure.rst
@@ -545,7 +545,7 @@ the same factory that resolves the type record. The data-only layouts are:
        DebugDynamicKind kind;
        std::uint8_t reserved0;
        DebugDynamicFlags flags;
-       std::uint32_t reserved1;
+       std::uint32_t key_auxiliary_offset;
        std::size_t size_offset;
        std::size_t size_constant;
        std::size_t data_offset;
@@ -557,7 +557,7 @@ the same factory that resolves the type record. The data-only layouts are:
        std::size_t entry_offset;
    };
 
-The descriptor is 64 bytes and each fixed field is 32 bytes on supported
+The descriptor is 72 bytes and each fixed field is 32 bytes on supported
 64-bit platforms. Atomic representation is selected from the registered C++
 type, never inferred from a semantic label: bool, signed/unsigned integers, and
 32/64-bit floating point values can be decoded directly; other atomic storage

--- a/docs/source/developer_guide/data_structures/unified_type_erasure.rst
+++ b/docs/source/developer_guide/data_structures/unified_type_erasure.rst
@@ -537,6 +537,7 @@ the same factory that resolves the type record. The data-only layouts are:
        const TypeRecord *key_type;
        const TypeRecord *element_type;
        const DebugDynamicLayout *dynamic_layout;
+       const DebugTimeSeriesLayout *time_series_layout;
    };
 
    struct DebugDynamicLayout {
@@ -564,7 +565,11 @@ type, never inferred from a semantic label: bool, signed/unsigned integers, and
 remains explicitly opaque. Fixed-composite fields connect semantic child type
 records to physical plan offsets. Tuple and bundle descriptors also publish the
 validity-word offset and one bit index per field, so an unset child is displayed
-as typed-null rather than reading uninitialised payload bytes.
+as typed-null rather than reading uninitialised payload bytes. Time-series
+records additionally publish ``time_series_layout`` — the value/delta type
+records plus the value, tracking, last-modified, parent-link, and observer
+offsets (and whether the delta aliases the value) — so debugger tooling can
+inspect live TSData without invoking any ops table.
 
 The version-three dynamic layout remains 88 bytes on supported 64-bit
 platforms. It distinguishes contiguous storage from stable pointer slots and

--- a/docs/source/developer_guide/data_structures/unified_type_erasure_implementation_plan.rst
+++ b/docs/source/developer_guide/data_structures/unified_type_erasure_implementation_plan.rst
@@ -4,6 +4,14 @@ Unified Type Erasure Implementation Plan
 Status And Scope
 ----------------
 
+.. admonition:: Historical record
+
+   This plan is **complete** — every milestone through M15 was implemented,
+   reviewed, and committed. The chapter is retained as the migration's
+   process and evidence log. For the current shape of the type system see
+   :doc:`unified_type_erasure` and
+   :doc:`plans_and_ops/ops_catalogue`.
+
 This chapter is the proposed delivery plan for :doc:`unified_type_erasure`.
 Each milestone must be independently buildable, testable, reviewable, and
 reversible.  The migration must not require a flag day across values,
@@ -285,8 +293,9 @@ Iteration 4D
    dynamic roots are supported; non-peered dynamic structural prefixes remain
    rejected. Window removal queries at the data layer require an explicit
    evaluation time, while input endpoints supply the current cycle. Window
-   buffer and eviction algorithms are unchanged. This records implementation
-   status only; review acceptance and commit status remain open.
+   buffer and eviction algorithms are unchanged. (Review acceptance and
+   commit are recorded in the later milestone entries; the plan completed
+   through Milestone 15.)
 
 Technical model
    TS, TSS, TSL, TSB, TSD, and REF remain schema kinds.  Data, Input, and Output


### PR DESCRIPTION
## What

**New `plans_and_ops/ops_catalogue.rst`** — the current-state reference the erasure corpus lacked: a docs audit found the only family-wide ops matrix lives in the *historical* Milestone-0 inventory (using type names removed in Milestone 9), `TSDataOps`'s ~30 fn-ptrs and its four sub-tables essentially undocumented, and zero diagrams in `unified_type_erasure.rst`. The catalogue adds:

- the `TypeRecord` anchor diagram (record → schema/plan/ops/debug → TypeRefs → tagged typed pointers)
- the six-family matrix and the ops-ABI ledger (Value 6, TSData 9, Node 4, Graph 7, Executor 5, Clock 1)
- `ValueOps` / `TSDataOps` grouped member tables with the per-slot null-default policy
- container-ops and TS-ops inheritance diagrams; value and TS specialisation matrices
- the typed read/write dispatch chains, including the `direct_native_value` gate
- access-mode rules (the Writable-vs-Mutation re-tag trap, pinned)

**Staleness fixes**, reconciling toward the code per CLAUDE.md §2.4:
- `time_series.rst`: `TSDataParentLink` → `TSParentLink` (11 uses; the doc name never existed in code)
- `unified_type_erasure.rst`: `DebugDescriptor` is 72 bytes (code asserts 9 words), not 64; the `DebugDynamicLayout` snippet's `reserved1` is `key_auxiliary_offset`
- `erased_types.rst`: `TypeRecord` snippet now matches `type_record.h`; mutable map is implemented, not pending
- `scalar.rst` / `core_concepts.rst`: retire the transitional *binding* vocabulary
- `type_erasure_inventory.rst`: "Current …" tables retitled "Milestone-0 …"
- `unified_type_erasure_implementation_plan.rst`: historical-record banner; stale 4D leftover fixed

Docs build green with `-W --keep-going` (CI parity).

## Stack

Based on `perf/typed-scalar-set-mainline` (PR #482) because the catalogue documents `direct_native_value`, which is in #482's content. **Merge #482 first, then retarget this PR to main before merging** — verify with `git merge-base --is-ancestor` (the #479 lesson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)