### PR TITLE
Audit the format-injection class and pin the HTTP/2 recovery contract

### DIFF
--- a/extensions/web/tests/test_h2_engine.cpp
+++ b/extensions/web/tests/test_h2_engine.cpp
@@ -488,6 +488,37 @@ void test_goaway_finishes_in_flight_and_refuses_new() {
 
 } // namespace
 
+void test_unopenable_file_response_is_reported_not_swallowed() {
+  // The driver relies on this contract to finish the stream itself: a
+  // configured static file can vanish or lose read permission between the
+  // metadata resolving and the response being submitted. If this ever
+  // started returning true, or throwing, the driver's recovery would be
+  // dead code and the peer would wait on the stream forever.
+  RecordingHost host;
+  H2Engine engine{host, H2Settings{}};
+  TestClient client;
+  const auto stream_id = client.submit_request("GET", "/gone.txt", nullptr);
+  pump(client, engine);
+
+  require(!engine.submit_file_response(
+              stream_id, 200, H2Headers{{"content-type", "text/plain"}},
+              "/nonexistent/hgraph-web/definitely-not-here.txt", {}),
+          "an unopenable file must be reported as a failed submit");
+
+  // Nothing may be half-registered: the stream must still be answerable,
+  // which is what lets the driver fall back to a 500 on the same stream.
+  require(engine.submit_response(stream_id, 500,
+                                 H2Headers{{"content-type", "text/plain"}},
+                                 "static file error", {}),
+          "the stream must remain answerable after a failed file submit");
+  pump(client, engine);
+  const auto &stream = client.streams[stream_id];
+  require(stream.status == 500, "the fallback response did not reach the client");
+  require(stream.body == "static file error",
+          "the fallback body did not reach the client");
+  require(stream.closed, "the stream did not complete");
+}
+
 int main() {
   try {
     test_get_round_trip_with_trailers();
@@ -497,6 +528,7 @@ int main() {
     test_client_reset_surfaces_as_cancellation();
     test_max_concurrent_streams_gates_a_compliant_client();
     test_goaway_finishes_in_flight_and_refuses_new();
+    test_unopenable_file_response_is_reported_not_swallowed();
   } catch (const std::exception &error) {
     std::cerr << "hgraph_web_h2_engine_tests failed: " << error.what()
               << "\n";


### PR DESCRIPTION
Follow-up to the four fixes in #525, closing the two things I flagged there as unresolved.

## 1. Format-injection audit

The bug fixed in #525 was that substituted values were injected into a query *before* `str.format` ran, so braces arriving inside a secret were re-read as format fields — and, as the test there demonstrates, a value of `{symbol.__class__}` actually resolved to `<class 'str'>`, reading the caller's options back out. That warranted checking whether the same shape existed anywhere else.

**It does not.** Every other `.format()` site takes a developer-authored template with runtime data only ever arriving as *arguments*, which is safe for this class:

| Site | Verdict |
|---|---|
| `delta_query_subscriber.py:38` | Plain `self.query.format(**options)`, no substitution — same safe shape as the batch source |
| `sql_adaptor_batch.py:65` | Plain format, no substitution |
| `_wiring/_core.py`, `_operator_signature.py` | `PublicTypePatternFormatter` over internal type patterns |
| `_node.py:466` | `format_map` over a developer-authored node label |
| `parse_connection_params` | Substitutes but never formats afterwards, **and** percent-encodes the result, so braces cannot survive as fields |

That last one is the interesting near-miss: it is the only other `process_substitution` consumer, and it is safe for a different reason than the fixed site — `quote(..., safe="")` neutralises braces rather than escaping them.

**One adjacent observation, deliberately not actioned.** `sql_adaptor_batch.py:239` formats a developer-authored filter template with runtime option values and passes the result to `pl.sql_expr`. That is the *inverse* shape — trusted template, untrusted values — so it is not a format injection, but it does mean a runtime option value becomes part of a SQL expression. The blast radius is a Polars in-memory frame rather than a database, and it predates #525, so I have left it alone; flagging it in case filters are ever relied on for row-level access control.

## 2. The HTTP/2 recovery has a test now — for the half that can have one

#525 made the driver answer 500 and reset the stream when `submit_file_response` fails, and I said plainly there that the branch was verified by inspection only. It is reachable just when a configured file vanishes or loses read permission *between* metadata resolution and send, which no test can stage deterministically.

The half that **can** be pinned is the engine contract underneath it: an unopenable path is reported as a failed submit rather than swallowed or thrown, and leaves nothing half-registered — so the same stream is still answerable, which is exactly what lets the driver put a 500 on it. If either property changed, the driver's recovery would silently become dead code and the peer would wait on that stream forever.

I did **not** stage the failure with `chmod`. A permission-based test passes as root and would be a flake waiting for whichever CI image happens to run that way.

The driver branch itself remains covered by inspection. Testing it properly would need a fault-injection seam in `H2Engine`, which is more machinery than the finding justifies — happy to add one if you disagree.

## Verification

All 8 web suites pass, including both HTTP/2 loopback suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
