### PR TITLE
Only blame the missing extension when it is actually implicated

### DIFF
--- a/python/hgraph/_wiring/_core.py
+++ b/python/hgraph/_wiring/_core.py
@@ -5,6 +5,7 @@ serialized because the stack and native operator registry are process-wide;
 the serialization ends once the native executor has been built, so distinct
 executors may run concurrently. ``_wiring_stack`` is THE single list object:
 tests and C++ re-entry mutate it in place; nothing may rebind it."""
+import re
 import threading
 
 import _hgraph
@@ -45,6 +46,18 @@ def register_record_replay_wiring_adapter(adapter):
 # one of these is a candidate for the missing-extension diagnosis whatever
 # backend is configured.
 _EXTENSION_ONLY_OPERATORS = frozenset({"replay_const"})
+
+# The native resolver reports a resolution failure two ways, and a missing
+# extension shows up as EITHER: overloads exist but none matched the call, or
+# the operator marker itself is absent because only the extension registers
+# one. Anything else -- an argument type error, a bad key -- is not about
+# which overloads are registered and must not attract install advice.
+_NO_MATCHING_OVERLOAD = "no matching overload for operator"
+_NO_SUCH_OPERATOR = re.compile(r"no operator '[^']*' is registered")
+
+
+def _is_resolution_failure(message):
+    return _NO_MATCHING_OVERLOAD in message or _NO_SUCH_OPERATOR.search(message) is not None
 
 
 def _durable_backend_selected(kwargs):
@@ -95,7 +108,7 @@ def _durable_wiring_hint(name, kwargs=None, message=""):
     """
     if name not in _DURABLE_OPERATORS:
         return ""
-    if "no matching overload" not in message:
+    if not _is_resolution_failure(message):
         return ""
     if name not in _EXTENSION_ONLY_OPERATORS and not _durable_backend_selected(kwargs):
         return ""

--- a/python/hgraph/_wiring/_core.py
+++ b/python/hgraph/_wiring/_core.py
@@ -67,7 +67,11 @@ def _durable_backend_selected(kwargs):
         model = _LEGACY_BACKENDS.get(model, model)
     except Exception:  # translation is best-effort; the id check still holds
         pass
-    return isinstance(model, str) and model.startswith("hgraph.")
+    # The SAME prefix the load point in _ensure_backend_extension recognises.
+    # Backend selection is open, so an independently registered backend may
+    # legitimately use another "hgraph.*" id; blaming persistence for it would
+    # be the very misattribution this function exists to stop.
+    return isinstance(model, str) and model.startswith("hgraph.persistence.")
 
 
 def _durable_wiring_hint(name, kwargs=None, message=""):

--- a/python/hgraph/_wiring/_core.py
+++ b/python/hgraph/_wiring/_core.py
@@ -40,17 +40,60 @@ def register_record_replay_wiring_adapter(adapter):
     _record_replay_wiring_adapter = adapter
 
 
-def _durable_wiring_hint(name):
+# Operators with NO in-memory implementation: core declares the contract and
+# only hgraph-persistence registers an overload, so a resolution failure on
+# one of these is a candidate for the missing-extension diagnosis whatever
+# backend is configured.
+_EXTENSION_ONLY_OPERATORS = frozenset({"replay_const"})
+
+
+def _durable_backend_selected(kwargs):
+    """Whether a durable backend is actually in play for this call."""
+    model = (kwargs or {}).get("model")
+    if model is None:
+        try:
+            from ._state import GlobalState
+
+            model = GlobalState.instance().get("__record_replay_model__")
+        except Exception:  # no active global state — nothing was selected
+            return False
+    if model is None:
+        return False
+    try:
+        from ._state import _LEGACY_BACKENDS, _LEGACY_DATA_FRAME_RECORD_REPLAY
+
+        if model == _LEGACY_DATA_FRAME_RECORD_REPLAY:
+            model = _hgraph.DATA_FRAME
+        model = _LEGACY_BACKENDS.get(model, model)
+    except Exception:  # translation is best-effort; the id check still holds
+        pass
+    return isinstance(model, str) and model.startswith("hgraph.")
+
+
+def _durable_wiring_hint(name, kwargs=None, message=""):
     """The missing-extension diagnosis for a durable operator's wiring failure.
 
-    Wiring diagnoses the missing backend (RFC 0025): a resolution failure on a
-    record/replay operator is unexplained when the cause is that the durable
-    overloads never registered — either the optional distribution is absent, or
-    it is installed but nothing selected a durable backend, so it never loaded.
+    Wiring diagnoses the missing backend (RFC 0025), but only where the durable
+    path is genuinely implicated. Two gates keep it honest:
+
+    * The failure must be a resolution failure. Appending install advice to an
+      argument-type error sends the caller after a distribution they do not
+      need.
+    * Selecting a durable backend IS the extension load point, at graph level
+      or per call, and an absent distribution raises a pointed error THERE. So
+      for ``record``/``replay``/``compare`` an unloaded extension means no
+      durable backend was ever selected and the failure is unrelated. Only
+      ``replay_const``, which has no in-memory implementation at all, can fail
+      this way without a durable selection.
+
     Availability is probed without importing (importing would register the
     overloads as an error-path side effect).
     """
     if name not in _DURABLE_OPERATORS:
+        return ""
+    if "no matching overload" not in message:
+        return ""
+    if name not in _EXTENSION_ONLY_OPERATORS and not _durable_backend_selected(kwargs):
         return ""
     import importlib.util
     import sys
@@ -145,7 +188,8 @@ def wire(name, *args, __output_type__=None, **kwargs):
         # std::invalid_argument surfaces as ValueError; both are wiring-time.
         # (RequirementsNotMetWiringError arrives ALREADY typed - the C++
         # resolver throws OperatorRequirementsError, translated directly.)
-        raise WiringError(str(error) + _durable_wiring_hint(name)) from error
+        message = str(error)
+        raise WiringError(message + _durable_wiring_hint(name, kwargs, message)) from error
     return WiringPort(result) if result is not None else None
 
 

--- a/python/tests/test_durable_wiring_hint.py
+++ b/python/tests/test_durable_wiring_hint.py
@@ -22,8 +22,13 @@ import hgraph as hg
 from hgraph._wiring._core import _durable_wiring_hint
 
 _INSTALL_ADVICE = "hgraph-persistence"
+# The native resolver has TWO resolution-failure wordings and the hint must
+# read both: overloads registered but none matched, and the operator marker
+# absent entirely. The second is how replay_const fails without the extension,
+# and gating on the first alone silently dropped the diagnosis for it.
 _RECORD_FAILURE = "no matching overload for operator 'record' with 2 argument(s)"
-_REPLAY_CONST_FAILURE = (
+_REPLAY_CONST_FAILURE = "no operator 'replay_const' is registered"
+_REPLAY_CONST_NO_OVERLOAD = (
     "no matching overload for operator 'replay_const' with 1 argument(s)"
 )
 
@@ -77,11 +82,29 @@ def test_another_vendors_backend_is_not_blamed_on_persistence(extension_unloaded
     assert _durable_wiring_hint("record", {"model": "hgraph.custom"}, _RECORD_FAILURE) == ""
 
 
-def test_extension_only_operator_is_diagnosed_without_a_selection(extension_unloaded):
+@pytest.mark.parametrize(
+    "failure", [_REPLAY_CONST_FAILURE, _REPLAY_CONST_NO_OVERLOAD], ids=["absent", "no-overload"]
+)
+def test_extension_only_operator_is_diagnosed_without_a_selection(
+    failure, extension_unloaded
+):
     # replay_const has no in-memory implementation, so it can fail this way
-    # with no durable backend configured at all.
-    assert _INSTALL_ADVICE in _durable_wiring_hint(
-        "replay_const", {}, _REPLAY_CONST_FAILURE
+    # with no durable backend configured at all -- and it fails with EITHER
+    # wording depending on whether the marker itself got registered.
+    assert _INSTALL_ADVICE in _durable_wiring_hint("replay_const", {}, failure)
+
+
+def test_a_non_resolution_error_mentioning_registration_is_not_a_resolution_failure(
+    extension_unloaded,
+):
+    # The "absent operator" wording is matched by shape, not by the loose
+    # substring "is registered", so an unrelated message carrying those words
+    # does not attract install advice.
+    assert (
+        _durable_wiring_hint(
+            "replay_const", {}, "the recordable id is registered to another graph"
+        )
+        == ""
     )
 
 

--- a/python/tests/test_durable_wiring_hint.py
+++ b/python/tests/test_durable_wiring_hint.py
@@ -6,7 +6,15 @@ argument errors, which sent the caller after a distribution they did not
 need. Selecting a durable backend is itself the extension load point and
 raises a pointed error there, so an unloaded extension means no durable
 backend was ever selected (RFC 0025).
+
+Every test here states the load state it is about. The diagnosis is
+deliberately silent once the extension is imported, and the wheel test
+workflow installs it and imports it from an earlier test module — so a test
+that inherited the state from suite order would pass locally and fail there.
 """
+
+import sys
+import types
 
 import pytest
 
@@ -14,47 +22,81 @@ import hgraph as hg
 from hgraph._wiring._core import _durable_wiring_hint
 
 _INSTALL_ADVICE = "hgraph-persistence"
-_RESOLUTION_FAILURE = "no matching overload for operator 'record' with 2 argument(s)"
+_RECORD_FAILURE = "no matching overload for operator 'record' with 2 argument(s)"
+_REPLAY_CONST_FAILURE = (
+    "no matching overload for operator 'replay_const' with 1 argument(s)"
+)
 
 
-def test_argument_errors_do_not_advertise_the_extension():
+@pytest.fixture
+def extension_unloaded(monkeypatch):
+    """Force the not-loaded state, whatever the rest of the suite did."""
+    for name in [
+        name
+        for name in sys.modules
+        if name == "hgraph_persistence" or name.startswith("hgraph_persistence.")
+    ]:
+        monkeypatch.delitem(sys.modules, name)
+
+
+@pytest.fixture
+def extension_loaded(monkeypatch):
+    """Force the loaded state without requiring the distribution."""
+    monkeypatch.setitem(
+        sys.modules, "hgraph_persistence", types.ModuleType("hgraph_persistence")
+    )
+
+
+def test_argument_errors_do_not_advertise_the_extension(extension_unloaded):
     # Not a resolution failure at all: nothing about it implicates a backend.
     assert _durable_wiring_hint("record", {}, "key must be a str, got int") == ""
 
 
-def test_core_backend_resolution_failure_does_not_advertise_the_extension():
+def test_core_backend_resolution_failure_does_not_advertise_the_extension(
+    extension_unloaded,
+):
     # A resolution failure with no durable backend selected is an ordinary
     # signature mismatch against the built-in backends.
-    assert _durable_wiring_hint("record", {}, _RESOLUTION_FAILURE) == ""
+    assert _durable_wiring_hint("record", {}, _RECORD_FAILURE) == ""
 
 
-def test_non_durable_operator_never_advertises_the_extension():
-    assert _durable_wiring_hint("add_", {}, _RESOLUTION_FAILURE) == ""
+def test_non_durable_operator_never_advertises_the_extension(extension_unloaded):
+    assert _durable_wiring_hint("add_", {}, _RECORD_FAILURE) == ""
 
 
-@pytest.mark.parametrize(
-    "model",
-    ["hgraph.persistence.frame", "DataFrame"],
-)
-def test_durable_selection_still_gets_the_diagnosis(model):
+@pytest.mark.parametrize("model", ["hgraph.persistence.frame", "DataFrame"])
+def test_durable_selection_still_gets_the_diagnosis(model, extension_unloaded):
     # Both the backend id and the legacy model constant count as a durable
     # selection; the hint is the whole point when one is in play.
-    hint = _durable_wiring_hint("record", {"model": model}, _RESOLUTION_FAILURE)
-    assert _INSTALL_ADVICE in hint
+    assert _INSTALL_ADVICE in _durable_wiring_hint("record", {"model": model}, _RECORD_FAILURE)
 
 
-def test_extension_only_operator_is_diagnosed_without_a_selection():
+def test_another_vendors_backend_is_not_blamed_on_persistence(extension_unloaded):
+    # Backend selection is open. An independently registered "hgraph.*" id is
+    # not persistence's, and installing persistence would not supply it.
+    assert _durable_wiring_hint("record", {"model": "hgraph.custom"}, _RECORD_FAILURE) == ""
+
+
+def test_extension_only_operator_is_diagnosed_without_a_selection(extension_unloaded):
     # replay_const has no in-memory implementation, so it can fail this way
     # with no durable backend configured at all.
-    hint = _durable_wiring_hint(
-        "replay_const",
-        {},
-        "no matching overload for operator 'replay_const' with 1 argument(s)",
+    assert _INSTALL_ADVICE in _durable_wiring_hint(
+        "replay_const", {}, _REPLAY_CONST_FAILURE
     )
-    assert _INSTALL_ADVICE in hint
 
 
-def test_bad_record_signature_reports_only_the_signature():
+def test_a_loaded_extension_is_never_blamed(extension_loaded):
+    # Once the overloads are registered, a failure cannot be their absence.
+    assert _durable_wiring_hint("replay_const", {}, _REPLAY_CONST_FAILURE) == ""
+    assert (
+        _durable_wiring_hint(
+            "record", {"model": "hgraph.persistence.frame"}, _RECORD_FAILURE
+        )
+        == ""
+    )
+
+
+def test_bad_record_signature_reports_only_the_signature(extension_unloaded):
     # End to end, and the exact case the gates exist for: a wrong `key` type
     # on `record` with no durable backend selected. This raised a real
     # resolution failure with "install hgraph-persistence" appended, sending

--- a/python/tests/test_durable_wiring_hint.py
+++ b/python/tests/test_durable_wiring_hint.py
@@ -1,0 +1,72 @@
+"""The missing-extension wiring diagnosis must accuse the right thing.
+
+``record``/``replay``/``compare`` had install advice appended to EVERY
+wiring failure while ``hgraph_persistence`` was unloaded — including plain
+argument errors, which sent the caller after a distribution they did not
+need. Selecting a durable backend is itself the extension load point and
+raises a pointed error there, so an unloaded extension means no durable
+backend was ever selected (RFC 0025).
+"""
+
+import pytest
+
+import hgraph as hg
+from hgraph._wiring._core import _durable_wiring_hint
+
+_INSTALL_ADVICE = "hgraph-persistence"
+_RESOLUTION_FAILURE = "no matching overload for operator 'record' with 2 argument(s)"
+
+
+def test_argument_errors_do_not_advertise_the_extension():
+    # Not a resolution failure at all: nothing about it implicates a backend.
+    assert _durable_wiring_hint("record", {}, "key must be a str, got int") == ""
+
+
+def test_core_backend_resolution_failure_does_not_advertise_the_extension():
+    # A resolution failure with no durable backend selected is an ordinary
+    # signature mismatch against the built-in backends.
+    assert _durable_wiring_hint("record", {}, _RESOLUTION_FAILURE) == ""
+
+
+def test_non_durable_operator_never_advertises_the_extension():
+    assert _durable_wiring_hint("add_", {}, _RESOLUTION_FAILURE) == ""
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["hgraph.persistence.frame", "DataFrame"],
+)
+def test_durable_selection_still_gets_the_diagnosis(model):
+    # Both the backend id and the legacy model constant count as a durable
+    # selection; the hint is the whole point when one is in play.
+    hint = _durable_wiring_hint("record", {"model": model}, _RESOLUTION_FAILURE)
+    assert _INSTALL_ADVICE in hint
+
+
+def test_extension_only_operator_is_diagnosed_without_a_selection():
+    # replay_const has no in-memory implementation, so it can fail this way
+    # with no durable backend configured at all.
+    hint = _durable_wiring_hint(
+        "replay_const",
+        {},
+        "no matching overload for operator 'replay_const' with 1 argument(s)",
+    )
+    assert _INSTALL_ADVICE in hint
+
+
+def test_bad_record_signature_reports_only_the_signature():
+    # End to end, and the exact case the gates exist for: a wrong `key` type
+    # on `record` with no durable backend selected. This raised a real
+    # resolution failure with "install hgraph-persistence" appended, sending
+    # the caller after a distribution that would not have helped.
+    @hg.graph
+    def bad_record():
+        hg.record(hg.const(1), key=5)
+
+    with pytest.raises(Exception) as caught:
+        hg.eval_node(bad_record)
+    message = str(caught.value)
+    # Pins the native wording the hint gates on: if it changes, the gate
+    # silently stops firing and this test says so.
+    assert "no matching overload" in message
+    assert _INSTALL_ADVICE not in message


### PR DESCRIPTION
The missing-extension wiring diagnosis accused `hgraph-persistence` of failures it had nothing to do with.

```python
@hg.graph
def bad_record():
    hg.record(hg.const(1), key=5)   # key must be a str
```

raised the correct signature error **plus** `(durable record/replay overloads are provided by the optional 'hgraph-persistence' distribution; install it with pip install hgraph-persistence …)`. Installing it would not have helped — the argument was simply wrong.

### Why the premise was unsound

The hint fired for any `RuntimeError`/`ValueError` from `record`, `replay`, `compare` or `replay_const` whenever `hgraph_persistence` was not in `sys.modules`. But **selecting a durable backend is itself the extension load point** (RFC 0025) — `set_record_replay_config` and the per-call `model=` path both call `_ensure_backend_extension`, which imports the distribution or raises a pointed `ModuleNotFoundError` right there.

So for `record`/`replay`/`compare`, "extension not loaded" at wiring time means *no durable backend was ever selected*, which means the failure cannot be the missing overloads. The condition the hint tested was very nearly the negation of the condition that would make it true.

`replay_const` is the genuine exception: core declares the contract and only the extension registers an overload, so it can fail this way with nothing selected.

### The fix

Two gates:

1. **It must be a resolution failure** — `no matching overload` in the message. An argument-type error never gets install advice.
2. **The durable path must be in play** — either the operator is extension-only (`replay_const`), or a durable backend id is selected, by per-call `model=` or the `__record_replay_model__` mirror. Legacy model constants (`DataFrame`, and the 0.5 data-frame sentinel) are translated first, so they count.

### Tests

Nothing asserted this behaviour before — the hint was entirely untested, which is how it stayed wrong. Seven tests now cover it, and both gates were falsified (disabled in place, tests observed to fail).

The end-to-end test doubles as a contract pin: it asserts the native `no matching overload` wording is present in a real failure. The gate reads that substring, so if the C++ wording changes the diagnosis would silently stop firing — this test fails instead.

### Verification

Full core Python suite: 2118 passed, same 6 pre-existing local failures as the untouched baseline (`test_api_inventory` ×3 and three record/replay tests that fail identically without this change — a stale installed wheel against worktree tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
