### PR TITLE
Run a real durable round trip in the installed-SDK consumer

### DIFF
--- a/extensions/persistence/test_package/main.cpp
+++ b/extensions/persistence/test_package/main.cpp
@@ -1,11 +1,23 @@
 #include <hgraph/persistence/frame_store.h>
 #include <hgraph/persistence/recording_store.h>
 
+#include <hgraph/lib/std/std_operators.h>
 #include <hgraph/runtime/global_state.h>
+#include <hgraph/runtime/runtime.h>
+#include <hgraph/types/frame.h>
+#include <hgraph/types/graph_wiring.h>
 #include <hgraph/types/operator_dispatch.h>
+#include <hgraph/types/record_replay.h>
+#include <hgraph/types/static_schema.h>
+#include <hgraph/types/value/table_codec.h>
 
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace
 {
@@ -19,12 +31,101 @@ namespace
             throw std::runtime_error(what);
         }
     }
+
+    /** The stream both halves of the round trip carry, at the engine times
+        replay must re-emit it on (cycle 0 and cycle 2 - the gap is part of
+        what a recorded stream preserves). */
+    [[nodiscard]] const std::vector<std::pair<hg::DateTime, hg::Int>> &round_trip_rows()
+    {
+        static const std::vector<std::pair<hg::DateTime, hg::Int>> rows{
+            {hg::MIN_ST, hg::Int{11}},
+            {hg::MIN_ST + hg::MIN_TD * 2, hg::Int{22}},
+        };
+        return rows;
+    }
+
+    /** A bitemporal recording of those rows, built through the installed
+        table codec rather than by hand: the frame layout replay reads is the
+        backend's, so the consumer must not re-spell it. */
+    [[nodiscard]] hg::Frame seeded_recording()
+    {
+        hg::FrameRecorder recorder{
+            hg::table_converter(hg::scalar_descriptor<hg::Int>::value_meta())};
+        for (const auto &[when, value] : round_trip_rows())
+        {
+            const hg::Value cell{value};
+            recorder.append(when, when, cell.view());
+        }
+        return recorder.finish();
+    }
+
+    void check_frame_backend_round_trip()
+    {
+        using namespace hgraph;
+
+        // A real graph over the DURABLE backend: replay reads the seeded
+        // recording out of the state-selected frame store and record writes
+        // it back under a second key. Both overloads live in the installed
+        // extension, so the second key exists only if the extension's
+        // operator overloads resolve and evaluate across the install boundary.
+        Wiring     wiring;
+        const auto wiring_state = wiring.global_state();
+        hgp::set_frame_store(wiring_state,
+                             hgp::store::make_frame_store(hgp::store::FrameStoreConfig{}));
+        record_replay::set_config(
+            wiring_state,
+            record_replay::RecordReplayConfig{.backend = std::string{hgp::FRAME_BACKEND}});
+        hgp::store_write(wiring_state, "consumer.in", seeded_recording());
+
+        auto replayed =
+            wire<stdlib::replay, TS<Int>>(wiring, Str{"in"}, arg<"recordable_id">(Str{"consumer"}));
+        wire<stdlib::record>(wiring, replayed, Str{"out"}, arg<"recordable_id">(Str{"consumer"}));
+
+        GraphExecutorBuilder executor_builder;
+        executor_builder.graph_builder(std::move(wiring).finish())
+            .start_time(MIN_ST)
+            .end_time(MIN_ST + MIN_TD * 6);
+        GraphExecutorValue executor = executor_builder.make_executor();
+        const auto         view     = executor.view();
+        view.run();
+
+        // The store outlives the run: what the recording sink wrote is read
+        // back out of it and must match the replayed stream row for row.
+        const auto state = view.graph().global_state();
+        require(hgp::store_contains(state, "consumer.out"),
+                "the run recorded through the durable frame backend");
+        const Frame recorded  = hgp::store_read(state, "consumer.out");
+        const auto &converter = table_converter(scalar_descriptor<Int>::value_meta());
+        require(frame_rows(recorded) == static_cast<std::int64_t>(round_trip_rows().size()),
+                "every replayed row was recorded again");
+        for (std::size_t row = 0; row < round_trip_rows().size(); ++row)
+        {
+            const auto &[when, value] = round_trip_rows()[row];
+            const auto index          = static_cast<std::int64_t>(row);
+            require(frame_value_time(converter, recorded, index) == when,
+                    "each row replayed at its recorded time");
+            require(read_row(converter, recorded, index).view().checked_as<Int>() == value,
+                    "each row replayed its recorded value");
+        }
+
+        // ``reset_all_registries()`` is deliberately NOT called here: it
+        // invalidates the interned metadata every live value above still
+        // points at, so a full reset cannot run mid-consumer (the documented
+        // test-only reset hazard). The installer replay this extension
+        // registers is covered by the in-tree installer tests and the Python
+        // extension consumer.
+    }
 }  // namespace
 
 int main()
 {
     try
     {
+        // The standard operators first, so the built-in record/replay
+        // backends are registered alongside the durable one: the round trip
+        // below then proves the extension's overloads were SELECTED, not
+        // merely the only candidates left.
+        hg::stdlib::register_standard_operators();
         // The installed extension registers its backend through the shared
         // runtime's keyed-installer mechanism.
         hgp::register_frame_backend();
@@ -33,23 +134,29 @@ int main()
                      .empty(),
                 "durable record overload registered");
 
-        // The GlobalState-scoped store round-trips a frame with immutable
-        // keys through the installed SDK.
-        hg::GlobalContext context;
-        const auto        state = context.state().view();
-        hgp::set_frame_store(state,
-                             hgp::store::make_frame_store(hgp::store::FrameStoreConfig{}));
-        hgp::store_write(state, "consumer/frame", hg::Frame{});
-        require(hgp::store_contains(state, "consumer/frame"),
-                "stored frame is retrievable");
-        require(!hgp::store_contains(state, "consumer/absent"),
-                "absent keys read as absent");
+        {
+            // The GlobalState-scoped store round-trips a frame with immutable
+            // keys through the installed SDK.
+            hg::GlobalContext context;
+            const auto        state = context.state().view();
+            hgp::set_frame_store(state,
+                                 hgp::store::make_frame_store(hgp::store::FrameStoreConfig{}));
+            hgp::store_write(state, "consumer/frame", hg::Frame{});
+            require(hgp::store_contains(state, "consumer/frame"),
+                    "stored frame is retrievable");
+            require(!hgp::store_contains(state, "consumer/absent"),
+                    "absent keys read as absent");
+        }
 
         // The segmented-recording protocol survives the installed boundary.
         const hg::Frame marker = hgp::segmented_recording_marker();
         require(hgp::is_segmented_recording(marker),
                 "segmented-recording marker recognised");
         require(hgp::segment_key("k", 2) == "k.2", "segment key shape");
+
+        // The store and the protocol exist for the operators built on them:
+        // run those operators in a graph.
+        check_frame_backend_round_trip();
 
         std::cout << "hgraph-persistence installed consumer passed\n";
         return 0;


### PR DESCRIPTION
The installed-SDK consumer for `hgraph-persistence` proved registration and store reads/writes, but never ran a graph. So nothing in it showed that the durable `record`/`replay` overloads actually **resolve and evaluate across an installed-DSO boundary** — which is the one thing an installed-SDK consumer exists to prove. The core consumer already does exactly this (`tests/install_consumer/main.cpp`, `check_probe_backend_round_trip`), but with a stub backend.

### What it does now

`check_frame_backend_round_trip()` runs a real graph over the real durable backend:

1. Seeds `consumer.in` with a bitemporal recording built through the installed table codec (`FrameRecorder` + `table_converter`), so the consumer never re-spells the frame layout the backend owns.
2. Wires `replay<TS<Int>>("in")` → `record("out")` under `recordable_id="consumer"`, with a real `make_frame_store` and the backend selected by `hgp::FRAME_BACKEND` (the constant, not the string literal).
3. Runs the executor, then reads `consumer.out` back out of the store and checks the row count, each row's **value**, and each row's **recorded time** — including the deliberate gap at cycle 1, since preserving gaps is part of what a recorded stream means.

The standard operators are registered **before** the extension, so the `memory` and `testing` backends are present too. That matters: it makes the run prove the durable overloads were *selected*, not merely the only candidates left in the registry.

### The assertions are load-bearing

Each was broken in turn, rebuilt, and observed to fail:

| Probe | Failure surfaced |
|---|---|
| expected value `== value + 1` | `each row replayed its recorded value` |
| expected time `== when + MIN_TD` | `each row replayed at its recorded time` |
| `set_config` removed, so the memory backend wins | `the run recorded through the durable frame backend` |

The third is the important one — with the memory backend selected nothing reaches the frame store at all, so the passing check really does depend on the durable path running.

`reset_all_registries()` is deliberately still not called; the core consumer documents why (a full reset invalidates interned metadata that live values still point at).

### Verification

Built and run against an installed shared SDK, the shape CI's `native-shared-install` job uses: shared build → `cmake --install` → configure `test_package` against the prefix → `ctest`. Passes, and rebuilds warning-clean under `-Wall -Wextra -Wpedantic`.

### Unrelated finding while doing this

An unqualified `-DHGRAPH_BUILD_SHARED=ON` native build **fails to link on macOS** at `main`:

```
Undefined symbols for architecture arm64:
  "hgraph::clear_table_type_ops()", referenced from:
      hgraph::reset_all_registries() in ... libhgraph_wiring.dylib
```

`reset_all_registries` is in `hgraph_wiring`; `clear_table_type_ops` is defined in `table_impl.cpp`, which is in `hgraph_stdlib` — and `hgraph_stdlib` links *above* wiring (`src/CMakeLists.txt:172`). `include/hgraph/types/registry_reset.h:11-17` names this exact situation and forbids it: a cache above that function in the link order "cannot be named without inverting the dependency" and must self-invalidate on `reset_generation()` instead. ELF tolerates the undefined symbol so CI's Linux-only shared leg stays green; Mach-O's default `-undefined error` does not. Introduced by `9dbb93703` (RFC 0019 native table recording, 2026-08-13).

Not fixed here — it touches load-bearing reset ordering and deserves its own change. Worked around locally with `-Wl,-undefined,dynamic_lookup`, no source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
