### PR TITLE
Propose the checkpoint-8 deprecation and removal policy

### DIFF
--- a/docs/source/rfc/rfc_0025_hgraph_persistence.rst
+++ b/docs/source/rfc/rfc_0025_hgraph_persistence.rst
@@ -329,6 +329,87 @@ Compatibility and migration
   must define re-registration behaviour for installed extensions —
   decided at checkpoint 3 and recorded here when implemented.
 
+Deprecation and removal policy
+------------------------------
+
+**Status: proposed.** Checkpoint 8 executes against this section; the tier
+assignment below is the open decision.
+
+The extraction left a set of compatibility surfaces in core. As of the
+checkpoint-5 audit exactly ONE of them warns — the ``hgraph.RecordAsOf`` /
+``hgraph.RecordRemoves`` aliases — while the legacy backend constants and
+the ``hgraph.adaptors.data_frame`` storage surface translate silently, some
+under comments describing a "deprecation window" that emits nothing. A user
+of those gets no signal at all until the name disappears.
+
+Three rules apply to every surface classified **shim** in `Appendix: symbol
+and migration inventory`_:
+
+* **A shim warns.** Resolving it emits ``DeprecationWarning`` naming both
+  the replacement and the release that removes it. A silent translation is
+  not a deprecation. Graphs and operators carry the message through
+  ``deprecated=`` on the decorator and let the wiring layer emit it
+  (``_warn_deprecated``); module ``__getattr__`` hooks and plain functions
+  call ``warnings.warn(..., DeprecationWarning, stacklevel=2)`` directly.
+  This is the analytics extraction's mechanism (``_analytics_compat.py``)
+  with one addition: those messages name no removal release, and these must.
+* **A shim is tested.** A test asserts the warning actually fires, with
+  ``pytest.warns(DeprecationWarning, match=...)`` around the USE. A
+  structural check that the shim exists cannot tell a warning from a silent
+  forward, and today's only warning has exactly that non-test.
+* **A shim is not the seam.** The extension mechanism itself is permanent
+  API and must never warn.
+
+Removal tiers
+~~~~~~~~~~~~~
+
+A single removal release would be wrong here, because the surfaces differ in
+what they promised.
+
+**Tier 1 — removed in 0.9.** Names that lived in *core's own* namespace and
+described durable behaviour core never implemented: ``hgraph.RecordAsOf``,
+``hgraph.RecordRemoves``, ``hgraph.frame_store_contains``,
+``hgraph.frame_store_read``. These were never part of the 0.5 upstream
+surface being preserved; they are artifacts of the pre-extraction layout,
+and keeping them invites new code to depend on core for durable vocabulary.
+
+**Tier 2 — warned from 0.9, removed no earlier than 1.0.** The released 0.5
+import paths under ``hgraph.adaptors.data_frame``: ``WriteMode``,
+``DataFrameStorage``, ``BaseDataFrameStorage``, ``FileBasedDataFrameStorage``,
+``MemoryDataFrameStorage``, ``DATA_FRAME_RECORD_REPLAY`` and the two
+override-registry constants, and ``set_data_frame_record_path`` /
+``set_data_frame_overrides`` / ``get_data_frame_record_overrides``.
+
+Keeping these working is the compatibility promise that justified the
+guarded lazy re-export design in the first place. Removing them one minor
+after introducing the warning would break exactly the code the design set
+out to protect. They warn so new code is steered to
+``hgraph_persistence.compat``, and survive until the 1.0 API freeze decides
+their fate deliberately (RFC 0005).
+
+**Tier 3 — legacy model constants, translated through 1.0.** ``InMemory``,
+``InMemoryDense`` and ``DataFrame`` translate to ``"memory"``, ``"testing"``
+and ``"hgraph.persistence.frame"``, and ``set_record_replay_model`` aliases
+``set_record_replay_config``. The translation is a small map with no
+maintenance cost and appears in nearly every 0.5 record/replay call site. It
+warns from 0.9 and is reconsidered at 1.0 with the rest of the naming
+surface, not before.
+
+The seam is not a shim
+~~~~~~~~~~~~~~~~~~~~~~
+
+These are how an extension participates. They are permanent public API,
+carry no removal date, and must not warn:
+
+* ``replay_const`` in core's extension-operator contracts — core owns the
+  operator contract; the extension registers the overload.
+* the backend-id load point that imports the distribution when a
+  ``hgraph.persistence.*`` id is selected, at graph level or per call;
+* ``register_record_replay_wiring_adapter`` and the adapter slot the
+  extension's ``compat`` module installs into; and
+* the missing-extension wiring diagnosis, which is a diagnostic rather than
+  a compatibility shim.
+
 Performance and memory
 ----------------------
 

--- a/docs/source/rfc/rfc_0025_hgraph_persistence.rst
+++ b/docs/source/rfc/rfc_0025_hgraph_persistence.rst
@@ -332,8 +332,10 @@ Compatibility and migration
 Deprecation and removal policy
 ------------------------------
 
-**Status: proposed.** Checkpoint 8 executes against this section; the tier
-assignment below is the open decision.
+**Status: agreed** (2026-08-19). Checkpoint 8 executes against this section.
+The compatibility layer is retained in full through the pre-1.0 bridge
+release and removed at 1.0, along with the ``hgraph.adaptors`` package
+itself; nothing here is removed before then.
 
 The extraction left a set of compatibility surfaces in core. As of the
 checkpoint-5 audit exactly ONE of them warns — the ``hgraph.RecordAsOf`` /
@@ -360,40 +362,53 @@ and migration inventory`_:
 * **A shim is not the seam.** The extension mechanism itself is permanent
   API and must never warn.
 
-Removal tiers
-~~~~~~~~~~~~~
+One removal release: 1.0
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-A single removal release would be wrong here, because the surfaces differ in
-what they promised.
+There are no tiers. **Every shim below warns from the pre-1.0 bridge release
+and is removed in 1.0**, which is :doc:`rfc_0005_hgraph_1_0_api`'s existing
+rule rather than a new one: renamed surfaces get a warning shim "in a
+designated pre-1.0 bridge release only; 1.0 carries the new names
+exclusively", and the ``hgraph.adaptors`` namespace "exists in that bridge as
+warning shims and does not exist in 1.0".
 
-**Tier 1 — removed in 0.9.** Names that lived in *core's own* namespace and
-described durable behaviour core never implemented: ``hgraph.RecordAsOf``,
-``hgraph.RecordRemoves``, ``hgraph.frame_store_contains``,
-``hgraph.frame_store_read``. These were never part of the 0.5 upstream
-surface being preserved; they are artifacts of the pre-extraction layout,
-and keeping them invites new code to depend on core for durable vocabulary.
+That settles the whole persistence compatibility surface at once, because it
+is entirely contained in the bridge release:
 
-**Tier 2 — warned from 0.9, removed no earlier than 1.0.** The released 0.5
-import paths under ``hgraph.adaptors.data_frame``: ``WriteMode``,
-``DataFrameStorage``, ``BaseDataFrameStorage``, ``FileBasedDataFrameStorage``,
-``MemoryDataFrameStorage``, ``DATA_FRAME_RECORD_REPLAY`` and the two
-override-registry constants, and ``set_data_frame_record_path`` /
-``set_data_frame_overrides`` / ``get_data_frame_record_overrides``.
+* **Core-namespace names** — ``hgraph.RecordAsOf``, ``hgraph.RecordRemoves``,
+  ``hgraph.frame_store_contains``, ``hgraph.frame_store_read``. Replacement:
+  the same names from ``hgraph_persistence``.
+* **The 0.5 adaptor surface** — every export of
+  ``hgraph.adaptors.data_frame._data_frame_record_replay``: ``WriteMode``,
+  ``DataFrameStorage``, ``BaseDataFrameStorage``,
+  ``FileBasedDataFrameStorage``, ``MemoryDataFrameStorage``,
+  ``replay_data_frame``, ``set_data_frame_record_path``,
+  ``set_data_frame_overrides``, ``get_data_frame_record_overrides``, and the
+  ``DATA_FRAME_RECORD_REPLAY_PATH`` / ``DATA_FRAME_RECORD_OVERRIDES``
+  constants. Replacement: the corresponding
+  ``hgraph_persistence.compat`` name. This whole group goes with the
+  ``hgraph.adaptors`` namespace, so its removal is not a persistence
+  decision to take separately.
+* **The backend sentinel** — ``DATA_FRAME_RECORD_REPLAY``. Its replacement is
+  **not** in ``hgraph_persistence.compat``, which does not define it: a user
+  selecting a backend wants ``hgraph_persistence.FRAME_BACKEND`` (the
+  ``"hgraph.persistence.frame"`` id). Naming ``compat`` here would send them
+  to an ``AttributeError``.
+* **Legacy model constants** — ``InMemory``, ``InMemoryDense`` and
+  ``DataFrame`` translating to ``"memory"``, ``"testing"`` and
+  ``"hgraph.persistence.frame"``, and ``set_record_replay_model`` aliasing
+  ``set_record_replay_config``. Replacement: the backend id, or
+  ``FRAME_BACKEND`` for the durable one.
 
-Keeping these working is the compatibility promise that justified the
-guarded lazy re-export design in the first place. Removing them one minor
-after introducing the warning would break exactly the code the design set
-out to protect. They warn so new code is steered to
-``hgraph_persistence.compat``, and survive until the 1.0 API freeze decides
-their fate deliberately (RFC 0005).
+The bridge release is not imminent — basic 0.5 compatibility comes first — so
+the warning window is long by construction. That is the argument for warning
+on everything now rather than staging it: the cost of an early warning is a
+line of output, and the cost of a late one is a user who never saw it.
 
-**Tier 3 — legacy model constants, translated through 1.0.** ``InMemory``,
-``InMemoryDense`` and ``DataFrame`` translate to ``"memory"``, ``"testing"``
-and ``"hgraph.persistence.frame"``, and ``set_record_replay_model`` aliases
-``set_record_replay_config``. The translation is a small map with no
-maintenance cost and appears in nearly every 0.5 record/replay call site. It
-warns from 0.9 and is reconsidered at 1.0 with the rest of the naming
-surface, not before.
+**A correction this obliges.** ``hgraph.RecordAsOf`` /
+``hgraph.RecordRemoves`` currently warn that the alias "is removed in 0.9".
+Under this policy that is wrong, and it is the one shim message a user can
+already be reading. It must say 1.0.
 
 The seam is not a shim
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/python/hgraph/__init__.py
+++ b/python/hgraph/__init__.py
@@ -157,8 +157,9 @@ _EXTENSION_OPERATOR_CONTRACTS = frozenset({"replay_const"})
 
 # Durable recording option vocabularies moved to hgraph-persistence at
 # RFC 0025 checkpoint 5. The C++ names moved outright (pre-1.0); these
-# Python spellings remain as deprecated aliases for the deprecation window
-# and are removed at checkpoint 8.
+# Python spellings remain as deprecated aliases for the whole pre-1.0
+# bridge release and are removed at 1.0, with the rest of the compatibility
+# layer (RFC 0025 "Deprecation and removal policy", RFC 0005).
 _MOVED_TO_PERSISTENCE = frozenset({"RecordAsOf", "RecordRemoves"})
 
 
@@ -172,7 +173,7 @@ def __getattr__(name):
 
         warnings.warn(
             f"hgraph.{name} moved to hgraph-persistence in 0.8; import it from "
-            f"'hgraph_persistence' instead. The alias is removed in 0.9.",
+            f"'hgraph_persistence' instead. The alias is removed in 1.0.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/python/tests/test_optional_adaptor_imports.py
+++ b/python/tests/test_optional_adaptor_imports.py
@@ -190,3 +190,27 @@ def test_per_call_durable_model_names_the_missing_persistence_extension():
     )
 
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_moved_persistence_aliases_warn_and_name_their_removal_release():
+    # RFC 0025's deprecation policy: a shim warns, naming its replacement AND
+    # the release that removes it. This is the one persistence shim that
+    # already warned, and nothing asserted it fired -- only a source grep,
+    # which cannot tell a warning from a silent forward. The release is 1.0,
+    # when the whole compatibility layer goes (RFC 0005); it said 0.9.
+    import pytest
+
+    import hgraph
+
+    for name in ("RecordAsOf", "RecordRemoves"):
+        # __getattr__ caches the resolved value, so a second access would not
+        # warn again; drop it to test the first access every time.
+        hgraph.__dict__.pop(name, None)
+        expected = rf"hgraph\.{name}.*hgraph_persistence.*removed in 1\.0"
+        with pytest.warns(DeprecationWarning, match=expected):
+            try:
+                getattr(hgraph, name)
+            except ModuleNotFoundError as error:
+                # Core-only install: the warning fires before the pointed
+                # install error, so the assertion holds either way.
+                assert error.name == "hgraph_persistence"


### PR DESCRIPTION
**This is a proposal, and it contains one decision I'd like ruled on before writing any code.** Doc only — no behaviour change.

### The problem

Checkpoint 8 is "compatibility cleanup", but there was no policy saying what that means. An audit of the surfaces the extraction left in core found:

| | |
|---|---|
| Surfaces that warn | **1** — `hgraph.RecordAsOf` / `hgraph.RecordRemoves` |
| Surfaces that translate silently | the legacy backend constants, `set_record_replay_model`, and the whole `hgraph.adaptors.data_frame` storage surface |

Several of the silent ones carry comments describing a *"deprecation window"* while emitting nothing at all. A user of those learns about the move when their code stops working. And the one warning that does exist has no test asserting it fires — only a grep asserting the shim is still present, which cannot tell a warning from a silent forward.

### The policy

Three rules for anything classified **shim** in the RFC's inventory: it warns naming both its replacement and its removal release; it is tested by `pytest.warns` around the *use*; and the extension seam is not a shim and never warns.

The mechanism is the analytics extraction's (`deprecated=` on decorators, `warnings.warn(..., stacklevel=2)` in `__getattr__` hooks), with one addition — the analytics messages name no removal release, and these must.

### The decision I need

**Removal is tiered rather than uniform**, and that's the part to agree or overrule:

- **Tier 1 → 0.9.** `hgraph.RecordAsOf`, `hgraph.RecordRemoves`, `hgraph.frame_store_contains`, `hgraph.frame_store_read`. These only ever lived in *core's own* namespace and described durable behaviour core never implemented — they're artifacts of the pre-extraction layout, not part of the 0.5 surface being preserved.
- **Tier 2 → warn from 0.9, remove no earlier than 1.0.** The released 0.5 `hgraph.adaptors.data_frame` import paths. My reasoning: keeping these working is the compatibility promise that justified the guarded lazy re-export design in the first place. Removing them one minor after introducing the warning would break exactly the code that design set out to protect.
- **Tier 3 → translated through 1.0.** The legacy model constants and `set_record_replay_model`. A small map, no maintenance cost, and it appears in nearly every 0.5 record/replay call site.

If you'd rather everything went in 0.9, say so and I'll collapse it to one tier — it's a smaller change, and the argument for it is that a longer window mostly delays the cleanup. I've proposed the tiers because tier 2 is the only group with an explicit promise attached.

Nothing is implemented yet. Once the tiers are settled, the follow-up adds the warnings and the tests that assert each one fires.

Refs #498 (checkpoint 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
