### PR TITLE
Prove RFC 0026 core extension seam

### DIFF
--- a/docs/source/developer_guide/data_structures/plans_and_ops/ops_catalogue.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/ops_catalogue.rst
@@ -142,7 +142,7 @@ constant when the ops struct layout changes.
      - 10
      - ``include/hgraph/types/time_series/ts_type_ref.h``
    * - ``NODE_OPS_ABI_VERSION``
-     - 4
+     - 5
      - ``include/hgraph/runtime/node_type_ref.h``
    * - ``GRAPH_OPS_ABI_VERSION``
      - 7

--- a/docs/source/developer_guide/data_structures/schemas/node.rst
+++ b/docs/source/developer_guide/data_structures/schemas/node.rst
@@ -215,6 +215,14 @@ shape as the lower layers:
     values belong in builder scalars or runtime storage, not in a canonical
     callback capture.
 
+    ``visit_child_graphs`` is the cold-path inspection surface for immediate
+    compiled child graph templates.  It dispatches through the passive
+    ``ChildGraphInspectionOps`` contract, so an extension can recurse through
+    nested plans without identifying a concrete map, mesh, reduce, switch or
+    single-nested representation.  Ordinary nodes bind the canonical no-op
+    implementation.  The borrowed ``GraphBuilder`` references are valid only
+    during the visitor call, and evaluation never consults this operation.
+
     Graph runtime types are likewise reused only when the graph label, ordered
     node runtime types, edge paths, and push-source boundary all match. Executor
     runtime types are reused by mode and label. Node labels, scalar values,

--- a/docs/source/developer_guide/graph_wiring.rst
+++ b/docs/source/developer_guide/graph_wiring.rst
@@ -115,6 +115,30 @@ such an exception; it resolves to an ordinary source before ranking and therefor
 cannot create a cycle.
 
 
+Inspecting compiled child plans
+-------------------------------
+
+An extension-owned wiring planner may need to inspect declared dependencies
+inside a non-flattening nested owner.  Following only the owner's outer input
+edges is insufficient when the child graph creates its own source.  The public
+``NodeBuilder::visit_child_graphs`` contract visits the node's immediate
+compiled child graph templates as borrowed ``GraphBuilder`` references.
+
+The contract is deliberately cold-path and representation-erased:
+
+- ordinary nodes dispatch to a canonical no-op visitor;
+- ``nested_``, ``map_``, ``mesh_``, associative and ordered reduce,
+  ``switch_`` and dynamic-TSL map expose their children through the same call;
+- a switch visits each declared branch and its optional default;
+- callers recurse explicitly through each child's ``nodes()`` when they need
+  the complete plan forest; and
+- borrowed child references are valid only during the callback.
+
+No runtime graph is constructed and no evaluation operation consults this
+contract.  The child owner remains responsible for its concrete spec and
+storage representation; extension planners see only ``GraphBuilder``.
+
+
 The shared core
 ---------------
 

--- a/docs/source/rfc/rfc_0026_versioned_dataflow_fabric.rst
+++ b/docs/source/rfc/rfc_0026_versioned_dataflow_fabric.rst
@@ -318,6 +318,15 @@ execution and extension authoring:
 Core does not name fabric data ids, versions, revisions, stores, topics,
 subscription modes or consistency policies.
 
+The public extension seam has been validated from a separately built installed
+SDK consumer.  A fabric-shaped proof can retain one wiring-owned plan, defer
+and bind its source in an idempotent pre-rank finalizer, discover marked sources
+through public upstream edges (including an owning nested-graph node), and use
+a typed same-root subscription handle when the data edge is deliberately
+hidden.  The source selects simulation or real-time behavior once in
+``start`` from ``EngineControlView``; its ``eval`` has no mode branch.  No
+fabric-specific core hook is required by this proof.
+
 hgraph-persistence owns
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -332,12 +341,12 @@ duplicate:
 * object reads and prefix/range discovery; and
 * compare/exchange of small named references such as ``latest``.
 
-The released ``FrameStore`` has ``write/read/contains/clear`` operations and
-does not yet expose all of the immutable-object, ordered-index and conditional
-reference operations required here.  Before fabric implementation,
-``hgraph-persistence`` must expose the reusable object-store portion already
+``hgraph-persistence`` now exposes the reusable public ``ObjectStore`` contract
 anticipated by :doc:`rfc_0023_graph_checkpoint_recovery` and RFC 0025's durable
-checkpoint work.  That contract remains persistence-owned.  Fabric must not
+checkpoint work.  Its memory, local-filesystem and S3 strategies provide typed
+immutable creation, typed reads, paginated ordered listing and conditional
+reference publication; ``FrameStore`` uses the same atomic backend semantics.
+That contract remains persistence-owned.  Fabric must consume it rather than
 grow a private second S3 client or put persistence types back into core.
 
 hgraph-kafka owns

--- a/docs/source/rfc/rfc_0026_versioned_dataflow_fabric.rst
+++ b/docs/source/rfc/rfc_0026_versioned_dataflow_fabric.rst
@@ -309,7 +309,8 @@ execution and extension authoring:
 
 * C++ and Python graph/operator authoring;
 * time-series values, root sources and sinks;
-* wiring-time graph inspection and traits;
+* wiring-time graph inspection and traits, including the cold-path
+  ``NodeBuilder::visit_child_graphs`` contract for compiled nested owners;
 * graph-time and real-time scheduling;
 * ``GlobalState`` lifetime and configuration scoping;
 * extension operator registration; and
@@ -321,11 +322,21 @@ subscription modes or consistency policies.
 The public extension seam has been validated from a separately built installed
 SDK consumer.  A fabric-shaped proof can retain one wiring-owned plan, defer
 and bind its source in an idempotent pre-rank finalizer, discover marked sources
-through public upstream edges (including an owning nested-graph node), and use
-a typed same-root subscription handle when the data edge is deliberately
-hidden.  The source selects simulation or real-time behavior once in
-``start`` from ``EngineControlView``; its ``eval`` has no mode branch.  No
-fabric-specific core hook is required by this proof.
+through public upstream edges and through the compiled child plans of nested
+owners, and use a typed same-root subscription handle when the data edge is
+deliberately hidden.  The nested case creates ``subscribe_data`` inside the
+child graph and feeds only the child output to an outer publisher; it therefore
+proves the ownership boundary rather than merely following an outer input.
+The source selects simulation or real-time behavior once in ``start`` from
+``EngineControlView``; its ``eval`` has no mode branch.
+
+The proof exposed one missing generally reusable core seam.  ``NodeBuilder``
+now visits its immediate compiled child graph templates through a passive,
+type-erased cold-path contract.  ``nested_``, ``map_``, ``mesh_``, associative
+and ordered reduce, ``switch_`` and dynamic-TSL map all install the same
+contract; ordinary nodes use its canonical no-op implementation.  Extensions
+recurse explicitly when they need the complete plan forest.  This adds no
+evaluation-path work and carries no fabric ids, lineage or consistency policy.
 
 hgraph-persistence owns
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -1533,9 +1544,12 @@ implementation should proceed as separately reviewable checkpoints:
    metrics; and
 9. update this RFC to ``Accepted`` with any reviewed implementation differences.
 
-Core changes, if the extension reveals a missing generally reusable runtime
-hook, require their own focused commit and C++/Python parity.  Fabric-specific
-policy stays in the extension.
+The checkpoint-0 proof found and supplied the generally reusable compiled-child
+inspection hook described above.  It lives under the shared C++ wiring path, so
+Python-authored graphs which lower through that path receive the same behavior
+without a second Python runtime implementation.  Any further core hook requires
+its own focused commit and C++/Python behavioral parity.  Fabric-specific policy
+stays in the extension.
 
 Acceptance criteria and test plan
 ---------------------------------

--- a/include/hgraph/runtime/child_graph_inspection.h
+++ b/include/hgraph/runtime/child_graph_inspection.h
@@ -1,0 +1,42 @@
+#ifndef HGRAPH_RUNTIME_CHILD_GRAPH_INSPECTION_H
+#define HGRAPH_RUNTIME_CHILD_GRAPH_INSPECTION_H
+
+#include <hgraph/hgraph_export.h>
+
+namespace hgraph
+{
+    class GraphBuilder;
+    class NodeBuilder;
+
+    /** Borrowed callback used to inspect one immediate compiled child graph.
+     *
+     * The graph reference is valid only for the duration of the callback.
+     * Inspection is a wiring/build-time operation; runtime evaluation never
+     * dispatches this contract.
+     */
+    using ChildGraphVisitor = void (*)(void *visitor_context, const GraphBuilder &child);
+
+    namespace child_graph_inspection_detail
+    {
+        /** Program-wide canonical no-op used by node types without children. */
+        HGRAPH_EXPORT void visit_none(const void *, const NodeBuilder &, void *, ChildGraphVisitor);
+    }  // namespace child_graph_inspection_detail
+
+    /** Passive type-erased contract for a node builder's compiled children.
+     *
+     * Concrete nested-node strategies install a visitor which exposes their
+     * immediate child graph templates without leaking their private context
+     * representation. The canonical no-op visitor keeps ordinary nodes'
+     * inspection contract non-null.
+     */
+    struct HGRAPH_EXPORT ChildGraphInspectionOps
+    {
+        const void *context{nullptr};
+        void (*visit_impl)(const void *context,
+                           const NodeBuilder &owner,
+                           void *visitor_context,
+                           ChildGraphVisitor visitor){&child_graph_inspection_detail::visit_none};
+    };
+}  // namespace hgraph
+
+#endif  // HGRAPH_RUNTIME_CHILD_GRAPH_INSPECTION_H

--- a/include/hgraph/runtime/node.h
+++ b/include/hgraph/runtime/node.h
@@ -8,6 +8,7 @@
 #define HGRAPH_RUNTIME_NODE_H
 
 #include <hgraph/hgraph_export.h>
+#include <hgraph/runtime/child_graph_inspection.h>
 #include <hgraph/runtime/evaluation_clock.h>
 #include <hgraph/runtime/global_state.h>
 #include <hgraph/runtime/node_error.h>
@@ -201,6 +202,9 @@ namespace hgraph
                                                    const void *memory) noexcept = nullptr;
         NodeInspectionMetrics (*inspection_metrics_impl)(const void *context,
                                                          const void *memory) noexcept = nullptr;
+
+        /** Cold-path build-time inspection of immediate compiled child graphs. */
+        ChildGraphInspectionOps child_graph_inspection{};
 
         const void *extended_view_type_id{nullptr};
         const void *extended_view_context{nullptr};
@@ -498,6 +502,14 @@ namespace hgraph
 
         [[nodiscard]] NodeTypeRef type() const;
         [[nodiscard]] const TSEndpointSchema &input_endpoint() const noexcept;
+        /**
+         * Visit this node's immediate compiled child graph templates.
+         *
+         * The callback receives borrowed references valid only for the call.
+         * Ordinary nodes visit nothing. Callers recurse explicitly when they
+         * need the complete nested plan forest.
+         */
+        void visit_child_graphs(void *visitor_context, ChildGraphVisitor visitor) const;
         /**
          * Construct this node directly into caller-owned storage matching
          * ``type().checked_plan()``. The caller owns destruction through the

--- a/include/hgraph/runtime/node_type_ref.h
+++ b/include/hgraph/runtime/node_type_ref.h
@@ -17,7 +17,7 @@ namespace hgraph
     struct NodeOps;
     struct NodeTypeMetaData;
 
-    inline constexpr std::uint16_t NODE_OPS_ABI_VERSION = 4;
+    inline constexpr std::uint16_t NODE_OPS_ABI_VERSION = 5;
 
     /** One-word canonical identity for a runtime node implementation. */
     class HGRAPH_EXPORT NodeTypeRef

--- a/include/hgraph/runtime/runtime.h
+++ b/include/hgraph/runtime/runtime.h
@@ -6,6 +6,7 @@
 #include <hgraph/runtime/evaluation_trace.h>
 #include <hgraph/runtime/graph_diagnostics.h>
 #include <hgraph/runtime/lifecycle_observer.h>
+#include <hgraph/runtime/child_graph_inspection.h>
 #include <hgraph/runtime/node.h>
 #include <hgraph/runtime/graph.h>
 #include <hgraph/runtime/context_node.h>

--- a/python/tests/test_distribution_audit.py
+++ b/python/tests/test_distribution_audit.py
@@ -32,6 +32,8 @@ SDIST_FILES = (
     "src/CMakeLists.txt",
     "tests/install_consumer/CMakeLists.txt",
     "tests/install_consumer/check.py",
+    "tests/install_consumer/fabric_extension_probe.cpp",
+    "tests/install_consumer/fabric_extension_probe.h",
     "tests/python_extension_consumer/CMakeLists.txt",
     "tests/python_extension_consumer/check.py",
     "tests/python_extension_consumer/module.cpp",

--- a/src/hgraph/runtime/map_node.cpp
+++ b/src/hgraph/runtime/map_node.cpp
@@ -321,6 +321,18 @@ namespace hgraph
             return *context;
         }
 
+        void visit_map_child(const void *, const NodeBuilder &owner,
+                             void *visitor_context, ChildGraphVisitor visitor)
+        {
+            const ValueView scalar_context = owner.scalars().view();
+            const auto &context = scalar_context.checked_as<MapNodeContextPtr>();
+            if (!context)
+            {
+                throw std::logic_error("map node builder has no compiled child context");
+            }
+            visitor(visitor_context, context->spec.child.graph_builder);
+        }
+
         [[nodiscard]] NodeStorageMetrics map_storage_metrics(
             const void *raw_context, const void *memory) noexcept
         {
@@ -1442,6 +1454,9 @@ namespace hgraph
             descriptor.storage_plan->component(map_storage_field_name).offset,
             graph_layout);
         descriptor.ops.extended_view_context = descriptor.storage_plan;
+        descriptor.ops.child_graph_inspection = ChildGraphInspectionOps{
+            .visit_impl = &visit_map_child,
+        };
 
         static const std::byte runtime_type_id{};
         NodeBuilder builder = NodeBuilder::from_canonical_descriptor(

--- a/src/hgraph/runtime/mesh_node.cpp
+++ b/src/hgraph/runtime/mesh_node.cpp
@@ -383,7 +383,7 @@ mesh_node_contexts() noexcept {
   return *contexts;
 }
 
-[[nodiscard]] const MeshNodeContext &
+[[nodiscard]] const MeshNodeContext *
 register_mesh_node_context(MeshNodeSpec spec,
                            runtime_detail::MappedChildAccessPlan access,
                            std::size_t storage_offset,
@@ -398,7 +398,7 @@ register_mesh_node_context(MeshNodeSpec spec,
   });
   const auto *result = context.get();
   mesh_node_contexts().push_back(std::move(context));
-  return *result;
+  return result;
 }
 
 [[nodiscard]] NodeStorageMetrics mesh_storage_metrics(
@@ -1649,14 +1649,14 @@ NodeBuilder mesh_node(NodeTypeMetaData meta, MeshNodeSpec spec) {
               entries_offset,
           graph_pointer_offset, true),
   };
-  const auto &context = register_mesh_node_context(
+  const auto *context = register_mesh_node_context(
       std::move(spec),
       std::move(access),
       descriptor.storage_plan->component(mesh_storage_field_name).offset,
       key_binding, graph_layout);
-  descriptor.ops.extended_view_context = &context;
+  descriptor.ops.extended_view_context = context;
   descriptor.ops.child_graph_inspection = ChildGraphInspectionOps{
-      .context = &context,
+      .context = context,
       .visit_impl = &visit_mesh_child,
   };
 

--- a/src/hgraph/runtime/mesh_node.cpp
+++ b/src/hgraph/runtime/mesh_node.cpp
@@ -415,6 +415,12 @@ register_mesh_node_context(MeshNodeSpec spec,
   };
 }
 
+void visit_mesh_child(const void *raw_context, const NodeBuilder &,
+                      void *visitor_context, ChildGraphVisitor visitor) {
+  const auto &context = *static_cast<const MeshNodeContext *>(raw_context);
+  visitor(visitor_context, context.spec.child.graph_builder);
+}
+
 [[nodiscard]] std::vector<std::unique_ptr<MeshSubscribeContext>> &
 mesh_subscribe_contexts() noexcept {
   static auto *contexts =
@@ -1643,11 +1649,16 @@ NodeBuilder mesh_node(NodeTypeMetaData meta, MeshNodeSpec spec) {
               entries_offset,
           graph_pointer_offset, true),
   };
-  descriptor.ops.extended_view_context = &register_mesh_node_context(
+  const auto &context = register_mesh_node_context(
       std::move(spec),
       std::move(access),
       descriptor.storage_plan->component(mesh_storage_field_name).offset,
       key_binding, graph_layout);
+  descriptor.ops.extended_view_context = &context;
+  descriptor.ops.child_graph_inspection = ChildGraphInspectionOps{
+      .context = &context,
+      .visit_impl = &visit_mesh_child,
+  };
 
   return NodeBuilder::from_descriptor(std::move(descriptor));
 }

--- a/src/hgraph/runtime/nested_graph_node.cpp
+++ b/src/hgraph/runtime/nested_graph_node.cpp
@@ -33,7 +33,7 @@ namespace hgraph
             return *contexts;
         }
 
-        [[nodiscard]] const SingleNestedGraphNodeContext &register_single_nested_graph_context(
+        [[nodiscard]] const SingleNestedGraphNodeContext *register_single_nested_graph_context(
             SingleNestedGraphNodeSpec spec,
             SingleNestedGraphNodeOptions options,
             std::size_t graph_storage_offset,
@@ -49,7 +49,7 @@ namespace hgraph
             });
             const auto *result = context.get();
             single_nested_graph_contexts().push_back(std::move(context));
-            return *result;
+            return result;
         }
 
         [[nodiscard]] NodeStorageMetrics single_nested_storage_metrics(
@@ -271,15 +271,15 @@ namespace hgraph
         descriptor.ops.evaluate_impl = &single_nested_graph_evaluate_impl;
         descriptor.ops.storage_metrics_impl = &single_nested_storage_metrics;
         descriptor.ops.extended_view_type_id = SingleNestedGraphNodeView::node_view_type_id();
-        const auto &context = register_single_nested_graph_context(
+        const auto *context = register_single_nested_graph_context(
             std::move(spec),
             options,
             descriptor.storage_plan->component(child_graph_field_name).offset,
             descriptor.storage_plan->component(child_graph_memory_field_name).offset,
             child_graph_layout);
-        descriptor.ops.extended_view_context = &context;
+        descriptor.ops.extended_view_context = context;
         descriptor.ops.child_graph_inspection = ChildGraphInspectionOps{
-            .context = &context,
+            .context = context,
             .visit_impl = &visit_single_nested_child,
         };
 

--- a/src/hgraph/runtime/nested_graph_node.cpp
+++ b/src/hgraph/runtime/nested_graph_node.cpp
@@ -64,6 +64,15 @@ namespace hgraph
             };
         }
 
+        void visit_single_nested_child(const void *raw_context,
+                                       const NodeBuilder &,
+                                       void *visitor_context,
+                                       ChildGraphVisitor visitor)
+        {
+            const auto &context = *static_cast<const SingleNestedGraphNodeContext *>(raw_context);
+            visitor(visitor_context, context.spec.graph_builder);
+        }
+
         [[nodiscard]] SingleNestedGraphNodeView checked_nested_view(const NodeView &view)
         {
             return view.as<SingleNestedGraphNodeView>();
@@ -262,12 +271,17 @@ namespace hgraph
         descriptor.ops.evaluate_impl = &single_nested_graph_evaluate_impl;
         descriptor.ops.storage_metrics_impl = &single_nested_storage_metrics;
         descriptor.ops.extended_view_type_id = SingleNestedGraphNodeView::node_view_type_id();
-        descriptor.ops.extended_view_context = &register_single_nested_graph_context(
+        const auto &context = register_single_nested_graph_context(
             std::move(spec),
             options,
             descriptor.storage_plan->component(child_graph_field_name).offset,
             descriptor.storage_plan->component(child_graph_memory_field_name).offset,
             child_graph_layout);
+        descriptor.ops.extended_view_context = &context;
+        descriptor.ops.child_graph_inspection = ChildGraphInspectionOps{
+            .context = &context,
+            .visit_impl = &visit_single_nested_child,
+        };
 
         return descriptor;
     }

--- a/src/hgraph/runtime/node.cpp
+++ b/src/hgraph/runtime/node.cpp
@@ -26,6 +26,11 @@
 
 namespace hgraph
 {
+    namespace child_graph_inspection_detail
+    {
+        void visit_none(const void *, const NodeBuilder &, void *, ChildGraphVisitor) {}
+    }
+
     namespace
     {
         void schedule_node_from_storage(GraphValue *graph, std::size_t node_index, DateTime modified_time);
@@ -1146,6 +1151,10 @@ namespace hgraph
                 {
                     ops.recordable_state_view_impl = &recordable_state_view_impl;
                 }
+                if (ops.child_graph_inspection.visit_impl == nullptr)
+                {
+                    ops.child_graph_inspection.visit_impl = &child_graph_inspection_detail::visit_none;
+                }
             }
 
             void clear() noexcept
@@ -1189,7 +1198,7 @@ namespace hgraph
             }
             if (record.ops_abi_version != NODE_OPS_ABI_VERSION || record.ops == nullptr)
             {
-                throw std::invalid_argument("NodeTypeRef requires node ops ABI version 1");
+                throw std::invalid_argument("NodeTypeRef requires the current node ops ABI version");
             }
             if (record.capabilities != node_type_capabilities(*record.plan))
             {
@@ -1828,6 +1837,17 @@ namespace hgraph
     {
         if (!type_) { throw std::logic_error("NodeBuilder has no type"); }
         return type_;
+    }
+
+    void NodeBuilder::visit_child_graphs(void *visitor_context, ChildGraphVisitor visitor) const
+    {
+        if (!type_) { throw std::logic_error("NodeBuilder has no type"); }
+        if (visitor == nullptr)
+        {
+            throw std::invalid_argument("NodeBuilder::visit_child_graphs requires a visitor");
+        }
+        const ChildGraphInspectionOps &inspection = type_.ops_ref().child_graph_inspection;
+        inspection.visit_impl(inspection.context, *this, visitor_context, visitor);
     }
 
     NodeBuilder NodeBuilder::with_error_capture(const TSValueTypeMetaData *error_schema,

--- a/src/hgraph/runtime/ordered_reduce_node.cpp
+++ b/src/hgraph/runtime/ordered_reduce_node.cpp
@@ -121,7 +121,7 @@ namespace hgraph
             return *contexts;
         }
 
-        [[nodiscard]] const OrderedReduceContext &register_ordered_reduce_context(
+        [[nodiscard]] const OrderedReduceContext *register_ordered_reduce_context(
             OrderedReduceNodeSpec spec,
             std::size_t storage_offset,
             MemoryUtils::StorageLayout graph_layout,
@@ -135,7 +135,7 @@ namespace hgraph
             });
             const auto *result = context.get();
             ordered_reduce_contexts().push_back(std::move(context));
-            return *result;
+            return result;
         }
 
         void visit_ordered_reduce_child(const void *raw_context,
@@ -590,14 +590,14 @@ namespace hgraph
         descriptor.ops.evaluate_impl = &ordered_reduce_evaluate_impl;
         descriptor.ops.storage_metrics_impl = &ordered_reduce_storage_metrics;
         descriptor.ops.extended_view_type_id = OrderedReduceNodeView::node_view_type_id();
-        const auto &context = register_ordered_reduce_context(
+        const auto *context = register_ordered_reduce_context(
             std::move(spec),
             descriptor.storage_plan->component(ordered_reduce_storage_field_name).offset,
             graph_layout,
             collection_ops);
-        descriptor.ops.extended_view_context = &context;
+        descriptor.ops.extended_view_context = context;
         descriptor.ops.child_graph_inspection = ChildGraphInspectionOps{
-            .context = &context,
+            .context = context,
             .visit_impl = &visit_ordered_reduce_child,
         };
         return NodeBuilder::from_descriptor(std::move(descriptor));

--- a/src/hgraph/runtime/ordered_reduce_node.cpp
+++ b/src/hgraph/runtime/ordered_reduce_node.cpp
@@ -138,6 +138,15 @@ namespace hgraph
             return *result;
         }
 
+        void visit_ordered_reduce_child(const void *raw_context,
+                                        const NodeBuilder &,
+                                        void *visitor_context,
+                                        ChildGraphVisitor visitor)
+        {
+            const auto &context = *static_cast<const OrderedReduceContext *>(raw_context);
+            visitor(visitor_context, context.spec.child.graph_builder);
+        }
+
         [[nodiscard]] NodeStorageMetrics ordered_reduce_storage_metrics(
             const void *raw_context, const void *memory) noexcept
         {
@@ -581,11 +590,16 @@ namespace hgraph
         descriptor.ops.evaluate_impl = &ordered_reduce_evaluate_impl;
         descriptor.ops.storage_metrics_impl = &ordered_reduce_storage_metrics;
         descriptor.ops.extended_view_type_id = OrderedReduceNodeView::node_view_type_id();
-        descriptor.ops.extended_view_context = &register_ordered_reduce_context(
+        const auto &context = register_ordered_reduce_context(
             std::move(spec),
             descriptor.storage_plan->component(ordered_reduce_storage_field_name).offset,
             graph_layout,
             collection_ops);
+        descriptor.ops.extended_view_context = &context;
+        descriptor.ops.child_graph_inspection = ChildGraphInspectionOps{
+            .context = &context,
+            .visit_impl = &visit_ordered_reduce_child,
+        };
         return NodeBuilder::from_descriptor(std::move(descriptor));
     }
 }  // namespace hgraph

--- a/src/hgraph/runtime/reduce_node.cpp
+++ b/src/hgraph/runtime/reduce_node.cpp
@@ -264,6 +264,15 @@ namespace hgraph
             return result;
         }
 
+        void visit_reduce_child(const void *raw_context,
+                                const NodeBuilder &,
+                                void *visitor_context,
+                                ChildGraphVisitor visitor)
+        {
+            const auto &context = *static_cast<const ReduceNodeContext *>(raw_context);
+            visitor(visitor_context, context.spec.child.graph_builder);
+        }
+
         /** Where an aggregate currently comes from, without materialising it. */
         struct Aggregate
         {
@@ -1510,9 +1519,14 @@ namespace hgraph
         descriptor.ops.evaluate_impl         = &reduce_evaluate_impl;
         descriptor.ops.storage_metrics_impl  = &reduce_storage_metrics;
         descriptor.ops.extended_view_type_id = ReduceNodeView::node_view_type_id();
-        descriptor.ops.extended_view_context = &register_reduce_node_context(
+        const auto &context = register_reduce_node_context(
             std::move(spec), descriptor.storage_plan->component(reduce_storage_field_name).offset,
             graph_layout, collection_ops, publication_ops);
+        descriptor.ops.extended_view_context = &context;
+        descriptor.ops.child_graph_inspection = ChildGraphInspectionOps{
+            .context = &context,
+            .visit_impl = &visit_reduce_child,
+        };
 
         return NodeBuilder::from_descriptor(std::move(descriptor));
     }

--- a/src/hgraph/runtime/reduce_node.cpp
+++ b/src/hgraph/runtime/reduce_node.cpp
@@ -230,7 +230,7 @@ namespace hgraph
             return *contexts;
         }
 
-        [[nodiscard]] const ReduceNodeContext &register_reduce_node_context(
+        [[nodiscard]] const ReduceNodeContext *register_reduce_node_context(
             ReduceNodeSpec spec, std::size_t storage_offset, MemoryUtils::StorageLayout graph_layout,
             const ReduceCollectionOps &collection_ops, const ReducePublicationOps &publication_ops)
         {
@@ -243,7 +243,7 @@ namespace hgraph
             });
             const auto *result = context.get();
             reduce_node_contexts().push_back(std::move(context));
-            return *result;
+            return result;
         }
 
         [[nodiscard]] NodeStorageMetrics reduce_storage_metrics(
@@ -1519,12 +1519,12 @@ namespace hgraph
         descriptor.ops.evaluate_impl         = &reduce_evaluate_impl;
         descriptor.ops.storage_metrics_impl  = &reduce_storage_metrics;
         descriptor.ops.extended_view_type_id = ReduceNodeView::node_view_type_id();
-        const auto &context = register_reduce_node_context(
+        const auto *context = register_reduce_node_context(
             std::move(spec), descriptor.storage_plan->component(reduce_storage_field_name).offset,
             graph_layout, collection_ops, publication_ops);
-        descriptor.ops.extended_view_context = &context;
+        descriptor.ops.extended_view_context = context;
         descriptor.ops.child_graph_inspection = ChildGraphInspectionOps{
-            .context = &context,
+            .context = context,
             .visit_impl = &visit_reduce_child,
         };
 

--- a/src/hgraph/runtime/switch_node.cpp
+++ b/src/hgraph/runtime/switch_node.cpp
@@ -65,7 +65,7 @@ switch_node_contexts() noexcept {
   return *contexts;
 }
 
-[[nodiscard]] const SwitchNodeContext &
+[[nodiscard]] const SwitchNodeContext *
 register_switch_node_context(SwitchNodeSpec spec, std::size_t storage_offset,
                              std::size_t graph_memory_offset,
                              std::size_t graph_slot_stride,
@@ -79,7 +79,7 @@ register_switch_node_context(SwitchNodeSpec spec, std::size_t storage_offset,
   });
   const auto *result = context.get();
   switch_node_contexts().push_back(std::move(context));
-  return *result;
+  return result;
 }
 
 [[nodiscard]] NodeStorageMetrics switch_storage_metrics(
@@ -549,14 +549,14 @@ NodeBuilder switch_node(NodeTypeMetaData meta, SwitchNodeSpec spec) {
   descriptor.ops.evaluate_impl = &switch_evaluate_impl;
   descriptor.ops.storage_metrics_impl = &switch_storage_metrics;
   descriptor.ops.extended_view_type_id = SwitchNodeView::node_view_type_id();
-  const auto &context = register_switch_node_context(
+  const auto *context = register_switch_node_context(
       std::move(spec),
       descriptor.storage_plan->component(switch_storage_field_name).offset,
       descriptor.storage_plan->component(switch_graph_memory_field_name).offset,
       graph_memory_plan.array_stride(), graph_slot_layout);
-  descriptor.ops.extended_view_context = &context;
+  descriptor.ops.extended_view_context = context;
   descriptor.ops.child_graph_inspection = ChildGraphInspectionOps{
-      .context = &context,
+      .context = context,
       .visit_impl = &visit_switch_children,
   };
 

--- a/src/hgraph/runtime/switch_node.cpp
+++ b/src/hgraph/runtime/switch_node.cpp
@@ -99,6 +99,17 @@ register_switch_node_context(SwitchNodeSpec spec, std::size_t storage_offset,
   };
 }
 
+void visit_switch_children(const void *raw_context, const NodeBuilder &,
+                           void *visitor_context, ChildGraphVisitor visitor) {
+  const auto &context = *static_cast<const SwitchNodeContext *>(raw_context);
+  for (const SwitchBranch &branch : context.spec.branches) {
+    visitor(visitor_context, branch.spec.graph_builder);
+  }
+  if (context.spec.default_branch.has_value()) {
+    visitor(visitor_context, context.spec.default_branch->graph_builder);
+  }
+}
+
 [[nodiscard]] void *switch_graph_memory(const NodeView &view,
                                         const SwitchNodeContext &context,
                                         std::size_t slot) noexcept {
@@ -538,11 +549,16 @@ NodeBuilder switch_node(NodeTypeMetaData meta, SwitchNodeSpec spec) {
   descriptor.ops.evaluate_impl = &switch_evaluate_impl;
   descriptor.ops.storage_metrics_impl = &switch_storage_metrics;
   descriptor.ops.extended_view_type_id = SwitchNodeView::node_view_type_id();
-  descriptor.ops.extended_view_context = &register_switch_node_context(
+  const auto &context = register_switch_node_context(
       std::move(spec),
       descriptor.storage_plan->component(switch_storage_field_name).offset,
       descriptor.storage_plan->component(switch_graph_memory_field_name).offset,
       graph_memory_plan.array_stride(), graph_slot_layout);
+  descriptor.ops.extended_view_context = &context;
+  descriptor.ops.child_graph_inspection = ChildGraphInspectionOps{
+      .context = &context,
+      .visit_impl = &visit_switch_children,
+  };
 
   return NodeBuilder::from_descriptor(std::move(descriptor));
 }

--- a/src/hgraph/runtime/tsl_map_node.cpp
+++ b/src/hgraph/runtime/tsl_map_node.cpp
@@ -95,7 +95,7 @@ namespace hgraph
             return *contexts;
         }
 
-        [[nodiscard]] const TslMapNodeContext &register_tsl_map_node_context(TslMapNodeSpec spec,
+        [[nodiscard]] const TslMapNodeContext *register_tsl_map_node_context(TslMapNodeSpec spec,
                                                                              runtime_detail::MappedChildAccessPlan access,
                                                                              std::size_t storage_offset,
                                                                              MemoryUtils::StorageLayout graph_layout) {
@@ -107,7 +107,7 @@ namespace hgraph
             });
             const auto *result  = context.get();
             tsl_map_node_contexts().push_back(std::move(context));
-            return *result;
+            return result;
         }
 
         [[nodiscard]] NodeStorageMetrics tsl_map_storage_metrics(
@@ -483,12 +483,12 @@ namespace hgraph
             .layout       = debug_exemplar.entries.debug_layout(
                 descriptor.storage_plan->component(tsl_map_storage_field_name).offset + entries_offset, graph_pointer_offset, true),
         };
-        const auto &context = register_tsl_map_node_context(
+        const auto *context = register_tsl_map_node_context(
             std::move(spec), std::move(access),
             descriptor.storage_plan->component(tsl_map_storage_field_name).offset, graph_layout);
-        descriptor.ops.extended_view_context = &context;
+        descriptor.ops.extended_view_context = context;
         descriptor.ops.child_graph_inspection = ChildGraphInspectionOps{
-            .context = &context,
+            .context = context,
             .visit_impl = &visit_tsl_map_child,
         };
 

--- a/src/hgraph/runtime/tsl_map_node.cpp
+++ b/src/hgraph/runtime/tsl_map_node.cpp
@@ -124,6 +124,15 @@ namespace hgraph
             };
         }
 
+        void visit_tsl_map_child(const void *raw_context,
+                                 const NodeBuilder &,
+                                 void *visitor_context,
+                                 ChildGraphVisitor visitor)
+        {
+            const auto &context = *static_cast<const TslMapNodeContext *>(raw_context);
+            visitor(visitor_context, context.spec.child.graph_builder);
+        }
+
         [[nodiscard]] TSOutputHandle effective_output_handle(TSOutputView source) {
             if (!source.bound()) { return {}; }
 
@@ -474,9 +483,14 @@ namespace hgraph
             .layout       = debug_exemplar.entries.debug_layout(
                 descriptor.storage_plan->component(tsl_map_storage_field_name).offset + entries_offset, graph_pointer_offset, true),
         };
-        descriptor.ops.extended_view_context = &register_tsl_map_node_context(
+        const auto &context = register_tsl_map_node_context(
             std::move(spec), std::move(access),
             descriptor.storage_plan->component(tsl_map_storage_field_name).offset, graph_layout);
+        descriptor.ops.extended_view_context = &context;
+        descriptor.ops.child_graph_inspection = ChildGraphInspectionOps{
+            .context = &context,
+            .visit_impl = &visit_tsl_map_child,
+        };
 
         return NodeBuilder::from_descriptor(std::move(descriptor));
     }

--- a/tests/cpp/test_nested_wiring.cpp
+++ b/tests/cpp/test_nested_wiring.cpp
@@ -658,6 +658,40 @@ TEST_CASE("nested wiring: every dynamic child graph uses planned or stable in-pl
     CHECK(saw_switch);
 }
 
+TEST_CASE("nested wiring: node builders expose every immediate compiled child through one contract")
+{
+    using namespace hgraph;
+    stdlib::register_standard_operators();
+
+    GraphBuilder graph = build_graph<NestedAllocationGraph>();
+    struct Inspection
+    {
+        std::size_t children{0};
+        std::size_t owners{0};
+        bool all_children_non_empty{true};
+    } inspection;
+
+    const auto visitor = [](void *raw, const GraphBuilder &child) {
+        auto &state = *static_cast<Inspection *>(raw);
+        ++state.children;
+        state.all_children_non_empty = state.all_children_non_empty && child.node_count() > 0;
+    };
+
+    for (const NodeBuilder &node : graph.nodes())
+    {
+        const std::size_t before = inspection.children;
+        node.visit_child_graphs(&inspection, visitor);
+        if (inspection.children != before) { ++inspection.owners; }
+    }
+
+    // nested_, map_, mesh_, associative reduce, ordered reduce and switch_
+    // each own one immediate compiled child in this graph. Ordinary nodes use
+    // the same contract and visit nothing.
+    CHECK(inspection.owners == 6);
+    CHECK(inspection.children == 6);
+    CHECK(inspection.all_children_non_empty);
+}
+
 TEST_CASE("nested wiring: a sub-graph with multiple boundary inputs binds each arg")
 {
     using namespace hgraph;

--- a/tests/cpp/test_type_erasure_layout.cpp
+++ b/tests/cpp/test_type_erasure_layout.cpp
@@ -40,6 +40,10 @@ TEST_CASE("current type-erasure records retain their baseline layouts")
     static_assert(std::is_trivially_copyable_v<ValueTypeRef>);
     static_assert(sizeof(NodeTypeRef) == sizeof(void *));
     static_assert(std::is_trivially_copyable_v<NodeTypeRef>);
+    // ABI 5 adds the cold-path compiled-child inspection contract.
+    static_assert(NODE_OPS_ABI_VERSION == 5);
+    static_assert(std::is_standard_layout_v<ChildGraphInspectionOps>);
+    static_assert(std::is_trivially_copyable_v<ChildGraphInspectionOps>);
     static_assert(sizeof(GraphTypeRef) == sizeof(void *));
     static_assert(std::is_trivially_copyable_v<GraphTypeRef>);
     static_assert(GRAPH_OPS_ABI_VERSION == 7);

--- a/tests/install_consumer/CMakeLists.txt
+++ b/tests/install_consumer/CMakeLists.txt
@@ -4,7 +4,7 @@ project(hgraph_install_consumer LANGUAGES CXX)
 
 find_package(hgraph CONFIG REQUIRED)
 
-add_executable(hgraph_install_consumer main.cpp)
+add_executable(hgraph_install_consumer main.cpp fabric_extension_probe.cpp)
 target_link_libraries(hgraph_install_consumer PRIVATE hgraph::core)
 if(COMMAND hgraph_link_python_embedding)
     # Python-enabled wheel runtimes resolve their stable-ABI symbols from an

--- a/tests/install_consumer/fabric_extension_probe.cpp
+++ b/tests/install_consumer/fabric_extension_probe.cpp
@@ -1,0 +1,313 @@
+#include "fabric_extension_probe.h"
+
+#include <hgraph/lib/std/std_nodes.h>
+#include <hgraph/runtime/runtime.h>
+#include <hgraph/types/graph_wiring.h>
+#include <hgraph/types/static_node.h>
+#include <hgraph/types/subgraph_wiring.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string_view>
+#include <typeindex>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace hgraph_install_consumer {
+namespace {
+// RFC 0026 checkpoint 0: an installed extension can defer a source,
+// discover that marked source through public wiring edges from a sink,
+// bind the source after composition, and select its runtime mode once in
+// start. This deliberately remains a consumer-side proof rather than
+// introducing fabric policy or a new hook in core.
+
+constexpr std::string_view kDependencyCount{":fabric_probe:dependency_count"};
+constexpr std::string_view kSinkValue{":fabric_probe:sink_value"};
+
+class FabricProbeDependencyHandle {
+public:
+  [[nodiscard]] std::uint64_t root_identity() const noexcept {
+    return root_identity_;
+  }
+
+  [[nodiscard]] const hgraph::WiringPortRef &source() const noexcept {
+    return source_;
+  }
+
+private:
+  friend struct FabricProbeSubscription;
+
+  FabricProbeDependencyHandle(std::uint64_t root_identity,
+                              hgraph::WiringPortRef source)
+      : root_identity_{root_identity}, source_{std::move(source)} {}
+
+  std::uint64_t root_identity_{};
+  hgraph::WiringPortRef source_{};
+};
+
+/** A subscription exposes its data port and an opaque dependency handle.
+    The handle is constructed only from this subscription result; it is
+    not a data-id string which can claim lineage the graph did not load. */
+struct FabricProbeSubscription {
+  FabricProbeSubscription(std::uint64_t root_identity,
+                          hgraph::Port<hgraph::TS<hgraph::Int>> source)
+      : value{source}, dependency{root_identity, source.erased()} {}
+
+  hgraph::Port<hgraph::TS<hgraph::Int>> value;
+  FabricProbeDependencyHandle dependency;
+};
+
+/** Installed proof source: one startup schedule, one output tick, and no
+    runtime policy branch. ``start`` selects the immutable executor mode;
+    ``eval`` only publishes that already-selected value. */
+struct FabricProbeModeSource {
+  static constexpr auto name = "fabric_probe_mode_source";
+  static constexpr bool schedule_on_start = true;
+
+  static void start(hgraph::EngineControlView engine,
+                    hgraph::State<hgraph::Int> mode) {
+    mode.set(engine.mode() == hgraph::GraphExecutorMode::Simulation
+                 ? hgraph::Int{11}
+                 : hgraph::Int{22});
+  }
+
+  static void eval(hgraph::State<hgraph::Int> mode,
+                   hgraph::Out<hgraph::TS<hgraph::Int>> out) {
+    out.set(mode.get());
+  }
+};
+
+/** Installed proof sink: capture the selected source value in run-scoped
+    state so the consumer can verify the deferred edge evaluated. */
+struct FabricProbeSink {
+  static constexpr auto name = "fabric_probe_sink";
+
+  static void eval(hgraph::In<"value", hgraph::TS<hgraph::Int>> value,
+                   hgraph::GlobalStateView state) {
+    state.set(kSinkValue, hgraph::Value{value.value()});
+  }
+};
+
+/** Independent proof value used to show that an explicit subscription
+    handle supplies lineage even when the data edge is intentionally
+    hidden from ordinary upstream traversal. */
+struct FabricProbeIndependentSource {
+  static constexpr auto name = "fabric_probe_independent_source";
+  static constexpr bool schedule_on_start = true;
+
+  static void eval(hgraph::Out<hgraph::TS<hgraph::Int>> out) {
+    out.set(hgraph::Int{33});
+  }
+};
+
+struct FabricProbeNestedPassThrough {
+  static hgraph::Port<hgraph::TS<hgraph::Int>>
+  compose(hgraph::Wiring &wiring, hgraph::Port<hgraph::TS<hgraph::Int>> value) {
+    return hgraph::wire<hgraph::stdlib::pass_through_node>(wiring, value)
+        .template as<hgraph::TS<hgraph::Int>>();
+  }
+};
+
+struct FabricProbePublisher {
+  hgraph::WiringPortRef value;
+  std::vector<FabricProbeDependencyHandle> explicit_dependencies;
+};
+
+struct FabricProbePlanner {
+  std::vector<hgraph::DelayedBindingWiringPort<hgraph::TS<hgraph::Int>>>
+      sources;
+  std::vector<FabricProbePublisher> publishers;
+  bool finalizer_registered{false};
+
+  static void collect_marked_sources(
+      const hgraph::WiringPortRef &source,
+      std::unordered_set<const hgraph::WiringInstance *> &visited,
+      std::size_t &marked_sources) {
+    using SourceKind = hgraph::WiringPortRef::SourceKind;
+
+    switch (source.source_kind()) {
+    case SourceKind::Null:
+      return;
+    case SourceKind::Structural:
+      for (const auto &child : source.structural_children()) {
+        collect_marked_sources(child, visited, marked_sources);
+      }
+      return;
+    case SourceKind::Delayed: {
+      const auto &resolved = source.delayed_state()->source;
+      if (!resolved) {
+        throw std::logic_error(
+            "fabric probe encountered an unbound deferred source");
+      }
+      collect_marked_sources(*resolved, visited, marked_sources);
+      return;
+    }
+    case SourceKind::Peered: {
+      const hgraph::WiringInstance *node = source.peered_node();
+      if (!visited.insert(node).second) {
+        return;
+      }
+      if (node->definition == std::type_index(typeid(FabricProbeModeSource))) {
+        ++marked_sources;
+      }
+      for (const auto &input : node->inputs) {
+        collect_marked_sources(input.source, visited, marked_sources);
+      }
+      return;
+    }
+    case SourceKind::Boundary:
+      throw std::logic_error(
+          "fabric probe expected a top-level source, not a child boundary");
+    case SourceKind::Unbound:
+      throw std::logic_error(
+          "fabric probe encountered an unbound wiring source");
+    }
+  }
+
+  void finalize(hgraph::Wiring &wiring) {
+    for (auto &source : sources) {
+      if (!source.bound()) {
+        source(hgraph::wire<FabricProbeModeSource>(wiring));
+      }
+    }
+
+    for (const auto &publisher : publishers) {
+      std::unordered_set<const hgraph::WiringInstance *> visited;
+      std::size_t marked_sources{0};
+      if (publisher.explicit_dependencies.empty()) {
+        collect_marked_sources(publisher.value, visited, marked_sources);
+      } else {
+        for (const auto &dependency : publisher.explicit_dependencies) {
+          if (dependency.root_identity() != wiring.identity()) {
+            throw std::logic_error("fabric probe explicit dependency belongs "
+                                   "to another wired root");
+          }
+          collect_marked_sources(dependency.source(), visited, marked_sources);
+        }
+      }
+      if (marked_sources != 1) {
+        throw std::logic_error(
+            "fabric probe did not discover exactly one upstream marked source");
+      }
+      wiring.global_state().set(
+          kDependencyCount, hgraph::Value{hgraph::Int{
+                                static_cast<std::int64_t>(marked_sources)}});
+    }
+  }
+};
+
+[[nodiscard]] std::shared_ptr<FabricProbePlanner>
+planner_for(hgraph::Wiring &wiring) {
+  auto planner = std::static_pointer_cast<FabricProbePlanner>(
+      wiring.acquire_extension_state(
+          std::type_index(typeid(FabricProbePlanner)),
+          [] { return std::make_shared<FabricProbePlanner>(); }));
+  if (!planner->finalizer_registered) {
+    planner->finalizer_registered = true;
+    std::weak_ptr<FabricProbePlanner> weak = planner;
+    wiring.register_pre_rank_finalizer([weak](hgraph::Wiring &target) {
+      if (const auto locked = weak.lock()) {
+        locked->finalize(target);
+      }
+    });
+  }
+  return planner;
+}
+
+[[nodiscard]] FabricProbeSubscription subscribe(hgraph::Wiring &wiring) {
+  auto delayed = hgraph::delayed_binding<hgraph::TS<hgraph::Int>>(wiring);
+  planner_for(wiring)->sources.push_back(delayed);
+  auto value = delayed();
+  return FabricProbeSubscription{wiring.identity(), value};
+}
+
+void publish(
+    hgraph::Wiring &wiring, hgraph::Port<hgraph::TS<hgraph::Int>> value,
+    std::vector<FabricProbeDependencyHandle> explicit_dependencies = {}) {
+  planner_for(wiring)->publishers.push_back(
+      FabricProbePublisher{value.erased(), std::move(explicit_dependencies)});
+  hgraph::wire<FabricProbeSink>(wiring, value);
+}
+
+struct FabricNestedExtensionProbeGraph {
+  static void compose(hgraph::Wiring &wiring) {
+    auto subscribed = subscribe(wiring);
+    auto forwarded =
+        hgraph::nested_<FabricProbeNestedPassThrough>(wiring, subscribed.value);
+    publish(wiring, forwarded);
+  }
+};
+
+struct FabricExplicitExtensionProbeGraph {
+  static void compose(hgraph::Wiring &wiring) {
+    auto subscribed = subscribe(wiring);
+    auto value = hgraph::wire<FabricProbeIndependentSource>(wiring);
+    publish(wiring, value, {subscribed.dependency});
+  }
+};
+} // namespace
+
+void check_fabric_core_extension_seam() {
+  using namespace hgraph;
+
+  const auto run = []<typename Graph>(GraphExecutorMode mode, Int expected) {
+    Wiring wiring;
+    Graph::compose(wiring);
+    // A pre-rank finalizer must tolerate notebook-style snapshots and
+    // the final consuming build without rebinding its delayed source.
+    GraphBuilder snapshot = wiring.snapshot();
+    if (snapshot.global_state().get(kDependencyCount).checked_as<Int>() !=
+        Int{1}) {
+      throw std::runtime_error(
+          "installed fabric probe did not finalize an intermediate snapshot");
+    }
+    GraphBuilder graph = std::move(wiring).finish();
+    if (graph.global_state().get(kDependencyCount).checked_as<Int>() !=
+        Int{1}) {
+      throw std::runtime_error(
+          "installed fabric probe did not retain its discovered dependency");
+    }
+
+    GraphExecutorBuilder executor_builder;
+    executor_builder.graph_builder(std::move(graph))
+        .mode(mode)
+        .start_time(MIN_ST)
+        .end_time(MIN_ST + MIN_TD * 2);
+    GraphExecutorValue executor = executor_builder.make_executor();
+    auto view = executor.view();
+    view.run();
+
+    const auto result = view.graph().global_state().get(kSinkValue);
+    if (!result.valid() || result.checked_as<Int>() != expected) {
+      throw std::runtime_error("installed fabric probe did not evaluate its "
+                               "deferred source and sink");
+    }
+  };
+
+  run.template operator()<FabricNestedExtensionProbeGraph>(
+      GraphExecutorMode::Simulation, Int{11});
+  run.template operator()<FabricNestedExtensionProbeGraph>(
+      GraphExecutorMode::RealTime, Int{22});
+  run.template operator()<FabricExplicitExtensionProbeGraph>(
+      GraphExecutorMode::Simulation, Int{33});
+
+  Wiring first_root;
+  auto first_subscription = subscribe(first_root);
+  Wiring second_root;
+  auto value = wire<FabricProbeIndependentSource>(second_root);
+  publish(second_root, value, {first_subscription.dependency});
+  try {
+    static_cast<void>(std::move(second_root).finish());
+    throw std::runtime_error(
+        "installed fabric probe accepted a dependency from another wired root");
+  } catch (const std::logic_error &error) {
+    if (std::string_view{error.what()} !=
+        "fabric probe explicit dependency belongs to another wired root") {
+      throw;
+    }
+  }
+}
+} // namespace hgraph_install_consumer

--- a/tests/install_consumer/fabric_extension_probe.cpp
+++ b/tests/install_consumer/fabric_extension_probe.cpp
@@ -19,10 +19,11 @@
 namespace hgraph_install_consumer {
 namespace {
 // RFC 0026 checkpoint 0: an installed extension can defer a source,
-// discover that marked source through public wiring edges from a sink,
-// bind the source after composition, and select its runtime mode once in
-// start. This deliberately remains a consumer-side proof rather than
-// introducing fabric policy or a new hook in core.
+// discover that marked source through public wiring edges and compiled child
+// graph plans from a sink, bind the source after composition, and select its
+// runtime mode once in start. This deliberately remains a consumer-side proof;
+// core supplies only the general child-plan inspection contract, never fabric
+// policy.
 
 constexpr std::string_view kDependencyCount{":fabric_probe:dependency_count"};
 constexpr std::string_view kSinkValue{":fabric_probe:sink_value"};
@@ -59,6 +60,8 @@ struct FabricProbeSubscription {
   hgraph::Port<hgraph::TS<hgraph::Int>> value;
   FabricProbeDependencyHandle dependency;
 };
+
+[[nodiscard]] FabricProbeSubscription subscribe(hgraph::Wiring &wiring);
 
 /** Installed proof source: one startup schedule, one output tick, and no
     runtime policy branch. ``start`` selects the immutable executor mode;
@@ -103,10 +106,12 @@ struct FabricProbeIndependentSource {
   }
 };
 
-struct FabricProbeNestedPassThrough {
+struct FabricProbeNestedSubscription {
   static hgraph::Port<hgraph::TS<hgraph::Int>>
-  compose(hgraph::Wiring &wiring, hgraph::Port<hgraph::TS<hgraph::Int>> value) {
-    return hgraph::wire<hgraph::stdlib::pass_through_node>(wiring, value)
+  compose(hgraph::Wiring &wiring) {
+    auto subscribed = subscribe(wiring);
+    return hgraph::wire<hgraph::stdlib::pass_through_node>(wiring,
+                                                           subscribed.value)
         .template as<hgraph::TS<hgraph::Int>>();
   }
 };
@@ -122,10 +127,33 @@ struct FabricProbePlanner {
   std::vector<FabricProbePublisher> publishers;
   bool finalizer_registered{false};
 
+  struct SourceCollection {
+    std::unordered_set<const hgraph::WiringInstance *> wiring_nodes;
+    std::unordered_set<const hgraph::GraphBuilder *> compiled_graphs;
+    std::size_t marked_sources{0};
+  };
+
+  [[nodiscard]] static hgraph::NodeTypeRef marked_source_type() {
+    static const hgraph::NodeTypeRef type = [] {
+      hgraph::NodeBuilder builder;
+      builder.implementation<FabricProbeModeSource>();
+      return builder.type();
+    }();
+    return type;
+  }
+
+  static void collect_compiled_graph(const hgraph::GraphBuilder &graph,
+                                     SourceCollection &collection);
+
+  static void collect_compiled_child(void *raw_collection,
+                                     const hgraph::GraphBuilder &child) {
+    collect_compiled_graph(
+        child, *static_cast<SourceCollection *>(raw_collection));
+  }
+
   static void collect_marked_sources(
       const hgraph::WiringPortRef &source,
-      std::unordered_set<const hgraph::WiringInstance *> &visited,
-      std::size_t &marked_sources) {
+      SourceCollection &collection) {
     using SourceKind = hgraph::WiringPortRef::SourceKind;
 
     switch (source.source_kind()) {
@@ -133,7 +161,7 @@ struct FabricProbePlanner {
       return;
     case SourceKind::Structural:
       for (const auto &child : source.structural_children()) {
-        collect_marked_sources(child, visited, marked_sources);
+        collect_marked_sources(child, collection);
       }
       return;
     case SourceKind::Delayed: {
@@ -142,19 +170,20 @@ struct FabricProbePlanner {
         throw std::logic_error(
             "fabric probe encountered an unbound deferred source");
       }
-      collect_marked_sources(*resolved, visited, marked_sources);
+      collect_marked_sources(*resolved, collection);
       return;
     }
     case SourceKind::Peered: {
       const hgraph::WiringInstance *node = source.peered_node();
-      if (!visited.insert(node).second) {
+      if (!collection.wiring_nodes.insert(node).second) {
         return;
       }
       if (node->definition == std::type_index(typeid(FabricProbeModeSource))) {
-        ++marked_sources;
+        ++collection.marked_sources;
       }
+      node->builder.visit_child_graphs(&collection, &collect_compiled_child);
       for (const auto &input : node->inputs) {
-        collect_marked_sources(input.source, visited, marked_sources);
+        collect_marked_sources(input.source, collection);
       }
       return;
     }
@@ -175,29 +204,42 @@ struct FabricProbePlanner {
     }
 
     for (const auto &publisher : publishers) {
-      std::unordered_set<const hgraph::WiringInstance *> visited;
-      std::size_t marked_sources{0};
+      SourceCollection collection;
       if (publisher.explicit_dependencies.empty()) {
-        collect_marked_sources(publisher.value, visited, marked_sources);
+        collect_marked_sources(publisher.value, collection);
       } else {
         for (const auto &dependency : publisher.explicit_dependencies) {
           if (dependency.root_identity() != wiring.identity()) {
             throw std::logic_error("fabric probe explicit dependency belongs "
                                    "to another wired root");
           }
-          collect_marked_sources(dependency.source(), visited, marked_sources);
+          collect_marked_sources(dependency.source(), collection);
         }
       }
-      if (marked_sources != 1) {
+      if (collection.marked_sources != 1) {
         throw std::logic_error(
             "fabric probe did not discover exactly one upstream marked source");
       }
       wiring.global_state().set(
           kDependencyCount, hgraph::Value{hgraph::Int{
-                                static_cast<std::int64_t>(marked_sources)}});
+                                static_cast<std::int64_t>(
+                                    collection.marked_sources)}});
     }
   }
 };
+
+void FabricProbePlanner::collect_compiled_graph(
+    const hgraph::GraphBuilder &graph, SourceCollection &collection) {
+  if (!collection.compiled_graphs.insert(&graph).second) {
+    return;
+  }
+  for (const hgraph::NodeBuilder &node : graph.nodes()) {
+    if (node.type() == marked_source_type()) {
+      ++collection.marked_sources;
+    }
+    node.visit_child_graphs(&collection, &collect_compiled_child);
+  }
+}
 
 [[nodiscard]] std::shared_ptr<FabricProbePlanner>
 planner_for(hgraph::Wiring &wiring) {
@@ -234,9 +276,7 @@ void publish(
 
 struct FabricNestedExtensionProbeGraph {
   static void compose(hgraph::Wiring &wiring) {
-    auto subscribed = subscribe(wiring);
-    auto forwarded =
-        hgraph::nested_<FabricProbeNestedPassThrough>(wiring, subscribed.value);
+    auto forwarded = hgraph::nested_<FabricProbeNestedSubscription>(wiring);
     publish(wiring, forwarded);
   }
 };

--- a/tests/install_consumer/fabric_extension_probe.h
+++ b/tests/install_consumer/fabric_extension_probe.h
@@ -1,0 +1,8 @@
+#ifndef HGRAPH_INSTALL_CONSUMER_FABRIC_EXTENSION_PROBE_H
+#define HGRAPH_INSTALL_CONSUMER_FABRIC_EXTENSION_PROBE_H
+
+namespace hgraph_install_consumer {
+void check_fabric_core_extension_seam();
+}
+
+#endif // HGRAPH_INSTALL_CONSUMER_FABRIC_EXTENSION_PROBE_H

--- a/tests/install_consumer/main.cpp
+++ b/tests/install_consumer/main.cpp
@@ -1,3 +1,5 @@
+#include "fabric_extension_probe.h"
+
 #include <hgraph/lib/std/standard_types.h>
 #include <hgraph/lib/std/operators/io.h>
 #include <hgraph/lib/std/operators/table.h>
@@ -511,6 +513,7 @@ int main()
     }
 
     check_probe_backend_round_trip();
+    hgraph_install_consumer::check_fabric_core_extension_seam();
 
     return 0;
 }

--- a/tests/install_consumer/main.cpp
+++ b/tests/install_consumer/main.cpp
@@ -256,6 +256,10 @@ int main()
     static_assert(std::is_trivially_copyable_v<TypeRecord>);
     static_assert(std::is_standard_layout_v<AnyPtr>);
     static_assert(std::is_trivially_copyable_v<AnyPtr>);
+    // ABI 5 adds the cold-path compiled-child inspection contract.
+    static_assert(NODE_OPS_ABI_VERSION == 5);
+    static_assert(std::is_standard_layout_v<ChildGraphInspectionOps>);
+    static_assert(std::is_trivially_copyable_v<ChildGraphInspectionOps>);
     static_assert(GRAPH_OPS_ABI_VERSION == 7);
     static_assert(EXECUTOR_OPS_ABI_VERSION == 5);
     // ABI 10: the never-dispatched reset_delta hook was removed.

--- a/tools/audit_distribution.py
+++ b/tools/audit_distribution.py
@@ -21,6 +21,8 @@ SDIST_REQUIRED = {
     "src/CMakeLists.txt",
     "tests/install_consumer/CMakeLists.txt",
     "tests/install_consumer/check.py",
+    "tests/install_consumer/fabric_extension_probe.cpp",
+    "tests/install_consumer/fabric_extension_probe.h",
     "tests/python_extension_consumer/CMakeLists.txt",
     "tests/python_extension_consumer/check.py",
     "tests/python_extension_consumer/module.cpp",


### PR DESCRIPTION
## Summary

- add a separately built installed-SDK proof for the RFC 0026 wiring extension seam
- defer and bind a subscription source through an idempotent pre-rank finalizer
- discover marked sources through an owning nested graph and through typed explicit dependency handles
- reject dependency handles from another wired root
- select simulation versus real-time behavior once in `start`, leaving `eval` branch-free
- record that no fabric-specific core hook is required and update the persistence prerequisite status

## Why

Issue #512 requires executable evidence that the public core SDK can support fabric wiring before the extension is scaffolded. This keeps fabric policy out of core while proving the required lifecycle, graph inspection, nested composition, and explicit-lineage paths from an external consumer.

## Validation

- complete native suite: 1,602 passed
- stable-ABI wheel built with Python 3.12
- complete Python 3.14 non-WIP suite: 2,098 passed, 10 skipped
- installed-SDK native consumer: passed against the freshly built wheel
- source and wheel distribution audits: passed
- focused packaging tests: 35 passed

Part of #512.