### PR TITLE
Stop describing durable record/replay as a core capability

### DIFF
--- a/docs/source/developer_guide/extension_policy.rst
+++ b/docs/source/developer_guide/extension_policy.rst
@@ -186,9 +186,10 @@ the serialized artifact.
 Durable checkpoint and store contract
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**Priority: medium.** The core has typed record/replay and in-memory/Arrow
-foundations, but long-running applications still need a generic durable store
-and checkpoint/recovery contract. Any proposal must define consistency
+**Priority: medium.** Core has the typed record/replay participation contracts
+and the in-memory reference backends, and ``hgraph-persistence`` has the
+durable Arrow stores, but long-running applications still need a generic
+checkpoint/recovery contract spanning the two. Any proposal must define consistency
 boundaries, schema/version migration, idempotency, and the relation between
 recorded inputs, node state, and external effects.
 

--- a/docs/source/developer_guide/parity_matrix.rst
+++ b/docs/source/developer_guide/parity_matrix.rst
@@ -643,7 +643,9 @@ Types and scalars
        ``__arrow_c_stream__``; frame reads yield ``pyarrow.Table`` and
        consumers use ``pl.from_arrow``. The to-frame ``convert`` family, the
        DATA_FRAME record/replay model (``recordable_id`` +
-       ``set_data_frame_overrides``), the data-source generators, join,
+       ``set_data_frame_overrides``, now served by ``hgraph-persistence``
+       under backend id ``"hgraph.persistence.frame"``), the data-source
+       generators, join,
        structural filters, group/ungroup, sorting, concatenation, column
        replacement/projection, and Series-to-tuple conversion execute
        Arrow-native. Python expression filters are retained for the

--- a/docs/source/developer_guide/roadmap.rst
+++ b/docs/source/developer_guide/roadmap.rst
@@ -518,8 +518,10 @@ The following deliberate restrictions replace advanced Python-first code:
   work. Perspective 2.10's legacy manager API is intentionally not restored;
   the optional extra targets the current server/client API.
 - The dataframe record/replay names delegate to the C++ record/replay
-  operators. Arrow memory/file storage remains a client utility; the old
-  Polars-owned pluggable runtime store is not restored.
+  operators. Arrow memory/file storage remains a client utility, now owned by
+  ``hgraph-persistence`` (RFC 0025) and reached through the lazy re-exports
+  that keep the released ``hgraph.adaptors.data_frame`` import paths valid;
+  the old Polars-owned pluggable runtime store is not restored.
 
 This completed slice passed clean macOS arm64/AppleClang 21 and Ubuntu 24.04
 x86_64/GCC 13.3 Release gates with warnings as errors: 1089/1089 native tests
@@ -600,8 +602,8 @@ operational requirements.
 
 **Remaining:**
 
-- durable/pluggable record and replay stores beyond the default in-memory
-  stores and current Arrow frame backend;
+- durable/pluggable record and replay stores beyond core's in-memory reference
+  backends and the Arrow frame backend ``hgraph-persistence`` now ships;
 - integration-specific authentication, deployment, and scheduling policies
   beyond the lifecycle hooks exposed by the current adaptors; and
 - broader JSON/table/Arrow scalar and serialization forms only where a real
@@ -717,8 +719,9 @@ The following are intentional unless separately re-opened:
   that boundary conversion; the conversions themselves are exercised
   unchanged.  The ``convert``-to-frame operator family and the DATA_FRAME
   record/replay model are Arrow-native
-  (``hgraph.adaptors.data_frame._to_frame_converters`` /
-  ``_data_frame_record_replay``).
+  (``hgraph.adaptors.data_frame._to_frame_converters``; the record/replay half
+  is implemented in ``hgraph-persistence`` and reached through the compat
+  re-exports of ``_data_frame_record_replay``).
 - ``datetime.timestamp()`` (the ``timestamp`` attribute operator, issue #82)
   is the **UTC** fractional epoch second count (``TS[float]``, preserving
   microseconds — Python's own return type): hgraph datetimes are UTC by

--- a/docs/source/reference/modules.rst
+++ b/docs/source/reference/modules.rst
@@ -38,7 +38,8 @@ Adaptor packages
      - Purpose
      - Installation
    * - ``hgraph.adaptors.data_frame``
-     - Arrow/Polars data sources and frame record/replay
+     - Arrow/Polars data sources; durable record/replay resolves lazily from
+       ``hgraph-persistence``
      - ``hgraph[dataframe]``
    * - ``hgraph.adaptors.sql``
      - SQL sources, sinks and batch access
@@ -68,6 +69,11 @@ Adaptor packages
      - Run child graph engines on worker threads
      - core package
 
-Kafka is a separate first-party extension distribution, ``hgraph-kafka``, not
-an extra of the core wheel. Each module's exact public names are listed in
-:doc:`python_api_inventory`.
+``hgraph-kafka``, ``hgraph-analytics``, ``hgraph-web`` and
+``hgraph-persistence`` are separate first-party extension distributions, not
+extras of the core wheel — though an extra may depend on one, as
+``hgraph[dataframe]`` depends on ``hgraph-persistence``. The durable
+record/replay surface reached through ``hgraph.adaptors.data_frame`` keeps its
+released import paths and resolves lazily from that distribution, raising a
+pointed install error only when a durable name is used. Each module's exact
+public names are listed in :doc:`python_api_inventory`.

--- a/docs/source/user_guide/cpp/authoring_graphs.rst
+++ b/docs/source/user_guide/cpp/authoring_graphs.rst
@@ -1219,7 +1219,8 @@ Lowering a graph over Arrow frames
 It wires each input ``Frame`` through the native ``from_data_frame`` source,
 invokes the graph through ``WiredFn``, snapshots output ticks with
 ``to_data_frame``, and concatenates those snapshots into one result frame. No
-record/replay backend or process-global frame store is involved.
+record/replay backend is involved, and it needs no ``hgraph-persistence``
+install: ``lower`` is core stdlib over the core ``Frame`` value kind.
 
 Input frames follow the graph's time-series ``Port`` parameter order. Scalar
 ``TS<T>`` uses ``date`` and ``value`` columns by default; ``TSD<K, TS<T>>``

--- a/docs/source/user_guide/python_compatibility.rst
+++ b/docs/source/user_guide/python_compatibility.rst
@@ -368,6 +368,13 @@ conversion and DataFrame storage metadata. Inside a Python node, declare a
 ``DataFrameStorage.write_frame`` directly; runtime code must not call
 ``GlobalState.instance()``.
 
+``DataFrameStorage`` and the rest of the durable surface are served by the
+optional ``hgraph-persistence`` distribution (RFC 0025), which
+``hgraph[dataframe]`` installs. The released
+``hgraph.adaptors.data_frame`` import paths still resolve them, and the two
+table-schema setters above are core — but using a durable name without the
+extension installed raises a pointed install error.
+
 Individual recordings can override the graph defaults. Supply the same
 projection to ``replay``; current recordings persist this contract in Arrow
 schema metadata and reject a mismatch at graph start:


### PR DESCRIPTION
A documentation audit for the persistence extraction (#498) found six pages still describing the durable record/replay surface as core's, months after it moved to `hgraph-persistence`.

None of this is new behaviour — it is stale prose that misleads about what a core-only install can do.

### What was wrong

| File | Claim |
|---|---|
| `reference/modules.rst` | `hgraph.adaptors.data_frame` advertised as "Arrow/Polars data sources **and frame record/replay**"; the closing note named Kafka as the *only* separate first-party distribution |
| `developer_guide/extension_policy.rst` | "The core has typed record/replay and **in-memory/Arrow** foundations" — contradicting this same file's ownership split 170 lines above it |
| `developer_guide/roadmap.rst` | Arrow memory/file storage listed as a core client utility; durable stores listed as remaining *core* work; `_data_frame_record_replay` named as the implementing core module |
| `user_guide/python_compatibility.rst` | Told users to call `DataFrameStorage.write_frame` with no indication it needs an extension installed |
| `user_guide/cpp/authoring_graphs.rst` | Reassured readers that `lower` involves no "process-global frame store" — implying core still has one |
| `developer_guide/parity_matrix.rst` | The DATA_FRAME record/replay model listed in the core polars-boundary ruling without the ownership note analytics already got in the same sentence |

### Approach

Each sentence is re-attributed rather than deleted, keeping the distinction that actually matters and that `extension_policy.rst` already states correctly: **core owns the record/replay participation contracts and the in-memory reference backends; the durable Arrow stores and storage policy belong to the extension**, reached through the lazy re-exports that keep the released `hgraph.adaptors.data_frame` import paths valid.

The `lower` note is the one outright deletion — there is no core frame store to disclaim.

`python_api_inventory.rst` is deliberately untouched: it is generated by `tools/api_inventory.py` and correctly reflects the names core still lazily exports.

### Verification

Sphinx `-W --keep-going` build succeeds; the doctest builder passes all 67 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
