### PR TITLE
Validate every package the release workflow publishes

### DIFF
--- a/docs/source/developer_guide/build_system.rst
+++ b/docs/source/developer_guide/build_system.rst
@@ -62,13 +62,13 @@ compatibility oracle.
 ``.github/workflows/release-wheels.yml`` builds one ``cp312-abi3`` wheel for Linux x86_64,
 Windows x86_64, and Apple Silicon macOS, then installs each platform wheel under
 CPython 3.12, 3.13, and 3.14. A bare tag matching ``x.x.x`` publishes the tested
-core, Kafka, and analytics wheels and source distributions through PyPI trusted
-publishing.
+core, Kafka, analytics, web, and persistence wheels and source distributions
+through PyPI trusted publishing.
 Standalone C++ validation runs independently in
 ``.github/workflows/native-cpp.yml``. It covers native Linux and macOS builds,
 plus a fully optimized Linux shared-library build with IPO, the complete native
-test suite, installation, and downstream core, Kafka, and analytics SDK
-consumers. This deliberately expensive validation remains visible on pull
+test suite, installation, and downstream core, Kafka, analytics, web, and
+persistence SDK consumers. This deliberately expensive validation remains visible on pull
 requests and ``main`` without delaying or gating publication of wheel artifacts.
 The tag is the shared release version authority: the publish jobs restamp the
 metadata of artifacts already tested for that exact commit, rather than
@@ -84,7 +84,10 @@ sentinel; it is never the version published to PyPI.  CMake's numeric
 ``project(VERSION)`` and ``docs/source/conf.py`` track the current C++ API line
 independently.  Packaging tests enforce these relationships and the release
 workflow validates the tag syntax and rejects a version already present for
-either package on PyPI. The PyPI trusted publishers are bound to the
+any published package on PyPI. Every package the workflow publishes must appear
+in ``RELEASE_PACKAGES``; the publish jobs gate on that validation, so a
+distribution missing from it would be published unvalidated and a collision
+would fail the tag part-way through. The PyPI trusted publishers are bound to the
 ``release-wheels.yml`` workflow and
 the GitHub ``release`` environment.
 
@@ -191,6 +194,12 @@ extension can be built independently, for example::
    CMAKE_PREFIX_PATH=/path/to/hgraph/sdk \
      uv build --wheel --package hgraph-analytics --python 3.12
 
+   CMAKE_PREFIX_PATH=/path/to/hgraph/sdk \
+     uv build --wheel --package hgraph-web --python 3.12
+
+   CMAKE_PREFIX_PATH=/path/to/hgraph/sdk \
+     uv build --wheel --package hgraph-persistence --python 3.12
+
 The Kafka C++ targets can also be included in a repository build with
 ``HGRAPH_BUILD_KAFKA_EXTENSION=ON``.  That option is off by default: a normal
 core configure neither resolves nor links librdkafka.  A standalone native
@@ -204,14 +213,21 @@ repository build; standalone consumers find ``hgraph-analytics`` and link
 and CMake package as well as the stable-ABI Python registration module, so the
 same distribution is usable by C++ and Python authoring environments.
 
+The web and persistence packages have the same shape.
+``HGRAPH_BUILD_WEB_EXTENSION=ON`` and ``HGRAPH_BUILD_PERSISTENCE_EXTENSION=ON``
+include them in a repository build; standalone consumers find ``hgraph-web`` or
+``hgraph-persistence`` and link ``hgraph::web`` or ``hgraph::persistence``. Both
+options are off by default, so a normal core configure resolves neither their
+dependencies nor their targets.
+
 Each extension owns its nested ``pyproject.toml``, CMake package configuration,
 and tests. Cross-cutting changes are tested against core at the same commit,
 while the resulting wheels remain separate distribution artifacts. During the
-current release line, core, Kafka, and analytics are co-versioned and
-co-released: a bare ``<version>`` tag validates that the version is new for all
-three packages, restamps their distributions, and publishes each package.
-Independent extension tags are intentionally not part of this release
-workflow.
+current release line, core, Kafka, analytics, web, and persistence are
+co-versioned and co-released: a bare ``<version>`` tag validates that the
+version is new for all five packages, restamps their distributions, and
+publishes each package. Independent extension tags are intentionally not part
+of this release workflow.
 
 The Kafka PEP 517 build requirements include ``hgraph>=0.8.0`` because its standalone
 CMake configure consumes the installed core SDK.  In-repository CI installs

--- a/docs/source/developer_guide/release_readiness.rst
+++ b/docs/source/developer_guide/release_readiness.rst
@@ -92,10 +92,12 @@ requires all of the following from a clean checkout:
 
 GitHub CI is post-push platform evidence, not a substitute for the local gates.
 Tagged releases reuse the successful distribution artifacts for the exact
-commit SHA and restamp ``hgraph``, ``hgraph-kafka``, and ``hgraph-analytics``
-package metadata to the shared bare-version tag. For example, ``0.8.3``
-publishes all three packages as version ``0.8.3``; prereleases use the same
-form, such as ``0.8.3rc1``.
+commit SHA and restamp ``hgraph``, ``hgraph-kafka``, ``hgraph-analytics``,
+``hgraph-web``, and ``hgraph-persistence`` package metadata to the shared
+bare-version tag. For example, ``0.8.3`` publishes all five packages as version
+``0.8.3``; prereleases use the same form, such as ``0.8.3rc1``. Tag validation
+covers exactly this set: a package the workflow publishes but the validator
+omits is released without its version being checked.
 
 Performance evidence
 --------------------

--- a/python/tests/test_release_metadata.py
+++ b/python/tests/test_release_metadata.py
@@ -2,6 +2,7 @@ import re
 from pathlib import Path
 
 import pytest
+import yaml
 
 from tools.validate_release import (
     RELEASE_PACKAGES,
@@ -109,25 +110,66 @@ def test_shared_release_checks_all_pypi_packages():
     ]
 
 
+def _publish_jobs() -> dict[str, str]:
+    """Every job that uploads to PyPI, mapped to the package it uploads.
+
+    Driven by the publish ACTION rather than by scraping URLs: a job that runs
+    ``pypa/gh-action-pypi-publish`` is a release of something, so if it does
+    not identify what, that is itself the failure. Scraping ``environment.url``
+    alone would silently skip such a job and report agreement.
+    """
+    workflow = yaml.safe_load(
+        (
+            Path(__file__).resolve().parents[2]
+            / ".github"
+            / "workflows"
+            / "release-wheels.yml"
+        ).read_text()
+    )
+
+    published: dict[str, str] = {}
+    for job_name, job in (workflow.get("jobs") or {}).items():
+        steps = job.get("steps") or []
+        if not any(
+            str(step.get("uses", "")).startswith("pypa/gh-action-pypi-publish")
+            for step in steps
+        ):
+            continue
+        environment = job.get("environment")
+        url = environment.get("url", "") if isinstance(environment, dict) else ""
+        match = re.fullmatch(r"https://pypi\.org/p/(\S+)", str(url))
+        assert match, (
+            f"publish job {job_name!r} uploads to PyPI but does not name its "
+            "package; give it an `environment.url` of https://pypi.org/p/<name> "
+            "so release validation can cover it"
+        )
+        published[job_name] = match.group(1)
+    return published
+
+
 def test_every_published_package_is_validated():
     # The publish jobs gate on validate-release, so a package the workflow
     # publishes but the validator does not know about is released without its
     # version ever being checked -- and a collision fails the tag part-way
     # through, after the earlier packages are already on PyPI. hgraph-web was
     # in exactly that state.
-    workflow = (
-        Path(__file__).resolve().parents[2]
-        / ".github"
-        / "workflows"
-        / "release-wheels.yml"
-    ).read_text()
-    published = set(re.findall(r"url:\s*https://pypi\.org/p/(\S+)", workflow))
+    published = _publish_jobs()
 
-    assert published, "no PyPI publish targets found in the release workflow"
-    assert published == set(RELEASE_PACKAGES), (
+    assert published, "no PyPI publish jobs found in the release workflow"
+    assert set(published.values()) == set(RELEASE_PACKAGES), (
         "the release workflow and RELEASE_PACKAGES disagree: "
-        f"published only {sorted(published - set(RELEASE_PACKAGES))}, "
-        f"validated only {sorted(set(RELEASE_PACKAGES) - published)}"
+        f"published only {sorted(set(published.values()) - set(RELEASE_PACKAGES))}, "
+        f"validated only {sorted(set(RELEASE_PACKAGES) - set(published.values()))}"
+    )
+
+
+def test_each_publish_job_uploads_a_distinct_package():
+    # Two jobs pointing at one package would make the set comparison above
+    # pass while some other package went unpublished.
+    published = _publish_jobs()
+
+    assert len(set(published.values())) == len(published), (
+        f"publish jobs share a package: {sorted(published.items())}"
     )
 
 

--- a/python/tests/test_release_metadata.py
+++ b/python/tests/test_release_metadata.py
@@ -1,8 +1,13 @@
+import re
 from pathlib import Path
 
 import pytest
 
-from tools.validate_release import parse_release_tag, validate_release
+from tools.validate_release import (
+    RELEASE_PACKAGES,
+    parse_release_tag,
+    validate_release,
+)
 
 
 def _cmake_projects(
@@ -75,7 +80,13 @@ def test_shared_prerelease_uses_numeric_release_core():
         release_exists=lambda _package, _version: False,
     )
 
-    assert release.packages == ("hgraph", "hgraph-kafka", "hgraph-analytics", "hgraph-persistence")
+    assert release.packages == (
+        "hgraph",
+        "hgraph-kafka",
+        "hgraph-analytics",
+        "hgraph-web",
+        "hgraph-persistence",
+    )
     assert release.version == "0.8.0rc1"
     assert release.core == (0, 8, 0)
 
@@ -93,8 +104,31 @@ def test_shared_release_checks_all_pypi_packages():
         ("hgraph", "0.8.0"),
         ("hgraph-kafka", "0.8.0"),
         ("hgraph-analytics", "0.8.0"),
+        ("hgraph-web", "0.8.0"),
         ("hgraph-persistence", "0.8.0"),
     ]
+
+
+def test_every_published_package_is_validated():
+    # The publish jobs gate on validate-release, so a package the workflow
+    # publishes but the validator does not know about is released without its
+    # version ever being checked -- and a collision fails the tag part-way
+    # through, after the earlier packages are already on PyPI. hgraph-web was
+    # in exactly that state.
+    workflow = (
+        Path(__file__).resolve().parents[2]
+        / ".github"
+        / "workflows"
+        / "release-wheels.yml"
+    ).read_text()
+    published = set(re.findall(r"url:\s*https://pypi\.org/p/(\S+)", workflow))
+
+    assert published, "no PyPI publish targets found in the release workflow"
+    assert published == set(RELEASE_PACKAGES), (
+        "the release workflow and RELEASE_PACKAGES disagree: "
+        f"published only {sorted(published - set(RELEASE_PACKAGES))}, "
+        f"validated only {sorted(set(RELEASE_PACKAGES) - published)}"
+    )
 
 
 def test_release_rejects_existing_pypi_version():

--- a/tools/validate_release.py
+++ b/tools/validate_release.py
@@ -11,7 +11,17 @@ from urllib.request import urlopen
 
 
 MINIMUM_CORE_VERSION = (0, 8, 0)
-RELEASE_PACKAGES = ("hgraph", "hgraph-kafka", "hgraph-analytics", "hgraph-persistence")
+# Every package the release workflow publishes must appear here: the publish
+# jobs gate on this validation, so a distribution missing from the tuple is
+# published without its version ever being checked. Kept in publish order and
+# pinned against the workflow by test_release_metadata.
+RELEASE_PACKAGES = (
+    "hgraph",
+    "hgraph-kafka",
+    "hgraph-analytics",
+    "hgraph-web",
+    "hgraph-persistence",
+)
 _TAG_PATTERN = re.compile(r"(\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?)")
 _VERSION_CORE = re.compile(r"(\d+)\.(\d+)\.(\d+)")
 _CMAKE_PROJECT_VERSION = re.compile(
@@ -71,6 +81,7 @@ def validate_release(
     cmake_path: Path = Path("CMakeLists.txt"),
     kafka_cmake_path: Path = Path("extensions/kafka/CMakeLists.txt"),
     analytics_cmake_path: Path = Path("extensions/analytics/CMakeLists.txt"),
+    web_cmake_path: Path = Path("extensions/web/CMakeLists.txt"),
     persistence_cmake_path: Path = Path("extensions/persistence/CMakeLists.txt"),
     release_exists: Callable[[str, str], bool] = pypi_release_exists,
 ) -> Release:
@@ -84,6 +95,7 @@ def validate_release(
         ("hgraph", cmake_path),
         ("hgraph-kafka", kafka_cmake_path),
         ("hgraph-analytics", analytics_cmake_path),
+        ("hgraph-web", web_cmake_path),
         ("hgraph-persistence", persistence_cmake_path),
     ):
         native_version = native_project_version(path)


### PR DESCRIPTION
`hgraph-web` is published by the release workflow but was absent from release validation.

### The hole

`release-wheels.yml` has **five** publish jobs — core, Kafka, analytics, web, persistence — and every one of them gates on `needs.validate-release.result == 'success'`. `RELEASE_PACKAGES` listed **four**; `hgraph-web` was in neither the PyPI existence check nor the native-version check.

So a tag whose version already exists on PyPI for `hgraph-web` passes validation, publishes the other four, and then fails on the fifth. PyPI has no delete-and-retry, so that leaves a partially published release that the same tag cannot repair. The web extension's `project(hgraph_web VERSION ...)` was also never compared against the tag, unlike the other three extensions.

### The fix

`hgraph-web` joins `RELEASE_PACKAGES` and the CMake version loop, in publish order.

More usefully, `test_every_published_package_is_validated` now reads the publish targets straight out of the workflow (`url: https://pypi.org/p/<name>`) and asserts they are exactly `RELEASE_PACKAGES`. Adding a sixth package without validating it now fails the suite instead of the release. That test fails on `main` as it stands, which is the point.

### Docs

The developer-guide enumerations had drifted the same way — both `build_system.rst` and `release_readiness.rst` still described **three** co-released packages. They now name five. While there, `build_system.rst` gained the `hgraph-web` / `hgraph-persistence` standalone build examples and the `HGRAPH_BUILD_WEB_EXTENSION` / `HGRAPH_BUILD_PERSISTENCE_EXTENSION` options, which the file documented nowhere.

Found while auditing the persistence extraction (#498); the bug itself predates it and is independent of that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)