### PR TITLE
Work through the remaining erasure-audit findings

### DIFF
--- a/docs/source/developer_guide/data_structures/plans_and_ops/erased_types.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/erased_types.rst
@@ -223,13 +223,15 @@ the lifted kernels read through it and fall back to the erased
 read-side twin, skipping the two transient value views, the
 ``concrete()`` projection, and the per-read ``checked_as`` ceremony).
 
-The mutation is closed by calling ``end_mutation()`` on the mutable
-view. For the current scalar value-layer ops this is a no-op; the
-method exists so the same view contract can be used by slot-store-
-backed time-series ops, where close-time hooks update delta state.
-Those future mutable views should also provide RAII closure so a
-mutation is not left dangling if a caller forgets to close it
-explicitly or an exception unwinds the stack.
+Mutation closure is owned by the layer that opened it. Value-layer
+mutation views are transient — dropping the view ends the scope; there
+is no close call (an earlier no-op ``end_mutation()`` placeholder was
+removed as dead API). The time-series layer closes mutations through
+``TSDataMutationView``'s RAII scope, whose commit path performs the
+modification recording and parent notification. The pointer-level
+``AnyPtr::end_mutation`` / ``TypedPtr::end_mutation`` downgrade
+(Mutation back to Writable) remains for callers that hold tagged
+pointers across a scope boundary.
 
 .. note::
 
@@ -279,9 +281,9 @@ The base specialised views never expose mutation methods other than
 the explicit transition call. Mutation goes through a separate
 **mutable** view obtained from the read-only/writable view by calling
 ``begin_mutation()`` (see *Read-Only and Mutable Views* above). The
-mutable view is closed with ``end_mutation()`` and is the only place
-per-element ``set`` / ``insert`` / ``remove`` / ``push_back`` style
-operations exist. Compact value-layer container storage does not allow
+mutable view is the only place per-element ``set`` / ``insert`` /
+``remove`` / ``push_back`` style operations exist, and its scope ends
+when the view is dropped. Compact value-layer container storage does not allow
 that transition; replacement happens at the ``Value`` level
 (whole-container copy/move or ``from_python()``).
 

--- a/docs/source/developer_guide/data_structures/plans_and_ops/ops_catalogue.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/ops_catalogue.rst
@@ -239,6 +239,16 @@ argument** to every slot. Groups of slots:
      Set schema (the projection reuses the map's storage); this is the
      one sanctioned violation of "the plan describes the schema's
      layout".
+   - Per-kind delta policy is declared in ``ts_data/ops.h``, installed
+     by the metadata factories, and implemented in ``ts_delta.cpp`` —
+     three homes by design: the free functions ARE the kind policy and
+     the factories select them once. Consolidating would re-architect
+     the factory split for locality alone; navigate via this catalogue.
+   - Compact container storages carry their element binding both in the
+     plan's state and per instance (8+ bytes each). Removing the copy
+     means per-instantiation ops contexts instead of shared statics —
+     deferred until a measured need; do not add new per-instance
+     duplicates.
 
 Container ops derive from ``ValueOps`` by struct inheritance; the
 ``ValueOpsKind`` discriminant makes narrowing safe.

--- a/docs/source/developer_guide/data_structures/plans_and_ops/ops_catalogue.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/ops_catalogue.rst
@@ -220,6 +220,26 @@ argument** to every slot. Groups of slots:
    an error, a missing ``equals`` is a semantic default). When adding a
    slot, record its default in the table above.
 
+.. admonition:: Recorded exceptions (audit 2026-08-16, accepted)
+
+   - ``CyclicBufferValueOps::head`` and ``QueueValueOps::front`` take
+     only ``(memory)`` — no leading context. Aligning them costs a
+     ValueOps ABI bump for zero functional gain; accepted as-is. Do not
+     copy the shape into new slots.
+   - ``equals_impl`` may throw while ``compare_impl`` is ``noexcept``;
+     ``ValueView::compare`` fences its semantic fallback with
+     ``fallback_on_exception``. The asymmetry is cosmetic and the fence
+     is load-bearing — changing either signature is an ABI bump with no
+     behavioural benefit.
+   - ``TSDataOps.copy_value_from`` / ``move_value_from`` return
+     *first-for-time*, while ``from_python``'s bool is cross-checked
+     against modification recording — same shape, different meaning.
+     Read the member docs before implementing a new strategy.
+   - The map key-set adapter records intern the **map's** plan under a
+     Set schema (the projection reuses the map's storage); this is the
+     one sanctioned violation of "the plan describes the schema's
+     layout".
+
 Container ops derive from ``ValueOps`` by struct inheritance; the
 ``ValueOpsKind`` discriminant makes narrowing safe.
 ``try_value_ops<Ops>`` / ``checked_value_ops<Ops>`` validate the kind

--- a/docs/source/developer_guide/data_structures/plans_and_ops/ops_catalogue.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/ops_catalogue.rst
@@ -348,7 +348,8 @@ context is the interned per-shape layout/context object; generic policy
      - Members
    * - identity / policy
      - ``kind`` · ``context`` · ``allows_mutation`` ·
-       ``indexed_child_growth`` · ``direct_native_value``
+       ``indexed_child_growth`` · ``direct_native_value`` ·
+       ``is_target_link``
    * - sub-tables
      - ``ownership_ops`` (nullable) · ``inspection_ops`` ·
        ``current_state_ops`` · ``python_ops``

--- a/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
@@ -137,7 +137,10 @@ The implementation uses the following names consistently:
     owned Input selects the corresponding physical plan under a read-only
     role, while peered positions select target-link storage and ops.
     ``TS_DATA_OPS_ABI_VERSION`` is 10. ABI 10 removes the never-dispatched
-    ``reset_delta`` hook (slot deltas roll lazily inside the storages). ABI 9
+    ``reset_delta`` hook (slot deltas roll lazily inside the storages), adds
+    the explicit ``is_target_link`` discriminator (replacing an
+    ownership-ops pointer-identity comparison), and gives the required TSW
+    window members named throwing defaults. ABI 9
     adds an explicit data-only
     inspection table for debugger-visible representation fields. ABI 8 adds
     recursive source-topology validation to the current-state strategy table

--- a/include/hgraph/types/time_series/ts_data/ops.h
+++ b/include/hgraph/types/time_series/ts_data/ops.h
@@ -98,6 +98,14 @@ namespace hgraph
         HGRAPH_EXPORT void missing_subscribe_slot_observer(const void *, void *, SlotObserver *);
         HGRAPH_EXPORT void missing_unsubscribe_slot_observer(const void *, void *, SlotObserver *);
         [[nodiscard]] HGRAPH_EXPORT const void *missing_child_at_slot(const void *, const void *, std::size_t);
+        [[nodiscard]] HGRAPH_EXPORT std::size_t missing_window_size(const void *, const void *);
+        [[nodiscard]] HGRAPH_EXPORT const void *missing_window_element(const void *, const void *, std::size_t);
+        [[nodiscard]] HGRAPH_EXPORT DateTime missing_window_time(const void *, const void *, std::size_t);
+        [[nodiscard]] HGRAPH_EXPORT const void *missing_window_time_element(const void *, const void *, std::size_t);
+        [[nodiscard]] HGRAPH_EXPORT std::size_t missing_window_capacity(const void *, const void *);
+        [[nodiscard]] HGRAPH_EXPORT bool missing_window_full(const void *, const void *);
+        HGRAPH_EXPORT void missing_window_push(const void *, void *, const ValueView &, DateTime);
+        HGRAPH_EXPORT void missing_window_clear(const void *, void *, DateTime);
 
         [[nodiscard]] Value empty_delta_atomic(const TSRoleTypeRef &binding);
         [[nodiscard]] Value empty_delta_tss(const TSRoleTypeRef &binding);
@@ -176,6 +184,12 @@ namespace hgraph
         // copy_value_from_impl, which owns their invalidation rules. Gates
         // TSDataMutationView::mutable_value() — the typed fast-write path.
         bool        direct_native_value{false};
+        // True only for the input-side target-link alias tables, which own no
+        // payload and forward to the bound target. The explicit flag is the
+        // discriminator target_link_context_for_ops keys on; it replaced a
+        // fragile ownership-ops pointer-identity comparison (audit finding,
+        // 2026-08-16).
+        bool        is_target_link{false};
         const detail::TSDataOwnershipOps *ownership_ops{nullptr};
         const TSDataInspectionOps *inspection_ops{
             &ts_data_detail::empty_inspection_ops()};
@@ -399,15 +413,27 @@ namespace hgraph
 
     struct TSWDataOps : TSDataOps
     {
-        std::size_t (*size_impl)(const void *context, const void *memory) = nullptr;
-        const void *(*element_at_impl)(const void *context, const void *memory, std::size_t index) = nullptr;
-        DateTime (*time_at_impl)(const void *context, const void *memory, std::size_t index) = nullptr;
-        const void *(*time_element_at_impl)(const void *context, const void *memory, std::size_t index) = nullptr;
-        std::size_t (*capacity_impl)(const void *context, const void *memory) = nullptr;
-        bool (*full_impl)(const void *context, const void *memory) = nullptr;
+        // Required window surface: defaults throw with the member's name so a
+        // strategy that forgets an install fails loudly instead of crashing
+        // through a null fn-ptr (audit finding, 2026-08-16).
+        std::size_t (*size_impl)(const void *context,
+                                 const void *memory) = &ts_data_detail::missing_window_size;
+        const void *(*element_at_impl)(const void *context, const void *memory,
+                                       std::size_t index) = &ts_data_detail::missing_window_element;
+        DateTime (*time_at_impl)(const void *context, const void *memory,
+                                 std::size_t index) = &ts_data_detail::missing_window_time;
+        const void *(*time_element_at_impl)(const void *context, const void *memory,
+                                            std::size_t index) = &ts_data_detail::missing_window_time_element;
+        std::size_t (*capacity_impl)(const void *context,
+                                     const void *memory) = &ts_data_detail::missing_window_capacity;
+        bool (*full_impl)(const void *context, const void *memory) = &ts_data_detail::missing_window_full;
         void (*push_impl)(const void *context, void *memory, const ValueView &source,
-                          DateTime modified_time) = nullptr;
-        void (*clear_impl)(const void *context, void *memory, DateTime modified_time) = nullptr;
+                          DateTime modified_time) = &ts_data_detail::missing_window_push;
+        void (*clear_impl)(const void *context, void *memory,
+                           DateTime modified_time) = &ts_data_detail::missing_window_clear;
+        // Optional capabilities: null means the strategy does not track the
+        // fact, and the window views degrade gracefully (no cleared/evicted
+        // reporting). Same null-slot idiom as ValueOps optional hooks.
         DateTime (*cleared_time_impl)(const void *context, const void *memory) = nullptr;
         // The element most recently EVICTED by a push (hgraph's
         // removed_value): the time it fell out plus its value memory

--- a/include/hgraph/types/time_series/ts_data/ops.h
+++ b/include/hgraph/types/time_series/ts_data/ops.h
@@ -385,6 +385,20 @@ namespace hgraph
     };
 
     /**
+     * Reset every mutating entry point of a cloned set-surface table back to
+     * its throwing default, making the clone a strictly read-only projection
+     * (over and above the ``allows_mutation`` gate). This is THE single
+     * enumeration of the family's mutators: a new mutating member MUST be
+     * stripped here, or every read-only projection cloned from a live table
+     * silently keeps it callable — the fail-open hazard the 2026-08-16 audit
+     * flagged (the previous inline strip already missed move_value_from,
+     * clear_collection, mutable_indexed_child_memory, and reserve).
+     * Tracking hooks are deliberately untouched: projections keep dedicated
+     * tracking and subscription wiring.
+     */
+    HGRAPH_EXPORT void strip_to_read_only(TSSDataOps &ops) noexcept;
+
+    /**
      * Extension ops for TSData shapes with indexed element access.
      *
      * Fixed and dynamic TSL can share this view-facing surface while keeping

--- a/include/hgraph/types/value/compact_container_ops.h
+++ b/include/hgraph/types/value/compact_container_ops.h
@@ -990,8 +990,6 @@ namespace hgraph
             return result;
         }
 
-        void map_key_adapter_from_python(const void *, const ValueTypeRef &binding, void *memory,
-                                         nb::handle source);
 #endif
     }  // namespace container_ops_detail
 
@@ -1017,33 +1015,35 @@ namespace hgraph
         void compact_list_copy_assign_from(
             const void *, ValueTypeRef binding, void *dst,
             ValueTypeRef source, const void *src);
-        void compact_list_move_assign_from(
-            const void *, ValueTypeRef binding, void *dst,
-            ValueTypeRef source, void *src);
         void compact_set_copy_assign_from(
             const void *, ValueTypeRef binding, void *dst,
             ValueTypeRef source, const void *src);
-        void compact_set_move_assign_from(
-            const void *, ValueTypeRef binding, void *dst,
-            ValueTypeRef source, void *src);
         void compact_map_copy_assign_from(
             const void *, ValueTypeRef binding, void *dst,
             ValueTypeRef source, const void *src);
-        void compact_map_move_assign_from(
-            const void *, ValueTypeRef binding, void *dst,
-            ValueTypeRef source, void *src);
         void compact_cyclic_buffer_copy_assign_from(
             const void *, ValueTypeRef binding, void *dst,
             ValueTypeRef source, const void *src);
-        void compact_cyclic_buffer_move_assign_from(
-            const void *, ValueTypeRef binding, void *dst,
-            ValueTypeRef source, void *src);
         void compact_queue_copy_assign_from(
             const void *, ValueTypeRef binding, void *dst,
             ValueTypeRef source, const void *src);
-        void compact_queue_move_assign_from(
-            const void *, ValueTypeRef binding, void *dst,
-            ValueTypeRef source, void *src);
+
+        /** Shared move-assign: identical bindings move storage directly;
+            cross-representation moves rebuild through the kind's
+            copy_assign_from (compact storages have nothing cheaper to
+            steal across representations). One template replaces five
+            hand-written identical wrappers (audit finding, 2026-08-16). */
+        template <auto CopyAssignFrom>
+        void compact_move_assign_via_copy(const void *context, ValueTypeRef binding, void *dst,
+                                          ValueTypeRef source, void *src)
+        {
+            if (binding == source)
+            {
+                binding.move_assign_at(dst, src);
+                return;
+            }
+            CopyAssignFrom(context, binding, dst, source, src);
+        }
 
         template <typename Storage>
         [[nodiscard]] DynamicStorageMetrics compact_dynamic_storage_metrics(
@@ -1100,7 +1100,9 @@ namespace hgraph
                 value.element_valid = &container_ops_detail::list_element_valid;
                 value.accepts_source_impl = &compact_accepts_source;
                 value.copy_assign_from_impl = &compact_list_copy_assign_from;
-                value.move_assign_from_impl = &compact_list_move_assign_from;
+                value.move_assign_from_impl =
+                &container_ops_detail::compact_move_assign_via_copy<
+                    &container_ops_detail::compact_list_copy_assign_from>;
                 return value;
             }();
             return ops;
@@ -1144,7 +1146,8 @@ namespace hgraph
             value.copy_assign_from_impl =
                 &container_ops_detail::compact_set_copy_assign_from;
             value.move_assign_from_impl =
-                &container_ops_detail::compact_set_move_assign_from;
+                &container_ops_detail::compact_move_assign_via_copy<
+                    &container_ops_detail::compact_set_copy_assign_from>;
             return value;
         }();
         return ops;
@@ -1204,7 +1207,8 @@ namespace hgraph
             value.copy_assign_from_impl =
                 &container_ops_detail::compact_map_copy_assign_from;
             value.move_assign_from_impl =
-                &container_ops_detail::compact_map_move_assign_from;
+                &container_ops_detail::compact_move_assign_via_copy<
+                    &container_ops_detail::compact_map_copy_assign_from>;
             return value;
         }();
         return ops;
@@ -1242,7 +1246,8 @@ namespace hgraph
             value.copy_assign_from_impl =
                 &container_ops_detail::compact_cyclic_buffer_copy_assign_from;
             value.move_assign_from_impl =
-                &container_ops_detail::compact_cyclic_buffer_move_assign_from;
+                &container_ops_detail::compact_move_assign_via_copy<
+                    &container_ops_detail::compact_cyclic_buffer_copy_assign_from>;
             return value;
         }();
         return ops;
@@ -1280,7 +1285,8 @@ namespace hgraph
             value.copy_assign_from_impl =
                 &container_ops_detail::compact_queue_copy_assign_from;
             value.move_assign_from_impl =
-                &container_ops_detail::compact_queue_move_assign_from;
+                &container_ops_detail::compact_move_assign_via_copy<
+                    &container_ops_detail::compact_queue_copy_assign_from>;
             return value;
         }();
         return ops;
@@ -1304,7 +1310,10 @@ namespace hgraph
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
               ,
               &container_ops_detail::map_key_adapter_to_python,
-              &container_ops_detail::map_key_adapter_from_python
+              // Read-only projection: null = unsupported, the one idiom for
+              // the fact (the wrapper throws); a bespoke throwing thunk was
+              // a second idiom for the same statement.
+              nullptr
 #endif
              },
              &container_ops_detail::map_size,

--- a/include/hgraph/types/value/value_view.h
+++ b/include/hgraph/types/value/value_view.h
@@ -164,8 +164,6 @@ namespace hgraph
             return ValueView{pointer_.begin_mutation(), TrustedPointer{}};
         }
 
-        void end_mutation() const noexcept {}
-
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
         /**
          * Assign this view's storage FROM a python object through the

--- a/src/hgraph/types/metadata/ts_data_slot_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_slot_ops.cpp
@@ -2164,32 +2164,14 @@ namespace hgraph::ts_data_plan_factory_detail
                 // dictionary's value ticks (subscriptions stay on the shared
                 // root set, so notification wiring is unchanged).
                 key_set_ts_ops = set_ops;
-                {
-                    // The projection is STRICTLY read-only: it reports the
-                    // owner's mutations (dedicated tracking + observers) but
-                    // can never perform one — every mutating entry point is
-                    // stripped back to the throwing defaults, over and above
-                    // the ``allows_mutation = false`` gate.
-                    const TSDataOps  read_only_base{};
-                    const TSSDataOps read_only_set{};
-                    TSDataOps       &ks = key_set_ts_ops;
-                    ks.allows_mutation           = false;
-                    ks.tracking_impl             = &tsd_key_set_tracking;
-                    ks.mutable_tracking_impl     = &tsd_key_set_mutable_tracking;   // subscriptions only
-                    ks.has_current_value_impl    = &tsd_key_set_has_current_value;
-                    ks.copy_value_from_impl      = read_only_base.copy_value_from_impl;
-                    ks.apply_delta_impl          = read_only_base.apply_delta_impl;
-                    ks.mutable_value_memory_impl = read_only_base.mutable_value_memory_impl;
-                    ks.mutable_delta_memory_impl = read_only_base.mutable_delta_memory_impl;
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-                    ks.from_python_impl          = read_only_base.from_python_impl;
-#endif
-                    key_set_ts_ops.insert_key_impl = read_only_set.insert_key_impl;
-                    key_set_ts_ops.insert_key_move_impl = read_only_set.insert_key_move_impl;
-                    key_set_ts_ops.remove_key_impl = read_only_set.remove_key_impl;
-                    key_set_ts_ops.remove_slot_impl = read_only_set.remove_slot_impl;
-                    key_set_ts_ops.touch_impl      = read_only_set.touch_impl;
-                }
+                // The projection is STRICTLY read-only: it reports the
+                // owner's mutations (dedicated tracking + observers) but can
+                // never perform one. strip_to_read_only is the single place
+                // that enumerates the family's mutators.
+                strip_to_read_only(key_set_ts_ops);
+                key_set_ts_ops.tracking_impl          = &tsd_key_set_tracking;
+                key_set_ts_ops.mutable_tracking_impl  = &tsd_key_set_mutable_tracking;  // subscriptions only
+                key_set_ts_ops.has_current_value_impl = &tsd_key_set_has_current_value;
                 const auto *key_set_schema = TypeRegistry::instance().tss(schema_.key_type());
                 const auto role_label = ts_labels::tsd_key_set_label(role);
                 key_set_ts_type = TSRoleTypeRef{intern_ts_type(

--- a/src/hgraph/types/time_series/ts_data/ops.cpp
+++ b/src/hgraph/types/time_series/ts_data/ops.cpp
@@ -324,4 +324,32 @@ namespace hgraph::ts_data_detail
     {
         missing_ts_data_op("child at slot");
     }
+
+    std::size_t missing_window_size(const void *, const void *) { missing_ts_data_op("window size"); }
+
+    const void *missing_window_element(const void *, const void *, std::size_t)
+    {
+        missing_ts_data_op("window element");
+    }
+
+    DateTime missing_window_time(const void *, const void *, std::size_t)
+    {
+        missing_ts_data_op("window element time");
+    }
+
+    const void *missing_window_time_element(const void *, const void *, std::size_t)
+    {
+        missing_ts_data_op("window time element");
+    }
+
+    std::size_t missing_window_capacity(const void *, const void *) { missing_ts_data_op("window capacity"); }
+
+    bool missing_window_full(const void *, const void *) { missing_ts_data_op("window full"); }
+
+    void missing_window_push(const void *, void *, const ValueView &, DateTime)
+    {
+        missing_ts_data_op("window push");
+    }
+
+    void missing_window_clear(const void *, void *, DateTime) { missing_ts_data_op("window clear"); }
 }  // namespace hgraph::ts_data_detail

--- a/src/hgraph/types/time_series/ts_data/ops.cpp
+++ b/src/hgraph/types/time_series/ts_data/ops.cpp
@@ -353,3 +353,30 @@ namespace hgraph::ts_data_detail
 
     void missing_window_clear(const void *, void *, DateTime) { missing_ts_data_op("window clear"); }
 }  // namespace hgraph::ts_data_detail
+
+namespace hgraph
+{
+    void strip_to_read_only(TSSDataOps &ops) noexcept
+    {
+        const TSDataOps  base_defaults{};
+        const TSSDataOps set_defaults{};
+        ops.allows_mutation                   = false;
+        ops.direct_native_value               = false;
+        ops.copy_value_from_impl              = base_defaults.copy_value_from_impl;
+        ops.move_value_from_impl              = base_defaults.move_value_from_impl;
+        ops.apply_delta_impl                  = base_defaults.apply_delta_impl;
+        ops.clear_collection_impl             = base_defaults.clear_collection_impl;
+        ops.mutable_value_memory_impl         = base_defaults.mutable_value_memory_impl;
+        ops.mutable_delta_memory_impl         = base_defaults.mutable_delta_memory_impl;
+        ops.mutable_indexed_child_memory_impl = base_defaults.mutable_indexed_child_memory_impl;
+#if HGRAPH_ENABLE_PYTHON_USER_NODES
+        ops.from_python_impl                  = base_defaults.from_python_impl;
+#endif
+        ops.insert_key_impl      = set_defaults.insert_key_impl;
+        ops.insert_key_move_impl = set_defaults.insert_key_move_impl;
+        ops.remove_key_impl      = set_defaults.remove_key_impl;
+        ops.remove_slot_impl     = set_defaults.remove_slot_impl;
+        ops.touch_impl           = set_defaults.touch_impl;
+        ops.reserve_impl         = set_defaults.reserve_impl;
+    }
+}  // namespace hgraph

--- a/src/hgraph/types/time_series/ts_input/target_link_ops.cpp
+++ b/src/hgraph/types/time_series/ts_input/target_link_ops.cpp
@@ -1257,6 +1257,7 @@ namespace hgraph::detail
                 .context                   = &context,
                 .kind                      = context.schema->kind,
                 .allows_mutation           = true,
+                .is_target_link            = true,
                 .ownership_ops             = &target_link_ownership_ops(),
                 .current_state_ops =
                     &ts_current_state_detail::current_state_ops_for(context.schema->kind),
@@ -1569,7 +1570,7 @@ namespace hgraph::detail
 
     const TSInputTargetLinkContext *target_link_context_for_ops(const TSDataOps *ops) noexcept
     {
-        return ops != nullptr && ops->ownership_ops == &target_link_ownership_ops()
+        return ops != nullptr && ops->is_target_link
                    ? static_cast<const TSInputTargetLinkContext *>(ops->context)
                    : nullptr;
     }

--- a/src/hgraph/types/value/compact_container_ops.cpp
+++ b/src/hgraph/types/value/compact_container_ops.cpp
@@ -50,18 +50,6 @@ namespace hgraph
             }
             *static_cast<ListStorage *>(dst) = builder.build_storage();
         }
-
-        void compact_list_move_assign_from(const void *context, ValueTypeRef binding, void *dst, ValueTypeRef source,
-                                           void *src)
-        {
-            if (binding == source)
-            {
-                binding.move_assign_at(dst, src);
-                return;
-            }
-            compact_list_copy_assign_from(context, binding, dst, source, src);
-        }
-
         void compact_set_copy_assign_from(const void *, ValueTypeRef binding, void *dst, ValueTypeRef source,
                                           const void *src)
         {
@@ -79,18 +67,6 @@ namespace hgraph
             }
             *static_cast<SetStorage *>(dst) = builder.build_storage();
         }
-
-        void compact_set_move_assign_from(const void *context, ValueTypeRef binding, void *dst, ValueTypeRef source,
-                                          void *src)
-        {
-            if (binding == source)
-            {
-                binding.move_assign_at(dst, src);
-                return;
-            }
-            compact_set_copy_assign_from(context, binding, dst, source, src);
-        }
-
         void compact_map_copy_assign_from(const void *, ValueTypeRef binding, void *dst, ValueTypeRef source,
                                           const void *src)
         {
@@ -113,18 +89,6 @@ namespace hgraph
             }
             *static_cast<MapStorage *>(dst) = builder.build_storage();
         }
-
-        void compact_map_move_assign_from(const void *context, ValueTypeRef binding, void *dst, ValueTypeRef source,
-                                          void *src)
-        {
-            if (binding == source)
-            {
-                binding.move_assign_at(dst, src);
-                return;
-            }
-            compact_map_copy_assign_from(context, binding, dst, source, src);
-        }
-
         void compact_cyclic_buffer_copy_assign_from(const void *, ValueTypeRef binding, void *dst, ValueTypeRef source,
                                                     const void *src)
         {
@@ -143,18 +107,6 @@ namespace hgraph
             }
             *static_cast<CyclicBufferStorage *>(dst) = builder.build_storage();
         }
-
-        void compact_cyclic_buffer_move_assign_from(const void *context, ValueTypeRef binding, void *dst,
-                                                    ValueTypeRef source, void *src)
-        {
-            if (binding == source)
-            {
-                binding.move_assign_at(dst, src);
-                return;
-            }
-            compact_cyclic_buffer_copy_assign_from(context, binding, dst, source, src);
-        }
-
         void compact_queue_copy_assign_from(const void *, ValueTypeRef binding, void *dst, ValueTypeRef source,
                                             const void *src)
         {
@@ -172,17 +124,6 @@ namespace hgraph
                 builder.push(values.at(index));
             }
             *static_cast<QueueStorage *>(dst) = builder.build_storage();
-        }
-
-        void compact_queue_move_assign_from(const void *context, ValueTypeRef binding, void *dst, ValueTypeRef source,
-                                            void *src)
-        {
-            if (binding == source)
-            {
-                binding.move_assign_at(dst, src);
-                return;
-            }
-            compact_queue_copy_assign_from(context, binding, dst, source, src);
         }
     } // namespace container_ops_detail
 
@@ -526,10 +467,6 @@ namespace hgraph
             *static_cast<MapStorage *>(memory) = builder.build_storage();
         }
 
-        void map_key_adapter_from_python(const void *, const ValueTypeRef &, void *, nb::handle)
-        {
-            throw std::logic_error("Map key-set adapter is read-only and cannot load from Python");
-        }
     }  // namespace container_ops_detail
 #endif
 }  // namespace hgraph


### PR DESCRIPTION
## What

The remaining 13 findings from the type-erasure quality review, resolved as four commits of fixes plus recorded decisions for the rest. Every code fix keeps behaviour identical for legitimate callers; the TSData ops-table changes fold into the still-unreleased ABI 10.

**Fixed:**

1. **TSW required members no longer crash when missing** — the eight required `TSWDataOps` members defaulted to bare `nullptr` (a forgotten install was a segfault through a null fn-ptr); they now default to named `missing_window_*` throwing thunks, and `cleared`/`evicted` are documented as null-when-absent optional capabilities (the ValueOps idiom).
2. **Target-link detection no longer keys on pointer identity** — `TSDataOps.is_target_link` replaces the `ownership_ops == &target_link_ownership_ops()` comparison that a link-ownership refactor would have silently broken.
3. **One move-assign instead of five** — the identical compact-container move-assign wrappers collapse into `compact_move_assign_via_copy<&kind_copy_assign_from>`.
4. **One idiom for "from_python unsupported"** — the key-set adapter's bespoke always-throwing thunk becomes a null slot (the wrapper throws), matching the mutable containers.
5. **Dead `ValueView::end_mutation()` removed** — a no-op with zero callers, documented as a placeholder for TS close-time hooks that actually live in `TSDataMutationView`'s RAII scope; `erased_types.rst` now describes the real closure model.
6. **The read-only projection strip is centralized and fail-closed** — `strip_to_read_only(TSSDataOps&)` is the single enumeration of the set-family's mutators. The inline strip it replaces had already gone fail-open (missed `move_value_from`, `clear_collection`, `mutable_indexed_child_memory`, `reserve`).

**Recorded as accepted/deferred (catalogue admonition, with rationale):** the `head`/`front` context-less slots, the `equals`/`compare` noexcept split, the twin bool contracts, the key-set plan-under-set-schema record, the three-home per-kind delta policy, and the per-instance element-binding duplicate (deferred until a measured need).

## Verification

- Full C++ suite after each commit: 1610 cases, 255,960 assertions, all passed
- Warnings-as-errors build clean; docs build green with `-W`
- Full `python/tests` tier on a fresh native build: **2192 passed, 9 skipped**
- ABI history (`time_series.rst`) and the ops catalogue updated in the same changes

Base is **main** directly — no stack this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)