### PR TITLE
Publish the persistence migration guide and finish the extraction docs

### DIFF
--- a/docs/source/developer_guide/build_system.rst
+++ b/docs/source/developer_guide/build_system.rst
@@ -220,6 +220,14 @@ include them in a repository build; standalone consumers find ``hgraph-web`` or
 options are off by default, so a normal core configure resolves neither their
 dependencies nor their targets.
 
+For persistence that default carries a design rule rather than a convenience:
+durable-store policy — Parquet and S3 detection, the recording option
+vocabularies — belongs to the extension, so a core configure resolves neither
+(RFC 0025). The ``Native C++ / Linux core-only`` leg in ``native-cpp.yml``
+builds core with every extension off and fails if the configure resolves
+Parquet at all, because the other native legs force the extensions on and
+would not notice the dependency coming back.
+
 Each extension owns its nested ``pyproject.toml``, CMake package configuration,
 and tests. Cross-cutting changes are tested against core at the same commit,
 while the resulting wheels remain separate distribution artifacts. During the

--- a/docs/source/developer_guide/record_replay_table.rst
+++ b/docs/source/developer_guide/record_replay_table.rst
@@ -372,18 +372,20 @@ Step 4 — landed
 ---------------
 
 The Arrow data-frame record/replay backend, backend id
-``"hgraph.persistence.frame"`` (RFC 0025: the id belongs to the persistence
-extension; the transitional in-core implementation answers to it until the
-checkpoint-5 move):
+``"hgraph.persistence.frame"``. The id and the implementation both belong to
+the ``hgraph-persistence`` extension; the move completed at RFC 0025
+checkpoint 5, and core now retains only the participation contracts described
+in the earlier steps:
 
 - **The P6 content store** — a graph-scoped, owning type-erased
   ``store::FrameStore`` selected in ``GlobalState``. The handle shares an
   erased context and dispatches through a non-null ``store::FrameStoreOps``
-  table; it is not an abstract base class. Native memory, local-filesystem and
-  S3 representations remain private and own key validation, serialization,
-  compression and immutable-key enforcement. The process fallback uses the
-  same erased handle; graph execution first resolves the store belonging to
-  that graph.
+  table; it is not an abstract base class. The extension's native memory,
+  local-filesystem and S3 representations remain private to it and own key
+  validation, serialization, compression and immutable-key enforcement. Its
+  process fallback uses the same erased handle; graph execution first resolves
+  the store belonging to that graph. (This fallback is the extension's, not a
+  second process-global store in core — see P2 above.)
 - **``TraitsView``** — the node-level injectable completing the traits
   primitive: a transparent stateless injectable (the ``SingleShotScheduler``
   pattern) giving hooks ``trait``/``trait_or`` over the owning graph's
@@ -414,8 +416,8 @@ checkpoint-5 move):
   the last row with value-time <= ``tm`` and as-of <= ``as_of``.
 - **``recorded_seed_resolver``** (``component`` RECOVER) dispatches over
   exactly the backend ids core serves: ``"memory"`` reads the sparse
-  ``:memory:`` buffer; ``"testing"`` and the transitional frame id read
-  through ``replay_const_value``; anything else is a pointed error naming
+  ``:memory:`` buffer and ``"testing"`` reads through
+  ``replay_const_value``; anything else is a pointed error naming
   the backend — extension seed resolution registers with the extension
   (RFC 0025, checkpoints 3/5).
 
@@ -539,15 +541,16 @@ The Compare sink (landed)
 
 The Q-compare ruling realised, re-based on the RFC 0025 core-neutral
 summary at checkpoint 2.  ``compare(lhs, rhs, recordable_id="")`` under
-the ``"testing"`` or frame backend is a sink recording per-tick equality
+the ``"testing"`` backend is a sink recording per-tick equality
 (erased ``ValueView::equals``) into a bitemporal ``Bool`` frame via the
 ``FrameRecorder``, written through the **registered frame store** (P6) at
 stop under ``fq.__compare__``; the memory backend's ``memory_compare``
-keeps the interactive contract (a mismatch fails the run).  Every core
-compare guard names exactly the backend ids it serves — selection is
-open, so an unrecognised or extension-owned identifier produces the
-no-match wiring error (or the extension's own overload), never a silent
-fall-through into the built-in frame compare.  Activation with a
+keeps the interactive contract (a mismatch fails the run).  The frame
+backend's compare is the extension's own overload, registered with it.
+Every core compare guard names exactly the backend ids it serves —
+selection is open, so an unrecognised or extension-owned identifier
+produces the no-match wiring error (or the extension's own overload),
+never a silent fall-through into a frame compare.  Activation with a
 one-sided value IS a mismatch (one series produced where the other did
 not) and is recorded as a failure — never skipped.
 
@@ -680,8 +683,9 @@ Step 7 — native segmented recordings
 ------------------------------------
 
 ``record`` normally retains one run in Arrow builders and writes one immutable
-frame at ``stop``. Native memory, local-filesystem, and S3 stores additionally
-honour the wiring-time ``flush_rows`` and ``flush_interval`` thresholds. A
+frame at ``stop``. The extension's native memory, local-filesystem, and S3
+stores additionally honour the wiring-time ``flush_rows`` and
+``flush_interval`` thresholds. A
 flush happens only after the current evaluation tick has been emitted, so the
 rows of one frame-valued tick are never split between segments.
 
@@ -693,8 +697,9 @@ then probes the next number. An interrupted run therefore replays every fully
 published segment and nothing torn. A writer refuses either a claimed base key
 or a pre-existing ``.0`` legacy/segment key.
 
-Segmentation is intentionally not part of ``FrameStoreOps``. Core identifies
-its own immutable native stores without changing that public ops-table ABI.
+Segmentation is intentionally not part of ``FrameStoreOps``. The extension
+identifies its own immutable native stores without changing that public
+ops-table ABI, which stays core-facing.
 Python and other custom frame stores remain the compatibility seam promised by
 RFC 0019: one complete ``store``/``load``/``has`` frame operation per run,
 even when the call supplied flush thresholds.

--- a/docs/source/reference/modules.rst
+++ b/docs/source/reference/modules.rst
@@ -75,5 +75,6 @@ extras of the core wheel — though an extra may depend on one, as
 ``hgraph[dataframe]`` depends on ``hgraph-persistence``. The durable
 record/replay surface reached through ``hgraph.adaptors.data_frame`` keeps its
 released import paths and resolves lazily from that distribution, raising a
-pointed install error only when a durable name is used. Each module's exact
-public names are listed in :doc:`python_api_inventory`.
+pointed install error only when a durable name is used; the name mapping is in
+:doc:`../user_guide/persistence_migration`. Each module's exact public names
+are listed in :doc:`python_api_inventory`.

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -42,6 +42,7 @@ library authors and performance-sensitive integrations.
 
    python_compatibility
    analytics_migration
+   persistence_migration
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/user_guide/persistence_migration.rst
+++ b/docs/source/user_guide/persistence_migration.rst
@@ -74,13 +74,21 @@ Python name changes
      - ``hgraph_persistence.compat.set_data_frame_record_path``
    * - ``hgraph.adaptors.data_frame.set_data_frame_overrides``
      - ``hgraph_persistence.compat.set_data_frame_overrides``
-   * - ``hgraph.adaptors.data_frame.get_data_frame_record_overrides``
+   * - ``hgraph.adaptors.data_frame._data_frame_record_replay``
+       ``.get_data_frame_record_overrides``
      - ``hgraph_persistence.compat.get_data_frame_record_overrides``
 
 The ``hgraph.adaptors.data_frame`` spellings above continue to resolve; the
 table records where the implementation now lives so new code can import it
-directly. ``hgraph.RecordAsOf`` and ``hgraph.RecordRemoves`` are different:
-they emit a ``DeprecationWarning`` and are removed in 0.9.
+directly. One name is an exception, and the table gives its real path:
+``get_data_frame_record_overrides`` was never re-exported at package level and
+is reachable only through the private ``_data_frame_record_replay`` module —
+as are ``DATA_FRAME_RECORD_REPLAY_PATH`` and ``DATA_FRAME_RECORD_OVERRIDES``.
+
+None of this survives 1.0. Per :doc:`../rfc/rfc_0005_hgraph_1_0_api`, the
+``hgraph.adaptors`` namespace exists only as warning shims in the pre-1.0
+bridge release and does not exist in 1.0, so treat every row in this table as
+work to do before then rather than a permanent alias.
 
 Backend and model names
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -114,8 +122,10 @@ operators:
 
 .. code-block:: cpp
 
-   #include <hgraph/persistence/frame_store.h>
-   #include <hgraph/persistence/recording_options.h>
+   #include <hgraph/lib/std/std_operators.h>          // register_standard_operators
+   #include <hgraph/persistence/recording_store.h>     // register_frame_backend
+   #include <hgraph/persistence/frame_store.h>         // store::FrameStore
+   #include <hgraph/persistence/recording_options.h>   // RecordAsOf, RecordRemoves
 
    namespace hgp = hgraph::persistence;
 
@@ -132,6 +142,12 @@ Header and symbol moves:
      - New persistence name
    * - ``hgraph/types/frame_store.h``
      - ``hgraph/persistence/frame_store.h``
+   * - ``hgraph::store`` (namespace)
+     - ``hgraph::persistence::store`` — the whole store surface moved with the
+       header, so ``FrameStore``, ``FrameStoreOps``, ``FrameStoreConfig``,
+       ``make_frame_store`` and ``Compression`` all requalify. Changing the
+       include alone leaves every former ``hgraph::store::`` reference
+       uncompilable.
    * - ``hgraph::stdlib::RecordAsOf``
      - ``hgraph::persistence::RecordAsOf``
    * - ``hgraph::stdlib::RecordRemoves``

--- a/docs/source/user_guide/persistence_migration.rst
+++ b/docs/source/user_guide/persistence_migration.rst
@@ -1,0 +1,179 @@
+Persistence package migration
+=============================
+
+Durable record and replay — the frame stores, the Arrow record/replay
+backend, and the 0.5 ``DataFrameStorage`` surface — moved from core
+``hgraph`` to the separately installed ``hgraph-persistence`` distribution
+in 0.8. Core keeps the *participation contracts*: the ``record``,
+``replay`` and ``compare`` operator markers, record/replay modes,
+recordable identity, and the in-memory reference backends. Storage policy
+— durable stores, formats, compression, retention, Parquet and S3 — lives
+in the extension (:doc:`../rfc/rfc_0025_hgraph_persistence`).
+
+Install it alongside core, either directly or through the extra that
+depends on it:
+
+.. code-block:: bash
+
+   pip install hgraph hgraph-persistence
+   # or, which pulls hgraph-persistence in as a dependency:
+   pip install "hgraph[dataframe]"
+
+Durable names are then reached from the new distribution:
+
+.. code-block:: python
+
+   import hgraph as hg
+   from hgraph_persistence import RecordAsOf, RecordRemoves
+
+   @hg.graph
+   def record_positions(positions: hg.TSD[str, hg.TS[float]]):
+       hg.record(
+           positions,
+           key="positions",
+           recordable_id="book",
+           model="hgraph.persistence.frame",
+           removes=RecordRemoves.TRACK,
+       )
+
+**Nothing needs to move at once.** Released import paths keep working:
+``hgraph.adaptors.data_frame`` re-exports the durable surface lazily from
+the extension, so ``import hgraph`` never pulls the distribution in and a
+core-only install still imports the module. Using a durable name without
+the extension installed raises a pointed install error naming
+``hgraph-persistence`` — it fails at *use*, not at import.
+
+Python name changes
+-------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 48 52
+
+   * - Former core name
+     - New persistence name
+   * - ``hgraph.RecordAsOf``
+     - ``hgraph_persistence.RecordAsOf``
+   * - ``hgraph.RecordRemoves``
+     - ``hgraph_persistence.RecordRemoves``
+   * - ``hgraph.frame_store_contains``
+     - ``hgraph_persistence.frame_store_contains``
+   * - ``hgraph.frame_store_read``
+     - ``hgraph_persistence.frame_store_read``
+   * - ``hgraph.adaptors.data_frame.WriteMode``
+     - ``hgraph_persistence.compat.WriteMode``
+   * - ``hgraph.adaptors.data_frame.DataFrameStorage``
+     - ``hgraph_persistence.compat.DataFrameStorage``
+   * - ``hgraph.adaptors.data_frame.BaseDataFrameStorage``
+     - ``hgraph_persistence.compat.BaseDataFrameStorage``
+   * - ``hgraph.adaptors.data_frame.FileBasedDataFrameStorage``
+     - ``hgraph_persistence.compat.FileBasedDataFrameStorage``
+   * - ``hgraph.adaptors.data_frame.MemoryDataFrameStorage``
+     - ``hgraph_persistence.compat.MemoryDataFrameStorage``
+   * - ``hgraph.adaptors.data_frame.set_data_frame_record_path``
+     - ``hgraph_persistence.compat.set_data_frame_record_path``
+   * - ``hgraph.adaptors.data_frame.set_data_frame_overrides``
+     - ``hgraph_persistence.compat.set_data_frame_overrides``
+   * - ``hgraph.adaptors.data_frame.get_data_frame_record_overrides``
+     - ``hgraph_persistence.compat.get_data_frame_record_overrides``
+
+The ``hgraph.adaptors.data_frame`` spellings above continue to resolve; the
+table records where the implementation now lives so new code can import it
+directly. ``hgraph.RecordAsOf`` and ``hgraph.RecordRemoves`` are different:
+they emit a ``DeprecationWarning`` and are removed in 0.9.
+
+Backend and model names
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Record/replay selects a backend by string id rather than by model constant.
+The 0.5 constants are still accepted and translated:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - 0.5 model constant
+     - Backend id
+   * - ``InMemory``
+     - ``"memory"`` — core, the interactive in-memory backend
+   * - ``InMemoryDense``
+     - ``"testing"`` — core, the cycle-aligned test backend
+   * - ``DataFrame``
+     - ``"hgraph.persistence.frame"`` — the extension's Arrow backend
+
+Only the third requires ``hgraph-persistence``; the first two are core and
+need no extension. ``set_record_replay_model`` remains as an alias for
+``set_record_replay_config``.
+
+C++ name changes
+----------------
+
+Native applications take the extension's headers, link
+``hgraph::persistence``, and register the backend after the core standard
+operators:
+
+.. code-block:: cpp
+
+   #include <hgraph/persistence/frame_store.h>
+   #include <hgraph/persistence/recording_options.h>
+
+   namespace hgp = hgraph::persistence;
+
+   hgraph::stdlib::register_standard_operators();
+   hgp::register_frame_backend();
+
+Header and symbol moves:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 48 52
+
+   * - Former core name
+     - New persistence name
+   * - ``hgraph/types/frame_store.h``
+     - ``hgraph/persistence/frame_store.h``
+   * - ``hgraph::stdlib::RecordAsOf``
+     - ``hgraph::persistence::RecordAsOf``
+   * - ``hgraph::stdlib::RecordRemoves``
+     - ``hgraph::persistence::RecordRemoves``
+   * - ``HGRAPH_WITH_PARQUET``
+     - ``HGRAPH_PERSISTENCE_WITH_PARQUET``
+   * - ``HGRAPH_WITH_S3``
+     - ``HGRAPH_PERSISTENCE_WITH_S3``
+
+Core keeps **no forwarding stubs** for these: a core-only build must not
+name ``FrameStore``, and the C++ constants were replaced outright rather
+than aliased. That is deliberate and allowed pre-1.0 — the C++ surface
+follows the extension policy's source-compatibility rules, not an ABI
+promise. Only the Python spellings keep deprecated aliases.
+
+Build and packaging
+-------------------
+
+``HGRAPH_BUILD_PERSISTENCE_EXTENSION=ON`` includes the extension in a
+repository build; it is off by default. Standalone consumers find
+``hgraph-persistence`` and link ``hgraph::persistence``.
+
+Durable-store *build* policy moved with the code. Core no longer detects
+Parquet or S3, no longer exports ``HGRAPH_WITH_PARQUET``/``HGRAPH_WITH_S3``
+on its public interface, and no longer emits ``find_dependency(Parquet)``
+into its installed CMake package. A downstream project that relied on
+inheriting those answers from core must detect them itself or link the
+extension, whose own ``HGRAPH_PERSISTENCE_WITH_*`` macros carry them.
+
+Scope
+-----
+
+This migration covers durable record/replay only. Core still owns, and
+needs no extension for:
+
+* the ``record``, ``replay``, ``replay_const`` and ``compare`` operator
+  contracts, record/replay modes, and recordable identity;
+* the ``"memory"`` and ``"testing"`` backends, which serve interactive use
+  and the testing harness;
+* the ``Frame`` value kind, the ``convert``-to-frame operator family, the
+  Arrow data sources in ``hgraph.adaptors.data_frame``, and
+  ``stdlib::lower``;
+* the ``lib/std/operators/table_rows.h`` table seam a durable backend
+  consumes; and
+* graph state capture and restore mechanics.

--- a/docs/source/user_guide/python_compatibility.rst
+++ b/docs/source/user_guide/python_compatibility.rst
@@ -373,7 +373,8 @@ optional ``hgraph-persistence`` distribution (RFC 0025), which
 ``hgraph[dataframe]`` installs. The released
 ``hgraph.adaptors.data_frame`` import paths still resolve them, and the two
 table-schema setters above are core — but using a durable name without the
-extension installed raises a pointed install error.
+extension installed raises a pointed install error. The complete name and
+backend mapping is in :doc:`persistence_migration`.
 
 Individual recordings can override the graph defaults. Supply the same
 projection to ``replay``; current recordings persist this contract in Arrow


### PR DESCRIPTION
The extraction moved a released Python surface and a set of C++ names, and there was no single page telling a user what became what. The analytics extraction shipped `analytics_migration.rst` for exactly this; persistence had nothing.

### The guide

`docs/source/user_guide/persistence_migration.rst`, mirroring the analytics precedent's structure:

- **Python name changes** — a table mapping every moved name to its new home, plus the distinction that matters: the `hgraph.adaptors.data_frame` spellings still resolve (the table just records where the implementation now lives), while `hgraph.RecordAsOf` / `hgraph.RecordRemoves` warn and go in 0.9.
- **Backend and model names** — the `InMemory` / `InMemoryDense` / `DataFrame` → `"memory"` / `"testing"` / `"hgraph.persistence.frame"` mapping, and the point users most need: only the third requires the extension.
- **C++ name changes** — header and symbol moves, with the registration snippet, and why core keeps **no** forwarding stubs (pre-1.0 source-compatibility rules, not an ABI promise) while the Python spellings do keep aliases.
- **Build and packaging** — durable-store build policy moved too, so a downstream project that inherited `HGRAPH_WITH_PARQUET`/`HGRAPH_WITH_S3` from core must now detect them itself or link the extension.
- **Scope** — what core still owns and needs no extension for.

Every mapping was checked against the merged tree rather than written from the change description: each Python export, each core shim, the header moves, the macro renames, the backend ids, and that the `dataframe` extra pulls the distribution in.

Wired into the Compatibility toctree beside `analytics_migration`, with inbound `:doc:` links from `python_compatibility.rst` and `reference/modules.rst` — the two places a reader hits the durable surface and needs the mapping.

### Stale prose that checkpoint 5 made false

`record_replay_table.rst` described the frame backend as *"the transitional in-core implementation ... until the checkpoint-5 move"*. That move has landed, so the sentence now describes something that does not exist. Four smaller attributions went with it — the seed resolver's backend set (which still listed "the transitional frame id" among the ids **core** serves), the compare guard, the flushing stores, and segmentation identity. Each is re-attributed to the extension, while `FrameStoreOps` itself stays described as the core-facing seam, which is still true.

This is the follow-up to #515, which could only fix the pages that were *already* wrong on main; these became wrong when #513 merged.

### Also

`build_system.rst` now records the core-only CI leg and why it exists: the other native legs force the extensions on, so nothing else would notice durable-store policy coming back into core. I deliberately left this out of #514 because the leg did not exist on main yet.

### Verification

Sphinx `-W --keep-going` builds clean; all 67 doctests pass.

Refs #498 (checkpoint 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
