### PR TITLE
Allocation-free activity walk; passive-trust falsified

### DIFF
--- a/include/hgraph/types/time_series/ts_data/types.h
+++ b/include/hgraph/types/time_series/ts_data/types.h
@@ -189,6 +189,11 @@ namespace hgraph
          */
         [[nodiscard]] std::vector<std::size_t> path_from_root() const;
 
+        /** The next link outward: the parent TSData node's own parent link,
+            or an empty link at the root — the public chain-walking step
+            behind allocation-free path traversals. */
+        [[nodiscard]] TSParentLink parent_link() const;
+
         /** Resolve the root TSData view reached by repeatedly following links. */
         [[nodiscard]] TSDataView root_view() const;
 

--- a/include/hgraph/types/time_series/ts_input.h
+++ b/include/hgraph/types/time_series/ts_input.h
@@ -161,6 +161,12 @@ namespace hgraph
         void make_passive(const std::vector<std::size_t> &path);
         [[nodiscard]] bool active(const std::vector<std::size_t> &path) const noexcept;
 
+        /** Allocation-free twin of ``active(path)``: walks the parent chain
+            recursively and descends the activity trie on the unwind, so the
+            per-call ``path_from_root()`` vector disappears from the hot
+            activity probe (access-path audit deferred item, 2026-08-16). */
+        [[nodiscard]] bool active(const TSParentLink &leaf_link) const noexcept;
+
         const TSInputBuilder             *builder_{nullptr};
         const TSValueTypeMetaData        *schema_{nullptr};
         TSData                            data_{};

--- a/python/tests/test_audit_behavior_fixes.py
+++ b/python/tests/test_audit_behavior_fixes.py
@@ -58,3 +58,25 @@ def test_container_mean_honours_default_when_empty():
 def test_container_sum_with_default_still_sums_when_non_empty():
     assert eval_node(_sum_default, [(1, 2, 3)]) == [6]
     assert eval_node(_mean_default, [(2.0, 4.0)]) == [3.0]
+
+
+def test_passive_read_follows_reference_retarget():
+    """Pin for the passive-trust work (access-path ledger, deferred item 1):
+    a PASSIVE input reading through an if_-routed reference must follow
+    every retarget — whichever resolution path (full walk today, trusted
+    handle after the trie maintains passive nodes) serves the read."""
+    from hgraph import TS, graph, if_, sample, eval_node
+
+    @graph
+    def g(cond: TS[bool], value: TS[int], sig: TS[bool]) -> TS[int]:
+        routed = if_(cond, value)
+        return sample(sig, routed.true)
+
+    # cond flips the .true branch's binding between samples; the sampled
+    # (passive) read must reflect the CURRENT binding each time.
+    assert eval_node(
+        g,
+        [True, None, False, None, True, None],
+        [1, 2, 3, 4, 5, 6],
+        [None, True, None, True, None, True],
+    ) == [None, 2, None, None, None, 6]

--- a/src/hgraph/types/time_series/ts_data/types.cpp
+++ b/src/hgraph/types/time_series/ts_data/types.cpp
@@ -446,6 +446,11 @@ namespace hgraph
         if (state.record_modified(mutation_time)) { state.parent.notify_child_modified(mutation_time); }
     }
 
+    TSParentLink TSParentLink::parent_link() const
+    {
+        return has_ts_data_parent() ? parent_tracking().parent : TSParentLink{};
+    }
+
     std::vector<std::size_t> TSParentLink::path_from_root() const
     {
         std::vector<std::size_t> reversed_path;

--- a/src/hgraph/types/time_series/ts_input.cpp
+++ b/src/hgraph/types/time_series/ts_input.cpp
@@ -3173,4 +3173,25 @@ namespace hgraph
         return active != nullptr && active->active;
     }
 
+    namespace
+    {
+        /** Descend the activity trie along the parent chain: recurse to the
+            root, then take one ``child_at(child_id)`` step per level on the
+            unwind — the same traversal ``active(path)`` performs, without
+            materialising the path vector. */
+        [[nodiscard]] const detail::TSInputActiveTarget *descend_active_trie(
+            const TSParentLink &link, const detail::TSInputActiveTarget *root) noexcept
+        {
+            if (!link.has_ts_data_parent()) { return root; }
+            const auto *parent_node = descend_active_trie(link.parent_link(), root);
+            return parent_node != nullptr ? parent_node->child_at(link.child_id) : nullptr;
+        }
+    }  // namespace
+
+    bool TSInput::active(const TSParentLink &leaf_link) const noexcept
+    {
+        const auto *node = descend_active_trie(leaf_link, active_root_.get());
+        return node != nullptr && node->active;
+    }
+
 }  // namespace hgraph

--- a/src/hgraph/types/time_series/ts_input/base_view.cpp
+++ b/src/hgraph/types/time_series/ts_input/base_view.cpp
@@ -258,7 +258,7 @@ namespace hgraph
     bool TSInputView::InputDataCursor::active(const TSInput *input) const
     {
         if (is_target_position()) { return detail::target_link_active(raw_data, target_path_node()); }
-        return input != nullptr && value_data.valid() && input->active(value_data.path_from_root());
+        return input != nullptr && value_data.valid() && input->active(value_data.tracking().parent);
     }
 
     TSInputView::TSInputView(TSInput                  *input,

--- a/tests/cpp/test_std_operators.cpp
+++ b/tests/cpp/test_std_operators.cpp
@@ -1261,6 +1261,24 @@ namespace
         }
     };
 
+    /** The passive twin of SampleIfTrueRouteGraph: the if_-routed branch is
+        the PASSIVELY sampled input and a separate trigger drives sample —
+        the C++ public-wiring pin for passive reads following reference
+        retargets (mirrors test_passive_read_follows_reference_retarget;
+        review finding on #495). */
+    struct SamplePassiveRoutedGraph
+    {
+        static constexpr auto name = "sample_passive_routed_graph";
+
+        static Port<TS<Int>> compose(Wiring &w, Port<TS<Bool>> condition, Port<TS<Int>> ts,
+                                     Port<TS<Bool>> trigger)
+        {
+            auto routed = wire<stdlib::if_, IfIntRefBundle>(w, condition, ts).as<IfIntRefBundle>();
+            auto branch = wire<stdlib::getitem_>(w, routed, Str{"true"}).as<TS<Int>>();
+            return wire<stdlib::sample>(w, trigger, branch).as<TS<Int>>();
+        }
+    };
+
     struct IfTrueTsdFilterGraph
     {
         static constexpr auto name = "if_true_tsd_filter_graph";
@@ -3161,6 +3179,13 @@ TEST_CASE("std operators: control operators cover variadic booleans merge and se
     CHECK_OUTPUT(eval_node<SampleIfTrueRouteGraph>(values<Bool>(false, false, true, false, true),
                                                    values<Int>(1, 2, 3, 4, 5)),
                  values<Int>(none, none, 1, none, 1));
+    // Passive twin: the routed branch is the sampled (passive) input; every
+    // trigger must observe the branch's CURRENT binding across retargets.
+    CHECK_OUTPUT(eval_node<SamplePassiveRoutedGraph>(
+                     values<Bool>(true, none, false, none, true, none),
+                     values<Int>(1, 2, 3, 4, 5, 6),
+                     values<Bool>(none, true, none, true, none, true)),
+                 values<Int>(none, 2, none, none, none, 6));
     CHECK_OUTPUT(eval_node<RouteByIndexSlotTwoGraph>(values<Int>(0, 2, none, 1, 2),
                                                      values<Int>(10, 20, 30, 40, 50)),
                  values<Int>(none, 20, 30, none, 50));


### PR DESCRIPTION
The two remaining deferred items from the access-path audit ([ledger](https://claude.ai/code/artifact/fc6e8c0e-e9cd-46a5-acdb-445d5da25eea)):

**Item 2 — done.** The per-call activity probe allocated a vector purely to reverse the parent chain before `TSInput::active(path)` replayed the same traversal. The new `active(TSParentLink)` overload recurses to the root and descends the trie on the unwind — identical traversal, zero allocation. `TSParentLink` gains the public `parent_link()` chain step; the vector API remains for activation, which stores the path.

**Item 1 — attempted, falsified, recorded.** The cheap passive-trust design (maintain trie handles for passive nodes via `resubscribe_tree` + heal from walked resolutions, drop `locally_active` from the trust checks) was implemented and immediately killed by the reduce suite: reduce re-points targets through **output-side mechanisms that are not input-link topology events**, so passively-held handles go stale regardless of bind-time refreshes. Subscription *is* the maintenance contract — which is precisely why `locally_active` sits in the trust check. The passive cliff's real fix needs passive nodes registered as observe-without-notify in the subscription machinery — a notifier design change to be RFC'd, not a cleanup. This PR ships the pinning test (a passively-sampled input following `if_` retargets) that any future attempt must keep green.

## Verification

- Full C++ suite: 1619 cases, all passed; werror clean
- The new python pin passes; registry/audit suites green

🤖 Generated with [Claude Code](https://claude.com/claude-code)