### PR TITLE
Complete checkpoint 5: diagnostics, dataframe extra, back-edge removal

### DIFF
--- a/docs/source/developer_guide/record_replay_table.rst
+++ b/docs/source/developer_guide/record_replay_table.rst
@@ -427,14 +427,18 @@ memory, local and S3 paths stay entirely in C++. Store callbacks receive the
 Arrow table in the established naive-UTC Python timestamp form, never the
 optional user-facing Polars presentation, because Arrow schema metadata is part
 of the persisted recording contract. The legacy override registry is translated
-at wiring time into explicit native record/replay options.
+at wiring time into explicit native record/replay options — by
+``hgraph_persistence.compat``, registered through core's
+``register_record_replay_wiring_adapter`` seam when the storage surface loads
+(RFC 0025 checkpoint 5: core wiring imports no adaptor modules).
 
 RFC 0019 completes this backend with per-record column projection,
 Tick/Sample/Snap recording, keyed frame expansion, and optional native
-segmentation. Tests: ``tests/cpp/test_record_replay_frame.cpp``,
-``tests/cpp/test_record_replay_partitioned.cpp``,
-``python/tests/test_native_table_recording.py``, and
-``python/tests/test_python_frame_store.py``.
+segmentation. Tests (relocated with the extraction, RFC 0025 checkpoint 4):
+``extensions/persistence/tests/test_record_replay_frame.cpp``,
+``extensions/persistence/tests/test_record_replay_partitioned.cpp``,
+``extensions/persistence/python/tests/test_native_table_recording.py``, and
+``extensions/persistence/python/tests/test_python_frame_store.py``.
 
 Step 5 — landed (first pass)
 ----------------------------

--- a/docs/source/rfc/rfc_0025_hgraph_persistence.rst
+++ b/docs/source/rfc/rfc_0025_hgraph_persistence.rst
@@ -454,10 +454,27 @@ Python compatibility store; ``hgraph_persistence`` with the
 lazily importing the extension (the activation contract, live);
 ``hgraph.adaptors.data_frame`` as the guarded lazy re-export; and the
 frame test suites relocated (C++ Catch2 suite and the Python suites) —
-core keeps memory/testing coverage only.  Remaining from checkpoint 5:
-the explicit missing-extension diagnostics polish and the ``dataframe``
-extra gaining ``hgraph-persistence`` (deferred with the ``uv.lock``
-regeneration).
+core keeps memory/testing coverage only.
+
+Checkpoint 5 is complete.  The operator-implementation move landed with
+checkpoint 4 (the recorded sequencing decision above); the merged PR's
+review round additionally made the per-call ``model=`` argument a load
+point (the activation contract's "graph default and per-call override
+alike", which only the graph-level setter had implemented).  The
+remainder landed separately: **explicit missing-extension diagnostics**
+— a wiring failure on ``record``/``replay``/``compare``/``replay_const``
+appends a pointed diagnosis when the durable overloads never registered,
+distinguishing "the distribution is absent (``pip install
+hgraph-persistence``)" from "installed but not loaded (select a durable
+backend, or import the package)", probed without importing so the error
+path cannot register overloads as a side effect — the core→adaptor
+back-edge removed (the 0.5 override-registry translation
+``_legacy_record_replay_kwargs`` lives in ``hgraph_persistence.compat``,
+which registers it through core's
+``register_record_replay_wiring_adapter`` seam when the storage surface
+loads; core wiring imports no adaptor modules) — and the ``dataframe``
+extra now installs ``hgraph-persistence`` (workspace-sourced,
+``uv.lock`` regenerated).
 
 Appendix: symbol and migration inventory
 ----------------------------------------

--- a/extensions/persistence/python/hgraph_persistence/compat.py
+++ b/extensions/persistence/python/hgraph_persistence/compat.py
@@ -261,3 +261,63 @@ def _as_arrow(value):
     return table
 
 
+def _legacy_record_replay_kwargs(name, args, kwargs):
+    """Translate the 0.5 override registry into native call-site options.
+
+    This is wiring-only compatibility. The native recorder still receives
+    explicit immutable scalar options and does not consult Python state at
+    runtime.
+    """
+    from hgraph import DATA_FRAME
+    from hgraph.adaptors.data_frame._data_frame_record_replay import (
+        get_data_frame_record_overrides,
+    )
+
+    if not GlobalState.has_instance():
+        return kwargs
+    state = GlobalState.instance()
+    if state.get("__record_replay_model__") != DATA_FRAME:
+        return kwargs
+    if DataFrameStorage.instance(state) is None:
+        return kwargs
+
+    key_position = 1 if name == "record" else 0
+    key = kwargs.get("key", args[key_position] if len(args) > key_position else "out")
+    recordable_id_position = 2 if name == "record" else 1
+    recordable_id = kwargs.get(
+        "recordable_id",
+        args[recordable_id_position] if len(args) > recordable_id_position else None,
+    )
+    options = get_data_frame_record_overrides(key, recordable_id, state)
+    translated = dict(kwargs)
+
+    if name == "record":
+        from hgraph import RecordAsOf, RecordRemoves
+
+        translated.setdefault(
+            # The 0.5 flag controls whether the column is present; it does not
+            # override a fixed graph-level ``set_as_of`` value.  ``INHERIT``
+            # preserves that distinction while still tracking evaluation time
+            # when no fixed value is configured.  Callers can continue to pass
+            # ``RecordAsOf.TRACK`` explicitly when they want that override.
+            "as_of", RecordAsOf.INHERIT if options.get("track_as_of", True) else RecordAsOf.OMIT
+        )
+        translated.setdefault(
+            "removes", RecordRemoves.TRACK if options.get("track_removes", False) else RecordRemoves.OMIT
+        )
+    if name in ("record", "replay"):
+        if options.get("partition_keys") is not None:
+            translated.setdefault("partition_names", tuple(options["partition_keys"]))
+        if options.get("remove_partition_keys") is not None:
+            translated.setdefault("removed_names", tuple(options["remove_partition_keys"]))
+    return translated
+
+
+# Core wiring must not import adaptor modules (RFC 0025 checkpoint 5): the
+# 0.5 translation registers itself when this compatibility surface loads —
+# the only route to an ACTIVE DataFrameStorage, without which it is a no-op.
+from hgraph._wiring._core import register_record_replay_wiring_adapter
+
+register_record_replay_wiring_adapter(_legacy_record_replay_kwargs)
+
+

--- a/extensions/persistence/python/tests/test_api_persistence.py
+++ b/extensions/persistence/python/tests/test_api_persistence.py
@@ -49,6 +49,36 @@ def test_per_call_model_selection_loads_the_extension():
     assert result.returncode == 0, result.stdout + result.stderr
 
 
+def test_per_call_model_on_replay_const_loads_the_extension():
+    # replay_const's durable overload accepts a per-call ``model=`` (the
+    # operator has no in-memory implementation), so that call shape is a load
+    # point exactly like record/replay/compare's (PR #507 review finding).
+    import os
+    import subprocess
+    import sys
+
+    script = (
+        "import sys\n"
+        "sys.meta_path = [finder for finder in sys.meta_path"
+        " if 'ScikitBuild' not in type(finder).__name__]\n"
+        "import hgraph as hg\n"
+        "from hgraph import TS\n"
+        "assert 'hgraph_persistence' not in sys.modules\n"
+        "try:\n"
+        "    hg.replay_const[TS[int]](key='price', model=hg.DATA_FRAME)\n"
+        "except RuntimeError:\n"
+        "    pass  # no active wiring — the load fires before wiring begins\n"
+        "assert 'hgraph_persistence' in sys.modules, 'selection did not load'\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": os.pathsep.join(sys.path)},
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
 def test_unloaded_extension_wiring_failure_names_the_activation_paths():
     # With hgraph-persistence INSTALLED but never loaded, a durable operator's
     # wiring failure explains that overloads register on backend selection

--- a/extensions/persistence/python/tests/test_api_persistence.py
+++ b/extensions/persistence/python/tests/test_api_persistence.py
@@ -49,6 +49,45 @@ def test_per_call_model_selection_loads_the_extension():
     assert result.returncode == 0, result.stdout + result.stderr
 
 
+def test_unloaded_extension_wiring_failure_names_the_activation_paths():
+    # With hgraph-persistence INSTALLED but never loaded, a durable operator's
+    # wiring failure explains that overloads register on backend selection
+    # (RFC 0025's "wiring diagnoses the missing backend") rather than leaving
+    # an unexplained resolution failure. Clean interpreter: this suite's own
+    # imports must not mask the unloaded state.
+    import os
+    import subprocess
+    import sys
+
+    script = (
+        "import sys\n"
+        "sys.meta_path = [finder for finder in sys.meta_path"
+        " if 'ScikitBuild' not in type(finder).__name__]\n"
+        "import hgraph as hg\n"
+        "from hgraph import TS, GlobalState\n"
+        "from hgraph.test import eval_node\n"
+        "assert 'hgraph_persistence' not in sys.modules\n"
+        "@hg.graph\n"
+        "def g() -> TS[int]:\n"
+        "    return hg.replay_const[TS[int]](key='price')\n"
+        "try:\n"
+        "    with GlobalState():\n"
+        "        eval_node(g)\n"
+        "except Exception as error:\n"
+        "    assert 'installed but not loaded' in str(error), str(error)\n"
+        "    assert 'set_record_replay_config' in str(error), str(error)\n"
+        "else:\n"
+        "    raise AssertionError('replay_const wired without activation')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": os.pathsep.join(sys.path)},
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
 def test_durable_replay_overload_registers_partition_signature():
     # Moved from core's test_native_docstrings when the partitioned frame
     # replay overload became extension-registered (RFC 0025 checkpoint 4).

--- a/extensions/persistence/python/tests/test_packaging.py
+++ b/extensions/persistence/python/tests/test_packaging.py
@@ -26,6 +26,10 @@ def test_persistence_is_a_separate_workspace_distribution():
 
     assert root["tool"]["uv"]["workspace"]["members"] == ["extensions/*"]
     assert root["tool"]["uv"]["sources"]["hgraph"] == {"workspace": True}
+    # hgraph[dataframe] installs the durable record/replay implementation
+    # (RFC 0025 checkpoint 5).
+    assert "hgraph-persistence>=0.8.0" in root["project"]["optional-dependencies"]["dataframe"]
+    assert root["tool"]["uv"]["sources"]["hgraph-persistence"] == {"workspace": True}
     assert project["project"]["name"] == "hgraph-persistence"
     assert "uv" not in project.get("tool", {})
     assert project["tool"]["scikit-build"]["wheel"]["py-api"] == "cp312"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,9 @@ perspective = [
     "tornado>=6.5",
 ]
 dataframe = [
+    # Durable record/replay — DataFrameStorage and the frame store — is
+    # served by the hgraph-persistence extension (RFC 0025).
+    "hgraph-persistence>=0.8.0",
     "polars>=1.32",
 ]
 docs = [
@@ -129,6 +132,7 @@ Issues = "https://github.com/hhenson/hgraph/issues"
 
 [tool.uv.sources]
 hgraph = {workspace = true}
+hgraph-persistence = {workspace = true}
 hgraph-web = {workspace = true}
 
 [tool.uv.workspace]

--- a/python/hgraph/_wiring/_core.py
+++ b/python/hgraph/_wiring/_core.py
@@ -23,6 +23,59 @@ def _current_wiring():
     return _wiring_stack[-1]
 
 
+# Operators whose durable overloads register from hgraph-persistence
+# (RFC 0025). replay_const has no in-memory implementation at all.
+_DURABLE_OPERATORS = frozenset({"record", "replay", "compare", "replay_const"})
+
+# Wiring-time kwargs adaptation for record/replay, registered by
+# hgraph_persistence.compat (the 0.5 override-registry translation). Module
+# state, not registry state: it survives native registry resets, exactly like
+# the compat storage classes that install it.
+_record_replay_wiring_adapter = None
+
+
+def register_record_replay_wiring_adapter(adapter):
+    """Install the record/replay wiring-kwargs adapter (RFC 0025 compat seam)."""
+    global _record_replay_wiring_adapter
+    _record_replay_wiring_adapter = adapter
+
+
+def _durable_wiring_hint(name):
+    """The missing-extension diagnosis for a durable operator's wiring failure.
+
+    Wiring diagnoses the missing backend (RFC 0025): a resolution failure on a
+    record/replay operator is unexplained when the cause is that the durable
+    overloads never registered — either the optional distribution is absent, or
+    it is installed but nothing selected a durable backend, so it never loaded.
+    Availability is probed without importing (importing would register the
+    overloads as an error-path side effect).
+    """
+    if name not in _DURABLE_OPERATORS:
+        return ""
+    import importlib.util
+    import sys
+
+    if "hgraph_persistence" in sys.modules:
+        return ""
+    try:
+        spec = importlib.util.find_spec("hgraph_persistence")
+    except ModuleNotFoundError:
+        spec = None
+    if spec is None:
+        return (
+            "\n(durable record/replay overloads are provided by the optional "
+            "'hgraph-persistence' distribution; install it with "
+            "`pip install hgraph-persistence` — the built-in backends are "
+            "'memory' and 'testing')"
+        )
+    return (
+        "\n(hgraph-persistence is installed but not loaded: durable overloads "
+        "register when a durable backend is selected — for example "
+        "hg.set_record_replay_config(hg.DATA_FRAME) or a per-call "
+        "model=hg.DATA_FRAME — or on `import hgraph_persistence`)"
+    )
+
+
 class WiringPort:
     """A time-series edge source; supports hgraph's operator sugar."""
 
@@ -92,7 +145,7 @@ def wire(name, *args, __output_type__=None, **kwargs):
         # std::invalid_argument surfaces as ValueError; both are wiring-time.
         # (RequirementsNotMetWiringError arrives ALREADY typed - the C++
         # resolver throws OperatorRequirementsError, translated directly.)
-        raise WiringError(str(error)) from error
+        raise WiringError(str(error) + _durable_wiring_hint(name)) from error
     return WiringPort(result) if result is not None else None
 
 
@@ -344,18 +397,13 @@ class _OperatorFunction:
             from ._state import _ensure_backend_extension
 
             _ensure_backend_extension(kwargs["model"])
-        if self.__name__ in ("record", "replay"):
-            from ._state import GlobalState
-
-            if (GlobalState.has_instance()
-                    and GlobalState.instance().get("__record_replay_model__") == _hgraph.DATA_FRAME):
-                # release/0.5's data-frame override registry is translated at
-                # the Python wiring boundary into native scalar options. The
-                # adaptor remains unloaded for ordinary in-memory recording.
-                from ..adaptors.data_frame._data_frame_record_replay import (
-                    _legacy_record_replay_kwargs,
-                )
-                kwargs = _legacy_record_replay_kwargs(self.__name__, args, kwargs)
+        if self.__name__ in ("record", "replay") and _record_replay_wiring_adapter is not None:
+            # release/0.5's data-frame override registry is translated at the
+            # Python wiring boundary into native scalar options. The adapter is
+            # registered by hgraph_persistence.compat when its storage surface
+            # loads (RFC 0025: core wiring must not import adaptor modules) and
+            # is a no-op unless a compatibility storage is active.
+            kwargs = _record_replay_wiring_adapter(self.__name__, args, kwargs)
         if (self.__name__ == "apply" and args
                 and "tp" not in kwargs and "output_type" not in kwargs
                 and self._output_type is None and callable(args[0])

--- a/python/hgraph/_wiring/_core.py
+++ b/python/hgraph/_wiring/_core.py
@@ -388,7 +388,7 @@ class _OperatorFunction:
         self._resolutions = resolutions
 
     def __call__(self, *args, **kwargs):
-        if self.__name__ in ("record", "replay", "compare") and kwargs.get("model"):
+        if self.__name__ in _DURABLE_OPERATORS and kwargs.get("model"):
             # A per-call ``model=`` selects the backend for this node alone,
             # so it is an extension load point exactly like the graph-level
             # configuration setter (RFC 0025) — without the import, the

--- a/python/hgraph/adaptors/data_frame/_data_frame_record_replay.py
+++ b/python/hgraph/adaptors/data_frame/_data_frame_record_replay.py
@@ -5,7 +5,6 @@ import pyarrow as pa
 
 from hgraph import (
     AUTO_RESOLVE,
-    DATA_FRAME,
     MAX_DT,
     OUT,
     Frame,
@@ -106,53 +105,10 @@ def get_data_frame_record_overrides(key, recordable_id, global_state=None):
     )
 
 
-def _legacy_record_replay_kwargs(name, args, kwargs):
-    """Translate the 0.5 override registry into native call-site options.
-
-    This is wiring-only compatibility. The native recorder still receives
-    explicit immutable scalar options and does not consult Python state at
-    runtime.
-    """
-    if not GlobalState.has_instance():
-        return kwargs
-    state = GlobalState.instance()
-    if state.get("__record_replay_model__") != DATA_FRAME:
-        return kwargs
-    import sys as _sys
-    _storage_cls = getattr(_sys.modules[__name__], "DataFrameStorage")
-    if _storage_cls.instance(state) is None:
-        return kwargs
-
-    key_position = 1 if name == "record" else 0
-    key = kwargs.get("key", args[key_position] if len(args) > key_position else "out")
-    recordable_id_position = 2 if name == "record" else 1
-    recordable_id = kwargs.get(
-        "recordable_id",
-        args[recordable_id_position] if len(args) > recordable_id_position else None,
-    )
-    options = get_data_frame_record_overrides(key, recordable_id, state)
-    translated = dict(kwargs)
-
-    if name == "record":
-        from hgraph import RecordAsOf, RecordRemoves
-
-        translated.setdefault(
-            # The 0.5 flag controls whether the column is present; it does not
-            # override a fixed graph-level ``set_as_of`` value.  ``INHERIT``
-            # preserves that distinction while still tracking evaluation time
-            # when no fixed value is configured.  Callers can continue to pass
-            # ``RecordAsOf.TRACK`` explicitly when they want that override.
-            "as_of", RecordAsOf.INHERIT if options.get("track_as_of", True) else RecordAsOf.OMIT
-        )
-        translated.setdefault(
-            "removes", RecordRemoves.TRACK if options.get("track_removes", False) else RecordRemoves.OMIT
-        )
-    if name in ("record", "replay"):
-        if options.get("partition_keys") is not None:
-            translated.setdefault("partition_names", tuple(options["partition_keys"]))
-        if options.get("remove_partition_keys") is not None:
-            translated.setdefault("removed_names", tuple(options["remove_partition_keys"]))
-    return translated
+# The 0.5 override-registry translation into native call-site options moved
+# to hgraph_persistence.compat (RFC 0025 checkpoint 5): it only acts under an
+# ACTIVE DataFrameStorage, and core wiring must not import adaptor modules —
+# the compat surface registers the wiring adapter itself when it loads.
 
 
 # These names are compatibility views over the C++-owned record/replay nodes.

--- a/python/tests/test_optional_adaptor_imports.py
+++ b/python/tests/test_optional_adaptor_imports.py
@@ -158,6 +158,24 @@ def test_per_call_durable_model_names_the_missing_persistence_extension():
             assert "pip install hgraph-persistence" in str(error)
         else:
             raise AssertionError("per-call durable model wired without hgraph-persistence")
+
+        # Wiring failures on the durable operators also diagnose the missing
+        # distribution: replay_const has no in-memory implementation, so its
+        # resolution failure names the install, not just "no operator".
+        from hgraph import GlobalState
+        from hgraph.test import eval_node
+
+        @hg.graph
+        def use_replay_const() -> TS[int]:
+            return hg.replay_const[TS[int]](key="price")
+
+        try:
+            with GlobalState():
+                eval_node(use_replay_const)
+        except Exception as error:
+            assert "pip install hgraph-persistence" in str(error), str(error)
+        else:
+            raise AssertionError("replay_const wired without hgraph-persistence")
         """
     )
     python_path = os.pathsep.join(

--- a/uv.lock
+++ b/uv.lock
@@ -435,6 +435,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dataframe = [
+    { name = "hgraph-persistence" },
     { name = "polars" },
 ]
 delta = [
@@ -520,6 +521,7 @@ requires-dist = [
     { name = "duckdb", marker = "extra == 'sql'", specifier = ">=1.4" },
     { name = "duckdb", marker = "extra == 'test'", specifier = ">=1.4" },
     { name = "frozendict", specifier = ">=2.4" },
+    { name = "hgraph-persistence", marker = "extra == 'dataframe'", editable = "extensions/persistence" },
     { name = "hgraph-web", marker = "extra == 'web'", editable = "extensions/web" },
     { name = "hypothesis", marker = "extra == 'parity'", specifier = ">=6" },
     { name = "hypothesis", marker = "extra == 'test'", specifier = ">=6" },


### PR DESCRIPTION
The checkpoint-5 remainder of #498 (design record: RFC 0025). The operator-implementation move itself landed fused with checkpoint 4 (#506, recorded sequencing decision), and that PR's review round already made the per-call `model=` argument a load point. This PR lands the three outstanding pieces and records checkpoint 5 complete.

**Explicit missing-extension diagnostics.** A wiring failure on `record`/`replay`/`compare`/`replay_const` now appends a pointed diagnosis when the durable overloads never registered, distinguishing the two states a user can actually be in: the distribution is absent (`pip install hgraph-persistence`; the built-in backends are `memory` and `testing`), or it is installed but nothing loaded it (durable overloads register on backend selection — `hg.set_record_replay_config(hg.DATA_FRAME)`, a per-call `model=`, or `import hgraph_persistence`). Availability is probed with `find_spec`, so the error path can never register overloads as a side effect. Before this, `replay_const` failed with an unexplained `no operator 'replay_const' is registered`, and a natively-selected durable config produced a bare requires-predicate rejection. Pinned from both sides: the blocked-extension core test asserts the install pointer, and a clean-interpreter extension test asserts the not-loaded diagnosis names the activation paths.

**`hgraph[dataframe]` installs the durable implementation.** The extra gains `hgraph-persistence>=0.8.0` (workspace-sourced), with `uv.lock` regenerated by a real `uv lock` — a two-line diff, which also validates the checkpoint-4 hand-edited lock entries. Asserted in the extension's packaging tests.

**The core→adaptor back-edge is removed** (the RFC appendix's recorded checkpoint-5 disposition). The 0.5 override-registry translation `_legacy_record_replay_kwargs` moved to `hgraph_persistence.compat`, which registers it through core's new `register_record_replay_wiring_adapter` seam when the storage surface loads — the only route to an ACTIVE `DataFrameStorage`, without which the translation was always a no-op, so activation timing is behaviour-preserving. Core wiring imports no adaptor modules.

**Docs in the same change:** RFC 0025 implementation status records checkpoint 5 complete (including the review-round per-call load point); `record_replay_table.rst` names the translation's new home and the test paths relocated at checkpoint 4.

**Verification:** extension python suite 81/81 (including the four ported override tests exercising the moved translation end-to-end and the two new diagnostics tests); core python suite green except the two known local-environment artifacts (tornado tests need hgraph-web; the inventory `--check` subprocess resolves the dev venv's stale build — both CI-covered); extension packaging/audit tests 6/6.

Refs #498 (checkpoint 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
