### PR TITLE
Warn on every persistence compatibility shim

### DIFF
--- a/python/hgraph/__init__.py
+++ b/python/hgraph/__init__.py
@@ -82,12 +82,28 @@ def _persistence():
 
 
 def frame_store_contains(key, global_state=None):
-    """Whether the active graph's frame store contains ``key``."""
+    """Whether the active graph's frame store contains ``key``.
+
+    Deprecated: the frame store belongs to hgraph-persistence (RFC 0025).
+    """
+    from ._deprecation import warn_moved_to_persistence
+
+    warn_moved_to_persistence(
+        "hgraph.frame_store_contains", "hgraph_persistence.frame_store_contains"
+    )
     return _persistence().frame_store_contains(key, global_state)
 
 
 def frame_store_read(key, global_state=None):
-    """Load one complete frame from the active graph's frame store."""
+    """Load one complete frame from the active graph's frame store.
+
+    Deprecated: the frame store belongs to hgraph-persistence (RFC 0025).
+    """
+    from ._deprecation import warn_moved_to_persistence
+
+    warn_moved_to_persistence(
+        "hgraph.frame_store_read", "hgraph_persistence.frame_store_read"
+    )
     return _persistence().frame_store_read(key, global_state)
 
 TimeSeries = _hgraph.TimeSeries
@@ -169,13 +185,10 @@ def __getattr__(name):
         globals()[name] = fn  # cache
         return fn
     if name in _MOVED_TO_PERSISTENCE:
-        import warnings
+        from ._deprecation import warn_moved_to_persistence
 
-        warnings.warn(
-            f"hgraph.{name} moved to hgraph-persistence in 0.8; import it from "
-            f"'hgraph_persistence' instead. The alias is removed in 1.0.",
-            DeprecationWarning,
-            stacklevel=2,
+        warn_moved_to_persistence(
+            f"hgraph.{name}", f"hgraph_persistence.{name}", stacklevel=3
         )
         value = getattr(_persistence(), name)
         globals()[name] = value  # cache

--- a/python/hgraph/_deprecation.py
+++ b/python/hgraph/_deprecation.py
@@ -1,0 +1,64 @@
+"""One definition of the persistence compatibility deprecation message.
+
+RFC 0025's removal policy: the compatibility layer is retained in full
+through the pre-1.0 bridge release and removed at 1.0, together with the
+``hgraph.adaptors`` package itself (RFC 0005). Warning early is deliberate --
+the bridge release is not imminent, so the window is long by construction,
+and the cost of an early warning is a line of output where the cost of a late
+one is a user who never saw it.
+
+The release string lives HERE and nowhere else. It was previously inlined in
+one message, which then said 0.9 after the policy settled on 1.0; a user
+reading that message was told the wrong thing. A second copy is a second
+chance to go stale.
+"""
+
+import warnings
+
+#: The release that removes the persistence compatibility layer.
+PERSISTENCE_REMOVAL_RELEASE = "1.0"
+
+
+def moved_to_persistence(name: str, replacement: str) -> str:
+    """The deprecation message for a name that moved to hgraph-persistence."""
+    return (
+        f"{name} moved to hgraph-persistence in 0.8; use {replacement} instead. "
+        f"The compatibility alias is removed in {PERSISTENCE_REMOVAL_RELEASE}."
+    )
+
+
+def deprecated_compat_name(name: str, replacement: str) -> str:
+    """The deprecation message for a 0.5 spelling that did not move packages.
+
+    Separate from ``moved_to_persistence`` because saying a name "moved to
+    hgraph-persistence" when it was merely renamed inside core sends the
+    reader to the wrong distribution.
+    """
+    return (
+        f"{name} is a 0.5 compatibility name; use {replacement} instead. "
+        f"It is removed in {PERSISTENCE_REMOVAL_RELEASE}."
+    )
+
+
+def warn_moved_to_persistence(name: str, replacement: str, stacklevel: int = 3) -> None:
+    """Emit the deprecation for a moved name.
+
+    ``stacklevel`` defaults to 3 so the warning points at the caller of the
+    shim rather than at the shim itself: 1 is this function, 2 is the shim.
+    """
+    warnings.warn(
+        moved_to_persistence(name, replacement),
+        DeprecationWarning,
+        stacklevel=stacklevel,
+    )
+
+
+def warn_deprecated_compat_name(
+    name: str, replacement: str, stacklevel: int = 3
+) -> None:
+    """Emit the deprecation for a retained 0.5 spelling."""
+    warnings.warn(
+        deprecated_compat_name(name, replacement),
+        DeprecationWarning,
+        stacklevel=stacklevel,
+    )

--- a/python/hgraph/_wiring/_state.py
+++ b/python/hgraph/_wiring/_state.py
@@ -258,9 +258,25 @@ def _ensure_backend_extension(model):
     # The 0.5 data-frame adaptor exported a private-looking model sentinel
     # which became part of the user surface. Keep accepting it while the C++
     # runtime has one canonical backend id per implementation (RFC 0025).
-    backend = (
-        _hgraph.DATA_FRAME if model == _LEGACY_DATA_FRAME_RECORD_REPLAY else model
-    )
+    from .._deprecation import warn_deprecated_compat_name
+
+    if model == _LEGACY_DATA_FRAME_RECORD_REPLAY:
+        warn_deprecated_compat_name(
+            "the DATA_FRAME_RECORD_REPLAY record/replay model",
+            "the backend id hgraph_persistence.FRAME_BACKEND",
+            stacklevel=4,
+        )
+        backend = _hgraph.DATA_FRAME
+    else:
+        backend = model
+    if backend in _LEGACY_BACKENDS:
+        # A silent translation is not a deprecation: these were described as
+        # living in a deprecation window while emitting nothing at all.
+        warn_deprecated_compat_name(
+            f"the {backend!r} record/replay model",
+            f"the backend id {_LEGACY_BACKENDS[backend]!r}",
+            stacklevel=4,
+        )
     backend = _LEGACY_BACKENDS.get(backend, backend)
     if isinstance(backend, str) and backend.startswith("hgraph.persistence."):
         try:
@@ -364,7 +380,12 @@ class RecordReplayContext(record_replay_scope):
 
 
 def set_record_replay_model(model):
-    """hgraph parity alias for set_record_replay_config."""
+    """hgraph parity alias for set_record_replay_config (deprecated)."""
+    from .._deprecation import warn_deprecated_compat_name
+
+    warn_deprecated_compat_name(
+        "hgraph.set_record_replay_model", "hgraph.set_record_replay_config"
+    )
     set_record_replay_config(model)
 
 def comparison_summary(fq_key):

--- a/python/hgraph/adaptors/data_frame/_data_frame_record_replay.py
+++ b/python/hgraph/adaptors/data_frame/_data_frame_record_replay.py
@@ -35,7 +35,11 @@ __all__ = (
 # Preserve the 0.5 public sentinel: downstream code imports it directly and
 # uses it with ``set_record_replay_model``. The state setter translates this
 # compatibility name to the native ``DataFrame`` model.
-DATA_FRAME_RECORD_REPLAY = ":data_frame:__data_frame_record_replay__"
+#
+# Served through __getattr__ rather than bound eagerly so that reading it can
+# warn: it is a shim like the rest of this surface, and a module constant
+# assigned here would be fetched without passing through any code of ours.
+_DATA_FRAME_RECORD_REPLAY = ":data_frame:__data_frame_record_replay__"
 # The 0.5 override-registry translation into native call-site options moved
 # to hgraph_persistence.compat (RFC 0025 checkpoint 5): it only acts under an
 # ACTIVE DataFrameStorage, and core wiring must not import adaptor modules —
@@ -71,8 +75,25 @@ def __getattr__(name):
     # The storage surface lives in the optional hgraph-persistence
     # distribution (RFC 0025); the pointed install error fires when a
     # durable name is USED, never at import of this module.
+    from ..._deprecation import (
+        warn_deprecated_compat_name,
+        warn_moved_to_persistence,
+    )
+
+    if name == "DATA_FRAME_RECORD_REPLAY":
+        # The replacement is NOT in hgraph_persistence.compat, which does not
+        # define this name: a caller selecting a backend wants the id.
+        warn_deprecated_compat_name(
+            "hgraph.adaptors.data_frame.DATA_FRAME_RECORD_REPLAY",
+            "hgraph_persistence.FRAME_BACKEND",
+        )
+        globals()[name] = _DATA_FRAME_RECORD_REPLAY
+        return _DATA_FRAME_RECORD_REPLAY
     if name not in _STORAGE_EXPORTS:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    warn_moved_to_persistence(
+        f"hgraph.adaptors.data_frame.{name}", f"hgraph_persistence.compat.{name}"
+    )
     try:
         from hgraph_persistence import compat
     except ModuleNotFoundError as error:

--- a/python/hgraph/adaptors/data_frame/_data_frame_record_replay.py
+++ b/python/hgraph/adaptors/data_frame/_data_frame_record_replay.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pyarrow as pa
 
+from hgraph._deprecation import deprecated_compat_name as _deprecated_compat_name
 from hgraph import (
     AUTO_RESOLVE,
     MAX_DT,
@@ -118,7 +119,15 @@ def _as_arrow(value):
     return table
 
 
-@graph
+@graph(
+    # An eagerly defined graph never reaches this module's __getattr__, so it
+    # opts into the wiring layer's deprecation instead: the message is emitted
+    # when the graph is WIRED. Its replacement is the core operator it wraps —
+    # this shim goes with the hgraph.adaptors package, not to the extension.
+    deprecated=_deprecated_compat_name(
+        "hgraph.adaptors.data_frame.replay_data_frame", "hgraph.replay_data_frame"
+    )
+)
 def replay_data_frame(
     data_frame: Frame,
     schema: object = None,

--- a/python/tests/test_persistence_deprecations.py
+++ b/python/tests/test_persistence_deprecations.py
@@ -135,3 +135,26 @@ def test_the_removal_release_has_exactly_one_definition():
         _deprecation.deprecated_compat_name("a", "b"),
     ):
         assert REMOVAL in message
+
+
+def test_replay_data_frame_graph_warns_when_wired():
+    # An eagerly defined @graph never reaches the module __getattr__, so it
+    # carries its deprecation through the wiring layer instead. Wire it for
+    # real rather than checking the flag: the policy is that the warning fires
+    # at the point of USE.
+    import pyarrow as pa
+
+    from hgraph.adaptors.data_frame import replay_data_frame
+
+    frame = pa.table(
+        {
+            "__date_time__": [hg.MIN_ST, hg.MIN_ST + hg.MIN_TD],
+            "__as_of__": [hg.MIN_ST, hg.MIN_ST],
+            "value": [10, 30],
+        }
+    )
+    with pytest.warns(
+        DeprecationWarning,
+        match=rf"replay_data_frame.*hgraph\.replay_data_frame.*removed in {REMOVAL}",
+    ):
+        assert hg.eval_node(replay_data_frame[hg.TS[int]], frame) == [10, 30]

--- a/python/tests/test_persistence_deprecations.py
+++ b/python/tests/test_persistence_deprecations.py
@@ -1,0 +1,137 @@
+"""Every persistence compatibility shim warns, and says when it goes.
+
+RFC 0025's deprecation policy: the compatibility layer is retained in full
+through the pre-1.0 bridge release and removed at 1.0 with the
+``hgraph.adaptors`` package (RFC 0005). A silent translation is not a
+deprecation -- before this, one shim of seven warned and the rest forwarded
+quietly, some under comments describing a "deprecation window" that emitted
+nothing.
+
+Each test asserts the warning at the point of USE. A structural check that a
+shim still exists cannot tell a warning from a silent forward, which is how
+the one warning that did exist came to name the wrong release.
+"""
+
+import importlib
+import sys
+
+import pytest
+
+import hgraph as hg
+
+
+REMOVAL = "1.0"
+
+
+def _uncached(module_name, *names):
+    """Drop __getattr__ caches so the first-access warning fires again."""
+    modules = [sys.modules.get(module_name)]
+    if module_name.endswith("._data_frame_record_replay"):
+        modules.append(sys.modules.get(module_name.rsplit(".", 1)[0]))
+    for module in modules:
+        if module is None:
+            continue
+        for name in names:
+            module.__dict__.pop(name, None)
+
+
+@pytest.mark.parametrize("name", ["frame_store_contains", "frame_store_read"])
+def test_core_frame_store_helpers_warn(name):
+    with pytest.warns(DeprecationWarning, match=rf"hgraph\.{name}.*removed in {REMOVAL}"):
+        try:
+            getattr(hg, name)("some/key")
+        except ModuleNotFoundError as error:
+            # Core-only install: the warning precedes the pointed install error.
+            assert error.name == "hgraph_persistence"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "WriteMode",
+        "DataFrameStorage",
+        "BaseDataFrameStorage",
+        "FileBasedDataFrameStorage",
+        "MemoryDataFrameStorage",
+        "set_data_frame_record_path",
+        "set_data_frame_overrides",
+    ],
+)
+def test_adaptor_storage_surface_warns(name):
+    module_name = "hgraph.adaptors.data_frame._data_frame_record_replay"
+    module = importlib.import_module(module_name)
+    _uncached(module_name, name)
+    expected = rf"hgraph\.adaptors\.data_frame\.{name}.*hgraph_persistence\.compat\.{name}.*removed in {REMOVAL}"
+    with pytest.warns(DeprecationWarning, match=expected):
+        try:
+            getattr(module, name)
+        except ModuleNotFoundError as error:
+            assert error.name == "hgraph_persistence"
+
+
+def test_module_only_storage_names_warn():
+    # These three were never re-exported at package level; they are reachable
+    # only through the private module, and are shims all the same.
+    module_name = "hgraph.adaptors.data_frame._data_frame_record_replay"
+    module = importlib.import_module(module_name)
+    for name in (
+        "get_data_frame_record_overrides",
+        "DATA_FRAME_RECORD_REPLAY_PATH",
+        "DATA_FRAME_RECORD_OVERRIDES",
+    ):
+        _uncached(module_name, name)
+        with pytest.warns(DeprecationWarning, match=rf"removed in {REMOVAL}"):
+            try:
+                getattr(module, name)
+            except ModuleNotFoundError as error:
+                assert error.name == "hgraph_persistence"
+
+
+def test_backend_sentinel_warns_and_points_at_the_backend_id():
+    # Its replacement is NOT in hgraph_persistence.compat, which does not
+    # define it; a warning naming compat would send the reader to an
+    # AttributeError.
+    module_name = "hgraph.adaptors.data_frame._data_frame_record_replay"
+    module = importlib.import_module(module_name)
+    _uncached(module_name, "DATA_FRAME_RECORD_REPLAY")
+    with pytest.warns(
+        DeprecationWarning,
+        match=rf"DATA_FRAME_RECORD_REPLAY.*FRAME_BACKEND.*removed in {REMOVAL}",
+    ):
+        value = getattr(module, "DATA_FRAME_RECORD_REPLAY")
+    assert value == ":data_frame:__data_frame_record_replay__"
+
+
+@pytest.mark.parametrize(
+    ("legacy", "backend"), [("InMemory", "memory"), ("InMemoryDense", "testing")]
+)
+def test_legacy_model_constants_warn_and_still_translate(legacy, backend):
+    with hg.GlobalState() as state:
+        with pytest.warns(
+            DeprecationWarning, match=rf"{legacy}.*{backend}.*removed in {REMOVAL}"
+        ):
+            hg.set_record_replay_config(legacy)
+        # The translation still happens: deprecating it must not break it.
+        assert state["__record_replay_model__"] == backend
+
+
+def test_set_record_replay_model_alias_warns():
+    with hg.GlobalState():
+        with pytest.warns(
+            DeprecationWarning,
+            match=rf"set_record_replay_model.*set_record_replay_config.*removed in {REMOVAL}",
+        ):
+            hg.set_record_replay_model("memory")
+
+
+def test_the_removal_release_has_exactly_one_definition():
+    # The release was inlined in a message once and went stale, telling users
+    # 0.9 after the policy settled on 1.0. Keep one source of truth.
+    from hgraph import _deprecation
+
+    assert _deprecation.PERSISTENCE_REMOVAL_RELEASE == REMOVAL
+    for message in (
+        _deprecation.moved_to_persistence("a", "b"),
+        _deprecation.deprecated_compat_name("a", "b"),
+    ):
+        assert REMOVAL in message


### PR DESCRIPTION
The last checkpoint-8 item: make the compatibility layer actually say it is one.

### Before

| | |
|---|---|
| Shims that warned | **1** of 7 |
| Shims that forwarded silently | the frame-store helpers, the whole `adaptors.data_frame` storage surface, the `DATA_FRAME_RECORD_REPLAY` sentinel, the legacy model constants, `set_record_replay_model` |

Several of the silent ones carried comments describing a *"deprecation window"* while emitting nothing at all. Under the agreed policy those names disappear at 1.0 with the `hgraph.adaptors` package, so a user of them currently gets no signal until their code breaks.

### After

Each warns at the point of **use**, naming its replacement and the release that removes it.

**The release string has exactly one definition**, in `_deprecation.py`. This is the direct lesson from the last round: it was inlined in a message, the policy settled on 1.0, and the message went on telling users 0.9. A second copy is a second chance to go stale, and `test_the_removal_release_has_exactly_one_definition` pins it.

**Two message shapes, deliberately.** Names that genuinely moved to the extension say so. 0.5 spellings that were renamed *inside core* — `set_record_replay_model` → `set_record_replay_config`, `InMemory` → `"memory"` — do not, because telling someone their name "moved to hgraph-persistence" when it did not sends them to install a distribution they don't need. That is the same misattribution class as #517.

**The sentinel needed restructuring to warn at all.** `DATA_FRAME_RECORD_REPLAY` was an eager module constant, so reading it passed through no code of ours; it now resolves through `__getattr__`. It points at `hgraph_persistence.FRAME_BACKEND`, not `compat` — which does not define the name, so the obvious target would have handed the reader an `AttributeError`.

### Verification

- 15 new tests, one per shim, asserting the warning **at the point of use**. A structural check that a shim exists cannot tell a warning from a silent forward — which is precisely how the wrong release survived.
- They pass with or without `hgraph-persistence` installed: the warning fires before the pointed install error either way.
- The legacy-constant test asserts the value it still translates to. Deprecating a shim must not break it.
- **Nothing fires at import.** Verified by importing `hgraph` and `hgraph.adaptors.data_frame` with `DeprecationWarning` escalated to an error — a deprecation firing at import would be noise for every user, including those who never touch persistence.
- Full core suite: 2142 passed, same 6 pre-existing local failures as the untouched baseline. Docs and all doctests pass.

The extension's ported 0.5 tests use these spellings deliberately — that is what they are for — and no suite escalates warnings to errors, so they continue to pass while exercising the shims.

Closes the checkpoint-8 warning work. Refs #498.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
