### PR TITLE
Implement RFC 0026 consistency resolution

### DIFF
--- a/extensions/fabric/CMakeLists.txt
+++ b/extensions/fabric/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(hgraph_fabric
     src/operators.cpp
     src/planning.cpp
     src/publication.cpp
+    src/resolution.cpp
     src/types.cpp
     src/value_builders.cpp
     src/impl/memory_notifier.cpp

--- a/extensions/fabric/README.md
+++ b/extensions/fabric/README.md
@@ -15,8 +15,14 @@ change the durable winner. The wiring-time planner discovers subscriptions
 through direct and nested graph ownership, validates explicit dependency
 handles, partitions
 independent consistency forests, and wires one root coordinator with hidden
-lineage cuts. Later RFC checkpoints connect that plan to consistent-cut
-resolution, subscription modes, and Kafka.
+lineage cuts. The ingress consistency resolver observes and repairs accepted
+heads, caches immutable revisions and Frames,
+indexes revision runs by output version, and selects the unique greatest
+newest-compatible cut. Its coordinator dynamically merges and splits
+consistency forests, isolates failed forests, prevents exposed root regression,
+and returns changed roots as one atomic graph-delivery batch together with the
+updated hidden lineage. Later RFC checkpoints connect that coordinator to
+subscription modes and Kafka.
 
 Durable keys use a canonical reversible data-id segment and a portable
 1,024-byte whole-key limit shared with S3. The fabric prefix and encoded data

--- a/extensions/fabric/include/hgraph/fabric/fabric.h
+++ b/extensions/fabric/include/hgraph/fabric/fabric.h
@@ -8,6 +8,7 @@
 #include <hgraph/fabric/operators.h>
 #include <hgraph/fabric/planning.h>
 #include <hgraph/fabric/publication.h>
+#include <hgraph/fabric/resolution.h>
 #include <hgraph/fabric/types.h>
 #include <hgraph/fabric/value_builders.h>
 

--- a/extensions/fabric/include/hgraph/fabric/resolution.h
+++ b/extensions/fabric/include/hgraph/fabric/resolution.h
@@ -1,0 +1,199 @@
+#ifndef HGRAPH_FABRIC_RESOLUTION_H
+#define HGRAPH_FABRIC_RESOLUTION_H
+
+#include <hgraph/fabric/config.h>
+#include <hgraph/fabric/export.h>
+#include <hgraph/fabric/types.h>
+
+#include <hgraph/types/frame.h>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <ostream>
+#include <span>
+#include <string_view>
+#include <vector>
+
+namespace hgraph::fabric {
+/** Outcome of resolving one independent RFC 0026 consistency forest. */
+enum class ResolutionStatus : std::uint8_t {
+  Ready,
+  Unchanged,
+  Pending,
+  Ambiguous,
+  Cyclic,
+  Corrupt,
+};
+
+[[nodiscard]] constexpr std::string_view
+enum_name(ResolutionStatus value) noexcept {
+  switch (value) {
+  case ResolutionStatus::Ready:
+    return "Ready";
+  case ResolutionStatus::Unchanged:
+    return "Unchanged";
+  case ResolutionStatus::Pending:
+    return "Pending";
+  case ResolutionStatus::Ambiguous:
+    return "Ambiguous";
+  case ResolutionStatus::Cyclic:
+    return "Cyclic";
+  case ResolutionStatus::Corrupt:
+    return "Corrupt";
+  }
+  return "Unknown";
+}
+
+inline std::ostream &operator<<(std::ostream &stream, ResolutionStatus value) {
+  return stream << enum_name(value);
+}
+
+/** Previously exposed version of one direct root. It is a lower bound:
+    resolution may change hidden lineage but never return an older root
+    version to a running graph. */
+struct ExposedRootVersion {
+  Str data_id{};
+  DataVersion output_version{};
+
+  friend bool operator==(const ExposedRootVersion &,
+                         const ExposedRootVersion &) = default;
+};
+
+/** One immutable revision selected into a resolved transitive closure. */
+struct ResolvedRevision {
+  Str data_id{};
+  RevisionId revision{};
+  DataVersion output_version{};
+  std::vector<DataDependencyInput> dependencies{};
+  DateTime as_of{MIN_DT};
+
+  friend bool operator==(const ResolvedRevision &,
+                         const ResolvedRevision &) = default;
+};
+
+struct ResolvedCut {
+  std::vector<Str> roots{};
+  std::vector<ResolvedRevision> revisions{};
+
+  friend bool operator==(const ResolvedCut &, const ResolvedCut &) = default;
+};
+
+/** A direct root Frame which must be delivered in the next single graph
+    evaluation cycle. No entry is emitted for a root whose selected
+    revision changed while its output version remained unchanged. */
+struct RootUpdate {
+  Str data_id{};
+  RevisionId revision{};
+  DataVersion output_version{};
+  Frame frame{};
+};
+
+/** Per-call resolver work counters. Cache counters describe immutable
+    revision/Frame reuse; depth_sum / candidate_selections is the average
+    explored backtracking depth. */
+struct ResolverMetrics {
+  std::uint64_t accepted_heads_observed{};
+  std::uint64_t revision_cache_hits{};
+  std::uint64_t revision_cache_misses{};
+  std::uint64_t frame_cache_hits{};
+  std::uint64_t frame_cache_misses{};
+  std::uint64_t output_index_hits{};
+  std::uint64_t output_index_misses{};
+  std::uint64_t revisions_examined{};
+  std::uint64_t edges_examined{};
+  std::uint64_t candidate_selections{};
+  std::uint64_t backtracking_depth_sum{};
+  std::uint64_t maximum_backtracking_depth{};
+  /** Present on a coordinator result when both a notice timestamp and a
+      successful-cut timestamp were supplied. */
+  std::optional<TimeDelta> notice_to_ready{};
+
+  [[nodiscard]] double average_backtracking_depth() const noexcept {
+    return candidate_selections == 0
+               ? 0.0
+               : static_cast<double>(backtracking_depth_sum) /
+                     static_cast<double>(candidate_selections);
+  }
+};
+
+struct ForestResolution {
+  ResolutionStatus status{ResolutionStatus::Pending};
+  std::vector<Str> roots{};
+  /** Union of newest-compatible ancestry considered when deciding
+      dynamic forest membership. */
+  std::vector<Str> observed_data_ids{};
+  std::optional<ResolvedCut> cut{};
+  std::vector<RootUpdate> changed_roots{};
+  ResolverMetrics metrics{};
+  Str diagnostic{};
+};
+
+/** Stateful cold-path consistency resolver.
+
+    Immutable revisions and Frames are cached for the resolver lifetime;
+    each new accepted slot is validated exactly once and indexed by output
+    version. Search is newest-first depth-first backtracking. Its worst-case
+    time is exponential in an ambiguous forest (the contract requires all
+    maximal closures to be distinguished), O(R + E) for the usual unique
+    closure, and O(new revisions + retained indexes) storage. The class is
+    intended to be owned by one ingress coordinator and is not thread-safe. */
+class HGRAPH_FABRIC_EXPORT ConsistencyResolver final {
+public:
+  explicit ConsistencyResolver(FabricConfig config);
+  ~ConsistencyResolver();
+
+  ConsistencyResolver(const ConsistencyResolver &) = delete;
+  ConsistencyResolver &operator=(const ConsistencyResolver &) = delete;
+  ConsistencyResolver(ConsistencyResolver &&) noexcept;
+  ConsistencyResolver &operator=(ConsistencyResolver &&) noexcept;
+
+  [[nodiscard]] ForestResolution
+  resolve_forest(std::vector<Str> roots,
+                 std::span<const ExposedRootVersion> exposed_roots = {});
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+/** One atomic ingress decision. Successful forests may advance while an
+    unrelated forest remains pending or fails. changed_roots is the single
+    visible delivery batch; committed_lineage is the hidden selection after
+    applying every successful forest in the same decision. */
+struct CoordinationResult {
+  std::vector<ForestResolution> forests{};
+  std::vector<RootUpdate> changed_roots{};
+  std::vector<ResolvedRevision> committed_lineage{};
+};
+
+/** Repartitions roots on each resolve, merging newest ancestry which
+    intersects and allowing dependency-set changes to split it again.
+    Successful cuts and their hidden lineage commit atomically with the
+    returned root batch; failed forests retain their previously exposed
+    cut and do not block independent forests. */
+class HGRAPH_FABRIC_EXPORT ConsistencyCoordinator final {
+public:
+  ConsistencyCoordinator(FabricConfig config, std::vector<Str> roots);
+  ~ConsistencyCoordinator();
+
+  ConsistencyCoordinator(const ConsistencyCoordinator &) = delete;
+  ConsistencyCoordinator &operator=(const ConsistencyCoordinator &) = delete;
+  ConsistencyCoordinator(ConsistencyCoordinator &&) noexcept;
+  ConsistencyCoordinator &operator=(ConsistencyCoordinator &&) noexcept;
+
+  /** Conflate a notice by data id while retaining its earliest latency origin.
+   */
+  void observe_notice(Str data_id, DateTime noticed_at);
+
+  /** Resolve current accepted heads. MIN_DT omits notice latency for startup
+      image calls which did not originate from a notice. */
+  [[nodiscard]] CoordinationResult resolve(DateTime ready_at = MIN_DT);
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+} // namespace hgraph::fabric
+
+#endif // HGRAPH_FABRIC_RESOLUTION_H

--- a/extensions/fabric/python/hgraph_fabric/__init__.py
+++ b/extensions/fabric/python/hgraph_fabric/__init__.py
@@ -22,6 +22,7 @@ DataVersion = int
 RevisionId = int
 SubscriptionMode = _native.SubscriptionMode
 FabricSubscriptionMode = SubscriptionMode
+ResolutionStatus = _native.ResolutionStatus
 
 
 @dataclass(frozen=True)
@@ -196,6 +197,22 @@ def decode_latest_reference(encoded: bytes) -> RevisionId:
     return _native._decode_revision_reference(3, encoded)
 
 
+def _resolve_fixture(
+    revisions: tuple[DataRevision, ...],
+    roots: tuple[str, ...],
+    exposed: tuple[tuple[str, DataVersion], ...] = (),
+):
+    """Exercise the native resolver over an isolated in-memory history.
+
+    This private compatibility-test seam keeps Python examples on the same
+    C++ resolver and persistence contracts as production ingress.
+    """
+
+    return _native._resolve_fixture(
+        [encode_revision(revision) for revision in revisions], roots, exposed
+    )
+
+
 __all__ = [
     "AS_OF_MEDIA_TYPE",
     "AUTO",
@@ -208,6 +225,7 @@ __all__ = [
     "LATEST_MEDIA_TYPE",
     "REVISION_MEDIA_TYPE",
     "RevisionId",
+    "ResolutionStatus",
     "SubscriptionMode",
     "decode_as_of_reference",
     "decode_latest_reference",

--- a/extensions/fabric/python/tests/test_distribution_audit.py
+++ b/extensions/fabric/python/tests/test_distribution_audit.py
@@ -29,6 +29,7 @@ def test_wheel_audit_accepts_platform_library_directories(
         "include/hgraph/fabric/operators.h": "",
         "include/hgraph/fabric/planning.h": "",
         "include/hgraph/fabric/publication.h": "",
+        "include/hgraph/fabric/resolution.h": "",
         "include/hgraph/fabric/types.h": "",
         "include/hgraph/fabric/value_builders.h": "",
         f"{library_directory}/libhgraph_fabric.a": "",

--- a/extensions/fabric/python/tests/test_resolution.py
+++ b/extensions/fabric/python/tests/test_resolution.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+import hgraph_fabric as hgf
+
+
+BASE = datetime(2027, 1, 15)
+
+
+def revision(
+    data_id: str,
+    revision_id: int,
+    output_version: int,
+    dependencies: tuple[tuple[str, int], ...] = (),
+    self_predecessor: int | None = None,
+) -> hgf.DataRevision:
+    return hgf.DataRevision(
+        format_version=1,
+        data_id=data_id,
+        revision=revision_id,
+        output_version=output_version,
+        dependencies=tuple(hgf.DataDependency(*item) for item in dependencies),
+        self_predecessor=self_predecessor,
+        as_of=BASE + timedelta(microseconds=revision_id),
+    )
+
+
+def bootstrap() -> list[hgf.DataRevision]:
+    values: list[hgf.DataRevision] = []
+    for revision_id in range(1, 4):
+        values.append(revision("D1", revision_id, revision_id))
+        values.append(
+            revision(
+                "D2",
+                revision_id,
+                revision_id,
+                (("D1", revision_id),),
+            )
+        )
+    values.extend(
+        [
+            revision("D3", 1, 1, (("D2", 1),)),
+            revision("D3", 2, 2, (("D2", 2),)),
+        ]
+    )
+    return values
+
+
+def cut(result) -> dict[str, tuple[int, int]]:
+    return {data_id: (revision_id, version) for data_id, revision_id, version in result["cut"]}
+
+
+def test_python_uses_native_resolver_for_bootstrap_and_held_parent_release():
+    initial = hgf._resolve_fixture(tuple(bootstrap()), ("D1", "D3"))
+    assert initial["status"] is hgf.ResolutionStatus.READY
+    assert cut(initial) == {"D1": (2, 2), "D2": (2, 2), "D3": (2, 2)}
+    assert initial["changed_roots"] == [("D1", 2, 2), ("D3", 2, 2)]
+
+    released_history = bootstrap()
+    released_history.append(revision("D3", 3, 2, (("D2", 3),)))
+    released = hgf._resolve_fixture(
+        tuple(released_history),
+        ("D1", "D3"),
+        (("D1", 2), ("D3", 2)),
+    )
+    assert released["status"] is hgf.ResolutionStatus.READY
+    assert cut(released)["D3"] == (3, 2)
+    assert released["changed_roots"] == [("D1", 3, 3)]
+
+
+def test_python_native_resolver_rolls_same_output_ancestry_newest_first():
+    count = 40
+    history: list[hgf.DataRevision] = []
+    for revision_id in range(1, count + 1):
+        history.append(revision("P", revision_id, revision_id))
+        history.append(
+            revision(
+                "A",
+                revision_id,
+                count + 1,
+                (("P", revision_id),),
+            )
+        )
+    history.append(revision("D", 1, 1, (("A", count + 1),)))
+
+    result = hgf._resolve_fixture(tuple(history), ("D", "P"))
+    assert result["status"] is hgf.ResolutionStatus.READY
+    assert cut(result)["A"] == (count, count + 1)
+    assert result["metrics"]["output_index_hits"] >= count
+
+
+def test_python_native_resolver_reports_ambiguous_cyclic_and_self_audit():
+    ambiguous = hgf._resolve_fixture(
+        (
+            revision("X", 1, 1),
+            revision("X", 2, 2),
+            revision("A", 1, 1, (("X", 1),)),
+            revision("A", 2, 2, (("X", 2),)),
+            revision("B", 1, 1, (("X", 2),)),
+            revision("B", 2, 2, (("X", 1),)),
+        ),
+        ("A", "B"),
+    )
+    assert ambiguous["status"] is hgf.ResolutionStatus.AMBIGUOUS
+
+    cyclic = hgf._resolve_fixture(
+        (
+            revision("A", 1, 1, (("B", 1),)),
+            revision("B", 1, 1, (("A", 1),)),
+        ),
+        ("A",),
+    )
+    assert cyclic["status"] is hgf.ResolutionStatus.CYCLIC
+
+    self_audit = hgf._resolve_fixture(
+        (revision("A", 1, 1), revision("A", 2, 2, self_predecessor=1)),
+        ("A",),
+    )
+    assert self_audit["status"] is hgf.ResolutionStatus.READY
+    assert cut(self_audit)["A"] == (2, 2)

--- a/extensions/fabric/src/python_module.cpp
+++ b/extensions/fabric/src/python_module.cpp
@@ -1,5 +1,7 @@
+#include <hgraph/fabric/keys.h>
 #include <hgraph/fabric/metadata_codec.h>
 #include <hgraph/fabric/operators.h>
+#include <hgraph/fabric/resolution.h>
 #include <hgraph/fabric/value_builders.h>
 
 #include <hgraph/python/native_scalar_registration.h>
@@ -11,8 +13,14 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
+#include <arrow/builder.h>
+#include <arrow/table.h>
+
+#include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <span>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -31,6 +39,23 @@ namespace
     {
         return {reinterpret_cast<const std::byte *>(value.c_str()), value.size()};
     }
+
+    [[nodiscard]] hgraph::Frame fixture_frame(std::int64_t value)
+    {
+        arrow::Int64Builder builder;
+        if (!builder.Append(value).ok())
+        {
+            throw std::runtime_error("failed to append resolver fixture value");
+        }
+        auto array = builder.Finish();
+        if (!array.ok())
+        {
+            throw std::runtime_error("failed to finish resolver fixture value");
+        }
+        return hgraph::Frame{arrow::Table::Make(
+            arrow::schema({arrow::field("value", arrow::int64())}),
+            {std::move(array).ValueOrDie()})};
+    }
 }  // namespace
 
 NB_MODULE(_hgraph_fabric, module)
@@ -42,6 +67,13 @@ NB_MODULE(_hgraph_fabric, module)
                     .value("LIVE", SubscriptionMode::Live)
                     .value("REPLAY", SubscriptionMode::Replay)
                     .value("SNAPSHOT", SubscriptionMode::Snapshot);
+    nb::enum_<ResolutionStatus>(module, "ResolutionStatus")
+        .value("READY", ResolutionStatus::Ready)
+        .value("UNCHANGED", ResolutionStatus::Unchanged)
+        .value("PENDING", ResolutionStatus::Pending)
+        .value("AMBIGUOUS", ResolutionStatus::Ambiguous)
+        .value("CYCLIC", ResolutionStatus::Cyclic)
+        .value("CORRUPT", ResolutionStatus::Corrupt);
 
     register_fabric_operators();
     OperatorRegistry::instance().register_installer(
@@ -122,6 +154,102 @@ NB_MODULE(_hgraph_fabric, module)
                 static_cast<MetadataObjectKind>(kind), bytes_view(encoded));
         },
         nb::arg("kind"), nb::arg("encoded"));
+
+    module.def(
+        "_resolve_fixture",
+        [](nb::iterable encoded_revisions, std::vector<Str> roots,
+           std::vector<std::pair<Str, DataVersion>> exposed) {
+            std::vector<DataRevisionInput> revisions;
+            for (nb::handle item : encoded_revisions)
+            {
+                const nb::bytes encoded = nb::cast<nb::bytes>(item);
+                revisions.push_back(data_revision_input(
+                    decode_revision(bytes_view(encoded)).view()));
+            }
+            std::ranges::sort(
+                revisions,
+                [](const DataRevisionInput &lhs, const DataRevisionInput &rhs) {
+                    if (lhs.data_id == rhs.data_id)
+                    {
+                        return lhs.revision < rhs.revision;
+                    }
+                    return canonical_data_id_less(lhs.data_id, rhs.data_id);
+                });
+
+            FabricConfig config =
+                make_memory_fabric_config("python/resolution-fixture");
+            for (const auto &revision : revisions)
+            {
+                const std::string frame_key = data_version_key(
+                    config.prefix, revision.data_id, revision.output_version);
+                if (!config.frames.contains(frame_key))
+                {
+                    config.frames.write(
+                        frame_key, fixture_frame(revision.output_version));
+                }
+                Value value = make_data_revision(revision);
+                const auto stored = config.objects.put_immutable(
+                    revision_key(config.prefix, revision.data_id,
+                                 revision.revision),
+                    encode_revision(value.view()));
+                if (stored.status !=
+                    persistence::store::ImmutableWriteStatus::Created)
+                {
+                    throw std::invalid_argument(
+                        "resolver fixture revisions must have unique slots");
+                }
+            }
+            std::vector<ExposedRootVersion> native_exposed;
+            native_exposed.reserve(exposed.size());
+            for (auto &[data_id, version] : exposed)
+            {
+                native_exposed.push_back(
+                    {.data_id = std::move(data_id), .output_version = version});
+            }
+
+            ConsistencyResolver resolver{std::move(config)};
+            const ForestResolution result =
+                resolver.resolve_forest(std::move(roots), native_exposed);
+            nb::dict output;
+            output["status"] = result.status;
+            output["diagnostic"] = result.diagnostic;
+            output["observed_data_ids"] = result.observed_data_ids;
+            nb::list cut;
+            if (result.cut.has_value())
+            {
+                for (const auto &revision : result.cut->revisions)
+                {
+                    cut.append(nb::make_tuple(
+                        revision.data_id, revision.revision,
+                        revision.output_version));
+                }
+            }
+            output["cut"] = std::move(cut);
+            nb::list changed;
+            for (const auto &root : result.changed_roots)
+            {
+                changed.append(nb::make_tuple(
+                    root.data_id, root.revision, root.output_version));
+            }
+            output["changed_roots"] = std::move(changed);
+            nb::dict metrics;
+            metrics["revision_cache_hits"] = result.metrics.revision_cache_hits;
+            metrics["revision_cache_misses"] =
+                result.metrics.revision_cache_misses;
+            metrics["output_index_hits"] = result.metrics.output_index_hits;
+            metrics["revisions_examined"] = result.metrics.revisions_examined;
+            metrics["edges_examined"] = result.metrics.edges_examined;
+            metrics["maximum_backtracking_depth"] =
+                result.metrics.maximum_backtracking_depth;
+            metrics["notice_to_ready_microseconds"] =
+                result.metrics.notice_to_ready.has_value()
+                    ? nb::cast(result.metrics.notice_to_ready->count())
+                    : nb::none();
+            output["metrics"] = std::move(metrics);
+            return output;
+        },
+        nb::arg("encoded_revisions"), nb::arg("roots"),
+        nb::arg("exposed") = std::vector<std::pair<Str, DataVersion>>{});
 
     module.attr("REVISION_MEDIA_TYPE") = std::string{REVISION_MEDIA_TYPE};
     module.attr("AS_OF_MEDIA_TYPE") = std::string{AS_OF_MEDIA_TYPE};

--- a/extensions/fabric/src/resolution.cpp
+++ b/extensions/fabric/src/resolution.cpp
@@ -398,14 +398,14 @@ struct ConsistencyResolver::Impl {
       return;
     }
 
-    if (root) {
-      // Forest membership follows the newest accepted acknowledgement, not
-      // every historical acknowledgement which reused its output version.
-      // Older same-output ancestry remains available to compatible-cut search,
-      // but must not keep roots coupled after their latest lineages split.
-      values.resize(1);
-    }
-    for (const auto *candidate : values) {
+    // Forest membership follows only the newest accepted acknowledgement for
+    // a root, not every historical acknowledgement which reused its output
+    // version. Older same-output ancestry remains available to compatible-cut
+    // search, but must not keep roots coupled after their latest lineages
+    // split.
+    const auto candidate_count = root ? std::size_t{1} : values.size();
+    for (std::size_t index = 0; index < candidate_count; ++index) {
+      const auto *candidate = values[index];
       for (const auto &dependency : candidate->dependencies) {
         discover_requirement(dependency.data_id, dependency.version, false,
                              visited, observed);

--- a/extensions/fabric/src/resolution.cpp
+++ b/extensions/fabric/src/resolution.cpp
@@ -1,0 +1,892 @@
+#include <hgraph/fabric/resolution.h>
+
+#include <hgraph/fabric/keys.h>
+#include <hgraph/fabric/metadata_codec.h>
+#include <hgraph/fabric/value_builders.h>
+
+#include <arrow/table.h>
+
+#include <algorithm>
+#include <limits>
+#include <map>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+namespace hgraph::fabric {
+namespace {
+using persistence::store::ImmutableWriteStatus;
+using persistence::store::ObjectBytes;
+using persistence::store::StoredObject;
+
+struct IdLess {
+  using is_transparent = void;
+
+  [[nodiscard]] bool operator()(std::string_view lhs,
+                                std::string_view rhs) const noexcept {
+    return canonical_data_id_less(lhs, rhs);
+  }
+};
+
+class CorruptHistory final : public std::runtime_error {
+public:
+  using std::runtime_error::runtime_error;
+};
+
+[[nodiscard]] Int checked_increment(Int value, std::string_view field) {
+  if (value == std::numeric_limits<Int>::max()) {
+    throw CorruptHistory("fabric " + std::string{field} + " is exhausted");
+  }
+  return value + 1;
+}
+
+void canonicalise_ids(std::vector<Str> &ids, std::string_view subject) {
+  if (ids.empty()) {
+    throw std::invalid_argument("fabric " + std::string{subject} +
+                                " must not be empty");
+  }
+  for (const auto &id : ids) {
+    require_data_id(id);
+  }
+  std::ranges::sort(ids, canonical_data_id_less);
+  if (std::ranges::adjacent_find(ids) != ids.end()) {
+    throw std::invalid_argument("fabric " + std::string{subject} +
+                                " data ids must be unique");
+  }
+}
+
+[[nodiscard]] bool same_tuple(const DataRevisionInput &lhs,
+                              const DataRevisionInput &rhs) {
+  return lhs.output_version == rhs.output_version &&
+         lhs.dependencies == rhs.dependencies &&
+         lhs.self_predecessor == rhs.self_predecessor;
+}
+
+[[nodiscard]] ResolvedRevision resolved(const DataRevisionInput &value) {
+  return ResolvedRevision{
+      .data_id = value.data_id,
+      .revision = value.revision,
+      .output_version = value.output_version,
+      .dependencies = value.dependencies,
+      .as_of = value.as_of,
+  };
+}
+
+[[nodiscard]] bool successful(ResolutionStatus status) noexcept {
+  return status == ResolutionStatus::Ready ||
+         status == ResolutionStatus::Unchanged;
+}
+
+[[nodiscard]] bool intersects(const std::vector<Str> &lhs,
+                              const std::vector<Str> &rhs) {
+  auto left = lhs.begin();
+  auto right = rhs.begin();
+  while (left != lhs.end() && right != rhs.end()) {
+    if (*left == *right) {
+      return true;
+    }
+    if (canonical_data_id_less(*left, *right)) {
+      ++left;
+    } else {
+      ++right;
+    }
+  }
+  return false;
+}
+} // namespace
+
+struct ConsistencyResolver::Impl {
+  struct CachedData {
+    std::vector<DataRevisionInput> revisions{};
+    std::map<DataVersion, std::vector<std::size_t>> output_index{};
+    std::map<DataVersion, Frame> frames{};
+    std::shared_ptr<arrow::Schema> fixed_schema{};
+  };
+
+  struct Requirement {
+    bool root{};
+    std::optional<DataVersion> version{};
+  };
+
+  struct SearchState {
+    std::map<Str, Requirement, IdLess> requirements{};
+    std::map<Str, DataRevisionInput, IdLess> selected{};
+  };
+
+  FabricConfig config;
+  std::map<Str, CachedData, IdLess> cache{};
+  std::set<Str, IdLess> refreshed_this_call{};
+  ResolverMetrics metrics{};
+  std::map<Str, DataVersion, IdLess> lower_bounds{};
+  std::vector<ResolvedCut> maxima{};
+  bool saw_cycle{};
+
+  explicit Impl(FabricConfig configured) : config(std::move(configured)) {
+    require_valid_config(config);
+  }
+
+  [[nodiscard]] DataRevisionInput
+  decode_slot(std::string_view data_id, RevisionId revision,
+              const StoredObject &object) const {
+    try {
+      DataRevisionInput decoded =
+          data_revision_input(decode_revision(object.data).view());
+      if (decoded.data_id != data_id || decoded.revision != revision) {
+        throw CorruptHistory(
+            "fabric revision payload does not match its durable key");
+      }
+      return decoded;
+    } catch (const CorruptHistory &) {
+      throw;
+    } catch (const std::exception &error) {
+      throw CorruptHistory("fabric revision slot is malformed for '" +
+                           std::string{data_id} + "': " + error.what());
+    }
+  }
+
+  [[nodiscard]] std::optional<RevisionId>
+  indexed_latest(std::string_view data_id) const {
+    const auto object = config.objects.get(latest_key(config.prefix, data_id));
+    if (!object.has_value()) {
+      return std::nullopt;
+    }
+    try {
+      return decode_revision_reference(MetadataObjectKind::Latest,
+                                       object->data);
+    } catch (const std::exception &error) {
+      throw CorruptHistory("fabric latest index is malformed for '" +
+                           std::string{data_id} + "': " + error.what());
+    }
+  }
+
+  void repair_as_of(const DataRevisionInput &revision) const {
+    const ObjectBytes desired =
+        encode_revision_reference(MetadataObjectKind::AsOf, revision.revision);
+    const auto result = config.objects.put_immutable(
+        as_of_key(config.prefix, revision.data_id, revision.as_of), desired);
+    if (result.status == ImmutableWriteStatus::Conflict) {
+      throw CorruptHistory(
+          "fabric as-of entry conflicts with accepted revision '" +
+          revision.data_id + "':" + std::to_string(revision.revision));
+    }
+  }
+
+  void advance_latest(std::string_view data_id, RevisionId target) const {
+    const std::string key = latest_key(config.prefix, data_id);
+    const ObjectBytes desired =
+        encode_revision_reference(MetadataObjectKind::Latest, target);
+    for (;;) {
+      const auto current = config.objects.get(key);
+      if (current.has_value()) {
+        RevisionId current_revision{};
+        try {
+          current_revision = decode_revision_reference(
+              MetadataObjectKind::Latest, current->data);
+        } catch (const std::exception &error) {
+          throw CorruptHistory("fabric latest index is malformed for '" +
+                               std::string{data_id} + "': " + error.what());
+        }
+        if (current_revision >= target) {
+          return;
+        }
+      }
+      const auto result = config.objects.compare_exchange_ref(
+          key,
+          current.has_value()
+              ? std::optional<std::string_view>{current->version_token}
+              : std::nullopt,
+          desired);
+      if (result.exchanged) {
+        return;
+      }
+      if (!result.current.has_value()) {
+        continue;
+      }
+      try {
+        if (decode_revision_reference(MetadataObjectKind::Latest,
+                                      result.current->data) >= target) {
+          return;
+        }
+      } catch (const std::exception &error) {
+        throw CorruptHistory("fabric latest index is malformed for '" +
+                             std::string{data_id} + "': " + error.what());
+      }
+    }
+  }
+
+  void validate_frame(CachedData &data, const DataRevisionInput &revision) {
+    if (data.frames.contains(revision.output_version)) {
+      ++metrics.frame_cache_hits;
+      return;
+    }
+
+    ++metrics.frame_cache_misses;
+    Frame frame = config.frames.read(data_version_key(
+        config.prefix, revision.data_id, revision.output_version));
+    if (!frame.has_value()) {
+      throw CorruptHistory(
+          "fabric accepted revision references a missing durable Frame: " +
+          revision.data_id + ":" + std::to_string(revision.output_version));
+    }
+    if (data.fixed_schema == nullptr) {
+      data.fixed_schema = frame.table->schema();
+    } else if (!frame.table->schema()->Equals(*data.fixed_schema, true)) {
+      throw CorruptHistory(
+          "fabric accepted Frame violates the fixed schema for data id '" +
+          revision.data_id + "'");
+    }
+    data.frames.emplace(revision.output_version, std::move(frame));
+  }
+
+  void append(CachedData &data, DataRevisionInput revision) {
+    if (data.revisions.empty()) {
+      if (revision.revision != 1) {
+        throw CorruptHistory("fabric revision history does not start at one");
+      }
+    } else {
+      const auto &previous = data.revisions.back();
+      if (revision.revision !=
+          checked_increment(previous.revision, "revision id")) {
+        throw CorruptHistory("fabric revision history is not contiguous");
+      }
+      if (revision.as_of <= previous.as_of) {
+        throw CorruptHistory("fabric revision as-of history is not monotonic");
+      }
+      if (revision.output_version < previous.output_version) {
+        throw CorruptHistory("fabric output version history regressed");
+      }
+      if (same_tuple(revision, previous)) {
+        throw CorruptHistory(
+            "fabric revision history contains a duplicate accepted tuple");
+      }
+    }
+
+    validate_frame(data, revision);
+    repair_as_of(revision);
+    data.output_index[revision.output_version].push_back(data.revisions.size());
+    data.revisions.push_back(std::move(revision));
+    ++metrics.revision_cache_misses;
+  }
+
+  void require_no_gap(std::string_view data_id, RevisionId expected) const {
+    const std::string prefix = revision_key_prefix(config.prefix, data_id);
+    const std::optional<std::string> start_after =
+        expected == 1 ? std::nullopt
+                      : std::optional<std::string>{
+                            revision_key(config.prefix, data_id, expected - 1)};
+    const auto page = config.objects.list(
+        prefix,
+        start_after.has_value() ? std::optional<std::string_view>{*start_after}
+                                : std::nullopt,
+        1);
+    if (page.objects.empty()) {
+      return;
+    }
+    if (page.objects.front().key !=
+        revision_key(config.prefix, data_id, expected)) {
+      throw CorruptHistory("fabric revision history contains a non-contiguous "
+                           "or malformed slot");
+    }
+    throw CorruptHistory(
+        "fabric revision listing disagrees with immutable slot lookup");
+  }
+
+  CachedData &refresh(std::string_view data_id) {
+    require_data_id(data_id);
+    if (!refreshed_this_call.emplace(data_id).second) {
+      ++metrics.revision_cache_hits;
+      return cache.find(data_id)->second;
+    }
+    auto [entry, inserted] = cache.try_emplace(Str{data_id});
+    auto &data = entry->second;
+    const std::size_t before = data.revisions.size();
+    const auto latest = indexed_latest(data_id);
+    if (data.revisions.size() >=
+        static_cast<std::size_t>(std::numeric_limits<RevisionId>::max())) {
+      throw CorruptHistory("fabric revision id is exhausted");
+    }
+    RevisionId next = static_cast<RevisionId>(data.revisions.size() + 1);
+
+    if (latest.has_value() && *latest < 1) {
+      throw CorruptHistory("fabric latest index must be positive");
+    }
+    while (latest.has_value() && next <= *latest) {
+      const auto object =
+          config.objects.get(revision_key(config.prefix, data_id, next));
+      if (!object.has_value()) {
+        throw CorruptHistory("fabric accepted revision slot is missing: " +
+                             std::string{data_id} + ":" + std::to_string(next));
+      }
+      append(data, decode_slot(data_id, next, *object));
+      next = checked_increment(next, "revision id");
+    }
+
+    for (;;) {
+      const auto object =
+          config.objects.get(revision_key(config.prefix, data_id, next));
+      if (!object.has_value()) {
+        break;
+      }
+      append(data, decode_slot(data_id, next, *object));
+      next = checked_increment(next, "revision id");
+    }
+    require_no_gap(data_id, next);
+
+    if (data.revisions.empty()) {
+      if (latest.has_value()) {
+        throw CorruptHistory(
+            "fabric latest refers to an empty revision history");
+      }
+    } else {
+      advance_latest(data_id, data.revisions.back().revision);
+    }
+
+    if (!inserted && data.revisions.size() == before && before != 0) {
+      ++metrics.revision_cache_hits;
+    }
+    ++metrics.accepted_heads_observed;
+    return data;
+  }
+
+  [[nodiscard]] std::vector<const DataRevisionInput *>
+  candidates(const Str &data_id, const Requirement &requirement) {
+    auto &data = refresh(data_id);
+    std::vector<const DataRevisionInput *> result;
+    if (requirement.version.has_value()) {
+      const auto found = data.output_index.find(*requirement.version);
+      if (found == data.output_index.end()) {
+        ++metrics.output_index_misses;
+        throw CorruptHistory(
+            "fabric accepted revision references missing data version '" +
+            data_id + "':" + std::to_string(*requirement.version));
+      }
+      ++metrics.output_index_hits;
+      result.reserve(found->second.size());
+      for (auto index = found->second.rbegin(); index != found->second.rend();
+           ++index) {
+        result.push_back(&data.revisions[*index]);
+      }
+      return result;
+    }
+
+    result.reserve(data.revisions.size());
+    const auto lower = lower_bounds.find(data_id);
+    for (auto revision = data.revisions.rbegin();
+         revision != data.revisions.rend(); ++revision) {
+      if (lower != lower_bounds.end() &&
+          revision->output_version < lower->second) {
+        continue;
+      }
+      result.push_back(&*revision);
+    }
+    return result;
+  }
+
+  void discover_requirement(
+      const Str &data_id, std::optional<DataVersion> version, bool root,
+      std::set<std::pair<Str, std::optional<DataVersion>>> &visited,
+      std::set<Str, IdLess> &observed) {
+    if (!visited.emplace(data_id, version).second) {
+      return;
+    }
+    observed.insert(data_id);
+    Requirement requirement{.root = root, .version = version};
+    auto values = candidates(data_id, requirement);
+    if (values.empty()) {
+      return;
+    }
+
+    if (root) {
+      const DataVersion newest = values.front()->output_version;
+      std::erase_if(values, [newest](const DataRevisionInput *item) {
+        return item->output_version != newest;
+      });
+    }
+    for (const auto *candidate : values) {
+      for (const auto &dependency : candidate->dependencies) {
+        discover_requirement(dependency.data_id, dependency.version, false,
+                             visited, observed);
+      }
+    }
+  }
+
+  [[nodiscard]] std::vector<Str>
+  discover_frontier(const std::vector<Str> &roots) {
+    std::set<std::pair<Str, std::optional<DataVersion>>> visited;
+    std::set<Str, IdLess> observed;
+    for (const auto &root : roots) {
+      discover_requirement(root, std::nullopt, true, visited, observed);
+    }
+    return {observed.begin(), observed.end()};
+  }
+
+  [[nodiscard]] static bool
+  add_requirement(SearchState &state, const Str &data_id, DataVersion version) {
+    auto [found, inserted] = state.requirements.try_emplace(
+        data_id, Requirement{.version = version});
+    if (!inserted) {
+      if (found->second.version.has_value() &&
+          *found->second.version != version) {
+        return false;
+      }
+      found->second.version = version;
+    }
+    const auto selected = state.selected.find(data_id);
+    return selected == state.selected.end() ||
+           selected->second.output_version == version;
+  }
+
+  [[nodiscard]] static bool cyclic(const SearchState &state) {
+    enum class Mark : std::uint8_t {
+      Visiting,
+      Complete,
+    };
+    std::map<Str, Mark, IdLess> marks;
+    const auto visit = [&](const auto &self, const Str &id) -> bool {
+      const auto mark = marks.find(id);
+      if (mark != marks.end()) {
+        return mark->second == Mark::Visiting;
+      }
+      marks.emplace(id, Mark::Visiting);
+      const auto selected = state.selected.find(id);
+      if (selected != state.selected.end()) {
+        for (const auto &dependency : selected->second.dependencies) {
+          if (state.selected.contains(dependency.data_id) &&
+              self(self, dependency.data_id)) {
+            return true;
+          }
+        }
+      }
+      marks[id] = Mark::Complete;
+      return false;
+    };
+    for (const auto &[id, revision] : state.selected) {
+      static_cast<void>(revision);
+      if (visit(visit, id)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  [[nodiscard]] static ResolvedCut make_cut(const std::vector<Str> &roots,
+                                            const SearchState &state) {
+    ResolvedCut cut{.roots = roots};
+    cut.revisions.reserve(state.selected.size());
+    for (const auto &[id, revision] : state.selected) {
+      static_cast<void>(id);
+      cut.revisions.push_back(resolved(revision));
+    }
+    return cut;
+  }
+
+  [[nodiscard]] static RevisionId selected_revision(const ResolvedCut &cut,
+                                                    std::string_view data_id) {
+    const auto found =
+        std::ranges::lower_bound(cut.revisions, data_id, canonical_data_id_less,
+                                 &ResolvedRevision::data_id);
+    return found != cut.revisions.end() && found->data_id == data_id
+               ? found->revision
+               : RevisionId{0};
+  }
+
+  [[nodiscard]] static bool dominates(const ResolvedCut &lhs,
+                                      const ResolvedCut &rhs) {
+    for (const auto &revision : rhs.revisions) {
+      const RevisionId left = selected_revision(lhs, revision.data_id);
+      // Dependency sets may legitimately change. Components absent
+      // from the other closure do not order the two cuts; roots and
+      // shared ancestry do. This lets a newer root replace an old
+      // dependency rather than making every dependency-set change
+      // ambiguous.
+      if (left != 0 && left < revision.revision) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  void consider(ResolvedCut cut) {
+    for (const auto &current : maxima) {
+      if (dominates(current, cut)) {
+        return;
+      }
+    }
+    std::erase_if(maxima, [&cut](const ResolvedCut &current) {
+      return dominates(cut, current);
+    });
+    maxima.push_back(std::move(cut));
+  }
+
+  void search(const std::vector<Str> &roots, const SearchState &state) {
+    const auto unresolved =
+        std::ranges::find_if(state.requirements, [&state](const auto &entry) {
+          return !state.selected.contains(entry.first);
+        });
+    if (unresolved == state.requirements.end()) {
+      if (cyclic(state)) {
+        saw_cycle = true;
+        return;
+      }
+      consider(make_cut(roots, state));
+      return;
+    }
+
+    const Str data_id = unresolved->first;
+    const Requirement requirement = unresolved->second;
+    const auto available = candidates(data_id, requirement);
+    for (const auto *candidate : available) {
+      ++metrics.revisions_examined;
+      ++metrics.candidate_selections;
+      const std::uint64_t depth = state.selected.size() + 1;
+      metrics.backtracking_depth_sum += depth;
+      metrics.maximum_backtracking_depth =
+          std::max(metrics.maximum_backtracking_depth, depth);
+
+      SearchState next = state;
+      next.selected.emplace(data_id, *candidate);
+      bool compatible = true;
+      for (const auto &dependency : candidate->dependencies) {
+        ++metrics.edges_examined;
+        if (!add_requirement(next, dependency.data_id, dependency.version)) {
+          compatible = false;
+          break;
+        }
+      }
+      if (compatible) {
+        search(roots, next);
+      }
+    }
+  }
+
+  [[nodiscard]] const DataRevisionInput &
+  selection(const ResolvedCut &cut, std::string_view data_id) const {
+    const auto found =
+        std::ranges::lower_bound(cut.revisions, data_id, canonical_data_id_less,
+                                 &ResolvedRevision::data_id);
+    if (found == cut.revisions.end() || found->data_id != data_id) {
+      throw std::logic_error("resolved cut omitted a direct fabric root");
+    }
+    const auto data = cache.find(found->data_id);
+    if (data == cache.end() || found->revision < 1 ||
+        static_cast<std::size_t>(found->revision) >
+            data->second.revisions.size()) {
+      throw std::logic_error("resolved cut references an uncached revision");
+    }
+    return data->second
+        .revisions[static_cast<std::size_t>(found->revision - 1)];
+  }
+
+  [[nodiscard]] Frame selected_frame(const DataRevisionInput &revision) {
+    auto data = cache.find(revision.data_id);
+    if (data == cache.end()) {
+      throw std::logic_error("resolved root has no cached data");
+    }
+    const auto frame = data->second.frames.find(revision.output_version);
+    if (frame == data->second.frames.end()) {
+      throw std::logic_error("resolved root has no cached Frame");
+    }
+    ++metrics.frame_cache_hits;
+    return frame->second;
+  }
+
+  ForestResolution resolve(std::vector<Str> roots,
+                           std::span<const ExposedRootVersion> exposed) {
+    canonicalise_ids(roots, "resolver roots");
+    metrics = {};
+    lower_bounds.clear();
+    refreshed_this_call.clear();
+    maxima.clear();
+    saw_cycle = false;
+
+    for (const auto &item : exposed) {
+      require_data_id(item.data_id);
+      if (item.output_version <= 0) {
+        throw std::invalid_argument(
+            "fabric exposed root version must be positive");
+      }
+      if (!std::ranges::binary_search(roots, item.data_id,
+                                      canonical_data_id_less)) {
+        throw std::invalid_argument(
+            "fabric exposed version is not a resolver root");
+      }
+      if (!lower_bounds.emplace(item.data_id, item.output_version).second) {
+        throw std::invalid_argument(
+            "fabric exposed root versions must be unique");
+      }
+    }
+
+    ForestResolution result{.roots = roots};
+    try {
+      result.observed_data_ids = discover_frontier(roots);
+      SearchState initial;
+      for (const auto &root : roots) {
+        initial.requirements.emplace(root, Requirement{.root = true});
+      }
+      search(roots, initial);
+    } catch (const CorruptHistory &error) {
+      result.status = ResolutionStatus::Corrupt;
+      result.diagnostic = error.what();
+      result.metrics = metrics;
+      if (result.observed_data_ids.empty()) {
+        result.observed_data_ids = roots;
+      }
+      return result;
+    }
+
+    result.metrics = metrics;
+    if (maxima.empty()) {
+      result.status =
+          saw_cycle ? ResolutionStatus::Cyclic : ResolutionStatus::Pending;
+      result.diagnostic = saw_cycle
+                              ? "ordinary dependency closure is cyclic"
+                              : "no compatible acknowledgement is available";
+      return result;
+    }
+    if (maxima.size() != 1) {
+      result.status = ResolutionStatus::Ambiguous;
+      result.diagnostic =
+          "consistent closures have no unique component-wise greatest cut";
+      return result;
+    }
+
+    result.cut = std::move(maxima.front());
+    bool changed = false;
+    for (const auto &root : roots) {
+      const auto &chosen = selection(*result.cut, root);
+      const auto prior = lower_bounds.find(root);
+      if (prior == lower_bounds.end() ||
+          chosen.output_version > prior->second) {
+        changed = true;
+        result.changed_roots.push_back(RootUpdate{
+            .data_id = root,
+            .revision = chosen.revision,
+            .output_version = chosen.output_version,
+            .frame = selected_frame(chosen),
+        });
+      }
+    }
+    result.status =
+        changed ? ResolutionStatus::Ready : ResolutionStatus::Unchanged;
+    result.metrics = metrics;
+    return result;
+  }
+};
+
+ConsistencyResolver::ConsistencyResolver(FabricConfig config)
+    : impl_(std::make_unique<Impl>(std::move(config))) {}
+
+ConsistencyResolver::~ConsistencyResolver() = default;
+ConsistencyResolver::ConsistencyResolver(ConsistencyResolver &&) noexcept =
+    default;
+ConsistencyResolver &
+ConsistencyResolver::operator=(ConsistencyResolver &&) noexcept = default;
+
+ForestResolution ConsistencyResolver::resolve_forest(
+    std::vector<Str> roots, std::span<const ExposedRootVersion> exposed_roots) {
+  return impl_->resolve(std::move(roots), exposed_roots);
+}
+
+struct ConsistencyCoordinator::Impl {
+  ConsistencyResolver resolver;
+  std::vector<Str> roots;
+  std::map<Str, DataVersion, IdLess> exposed{};
+  std::map<Str, ResolvedCut, IdLess> root_cuts{};
+  std::map<Str, DateTime, IdLess> pending_notices{};
+
+  Impl(FabricConfig config, std::vector<Str> configured_roots)
+      : resolver(std::move(config)), roots(std::move(configured_roots)) {
+    canonicalise_ids(roots, "coordinator roots");
+  }
+
+  [[nodiscard]] std::vector<ExposedRootVersion>
+  bounds(const std::vector<Str> &group) const {
+    std::vector<ExposedRootVersion> result;
+    for (const auto &root : group) {
+      const auto found = exposed.find(root);
+      if (found != exposed.end()) {
+        result.push_back({root, found->second});
+      }
+    }
+    return result;
+  }
+
+  void observe(Str data_id, DateTime noticed_at) {
+    require_data_id(data_id);
+    if (noticed_at <= MIN_DT) {
+      throw std::invalid_argument("fabric notice time must be a real instant");
+    }
+    const auto found = pending_notices.find(data_id);
+    if (found == pending_notices.end()) {
+      pending_notices.emplace(std::move(data_id), noticed_at);
+    } else {
+      found->second = std::min(found->second, noticed_at);
+    }
+  }
+
+  [[nodiscard]] static std::size_t find(std::vector<std::size_t> &parent,
+                                        std::size_t value) {
+    while (parent[value] != value) {
+      parent[value] = parent[parent[value]];
+      value = parent[value];
+    }
+    return value;
+  }
+
+  [[nodiscard]] static bool
+  merge_overlaps(std::vector<std::vector<Str>> &groups,
+                 const std::vector<ForestResolution> &results) {
+    std::vector<std::size_t> parent(groups.size());
+    for (std::size_t index = 0; index < parent.size(); ++index) {
+      parent[index] = index;
+    }
+    bool merged = false;
+    for (std::size_t left = 0; left < results.size(); ++left) {
+      for (std::size_t right = left + 1; right < results.size(); ++right) {
+        if (!intersects(results[left].observed_data_ids,
+                        results[right].observed_data_ids)) {
+          continue;
+        }
+        auto left_root = find(parent, left);
+        auto right_root = find(parent, right);
+        if (left_root != right_root) {
+          parent[right_root] = left_root;
+          merged = true;
+        }
+      }
+    }
+    if (!merged) {
+      return false;
+    }
+
+    std::map<std::size_t, std::vector<Str>> combined;
+    for (std::size_t index = 0; index < groups.size(); ++index) {
+      auto &destination = combined[find(parent, index)];
+      destination.insert(destination.end(), groups[index].begin(),
+                         groups[index].end());
+    }
+    groups.clear();
+    for (auto &[root, group] : combined) {
+      static_cast<void>(root);
+      std::ranges::sort(group, canonical_data_id_less);
+      groups.push_back(std::move(group));
+    }
+    std::ranges::sort(groups, [](const auto &lhs, const auto &rhs) {
+      return canonical_data_id_less(lhs.front(), rhs.front());
+    });
+    return true;
+  }
+
+  [[nodiscard]] CoordinationResult resolve_all(DateTime ready_at) {
+    std::vector<std::vector<Str>> groups;
+    groups.reserve(roots.size());
+    for (const auto &root : roots) {
+      groups.push_back({root});
+    }
+
+    std::vector<ForestResolution> results;
+    for (;;) {
+      results.clear();
+      results.reserve(groups.size());
+      for (const auto &group : groups) {
+        const auto exposed_bounds = bounds(group);
+        results.push_back(resolver.resolve_forest(group, exposed_bounds));
+      }
+      if (!merge_overlaps(groups, results)) {
+        break;
+      }
+    }
+
+    auto next_exposed = exposed;
+    auto next_root_cuts = root_cuts;
+    auto next_notices = pending_notices;
+    std::vector<RootUpdate> updates;
+    for (auto &result : results) {
+      if (!successful(result.status) || !result.cut.has_value()) {
+        continue;
+      }
+      std::optional<DateTime> earliest_notice;
+      for (const auto &data_id : result.observed_data_ids) {
+        const auto notice = next_notices.find(data_id);
+        if (notice == next_notices.end()) {
+          continue;
+        }
+        if (!earliest_notice.has_value() || notice->second < *earliest_notice) {
+          earliest_notice = notice->second;
+        }
+        next_notices.erase(notice);
+      }
+      if (earliest_notice.has_value() && ready_at > MIN_DT) {
+        if (ready_at < *earliest_notice) {
+          throw std::invalid_argument(
+              "fabric ready time precedes its observed notice");
+        }
+        result.metrics.notice_to_ready = ready_at - *earliest_notice;
+      }
+      for (const auto &root : result.roots) {
+        const auto found = std::ranges::lower_bound(result.cut->revisions, root,
+                                                    canonical_data_id_less,
+                                                    &ResolvedRevision::data_id);
+        if (found == result.cut->revisions.end() || found->data_id != root) {
+          throw std::logic_error("successful fabric cut omitted a root");
+        }
+        next_exposed[root] = found->output_version;
+        next_root_cuts[root] = *result.cut;
+      }
+      updates.insert(updates.end(), result.changed_roots.begin(),
+                     result.changed_roots.end());
+    }
+
+    std::map<Str, ResolvedRevision, IdLess> lineage;
+    for (const auto &[root, cut] : next_root_cuts) {
+      static_cast<void>(root);
+      for (const auto &revision : cut.revisions) {
+        const auto found = lineage.find(revision.data_id);
+        if (found == lineage.end() ||
+            found->second.revision < revision.revision) {
+          lineage[revision.data_id] = revision;
+        }
+      }
+    }
+    std::vector<ResolvedRevision> committed;
+    committed.reserve(lineage.size());
+    for (auto &[id, revision] : lineage) {
+      static_cast<void>(id);
+      committed.push_back(std::move(revision));
+    }
+
+    std::ranges::sort(updates,
+                      [](const RootUpdate &lhs, const RootUpdate &rhs) {
+                        return canonical_data_id_less(lhs.data_id, rhs.data_id);
+                      });
+    exposed.swap(next_exposed);
+    root_cuts.swap(next_root_cuts);
+    pending_notices.swap(next_notices);
+    return CoordinationResult{
+        .forests = std::move(results),
+        .changed_roots = std::move(updates),
+        .committed_lineage = std::move(committed),
+    };
+  }
+};
+
+ConsistencyCoordinator::ConsistencyCoordinator(FabricConfig config,
+                                               std::vector<Str> roots)
+    : impl_(std::make_unique<Impl>(std::move(config), std::move(roots))) {}
+
+ConsistencyCoordinator::~ConsistencyCoordinator() = default;
+ConsistencyCoordinator::ConsistencyCoordinator(
+    ConsistencyCoordinator &&) noexcept = default;
+ConsistencyCoordinator &
+ConsistencyCoordinator::operator=(ConsistencyCoordinator &&) noexcept = default;
+
+void ConsistencyCoordinator::observe_notice(Str data_id, DateTime noticed_at) {
+  impl_->observe(std::move(data_id), noticed_at);
+}
+
+CoordinationResult ConsistencyCoordinator::resolve(DateTime ready_at) {
+  return impl_->resolve_all(ready_at);
+}
+} // namespace hgraph::fabric

--- a/extensions/fabric/src/resolution.cpp
+++ b/extensions/fabric/src/resolution.cpp
@@ -399,10 +399,11 @@ struct ConsistencyResolver::Impl {
     }
 
     if (root) {
-      const DataVersion newest = values.front()->output_version;
-      std::erase_if(values, [newest](const DataRevisionInput *item) {
-        return item->output_version != newest;
-      });
+      // Forest membership follows the newest accepted acknowledgement, not
+      // every historical acknowledgement which reused its output version.
+      // Older same-output ancestry remains available to compatible-cut search,
+      // but must not keep roots coupled after their latest lineages split.
+      values.resize(1);
     }
     for (const auto *candidate : values) {
       for (const auto &dependency : candidate->dependencies) {

--- a/extensions/fabric/test_package/main.cpp
+++ b/extensions/fabric/test_package/main.cpp
@@ -72,6 +72,13 @@ int main()
         return 4;
     }
 
+    hgf::ConsistencyResolver resolver{*config};
+    if (resolver.resolve_forest({"installed/input"}).status !=
+        hgf::ResolutionStatus::Pending)
+    {
+        return 5;
+    }
+
     auto graph = hg::build_graph<InstalledFabricGraph>();
     const auto plan = hgf::dependency_plan_input(
         graph.traits().get(hgf::DEPENDENCY_PLAN_TRAIT));
@@ -81,5 +88,5 @@ int main()
                        .forests = {{{"installed/input"}}},
                    }
                ? 0
-               : 5;
+               : 6;
 }

--- a/extensions/fabric/tests/CMakeLists.txt
+++ b/extensions/fabric/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(hgraph_fabric_tests
     registry_test_listener.cpp
     test_public_contracts.cpp
     test_publication.cpp
+    test_resolution.cpp
 )
 target_link_libraries(hgraph_fabric_tests
     PRIVATE hgraph::fabric Catch2::Catch2WithMain)
@@ -26,3 +27,7 @@ add_test(NAME hgraph_fabric.tests COMMAND hgraph_fabric_tests)
 if(COMMAND hgraph_configure_test_runtime_paths)
     hgraph_configure_test_runtime_paths(hgraph_fabric_tests)
 endif()
+
+add_executable(hgraph_fabric_resolution_perf resolution_perf.cpp)
+target_link_libraries(hgraph_fabric_resolution_perf PRIVATE hgraph::fabric)
+target_compile_features(hgraph_fabric_resolution_perf PRIVATE cxx_std_23)

--- a/extensions/fabric/tests/resolution_perf.cpp
+++ b/extensions/fabric/tests/resolution_perf.cpp
@@ -1,0 +1,116 @@
+#include <hgraph/fabric/fabric.h>
+
+#include <arrow/builder.h>
+#include <arrow/table.h>
+
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <ranges>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+namespace hg = hgraph;
+namespace hgf = hgraph::fabric;
+
+[[nodiscard]] hg::Frame frame(std::int64_t value) {
+  arrow::Int64Builder builder;
+  if (!builder.Append(value).ok()) {
+    throw std::runtime_error("failed to append benchmark Frame value");
+  }
+  auto array = builder.Finish();
+  if (!array.ok()) {
+    throw std::runtime_error("failed to finish benchmark Frame value");
+  }
+  return hg::Frame{
+      arrow::Table::Make(arrow::schema({arrow::field("value", arrow::int64())}),
+                         {std::move(array).ValueOrDie()})};
+}
+
+void seed(const hgf::FabricConfig &config,
+          const hgf::DataRevisionInput &input) {
+  const auto frame_key =
+      hgf::data_version_key(config.prefix, input.data_id, input.output_version);
+  if (!config.frames.contains(frame_key)) {
+    config.frames.write(frame_key, frame(input.output_version));
+  }
+  auto value = hgf::make_data_revision(input);
+  const auto result = config.objects.put_immutable(
+      hgf::revision_key(config.prefix, input.data_id, input.revision),
+      hgf::encode_revision(value.view()));
+  if (result.status !=
+      hgraph::persistence::store::ImmutableWriteStatus::Created) {
+    throw std::runtime_error("failed to seed resolver benchmark");
+  }
+}
+} // namespace
+
+int main() {
+  try {
+    constexpr hgf::RevisionId run_length{2'048};
+    constexpr std::size_t samples{9};
+    auto config = hgf::make_memory_fabric_config("bench/resolution");
+    const hg::DateTime base{hg::TimeDelta{1'800'000'000'000'000}};
+    for (hgf::RevisionId revision = 1; revision <= run_length; ++revision) {
+      seed(config, hgf::DataRevisionInput{
+                       .data_id = "parent",
+                       .revision = revision,
+                       .output_version = revision,
+                       .as_of = base + hg::TimeDelta{revision},
+                   });
+      seed(config, hgf::DataRevisionInput{
+                       .data_id = "rolling",
+                       .revision = revision,
+                       .output_version = run_length + 1,
+                       .dependencies = {{"parent", revision}},
+                       .as_of = base + hg::TimeDelta{revision},
+                   });
+    }
+    seed(config, hgf::DataRevisionInput{
+                     .data_id = "root",
+                     .revision = 1,
+                     .output_version = 1,
+                     .dependencies = {{"rolling", run_length + 1}},
+                     .as_of = base + hg::TimeDelta{1},
+                 });
+
+    hgf::ConsistencyResolver resolver{config};
+    const auto cold = resolver.resolve_forest({"parent", "root"});
+    if (cold.status != hgf::ResolutionStatus::Ready) {
+      throw std::runtime_error("resolver benchmark cold cut did not resolve");
+    }
+    const std::vector<hgf::ExposedRootVersion> exposed{{"parent", run_length},
+                                                       {"root", 1}};
+
+    std::vector<double> elapsed;
+    elapsed.reserve(samples);
+    hgf::ResolverMetrics last{};
+    for (std::size_t sample = 0; sample < samples; ++sample) {
+      const auto started = std::chrono::steady_clock::now();
+      const auto result = resolver.resolve_forest({"parent", "root"}, exposed);
+      elapsed.push_back(std::chrono::duration<double, std::micro>(
+                            std::chrono::steady_clock::now() - started)
+                            .count());
+      if (result.status != hgf::ResolutionStatus::Unchanged ||
+          result.metrics.revision_cache_misses != 0) {
+        throw std::runtime_error(
+            "resolver benchmark warm cut missed immutable cache");
+      }
+      last = result.metrics;
+    }
+    std::ranges::sort(elapsed);
+    std::cout << "benchmark name=fabric.same_output_rolling_ancestry"
+              << " run_length=" << run_length << " samples=" << samples
+              << " median_us=" << elapsed[elapsed.size() / 2]
+              << " revisions_examined=" << last.revisions_examined
+              << " output_index_hits=" << last.output_index_hits
+              << " revision_cache_hits=" << last.revision_cache_hits
+              << " max_depth=" << last.maximum_backtracking_depth
+              << " average_depth=" << last.average_backtracking_depth() << '\n';
+    return 0;
+  } catch (const std::exception &error) {
+    std::cerr << "fabric resolver benchmark failed: " << error.what() << '\n';
+    return 1;
+  }
+}

--- a/extensions/fabric/tests/test_resolution.cpp
+++ b/extensions/fabric/tests/test_resolution.cpp
@@ -1,0 +1,316 @@
+#include <hgraph/fabric/fabric.h>
+
+#include <arrow/array.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace {
+namespace hg = hgraph;
+namespace hgf = hgraph::fabric;
+namespace hgps = hgraph::persistence::store;
+
+constexpr hg::DateTime BASE_TIME{hg::TimeDelta{1'800'000'000'000'000}};
+
+[[nodiscard]] hg::Frame frame(std::int64_t value, std::string field = "value") {
+  arrow::Int64Builder builder;
+  REQUIRE(builder.Append(value).ok());
+  auto array = builder.Finish();
+  REQUIRE(array.ok());
+  return hg::Frame{arrow::Table::Make(
+      arrow::schema({arrow::field(std::move(field), arrow::int64())}),
+      {std::move(array).ValueOrDie()})};
+}
+
+void seed(const hgf::FabricConfig &config, std::string data_id,
+          hgf::RevisionId revision, hgf::DataVersion output_version,
+          std::vector<hgf::DataDependencyInput> dependencies = {},
+          std::optional<hgf::DataVersion> self_predecessor = {},
+          std::string field = "value", bool write_frame = true) {
+  const std::string frame_key =
+      hgf::data_version_key(config.prefix, data_id, output_version);
+  if (write_frame && !config.frames.contains(frame_key)) {
+    config.frames.write(frame_key, frame(output_version, std::move(field)));
+  }
+  const auto value = hgf::make_data_revision(hgf::DataRevisionInput{
+      .data_id = std::move(data_id),
+      .revision = revision,
+      .output_version = output_version,
+      .dependencies = std::move(dependencies),
+      .self_predecessor = self_predecessor,
+      .as_of = BASE_TIME + hg::TimeDelta{revision},
+  });
+  const auto decoded = hgf::data_revision_input(value.view());
+  REQUIRE(config.objects
+              .put_immutable(hgf::revision_key(config.prefix, decoded.data_id,
+                                               decoded.revision),
+                             hgf::encode_revision(value.view()))
+              .status == hgps::ImmutableWriteStatus::Created);
+}
+
+[[nodiscard]] const hgf::ResolvedRevision &
+selection(const hgf::ForestResolution &result, std::string_view data_id) {
+  REQUIRE(result.cut.has_value());
+  const auto found = std::ranges::find(result.cut->revisions, data_id,
+                                       &hgf::ResolvedRevision::data_id);
+  REQUIRE(found != result.cut->revisions.end());
+  return *found;
+}
+
+[[nodiscard]] const hgf::ForestResolution &
+forest(const hgf::CoordinationResult &result, std::string_view root) {
+  const auto found = std::ranges::find_if(
+      result.forests, [root](const hgf::ForestResolution &candidate) {
+        return std::ranges::find(candidate.roots, root) !=
+               candidate.roots.end();
+      });
+  REQUIRE(found != result.forests.end());
+  return *found;
+}
+
+void seed_bootstrap(const hgf::FabricConfig &config) {
+  for (hgf::RevisionId revision = 1; revision <= 3; ++revision) {
+    seed(config, "D1", revision, revision);
+    seed(config, "D2", revision, revision, {{"D1", revision}});
+  }
+  seed(config, "D3", 1, 1, {{"D2", 1}});
+  seed(config, "D3", 2, 2, {{"D2", 2}});
+}
+} // namespace
+
+TEST_CASE("resolver reproduces the RFC D1 D2 D3 bootstrap cut") {
+  auto config = hgf::make_memory_fabric_config("tests/resolution/bootstrap");
+  seed_bootstrap(config);
+
+  hgf::ConsistencyResolver resolver{config};
+  const auto result = resolver.resolve_forest({"D1", "D3"});
+  REQUIRE(result.status == hgf::ResolutionStatus::Ready);
+  CHECK(selection(result, "D1").revision == 2);
+  CHECK(selection(result, "D2").revision == 2);
+  CHECK(selection(result, "D3").revision == 2);
+  REQUIRE(result.changed_roots.size() == 2);
+  CHECK(result.changed_roots[0].output_version == 2);
+  CHECK(result.changed_roots[1].output_version == 2);
+  CHECK(result.metrics.output_index_hits > 0);
+
+  const auto latest = config.objects.get(hgf::latest_key(config.prefix, "D1"));
+  REQUIRE(latest.has_value());
+  CHECK(hgf::decode_revision_reference(hgf::MetadataObjectKind::Latest,
+                                       latest->data) == 3);
+  const auto as_of = config.objects.get(
+      hgf::as_of_key(config.prefix, "D1", BASE_TIME + hg::TimeDelta{3}));
+  REQUIRE(as_of.has_value());
+  CHECK(hgf::decode_revision_reference(hgf::MetadataObjectKind::AsOf,
+                                       as_of->data) == 3);
+}
+
+TEST_CASE(
+    "an unchanged child acknowledgement releases a held parent atomically") {
+  auto config = hgf::make_memory_fabric_config("tests/resolution/held");
+  seed_bootstrap(config);
+  hgf::ConsistencyCoordinator coordinator{config, {"D1", "D3"}};
+
+  const auto initial = coordinator.resolve();
+  REQUIRE(initial.forests.size() == 1);
+  REQUIRE(initial.changed_roots.size() == 2);
+  CHECK(selection(initial.forests.front(), "D1").output_version == 2);
+  CHECK(selection(initial.forests.front(), "D3").output_version == 2);
+
+  seed(config, "D3", 3, 2, {{"D2", 3}});
+  const auto released = coordinator.resolve();
+  REQUIRE(released.forests.size() == 1);
+  REQUIRE(released.forests.front().status == hgf::ResolutionStatus::Ready);
+  REQUIRE(released.changed_roots.size() == 1);
+  CHECK(released.changed_roots.front().data_id == "D1");
+  CHECK(released.changed_roots.front().output_version == 3);
+  CHECK(selection(released.forests.front(), "D3").revision == 3);
+  const auto hidden = std::ranges::find(released.committed_lineage, "D3",
+                                        &hgf::ResolvedRevision::data_id);
+  REQUIRE(hidden != released.committed_lineage.end());
+  CHECK(hidden->revision == 3);
+
+  const auto unchanged = coordinator.resolve();
+  CHECK(unchanged.forests.front().status == hgf::ResolutionStatus::Unchanged);
+  CHECK(unchanged.changed_roots.empty());
+}
+
+TEST_CASE("resolver reports all six normative outcomes") {
+  SECTION("Pending") {
+    auto config = hgf::make_memory_fabric_config("tests/resolution/pending");
+    seed(config, "Z", 1, 1);
+    seed(config, "Z", 2, 2);
+    seed(config, "A", 1, 1, {{"Z", 1}});
+    seed(config, "B", 1, 1, {{"Z", 2}});
+    hgf::ConsistencyResolver resolver{config};
+    CHECK(resolver.resolve_forest({"A", "B"}).status ==
+          hgf::ResolutionStatus::Pending);
+  }
+
+  SECTION("Ambiguous") {
+    auto config = hgf::make_memory_fabric_config("tests/resolution/ambiguous");
+    seed(config, "X", 1, 1);
+    seed(config, "X", 2, 2);
+    seed(config, "A", 1, 1, {{"X", 1}});
+    seed(config, "A", 2, 2, {{"X", 2}});
+    seed(config, "B", 1, 1, {{"X", 2}});
+    seed(config, "B", 2, 2, {{"X", 1}});
+    hgf::ConsistencyResolver resolver{config};
+    CHECK(resolver.resolve_forest({"A", "B"}).status ==
+          hgf::ResolutionStatus::Ambiguous);
+  }
+
+  SECTION("Cyclic and self predecessor exclusion") {
+    auto cyclic_config =
+        hgf::make_memory_fabric_config("tests/resolution/cyclic");
+    seed(cyclic_config, "A", 1, 1, {{"B", 1}});
+    seed(cyclic_config, "B", 1, 1, {{"A", 1}});
+    hgf::ConsistencyResolver cyclic{cyclic_config};
+    CHECK(cyclic.resolve_forest({"A"}).status == hgf::ResolutionStatus::Cyclic);
+
+    auto audit_config = hgf::make_memory_fabric_config("tests/resolution/self");
+    seed(audit_config, "A", 1, 1);
+    seed(audit_config, "A", 2, 2, {}, 1);
+    hgf::ConsistencyResolver audit{audit_config};
+    const auto result = audit.resolve_forest({"A"});
+    CHECK(result.status == hgf::ResolutionStatus::Ready);
+    CHECK(selection(result, "A").revision == 2);
+  }
+
+  SECTION("Corrupt missing accepted ancestry") {
+    auto config = hgf::make_memory_fabric_config("tests/resolution/corrupt");
+    seed(config, "A", 1, 1, {{"missing", 7}});
+    hgf::ConsistencyResolver resolver{config};
+    const auto result = resolver.resolve_forest({"A"});
+    CHECK(result.status == hgf::ResolutionStatus::Corrupt);
+    CHECK(result.diagnostic.find("missing data version") != std::string::npos);
+  }
+
+  SECTION("Ready then Unchanged") {
+    auto config = hgf::make_memory_fabric_config("tests/resolution/unchanged");
+    seed(config, "A", 1, 1);
+    hgf::ConsistencyResolver resolver{config};
+    CHECK(resolver.resolve_forest({"A"}).status ==
+          hgf::ResolutionStatus::Ready);
+    const std::vector<hgf::ExposedRootVersion> exposed{{"A", 1}};
+    CHECK(resolver.resolve_forest({"A"}, exposed).status ==
+          hgf::ResolutionStatus::Unchanged);
+  }
+}
+
+TEST_CASE("accepted immutable and Frame corruption never becomes pending") {
+  SECTION("missing Frame") {
+    auto config =
+        hgf::make_memory_fabric_config("tests/resolution/missing-frame");
+    seed(config, "A", 1, 1, {}, {}, "value", false);
+    hgf::ConsistencyResolver resolver{config};
+    CHECK(resolver.resolve_forest({"A"}).status ==
+          hgf::ResolutionStatus::Corrupt);
+  }
+
+  SECTION("fixed schema mismatch") {
+    auto config = hgf::make_memory_fabric_config("tests/resolution/schema");
+    seed(config, "A", 1, 1);
+    seed(config, "A", 2, 2, {}, {}, "different");
+    hgf::ConsistencyResolver resolver{config};
+    CHECK(resolver.resolve_forest({"A"}).status ==
+          hgf::ResolutionStatus::Corrupt);
+  }
+}
+
+TEST_CASE(
+    "coordinator dynamically merges splits and isolates forest failures") {
+  SECTION("independent failure") {
+    auto config = hgf::make_memory_fabric_config("tests/resolution/isolation");
+    seed(config, "good", 1, 1);
+    seed(config, "bad-a", 1, 1, {{"bad-b", 1}});
+    seed(config, "bad-b", 1, 1, {{"bad-a", 1}});
+    hgf::ConsistencyCoordinator coordinator{config, {"good", "bad-a"}};
+    const auto result = coordinator.resolve();
+    REQUIRE(result.forests.size() == 2);
+    CHECK(forest(result, "good").status == hgf::ResolutionStatus::Ready);
+    CHECK(forest(result, "bad-a").status == hgf::ResolutionStatus::Cyclic);
+    REQUIRE(result.changed_roots.size() == 1);
+    CHECK(result.changed_roots.front().data_id == "good");
+  }
+
+  SECTION("merge then split") {
+    auto config =
+        hgf::make_memory_fabric_config("tests/resolution/repartition");
+    seed(config, "X", 1, 1);
+    seed(config, "A", 1, 1, {{"X", 1}});
+    seed(config, "B", 1, 1, {{"X", 1}});
+    hgf::ConsistencyCoordinator coordinator{config, {"A", "B"}};
+    const auto merged = coordinator.resolve();
+    REQUIRE(merged.forests.size() == 1);
+
+    seed(config, "Y", 1, 1);
+    seed(config, "Z", 1, 1);
+    seed(config, "A", 2, 2, {{"Y", 1}});
+    seed(config, "B", 2, 2, {{"Z", 1}});
+    const auto split = coordinator.resolve();
+    REQUIRE(split.forests.size() == 2);
+    CHECK(split.changed_roots.size() == 2);
+    CHECK(forest(split, "A").status == hgf::ResolutionStatus::Ready);
+    CHECK(forest(split, "B").status == hgf::ResolutionStatus::Ready);
+  }
+}
+
+TEST_CASE("root versions never regress below an exposed cut") {
+  auto config = hgf::make_memory_fabric_config("tests/resolution/lower-bound");
+  seed(config, "A", 1, 1);
+  seed(config, "A", 2, 2);
+  hgf::ConsistencyResolver resolver{config};
+  const std::vector<hgf::ExposedRootVersion> exposed{{"A", 2}};
+  const auto result = resolver.resolve_forest({"A"}, exposed);
+  REQUIRE(result.status == hgf::ResolutionStatus::Unchanged);
+  CHECK(selection(result, "A").output_version == 2);
+  CHECK(result.changed_roots.empty());
+}
+
+TEST_CASE("coordinator measures conflated notice to ready latency") {
+  auto config = hgf::make_memory_fabric_config("tests/resolution/latency");
+  seed(config, "A", 1, 1);
+  hgf::ConsistencyCoordinator coordinator{config, {"A"}};
+  REQUIRE(coordinator.resolve().forests.front().status ==
+          hgf::ResolutionStatus::Ready);
+
+  seed(config, "A", 2, 2);
+  coordinator.observe_notice("A", BASE_TIME + hg::TimeDelta{10});
+  coordinator.observe_notice("A", BASE_TIME + hg::TimeDelta{12});
+  const auto result = coordinator.resolve(BASE_TIME + hg::TimeDelta{25});
+  REQUIRE(result.forests.front().metrics.notice_to_ready.has_value());
+  CHECK(*result.forests.front().metrics.notice_to_ready == hg::TimeDelta{15});
+}
+
+TEST_CASE(
+    "same-output rolling ancestry uses immutable caches and version indexes") {
+  constexpr hgf::RevisionId count{256};
+  auto config = hgf::make_memory_fabric_config("tests/resolution/index");
+  for (hgf::RevisionId revision = 1; revision <= count; ++revision) {
+    seed(config, "P", revision, revision);
+    seed(config, "A", revision, count + 1, {{"P", revision}});
+  }
+  seed(config, "D", 1, 1, {{"A", count + 1}});
+
+  hgf::ConsistencyResolver resolver{config};
+  const auto initial = resolver.resolve_forest({"D", "P"});
+  REQUIRE(initial.status == hgf::ResolutionStatus::Ready);
+  CHECK(selection(initial, "A").revision == count);
+  const std::vector<hgf::ExposedRootVersion> exposed{{"D", 1}, {"P", count}};
+  const auto warm = resolver.resolve_forest({"D", "P"}, exposed);
+  REQUIRE(warm.status == hgf::ResolutionStatus::Unchanged);
+  CHECK(warm.metrics.revision_cache_misses == 0);
+  CHECK(warm.metrics.revision_cache_hits > 0);
+  CHECK(warm.metrics.output_index_hits >= static_cast<std::uint64_t>(count));
+  CHECK(warm.metrics.maximum_backtracking_depth >= 3);
+  CHECK(warm.metrics.average_backtracking_depth() > 0.0);
+}

--- a/extensions/fabric/tests/test_resolution.cpp
+++ b/extensions/fabric/tests/test_resolution.cpp
@@ -262,6 +262,26 @@ TEST_CASE(
     CHECK(forest(split, "A").status == hgf::ResolutionStatus::Ready);
     CHECK(forest(split, "B").status == hgf::ResolutionStatus::Ready);
   }
+
+  SECTION("same-output acknowledgements replace superseded ancestry") {
+    auto config = hgf::make_memory_fabric_config(
+        "tests/resolution/same-output-repartition");
+    seed(config, "X", 1, 1);
+    seed(config, "A", 1, 1, {{"X", 1}});
+    seed(config, "B", 1, 1, {{"X", 1}});
+    hgf::ConsistencyCoordinator coordinator{config, {"A", "B"}};
+    REQUIRE(coordinator.resolve().forests.size() == 1);
+
+    seed(config, "Y", 1, 1);
+    seed(config, "Z", 1, 1);
+    seed(config, "A", 2, 1, {{"Y", 1}});
+    seed(config, "B", 2, 1, {{"Z", 1}});
+    const auto split = coordinator.resolve();
+    REQUIRE(split.forests.size() == 2);
+    CHECK(split.changed_roots.empty());
+    CHECK(forest(split, "A").status == hgf::ResolutionStatus::Unchanged);
+    CHECK(forest(split, "B").status == hgf::ResolutionStatus::Unchanged);
+  }
 }
 
 TEST_CASE("root versions never regress below an exposed cut") {

--- a/extensions/fabric/tools/audit_distribution.py
+++ b/extensions/fabric/tools/audit_distribution.py
@@ -22,6 +22,7 @@ WHEEL_REQUIRED = (
     "include/hgraph/fabric/operators.h",
     "include/hgraph/fabric/planning.h",
     "include/hgraph/fabric/publication.h",
+    "include/hgraph/fabric/resolution.h",
     "include/hgraph/fabric/types.h",
     "include/hgraph/fabric/value_builders.h",
     # GNUInstallDirs selects lib64 on manylinux, while macOS and Windows wheels
@@ -41,6 +42,7 @@ SDIST_REQUIRED = (
     "include/hgraph/fabric/operators.h",
     "include/hgraph/fabric/planning.h",
     "include/hgraph/fabric/publication.h",
+    "include/hgraph/fabric/resolution.h",
     "include/hgraph/fabric/types.h",
     "include/hgraph/fabric/value_builders.h",
     "python/hgraph_fabric/__init__.py",
@@ -53,6 +55,7 @@ SDIST_REQUIRED = (
     "src/operators.cpp",
     "src/planning.cpp",
     "src/publication.cpp",
+    "src/resolution.cpp",
     "src/python_module.cpp",
     "src/types.cpp",
     "src/value_builders.cpp",
@@ -63,6 +66,8 @@ SDIST_REQUIRED = (
     "tests/fixtures/revision_v1.hex",
     "tests/test_public_contracts.cpp",
     "tests/test_publication.cpp",
+    "tests/test_resolution.cpp",
+    "tests/resolution_perf.cpp",
     "tools/audit_distribution.py",
 )
 


### PR DESCRIPTION
## Summary

- add the RFC 0026 consistency resolver over accepted durable revision histories
- compute newest compatible transitive cuts with explicit ready, unchanged, pending, ambiguous, cyclic, and corrupt outcomes
- coordinate dynamic consistency forests, atomic root delivery, hidden lineage, non-regression, and notice-to-ready latency
- expose the native resolver to Python through a private fixture bridge and install the public C++ contract
- add native/Python regressions, distribution audits, installed-SDK coverage, and a rolling-history benchmark

## Checkpoint

This is checkpoint 4 of #512 and stacks on #530.

## Validation

- macOS fresh native acceptance after restacking: 1,605/1,605
- macOS Python 3.14 compatibility via Python 3.12 abi3 wheel: 2,122 passed, 10 skipped
- macOS Fabric Python wheel: 15/15
- macOS installed Fabric C++ consumer: 1/1
- macOS Fabric wheel and sdist audit
- Linux GCC 14 fresh native acceptance after restacking: 1,605/1,605
- Linux Python 3.14 compatibility via Python 3.12 abi3 wheel: 2,122 passed, 10 skipped
- Linux Fabric Python wheel: 15/15
- Linux Fabric wheel and sdist audit
- Linux ASan Fabric native suite: 1/1 with ARROW_DEFAULT_MEMORY_POOL=system
- resolver benchmark (2,048 rolling revisions): median 1.33 ms; 2,050 revisions examined; max search depth 3