### PR TITLE
Activate the HTTP/2 server behind the RFC 0024 ALPN seam

### DIFF
--- a/.github/workflows/native-cpp.yml
+++ b/.github/workflows/native-cpp.yml
@@ -78,6 +78,15 @@ jobs:
         run: cmake --build build-native --parallel ${{ matrix.parallel }}
       - name: Run native C++ tests
         run: ctest --test-dir build-native --output-on-failure --parallel ${{ matrix.parallel }}
+      - name: HTTP/2 conformance (h2spec)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          curl -fsSL -o /tmp/h2spec.tar.gz \
+            https://github.com/summerwind/h2spec/releases/download/v2.6.0/h2spec_linux_amd64.tar.gz
+          tar -xzf /tmp/h2spec.tar.gz -C /tmp
+          python3 extensions/web/tools/run_h2spec.py \
+            build-native/extensions/web/tests/hgraph_web_h2spec_server /tmp/h2spec
       - name: Start the S3 conformance endpoint
         if: runner.os == 'Linux'
         shell: bash

--- a/.github/workflows/native-cpp.yml
+++ b/.github/workflows/native-cpp.yml
@@ -82,7 +82,7 @@ jobs:
         if: runner.os == 'Linux'
         shell: bash
         run: |
-          curl -fsSL -o /tmp/h2spec.tar.gz \
+          curl -fsSL --proto '=https' --tlsv1.2 -o /tmp/h2spec.tar.gz \
             https://github.com/summerwind/h2spec/releases/download/v2.6.0/h2spec_linux_amd64.tar.gz
           tar -xzf /tmp/h2spec.tar.gz -C /tmp
           python3 extensions/web/tools/run_h2spec.py \

--- a/docs/source/rfc/index.rst
+++ b/docs/source/rfc/index.rst
@@ -10,6 +10,20 @@ hgraph change.
 The lifecycle, required sections, numbering, and proposal/implementation
 workflow are defined by :doc:`rfc_0000`.
 
+Research notes
+--------------
+
+Research notes capture design evidence and open questions before a numbered
+RFC fixes a public contract. They are informative rather than normative.
+
+.. toctree::
+   :maxdepth: 1
+
+   research_layered_network_services
+
+RFC catalogue
+-------------
+
 .. toctree::
    :maxdepth: 2
 

--- a/docs/source/rfc/research_layered_network_services.rst
+++ b/docs/source/rfc/research_layered_network_services.rst
@@ -1,0 +1,431 @@
+Research Note: Layered Network Services and Conflated State Distribution
+=========================================================================
+
+:Status: Research
+:Author: Howard Henson
+:Created: 2026-08-17
+:Related: :doc:`rfc_0014_request_reply_transport_planning`,
+          :doc:`rfc_0015_kafka_extension_api`, and
+          :doc:`rfc_0024_web_extension_api`
+
+Purpose
+-------
+
+This note records the protocol research that should guide the HTTP/2 streaming
+API, a future gRPC extension, cached time-series distribution, and network
+service discovery. It does not propose a public API or wire format. Those
+decisions require separate numbered RFCs.
+
+The central conclusion is that hgraph needs three distinct data-plane
+contracts rather than one configurable messaging abstraction:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 31 24 23
+
+   * - Contract
+     - Delivery semantics
+     - Normal completion
+     - Recovery
+   * - Unary request/reply
+     - One request and one response, with no silent loss
+     - Response plus terminal status
+     - Retry under an explicit idempotency policy
+   * - Streaming request/reply
+     - Ordered, non-conflated messages in each direction, with no silent loss
+     - Half-close followed by terminal status
+     - Restart or an application resume protocol
+   * - Cached state subscription
+     - Current-state accurate; intermediate states may be conflated
+     - Unsubscribe or terminal state
+     - Resume from a usable cache state or receive a fresh image
+
+Event-accurate subscriptions are a fourth use case, but not a fourth hgraph
+wire protocol. Kafka or another standard event broker should provide retained
+event logs, consumer offsets, replay, and broker replication. RFC 0015 defines
+the corresponding hgraph integration boundary.
+
+Layering model
+--------------
+
+The intended separation is:
+
+.. code-block:: text
+
+   HTTP/2 transport
+   +-- unary request/reply
+   +-- reliable streaming request/reply
+   +-- cached state subscription
+       +-- initial image
+       +-- structural deltas
+       +-- temporal conflation
+       +-- cache fan-out
+       +-- re-image and recovery
+
+   event-accurate subscription --> Kafka or another event broker
+
+   control plane
+   +-- service and endpoint discovery
+   +-- connection state
+   +-- readiness and availability
+   +-- draining and removal
+   +-- capacity and observed load
+   +-- data quality and cache freshness
+
+HTTP/2 is the common byte-stream substrate. gRPC is one protocol layered on
+that substrate. Cached state distribution is another. Neither gRPC framing nor
+time-series semantics belong in the generic HTTP/2 session API.
+
+Unary and reliable-streaming semantics
+--------------------------------------
+
+gRPC is the primary interoperability reference for request/reply. It defines
+unary, server-streaming, client-streaming, and bidirectional-streaming calls,
+and preserves message order within an individual call. [#grpc-core-concepts]_
+The generic hgraph streaming contract should be expressive enough to implement
+all four forms without depending on protobuf or gRPC status codes.
+
+"Non-lossy" must have a bounded meaning. For an active call, an accepted
+message is delivered in order or the call terminates with an explicit error.
+It does not imply exactly-once processing across a broken connection. The gRPC
+HTTP/2 protocol similarly closes calls when a connection fails. [#grpc-h2]_
+Retry can duplicate work unless the application supplies idempotency or resume
+semantics.
+
+The common HTTP/2 contract consequently needs to preserve:
+
+* initial metadata and terminal trailers as distinct collections;
+* ordered incremental body or message delivery in both directions;
+* independent half-close of each direction;
+* explicit inbound flow-control release after application admission;
+* bounded outbound buffering and observable backpressure;
+* per-stream cancellation and reset reasons;
+* deadlines and terminal status;
+* connection and stream identity;
+* GOAWAY and graceful drain, including the last accepted stream; and
+* failure that is explicit rather than represented by an empty or partial
+  successful result.
+
+The transport should expose these primitives once. Unary HTTP, streaming HTTP,
+gRPC, and cached subscriptions should adapt them rather than implement
+independent socket or lifecycle machinery.
+
+Cached state subscription
+-------------------------
+
+The cached subscription contract is **state-lossless but event-lossy**. Its
+purpose is to keep a consumer's materialized state current, not to reproduce
+every intermediate producer event.
+
+The first concrete application is TSD distribution. The same model may extend
+to other time-series types when their snapshot, delta-application, and
+delta-conflation operations are well defined. The protocol must not assume
+that retaining the last serialized frame is a valid conflation algorithm.
+
+Three optimizations must remain distinct:
+
+``structural delta``
+   Transmit only keys, fields, or structural elements that changed.
+
+``temporal conflation``
+   Compose pending changes so that obsolete intermediate states are not sent
+   to a slower consumer.
+
+``wire compression``
+   Compress the serialized bytes without changing the message sequence.
+
+Conflation is part of the value or time-series delta algebra. For a dictionary,
+the pending state normally follows these rules:
+
+* repeated add/update operations for one key retain the latest value;
+* add/update followed by removal becomes a tombstone;
+* removal followed by add/update becomes the new current value; and
+* nested values conflate through their registered delta operation rather than
+  through a byte-level last-write rule.
+
+Images and the live hand-off
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A subscription begins with an image representing a coherent cache state. A
+large image may be chunked, but the chunks share one image identity, source
+epoch, and target revision. Updates that arrive while the image is being
+transmitted are accumulated behind the image barrier and may be conflated.
+
+After the image completes, the consumer receives a delta that moves it toward
+the cache's then-current state. The next target revision need not be the image
+revision plus one: revision gaps are expected when intermediate updates have
+been conflated. A gap is therefore not, by itself, a data-loss error.
+
+A revision identifies ordering within a source epoch. An epoch or generation
+change identifies loss of continuity, such as primary failover or cache
+reconstruction. Unless the protocol can prove a valid cross-epoch transition,
+the safe response is a new image.
+
+The minimum logical message vocabulary is expected to cover:
+
+* subscribe, amend selection, and unsubscribe;
+* image begin, image part, and image complete;
+* delta with source epoch and target revision;
+* item or stream status, including stale/suspect and recovering states;
+* re-image required; and
+* terminal close or error.
+
+Exact message shapes, acknowledgements, and resume tokens remain RFC work.
+
+Cache fan-out and slow consumers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The producer publishes each state change once. Cache servers maintain the
+current materialized value, construct initial images, and fan out subsequent
+deltas. This prevents each new subscriber from imposing image-construction or
+network work on the producer.
+
+HTTP/2 flow control bounds bytes admitted by a stream but does not implement
+state-aware conflation. The cache must manage queued, not-yet-emitted changes
+using the delta algebra. Bytes already handed to the transport cannot be
+replaced safely; an application acknowledgement is required if recovery must
+distinguish transport delivery from consumer application.
+
+Consumers can be partitioned by progress or service class:
+
+* fast consumers receive frequent small deltas;
+* slower cohorts receive increasingly conflated deltas; and
+* consumers beyond the supported lag or memory bound receive a new image.
+
+The implementation should share immutable values or delta segments between
+cohort members. It must not copy the full materialized state or retain an
+unbounded event queue per subscriber.
+
+Primary and secondary caches require explicit ownership and failover rules:
+
+* source and cache instance identity;
+* monotonic epochs with fencing of obsolete primaries;
+* snapshot or state transfer to a secondary;
+* freshness and data-quality state; and
+* a defined re-image boundary after continuity is lost.
+
+Comparable state-distribution systems
+-------------------------------------
+
+LSEG Real-Time
+~~~~~~~~~~~~~~
+
+LSEG Real-Time is the closest direct precedent. A provider publishes a Refresh
+message (the image) and subsequent Update messages. The distribution system
+caches the item, serves the cached image to a new consumer, forwards updates,
+and propagates Status messages. Its guidance recommends an unsolicited fresh
+image after source recovery so the distribution cache and consumers return to
+a known coherent state. [#lseg-cache]_
+
+The useful lessons are the explicit separation of image, update, and status;
+cache-mediated fan-out; data quality independent of connectivity; multipart
+images for large structures; and re-image after recovery.
+
+Solace message eliding
+~~~~~~~~~~~~~~~~~~~~~~
+
+Solace calls slow-consumer conflation "message eliding". Eligible direct
+messages representing current state are delivered at a rate the consumer can
+handle instead of queueing obsolete intermediate values. [#solace-eliding]_
+This supports an explicit per-stream or per-subscription eligibility policy:
+reliable event messages must never enter an eliding queue accidentally.
+
+DDS
+~~~
+
+DDS provides a mature policy vocabulary for state distribution: keyed
+instances, reliable versus best-effort delivery, ``KEEP_LAST`` versus
+``KEEP_ALL`` history, durability for late joiners, resource limits,
+liveliness, ownership, and content/time filtering. With ``KEEP_LAST`` the
+history depth applies per keyed instance, and non-volatile durability can
+supply retained samples to a late reader. [#dds-qos]_ [#dds-durability]_
+
+hgraph should learn from the separation of these policies without recreating
+the complete DDS API. In particular, reliability, history, durability, and
+resource bounds must not be collapsed into one "quality" option.
+
+NATS KV and Kafka tables
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+NATS KV watchers can receive the initial values followed by live changes, and
+the default history retains only the latest operation per key. [#nats-kv]_
+This is a useful compact reference for image-plus-watch usability, although it
+does not by itself define hgraph's structural delta algebra or cache cohorts.
+
+Kafka log compaction retains at least the latest known value per key and uses
+tombstones for deletion. [#kafka-compaction]_ Kafka Streams makes the semantic
+boundary especially clear: compaction is valid for a table/changelog, but
+would violate a stream contract where every record matters. [#kafka-table]_
+That is the same reason cached state subscription and event subscription must
+remain different public contracts.
+
+Control plane: discovery, lifecycle, and load
+---------------------------------------------
+
+The data protocols require a control plane, but connection state, service
+availability, data quality, and load are not interchangeable:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 36 42
+
+   * - Signal
+     - Example states
+     - Meaning
+   * - Connection
+     - idle, connecting, ready, transient failure, shutdown
+     - Whether a transport channel can currently carry work
+   * - Service readiness
+     - serving, not serving, unknown
+     - Whether an application service accepts new work
+   * - Endpoint lifecycle
+     - discovered, active, draining, removed
+     - Whether routing may select the endpoint
+   * - Data quality
+     - current, stale/suspect, recovering, unavailable
+     - Whether cached values may be trusted
+   * - Load and capacity
+     - weight, utilization, queue depth, request cost
+     - How suitable an otherwise available endpoint is for new work
+
+gRPC already separates channel connectivity from the standard health service.
+Its health ``Watch`` RPC allows clients to stop selecting a connected endpoint
+whose service reports ``NOT_SERVING``. [#grpc-connectivity]_
+[#grpc-health]_
+
+Graceful drain is a first-class lifecycle state. A draining endpoint remains
+alive for accepted unary calls and existing streams but receives no new work.
+Long-lived streams are bound to the selected endpoint; moving them requires an
+application resubscription or hand-off. Cached subscriptions can make that
+movement cheap because the destination cache can supply a fresh image or a
+valid state transition.
+
+xDS as a control-plane reference
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+xDS is valuable both as deployable infrastructure and as protocol prior art.
+It supports State-of-the-World and incremental resource delivery, explicit
+resource removal, resource versions, ACK/NACK, reconnect state, lazy resource
+subscription, and optional TTL heartbeats. [#xds-protocol]_
+
+Endpoint Discovery Service supplies endpoint membership, locality, priority,
+health, and load-balancing weights. [#envoy-eds]_ Load Reporting Service sends
+proxy-observed request and endpoint statistics to the management server.
+[#envoy-lrs]_ ORCA complements this with backend-reported utilization and
+per-request cost metrics, including an out-of-band stream suitable for
+long-lived calls. [#grpc-orca]_
+
+A likely integration boundary is:
+
+* Envoy handles TLS termination where desired, HTTP/2 proxying, routing,
+  ordinary health checks, load balancing, observability, and connection
+  management;
+* an xDS-compatible or xDS-inspired control plane distributes service and
+  endpoint state;
+* hgraph services report application readiness, data quality, cache epoch,
+  cache coverage, and application-specific load; and
+* the cached subscription protocol owns image, delta, conflation, and recovery
+  semantics that a generic proxy cannot infer.
+
+Load-aware cached routing has an additional locality dimension: an endpoint
+that already owns the requested partition or image may be a better choice than
+a nominally less-loaded endpoint that must first acquire the state. Endpoint
+metadata and weights can carry inputs to that choice, but the policy must
+avoid oscillation and stale load reports. Capacity, measured utilization,
+cache affinity, and data freshness should remain distinguishable inputs.
+
+Implications for hgraph services
+--------------------------------
+
+The network API should compose with hgraph's existing keyed services rather
+than introduce a process-global client or server runtime:
+
+* unary calls naturally map to request/reply services;
+* server subscriptions and bidirectional calls need a first-class streaming
+  service boundary rather than a completed-response value;
+* cached subscriptions need selection identity, image/delta/status output,
+  and observable subscription lifecycle;
+* service discovery and events should be shared reference-service outputs;
+  and
+* connection creation, listeners, workers, and registrations follow graph
+  start/stop ownership.
+
+The streaming service design must preserve C++ as the semantic owner. Python
+adapts values and callables to the same native path; it must not implement a
+second stream scheduler or cache protocol.
+
+HTTP/2 review criteria
+----------------------
+
+Until the streaming RFC fixes the public contract, HTTP/2 changes should be
+reviewed for whether they preserve the required extension points:
+
+* body data can be delivered incrementally instead of requiring one complete
+  request or response allocation;
+* flow-control credit is released only after bounded application admission;
+* ingress and egress pressure are isolated per stream;
+* headers, trailers, half-close, reset, timeout, and GOAWAY remain observable;
+* a slow stream can be reset without terminating unrelated streams;
+* connection shutdown stops new streams and gives accepted streams a bounded
+  drain period;
+* stream identities remain stable across the transport/service boundary;
+* transport code does not assume unary completion, protobuf, gRPC, TSD, or
+  event-accurate replay; and
+* buffering and callbacks are structured so a later streaming API can avoid
+  copying complete bodies through an intermediate unary representation.
+
+Open questions for numbered RFCs
+--------------------------------
+
+* Should streaming service calls expose one bidirectional primitive with unary
+  and one-way forms as restrictions, or four explicit gRPC-like call shapes?
+* What is the graph-time-series representation of half-close, cancellation,
+  terminal status, and backpressure?
+* Which acknowledgements are transport-only, and which prove that a consumer
+  applied a cached delta?
+* What snapshot and delta operations must a time-series type register to be
+  distributable?
+* Are cache cohorts selected automatically from lag, or may clients request a
+  maximum update frequency or freshness bound?
+* Which cache state is replicated to secondaries, and what continuity can be
+  promised across promotion?
+* Should service discovery consume xDS directly, integrate through Envoy, or
+  expose an hgraph contract with xDS as its first implementation?
+* Which load metrics are routing inputs, which are observability only, and how
+  are stale measurements expired?
+* How are authentication, authorization, schema negotiation, and protocol
+  evolution represented without coupling them to one serialization format?
+
+References
+----------
+
+.. [#grpc-core-concepts] `gRPC core concepts, architecture, and lifecycle
+   <https://grpc.io/docs/what-is-grpc/core-concepts/>`__.
+.. [#grpc-h2] `gRPC over HTTP/2
+   <https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md>`__.
+.. [#lseg-cache] `LSEG Real-Time cached image and update workflow
+   <https://developers.lseg.com/en/api-catalog/real-time-opnsrc/rt-sdk-cc/tutorials/ema-ni-provider/ema-ni-provider-publishing-our-first-market-price>`__.
+.. [#solace-eliding] `Solace message eliding
+   <https://docs.solace.com/Messaging/Direct-Msg/Direct-Messages.htm#Message_Eliding>`__.
+.. [#dds-qos] `RTI Connext DDS history QoS
+   <https://community.rti.com/static/documentation/connext-dds/current/doc/manuals/connext_dds_professional/getting_started_guide/csharp/intro_qos.html>`__.
+.. [#dds-durability] `RTI Connext DDS durability QoS
+   <https://community.rti.com/static/documentation/connext-dds/current/doc/manuals/connext_dds_professional/users_manual/users_manual/DURABILITY_QosPolicy.htm>`__.
+.. [#nats-kv] `NATS JetStream key/value store
+   <https://docs.nats.io/nats-concepts/jetstream/key-value-store>`__.
+.. [#kafka-compaction] `Apache Kafka log compaction design
+   <https://kafka.apache.org/documentation/#compaction>`__.
+.. [#kafka-table] `Kafka Streams KTable and KStream semantics
+   <https://kafka.apache.org/documentation/streams/developer-guide/dsl-api.html>`__.
+.. [#grpc-connectivity] `gRPC connectivity semantics
+   <https://grpc.github.io/grpc/core/md_doc_connectivity-semantics-and-api.html>`__.
+.. [#grpc-health] `gRPC health checking
+   <https://grpc.io/docs/guides/health-checking/>`__.
+.. [#xds-protocol] `Envoy xDS protocol
+   <https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol>`__.
+.. [#envoy-eds] `Envoy endpoint discovery configuration
+   <https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/endpoint/v3/endpoint.proto.html>`__.
+.. [#envoy-lrs] `Envoy Load Reporting Service
+   <https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/load_stats/v3/lrs.proto>`__.
+.. [#grpc-orca] `gRPC custom backend metrics and ORCA
+   <https://github.com/grpc/proposal/blob/master/A51-custom-backend-metrics.md>`__.

--- a/docs/source/rfc/rfc_0024_web_extension_api.rst
+++ b/docs/source/rfc/rfc_0024_web_extension_api.rst
@@ -484,7 +484,12 @@ just TLS (mismatch is a start error); an
 overlapping (method, pattern) registration across service paths is a start
 error naming both paths; the last detach closes the listener so the port
 can be rebound by a later run.  Keep-alive connections may span attached
-services; dispatch is per-request by route match.
+services; dispatch is per-request by route match.  Shutdown on a shared
+listener is runtime-scoped: a stopping attachee retires only ITS pending
+work (its h2 streams answer 503; the connection keeps serving the other
+attachees), and the orderly close of every live connection — idle ones
+included, with GOAWAY on h2 — belongs to the LAST detaching runtime via
+the listener's live-connection registry.
 
 Runtime architecture
 --------------------
@@ -550,7 +555,11 @@ closes 1013 from the transport without graph involvement.  A stopped
 bridge rejects late completions from a shared listener's still-draining
 connections instead of treating them as errors.
 Configuration floors guarantee a single maximal payload always fits an
-empty channel, so an admitted wait always terminates.
+empty channel, so an admitted wait always terminates.  On HTTP/2 the
+per-connection read loop additionally stalls once one window's worth of
+bytes is buffered ahead of admission across all streams, so backpressured
+streams cannot accumulate stream-window times stream-count outside the
+budget.
 
 Outbound, each connection owns a bounded queue on its strand.  A slow
 WebSocket consumer triggers the explicit ``slow_consumer_policy``: ``Close``

--- a/docs/source/rfc/rfc_0024_web_extension_api.rst
+++ b/docs/source/rfc/rfc_0024_web_extension_api.rst
@@ -792,7 +792,13 @@ to the general criteria of this RFC:
   breaches the slow-consumer policy is reset with ``RST_STREAM`` without
   tearing down the connection; connection close remains reserved for
   protocol errors.
-* h2spec conformance passes in CI for the activated build.
+* h2spec conformance passes in CI for the activated build.  One accepted
+  deviation is recorded in ``extensions/web/tools/run_h2spec.py``: h2spec
+  5.1.1/2 (a HEADERS frame with a stream id lower than a previous one)
+  expects a connection error, but nghttp2 ignores the frame as
+  implicitly-closed-stream noise — the reference ``nghttpd`` fails the
+  identical case identically, so the CI gate requires 93/94 with only
+  that failure.
 
 Alternatives considered
 -----------------------

--- a/docs/source/rfc/rfc_0024_web_extension_api.rst
+++ b/docs/source/rfc/rfc_0024_web_extension_api.rst
@@ -739,18 +739,19 @@ only through a new RFC.
    * - Streaming / incremental bodies
      - excluded
      - excluded
-     - v1 is complete-message bodies on every transport.  A follow-up
-       streaming-body RFC is required (see below).
+     - v1 is complete-message bodies on every transport.  Phase 3 below
+       defines the generic streaming foundation required for a later release.
 
 **Milestone boundary.**  *v1* is the HTTP/1.1(+TLS) server, the RFC 6455
 WebSocket server and client, and the h1/h2 client.  *v1.x* activates the
 HTTP/2 server behind the already-shipped seam, gated on the acceptance
 criteria below.  Because HTTP/2 without streaming bodies leaves a
 substantial part of its value inaccessible (long-lived streams, incremental
-responses, SSE), the streaming-body follow-up RFC is a companion to h2
-server activation — it must be Accepted no later than the release that
-activates h2, so the stream-aware model and the streaming surface are
-designed against each other rather than sequentially bolted on.
+responses, SSE), the streaming-body work is a companion to h2 server
+activation.  Phase 3 below supplies that contract and must be Accepted
+no later than the release that activates h2, so the stream-aware model and the
+streaming surface are designed against each other rather than sequentially
+bolted on.
 
 HTTP/2 activation plan
 ----------------------
@@ -808,6 +809,149 @@ to the general criteria of this RFC:
   implicitly-closed-stream noise — the reference ``nghttpd`` fails the
   identical case identically, so the CI gate requires 93/94 with only
   that failure.
+
+Phase 3: generic bidirectional streaming foundation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Phases 1 and 2 establish the confined nghttp2 protocol engine and the Asio
+connection driver, then adapt an HTTP/2 stream to the existing complete-
+message request/reply surface.  Phase 3 adds the native streaming service
+boundary that makes the transport reusable without teaching it gRPC,
+protobuf, or time-series semantics.  It follows the layering developed in
+:doc:`research_layered_network_services`: HTTP/2 supplies ordered duplex byte
+streams and flow control; higher layers supply message framing and application
+meaning.
+
+One bidirectional stream is the primitive.  Unary, server-streaming,
+client-streaming, and bidirectional-streaming calls are restrictions or graph
+adaptors over that primitive, not four independent transports.  The current
+``HttpRequest`` / ``HttpResponse`` services remain supported as the unary
+complete-message adaptor.  Phase 3 is additive; a user that does not request a
+streaming service pays no streaming bridge or scheduling cost.
+
+Reliability is scoped to one active call: every accepted chunk is delivered in
+order or the call terminates with an explicit error.  It does not promise
+exactly-once processing, transparent retry, or stream resumption across a
+broken connection; those require application idempotency or a higher-level
+resume protocol.
+
+The public semantic contract is native C++ first and contains no curl,
+nghttp2, Asio, protobuf, or Python type.  Exact schema and service names remain
+reviewable while this RFC is Proposed, but the contract must represent:
+
+* a logical call id, connection id, protocol stream id, client/server role,
+  selected route or service, peer identity, and optional deadline;
+* an open event carrying initial metadata, followed by ordered DATA chunks in
+  each direction;
+* independent local and remote half-close, with terminal trailers kept
+  distinct from initial metadata even when no DATA chunk was sent;
+* local cancel, peer ``RST_STREAM``, timeout, transport failure, and terminal
+  status as explicit outcomes — never an empty successful result;
+* connection draining and ``GOAWAY``, including its last accepted stream id,
+  so new work is rejected while eligible in-flight streams finish; and
+* separate acceptance and delivery reports for outbound commands.  Acceptance
+  means bounded transport ownership was acquired; delivery means the bytes
+  crossed the transport boundary.  Neither claims that a remote application
+  decoded or applied the message.
+
+The graph-facing shape is one keyed stream-lifecycle source plus one keyed
+command sink per direction.  Opening a client call allocates a logical call id
+before the wire stream id necessarily exists.  Subsequent headers, data,
+half-close, trailers, cancel, and delivery events correlate by that call id;
+the real HTTP/2 stream id is added once assigned.  Server calls use the same
+event and command vocabulary with direction reversed.  A terminal event occurs
+exactly once and retires all retained reservations, pending commands, timers,
+and route/runtime ownership for that call.  Python exposes the same schemas and
+services through the native bridge rather than running a second stream
+scheduler.
+
+Flow control is part of this service contract, not an implementation detail:
+
+* Inbound DATA credit is released only after the corresponding chunk has a
+  bounded bridge reservation.  The graph may therefore lag the socket without
+  creating unaccounted payload storage.
+* Initial metadata, trailers, envelope overhead, compression state, and queued
+  protocol output count toward memory limits as well as DATA.  A configured
+  maximal stream must fit an empty channel, including both its initial and
+  terminal metadata, or wiring fails.  Header-list limits apply to the
+  uncompressed fields and a connection-wide bound covers metadata that HTTP/2
+  flow control does not govern.
+* Outbound commands use bounded per-stream and per-connection admission.
+  Writable/credit events let a graph resume production without polling.  A
+  blocked stream cannot accumulate an unbounded queue or prevent unrelated
+  streams from progressing; fair scheduling is required between writable
+  streams.
+* Cancel, reset, timeout, and shutdown release reservations exactly once.
+  Every accepted-but-undelivered command receives a terminal report.
+* Buffer ownership and lifetime are explicit across the type-erased bridge.
+  The streaming hot path must not first assemble or copy a complete unary body.
+
+HTTP/2 is the first implementation, but the public primitive is not named for
+nghttp2 and does not expose HTTP/2 frame boundaries.  DATA callbacks are byte
+chunks, not application messages: a codec may receive a partial message or
+several messages in one chunk and must frame incrementally.  HTTP/1.1 chunked
+responses and SSE may later adapt the same one-way subset without changing the
+graph contract.
+
+The existing curl-multi client remains the preferred complete-message HTTP
+client.  Before Phase 3 freezes its client implementation, a focused prototype
+must prove that curl can provide incremental upload and download, independent
+half-close, trailers-only completion, cancellation, and bounded resume signals
+for all four call shapes without hidden whole-body buffering.  If it cannot,
+the confined nghttp2 engine gains a client role symmetric with the server and
+curl remains the unary HTTP adaptor.  The public service contract must not be
+weakened to fit one client library.
+
+Protocol layers above Phase 3
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Phase 3 deliberately stops at reliable ordered bytes and metadata:
+
+* A gRPC extension adds the five-byte message prefix, compression negotiation,
+  content type, deadlines, cancellation mapping, and ``grpc-status`` /
+  ``grpc-message`` terminal trailers.  A minimal interoperability adaptor must
+  exercise unary, server-streaming, client-streaming, and bidirectional calls
+  against a reference gRPC peer before the common stream API is accepted.
+* The cached-subscription protocol adds subscribe/amend/unsubscribe, coherent
+  initial image, delta, status, epoch/revision, acknowledgement, re-image, and
+  terminal messages.  Its cache owns materialization, fan-out, slow-client
+  cohorts, and type-aware conflated queues; HTTP/2 flow control does not
+  conflate application state.  A Phase 3 composition test must demonstrate an
+  image followed by deltas and a deliberately slow subscriber without adding
+  cache semantics to the transport.
+* Event-accurate subscriptions remain the responsibility of a durable
+  messaging system such as Kafka.  Service discovery, readiness, load, cache
+  affinity, xDS/Envoy integration, authentication policy, and cache replication
+  remain separate control-plane or protocol RFCs.
+
+Phase 3 acceptance criteria
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In addition to the extension-wide gates below, Phase 3 requires:
+
+* first-class installed-SDK C++ wiring and equivalent Python authoring tests
+  for the same native services;
+* in-memory engine and live TLS loopback coverage for unary, server-streaming,
+  client-streaming, and bidirectional traffic, including message fragments
+  split and coalesced across arbitrary DATA chunks;
+* header-only, data-bearing, empty-body trailers-only, and both half-close
+  orderings, with duplicate ordered metadata preserved;
+* per-stream reset/cancel and deadline expiry that leave concurrent streams
+  usable, plus ``GOAWAY`` last-stream and bounded-drain behavior;
+* a stalled graph and a stalled peer proving bounded ingress and egress,
+  correct credit resumption, fair progress by other streams, and complete
+  terminal delivery reports;
+* shared-listener tests in which stopping one runtime retires all of that
+  runtime's streams — including streams blocked before graph dispatch — while
+  other attached runtimes and their streams continue;
+* malformed framing, oversized initial metadata, oversized trailers, and
+  aggregate metadata-plus-body limit tests, with no connection-wide failure
+  for a stream-local fault;
+* the gRPC interoperability and cached-subscription composition proofs above;
+  and
+* the normal native/Python acceptance suites on supported platforms, an
+  installed static-SDK consumer, h2spec, and ASan coverage of reset, timeout,
+  shutdown, and late-callback ownership paths.
 
 Alternatives considered
 -----------------------

--- a/docs/source/rfc/rfc_0024_web_extension_api.rst
+++ b/docs/source/rfc/rfc_0024_web_extension_api.rst
@@ -769,8 +769,10 @@ The activation splits along the third-party confinement rule: the protocol
 engine (``nghttp2_session.cpp``, the only nghttp2 TU) is a pure
 bytes-in/actions-out wrapper over an nghttp2 server session in the pull
 model, with automatic window updates disabled so request-DATA flow control
-releases only through an explicit consume — the reservation-admission
-lever; the connection driver (in ``asio_server.cpp``, the only Asio TU)
+releases only through an explicit consume after reservation, or an explicit
+discard when the bytes will not be retained.  The latter restores connection
+credit immediately because a reset may remove stream-scoped queued updates;
+the connection driver (in ``asio_server.cpp``, the only Asio TU)
 owns the socket, the strand, and the bridge integration.  The engine is
 validated in-memory against a genuine nghttp2 client session
 (``hgraph_web_h2_engine_tests``) before any socket exists.
@@ -793,7 +795,9 @@ to the general criteria of this RFC:
 * Stream-level flow control maps to the bridge contract: window updates
   are withheld per stream while its ingress reservation cannot be taken
   (the same admission rule as h1), and the connection-level window tracks
-  the watermark state.
+  the watermark state.  Rejected and reset streams return abandoned DATA
+  credit before releasing their reservation, so repeated stream-local faults
+  cannot exhaust the shared connection window.
 * Connection-level limits are enforced from the shipped configuration:
   streams beyond ``h2_max_concurrent_streams`` are refused with
   ``REFUSED_STREAM``; ``h2_initial_window_bytes`` seeds both window

--- a/docs/source/rfc/rfc_0024_web_extension_api.rst
+++ b/docs/source/rfc/rfc_0024_web_extension_api.rst
@@ -755,6 +755,16 @@ correct nghttp2 server session is a multi-week item that must not gate
 v1.0, and its activation is purely additive: one translation unit and a
 registry entry, zero schema or API change.
 
+The activation splits along the third-party confinement rule: the protocol
+engine (``nghttp2_session.cpp``, the only nghttp2 TU) is a pure
+bytes-in/actions-out wrapper over an nghttp2 server session in the pull
+model, with automatic window updates disabled so request-DATA flow control
+releases only through an explicit consume — the reservation-admission
+lever; the connection driver (in ``asio_server.cpp``, the only Asio TU)
+owns the socket, the strand, and the bridge integration.  The engine is
+validated in-memory against a genuine nghttp2 client session
+(``hgraph_web_h2_engine_tests``) before any socket exists.
+
 Activation is gated on these server-side acceptance criteria, in addition
 to the general criteria of this RFC:
 

--- a/docs/source/user_guide/adaptors/web.rst
+++ b/docs/source/user_guide/adaptors/web.rst
@@ -4,81 +4,443 @@ Web (HTTP/S and WebSockets)
 ``hgraph-web`` is a first-party *extension* (like Kafka): a separate
 distribution with its own native transports, built against the hgraph SDK.
 Install it with ``pip install hgraph-web``.  The design record is
-:doc:`RFC 0024 <../../rfc/rfc_0024_web_extension_api>`.
+:doc:`RFC 0024 <../../rfc/rfc_0024_web_extension_api>`; this page is the
+user-facing guide.
 
 It provides all four transports — HTTP(S) server, HTTP(S) client, WebSocket
-server, and WebSocket client — as native services: an Asio/Beast server and
-a libcurl client (HTTP/2 capable on the client; the server activates HTTP/2
-in a later release behind its ALPN seam).  Requests, frames, and connection
+server, and WebSocket client — as native services: an Asio/Beast + nghttp2
+server and a libcurl client.  Both sides speak HTTP/1.1 and HTTP/2 (the
+server negotiates HTTP/2 over TLS when ``"h2"`` is advertised in the ALPN
+list; the client via its version policy).  Requests, frames, and connection
 lifecycles are ordinary graph data with bounded queues throughout; there is
 no user-held server or client object outside the graph.
+
+The model
+---------
+
+The extension adds no web-specific runtime concepts.  Each operation maps
+onto an existing hgraph service contract, registered once per *service
+path* and used from anywhere in the graph:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 26 50
+
+   * - Verb
+     - Contract
+     - Meaning
+   * - ``web_serve(route, path=)``
+     - subscription
+     - The immutable :class:`WebRoute` is the key; requests matching it
+       stream out, already routed — no in-graph URL matching.
+   * - ``web_respond(request_id, response, path=)``
+     - request/reply
+     - Answers are correlated by the transport-assigned ``request_id``;
+       each responder receives delivery reports for its own answers.
+   * - ``web_ws_serve(route, path=)`` / ``web_ws_send(...)``
+     - subscription / request/reply
+     - Upgrade routes stream connection events and inbound frames; sends
+       are keyed by ``connection_id`` and acknowledged by reports.
+   * - ``web_http_request(request, options=, path=)``
+     - request/reply
+     - One request time series maps to one result with distinct
+       ``response`` / ``failure`` arms.
+   * - ``web_ws_connect(key, path=)`` / ``web_ws_client_send(...)``
+     - subscription / request/reply
+     - The immutable :class:`WsClientKey` *is* the connection: adding it
+       connects, removing it closes.
+   * - ``web_server_events`` / ``web_client_events``
+     - reference
+     - One shared, typed :class:`WebEvent` stream per path.
+   * - ``web_server_stats`` / ``web_client_stats``
+     - reference
+     - One shared, periodically ticking statistics record per path.
+
+Under the hood, transport I/O threads deliver into the graph only through
+root push sources, and the graph reaches the sockets only through sink
+nodes — evaluation itself stays single-threaded and lock-free.  A request
+that a same-cycle handler can answer dispatches its response in that same
+engine cycle; there is no per-request feedback cycle.
+
+Nothing exists before the owning graph starts: sockets, TLS contexts, and
+worker threads are created at node start (a bind failure fails graph
+start), and stop drains bounded work before tearing down.  Several server
+registrations may share one listening port when their configurations are
+identical; requests dispatch per route, and a stopping registration
+retires only its own work while the shared listener keeps serving the
+rest.
 
 Serving HTTP
 ------------
 
-A server is registered at a service path; routes are data.  A route's
-requests arrive as a keyed stream, and responses are sent back through the
-respond service correlated by the transport-assigned request id:
+A server is registered at a path; routes are data.  A route's requests
+arrive as a keyed stream and responses go back through ``web_respond``,
+correlated by the transport-assigned request id:
 
 .. code-block:: python
 
-    from hgraph import TS, TSB, graph
-    from hgraph_web import (
-        HttpMethod, HttpResponse, HttpServerRequest, WebRoute, WebRouteOutput,
-        WebServerConfig, register_web_server, web_respond, web_serve,
-    )
+    import hgraph as hg
+    import hgraph_web as web
 
-    @graph
-    def serve_orders():
-        register_web_server(WebServerConfig(port=8080), path="site")
-        routed = web_serve(WebRoute(HttpMethod.GET, "/orders/{id}"), path="site")
-        response = handle_order(routed.request)      # your graph logic
-        web_respond(request_id(routed.request), response, path="site")
+    @hg.compute_node
+    def request_id(request: hg.TS[web.HttpServerRequest]) -> hg.TS[int]:
+        return request.value.request_id
 
-Key properties of the value contract (all defects of the tornado adaptor's
-shapes are unrepresentable here):
+    @hg.compute_node
+    def echo(request: hg.TS[web.HttpServerRequest]) -> hg.TS[web.HttpResponse]:
+        inbound = request.value.request
+        name = next(
+            (p.value for p in inbound.path_params if p.name == "name"), ""
+        )
+        return web.HttpResponse(
+            200,
+            headers=(web.WebHeader("content-type", "text/plain"),),
+            body=f"hello {name}".encode(),
+        )
 
-* headers and query parameters are ordered sequences of name/value pairs —
-  duplicates and order survive;
+    @hg.graph
+    def app():
+        web.register_web_server(web.WebServerConfig(port=8080), path="site")
+        served = web.web_serve(
+            web.WebRoute(web.HttpMethod.GET, "/echo/{name}"), path="site"
+        )
+        web.web_respond(
+            request_id(served["request"]), echo(served["request"]), path="site"
+        )
+
+Route patterns are literal segments, ``{name}`` captures, and an optional
+trailing ``/*rest``; precedence is literal over capture over rest, and
+path segments are percent-decoded before matching.  ``HEAD`` requests are
+served by a matching ``GET`` route with the body suppressed on the way
+out.  An unanswered request receives a transport ``503`` at the configured
+``request_timeout_ms`` and again at shutdown — requests are never silently
+dropped.
+
+Key properties of the value contract:
+
+* headers, query parameters, and trailers are **ordered sequences** of
+  name/value pairs — duplicates and arrival order survive;
 * bodies are ``bytes``; text and JSON are codec decisions above the
-  transport;
-* path captures (``{id}``) arrive decoded and typed in ``path_params``;
-* an unanswered request receives a transport ``503`` at the configured
-  request timeout — requests are never silently dropped;
+  transport (see `Endpoints and codecs`_);
+* path captures arrive decoded and named in ``path_params``;
 * TLS (including mTLS, with the verified client-certificate subject on
-  ``WebPeer``) is part of ``WebServerConfig``.
+  :class:`WebPeer`) is part of :class:`WebServerConfig`.
+
+Data structures
+---------------
+
+Server side
+~~~~~~~~~~~
+
+:class:`WebRoute` — ``(method, pattern, upgrade=False)``.  The immutable
+subscription key.  ``upgrade=True`` marks a WebSocket route.
+
+:class:`HttpServerRequest` — what ``web_serve`` streams (the ``request``
+field of its output bundle):
+
+* ``request_id`` — transport-assigned, monotonic; the correlation token
+  ``web_respond`` needs;
+* ``connection_id`` / ``stream_id`` — the physical connection and (on
+  HTTP/2) the real stream, for logging and diagnostics;
+* ``request`` — the :class:`HttpRequest` payload;
+* ``peer`` — the :class:`WebPeer` transport facts.
+
+:class:`HttpRequest` — one shape for both directions: ``method``
+(:class:`HttpMethod`), ``target`` (the raw request target), ``path``
+(percent-decoded), ``query`` and ``path_params`` (tuples of
+:class:`WebParam`), ``headers`` / ``trailers`` (tuples of
+:class:`WebHeader`), ``body`` (``bytes``).  On HTTP/2, request trailers
+(gRPC-style) arrive on ``trailers``.
+
+:class:`HttpResponse` — ``status``, ``headers``, ``body``, ``trailers``.
+Trailers on an HTTP/1.1 response are carried via chunked transfer; on
+HTTP/2 they are native trailing headers.
+
+:class:`WebPeer` — ``remote_address``, ``remote_port``, ``local_port``,
+``tls``, ``negotiated_protocol`` (``"h2"`` when HTTP/2 was negotiated),
+``sni``, and ``client_cert_subject`` (populated under mTLS).
 
 WebSockets
-----------
+~~~~~~~~~~
 
-Upgrade routes (``WebRoute(..., upgrade=True)``) stream connection events
-and inbound frames; sends are keyed by connection id.  Connection open and
-close are data (``WsEvent``), so session lifecycle is ordinary graph logic.
+:class:`WsEvent` — connection lifecycle as data: ``connection_id``,
+``state`` (:class:`WsConnectionState`: ``OPEN`` / ``CLOSING`` /
+``CLOSED`` / ``FAILED``), the originating upgrade ``request`` on open, and
+``close_code`` / ``close_reason`` on close.
 
-HTTP client
+:class:`WsInboundFrame` — ``connection_id`` plus a :class:`WsFrame`.
+
+:class:`WsFrame` — ``kind`` (:class:`WsFrameKind`: ``TEXT`` / ``BINARY``
+/ ``PING`` / ``PONG`` / ``CLOSE``) with ``text`` or ``data`` payloads and
+close fields; build them with ``text_frame`` / ``binary_frame`` or the
+codecs below.  Inbound messages are delivered complete (reassembled up to
+``ws_max_message_bytes``); outbound messages are fragmented at
+``ws_max_frame_bytes``.
+
+:class:`WsClientKey` — ``url``, extra ``headers``, ``subprotocols``; the
+client-side connection identity and lifecycle.
+
+Client side
+~~~~~~~~~~~
+
+:class:`HttpClientRequest` — ``method``, absolute ``url``, ``headers``,
+``body``.
+
+:class:`HttpClientOptions` — per-call ``connect_timeout_ms``,
+``request_timeout_ms``, redirect behaviour, and the ``http_version``
+policy (:class:`WebHttpVersionPolicy`: ``AUTO`` negotiates, ``H1_ONLY``
+pins 1.1, ``H2_ONLY`` *requires* HTTP/2 — an h1 answer is reported as a
+transport failure, never silently downgraded).
+
+``web_http_request`` output — a bundle with two arms: ``response``
+(:class:`HttpResponse`, whatever its status) and ``failure``
+(:class:`WebTransportError` with the curl error code).  A ``404`` is a
+response; a refused connection is a failure — fault domains never mix.
+
+Reports, events, statistics
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:class:`WebDeliveryReport` — the asynchronous acknowledgement for
+responses and WebSocket sends: ``request_id`` (or connection id for
+sends), ``status`` (:class:`WebDeliveryStatus`: ``DELIVERED`` only after
+the bytes left the connection; ``DROPPED`` when the peer cancelled or a
+slow consumer was cut; ``ENQUEUE_REJECTED``, ``RETRIABLE_FAILURE``, or
+``PERMANENT_FAILURE`` otherwise), plus ``retriable`` / ``fatal`` /
+``message``.
+
+:class:`WebEvent` — the shared diagnostics stream: ``severity``
+(:class:`WebSeverity`), ``component`` / ``category`` / ``message``,
+``service_path``, and ``connection_id`` where relevant.  Fatal transport
+conditions arrive here (and stop the graph under
+``WebFailurePolicy.STOP_GRAPH``).
+
+:class:`WebServerStats` / :class:`WebClientStats` — periodic (enable with
+``stats_interval_ms > 0``): the bound ``listening_port`` (the
+deterministic-test hook when ``port=0`` binds ephemerally), connection and
+pending counts, ingress queue depths in records and bytes, and the
+``dropped_count``.
+
+WebSockets, served and dialled
+------------------------------
+
+.. code-block:: python
+
+    @hg.graph
+    def live():
+        web.register_web_server(web.WebServerConfig(port=8080), path="site")
+        ws = web.web_ws_serve(
+            web.WebRoute(web.HttpMethod.GET, "/live", upgrade=True), path="site"
+        )
+        # ws["event"]  : TS[WsEvent]        — open/close as data
+        # ws["frame"]  : TS[WsInboundFrame] — complete inbound messages
+        replies = handle(web.ws_text(ws["frame"]))       # your logic
+        web.web_ws_send(connection_of(ws), web.text_frame(replies), path="site")
+
+Connection open and close are just events, so session lifecycle is
+ordinary graph logic; the served request that opened the socket rides on
+the ``OPEN`` event.  The client mirror is ``web_ws_connect(key)`` —
+producing the same event/frame shape — with ``web_ws_client_send(key,
+frame)`` for output; removing the key closes the connection with a normal
+close handshake.
+
+Calling out
 -----------
 
-``web_http_request`` maps one request time series to one result with
-distinct arms: an HTTP ``response`` (whatever its status) or a transport
-``failure`` (``WebTransportError`` with the curl error code) — transport
-failure is never disguised as a status code.  The WebSocket client connects
-per immutable ``WsClientKey``; removing the key closes the connection.
+.. code-block:: python
 
-Events, statistics, and flow control
-------------------------------------
+    result = web.web_http_request(
+        hg.const(
+            web.HttpClientRequest(web.HttpMethod.GET, "https://example.com/api")
+        ),
+        options=hg.const(web.HttpClientOptions(request_timeout_ms=5_000)),
+        path="api",
+    )
+    handle_response(result["response"])
+    handle_outage(result["failure"])
 
-Every server/client path also publishes a typed event stream
-(``web_server_events`` / ``web_client_events``) and periodic statistics
-(including the bound ``listening_port`` when ``port=0`` binds ephemerally —
-the deterministic-test hook).  All boundary queues are bounded in records
-and bytes with explicit overflow policies; watermarks pause socket reads
-while the graph catches up.
+The client pool is bounded (``max_connections_per_host`` /
+``max_total_connections``) and every call **reserves** its maximum
+response size (``max_response_bytes``) before it is handed to the
+transport, so a completed response can never be dropped for lack of queue
+space — the in-flight ceiling is ``ingress_byte_limit /
+max_response_bytes``.  Calls beyond the ceiling are staged or failed per
+``overflow`` / ``stage_overflow``.
+
+HTTP/2
+------
+
+*Server*: advertise it in the TLS ALPN list —
+
+.. code-block:: python
+
+    web.WebServerConfig(
+        port=8443,
+        tls=web.TlsServerConfig(
+            cert_path="server.pem", key_path="server.key",
+            alpn=("h2", "http/1.1"),
+        ),
+        h2_max_concurrent_streams=100,
+        h2_initial_window_bytes=1024 * 1024,
+    )
+
+Clients that negotiate ``h2`` get genuine multiplexing: concurrent
+streams on one connection (each with the real ``stream_id`` on its
+requests), per-stream flow control mapped onto the same ingress admission
+as HTTP/1.1, per-stream cancellation (a client ``RST_STREAM`` retires
+exactly that request; a late graph answer reports ``DROPPED``), and
+GOAWAY-based draining at shutdown.  Everything else on this page applies
+unchanged — same routes, same values, same reports.  What HTTP/2 does
+*not* include (WebSocket-over-h2, server push, streaming bodies, HTTP/3)
+is recorded in the RFC's protocol matrix.
+
+*Client*: ``WebHttpVersionPolicy.AUTO`` (the default) negotiates per
+connection; ``H2_ONLY`` uses prior knowledge on ``http://`` and ALPN on
+``https://``, verifying the negotiated version after completion.
+
+TLS
+---
+
+:class:`TlsServerConfig` takes the certificate chain and key as file
+paths *or* inline PEM (exactly one of each), an optional key password,
+and — for mTLS — a client CA plus ``client_verify``
+(:class:`WebClientVerify`: ``NONE`` / ``OPTIONAL`` / ``REQUIRED``); the
+verified subject appears on ``WebPeer.client_cert_subject``.  The minimum
+TLS version defaults to 1.2.  :class:`TlsClientConfig` mirrors it for the
+client (custom CA, client certificate, ``sni``, ``verify_peer`` /
+``verify_host``, ALPN).
+
+Endpoints and codecs
+--------------------
+
+The decorators wrap the serve/respond pairing for the common shapes, and
+the codec helpers compose hgraph's native JSON codec:
+
+.. code-block:: python
+
+    @web.http_endpoint(web.WebRoute(web.HttpMethod.POST, "/greet"), path="site")
+    @hg.graph
+    def greet(request: hg.TS[web.HttpServerRequest]) -> hg.TS[web.HttpResponse]:
+        return web.json_response(bump(web.request_json(request, Greeting)))
+
+``request_json(request, T)`` decodes the body into ``TS[T]``;
+``json_response(value, status=200)`` encodes with the right content type.
+``ws_endpoint`` does the same for WebSocket routes, and ``ws_text`` /
+``ws_binary`` / ``ws_json`` convert between frames and payload streams.
+
+Authentication is a wiring argument, not a process global: pass
+``auth=`` a graph ``TS[HttpServerRequest] -> TS[AuthResult]``; a denial
+short-circuits with the given status before your handler runs:
+
+.. code-block:: python
+
+    @hg.compute_node
+    def authenticate(request: hg.TS[web.HttpServerRequest]) -> hg.TS[web.AuthResult]:
+        ok = any(h.name == "authorization" for h in request.value.request.headers)
+        return web.AuthResult(allowed=ok, status=401, reason="credentials required")
+
+    @web.http_endpoint("/private", path="site", auth=authenticate)
+    @hg.compute_node
+    def private(request: hg.TS[web.HttpServerRequest]) -> hg.TS[web.HttpResponse]:
+        return web.HttpResponse(200, body=b"secret")
+
+Flow control and memory bounds
+------------------------------
+
+Every boundary queue is bounded in **records and bytes**, and the byte
+accounting is real: a request's admission is *reserved* against
+``ingress_byte_limit`` before its body is even read off the socket, so a
+flood cannot make the graph retain more than you configured — the excess
+stays in the kernel (HTTP/1.1 and WebSocket via paused reads, HTTP/2 via
+withheld per-stream flow-control window).  At the configured watermarks
+(``watermark_high_pct`` / ``watermark_low_pct``) socket reads pause and
+resume; at the hard limit the ``inbound_overflow`` policy applies:
+
+* ``BACKPRESSURE`` (default) — leave the request unread until capacity
+  returns;
+* ``REJECT`` — answer ``503`` (or close a WebSocket with ``1013``) from
+  the transport without graph involvement.
+
+A payload that could *never* fit is rejected outright (``413``, or
+WebSocket close ``1009``) rather than waiting forever, and configuration
+that would make legal payloads unadmittable — limits below the documented
+floors, or a route whose pattern is too large for the configured limits —
+fails at wiring or route-application time with a pointed error.
+
+Outbound, each connection owns a bounded queue; a slow WebSocket consumer
+triggers ``slow_consumer_policy`` (``CLOSE`` with code ``1013``, or
+``DROP_NEWEST``), and on HTTP/2 a slow stream is reset without harming
+its connection.  Delivery reports tell you which fate each send met.
+
+Testing
+-------
+
+The loopback pattern makes live-transport tests deterministic without
+fixed ports: bind with ``port=0``, enable ``stats_interval_ms``, and
+trigger the client off the discovered port —
+
+.. code-block:: python
+
+    web.register_web_server(
+        web.WebServerConfig(port=0, stats_interval_ms=50), path="site"
+    )
+    web.register_web_client(web.WebClientConfig(), path="api")
+
+    @hg.compute_node
+    def when_listening(stats: hg.TS[web.WebServerStats]) -> hg.TS[web.HttpClientRequest]:
+        port = stats.value.listening_port
+        if port:
+            return web.HttpClientRequest(
+                web.HttpMethod.GET, f"http://127.0.0.1:{port}/echo/it"
+            )
+
+    result = web.web_http_request(
+        when_listening(web.web_server_stats(path="site")), path="api"
+    )
+
+The extension's own suites run exactly this shape — the graph is both
+server and client of the same process.
+
+Configuration reference
+-----------------------
+
+:class:`WebServerConfig` (defaults in parentheses):
+
+* ``bind_address`` (``0.0.0.0``), ``port`` (``0`` = ephemeral),
+  ``bind_deferred`` (bind at first route instead of start), ``io_threads``
+  (1), ``max_connections`` (10 000);
+* request shape: ``max_header_bytes`` (64 KiB), ``max_body_bytes``
+  (16 MiB);
+* time: ``request_timeout_ms`` (30 s — the transport-503 deadline),
+  ``idle_timeout_ms`` (60 s), ``keep_alive_timeout_ms`` (15 s),
+  ``shutdown_drain_timeout_ms`` (5 s);
+* ingress bounds: ``ingress_record_limit`` / ``ingress_byte_limit``
+  (10 000 / 64 MiB) and the WS pair, ``watermark_high_pct`` /
+  ``watermark_low_pct`` (80/50), ``inbound_overflow`` (``BACKPRESSURE``);
+* outbound: ``outbound_message_limit`` / ``outbound_byte_limit``
+  (1 000 / 16 MiB), ``slow_consumer_policy`` (``CLOSE``);
+* WebSocket: ``ws_max_frame_bytes`` (1 MiB), ``ws_max_message_bytes``
+  (16 MiB), ``ping_interval_ms`` / ``pong_timeout_ms`` (30 s / 10 s);
+* HTTP/2: ``h2_max_concurrent_streams`` (100),
+  ``h2_initial_window_bytes`` (1 MiB);
+* ``failure_policy`` (``REPORT``; ``STOP_GRAPH`` turns fatal transport
+  events into an engine stop), ``stats_interval_ms`` (0 = off),
+  ``tls`` (``None`` = plaintext).
+
+:class:`WebClientConfig`: ``http_version_policy`` (``AUTO``), pool sizes
+``max_connections_per_host`` / ``max_total_connections`` (6/64), the
+timeout family, ``proxy``, ``max_response_bytes`` (16 MiB — the per-call
+reservation), the same ingress/watermark family, call staging
+``overflow`` / ``stage_overflow`` (``STAGE`` / ``FAIL``), the WebSocket
+family, ``failure_policy``, ``stats_interval_ms``, ``tls``.
 
 Relationship to ``hgraph.adaptors.tornado``
 -------------------------------------------
 
-The released tornado adaptor keeps working unchanged and does not require
-this extension.  A compatibility surface re-implementing the tornado API on
-the native transports ships as ``hgraph_web.compat``; migration of the
-tornado package itself is a separate, evidence-driven decision
-(RFC 0024, compatibility and migration).
+The released tornado *server* surface (``http_server_handler``,
+``websocket_server_handler``, their adaptors, and ``@rest_handler`` above
+them) is now **implemented by this extension**: ``hgraph_web.compat``
+reproduces the released semantics on the native transports, and the
+``hgraph[web]`` extra installs ``hgraph-web`` alongside Tornado so those
+import paths keep working unchanged.  The tornado-backed HTTP/WebSocket
+*clients* remain in core.  New code should use ``hgraph_web`` directly —
+everything above this section.

--- a/docs/source/user_guide/adaptors/web.rst
+++ b/docs/source/user_guide/adaptors/web.rst
@@ -58,7 +58,9 @@ path* and used from anywhere in the graph:
 
 Under the hood, transport I/O threads deliver into the graph only through
 root push sources, and the graph reaches the sockets only through sink
-nodes — evaluation itself stays single-threaded and lock-free.  A request
+nodes — evaluation itself stays single-threaded, with the bounded boundary
+queues (and their short handoff locks) as the only cross-thread
+touchpoints.  A request
 that a same-cycle handler can answer dispatches its response in that same
 engine cycle; there is no per-request feedback cycle.
 
@@ -174,8 +176,9 @@ WebSockets
 / ``PING`` / ``PONG`` / ``CLOSE``) with ``text`` or ``data`` payloads and
 close fields; build them with ``text_frame`` / ``binary_frame`` or the
 codecs below.  Inbound messages are delivered complete (reassembled up to
-``ws_max_message_bytes``); outbound messages are fragmented at
-``ws_max_frame_bytes``.
+``ws_max_message_bytes``); on the server, outbound messages are fragmented
+at ``ws_max_frame_bytes``, while the client rejects an oversized outbound
+frame with a delivery report instead of fragmenting it.
 
 :class:`WsClientKey` — ``url``, extra ``headers``, ``subprotocols``; the
 client-side connection identity and lifecycle.
@@ -240,8 +243,9 @@ Connection open and close are just events, so session lifecycle is
 ordinary graph logic; the served request that opened the socket rides on
 the ``OPEN`` event.  The client mirror is ``web_ws_connect(key)`` —
 producing the same event/frame shape — with ``web_ws_client_send(key,
-frame)`` for output; removing the key closes the connection with a normal
-close handshake.
+frame)`` for output; removing the key sends a Close frame and tears the
+connection down promptly (the client does not wait for the peer's close
+echo; the server side performs the full close handshake).
 
 Calling out
 -----------

--- a/docs/source/user_guide/adaptors/web.rst
+++ b/docs/source/user_guide/adaptors/web.rst
@@ -244,8 +244,9 @@ ordinary graph logic; the served request that opened the socket rides on
 the ``OPEN`` event.  The client mirror is ``web_ws_connect(key)`` —
 producing the same event/frame shape — with ``web_ws_client_send(key,
 frame)`` for output; removing the key sends a Close frame and tears the
-connection down promptly (the client does not wait for the peer's close
-echo; the server side performs the full close handshake).
+connection down promptly.  Both transports send a Close frame; they then
+tear down once that write completes or peer closure is observed rather than
+waiting indefinitely for a close echo.
 
 Calling out
 -----------

--- a/extensions/web/CMakeLists.txt
+++ b/extensions/web/CMakeLists.txt
@@ -221,6 +221,7 @@ unset(_hgraph_web_saved_build_testing)
 add_library(hgraph_web
     src/asio_server.cpp
     src/curl_client.cpp
+    src/nghttp2_session.cpp
     src/detail/route_table.cpp
     src/service.cpp
     src/value_builders.cpp
@@ -249,6 +250,7 @@ target_link_libraries(hgraph_web
     # leg; wheels are always shared).
     PRIVATE $<BUILD_INTERFACE:${HGRAPH_WEB_BOOST_TARGETS}>
             $<BUILD_INTERFACE:${HGRAPH_WEB_CURL_TARGET}>
+            $<BUILD_INTERFACE:${HGRAPH_WEB_NGHTTP2_TARGET}>
             OpenSSL::SSL OpenSSL::Crypto
 )
 target_include_directories(hgraph_web

--- a/extensions/web/cmake/hgraph-webConfig.cmake.in
+++ b/extensions/web/cmake/hgraph-webConfig.cmake.in
@@ -17,6 +17,21 @@ get_target_property(_hgraph_web_type hgraph::web TYPE)
 if(_hgraph_web_type STREQUAL "STATIC_LIBRARY")
     find_dependency(CURL)
     target_link_libraries(hgraph::web INTERFACE CURL::libcurl)
+    # The HTTP/2 session references nghttp2 symbols directly from the
+    # archive, so a STATIC consumer needs nghttp2 at its final link as
+    # well (a shared/system curl does not satisfy those references).
+    find_package(nghttp2 CONFIG QUIET)
+    if(TARGET nghttp2::nghttp2)
+        target_link_libraries(hgraph::web INTERFACE nghttp2::nghttp2)
+    else()
+        find_library(HGRAPH_WEB_NGHTTP2_LIBRARY NAMES nghttp2)
+        if(NOT HGRAPH_WEB_NGHTTP2_LIBRARY)
+            message(FATAL_ERROR
+                "hgraph-web (static) needs libnghttp2 at the consumer's "
+                "final link; install its development package")
+        endif()
+        target_link_libraries(hgraph::web INTERFACE "${HGRAPH_WEB_NGHTTP2_LIBRARY}")
+    endif()
 endif()
 unset(_hgraph_web_type)
 

--- a/extensions/web/include/hgraph/web/value_builders.h
+++ b/extensions/web/include/hgraph/web/value_builders.h
@@ -94,6 +94,8 @@ namespace hgraph::web
         ServerConfigBuilder &idle_timeout(std::chrono::milliseconds value);
         ServerConfigBuilder &keep_alive_timeout(std::chrono::milliseconds value);
         ServerConfigBuilder &bind_deferred(bool value);
+        ServerConfigBuilder &h2_max_concurrent_streams(Int value);
+        ServerConfigBuilder &h2_initial_window_bytes(Int value);
         ServerConfigBuilder &ingress_limits(Int records, Int bytes);
         ServerConfigBuilder &ws_ingress_limits(Int records, Int bytes);
         ServerConfigBuilder &watermarks(Int high_pct, Int low_pct);

--- a/extensions/web/python/hgraph_web/__init__.py
+++ b/extensions/web/python/hgraph_web/__init__.py
@@ -298,13 +298,11 @@ class TlsServerConfig(CompoundScalar, namespace=_NAMESPACE):
             raise ValueError("Web server TLS requires a private key")
         if self.client_verify != WebClientVerify.NONE and not self.ca_path and not self.ca_pem:
             raise ValueError("Web client-certificate verification requires a CA")
-        # Advertising a protocol the server does not speak is a protocol
-        # violation: "h2" stays rejected until the HTTP/2 session activates
-        # behind the ALPN seam (RFC 0024).
-        if any(protocol == "h2" for protocol in self.alpn):
-            raise ValueError(
-                "Web server ALPN cannot advertise h2 before the HTTP/2 session is activated"
-            )
+        # The HTTP/2 session is active behind the ALPN seam (RFC 0024,
+        # activation plan): "h2" is a legal server protocol.  Only known
+        # protocols may be advertised.
+        if any(protocol not in ("h2", "http/1.1") for protocol in self.alpn):
+            raise ValueError('Web server ALPN accepts only "h2" and "http/1.1"')
 
 
 @dataclass(frozen=True)

--- a/extensions/web/python/hgraph_web/__init__.py
+++ b/extensions/web/python/hgraph_web/__init__.py
@@ -391,12 +391,12 @@ class WebServerConfig(CompoundScalar, namespace=_NAMESPACE):
         _require_non_negative(self.stats_interval_ms, "stats interval")
         # Mirrors the native builders: a single maximal payload must always
         # fit an empty ingress channel, or Backpressure would hold it forever.
-        # Two header blocks: HTTP/2 caps the initial headers and the
-        # trailers separately, and each may reach max_header_bytes.
-        if self.ingress_byte_limit < self.max_body_bytes + 2 * self.max_header_bytes + 512:
+        # Two header blocks (HTTP/2 caps initial headers and trailers
+        # separately), each weighed twice for the source-plus-graph copies.
+        if self.ingress_byte_limit < self.max_body_bytes + 4 * self.max_header_bytes + 1024:
             raise ValueError(
                 "Web ingress_byte_limit must cover one maximal request "
-                "(max_body_bytes + 2*max_header_bytes + 512)"
+                "(max_body_bytes + 4*max_header_bytes + 1024)"
             )
         if self.ws_ingress_byte_limit < self.ws_max_message_bytes + 256:
             raise ValueError(

--- a/extensions/web/python/hgraph_web/__init__.py
+++ b/extensions/web/python/hgraph_web/__init__.py
@@ -401,6 +401,14 @@ class WebServerConfig(CompoundScalar, namespace=_NAMESPACE):
                 "Web ws_ingress_byte_limit must cover one maximal message "
                 "(ws_max_message_bytes + 256)"
             )
+        _require_positive(self.h2_max_concurrent_streams, "h2_max_concurrent_streams")
+        _require_positive(self.h2_initial_window_bytes, "h2_initial_window_bytes")
+        # HTTP/2 windows and stream counts are 31-bit quantities (mirrors
+        # the native builder).
+        if self.h2_initial_window_bytes > 2**31 - 1:
+            raise ValueError("Web h2_initial_window_bytes must be at most 2^31-1")
+        if self.h2_max_concurrent_streams > 2**31 - 1:
+            raise ValueError("Web h2_max_concurrent_streams must be at most 2^31-1")
 
 
 @dataclass(frozen=True)

--- a/extensions/web/python/hgraph_web/__init__.py
+++ b/extensions/web/python/hgraph_web/__init__.py
@@ -391,10 +391,12 @@ class WebServerConfig(CompoundScalar, namespace=_NAMESPACE):
         _require_non_negative(self.stats_interval_ms, "stats interval")
         # Mirrors the native builders: a single maximal payload must always
         # fit an empty ingress channel, or Backpressure would hold it forever.
-        if self.ingress_byte_limit < self.max_body_bytes + self.max_header_bytes + 512:
+        # Two header blocks: HTTP/2 caps the initial headers and the
+        # trailers separately, and each may reach max_header_bytes.
+        if self.ingress_byte_limit < self.max_body_bytes + 2 * self.max_header_bytes + 512:
             raise ValueError(
                 "Web ingress_byte_limit must cover one maximal request "
-                "(max_body_bytes + max_header_bytes + 512)"
+                "(max_body_bytes + 2*max_header_bytes + 512)"
             )
         if self.ws_ingress_byte_limit < self.ws_max_message_bytes + 256:
             raise ValueError(

--- a/extensions/web/python/hgraph_web/__init__.py
+++ b/extensions/web/python/hgraph_web/__init__.py
@@ -391,12 +391,12 @@ class WebServerConfig(CompoundScalar, namespace=_NAMESPACE):
         _require_non_negative(self.stats_interval_ms, "stats interval")
         # Mirrors the native builders: a single maximal payload must always
         # fit an empty ingress channel, or Backpressure would hold it forever.
-        # Two header blocks (HTTP/2 caps initial headers and trailers
-        # separately), each weighed twice for the source-plus-graph copies.
-        if self.ingress_byte_limit < self.max_body_bytes + 4 * self.max_header_bytes + 1024:
+        # The transport's worst-case weight: a 2x initial header block with
+        # a 4x-weighted target (worst case 4x one block) plus 2x trailers.
+        if self.ingress_byte_limit < self.max_body_bytes + 6 * self.max_header_bytes + 1024:
             raise ValueError(
                 "Web ingress_byte_limit must cover one maximal request "
-                "(max_body_bytes + 4*max_header_bytes + 1024)"
+                "(max_body_bytes + 6*max_header_bytes + 1024)"
             )
         if self.ws_ingress_byte_limit < self.ws_max_message_bytes + 256:
             raise ValueError(

--- a/extensions/web/python/tests/test_api.py
+++ b/extensions/web/python/tests/test_api.py
@@ -327,6 +327,15 @@ def test_invalid_public_values_are_rejected_at_construction(factory, error) -> N
         factory()
 
 
+def test_server_alpn_accepts_h2() -> None:
+    # The HTTP/2 session is active behind the ALPN seam (RFC 0024,
+    # activation plan): advertising h2 is a legal configuration.
+    config = web.TlsServerConfig(
+        cert_path="cert.pem", key_path="key.pem", alpn=("h2", "http/1.1")
+    )
+    assert config.alpn == ("h2", "http/1.1")
+
+
 def test_ws_frame_helpers_mirror_the_native_makers() -> None:
     text = web.WsFrame.text_frame("hello")
     assert (text.kind, text.text, text.data) == (web.WsFrameKind.TEXT, "hello", None)

--- a/extensions/web/python/tests/test_api.py
+++ b/extensions/web/python/tests/test_api.py
@@ -248,9 +248,9 @@ def test_config_defaults_match_the_native_builders() -> None:
         ),
         (
             lambda: web.TlsServerConfig(
-                cert_path="cert.pem", key_path="key.pem", alpn=("h2", "http/1.1")
+                cert_path="cert.pem", key_path="key.pem", alpn=("spdy/3",)
             ),
-            "cannot advertise h2",
+            'accepts only "h2" and "http/1.1"',
         ),
         (
             lambda: web.TlsServerConfig(

--- a/extensions/web/python/tests/test_compat.py
+++ b/extensions/web/python/tests/test_compat.py
@@ -9,6 +9,7 @@ a listening port before it sends, which is why the server is registered with a
 non-zero ``stats_interval_ms``.
 """
 
+import random
 import socket
 from datetime import timedelta
 
@@ -53,9 +54,20 @@ def _client_config():
 
 @pytest.fixture
 def free_tcp_port():
-    with socket.socket() as sock:
-        sock.bind(("127.0.0.1", 0))
-        return sock.getsockname()[1]
+    # Allocate OUTSIDE the OS ephemeral range: a probe-close-bind port from
+    # the ephemeral range can be reissued as an outbound SOURCE port (client
+    # connection pools) before the server binds it — the "Address already in
+    # use" flake seen on the macOS CI leg.
+    start = random.randint(20000, 31000)
+    for offset in range(1000):
+        candidate = start + offset
+        with socket.socket() as sock:
+            try:
+                sock.bind(("127.0.0.1", candidate))
+            except OSError:
+                continue
+            return candidate
+    raise RuntimeError("no free TCP port found")
 
 
 def _call(port, target, *, method=None, headers=(), body=b"", extra=None):

--- a/extensions/web/src/asio_server.cpp
+++ b/extensions/web/src/asio_server.cpp
@@ -1045,32 +1045,30 @@ public:
       if (self->closed_) {
         return;
       }
-      // Only the stopping runtime's streams retire; a shared listener's
-      // other attachees keep this connection serving (review P1).
-      std::vector<std::int32_t> retiring;
-      for (const auto &[stream_id, stream] : self->streams_) {
-        if (stream.matched.runtime.get() == runtime && !stream.discarding) {
-          retiring.push_back(stream_id);
-        }
-      }
-      for (const std::int32_t stream_id : retiring) {
-        self->respond_transport(stream_id, 503, "server shutting down");
-      }
+      // Stamp FIRST, respond after: a small 503 or RST can reach
+      // on_stream_closed inside the very pump that sends it, erasing the
+      // stream — stamping afterwards would let the retirement token
+      // release while that socket write is still outstanding (review P1).
       // Delivery reports already queued for the retiring runtime release
-      // the barrier only when their carrying write completes (review P1).
+      // the barrier only when their carrying write completes.
       for (auto &report : self->pending_flush_reports_) {
         if (report.runtime.get() == runtime) {
           report.barrier = barrier;
         }
       }
-      // The barrier rides EVERY stream of the retiring runtime to its
-      // terminal event (close/reset/write failure) — an output-queue
-      // sentinel would release while a zero-window client still blocks a
-      // submitted response (review P1).
+      std::vector<std::int32_t> retiring;
       for (auto &[stream_id, stream] : self->streams_) {
         if (stream.matched.runtime.get() == runtime) {
           stream.retire_barrier = barrier;
+          if (!stream.discarding) {
+            retiring.push_back(stream_id);
+          }
         }
+      }
+      // Only the stopping runtime's streams retire; a shared listener's
+      // other attachees keep this connection serving.
+      for (const std::int32_t stream_id : retiring) {
+        self->respond_transport(stream_id, 503, "server shutting down");
       }
       if (!retiring.empty() && !self->closed_) {
         self->pump_writes();
@@ -1773,6 +1771,14 @@ void WebServerRuntime::unregister_ws_connection(Int connection_id) noexcept {
 bool WebServerRuntime::push_request_reserved(Value route, Value request,
                                              std::size_t retained_bytes,
                                              std::size_t reserved_bytes) {
+  if (retained_bytes > reserved_bytes) {
+    // Admission projects the exact derived sizes, so this cannot happen
+    // by construction; if it ever does, surface it instead of letting a
+    // silent clamp mask the under-accounting (review P2).
+    emit_event(WebSeverity::Warning, Str{"server"}, Str{"accounting"},
+               Str{"request retained estimate exceeded its reservation"});
+    retained_bytes = reserved_bytes;
+  }
   return bridge_.value->push_reserved(
       index(ServerChannel::Request),
       build_on(bindings_.request_envelope,
@@ -1780,7 +1786,7 @@ bool WebServerRuntime::push_request_reserved(Value route, Value request,
                    {"route", std::move(route)},
                    {"request", std::move(request)},
                }),
-      std::min(retained_bytes, reserved_bytes), reserved_bytes);
+      retained_bytes, reserved_bytes);
 }
 
 void WebServerRuntime::push_ws_event(Value route, Value event,
@@ -2138,11 +2144,25 @@ void ServerConnection::admit_and_read_body(MatchedRoute matched) {
       : content_length.has_value()
           ? static_cast<std::size_t>(*content_length)
           : config_->max_body_bytes;
-  // The Beast source is released at dispatch, so headers single-count;
-  // the target weighs 4x to bound its request-controlled derivations
-  // (decoded path, query pairs, path-parameter values).
-  const std::size_t projected =
-      projected_body + header_bytes + 4 * header.target().size() + 512;
+  // The derived sizes are already known at admission — decoded path,
+  // query slice, and the MATCHED parameter names and values (route
+  // patterns can carry capture names with no length relation to the
+  // target) — so the projection uses them exactly (review P2).
+  const std::string_view admission_target{header.target().data(),
+                                          header.target().size()};
+  const auto admission_query = admission_target.find('?');
+  const std::size_t query_size =
+      admission_query == std::string_view::npos
+          ? 0
+          : admission_target.size() - admission_query - 1;
+  std::size_t params_bytes = 0;
+  for (const auto &[name, value] : matched.params) {
+    params_bytes += name.size() + value.size();
+  }
+  const std::size_t projected = projected_body + header_bytes +
+                                admission_target.size() +
+                                decoded_path_.size() + query_size +
+                                params_bytes + 512;
   const std::shared_ptr<WebServerRuntime> runtime = matched.runtime;
   serving_runtime_ = runtime.get();
   if (runtime->reserve_request(projected)) {
@@ -2594,6 +2614,11 @@ void ServerConnection::accept_ws(MatchedRoute matched) {
                          {"request", server_request.clone()},
                      }),
             request_bytes + 512);
+        // Beast no longer needs the upgrade request; releasing it keeps
+        // the single-counted accounting honest for the WebSocket's whole
+        // lifetime (review P1).
+        self->request_ = http::request<http::string_body>{};
+        self->decoded_path_ = std::string{};
         self->ws_read_continue();
       });
   if (tls_stream_.has_value()) {
@@ -3221,12 +3246,24 @@ void H2Driver::admit_stream(std::int32_t stream_id) {
   // Header admission mirrors h1: the header block plus envelope overhead
   // reserves before any DATA window is released; the body then grows the
   // same reservation chunk-by-chunk (RFC 0024, flow control).
-  // Transport copies are released once the graph value is built, so the
-  // reservation single-counts the headers; the target weighs 4x to bound
-  // its request-controlled derivations (decoded path, query pairs,
-  // path-parameter values, each <= the target).
-  const std::size_t projected =
-      stream.header_bytes + 4 * stream.target.size() + 512;
+  // The derived sizes are already known at admission — decoded path,
+  // query slice, and the MATCHED parameter names and values (route
+  // patterns can carry capture names with no length relation to the
+  // target) — so the projection uses them exactly instead of a
+  // target-multiplier bound (review P2).
+  const std::string_view target_view{stream.target};
+  const auto admission_query = target_view.find('?');
+  const std::size_t query_size =
+      admission_query == std::string_view::npos
+          ? 0
+          : target_view.size() - admission_query - 1;
+  std::size_t params_bytes = 0;
+  for (const auto &[name, value] : stream.matched.params) {
+    params_bytes += name.size() + value.size();
+  }
+  const std::size_t projected = stream.header_bytes + stream.target.size() +
+                                stream.decoded_path.size() + query_size +
+                                params_bytes + 512;
   if (runtime->reserve_request(projected)) {
     stream.admitted = true;
     stream.reserved = projected;

--- a/extensions/web/src/asio_server.cpp
+++ b/extensions/web/src/asio_server.cpp
@@ -668,6 +668,9 @@ public:
                                            std::size_t reserved_bytes);
   [[nodiscard]] bool push_ws_event(Value route, Value event,
                                    std::size_t retained_bytes);
+  [[nodiscard]] bool push_ws_event_reserved(Value route, Value event,
+                                            std::size_t retained_bytes,
+                                            std::size_t reserved_bytes);
   [[nodiscard]] bool push_ws_frame_reserved(Value route, Value inbound_frame,
                                             std::size_t retained_bytes,
                                             std::size_t reserved_bytes);
@@ -981,6 +984,9 @@ private:
   std::shared_ptr<const void> retire_barrier_{};
   std::size_t ws_reserved_bytes_{};
   std::size_t ws_unaccounted_bytes_{};
+  // Capacity for THIS connection's terminal Closed/Failed event, reserved
+  // at accept and held for the socket's lifetime (review P1).
+  std::size_t ws_close_reserved_{};
   // Message bytes accumulate here — storage the reservation accounts —
   // while ws_read_buffer_ stays chunk-sized: Beast's flat_buffer keeps its
   // allocated capacity after consume(), so assembling messages inside it
@@ -1858,6 +1864,21 @@ bool WebServerRuntime::push_request_reserved(Value route, Value request,
       retained_bytes, reserved_bytes);
 }
 
+bool WebServerRuntime::push_ws_event_reserved(Value route, Value event,
+                                              std::size_t retained_bytes,
+                                              std::size_t reserved_bytes) {
+  // Terminal lifecycle events ride capacity reserved at accept, so a full
+  // channel can never lose a Closed/Failed event (review P1).
+  return bridge_.value->push_reserved(
+      index(ServerChannel::WsIngress),
+      build_on(bindings_.ws_ingress_envelope,
+               {
+                   {"route", std::move(route)},
+                   {"event", std::move(event)},
+               }),
+      std::min(retained_bytes, reserved_bytes), reserved_bytes);
+}
+
 bool WebServerRuntime::push_ws_event(Value route, Value event,
                                      std::size_t retained_bytes) {
   // Connection lifecycle is graph data and must never be lost (review P1):
@@ -2712,6 +2733,22 @@ void ServerConnection::accept_ws(MatchedRoute matched) {
           self->close();
           return;
         }
+        // Reserve the terminal event's capacity for the connection's
+        // lifetime: lifecycle-as-data means the Closed/Failed event must
+        // never be lost to a full channel (review P1).  A connection
+        // whose terminal event cannot be guaranteed does not open.
+        const std::size_t close_weight = self->ws_route_weight_ + 128 + 512;
+        if (!runtime->reserve_ws_ingress(close_weight)) {
+          runtime->count_drop();
+          runtime->emit_event(
+              WebSeverity::Warning, Str{"server"}, Str{"ws_ingress"},
+              Str{"terminal-event capacity unavailable; closing"}, 0, true,
+              false, self->ws_connection_id_);
+          runtime->unregister_ws_connection(self->ws_connection_id_);
+          self->close();
+          return;
+        }
+        self->ws_close_reserved_ = close_weight;
         // Beast no longer needs the upgrade request; releasing it keeps
         // the single-counted accounting honest for the WebSocket's whole
         // lifetime (review P1).
@@ -2756,19 +2793,29 @@ void ServerConnection::ws_read_next() {
                                            reason.reason.size()}};
           }
           const auto &b = runtime->bindings();
-          static_cast<void>(runtime->push_ws_event(
-              self->ws_route_->clone(),
-              build_on(b.ws_event,
-                       {
-                           {"connection_id",
-                            b.number(self->ws_connection_id_)},
-                           {"state",
-                            b.enum_value(orderly ? WsConnectionState::Closed
-                                                 : WsConnectionState::Failed)},
-                           {"close_code", b.number(close_code)},
-                           {"close_reason", b.string(close_reason)},
-                       }),
-              close_reason.size() + self->ws_route_weight_ + 512));
+          Value terminal = build_on(
+              b.ws_event,
+              {
+                  {"connection_id", b.number(self->ws_connection_id_)},
+                  {"state",
+                   b.enum_value(orderly ? WsConnectionState::Closed
+                                        : WsConnectionState::Failed)},
+                  {"close_code", b.number(close_code)},
+                  {"close_reason", b.string(close_reason)},
+              });
+          const std::size_t terminal_bytes =
+              close_reason.size() + self->ws_route_weight_ + 512;
+          if (self->ws_close_reserved_ != 0) {
+            const std::size_t reserved = self->ws_close_reserved_;
+            self->ws_close_reserved_ = 0;
+            static_cast<void>(runtime->push_ws_event_reserved(
+                self->ws_route_->clone(), std::move(terminal),
+                terminal_bytes, reserved));
+          } else {
+            static_cast<void>(runtime->push_ws_event(
+                self->ws_route_->clone(), std::move(terminal),
+                terminal_bytes));
+          }
           self->close();
           return;
         }
@@ -3078,6 +3125,12 @@ void ServerConnection::ws_close(websocket::close_code code,
 void ServerConnection::close() {
   release_admission();
   release_ws_reservation_held();
+  if (ws_close_reserved_ != 0 && ws_runtime_) {
+    // Torn down without a terminal event (forced teardown): return the
+    // reserved capacity.
+    ws_runtime_->release_ws_reservation(ws_close_reserved_);
+    ws_close_reserved_ = 0;
+  }
   close_socket_only();
   retire_barrier_.reset();
 }
@@ -3437,16 +3490,12 @@ void H2Driver::on_request_data(std::int32_t stream_id, std::string_view data,
   }
   if (stream.body.size() + data.size() >
       stream.matched.runtime->config().max_body_bytes) {
-    // The per-request cap, the h2 mirror of Beast's body_limit: the
-    // over-cap body is never retained, and the window held by any
-    // unaccounted bytes is released before the stream starts discarding
+    // The per-request cap, the h2 mirror of Beast's body_limit.  The
+    // just-arrived chunk was never buffered, so its window is released
+    // here; respond_transport restores the rest and discards uniformly
     // (review P1).
-    engine_.consume(stream_id, stream.unaccounted + data.size());
-    unaccounted_total_ -= std::min(unaccounted_total_, stream.unaccounted);
-    stream.unaccounted = 0;
-    stream.body = std::string{};
+    engine_.consume(stream_id, data.size());
     respond_transport(stream_id, 413, "body exceeds max_body_bytes");
-    resume_stalled_read();
     return;
   }
   stream.body.append(data);
@@ -3526,17 +3575,10 @@ void H2Driver::account_stream_data(std::int32_t stream_id) {
     const std::size_t pending = data_pending + stream.trailer_unaccounted;
     if (stream.reserved + pending >
         stream.matched.runtime->config().ingress.bytes) {
-      // Incremental growth that can NEVER fit: release the held window
-      // and answer, mirroring the body-cap path (review P1).
-      engine_.consume(stream_id, stream.unaccounted);
-      unaccounted_total_ -=
-          std::min(unaccounted_total_,
-                   stream.unaccounted + stream.trailer_unaccounted);
-      stream.unaccounted = 0;
-      stream.trailer_unaccounted = 0;
+      // Incremental growth that can NEVER fit: respond_transport restores
+      // the held window and discards the buffers uniformly (review P1).
       respond_transport(stream_id, 413,
                         "request cannot fit the ingress limit");
-      resume_stalled_read();
       return;
     }
     if (stream.matched.runtime->grow_request_reservation(pending)) {
@@ -3672,8 +3714,27 @@ void H2Driver::respond_transport(std::int32_t stream_id, int status,
                                  std::string_view body) {
   const auto found = streams_.find(stream_id);
   if (found != streams_.end()) {
-    release_stream(stream_id, found->second);
-    found->second.discarding = true;
+    Stream &stream = found->second;
+    // Every transport answer discards uniformly BEFORE the budget is
+    // released: restore the flow-control window held by unconsumed DATA
+    // (auto window updates are off, so a skipped consume() shrinks the
+    // connection window forever) and drop the retained request buffers —
+    // releasing the reservation while still holding the body would keep
+    // memory outside the advertised bound until the peer half-closes
+    // (review P1).
+    if (stream.unaccounted != 0) {
+      engine_.consume(stream_id, stream.unaccounted);
+    }
+    const std::size_t buffered =
+        stream.unaccounted + stream.trailer_unaccounted;
+    unaccounted_total_ -= std::min(unaccounted_total_, buffered);
+    stream.unaccounted = 0;
+    stream.trailer_unaccounted = 0;
+    stream.body = std::string{};
+    stream.trailers = H2Headers{};
+    release_stream(stream_id, stream);
+    stream.discarding = true;
+    resume_stalled_read();
   }
   // Transport answers obey the same outbound budgets as graph responses:
   // a slow peer accumulating error responses is reset instead of growing

--- a/extensions/web/src/asio_server.cpp
+++ b/extensions/web/src/asio_server.cpp
@@ -8,6 +8,7 @@
 #include <hgraph/web/service.h>
 #include <hgraph/web/value_builders.h>
 
+#include "detail/h2_engine.h"
 #include "detail/route_table.h"
 #include "detail/service_bridge.h"
 #include "detail/web_bindings.h"
@@ -30,6 +31,7 @@
 #include <compare>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <deque>
 #include <functional>
 #include <map>
@@ -111,6 +113,8 @@ struct ServerRuntimeConfig {
   std::chrono::milliseconds ping_interval{};
   std::chrono::milliseconds pong_timeout{};
   std::chrono::milliseconds stats_interval{};
+  Int h2_max_concurrent_streams{};
+  Int h2_initial_window_bytes{};
 };
 
 [[nodiscard]] std::size_t positive_size(const ValueView &field,
@@ -194,6 +198,10 @@ milliseconds_field(const ValueView &field, std::string_view name) {
       milliseconds_field(root.at("pong_timeout_ms"), "pong timeout");
   result.stats_interval =
       milliseconds_field(root.at("stats_interval_ms"), "stats interval");
+  result.h2_max_concurrent_streams = static_cast<Int>(positive_size(
+      root.at("h2_max_concurrent_streams"), "h2_max_concurrent_streams"));
+  result.h2_initial_window_bytes = static_cast<Int>(positive_size(
+      root.at("h2_initial_window_bytes"), "h2_initial_window_bytes"));
 
   // A single maximal payload must always fit an EMPTY ingress channel:
   // under Backpressure a message that can never fit would otherwise be
@@ -276,6 +284,20 @@ inline std::ostream &operator<<(std::ostream &stream,
   default:
     return std::nullopt;
   }
+}
+
+/** The h2 ``:method`` token (always uppercase on the wire). */
+[[nodiscard]] std::optional<HttpMethod>
+method_from_token(std::string_view token) noexcept {
+  if (token == "GET") { return HttpMethod::Get; }
+  if (token == "HEAD") { return HttpMethod::Head; }
+  if (token == "POST") { return HttpMethod::Post; }
+  if (token == "PUT") { return HttpMethod::Put; }
+  if (token == "DELETE") { return HttpMethod::Delete; }
+  if (token == "PATCH") { return HttpMethod::Patch; }
+  if (token == "OPTIONS") { return HttpMethod::Options; }
+  if (token == "TRACE") { return HttpMethod::Trace; }
+  return std::nullopt;
 }
 
 // Query strings stay raw: decoding is a codec-tier decision (RFC 0024).
@@ -512,6 +534,19 @@ inline void atomic_store_routes(std::shared_ptr<const CompiledRoutes> *slot,
 #endif
 
 class ServerConnection;
+class WebServerRuntime;
+
+/** The respond surface a pending request routes back to: the h1
+ * connection or the h2 stream driver that owns the transport side of the
+ * request (RFC 0024, HTTP/2 activation plan). */
+class PendingTarget {
+public:
+  virtual ~PendingTarget() = default;
+  virtual void deliver_response(Int request_id, Value response, Int client_id,
+                                std::shared_ptr<WebServerRuntime> runtime) = 0;
+  virtual void answer_timeout(Int request_id) = 0;
+  virtual void begin_shutdown() = 0;
+};
 
 class WebServerRuntime
     : public std::enable_shared_from_this<WebServerRuntime> {
@@ -554,7 +589,7 @@ public:
     return atomic_load_routes(&ws_routes_);
   }
 
-  [[nodiscard]] Int register_pending(const std::shared_ptr<ServerConnection> &connection);
+  [[nodiscard]] Int register_pending(const std::shared_ptr<PendingTarget> &target);
   void unregister_pending(Int request_id) noexcept;
   [[nodiscard]] Int register_ws_connection(
       const std::shared_ptr<ServerConnection> &connection);
@@ -591,6 +626,13 @@ public:
   [[nodiscard]] bool reserve_request(std::size_t bytes) {
     return bridge_.value->reserve(index(ServerChannel::Request), bytes);
   }
+  [[nodiscard]] bool grow_request_reservation(std::size_t bytes) {
+    return bridge_.value->grow_reservation(index(ServerChannel::Request),
+                                           bytes);
+  }
+  [[nodiscard]] Int allocate_connection_id() noexcept {
+    return ++next_request_id_;
+  }
   void release_request_reservation(std::size_t bytes) noexcept {
     bridge_.value->release_reservation(index(ServerChannel::Request), bytes);
   }
@@ -625,6 +667,9 @@ private:
   bool started_{};
   std::shared_ptr<WebListener> listener_{};
   std::unique_ptr<asio::ssl::context> tls_context_{};
+  // The wire-format ALPN preference list the select callback reads; owned
+  // here so its address outlives every TLS handshake on this context.
+  std::vector<unsigned char> alpn_wire_{};
   std::shared_ptr<const CompiledRoutes> http_routes_{
       std::make_shared<CompiledRoutes>()};
   std::shared_ptr<const CompiledRoutes> ws_routes_{
@@ -637,9 +682,9 @@ private:
   std::atomic<Int> next_request_id_{0};
   struct Pending {
     // Owning: between dispatch and the graph's answer no async operation
-    // holds the connection, so the pending registry keeps it alive until it
-    // is answered, timed out, or shut down.
-    std::shared_ptr<ServerConnection> connection{};
+    // holds the transport target, so the pending registry keeps it alive
+    // until it is answered, timed out, or shut down.
+    std::shared_ptr<PendingTarget> target{};
     std::chrono::steady_clock::time_point deadline{};
   };
   std::map<Int, Pending> pending_{};
@@ -657,7 +702,10 @@ private:
 // thread never touches a socket — respond/ws_send post owned data onto the
 // strand (RFC 0024, threading).
 
-class ServerConnection : public std::enable_shared_from_this<ServerConnection> {
+using ServerTlsStream = asio::ssl::stream<beast::tcp_stream>;
+
+class ServerConnection : public std::enable_shared_from_this<ServerConnection>,
+                         public PendingTarget {
 public:
   ServerConnection(std::shared_ptr<WebListener> listener,
                    std::shared_ptr<const ServerRuntimeConfig> config,
@@ -683,7 +731,7 @@ public:
   }
 
   void deliver_response(Int request_id, Value response, Int client_id,
-                        std::shared_ptr<WebServerRuntime> runtime) {
+                        std::shared_ptr<WebServerRuntime> runtime) override {
     asio::post(strand_, [self = shared_from_this(), request_id,
                          response = std::move(response), client_id, runtime] {
       self->write_response(request_id, response, client_id, runtime);
@@ -698,7 +746,7 @@ public:
     });
   }
 
-  void answer_timeout(Int request_id) {
+  void answer_timeout(Int request_id) override {
     asio::post(strand_, [self = shared_from_this(), request_id] {
       if (self->pending_request_id_ == request_id && !self->writing_) {
         self->send_simple_response(http::status::service_unavailable,
@@ -708,7 +756,7 @@ public:
     });
   }
 
-  void begin_shutdown() {
+  void begin_shutdown() override {
     asio::post(strand_, [self = shared_from_this()] {
       self->shutting_down_ = true;
       if (self->ws_) {
@@ -734,7 +782,7 @@ public:
 
 private:
   using PlainStream = beast::tcp_stream;
-  using TlsStream = asio::ssl::stream<beast::tcp_stream>;
+  using TlsStream = ServerTlsStream;
   using PlainWs = websocket::stream<beast::tcp_stream>;
   using TlsWs = websocket::stream<TlsStream>;
 
@@ -750,8 +798,13 @@ private:
                   self->close();
                   return;
                 }
-                // The ALPN seam: h1 is the only wired protocol until the
-                // HTTP/2 session lands (RFC 0024, activation plan).
+                // The ALPN seam (RFC 0024, activation plan): "h2"
+                // hands the socket to the HTTP/2 driver; everything
+                // else stays on the h1 path.
+                if (self->negotiated_h2()) {
+                  self->start_h2();
+                  return;
+                }
                 self->read_next();
               }));
     } else {
@@ -759,6 +812,16 @@ private:
     }
   }
 
+
+  [[nodiscard]] bool negotiated_h2() const {
+    const unsigned char *protocol = nullptr;
+    unsigned int length = 0;
+    SSL_get0_alpn_selected(
+        const_cast<TlsStream &>(*tls_stream_).native_handle(), &protocol,
+        &length);
+    return length == 2 && std::memcmp(protocol, "h2", 2) == 0;
+  }
+  void start_h2();
 
   void read_next();
   void on_headers();
@@ -843,6 +906,146 @@ private:
   std::string ws_send_buffer_{};
   std::size_t ws_send_offset_{};
   beast::flat_buffer ws_read_buffer_{};
+};
+
+// ---------------------------------------------------------------------------
+// HTTP/2 connection driver (RFC 0024, HTTP/2 activation plan).
+//
+// Owns the TLS socket after ALPN selects "h2" and pumps bytes through the
+// pure H2Engine; every protocol event arrives via H2Host on this strand.
+// Requests flow through the SAME bridge contract as h1: header admission
+// reserves on the matched runtime before any DATA window is released, DATA
+// chunks grow the reservation before the engine may consume them, and the
+// reserved push transfers everything to the queued value.
+
+class H2Driver final : public std::enable_shared_from_this<H2Driver>,
+                       public PendingTarget,
+                       private H2Host {
+public:
+  H2Driver(std::shared_ptr<WebListener> listener,
+           std::shared_ptr<const ServerRuntimeConfig> config,
+           ServerTlsStream stream)
+      : listener_{std::move(listener)}, config_{std::move(config)},
+        strand_{asio::make_strand(listener_->io_context())},
+        stream_{std::move(stream)},
+        engine_{*this,
+                H2Settings{
+                    static_cast<std::size_t>(
+                        config_->h2_max_concurrent_streams),
+                    static_cast<std::size_t>(config_->h2_initial_window_bytes),
+                    config_->max_header_bytes,
+                }} {
+    listener_->connection_opened();
+  }
+
+  ~H2Driver() override { listener_->connection_closed(); }
+
+  void run() {
+    asio::post(strand_, [self = shared_from_this()] {
+      self->pump_writes(); // the server SETTINGS/window preface
+      self->read_next();
+    });
+  }
+
+  // --- PendingTarget ---
+  void deliver_response(Int request_id, Value response, Int client_id,
+                        std::shared_ptr<WebServerRuntime> runtime) override {
+    asio::post(strand_, [self = shared_from_this(), request_id,
+                         response = std::move(response), client_id,
+                         runtime = std::move(runtime)] {
+      self->write_stream_response(request_id, response, client_id, runtime);
+    });
+  }
+
+  void answer_timeout(Int request_id) override {
+    asio::post(strand_, [self = shared_from_this(), request_id] {
+      self->finish_stream_transport(request_id, 503,
+                                    "the graph did not answer in time");
+    });
+  }
+
+  void begin_shutdown() override {
+    asio::post(strand_, [self = shared_from_this()] {
+      if (self->shutting_down_) {
+        return;
+      }
+      self->shutting_down_ = true;
+      // GOAWAY carries the last processed stream id; unanswered streams
+      // get the transport 503 and in-flight writes drain (RFC 0024,
+      // lifecycle; h2 acceptance criteria).
+      std::vector<Int> unanswered;
+      for (const auto &[request_id, stream_id] : self->request_to_stream_) {
+        unanswered.push_back(request_id);
+      }
+      for (const Int request_id : unanswered) {
+        self->finish_stream_transport(request_id, 503,
+                                      "server shutting down");
+      }
+      self->engine_.submit_goaway();
+      self->pump_writes();
+    });
+  }
+
+private:
+  struct Stream {
+    MatchedRoute matched{};
+    HttpMethod method{HttpMethod::Get};
+    bool head_fallback{};
+    std::string target{};
+    std::string decoded_path{};
+    H2Headers headers{};
+    std::size_t header_bytes{};
+    std::string body{};
+    std::size_t reserved{};
+    std::size_t unaccounted{};
+    bool admitted{};
+    bool admission_in_flight{};
+    bool end_stream_seen{};
+    bool discarding{};
+    Int request_id{-1};
+  };
+
+  // --- H2Host (all calls arrive inside engine_.receive on the strand) ---
+  void on_request_headers(std::int32_t stream_id, std::string method,
+                          std::string target, H2Headers headers,
+                          bool end_stream) override;
+  void on_request_data(std::int32_t stream_id, std::string_view data,
+                       bool end_stream) override;
+  void on_stream_reset(std::int32_t stream_id,
+                       std::uint32_t error_code) override;
+  void on_stream_closed(std::int32_t stream_id) override;
+  void on_goaway_received() override { shutting_down_ = true; }
+
+  void read_next();
+  void pump_writes();
+  void close();
+  void admit_stream(std::int32_t stream_id);
+  void account_stream_data(std::int32_t stream_id);
+  void maybe_dispatch(std::int32_t stream_id);
+  void respond_transport(std::int32_t stream_id, int status,
+                         std::string_view body);
+  void write_stream_response(Int request_id, const Value &response,
+                             Int client_id,
+                             const std::shared_ptr<WebServerRuntime> &runtime);
+  void finish_stream_transport(Int request_id, int status,
+                               std::string_view body);
+  void release_stream(std::int32_t stream_id, Stream &stream);
+  [[nodiscard]] Value peer_value(const WebBindings &bindings);
+
+  std::shared_ptr<WebListener> listener_;
+  std::shared_ptr<const ServerRuntimeConfig> config_;
+  asio::strand<asio::io_context::executor_type> strand_;
+  ServerTlsStream stream_;
+  H2Engine engine_;
+  std::map<std::int32_t, Stream> streams_{};
+  std::map<Int, std::int32_t> request_to_stream_{};
+  std::array<char, 16 * 1024> read_buffer_{};
+  std::string write_buffer_{};
+  std::size_t outstanding_response_bytes_{};
+  Int connection_id_{-1};
+  bool writing_{};
+  bool shutting_down_{};
+  bool closed_{};
 };
 
 // ---------------------------------------------------------------------------
@@ -1094,24 +1297,35 @@ void WebServerRuntime::start() {
                               asio::ssl::verify_fail_if_no_peer_cert);
       break;
     }
-    // The ALPN callback is the HTTP/2 seam: only h1 is selectable until the
-    // nghttp2 session activates (config validation rejects "h2").
+    // The ALPN callback selects from the CONFIGURED list, in configured
+    // preference order; "h2" hands the connection to the HTTP/2 driver
+    // after the handshake (RFC 0024, activation plan).
+    alpn_wire_.clear();
+    const std::vector<Str> protocols =
+        config_->tls.alpn.empty() ? std::vector<Str>{Str{"http/1.1"}}
+                                  : config_->tls.alpn;
+    for (const Str &protocol : protocols) {
+      alpn_wire_.push_back(static_cast<unsigned char>(protocol.size()));
+      alpn_wire_.insert(alpn_wire_.end(), protocol.begin(), protocol.end());
+    }
     SSL_CTX_set_alpn_select_cb(
         context.native_handle(),
         [](SSL *, const unsigned char **out, unsigned char *out_length,
            const unsigned char *in, unsigned int in_length,
-           void *) noexcept -> int {
+           void *wire) noexcept -> int {
+          const auto *preference =
+              static_cast<const std::vector<unsigned char> *>(wire);
           unsigned char *selected = nullptr;
           if (SSL_select_next_proto(
-                  &selected, out_length,
-                  reinterpret_cast<const unsigned char *>("\x08http/1.1"), 9,
-                  in, in_length) == OPENSSL_NPN_NEGOTIATED) {
+                  &selected, out_length, preference->data(),
+                  static_cast<unsigned int>(preference->size()), in,
+                  in_length) == OPENSSL_NPN_NEGOTIATED) {
             *out = selected;
             return SSL_TLSEXT_ERR_OK;
           }
           return SSL_TLSEXT_ERR_NOACK;
         },
-        nullptr);
+        &alpn_wire_);
   }
 
   listener_ = ListenerRegistry::instance().acquire(
@@ -1209,22 +1423,22 @@ void WebServerRuntime::stop() noexcept {
       listener_->set_reads_paused(WebListener::ReadTier::Http, this, false);
       listener_->set_reads_paused(WebListener::ReadTier::Ws, this, false);
 
-      std::vector<std::shared_ptr<ServerConnection>> connections;
+      std::vector<std::shared_ptr<PendingTarget>> targets;
       {
         std::lock_guard lock{pending_mutex_};
         for (auto &[request_id, pending] : pending_) {
-          connections.push_back(std::move(pending.connection));
+          targets.push_back(std::move(pending.target));
         }
         for (auto &[connection_id, weak] : ws_connections_) {
           if (auto connection = weak.lock()) {
-            connections.push_back(std::move(connection));
+            targets.push_back(std::move(connection));
           }
         }
         pending_.clear();
         ws_connections_.clear();
       }
-      for (const auto &connection : connections) {
-        connection->begin_shutdown();
+      for (const auto &target : targets) {
+        target->begin_shutdown();
       }
       const auto deadline =
           std::chrono::steady_clock::now() + config_->shutdown_drain_timeout;
@@ -1327,12 +1541,12 @@ void WebServerRuntime::apply_ws_routes(std::vector<Value> added,
 }
 
 Int WebServerRuntime::register_pending(
-    const std::shared_ptr<ServerConnection> &connection) {
+    const std::shared_ptr<PendingTarget> &target) {
   const Int request_id = ++next_request_id_;
   std::lock_guard lock{pending_mutex_};
   pending_[request_id] =
-      Pending{connection, std::chrono::steady_clock::now() +
-                              config_->request_timeout};
+      Pending{target, std::chrono::steady_clock::now() +
+                          config_->request_timeout};
   return request_id;
 }
 
@@ -1464,21 +1678,21 @@ void WebServerRuntime::sweep_expired_requests() {
   if (stopping_.load(std::memory_order_acquire)) {
     return;
   }
-  std::vector<std::pair<Int, std::shared_ptr<ServerConnection>>> expired;
+  std::vector<std::pair<Int, std::shared_ptr<PendingTarget>>> expired;
   {
     std::lock_guard lock{pending_mutex_};
     const auto now = std::chrono::steady_clock::now();
     for (auto item = pending_.begin(); item != pending_.end();) {
       if (item->second.deadline <= now) {
-        expired.emplace_back(item->first, std::move(item->second.connection));
+        expired.emplace_back(item->first, std::move(item->second.target));
         item = pending_.erase(item);
       } else {
         ++item;
       }
     }
   }
-  for (auto &[request_id, connection] : expired) {
-    connection->answer_timeout(request_id);
+  for (auto &[request_id, target] : expired) {
+    target->answer_timeout(request_id);
   }
   arm_sweep_timer();
 }
@@ -1552,16 +1766,16 @@ void WebServerRuntime::respond(Int client_id, Int request_id, Value response) {
                            Str{"web server is not serving"}));
     return;
   }
-  std::shared_ptr<ServerConnection> connection;
+  std::shared_ptr<PendingTarget> target;
   {
     std::lock_guard lock{pending_mutex_};
     const auto found = pending_.find(request_id);
     if (found != pending_.end()) {
-      connection = std::move(found->second.connection);
+      target = std::move(found->second.target);
       pending_.erase(found);
     }
   }
-  if (!connection) {
+  if (!target) {
     // Responding to an unknown or already-answered id is a reported error,
     // never silence (RFC 0024).
     report(index(ServerChannel::RespondDelivery), client_id,
@@ -1569,8 +1783,8 @@ void WebServerRuntime::respond(Int client_id, Int request_id, Value response) {
                            Str{"unknown or already-answered request id"}));
     return;
   }
-  connection->deliver_response(request_id, std::move(response), client_id,
-                               shared_from_this());
+  target->deliver_response(request_id, std::move(response), client_id,
+                           shared_from_this());
 }
 
 void WebServerRuntime::ws_send(Int client_id, Int connection_id, Value frame) {
@@ -2525,6 +2739,489 @@ void ServerConnection::close_socket_only() {
   } else if (plain_stream_.has_value()) {
     static_cast<void>(plain_stream_->socket().close(ec));
   }
+}
+
+// ---------------------------------------------------------------------------
+// H2Driver implementation
+
+void ServerConnection::start_h2() {
+  auto driver = std::make_shared<H2Driver>(listener_, config_,
+                                           std::move(*tls_stream_));
+  tls_stream_.reset();
+  driver->run();
+}
+
+void H2Driver::read_next() {
+  if (closed_) {
+    return;
+  }
+  beast::get_lowest_layer(stream_).expires_after(config_->idle_timeout);
+  stream_.async_read_some(
+      asio::buffer(read_buffer_),
+      asio::bind_executor(
+          strand_, [self = shared_from_this()](beast::error_code ec,
+                                               std::size_t received) {
+            if (ec) {
+              self->close();
+              return;
+            }
+            if (!self->engine_.receive(
+                    std::string_view{self->read_buffer_.data(), received})) {
+              // Fatal protocol error: flush the GOAWAY and close.
+              self->pump_writes();
+              return;
+            }
+            self->pump_writes();
+            self->read_next();
+          }));
+}
+
+void H2Driver::pump_writes() {
+  if (closed_ || writing_) {
+    return;
+  }
+  write_buffer_.clear();
+  while (write_buffer_.size() < 64 * 1024) {
+    const std::string_view output = engine_.next_output();
+    if (output.empty()) {
+      break;
+    }
+    write_buffer_.append(output);
+  }
+  if (write_buffer_.empty()) {
+    if (engine_.finished()) {
+      close();
+    }
+    return;
+  }
+  writing_ = true;
+  asio::async_write(
+      stream_, asio::buffer(write_buffer_),
+      asio::bind_executor(
+          strand_,
+          [self = shared_from_this()](beast::error_code ec, std::size_t) {
+            self->writing_ = false;
+            if (ec) {
+              self->close();
+              return;
+            }
+            self->pump_writes();
+          }));
+}
+
+void H2Driver::close() {
+  if (closed_) {
+    return;
+  }
+  closed_ = true;
+  // Retire every live stream: release reservations, unregister pending
+  // entries, and drop the maps so late graph answers report cleanly.
+  for (auto &[stream_id, stream] : streams_) {
+    release_stream(stream_id, stream);
+  }
+  streams_.clear();
+  request_to_stream_.clear();
+  beast::error_code ec;
+  static_cast<void>(beast::get_lowest_layer(stream_).socket().close(ec));
+}
+
+void H2Driver::release_stream(std::int32_t, Stream &stream) {
+  if (stream.request_id >= 0 && stream.matched.runtime) {
+    stream.matched.runtime->unregister_pending(stream.request_id);
+    request_to_stream_.erase(stream.request_id);
+    stream.request_id = -1;
+  }
+  if (stream.reserved != 0 && stream.matched.runtime) {
+    stream.matched.runtime->release_request_reservation(stream.reserved);
+    stream.reserved = 0;
+  }
+}
+
+void H2Driver::on_request_headers(std::int32_t stream_id, std::string method,
+                                  std::string target, H2Headers headers,
+                                  bool end_stream) {
+  if (shutting_down_) {
+    engine_.reset_stream(stream_id, H2StreamError::RefusedStream);
+    return;
+  }
+  Stream stream;
+  stream.target = std::move(target);
+  stream.headers = std::move(headers);
+  stream.end_stream_seen = end_stream;
+  for (const auto &[name, value] : stream.headers) {
+    stream.header_bytes += name.size() + value.size();
+  }
+  const auto method_value = method_from_token(method);
+  if (!method_value.has_value()) {
+    streams_.emplace(stream_id, std::move(stream));
+    respond_transport(stream_id, 501, "unsupported method");
+    return;
+  }
+  stream.method = *method_value;
+
+  const std::string_view full_target{stream.target};
+  const auto query_start = full_target.find('?');
+  const std::string_view path = full_target.substr(0, query_start);
+  auto decoded_path = RouteTable::decode_path(path);
+  if (!decoded_path.has_value()) {
+    streams_.emplace(stream_id, std::move(stream));
+    respond_transport(stream_id, 400, "malformed percent-encoding");
+    return;
+  }
+  stream.decoded_path = std::move(*decoded_path);
+
+  auto matched = listener_->match(stream.method, path, false);
+  if (!matched.has_value() && stream.method == HttpMethod::Head) {
+    // Standard HTTP: HEAD is GET without the body (transport suppresses
+    // the body on the way out), exactly like the h1 path.
+    matched = listener_->match(HttpMethod::Get, path, false);
+    stream.head_fallback = matched.has_value();
+  }
+  if (!matched.has_value()) {
+    streams_.emplace(stream_id, std::move(stream));
+    respond_transport(stream_id, 404, "no such route");
+    return;
+  }
+  stream.matched = std::move(*matched);
+  streams_.emplace(stream_id, std::move(stream));
+  admit_stream(stream_id);
+}
+
+void H2Driver::admit_stream(std::int32_t stream_id) {
+  const auto found = streams_.find(stream_id);
+  if (found == streams_.end() || closed_) {
+    return;
+  }
+  Stream &stream = found->second;
+  stream.admission_in_flight = false;
+  const std::shared_ptr<WebServerRuntime> runtime = stream.matched.runtime;
+  // Header admission mirrors h1: the header block plus envelope overhead
+  // reserves before any DATA window is released; the body then grows the
+  // same reservation chunk-by-chunk (RFC 0024, flow control).
+  const std::size_t projected = stream.header_bytes + stream.target.size() + 512;
+  if (runtime->reserve_request(projected)) {
+    stream.admitted = true;
+    stream.reserved = projected;
+    account_stream_data(stream_id);
+    return;
+  }
+  if (runtime->config().inbound_overflow == WebInboundOverflow::Reject) {
+    respond_transport(stream_id, 503, "server is at capacity");
+    return;
+  }
+  // Backpressure: no window is released, so the sender stalls; retry on
+  // the watermark resume or a timer, exactly like the h1 admission wait.
+  stream.admission_in_flight = true;
+  if (listener_->reads_paused(WebListener::ReadTier::Http)) {
+    listener_->park_for_resume(
+        WebListener::ReadTier::Http, [self = shared_from_this(), stream_id] {
+          asio::post(self->strand_,
+                     [self, stream_id] { self->admit_stream(stream_id); });
+        });
+    return;
+  }
+  auto retry = std::make_shared<asio::steady_timer>(listener_->io_context());
+  retry->expires_after(std::chrono::milliseconds{50});
+  retry->async_wait(asio::bind_executor(
+      strand_,
+      [self = shared_from_this(), stream_id, retry](beast::error_code ec) {
+        if (!ec && !self->closed_) {
+          self->admit_stream(stream_id);
+        }
+      }));
+}
+
+void H2Driver::on_request_data(std::int32_t stream_id, std::string_view data,
+                               bool end_stream) {
+  const auto found = streams_.find(stream_id);
+  if (found == streams_.end()) {
+    // A stream answered by the transport (404/503/...): release the
+    // window immediately so a still-sending peer cannot wedge the
+    // connection; the bytes are never retained.
+    engine_.consume(stream_id, data.size());
+    return;
+  }
+  Stream &stream = found->second;
+  if (stream.discarding) {
+    engine_.consume(stream_id, data.size());
+    return;
+  }
+  stream.body.append(data);
+  stream.unaccounted += data.size();
+  if (end_stream) {
+    stream.end_stream_seen = true;
+  }
+  if (stream.admitted) {
+    account_stream_data(stream_id);
+  }
+}
+
+void H2Driver::account_stream_data(std::int32_t stream_id) {
+  const auto found = streams_.find(stream_id);
+  if (found == streams_.end() || closed_) {
+    return;
+  }
+  Stream &stream = found->second;
+  if (stream.unaccounted != 0) {
+    const std::size_t pending = stream.unaccounted;
+    if (stream.matched.runtime->grow_request_reservation(pending)) {
+      stream.reserved += pending;
+      stream.unaccounted = 0;
+      engine_.consume(stream_id, pending);
+      pump_writes(); // the WINDOW_UPDATE this consume released
+    } else if (stream.matched.runtime->config().inbound_overflow ==
+               WebInboundOverflow::Reject) {
+      respond_transport(stream_id, 503, "server is at capacity");
+      return;
+    } else {
+      // Backpressure: the unaccounted bytes stay window-unreleased, so
+      // the sender stalls; retry on the watermark resume or a timer.
+      if (listener_->reads_paused(WebListener::ReadTier::Http)) {
+        listener_->park_for_resume(
+            WebListener::ReadTier::Http,
+            [self = shared_from_this(), stream_id] {
+              asio::post(self->strand_, [self, stream_id] {
+                self->account_stream_data(stream_id);
+              });
+            });
+        return;
+      }
+      auto retry =
+          std::make_shared<asio::steady_timer>(listener_->io_context());
+      retry->expires_after(std::chrono::milliseconds{50});
+      retry->async_wait(asio::bind_executor(
+          strand_, [self = shared_from_this(), stream_id,
+                    retry](beast::error_code ec) {
+            if (!ec && !self->closed_) {
+              self->account_stream_data(stream_id);
+            }
+          }));
+      return;
+    }
+  }
+  maybe_dispatch(stream_id);
+}
+
+void H2Driver::maybe_dispatch(std::int32_t stream_id) {
+  const auto found = streams_.find(stream_id);
+  if (found == streams_.end()) {
+    return;
+  }
+  Stream &stream = found->second;
+  if (!stream.admitted || !stream.end_stream_seen ||
+      stream.unaccounted != 0 || stream.request_id >= 0) {
+    return;
+  }
+  const std::shared_ptr<WebServerRuntime> runtime = stream.matched.runtime;
+  const auto &b = runtime->bindings();
+  if (connection_id_ < 0) {
+    connection_id_ = runtime->allocate_connection_id();
+  }
+
+  const std::string_view full_target{stream.target};
+  const auto query_start = full_target.find('?');
+  const std::string_view query =
+      query_start == std::string_view::npos
+          ? std::string_view{}
+          : full_target.substr(query_start + 1);
+  WebBindings::NamedPairs headers{stream.headers.begin(),
+                                  stream.headers.end()};
+  const std::size_t retained = stream.body.size() + stream.header_bytes +
+                               stream.target.size() + 512;
+  Value request = build_on(
+      b.http_request,
+      {
+          {"method", b.enum_value(stream.head_fallback ? HttpMethod::Head
+                                                       : stream.method)},
+          {"target", b.string(Str{stream.target})},
+          {"path", b.string(Str{stream.decoded_path})},
+          {"query", b.params(parse_query(query))},
+          {"path_params", b.params(stream.matched.params)},
+          {"headers", b.headers(headers)},
+          {"body", b.bytes(Bytes{std::move(stream.body)})},
+          {"trailers", b.headers({})},
+      });
+  stream.body = std::string{};
+  const Int request_id = runtime->register_pending(shared_from_this());
+  Value server_request =
+      build_on(b.server_request,
+               {
+                   {"request_id", b.number(request_id)},
+                   {"connection_id", b.number(connection_id_)},
+                   {"stream_id", b.number(Int{stream_id})},
+                   {"request", std::move(request)},
+                   {"peer", peer_value(b)},
+               });
+  const std::size_t reserved = stream.reserved;
+  stream.reserved = 0;
+  const bool pushed = runtime->push_request_reserved(
+      stream.matched.route.clone(), std::move(server_request), retained,
+      reserved);
+  if (!pushed) {
+    runtime->unregister_pending(request_id);
+    respond_transport(stream_id, 503, "server shutting down");
+    return;
+  }
+  stream.request_id = request_id;
+  request_to_stream_[request_id] = stream_id;
+}
+
+void H2Driver::respond_transport(std::int32_t stream_id, int status,
+                                 std::string_view body) {
+  const auto found = streams_.find(stream_id);
+  if (found != streams_.end()) {
+    release_stream(stream_id, found->second);
+    found->second.discarding = true;
+  }
+  static_cast<void>(engine_.submit_response(
+      stream_id, status, H2Headers{{"content-type", "text/plain"}},
+      std::string{body}, {}));
+  pump_writes();
+}
+
+void H2Driver::write_stream_response(
+    Int request_id, const Value &response, Int client_id,
+    const std::shared_ptr<WebServerRuntime> &runtime) {
+  const auto found = request_to_stream_.find(request_id);
+  if (found == request_to_stream_.end()) {
+    // The peer reset the stream before the graph answered: the late
+    // answer is Dropped, never written to a dead stream (h2 acceptance
+    // criteria).
+    runtime->report(index(ServerChannel::RespondDelivery), client_id,
+                    runtime->delivery_report(
+                        request_id, WebDeliveryStatus::Dropped, 0,
+                        Str{"the stream was cancelled by the peer"}));
+    return;
+  }
+  const std::int32_t stream_id = found->second;
+  request_to_stream_.erase(found);
+  const auto stream_found = streams_.find(stream_id);
+  const bool head =
+      stream_found != streams_.end() && stream_found->second.head_fallback;
+  if (stream_found != streams_.end()) {
+    stream_found->second.request_id = -1;
+  }
+
+  const auto fields = response.view().as_bundle();
+  const auto status =
+      static_cast<int>(fields.at("status").checked_as<Int>());
+  std::string body;
+  const auto body_field = fields.at("body");
+  if (!head && body_field.data() != nullptr) {
+    body = std::string{body_field.checked_as<Bytes>().data};
+  }
+  H2Headers headers;
+  const auto header_fields = fields.at("headers");
+  if (header_fields.data() != nullptr) {
+    for (const auto header : header_fields.as_list()) {
+      const auto pair = header.as_bundle();
+      headers.emplace_back(std::string{pair.at("name").checked_as<Str>()},
+                           std::string{pair.at("value").checked_as<Str>()});
+    }
+  }
+  H2Headers trailers;
+  const auto trailer_fields = fields.at("trailers");
+  if (!head && trailer_fields.data() != nullptr) {
+    for (const auto trailer : trailer_fields.as_list()) {
+      const auto pair = trailer.as_bundle();
+      trailers.emplace_back(std::string{pair.at("name").checked_as<Str>()},
+                            std::string{pair.at("value").checked_as<Str>()});
+    }
+  }
+
+  // Per-stream slow-consumer policy: a response that would push the
+  // buffered outbound share past the configured byte limit resets JUST
+  // this stream (h2 acceptance criteria).
+  if (outstanding_response_bytes_ + body.size() >
+      static_cast<std::size_t>(config_->outbound_byte_limit)) {
+    engine_.reset_stream(stream_id, H2StreamError::EnhanceYourCalm);
+    pump_writes();
+    runtime->report(index(ServerChannel::RespondDelivery), client_id,
+                    runtime->delivery_report(
+                        request_id, WebDeliveryStatus::Dropped, 0,
+                        Str{"slow consumer: the stream was reset"}));
+    return;
+  }
+
+  const std::size_t response_bytes = body.size();
+  if (engine_.submit_response(stream_id, status, headers, std::move(body),
+                              trailers)) {
+    outstanding_response_bytes_ += response_bytes;
+    runtime->report(
+        index(ServerChannel::RespondDelivery), client_id,
+        runtime->delivery_report(request_id, WebDeliveryStatus::Delivered));
+  } else {
+    runtime->report(index(ServerChannel::RespondDelivery), client_id,
+                    runtime->delivery_report(
+                        request_id, WebDeliveryStatus::PermanentFailure, 0,
+                        Str{"the stream could not accept the response"}));
+  }
+  pump_writes();
+}
+
+void H2Driver::finish_stream_transport(Int request_id, int status,
+                                       std::string_view body) {
+  const auto found = request_to_stream_.find(request_id);
+  if (found == request_to_stream_.end()) {
+    return;
+  }
+  const std::int32_t stream_id = found->second;
+  request_to_stream_.erase(found);
+  const auto stream_found = streams_.find(stream_id);
+  if (stream_found != streams_.end()) {
+    stream_found->second.request_id = -1;
+  }
+  respond_transport(stream_id, status, body);
+}
+
+void H2Driver::on_stream_reset(std::int32_t stream_id, std::uint32_t) {
+  const auto found = streams_.find(stream_id);
+  if (found == streams_.end()) {
+    return;
+  }
+  // Per-stream cancellation: exactly this request is retired; a late
+  // graph answer will be reported Dropped (h2 acceptance criteria).
+  release_stream(stream_id, found->second);
+}
+
+void H2Driver::on_stream_closed(std::int32_t stream_id) {
+  const auto found = streams_.find(stream_id);
+  if (found != streams_.end()) {
+    release_stream(stream_id, found->second);
+    streams_.erase(found);
+  }
+}
+
+Value H2Driver::peer_value(const WebBindings &b) {
+  beast::error_code ec;
+  auto &socket = beast::get_lowest_layer(stream_).socket();
+  const auto remote = socket.remote_endpoint(ec);
+  const auto local = socket.local_endpoint(ec);
+  Str negotiated{"h2"};
+  Str sni{};
+  Str subject{};
+  SSL *ssl = stream_.native_handle();
+  if (const char *name = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name)) {
+    sni = Str{name};
+  }
+  if (X509 *cert = SSL_get_peer_certificate(ssl)) {
+    char buffer[512];
+    X509_NAME_oneline(X509_get_subject_name(cert), buffer, sizeof(buffer));
+    subject = Str{buffer};
+    X509_free(cert);
+  }
+  return build_on(
+      b.peer,
+      {
+          {"remote_address",
+           b.string(Str{ec ? std::string{} : remote.address().to_string()})},
+          {"remote_port", b.number(Int{ec ? 0 : remote.port()})},
+          {"local_port", b.number(Int{ec ? 0 : local.port()})},
+          {"tls", b.flag(Bool{true})},
+          {"negotiated_protocol", b.string(negotiated)},
+          {"sni", b.string(sni)},
+          {"client_cert_subject", b.string(subject)},
+      });
 }
 } // namespace
 

--- a/extensions/web/src/asio_server.cpp
+++ b/extensions/web/src/asio_server.cpp
@@ -794,6 +794,7 @@ public:
   ~ServerConnection() {
     release_admission();
     release_ws_reservation_held();
+    release_ws_terminal_reservation();
     listener_->connection_closed();
   }
 
@@ -860,7 +861,8 @@ public:
   void shutdown_now() {
     shutting_down_ = true;
     if (ws_) {
-      ws_close(websocket::close_code{1001}, "going away");
+      ws_close(websocket::close_code{1001}, "going away",
+               WsConnectionState::Closed);
     } else if (pending_request_id_ >= 0 && !writing_) {
       send_simple_response(http::status::service_unavailable,
                            "server shutting down", false);
@@ -945,7 +947,10 @@ private:
                       const std::shared_ptr<WebServerRuntime> &runtime);
   void ws_write_next();
   void ws_send_fragment();
-  void ws_close(websocket::close_code code, beast::string_view reason);
+  void ws_close(websocket::close_code code, beast::string_view reason,
+                WsConnectionState terminal_state);
+  void finish_ws(WsConnectionState state, Int close_code, Str close_reason);
+  void release_ws_terminal_reservation() noexcept;
   void send_simple_response(http::status status, std::string_view body,
                             bool keep_alive);
   void close();
@@ -987,6 +992,8 @@ private:
   // Capacity for THIS connection's terminal Closed/Failed event, reserved
   // at accept and held for the socket's lifetime (review P1).
   std::size_t ws_close_reserved_{};
+  bool ws_close_started_{};
+  bool ws_terminal_emitted_{};
   // Message bytes accumulate here — storage the reservation accounts —
   // while ws_read_buffer_ stays chunk-sized: Beast's flat_buffer keeps its
   // allocated capacity after consume(), so assembling messages inside it
@@ -1203,6 +1210,7 @@ private:
   void finish_stream_transport(Int request_id, int status,
                                std::string_view body);
   void release_stream(std::int32_t stream_id, Stream &stream);
+  void discard_stream_input(std::int32_t stream_id, Stream &stream);
   [[nodiscard]] Value peer_value(const WebBindings &bindings);
 
   std::shared_ptr<WebListener> listener_;
@@ -2707,6 +2715,22 @@ void ServerConnection::accept_ws(MatchedRoute matched) {
         }
         self->ws_ = true;
         const auto &b = runtime->bindings();
+        // Reserve the terminal event BEFORE publishing Open.  Once the graph
+        // can observe the connection it must also be guaranteed to observe
+        // exactly one Closed/Failed event, even when Open itself fills the
+        // payload lane (review P1).
+        const std::size_t close_weight = self->ws_route_weight_ + 128 + 512;
+        if (!runtime->reserve_ws_ingress(close_weight)) {
+          runtime->count_drop();
+          runtime->emit_event(
+              WebSeverity::Warning, Str{"server"}, Str{"ws_ingress"},
+              Str{"terminal-event capacity unavailable; closing"}, 0, true,
+              false, self->ws_connection_id_);
+          runtime->unregister_ws_connection(self->ws_connection_id_);
+          self->close();
+          return;
+        }
+        self->ws_close_reserved_ = close_weight;
         const bool open_delivered = runtime->push_ws_event(
             self->ws_route_->clone(),
             build_on(b.ws_event,
@@ -2733,22 +2757,6 @@ void ServerConnection::accept_ws(MatchedRoute matched) {
           self->close();
           return;
         }
-        // Reserve the terminal event's capacity for the connection's
-        // lifetime: lifecycle-as-data means the Closed/Failed event must
-        // never be lost to a full channel (review P1).  A connection
-        // whose terminal event cannot be guaranteed does not open.
-        const std::size_t close_weight = self->ws_route_weight_ + 128 + 512;
-        if (!runtime->reserve_ws_ingress(close_weight)) {
-          runtime->count_drop();
-          runtime->emit_event(
-              WebSeverity::Warning, Str{"server"}, Str{"ws_ingress"},
-              Str{"terminal-event capacity unavailable; closing"}, 0, true,
-              false, self->ws_connection_id_);
-          runtime->unregister_ws_connection(self->ws_connection_id_);
-          self->close();
-          return;
-        }
-        self->ws_close_reserved_ = close_weight;
         // Beast no longer needs the upgrade request; releasing it keeps
         // the single-counted accounting honest for the WebSocket's whole
         // lifetime (review P1).
@@ -2777,10 +2785,7 @@ void ServerConnection::ws_read_next() {
   const auto on_read = asio::bind_executor(
       strand_,
       [self = shared_from_this()](beast::error_code ec, std::size_t received) {
-        const std::shared_ptr<WebServerRuntime> runtime = self->ws_runtime_;
         if (ec) {
-          self->release_ws_reservation_held();
-          runtime->unregister_ws_connection(self->ws_connection_id_);
           const bool orderly = ec == websocket::error::closed;
           Int close_code = 1005;
           Str close_reason{};
@@ -2791,32 +2796,13 @@ void ServerConnection::ws_read_next() {
             close_code = static_cast<Int>(reason.code);
             close_reason = Str{std::string{reason.reason.data(),
                                            reason.reason.size()}};
-          }
-          const auto &b = runtime->bindings();
-          Value terminal = build_on(
-              b.ws_event,
-              {
-                  {"connection_id", b.number(self->ws_connection_id_)},
-                  {"state",
-                   b.enum_value(orderly ? WsConnectionState::Closed
-                                        : WsConnectionState::Failed)},
-                  {"close_code", b.number(close_code)},
-                  {"close_reason", b.string(close_reason)},
-              });
-          const std::size_t terminal_bytes =
-              close_reason.size() + self->ws_route_weight_ + 512;
-          if (self->ws_close_reserved_ != 0) {
-            const std::size_t reserved = self->ws_close_reserved_;
-            self->ws_close_reserved_ = 0;
-            static_cast<void>(runtime->push_ws_event_reserved(
-                self->ws_route_->clone(), std::move(terminal),
-                terminal_bytes, reserved));
           } else {
-            static_cast<void>(runtime->push_ws_event(
-                self->ws_route_->clone(), std::move(terminal),
-                terminal_bytes));
+            close_code = 1006;
+            close_reason = Str{ec.message()};
           }
-          self->close();
+          self->finish_ws(orderly ? WsConnectionState::Closed
+                                  : WsConnectionState::Failed,
+                          close_code, std::move(close_reason));
           return;
         }
         static_cast<void>(received);
@@ -2911,7 +2897,8 @@ void ServerConnection::ws_account_chunk() {
     runtime->emit_event(WebSeverity::Warning, Str{"server"}, Str{"ws_ingress"},
                         Str{"message cannot fit the WS ingress limit"}, 0,
                         false, false, ws_connection_id_);
-    ws_close(websocket::close_code{1009}, "message too big to admit");
+    ws_close(websocket::close_code{1009}, "message too big to admit",
+             WsConnectionState::Failed);
     return;
   }
   const bool accounted = first ? runtime->reserve_ws_ingress(wanted)
@@ -2927,7 +2914,8 @@ void ServerConnection::ws_account_chunk() {
     runtime->emit_event(WebSeverity::Warning, Str{"server"}, Str{"ws_ingress"},
                         Str{"WebSocket ingress rejected at the hard limit"}, 0,
                         true, false, ws_connection_id_);
-    ws_close(websocket::close_code{1013}, "server is at capacity");
+    ws_close(websocket::close_code{1013}, "server is at capacity",
+             WsConnectionState::Failed);
     return;
   }
   // Backpressure: hold what is already read and retry the accounting; no
@@ -2979,7 +2967,8 @@ void ServerConnection::queue_ws_frame(
                  code.data() != nullptr ? code.checked_as<Int>() : 1000)},
              reason.data() != nullptr
                  ? std::string{reason.checked_as<Str>()}
-                 : std::string{});
+                 : std::string{},
+             WsConnectionState::Closed);
     runtime->report(index(ServerChannel::WsSendDelivery), client_id,
                     runtime->delivery_report(ws_connection_id_,
                                              WebDeliveryStatus::Delivered));
@@ -3020,7 +3009,8 @@ void ServerConnection::queue_ws_frame(
       }
       ws_outbound_.clear();
       ws_outbound_bytes_ = 0;
-      ws_close(websocket::close_code{1013}, "slow consumer");
+      ws_close(websocket::close_code{1013}, "slow consumer",
+               WsConnectionState::Failed);
     }
     runtime->report(index(ServerChannel::WsSendDelivery), client_id,
                     runtime->delivery_report(ws_connection_id_,
@@ -3092,7 +3082,7 @@ void ServerConnection::ws_send_fragment() {
                 ec ? ec.value() : 0, ec ? Str{ec.message()} : Str{}));
         if (ec) {
           self->writing_ = false;
-          self->close();
+          self->finish_ws(WsConnectionState::Failed, 1006, Str{ec.message()});
           return;
         }
         self->ws_write_next();
@@ -3107,10 +3097,23 @@ void ServerConnection::ws_send_fragment() {
 }
 
 void ServerConnection::ws_close(websocket::close_code code,
-                                beast::string_view reason) {
-  const auto on_close =
-      asio::bind_executor(strand_, [self = shared_from_this()](
-                                       beast::error_code) { self->close(); });
+                                beast::string_view reason,
+                                WsConnectionState terminal_state) {
+  if (ws_close_started_ || ws_terminal_emitted_) {
+    return;
+  }
+  ws_close_started_ = true;
+  const Int close_code = static_cast<Int>(code);
+  Str close_reason{reason};
+  const auto on_close = asio::bind_executor(
+      strand_, [self = shared_from_this(), terminal_state, close_code,
+                close_reason](beast::error_code ec) mutable {
+        if (ec) {
+          self->finish_ws(WsConnectionState::Failed, 1006, Str{ec.message()});
+        } else {
+          self->finish_ws(terminal_state, close_code, std::move(close_reason));
+        }
+      });
   websocket::close_reason close{code};
   close.reason = reason;
   if (plain_ws_.has_value()) {
@@ -3118,19 +3121,64 @@ void ServerConnection::ws_close(websocket::close_code code,
   } else if (tls_ws_.has_value()) {
     tls_ws_->async_close(close, on_close);
   } else {
-    close_socket_only();
+    finish_ws(WsConnectionState::Failed, 1006,
+              Str{"WebSocket transport is unavailable"});
+  }
+}
+
+void ServerConnection::finish_ws(WsConnectionState state, Int close_code,
+                                 Str close_reason) {
+  if (ws_terminal_emitted_) {
+    close();
+    return;
+  }
+  ws_terminal_emitted_ = true;
+  release_ws_reservation_held();
+
+  const std::shared_ptr<WebServerRuntime> runtime = ws_runtime_;
+  if (runtime) {
+    runtime->unregister_ws_connection(ws_connection_id_);
+  }
+  if (runtime && ws_route_ != nullptr) {
+    const auto &b = runtime->bindings();
+    Value terminal =
+        build_on(b.ws_event, {
+                                 {"connection_id", b.number(ws_connection_id_)},
+                                 {"state", b.enum_value(state)},
+                                 {"close_code", b.number(close_code)},
+                                 {"close_reason", b.string(close_reason)},
+                             });
+    const std::size_t terminal_bytes =
+        close_reason.size() + ws_route_weight_ + 512;
+    if (ws_close_reserved_ != 0) {
+      const std::size_t reserved = ws_close_reserved_;
+      ws_close_reserved_ = 0;
+      static_cast<void>(runtime->push_ws_event_reserved(
+          ws_route_->clone(), std::move(terminal), terminal_bytes, reserved));
+    } else {
+      // Only reachable after bridge teardown or for a pre-reservation
+      // connection; retain the best-effort fallback for orderly cleanup.
+      static_cast<void>(runtime->push_ws_event(
+          ws_route_->clone(), std::move(terminal), terminal_bytes));
+    }
+  }
+  close();
+}
+
+void ServerConnection::release_ws_terminal_reservation() noexcept {
+  if (ws_close_reserved_ != 0 && ws_runtime_) {
+    ws_runtime_->release_ws_reservation(ws_close_reserved_);
+    ws_close_reserved_ = 0;
   }
 }
 
 void ServerConnection::close() {
   release_admission();
   release_ws_reservation_held();
-  if (ws_close_reserved_ != 0 && ws_runtime_) {
-    // Torn down without a terminal event (forced teardown): return the
-    // reserved capacity.
-    ws_runtime_->release_ws_reservation(ws_close_reserved_);
-    ws_close_reserved_ = 0;
-  }
+  // Pre-Open failures and forced teardown have no graph-visible lifecycle
+  // to terminate; return any capacity that was never converted into an
+  // event.  Every post-Open transport path calls finish_ws first.
+  release_ws_terminal_reservation();
   close_socket_only();
   retire_barrier_.reset();
 }
@@ -3302,32 +3350,56 @@ void H2Driver::close() {
   static_cast<void>(beast::get_lowest_layer(stream_).socket().close(ec));
 }
 
-void H2Driver::release_stream(std::int32_t, Stream &stream) {
-  // Subtract exactly what this stream contributed: header bytes only
-  // while their flag is set (early-error streams that were refused
-  // before counting contribute nothing) — a mismatched subtraction here
-  // would steal accounting from other blocked streams and prematurely
-  // resume reads (review P1).
+void H2Driver::discard_stream_input(std::int32_t stream_id, Stream &stream) {
+  // DATA is flow-controlled even when the request is rejected or reset.
+  // Returning every byte the application stops retaining is what keeps a
+  // discarded stream from permanently shrinking the shared connection
+  // window (review P1).
+  if (stream.unaccounted != 0) {
+    engine_.discard(stream_id, stream.unaccounted);
+  }
+
+  // Subtract exactly what this stream contributed: header bytes only while
+  // their flag is set (early-error streams refused before counting contribute
+  // nothing).  Trailer metadata is retained but not flow-controlled.
   const std::size_t header_part =
       stream.headers_counted ? stream.header_bytes + stream.target.size() : 0;
-  stream.headers_counted = false;
   const std::size_t buffered =
       stream.unaccounted + stream.trailer_unaccounted + header_part;
   if (buffered != 0) {
     unaccounted_total_ -= std::min(unaccounted_total_, buffered);
-    stream.unaccounted = 0;
-    stream.trailer_unaccounted = 0;
-    resume_stalled_read();
   }
+
+  stream.unaccounted = 0;
+  stream.trailer_unaccounted = 0;
+  stream.headers_counted = false;
+  stream.header_bytes = 0;
+  stream.trailer_bytes = 0;
+  stream.body = std::string{};
+  stream.headers = H2Headers{};
+  stream.trailers = H2Headers{};
+  stream.target = std::string{};
+  stream.decoded_path = std::string{};
+  stream.matched.params = {};
+  stream.matched.route = nullptr;
+  stream.matched.snapshot.reset();
+  resume_stalled_read();
+}
+
+void H2Driver::release_stream(std::int32_t stream_id, Stream &stream) {
   if (stream.request_id >= 0 && stream.matched.runtime) {
     stream.matched.runtime->unregister_pending(stream.request_id);
     request_to_stream_.erase(stream.request_id);
     stream.request_id = -1;
   }
+  discard_stream_input(stream_id, stream);
   if (stream.reserved != 0 && stream.matched.runtime) {
     stream.matched.runtime->release_request_reservation(stream.reserved);
     stream.reserved = 0;
   }
+  stream.matched.runtime.reset();
+  stream.admitted = false;
+  stream.admission_in_flight = false;
 }
 
 void H2Driver::on_request_headers(std::int32_t stream_id, std::string method,
@@ -3480,12 +3552,12 @@ void H2Driver::on_request_data(std::int32_t stream_id, std::string_view data,
     // A stream answered by the transport (404/503/...): release the
     // window immediately so a still-sending peer cannot wedge the
     // connection; the bytes are never retained.
-    engine_.consume(stream_id, data.size());
+    engine_.discard(stream_id, data.size());
     return;
   }
   Stream &stream = found->second;
   if (stream.discarding) {
-    engine_.consume(stream_id, data.size());
+    engine_.discard(stream_id, data.size());
     return;
   }
   if (stream.body.size() + data.size() >
@@ -3494,7 +3566,7 @@ void H2Driver::on_request_data(std::int32_t stream_id, std::string_view data,
     // just-arrived chunk was never buffered, so its window is released
     // here; respond_transport restores the rest and discards uniformly
     // (review P1).
-    engine_.consume(stream_id, data.size());
+    engine_.discard(stream_id, data.size());
     respond_transport(stream_id, 413, "body exceeds max_body_bytes");
     return;
   }
@@ -3715,26 +3787,12 @@ void H2Driver::respond_transport(std::int32_t stream_id, int status,
   const auto found = streams_.find(stream_id);
   if (found != streams_.end()) {
     Stream &stream = found->second;
-    // Every transport answer discards uniformly BEFORE the budget is
-    // released: restore the flow-control window held by unconsumed DATA
-    // (auto window updates are off, so a skipped consume() shrinks the
-    // connection window forever) and drop the retained request buffers —
-    // releasing the reservation while still holding the body would keep
-    // memory outside the advertised bound until the peer half-closes
-    // (review P1).
-    if (stream.unaccounted != 0) {
-      engine_.consume(stream_id, stream.unaccounted);
-    }
-    const std::size_t buffered =
-        stream.unaccounted + stream.trailer_unaccounted;
-    unaccounted_total_ -= std::min(unaccounted_total_, buffered);
-    stream.unaccounted = 0;
-    stream.trailer_unaccounted = 0;
-    stream.body = std::string{};
-    stream.trailers = H2Headers{};
+    // One release path restores unconsumed DATA credit and drops every
+    // retained request buffer before giving the bridge reservation back.
+    // Trailer-overflow resets, peer resets, transport answers, and shutdown
+    // all share the same invariant (review P1).
     release_stream(stream_id, stream);
     stream.discarding = true;
-    resume_stalled_read();
   }
   // Transport answers obey the same outbound budgets as graph responses:
   // a slow peer accumulating error responses is reset instead of growing

--- a/extensions/web/src/asio_server.cpp
+++ b/extensions/web/src/asio_server.cpp
@@ -347,8 +347,22 @@ struct MatchedRoute {
   // which the retained estimate accounts via route_weight().
   std::shared_ptr<const CompiledRoutes> snapshot{};
   const Value *route{};
-  NamedPairs params{};
+  // Capture NAMES are views into the snapshot's route table; values are
+  // owned (request-derived).  Materialized into owning pairs only after
+  // admission (review P1).
+  std::vector<std::pair<std::string_view, std::string>> params{};
 };
+
+[[nodiscard]] WebBindings::NamedPairs
+materialize_params(
+    const std::vector<std::pair<std::string_view, std::string>> &params) {
+  WebBindings::NamedPairs owned;
+  owned.reserve(params.size());
+  for (const auto &[name, value] : params) {
+    owned.emplace_back(std::string{name}, value);
+  }
+  return owned;
+}
 
 /** The bytes the envelope's owning route copy retains (pattern + fixed
  * fields); route patterns are server-defined but can be long relative to
@@ -1753,6 +1767,19 @@ void WebServerRuntime::apply_ws_routes(std::vector<Value> added,
   if (listener_) {
     listener_->check_route_conflicts(this, true, added);
   }
+  for (const Value &route : added) {
+    // Route-aware floor: every maximal message on this route must fit an
+    // empty channel including the envelope's route copy (review P1).
+    const std::size_t weight = route_weight(route);
+    if (config_->ws_ingress.bytes <
+        config_->ws_max_message_bytes + 256 + weight) {
+      throw std::invalid_argument(
+          "Web ws_ingress_byte_limit cannot admit a maximal message on "
+          "route '" +
+          std::string{route.view().as_bundle().at("pattern").checked_as<Str>()} +
+          "' (needs ws_max_message_bytes + 256 + route pattern bytes)");
+    }
+  }
   rebuild(ws_routes_, ws_master_, std::move(added), std::move(removed));
   if (config_->bind_deferred && listener_) {
     listener_->ensure_listening();
@@ -2339,7 +2366,7 @@ Value ServerConnection::build_server_request(const MatchedRoute &matched,
           {"target", b.string(Str{std::string{target}})},
           {"path", b.string(Str{decoded_path_})},
           {"query", b.params(parse_query(query))},
-          {"path_params", b.params(matched.params)},
+          {"path_params", b.params(materialize_params(matched.params))},
           {"headers", b.headers(headers)},
           {"body", b.bytes(body)},
           {"trailers", b.headers({})},
@@ -2636,7 +2663,10 @@ void ServerConnection::accept_ws(MatchedRoute matched) {
                          {"state", b.enum_value(WsConnectionState::Open)},
                          {"request", server_request.clone()},
                      }),
-            request_bytes + self->ws_route_weight_ + 512);
+            // request_bytes (build_server_request) already includes the
+            // route weight — adding it again could overcharge a genuinely
+            // fitting event off the control lane (review P1).
+            request_bytes + 512);
         // Beast no longer needs the upgrade request; releasing it keeps
         // the single-counted accounting honest for the WebSocket's whole
         // lifetime (review P1).
@@ -2780,6 +2810,18 @@ void ServerConnection::ws_account_chunk() {
   const bool first = ws_reserved_bytes_ == 0;
   const std::size_t wanted =
       first ? pending + 256 + ws_route_weight_ : pending;
+  // Absolute oversize rejection: a record that cannot fit even an EMPTY
+  // channel (route weight included) must never enter the Backpressure
+  // retry loop — it would stall forever (review P1).
+  if (ws_reserved_bytes_ + wanted >
+      static_cast<std::size_t>(runtime->config().ws_ingress.bytes)) {
+    runtime->count_drop();
+    runtime->emit_event(WebSeverity::Warning, Str{"server"}, Str{"ws_ingress"},
+                        Str{"message cannot fit the WS ingress limit"}, 0,
+                        false, false, ws_connection_id_);
+    ws_close(websocket::close_code{1009}, "message too big to admit");
+    return;
+  }
   const bool accounted = first ? runtime->reserve_ws_ingress(wanted)
                                : runtime->grow_ws_reservation(wanted);
   if (accounted) {
@@ -3518,7 +3560,7 @@ void H2Driver::maybe_dispatch(std::int32_t stream_id) {
           {"target", b.string(Str{stream.target})},
           {"path", b.string(Str{stream.decoded_path})},
           {"query", b.params(parse_query(query))},
-          {"path_params", b.params(stream.matched.params)},
+          {"path_params", b.params(materialize_params(stream.matched.params))},
           {"headers", b.headers(headers)},
           {"body", b.bytes(Bytes{std::move(stream.body)})},
           {"trailers",
@@ -3531,7 +3573,8 @@ void H2Driver::maybe_dispatch(std::int32_t stream_id) {
   stream.headers = H2Headers{};
   stream.trailers = H2Headers{};
   stream.decoded_path = std::string{};
-  stream.matched.params = NamedPairs{};
+  stream.matched.params.clear();
+  stream.matched.params.shrink_to_fit();
   const Int request_id = runtime->register_pending(shared_from_this());
   Value server_request =
       build_on(b.server_request,

--- a/extensions/web/src/asio_server.cpp
+++ b/extensions/web/src/asio_server.cpp
@@ -333,11 +333,29 @@ method_from_token(std::string_view token) noexcept {
 
 class WebServerRuntime;
 
+struct CompiledRoutes {
+  RouteTable table{RouteTable::build({})};
+  std::vector<Value> routes{};
+};
+
 struct MatchedRoute {
   std::shared_ptr<WebServerRuntime> runtime{};
-  Value route{};
+  // The route is SHARED, not cloned: the snapshot pin keeps the pointed-at
+  // value alive across concurrent route swaps, so a backpressured request
+  // holds O(1) route memory instead of an owning copy per request
+  // (review P1).  The single owning copy is the envelope clone at push,
+  // which the retained estimate accounts via route_weight().
+  std::shared_ptr<const CompiledRoutes> snapshot{};
+  const Value *route{};
   NamedPairs params{};
 };
+
+/** The bytes the envelope's owning route copy retains (pattern + fixed
+ * fields); route patterns are server-defined but can be long relative to
+ * tiny requests, so they are accounted, not assumed (review P1). */
+[[nodiscard]] std::size_t route_weight(const Value &route) {
+  return route.view().as_bundle().at("pattern").checked_as<Str>().size() + 64;
+}
 
 // ---------------------------------------------------------------------------
 // Listener: owns the io_context pool and acceptor for one (address, port).
@@ -533,11 +551,6 @@ private:
 
 // ---------------------------------------------------------------------------
 // Runtime
-
-struct CompiledRoutes {
-  RouteTable table{RouteTable::build({})};
-  std::vector<Value> routes{};
-};
 
 // Lock-free published-snapshot access for io threads.  Apple's libc++ does
 // not provide std::atomic<std::shared_ptr>, and GCC deprecates the free
@@ -962,7 +975,12 @@ private:
   Int pending_request_id_{-1};
   Int ws_connection_id_{-1};
   std::shared_ptr<WebServerRuntime> ws_runtime_{};
-  Value ws_route_{};
+  // Shared route for the WebSocket lifetime: the snapshot pin replaces a
+  // per-connection owning clone (review P1); envelope clones are per-push
+  // and accounted via ws_route_weight_.
+  std::shared_ptr<const CompiledRoutes> ws_route_snapshot_{};
+  const Value *ws_route_{};
+  std::size_t ws_route_weight_{};
   std::optional<http::response<http::string_body>> outgoing_{};
   std::optional<http::response<http::empty_body>> chunk_head_{};
   std::optional<http::response_serializer<http::empty_body>> chunk_serializer_{};
@@ -1293,7 +1311,8 @@ std::optional<MatchedRoute> WebListener::match(HttpMethod method,
     const auto snapshot = upgrade ? runtime->ws_routes() : runtime->http_routes();
     const auto matched = snapshot->table.match(method, path);
     if (matched.matched) {
-      return MatchedRoute{runtime, snapshot->routes[matched.entry_index].clone(),
+      return MatchedRoute{runtime, snapshot,
+                          &snapshot->routes[matched.entry_index],
                           matched.params};
     }
   }
@@ -2162,7 +2181,8 @@ void ServerConnection::admit_and_read_body(MatchedRoute matched) {
   const std::size_t projected = projected_body + header_bytes +
                                 admission_target.size() +
                                 decoded_path_.size() + query_size +
-                                params_bytes + 512;
+                                params_bytes + route_weight(*matched.route) +
+                                512;
   const std::shared_ptr<WebServerRuntime> runtime = matched.runtime;
   serving_runtime_ = runtime.get();
   if (runtime->reserve_request(projected)) {
@@ -2309,7 +2329,8 @@ Value ServerConnection::build_server_request(const MatchedRoute &matched,
     params_bytes += name.size() + value.size();
   }
   retained_bytes = body.data.size() + header_bytes + target.size() +
-                   decoded_path_.size() + query.size() + params_bytes + 512;
+                   decoded_path_.size() + query.size() + params_bytes +
+                   route_weight(*matched.route) + 512;
 
   Value request = build_on(
       b.http_request,
@@ -2343,7 +2364,7 @@ void ServerConnection::dispatch_http(MatchedRoute matched, bool keep_alive) {
   // capacity was decided there, so no retry can retain a body outside the
   // bridge (review P1).  It fails only once the bridge stops accepting.
   const bool pushed = runtime->push_request_reserved(
-      matched.route.clone(), std::move(server_request), retained_bytes,
+      matched.route->clone(), std::move(server_request), retained_bytes,
       admitted_bytes_);
   admitted_runtime_.reset();
   admitted_bytes_ = 0;
@@ -2573,7 +2594,9 @@ void ServerConnection::accept_ws(MatchedRoute matched) {
   const std::shared_ptr<WebServerRuntime> runtime = matched.runtime;
   serving_runtime_ = runtime.get();
   ws_runtime_ = runtime;
-  ws_route_ = matched.route.clone();
+  ws_route_snapshot_ = matched.snapshot;
+  ws_route_ = matched.route;
+  ws_route_weight_ = route_weight(*ws_route_);
   ws_connection_id_ = runtime->register_ws_connection(shared_from_this());
 
   const auto &config = runtime->config();
@@ -2606,14 +2629,14 @@ void ServerConnection::accept_ws(MatchedRoute matched) {
         self->ws_ = true;
         const auto &b = runtime->bindings();
         runtime->push_ws_event(
-            self->ws_route_.clone(),
+            self->ws_route_->clone(),
             build_on(b.ws_event,
                      {
                          {"connection_id", b.number(self->ws_connection_id_)},
                          {"state", b.enum_value(WsConnectionState::Open)},
                          {"request", server_request.clone()},
                      }),
-            request_bytes + 512);
+            request_bytes + self->ws_route_weight_ + 512);
         // Beast no longer needs the upgrade request; releasing it keeps
         // the single-counted accounting honest for the WebSocket's whole
         // lifetime (review P1).
@@ -2659,7 +2682,7 @@ void ServerConnection::ws_read_next() {
           }
           const auto &b = runtime->bindings();
           runtime->push_ws_event(
-              self->ws_route_.clone(),
+              self->ws_route_->clone(),
               build_on(b.ws_event,
                        {
                            {"connection_id",
@@ -2670,7 +2693,7 @@ void ServerConnection::ws_read_next() {
                            {"close_code", b.number(close_code)},
                            {"close_reason", b.string(close_reason)},
                        }),
-              close_reason.size() + 512);
+              close_reason.size() + self->ws_route_weight_ + 512);
           self->close();
           return;
         }
@@ -2702,7 +2725,7 @@ void ServerConnection::ws_continue_message() {
   std::string payload{std::move(ws_message_)};
   ws_message_ = std::string{};
   const auto &b = runtime->bindings();
-  const std::size_t frame_bytes = payload.size() + 256;
+  const std::size_t frame_bytes = payload.size() + 256 + ws_route_weight_;
   Value frame =
       text ? build_on(b.ws_frame,
                       {
@@ -2730,7 +2753,7 @@ void ServerConnection::deliver_ws_ingress(Value inbound, std::size_t bytes) {
   const std::shared_ptr<WebServerRuntime> runtime = ws_runtime_;
   const std::size_t reserved = ws_reserved_bytes_;
   ws_reserved_bytes_ = 0;
-  if (runtime->push_ws_frame_reserved(ws_route_.clone(), std::move(inbound),
+  if (runtime->push_ws_frame_reserved(ws_route_->clone(), std::move(inbound),
                                       bytes, reserved)) {
     ws_read_continue();
   }
@@ -2755,7 +2778,8 @@ void ServerConnection::ws_account_chunk() {
   // The first chunk of a message takes the record slot and the envelope
   // overhead; later chunks grow the same reservation by bytes only.
   const bool first = ws_reserved_bytes_ == 0;
-  const std::size_t wanted = first ? pending + 256 : pending;
+  const std::size_t wanted =
+      first ? pending + 256 + ws_route_weight_ : pending;
   const bool accounted = first ? runtime->reserve_ws_ingress(wanted)
                                : runtime->grow_ws_reservation(wanted);
   if (accounted) {
@@ -3263,7 +3287,8 @@ void H2Driver::admit_stream(std::int32_t stream_id) {
   }
   const std::size_t projected = stream.header_bytes + stream.target.size() +
                                 stream.decoded_path.size() + query_size +
-                                params_bytes + 512;
+                                params_bytes +
+                                route_weight(*stream.matched.route) + 512;
   if (runtime->reserve_request(projected)) {
     stream.admitted = true;
     stream.reserved = projected;
@@ -3484,7 +3509,7 @@ void H2Driver::maybe_dispatch(std::int32_t stream_id) {
   const std::size_t retained =
       stream.body.size() + stream.header_bytes + stream.trailer_bytes +
       stream.target.size() + stream.decoded_path.size() + query.size() +
-      params_bytes + 512;
+      params_bytes + route_weight(*stream.matched.route) + 512;
   Value request = build_on(
       b.http_request,
       {
@@ -3520,7 +3545,7 @@ void H2Driver::maybe_dispatch(std::int32_t stream_id) {
   const std::size_t reserved = stream.reserved;
   stream.reserved = 0;
   const bool pushed = runtime->push_request_reserved(
-      stream.matched.route.clone(), std::move(server_request), retained,
+      stream.matched.route->clone(), std::move(server_request), retained,
       reserved);
   if (!pushed) {
     runtime->unregister_pending(request_id);
@@ -3528,7 +3553,8 @@ void H2Driver::maybe_dispatch(std::int32_t stream_id) {
     return;
   }
   stream.target = std::string{};
-  stream.matched.route = Value{};
+  stream.matched.route = nullptr;
+  stream.matched.snapshot.reset();
   stream.request_id = request_id;
   request_to_stream_[request_id] = stream_id;
 }

--- a/extensions/web/src/asio_server.cpp
+++ b/extensions/web/src/asio_server.cpp
@@ -1063,11 +1063,16 @@ public:
           report.barrier = barrier;
         }
       }
+      // The barrier rides EVERY stream of the retiring runtime to its
+      // terminal event (close/reset/write failure) — an output-queue
+      // sentinel would release while a zero-window client still blocks a
+      // submitted response (review P1).
+      for (auto &[stream_id, stream] : self->streams_) {
+        if (stream.matched.runtime.get() == runtime) {
+          stream.retire_barrier = barrier;
+        }
+      }
       if (!retiring.empty() && !self->closed_) {
-        // Hold the barrier until the write batch carrying these 503s
-        // completes (a barrier-only sentinel in the flush queue).
-        self->pending_flush_reports_.push_back(
-            PendingReport{nullptr, 0, 0, true, std::move(barrier)});
         self->pump_writes();
       }
     });
@@ -1116,6 +1121,10 @@ private:
     // connection's unaccounted bound; cleared exactly once, on admission
     // (into the reservation) or on release (review P1).
     bool headers_counted{};
+    // A retirement barrier rides the stream to its terminal event —
+    // close, reset, or write failure — so a flow-control-blocked
+    // response cannot let stop() clear the bridge early (review P1).
+    std::shared_ptr<const void> retire_barrier{};
     bool end_stream_seen{};
     bool discarding{};
     Int request_id{-1};
@@ -2129,8 +2138,11 @@ void ServerConnection::admit_and_read_body(MatchedRoute matched) {
       : content_length.has_value()
           ? static_cast<std::size_t>(*content_length)
           : config_->max_body_bytes;
+  // The Beast source is released at dispatch, so headers single-count;
+  // the target weighs 4x to bound its request-controlled derivations
+  // (decoded path, query pairs, path-parameter values).
   const std::size_t projected =
-      projected_body + 2 * header_bytes + 4 * header.target().size() + 512;
+      projected_body + header_bytes + 4 * header.target().size() + 512;
   const std::shared_ptr<WebServerRuntime> runtime = matched.runtime;
   serving_runtime_ = runtime.get();
   if (runtime->reserve_request(projected)) {
@@ -2270,13 +2282,14 @@ Value ServerConnection::build_server_request(const MatchedRoute &matched,
   // Moving the body out empties the Beast message, so once the value is
   // pushed the connection itself no longer retains the payload.
   Bytes body{std::move(request_.body())};
-  // The graph value owns COPIES of the metadata (headers, target, decoded
-  // path, parsed query, path params) while the transport still retains
-  // the source until the request is answered, so headers weigh double and
-  // the target triple (target + decoded path + query) — otherwise large
-  // paths and queries exceed the advertised bound (review P1).
-  retained_bytes =
-      body.data.size() + 2 * header_bytes + 4 * target.size() + 512;
+  // EXACT derived sizes: the Beast message is released right after the
+  // push, so the graph value's copies are single-counted (review P1).
+  std::size_t params_bytes = 0;
+  for (const auto &[name, value] : matched.params) {
+    params_bytes += name.size() + value.size();
+  }
+  retained_bytes = body.data.size() + header_bytes + target.size() +
+                   decoded_path_.size() + query.size() + params_bytes + 512;
 
   Value request = build_on(
       b.http_request,
@@ -2323,6 +2336,10 @@ void ServerConnection::dispatch_http(MatchedRoute matched, bool keep_alive) {
   pending_request_id_ = request_id;
   request_keep_alive_ = keep_alive;
   pending_is_head_ = request_.method() == http::verb::head;
+  // The graph value owns its copies; drop the transport's source message
+  // so the retained estimate single-counts everything (review P1).
+  request_ = http::request<http::string_body>{};
+  decoded_path_ = std::string{};
 }
 
 void ServerConnection::write_response(
@@ -3204,11 +3221,12 @@ void H2Driver::admit_stream(std::int32_t stream_id) {
   // Header admission mirrors h1: the header block plus envelope overhead
   // reserves before any DATA window is released; the body then grows the
   // same reservation chunk-by-chunk (RFC 0024, flow control).
-  // Headers double (source + graph copies); the target weighs 4x — raw
-  // target, decoded path, parsed query pairs, and path-parameter values
-  // are separate owned copies (review P1).
+  // Transport copies are released once the graph value is built, so the
+  // reservation single-counts the headers; the target weighs 4x to bound
+  // its request-controlled derivations (decoded path, query pairs,
+  // path-parameter values, each <= the target).
   const std::size_t projected =
-      2 * stream.header_bytes + 4 * stream.target.size() + 512;
+      stream.header_bytes + 4 * stream.target.size() + 512;
   if (runtime->reserve_request(projected)) {
     stream.admitted = true;
     stream.reserved = projected;
@@ -3347,19 +3365,15 @@ void H2Driver::account_stream_data(std::int32_t stream_id) {
     // Trailer bytes grow the reservation but never consume flow-control
     // window — HEADERS frames are not flow-controlled (RFC 9113 §6.9).
     const std::size_t data_pending = stream.unaccounted;
-    // The connection counter tracks RAW buffered bytes; the bridge
-    // reservation weighs trailers double for the graph copy.  Subtracting
-    // the weighted amount from the raw counter would steal accounting
-    // from other blocked streams (review P1).
-    const std::size_t raw_pending =
-        data_pending + stream.trailer_unaccounted;
-    const std::size_t reserve_pending =
-        data_pending + 2 * stream.trailer_unaccounted;
-    if (stream.matched.runtime->grow_request_reservation(reserve_pending)) {
-      stream.reserved += reserve_pending;
+    // Raw buffered bytes and the reservation growth are the same amount
+    // now that transport copies are released at dispatch: the graph copy
+    // is the only survivor, single-counted (review P1).
+    const std::size_t pending = data_pending + stream.trailer_unaccounted;
+    if (stream.matched.runtime->grow_request_reservation(pending)) {
+      stream.reserved += pending;
       stream.unaccounted = 0;
       stream.trailer_unaccounted = 0;
-      unaccounted_total_ -= std::min(unaccounted_total_, raw_pending);
+      unaccounted_total_ -= std::min(unaccounted_total_, pending);
       if (data_pending != 0) {
         engine_.consume(stream_id, data_pending);
         pump_writes(); // the WINDOW_UPDATE this consume released
@@ -3422,9 +3436,18 @@ void H2Driver::maybe_dispatch(std::int32_t stream_id) {
           : full_target.substr(query_start + 1);
   WebBindings::NamedPairs headers{stream.headers.begin(),
                                   stream.headers.end()};
+  // The EXACT derived sizes, not multipliers: every owned copy in the
+  // graph value is measurable here, and the transport copies are released
+  // right after the value is built, so single-counting bounds retained
+  // memory (review P1).
+  std::size_t params_bytes = 0;
+  for (const auto &[name, value] : stream.matched.params) {
+    params_bytes += name.size() + value.size();
+  }
   const std::size_t retained =
-      stream.body.size() + 2 * stream.header_bytes +
-      2 * stream.trailer_bytes + 4 * stream.target.size() + 512;
+      stream.body.size() + stream.header_bytes + stream.trailer_bytes +
+      stream.target.size() + stream.decoded_path.size() + query.size() +
+      params_bytes + 512;
   Value request = build_on(
       b.http_request,
       {
@@ -3441,6 +3464,12 @@ void H2Driver::maybe_dispatch(std::int32_t stream_id) {
                                              stream.trailers.end()})},
       });
   stream.body = std::string{};
+  // The graph value owns its copies now; drop the transport's so the
+  // retained estimate above single-counts everything still alive.
+  stream.headers = H2Headers{};
+  stream.trailers = H2Headers{};
+  stream.decoded_path = std::string{};
+  stream.matched.params = NamedPairs{};
   const Int request_id = runtime->register_pending(shared_from_this());
   Value server_request =
       build_on(b.server_request,
@@ -3461,6 +3490,8 @@ void H2Driver::maybe_dispatch(std::int32_t stream_id) {
     respond_transport(stream_id, 503, "server shutting down");
     return;
   }
+  stream.target = std::string{};
+  stream.matched.route = Value{};
   stream.request_id = request_id;
   request_to_stream_[request_id] = stream_id;
 }
@@ -3639,6 +3670,12 @@ void H2Driver::on_stream_closed(std::int32_t stream_id) {
   if (stream.response_submitted && stream.report_runtime) {
     queue_report(std::move(stream.report_runtime), stream.report_client_id,
                  stream.report_request_id, stream.close_error == 0);
+    pending_flush_reports_.back().barrier = std::move(stream.retire_barrier);
+  } else if (stream.retire_barrier) {
+    // No report to carry it: a barrier-only entry releases once the
+    // frames that closed this stream have been written.
+    pending_flush_reports_.push_back(
+        PendingReport{nullptr, 0, 0, true, std::move(stream.retire_barrier)});
   }
   release_stream(stream_id, stream);
   streams_.erase(found);

--- a/extensions/web/src/asio_server.cpp
+++ b/extensions/web/src/asio_server.cpp
@@ -213,10 +213,12 @@ milliseconds_field(const ValueView &field, std::string_view name) {
   // parked forever with no pauser left to resume it (review P1).  The
   // constants mirror the transport's retained-byte estimates.
   if (result.ingress.bytes <
-      result.max_body_bytes + result.max_header_bytes + 512) {
+      result.max_body_bytes + 2 * result.max_header_bytes + 512) {
+    // Two header blocks: h2 initial headers and trailers are capped
+    // separately, and a maximal valid request carries both (review P1).
     throw std::invalid_argument(
         "Web server ingress_byte_limit must cover one maximal request "
-        "(max_body_bytes + max_header_bytes + 512)");
+        "(max_body_bytes + 2*max_header_bytes + 512)");
   }
   if (result.ws_ingress.bytes < result.ws_max_message_bytes + 256) {
     throw std::invalid_argument(
@@ -369,9 +371,10 @@ public:
     runtimes_.push_back(std::move(runtime));
   }
 
-  /** Every live connection registers here so the LAST detaching runtime
-   * can shut them all down — including idle ones that no pending
-   * registry references (review P1). */
+  /** Every live connection registers here so a stopping runtime can
+   * retire ITS work everywhere — streams still blocked before dispatch
+   * included — and so the LAST detaching runtime can shut every
+   * connection down, idle ones included (review P1). */
   void register_connection(std::weak_ptr<PendingTarget> connection) {
     std::lock_guard lock{mutex_};
     std::erase_if(live_connections_,
@@ -379,6 +382,7 @@ public:
     live_connections_.push_back(std::move(connection));
   }
 
+  void retire_runtime_connections(const WebServerRuntime *runtime);
   void shutdown_connections();
 
   /** @return true when this was the last attached runtime. */
@@ -788,10 +792,22 @@ public:
     });
   }
 
-  void retire_runtime(const WebServerRuntime *) override {
-    // An h1 connection serves one request at a time; the stopping
-    // runtime owns whatever is pending here, so retiring == closing.
-    connection_shutdown();
+  void retire_runtime(const WebServerRuntime *runtime) override {
+    asio::post(strand_, [self = shared_from_this(), runtime] {
+      // Only close when the stopping runtime owns this connection's
+      // current activity; an idle keep-alive connection (or one serving
+      // another attachee) must keep serving (review P1).
+      if (self->ws_) {
+        if (self->ws_runtime_.get() == runtime) {
+          self->connection_shutdown();
+        }
+        return;
+      }
+      if (self->pending_request_id_ >= 0 &&
+          self->pending_runtime_ == runtime) {
+        self->connection_shutdown();
+      }
+    });
   }
 
   void connection_shutdown() override {
@@ -916,6 +932,7 @@ private:
   std::string decoded_path_{};
   std::size_t admitted_bytes_{};
   std::shared_ptr<WebServerRuntime> admitted_runtime_{};
+  const WebServerRuntime *pending_runtime_{};
   std::size_t ws_reserved_bytes_{};
   std::size_t ws_unaccounted_bytes_{};
   // Message bytes accumulate here — storage the reservation accounts —
@@ -1115,6 +1132,7 @@ private:
   std::array<char, 16 * 1024> read_buffer_{};
   std::string write_buffer_{};
   std::size_t outstanding_response_bytes_{};
+  std::size_t outstanding_response_messages_{};
   struct PendingReport {
     std::shared_ptr<WebServerRuntime> runtime{};
     Int client_id{};
@@ -1233,6 +1251,19 @@ std::optional<MatchedRoute> WebListener::match(HttpMethod method,
     }
   }
   return std::nullopt;
+}
+
+void WebListener::retire_runtime_connections(const WebServerRuntime *runtime) {
+  std::vector<std::weak_ptr<PendingTarget>> live;
+  {
+    std::lock_guard lock{mutex_};
+    live = live_connections_;
+  }
+  for (const auto &weak : live) {
+    if (const auto connection = weak.lock()) {
+      connection->retire_runtime(runtime);
+    }
+  }
 }
 
 void WebListener::shutdown_connections() {
@@ -1531,35 +1562,29 @@ void WebServerRuntime::stop() noexcept {
       listener_->set_reads_paused(WebListener::ReadTier::Http, this, false);
       listener_->set_reads_paused(WebListener::ReadTier::Ws, this, false);
 
-      std::vector<std::shared_ptr<PendingTarget>> targets;
       {
+        // The pending and WS registries are bookkeeping only from here;
+        // retirement itself reaches EVERY live connection through the
+        // listener, so streams still blocked before dispatch retire too
+        // (review P1).
         std::lock_guard lock{pending_mutex_};
-        for (auto &[request_id, pending] : pending_) {
-          targets.push_back(std::move(pending.target));
-        }
-        for (auto &[connection_id, weak] : ws_connections_) {
-          if (auto connection = weak.lock()) {
-            targets.push_back(std::move(connection));
-          }
-        }
         pending_.clear();
         ws_connections_.clear();
       }
-      for (const auto &target : targets) {
-        target->retire_runtime(this);
-      }
+      listener_->retire_runtime_connections(this);
       if (last) {
         // The listener is going away: every live connection — idle ones
-        // included — gets its orderly shutdown (GOAWAY on h2).
+        // included — gets its orderly shutdown (GOAWAY on h2), and only
+        // then is the connection drain awaited.  A non-last stop must NOT
+        // wait on listener-wide connections that stay open serving the
+        // other attachees (review P1); its 503s flush on the live io pool.
         listener_->shutdown_connections();
-      }
-      const auto deadline =
-          std::chrono::steady_clock::now() + config_->shutdown_drain_timeout;
-      while (std::chrono::steady_clock::now() < deadline &&
-             listener_->open_connections() != 0) {
-        std::this_thread::sleep_for(std::chrono::milliseconds{10});
-      }
-      if (last) {
+        const auto deadline = std::chrono::steady_clock::now() +
+                              config_->shutdown_drain_timeout;
+        while (std::chrono::steady_clock::now() < deadline &&
+               listener_->open_connections() != 0) {
+          std::this_thread::sleep_for(std::chrono::milliseconds{10});
+        }
         listener_->stop_io();
       }
       // Cancellation is posted onto each timer's strand: for a non-last
@@ -2233,6 +2258,7 @@ void ServerConnection::dispatch_http(MatchedRoute matched, bool keep_alive) {
     return;
   }
   pending_request_id_ = request_id;
+  pending_runtime_ = runtime.get();
   request_keep_alive_ = keep_alive;
   pending_is_head_ = request_.method() == http::verb::head;
 }
@@ -3004,7 +3030,15 @@ void H2Driver::close() {
 }
 
 void H2Driver::release_stream(std::int32_t, Stream &stream) {
-  const std::size_t buffered = stream.unaccounted + stream.trailer_unaccounted;
+  const std::size_t header_part =
+      stream.admitted ? 0 : stream.header_bytes + stream.target.size();
+  const std::size_t buffered =
+      stream.unaccounted + stream.trailer_unaccounted + header_part;
+  if (!stream.admitted) {
+    // release runs at most once per stream; mark so a second call cannot
+    // double-subtract the header part.
+    stream.admitted = true;
+  }
   if (buffered != 0) {
     unaccounted_total_ -= std::min(unaccounted_total_, buffered);
     stream.unaccounted = 0;
@@ -3068,6 +3102,10 @@ void H2Driver::on_request_headers(std::int32_t stream_id, std::string method,
     return;
   }
   stream.matched = std::move(*matched);
+  // Until admission succeeds the header block is buffered driver memory,
+  // so it counts toward the connection's unaccounted bound — otherwise
+  // header-only streams could exceed the one-window claim (review P1).
+  unaccounted_total_ += stream.header_bytes + stream.target.size();
   streams_.emplace(stream_id, std::move(stream));
   admit_stream(stream_id);
 }
@@ -3078,6 +3116,12 @@ void H2Driver::admit_stream(std::int32_t stream_id) {
     return;
   }
   Stream &stream = found->second;
+  if (stream.discarding) {
+    // Already answered by the transport (a retiring runtime's 503): the
+    // admission retry loop ends here instead of spinning against a
+    // stopped bridge (review P1).
+    return;
+  }
   stream.admission_in_flight = false;
   const std::shared_ptr<WebServerRuntime> runtime = stream.matched.runtime;
   // Header admission mirrors h1: the header block plus envelope overhead
@@ -3087,6 +3131,9 @@ void H2Driver::admit_stream(std::int32_t stream_id) {
   if (runtime->reserve_request(projected)) {
     stream.admitted = true;
     stream.reserved = projected;
+    const std::size_t header_part = stream.header_bytes + stream.target.size();
+    unaccounted_total_ -= std::min(unaccounted_total_, header_part);
+    resume_stalled_read();
     account_stream_data(stream_id);
     return;
   }
@@ -3197,6 +3244,9 @@ void H2Driver::account_stream_data(std::int32_t stream_id) {
     return;
   }
   Stream &stream = found->second;
+  if (stream.discarding) {
+    return;
+  }
   if (stream.unaccounted != 0 || stream.trailer_unaccounted != 0) {
     // Trailer bytes grow the reservation but never consume flow-control
     // window — HEADERS frames are not flow-controlled (RFC 9113 §6.9).
@@ -3378,10 +3428,21 @@ void H2Driver::write_stream_response(
   }
 
   // Per-stream slow-consumer policy: a response that would push the
-  // buffered outbound share past the configured byte limit resets JUST
-  // this stream (h2 acceptance criteria).
-  if (outstanding_response_bytes_ + body.size() >
-      static_cast<std::size_t>(config_->outbound_byte_limit)) {
+  // buffered outbound share past the configured byte OR message limits
+  // resets JUST this stream.  The weight covers headers and trailers, so
+  // metadata-heavy or empty-body responses cannot bypass the bounds
+  // (review P1).
+  std::size_t response_weight = body.size() + 256;
+  for (const auto &[name, value] : headers) {
+    response_weight += name.size() + value.size();
+  }
+  for (const auto &[name, value] : trailers) {
+    response_weight += name.size() + value.size();
+  }
+  if (outstanding_response_bytes_ + response_weight >
+          static_cast<std::size_t>(config_->outbound_byte_limit) ||
+      outstanding_response_messages_ >=
+          static_cast<std::size_t>(config_->outbound_message_limit)) {
     engine_.reset_stream(stream_id, H2StreamError::EnhanceYourCalm);
     pump_writes();
     runtime->report(index(ServerChannel::RespondDelivery), client_id,
@@ -3391,16 +3452,16 @@ void H2Driver::write_stream_response(
     return;
   }
 
-  const std::size_t response_bytes = body.size();
   if (engine_.submit_response(stream_id, status, headers, std::move(body),
                               trailers)) {
-    outstanding_response_bytes_ += response_bytes;
+    outstanding_response_bytes_ += response_weight;
+    ++outstanding_response_messages_;
     if (stream_found != streams_.end()) {
       // Delivery is reported from the write pump once the stream closes
       // and its bytes have left the connection — never at enqueue
       // (review P1; the RFC separates acceptance from delivery).
       Stream &stream = stream_found->second;
-      stream.response_bytes += response_bytes;
+      stream.response_bytes += response_weight;
       stream.response_submitted = true;
       stream.report_client_id = client_id;
       stream.report_request_id = request_id;
@@ -3448,9 +3509,12 @@ void H2Driver::on_stream_closed(std::int32_t stream_id) {
     return;
   }
   Stream &stream = found->second;
-  // The buffered-outbound budget frees as streams retire (review P1).
+  // The buffered-outbound budgets free as streams retire (review P1).
   outstanding_response_bytes_ -=
       std::min(outstanding_response_bytes_, stream.response_bytes);
+  if (stream.response_submitted && outstanding_response_messages_ != 0) {
+    --outstanding_response_messages_;
+  }
   if (stream.response_submitted && stream.report_runtime) {
     queue_report(std::move(stream.report_runtime), stream.report_client_id,
                  stream.report_request_id, stream.close_error == 0);

--- a/extensions/web/src/asio_server.cpp
+++ b/extensions/web/src/asio_server.cpp
@@ -213,13 +213,13 @@ milliseconds_field(const ValueView &field, std::string_view name) {
   // parked forever with no pauser left to resume it (review P1).  The
   // constants mirror the transport's retained-byte estimates.
   if (result.ingress.bytes <
-      result.max_body_bytes + 4 * result.max_header_bytes + 1024) {
-    // Two header blocks (h2 initial headers and trailers are capped
-    // separately), each weighed twice for the source-plus-graph copies
-    // (review P1).
+      result.max_body_bytes + 6 * result.max_header_bytes + 1024) {
+    // The implementation's own worst-case weight: initial headers at 2x
+    // plus a 4x-weighted target (both inside one max_header_bytes block,
+    // worst case 4x) plus trailers at 2x (review P1).
     throw std::invalid_argument(
         "Web server ingress_byte_limit must cover one maximal request "
-        "(max_body_bytes + 4*max_header_bytes + 1024)");
+        "(max_body_bytes + 6*max_header_bytes + 1024)");
   }
   if (result.ws_ingress.bytes < result.ws_max_message_bytes + 256) {
     throw std::invalid_argument(
@@ -810,6 +810,11 @@ public:
       // another runtime's next request) between check and close
       // (review P1).
       if (self->serving_runtime_ == runtime) {
+        // The barrier must survive the ASYNC tail — the 503 write, the
+        // WS close handshake, an already-running response — all of which
+        // terminate in close(); holding it as a member until then lets
+        // the stopping runtime await true completion (review P1).
+        self->retire_barrier_ = std::move(barrier);
         self->shutdown_now();
       }
     });
@@ -945,6 +950,7 @@ private:
   // (admission wait, body read, WS handshake) through completion, so a
   // stopping runtime can retire pre-dispatch work too (review P1).
   const WebServerRuntime *serving_runtime_{};
+  std::shared_ptr<const void> retire_barrier_{};
   std::size_t ws_reserved_bytes_{};
   std::size_t ws_unaccounted_bytes_{};
   // Message bytes accumulate here — storage the reservation accounts —
@@ -1049,6 +1055,13 @@ public:
       }
       for (const std::int32_t stream_id : retiring) {
         self->respond_transport(stream_id, 503, "server shutting down");
+      }
+      // Delivery reports already queued for the retiring runtime release
+      // the barrier only when their carrying write completes (review P1).
+      for (auto &report : self->pending_flush_reports_) {
+        if (report.runtime.get() == runtime) {
+          report.barrier = barrier;
+        }
       }
       if (!retiring.empty() && !self->closed_) {
         // Hold the barrier until the write batch carrying these 503s
@@ -2117,7 +2130,7 @@ void ServerConnection::admit_and_read_body(MatchedRoute matched) {
           ? static_cast<std::size_t>(*content_length)
           : config_->max_body_bytes;
   const std::size_t projected =
-      projected_body + 2 * header_bytes + 3 * header.target().size() + 512;
+      projected_body + 2 * header_bytes + 4 * header.target().size() + 512;
   const std::shared_ptr<WebServerRuntime> runtime = matched.runtime;
   serving_runtime_ = runtime.get();
   if (runtime->reserve_request(projected)) {
@@ -2263,7 +2276,7 @@ Value ServerConnection::build_server_request(const MatchedRoute &matched,
   // the target triple (target + decoded path + query) — otherwise large
   // paths and queries exceed the advertised bound (review P1).
   retained_bytes =
-      body.data.size() + 2 * header_bytes + 3 * target.size() + 512;
+      body.data.size() + 2 * header_bytes + 4 * target.size() + 512;
 
   Value request = build_on(
       b.http_request,
@@ -2913,6 +2926,7 @@ void ServerConnection::close() {
   release_admission();
   release_ws_reservation_held();
   close_socket_only();
+  retire_barrier_.reset();
 }
 
 void ServerConnection::close_socket_only() {
@@ -3190,10 +3204,11 @@ void H2Driver::admit_stream(std::int32_t stream_id) {
   // Header admission mirrors h1: the header block plus envelope overhead
   // reserves before any DATA window is released; the body then grows the
   // same reservation chunk-by-chunk (RFC 0024, flow control).
-  // Headers double (source + graph copies), target triple (target +
-  // decoded path + parsed query), matching the h1 estimate (review P1).
+  // Headers double (source + graph copies); the target weighs 4x — raw
+  // target, decoded path, parsed query pairs, and path-parameter values
+  // are separate owned copies (review P1).
   const std::size_t projected =
-      2 * stream.header_bytes + 3 * stream.target.size() + 512;
+      2 * stream.header_bytes + 4 * stream.target.size() + 512;
   if (runtime->reserve_request(projected)) {
     stream.admitted = true;
     stream.reserved = projected;
@@ -3332,12 +3347,19 @@ void H2Driver::account_stream_data(std::int32_t stream_id) {
     // Trailer bytes grow the reservation but never consume flow-control
     // window — HEADERS frames are not flow-controlled (RFC 9113 §6.9).
     const std::size_t data_pending = stream.unaccounted;
-    const std::size_t pending = data_pending + 2 * stream.trailer_unaccounted;
-    if (stream.matched.runtime->grow_request_reservation(pending)) {
-      stream.reserved += pending;
+    // The connection counter tracks RAW buffered bytes; the bridge
+    // reservation weighs trailers double for the graph copy.  Subtracting
+    // the weighted amount from the raw counter would steal accounting
+    // from other blocked streams (review P1).
+    const std::size_t raw_pending =
+        data_pending + stream.trailer_unaccounted;
+    const std::size_t reserve_pending =
+        data_pending + 2 * stream.trailer_unaccounted;
+    if (stream.matched.runtime->grow_request_reservation(reserve_pending)) {
+      stream.reserved += reserve_pending;
       stream.unaccounted = 0;
       stream.trailer_unaccounted = 0;
-      unaccounted_total_ -= std::min(unaccounted_total_, pending);
+      unaccounted_total_ -= std::min(unaccounted_total_, raw_pending);
       if (data_pending != 0) {
         engine_.consume(stream_id, data_pending);
         pump_writes(); // the WINDOW_UPDATE this consume released
@@ -3402,7 +3424,7 @@ void H2Driver::maybe_dispatch(std::int32_t stream_id) {
                                   stream.headers.end()};
   const std::size_t retained =
       stream.body.size() + 2 * stream.header_bytes +
-      2 * stream.trailer_bytes + 3 * stream.target.size() + 512;
+      2 * stream.trailer_bytes + 4 * stream.target.size() + 512;
   Value request = build_on(
       b.http_request,
       {

--- a/extensions/web/src/asio_server.cpp
+++ b/extensions/web/src/asio_server.cpp
@@ -202,6 +202,11 @@ milliseconds_field(const ValueView &field, std::string_view name) {
       root.at("h2_max_concurrent_streams"), "h2_max_concurrent_streams"));
   result.h2_initial_window_bytes = static_cast<Int>(positive_size(
       root.at("h2_initial_window_bytes"), "h2_initial_window_bytes"));
+  if (result.h2_initial_window_bytes > 2'147'483'647 ||
+      result.h2_max_concurrent_streams > 2'147'483'647) {
+    throw std::invalid_argument(
+        "Web server h2 settings must be at most 2^31-1");
+  }
 
   // A single maximal payload must always fit an EMPTY ingress channel:
   // under Backpressure a message that can never fit would otherwise be
@@ -536,6 +541,12 @@ inline void atomic_store_routes(std::shared_ptr<const CompiledRoutes> *slot,
 class ServerConnection;
 class WebServerRuntime;
 
+// Request and connection ids are unique across every runtime in the
+// process: one h2 connection on a shared listener can carry streams from
+// several runtimes in a single map, so per-runtime counters could collide
+// (review P1).
+inline std::atomic<Int> process_request_ids{0};
+
 /** The respond surface a pending request routes back to: the h1
  * connection or the h2 stream driver that owns the transport side of the
  * request (RFC 0024, HTTP/2 activation plan). */
@@ -631,7 +642,7 @@ public:
                                            bytes);
   }
   [[nodiscard]] Int allocate_connection_id() noexcept {
-    return ++next_request_id_;
+    return ++process_request_ids;
   }
   void release_request_reservation(std::size_t bytes) noexcept {
     bridge_.value->release_reservation(index(ServerChannel::Request), bytes);
@@ -679,7 +690,6 @@ private:
   std::vector<std::tuple<HttpMethod, std::string, Value>> ws_master_{};
 
   std::mutex pending_mutex_{};
-  std::atomic<Int> next_request_id_{0};
   struct Pending {
     // Owning: between dispatch and the graph's answer no async operation
     // holds the transport target, so the pending registry keeps it alive
@@ -1003,6 +1013,14 @@ private:
     bool end_stream_seen{};
     bool discarding{};
     Int request_id{-1};
+    // Delivery is reported from the write pump once the response bytes
+    // have actually left the connection (review P1).
+    std::size_t response_bytes{};
+    bool response_submitted{};
+    std::uint32_t close_error{};
+    Int report_client_id{-1};
+    Int report_request_id{-1};
+    std::shared_ptr<WebServerRuntime> report_runtime{};
   };
 
   // --- H2Host (all calls arrive inside engine_.receive on the strand) ---
@@ -1042,9 +1060,25 @@ private:
   std::array<char, 16 * 1024> read_buffer_{};
   std::string write_buffer_{};
   std::size_t outstanding_response_bytes_{};
+  struct PendingReport {
+    std::shared_ptr<WebServerRuntime> runtime{};
+    Int client_id{};
+    Int request_id{};
+    bool clean{};
+  };
+  void queue_report(std::shared_ptr<WebServerRuntime> runtime, Int client_id,
+                    Int request_id, bool clean) {
+    pending_flush_reports_.push_back(
+        PendingReport{std::move(runtime), client_id, request_id, clean});
+  }
+  void flush_reports(std::size_t count, bool written);
+  void shutdown_send();
+
+  std::vector<PendingReport> pending_flush_reports_{};
   Int connection_id_{-1};
   bool writing_{};
   bool shutting_down_{};
+  bool sent_fin_{};
   bool closed_{};
 };
 
@@ -1542,7 +1576,7 @@ void WebServerRuntime::apply_ws_routes(std::vector<Value> added,
 
 Int WebServerRuntime::register_pending(
     const std::shared_ptr<PendingTarget> &target) {
-  const Int request_id = ++next_request_id_;
+  const Int request_id = ++process_request_ids;
   std::lock_guard lock{pending_mutex_};
   pending_[request_id] =
       Pending{target, std::chrono::steady_clock::now() +
@@ -1557,7 +1591,7 @@ void WebServerRuntime::unregister_pending(Int request_id) noexcept {
 
 Int WebServerRuntime::register_ws_connection(
     const std::shared_ptr<ServerConnection> &connection) {
-  const Int connection_id = ++next_request_id_;
+  const Int connection_id = ++process_request_ids;
   std::lock_guard lock{pending_mutex_};
   ws_connections_[connection_id] = connection;
   return connection_id;
@@ -2745,10 +2779,16 @@ void ServerConnection::close_socket_only() {
 // H2Driver implementation
 
 void ServerConnection::start_h2() {
-  auto driver = std::make_shared<H2Driver>(listener_, config_,
-                                           std::move(*tls_stream_));
-  tls_stream_.reset();
-  driver->run();
+  try {
+    auto driver = std::make_shared<H2Driver>(listener_, config_,
+                                             std::move(*tls_stream_));
+    tls_stream_.reset();
+    driver->run();
+  } catch (const std::exception &) {
+    // An engine construction failure must never escape the handshake
+    // handler into io_context::run() (review P2).
+    close();
+  }
 }
 
 void H2Driver::read_next() {
@@ -2789,36 +2829,88 @@ void H2Driver::pump_writes() {
     write_buffer_.append(output);
   }
   if (write_buffer_.empty()) {
+    // Everything queued so far is on the wire; reports collected while
+    // frames were generated are now deliverable.
+    flush_reports(pending_flush_reports_.size(), true);
     if (engine_.finished()) {
-      close();
+      // An orderly session end closes with a FIN, never a hard close: the
+      // read loop keeps draining to EOF so late peer bytes cannot turn
+      // the close into a TCP RST (review; h2spec 7/1 on slow runners).
+      shutdown_send();
     }
     return;
   }
   writing_ = true;
+  const std::size_t report_batch = pending_flush_reports_.size();
   asio::async_write(
       stream_, asio::buffer(write_buffer_),
       asio::bind_executor(
           strand_,
-          [self = shared_from_this()](beast::error_code ec, std::size_t) {
+          [self = shared_from_this(), report_batch](beast::error_code ec,
+                                                    std::size_t) {
             self->writing_ = false;
             if (ec) {
               self->close();
               return;
             }
+            self->flush_reports(report_batch, true);
             self->pump_writes();
           }));
+}
+
+void H2Driver::flush_reports(std::size_t count, bool written) {
+  count = std::min(count, pending_flush_reports_.size());
+  for (std::size_t position = 0; position != count; ++position) {
+    const PendingReport &report = pending_flush_reports_[position];
+    if (!written) {
+      report.runtime->report(
+          index(ServerChannel::RespondDelivery), report.client_id,
+          report.runtime->delivery_report(
+              report.request_id, WebDeliveryStatus::PermanentFailure, 0,
+              Str{"the connection closed before the response was written"}));
+    } else if (report.clean) {
+      report.runtime->report(index(ServerChannel::RespondDelivery), report.client_id,
+                             report.runtime->delivery_report(
+                                 report.request_id,
+                                 WebDeliveryStatus::Delivered));
+    } else {
+      report.runtime->report(
+          index(ServerChannel::RespondDelivery), report.client_id,
+          report.runtime->delivery_report(
+              report.request_id, WebDeliveryStatus::Dropped, 0,
+              Str{"the stream was reset before delivery"}));
+    }
+  }
+  pending_flush_reports_.erase(pending_flush_reports_.begin(),
+                               pending_flush_reports_.begin() +
+                                   static_cast<std::ptrdiff_t>(count));
+}
+
+void H2Driver::shutdown_send() {
+  if (closed_ || sent_fin_) {
+    return;
+  }
+  sent_fin_ = true;
+  beast::error_code ec;
+  static_cast<void>(beast::get_lowest_layer(stream_).socket().shutdown(
+      asio::ip::tcp::socket::shutdown_send, ec));
 }
 
 void H2Driver::close() {
   if (closed_) {
     return;
   }
-  closed_ = true;
-  // Retire every live stream: release reservations, unregister pending
-  // entries, and drop the maps so late graph answers report cleanly.
+  // Answers whose streams never closed report as write failures, then
+  // everything already queued flushes as failed too (review P1).
   for (auto &[stream_id, stream] : streams_) {
+    if (stream.response_submitted && stream.report_runtime) {
+      queue_report(std::move(stream.report_runtime), stream.report_client_id,
+                   stream.report_request_id, false);
+    }
     release_stream(stream_id, stream);
   }
+  flush_reports(pending_flush_reports_.size(), false);
+  closed_ = true;
   streams_.clear();
   request_to_stream_.clear();
   beast::error_code ec;
@@ -2944,6 +3036,18 @@ void H2Driver::on_request_data(std::int32_t stream_id, std::string_view data,
   Stream &stream = found->second;
   if (stream.discarding) {
     engine_.consume(stream_id, data.size());
+    return;
+  }
+  if (stream.body.size() + data.size() >
+      stream.matched.runtime->config().max_body_bytes) {
+    // The per-request cap, the h2 mirror of Beast's body_limit: the
+    // over-cap body is never retained, and the window held by any
+    // unaccounted bytes is released before the stream starts discarding
+    // (review P1).
+    engine_.consume(stream_id, stream.unaccounted + data.size());
+    stream.unaccounted = 0;
+    stream.body = std::string{};
+    respond_transport(stream_id, 413, "body exceeds max_body_bytes");
     return;
   }
   stream.body.append(data);
@@ -3096,8 +3200,10 @@ void H2Driver::write_stream_response(
   const std::int32_t stream_id = found->second;
   request_to_stream_.erase(found);
   const auto stream_found = streams_.find(stream_id);
-  const bool head =
-      stream_found != streams_.end() && stream_found->second.head_fallback;
+  // HTTP HEAD semantics apply to every HEAD request, explicit route or
+  // GET fallback alike (review P2).
+  const bool head = stream_found != streams_.end() &&
+                    stream_found->second.method == HttpMethod::Head;
   if (stream_found != streams_.end()) {
     stream_found->second.request_id = -1;
   }
@@ -3147,9 +3253,17 @@ void H2Driver::write_stream_response(
   if (engine_.submit_response(stream_id, status, headers, std::move(body),
                               trailers)) {
     outstanding_response_bytes_ += response_bytes;
-    runtime->report(
-        index(ServerChannel::RespondDelivery), client_id,
-        runtime->delivery_report(request_id, WebDeliveryStatus::Delivered));
+    if (stream_found != streams_.end()) {
+      // Delivery is reported from the write pump once the stream closes
+      // and its bytes have left the connection — never at enqueue
+      // (review P1; the RFC separates acceptance from delivery).
+      Stream &stream = stream_found->second;
+      stream.response_bytes += response_bytes;
+      stream.response_submitted = true;
+      stream.report_client_id = client_id;
+      stream.report_request_id = request_id;
+      stream.report_runtime = runtime;
+    }
   } else {
     runtime->report(index(ServerChannel::RespondDelivery), client_id,
                     runtime->delivery_report(
@@ -3174,22 +3288,33 @@ void H2Driver::finish_stream_transport(Int request_id, int status,
   respond_transport(stream_id, status, body);
 }
 
-void H2Driver::on_stream_reset(std::int32_t stream_id, std::uint32_t) {
+void H2Driver::on_stream_reset(std::int32_t stream_id,
+                               std::uint32_t error_code) {
   const auto found = streams_.find(stream_id);
   if (found == streams_.end()) {
     return;
   }
   // Per-stream cancellation: exactly this request is retired; a late
   // graph answer will be reported Dropped (h2 acceptance criteria).
+  found->second.close_error = error_code;
   release_stream(stream_id, found->second);
 }
 
 void H2Driver::on_stream_closed(std::int32_t stream_id) {
   const auto found = streams_.find(stream_id);
-  if (found != streams_.end()) {
-    release_stream(stream_id, found->second);
-    streams_.erase(found);
+  if (found == streams_.end()) {
+    return;
   }
+  Stream &stream = found->second;
+  // The buffered-outbound budget frees as streams retire (review P1).
+  outstanding_response_bytes_ -=
+      std::min(outstanding_response_bytes_, stream.response_bytes);
+  if (stream.response_submitted && stream.report_runtime) {
+    queue_report(std::move(stream.report_runtime), stream.report_client_id,
+                 stream.report_request_id, stream.close_error == 0);
+  }
+  release_stream(stream_id, stream);
+  streams_.erase(found);
 }
 
 Value H2Driver::peer_value(const WebBindings &b) {

--- a/extensions/web/src/asio_server.cpp
+++ b/extensions/web/src/asio_server.cpp
@@ -342,6 +342,8 @@ struct MatchedRoute {
 // first to start binds, later starts attach after a full-config identity
 // check, and the last detach closes the listener.
 
+class PendingTarget;
+
 class WebListener : public std::enable_shared_from_this<WebListener> {
 public:
   WebListener(std::string address, std::uint16_t port, Value config_identity,
@@ -366,6 +368,18 @@ public:
     std::lock_guard lock{mutex_};
     runtimes_.push_back(std::move(runtime));
   }
+
+  /** Every live connection registers here so the LAST detaching runtime
+   * can shut them all down — including idle ones that no pending
+   * registry references (review P1). */
+  void register_connection(std::weak_ptr<PendingTarget> connection) {
+    std::lock_guard lock{mutex_};
+    std::erase_if(live_connections_,
+                  [](const auto &weak) { return weak.expired(); });
+    live_connections_.push_back(std::move(connection));
+  }
+
+  void shutdown_connections();
 
   /** @return true when this was the last attached runtime. */
   bool detach(const WebServerRuntime *runtime) {
@@ -442,6 +456,7 @@ private:
   // frames) has drained.  detach() drops this reference at stop, breaking
   // the runtime->listener->runtime cycle.
   std::vector<std::shared_ptr<WebServerRuntime>> runtimes_{};
+  std::vector<std::weak_ptr<PendingTarget>> live_connections_{};
   std::array<std::set<const void *>, 2> pause_tokens_{};
   std::array<std::vector<std::function<void()>>, 2> parked_{};
 };
@@ -556,7 +571,12 @@ public:
   virtual void deliver_response(Int request_id, Value response, Int client_id,
                                 std::shared_ptr<WebServerRuntime> runtime) = 0;
   virtual void answer_timeout(Int request_id) = 0;
-  virtual void begin_shutdown() = 0;
+  /** One runtime is stopping: retire only ITS work.  A shared h2
+   * connection keeps serving the other attachees' streams (review P1). */
+  virtual void retire_runtime(const WebServerRuntime *runtime) = 0;
+  /** The listener itself is shutting down (last attachee): close the
+   * whole connection — GOAWAY for h2, close for h1 — idle or not. */
+  virtual void connection_shutdown() = 0;
 };
 
 class WebServerRuntime
@@ -737,6 +757,8 @@ public:
   }
 
   void run() {
+    listener_->register_connection(
+        std::weak_ptr<PendingTarget>{shared_from_this()});
     asio::post(strand_, [self = shared_from_this()] { self->handshake(); });
   }
 
@@ -766,7 +788,13 @@ public:
     });
   }
 
-  void begin_shutdown() override {
+  void retire_runtime(const WebServerRuntime *) override {
+    // An h1 connection serves one request at a time; the stopping
+    // runtime owns whatever is pending here, so retiring == closing.
+    connection_shutdown();
+  }
+
+  void connection_shutdown() override {
     asio::post(strand_, [self = shared_from_this()] {
       self->shutting_down_ = true;
       if (self->ws_) {
@@ -951,6 +979,8 @@ public:
   ~H2Driver() override { listener_->connection_closed(); }
 
   void run() {
+    listener_->register_connection(
+        std::weak_ptr<PendingTarget>{shared_from_this()});
     asio::post(strand_, [self = shared_from_this()] {
       self->pump_writes(); // the server SETTINGS/window preface
       self->read_next();
@@ -974,7 +1004,26 @@ public:
     });
   }
 
-  void begin_shutdown() override {
+  void retire_runtime(const WebServerRuntime *runtime) override {
+    asio::post(strand_, [self = shared_from_this(), runtime] {
+      if (self->closed_) {
+        return;
+      }
+      // Only the stopping runtime's streams retire; a shared listener's
+      // other attachees keep this connection serving (review P1).
+      std::vector<std::int32_t> retiring;
+      for (const auto &[stream_id, stream] : self->streams_) {
+        if (stream.matched.runtime.get() == runtime && !stream.discarding) {
+          retiring.push_back(stream_id);
+        }
+      }
+      for (const std::int32_t stream_id : retiring) {
+        self->respond_transport(stream_id, 503, "server shutting down");
+      }
+    });
+  }
+
+  void connection_shutdown() override {
     asio::post(strand_, [self = shared_from_this()] {
       if (self->shutting_down_) {
         return;
@@ -1005,6 +1054,9 @@ private:
     std::string decoded_path{};
     H2Headers headers{};
     std::size_t header_bytes{};
+    H2Headers trailers{};
+    std::size_t trailer_bytes{};
+    std::size_t trailer_unaccounted{};
     std::string body{};
     std::size_t reserved{};
     std::size_t unaccounted{};
@@ -1029,12 +1081,15 @@ private:
                           bool end_stream) override;
   void on_request_data(std::int32_t stream_id, std::string_view data,
                        bool end_stream) override;
+  void on_request_trailers(std::int32_t stream_id, H2Headers trailers,
+                           bool end_stream) override;
   void on_stream_reset(std::int32_t stream_id,
                        std::uint32_t error_code) override;
   void on_stream_closed(std::int32_t stream_id) override;
   void on_goaway_received() override { shutting_down_ = true; }
 
   void read_next();
+  void resume_stalled_read();
   void pump_writes();
   void close();
   void admit_stream(std::int32_t stream_id);
@@ -1075,6 +1130,12 @@ private:
   void shutdown_send();
 
   std::vector<PendingReport> pending_flush_reports_{};
+  // Bytes buffered ahead of admission across ALL streams; the connection
+  // read loop stalls at one window's worth so backpressured streams
+  // cannot accumulate stream-window x stream-count outside the bridge
+  // budget (review P1).
+  std::size_t unaccounted_total_{};
+  bool read_stalled_{};
   Int connection_id_{-1};
   bool writing_{};
   bool shutting_down_{};
@@ -1172,6 +1233,19 @@ std::optional<MatchedRoute> WebListener::match(HttpMethod method,
     }
   }
   return std::nullopt;
+}
+
+void WebListener::shutdown_connections() {
+  std::vector<std::weak_ptr<PendingTarget>> live;
+  {
+    std::lock_guard lock{mutex_};
+    live.swap(live_connections_);
+  }
+  for (const auto &weak : live) {
+    if (const auto connection = weak.lock()) {
+      connection->connection_shutdown();
+    }
+  }
 }
 
 void WebListener::check_route_conflicts(const WebServerRuntime *applying,
@@ -1472,7 +1546,12 @@ void WebServerRuntime::stop() noexcept {
         ws_connections_.clear();
       }
       for (const auto &target : targets) {
-        target->begin_shutdown();
+        target->retire_runtime(this);
+      }
+      if (last) {
+        // The listener is going away: every live connection — idle ones
+        // included — gets its orderly shutdown (GOAWAY on h2).
+        listener_->shutdown_connections();
       }
       const auto deadline =
           std::chrono::steady_clock::now() + config_->shutdown_drain_timeout;
@@ -2795,6 +2874,13 @@ void H2Driver::read_next() {
   if (closed_) {
     return;
   }
+  if (unaccounted_total_ >=
+      static_cast<std::size_t>(config_->h2_initial_window_bytes)) {
+    // Enough unadmitted bytes are already buffered: stop reading the
+    // connection so TCP backpressure applies until accounting drains.
+    read_stalled_ = true;
+    return;
+  }
   beast::get_lowest_layer(stream_).expires_after(config_->idle_timeout);
   stream_.async_read_some(
       asio::buffer(read_buffer_),
@@ -2918,6 +3004,13 @@ void H2Driver::close() {
 }
 
 void H2Driver::release_stream(std::int32_t, Stream &stream) {
+  const std::size_t buffered = stream.unaccounted + stream.trailer_unaccounted;
+  if (buffered != 0) {
+    unaccounted_total_ -= std::min(unaccounted_total_, buffered);
+    stream.unaccounted = 0;
+    stream.trailer_unaccounted = 0;
+    resume_stalled_read();
+  }
   if (stream.request_id >= 0 && stream.matched.runtime) {
     stream.matched.runtime->unregister_pending(stream.request_id);
     request_to_stream_.erase(stream.request_id);
@@ -3045,18 +3138,56 @@ void H2Driver::on_request_data(std::int32_t stream_id, std::string_view data,
     // unaccounted bytes is released before the stream starts discarding
     // (review P1).
     engine_.consume(stream_id, stream.unaccounted + data.size());
+    unaccounted_total_ -= std::min(unaccounted_total_, stream.unaccounted);
     stream.unaccounted = 0;
     stream.body = std::string{};
     respond_transport(stream_id, 413, "body exceeds max_body_bytes");
+    resume_stalled_read();
     return;
   }
   stream.body.append(data);
   stream.unaccounted += data.size();
+  unaccounted_total_ += data.size();
   if (end_stream) {
     stream.end_stream_seen = true;
   }
   if (stream.admitted) {
     account_stream_data(stream_id);
+  }
+}
+
+void H2Driver::on_request_trailers(std::int32_t stream_id,
+                                   H2Headers trailers, bool end_stream) {
+  const auto found = streams_.find(stream_id);
+  if (found == streams_.end()) {
+    return;
+  }
+  Stream &stream = found->second;
+  if (stream.discarding) {
+    return;
+  }
+  std::size_t bytes = 0;
+  for (const auto &[name, value] : trailers) {
+    bytes += name.size() + value.size();
+  }
+  stream.trailers = std::move(trailers);
+  stream.trailer_bytes += bytes;
+  stream.trailer_unaccounted += bytes;
+  unaccounted_total_ += bytes;
+  if (end_stream) {
+    stream.end_stream_seen = true;
+  }
+  if (stream.admitted) {
+    account_stream_data(stream_id);
+  }
+}
+
+void H2Driver::resume_stalled_read() {
+  if (read_stalled_ &&
+      unaccounted_total_ <
+          static_cast<std::size_t>(config_->h2_initial_window_bytes)) {
+    read_stalled_ = false;
+    read_next();
   }
 }
 
@@ -3066,13 +3197,21 @@ void H2Driver::account_stream_data(std::int32_t stream_id) {
     return;
   }
   Stream &stream = found->second;
-  if (stream.unaccounted != 0) {
-    const std::size_t pending = stream.unaccounted;
+  if (stream.unaccounted != 0 || stream.trailer_unaccounted != 0) {
+    // Trailer bytes grow the reservation but never consume flow-control
+    // window — HEADERS frames are not flow-controlled (RFC 9113 §6.9).
+    const std::size_t data_pending = stream.unaccounted;
+    const std::size_t pending = data_pending + stream.trailer_unaccounted;
     if (stream.matched.runtime->grow_request_reservation(pending)) {
       stream.reserved += pending;
       stream.unaccounted = 0;
-      engine_.consume(stream_id, pending);
-      pump_writes(); // the WINDOW_UPDATE this consume released
+      stream.trailer_unaccounted = 0;
+      unaccounted_total_ -= std::min(unaccounted_total_, pending);
+      if (data_pending != 0) {
+        engine_.consume(stream_id, data_pending);
+        pump_writes(); // the WINDOW_UPDATE this consume released
+      }
+      resume_stalled_read();
     } else if (stream.matched.runtime->config().inbound_overflow ==
                WebInboundOverflow::Reject) {
       respond_transport(stream_id, 503, "server is at capacity");
@@ -3131,7 +3270,8 @@ void H2Driver::maybe_dispatch(std::int32_t stream_id) {
   WebBindings::NamedPairs headers{stream.headers.begin(),
                                   stream.headers.end()};
   const std::size_t retained = stream.body.size() + stream.header_bytes +
-                               stream.target.size() + 512;
+                               stream.trailer_bytes + stream.target.size() +
+                               512;
   Value request = build_on(
       b.http_request,
       {
@@ -3143,7 +3283,9 @@ void H2Driver::maybe_dispatch(std::int32_t stream_id) {
           {"path_params", b.params(stream.matched.params)},
           {"headers", b.headers(headers)},
           {"body", b.bytes(Bytes{std::move(stream.body)})},
-          {"trailers", b.headers({})},
+          {"trailers",
+           b.headers(WebBindings::NamedPairs{stream.trailers.begin(),
+                                             stream.trailers.end()})},
       });
   stream.body = std::string{};
   const Int request_id = runtime->register_pending(shared_from_this());

--- a/extensions/web/src/asio_server.cpp
+++ b/extensions/web/src/asio_server.cpp
@@ -213,12 +213,13 @@ milliseconds_field(const ValueView &field, std::string_view name) {
   // parked forever with no pauser left to resume it (review P1).  The
   // constants mirror the transport's retained-byte estimates.
   if (result.ingress.bytes <
-      result.max_body_bytes + 2 * result.max_header_bytes + 512) {
-    // Two header blocks: h2 initial headers and trailers are capped
-    // separately, and a maximal valid request carries both (review P1).
+      result.max_body_bytes + 4 * result.max_header_bytes + 1024) {
+    // Two header blocks (h2 initial headers and trailers are capped
+    // separately), each weighed twice for the source-plus-graph copies
+    // (review P1).
     throw std::invalid_argument(
         "Web server ingress_byte_limit must cover one maximal request "
-        "(max_body_bytes + 2*max_header_bytes + 512)");
+        "(max_body_bytes + 4*max_header_bytes + 1024)");
   }
   if (result.ws_ingress.bytes < result.ws_max_message_bytes + 256) {
     throw std::invalid_argument(
@@ -382,7 +383,8 @@ public:
     live_connections_.push_back(std::move(connection));
   }
 
-  void retire_runtime_connections(const WebServerRuntime *runtime);
+  void retire_runtime_connections(const WebServerRuntime *runtime,
+                                  std::shared_ptr<const void> barrier);
   void shutdown_connections();
 
   /** @return true when this was the last attached runtime. */
@@ -576,8 +578,12 @@ public:
                                 std::shared_ptr<WebServerRuntime> runtime) = 0;
   virtual void answer_timeout(Int request_id) = 0;
   /** One runtime is stopping: retire only ITS work.  A shared h2
-   * connection keeps serving the other attachees' streams (review P1). */
-  virtual void retire_runtime(const WebServerRuntime *runtime) = 0;
+   * connection keeps serving the other attachees' streams (review P1).
+   * The barrier is held through every handler the retirement schedules,
+   * so the stopping runtime can await ITS completion — without waiting
+   * on other attachees' connections — before clearing its bridge. */
+  virtual void retire_runtime(const WebServerRuntime *runtime,
+                              std::shared_ptr<const void> barrier) = 0;
   /** The listener itself is shutting down (last attachee): close the
    * whole connection — GOAWAY for h2, close for h1 — idle or not. */
   virtual void connection_shutdown() = 0;
@@ -792,32 +798,40 @@ public:
     });
   }
 
-  void retire_runtime(const WebServerRuntime *runtime) override {
-    asio::post(strand_, [self = shared_from_this(), runtime] {
+  void retire_runtime(const WebServerRuntime *runtime,
+                      std::shared_ptr<const void> barrier) override {
+    asio::post(strand_, [self = shared_from_this(), runtime, barrier] {
       // Close only when the stopping runtime owns this connection's
       // CURRENT activity — from route match (admission wait, body read,
       // WS handshake) through the answered response; an idle keep-alive
-      // or a connection serving another attachee keeps serving
+      // or a connection serving another attachee keeps serving.  The
+      // shutdown runs INLINE on this same handler: a second post would
+      // let a queued completion return the connection to idle (or to
+      // another runtime's next request) between check and close
       // (review P1).
       if (self->serving_runtime_ == runtime) {
-        self->connection_shutdown();
+        self->shutdown_now();
       }
     });
   }
 
   void connection_shutdown() override {
-    asio::post(strand_, [self = shared_from_this()] {
-      self->shutting_down_ = true;
-      if (self->ws_) {
-        self->ws_close(websocket::close_code{1001}, "going away");
-      } else if (self->pending_request_id_ >= 0 && !self->writing_) {
-        self->send_simple_response(http::status::service_unavailable,
-                                   "server shutting down", false);
-        self->pending_request_id_ = -1;
-      } else if (!self->writing_) {
-        self->close();
-      }
-    });
+    asio::post(strand_,
+               [self = shared_from_this()] { self->shutdown_now(); });
+  }
+
+  // Must run on the strand.
+  void shutdown_now() {
+    shutting_down_ = true;
+    if (ws_) {
+      ws_close(websocket::close_code{1001}, "going away");
+    } else if (pending_request_id_ >= 0 && !writing_) {
+      send_simple_response(http::status::service_unavailable,
+                           "server shutting down", false);
+      pending_request_id_ = -1;
+    } else if (!writing_) {
+      close();
+    }
   }
 
   void resume_reading() {
@@ -1019,8 +1033,9 @@ public:
     });
   }
 
-  void retire_runtime(const WebServerRuntime *runtime) override {
-    asio::post(strand_, [self = shared_from_this(), runtime] {
+  void retire_runtime(const WebServerRuntime *runtime,
+                      std::shared_ptr<const void> barrier) override {
+    asio::post(strand_, [self = shared_from_this(), runtime, barrier] {
       if (self->closed_) {
         return;
       }
@@ -1034,6 +1049,13 @@ public:
       }
       for (const std::int32_t stream_id : retiring) {
         self->respond_transport(stream_id, 503, "server shutting down");
+      }
+      if (!retiring.empty() && !self->closed_) {
+        // Hold the barrier until the write batch carrying these 503s
+        // completes (a barrier-only sentinel in the flush queue).
+        self->pending_flush_reports_.push_back(
+            PendingReport{nullptr, 0, 0, true, std::move(barrier)});
+        self->pump_writes();
       }
     });
   }
@@ -1140,6 +1162,9 @@ private:
     Int client_id{};
     Int request_id{};
     bool clean{};
+    // Barrier-only sentinel entries carry no runtime; they exist to hold
+    // a retirement barrier until the write that flushes them completes.
+    std::shared_ptr<const void> barrier{};
   };
   void queue_report(std::shared_ptr<WebServerRuntime> runtime, Int client_id,
                     Int request_id, bool clean) {
@@ -1255,7 +1280,8 @@ std::optional<MatchedRoute> WebListener::match(HttpMethod method,
   return std::nullopt;
 }
 
-void WebListener::retire_runtime_connections(const WebServerRuntime *runtime) {
+void WebListener::retire_runtime_connections(
+    const WebServerRuntime *runtime, std::shared_ptr<const void> barrier) {
   std::vector<std::weak_ptr<PendingTarget>> live;
   {
     std::lock_guard lock{mutex_};
@@ -1263,7 +1289,7 @@ void WebListener::retire_runtime_connections(const WebServerRuntime *runtime) {
   }
   for (const auto &weak : live) {
     if (const auto connection = weak.lock()) {
-      connection->retire_runtime(runtime);
+      connection->retire_runtime(runtime, barrier);
     }
   }
 }
@@ -1573,7 +1599,21 @@ void WebServerRuntime::stop() noexcept {
         pending_.clear();
         ws_connections_.clear();
       }
-      listener_->retire_runtime_connections(this);
+      // Retirement completion barrier: the barrier is captured by every
+      // handler the retirement schedules, so use_count falls back to one
+      // exactly when THIS runtime's 503s and releases have run — no wait
+      // on other attachees' live connections (review P1).
+      const std::shared_ptr<const void> barrier =
+          std::make_shared<const int>(0);
+      listener_->retire_runtime_connections(this, barrier);
+      {
+        const auto retire_deadline = std::chrono::steady_clock::now() +
+                                     config_->shutdown_drain_timeout;
+        while (std::chrono::steady_clock::now() < retire_deadline &&
+               barrier.use_count() > 1) {
+          std::this_thread::sleep_for(std::chrono::milliseconds{10});
+        }
+      }
       if (last) {
         // The listener is going away: every live connection — idle ones
         // included — gets its orderly shutdown (GOAWAY on h2), and only
@@ -2077,7 +2117,7 @@ void ServerConnection::admit_and_read_body(MatchedRoute matched) {
           ? static_cast<std::size_t>(*content_length)
           : config_->max_body_bytes;
   const std::size_t projected =
-      projected_body + header_bytes + header.target().size() + 512;
+      projected_body + 2 * header_bytes + 3 * header.target().size() + 512;
   const std::shared_ptr<WebServerRuntime> runtime = matched.runtime;
   serving_runtime_ = runtime.get();
   if (runtime->reserve_request(projected)) {
@@ -2217,7 +2257,13 @@ Value ServerConnection::build_server_request(const MatchedRoute &matched,
   // Moving the body out empties the Beast message, so once the value is
   // pushed the connection itself no longer retains the payload.
   Bytes body{std::move(request_.body())};
-  retained_bytes = body.data.size() + header_bytes + target.size() + 512;
+  // The graph value owns COPIES of the metadata (headers, target, decoded
+  // path, parsed query, path params) while the transport still retains
+  // the source until the request is answered, so headers weigh double and
+  // the target triple (target + decoded path + query) — otherwise large
+  // paths and queries exceed the advertised bound (review P1).
+  retained_bytes =
+      body.data.size() + 2 * header_bytes + 3 * target.size() + 512;
 
   Value request = build_on(
       b.http_request,
@@ -2978,6 +3024,9 @@ void H2Driver::flush_reports(std::size_t count, bool written) {
   count = std::min(count, pending_flush_reports_.size());
   for (std::size_t position = 0; position != count; ++position) {
     const PendingReport &report = pending_flush_reports_[position];
+    if (!report.runtime) {
+      continue; // a barrier-only sentinel: released on erase below
+    }
     if (!written) {
       report.runtime->report(
           index(ServerChannel::RespondDelivery), report.client_id,
@@ -3141,7 +3190,10 @@ void H2Driver::admit_stream(std::int32_t stream_id) {
   // Header admission mirrors h1: the header block plus envelope overhead
   // reserves before any DATA window is released; the body then grows the
   // same reservation chunk-by-chunk (RFC 0024, flow control).
-  const std::size_t projected = stream.header_bytes + stream.target.size() + 512;
+  // Headers double (source + graph copies), target triple (target +
+  // decoded path + parsed query), matching the h1 estimate (review P1).
+  const std::size_t projected =
+      2 * stream.header_bytes + 3 * stream.target.size() + 512;
   if (runtime->reserve_request(projected)) {
     stream.admitted = true;
     stream.reserved = projected;
@@ -3234,6 +3286,18 @@ void H2Driver::on_request_trailers(std::int32_t stream_id,
   for (const auto &[name, value] : trailers) {
     bytes += name.size() + value.size();
   }
+  // The hard per-receive metadata bound applies to trailer blocks exactly
+  // as to initial headers: an over-bound block kills the stream before it
+  // is retained (review P1).  Unlike a refused-at-open stream, this one
+  // was partially consumed, so REFUSED_STREAM's safe-retry promise would
+  // be wrong.
+  if (unaccounted_total_ + bytes >
+      static_cast<std::size_t>(config_->h2_initial_window_bytes)) {
+    release_stream(stream_id, stream);
+    stream.discarding = true;
+    engine_.reset_stream(stream_id, H2StreamError::EnhanceYourCalm);
+    return;
+  }
   stream.trailers = std::move(trailers);
   stream.trailer_bytes += bytes;
   stream.trailer_unaccounted += bytes;
@@ -3268,7 +3332,7 @@ void H2Driver::account_stream_data(std::int32_t stream_id) {
     // Trailer bytes grow the reservation but never consume flow-control
     // window — HEADERS frames are not flow-controlled (RFC 9113 §6.9).
     const std::size_t data_pending = stream.unaccounted;
-    const std::size_t pending = data_pending + stream.trailer_unaccounted;
+    const std::size_t pending = data_pending + 2 * stream.trailer_unaccounted;
     if (stream.matched.runtime->grow_request_reservation(pending)) {
       stream.reserved += pending;
       stream.unaccounted = 0;
@@ -3336,9 +3400,9 @@ void H2Driver::maybe_dispatch(std::int32_t stream_id) {
           : full_target.substr(query_start + 1);
   WebBindings::NamedPairs headers{stream.headers.begin(),
                                   stream.headers.end()};
-  const std::size_t retained = stream.body.size() + stream.header_bytes +
-                               stream.trailer_bytes + stream.target.size() +
-                               512;
+  const std::size_t retained =
+      stream.body.size() + 2 * stream.header_bytes +
+      2 * stream.trailer_bytes + 3 * stream.target.size() + 512;
   Value request = build_on(
       b.http_request,
       {

--- a/extensions/web/src/asio_server.cpp
+++ b/extensions/web/src/asio_server.cpp
@@ -666,7 +666,8 @@ public:
   [[nodiscard]] bool push_request_reserved(Value route, Value request,
                                            std::size_t retained_bytes,
                                            std::size_t reserved_bytes);
-  void push_ws_event(Value route, Value event, std::size_t retained_bytes);
+  [[nodiscard]] bool push_ws_event(Value route, Value event,
+                                   std::size_t retained_bytes);
   [[nodiscard]] bool push_ws_frame_reserved(Value route, Value inbound_frame,
                                             std::size_t retained_bytes,
                                             std::size_t reserved_bytes);
@@ -1736,6 +1737,21 @@ void WebServerRuntime::apply_http_routes(std::vector<Value> added,
   if (listener_) {
     listener_->check_route_conflicts(this, false, added);
   }
+  for (const Value &route : added) {
+    // Route-aware floor: a maximal request on this route (its envelope
+    // route copy and capture names included) must fit an empty ingress
+    // channel, or Backpressure could park it forever (review P1).
+    if (config_->ingress.bytes <
+        config_->max_body_bytes + 6 * config_->max_header_bytes + 1024 +
+            2 * route_weight(route)) {
+      throw std::invalid_argument(
+          "Web ingress_byte_limit cannot admit a maximal request on route "
+          "'" +
+          std::string{
+              route.view().as_bundle().at("pattern").checked_as<Str>()} +
+          "'");
+    }
+  }
   std::vector<Value> announce;
   for (const Value &route : added) {
     announce.push_back(route.clone());
@@ -1768,16 +1784,23 @@ void WebServerRuntime::apply_ws_routes(std::vector<Value> added,
     listener_->check_route_conflicts(this, true, added);
   }
   for (const Value &route : added) {
-    // Route-aware floor: every maximal message on this route must fit an
-    // empty channel including the envelope's route copy (review P1).
+    // Route-aware floor: BOTH the maximal message and the largest
+    // lifecycle record (the Open event carries the upgrade request's
+    // metadata and capture names) must fit — the payload lane for the
+    // former, and the guaranteed control lane for the latter (review P1).
     const std::size_t weight = route_weight(route);
+    const std::size_t open_event_worst =
+        3 * config_->max_header_bytes + 2 * weight + 1024;
     if (config_->ws_ingress.bytes <
-        config_->ws_max_message_bytes + 256 + weight) {
+            config_->ws_max_message_bytes + 256 + weight ||
+        config_->ws_ingress.bytes < open_event_worst ||
+        kControlLaneBytes < open_event_worst) {
       throw std::invalid_argument(
-          "Web ws_ingress_byte_limit cannot admit a maximal message on "
-          "route '" +
-          std::string{route.view().as_bundle().at("pattern").checked_as<Str>()} +
-          "' (needs ws_max_message_bytes + 256 + route pattern bytes)");
+          "Web ws_ingress_byte_limit cannot admit route '" +
+          std::string{
+              route.view().as_bundle().at("pattern").checked_as<Str>()} +
+          "': a maximal message and its largest lifecycle record must both "
+          "fit (control lane included)");
     }
   }
   rebuild(ws_routes_, ws_master_, std::move(added), std::move(removed));
@@ -1835,7 +1858,7 @@ bool WebServerRuntime::push_request_reserved(Value route, Value request,
       retained_bytes, reserved_bytes);
 }
 
-void WebServerRuntime::push_ws_event(Value route, Value event,
+bool WebServerRuntime::push_ws_event(Value route, Value event,
                                      std::size_t retained_bytes) {
   // Connection lifecycle is graph data and must never be lost (review P1):
   // an event the payload lane cannot take goes through the control lane,
@@ -1845,11 +1868,12 @@ void WebServerRuntime::push_ws_event(Value route, Value event,
                                       {"route", std::move(route)},
                                       {"event", std::move(event)},
                                   });
-  if (!bridge_.value->push(index(ServerChannel::WsIngress), envelope.clone(),
-                           retained_bytes)) {
-    static_cast<void>(bridge_.value->push_control(
-        index(ServerChannel::WsIngress), envelope.clone(), retained_bytes));
+  if (bridge_.value->push(index(ServerChannel::WsIngress), envelope.clone(),
+                          retained_bytes)) {
+    return true;
   }
+  return bridge_.value->push_control(index(ServerChannel::WsIngress),
+                                     envelope.clone(), retained_bytes);
 }
 
 [[nodiscard]] bool
@@ -2212,6 +2236,13 @@ void ServerConnection::admit_and_read_body(MatchedRoute matched) {
                                 512;
   const std::shared_ptr<WebServerRuntime> runtime = matched.runtime;
   serving_runtime_ = runtime.get();
+  // Absolute oversize rejection: a request that cannot fit even an EMPTY
+  // channel must never enter the Backpressure retry loop (review P1).
+  if (projected > runtime->config().ingress.bytes) {
+    send_simple_response(http::status::payload_too_large,
+                         "request cannot fit the ingress limit", false);
+    return;
+  }
   if (runtime->reserve_request(projected)) {
     admitted_runtime_ = runtime;
     admitted_bytes_ = projected;
@@ -2655,7 +2686,7 @@ void ServerConnection::accept_ws(MatchedRoute matched) {
         }
         self->ws_ = true;
         const auto &b = runtime->bindings();
-        runtime->push_ws_event(
+        const bool open_delivered = runtime->push_ws_event(
             self->ws_route_->clone(),
             build_on(b.ws_event,
                      {
@@ -2667,6 +2698,20 @@ void ServerConnection::accept_ws(MatchedRoute matched) {
             // route weight — adding it again could overcharge a genuinely
             // fitting event off the control lane (review P1).
             request_bytes + 512);
+        if (!open_delivered) {
+          // A connection whose Open event the graph never saw must not
+          // proceed: the graph could neither serve nor close it
+          // (review P1).
+          runtime->count_drop();
+          runtime->emit_event(WebSeverity::Warning, Str{"server"},
+                              Str{"ws_ingress"},
+                              Str{"WebSocket Open event could not be "
+                                  "delivered; closing the connection"},
+                              0, true, false, self->ws_connection_id_);
+          runtime->unregister_ws_connection(self->ws_connection_id_);
+          self->close();
+          return;
+        }
         // Beast no longer needs the upgrade request; releasing it keeps
         // the single-counted accounting honest for the WebSocket's whole
         // lifetime (review P1).
@@ -2711,7 +2756,7 @@ void ServerConnection::ws_read_next() {
                                            reason.reason.size()}};
           }
           const auto &b = runtime->bindings();
-          runtime->push_ws_event(
+          static_cast<void>(runtime->push_ws_event(
               self->ws_route_->clone(),
               build_on(b.ws_event,
                        {
@@ -2723,7 +2768,7 @@ void ServerConnection::ws_read_next() {
                            {"close_code", b.number(close_code)},
                            {"close_reason", b.string(close_reason)},
                        }),
-              close_reason.size() + self->ws_route_weight_ + 512);
+              close_reason.size() + self->ws_route_weight_ + 512));
           self->close();
           return;
         }
@@ -3331,6 +3376,12 @@ void H2Driver::admit_stream(std::int32_t stream_id) {
                                 stream.decoded_path.size() + query_size +
                                 params_bytes +
                                 route_weight(*stream.matched.route) + 512;
+  // Absolute oversize rejection: never park what can never fit
+  // (review P1).
+  if (projected > runtime->config().ingress.bytes) {
+    respond_transport(stream_id, 413, "request cannot fit the ingress limit");
+    return;
+  }
   if (runtime->reserve_request(projected)) {
     stream.admitted = true;
     stream.reserved = projected;
@@ -3473,6 +3524,21 @@ void H2Driver::account_stream_data(std::int32_t stream_id) {
     // now that transport copies are released at dispatch: the graph copy
     // is the only survivor, single-counted (review P1).
     const std::size_t pending = data_pending + stream.trailer_unaccounted;
+    if (stream.reserved + pending >
+        stream.matched.runtime->config().ingress.bytes) {
+      // Incremental growth that can NEVER fit: release the held window
+      // and answer, mirroring the body-cap path (review P1).
+      engine_.consume(stream_id, stream.unaccounted);
+      unaccounted_total_ -=
+          std::min(unaccounted_total_,
+                   stream.unaccounted + stream.trailer_unaccounted);
+      stream.unaccounted = 0;
+      stream.trailer_unaccounted = 0;
+      respond_transport(stream_id, 413,
+                        "request cannot fit the ingress limit");
+      resume_stalled_read();
+      return;
+    }
     if (stream.matched.runtime->grow_request_reservation(pending)) {
       stream.reserved += pending;
       stream.unaccounted = 0;

--- a/extensions/web/src/asio_server.cpp
+++ b/extensions/web/src/asio_server.cpp
@@ -794,17 +794,12 @@ public:
 
   void retire_runtime(const WebServerRuntime *runtime) override {
     asio::post(strand_, [self = shared_from_this(), runtime] {
-      // Only close when the stopping runtime owns this connection's
-      // current activity; an idle keep-alive connection (or one serving
-      // another attachee) must keep serving (review P1).
-      if (self->ws_) {
-        if (self->ws_runtime_.get() == runtime) {
-          self->connection_shutdown();
-        }
-        return;
-      }
-      if (self->pending_request_id_ >= 0 &&
-          self->pending_runtime_ == runtime) {
+      // Close only when the stopping runtime owns this connection's
+      // CURRENT activity — from route match (admission wait, body read,
+      // WS handshake) through the answered response; an idle keep-alive
+      // or a connection serving another attachee keeps serving
+      // (review P1).
+      if (self->serving_runtime_ == runtime) {
         self->connection_shutdown();
       }
     });
@@ -932,7 +927,10 @@ private:
   std::string decoded_path_{};
   std::size_t admitted_bytes_{};
   std::shared_ptr<WebServerRuntime> admitted_runtime_{};
-  const WebServerRuntime *pending_runtime_{};
+  // The runtime this connection is working FOR, tracked from route match
+  // (admission wait, body read, WS handshake) through completion, so a
+  // stopping runtime can retire pre-dispatch work too (review P1).
+  const WebServerRuntime *serving_runtime_{};
   std::size_t ws_reserved_bytes_{};
   std::size_t ws_unaccounted_bytes_{};
   // Message bytes accumulate here — storage the reservation accounts —
@@ -1079,6 +1077,10 @@ private:
     std::size_t unaccounted{};
     bool admitted{};
     bool admission_in_flight{};
+    // True while this stream's header block is counted in the
+    // connection's unaccounted bound; cleared exactly once, on admission
+    // (into the reservation) or on release (review P1).
+    bool headers_counted{};
     bool end_stream_seen{};
     bool discarding{};
     Int request_id{-1};
@@ -1958,6 +1960,7 @@ void ServerConnection::read_next() {
     close();
     return;
   }
+  serving_runtime_ = nullptr;  // a fresh request cycle owns nothing yet
   if (listener_->reads_paused(WebListener::ReadTier::Http)) {
     read_parked_ = true;
     listener_->park_for_resume(
@@ -2076,6 +2079,7 @@ void ServerConnection::admit_and_read_body(MatchedRoute matched) {
   const std::size_t projected =
       projected_body + header_bytes + header.target().size() + 512;
   const std::shared_ptr<WebServerRuntime> runtime = matched.runtime;
+  serving_runtime_ = runtime.get();
   if (runtime->reserve_request(projected)) {
     admitted_runtime_ = runtime;
     admitted_bytes_ = projected;
@@ -2258,7 +2262,6 @@ void ServerConnection::dispatch_http(MatchedRoute matched, bool keep_alive) {
     return;
   }
   pending_request_id_ = request_id;
-  pending_runtime_ = runtime.get();
   request_keep_alive_ = keep_alive;
   pending_is_head_ = request_.method() == http::verb::head;
 }
@@ -2472,6 +2475,7 @@ void ServerConnection::send_simple_response(http::status status,
 
 void ServerConnection::accept_ws(MatchedRoute matched) {
   const std::shared_ptr<WebServerRuntime> runtime = matched.runtime;
+  serving_runtime_ = runtime.get();
   ws_runtime_ = runtime;
   ws_route_ = matched.route.clone();
   ws_connection_id_ = runtime->register_ws_connection(shared_from_this());
@@ -3030,15 +3034,16 @@ void H2Driver::close() {
 }
 
 void H2Driver::release_stream(std::int32_t, Stream &stream) {
+  // Subtract exactly what this stream contributed: header bytes only
+  // while their flag is set (early-error streams that were refused
+  // before counting contribute nothing) — a mismatched subtraction here
+  // would steal accounting from other blocked streams and prematurely
+  // resume reads (review P1).
   const std::size_t header_part =
-      stream.admitted ? 0 : stream.header_bytes + stream.target.size();
+      stream.headers_counted ? stream.header_bytes + stream.target.size() : 0;
+  stream.headers_counted = false;
   const std::size_t buffered =
       stream.unaccounted + stream.trailer_unaccounted + header_part;
-  if (!stream.admitted) {
-    // release runs at most once per stream; mark so a second call cannot
-    // double-subtract the header part.
-    stream.admitted = true;
-  }
   if (buffered != 0) {
     unaccounted_total_ -= std::min(unaccounted_total_, buffered);
     stream.unaccounted = 0;
@@ -3070,6 +3075,19 @@ void H2Driver::on_request_headers(std::int32_t stream_id, std::string method,
   for (const auto &[name, value] : stream.headers) {
     stream.header_bytes += name.size() + value.size();
   }
+  // The connection metadata bound is HARD inside a single receive(): one
+  // socket read can decode many HPACK-compressed blocks, so a block that
+  // would cross the bound is refused before it is retained, and EVERY
+  // retained stream — early-error paths included — is accounted the same
+  // way (review P1).
+  const std::size_t header_part = stream.header_bytes + stream.target.size();
+  if (unaccounted_total_ + header_part >
+      static_cast<std::size_t>(config_->h2_initial_window_bytes)) {
+    engine_.reset_stream(stream_id, H2StreamError::RefusedStream);
+    return;
+  }
+  unaccounted_total_ += header_part;
+  stream.headers_counted = true;
   const auto method_value = method_from_token(method);
   if (!method_value.has_value()) {
     streams_.emplace(stream_id, std::move(stream));
@@ -3102,10 +3120,6 @@ void H2Driver::on_request_headers(std::int32_t stream_id, std::string method,
     return;
   }
   stream.matched = std::move(*matched);
-  // Until admission succeeds the header block is buffered driver memory,
-  // so it counts toward the connection's unaccounted bound — otherwise
-  // header-only streams could exceed the one-window claim (review P1).
-  unaccounted_total_ += stream.header_bytes + stream.target.size();
   streams_.emplace(stream_id, std::move(stream));
   admit_stream(stream_id);
 }
@@ -3131,9 +3145,12 @@ void H2Driver::admit_stream(std::int32_t stream_id) {
   if (runtime->reserve_request(projected)) {
     stream.admitted = true;
     stream.reserved = projected;
-    const std::size_t header_part = stream.header_bytes + stream.target.size();
-    unaccounted_total_ -= std::min(unaccounted_total_, header_part);
-    resume_stalled_read();
+    if (stream.headers_counted) {
+      stream.headers_counted = false;
+      unaccounted_total_ -= std::min(
+          unaccounted_total_, stream.header_bytes + stream.target.size());
+      resume_stalled_read();
+    }
     account_stream_data(stream_id);
     return;
   }
@@ -3369,9 +3386,27 @@ void H2Driver::respond_transport(std::int32_t stream_id, int status,
     release_stream(stream_id, found->second);
     found->second.discarding = true;
   }
-  static_cast<void>(engine_.submit_response(
-      stream_id, status, H2Headers{{"content-type", "text/plain"}},
-      std::string{body}, {}));
+  // Transport answers obey the same outbound budgets as graph responses:
+  // a slow peer accumulating error responses is reset instead of growing
+  // buffered metadata past the configured bounds (review P1).
+  const std::size_t weight = body.size() + 256;
+  if (outstanding_response_bytes_ + weight >
+          static_cast<std::size_t>(config_->outbound_byte_limit) ||
+      outstanding_response_messages_ >=
+          static_cast<std::size_t>(config_->outbound_message_limit)) {
+    engine_.reset_stream(stream_id, H2StreamError::EnhanceYourCalm);
+    pump_writes();
+    return;
+  }
+  if (engine_.submit_response(stream_id, status,
+                              H2Headers{{"content-type", "text/plain"}},
+                              std::string{body}, {}) &&
+      found != streams_.end()) {
+    outstanding_response_bytes_ += weight;
+    ++outstanding_response_messages_;
+    found->second.response_bytes += weight;
+    found->second.response_submitted = true;
+  }
   pump_writes();
 }
 

--- a/extensions/web/src/curl_client.cpp
+++ b/extensions/web/src/curl_client.cpp
@@ -308,13 +308,15 @@ template <typename T>
 }
 
 [[nodiscard]] Value http_response(const ValueBindings &b, Int status,
-                                  const NameValues &headers, std::string body) {
-  return build(b.http_response, {
-                                    {"status", b.number(status)},
-                                    {"headers", b.headers(headers)},
-                                    {"body", b.bytes(Bytes{std::move(body)})},
-                                    {"trailers", b.headers({})},
-                                });
+                                  const NameValues &headers, std::string body,
+                                  const NameValues &trailers = {}) {
+  return build(b.http_response,
+               {
+                   {"status", b.number(status)},
+                   {"headers", b.headers(headers)},
+                   {"body", b.bytes(Bytes{std::move(body)})},
+                   {"trailers", b.headers(trailers)},
+               });
 }
 
 /** The WsEvent `request` field is server-side only and stays unset here. */
@@ -692,7 +694,12 @@ struct HttpTransfer : TransferTag {
   std::size_t max_response_bytes{};
   WebHttpVersionPolicy http_version{WebHttpVersionPolicy::Auto};
   std::string body{};
+  bool body_seen{};
   NameValues response_headers{};
+  // Header lines arriving after the first body byte are trailers (h2
+  // trailing HEADERS, h1 chunked trailers); they stay distinct from the
+  // header block — a gRPC-style terminal status depends on it (review P1).
+  NameValues response_trailers{};
   /** Running total of `header_bytes(response_headers)`, maintained by the
    * header callback so the cap is enforced as headers arrive rather than
    * recomputed per line. */
@@ -1533,6 +1540,7 @@ private:
       transfer->truncated = true;
       return CURL_WRITEFUNC_ERROR;
     }
+    transfer->body_seen = true;
     transfer->body.append(data, total);
     return total;
   }
@@ -1555,6 +1563,8 @@ private:
     if (colon == std::string_view::npos) {
       if (line.starts_with("HTTP/")) {
         transfer->response_headers.clear();
+        transfer->response_trailers.clear();
+        transfer->body_seen = false;
         transfer->header_bytes_used = 0;
       }
       return total;
@@ -1570,7 +1580,9 @@ private:
       return CURL_WRITEFUNC_ERROR;
     }
     transfer->header_bytes_used += entry;
-    transfer->response_headers.emplace_back(Str{name}, Str{value});
+    (transfer->body_seen ? transfer->response_trailers
+                         : transfer->response_headers)
+        .emplace_back(Str{name}, Str{value});
     return total;
   }
 
@@ -1661,7 +1673,8 @@ private:
         response_envelope(bindings_, owned->client_id,
                           http_response(bindings_, static_cast<Int>(status),
                                         owned->response_headers,
-                                        std::move(owned->body)),
+                                        std::move(owned->body),
+                                        owned->response_trailers),
                           Value{}),
         retained, reserved);
   }

--- a/extensions/web/src/curl_client.cpp
+++ b/extensions/web/src/curl_client.cpp
@@ -694,12 +694,6 @@ struct HttpTransfer : TransferTag {
   std::size_t max_response_bytes{};
   WebHttpVersionPolicy http_version{WebHttpVersionPolicy::Auto};
   std::string body{};
-  bool body_seen{};
-  NameValues response_headers{};
-  // Header lines arriving after the first body byte are trailers (h2
-  // trailing HEADERS, h1 chunked trailers); they stay distinct from the
-  // header block — a gRPC-style terminal status depends on it (review P1).
-  NameValues response_trailers{};
   /** Running total of `header_bytes(response_headers)`, maintained by the
    * header callback so the cap is enforced as headers arrive rather than
    * recomputed per line. */
@@ -1540,14 +1534,15 @@ private:
       transfer->truncated = true;
       return CURL_WRITEFUNC_ERROR;
     }
-    transfer->body_seen = true;
     transfer->body.append(data, total);
     return total;
   }
 
-  /** Headers are captured in arrival order with duplicates preserved; a new
-   * status line resets the block so only the FINAL response survives a
-   * redirect chain or a 100-continue. */
+  /** The callback only enforces the retained-byte budget as lines arrive;
+   * the names and values are harvested at completion through curl's
+   * header API, which records each block's ORIGIN — headers and trailers
+   * stay distinct even for empty-body (gRPC trailers-only) responses
+   * (review P1; CURLOPT_HEADERFUNCTION documents the origin model). */
   static std::size_t on_header(char *data, std::size_t size, std::size_t nitems,
                                void *userdata) {
     auto *transfer = static_cast<HttpTransfer *>(userdata);
@@ -1562,28 +1557,33 @@ private:
     const auto colon = line.find(':');
     if (colon == std::string_view::npos) {
       if (line.starts_with("HTTP/")) {
-        transfer->response_headers.clear();
-        transfer->response_trailers.clear();
-        transfer->body_seen = false;
+        // A new status line (redirect hop, 100-continue): only the final
+        // response's blocks are charged.
         transfer->header_bytes_used = 0;
       }
       return total;
     }
-    std::string_view name = line.substr(0, colon);
-    std::string_view value = line.substr(colon + 1);
-    if (!value.empty() && value.front() == ' ') {
-      value.remove_prefix(1);
-    }
-    const std::size_t entry = header_entry_bytes(name.size(), value.size());
+    const std::size_t value_length = line.size() - colon - 1;
+    const std::size_t entry = header_entry_bytes(colon, value_length);
     if (transfer->would_exceed_budget(entry)) {
       transfer->truncated = true;
       return CURL_WRITEFUNC_ERROR;
     }
     transfer->header_bytes_used += entry;
-    (transfer->body_seen ? transfer->response_trailers
-                         : transfer->response_headers)
-        .emplace_back(Str{name}, Str{value});
     return total;
+  }
+
+  /** Enumerate the final response's header block of one origin, arrival
+   * order and duplicates preserved. */
+  [[nodiscard]] static NameValues harvest_headers(CURL *easy,
+                                                  unsigned int origin) {
+    NameValues result;
+    curl_header *header = nullptr;
+    while ((header = curl_easy_nextheader(easy, origin, -1, header)) !=
+           nullptr) {
+      result.emplace_back(Str{header->name}, Str{header->value});
+    }
+    return result;
   }
 
   void collect_completions() {
@@ -1672,9 +1672,11 @@ private:
     push_response(
         response_envelope(bindings_, owned->client_id,
                           http_response(bindings_, static_cast<Int>(status),
-                                        owned->response_headers,
+                                        harvest_headers(owned->easy,
+                                                        CURLH_HEADER),
                                         std::move(owned->body),
-                                        owned->response_trailers),
+                                        harvest_headers(owned->easy,
+                                                        CURLH_TRAILER)),
                           Value{}),
         retained, reserved);
   }

--- a/extensions/web/src/detail/h2_engine.h
+++ b/extensions/web/src/detail/h2_engine.h
@@ -1,0 +1,129 @@
+#ifndef HGRAPH_WEB_DETAIL_H2_ENGINE_H
+#define HGRAPH_WEB_DETAIL_H2_ENGINE_H
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace hgraph::web::detail {
+
+// The HTTP/2 protocol engine (RFC 0024, HTTP/2 activation plan).
+//
+// A pure bytes-in/actions-out wrapper over an nghttp2 server session:
+// the owning driver (asio_server.cpp) feeds TLS-decrypted bytes in via
+// receive(), drains frames to write via next_output(), and receives
+// protocol events through H2Host.  nghttp2 itself is confined to
+// nghttp2_session.cpp; this header carries no third-party types, and the
+// driver carries no HTTP/2 framing knowledge.
+//
+// Flow control IS the ingress admission contract: the engine never
+// releases connection or stream window for request DATA by itself — the
+// host calls consume() once (and only once) the bytes are
+// reservation-accounted on the bridge, so an unadmitted stream stalls at
+// the sender exactly like an unread h1 socket (RFC 0024, flow control).
+
+using H2Headers = std::vector<std::pair<std::string, std::string>>;
+
+struct H2Settings {
+  std::size_t max_concurrent_streams{100};
+  std::size_t initial_window_bytes{1024 * 1024};
+  std::size_t max_header_bytes{64 * 1024};
+};
+
+/** Stream-level error codes the driver may reset with (RFC 9113 §7);
+ * mirrored here so the driver does not include nghttp2 headers. */
+enum class H2StreamError : std::uint32_t {
+  NoError = 0x0,
+  InternalError = 0x2,
+  RefusedStream = 0x7,
+  Cancel = 0x8,
+  EnhanceYourCalm = 0xb,
+};
+
+/** Engine-to-driver events.  All calls arrive synchronously from inside
+ * receive() on the driver's strand. */
+class H2Host {
+public:
+  virtual ~H2Host() = default;
+
+  /** A request's header block is complete.  ``end_stream`` true means no
+   * body follows.  The method is the raw ``:method`` token; the driver
+   * owns the mapping onto HttpMethod and the route table. */
+  virtual void on_request_headers(std::int32_t stream_id, std::string method,
+                                  std::string target, H2Headers headers,
+                                  bool end_stream) = 0;
+
+  /** A request DATA chunk.  The engine has NOT released flow-control
+   * window for these bytes; the driver must account them and then call
+   * consume(). */
+  virtual void on_request_data(std::int32_t stream_id, std::string_view data,
+                               bool end_stream) = 0;
+
+  /** The peer reset the stream (per-stream cancellation). */
+  virtual void on_stream_reset(std::int32_t stream_id,
+                               std::uint32_t error_code) = 0;
+
+  /** The stream is fully closed (both directions); per-stream state can be
+   * dropped.  Follows on_stream_reset when the close was a reset. */
+  virtual void on_stream_closed(std::int32_t stream_id) = 0;
+
+  /** The peer sent GOAWAY: finish in-flight streams, start nothing new. */
+  virtual void on_goaway_received() = 0;
+};
+
+class H2Engine {
+public:
+  H2Engine(H2Host &host, const H2Settings &settings);
+  ~H2Engine();
+  H2Engine(const H2Engine &) = delete;
+  H2Engine &operator=(const H2Engine &) = delete;
+
+  /** Feed peer bytes.  Returns false on a fatal session error — the
+   * driver should flush any remaining output (a GOAWAY) and close. */
+  [[nodiscard]] bool receive(std::string_view bytes);
+
+  /** The next span of bytes the session wants on the wire, valid until
+   * the next engine call; empty when nothing is pending.  The driver
+   * loops this into its write pump. */
+  [[nodiscard]] std::string_view next_output();
+
+  /** Release flow-control window for request bytes the driver has
+   * accounted (window updates are withheld until admission; RFC 0024). */
+  void consume(std::int32_t stream_id, std::size_t bytes);
+
+  /** Submit a complete response on the stream.  Headers/trailers use the
+   * wire names; the engine adds ``:status``. */
+  [[nodiscard]] bool submit_response(std::int32_t stream_id, int status,
+                                     const H2Headers &headers,
+                                     std::string body,
+                                     const H2Headers &trailers);
+
+  /** Reset one stream (admission reject, slow consumer, cancel). */
+  void reset_stream(std::int32_t stream_id, H2StreamError error);
+
+  /** Graceful shutdown: GOAWAY carrying the last processed stream id;
+   * in-flight streams may still complete. */
+  void submit_goaway();
+
+  /** True while the session has (or may produce) bytes to write. */
+  [[nodiscard]] bool wants_write() const;
+
+  /** True once the session is over (GOAWAY completed or fatal error) and
+   * the connection should close after the final flush. */
+  [[nodiscard]] bool finished() const;
+
+  // Public so the nghttp2 C callbacks (file-local in nghttp2_session.cpp)
+  // can cast their user_data back; opaque everywhere else.
+  struct Impl;
+
+private:
+  std::unique_ptr<Impl> impl_;
+};
+
+} // namespace hgraph::web::detail
+
+#endif // HGRAPH_WEB_DETAIL_H2_ENGINE_H

--- a/extensions/web/src/detail/h2_engine.h
+++ b/extensions/web/src/detail/h2_engine.h
@@ -63,6 +63,12 @@ public:
   virtual void on_request_data(std::int32_t stream_id, std::string_view data,
                                bool end_stream) = 0;
 
+  /** A trailing HEADERS block (request trailers).  Ends the request when
+   * ``end_stream`` is set — a gRPC-style request always finishes this way
+   * (review P1: trailers must not be dropped, nor END_STREAM lost). */
+  virtual void on_request_trailers(std::int32_t stream_id, H2Headers trailers,
+                                   bool end_stream) = 0;
+
   /** The peer reset the stream (per-stream cancellation). */
   virtual void on_stream_reset(std::int32_t stream_id,
                                std::uint32_t error_code) = 0;

--- a/extensions/web/src/detail/h2_engine.h
+++ b/extensions/web/src/detail/h2_engine.h
@@ -22,9 +22,9 @@ namespace hgraph::web::detail {
 //
 // Flow control IS the ingress admission contract: the engine never
 // releases connection or stream window for request DATA by itself — the
-// host calls consume() once (and only once) the bytes are
-// reservation-accounted on the bridge, so an unadmitted stream stalls at
-// the sender exactly like an unread h1 socket (RFC 0024, flow control).
+// host calls consume() once reservation-accounted on the bridge, or discard()
+// once the bytes are deliberately abandoned, so an unadmitted stream stalls
+// at the sender exactly like an unread h1 socket (RFC 0024, flow control).
 
 using H2Headers = std::vector<std::pair<std::string, std::string>>;
 
@@ -100,6 +100,12 @@ public:
   /** Release flow-control window for request bytes the driver has
    * accounted (window updates are withheld until admission; RFC 0024). */
   void consume(std::int32_t stream_id, std::size_t bytes);
+
+  /** Release bytes that will never be retained because their request is
+   * being discarded.  Stream credit is consumed normally; connection credit
+   * is restored immediately so many reset streams cannot cumulatively wedge
+   * unrelated work before nghttp2's batching threshold is reached. */
+  void discard(std::int32_t stream_id, std::size_t bytes);
 
   /** Submit a complete response on the stream.  Headers/trailers use the
    * wire names; the engine adds ``:status``. */

--- a/extensions/web/src/detail/route_table.h
+++ b/extensions/web/src/detail/route_table.h
@@ -32,11 +32,14 @@ public:
   };
 
   /** `entry_index` indexes `entries()`; `params` are (name, decoded value)
-   * pairs in pattern order. */
+   * pairs in pattern order.  The NAME is a view into this table's own
+   * pattern storage — valid while the table lives (callers pin the route
+   * snapshot) — so matching never copies capture names; an owning copy is
+   * materialized only after admission reserves for it (review P1). */
   struct Match {
     bool matched{};
     std::size_t entry_index{};
-    std::vector<std::pair<std::string, std::string>> params{};
+    std::vector<std::pair<std::string_view, std::string>> params{};
   };
 
   /** Compile `entries`, preserving their order as the match index space.

--- a/extensions/web/src/detail/service_bridge.h
+++ b/extensions/web/src/detail/service_bridge.h
@@ -65,6 +65,11 @@ struct OutputLimits {
   std::size_t bytes{};
 };
 
+/** The guaranteed control lane per channel: lifecycle records that the
+ * payload lane cannot take fall back here, so configuration validation
+ * must keep every lifecycle record within this bound. */
+inline constexpr std::size_t kControlLaneBytes = 1024 * 1024;
+
 struct WatermarkConfig {
   OutputLimits high{};
   OutputLimits low{};
@@ -586,7 +591,7 @@ inline std::ostream &operator<<(std::ostream &stream,
       limits_from(view, "ws_ingress_record_limit", "ws_ingress_byte_limit");
   const auto outbound =
       limits_from(view, "outbound_message_limit", "outbound_byte_limit");
-  const OutputLimits control{1024, 1024 * 1024};
+  const OutputLimits control{1024, kControlLaneBytes};
   return ServerBridgeHandle{std::make_shared<ServerBridge>(
       std::array<OutputLimits, index(ServerChannel::Count)>{
           ingress, ws_ingress, outbound, outbound, OutputLimits{1024, 1024 * 1024},
@@ -603,7 +608,7 @@ inline std::ostream &operator<<(std::ostream &stream,
       limits_from(view, "ws_ingress_record_limit", "ws_ingress_byte_limit");
   const auto outbound =
       limits_from(view, "outbound_record_limit", "outbound_byte_limit");
-  const OutputLimits control{1024, 1024 * 1024};
+  const OutputLimits control{1024, kControlLaneBytes};
   return ClientBridgeHandle{std::make_shared<ClientBridge>(
       std::array<OutputLimits, index(ClientChannel::Count)>{
           ingress, ws_ingress, outbound, OutputLimits{1024, 1024 * 1024},

--- a/extensions/web/src/nghttp2_session.cpp
+++ b/extensions/web/src/nghttp2_session.cpp
@@ -335,6 +335,17 @@ void H2Engine::consume(std::int32_t stream_id, std::size_t bytes) {
       nghttp2_session_consume(impl_->session, stream_id, bytes));
 }
 
+void H2Engine::discard(std::int32_t stream_id, std::size_t bytes) {
+  // A reset may remove the stream-level WINDOW_UPDATE queued by consume().
+  // Split the two levels: stream credit may follow nghttp2's normal batching,
+  // while connection credit is returned explicitly and cannot disappear with
+  // the stream (review P1).
+  static_cast<void>(
+      nghttp2_session_consume_stream(impl_->session, stream_id, bytes));
+  static_cast<void>(nghttp2_submit_window_update(
+      impl_->session, NGHTTP2_FLAG_NONE, 0, static_cast<std::int32_t>(bytes)));
+}
+
 bool H2Engine::submit_response(std::int32_t stream_id, int status,
                                const H2Headers &headers, std::string body,
                                const H2Headers &trailers) {

--- a/extensions/web/src/nghttp2_session.cpp
+++ b/extensions/web/src/nghttp2_session.cpp
@@ -59,6 +59,7 @@ struct H2Engine::Impl {
   H2Settings settings;
   nghttp2_session *session{};
   std::map<std::int32_t, StreamState> requests{};
+  std::map<std::int32_t, StreamState> trailer_blocks{};
   std::map<std::int32_t, ResponseState> responses{};
   bool fatal{};
 
@@ -80,9 +81,15 @@ namespace {
 
 int on_begin_headers(nghttp2_session *, const nghttp2_frame *frame,
                      void *user_data) {
-  if (frame->hd.type == NGHTTP2_HEADERS &&
-      frame->headers.cat == NGHTTP2_HCAT_REQUEST) {
+  if (frame->hd.type != NGHTTP2_HEADERS) {
+    return 0;
+  }
+  if (frame->headers.cat == NGHTTP2_HCAT_REQUEST) {
     impl_of(user_data)->requests.emplace(frame->hd.stream_id, StreamState{});
+  } else if (frame->headers.cat == NGHTTP2_HCAT_HEADERS) {
+    // A trailing HEADERS block: request trailers.
+    impl_of(user_data)->trailer_blocks.emplace(frame->hd.stream_id,
+                                               StreamState{});
   }
   return 0;
 }
@@ -91,16 +98,24 @@ int on_header(nghttp2_session *, const nghttp2_frame *frame,
               const uint8_t *name, size_t name_length, const uint8_t *value,
               size_t value_length, uint8_t, void *user_data) {
   auto *impl = impl_of(user_data);
-  const auto found = impl->requests.find(frame->hd.stream_id);
-  if (found == impl->requests.end()) {
-    return 0;
+  auto found = impl->requests.find(frame->hd.stream_id);
+  const bool trailer = found == impl->requests.end();
+  if (trailer) {
+    found = impl->trailer_blocks.find(frame->hd.stream_id);
+    if (found == impl->trailer_blocks.end()) {
+      return 0;
+    }
   }
   StreamState &stream = found->second;
   stream.header_bytes += name_length + value_length;
   if (stream.header_bytes > impl->settings.max_header_bytes) {
     // Oversized header block: reset just this stream (RFC 0024 maps the
     // h1 header limit onto h2 per stream).
-    impl->requests.erase(found);
+    if (trailer) {
+      impl->trailer_blocks.erase(found);
+    } else {
+      impl->requests.erase(found);
+    }
     return NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE;
   }
   const std::string_view header_name{reinterpret_cast<const char *>(name),
@@ -130,6 +145,18 @@ int on_frame_recv(nghttp2_session *, const nghttp2_frame *frame,
   auto *impl = impl_of(user_data);
   switch (frame->hd.type) {
   case NGHTTP2_HEADERS: {
+    if (frame->headers.cat == NGHTTP2_HCAT_HEADERS) {
+      const auto trailer_found = impl->trailer_blocks.find(frame->hd.stream_id);
+      if (trailer_found == impl->trailer_blocks.end()) {
+        break;
+      }
+      H2Headers trailers = std::move(trailer_found->second.headers);
+      impl->trailer_blocks.erase(trailer_found);
+      impl->host.on_request_trailers(
+          frame->hd.stream_id, std::move(trailers),
+          (frame->hd.flags & NGHTTP2_FLAG_END_STREAM) != 0);
+      break;
+    }
     if (frame->headers.cat != NGHTTP2_HCAT_REQUEST) {
       break;
     }
@@ -177,6 +204,7 @@ int on_stream_close(nghttp2_session *, int32_t stream_id, uint32_t error_code,
                     void *user_data) {
   auto *impl = impl_of(user_data);
   impl->requests.erase(stream_id);
+  impl->trailer_blocks.erase(stream_id);
   impl->responses.erase(stream_id);
   if (error_code != NGHTTP2_NO_ERROR) {
     impl->host.on_stream_reset(stream_id, error_code);

--- a/extensions/web/src/nghttp2_session.cpp
+++ b/extensions/web/src/nghttp2_session.cpp
@@ -7,6 +7,12 @@
 
 #include "detail/h2_engine.h"
 
+// MSVC has no ssize_t; the v1 nghttp2 API is hidden and only the *2
+// entry points (which this code uses exclusively) remain.
+#ifdef _WIN32
+#define NGHTTP2_NO_SSIZE_T
+#endif
+
 #include <nghttp2/nghttp2.h>
 
 #include <algorithm>

--- a/extensions/web/src/nghttp2_session.cpp
+++ b/extensions/web/src/nghttp2_session.cpp
@@ -1,0 +1,356 @@
+// The HTTP/2 protocol engine: the only translation unit that includes
+// nghttp2 (RFC 0024, HTTP/2 activation plan).  H2Engine wraps a server
+// session in the pull model — nghttp2_session_mem_recv2 in, mem_send2 out —
+// with automatic window updates disabled so request-DATA flow control is
+// released only through consume(), i.e. only once the driver has
+// reservation-accounted the bytes (RFC 0024, flow control).
+
+#include "detail/h2_engine.h"
+
+#include <nghttp2/nghttp2.h>
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace hgraph::web::detail {
+namespace {
+
+[[nodiscard]] nghttp2_nv make_nv(std::string_view name,
+                                 std::string_view value) noexcept {
+  // nghttp2 copies name and value at submit time (no NO_COPY flags).
+  return nghttp2_nv{
+      reinterpret_cast<uint8_t *>(const_cast<char *>(name.data())),
+      reinterpret_cast<uint8_t *>(const_cast<char *>(value.data())),
+      name.size(), value.size(), NGHTTP2_NV_FLAG_NONE};
+}
+
+struct StreamState {
+  std::string method{};
+  std::string target{};
+  std::string authority{};
+  H2Headers headers{};
+  std::size_t header_bytes{};
+  bool host_seen{};
+};
+
+struct ResponseState {
+  std::string status{};
+  std::string body{};
+  std::size_t offset{};
+  H2Headers trailers{};
+};
+
+} // namespace
+
+struct H2Engine::Impl {
+  H2Host &host;
+  H2Settings settings;
+  nghttp2_session *session{};
+  std::map<std::int32_t, StreamState> requests{};
+  std::map<std::int32_t, ResponseState> responses{};
+  bool fatal{};
+
+  Impl(H2Host &host_ref, const H2Settings &config)
+      : host{host_ref}, settings{config} {}
+
+  ~Impl() {
+    if (session != nullptr) {
+      nghttp2_session_del(session);
+    }
+  }
+};
+
+namespace {
+
+[[nodiscard]] H2Engine::Impl *impl_of(void *user_data) noexcept {
+  return static_cast<H2Engine::Impl *>(user_data);
+}
+
+int on_begin_headers(nghttp2_session *, const nghttp2_frame *frame,
+                     void *user_data) {
+  if (frame->hd.type == NGHTTP2_HEADERS &&
+      frame->headers.cat == NGHTTP2_HCAT_REQUEST) {
+    impl_of(user_data)->requests.emplace(frame->hd.stream_id, StreamState{});
+  }
+  return 0;
+}
+
+int on_header(nghttp2_session *, const nghttp2_frame *frame,
+              const uint8_t *name, size_t name_length, const uint8_t *value,
+              size_t value_length, uint8_t, void *user_data) {
+  auto *impl = impl_of(user_data);
+  const auto found = impl->requests.find(frame->hd.stream_id);
+  if (found == impl->requests.end()) {
+    return 0;
+  }
+  StreamState &stream = found->second;
+  stream.header_bytes += name_length + value_length;
+  if (stream.header_bytes > impl->settings.max_header_bytes) {
+    // Oversized header block: reset just this stream (RFC 0024 maps the
+    // h1 header limit onto h2 per stream).
+    impl->requests.erase(found);
+    return NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE;
+  }
+  const std::string_view header_name{reinterpret_cast<const char *>(name),
+                                     name_length};
+  const std::string_view header_value{reinterpret_cast<const char *>(value),
+                                      value_length};
+  if (header_name == ":method") {
+    stream.method.assign(header_value);
+  } else if (header_name == ":path") {
+    stream.target.assign(header_value);
+  } else if (header_name == ":authority") {
+    stream.authority.assign(header_value);
+  } else if (header_name == ":scheme") {
+    // The scheme is implied by the listener's TLS configuration.
+  } else {
+    if (header_name == "host") {
+      stream.host_seen = true;
+    }
+    stream.headers.emplace_back(std::string{header_name},
+                                std::string{header_value});
+  }
+  return 0;
+}
+
+int on_frame_recv(nghttp2_session *, const nghttp2_frame *frame,
+                  void *user_data) {
+  auto *impl = impl_of(user_data);
+  switch (frame->hd.type) {
+  case NGHTTP2_HEADERS: {
+    if (frame->headers.cat != NGHTTP2_HCAT_REQUEST) {
+      break;
+    }
+    const auto found = impl->requests.find(frame->hd.stream_id);
+    if (found == impl->requests.end()) {
+      break;
+    }
+    StreamState stream = std::move(found->second);
+    impl->requests.erase(found);
+    if (!stream.host_seen && !stream.authority.empty()) {
+      // ``:authority`` carries what h1 sent as Host (RFC 9113 §8.3.1);
+      // surfacing it keeps the graph-visible header list h1-shaped.
+      stream.headers.emplace_back("host", stream.authority);
+    }
+    impl->host.on_request_headers(
+        frame->hd.stream_id, std::move(stream.method),
+        std::move(stream.target), std::move(stream.headers),
+        (frame->hd.flags & NGHTTP2_FLAG_END_STREAM) != 0);
+    break;
+  }
+  case NGHTTP2_DATA:
+    if ((frame->hd.flags & NGHTTP2_FLAG_END_STREAM) != 0) {
+      impl->host.on_request_data(frame->hd.stream_id, std::string_view{},
+                                 true);
+    }
+    break;
+  case NGHTTP2_GOAWAY:
+    impl->host.on_goaway_received();
+    break;
+  default:
+    break;
+  }
+  return 0;
+}
+
+int on_data_chunk_recv(nghttp2_session *, uint8_t, int32_t stream_id,
+                       const uint8_t *data, size_t length, void *user_data) {
+  impl_of(user_data)->host.on_request_data(
+      stream_id,
+      std::string_view{reinterpret_cast<const char *>(data), length}, false);
+  return 0;
+}
+
+int on_stream_close(nghttp2_session *, int32_t stream_id, uint32_t error_code,
+                    void *user_data) {
+  auto *impl = impl_of(user_data);
+  impl->requests.erase(stream_id);
+  impl->responses.erase(stream_id);
+  if (error_code != NGHTTP2_NO_ERROR) {
+    impl->host.on_stream_reset(stream_id, error_code);
+  }
+  impl->host.on_stream_closed(stream_id);
+  return 0;
+}
+
+nghttp2_ssize read_response_body(nghttp2_session *session, int32_t stream_id,
+                                 uint8_t *buffer, size_t length,
+                                 uint32_t *data_flags, nghttp2_data_source *,
+                                 void *user_data) {
+  auto *impl = impl_of(user_data);
+  const auto found = impl->responses.find(stream_id);
+  if (found == impl->responses.end()) {
+    return NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE;
+  }
+  ResponseState &response = found->second;
+  const std::size_t remaining = response.body.size() - response.offset;
+  const std::size_t take = std::min(remaining, length);
+  std::memcpy(buffer, response.body.data() + response.offset, take);
+  response.offset += take;
+  if (response.offset == response.body.size()) {
+    *data_flags |= NGHTTP2_DATA_FLAG_EOF;
+    if (!response.trailers.empty()) {
+      *data_flags |= NGHTTP2_DATA_FLAG_NO_END_STREAM;
+      std::vector<nghttp2_nv> nva;
+      nva.reserve(response.trailers.size());
+      for (const auto &[name, value] : response.trailers) {
+        nva.push_back(make_nv(name, value));
+      }
+      if (nghttp2_submit_trailer(session, stream_id, nva.data(),
+                                 nva.size()) != 0) {
+        return NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE;
+      }
+    }
+  }
+  return static_cast<nghttp2_ssize>(take);
+}
+
+} // namespace
+
+H2Engine::H2Engine(H2Host &host, const H2Settings &settings)
+    : impl_{std::make_unique<Impl>(host, settings)} {
+  nghttp2_session_callbacks *callbacks = nullptr;
+  if (nghttp2_session_callbacks_new(&callbacks) != 0) {
+    throw std::runtime_error("nghttp2 callbacks allocation failed");
+  }
+  nghttp2_session_callbacks_set_on_begin_headers_callback(callbacks,
+                                                          on_begin_headers);
+  nghttp2_session_callbacks_set_on_header_callback(callbacks, on_header);
+  nghttp2_session_callbacks_set_on_frame_recv_callback(callbacks,
+                                                       on_frame_recv);
+  nghttp2_session_callbacks_set_on_data_chunk_recv_callback(
+      callbacks, on_data_chunk_recv);
+  nghttp2_session_callbacks_set_on_stream_close_callback(callbacks,
+                                                         on_stream_close);
+
+  nghttp2_option *option = nullptr;
+  if (nghttp2_option_new(&option) != 0) {
+    nghttp2_session_callbacks_del(callbacks);
+    throw std::runtime_error("nghttp2 option allocation failed");
+  }
+  // Window updates are the admission lever: released only via consume()
+  // once the driver has reserved the bytes (RFC 0024, flow control).
+  nghttp2_option_set_no_auto_window_update(option, 1);
+
+  const int rc = nghttp2_session_server_new2(&impl_->session, callbacks,
+                                             impl_.get(), option);
+  nghttp2_option_del(option);
+  nghttp2_session_callbacks_del(callbacks);
+  if (rc != 0) {
+    throw std::runtime_error("nghttp2 server session allocation failed");
+  }
+
+  const std::array<nghttp2_settings_entry, 3> entries{{
+      {NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS,
+       static_cast<uint32_t>(settings.max_concurrent_streams)},
+      {NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE,
+       static_cast<uint32_t>(settings.initial_window_bytes)},
+      {NGHTTP2_SETTINGS_MAX_HEADER_LIST_SIZE,
+       static_cast<uint32_t>(settings.max_header_bytes)},
+  }};
+  if (nghttp2_submit_settings(impl_->session, NGHTTP2_FLAG_NONE,
+                              entries.data(), entries.size()) != 0) {
+    throw std::runtime_error("nghttp2 settings submission failed");
+  }
+  // The connection-level window follows the configured stream window so a
+  // single stream can use the whole configured budget.
+  static_cast<void>(nghttp2_session_set_local_window_size(
+      impl_->session, NGHTTP2_FLAG_NONE, 0,
+      static_cast<int32_t>(settings.initial_window_bytes)));
+}
+
+H2Engine::~H2Engine() = default;
+
+bool H2Engine::receive(std::string_view bytes) {
+  if (impl_->fatal) {
+    return false;
+  }
+  const nghttp2_ssize processed = nghttp2_session_mem_recv2(
+      impl_->session, reinterpret_cast<const uint8_t *>(bytes.data()),
+      bytes.size());
+  if (processed < 0 ||
+      static_cast<std::size_t>(processed) != bytes.size()) {
+    impl_->fatal = true;
+    return false;
+  }
+  return true;
+}
+
+std::string_view H2Engine::next_output() {
+  const uint8_t *data = nullptr;
+  const nghttp2_ssize length =
+      nghttp2_session_mem_send2(impl_->session, &data);
+  if (length <= 0) {
+    if (length < 0) {
+      impl_->fatal = true;
+    }
+    return {};
+  }
+  return std::string_view{reinterpret_cast<const char *>(data),
+                          static_cast<std::size_t>(length)};
+}
+
+void H2Engine::consume(std::int32_t stream_id, std::size_t bytes) {
+  static_cast<void>(
+      nghttp2_session_consume(impl_->session, stream_id, bytes));
+}
+
+bool H2Engine::submit_response(std::int32_t stream_id, int status,
+                               const H2Headers &headers, std::string body,
+                               const H2Headers &trailers) {
+  auto [slot, inserted] = impl_->responses.emplace(
+      stream_id, ResponseState{std::to_string(status), std::move(body), 0,
+                               trailers});
+  if (!inserted) {
+    return false;
+  }
+  std::vector<nghttp2_nv> nva;
+  nva.reserve(headers.size() + 1);
+  nva.push_back(make_nv(":status", slot->second.status));
+  for (const auto &[name, value] : headers) {
+    nva.push_back(make_nv(name, value));
+  }
+  nghttp2_data_provider2 provider{};
+  provider.read_callback = read_response_body;
+  const bool with_body =
+      !slot->second.body.empty() || !slot->second.trailers.empty();
+  const int rc = nghttp2_submit_response2(impl_->session, stream_id,
+                                          nva.data(), nva.size(),
+                                          with_body ? &provider : nullptr);
+  if (rc != 0) {
+    impl_->responses.erase(stream_id);
+    return false;
+  }
+  return true;
+}
+
+void H2Engine::reset_stream(std::int32_t stream_id, H2StreamError error) {
+  static_cast<void>(nghttp2_submit_rst_stream(
+      impl_->session, NGHTTP2_FLAG_NONE, stream_id,
+      static_cast<uint32_t>(error)));
+}
+
+void H2Engine::submit_goaway() {
+  static_cast<void>(nghttp2_submit_goaway(
+      impl_->session, NGHTTP2_FLAG_NONE,
+      nghttp2_session_get_last_proc_stream_id(impl_->session),
+      NGHTTP2_NO_ERROR, nullptr, 0));
+}
+
+bool H2Engine::wants_write() const {
+  return !impl_->fatal && nghttp2_session_want_write(impl_->session) != 0;
+}
+
+bool H2Engine::finished() const {
+  return impl_->fatal ||
+         (nghttp2_session_want_read(impl_->session) == 0 &&
+          nghttp2_session_want_write(impl_->session) == 0);
+}
+
+} // namespace hgraph::web::detail

--- a/extensions/web/src/value_builders.cpp
+++ b/extensions/web/src/value_builders.cpp
@@ -156,11 +156,13 @@ namespace hgraph::web
         if (client_verify_ != WebClientVerify::None && ca_path_.empty() && ca_pem_.empty()) {
             throw std::invalid_argument("Web client-certificate verification requires a CA");
         }
-        // Advertising a protocol the server does not speak is a protocol
-        // violation: "h2" stays rejected until the HTTP/2 session activates
-        // behind the ALPN seam (RFC 0024).
-        if (std::ranges::any_of(alpn_, [](const Str &protocol) { return protocol == "h2"; })) {
-            throw std::invalid_argument("Web server ALPN cannot advertise h2 before the HTTP/2 session is activated");
+        // The HTTP/2 session is active behind the ALPN seam (RFC 0024,
+        // activation plan): "h2" is a legal server protocol.  Only known
+        // protocols may be advertised.
+        if (std::ranges::any_of(alpn_, [](const Str &protocol) {
+                return protocol != "h2" && protocol != "http/1.1";
+            })) {
+            throw std::invalid_argument("Web server ALPN accepts only \"h2\" and \"http/1.1\"");
         }
         std::vector<std::pair<std::string_view, Value>> fields{
             {"client_verify", atomic(client_verify_)},

--- a/extensions/web/src/value_builders.cpp
+++ b/extensions/web/src/value_builders.cpp
@@ -384,6 +384,16 @@ namespace hgraph::web
         return *this;
     }
 
+    ServerConfigBuilder &ServerConfigBuilder::h2_max_concurrent_streams(Int value) {
+        h2_max_concurrent_streams_ = value;
+        return *this;
+    }
+
+    ServerConfigBuilder &ServerConfigBuilder::h2_initial_window_bytes(Int value) {
+        h2_initial_window_bytes_ = value;
+        return *this;
+    }
+
     Value ServerConfigBuilder::build() const {
         register_web_types();
         if (bind_address_.empty()) { throw std::invalid_argument("Web server bind address cannot be empty"); }

--- a/extensions/web/src/value_builders.cpp
+++ b/extensions/web/src/value_builders.cpp
@@ -432,11 +432,11 @@ namespace hgraph::web
         // A single maximal payload must always fit an empty ingress channel;
         // otherwise Backpressure would hold it forever (transport invariant,
         // mirrored in the runtime's config parse).
-        // Two header blocks: HTTP/2 caps the initial headers and the
-        // trailers separately, and each may reach max_header_bytes.
-        if (ingress_byte_limit_ < max_body_bytes_ + 2 * max_header_bytes_ + 512) {
+        // Two header blocks (HTTP/2 caps initial headers and trailers
+        // separately), each weighed twice for the source-plus-graph copies.
+        if (ingress_byte_limit_ < max_body_bytes_ + 4 * max_header_bytes_ + 1024) {
             throw std::invalid_argument(
-                "Web ingress_byte_limit must cover one maximal request (max_body_bytes + 2*max_header_bytes + 512)");
+                "Web ingress_byte_limit must cover one maximal request (max_body_bytes + 4*max_header_bytes + 1024)");
         }
         if (ws_ingress_byte_limit_ < ws_max_message_bytes_ + 256) {
             throw std::invalid_argument(

--- a/extensions/web/src/value_builders.cpp
+++ b/extensions/web/src/value_builders.cpp
@@ -432,11 +432,12 @@ namespace hgraph::web
         // A single maximal payload must always fit an empty ingress channel;
         // otherwise Backpressure would hold it forever (transport invariant,
         // mirrored in the runtime's config parse).
-        // Two header blocks (HTTP/2 caps initial headers and trailers
-        // separately), each weighed twice for the source-plus-graph copies.
-        if (ingress_byte_limit_ < max_body_bytes_ + 4 * max_header_bytes_ + 1024) {
+        // The transport's worst-case weight: a 2x initial header block
+        // with a 4x-weighted target (worst case 4x one block) plus 2x
+        // trailers.
+        if (ingress_byte_limit_ < max_body_bytes_ + 6 * max_header_bytes_ + 1024) {
             throw std::invalid_argument(
-                "Web ingress_byte_limit must cover one maximal request (max_body_bytes + 4*max_header_bytes + 1024)");
+                "Web ingress_byte_limit must cover one maximal request (max_body_bytes + 6*max_header_bytes + 1024)");
         }
         if (ws_ingress_byte_limit_ < ws_max_message_bytes_ + 256) {
             throw std::invalid_argument(

--- a/extensions/web/src/value_builders.cpp
+++ b/extensions/web/src/value_builders.cpp
@@ -408,6 +408,17 @@ namespace hgraph::web
         require_non_negative(ping_interval_ms_, "ping interval");
         require_non_negative(pong_timeout_ms_, "pong timeout");
         require_non_negative(stats_interval_ms_, "stats interval");
+        require_positive(h2_max_concurrent_streams_, "h2_max_concurrent_streams");
+        require_positive(h2_initial_window_bytes_, "h2_initial_window_bytes");
+        // HTTP/2 windows and stream counts are 31-bit quantities; larger
+        // values would fail inside the TLS handshake handler instead of at
+        // wiring time (review P2).
+        if (h2_initial_window_bytes_ > 2'147'483'647) {
+            throw std::invalid_argument("Web h2_initial_window_bytes must be at most 2^31-1");
+        }
+        if (h2_max_concurrent_streams_ > 2'147'483'647) {
+            throw std::invalid_argument("Web h2_max_concurrent_streams must be at most 2^31-1");
+        }
         // A single maximal payload must always fit an empty ingress channel;
         // otherwise Backpressure would hold it forever (transport invariant,
         // mirrored in the runtime's config parse).

--- a/extensions/web/src/value_builders.cpp
+++ b/extensions/web/src/value_builders.cpp
@@ -432,9 +432,11 @@ namespace hgraph::web
         // A single maximal payload must always fit an empty ingress channel;
         // otherwise Backpressure would hold it forever (transport invariant,
         // mirrored in the runtime's config parse).
-        if (ingress_byte_limit_ < max_body_bytes_ + max_header_bytes_ + 512) {
+        // Two header blocks: HTTP/2 caps the initial headers and the
+        // trailers separately, and each may reach max_header_bytes.
+        if (ingress_byte_limit_ < max_body_bytes_ + 2 * max_header_bytes_ + 512) {
             throw std::invalid_argument(
-                "Web ingress_byte_limit must cover one maximal request (max_body_bytes + max_header_bytes + 512)");
+                "Web ingress_byte_limit must cover one maximal request (max_body_bytes + 2*max_header_bytes + 512)");
         }
         if (ws_ingress_byte_limit_ < ws_max_message_bytes_ + 256) {
             throw std::invalid_argument(

--- a/extensions/web/tests/CMakeLists.txt
+++ b/extensions/web/tests/CMakeLists.txt
@@ -47,6 +47,12 @@ target_include_directories(hgraph_web_h2_engine_tests
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 target_link_libraries(hgraph_web_h2_engine_tests
     PRIVATE ${HGRAPH_WEB_NGHTTP2_TARGET})
+# The h2 loopback also carries a small independent nghttp2/TLS client for
+# rejection/window-restoration behavior that the public call shape cannot
+# express (an open stream plus DATA followed by request trailers).
+target_link_libraries(hgraph_web_h2_loopback_tests
+    PRIVATE ${HGRAPH_WEB_NGHTTP2_TARGET} OpenSSL::SSL OpenSSL::Crypto
+            ${HGRAPH_WEB_BOOST_TARGETS})
 
 foreach(target hgraph_web_tests hgraph_web_service_tests hgraph_web_route_table_tests hgraph_web_bridge_tests hgraph_web_h2_engine_tests hgraph_web_loopback_tests hgraph_web_client_loopback_tests hgraph_web_h2_loopback_tests)
     target_compile_features(${target} PRIVATE cxx_std_23)

--- a/extensions/web/tests/CMakeLists.txt
+++ b/extensions/web/tests/CMakeLists.txt
@@ -22,6 +22,13 @@ add_executable(hgraph_web_client_loopback_tests
 add_executable(hgraph_web_h2_loopback_tests
     test_h2_loopback.cpp
 )
+# Not a ctest target: a standalone server the h2spec conformance binary
+# drives from CI (RFC 0024, h2 acceptance criteria).
+add_executable(hgraph_web_h2spec_server
+    h2spec_server.cpp
+)
+target_compile_features(hgraph_web_h2spec_server PRIVATE cxx_std_23)
+target_link_libraries(hgraph_web_h2spec_server PRIVATE hgraph::web)
 # The loopback oracle is an independent Beast synchronous client, so this
 # test target reaches the (otherwise PRIVATE) header-only Boost targets.
 target_link_libraries(hgraph_web_loopback_tests

--- a/extensions/web/tests/CMakeLists.txt
+++ b/extensions/web/tests/CMakeLists.txt
@@ -10,6 +10,9 @@ add_executable(hgraph_web_route_table_tests
 add_executable(hgraph_web_bridge_tests
     test_bridge.cpp
 )
+add_executable(hgraph_web_h2_engine_tests
+    test_h2_engine.cpp
+)
 add_executable(hgraph_web_loopback_tests
     test_loopback.cpp
 )
@@ -28,8 +31,14 @@ target_include_directories(hgraph_web_route_table_tests
 # directly (late reserved completions after stop must reject, not throw).
 target_include_directories(hgraph_web_bridge_tests
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+# The H2 engine test converses with the engine through a genuine nghttp2
+# client session, so it links the same nghttp2 the extension uses.
+target_include_directories(hgraph_web_h2_engine_tests
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+target_link_libraries(hgraph_web_h2_engine_tests
+    PRIVATE ${HGRAPH_WEB_NGHTTP2_TARGET})
 
-foreach(target hgraph_web_tests hgraph_web_service_tests hgraph_web_route_table_tests hgraph_web_bridge_tests hgraph_web_loopback_tests hgraph_web_client_loopback_tests)
+foreach(target hgraph_web_tests hgraph_web_service_tests hgraph_web_route_table_tests hgraph_web_bridge_tests hgraph_web_h2_engine_tests hgraph_web_loopback_tests hgraph_web_client_loopback_tests)
     target_compile_features(${target} PRIVATE cxx_std_23)
     target_link_libraries(${target} PRIVATE hgraph::web)
 

--- a/extensions/web/tests/CMakeLists.txt
+++ b/extensions/web/tests/CMakeLists.txt
@@ -19,6 +19,9 @@ add_executable(hgraph_web_loopback_tests
 add_executable(hgraph_web_client_loopback_tests
     test_client_loopback.cpp
 )
+add_executable(hgraph_web_h2_loopback_tests
+    test_h2_loopback.cpp
+)
 # The loopback oracle is an independent Beast synchronous client, so this
 # test target reaches the (otherwise PRIVATE) header-only Boost targets.
 target_link_libraries(hgraph_web_loopback_tests
@@ -38,7 +41,7 @@ target_include_directories(hgraph_web_h2_engine_tests
 target_link_libraries(hgraph_web_h2_engine_tests
     PRIVATE ${HGRAPH_WEB_NGHTTP2_TARGET})
 
-foreach(target hgraph_web_tests hgraph_web_service_tests hgraph_web_route_table_tests hgraph_web_bridge_tests hgraph_web_h2_engine_tests hgraph_web_loopback_tests hgraph_web_client_loopback_tests)
+foreach(target hgraph_web_tests hgraph_web_service_tests hgraph_web_route_table_tests hgraph_web_bridge_tests hgraph_web_h2_engine_tests hgraph_web_loopback_tests hgraph_web_client_loopback_tests hgraph_web_h2_loopback_tests)
     target_compile_features(${target} PRIVATE cxx_std_23)
     target_link_libraries(${target} PRIVATE hgraph::web)
 

--- a/extensions/web/tests/h2spec_server.cpp
+++ b/extensions/web/tests/h2spec_server.cpp
@@ -1,0 +1,207 @@
+// A standalone HTTP/2 server for h2spec conformance runs (RFC 0024, h2
+// acceptance criteria).  Starts a real graph serving GET / over TLS with
+// ALPN ["h2"] on the requested port (default 8443), prints
+// "h2spec-server listening <port>" once bound, and runs until the
+// duration expires or the process is killed:
+//
+//   hgraph_web_h2spec_server [port] [seconds]
+//   h2spec http2 -t -k -h 127.0.0.1 -p <port>
+
+#include <hgraph/web/service.h>
+#include <hgraph/web/value_builders.h>
+
+#include <hgraph/lib/std/operators/conversion.h>
+#include <hgraph/lib/std/operators/registration.h>
+#include <hgraph/lib/std/std_nodes.h>
+#include <hgraph/lib/testing/runtime_support.h>
+#include <hgraph/runtime/runtime.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+namespace {
+using namespace hgraph;
+using namespace hgraph::web;
+using namespace hgraph::testing;
+using namespace std::chrono_literals;
+
+// The same 100-year loopback certificate the h2 loopback suite embeds.
+constexpr const char *kTestCertPem = R"pem(-----BEGIN CERTIFICATE-----
+MIIDJzCCAg+gAwIBAgIUcNava/ilBlFAAby854h6n3WklcYwDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJMTI3LjAuMC4xMCAXDTI2MDgxNzEwNTEyM1oYDzIxMjYw
+NzI0MTA1MTIzWjAUMRIwEAYDVQQDDAkxMjcuMC4wLjEwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCR/ul5caZPxNee1TPZRkgzwPgHpsJAMchsAmRnkRXm
+YGnzIvP7VZHFODj5nud2j/GCqBAxSCCbkLPfobnndehiCx40XEgpePsEDI7wnH6g
+bO51I2ENAXodKE0y9Lq8WtEFyzKFbD73HUoNX8xv+KQjDxoQUpvgnXLBo0U/WJJJ
+aUO1n1pAkEOMrNIj1Oda0JL6El+TbHJznRcfNh/RSKMDDYXrVXzFXt02I6dYvMKO
+FVwTrBC9/bKr2WAvUNU2ugzYueVAkm24buMawgqxMbFSokJmVVj6LQz5SVheUZjs
+4Rg1ASSvDs9FYAyFcAQ5X5ps4SZJa6lWhnobupq7mXj7AgMBAAGjbzBtMB0GA1Ud
+DgQWBBSxRx4oz39xyLrEtzTDhqwQCaaE/TAfBgNVHSMEGDAWgBSxRx4oz39xyLrE
+tzTDhqwQCaaE/TAPBgNVHRMBAf8EBTADAQH/MBoGA1UdEQQTMBGHBH8AAAGCCWxv
+Y2FsaG9zdDANBgkqhkiG9w0BAQsFAAOCAQEAf4R9Aekow3u747bg7c33t9rI0/7w
+RXGDOwb8JifIE420J6miDiFoWHwXmb1/pu+Ti+VsDYUsj6nkTXLYnO9tdDp71G6T
+wHa7e7bDA0fBfWvDGJMq+9SK76ZOf6gD26JEN86ejbY/YKymzRF5+Q/Njj+WjfGt
+IozucryoCL/TPpQW4W846THj6Jb6ePhfb8J65vxhU5e05Nn0Zv3KmJIg854kKFzE
+9DmMw+yRBc7+sgkidrC3Z43CJ2UqStxTeh7ObnTayPUUou6EEbZrAYfGW3XYI1xe
+/uMQ3iaGE08aFv7q8mjRN73rcvvqabBfqDcHGf93rUbCyh8HrPC6eLgSKQ==
+-----END CERTIFICATE-----
+)pem";
+
+constexpr const char *kTestKeyPem = R"pem(-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCR/ul5caZPxNee
+1TPZRkgzwPgHpsJAMchsAmRnkRXmYGnzIvP7VZHFODj5nud2j/GCqBAxSCCbkLPf
+obnndehiCx40XEgpePsEDI7wnH6gbO51I2ENAXodKE0y9Lq8WtEFyzKFbD73HUoN
+X8xv+KQjDxoQUpvgnXLBo0U/WJJJaUO1n1pAkEOMrNIj1Oda0JL6El+TbHJznRcf
+Nh/RSKMDDYXrVXzFXt02I6dYvMKOFVwTrBC9/bKr2WAvUNU2ugzYueVAkm24buMa
+wgqxMbFSokJmVVj6LQz5SVheUZjs4Rg1ASSvDs9FYAyFcAQ5X5ps4SZJa6lWhnob
+upq7mXj7AgMBAAECggEAAL/wjZy+gSQrN3GR20vlq8LnXur0jjqTOLBhQY6BJ+vB
+s824Hce/4rrm0d71vhTEKci2cArjFZUsOfninTm5OQbgUsz7dPTvMq31bl3FPvlV
+krPUgswWguPjmEWynDTShlDb7jHy812ZxlLO/asE7IHV2O5YedrtrXGALV+JtMmI
+uDviZONYad/xzVUYwdft77koeKjZGnJQJitTr86AMKOpKixwtSOo/8fMXBjC4dTT
+GWgfcxXorTDEUiiX3GvPgSEqRBxAkZ2epe1hdmO5rhZcry11tetupOq7tsHroASp
+3zhwPtd17te/vSeMoUvrwZcn0cBFP+wKDfKgOC4E7QKBgQDCxhJyXPnlGbJBCk6t
+OVJA6moRRjH62CbsC2WPjiL0z7P2NBezCuYqOUPXXsh+2TrHKfwQuj9Mv8HTonJB
+ZzyZVnhwiPchM/CC1hK1ps6eHbOeu9jrbXlmaDYVPUAHhRJzA+aBoo3RCB7eVUd4
+6qnUyGszXTP63daWnYQu8MudvQKBgQC/444NAMPnUgZmPlbfoxAYq5BTNPmjxzXS
+rmQu2hBpNQKLDMG+sIgpSMlK8ojn9Ko1Td61y/8Ub0qndPmkADeBWNMxxpoy/Cxv
+EI9x0JBN8UfoPnG2TllQ9ZiM6qH4/4jaXxahq2SkJ1ZJ+TmehCsYiqQv8eeP5m2H
+kaySEpPRFwKBgQCVQIrqL+0ebe52gJuBiidJr1fQHOY3vmM1BhaxRs3qoy7YP1rZ
+zERLns4pv2wMKBIuhDGv78iJ23d/4T+EdsOtDOIF+i7FtrNazwhPQp+Z8lCuFmxH
+HACnRLwM0n66RHK6yAZe2F2sDHj7DoZSViAF+f6LwaQPXOcPS2z7O3IMUQKBgCA7
+2IPkqgP0qnCIbk149d4/C6p+jqTtdOQkOV4JcZJKvlefV/hxbR4KRQ4a+daFKgZ0
+Q0Ikt3+2RkMlCj57bteClU+aPhLse4ZYsM/8qhD9xAeGXdGzDZvk9bBORdEvE80j
+Bgk4YlqU5RDeFcjECP1BZN1M9Ioeui140hVjm4MXAoGAeVrFpOGVToOedj3SG+4k
+UP85yV64d10flGkxbCCaEEV8gOjoG3YWh+r0oeIGVFUOi9TzbwI9xYJb154/+dOi
+ljQAIYegDzbgnKbPvtbj35Dy07fljW3WYT3fzH70nB3YieivDx2JXqp+DZ8AAnSc
+8n8PFd6yOYtIC1rQQ0aqWag=
+-----END PRIVATE KEY-----
+)pem";
+
+inline std::atomic<bool> announced{false};
+
+struct SpecAnnounce {
+  static constexpr auto name = "web_h2spec_announce";
+
+  static void eval(In<"stats", TS<WebServerStats>, InputValidity::Unchecked>
+                       stats) {
+    if (!stats.valid() || !stats.modified() || announced.load()) {
+      return;
+    }
+    const Int port = stats.base()
+                         .value()
+                         .as_bundle()
+                         .at("listening_port")
+                         .checked_as<Int>();
+    if (port == 0) {
+      return;
+    }
+    announced.store(true);
+    std::cout << "h2spec-server listening " << port << std::endl;
+  }
+};
+
+struct SpecId {
+  static constexpr auto name = "web_h2spec_id";
+
+  static void eval(In<"routed", WebRouteOutput, InputValidity::Unchecked>
+                       routed,
+                   Out<TS<Int>> out) {
+    auto request = routed.template field<"request">();
+    if (request.valid() && request.modified()) {
+      out.apply(request.base().value().as_bundle().at("request_id"));
+    }
+  }
+};
+
+struct SpecResponse {
+  static constexpr auto name = "web_h2spec_response";
+
+  static void eval(In<"routed", WebRouteOutput, InputValidity::Unchecked>
+                       routed,
+                   Out<TS<HttpResponse>> out) {
+    auto request = routed.template field<"request">();
+    if (request.valid() && request.modified()) {
+      const Value response = make_response(Int{200}, {}, Bytes{"conformant"});
+      out.apply(response.view());
+    }
+  }
+};
+
+int requested_port = 8443;
+
+struct H2SpecGraph {
+  static constexpr auto name = "web_h2spec_graph";
+
+  static void compose(Wiring &w) {
+    const auto server_path = service::path("web-h2spec-server");
+    register_server(w, server_path,
+                    server_config()
+                        .port(static_cast<Int>(requested_port))
+                        .request_timeout(5'000ms)
+                        .stats_interval(100ms)
+                        .tls(tls_server()
+                                 .cert_pem(Str{kTestCertPem})
+                                 .key_pem(Str{kTestKeyPem})
+                                 .alpn({Str{"h2"}})
+                                 .build())
+                        .build());
+    auto stats = server_stats(w, server_path);
+    static_cast<void>(wire<SpecAnnounce>(w, stats));
+
+    // h2spec exercises GET and POST on "/"; the rest-capture route serves
+    // every path so no case sees a transport 404.
+    auto route = wire<stdlib::const_, TS<WebRoute>>(
+        w, make_route(HttpMethod::Get, "/*rest"));
+    auto served = serve(w, server_path, route);
+    auto id = wire<SpecId>(w, served).as<TS<Int>>();
+    auto response = wire<SpecResponse>(w, served).as<TS<HttpResponse>>();
+    static_cast<void>(
+        respond(w, server_path, respond_request(w, id, response)));
+
+    auto post_route = wire<stdlib::const_, TS<WebRoute>>(
+        w, make_route(HttpMethod::Post, "/*rest"));
+    auto post_served = serve(w, server_path, post_route);
+    auto post_id = wire<SpecId>(w, post_served).as<TS<Int>>();
+    auto post_response =
+        wire<SpecResponse>(w, post_served).as<TS<HttpResponse>>();
+    static_cast<void>(respond(
+        w, server_path, respond_request(w, post_id, post_response)));
+  }
+};
+
+} // namespace
+
+int main(int argc, char **argv) {
+  try {
+    if (argc > 1) {
+      requested_port = std::atoi(argv[1]);
+    }
+    int seconds = 600;
+    if (argc > 2) {
+      seconds = std::atoi(argv[2]);
+    }
+    hgraph::stdlib::register_standard_operators();
+    register_web_types();
+
+    const DateTime start = wall_now();
+    GraphExecutorBuilder executor_builder;
+    executor_builder.graph_builder(build_graph<H2SpecGraph>())
+        .mode(GraphExecutorMode::RealTime)
+        .start_time(start)
+        .end_time(start + TimeDelta{static_cast<std::int64_t>(seconds) *
+                                    1'000'000});
+    auto executor = executor_builder.make_executor();
+    auto view = executor.view();
+    {
+      AsyncGraphExecutorRun runner{view};
+      runner.join();
+    }
+    return 0;
+  } catch (const std::exception &error) {
+    std::cerr << "h2spec server failed: " << error.what() << "\n";
+    return 1;
+  }
+}

--- a/extensions/web/tests/test_h2_engine.cpp
+++ b/extensions/web/tests/test_h2_engine.cpp
@@ -6,6 +6,12 @@
 
 #include "detail/h2_engine.h"
 
+// MSVC has no ssize_t; the v1 nghttp2 API is hidden and only the *2
+// entry points (which this code uses exclusively) remain.
+#ifdef _WIN32
+#define NGHTTP2_NO_SSIZE_T
+#endif
+
 #include <nghttp2/nghttp2.h>
 
 #include <cstring>

--- a/extensions/web/tests/test_h2_engine.cpp
+++ b/extensions/web/tests/test_h2_engine.cpp
@@ -1,0 +1,418 @@
+// H2Engine protocol tests (RFC 0024, HTTP/2 activation plan): a genuine
+// nghttp2 CLIENT session converses with the engine entirely in memory, so
+// request/response framing, withheld-window flow control, RST_STREAM,
+// REFUSED_STREAM, and GOAWAY are validated against the reference
+// implementation without sockets.
+
+#include "detail/h2_engine.h"
+
+#include <nghttp2/nghttp2.h>
+
+#include <cstring>
+#include <iostream>
+#include <map>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace {
+using hgraph::web::detail::H2Engine;
+using hgraph::web::detail::H2Headers;
+using hgraph::web::detail::H2Host;
+using hgraph::web::detail::H2Settings;
+using hgraph::web::detail::H2StreamError;
+
+void require(bool condition, std::string message) {
+  if (!condition) {
+    throw std::runtime_error(std::move(message));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Server side: a recording host.
+
+struct RecordedRequest {
+  std::int32_t stream_id{};
+  std::string method{};
+  std::string target{};
+  H2Headers headers{};
+  std::string body{};
+  bool complete{};
+};
+
+struct RecordingHost final : H2Host {
+  std::map<std::int32_t, RecordedRequest> requests{};
+  std::vector<std::int32_t> resets{};
+  std::vector<std::int32_t> closed{};
+  bool goaway_received{};
+
+  void on_request_headers(std::int32_t stream_id, std::string method,
+                          std::string target, H2Headers headers,
+                          bool end_stream) override {
+    RecordedRequest request{stream_id, std::move(method), std::move(target),
+                            std::move(headers), {}, end_stream};
+    requests[stream_id] = std::move(request);
+  }
+
+  void on_request_data(std::int32_t stream_id, std::string_view data,
+                       bool end_stream) override {
+    auto &request = requests[stream_id];
+    request.body.append(data);
+    if (end_stream) {
+      request.complete = true;
+    }
+  }
+
+  void on_stream_reset(std::int32_t stream_id, std::uint32_t) override {
+    resets.push_back(stream_id);
+  }
+
+  void on_stream_closed(std::int32_t stream_id) override {
+    closed.push_back(stream_id);
+  }
+
+  void on_goaway_received() override { goaway_received = true; }
+};
+
+// ---------------------------------------------------------------------------
+// Client side: a plain nghttp2 client session.
+
+struct ClientStream {
+  int status{};
+  H2Headers headers{};
+  std::string body{};
+  bool closed{};
+  std::uint32_t error_code{};
+};
+
+struct TestClient {
+  nghttp2_session *session{};
+  std::map<std::int32_t, ClientStream> streams{};
+  bool goaway_received{};
+
+  TestClient() {
+    nghttp2_session_callbacks *callbacks = nullptr;
+    require(nghttp2_session_callbacks_new(&callbacks) == 0,
+            "client callback allocation failed");
+    nghttp2_session_callbacks_set_on_header_callback(
+        callbacks,
+        [](nghttp2_session *, const nghttp2_frame *frame, const uint8_t *name,
+           size_t name_length, const uint8_t *value, size_t value_length,
+           uint8_t, void *user_data) -> int {
+          auto &self = *static_cast<TestClient *>(user_data);
+          auto &stream = self.streams[frame->hd.stream_id];
+          const std::string_view header_name{
+              reinterpret_cast<const char *>(name), name_length};
+          const std::string header_value{
+              reinterpret_cast<const char *>(value), value_length};
+          if (header_name == ":status") {
+            stream.status = std::stoi(header_value);
+          } else {
+            stream.headers.emplace_back(std::string{header_name},
+                                        header_value);
+          }
+          return 0;
+        });
+    nghttp2_session_callbacks_set_on_data_chunk_recv_callback(
+        callbacks,
+        [](nghttp2_session *, uint8_t, int32_t stream_id, const uint8_t *data,
+           size_t length, void *user_data) -> int {
+          static_cast<TestClient *>(user_data)->streams[stream_id].body.append(
+              reinterpret_cast<const char *>(data), length);
+          return 0;
+        });
+    nghttp2_session_callbacks_set_on_stream_close_callback(
+        callbacks,
+        [](nghttp2_session *, int32_t stream_id, uint32_t error_code,
+           void *user_data) -> int {
+          auto &stream =
+              static_cast<TestClient *>(user_data)->streams[stream_id];
+          stream.closed = true;
+          stream.error_code = error_code;
+          return 0;
+        });
+    nghttp2_session_callbacks_set_on_frame_recv_callback(
+        callbacks,
+        [](nghttp2_session *, const nghttp2_frame *frame,
+           void *user_data) -> int {
+          if (frame->hd.type == NGHTTP2_GOAWAY) {
+            static_cast<TestClient *>(user_data)->goaway_received = true;
+          }
+          return 0;
+        });
+    require(nghttp2_session_client_new(&session, callbacks, this) == 0,
+            "client session allocation failed");
+    nghttp2_session_callbacks_del(callbacks);
+    require(nghttp2_submit_settings(session, NGHTTP2_FLAG_NONE, nullptr, 0) ==
+                0,
+            "client settings submission failed");
+  }
+
+  ~TestClient() { nghttp2_session_del(session); }
+
+  [[nodiscard]] std::int32_t submit_request(std::string_view method,
+                                            std::string_view path,
+                                            const std::string *body) {
+    std::vector<nghttp2_nv> nva;
+    const auto nv = [](std::string_view name, std::string_view value) {
+      return nghttp2_nv{
+          reinterpret_cast<uint8_t *>(const_cast<char *>(name.data())),
+          reinterpret_cast<uint8_t *>(const_cast<char *>(value.data())),
+          name.size(), value.size(), NGHTTP2_NV_FLAG_NONE};
+    };
+    nva.push_back(nv(":method", method));
+    nva.push_back(nv(":scheme", "https"));
+    nva.push_back(nv(":authority", "loopback.test"));
+    nva.push_back(nv(":path", path));
+    nghttp2_data_provider2 provider{};
+    if (body != nullptr) {
+      provider.source.ptr = const_cast<std::string *>(body);
+      provider.read_callback =
+          [](nghttp2_session *, int32_t, uint8_t *buffer, size_t length,
+             uint32_t *data_flags, nghttp2_data_source *source,
+             void *) -> nghttp2_ssize {
+        auto &payload = *static_cast<std::string *>(source->ptr);
+        const size_t take = std::min(payload.size(), length);
+        std::memcpy(buffer, payload.data(), take);
+        payload.erase(0, take);
+        if (payload.empty()) {
+          *data_flags |= NGHTTP2_DATA_FLAG_EOF;
+        }
+        return static_cast<nghttp2_ssize>(take);
+      };
+    }
+    const std::int32_t stream_id = nghttp2_submit_request2(
+        session, nullptr, nva.data(), nva.size(),
+        body != nullptr ? &provider : nullptr, nullptr);
+    require(stream_id > 0, "client request submission failed");
+    return stream_id;
+  }
+};
+
+// Pump both directions until neither side has bytes to move.
+void pump(TestClient &client, H2Engine &engine) {
+  bool progressed = true;
+  while (progressed) {
+    progressed = false;
+    while (true) {
+      const uint8_t *data = nullptr;
+      const nghttp2_ssize length =
+          nghttp2_session_mem_send2(client.session, &data);
+      require(length >= 0, "client send failed");
+      if (length == 0) {
+        break;
+      }
+      require(engine.receive(std::string_view{
+                  reinterpret_cast<const char *>(data),
+                  static_cast<std::size_t>(length)}),
+              "engine rejected client bytes");
+      progressed = true;
+    }
+    while (true) {
+      const std::string_view output = engine.next_output();
+      if (output.empty()) {
+        break;
+      }
+      const nghttp2_ssize processed = nghttp2_session_mem_recv2(
+          client.session, reinterpret_cast<const uint8_t *>(output.data()),
+          output.size());
+      require(processed >= 0 &&
+                  static_cast<std::size_t>(processed) == output.size(),
+              "client rejected engine bytes");
+      progressed = true;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+void test_get_round_trip_with_trailers() {
+  RecordingHost host;
+  H2Engine engine{host, H2Settings{}};
+  TestClient client;
+  const auto stream_id = client.submit_request("GET", "/orders/42", nullptr);
+  pump(client, engine);
+
+  require(host.requests.count(stream_id) == 1, "the request did not arrive");
+  const auto &request = host.requests[stream_id];
+  require(request.method == "GET", "the method was not preserved");
+  require(request.target == "/orders/42", "the target was not preserved");
+  require(request.complete, "END_STREAM on HEADERS was not surfaced");
+  bool host_header = false;
+  for (const auto &[name, value] : request.headers) {
+    host_header |= name == "host" && value == "loopback.test";
+  }
+  require(host_header, ":authority was not surfaced as the host header");
+
+  require(engine.submit_response(stream_id, 200,
+                                 H2Headers{{"content-type", "text/plain"}},
+                                 "hello-h2",
+                                 H2Headers{{"x-trail", "checksum"}}),
+          "the response was not accepted");
+  pump(client, engine);
+
+  const auto &stream = client.streams[stream_id];
+  require(stream.status == 200, "the status did not round-trip");
+  require(stream.body == "hello-h2", "the body did not round-trip");
+  bool trailer = false;
+  bool content_type = false;
+  for (const auto &[name, value] : stream.headers) {
+    trailer |= name == "x-trail" && value == "checksum";
+    content_type |= name == "content-type" && value == "text/plain";
+  }
+  require(content_type, "the response header did not round-trip");
+  require(trailer, "the trailer did not round-trip");
+  require(stream.closed && stream.error_code == NGHTTP2_NO_ERROR,
+          "the stream did not close cleanly");
+}
+
+void test_withheld_window_stalls_the_sender_until_consume() {
+  RecordingHost host;
+  H2Settings settings;
+  settings.initial_window_bytes = 4096;
+  H2Engine engine{host, settings};
+  TestClient client;
+  pump(client, engine); // exchange SETTINGS so the 4KB window applies
+
+  std::string body(64 * 1024, 'b');
+  const auto stream_id = client.submit_request("POST", "/ingest", &body);
+  pump(client, engine);
+
+  // The engine withheld all window updates, so the client stalls at the
+  // initial stream window and the request cannot complete.
+  auto &request = host.requests[stream_id];
+  require(!request.complete, "the body completed without any consume()");
+  require(request.body.size() <= 4096,
+          "more than the initial window arrived without consume()");
+
+  // Accounting the received bytes releases window and the rest flows.
+  std::size_t consumed_total = request.body.size();
+  engine.consume(stream_id, consumed_total);
+  pump(client, engine);
+  while (!request.complete) {
+    const std::size_t newly = request.body.size() - consumed_total;
+    require(newly != 0, "no progress after consume()");
+    engine.consume(stream_id, newly);
+    consumed_total += newly;
+    pump(client, engine);
+  }
+  require(request.body == std::string(64 * 1024, 'b'),
+          "the streamed body was not delivered intact");
+
+  require(engine.submit_response(stream_id, 204, {}, {}, {}),
+          "the empty response was not accepted");
+  pump(client, engine);
+  require(client.streams[stream_id].status == 204,
+          "the response status did not round-trip");
+}
+
+void test_reset_stream_reaches_the_client() {
+  RecordingHost host;
+  H2Engine engine{host, H2Settings{}};
+  TestClient client;
+  std::string body(1024, 'x');
+  const auto stream_id = client.submit_request("POST", "/slow", &body);
+  pump(client, engine);
+
+  engine.reset_stream(stream_id, H2StreamError::EnhanceYourCalm);
+  pump(client, engine);
+  const auto &stream = client.streams[stream_id];
+  require(stream.closed, "the reset stream did not close at the client");
+  require(stream.error_code == NGHTTP2_ENHANCE_YOUR_CALM,
+          "the reset error code did not reach the client");
+}
+
+void test_client_reset_surfaces_as_cancellation() {
+  RecordingHost host;
+  H2Engine engine{host, H2Settings{}};
+  TestClient client;
+  std::string body(1024, 'x');
+  const auto stream_id = client.submit_request("POST", "/cancel-me", &body);
+  pump(client, engine);
+
+  require(nghttp2_submit_rst_stream(client.session, NGHTTP2_FLAG_NONE,
+                                    stream_id, NGHTTP2_CANCEL) == 0,
+          "the client reset submission failed");
+  pump(client, engine);
+  bool reset_seen = false;
+  for (const auto reset : host.resets) {
+    reset_seen |= reset == stream_id;
+  }
+  require(reset_seen, "the client cancellation did not reach the host");
+}
+
+void test_max_concurrent_streams_gates_a_compliant_client() {
+  // A compliant peer holds streams beyond the advertised
+  // SETTINGS_MAX_CONCURRENT_STREAMS instead of sending them, so the
+  // observable contract here is gating-then-release; the REFUSED_STREAM
+  // answer to a peer that violates the advertised limit is nghttp2's own
+  // enforcement, exercised by h2spec conformance in CI.
+  RecordingHost host;
+  H2Settings settings;
+  settings.max_concurrent_streams = 1;
+  H2Engine engine{host, settings};
+  TestClient client;
+  pump(client, engine); // exchange SETTINGS first
+
+  const auto first = client.submit_request("GET", "/one", nullptr);
+  const auto second = client.submit_request("GET", "/two", nullptr);
+  pump(client, engine);
+
+  require(host.requests.count(first) == 1, "the first stream did not arrive");
+  require(host.requests.count(second) == 0,
+          "the second stream was not gated by the advertised limit");
+
+  require(engine.submit_response(first, 200, {}, "one", {}),
+          "the first response was not accepted");
+  pump(client, engine);
+  require(host.requests.count(second) == 1,
+          "the gated stream was not released when a slot freed");
+  require(engine.submit_response(second, 200, {}, "two", {}),
+          "the second response was not accepted");
+  pump(client, engine);
+  require(client.streams[second].body == "two",
+          "the gated stream did not complete");
+}
+
+void test_goaway_finishes_in_flight_and_refuses_new() {
+  RecordingHost host;
+  H2Engine engine{host, H2Settings{}};
+  TestClient client;
+  const auto stream_id = client.submit_request("GET", "/inflight", nullptr);
+  pump(client, engine);
+  require(host.requests.count(stream_id) == 1,
+          "the in-flight request did not arrive");
+
+  engine.submit_goaway();
+  pump(client, engine);
+  require(client.goaway_received, "the GOAWAY did not reach the client");
+
+  // The in-flight stream still completes after GOAWAY.
+  require(engine.submit_response(stream_id, 200, {}, "late-but-fine", {}),
+          "the in-flight response was not accepted after GOAWAY");
+  pump(client, engine);
+  require(client.streams[stream_id].body == "late-but-fine",
+          "the in-flight stream did not complete after GOAWAY");
+}
+
+} // namespace
+
+int main() {
+  try {
+    test_get_round_trip_with_trailers();
+    test_withheld_window_stalls_the_sender_until_consume();
+    test_reset_stream_reaches_the_client();
+    test_client_reset_surfaces_as_cancellation();
+    test_max_concurrent_streams_gates_a_compliant_client();
+    test_goaway_finishes_in_flight_and_refuses_new();
+  } catch (const std::exception &error) {
+    std::cerr << "hgraph_web_h2_engine_tests failed: " << error.what()
+              << "\n";
+    return 1;
+  }
+  std::cout << "hgraph_web_h2_engine_tests passed\n";
+  return 0;
+}

--- a/extensions/web/tests/test_h2_engine.cpp
+++ b/extensions/web/tests/test_h2_engine.cpp
@@ -45,6 +45,7 @@ struct RecordedRequest {
   std::string method{};
   std::string target{};
   H2Headers headers{};
+  H2Headers trailers{};
   std::string body{};
   bool complete{};
 };
@@ -58,8 +59,10 @@ struct RecordingHost final : H2Host {
   void on_request_headers(std::int32_t stream_id, std::string method,
                           std::string target, H2Headers headers,
                           bool end_stream) override {
-    RecordedRequest request{stream_id, std::move(method), std::move(target),
-                            std::move(headers), {}, end_stream};
+    RecordedRequest request{stream_id,          std::move(method),
+                            std::move(target),  std::move(headers),
+                            {},                 {},
+                            end_stream};
     requests[stream_id] = std::move(request);
   }
 
@@ -67,6 +70,15 @@ struct RecordingHost final : H2Host {
                        bool end_stream) override {
     auto &request = requests[stream_id];
     request.body.append(data);
+    if (end_stream) {
+      request.complete = true;
+    }
+  }
+
+  void on_request_trailers(std::int32_t stream_id, H2Headers trailers,
+                           bool end_stream) override {
+    auto &request = requests[stream_id];
+    request.trailers = std::move(trailers);
     if (end_stream) {
       request.complete = true;
     }
@@ -159,9 +171,25 @@ struct TestClient {
 
   ~TestClient() { nghttp2_session_del(session); }
 
+  struct RequestBody {
+    std::string payload{};
+    H2Headers trailers{};
+  };
+
   [[nodiscard]] std::int32_t submit_request(std::string_view method,
                                             std::string_view path,
                                             const std::string *body) {
+    static RequestBody wrapped;
+    if (body == nullptr) {
+      return submit_request_with(method, path, nullptr);
+    }
+    wrapped = RequestBody{*body, {}};
+    return submit_request_with(method, path, &wrapped);
+  }
+
+  [[nodiscard]] std::int32_t
+  submit_request_with(std::string_view method, std::string_view path,
+                      RequestBody *body) {
     std::vector<nghttp2_nv> nva;
     const auto nv = [](std::string_view name, std::string_view value) {
       return nghttp2_nv{
@@ -175,17 +203,32 @@ struct TestClient {
     nva.push_back(nv(":path", path));
     nghttp2_data_provider2 provider{};
     if (body != nullptr) {
-      provider.source.ptr = const_cast<std::string *>(body);
+      provider.source.ptr = body;
       provider.read_callback =
-          [](nghttp2_session *, int32_t, uint8_t *buffer, size_t length,
-             uint32_t *data_flags, nghttp2_data_source *source,
+          [](nghttp2_session *session, int32_t stream_id, uint8_t *buffer,
+             size_t length, uint32_t *data_flags, nghttp2_data_source *source,
              void *) -> nghttp2_ssize {
-        auto &payload = *static_cast<std::string *>(source->ptr);
-        const size_t take = std::min(payload.size(), length);
-        std::memcpy(buffer, payload.data(), take);
-        payload.erase(0, take);
-        if (payload.empty()) {
+        auto &request = *static_cast<RequestBody *>(source->ptr);
+        const size_t take = std::min(request.payload.size(), length);
+        std::memcpy(buffer, request.payload.data(), take);
+        request.payload.erase(0, take);
+        if (request.payload.empty()) {
           *data_flags |= NGHTTP2_DATA_FLAG_EOF;
+          if (!request.trailers.empty()) {
+            *data_flags |= NGHTTP2_DATA_FLAG_NO_END_STREAM;
+            std::vector<nghttp2_nv> nva;
+            for (const auto &[name, value] : request.trailers) {
+              nva.push_back(nghttp2_nv{
+                  reinterpret_cast<uint8_t *>(const_cast<char *>(name.data())),
+                  reinterpret_cast<uint8_t *>(
+                      const_cast<char *>(value.data())),
+                  name.size(), value.size(), NGHTTP2_NV_FLAG_NONE});
+            }
+            if (nghttp2_submit_trailer(session, stream_id, nva.data(),
+                                       nva.size()) != 0) {
+              return NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE;
+            }
+          }
         }
         return static_cast<nghttp2_ssize>(take);
       };
@@ -315,6 +358,45 @@ void test_withheld_window_stalls_the_sender_until_consume() {
           "the response status did not round-trip");
 }
 
+void test_request_trailers_complete_the_request() {
+  // A gRPC-shaped request: body then trailing HEADERS carrying the
+  // trailers and END_STREAM (review P1: neither may be lost).
+  RecordingHost host;
+  H2Engine engine{host, H2Settings{}};
+  TestClient client;
+  TestClient::RequestBody body{std::string(2048, 'g'),
+                               H2Headers{{"grpc-like-checksum", "abc123"}}};
+  const auto stream_id =
+      client.submit_request_with("POST", "/with-trailers", &body);
+  pump(client, engine);
+
+  auto &request = host.requests[stream_id];
+  while (!request.complete) {
+    const std::size_t received = request.body.size();
+    require(received != 0, "no progress toward the trailered request");
+    engine.consume(stream_id, received);
+    pump(client, engine);
+    if (request.body.size() == received && !request.complete) {
+      break;
+    }
+  }
+  require(request.complete,
+          "END_STREAM on the trailing HEADERS did not complete the request");
+  require(request.body == std::string(2048, 'g'),
+          "the trailered request body was not delivered intact");
+  bool checksum = false;
+  for (const auto &[name, value] : request.trailers) {
+    checksum |= name == "grpc-like-checksum" && value == "abc123";
+  }
+  require(checksum, "the request trailers were not delivered");
+
+  require(engine.submit_response(stream_id, 200, {}, "ok", {}),
+          "the response after trailers was not accepted");
+  pump(client, engine);
+  require(client.streams[stream_id].status == 200,
+          "the trailered request was not answered");
+}
+
 void test_reset_stream_reaches_the_client() {
   RecordingHost host;
   H2Engine engine{host, H2Settings{}};
@@ -410,6 +492,7 @@ int main() {
   try {
     test_get_round_trip_with_trailers();
     test_withheld_window_stalls_the_sender_until_consume();
+    test_request_trailers_complete_the_request();
     test_reset_stream_reaches_the_client();
     test_client_reset_surfaces_as_cancellation();
     test_max_concurrent_streams_gates_a_compliant_client();

--- a/extensions/web/tests/test_h2_loopback.cpp
+++ b/extensions/web/tests/test_h2_loopback.cpp
@@ -1,0 +1,414 @@
+// The HTTP/2 loopback oracle (RFC 0024, HTTP/2 activation plan): the
+// extension's curl client — pinned H2Only — calls the extension's own
+// server over TLS with ALPN ["h2", "http/1.1"] on 127.0.0.1.  A completed
+// call therefore proves the ALPN dispatch, the nghttp2 session, header and
+// trailer round-trips, and the reservation-mapped flow control end to end;
+// the second call streams a body larger than the h2 stream window to
+// exercise incremental admission.
+
+#include <hgraph/web/service.h>
+#include <hgraph/web/value_builders.h>
+
+#include <hgraph/lib/std/operators/conversion.h>
+#include <hgraph/lib/std/operators/registration.h>
+#include <hgraph/lib/std/std_nodes.h>
+#include <hgraph/lib/testing/runtime_support.h>
+#include <hgraph/runtime/runtime.h>
+#include <hgraph/util/scope.h>
+
+#include <atomic>
+#include <chrono>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace {
+using namespace hgraph;
+using namespace hgraph::web;
+using namespace hgraph::testing;
+using namespace std::chrono_literals;
+
+void require(bool condition, std::string message) {
+  if (!condition) {
+    throw std::runtime_error(std::move(message));
+  }
+}
+
+// A 100-year self-signed certificate for 127.0.0.1/localhost, generated
+// once for this suite; the client disables verification, so nothing
+// depends on its trust chain.
+constexpr const char *kTestCertPem = R"pem(-----BEGIN CERTIFICATE-----
+MIIDJzCCAg+gAwIBAgIUcNava/ilBlFAAby854h6n3WklcYwDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJMTI3LjAuMC4xMCAXDTI2MDgxNzEwNTEyM1oYDzIxMjYw
+NzI0MTA1MTIzWjAUMRIwEAYDVQQDDAkxMjcuMC4wLjEwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCR/ul5caZPxNee1TPZRkgzwPgHpsJAMchsAmRnkRXm
+YGnzIvP7VZHFODj5nud2j/GCqBAxSCCbkLPfobnndehiCx40XEgpePsEDI7wnH6g
+bO51I2ENAXodKE0y9Lq8WtEFyzKFbD73HUoNX8xv+KQjDxoQUpvgnXLBo0U/WJJJ
+aUO1n1pAkEOMrNIj1Oda0JL6El+TbHJznRcfNh/RSKMDDYXrVXzFXt02I6dYvMKO
+FVwTrBC9/bKr2WAvUNU2ugzYueVAkm24buMawgqxMbFSokJmVVj6LQz5SVheUZjs
+4Rg1ASSvDs9FYAyFcAQ5X5ps4SZJa6lWhnobupq7mXj7AgMBAAGjbzBtMB0GA1Ud
+DgQWBBSxRx4oz39xyLrEtzTDhqwQCaaE/TAfBgNVHSMEGDAWgBSxRx4oz39xyLrE
+tzTDhqwQCaaE/TAPBgNVHRMBAf8EBTADAQH/MBoGA1UdEQQTMBGHBH8AAAGCCWxv
+Y2FsaG9zdDANBgkqhkiG9w0BAQsFAAOCAQEAf4R9Aekow3u747bg7c33t9rI0/7w
+RXGDOwb8JifIE420J6miDiFoWHwXmb1/pu+Ti+VsDYUsj6nkTXLYnO9tdDp71G6T
+wHa7e7bDA0fBfWvDGJMq+9SK76ZOf6gD26JEN86ejbY/YKymzRF5+Q/Njj+WjfGt
+IozucryoCL/TPpQW4W846THj6Jb6ePhfb8J65vxhU5e05Nn0Zv3KmJIg854kKFzE
+9DmMw+yRBc7+sgkidrC3Z43CJ2UqStxTeh7ObnTayPUUou6EEbZrAYfGW3XYI1xe
+/uMQ3iaGE08aFv7q8mjRN73rcvvqabBfqDcHGf93rUbCyh8HrPC6eLgSKQ==
+-----END CERTIFICATE-----
+)pem";
+
+constexpr const char *kTestKeyPem = R"pem(-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCR/ul5caZPxNee
+1TPZRkgzwPgHpsJAMchsAmRnkRXmYGnzIvP7VZHFODj5nud2j/GCqBAxSCCbkLPf
+obnndehiCx40XEgpePsEDI7wnH6gbO51I2ENAXodKE0y9Lq8WtEFyzKFbD73HUoN
+X8xv+KQjDxoQUpvgnXLBo0U/WJJJaUO1n1pAkEOMrNIj1Oda0JL6El+TbHJznRcf
+Nh/RSKMDDYXrVXzFXt02I6dYvMKOFVwTrBC9/bKr2WAvUNU2ugzYueVAkm24buMa
+wgqxMbFSokJmVVj6LQz5SVheUZjs4Rg1ASSvDs9FYAyFcAQ5X5ps4SZJa6lWhnob
+upq7mXj7AgMBAAECggEAAL/wjZy+gSQrN3GR20vlq8LnXur0jjqTOLBhQY6BJ+vB
+s824Hce/4rrm0d71vhTEKci2cArjFZUsOfninTm5OQbgUsz7dPTvMq31bl3FPvlV
+krPUgswWguPjmEWynDTShlDb7jHy812ZxlLO/asE7IHV2O5YedrtrXGALV+JtMmI
+uDviZONYad/xzVUYwdft77koeKjZGnJQJitTr86AMKOpKixwtSOo/8fMXBjC4dTT
+GWgfcxXorTDEUiiX3GvPgSEqRBxAkZ2epe1hdmO5rhZcry11tetupOq7tsHroASp
+3zhwPtd17te/vSeMoUvrwZcn0cBFP+wKDfKgOC4E7QKBgQDCxhJyXPnlGbJBCk6t
+OVJA6moRRjH62CbsC2WPjiL0z7P2NBezCuYqOUPXXsh+2TrHKfwQuj9Mv8HTonJB
+ZzyZVnhwiPchM/CC1hK1ps6eHbOeu9jrbXlmaDYVPUAHhRJzA+aBoo3RCB7eVUd4
+6qnUyGszXTP63daWnYQu8MudvQKBgQC/444NAMPnUgZmPlbfoxAYq5BTNPmjxzXS
+rmQu2hBpNQKLDMG+sIgpSMlK8ojn9Ko1Td61y/8Ub0qndPmkADeBWNMxxpoy/Cxv
+EI9x0JBN8UfoPnG2TllQ9ZiM6qH4/4jaXxahq2SkJ1ZJ+TmehCsYiqQv8eeP5m2H
+kaySEpPRFwKBgQCVQIrqL+0ebe52gJuBiidJr1fQHOY3vmM1BhaxRs3qoy7YP1rZ
+zERLns4pv2wMKBIuhDGv78iJ23d/4T+EdsOtDOIF+i7FtrNazwhPQp+Z8lCuFmxH
+HACnRLwM0n66RHK6yAZe2F2sDHj7DoZSViAF+f6LwaQPXOcPS2z7O3IMUQKBgCA7
+2IPkqgP0qnCIbk149d4/C6p+jqTtdOQkOV4JcZJKvlefV/hxbR4KRQ4a+daFKgZ0
+Q0Ikt3+2RkMlCj57bteClU+aPhLse4ZYsM/8qhD9xAeGXdGzDZvk9bBORdEvE80j
+Bgk4YlqU5RDeFcjECP1BZN1M9Ioeui140hVjm4MXAoGAeVrFpOGVToOedj3SG+4k
+UP85yV64d10flGkxbCCaEEV8gOjoG3YWh+r0oeIGVFUOi9TzbwI9xYJb154/+dOi
+ljQAIYegDzbgnKbPvtbj35Dy07fljW3WYT3fzH70nB3YieivDx2JXqp+DZ8AAnSc
+8n8PFd6yOYtIC1rQQ0aqWag=
+-----END PRIVATE KEY-----
+)pem";
+
+constexpr std::size_t kBigBodyBytes = 2 * 1024 * 1024;
+
+inline std::atomic<bool> get_triggered{false};
+inline std::atomic<bool> post_triggered{false};
+inline std::atomic<bool> get_response_seen{false};
+inline std::atomic<bool> post_response_seen{false};
+inline std::atomic<bool> failure_seen{false};
+inline std::atomic<Int> bound_port{0};
+inline Value observed_get_response{};
+inline Value observed_post_response{};
+inline Value observed_failure{};
+inline Value observed_server_peer{};
+
+void release_test_state() {
+  observed_get_response = Value{};
+  observed_post_response = Value{};
+  observed_failure = Value{};
+  observed_server_peer = Value{};
+}
+
+void maybe_stop(NodeView &node) {
+  if ((get_response_seen.load() && post_response_seen.load()) ||
+      failure_seen.load()) {
+    node.graph().executor().request_stop();
+  }
+}
+
+struct H2GetTrigger {
+  static constexpr auto name = "web_h2_loopback_get_trigger";
+
+  static void eval(In<"stats", TS<WebServerStats>, InputValidity::Unchecked>
+                       stats,
+                   Out<TS<HttpClientRequest>> out) {
+    if (!stats.valid() || !stats.modified() || get_triggered.load()) {
+      return;
+    }
+    const Int port = stats.base()
+                         .value()
+                         .as_bundle()
+                         .at("listening_port")
+                         .checked_as<Int>();
+    if (port == 0) {
+      return;
+    }
+    bound_port.store(port);
+    get_triggered.store(true);
+    const Value request = make_client_request(
+        HttpMethod::Get,
+        Str{"https://127.0.0.1:" + std::to_string(port) + "/h2/answer"});
+    out.apply(request.view());
+  }
+};
+
+struct H2GetCapture {
+  static constexpr auto name = "web_h2_loopback_get_capture";
+
+  static void eval(NodeView node,
+                   In<"result", HttpCallResult, InputValidity::Unchecked>
+                       result,
+                   Out<TS<HttpClientRequest>> out) {
+    auto failure = result.template field<"failure">();
+    if (failure.valid() && failure.modified()) {
+      observed_failure = failure.base().value().clone();
+      failure_seen.store(true);
+      maybe_stop(node);
+      return;
+    }
+    auto response = result.template field<"response">();
+    if (!response.valid() || !response.modified()) {
+      return;
+    }
+    observed_get_response = response.base().value().clone();
+    get_response_seen.store(true);
+    if (!post_triggered.exchange(true)) {
+      // Chain the streaming call: a body larger than the h2 stream window
+      // exercises the consume-gated flow control end to end.
+      const Value request = make_client_request(
+          HttpMethod::Post,
+          Str{"https://127.0.0.1:" + std::to_string(bound_port.load()) +
+              "/h2-ingest"},
+          {}, Bytes{std::string(kBigBodyBytes, 'z')});
+      out.apply(request.view());
+    }
+    maybe_stop(node);
+  }
+};
+
+struct H2PostCapture {
+  static constexpr auto name = "web_h2_loopback_post_capture";
+
+  static void eval(NodeView node,
+                   In<"result", HttpCallResult, InputValidity::Unchecked>
+                       result) {
+    auto failure = result.template field<"failure">();
+    if (failure.valid() && failure.modified()) {
+      observed_failure = failure.base().value().clone();
+      failure_seen.store(true);
+      maybe_stop(node);
+      return;
+    }
+    auto response = result.template field<"response">();
+    if (response.valid() && response.modified()) {
+      observed_post_response = response.base().value().clone();
+      post_response_seen.store(true);
+    }
+    maybe_stop(node);
+  }
+};
+
+struct H2AnswerId {
+  static constexpr auto name = "web_h2_loopback_answer_id";
+
+  static void eval(In<"routed", WebRouteOutput, InputValidity::Unchecked>
+                       routed,
+                   Out<TS<Int>> out) {
+    auto request = routed.template field<"request">();
+    if (request.valid() && request.modified()) {
+      const auto fields = request.base().value().as_bundle();
+      observed_server_peer = fields.at("peer").clone();
+      out.apply(fields.at("request_id"));
+    }
+  }
+};
+
+struct H2AnswerResponse {
+  static constexpr auto name = "web_h2_loopback_answer_response";
+
+  static void eval(In<"routed", WebRouteOutput, InputValidity::Unchecked>
+                       routed,
+                   Out<TS<HttpResponse>> out) {
+    auto request = routed.template field<"request">();
+    if (request.valid() && request.modified()) {
+      const auto name_param = request.base()
+                                  .value()
+                                  .as_bundle()
+                                  .at("request")
+                                  .as_bundle()
+                                  .at("path_params");
+      Str captured{};
+      for (const auto param : name_param.as_list()) {
+        captured = param.as_bundle().at("value").checked_as<Str>();
+      }
+      const Value response = make_response(
+          Int{200}, {{Str{"x-served-by"}, Str{"h2-loopback"}}},
+          Bytes{"hi " + std::string{captured}},
+          {{Str{"x-trail"}, Str{"h2-checksum"}}});
+      out.apply(response.view());
+    }
+  }
+};
+
+struct H2IngestId {
+  static constexpr auto name = "web_h2_loopback_ingest_id";
+
+  static void eval(In<"routed", WebRouteOutput, InputValidity::Unchecked>
+                       routed,
+                   Out<TS<Int>> out) {
+    auto request = routed.template field<"request">();
+    if (request.valid() && request.modified()) {
+      out.apply(request.base().value().as_bundle().at("request_id"));
+    }
+  }
+};
+
+struct H2IngestResponse {
+  static constexpr auto name = "web_h2_loopback_ingest_response";
+
+  static void eval(In<"routed", WebRouteOutput, InputValidity::Unchecked>
+                       routed,
+                   Out<TS<HttpResponse>> out) {
+    auto request = routed.template field<"request">();
+    if (request.valid() && request.modified()) {
+      const auto body = request.base()
+                            .value()
+                            .as_bundle()
+                            .at("request")
+                            .as_bundle()
+                            .at("body")
+                            .checked_as<Bytes>();
+      const Value response = make_response(
+          Int{200}, {}, Bytes{std::to_string(body.data.size())});
+      out.apply(response.view());
+    }
+  }
+};
+
+struct H2LoopbackGraph {
+  static constexpr auto name = "web_h2_loopback_test_graph";
+
+  static void compose(Wiring &w) {
+    const auto server_path = service::path("web-h2-server");
+    const auto client_path = service::path("web-h2-client");
+    register_server(w, server_path,
+                    server_config()
+                        .port(0)
+                        .request_timeout(5'000ms)
+                        .stats_interval(50ms)
+                        .tls(tls_server()
+                                 .cert_pem(Str{kTestCertPem})
+                                 .key_pem(Str{kTestKeyPem})
+                                 .alpn({Str{"h2"}, Str{"http/1.1"}})
+                                 .build())
+                        .build());
+    register_client(w, client_path,
+                    client_config()
+                        .http_version_policy(WebHttpVersionPolicy::H2Only)
+                        .tls(tls_client()
+                                 .verify_peer(false)
+                                 .verify_host(false)
+                                 .build())
+                        .build());
+
+    auto stats = server_stats(w, server_path);
+
+    auto answer_route = wire<stdlib::const_, TS<WebRoute>>(
+        w, make_route(HttpMethod::Get, "/h2/{name}"));
+    auto answered = serve(w, server_path, answer_route);
+    auto answer_id = wire<H2AnswerId>(w, answered).as<TS<Int>>();
+    auto answer_response =
+        wire<H2AnswerResponse>(w, answered).as<TS<HttpResponse>>();
+    static_cast<void>(respond(
+        w, server_path, respond_request(w, answer_id, answer_response)));
+
+    auto ingest_route = wire<stdlib::const_, TS<WebRoute>>(
+        w, make_route(HttpMethod::Post, "/h2-ingest"));
+    auto ingested = serve(w, server_path, ingest_route);
+    auto ingest_id = wire<H2IngestId>(w, ingested).as<TS<Int>>();
+    auto ingest_response =
+        wire<H2IngestResponse>(w, ingested).as<TS<HttpResponse>>();
+    static_cast<void>(respond(
+        w, server_path, respond_request(w, ingest_id, ingest_response)));
+
+    auto get_request =
+        wire<H2GetTrigger>(w, stats).as<TS<HttpClientRequest>>();
+    auto get_result =
+        http_request(w, client_path, http_client_call(w, get_request));
+    auto post_request =
+        wire<H2GetCapture>(w, get_result).as<TS<HttpClientRequest>>();
+    auto post_result =
+        http_request(w, client_path, http_client_call(w, post_request));
+    static_cast<void>(wire<H2PostCapture>(w, post_result));
+  }
+};
+
+} // namespace
+
+int main() {
+  try {
+    hgraph::stdlib::register_standard_operators();
+    const auto release_state = hgraph::make_scope_exit(release_test_state);
+    register_web_types();
+
+    const DateTime start = wall_now();
+    GraphExecutorBuilder executor_builder;
+    executor_builder.graph_builder(build_graph<H2LoopbackGraph>())
+        .mode(GraphExecutorMode::RealTime)
+        .start_time(start)
+        .end_time(start + TimeDelta{30'000'000});
+    auto executor = executor_builder.make_executor();
+    auto view = executor.view();
+    {
+      AsyncGraphExecutorRun runner{view};
+      runner.join();
+    }
+
+    require(!failure_seen.load(),
+            std::string{"a call took the transport-failure arm"} +
+                (observed_failure.has_value()
+                     ? ": " + std::string{observed_failure.view()
+                                              .as_bundle()
+                                              .at("message")
+                                              .checked_as<Str>()}
+                     : ""));
+    require(get_response_seen.load(), "the h2 GET did not complete");
+    const auto response = observed_get_response.view().as_bundle();
+    require(response.at("status").checked_as<Int>() == Int{200},
+            "the h2 GET status was not 200");
+    require(response.at("body").checked_as<Bytes>().data == "hi answer",
+            "the h2 GET body (path capture) did not round-trip");
+    bool served_by = false;
+    bool trailer = false;
+    // curl surfaces h2 trailers through the same header callback as
+    // headers, so the trailer may arrive on either field.
+    for (const auto field_name : {"headers", "trailers"}) {
+      const auto entries = response.at(field_name);
+      if (entries.data() == nullptr) {
+        continue;
+      }
+      for (const auto entry : entries.as_list()) {
+        const auto pair = entry.as_bundle();
+        const auto name = pair.at("name").checked_as<Str>();
+        const auto value = pair.at("value").checked_as<Str>();
+        served_by |= name == Str{"x-served-by"} && value == Str{"h2-loopback"};
+        trailer |= name == Str{"x-trail"} && value == Str{"h2-checksum"};
+      }
+    }
+    require(served_by, "the h2 response header did not round-trip");
+    require(trailer, "the h2 response trailer did not round-trip");
+
+    const auto peer = observed_server_peer.view().as_bundle();
+    require(peer.at("negotiated_protocol").checked_as<Str>() == Str{"h2"},
+            "the server-side peer did not record the h2 negotiation");
+    require(peer.at("tls").checked_as<Bool>(),
+            "the server-side peer did not record TLS");
+
+    require(post_response_seen.load(), "the h2 POST did not complete");
+    const auto post = observed_post_response.view().as_bundle();
+    require(post.at("status").checked_as<Int>() == Int{200},
+            "the h2 POST status was not 200");
+    require(post.at("body").checked_as<Bytes>().data ==
+                std::to_string(kBigBodyBytes),
+            "the h2 POST body was not delivered intact");
+
+    release_test_state();
+  } catch (const std::exception &error) {
+    release_test_state();
+    std::cerr << "hgraph_web_h2_loopback_tests failed: " << error.what()
+              << "\n";
+    return 1;
+  }
+  std::cout << "hgraph_web_h2_loopback_tests passed\n";
+  return 0;
+}

--- a/extensions/web/tests/test_h2_loopback.cpp
+++ b/extensions/web/tests/test_h2_loopback.cpp
@@ -16,18 +16,31 @@
 #include <hgraph/runtime/runtime.h>
 #include <hgraph/util/scope.h>
 
+#include <boost/asio/connect.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/ssl.hpp>
+#include <nghttp2/nghttp2.h>
+
+#include <array>
 #include <atomic>
 #include <chrono>
+#include <cstring>
 #include <iostream>
+#include <map>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <utility>
+#include <vector>
 
 namespace {
 using namespace hgraph;
 using namespace hgraph::web;
 using namespace hgraph::testing;
 using namespace std::chrono_literals;
+
+namespace asio = boost::asio;
+using tcp = asio::ip::tcp;
 
 void require(bool condition, std::string message) {
   if (!condition) {
@@ -91,6 +104,311 @@ ljQAIYegDzbgnKbPvtbj35Dy07fljW3WYT3fzH70nB3YieivDx2JXqp+DZ8AAnSc
 
 constexpr std::size_t kBigBodyBytes = 2 * 1024 * 1024;
 
+struct RawH2Stream {
+  int status{};
+  std::string body{};
+  bool closed{};
+  std::uint32_t error_code{};
+};
+
+/** A deliberately small synchronous nghttp2/TLS client used only for the
+ * discard regression below.  It can keep one request open while another
+ * sends DATA plus trailers, which the public HTTP client call shape cannot
+ * express. */
+class RawH2Client {
+public:
+  struct RequestBody {
+    std::string payload{};
+    std::size_t offset{};
+    std::vector<std::pair<std::string, std::string>> trailers{};
+    bool trailers_submitted{};
+  };
+
+  explicit RawH2Client(int port)
+      : context_{asio::ssl::context::tls_client}, stream_{io_, context_} {
+    context_.set_verify_mode(asio::ssl::verify_none);
+    const std::array<unsigned char, 3> alpn{{2, 'h', '2'}};
+    require(SSL_set_alpn_protos(stream_.native_handle(), alpn.data(),
+                                static_cast<unsigned int>(alpn.size())) == 0,
+            "failed to configure raw-client ALPN");
+    tcp::resolver resolver{io_};
+    asio::connect(stream_.next_layer(),
+                  resolver.resolve("127.0.0.1", std::to_string(port)));
+    stream_.handshake(asio::ssl::stream_base::client);
+    const unsigned char *selected = nullptr;
+    unsigned int selected_length = 0;
+    SSL_get0_alpn_selected(stream_.native_handle(), &selected,
+                           &selected_length);
+    require(selected_length == 2 && std::memcmp(selected, "h2", 2) == 0,
+            "raw client did not negotiate h2");
+
+    nghttp2_session_callbacks *callbacks = nullptr;
+    require(nghttp2_session_callbacks_new(&callbacks) == 0,
+            "raw client callback allocation failed");
+    nghttp2_session_callbacks_set_on_header_callback(
+        callbacks,
+        [](nghttp2_session *, const nghttp2_frame *frame, const uint8_t *name,
+           std::size_t name_length, const uint8_t *value,
+           std::size_t value_length, uint8_t, void *user_data) -> int {
+          auto &stream = static_cast<RawH2Client *>(user_data)
+                             ->streams_[frame->hd.stream_id];
+          const std::string_view header_name{
+              reinterpret_cast<const char *>(name), name_length};
+          if (header_name == ":status") {
+            stream.status = std::stoi(std::string{
+                reinterpret_cast<const char *>(value), value_length});
+          }
+          return 0;
+        });
+    nghttp2_session_callbacks_set_on_data_chunk_recv_callback(
+        callbacks,
+        [](nghttp2_session *, uint8_t, std::int32_t stream_id,
+           const uint8_t *data, std::size_t length, void *user_data) -> int {
+          static_cast<RawH2Client *>(user_data)
+              ->streams_[stream_id]
+              .body.append(reinterpret_cast<const char *>(data), length);
+          return 0;
+        });
+    nghttp2_session_callbacks_set_on_stream_close_callback(
+        callbacks,
+        [](nghttp2_session *, std::int32_t stream_id, std::uint32_t error_code,
+           void *user_data) -> int {
+          auto &stream =
+              static_cast<RawH2Client *>(user_data)->streams_[stream_id];
+          stream.closed = true;
+          stream.error_code = error_code;
+          return 0;
+        });
+    nghttp2_session_callbacks_set_on_frame_recv_callback(
+        callbacks,
+        [](nghttp2_session *, const nghttp2_frame *frame,
+           void *user_data) -> int {
+          if (frame->hd.type == NGHTTP2_SETTINGS &&
+              (frame->hd.flags & NGHTTP2_FLAG_ACK) == 0) {
+            static_cast<RawH2Client *>(user_data)->settings_seen_ = true;
+          }
+          return 0;
+        });
+    require(nghttp2_session_client_new(&session_, callbacks, this) == 0,
+            "raw client session allocation failed");
+    nghttp2_session_callbacks_del(callbacks);
+    require(nghttp2_submit_settings(session_, NGHTTP2_FLAG_NONE, nullptr, 0) ==
+                0,
+            "raw client SETTINGS submission failed");
+    stream_.next_layer().non_blocking(true);
+  }
+
+  ~RawH2Client() {
+    if (session_ != nullptr) {
+      nghttp2_session_del(session_);
+    }
+  }
+
+  RawH2Client(const RawH2Client &) = delete;
+  RawH2Client &operator=(const RawH2Client &) = delete;
+
+  void exchange_settings() {
+    pump_until([this] { return settings_seen_; },
+               "the server SETTINGS did not arrive");
+    flush_output(); // the automatically generated SETTINGS ACK
+  }
+
+  [[nodiscard]] std::int32_t submit_open_request(std::string_view path) {
+    auto headers = request_headers("POST", path);
+    const std::int32_t stream_id =
+        nghttp2_submit_headers(session_, NGHTTP2_FLAG_END_HEADERS, -1, nullptr,
+                               headers.data(), headers.size(), nullptr);
+    require(stream_id > 0, "open request submission failed");
+    streams_.try_emplace(stream_id);
+    return stream_id;
+  }
+
+  [[nodiscard]] std::int32_t submit_request(std::string_view path,
+                                            RequestBody &body) {
+    auto headers = request_headers("POST", path);
+    nghttp2_data_provider2 provider{};
+    provider.source.ptr = &body;
+    provider.read_callback =
+        [](nghttp2_session *session, std::int32_t stream_id, uint8_t *buffer,
+           std::size_t length, std::uint32_t *data_flags,
+           nghttp2_data_source *source, void *) -> nghttp2_ssize {
+      auto &request = *static_cast<RequestBody *>(source->ptr);
+      const std::size_t remaining = request.payload.size() - request.offset;
+      const std::size_t take = std::min(remaining, length);
+      std::memcpy(buffer, request.payload.data() + request.offset, take);
+      request.offset += take;
+      if (request.offset == request.payload.size()) {
+        *data_flags |= NGHTTP2_DATA_FLAG_EOF;
+        if (!request.trailers.empty() && !request.trailers_submitted) {
+          *data_flags |= NGHTTP2_DATA_FLAG_NO_END_STREAM;
+          request.trailers_submitted = true;
+          std::vector<nghttp2_nv> trailers;
+          trailers.reserve(request.trailers.size());
+          for (const auto &[name, value] : request.trailers) {
+            trailers.push_back(make_nv(name, value));
+          }
+          if (nghttp2_submit_trailer(session, stream_id, trailers.data(),
+                                     trailers.size()) != 0) {
+            return NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE;
+          }
+        }
+      }
+      return static_cast<nghttp2_ssize>(take);
+    };
+    const std::int32_t stream_id = nghttp2_submit_request2(
+        session_, nullptr, headers.data(), headers.size(), &provider, nullptr);
+    require(stream_id > 0, "raw request submission failed");
+    streams_.try_emplace(stream_id);
+    return stream_id;
+  }
+
+  void reset(std::int32_t stream_id) {
+    require(nghttp2_submit_rst_stream(session_, NGHTTP2_FLAG_NONE, stream_id,
+                                      NGHTTP2_CANCEL) == 0,
+            "raw client reset submission failed");
+  }
+
+  [[nodiscard]] const RawH2Stream &stream(std::int32_t stream_id) const {
+    return streams_.at(stream_id);
+  }
+
+  [[nodiscard]] std::int32_t connection_window() const {
+    return nghttp2_session_get_remote_window_size(session_);
+  }
+
+  template <typename Predicate>
+  void pump_until(Predicate predicate, std::string_view failure) {
+    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    while (std::chrono::steady_clock::now() < deadline) {
+      flush_output();
+      bool progressed = false;
+      while (read_input()) {
+        progressed = true;
+      }
+      if (predicate()) {
+        flush_output();
+        return;
+      }
+      if (!progressed) {
+        std::this_thread::sleep_for(1ms);
+      }
+    }
+    throw std::runtime_error(std::string{failure});
+  }
+
+private:
+  [[nodiscard]] static nghttp2_nv make_nv(std::string_view name,
+                                          std::string_view value) {
+    return nghttp2_nv{
+        reinterpret_cast<uint8_t *>(const_cast<char *>(name.data())),
+        reinterpret_cast<uint8_t *>(const_cast<char *>(value.data())),
+        name.size(), value.size(), NGHTTP2_NV_FLAG_NONE};
+  }
+
+  [[nodiscard]] static std::array<nghttp2_nv, 4>
+  request_headers(std::string_view method, std::string_view path) {
+    return {make_nv(":method", method), make_nv(":scheme", "https"),
+            make_nv(":authority", "127.0.0.1"), make_nv(":path", path)};
+  }
+
+  void flush_output() {
+    while (true) {
+      const uint8_t *bytes = nullptr;
+      const nghttp2_ssize length = nghttp2_session_mem_send2(session_, &bytes);
+      require(length >= 0, "raw client failed to encode output");
+      if (length == 0) {
+        return;
+      }
+      stream_.next_layer().non_blocking(false);
+      boost::system::error_code ec;
+      asio::write(stream_,
+                  asio::buffer(bytes, static_cast<std::size_t>(length)), ec);
+      stream_.next_layer().non_blocking(true);
+      require(!ec, "raw client TLS write failed: " + ec.message());
+    }
+  }
+
+  [[nodiscard]] bool read_input() {
+    boost::system::error_code ec;
+    const std::size_t available = stream_.next_layer().available(ec);
+    require(!ec, "raw client socket query failed: " + ec.message());
+    if (available == 0 && SSL_pending(stream_.native_handle()) == 0) {
+      return false;
+    }
+    std::array<char, 16 * 1024> buffer{};
+    const std::size_t received = stream_.read_some(asio::buffer(buffer), ec);
+    if (ec == asio::error::would_block || ec == asio::error::try_again) {
+      return false;
+    }
+    require(!ec, "raw client TLS read failed: " + ec.message());
+    const nghttp2_ssize processed = nghttp2_session_mem_recv2(
+        session_, reinterpret_cast<const uint8_t *>(buffer.data()), received);
+    require(processed >= 0 && static_cast<std::size_t>(processed) == received,
+            "raw client rejected server HTTP/2 bytes");
+    return received != 0;
+  }
+
+  asio::io_context io_{};
+  asio::ssl::context context_;
+  asio::ssl::stream<tcp::socket> stream_;
+  nghttp2_session *session_{};
+  std::map<std::int32_t, RawH2Stream> streams_{};
+  bool settings_seen_{};
+};
+
+void test_rejected_stream_restores_connection_window(int port) {
+  RawH2Client client{port};
+  client.exchange_settings();
+
+  // Stream 1 owns the only ingress record without completing.  Stream 3 is
+  // therefore backpressured: its DATA remains unconsumed when a large trailer
+  // block crosses the one-window metadata bound and forces a reset.
+  const std::int32_t holding =
+      client.submit_open_request("/h2-discard-probe");
+  // More than one default 65,535-byte connection window in aggregate: a
+  // driver that drops each stream's 3000-byte credit eventually wedges,
+  // while the correct consume path periodically emits WINDOW_UPDATE.
+  for (int attempt = 0; attempt != 24; ++attempt) {
+    RawH2Client::RequestBody rejected_body{
+        std::string(3000, 'r'),
+        0,
+        {{"x-overflow", std::string(2000, 't')}},
+        false};
+    const std::int32_t rejected =
+        client.submit_request("/h2-discard-probe", rejected_body);
+    client.pump_until([&] { return client.stream(rejected).closed; },
+                      "a trailer-overflow stream was not reset");
+    require(client.stream(rejected).error_code == NGHTTP2_ENHANCE_YOUR_CALM,
+            "a trailer-overflow stream used the wrong reset code");
+  }
+
+  client.reset(holding);
+  client.pump_until([&] { return client.stream(holding).closed; },
+                    "the holding stream did not reset");
+
+  // The rejected streams consumed more than the whole connection window.
+  // This complete request can reach dispatch only if every discard returned
+  // its credit; the deliberately unanswered route then produces the timeout
+  // 503 that proves dispatch completed.
+  RawH2Client::RequestBody recovery{std::string(3000, 'g')};
+  const std::int32_t recovered =
+      client.submit_request("/h2-discard-probe", recovery);
+  try {
+    client.pump_until([&] { return client.stream(recovered).closed; },
+                      "the connection window was not restored after discard");
+  } catch (const std::runtime_error &) {
+    throw std::runtime_error(
+        "the recovery stream stalled (sent=" + std::to_string(recovery.offset) +
+        ", window=" + std::to_string(client.connection_window()) +
+        ", status=" + std::to_string(client.stream(recovered).status) +
+        ", body='" + client.stream(recovered).body + "')");
+  }
+  require(client.stream(recovered).error_code == NGHTTP2_NO_ERROR,
+          "the recovery stream did not close cleanly");
+  require(client.stream(recovered).status == 503,
+          "the recovery request did not reach the dispatch timeout");
+}
+
 inline std::atomic<bool> get_triggered{false};
 inline std::atomic<bool> post_triggered{false};
 inline std::atomic<bool> status_triggered{false};
@@ -98,6 +416,7 @@ inline std::atomic<bool> get_response_seen{false};
 inline std::atomic<bool> post_response_seen{false};
 inline std::atomic<bool> status_response_seen{false};
 inline std::atomic<bool> failure_seen{false};
+inline std::atomic<bool> raw_rejection_complete{false};
 inline std::atomic<Int> bound_port{0};
 inline Value observed_get_response{};
 inline Value observed_post_response{};
@@ -114,8 +433,8 @@ void release_test_state() {
 }
 
 void maybe_stop(NodeView &node) {
-  if ((get_response_seen.load() && post_response_seen.load() &&
-       status_response_seen.load()) ||
+  if ((raw_rejection_complete.load() && get_response_seen.load() &&
+       post_response_seen.load() && status_response_seen.load()) ||
       failure_seen.load()) {
     node.graph().executor().request_stop();
   }
@@ -139,6 +458,9 @@ struct H2GetTrigger {
       return;
     }
     bound_port.store(port);
+    if (!raw_rejection_complete.load()) {
+      return;
+    }
     get_triggered.store(true);
     const Value request = make_client_request(
         HttpMethod::Get,
@@ -328,6 +650,13 @@ struct H2IngestResponse {
   }
 };
 
+struct H2DiscardProbeSink {
+  static constexpr auto name = "web_h2_discard_probe_sink";
+
+  static void
+  eval(In<"routed", WebRouteOutput, InputValidity::Unchecked>) {}
+};
+
 struct H2LoopbackGraph {
   static constexpr auto name = "web_h2_loopback_test_graph";
 
@@ -337,7 +666,9 @@ struct H2LoopbackGraph {
     register_server(w, server_path,
                     server_config()
                         .port(0)
-                        .request_timeout(5'000ms)
+                        .request_timeout(500ms)
+                        .ingress_limits(1, 64 * 1024 * 1024)
+                        .h2_initial_window_bytes(4096)
                         .stats_interval(50ms)
                         .tls(tls_server()
                                  .cert_pem(Str{kTestCertPem})
@@ -373,6 +704,11 @@ struct H2LoopbackGraph {
         wire<H2IngestResponse>(w, ingested).as<TS<HttpResponse>>();
     static_cast<void>(respond(
         w, server_path, respond_request(w, ingest_id, ingest_response)));
+
+    auto discard_probe_route = wire<stdlib::const_, TS<WebRoute>>(
+        w, make_route(HttpMethod::Post, "/h2-discard-probe"));
+    static_cast<void>(wire<H2DiscardProbeSink>(
+        w, serve(w, server_path, discard_probe_route)));
 
     auto status_route = wire<stdlib::const_, TS<WebRoute>>(
         w, make_route(HttpMethod::Get, "/h2-status"));
@@ -417,7 +753,23 @@ int main() {
     auto view = executor.view();
     {
       AsyncGraphExecutorRun runner{view};
-      runner.join();
+      try {
+        const auto deadline = std::chrono::steady_clock::now() + 5s;
+        while (bound_port.load() == 0 &&
+               std::chrono::steady_clock::now() < deadline) {
+          std::this_thread::sleep_for(10ms);
+        }
+        require(bound_port.load() != 0,
+                "the h2 server did not report its listening port");
+        test_rejected_stream_restores_connection_window(
+            static_cast<int>(bound_port.load()));
+        raw_rejection_complete.store(true);
+        runner.join();
+      } catch (...) {
+        view.request_stop();
+        runner.join();
+        throw;
+      }
     }
 
     require(!failure_seen.load(),

--- a/extensions/web/tests/test_h2_loopback.cpp
+++ b/extensions/web/tests/test_h2_loopback.cpp
@@ -93,24 +93,29 @@ constexpr std::size_t kBigBodyBytes = 2 * 1024 * 1024;
 
 inline std::atomic<bool> get_triggered{false};
 inline std::atomic<bool> post_triggered{false};
+inline std::atomic<bool> status_triggered{false};
 inline std::atomic<bool> get_response_seen{false};
 inline std::atomic<bool> post_response_seen{false};
+inline std::atomic<bool> status_response_seen{false};
 inline std::atomic<bool> failure_seen{false};
 inline std::atomic<Int> bound_port{0};
 inline Value observed_get_response{};
 inline Value observed_post_response{};
+inline Value observed_status_response{};
 inline Value observed_failure{};
 inline Value observed_server_peer{};
 
 void release_test_state() {
   observed_get_response = Value{};
   observed_post_response = Value{};
+  observed_status_response = Value{};
   observed_failure = Value{};
   observed_server_peer = Value{};
 }
 
 void maybe_stop(NodeView &node) {
-  if ((get_response_seen.load() && post_response_seen.load()) ||
+  if ((get_response_seen.load() && post_response_seen.load() &&
+       status_response_seen.load()) ||
       failure_seen.load()) {
     node.graph().executor().request_stop();
   }
@@ -181,6 +186,38 @@ struct H2PostCapture {
 
   static void eval(NodeView node,
                    In<"result", HttpCallResult, InputValidity::Unchecked>
+                       result,
+                   Out<TS<HttpClientRequest>> out) {
+    auto failure = result.template field<"failure">();
+    if (failure.valid() && failure.modified()) {
+      observed_failure = failure.base().value().clone();
+      failure_seen.store(true);
+      maybe_stop(node);
+      return;
+    }
+    auto response = result.template field<"response">();
+    if (!response.valid() || !response.modified()) {
+      return;
+    }
+    observed_post_response = response.base().value().clone();
+    post_response_seen.store(true);
+    if (!status_triggered.exchange(true)) {
+      // A gRPC-shaped exchange: empty body, terminal status in trailers.
+      const Value request = make_client_request(
+          HttpMethod::Get,
+          Str{"https://127.0.0.1:" + std::to_string(bound_port.load()) +
+              "/h2-status"});
+      out.apply(request.view());
+    }
+    maybe_stop(node);
+  }
+};
+
+struct H2StatusCapture {
+  static constexpr auto name = "web_h2_loopback_status_capture";
+
+  static void eval(NodeView node,
+                   In<"result", HttpCallResult, InputValidity::Unchecked>
                        result) {
     auto failure = result.template field<"failure">();
     if (failure.valid() && failure.modified()) {
@@ -191,10 +228,26 @@ struct H2PostCapture {
     }
     auto response = result.template field<"response">();
     if (response.valid() && response.modified()) {
-      observed_post_response = response.base().value().clone();
-      post_response_seen.store(true);
+      observed_status_response = response.base().value().clone();
+      status_response_seen.store(true);
     }
     maybe_stop(node);
+  }
+};
+
+struct H2StatusResponse {
+  static constexpr auto name = "web_h2_loopback_status_response";
+
+  static void eval(In<"routed", WebRouteOutput, InputValidity::Unchecked>
+                       routed,
+                   Out<TS<HttpResponse>> out) {
+    auto request = routed.template field<"request">();
+    if (request.valid() && request.modified()) {
+      const Value response = make_response(
+          Int{200}, {}, Bytes{},
+          {{Str{"grpc-like-status"}, Str{"0"}}});
+      out.apply(response.view());
+    }
   }
 };
 
@@ -321,6 +374,15 @@ struct H2LoopbackGraph {
     static_cast<void>(respond(
         w, server_path, respond_request(w, ingest_id, ingest_response)));
 
+    auto status_route = wire<stdlib::const_, TS<WebRoute>>(
+        w, make_route(HttpMethod::Get, "/h2-status"));
+    auto status_served = serve(w, server_path, status_route);
+    auto status_id = wire<H2IngestId>(w, status_served).as<TS<Int>>();
+    auto status_response =
+        wire<H2StatusResponse>(w, status_served).as<TS<HttpResponse>>();
+    static_cast<void>(respond(
+        w, server_path, respond_request(w, status_id, status_response)));
+
     auto get_request =
         wire<H2GetTrigger>(w, stats).as<TS<HttpClientRequest>>();
     auto get_result =
@@ -329,7 +391,11 @@ struct H2LoopbackGraph {
         wire<H2GetCapture>(w, get_result).as<TS<HttpClientRequest>>();
     auto post_result =
         http_request(w, client_path, http_client_call(w, post_request));
-    static_cast<void>(wire<H2PostCapture>(w, post_result));
+    auto status_request =
+        wire<H2PostCapture>(w, post_result).as<TS<HttpClientRequest>>();
+    auto status_result =
+        http_request(w, client_path, http_client_call(w, status_request));
+    static_cast<void>(wire<H2StatusCapture>(w, status_result));
   }
 };
 
@@ -401,6 +467,31 @@ int main() {
     require(post.at("body").checked_as<Bytes>().data ==
                 std::to_string(kBigBodyBytes),
             "the h2 POST body was not delivered intact");
+
+    // The gRPC-shaped exchange: an EMPTY body must not fold the trailer
+    // into the headers (review P1 — origin-based separation).
+    require(status_response_seen.load(),
+            "the trailers-only exchange did not complete");
+    const auto status = observed_status_response.view().as_bundle();
+    require(status.at("body").checked_as<Bytes>().data.empty(),
+            "the trailers-only response grew a body");
+    bool status_trailer = false;
+    const auto status_trailers = status.at("trailers");
+    require(status_trailers.data() != nullptr,
+            "the trailers-only response has no trailers field");
+    for (const auto entry : status_trailers.as_list()) {
+      const auto pair = entry.as_bundle();
+      status_trailer |=
+          pair.at("name").checked_as<Str>() == Str{"grpc-like-status"} &&
+          pair.at("value").checked_as<Str>() == Str{"0"};
+    }
+    require(status_trailer,
+            "the empty-body trailer did not arrive as a trailer");
+    for (const auto entry : status.at("headers").as_list()) {
+      const auto pair = entry.as_bundle();
+      require(pair.at("name").checked_as<Str>() != Str{"grpc-like-status"},
+              "the empty-body trailer leaked into the headers");
+    }
 
     release_test_state();
   } catch (const std::exception &error) {

--- a/extensions/web/tests/test_h2_loopback.cpp
+++ b/extensions/web/tests/test_h2_loopback.cpp
@@ -369,24 +369,24 @@ int main() {
     require(response.at("body").checked_as<Bytes>().data == "hi answer",
             "the h2 GET body (path capture) did not round-trip");
     bool served_by = false;
-    bool trailer = false;
-    // curl surfaces h2 trailers through the same header callback as
-    // headers, so the trailer may arrive on either field.
-    for (const auto field_name : {"headers", "trailers"}) {
-      const auto entries = response.at(field_name);
-      if (entries.data() == nullptr) {
-        continue;
-      }
-      for (const auto entry : entries.as_list()) {
-        const auto pair = entry.as_bundle();
-        const auto name = pair.at("name").checked_as<Str>();
-        const auto value = pair.at("value").checked_as<Str>();
-        served_by |= name == Str{"x-served-by"} && value == Str{"h2-loopback"};
-        trailer |= name == Str{"x-trail"} && value == Str{"h2-checksum"};
-      }
+    for (const auto entry : response.at("headers").as_list()) {
+      const auto pair = entry.as_bundle();
+      served_by |= pair.at("name").checked_as<Str>() == Str{"x-served-by"} &&
+                   pair.at("value").checked_as<Str>() == Str{"h2-loopback"};
     }
     require(served_by, "the h2 response header did not round-trip");
-    require(trailer, "the h2 response trailer did not round-trip");
+    // Trailers arrive on the TRAILERS field, distinct from headers — the
+    // separation a gRPC-style terminal status depends on (review P1).
+    bool trailer = false;
+    const auto trailer_entries = response.at("trailers");
+    require(trailer_entries.data() != nullptr,
+            "the h2 response trailers field was not populated");
+    for (const auto entry : trailer_entries.as_list()) {
+      const auto pair = entry.as_bundle();
+      trailer |= pair.at("name").checked_as<Str>() == Str{"x-trail"} &&
+                 pair.at("value").checked_as<Str>() == Str{"h2-checksum"};
+    }
+    require(trailer, "the h2 response trailer did not arrive as a trailer");
 
     const auto peer = observed_server_peer.view().as_bundle();
     require(peer.at("negotiated_protocol").checked_as<Str>() == Str{"h2"},

--- a/extensions/web/tests/test_loopback.cpp
+++ b/extensions/web/tests/test_loopback.cpp
@@ -57,12 +57,16 @@ void require(bool condition, std::string message) {
 }
 
 inline std::atomic<int> listening_port{0};
+inline std::atomic<int> close_test_port{0};
 inline std::atomic<int> observed_query_count{0};
 inline std::atomic<int> observed_dup_header_count{0};
 inline std::atomic<int> respond_delivered_count{0};
 inline std::atomic<int> ws_open_count{0};
 inline std::atomic<int> ws_frame_count{0};
 inline std::atomic<int> ws_closed_count{0};
+inline std::atomic<int> ws_server_closed_count{0};
+inline std::atomic<int> ws_server_failed_count{0};
+inline std::atomic<Int> ws_server_close_code{0};
 inline Value observed_ws_frame{};
 
 void release_test_state() { observed_ws_frame = Value{}; }
@@ -80,6 +84,22 @@ struct StatsCapture {
                                               .as_bundle()
                                               .at("listening_port")
                                               .checked_as<Int>()));
+  }
+};
+
+struct CloseStatsCapture {
+  static constexpr auto name = "web_loopback_close_stats_capture";
+
+  static void
+  eval(In<"stats", TS<WebServerStats>, InputValidity::Unchecked> stats) {
+    if (!stats.valid() || !stats.modified()) {
+      return;
+    }
+    close_test_port.store(static_cast<int>(stats.base()
+                                               .value()
+                                               .as_bundle()
+                                               .at("listening_port")
+                                               .checked_as<Int>()));
   }
 };
 
@@ -235,6 +255,47 @@ struct WsFrameCapture {
   }
 };
 
+struct WsServerCloseId {
+  static constexpr auto name = "web_loopback_ws_server_close_id";
+
+  static void eval(In<"routed", WsRouteOutput, InputValidity::Unchecked> routed,
+                   Out<TS<Int>> out) {
+    auto event = routed.template field<"event">();
+    if (!event.valid() || !event.modified()) {
+      return;
+    }
+    const auto fields = event.base().value().as_bundle();
+    const auto state = fields.at("state").checked_as<WsConnectionState>();
+    if (state == WsConnectionState::Open) {
+      out.apply(fields.at("connection_id"));
+    } else if (state == WsConnectionState::Closed) {
+      ++ws_server_closed_count;
+      ws_server_close_code.store(fields.at("close_code").checked_as<Int>());
+    } else if (state == WsConnectionState::Failed) {
+      ++ws_server_failed_count;
+    }
+  }
+};
+
+struct WsServerCloseFrame {
+  static constexpr auto name = "web_loopback_ws_server_close_frame";
+
+  static void eval(In<"routed", WsRouteOutput, InputValidity::Unchecked> routed,
+                   Out<TS<WsFrame>> out) {
+    auto event = routed.template field<"event">();
+    if (!event.valid() || !event.modified() ||
+        event.base()
+                .value()
+                .as_bundle()
+                .at("state")
+                .checked_as<WsConnectionState>() != WsConnectionState::Open) {
+      return;
+    }
+    const Value frame = make_close_frame(1000, Str{"graph requested close"});
+    out.apply(frame.view());
+  }
+};
+
 struct LoopbackGraph {
   static constexpr auto name = "web_loopback_test_graph";
 
@@ -278,6 +339,27 @@ struct LoopbackGraph {
     static_cast<void>(wire<WsFrameCapture>(w, ws_output));
 
     static_cast<void>(wire<StatsCapture>(w, server_stats(w, path)));
+
+    // A one-record WS ingress lane is the sharp reservation-order case: the
+    // terminal reservation must be taken first, forcing Open through the
+    // guaranteed control lane.  The graph then initiates the close, which
+    // must convert that reservation into exactly one terminal event.
+    const auto close_path = service::path("web-loopback-server-close");
+    register_server(w, close_path,
+                    server_config()
+                        .port(0)
+                        .ws_ingress_limits(1, 64 * 1024 * 1024)
+                        .stats_interval(50ms)
+                        .build());
+    auto close_route = wire<stdlib::const_, TS<WebRoute>>(
+        w, make_route(HttpMethod::Get, "/server-close", true));
+    auto close_output = ws_serve(w, close_path, close_route);
+    auto close_id = wire<WsServerCloseId>(w, close_output).as<TS<Int>>();
+    auto close_frame =
+        wire<WsServerCloseFrame>(w, close_output).as<TS<WsFrame>>();
+    static_cast<void>(
+        ws_send(w, close_path, ws_send_request(w, close_id, close_frame)));
+    static_cast<void>(wire<CloseStatsCapture>(w, server_stats(w, close_path)));
   }
 };
 
@@ -290,6 +372,18 @@ struct LoopbackGraph {
     std::this_thread::sleep_for(10ms);
   }
   throw std::runtime_error("the server did not report its listening port");
+}
+
+[[nodiscard]] int await_close_test_port() {
+  const auto deadline = std::chrono::steady_clock::now() + 5s;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (const int port = close_test_port.load(); port != 0) {
+      return port;
+    }
+    std::this_thread::sleep_for(10ms);
+  }
+  throw std::runtime_error(
+      "the close-test server did not report its listening port");
 }
 
 [[nodiscard]] tcp::endpoint loopback_endpoint(int port) {
@@ -335,6 +429,7 @@ int main() {
     AsyncGraphExecutorRun runner{view};
 
     const int port = await_listening_port();
+    const int server_close_port = await_close_test_port();
     asio::io_context ioc;
 
     {
@@ -469,6 +564,38 @@ int main() {
       }
       require(ws_closed_count.load() == 1,
               "the orderly close did not reach the graph as a Closed event");
+    }
+
+    {
+      bws::stream<beast::tcp_stream> ws{ioc};
+      beast::get_lowest_layer(ws).expires_after(5s);
+      beast::get_lowest_layer(ws).connect(loopback_endpoint(server_close_port));
+      ws.handshake("127.0.0.1", "/server-close");
+
+      beast::flat_buffer buffer;
+      beast::error_code ec;
+      ws.read(buffer, ec);
+      require(ec == bws::error::closed,
+              "the graph-initiated close did not reach the peer cleanly: " +
+                  ec.message());
+
+      const auto close_deadline = std::chrono::steady_clock::now() + 5s;
+      while (ws_server_closed_count.load() == 0 &&
+             ws_server_failed_count.load() == 0 &&
+             std::chrono::steady_clock::now() < close_deadline) {
+        std::this_thread::sleep_for(10ms);
+      }
+      // Both the read and close-write completions may run; give the losing
+      // completion time to prove the exactly-once guard, not merely first
+      // delivery.
+      std::this_thread::sleep_for(100ms);
+      require(ws_server_failed_count.load() == 0,
+              "the graph-initiated close produced a Failed event");
+      require(ws_server_closed_count.load() == 1,
+              "the graph-initiated close did not produce exactly one Closed "
+              "event");
+      require(ws_server_close_code.load() == 1000,
+              "the graph-initiated close code was not preserved");
     }
 
     require(respond_delivered_count.load() >= 1,

--- a/extensions/web/tests/test_types.cpp
+++ b/extensions/web/tests/test_types.cpp
@@ -107,17 +107,22 @@ void test_tls_server_config_validation() {
                               .build());
       },
       "client-certificate verification requires a CA");
-  // Advertising h2 before the server HTTP/2 session activates is a protocol
-  // violation and stays a wiring-time error (RFC 0024).
+  // The HTTP/2 session is active: "h2" is a legal server protocol, and
+  // only known protocols may be advertised (RFC 0024, activation plan).
+  static_cast<void>(tls_server()
+                        .cert_path("/tmp/cert.pem")
+                        .key_path("/tmp/key.pem")
+                        .alpn({"h2", "http/1.1"})
+                        .build());
   require_invalid(
       [] {
         static_cast<void>(tls_server()
                               .cert_path("/tmp/cert.pem")
                               .key_path("/tmp/key.pem")
-                              .alpn({"h2", "http/1.1"})
+                              .alpn({"spdy/3"})
                               .build());
       },
-      "server ALPN cannot advertise h2 before activation");
+      "server ALPN accepted an unknown protocol");
 }
 
 void test_client_config_validation() {

--- a/extensions/web/tools/run_h2spec.py
+++ b/extensions/web/tools/run_h2spec.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Run h2spec against the extension's HTTP/2 server (RFC 0024, h2
+acceptance criteria).
+
+Starts ``hgraph_web_h2spec_server``, waits for its listening line, runs
+``h2spec http2 -t -k``, and passes iff every failure is in the accepted
+deviation list below.
+
+Accepted deviations
+-------------------
+
+* ``5.1.1/2`` (stream identifier numerically smaller than previous):
+  nghttp2 treats the lower-numbered HEADERS as a frame on an implicitly
+  closed stream and ignores it instead of raising the connection error
+  h2spec expects.  The reference ``nghttpd`` server fails this exact case
+  the same way (verified 2026-08-17 against nghttp2 1.67 / h2spec 2.6.0),
+  so this is upstream leniency, not an integration defect.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import time
+
+ACCEPTED_DEVIATIONS = ("stream identifier that is numerically smaller",)
+PORT = 18443
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: run_h2spec.py <h2spec-server-binary> <h2spec-binary>")
+        return 2
+    server_binary, h2spec_binary = sys.argv[1], sys.argv[2]
+
+    server = subprocess.Popen(
+        [server_binary, str(PORT), "600"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        deadline = time.monotonic() + 30
+        listening = False
+        assert server.stdout is not None
+        while time.monotonic() < deadline:
+            line = server.stdout.readline()
+            if "listening" in line:
+                listening = True
+                break
+            if server.poll() is not None:
+                break
+        if not listening:
+            print("the h2spec server did not start")
+            return 1
+
+        result = subprocess.run(
+            [h2spec_binary, "http2", "-t", "-k", "-h", "127.0.0.1", "-p",
+             str(PORT)],
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+        print(result.stdout)
+        summary = re.search(
+            r"(\d+) tests, (\d+) passed, (\d+) skipped, (\d+) failed",
+            result.stdout,
+        )
+        if summary is None:
+            print("h2spec produced no summary")
+            return 1
+        failures = [
+            line
+            for line in result.stdout.splitlines()
+            if line.strip().startswith("×")
+        ]
+        unexpected = [
+            line
+            for line in set(failures)
+            if not any(accepted in line for accepted in ACCEPTED_DEVIATIONS)
+        ]
+        if unexpected:
+            print("unexpected h2spec failures:")
+            for line in unexpected:
+                print(f"  {line.strip()}")
+            return 1
+        print(
+            f"h2spec conformance OK: {summary.group(2)}/{summary.group(1)} "
+            f"passed, {summary.group(4)} failure(s) all in the accepted "
+            "deviation list"
+        )
+        return 0
+    finally:
+        server.terminate()
+        try:
+            server.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            server.kill()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/extensions/web/tools/run_h2spec.py
+++ b/extensions/web/tools/run_h2spec.py
@@ -19,10 +19,12 @@ Accepted deviations
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 ACCEPTED_DEVIATIONS = ("stream identifier that is numerically smaller",)
 PORT = 18443
@@ -32,7 +34,14 @@ def main() -> int:
     if len(sys.argv) != 3:
         print("usage: run_h2spec.py <h2spec-server-binary> <h2spec-binary>")
         return 2
-    server_binary, h2spec_binary = sys.argv[1], sys.argv[2]
+    # Both commands must be existing executables, resolved to absolute
+    # paths, before anything is spawned.
+    server_binary = str(Path(sys.argv[1]).resolve())
+    h2spec_binary = str(Path(sys.argv[2]).resolve())
+    for binary in (server_binary, h2spec_binary):
+        if not (Path(binary).is_file() and os.access(binary, os.X_OK)):
+            print(f"not an executable: {binary}")
+            return 2
 
     server = subprocess.Popen(
         [server_binary, str(PORT), "600"],

--- a/python/tests/adaptors/tornado/test_http_client_adaptor.py
+++ b/python/tests/adaptors/tornado/test_http_client_adaptor.py
@@ -2,6 +2,7 @@ import asyncio
 from datetime import datetime, timedelta, timezone
 import http.client
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import random
 import socket
 import sys
 from threading import Thread
@@ -182,9 +183,20 @@ def http_endpoint():
 
 @pytest.fixture
 def free_tcp_port():
-    with socket.socket() as sock:
-        sock.bind(("127.0.0.1", 0))
-        return sock.getsockname()[1]
+    # Allocate OUTSIDE the OS ephemeral range: a probe-close-bind port from
+    # the ephemeral range can be reissued as an outbound SOURCE port (client
+    # connection pools) before the server binds it — the "Address already in
+    # use" flake seen on the macOS CI leg.
+    start = random.randint(20000, 31000)
+    for offset in range(1000):
+        candidate = start + offset
+        with socket.socket() as sock:
+            try:
+                sock.bind(("127.0.0.1", candidate))
+            except OSError:
+                continue
+            return candidate
+    raise RuntimeError("no free TCP port found")
 
 
 @pytest.mark.parametrize(

--- a/python/tests/adaptors/tornado/test_rest_adaptor.py
+++ b/python/tests/adaptors/tornado/test_rest_adaptor.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 import http.client
+import random
 import socket
 from threading import Thread
 import time
@@ -244,9 +245,20 @@ def test_http_response_converts_to_typed_rest_response(
 
 @pytest.fixture
 def free_tcp_port():
-    with socket.socket() as sock:
-        sock.bind(("127.0.0.1", 0))
-        return sock.getsockname()[1]
+    # Allocate OUTSIDE the OS ephemeral range: a probe-close-bind port from
+    # the ephemeral range can be reissued as an outbound SOURCE port (client
+    # connection pools) before the server binds it — the "Address already in
+    # use" flake seen on the macOS CI leg.
+    start = random.randint(20000, 31000)
+    for offset in range(1000):
+        candidate = start + offset
+        with socket.socket() as sock:
+            try:
+                sock.bind(("127.0.0.1", candidate))
+            except OSError:
+                continue
+            return candidate
+    raise RuntimeError("no free TCP port found")
 
 
 def test_rest_handler_maps_live_delete_request(free_tcp_port):

--- a/python/tests/adaptors/tornado/test_websocket_adaptor.py
+++ b/python/tests/adaptors/tornado/test_websocket_adaptor.py
@@ -1,5 +1,6 @@
 import asyncio
 from datetime import datetime, timedelta, timezone
+import random
 import socket
 from threading import Thread
 import time
@@ -25,9 +26,20 @@ from hgraph.adaptors.tornado import (
 
 @pytest.fixture
 def free_tcp_port():
-    with socket.socket() as sock:
-        sock.bind(("127.0.0.1", 0))
-        return sock.getsockname()[1]
+    # Allocate OUTSIDE the OS ephemeral range: a probe-close-bind port from
+    # the ephemeral range can be reissued as an outbound SOURCE port (client
+    # connection pools) before the server binds it — the "Address already in
+    # use" flake seen on the macOS CI leg.
+    start = random.randint(20000, 31000)
+    for offset in range(1000):
+        candidate = start + offset
+        with socket.socket() as sock:
+            try:
+                sock.bind(("127.0.0.1", candidate))
+            except OSError:
+                continue
+            return candidate
+    raise RuntimeError("no free TCP port found")
 
 
 def test_feedback_supports_keyed_websocket_response_bundles():


### PR DESCRIPTION
Implements the RFC 0024 HTTP/2 server activation plan (v1.x milestone), in two phases:

**Protocol engine (ee618c790)** — `nghttp2_session.cpp` is the extension's only nghttp2 TU, wrapping a server session as a pure bytes-in/actions-out engine (`detail/h2_engine.h`, no third-party types). Automatic window updates are disabled: request-DATA flow control releases only through `consume()`, which is the ingress-admission lever. `hgraph_web_h2_engine_tests` validates the engine against a genuine nghttp2 *client* session entirely in memory: round-trips with trailers, withheld-window stalls until consume, RST_STREAM both directions, advertised max-concurrent gating, GOAWAY completing in-flight streams.

**Connection driver + activation (b0cbca728)** — the TLS ALPN callback selects from the configured list; "h2" hands the socket to `H2Driver` (Asio-confined), which maps every stream onto the existing bridge contract: header admission reserves before any window is released, DATA grows the same reservation before consume, and the reserved push transfers everything with the real stream id. Route matching, HEAD fallback, transport 501/400/404/503, timeout 503, GOAWAY drain, peer-reset cancellation (late answers report `Dropped`), and per-stream slow-consumer resets mirror h1. The pending registry routes responses through a transport-agnostic `PendingTarget`. Config validation accepts "h2" (and now rejects unknown ALPN protocols) in C++ and python.

**Acceptance criteria status** (RFC 0024 activation plan):
- ALPN dispatch beside the h1 path — done, proven by the loopback.
- Stream-aware delivery with real stream ids — done.
- Per-stream RST_STREAM cancellation with `Dropped` late answers — done (engine test + driver path).
- GOAWAY both directions bounded by the shutdown drain — done.
- Stream flow control mapped to the ingress reservation contract — done (engine test + 2MB loopback body).
- Connection limits from `h2_max_concurrent_streams` / `h2_initial_window_bytes` — advertised and enforced by nghttp2.
- Per-stream slow-consumer reset — done (outbound byte budget).
- h2spec conformance in CI — **follow-up on this branch before merge**.

`hgraph_web_h2_loopback_tests` is the end-to-end oracle: the extension's own curl client pinned `H2Only` over TLS ALPN ["h2","http/1.1"] — a completed call proves the negotiation because the client hard-fails on h1 downgrade. All 8 C++ suites and 116 python tests pass locally.

The streaming-body companion RFC (per the RFC 0024 milestone boundary) remains open before this ships in a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)