### PR TITLE
One tracking fetch per write commit

### DIFF
--- a/include/hgraph/types/time_series/ts_data/base_view.h
+++ b/include/hgraph/types/time_series/ts_data/base_view.h
@@ -430,7 +430,16 @@ namespace hgraph
 
         void mark_modified(const TSDataOps &table)
         {
-            if (record_modified_local(table)) { notify_parent_modified(table); }
+            // ONE tracking fetch for the whole commit: recording and the
+            // parent notify read the same record, but the split helpers
+            // fetched it twice per write (deferred audit item, unblocked
+            // once #488 merged).
+            require_active_mutation();
+            auto &state = *table.mutable_tracking_impl(table.context, storage_.data());
+            if (state.record_modified(mutation_time_))
+            {
+                state.parent.notify_child_modified(mutation_time_);
+            }
         }
 
         void require_active_mutation() const

--- a/src/hgraph/types/time_series/ts_data/base_view.cpp
+++ b/src/hgraph/types/time_series/ts_data/base_view.cpp
@@ -457,9 +457,7 @@ bool TSDataMutationView::copy_value_from(const ValueView &source) {
     // mutation (which marks it), or a write-through forwarding link
     // landed on pre-marked storage. Recording is idempotent; parents
     // are notified only by the first recording.
-    if (record_modified_local()) {
-      notify_parent_modified();
-    }
+    mark_modified(table);
   }
   return newly_modified;
 }
@@ -484,9 +482,7 @@ bool TSDataMutationView::move_value_from(ValueView source) {
     // mutation (which marks it), or a write-through forwarding link
     // landed on pre-marked storage. Recording is idempotent; parents
     // are notified only by the first recording.
-    if (record_modified_local()) {
-      notify_parent_modified();
-    }
+    mark_modified(table);
   }
   return newly_modified;
 }
@@ -540,12 +536,13 @@ bool TSDataMutationView::from_python(nb::handle source) {
   const auto &table = ops();
   const bool newly_modified = table.from_python_impl(
       table.context, storage_.data(), source, mutation_time_);
-  if (newly_modified && !record_modified_local()) {
-    throw std::logic_error("TSDataMutationView::from_python reported a new "
-                           "modification that was already recorded");
-  }
   if (newly_modified) {
-    notify_parent_modified();
+    auto &state = *table.mutable_tracking_impl(table.context, storage_.data());
+    if (!state.record_modified(mutation_time_)) {
+      throw std::logic_error("TSDataMutationView::from_python reported a new "
+                             "modification that was already recorded");
+    }
+    state.parent.notify_child_modified(mutation_time_);
   }
   return newly_modified;
 }


### PR DESCRIPTION
The last small deferred item from the access-path audit ([ledger](https://claude.ai/code/artifact/fc6e8c0e-e9cd-46a5-acdb-445d5da25eea)), unblocked by #488's merge: the write-commit path fetched the same tracking record twice — `mutable_tracking_impl` to record, then `tracking_impl` to notify the parent. `mark_modified` and the copy/move/from_python commit arms now fetch once and drive recording + parent notify from the same reference.

No A/B claimed — one indirect call removed on paths already measured in #488/#489.

- Full C++ suite: 1611 cases, all passed; werror clean
- Registry-snapshot + audit-behavior suites: 20 passed on a fresh build

Remaining deferred items (both need design discussion before code): the passive-input resolution cliff (a "route valid but passive" trust tier on the trie) and the `active()` path-vector allocation; plus the profile-gated root-atomic has-value capability bit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)