### PR TITLE
Implement RFC 0022 stage 1: the canonical graph manifest

### DIFF
--- a/docs/source/rfc/rfc_0022_serializable_graph_manifest.rst
+++ b/docs/source/rfc/rfc_0022_serializable_graph_manifest.rst
@@ -482,8 +482,55 @@ Acceptance criteria
 Implementation status
 ---------------------
 
-Not started.  This RFC defines the identity prerequisite before graph
-checkpoint implementation begins.
+Stage 1 is implemented (public headers ``hgraph/manifest/canonical.h``,
+``hgraph/manifest/schema_descriptor.h``, ``hgraph/manifest/graph_manifest.h``;
+tests ``tests/cpp/test_graph_manifest.cpp``).  Decisions recorded during
+implementation:
+
+* **Canonical grammar.**  LEB128 varints, zigzag signed varints, IEEE-754
+  little-endian fixed64 floats, varint-length-delimited byte strings and
+  nested scopes, ascending fixed field tags.  The writer/reader live in
+  ``hgraph::manifest`` free of manifest semantics, answering the open
+  question about sharing with RFC 0017: this layer IS the shared
+  substrate, defined here first because RFC 0017 is unimplemented.
+* **Schema descriptors.**  Recursive structural encoding of
+  ``ValueTypeMetaData``/``TSValueTypeMetaData`` — kind, the full flags
+  word, atomic identity through a stable wire-atomic enumeration (core
+  scalars) or the registered name (extension/python scalars, following
+  the named-bundle nominal rule), children, fixed sizes, TSW window
+  parameters, named-bundle nominal identity (namespace, local name,
+  generic arguments, discriminator).  Synthesis is cold-path and
+  computed on demand — no cache, no lock, no registry-reset coupling.
+  The conformance reference is ``time_series_schema_equivalent``.
+* **Identity id.**  ``ManifestId`` is SHA-256 (self-contained
+  ``hgraph/util/sha256.h``; the digest is a lookup/integrity device, not
+  a security boundary) over the canonical descriptor with the format
+  version as domain-separation prefix; the descriptor bytes remain the
+  compared identity.
+* **Node identity (stage 1).**  Semantic name (``NodeTypeMetaData``
+  display name) plus ``TypeRecord::implementation_label``; the full
+  ``package/facility/implementation/semver`` identity and overload
+  provenance land with stage 2's registration work.
+* **Node labels are NOT in the canonical descriptor.**  A label edit
+  must not change the manifest id; labels travel in the diagnostic
+  rendering, not the identity.
+* **Scalar values.**  Canonical schema-directed encoding covers the
+  core atomics, enums, and tuple/bundle/list composites, with set and
+  map content emitted in canonical encoded-key order.  A ``WiredFn``
+  scalar encodes as its REGISTERED identity — the lifted kernel's
+  authored name or the operator marker's name — never a function
+  address or RTTI name; an anonymous callable, and any value without a
+  canonical encoding (``Any``, queues/cyclic buffers, live handles,
+  ``PyNodeRef``), makes the graph non-manifestable with a
+  path-addressed ``ManifestCaptureError``.  ``NodeManifestOps``
+  (stage 2) supersedes the ``WiredFn`` rule with authored descriptors
+  and gives nested-graph owners their child-template encoding.
+* **Capture point.**  The finished ``GraphBuilder`` (after
+  ``Wiring::finish``/``snapshot``, before ``make_executor``); node and
+  edge order is the builder's canonical ranked order.
+
+Stages 2–4 (nested templates and implementation registration, binding
+and run manifests, checkpoint integration) are not started.
 
 References
 ----------

--- a/docs/source/rfc/rfc_0022_serializable_graph_manifest.rst
+++ b/docs/source/rfc/rfc_0022_serializable_graph_manifest.rst
@@ -515,8 +515,11 @@ implementation:
   must not change the manifest id; labels travel in the diagnostic
   rendering, not the identity.
 * **Scalar values.**  Canonical schema-directed encoding covers the
-  core atomics, enums, and tuple/bundle/list composites, with set and
-  map content emitted in canonical encoded-key order.  A ``WiredFn``
+  core atomics including the full engine date/time family (temporal
+  RFC 0002 types encode by semantic content — ``ZoneId`` by IANA name,
+  never its process-local slot), enums, and tuple/bundle/list
+  composites, with set and map content emitted in canonical
+  encoded-key order.  A ``WiredFn``
   scalar encodes as its REGISTERED identity — the lifted kernel's
   authored name or the operator marker's name — never a function
   address or RTTI name; an anonymous callable, and any value without a
@@ -527,7 +530,15 @@ implementation:
   and gives nested-graph owners their child-template encoding.
 * **Capture point.**  The finished ``GraphBuilder`` (after
   ``Wiring::finish``/``snapshot``, before ``make_executor``); node and
-  edge order is the builder's canonical ranked order.
+  edge order is the builder's canonical ranked order.  Node identity
+  includes the EFFECTIVE output endpoint annotation (the per-instance
+  override, falling back to the node type's schema annotation exactly
+  as runtime construction does) and the error-capture options
+  (traceback depth, value capture) alongside the capture flag.
+* **Strict decoding.**  Every scope field appears exactly once; a
+  missing or duplicated required field rejects the descriptor — a
+  well-formed frame around an empty or torn descriptor never decodes
+  into a valid manifest.
 
 Stages 2–4 (nested templates and implementation registration, binding
 and run manifests, checkpoint integration) are not started.

--- a/include/hgraph/manifest/canonical.h
+++ b/include/hgraph/manifest/canonical.h
@@ -1,0 +1,192 @@
+#ifndef HGRAPH_MANIFEST_CANONICAL_H
+#define HGRAPH_MANIFEST_CANONICAL_H
+
+/**
+ * @file canonical.h
+ * The canonical binary writer/reader for manifest descriptors (RFC 0022).
+ *
+ * The grammar is a versioned, length-delimited binary tree:
+ *
+ * - a FIELD is ``varint tag`` followed by a payload determined by the tag's
+ *   fixed wire class (the schema is static per format version; tags do not
+ *   self-describe their wire class);
+ * - unsigned integers are LEB128 varints; signed integers are zigzag
+ *   varints; floating-point payloads are IEEE-754 little-endian fixed64;
+ * - byte strings and nested scopes are varint-length-delimited; and
+ * - writers emit fields in ascending canonical tag order with map-like
+ *   content pre-sorted by its canonical encoded key, so equal semantic
+ *   content produces byte-identical descriptors across processes.
+ *
+ * This layer defines the byte grammar RFC 0022 names and is deliberately
+ * free of manifest semantics, so RFC 0017's codec work can adopt it as the
+ * shared substrate (RFC 0022 "Unresolved questions" records that choice).
+ */
+
+#include <cstddef>
+#include <cstring>
+#include <cstdint>
+#include <span>
+#include <stdexcept>
+#include <string_view>
+#include <vector>
+
+namespace hgraph::manifest
+{
+    /** Raised by ``CanonicalReader`` on malformed or truncated input. */
+    class CanonicalDecodeError : public std::runtime_error
+    {
+      public:
+        using std::runtime_error::runtime_error;
+    };
+
+    /** Appends canonical primitives to an owned byte buffer. */
+    class CanonicalWriter final
+    {
+      public:
+        [[nodiscard]] const std::vector<std::byte> &bytes() const noexcept { return buffer_; }
+        [[nodiscard]] std::vector<std::byte> take() noexcept { return std::move(buffer_); }
+        [[nodiscard]] std::size_t size() const noexcept { return buffer_.size(); }
+
+        /** LEB128 unsigned varint. */
+        void varint(std::uint64_t value)
+        {
+            while (value >= 0x80u)
+            {
+                buffer_.push_back(static_cast<std::byte>((value & 0x7fu) | 0x80u));
+                value >>= 7u;
+            }
+            buffer_.push_back(static_cast<std::byte>(value));
+        }
+
+        /** Zigzag-encoded signed varint. */
+        void svarint(std::int64_t value)
+        {
+            varint((static_cast<std::uint64_t>(value) << 1u) ^
+                   static_cast<std::uint64_t>(value >> 63));
+        }
+
+        /** IEEE-754 double as little-endian fixed64. */
+        void fixed_double(double value)
+        {
+            std::uint64_t bits{};
+            static_assert(sizeof(bits) == sizeof(value));
+            std::memcpy(&bits, &value, sizeof(bits));
+            for (unsigned i = 0; i < 8; ++i)
+            {
+                buffer_.push_back(static_cast<std::byte>(bits >> (8u * i)));
+            }
+        }
+
+        /** Varint-length-delimited raw bytes. */
+        void bytes_field(std::span<const std::byte> data)
+        {
+            varint(data.size());
+            buffer_.insert(buffer_.end(), data.begin(), data.end());
+        }
+
+        /** Varint-length-delimited UTF-8 string. */
+        void string_field(std::string_view text)
+        {
+            bytes_field(std::as_bytes(std::span{text.data(), text.size()}));
+        }
+
+        /** Field tag (ascending canonical order is the writer's contract). */
+        void tag(std::uint32_t field_tag) { varint(field_tag); }
+
+        /** Embed a fully built nested scope, length-delimited. */
+        void scope(const CanonicalWriter &child) { bytes_field(child.bytes()); }
+
+      private:
+        std::vector<std::byte> buffer_{};
+    };
+
+    /** Bounds-checked reader over a canonical byte span. */
+    class CanonicalReader final
+    {
+      public:
+        explicit CanonicalReader(std::span<const std::byte> data) noexcept
+            : data_(data)
+        {
+        }
+
+        [[nodiscard]] bool at_end() const noexcept { return offset_ == data_.size(); }
+        [[nodiscard]] std::size_t remaining() const noexcept { return data_.size() - offset_; }
+
+        [[nodiscard]] std::uint64_t varint()
+        {
+            std::uint64_t value = 0;
+            unsigned shift = 0;
+            for (;;)
+            {
+                if (offset_ >= data_.size())
+                {
+                    throw CanonicalDecodeError("canonical descriptor truncated inside varint");
+                }
+                const auto byte_value = static_cast<std::uint8_t>(data_[offset_++]);
+                if (shift >= 64u || (shift == 63u && byte_value > 1u))
+                {
+                    throw CanonicalDecodeError("canonical varint overflows 64 bits");
+                }
+                value |= static_cast<std::uint64_t>(byte_value & 0x7fu) << shift;
+                if ((byte_value & 0x80u) == 0u) { return value; }
+                shift += 7u;
+            }
+        }
+
+        [[nodiscard]] std::int64_t svarint()
+        {
+            const std::uint64_t raw = varint();
+            return static_cast<std::int64_t>((raw >> 1u) ^ (~(raw & 1u) + 1u));
+        }
+
+        [[nodiscard]] double fixed_double()
+        {
+            if (remaining() < 8u)
+            {
+                throw CanonicalDecodeError("canonical descriptor truncated inside fixed64");
+            }
+            std::uint64_t bits = 0;
+            for (unsigned i = 0; i < 8; ++i)
+            {
+                bits |= static_cast<std::uint64_t>(static_cast<std::uint8_t>(data_[offset_++]))
+                        << (8u * i);
+            }
+            double value{};
+            std::memcpy(&value, &bits, sizeof(value));
+            return value;
+        }
+
+        [[nodiscard]] std::span<const std::byte> bytes_field()
+        {
+            const std::uint64_t length = varint();
+            if (length > remaining())
+            {
+                throw CanonicalDecodeError("canonical descriptor truncated inside byte field");
+            }
+            const auto result = data_.subspan(offset_, static_cast<std::size_t>(length));
+            offset_ += static_cast<std::size_t>(length);
+            return result;
+        }
+
+        [[nodiscard]] std::string_view string_field()
+        {
+            const auto raw = bytes_field();
+            return {reinterpret_cast<const char *>(raw.data()), raw.size()};
+        }
+
+        [[nodiscard]] std::uint32_t tag()
+        {
+            const std::uint64_t value = varint();
+            if (value > 0xffffffffu) { throw CanonicalDecodeError("canonical tag overflows 32 bits"); }
+            return static_cast<std::uint32_t>(value);
+        }
+
+        [[nodiscard]] CanonicalReader scope() { return CanonicalReader{bytes_field()}; }
+
+      private:
+        std::span<const std::byte> data_;
+        std::size_t offset_{0};
+    };
+}  // namespace hgraph::manifest
+
+#endif  // HGRAPH_MANIFEST_CANONICAL_H

--- a/include/hgraph/manifest/graph_manifest.h
+++ b/include/hgraph/manifest/graph_manifest.h
@@ -1,0 +1,118 @@
+#ifndef HGRAPH_MANIFEST_GRAPH_MANIFEST_H
+#define HGRAPH_MANIFEST_GRAPH_MANIFEST_H
+
+/**
+ * @file graph_manifest.h
+ * The serializable graph manifest (RFC 0022, stage 1).
+ *
+ * ``capture`` walks a FINISHED ``GraphBuilder`` — after ``Wiring::finish``
+ * and before ``make_executor`` — and produces the canonical descriptor of
+ * the wired program: graph identity, the ordered node table (kind, all
+ * endpoint schemas, behaviour flags, selector vectors, implementation
+ * identity, canonical scalar-argument bytes), the ordered edge table with
+ * source kinds and structural paths, and the push-source boundary.
+ *
+ * The DESCRIPTOR BYTES are the identity; ``ManifestId`` (SHA-256 with
+ * format-version domain separation) is a lookup handle only. Validation
+ * decodes both descriptors and reports path-addressed differences — never
+ * just "hash mismatch".
+ *
+ * Stage 1 scope: static graphs whose scalar arguments carry canonically
+ * encodable values. A node holding a live handle in its scalars (nested
+ * graph contexts, Python callables) makes the graph non-manifestable and
+ * ``capture`` raises a path-addressed error — the conservative refusal RFC
+ * 0022 requires. Nested templates and extension identity follow in stage 2.
+ */
+
+#include <hgraph/hgraph_export.h>
+#include <hgraph/util/sha256.h>
+
+#include <cstdint>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace hgraph
+{
+    class GraphBuilder;
+}
+
+namespace hgraph::manifest
+{
+    /** The manifest format version encoded into every descriptor. */
+    inline constexpr std::uint16_t k_manifest_format_version = 1;
+
+    /** SHA-256 lookup handle over a canonical descriptor. */
+    struct ManifestId
+    {
+        util::Sha256Digest digest{};
+
+        friend bool operator==(const ManifestId &, const ManifestId &) = default;
+    };
+
+    /** A graph cannot be captured; ``path()`` addresses the refusing entry. */
+    class HGRAPH_EXPORT ManifestCaptureError : public std::runtime_error
+    {
+      public:
+        ManifestCaptureError(std::string path, const std::string &message);
+
+        [[nodiscard]] const std::string &path() const noexcept { return path_; }
+
+      private:
+        std::string path_;
+    };
+
+    /** One path-addressed difference between two manifests. */
+    struct ManifestDifference
+    {
+        std::string path;
+        std::string expected;
+        std::string actual;
+    };
+
+    /** Path-addressed comparison outcome; empty differences = identical. */
+    struct HGRAPH_EXPORT ValidationResult
+    {
+        std::vector<ManifestDifference> differences{};
+
+        [[nodiscard]] bool identical() const noexcept { return differences.empty(); }
+    };
+
+    /** Immutable description of a fully resolved wired program. */
+    class HGRAPH_EXPORT GraphManifest final
+    {
+      public:
+        [[nodiscard]] std::uint16_t format_version() const noexcept { return format_version_; }
+        [[nodiscard]] ManifestId id() const noexcept { return id_; }
+        [[nodiscard]] std::span<const std::byte> canonical_descriptor() const noexcept
+        {
+            return descriptor_;
+        }
+
+      private:
+        friend HGRAPH_EXPORT GraphManifest capture(const GraphBuilder &graph);
+        friend HGRAPH_EXPORT GraphManifest decode_graph(std::span<const std::byte> bytes);
+
+        GraphManifest(std::uint16_t format_version, std::vector<std::byte> descriptor);
+
+        std::uint16_t format_version_{k_manifest_format_version};
+        std::vector<std::byte> descriptor_{};
+        ManifestId id_{};
+    };
+
+    /** Capture the manifest of a finished graph builder. */
+    [[nodiscard]] HGRAPH_EXPORT GraphManifest capture(const GraphBuilder &graph);
+
+    /** Compare two manifests, reporting path-addressed differences (bounded). */
+    [[nodiscard]] HGRAPH_EXPORT ValidationResult validate(const GraphManifest &expected,
+                                                          const GraphManifest &actual);
+
+    /** Encode a manifest to its durable byte form (version-framed descriptor). */
+    [[nodiscard]] HGRAPH_EXPORT std::vector<std::byte> encode(const GraphManifest &manifest);
+
+    /** Decode a manifest, recomputing and verifying its id. */
+    [[nodiscard]] HGRAPH_EXPORT GraphManifest decode_graph(std::span<const std::byte> bytes);
+}  // namespace hgraph::manifest
+
+#endif  // HGRAPH_MANIFEST_GRAPH_MANIFEST_H

--- a/include/hgraph/manifest/schema_descriptor.h
+++ b/include/hgraph/manifest/schema_descriptor.h
@@ -1,0 +1,76 @@
+#ifndef HGRAPH_MANIFEST_SCHEMA_DESCRIPTOR_H
+#define HGRAPH_MANIFEST_SCHEMA_DESCRIPTOR_H
+
+/**
+ * @file schema_descriptor.h
+ * Canonical structural schema descriptors and scalar encoding (RFC 0022).
+ *
+ * A descriptor is the schema's durable identity: canonical bytes derived
+ * from structure (kind, wire-affecting flags, children, nominal names for
+ * named bundles and enums), never from interned pointers or diagnostic
+ * labels. Two schemas the runtime treats as equivalent produce identical
+ * descriptor bytes; anything the runtime distinguishes produces different
+ * bytes (the conformance reference is ``time_series_schema_equivalent``).
+ *
+ * Descriptor synthesis is cold-path (wiring/attachment time) and computed
+ * on demand — no cache, no lock, no registry-reset interaction.
+ *
+ * ``encode_manifest_scalar`` writes an immutable scalar Value in canonical
+ * schema-directed binary form. A scalar whose type has no canonical
+ * encoding (live handles, python-owned payloads, unregistered scalar
+ * kinds) raises ``UnsupportedManifestValue`` carrying the reason — RFC
+ * 0022's conservative refusal, surfaced with a path by the caller.
+ */
+
+#include <hgraph/manifest/canonical.h>
+
+#include <stdexcept>
+#include <string>
+
+namespace hgraph
+{
+    struct ValueTypeMetaData;
+    struct TSValueTypeMetaData;
+    class ValueView;
+}  // namespace hgraph
+
+namespace hgraph::manifest
+{
+    /** A value/scalar cannot participate in a manifest; ``what()`` says why. */
+    class UnsupportedManifestValue : public std::runtime_error
+    {
+      public:
+        using std::runtime_error::runtime_error;
+    };
+
+    /** Append the canonical descriptor for a value-layer schema. */
+    void append_value_descriptor(CanonicalWriter &writer, const ValueTypeMetaData *meta);
+
+    /** Append the canonical descriptor for a time-series schema. */
+    void append_ts_descriptor(CanonicalWriter &writer, const TSValueTypeMetaData *meta);
+
+    /** The canonical descriptor bytes for a value-layer schema. */
+    [[nodiscard]] std::vector<std::byte> value_descriptor(const ValueTypeMetaData *meta);
+
+    /** The canonical descriptor bytes for a time-series schema. */
+    [[nodiscard]] std::vector<std::byte> ts_descriptor(const TSValueTypeMetaData *meta);
+
+    /**
+     * Append a scalar value in canonical schema-directed binary form.
+     *
+     * Supported: the core atomic scalars (bool/int/float/str and the
+     * engine date/time family), enums, and tuples/bundles/lists/sets/maps
+     * of supported values (set and map content is emitted in canonical
+     * encoded-key order). Throws ``UnsupportedManifestValue`` otherwise.
+     */
+    void encode_manifest_scalar(CanonicalWriter &writer, const ValueView &value);
+
+    /**
+     * Whether a schema's values can be canonically encoded; when not,
+     * ``reason`` (optional) receives a stable human-readable explanation.
+     */
+    [[nodiscard]] bool manifest_scalar_encodable(const ValueTypeMetaData *meta,
+                                                 std::string *reason = nullptr);
+}  // namespace hgraph::manifest
+
+#endif  // HGRAPH_MANIFEST_SCHEMA_DESCRIPTOR_H

--- a/include/hgraph/manifest/schema_descriptor.h
+++ b/include/hgraph/manifest/schema_descriptor.h
@@ -22,6 +22,7 @@
  * 0022's conservative refusal, surfaced with a path by the caller.
  */
 
+#include <hgraph/hgraph_export.h>
 #include <hgraph/manifest/canonical.h>
 
 #include <stdexcept>
@@ -37,23 +38,23 @@ namespace hgraph
 namespace hgraph::manifest
 {
     /** A value/scalar cannot participate in a manifest; ``what()`` says why. */
-    class UnsupportedManifestValue : public std::runtime_error
+    class HGRAPH_EXPORT UnsupportedManifestValue : public std::runtime_error
     {
       public:
         using std::runtime_error::runtime_error;
     };
 
     /** Append the canonical descriptor for a value-layer schema. */
-    void append_value_descriptor(CanonicalWriter &writer, const ValueTypeMetaData *meta);
+    HGRAPH_EXPORT void append_value_descriptor(CanonicalWriter &writer, const ValueTypeMetaData *meta);
 
     /** Append the canonical descriptor for a time-series schema. */
-    void append_ts_descriptor(CanonicalWriter &writer, const TSValueTypeMetaData *meta);
+    HGRAPH_EXPORT void append_ts_descriptor(CanonicalWriter &writer, const TSValueTypeMetaData *meta);
 
     /** The canonical descriptor bytes for a value-layer schema. */
-    [[nodiscard]] std::vector<std::byte> value_descriptor(const ValueTypeMetaData *meta);
+    [[nodiscard]] HGRAPH_EXPORT std::vector<std::byte> value_descriptor(const ValueTypeMetaData *meta);
 
     /** The canonical descriptor bytes for a time-series schema. */
-    [[nodiscard]] std::vector<std::byte> ts_descriptor(const TSValueTypeMetaData *meta);
+    [[nodiscard]] HGRAPH_EXPORT std::vector<std::byte> ts_descriptor(const TSValueTypeMetaData *meta);
 
     /**
      * Append a scalar value in canonical schema-directed binary form.
@@ -63,14 +64,14 @@ namespace hgraph::manifest
      * of supported values (set and map content is emitted in canonical
      * encoded-key order). Throws ``UnsupportedManifestValue`` otherwise.
      */
-    void encode_manifest_scalar(CanonicalWriter &writer, const ValueView &value);
+    HGRAPH_EXPORT void encode_manifest_scalar(CanonicalWriter &writer, const ValueView &value);
 
     /**
      * Whether a schema's values can be canonically encoded; when not,
      * ``reason`` (optional) receives a stable human-readable explanation.
      */
-    [[nodiscard]] bool manifest_scalar_encodable(const ValueTypeMetaData *meta,
-                                                 std::string *reason = nullptr);
+    [[nodiscard]] HGRAPH_EXPORT bool manifest_scalar_encodable(
+        const ValueTypeMetaData *meta, std::string *reason = nullptr);
 }  // namespace hgraph::manifest
 
 #endif  // HGRAPH_MANIFEST_SCHEMA_DESCRIPTOR_H

--- a/include/hgraph/util/sha256.h
+++ b/include/hgraph/util/sha256.h
@@ -1,0 +1,55 @@
+#ifndef HGRAPH_UTIL_SHA256_H
+#define HGRAPH_UTIL_SHA256_H
+
+/**
+ * @file sha256.h
+ * Minimal self-contained SHA-256 (FIPS 180-4) for manifest identity.
+ *
+ * RFC 0022 uses SHA-256 over a canonical descriptor as a LOOKUP HANDLE; the
+ * descriptor bytes themselves remain the identity compared on attach. A
+ * self-contained implementation keeps the default build free of a
+ * cryptography dependency (the digest is an integrity/lookup device here,
+ * not a security boundary).
+ */
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+namespace hgraph::util
+{
+    /** A SHA-256 digest: 32 raw bytes. */
+    struct Sha256Digest
+    {
+        std::array<std::byte, 32> bytes{};
+
+        friend bool operator==(const Sha256Digest &, const Sha256Digest &) = default;
+    };
+
+    /** Streaming SHA-256 hasher. */
+    class Sha256 final
+    {
+      public:
+        Sha256() noexcept;
+
+        void update(std::span<const std::byte> data) noexcept;
+        [[nodiscard]] Sha256Digest finish() noexcept;
+
+      private:
+        void process_block(const std::uint8_t *block) noexcept;
+
+        std::array<std::uint32_t, 8> state_{};
+        std::array<std::uint8_t, 64> buffer_{};
+        std::uint64_t total_bytes_{0};
+        std::size_t buffered_{0};
+    };
+
+    /** One-shot digest of a byte span. */
+    [[nodiscard]] Sha256Digest sha256(std::span<const std::byte> data) noexcept;
+
+    /** Render a digest as lowercase hex (diagnostics only, 64 chars). */
+    [[nodiscard]] std::array<char, 64> sha256_hex(const Sha256Digest &digest) noexcept;
+}  // namespace hgraph::util
+
+#endif  // HGRAPH_UTIL_SHA256_H

--- a/include/hgraph/util/sha256.h
+++ b/include/hgraph/util/sha256.h
@@ -12,6 +12,8 @@
  * not a security boundary).
  */
 
+#include <hgraph/hgraph_export.h>
+
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -28,7 +30,7 @@ namespace hgraph::util
     };
 
     /** Streaming SHA-256 hasher. */
-    class Sha256 final
+    class HGRAPH_EXPORT Sha256 final
     {
       public:
         Sha256() noexcept;
@@ -46,10 +48,10 @@ namespace hgraph::util
     };
 
     /** One-shot digest of a byte span. */
-    [[nodiscard]] Sha256Digest sha256(std::span<const std::byte> data) noexcept;
+    [[nodiscard]] HGRAPH_EXPORT Sha256Digest sha256(std::span<const std::byte> data) noexcept;
 
     /** Render a digest as lowercase hex (diagnostics only, 64 chars). */
-    [[nodiscard]] std::array<char, 64> sha256_hex(const Sha256Digest &digest) noexcept;
+    [[nodiscard]] HGRAPH_EXPORT std::array<char, 64> sha256_hex(const Sha256Digest &digest) noexcept;
 }  // namespace hgraph::util
 
 #endif  // HGRAPH_UTIL_SHA256_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,8 @@
 set(HGRAPH_RUNTIME_SOURCES
     hgraph/version.cpp
+    hgraph/util/sha256.cpp
+    hgraph/manifest/schema_descriptor.cpp
+    hgraph/manifest/graph_manifest.cpp
     hgraph/runtime/context_node.cpp
     hgraph/runtime/diagnostic_path.cpp
     hgraph/runtime/evaluation_clock.cpp

--- a/src/hgraph/manifest/graph_manifest.cpp
+++ b/src/hgraph/manifest/graph_manifest.cpp
@@ -1,0 +1,597 @@
+#include <hgraph/manifest/graph_manifest.h>
+
+#include <hgraph/manifest/canonical.h>
+#include <hgraph/manifest/schema_descriptor.h>
+#include <hgraph/runtime/graph.h>
+#include <hgraph/runtime/node.h>
+#include <hgraph/types/metadata/type_record.h>
+#include <hgraph/types/time_series/endpoint_schema.h>
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <optional>
+
+namespace hgraph::manifest
+{
+    namespace
+    {
+        // Graph-level tags.
+        constexpr std::uint32_t k_graph_tag_version = 1;
+        constexpr std::uint32_t k_graph_tag_label = 2;
+        constexpr std::uint32_t k_graph_tag_nodes = 3;
+        constexpr std::uint32_t k_graph_tag_edges = 4;
+
+        // Node-level tags.
+        constexpr std::uint32_t k_node_tag_semantic_name = 1;
+        constexpr std::uint32_t k_node_tag_implementation = 2;
+        constexpr std::uint32_t k_node_tag_kind = 3;
+        constexpr std::uint32_t k_node_tag_behaviour = 4;
+        constexpr std::uint32_t k_node_tag_input_schema = 5;
+        constexpr std::uint32_t k_node_tag_output_schema = 6;
+        constexpr std::uint32_t k_node_tag_error_schema = 7;
+        constexpr std::uint32_t k_node_tag_recordable_schema = 8;
+        constexpr std::uint32_t k_node_tag_state_schema = 9;
+        constexpr std::uint32_t k_node_tag_scalar_schema = 10;
+        constexpr std::uint32_t k_node_tag_input_endpoint = 11;
+        constexpr std::uint32_t k_node_tag_output_endpoint = 12;
+        constexpr std::uint32_t k_node_tag_selectors = 13;
+        constexpr std::uint32_t k_node_tag_scalars = 14;
+
+        // Edge-level tags.
+        constexpr std::uint32_t k_edge_tag_source_node = 1;
+        constexpr std::uint32_t k_edge_tag_source_kind = 2;
+        constexpr std::uint32_t k_edge_tag_source_path = 3;
+        constexpr std::uint32_t k_edge_tag_target_node = 4;
+        constexpr std::uint32_t k_edge_tag_target_path = 5;
+
+        // Behaviour bit positions (canonical; append-only).
+        enum : std::uint64_t
+        {
+            k_behaviour_uses_scheduler = 1u << 0,
+            k_behaviour_uses_global_state = 1u << 1,
+            k_behaviour_uses_evaluation_clock = 1u << 2,
+            k_behaviour_uses_python_values = 1u << 3,
+            k_behaviour_simulation_capable_push = 1u << 4,
+            k_behaviour_requires_phase_runner = 1u << 5,
+            k_behaviour_schedule_on_start = 1u << 6,
+            k_behaviour_captures_errors = 1u << 7,
+        };
+
+        void append_endpoint_annotation(CanonicalWriter &writer, const TSEndpointSchema &endpoint)
+        {
+            CanonicalWriter scope;
+            if (!endpoint.empty())
+            {
+                scope.varint(static_cast<std::uint64_t>(endpoint.role()));
+                scope.varint(endpoint.child_count());
+                for (std::size_t i = 0; i < endpoint.child_count(); ++i)
+                {
+                    append_endpoint_annotation(scope, endpoint.child(i));
+                }
+            }
+            writer.scope(scope);
+        }
+
+        void append_selector(CanonicalWriter &writer,
+                             const std::optional<std::vector<std::size_t>> &selector)
+        {
+            if (!selector.has_value())
+            {
+                writer.varint(0);  // absent
+                return;
+            }
+            writer.varint(1);  // engaged
+            writer.varint(selector->size());
+            for (const auto index : *selector) { writer.varint(index); }
+        }
+
+        void append_selector(CanonicalWriter &writer, const std::vector<std::size_t> &selector)
+        {
+            writer.varint(1);
+            writer.varint(selector.size());
+            for (const auto index : selector) { writer.varint(index); }
+        }
+
+        void append_node(CanonicalWriter &writer, const NodeBuilder &node, std::size_t ordinal)
+        {
+            const auto *schema = node.type().schema();
+            const auto *record = node.type().record();
+            if (schema == nullptr)
+            {
+                throw ManifestCaptureError(fmt::format("node[{}]", ordinal),
+                                           "node has no type metadata");
+            }
+
+            CanonicalWriter scope;
+            scope.tag(k_node_tag_semantic_name);
+            scope.string_field(schema->name());
+            scope.tag(k_node_tag_implementation);
+            scope.string_field(record != nullptr ? record->implementation_name()
+                                                 : std::string_view{});
+            scope.tag(k_node_tag_kind);
+            scope.varint(static_cast<std::uint64_t>(schema->node_kind));
+
+            std::uint64_t behaviour = 0;
+            if (schema->uses_scheduler) { behaviour |= k_behaviour_uses_scheduler; }
+            if (schema->uses_global_state) { behaviour |= k_behaviour_uses_global_state; }
+            if (schema->uses_evaluation_clock) { behaviour |= k_behaviour_uses_evaluation_clock; }
+            if (schema->uses_python_values) { behaviour |= k_behaviour_uses_python_values; }
+            if (schema->simulation_capable_push_source)
+            {
+                behaviour |= k_behaviour_simulation_capable_push;
+            }
+            if (schema->requires_phase_runner) { behaviour |= k_behaviour_requires_phase_runner; }
+            if (schema->schedule_on_start) { behaviour |= k_behaviour_schedule_on_start; }
+            if (schema->captures_errors) { behaviour |= k_behaviour_captures_errors; }
+            scope.tag(k_node_tag_behaviour);
+            scope.varint(behaviour);
+
+            scope.tag(k_node_tag_input_schema);
+            append_ts_descriptor(scope, schema->input_schema);
+            scope.tag(k_node_tag_output_schema);
+            append_ts_descriptor(scope, schema->output_schema);
+            scope.tag(k_node_tag_error_schema);
+            append_ts_descriptor(scope, schema->error_output_schema);
+            scope.tag(k_node_tag_recordable_schema);
+            append_ts_descriptor(scope, schema->recordable_state_schema);
+            scope.tag(k_node_tag_state_schema);
+            append_value_descriptor(scope, schema->state_schema);
+            scope.tag(k_node_tag_scalar_schema);
+            append_value_descriptor(scope, schema->scalar_schema);
+
+            scope.tag(k_node_tag_input_endpoint);
+            append_endpoint_annotation(scope, node.input_endpoint());
+            scope.tag(k_node_tag_output_endpoint);
+            append_endpoint_annotation(scope, node.output_endpoint());
+
+            scope.tag(k_node_tag_selectors);
+            {
+                CanonicalWriter selectors;
+                append_selector(selectors, schema->active_inputs);
+                append_selector(selectors, schema->structural_inputs);
+                append_selector(selectors, schema->valid_inputs);
+                append_selector(selectors, schema->all_valid_inputs);
+                scope.scope(selectors);
+            }
+
+            scope.tag(k_node_tag_scalars);
+            {
+                CanonicalWriter scalars;
+                const Value &values = node.scalars();
+                if (values.has_value())
+                {
+                    try
+                    {
+                        encode_manifest_scalar(scalars, values.view());
+                    }
+                    catch (const UnsupportedManifestValue &error)
+                    {
+                        throw ManifestCaptureError(
+                            fmt::format("node[{}]:{}", ordinal, schema->name()), error.what());
+                    }
+                }
+                scope.scope(scalars);
+            }
+
+            writer.scope(scope);
+        }
+
+        void append_edge(CanonicalWriter &writer, const GraphEdge &edge)
+        {
+            CanonicalWriter scope;
+            scope.tag(k_edge_tag_source_node);
+            scope.varint(graph_edge_source_node(edge.source_node));
+            scope.tag(k_edge_tag_source_kind);
+            scope.varint(static_cast<std::uint64_t>(graph_edge_source_kind(edge.source_node)));
+            scope.tag(k_edge_tag_source_path);
+            scope.varint(edge.source_path.size());
+            for (const auto component : edge.source_path) { scope.varint(component); }
+            scope.tag(k_edge_tag_target_node);
+            scope.varint(edge.target_node);
+            scope.tag(k_edge_tag_target_path);
+            scope.varint(edge.target_path.size());
+            for (const auto component : edge.target_path) { scope.varint(component); }
+            writer.scope(scope);
+        }
+
+        [[nodiscard]] ManifestId compute_id(std::uint16_t format_version,
+                                            std::span<const std::byte> descriptor)
+        {
+            // Domain separation: the version participates in the digest input
+            // but the id field itself never does (no fixed-point).
+            util::Sha256 hasher;
+            const std::array<std::byte, 2> version_bytes{
+                static_cast<std::byte>(format_version & 0xffu),
+                static_cast<std::byte>((format_version >> 8u) & 0xffu)};
+            hasher.update(version_bytes);
+            hasher.update(descriptor);
+            return ManifestId{hasher.finish()};
+        }
+
+        // ------------------------------------------------------------------
+        // Decoded model (validation only; the bytes remain the identity).
+
+        struct DecodedEndpoint
+        {
+            std::optional<std::uint64_t> role{};
+            std::vector<DecodedEndpoint> children{};
+
+            friend bool operator==(const DecodedEndpoint &, const DecodedEndpoint &) = default;
+        };
+
+        struct DecodedNode
+        {
+            std::string semantic_name;
+            std::string implementation;
+            std::uint64_t kind{};
+            std::uint64_t behaviour{};
+            std::vector<std::byte> input_schema;
+            std::vector<std::byte> output_schema;
+            std::vector<std::byte> error_schema;
+            std::vector<std::byte> recordable_schema;
+            std::vector<std::byte> state_schema;
+            std::vector<std::byte> scalar_schema;
+            DecodedEndpoint input_endpoint;
+            DecodedEndpoint output_endpoint;
+            std::vector<std::byte> selectors;
+            std::vector<std::byte> scalars;
+        };
+
+        struct DecodedEdge
+        {
+            std::uint64_t source_node{};
+            std::uint64_t source_kind{};
+            std::vector<std::uint64_t> source_path;
+            std::uint64_t target_node{};
+            std::vector<std::uint64_t> target_path;
+        };
+
+        struct DecodedGraph
+        {
+            std::uint64_t format_version{};
+            std::string label;
+            std::vector<DecodedNode> nodes;
+            std::vector<DecodedEdge> edges;
+        };
+
+        DecodedEndpoint decode_endpoint(CanonicalReader reader)
+        {
+            DecodedEndpoint endpoint;
+            if (reader.at_end()) { return endpoint; }
+            endpoint.role = reader.varint();
+            const auto child_count = reader.varint();
+            endpoint.children.reserve(static_cast<std::size_t>(child_count));
+            for (std::uint64_t i = 0; i < child_count; ++i)
+            {
+                endpoint.children.push_back(decode_endpoint(reader.scope()));
+            }
+            return endpoint;
+        }
+
+        std::vector<std::byte> owned_bytes(std::span<const std::byte> bytes)
+        {
+            return {bytes.begin(), bytes.end()};
+        }
+
+        DecodedNode decode_node(CanonicalReader reader)
+        {
+            DecodedNode node;
+            while (!reader.at_end())
+            {
+                switch (reader.tag())
+                {
+                case k_node_tag_semantic_name: node.semantic_name = reader.string_field(); break;
+                case k_node_tag_implementation: node.implementation = reader.string_field(); break;
+                case k_node_tag_kind: node.kind = reader.varint(); break;
+                case k_node_tag_behaviour: node.behaviour = reader.varint(); break;
+                case k_node_tag_input_schema: node.input_schema = owned_bytes(reader.bytes_field()); break;
+                case k_node_tag_output_schema: node.output_schema = owned_bytes(reader.bytes_field()); break;
+                case k_node_tag_error_schema: node.error_schema = owned_bytes(reader.bytes_field()); break;
+                case k_node_tag_recordable_schema:
+                    node.recordable_schema = owned_bytes(reader.bytes_field());
+                    break;
+                case k_node_tag_state_schema: node.state_schema = owned_bytes(reader.bytes_field()); break;
+                case k_node_tag_scalar_schema:
+                    node.scalar_schema = owned_bytes(reader.bytes_field());
+                    break;
+                case k_node_tag_input_endpoint: node.input_endpoint = decode_endpoint(reader.scope()); break;
+                case k_node_tag_output_endpoint:
+                    node.output_endpoint = decode_endpoint(reader.scope());
+                    break;
+                case k_node_tag_selectors: node.selectors = owned_bytes(reader.bytes_field()); break;
+                case k_node_tag_scalars: node.scalars = owned_bytes(reader.bytes_field()); break;
+                default:
+                    throw CanonicalDecodeError("unknown required field in node descriptor");
+                }
+            }
+            return node;
+        }
+
+        DecodedEdge decode_edge(CanonicalReader reader)
+        {
+            DecodedEdge edge;
+            while (!reader.at_end())
+            {
+                switch (reader.tag())
+                {
+                case k_edge_tag_source_node: edge.source_node = reader.varint(); break;
+                case k_edge_tag_source_kind: edge.source_kind = reader.varint(); break;
+                case k_edge_tag_source_path: {
+                    const auto count = reader.varint();
+                    for (std::uint64_t i = 0; i < count; ++i)
+                    {
+                        edge.source_path.push_back(reader.varint());
+                    }
+                    break;
+                }
+                case k_edge_tag_target_node: edge.target_node = reader.varint(); break;
+                case k_edge_tag_target_path: {
+                    const auto count = reader.varint();
+                    for (std::uint64_t i = 0; i < count; ++i)
+                    {
+                        edge.target_path.push_back(reader.varint());
+                    }
+                    break;
+                }
+                default:
+                    throw CanonicalDecodeError("unknown required field in edge descriptor");
+                }
+            }
+            return edge;
+        }
+
+        DecodedGraph decode_descriptor(std::span<const std::byte> descriptor)
+        {
+            DecodedGraph graph;
+            CanonicalReader reader{descriptor};
+            while (!reader.at_end())
+            {
+                switch (reader.tag())
+                {
+                case k_graph_tag_version: graph.format_version = reader.varint(); break;
+                case k_graph_tag_label: graph.label = reader.string_field(); break;
+                case k_graph_tag_nodes: {
+                    const auto count = reader.varint();
+                    graph.nodes.reserve(static_cast<std::size_t>(count));
+                    for (std::uint64_t i = 0; i < count; ++i)
+                    {
+                        graph.nodes.push_back(decode_node(reader.scope()));
+                    }
+                    break;
+                }
+                case k_graph_tag_edges: {
+                    const auto count = reader.varint();
+                    graph.edges.reserve(static_cast<std::size_t>(count));
+                    for (std::uint64_t i = 0; i < count; ++i)
+                    {
+                        graph.edges.push_back(decode_edge(reader.scope()));
+                    }
+                    break;
+                }
+                default:
+                    throw CanonicalDecodeError("unknown required field in graph descriptor");
+                }
+            }
+            return graph;
+        }
+
+        constexpr std::size_t k_max_reported_differences = 32;
+
+        void report(ValidationResult &result, std::string path, std::string expected,
+                    std::string actual)
+        {
+            if (result.differences.size() >= k_max_reported_differences) { return; }
+            result.differences.push_back(
+                {std::move(path), std::move(expected), std::move(actual)});
+        }
+
+        std::string hex_preview(std::span<const std::byte> bytes)
+        {
+            constexpr std::size_t k_preview = 12;
+            std::string out;
+            for (std::size_t i = 0; i < bytes.size() && i < k_preview; ++i)
+            {
+                out += fmt::format("{:02x}", static_cast<unsigned>(bytes[i]));
+            }
+            if (bytes.size() > k_preview) { out += "…"; }
+            return out.empty() ? std::string{"<empty>"} : out;
+        }
+
+        void compare_bytes(ValidationResult &result, const std::string &path,
+                           const std::vector<std::byte> &expected,
+                           const std::vector<std::byte> &actual)
+        {
+            if (expected != actual)
+            {
+                report(result, path, hex_preview(expected), hex_preview(actual));
+            }
+        }
+
+        std::string path_list(const std::vector<std::uint64_t> &path)
+        {
+            std::string out = "[";
+            for (std::size_t i = 0; i < path.size(); ++i)
+            {
+                if (i != 0) { out += ","; }
+                out += fmt::format("{}", path[i]);
+            }
+            return out + "]";
+        }
+    }  // namespace
+
+    ManifestCaptureError::ManifestCaptureError(std::string path, const std::string &message)
+        : std::runtime_error(fmt::format("{}: {}", path, message))
+        , path_(std::move(path))
+    {
+    }
+
+    GraphManifest::GraphManifest(std::uint16_t format_version, std::vector<std::byte> descriptor)
+        : format_version_(format_version)
+        , descriptor_(std::move(descriptor))
+        , id_(compute_id(format_version_, descriptor_))
+    {
+    }
+
+    GraphManifest capture(const GraphBuilder &graph)
+    {
+        CanonicalWriter writer;
+        writer.tag(k_graph_tag_version);
+        writer.varint(k_manifest_format_version);
+        writer.tag(k_graph_tag_label);
+        writer.string_field(graph.label());
+
+        writer.tag(k_graph_tag_nodes);
+        writer.varint(graph.nodes().size());
+        for (std::size_t i = 0; i < graph.nodes().size(); ++i)
+        {
+            append_node(writer, graph.nodes()[i], i);
+        }
+
+        writer.tag(k_graph_tag_edges);
+        writer.varint(graph.edges().size());
+        for (const auto &edge : graph.edges()) { append_edge(writer, edge); }
+
+        return GraphManifest{k_manifest_format_version, writer.take()};
+    }
+
+    ValidationResult validate(const GraphManifest &expected, const GraphManifest &actual)
+    {
+        ValidationResult result;
+        if (expected.canonical_descriptor().size() == actual.canonical_descriptor().size() &&
+            std::equal(expected.canonical_descriptor().begin(),
+                       expected.canonical_descriptor().end(),
+                       actual.canonical_descriptor().begin()))
+        {
+            return result;
+        }
+
+        const auto expected_graph = decode_descriptor(expected.canonical_descriptor());
+        const auto actual_graph = decode_descriptor(actual.canonical_descriptor());
+
+        if (expected_graph.format_version != actual_graph.format_version)
+        {
+            report(result, "graph/format_version",
+                   fmt::format("{}", expected_graph.format_version),
+                   fmt::format("{}", actual_graph.format_version));
+        }
+        if (expected_graph.label != actual_graph.label)
+        {
+            report(result, "graph/label", expected_graph.label, actual_graph.label);
+        }
+        if (expected_graph.nodes.size() != actual_graph.nodes.size())
+        {
+            report(result, "graph/node_count",
+                   fmt::format("{}", expected_graph.nodes.size()),
+                   fmt::format("{}", actual_graph.nodes.size()));
+        }
+        const std::size_t node_count =
+            std::min(expected_graph.nodes.size(), actual_graph.nodes.size());
+        for (std::size_t i = 0; i < node_count; ++i)
+        {
+            const auto &lhs = expected_graph.nodes[i];
+            const auto &rhs = actual_graph.nodes[i];
+            const std::string base = fmt::format("node[{}]:{}", i, lhs.semantic_name);
+            if (lhs.semantic_name != rhs.semantic_name)
+            {
+                report(result, base + "/semantic_name", lhs.semantic_name, rhs.semantic_name);
+            }
+            if (lhs.implementation != rhs.implementation)
+            {
+                report(result, base + "/implementation", lhs.implementation, rhs.implementation);
+            }
+            if (lhs.kind != rhs.kind)
+            {
+                report(result, base + "/kind", fmt::format("{}", lhs.kind),
+                       fmt::format("{}", rhs.kind));
+            }
+            if (lhs.behaviour != rhs.behaviour)
+            {
+                report(result, base + "/behaviour", fmt::format("{:#x}", lhs.behaviour),
+                       fmt::format("{:#x}", rhs.behaviour));
+            }
+            compare_bytes(result, base + "/input_schema", lhs.input_schema, rhs.input_schema);
+            compare_bytes(result, base + "/output_schema", lhs.output_schema, rhs.output_schema);
+            compare_bytes(result, base + "/error_schema", lhs.error_schema, rhs.error_schema);
+            compare_bytes(result, base + "/recordable_state_schema", lhs.recordable_schema,
+                          rhs.recordable_schema);
+            compare_bytes(result, base + "/state_schema", lhs.state_schema, rhs.state_schema);
+            compare_bytes(result, base + "/scalar_schema", lhs.scalar_schema, rhs.scalar_schema);
+            if (lhs.input_endpoint != rhs.input_endpoint)
+            {
+                report(result, base + "/input_endpoint", "<endpoint annotation>",
+                       "<differs>");
+            }
+            if (lhs.output_endpoint != rhs.output_endpoint)
+            {
+                report(result, base + "/output_endpoint", "<endpoint annotation>",
+                       "<differs>");
+            }
+            compare_bytes(result, base + "/selectors", lhs.selectors, rhs.selectors);
+            compare_bytes(result, base + "/scalars", lhs.scalars, rhs.scalars);
+        }
+
+        if (expected_graph.edges.size() != actual_graph.edges.size())
+        {
+            report(result, "graph/edge_count",
+                   fmt::format("{}", expected_graph.edges.size()),
+                   fmt::format("{}", actual_graph.edges.size()));
+        }
+        const std::size_t edge_count =
+            std::min(expected_graph.edges.size(), actual_graph.edges.size());
+        for (std::size_t i = 0; i < edge_count; ++i)
+        {
+            const auto &lhs = expected_graph.edges[i];
+            const auto &rhs = actual_graph.edges[i];
+            if (lhs.source_node != rhs.source_node || lhs.source_kind != rhs.source_kind ||
+                lhs.source_path != rhs.source_path || lhs.target_node != rhs.target_node ||
+                lhs.target_path != rhs.target_path)
+            {
+                report(result, fmt::format("edge[{}]", i),
+                       fmt::format("{}#{}{} -> {}{}", lhs.source_node, lhs.source_kind,
+                                   path_list(lhs.source_path), lhs.target_node,
+                                   path_list(lhs.target_path)),
+                       fmt::format("{}#{}{} -> {}{}", rhs.source_node, rhs.source_kind,
+                                   path_list(rhs.source_path), rhs.target_node,
+                                   path_list(rhs.target_path)));
+            }
+        }
+
+        if (result.differences.empty())
+        {
+            // Byte inequality with no structural difference found: report the
+            // raw divergence rather than claiming identity.
+            report(result, "graph/descriptor", hex_preview(expected.canonical_descriptor()),
+                   hex_preview(actual.canonical_descriptor()));
+        }
+        return result;
+    }
+
+    std::vector<std::byte> encode(const GraphManifest &manifest)
+    {
+        CanonicalWriter writer;
+        writer.varint(manifest.format_version());
+        writer.bytes_field(manifest.canonical_descriptor());
+        return writer.take();
+    }
+
+    GraphManifest decode_graph(std::span<const std::byte> bytes)
+    {
+        CanonicalReader reader{bytes};
+        const auto version = reader.varint();
+        if (version != k_manifest_format_version)
+        {
+            throw CanonicalDecodeError(
+                fmt::format("unsupported manifest format version {}", version));
+        }
+        auto descriptor = reader.bytes_field();
+        if (!reader.at_end())
+        {
+            throw CanonicalDecodeError("trailing bytes after manifest descriptor");
+        }
+        // Decoding validates structure (and therefore rejects torn input).
+        (void)decode_descriptor(descriptor);
+        return GraphManifest{static_cast<std::uint16_t>(version),
+                             {descriptor.begin(), descriptor.end()}};
+    }
+}  // namespace hgraph::manifest

--- a/src/hgraph/manifest/graph_manifest.cpp
+++ b/src/hgraph/manifest/graph_manifest.cpp
@@ -38,6 +38,8 @@ namespace hgraph::manifest
         constexpr std::uint32_t k_node_tag_selectors = 13;
         constexpr std::uint32_t k_node_tag_scalars = 14;
 
+        constexpr std::uint32_t k_node_tag_error_capture = 15;
+
         // Edge-level tags.
         constexpr std::uint32_t k_edge_tag_source_node = 1;
         constexpr std::uint32_t k_edge_tag_source_kind = 2;
@@ -142,8 +144,13 @@ namespace hgraph::manifest
 
             scope.tag(k_node_tag_input_endpoint);
             append_endpoint_annotation(scope, node.input_endpoint());
+            // The EFFECTIVE annotation: runtime construction falls back to the
+            // schema annotation when the per-instance override is empty
+            // (nested owners rely on it for forwarding/ownership roles).
             scope.tag(k_node_tag_output_endpoint);
-            append_endpoint_annotation(scope, node.output_endpoint());
+            append_endpoint_annotation(scope, !node.output_endpoint().empty()
+                                                  ? node.output_endpoint()
+                                                  : schema->output_endpoint_schema);
 
             scope.tag(k_node_tag_selectors);
             {
@@ -172,6 +179,17 @@ namespace hgraph::manifest
                     }
                 }
                 scope.scope(scalars);
+            }
+
+            scope.tag(k_node_tag_error_capture);
+            {
+                // The capture options change the emitted NodeError content
+                // (traceback depth, captured values), so they are identity
+                // alongside the captures_errors bit.
+                CanonicalWriter capture;
+                capture.varint(schema->error_capture.trace_back_depth);
+                capture.varint(schema->error_capture.capture_values ? 1u : 0u);
+                scope.scope(capture);
             }
 
             writer.scope(scope);
@@ -236,6 +254,7 @@ namespace hgraph::manifest
             DecodedEndpoint output_endpoint;
             std::vector<std::byte> selectors;
             std::vector<std::byte> scalars;
+            std::vector<std::byte> error_capture;
         };
 
         struct DecodedEdge
@@ -254,6 +273,39 @@ namespace hgraph::manifest
             std::vector<DecodedNode> nodes;
             std::vector<DecodedEdge> edges;
         };
+
+        // Required-field discipline: every tag in a scope appears exactly
+        // once; a missing or duplicated required field rejects the descriptor
+        // (RFC 0022: readers never guess what an omission means).
+        void mark_seen(std::uint32_t &seen, std::uint32_t tag, const char *scope_name)
+        {
+            if (tag == 0 || tag > 31)
+            {
+                throw CanonicalDecodeError(
+                    fmt::format("unknown required field in {} descriptor", scope_name));
+            }
+            const std::uint32_t bit = 1u << tag;
+            if ((seen & bit) != 0)
+            {
+                throw CanonicalDecodeError(
+                    fmt::format("duplicate field {} in {} descriptor", tag, scope_name));
+            }
+            seen |= bit;
+        }
+
+        void require_seen(std::uint32_t seen, std::uint32_t first_tag, std::uint32_t last_tag,
+                          const char *scope_name)
+        {
+            for (std::uint32_t tag = first_tag; tag <= last_tag; ++tag)
+            {
+                if ((seen & (1u << tag)) == 0)
+                {
+                    throw CanonicalDecodeError(
+                        fmt::format("missing required field {} in {} descriptor", tag,
+                                    scope_name));
+                }
+            }
+        }
 
         DecodedEndpoint decode_endpoint(CanonicalReader reader)
         {
@@ -277,9 +329,12 @@ namespace hgraph::manifest
         DecodedNode decode_node(CanonicalReader reader)
         {
             DecodedNode node;
+            std::uint32_t seen = 0;
             while (!reader.at_end())
             {
-                switch (reader.tag())
+                const auto field_tag = reader.tag();
+                mark_seen(seen, field_tag, "node");
+                switch (field_tag)
                 {
                 case k_node_tag_semantic_name: node.semantic_name = reader.string_field(); break;
                 case k_node_tag_implementation: node.implementation = reader.string_field(); break;
@@ -301,19 +356,26 @@ namespace hgraph::manifest
                     break;
                 case k_node_tag_selectors: node.selectors = owned_bytes(reader.bytes_field()); break;
                 case k_node_tag_scalars: node.scalars = owned_bytes(reader.bytes_field()); break;
+                case k_node_tag_error_capture:
+                    node.error_capture = owned_bytes(reader.bytes_field());
+                    break;
                 default:
                     throw CanonicalDecodeError("unknown required field in node descriptor");
                 }
             }
+            require_seen(seen, k_node_tag_semantic_name, k_node_tag_error_capture, "node");
             return node;
         }
 
         DecodedEdge decode_edge(CanonicalReader reader)
         {
             DecodedEdge edge;
+            std::uint32_t seen = 0;
             while (!reader.at_end())
             {
-                switch (reader.tag())
+                const auto field_tag = reader.tag();
+                mark_seen(seen, field_tag, "edge");
+                switch (field_tag)
                 {
                 case k_edge_tag_source_node: edge.source_node = reader.varint(); break;
                 case k_edge_tag_source_kind: edge.source_kind = reader.varint(); break;
@@ -338,6 +400,7 @@ namespace hgraph::manifest
                     throw CanonicalDecodeError("unknown required field in edge descriptor");
                 }
             }
+            require_seen(seen, k_edge_tag_source_node, k_edge_tag_target_path, "edge");
             return edge;
         }
 
@@ -345,9 +408,12 @@ namespace hgraph::manifest
         {
             DecodedGraph graph;
             CanonicalReader reader{descriptor};
+            std::uint32_t seen = 0;
             while (!reader.at_end())
             {
-                switch (reader.tag())
+                const auto field_tag = reader.tag();
+                mark_seen(seen, field_tag, "graph");
+                switch (field_tag)
                 {
                 case k_graph_tag_version: graph.format_version = reader.varint(); break;
                 case k_graph_tag_label: graph.label = reader.string_field(); break;
@@ -373,6 +439,7 @@ namespace hgraph::manifest
                     throw CanonicalDecodeError("unknown required field in graph descriptor");
                 }
             }
+            require_seen(seen, k_graph_tag_version, k_graph_tag_edges, "graph");
             return graph;
         }
 
@@ -529,6 +596,8 @@ namespace hgraph::manifest
             }
             compare_bytes(result, base + "/selectors", lhs.selectors, rhs.selectors);
             compare_bytes(result, base + "/scalars", lhs.scalars, rhs.scalars);
+            compare_bytes(result, base + "/error_capture", lhs.error_capture,
+                          rhs.error_capture);
         }
 
         if (expected_graph.edges.size() != actual_graph.edges.size())

--- a/src/hgraph/manifest/schema_descriptor.cpp
+++ b/src/hgraph/manifest/schema_descriptor.cpp
@@ -12,6 +12,7 @@
 #include <fmt/format.h>
 
 #include <algorithm>
+#include <cstring>
 
 namespace hgraph::manifest
 {
@@ -392,6 +393,20 @@ namespace hgraph::manifest
 
     namespace
     {
+        // Explicitly bounded byte-wise ordering. The defaulted vector<byte>
+        // three-way compare trips gcc-14's -Wstringop-overread (a memcmp
+        // bound it cannot prove below PTRDIFF_MAX); the min() bound here is
+        // provable and the ordering is identical.
+        bool canonical_bytes_less(const std::vector<std::byte> &lhs,
+                                  const std::vector<std::byte> &rhs)
+        {
+            const std::size_t common = std::min(lhs.size(), rhs.size());
+            const int compared =
+                common == 0 ? 0 : std::memcmp(lhs.data(), rhs.data(), common);
+            if (compared != 0) { return compared < 0; }
+            return lhs.size() < rhs.size();
+        }
+
         void encode_atomic(CanonicalWriter &writer, const ValueView &value,
                            const ValueTypeMetaData *meta)
         {
@@ -487,7 +502,7 @@ namespace hgraph::manifest
                     encode_manifest_scalar(element_writer, element);
                     encoded.push_back(element_writer.take());
                 }
-                std::sort(encoded.begin(), encoded.end());
+                std::sort(encoded.begin(), encoded.end(), canonical_bytes_less);
                 writer.varint(encoded.size());
                 for (const auto &bytes : encoded) { writer.bytes_field(bytes); }
             },
@@ -503,7 +518,9 @@ namespace hgraph::manifest
                     encoded.emplace_back(key_writer.take(), value_writer.take());
                 }
                 std::sort(encoded.begin(), encoded.end(),
-                          [](const auto &lhs, const auto &rhs) { return lhs.first < rhs.first; });
+                          [](const auto &lhs, const auto &rhs) {
+                              return canonical_bytes_less(lhs.first, rhs.first);
+                          });
                 writer.varint(encoded.size());
                 for (const auto &[key_bytes, value_bytes] : encoded)
                 {

--- a/src/hgraph/manifest/schema_descriptor.cpp
+++ b/src/hgraph/manifest/schema_descriptor.cpp
@@ -407,6 +407,37 @@ namespace hgraph::manifest
             return lhs.size() < rhs.size();
         }
 
+        void encode_instant_bound(CanonicalWriter &writer, const Instant &value)
+        {
+            writer.svarint(value.time_since_epoch().count());
+        }
+
+        void encode_civil_date_bound(CanonicalWriter &writer, const CivilDate &value)
+        {
+            writer.svarint(
+                static_cast<std::int64_t>(std::chrono::sys_days{value}.time_since_epoch().count()));
+        }
+
+        // Canonical range form: one state byte derived from the public
+        // predicates, then the bounds that exist.
+        template <typename T, typename BoundEncoder>
+        void encode_range(CanonicalWriter &writer, const TimeRange<T> &range,
+                          BoundEncoder &&encode_bound)
+        {
+            std::uint64_t state = 0;
+            if (range.empty()) { state |= 1u << 0; }
+            if (range.lower_unbounded()) { state |= 1u << 1; }
+            if (range.upper_unbounded()) { state |= 1u << 2; }
+            if (range.lower_boundary() == Boundary::Closed) { state |= 1u << 3; }
+            if (range.upper_boundary() == Boundary::Closed) { state |= 1u << 4; }
+            writer.varint(state);
+            if (const auto start = range.start(); start.has_value())
+            {
+                encode_bound(writer, *start);
+            }
+            if (const auto end = range.end(); end.has_value()) { encode_bound(writer, *end); }
+        }
+
         void encode_atomic(CanonicalWriter &writer, const ValueView &value,
                            const ValueTypeMetaData *meta)
         {
@@ -460,6 +491,54 @@ namespace hgraph::manifest
             case WireAtomic::Time:
                 writer.svarint(value.checked_as<Time>().microseconds);
                 return;
+            case WireAtomic::CivilDateTime:
+                writer.svarint(value.checked_as<CivilDateTime>().epoch_microseconds());
+                return;
+            case WireAtomic::Period: {
+                const auto &period = value.checked_as<Period>();
+                writer.svarint(period.total_months());
+                writer.svarint(period.days());
+                return;
+            }
+            case WireAtomic::ZoneId: {
+                // Identity by IANA name; the slot/generation payload is
+                // process-local. An invalid/default zone encodes empty.
+                const auto &zone = value.checked_as<ZoneId>();
+                writer.string_field(zone.valid() ? zone.name() : std::string_view{});
+                return;
+            }
+            case WireAtomic::ZonedDateTime: {
+                const auto &zoned = value.checked_as<ZonedDateTime>();
+                writer.svarint(zoned.instant().time_since_epoch().count());
+                writer.string_field(zoned.zone().valid() ? zoned.zone().name()
+                                                         : std::string_view{});
+                writer.svarint(zoned.offset_seconds());
+                return;
+            }
+            case WireAtomic::InstantRange:
+                encode_range(writer, value.checked_as<InstantRange>(), encode_instant_bound);
+                return;
+            case WireAtomic::CivilDateRange:
+                encode_range(writer, value.checked_as<CivilDateRange>(), encode_civil_date_bound);
+                return;
+            case WireAtomic::InstantRangeSet: {
+                const auto &ranges = value.checked_as<InstantRangeSet>();
+                writer.varint(ranges.size());
+                for (const auto &range : ranges)
+                {
+                    encode_range(writer, range, encode_instant_bound);
+                }
+                return;
+            }
+            case WireAtomic::CivilDateRangeSet: {
+                const auto &ranges = value.checked_as<CivilDateRangeSet>();
+                writer.varint(ranges.size());
+                for (const auto &range : ranges)
+                {
+                    encode_range(writer, range, encode_civil_date_bound);
+                }
+                return;
+            }
             default:
                 throw UnsupportedManifestValue(fmt::format(
                     "scalar type '{}' has no canonical manifest encoding", meta->name()));

--- a/src/hgraph/manifest/schema_descriptor.cpp
+++ b/src/hgraph/manifest/schema_descriptor.cpp
@@ -1,0 +1,523 @@
+#include <hgraph/manifest/schema_descriptor.h>
+
+#include <hgraph/types/metadata/ts_value_type_meta_data.h>
+#include <hgraph/types/metadata/value_type_meta_data.h>
+#include <hgraph/types/static_schema.h>
+#include <hgraph/types/temporal.h>
+#include <hgraph/types/value/specialized_views.h>
+#include <hgraph/types/value/visitor.h>
+#include <hgraph/types/wired_fn.h>
+#include <hgraph/util/date_time.h>
+
+#include <fmt/format.h>
+
+#include <algorithm>
+
+namespace hgraph::manifest
+{
+    namespace
+    {
+        // Stable wire enumeration for atomic scalar identity. The numeric
+        // values are part of the canonical format — append-only.
+        enum class WireAtomic : std::uint8_t
+        {
+            Unknown = 0,
+            Bool = 1,
+            Int = 2,
+            Float = 3,
+            Str = 4,
+            Date = 5,
+            DateTime = 6,
+            TimeDelta = 7,
+            Time = 8,
+            CivilDateTime = 9,
+            Period = 10,
+            ZoneId = 11,
+            ZonedDateTime = 12,
+            InstantRange = 13,
+            CivilDateRange = 14,
+            InstantRangeSet = 15,
+            CivilDateRangeSet = 16,
+        };
+
+        WireAtomic wire_atomic_for(const ValueTypeMetaData *meta)
+        {
+            if (meta == scalar_descriptor<Bool>::value_meta()) { return WireAtomic::Bool; }
+            if (meta == scalar_descriptor<Int>::value_meta()) { return WireAtomic::Int; }
+            if (meta == scalar_descriptor<Float>::value_meta()) { return WireAtomic::Float; }
+            if (meta == scalar_descriptor<Str>::value_meta()) { return WireAtomic::Str; }
+            if (meta == scalar_descriptor<Date>::value_meta()) { return WireAtomic::Date; }
+            if (meta == scalar_descriptor<DateTime>::value_meta()) { return WireAtomic::DateTime; }
+            if (meta == scalar_descriptor<TimeDelta>::value_meta()) { return WireAtomic::TimeDelta; }
+            if (meta == scalar_descriptor<Time>::value_meta()) { return WireAtomic::Time; }
+            if (meta == scalar_descriptor<CivilDateTime>::value_meta())
+            {
+                return WireAtomic::CivilDateTime;
+            }
+            if (meta == scalar_descriptor<Period>::value_meta()) { return WireAtomic::Period; }
+            if (meta == scalar_descriptor<ZoneId>::value_meta()) { return WireAtomic::ZoneId; }
+            if (meta == scalar_descriptor<ZonedDateTime>::value_meta())
+            {
+                return WireAtomic::ZonedDateTime;
+            }
+            if (meta == scalar_descriptor<InstantRange>::value_meta())
+            {
+                return WireAtomic::InstantRange;
+            }
+            if (meta == scalar_descriptor<CivilDateRange>::value_meta())
+            {
+                return WireAtomic::CivilDateRange;
+            }
+            if (meta == scalar_descriptor<InstantRangeSet>::value_meta())
+            {
+                return WireAtomic::InstantRangeSet;
+            }
+            if (meta == scalar_descriptor<CivilDateRangeSet>::value_meta())
+            {
+                return WireAtomic::CivilDateRangeSet;
+            }
+            return WireAtomic::Unknown;
+        }
+
+        // Descriptor field tags (value scope).
+        constexpr std::uint32_t k_tag_kind = 1;
+        constexpr std::uint32_t k_tag_flags = 2;
+        constexpr std::uint32_t k_tag_atomic = 3;
+        constexpr std::uint32_t k_tag_atomic_name = 4;  // registered scalar without a wire tag
+        constexpr std::uint32_t k_tag_element = 5;
+        constexpr std::uint32_t k_tag_key = 6;
+        constexpr std::uint32_t k_tag_fixed_size = 7;
+        constexpr std::uint32_t k_tag_fields = 8;
+        constexpr std::uint32_t k_tag_nominal = 9;
+
+        // Nominal (named-bundle) scope tags.
+        constexpr std::uint32_t k_tag_namespace = 1;
+        constexpr std::uint32_t k_tag_local_name = 2;
+        constexpr std::uint32_t k_tag_generic_arguments = 3;
+        constexpr std::uint32_t k_tag_abstract = 4;
+        constexpr std::uint32_t k_tag_discriminator = 5;
+        constexpr std::uint32_t k_tag_discriminator_value = 6;
+
+        // Field scope tags.
+        constexpr std::uint32_t k_tag_field_name = 1;
+        constexpr std::uint32_t k_tag_field_enum_value = 2;
+        constexpr std::uint32_t k_tag_field_type = 3;
+
+        // Time-series scope tags.
+        constexpr std::uint32_t k_ts_tag_kind = 1;
+        constexpr std::uint32_t k_ts_tag_value = 2;
+        constexpr std::uint32_t k_ts_tag_element = 3;
+        constexpr std::uint32_t k_ts_tag_key = 4;
+        constexpr std::uint32_t k_ts_tag_fixed_size = 5;
+        constexpr std::uint32_t k_ts_tag_fields = 6;
+        constexpr std::uint32_t k_ts_tag_bundle_name = 7;
+        constexpr std::uint32_t k_ts_tag_window_duration = 8;
+        constexpr std::uint32_t k_ts_tag_window_a = 9;
+        constexpr std::uint32_t k_ts_tag_window_b = 10;
+
+        void append_string(CanonicalWriter &writer, std::uint32_t tag, const char *text)
+        {
+            writer.tag(tag);
+            writer.string_field(text == nullptr ? std::string_view{} : std::string_view{text});
+        }
+    }  // namespace
+
+    void append_value_descriptor(CanonicalWriter &writer, const ValueTypeMetaData *meta)
+    {
+        CanonicalWriter scope;
+        if (meta == nullptr)
+        {
+            writer.scope(scope);  // empty scope = absent schema
+            return;
+        }
+
+        const auto kind = meta->value_kind();
+        scope.tag(k_tag_kind);
+        scope.varint(static_cast<std::uint64_t>(kind));
+        scope.tag(k_tag_flags);
+        scope.varint(static_cast<std::uint64_t>(meta->flags));
+
+        if (kind == ValueTypeKind::Atomic)
+        {
+            const auto atomic = wire_atomic_for(meta);
+            scope.tag(k_tag_atomic);
+            scope.varint(static_cast<std::uint64_t>(atomic));
+            if (atomic == WireAtomic::Unknown)
+            {
+                // Registered (extension/python) scalar: nominal identity by
+                // registered name, following the named-bundle rule.
+                append_string(scope, k_tag_atomic_name, meta->header.label);
+            }
+            if (has_flag(meta->flags, ValueTypeFlags::Enum) && meta->fields != nullptr)
+            {
+                scope.tag(k_tag_fields);
+                scope.varint(meta->field_count);
+                for (std::size_t i = 0; i < meta->field_count; ++i)
+                {
+                    const auto &field = meta->fields[i];
+                    CanonicalWriter field_scope;
+                    append_string(field_scope, k_tag_field_name, field.name);
+                    field_scope.tag(k_tag_field_enum_value);
+                    field_scope.svarint(field.enum_value);
+                    scope.scope(field_scope);
+                }
+            }
+        }
+
+        if (meta->element_type != nullptr)
+        {
+            scope.tag(k_tag_element);
+            append_value_descriptor(scope, meta->element_type);
+        }
+        if (meta->key_type != nullptr)
+        {
+            scope.tag(k_tag_key);
+            append_value_descriptor(scope, meta->key_type);
+        }
+        if (meta->fixed_size != 0)
+        {
+            scope.tag(k_tag_fixed_size);
+            scope.varint(meta->fixed_size);
+        }
+        if (kind != ValueTypeKind::Atomic && meta->fields != nullptr && meta->field_count != 0)
+        {
+            scope.tag(k_tag_fields);
+            scope.varint(meta->field_count);
+            for (std::size_t i = 0; i < meta->field_count; ++i)
+            {
+                const auto &field = meta->fields[i];
+                CanonicalWriter field_scope;
+                if (field.name != nullptr)
+                {
+                    append_string(field_scope, k_tag_field_name, field.name);
+                }
+                field_scope.tag(k_tag_field_type);
+                append_value_descriptor(field_scope, field.type);
+                scope.scope(field_scope);
+            }
+        }
+        if (meta->is_named_bundle() && meta->bundle_hierarchy != nullptr)
+        {
+            const auto &nominal = *meta->bundle_hierarchy;
+            CanonicalWriter nominal_scope;
+            append_string(nominal_scope, k_tag_namespace, nominal.namespace_name);
+            append_string(nominal_scope, k_tag_local_name, nominal.local_name);
+            if (!nominal.generic_arguments.empty())
+            {
+                nominal_scope.tag(k_tag_generic_arguments);
+                nominal_scope.varint(nominal.generic_arguments.size());
+                for (const auto *argument : nominal.generic_arguments)
+                {
+                    append_value_descriptor(nominal_scope, argument);
+                }
+            }
+            if (nominal.is_abstract)
+            {
+                nominal_scope.tag(k_tag_abstract);
+                nominal_scope.varint(1);
+            }
+            append_string(nominal_scope, k_tag_discriminator, nominal.discriminator);
+            if (nominal.discriminator_value != nullptr)
+            {
+                append_string(nominal_scope, k_tag_discriminator_value, nominal.discriminator_value);
+            }
+            scope.tag(k_tag_nominal);
+            scope.scope(nominal_scope);
+        }
+
+        writer.scope(scope);
+    }
+
+    void append_ts_descriptor(CanonicalWriter &writer, const TSValueTypeMetaData *meta)
+    {
+        CanonicalWriter scope;
+        if (meta == nullptr)
+        {
+            writer.scope(scope);
+            return;
+        }
+
+        scope.tag(k_ts_tag_kind);
+        scope.varint(static_cast<std::uint64_t>(meta->kind));
+
+        switch (meta->kind)
+        {
+        case TSTypeKind::TS:
+        case TSTypeKind::TSS:
+            scope.tag(k_ts_tag_value);
+            append_value_descriptor(scope, meta->value_type);
+            break;
+        case TSTypeKind::TSD:
+            scope.tag(k_ts_tag_key);
+            append_value_descriptor(scope, meta->data.tsd.key_type);
+            scope.tag(k_ts_tag_element);
+            append_ts_descriptor(scope, meta->data.tsd.value_ts);
+            break;
+        case TSTypeKind::TSL:
+            scope.tag(k_ts_tag_element);
+            append_ts_descriptor(scope, meta->data.tsl.element_ts);
+            if (meta->data.tsl.fixed_size != 0)
+            {
+                scope.tag(k_ts_tag_fixed_size);
+                scope.varint(meta->data.tsl.fixed_size);
+            }
+            break;
+        case TSTypeKind::TSW: {
+            scope.tag(k_ts_tag_value);
+            append_value_descriptor(scope, meta->value_type);
+            const auto &window = meta->data.tsw;
+            scope.tag(k_ts_tag_window_duration);
+            scope.varint(window.is_duration_based ? 1u : 0u);
+            scope.tag(k_ts_tag_window_a);
+            if (window.is_duration_based)
+            {
+                scope.svarint(window.window.duration.time_range.count());
+            }
+            else
+            {
+                scope.varint(window.window.tick.period);
+            }
+            scope.tag(k_ts_tag_window_b);
+            if (window.is_duration_based)
+            {
+                scope.svarint(window.window.duration.min_time_range.count());
+            }
+            else
+            {
+                scope.varint(window.window.tick.min_period);
+            }
+            break;
+        }
+        case TSTypeKind::TSB: {
+            const auto &bundle = meta->data.tsb;
+            if (bundle.bundle_name != nullptr)
+            {
+                append_string(scope, k_ts_tag_bundle_name, bundle.bundle_name);
+            }
+            scope.tag(k_ts_tag_fields);
+            scope.varint(bundle.field_count);
+            for (std::size_t i = 0; i < bundle.field_count; ++i)
+            {
+                const auto &field = bundle.fields[i];
+                CanonicalWriter field_scope;
+                append_string(field_scope, k_tag_field_name, field.name);
+                field_scope.tag(k_tag_field_type);
+                append_ts_descriptor(field_scope, field.type);
+                scope.scope(field_scope);
+            }
+            break;
+        }
+        case TSTypeKind::REF:
+            scope.tag(k_ts_tag_element);
+            append_ts_descriptor(scope, meta->data.ref.referenced_ts);
+            break;
+        case TSTypeKind::SIGNAL:
+            break;
+        }
+
+        writer.scope(scope);
+    }
+
+    std::vector<std::byte> value_descriptor(const ValueTypeMetaData *meta)
+    {
+        CanonicalWriter writer;
+        append_value_descriptor(writer, meta);
+        return writer.take();
+    }
+
+    std::vector<std::byte> ts_descriptor(const TSValueTypeMetaData *meta)
+    {
+        CanonicalWriter writer;
+        append_ts_descriptor(writer, meta);
+        return writer.take();
+    }
+
+    bool manifest_scalar_encodable(const ValueTypeMetaData *meta, std::string *reason)
+    {
+        if (meta == nullptr)
+        {
+            if (reason != nullptr) { *reason = "value has no schema"; }
+            return false;
+        }
+        const auto kind = meta->try_value_kind();
+        if (!kind.has_value())
+        {
+            if (reason != nullptr) { *reason = "value kind is not a manifest value kind"; }
+            return false;
+        }
+        switch (*kind)
+        {
+        case ValueTypeKind::Atomic: {
+            if (has_flag(meta->flags, ValueTypeFlags::Enum)) { return true; }
+            if (wire_atomic_for(meta) != WireAtomic::Unknown) { return true; }
+            // Wired callables encode as registered identity; anonymous ones
+            // are refused per VALUE at encode time (the schema alone cannot
+            // tell).
+            if (meta == scalar_descriptor<WiredFn>::value_meta()) { return true; }
+            if (reason != nullptr)
+            {
+                *reason = fmt::format(
+                    "scalar type '{}' has no canonical manifest encoding",
+                    meta->name());
+            }
+            return false;
+        }
+        case ValueTypeKind::Tuple:
+        case ValueTypeKind::Bundle: {
+            for (std::size_t i = 0; i < meta->field_count; ++i)
+            {
+                if (!manifest_scalar_encodable(meta->fields[i].type, reason)) { return false; }
+            }
+            return true;
+        }
+        case ValueTypeKind::List:
+        case ValueTypeKind::Set:
+            return manifest_scalar_encodable(meta->element_type, reason);
+        case ValueTypeKind::Map:
+            return manifest_scalar_encodable(meta->key_type, reason) &&
+                   manifest_scalar_encodable(meta->element_type, reason);
+        case ValueTypeKind::CyclicBuffer:
+        case ValueTypeKind::Queue:
+        case ValueTypeKind::Any:
+            if (reason != nullptr)
+            {
+                *reason = fmt::format(
+                    "value kind of '{}' has no canonical manifest encoding (runtime container)",
+                    meta->name());
+            }
+            return false;
+        }
+        return false;
+    }
+
+    namespace
+    {
+        void encode_atomic(CanonicalWriter &writer, const ValueView &value,
+                           const ValueTypeMetaData *meta)
+        {
+            if (has_flag(meta->flags, ValueTypeFlags::Enum))
+            {
+                writer.svarint(value.checked_as<Int>());
+                return;
+            }
+            if (meta == scalar_descriptor<WiredFn>::value_meta())
+            {
+                // A wired callable is an implementation reference, not a
+                // value: its manifest form is the REGISTERED identity it was
+                // derived from. An anonymous callable has none and makes the
+                // graph non-manifestable (RFC 0022: core does not infer
+                // identity from a function address or RTTI name); NodeManifestOps
+                // (stage 2) supersedes this with authored descriptors.
+                const auto &fn = value.checked_as<WiredFn>();
+                if (fn.lifted != nullptr && fn.lifted->name != nullptr)
+                {
+                    writer.varint(1);
+                    writer.string_field(fn.lifted->name);
+                    return;
+                }
+                if (!fn.operator_name.empty())
+                {
+                    writer.varint(2);
+                    writer.string_field(fn.operator_name);
+                    return;
+                }
+                throw UnsupportedManifestValue(
+                    "anonymous wired callable has no registered implementation identity");
+            }
+            switch (wire_atomic_for(meta))
+            {
+            case WireAtomic::Bool: writer.varint(value.checked_as<Bool>() ? 1u : 0u); return;
+            case WireAtomic::Int: writer.svarint(value.checked_as<Int>()); return;
+            case WireAtomic::Float: writer.fixed_double(value.checked_as<Float>()); return;
+            case WireAtomic::Str: writer.string_field(value.checked_as<Str>()); return;
+            case WireAtomic::Date: {
+                const auto date = value.checked_as<Date>();
+                writer.svarint(static_cast<std::int64_t>(
+                    std::chrono::sys_days{date}.time_since_epoch().count()));
+                return;
+            }
+            case WireAtomic::DateTime:
+                writer.svarint(value.checked_as<DateTime>().time_since_epoch().count());
+                return;
+            case WireAtomic::TimeDelta:
+                writer.svarint(value.checked_as<TimeDelta>().count());
+                return;
+            case WireAtomic::Time:
+                writer.svarint(value.checked_as<Time>().microseconds);
+                return;
+            default:
+                throw UnsupportedManifestValue(fmt::format(
+                    "scalar type '{}' has no canonical manifest encoding", meta->name()));
+            }
+        }
+    }  // namespace
+
+    void encode_manifest_scalar(CanonicalWriter &writer, const ValueView &value)
+    {
+        visit(
+            value,
+            [&](const AtomicView &atomic) { encode_atomic(writer, atomic, atomic.schema()); },
+            [&](const TupleView &tuple) {
+                writer.varint(tuple.size());
+                for (std::size_t i = 0; i < tuple.size(); ++i)
+                {
+                    encode_manifest_scalar(writer, tuple.at(i));
+                }
+            },
+            [&](const BundleView &bundle) {
+                writer.varint(bundle.size());
+                for (std::size_t i = 0; i < bundle.size(); ++i)
+                {
+                    encode_manifest_scalar(writer, bundle.at(i));
+                }
+            },
+            [&](const ListView &list) {
+                writer.varint(list.size());
+                for (std::size_t i = 0; i < list.size(); ++i)
+                {
+                    encode_manifest_scalar(writer, list.at(i));
+                }
+            },
+            [&](const SetView &set) {
+                std::vector<std::vector<std::byte>> encoded;
+                encoded.reserve(set.size());
+                for (const auto element : set.elements())
+                {
+                    CanonicalWriter element_writer;
+                    encode_manifest_scalar(element_writer, element);
+                    encoded.push_back(element_writer.take());
+                }
+                std::sort(encoded.begin(), encoded.end());
+                writer.varint(encoded.size());
+                for (const auto &bytes : encoded) { writer.bytes_field(bytes); }
+            },
+            [&](const MapView &map) {
+                std::vector<std::pair<std::vector<std::byte>, std::vector<std::byte>>> encoded;
+                encoded.reserve(map.size());
+                for (const auto &[key, mapped] : map.entries())
+                {
+                    CanonicalWriter key_writer;
+                    encode_manifest_scalar(key_writer, key);
+                    CanonicalWriter value_writer;
+                    encode_manifest_scalar(value_writer, mapped);
+                    encoded.emplace_back(key_writer.take(), value_writer.take());
+                }
+                std::sort(encoded.begin(), encoded.end(),
+                          [](const auto &lhs, const auto &rhs) { return lhs.first < rhs.first; });
+                writer.varint(encoded.size());
+                for (const auto &[key_bytes, value_bytes] : encoded)
+                {
+                    writer.bytes_field(key_bytes);
+                    writer.bytes_field(value_bytes);
+                }
+            },
+            [&](const CyclicBufferView &) -> void {
+                throw UnsupportedManifestValue(
+                    "cyclic-buffer values have no canonical manifest encoding");
+            },
+            [&](const QueueView &) -> void {
+                throw UnsupportedManifestValue(
+                    "queue values have no canonical manifest encoding");
+            });
+    }
+}  // namespace hgraph::manifest

--- a/src/hgraph/util/sha256.cpp
+++ b/src/hgraph/util/sha256.cpp
@@ -1,5 +1,6 @@
 #include <hgraph/util/sha256.h>
 
+#include <algorithm>
 #include <cstring>
 
 namespace hgraph::util

--- a/src/hgraph/util/sha256.cpp
+++ b/src/hgraph/util/sha256.cpp
@@ -1,0 +1,159 @@
+#include <hgraph/util/sha256.h>
+
+#include <cstring>
+
+namespace hgraph::util
+{
+    namespace
+    {
+        constexpr std::array<std::uint32_t, 64> k_round_constants{
+            0x428a2f98u, 0x71374491u, 0xb5c0fbcfu, 0xe9b5dba5u, 0x3956c25bu, 0x59f111f1u,
+            0x923f82a4u, 0xab1c5ed5u, 0xd807aa98u, 0x12835b01u, 0x243185beu, 0x550c7dc3u,
+            0x72be5d74u, 0x80deb1feu, 0x9bdc06a7u, 0xc19bf174u, 0xe49b69c1u, 0xefbe4786u,
+            0x0fc19dc6u, 0x240ca1ccu, 0x2de92c6fu, 0x4a7484aau, 0x5cb0a9dcu, 0x76f988dau,
+            0x983e5152u, 0xa831c66du, 0xb00327c8u, 0xbf597fc7u, 0xc6e00bf3u, 0xd5a79147u,
+            0x06ca6351u, 0x14292967u, 0x27b70a85u, 0x2e1b2138u, 0x4d2c6dfcu, 0x53380d13u,
+            0x650a7354u, 0x766a0abbu, 0x81c2c92eu, 0x92722c85u, 0xa2bfe8a1u, 0xa81a664bu,
+            0xc24b8b70u, 0xc76c51a3u, 0xd192e819u, 0xd6990624u, 0xf40e3585u, 0x106aa070u,
+            0x19a4c116u, 0x1e376c08u, 0x2748774cu, 0x34b0bcb5u, 0x391c0cb3u, 0x4ed8aa4au,
+            0x5b9cca4fu, 0x682e6ff3u, 0x748f82eeu, 0x78a5636fu, 0x84c87814u, 0x8cc70208u,
+            0x90befffau, 0xa4506cebu, 0xbef9a3f7u, 0xc67178f2u};
+
+        constexpr std::uint32_t rotr(std::uint32_t value, unsigned bits) noexcept
+        {
+            return (value >> bits) | (value << (32u - bits));
+        }
+    }  // namespace
+
+    Sha256::Sha256() noexcept
+        : state_{0x6a09e667u, 0xbb67ae85u, 0x3c6ef372u, 0xa54ff53au,
+                 0x510e527fu, 0x9b05688cu, 0x1f83d9abu, 0x5be0cd19u}
+    {
+    }
+
+    void Sha256::process_block(const std::uint8_t *block) noexcept
+    {
+        std::array<std::uint32_t, 64> w{};
+        for (std::size_t i = 0; i < 16; ++i)
+        {
+            w[i] = (static_cast<std::uint32_t>(block[i * 4]) << 24) |
+                   (static_cast<std::uint32_t>(block[i * 4 + 1]) << 16) |
+                   (static_cast<std::uint32_t>(block[i * 4 + 2]) << 8) |
+                   static_cast<std::uint32_t>(block[i * 4 + 3]);
+        }
+        for (std::size_t i = 16; i < 64; ++i)
+        {
+            const std::uint32_t s0 = rotr(w[i - 15], 7) ^ rotr(w[i - 15], 18) ^ (w[i - 15] >> 3);
+            const std::uint32_t s1 = rotr(w[i - 2], 17) ^ rotr(w[i - 2], 19) ^ (w[i - 2] >> 10);
+            w[i] = w[i - 16] + s0 + w[i - 7] + s1;
+        }
+
+        std::uint32_t a = state_[0], b = state_[1], c = state_[2], d = state_[3];
+        std::uint32_t e = state_[4], f = state_[5], g = state_[6], h = state_[7];
+        for (std::size_t i = 0; i < 64; ++i)
+        {
+            const std::uint32_t s1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+            const std::uint32_t ch = (e & f) ^ (~e & g);
+            const std::uint32_t temp1 = h + s1 + ch + k_round_constants[i] + w[i];
+            const std::uint32_t s0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+            const std::uint32_t maj = (a & b) ^ (a & c) ^ (b & c);
+            const std::uint32_t temp2 = s0 + maj;
+            h = g;
+            g = f;
+            f = e;
+            e = d + temp1;
+            d = c;
+            c = b;
+            b = a;
+            a = temp1 + temp2;
+        }
+        state_[0] += a;
+        state_[1] += b;
+        state_[2] += c;
+        state_[3] += d;
+        state_[4] += e;
+        state_[5] += f;
+        state_[6] += g;
+        state_[7] += h;
+    }
+
+    void Sha256::update(std::span<const std::byte> data) noexcept
+    {
+        const auto *bytes = reinterpret_cast<const std::uint8_t *>(data.data());
+        std::size_t remaining = data.size();
+        total_bytes_ += remaining;
+
+        if (buffered_ != 0)
+        {
+            const std::size_t take = std::min(remaining, buffer_.size() - buffered_);
+            std::memcpy(buffer_.data() + buffered_, bytes, take);
+            buffered_ += take;
+            bytes += take;
+            remaining -= take;
+            if (buffered_ == buffer_.size())
+            {
+                process_block(buffer_.data());
+                buffered_ = 0;
+            }
+        }
+        while (remaining >= buffer_.size())
+        {
+            process_block(bytes);
+            bytes += buffer_.size();
+            remaining -= buffer_.size();
+        }
+        if (remaining != 0)
+        {
+            std::memcpy(buffer_.data(), bytes, remaining);
+            buffered_ = remaining;
+        }
+    }
+
+    Sha256Digest Sha256::finish() noexcept
+    {
+        const std::uint64_t bit_length = total_bytes_ * 8u;
+        const std::uint8_t pad_one = 0x80u;
+        update(std::span{reinterpret_cast<const std::byte *>(&pad_one), 1});
+        const std::uint8_t zero = 0u;
+        while (buffered_ != 56)
+        {
+            update(std::span{reinterpret_cast<const std::byte *>(&zero), 1});
+        }
+        std::array<std::uint8_t, 8> length_be{};
+        for (std::size_t i = 0; i < 8; ++i)
+        {
+            length_be[i] = static_cast<std::uint8_t>(bit_length >> (56 - 8 * i));
+        }
+        update(std::as_bytes(std::span{length_be}));
+
+        Sha256Digest digest{};
+        for (std::size_t i = 0; i < 8; ++i)
+        {
+            digest.bytes[i * 4] = static_cast<std::byte>(state_[i] >> 24);
+            digest.bytes[i * 4 + 1] = static_cast<std::byte>(state_[i] >> 16);
+            digest.bytes[i * 4 + 2] = static_cast<std::byte>(state_[i] >> 8);
+            digest.bytes[i * 4 + 3] = static_cast<std::byte>(state_[i]);
+        }
+        return digest;
+    }
+
+    Sha256Digest sha256(std::span<const std::byte> data) noexcept
+    {
+        Sha256 hasher;
+        hasher.update(data);
+        return hasher.finish();
+    }
+
+    std::array<char, 64> sha256_hex(const Sha256Digest &digest) noexcept
+    {
+        constexpr char alphabet[] = "0123456789abcdef";
+        std::array<char, 64> out{};
+        for (std::size_t i = 0; i < digest.bytes.size(); ++i)
+        {
+            const auto value = static_cast<std::uint8_t>(digest.bytes[i]);
+            out[i * 2] = alphabet[value >> 4];
+            out[i * 2 + 1] = alphabet[value & 0x0fu];
+        }
+        return out;
+    }
+}  // namespace hgraph::util

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -216,6 +216,7 @@ hgraph_add_test_objects(hgraph_wiring_test_objects
     test_erased_wiring.cpp
     test_error_handling.cpp
     test_eval_node.cpp
+    test_graph_manifest.cpp
     test_graph_wiring.cpp
     test_nested_wiring.cpp
     test_operators.cpp

--- a/tests/cpp/header_compile_check.cpp
+++ b/tests/cpp/header_compile_check.cpp
@@ -3,6 +3,9 @@
 // compiler chases through the heavier portions of memory_utils, the
 // slot stores, and intern_table.
 
+#include <hgraph/manifest/canonical.h>
+#include <hgraph/manifest/graph_manifest.h>
+#include <hgraph/manifest/schema_descriptor.h>
 #include <hgraph/types/metadata/ts_data_plan_factory.h>
 #include <hgraph/types/metadata/ts_value_type_meta_data.h>
 #include <hgraph/types/metadata/type_meta_data.h>

--- a/tests/cpp/test_graph_manifest.cpp
+++ b/tests/cpp/test_graph_manifest.cpp
@@ -1,0 +1,284 @@
+#include <hgraph/lib/std/std_operators.h>
+#include <hgraph/manifest/canonical.h>
+#include <hgraph/manifest/graph_manifest.h>
+#include <hgraph/manifest/schema_descriptor.h>
+#include <hgraph/types/graph_wiring.h>
+#include <hgraph/types/metadata/type_registry.h>
+#include <hgraph/types/operator_dispatch.h>
+#include <hgraph/util/sha256.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <optional>
+#include <span>
+#include <string>
+#include <vector>
+
+// RFC 0022 stage 1: canonical graph/node descriptors, exact validation, and
+// the byte layer under them. Graphs are wired the erased way (name-resolved
+// operators), matching the artifact `manifest::capture` receives from either
+// authoring frontend.
+
+namespace
+{
+    using namespace hgraph;
+
+    std::string hex(const util::Sha256Digest &digest)
+    {
+        const auto chars = util::sha256_hex(digest);
+        return {chars.data(), chars.size()};
+    }
+
+    WiringArg ts_arg(WiringPortRef port, std::string name = {})
+    {
+        WiringArg arg;
+        arg.kind = WiringArg::Kind::TimeSeries;
+        arg.port = std::move(port);
+        arg.name = std::move(name);
+        return arg;
+    }
+
+    WiringArg scalar_arg(Value value, const ValueTypeMetaData *meta, std::string name = {})
+    {
+        WiringArg arg;
+        arg.kind         = WiringArg::Kind::Scalar;
+        arg.scalar_value = std::move(value);
+        arg.scalar_meta  = meta;
+        arg.name         = std::move(name);
+        return arg;
+    }
+
+    OperatorWireResult call_operator(Wiring &w,
+                                     std::string_view name,
+                                     std::vector<WiringArg> args,
+                                     std::optional<bool> output_required = std::nullopt,
+                                     const TSValueTypeMetaData *expected_output = nullptr)
+    {
+        ResolvedOperatorCall resolved = OperatorRegistry::instance().resolve(
+            name, std::span<const WiringArg>{args.data(), args.size()}, output_required,
+            expected_output, {}, w.operator_state(), &w);
+        return resolved.impl->wire(w, resolved.map, resolved.args, resolved.kwargs);
+    }
+
+    struct RuntimeMetas
+    {
+        const ValueTypeMetaData   *int_meta{nullptr};
+        const ValueTypeMetaData   *str_meta{nullptr};
+        const TSValueTypeMetaData *ts_int{nullptr};
+    };
+
+    RuntimeMetas runtime_metas()
+    {
+        auto &registry = TypeRegistry::instance();
+        RuntimeMetas metas;
+        metas.int_meta = registry.register_scalar<Int>("int");
+        metas.str_meta = registry.register_scalar<Str>("str");
+        metas.ts_int   = registry.ts(metas.int_meta);
+        return metas;
+    }
+
+    // A small static graph: const lhs + const rhs -> add_ -> record sink.
+    GraphBuilder wire_sum_graph(Int lhs_value, Int rhs_value)
+    {
+        hgraph::stdlib::register_standard_operators();
+        const auto metas = runtime_metas();
+
+        Wiring w;
+        auto lhs = call_operator(w, "const",
+                                 {scalar_arg(Value{Int{lhs_value}}, metas.int_meta)}, true,
+                                 metas.ts_int);
+        auto rhs = call_operator(w, "const",
+                                 {scalar_arg(Value{Int{rhs_value}}, metas.int_meta)}, true,
+                                 metas.ts_int);
+        auto sum = call_operator(w, "add_",
+                                 {ts_arg(lhs.output.erased()), ts_arg(rhs.output.erased())}, true);
+        call_operator(w, "record",
+                      {ts_arg(sum.output.erased()),
+                       scalar_arg(Value{Str{"manifest::out"}}, metas.str_meta)},
+                      false);
+        return std::move(w).finish();
+    }
+}  // namespace
+
+TEST_CASE("sha256 matches FIPS 180-4 test vectors", "[manifest]")
+{
+    CHECK(hex(util::sha256({})) ==
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+
+    const std::string abc = "abc";
+    CHECK(hex(util::sha256(std::as_bytes(std::span{abc.data(), abc.size()}))) ==
+          "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+}
+
+TEST_CASE("canonical writer/reader round-trip and reject torn input", "[manifest]")
+{
+    using namespace hgraph::manifest;
+
+    CanonicalWriter writer;
+    writer.varint(0);
+    writer.varint(127);
+    writer.varint(128);
+    writer.varint(0xffffffffffffffffull);
+    writer.svarint(-1);
+    writer.svarint(1);
+    writer.svarint(std::numeric_limits<std::int64_t>::min());
+    writer.fixed_double(3.5);
+    writer.string_field("canonical");
+    CanonicalWriter child;
+    child.varint(7);
+    writer.scope(child);
+
+    CanonicalReader reader{writer.bytes()};
+    CHECK(reader.varint() == 0);
+    CHECK(reader.varint() == 127);
+    CHECK(reader.varint() == 128);
+    CHECK(reader.varint() == 0xffffffffffffffffull);
+    CHECK(reader.svarint() == -1);
+    CHECK(reader.svarint() == 1);
+    CHECK(reader.svarint() == std::numeric_limits<std::int64_t>::min());
+    CHECK(reader.fixed_double() == 3.5);
+    CHECK(reader.string_field() == "canonical");
+    auto nested = reader.scope();
+    CHECK(nested.varint() == 7);
+    CHECK(nested.at_end());
+    CHECK(reader.at_end());
+
+    // Truncation inside a varint and inside a length-delimited field both throw.
+    const auto &bytes = writer.bytes();
+    CanonicalReader torn{std::span{bytes.data(), 1}};
+    (void)torn.varint();  // 0 fits in one byte
+    CHECK_THROWS_AS(torn.varint(), CanonicalDecodeError);
+}
+
+TEST_CASE("the same wired graph produces byte-identical manifests", "[manifest]")
+{
+    const GraphBuilder first = wire_sum_graph(42, 8);
+    const GraphBuilder second = wire_sum_graph(42, 8);
+
+    const auto lhs = manifest::capture(first);
+    const auto rhs = manifest::capture(second);
+
+    REQUIRE(lhs.canonical_descriptor().size() == rhs.canonical_descriptor().size());
+    CHECK(std::equal(lhs.canonical_descriptor().begin(), lhs.canonical_descriptor().end(),
+                     rhs.canonical_descriptor().begin()));
+    CHECK(lhs.id() == rhs.id());
+    CHECK(manifest::validate(lhs, rhs).identical());
+}
+
+TEST_CASE("a changed scalar argument produces a path-addressed difference", "[manifest]")
+{
+    const auto expected = manifest::capture(wire_sum_graph(42, 8));
+    const auto actual = manifest::capture(wire_sum_graph(42, 9));
+
+    CHECK_FALSE(expected.id() == actual.id());
+
+    const auto result = manifest::validate(expected, actual);
+    REQUIRE_FALSE(result.identical());
+    bool scalar_difference = false;
+    for (const auto &difference : result.differences)
+    {
+        if (difference.path.find("/scalars") != std::string::npos &&
+            difference.path.starts_with("node["))
+        {
+            scalar_difference = true;
+        }
+    }
+    CHECK(scalar_difference);
+}
+
+TEST_CASE("a changed topology produces node and edge count differences", "[manifest]")
+{
+    hgraph::stdlib::register_standard_operators();
+    const auto metas = runtime_metas();
+
+    const auto expected = manifest::capture(wire_sum_graph(42, 8));
+
+    // Same sum graph plus one more recorded const: node/edge counts differ.
+    Wiring w;
+    auto lhs = call_operator(w, "const", {scalar_arg(Value{Int{42}}, metas.int_meta)}, true,
+                             metas.ts_int);
+    auto rhs = call_operator(w, "const", {scalar_arg(Value{Int{8}}, metas.int_meta)}, true,
+                             metas.ts_int);
+    auto sum = call_operator(w, "add_",
+                             {ts_arg(lhs.output.erased()), ts_arg(rhs.output.erased())}, true);
+    call_operator(w, "record",
+                  {ts_arg(sum.output.erased()),
+                   scalar_arg(Value{Str{"manifest::out"}}, metas.str_meta)},
+                  false);
+    call_operator(w, "record",
+                  {ts_arg(lhs.output.erased()),
+                   scalar_arg(Value{Str{"manifest::extra"}}, metas.str_meta)},
+                  false);
+    const auto actual = manifest::capture(std::move(w).finish());
+
+    CHECK_FALSE(expected.id() == actual.id());
+    const auto result = manifest::validate(expected, actual);
+    REQUIRE_FALSE(result.identical());
+    bool node_count_difference = false;
+    for (const auto &difference : result.differences)
+    {
+        if (difference.path == "graph/node_count") { node_count_difference = true; }
+    }
+    CHECK(node_count_difference);
+}
+
+TEST_CASE("schema descriptors reproduce runtime schema equivalence", "[manifest]")
+{
+    auto &registry = TypeRegistry::instance();
+    const auto *int_meta = registry.register_scalar<Int>("int");
+    const auto *float_meta = registry.register_scalar<Float>("float");
+
+    const auto ts_int = manifest::ts_descriptor(registry.ts(int_meta));
+    const auto ts_int_again = manifest::ts_descriptor(registry.ts(int_meta));
+    const auto ts_float = manifest::ts_descriptor(registry.ts(float_meta));
+    CHECK(ts_int == ts_int_again);
+    CHECK_FALSE(ts_int == ts_float);
+
+    // Wire-affecting qualifiers discriminate: fixed size, window shape.
+    const auto tsl_2 = manifest::ts_descriptor(registry.tsl(registry.ts(int_meta), 2));
+    const auto tsl_3 = manifest::ts_descriptor(registry.tsl(registry.ts(int_meta), 3));
+    CHECK_FALSE(tsl_2 == tsl_3);
+
+    const auto tsw_ticks = manifest::ts_descriptor(registry.tsw(int_meta, 10, 2));
+    const auto tsw_other = manifest::ts_descriptor(registry.tsw(int_meta, 10, 3));
+    CHECK_FALSE(tsw_ticks == tsw_other);
+
+    const auto tsd = manifest::ts_descriptor(registry.tsd(int_meta, registry.ts(float_meta)));
+    const auto tsd_other = manifest::ts_descriptor(registry.tsd(float_meta, registry.ts(float_meta)));
+    CHECK_FALSE(tsd == tsd_other);
+
+    // The descriptor never falls back to interned pointers: distinct calls
+    // for the equivalent schema give identical bytes (interning makes the
+    // metas pointer-equal; the bytes must also be equal by construction).
+    CHECK(manifest::value_descriptor(int_meta) == manifest::value_descriptor(int_meta));
+}
+
+TEST_CASE("manifest encode/decode round-trips and verifies", "[manifest]")
+{
+    const auto original = manifest::capture(wire_sum_graph(42, 8));
+    const auto encoded = manifest::encode(original);
+
+    const auto decoded = manifest::decode_graph(encoded);
+    CHECK(decoded.id() == original.id());
+    CHECK(decoded.format_version() == original.format_version());
+    CHECK(manifest::validate(original, decoded).identical());
+
+    // Torn input is rejected, never partially decoded.
+    const std::span<const std::byte> torn{encoded.data(), encoded.size() / 2};
+    CHECK_THROWS_AS(manifest::decode_graph(torn), manifest::CanonicalDecodeError);
+}
+
+TEST_CASE("values without a canonical encoding are refused with a reason", "[manifest]")
+{
+    auto &registry = TypeRegistry::instance();
+    const auto *int_meta = registry.register_scalar<Int>("int");
+
+    std::string reason;
+    CHECK(manifest::manifest_scalar_encodable(int_meta, &reason));
+    CHECK_FALSE(manifest::manifest_scalar_encodable(registry.any(), &reason));
+    CHECK_FALSE(reason.empty());
+
+    reason.clear();
+    CHECK_FALSE(manifest::manifest_scalar_encodable(registry.queue(int_meta, 4), &reason));
+    CHECK_FALSE(reason.empty());
+}

--- a/tests/cpp/test_graph_manifest.cpp
+++ b/tests/cpp/test_graph_manifest.cpp
@@ -9,6 +9,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <limits>
 #include <optional>
 #include <span>
 #include <string>

--- a/tests/cpp/test_graph_manifest.cpp
+++ b/tests/cpp/test_graph_manifest.cpp
@@ -269,6 +269,88 @@ TEST_CASE("manifest encode/decode round-trips and verifies", "[manifest]")
     CHECK_THROWS_AS(manifest::decode_graph(torn), manifest::CanonicalDecodeError);
 }
 
+TEST_CASE("a framed descriptor missing required fields is rejected", "[manifest]")
+{
+    using namespace hgraph::manifest;
+
+    // An empty descriptor omits every required graph field; the frame itself
+    // is well-formed, so acceptance would silently validate a torn manifest.
+    CanonicalWriter frame;
+    frame.varint(k_manifest_format_version);
+    frame.bytes_field({});
+    CHECK_THROWS_AS(decode_graph(frame.bytes()), CanonicalDecodeError);
+
+    // A duplicated field is rejected too.
+    CanonicalWriter descriptor;
+    descriptor.tag(1);
+    descriptor.varint(k_manifest_format_version);
+    descriptor.tag(1);
+    descriptor.varint(k_manifest_format_version);
+    CanonicalWriter duplicate_frame;
+    duplicate_frame.varint(k_manifest_format_version);
+    duplicate_frame.bytes_field(descriptor.bytes());
+    CHECK_THROWS_AS(decode_graph(duplicate_frame.bytes()), CanonicalDecodeError);
+}
+
+TEST_CASE("temporal scalar arguments have canonical encodings", "[manifest]")
+{
+    using namespace hgraph::manifest;
+
+    const auto encode = [](const Value &value) {
+        CanonicalWriter writer;
+        encode_manifest_scalar(writer, value.view());
+        return writer.take();
+    };
+
+    const auto period = encode(Value{Period{1, 2, 3}});
+    CHECK_FALSE(period.empty());
+    CHECK(period == encode(Value{Period{1, 2, 3}}));
+    CHECK_FALSE(period == encode(Value{Period{1, 2, 4}}));
+
+    const auto civil = encode(Value{CivilDateTime::from_epoch_microseconds(123456789)});
+    CHECK_FALSE(civil.empty());
+    CHECK_FALSE(civil == encode(Value{CivilDateTime::from_epoch_microseconds(987654321)}));
+
+    const auto zone = encode(Value{ZoneId{"Europe/London"}});
+    CHECK_FALSE(zone == encode(Value{ZoneId{"America/New_York"}}));
+
+    const auto zoned = encode(Value{
+        ZonedDateTime::from_resolved(Instant{TimeDelta{1000000}}, ZoneId{"UTC"}, 0)});
+    CHECK_FALSE(zoned.empty());
+
+    const auto range = encode(Value{InstantRange::bounded(Instant{TimeDelta{1}},
+                                                          Instant{TimeDelta{100}})});
+    const auto open_range = encode(Value{InstantRange::from(Instant{TimeDelta{1}})});
+    CHECK_FALSE(range == open_range);
+
+    const auto range_set = encode(Value{InstantRangeSet{}});
+    CHECK_FALSE(range_set.empty());
+}
+
+TEST_CASE("error-capture options participate in node identity", "[manifest]")
+{
+    GraphBuilder plain = wire_sum_graph(42, 8);
+    GraphBuilder captured = wire_sum_graph(42, 8);
+
+    // Rebind one node with error capture: the manifest must differ and the
+    // difference must name the node's capture identity (options included).
+    const auto *error_schema = captured.nodes()[2].type().schema()->error_output_schema;
+    if (error_schema == nullptr)
+    {
+        auto &registry = TypeRegistry::instance();
+        error_schema = registry.ts(registry.register_scalar<Int>("int"));
+    }
+    captured.node_at(2) = captured.node_at(2).with_error_capture(
+        error_schema, ErrorCaptureOptions{.trace_back_depth = 7, .capture_values = true});
+
+    const auto expected = manifest::capture(plain);
+    const auto actual = manifest::capture(captured);
+    CHECK_FALSE(expected.id() == actual.id());
+
+    const auto result = manifest::validate(expected, actual);
+    REQUIRE_FALSE(result.identical());
+}
+
 TEST_CASE("values without a canonical encoding are refused with a reason", "[manifest]")
 {
     auto &registry = TypeRegistry::instance();


### PR DESCRIPTION
Checkpoint 6 of #498, part 1. The checkpoint's design record (RFC 0023, re-read under RFC 0025's ownership boundary) opens its implementation plan with "Land RFC 0022" — the serializable graph manifest is the identity prerequisite for every restore-validation step — and RFC 0022 was unstarted, as was RFC 0017 whose byte layer it assumed. This PR lands **RFC 0022 stage 1**: the canonical graph and node descriptor, the canonical writer/reader, core node identity, schema/scalar encoding, graph templates, edges, and exact path-addressed validation.

**The canonical byte layer** (`hgraph/manifest/canonical.h`): LEB128 varints, zigzag signed varints, IEEE-754 little-endian fixed64, varint-length-delimited strings and nested scopes, fixed ascending field tags. Deliberately free of manifest semantics — this defines the shared substrate RFC 0017's codec work adopts, resolving that RFC's open framing question (decision recorded in RFC 0022's implementation status).

**Schema descriptors** (`hgraph/manifest/schema_descriptor.h`): recursive canonical descriptors for value and time-series schemas — kind, the full flags word, atomic identity via a stable wire enumeration (core scalars) or registered nominal name (extension/python scalars, the named-bundle rule), children, fixed sizes, TSW window parameters, and named-bundle nominal identity. Cold-path, computed on demand: no cache, no lock, no registry-reset coupling. The conformance reference is `time_series_schema_equivalent` — the descriptor reproduces exactly the runtime's notion of schema sameness, in portable bytes instead of interned pointers.

**Scalar values** encode schema-directed: core atomics, enums, tuples/bundles/lists, and sets/maps in canonical encoded-key order. A `WiredFn` scalar (every lifted-kernel node carries one) encodes as its **registered identity** — the lifted kernel's authored name or the operator marker's name — never a function address or RTTI name; an anonymous callable, and any value without a canonical encoding (`Any`, queues, live handles, `PyNodeRef`), makes the graph non-manifestable with a path-addressed `ManifestCaptureError`, RFC 0022's conservative refusal. `NodeManifestOps` (stage 2) supersedes the `WiredFn` rule with authored descriptors.

**The manifest** (`hgraph/manifest/graph_manifest.h`): `capture(const GraphBuilder&)` walks the finished builder — node table (semantic name, `TypeRecord` implementation label, kind, behaviour flags, all five endpoint schemas + scalar schema, endpoint-role annotations, selector vectors, canonical scalar bytes) and edge table (packed source kinds, structural index paths). `ManifestId` is SHA-256 (self-contained `hgraph/util/sha256.h` — a lookup/integrity device, not a security boundary) over the descriptor with format-version domain separation; **the descriptor bytes remain the compared identity**. `validate()` decodes both sides and reports path-addressed differences (`node[2]:scalar_add/scalars`, `graph/node_count`), never just "hash mismatch". `encode`/`decode_graph` are version-framed and reject torn input. Node labels are deliberately outside the canonical descriptor: a label edit must not change the id.

**Verification**: 8 new Catch2 cases — FIPS 180-4 SHA-256 vectors; canonical round-trips incl. truncation rejection; byte-identical manifests for the same graph wired twice (the RFC's cross-process determinism criterion, exercised through the erased name-resolved wiring path both frontends share); path-addressed diffs for a changed scalar argument and changed topology; schema-descriptor/equivalence conformance across TS/TSL/TSW/TSD qualifiers; encode/decode round-trip; refusal reasons for non-encodable values. Full C++ suite green (1580 cases / 255,766 assertions), header-compile check extended with the new headers, smoke test green.

RFC 0022's implementation status records every stage-1 decision in the same change. Next parts of checkpoint 6: RFC 0022 stage 2 (nested templates, `NodeManifestOps`, implementation registration/provenance) interleaved with RFC 0023 stage 1 (`TSCheckpointOps`, quiet import, recordable/scheduler state, root-cycle capture).

Refs #498 (checkpoint 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
