### PR TITLE
Add lifecycle-safe asynchronous node wakes

### DIFF
--- a/docs/source/developer_guide/architecture.rst
+++ b/docs/source/developer_guide/architecture.rst
@@ -246,13 +246,14 @@ The normal cycle shape is:
 
 1. run one-shot before-evaluation callbacks,
 2. notify lifecycle observers before graph evaluation,
-3. scan flattened nodes in rank order,
-4. evaluate nodes whose graph schedule equals ``evaluation_time``, notifying
+3. admit any deduplicated asynchronous node wakes on the evaluation thread,
+4. scan flattened nodes in rank order,
+5. evaluate nodes whose graph schedule equals ``evaluation_time``, notifying
    lifecycle observers immediately before and after each node's evaluation,
-5. fold future node schedules into the clock's next scheduled evaluation time,
-6. notify lifecycle observers after graph evaluation,
-7. run one-shot after-evaluation callbacks,
-8. advance the engine clock.
+6. fold future node schedules into the clock's next scheduled evaluation time,
+7. notify lifecycle observers after graph evaluation,
+8. run one-shot after-evaluation callbacks,
+9. advance the engine clock.
 
 This shape is uniform for root and nested graphs alike: a nested graph's own
 ``evaluate`` call brackets its scheduled nodes with the same before/after
@@ -267,6 +268,14 @@ from its ``eval`` implementation. In real-time mode, the evaluation clock owns
 the condition-variable wake-up state used to notice queued push messages; in
 simulation mode, push-source nodes are not supported. The graph/evaluator must
 not call a generic ``apply_message`` node operation directly.
+
+An ordinary node may instead request ``AsyncNodeWakeSender`` when an external
+notification contains no time-series value and only needs to schedule graph-
+thread reconciliation. The executor queue owns a cancellable token rather
+than a bare nested-graph pointer. Node teardown invalidates the token before
+dynamic child storage is erased; the next root boundary ignores an inactive
+queued wake. Root plans which contain no asynchronous-wake node skip this
+queue entirely on the evaluation hot path.
 
 Node Evaluation
 ~~~~~~~~~~~~~~~

--- a/docs/source/user_guide/cpp/authoring_nodes.rst
+++ b/docs/source/user_guide/cpp/authoring_nodes.rst
@@ -781,6 +781,9 @@ affect node-kind inference; the node simply receives them at evaluation.
    * - one-shot scheduler
      - ``SingleShotScheduler`` *(available, C++ only)*
      - —
+   * - asynchronous node wake
+     - ``AsyncNodeWakeSender`` *(available, C++ only)*
+     - —
    * - current time
      - ``DateTime`` *(available)*
      - ``_clock.evaluation_time``
@@ -803,6 +806,21 @@ injectable for ``clock.evaluation_time()``.
 exposes the evaluation mode, start/end bounds, evaluation clock, stop state,
 and ``request_stop()``. The registered C++ ``stop_engine`` sink uses this view;
 a request completes the current evaluation cycle before ending the run.
+
+``AsyncNodeWakeSender`` is the callback-side companion to ``NodeScheduler``.
+A node captures it during ``start`` and gives only copies to an external
+notifier callback. ``wake()`` is thread-safe: it does not evaluate or mutate
+the graph on the callback thread, and repeated wakes before the next root
+cycle are conflated into one node schedule. The runtime owns the token in the
+node's planned storage and invalidates every copy during ``stop`` before a
+nested graph slot can be erased. A callback racing with teardown therefore
+becomes a no-op. This is appropriate for an ordinary notifier-driven source
+which must also work inside ``nested_``, ``map_`` or ``mesh_``; a root-only
+stream of actual values should normally use a push-source policy instead.
+
+The handle adds one shared token only to nodes which request it. Ordinary
+nodes and root graphs which contain no such node take neither the token
+storage nor the queue-drain path.
 
 ``LoggerView`` borrows the executor-owned spdlog logger. Configure it with
 ``GraphExecutorBuilder::logger``; the executor retains shared ownership while

--- a/include/hgraph/runtime/executor.h
+++ b/include/hgraph/runtime/executor.h
@@ -25,6 +25,7 @@ namespace hgraph
 {
     namespace detail
     {
+        struct AsyncNodeWakeAccess;
         struct GraphExecutorPhaseActionAccess;
     }
 
@@ -32,6 +33,7 @@ namespace hgraph
     class GraphExecutorValue;
     class GraphExecutorView;
     class EngineControlView;
+    class AsyncNodeWakeSender;
     struct LifecycleObserver;
     class LifecycleObserverList;
     struct LoggerOps;
@@ -122,6 +124,11 @@ namespace hgraph
             Eval-thread only. */
         void (*add_evaluation_notification_impl)(const void *context, void *memory,
                                                  std::function<void()> fn, bool before) = nullptr;
+        /** Thread-safe ingress wake. The executor admits the node schedule at
+            the next root-cycle boundary, so nested graph scheduling remains
+            on the evaluation thread. */
+        void (*wake_node_impl)(const void *context, void *memory,
+                               AsyncNodeWakeSender sender) = nullptr;
         bool (*stop_requested_impl)(const void *context, const void *memory) noexcept = nullptr;
         DateTime (*start_time_impl)(const void *context, const void *memory) noexcept = nullptr;
         DateTime (*end_time_impl)(const void *context, const void *memory) noexcept = nullptr;
@@ -130,6 +137,8 @@ namespace hgraph
         void (*mark_push_update_pending_impl)(const void *context, void *memory) = nullptr;
         bool (*is_push_update_pending_impl)(const void *context, void *memory) noexcept = nullptr;
         bool (*reset_push_update_pending_impl)(const void *context, void *memory) noexcept = nullptr;
+        bool (*begin_push_cycle_impl)(const void *context, void *memory,
+                                      DateTime evaluation_time) = nullptr;
         /** The executor-owned lifecycle observer list; never null once constructed. */
         LifecycleObserverList *(*lifecycle_observers_impl)(const void *context, void *memory) noexcept = nullptr;
         /** Borrowed run logger; owned by the executor storage. */
@@ -158,6 +167,9 @@ namespace hgraph
 
         void mark_push_update_pending() const;
         [[nodiscard]] bool reset_push_update_pending() const noexcept;
+        /** Atomically claim the pending push flag and queued async node wakes,
+            then admit those node schedules on the evaluation thread. */
+        [[nodiscard]] bool begin_push_cycle(DateTime evaluation_time) const;
 
       private:
         [[nodiscard]] const GraphExecutorOps &ops() const;
@@ -197,11 +209,44 @@ namespace hgraph
         void add_after_evaluation_notification(std::function<void()> fn) const;
 
       private:
+        friend class AsyncNodeWakeSender;
+
+        void wake_node(AsyncNodeWakeSender sender) const;
+
         ExecutorPtr pointer_{};
     };
 
     static_assert(sizeof(EngineControlView) == sizeof(ExecutorPtr));
     static_assert(std::is_trivially_copyable_v<EngineControlView>);
+
+    /** Copyable thread-safe wake handle for an authored node.
+
+        ``wake`` never evaluates or mutates the graph on the caller's thread.
+        It queues one deduplicated schedule with the root executor, wakes an
+        idle real-time run, and admits the schedule on the next evaluation
+        boundary. This is the callback-side companion to ``NodeScheduler`` for
+        notifier-driven sources, including sources owned by nested graphs. */
+    class HGRAPH_EXPORT AsyncNodeWakeSender
+    {
+      public:
+        AsyncNodeWakeSender() noexcept = default;
+        AsyncNodeWakeSender(EngineControlView engine, GraphPtr graph,
+                            std::size_t node_index);
+
+        [[nodiscard]] bool valid() const noexcept;
+        void wake() const;
+        /** Invalidate every copy and make a racing callback wake a no-op. */
+        void close() noexcept;
+
+        friend bool operator==(const AsyncNodeWakeSender &,
+                               const AsyncNodeWakeSender &) noexcept = default;
+
+      private:
+        friend struct detail::AsyncNodeWakeAccess;
+
+        struct State;
+        std::shared_ptr<State> state_{};
+    };
 
     /** Borrowed type-erased executor view. */
     class HGRAPH_EXPORT GraphExecutorView

--- a/include/hgraph/runtime/graph.h
+++ b/include/hgraph/runtime/graph.h
@@ -121,6 +121,7 @@ struct HGRAPH_EXPORT GraphEdge
         std::vector<GraphNodeEntry> nodes{};
         std::vector<GraphEdge> edges{};
         std::size_t push_source_nodes_end{0};
+        bool waits_for_async_node_wakes{false};
 
         [[nodiscard]] std::string_view name() const noexcept;
     };

--- a/include/hgraph/runtime/node.h
+++ b/include/hgraph/runtime/node.h
@@ -38,6 +38,7 @@ namespace hgraph
     class GraphValue;
     class GraphView;
     class GraphBuilder;
+    class AsyncNodeWakeSender;
     class NodeBuilder;
     class NodeValue;
     struct NodeSchedulerState;
@@ -105,6 +106,8 @@ namespace hgraph
         bool     uses_scheduler{false};
         bool     uses_global_state{false};
         bool     uses_evaluation_clock{false};
+        /** A lifecycle hook requests a callback-side thread-safe wake handle. */
+        bool     uses_async_node_wake{false};
         // True when this node consumes and/or produces time-series values
         // through the Python object boundary. Wiring uses this to request
         // output-local Python-aware storage from upstream producers.
@@ -328,6 +331,8 @@ namespace hgraph
         [[nodiscard]] GlobalStateView global_state() const;
         [[nodiscard]] ClockPtr evaluation_clock_ptr() const;
         [[nodiscard]] EvaluationClockView evaluation_clock() const;
+        /** Borrow this node's lifecycle-owned callback-side wake token. */
+        [[nodiscard]] AsyncNodeWakeSender &async_node_wake_sender() const;
         [[nodiscard]] TSOutputView error_output(DateTime evaluation_time) const;
         [[nodiscard]] TSOutputView recordable_state(DateTime evaluation_time) const;
         /** Owned storage counters; the normal execution path never calls this. */

--- a/include/hgraph/types/static_node.h
+++ b/include/hgraph/types/static_node.h
@@ -1683,13 +1683,46 @@ namespace hgraph
         static constexpr auto field_name = Name;
 
         /** Supplied directly (graph ``compose`` parameter / wiring-time value). */
-        explicit Scalar(TValue value) : owned_(std::move(value)) {}
+        explicit Scalar(TValue value)
+            : owned_(std::make_unique<TValue>(std::move(value))), borrowed_(nullptr)
+        {
+        }
 
         /** Borrow from the immutable node scalar storage (node hook path). */
         explicit Scalar(const ValueView &view)
-            : borrowed_(std::addressof(view.template checked_as<TValue>()))
+            : owned_(nullptr), borrowed_(std::addressof(view.template checked_as<TValue>()))
         {
         }
+
+        Scalar(const Scalar &other)
+            requires std::is_copy_constructible_v<TValue>
+            : owned_(other.owned_ != nullptr
+                         ? std::make_unique<TValue>(*other.owned_)
+                         : nullptr),
+              borrowed_(other.borrowed_)
+        {
+        }
+        Scalar(const Scalar &)
+            requires(!std::is_copy_constructible_v<TValue>) = delete;
+
+        Scalar &operator=(const Scalar &other)
+            requires std::is_copy_constructible_v<TValue>
+        {
+            if (this != std::addressof(other))
+            {
+                auto owned = other.owned_ != nullptr
+                                 ? std::make_unique<TValue>(*other.owned_)
+                                 : nullptr;
+                owned_    = std::move(owned);
+                borrowed_ = other.borrowed_;
+            }
+            return *this;
+        }
+        Scalar &operator=(const Scalar &)
+            requires(!std::is_copy_constructible_v<TValue>) = delete;
+
+        Scalar(Scalar &&) noexcept            = default;
+        Scalar &operator=(Scalar &&) noexcept = default;
 
         /** The configured value of this scalar input. */
         [[nodiscard]] const value_type &value() const noexcept
@@ -1698,8 +1731,8 @@ namespace hgraph
         }
 
       private:
-        std::optional<TValue> owned_{};
-        const TValue        *borrowed_{nullptr};
+        std::unique_ptr<TValue> owned_{};
+        const TValue           *borrowed_{nullptr};
     };
 
     /**
@@ -1811,6 +1844,8 @@ namespace hgraph
 
         template <typename T> struct is_evaluation_clock_selector : std::false_type {};
         template <> struct is_evaluation_clock_selector<EvaluationClockView> : std::true_type {};
+        template <typename T> struct is_async_node_wake_selector : std::false_type {};
+        template <> struct is_async_node_wake_selector<AsyncNodeWakeSender> : std::true_type {};
 
         // ---- per-selector runtime metadata ----
         // ``schema`` / ``value_schema`` expose the selector's compile-time schema type
@@ -2131,6 +2166,24 @@ namespace hgraph
             static SingleShotScheduler get(const NodeView &view, DateTime evaluation_time)
             {
                 return SingleShotScheduler{view.graph_value(), view.node_index(), evaluation_time};
+            }
+        };
+
+        // Thread-safe callback-side wake handle. Like SingleShotScheduler it
+        // is transparent to the static signature and allocates no node state.
+        template <>
+        struct arg_provider<AsyncNodeWakeSender>
+        {
+            static AsyncNodeWakeSender get(const NodeView &view, DateTime)
+            {
+                auto &sender = view.async_node_wake_sender();
+                if (!sender.valid())
+                {
+                    sender = AsyncNodeWakeSender{
+                        view.graph().executor().engine_control(),
+                        view.graph().pointer(), view.node_index()};
+                }
+                return sender;
             }
         };
 
@@ -2808,6 +2861,12 @@ namespace hgraph
             return any_hook_uses_selector<static_node_detail::is_evaluation_clock_selector>();
         }
 
+        [[nodiscard]] static constexpr bool uses_async_node_wake()
+        {
+            return any_hook_uses_selector<
+                static_node_detail::is_async_node_wake_selector>();
+        }
+
         [[nodiscard]] static std::optional<std::vector<std::size_t>> active_inputs()
         {
             if constexpr (has_explicit_activity_policy(indices{}))
@@ -3116,6 +3175,7 @@ namespace hgraph
             schema.uses_scheduler        = signature::uses_scheduler();
             schema.uses_global_state     = signature::uses_global_state();
             schema.uses_evaluation_clock = signature::uses_evaluation_clock();
+            schema.uses_async_node_wake   = signature::uses_async_node_wake();
             if constexpr (has_uses_python_values<TImplementation>)
             {
                 schema.uses_python_values = TImplementation::uses_python_values;

--- a/src/hgraph/runtime/executor.cpp
+++ b/src/hgraph/runtime/executor.cpp
@@ -29,8 +29,32 @@
 
 namespace hgraph
 {
+    struct AsyncNodeWakeSender::State
+    {
+        EngineControlView engine{};
+        GraphPtr          graph{};
+        std::size_t       node_index{};
+        std::mutex        lifecycle_mutex{};
+        std::atomic_bool  active{true};
+    };
+
     namespace detail
     {
+        struct AsyncNodeWakeAccess
+        {
+            static void admit(const AsyncNodeWakeSender &sender,
+                              DateTime evaluation_time)
+            {
+                const auto &state = sender.state_;
+                if (state != nullptr &&
+                    state->active.load(std::memory_order_acquire))
+                {
+                    GraphView{state->graph}.schedule_node(state->node_index,
+                                                         evaluation_time);
+                }
+            }
+        };
+
         struct GraphExecutorPhaseActionAccess
         {
             static GraphExecutorPhaseAction make(void *context,
@@ -45,6 +69,14 @@ namespace hgraph
     {
         struct SimulationExecutorStorage;
         struct RealTimeExecutorStorage;
+
+        struct PendingNodeWake
+        {
+            AsyncNodeWakeSender sender{};
+
+            friend bool operator==(const PendingNodeWake &,
+                                   const PendingNodeWake &) = default;
+        };
 
         template <typename Storage>
         void stop_storage(Storage &state);
@@ -99,6 +131,8 @@ namespace hgraph
             // the run loop at the root cycle boundaries; eval-thread only.
             std::vector<std::function<void()>> before_evaluation_notifications{};
             std::vector<std::function<void()>> after_evaluation_notifications{};
+            std::mutex              node_wake_mutex{};
+            std::vector<PendingNodeWake> pending_node_wakes{};
             std::atomic_bool stop_requested{false};
             std::atomic_bool push_update_pending{false};
             bool                     cleanup_on_error{true};
@@ -150,6 +184,7 @@ namespace hgraph
             // the run loop at the root cycle boundaries; eval-thread only.
             std::vector<std::function<void()>> before_evaluation_notifications{};
             std::vector<std::function<void()>> after_evaluation_notifications{};
+            std::vector<PendingNodeWake>      pending_node_wakes{};
 
             mutable std::mutex           mutex{};
             std::condition_variable      condition{};
@@ -318,6 +353,24 @@ namespace hgraph
             }
         }
 
+        void simulation_wake_node_impl(const void *, void *memory,
+                                       AsyncNodeWakeSender sender)
+        {
+            auto &state = simulation_storage(memory);
+            if (state.stop_requested.load(std::memory_order_acquire)) { return; }
+            {
+                const std::lock_guard lock{state.node_wake_mutex};
+                const PendingNodeWake wake{std::move(sender)};
+                if (std::ranges::find(state.pending_node_wakes, wake) ==
+                    state.pending_node_wakes.end())
+                {
+                    state.pending_node_wakes.push_back(wake);
+                }
+                state.push_update_pending.store(true,
+                                                std::memory_order_release);
+            }
+        }
+
         bool simulation_is_push_update_pending_impl(const void *, void *memory) noexcept
         {
             return simulation_storage(memory).push_update_pending.load(
@@ -330,12 +383,50 @@ namespace hgraph
                 false, std::memory_order_acq_rel);
         }
 
+        bool simulation_begin_push_cycle_impl(const void *, void *memory,
+                                              DateTime evaluation_time)
+        {
+            auto &state = simulation_storage(memory);
+            std::vector<PendingNodeWake> wakes;
+            bool pending{};
+            {
+                const std::lock_guard lock{state.node_wake_mutex};
+                pending = state.push_update_pending.exchange(
+                    false, std::memory_order_acq_rel);
+                wakes.swap(state.pending_node_wakes);
+            }
+            for (const auto &wake : wakes)
+            {
+                detail::AsyncNodeWakeAccess::admit(wake.sender,
+                                                   evaluation_time);
+            }
+            return pending || !wakes.empty();
+        }
+
         void realtime_mark_push_update_pending_impl(const void *, void *memory)
         {
             auto &state = realtime_storage(memory);
             {
                 std::lock_guard lock{state.mutex};
                 if (state.stop_requested.load(std::memory_order_acquire)) { return; }
+                state.push_update_pending = true;
+            }
+            state.condition.notify_all();
+        }
+
+        void realtime_wake_node_impl(const void *, void *memory,
+                                     AsyncNodeWakeSender sender)
+        {
+            auto &state = realtime_storage(memory);
+            {
+                const std::lock_guard lock{state.mutex};
+                if (state.stop_requested.load(std::memory_order_acquire)) { return; }
+                const PendingNodeWake wake{std::move(sender)};
+                if (std::ranges::find(state.pending_node_wakes, wake) ==
+                    state.pending_node_wakes.end())
+                {
+                    state.pending_node_wakes.push_back(wake);
+                }
                 state.push_update_pending = true;
             }
             state.condition.notify_all();
@@ -355,6 +446,26 @@ namespace hgraph
             const bool pending = state.push_update_pending;
             state.push_update_pending = false;
             return pending;
+        }
+
+        bool realtime_begin_push_cycle_impl(const void *, void *memory,
+                                            DateTime evaluation_time)
+        {
+            auto &state = realtime_storage(memory);
+            std::vector<PendingNodeWake> wakes;
+            bool pending{};
+            {
+                const std::lock_guard lock{state.mutex};
+                pending = state.push_update_pending;
+                state.push_update_pending = false;
+                wakes.swap(state.pending_node_wakes);
+            }
+            for (const auto &wake : wakes)
+            {
+                detail::AsyncNodeWakeAccess::admit(wake.sender,
+                                                   evaluation_time);
+            }
+            return pending || !wakes.empty();
         }
 
         [[nodiscard]] DateTime advance_simulation(SimulationExecutorStorage &state, DateTime next_scheduled_time)
@@ -437,7 +548,8 @@ namespace hgraph
 
         [[nodiscard]] bool waits_for_push_sources(const RealTimeExecutorStorage &, const GraphView &graph) noexcept
         {
-            return graph.schema()->push_source_nodes_end > 0;
+            return graph.schema()->push_source_nodes_end > 0 ||
+                   graph.schema()->waits_for_async_node_wakes;
         }
 
         /**
@@ -794,6 +906,7 @@ namespace hgraph
                 .run_impl = &simulation_run_impl,
                 .request_stop_impl = &simulation_request_stop_impl,
                 .add_evaluation_notification_impl = &simulation_add_evaluation_notification_impl,
+                .wake_node_impl = &simulation_wake_node_impl,
                 .stop_requested_impl = &simulation_stop_requested_impl,
                 .start_time_impl = &simulation_start_time_impl,
                 .end_time_impl = &simulation_end_time_impl,
@@ -802,6 +915,7 @@ namespace hgraph
                 .mark_push_update_pending_impl = &simulation_mark_push_update_pending_impl,
                 .is_push_update_pending_impl = &simulation_is_push_update_pending_impl,
                 .reset_push_update_pending_impl = &simulation_reset_push_update_pending_impl,
+                .begin_push_cycle_impl = &simulation_begin_push_cycle_impl,
                 .lifecycle_observers_impl = &simulation_lifecycle_observers_impl,
                 .logger_impl = &simulation_logger_impl,
                 .logger_ops_impl = &simulation_logger_ops_impl,
@@ -818,6 +932,7 @@ namespace hgraph
                 .run_impl = &realtime_run_impl,
                 .request_stop_impl = &realtime_request_stop_impl,
                 .add_evaluation_notification_impl = &realtime_add_evaluation_notification_impl,
+                .wake_node_impl = &realtime_wake_node_impl,
                 .stop_requested_impl = &realtime_stop_requested_impl,
                 .start_time_impl = &realtime_start_time_impl,
                 .end_time_impl = &realtime_end_time_impl,
@@ -826,6 +941,7 @@ namespace hgraph
                 .mark_push_update_pending_impl = &realtime_mark_push_update_pending_impl,
                 .is_push_update_pending_impl = &realtime_is_push_update_pending_impl,
                 .reset_push_update_pending_impl = &realtime_reset_push_update_pending_impl,
+                .begin_push_cycle_impl = &realtime_begin_push_cycle_impl,
                 .lifecycle_observers_impl = &realtime_lifecycle_observers_impl,
                 .logger_impl = &realtime_logger_impl,
                 .logger_ops_impl = &realtime_logger_ops_impl,
@@ -1093,6 +1209,13 @@ namespace hgraph
         return ops().reset_push_update_pending_impl(ops().context, const_cast<void *>(pointer_.data()));
     }
 
+    bool PushQueueEngineView::begin_push_cycle(DateTime evaluation_time) const
+    {
+        if (!valid() || !pointer_.writable_access()) { return false; }
+        return ops().begin_push_cycle_impl(
+            ops().context, const_cast<void *>(pointer_.data()), evaluation_time);
+    }
+
     const GraphExecutorOps &PushQueueEngineView::ops() const
     {
         return ExecutorTypeRef{pointer_.record()}.ops_ref();
@@ -1135,6 +1258,25 @@ namespace hgraph
         GraphExecutorView{pointer_}.request_stop();
     }
 
+    void EngineControlView::wake_node(AsyncNodeWakeSender sender) const
+    {
+        if (!valid())
+        {
+            throw std::logic_error(
+                "AsyncNodeWakeSender requires a live executor");
+        }
+        if (!pointer_.writable_access())
+        {
+            throw std::logic_error(
+                "AsyncNodeWakeSender requires writable executor access");
+        }
+        const ExecutorTypeRef executor_type = GraphExecutorView{pointer_}.type();
+        const auto &table = executor_type.ops_ref();
+        table.wake_node_impl(table.context,
+                             const_cast<void *>(pointer_.data()),
+                             std::move(sender));
+    }
+
     void EngineControlView::add_before_evaluation_notification(std::function<void()> fn) const
     {
         GraphExecutorView view{pointer_};
@@ -1159,6 +1301,43 @@ namespace hgraph
             throw std::logic_error("executor does not support evaluation notifications");
         }
         table.add_evaluation_notification_impl(table.context, view.data(), std::move(fn), false);
+    }
+
+    AsyncNodeWakeSender::AsyncNodeWakeSender(
+        EngineControlView engine, GraphPtr graph, std::size_t node_index)
+        : state_(std::make_shared<State>())
+    {
+        state_->engine = engine;
+        state_->graph = graph;
+        state_->node_index = node_index;
+    }
+
+    bool AsyncNodeWakeSender::valid() const noexcept
+    {
+        return state_ != nullptr &&
+               state_->active.load(std::memory_order_acquire) &&
+               state_->engine.valid() && state_->graph.valid();
+    }
+
+    void AsyncNodeWakeSender::wake() const
+    {
+        if (state_ == nullptr)
+        {
+            throw std::logic_error(
+                "AsyncNodeWakeSender requires a live node");
+        }
+        const std::lock_guard lock{state_->lifecycle_mutex};
+        if (!state_->active.load(std::memory_order_acquire)) { return; }
+        state_->engine.wake_node(*this);
+    }
+
+    void AsyncNodeWakeSender::close() noexcept
+    {
+        if (state_ != nullptr)
+        {
+            const std::lock_guard lock{state_->lifecycle_mutex};
+            state_->active.store(false, std::memory_order_release);
+        }
     }
 
     GraphExecutorView::GraphExecutorView() noexcept = default;

--- a/src/hgraph/runtime/graph.cpp
+++ b/src/hgraph/runtime/graph.cpp
@@ -636,6 +636,33 @@ compute_push_source_nodes_end(const GraphBuilder &builder) {
   return prefix;
 }
 
+[[nodiscard]] bool graph_waits_for_async_node_wakes(
+    const GraphBuilder &builder);
+
+void inspect_async_wake_child(void *raw_result,
+                              ChildGraphInspectionView child) {
+  auto &result = *static_cast<bool *>(raw_result);
+  if (!result && child.graph != nullptr) {
+    result = graph_waits_for_async_node_wakes(*child.graph);
+  }
+}
+
+[[nodiscard]] bool graph_waits_for_async_node_wakes(
+    const GraphBuilder &builder) {
+  for (const NodeBuilder &node : builder.nodes()) {
+    const auto *schema = node.type().schema();
+    if (schema != nullptr && schema->uses_async_node_wake) {
+      return true;
+    }
+    bool child_waits{};
+    node.visit_child_graphs(&child_waits, &inspect_async_wake_child);
+    if (child_waits) {
+      return true;
+    }
+  }
+  return false;
+}
+
 template <typename Storage>
 void attach_nodes_impl(const void *context, void *memory, GraphValue *graph) {
   static_cast<void>(sizeof(Storage));
@@ -1109,10 +1136,15 @@ bool evaluate_impl(const void *context, const GraphView &graph,
     state.next_scheduled_time = MAX_DT;
 
     if constexpr (std::is_same_v<Storage, RootGraphRuntimeStorage>) {
-      if (first_normal_node > 0) {
+      bool push_update_pending = false;
+      if (first_normal_node > 0 ||
+          graph.schema()->waits_for_async_node_wakes) {
         PushQueueEngineView push_queue =
             graph.root().executor().push_queue_engine();
-        const bool push_update_pending = push_queue.reset_push_update_pending();
+        push_update_pending =
+            push_queue.begin_push_cycle(evaluation_time);
+      }
+      if (first_normal_node > 0) {
         bool push_phase_evaluated = push_update_pending;
         for (std::size_t index = 0; index < first_normal_node; ++index) {
           auto &scheduled = graph_schedule(runtime, graph.data(), index);
@@ -1283,6 +1315,8 @@ struct GraphRuntimeRegistry {
         entry.schema.edges.size() != builder.edges().size() ||
         entry.schema.push_source_nodes_end !=
             compute_push_source_nodes_end(builder) ||
+        entry.schema.waits_for_async_node_wakes !=
+            graph_waits_for_async_node_wakes(builder) ||
         graph_has_compound_scalar_storage(entry.root_context) !=
             pooled_storage) {
       return false;
@@ -1322,6 +1356,8 @@ struct GraphRuntimeRegistry {
     }
     meta.edges = builder.edges();
     meta.push_source_nodes_end = compute_push_source_nodes_end(builder);
+    meta.waits_for_async_node_wakes =
+        graph_waits_for_async_node_wakes(builder);
 
     return meta;
   }

--- a/src/hgraph/runtime/node.cpp
+++ b/src/hgraph/runtime/node.cpp
@@ -84,6 +84,7 @@ namespace hgraph
             std::size_t scheduler_offset{npos};
             std::size_t global_state_offset{npos};
             std::size_t evaluation_clock_offset{npos};
+            std::size_t async_node_wake_offset{npos};
             std::size_t error_output_offset{npos};
             std::size_t recordable_state_offset{npos};
             std::size_t prepared_inputs_offset{npos};
@@ -95,6 +96,7 @@ namespace hgraph
             [[nodiscard]] bool has_scheduler() const noexcept { return scheduler_offset != npos; }
             [[nodiscard]] bool has_global_state() const noexcept { return global_state_offset != npos; }
             [[nodiscard]] bool has_evaluation_clock() const noexcept { return evaluation_clock_offset != npos; }
+            [[nodiscard]] bool has_async_node_wake() const noexcept { return async_node_wake_offset != npos; }
             [[nodiscard]] bool has_error_output() const noexcept { return error_output_offset != npos; }
             [[nodiscard]] bool has_recordable_state() const noexcept { return recordable_state_offset != npos; }
         };
@@ -174,6 +176,13 @@ namespace hgraph
         {
             return *MemoryUtils::cast<ClockPtr>(
                 node_component(memory, context.layout.evaluation_clock_offset));
+        }
+
+        [[nodiscard]] AsyncNodeWakeSender &node_async_wake_sender(
+            const NodeRuntimeContext &context, void *memory)
+        {
+            return *MemoryUtils::cast<AsyncNodeWakeSender>(
+                node_component(memory, context.layout.async_node_wake_offset));
         }
 
         [[nodiscard]] TSOutput &node_error_output(const NodeRuntimeContext &context, void *memory)
@@ -518,6 +527,7 @@ namespace hgraph
                 {"scheduler", &NodeRuntimeLayout::scheduler_offset},
                 {"global_state", &NodeRuntimeLayout::global_state_offset},
                 {"evaluation_clock", &NodeRuntimeLayout::evaluation_clock_offset},
+                {"async_node_wake", &NodeRuntimeLayout::async_node_wake_offset},
                 {"error_output", &NodeRuntimeLayout::error_output_offset},
                 {"recordable_state", &NodeRuntimeLayout::recordable_state_offset},
                 {node_prepared_inputs_field.data(), &NodeRuntimeLayout::prepared_inputs_offset},
@@ -871,6 +881,10 @@ namespace hgraph
             auto rollback = UnwindCleanupGuard([&] {
                 static_cast<void>(activated);
                 deactivate_input_slots(view, evaluation_time);
+                if (runtime.layout.has_async_node_wake())
+                {
+                    node_async_wake_sender(runtime, view.data()).close();
+                }
             });
 
             state.starting = true;
@@ -901,6 +915,12 @@ namespace hgraph
             auto mark_stopped = make_scope_exit([&] noexcept { state.started = false; });
             state.stopping = true;
             auto clear_stopping = make_scope_exit([&] noexcept { state.stopping = false; });
+            auto close_async_wake = make_scope_exit([&] noexcept {
+                if (runtime.layout.has_async_node_wake())
+                {
+                    node_async_wake_sender(runtime, view.data()).close();
+                }
+            });
             auto deactivate = UnwindCleanupGuard([&] { deactivate_input_slots(view, evaluation_time); });
             if (callbacks(context).stop) { callbacks(context).stop(view, evaluation_time); }
             deactivate.complete();
@@ -1004,6 +1024,7 @@ namespace hgraph
                    lhs.uses_scheduler == rhs.uses_scheduler &&
                    lhs.uses_global_state == rhs.uses_global_state &&
                    lhs.uses_evaluation_clock == rhs.uses_evaluation_clock &&
+                   lhs.uses_async_node_wake == rhs.uses_async_node_wake &&
                    lhs.uses_python_values == rhs.uses_python_values &&
                    lhs.simulation_capable_push_source ==
                        rhs.simulation_capable_push_source &&
@@ -1377,6 +1398,11 @@ namespace hgraph
         {
             builder.add_field("evaluation_clock", MemoryUtils::plan_for<ClockPtr>());
         }
+        if (schema.uses_async_node_wake)
+        {
+            builder.add_field("async_node_wake",
+                              MemoryUtils::plan_for<AsyncNodeWakeSender>());
+        }
         if (schema.error_output_schema != nullptr)
         {
             builder.add_field("error_output", MemoryUtils::plan_for<TSOutput>());
@@ -1547,6 +1573,22 @@ namespace hgraph
     EvaluationClockView NodeView::evaluation_clock() const
     {
         return EvaluationClockView{evaluation_clock_ptr()};
+    }
+
+    AsyncNodeWakeSender &NodeView::async_node_wake_sender() const
+    {
+        if (!valid() || schema() == nullptr || !schema()->uses_async_node_wake)
+        {
+            throw std::logic_error(
+                "Node has no asynchronous wake sender");
+        }
+        const auto &runtime = runtime_context(ops().context);
+        if (!runtime.layout.has_async_node_wake())
+        {
+            throw std::logic_error(
+                "Node storage plan is missing its asynchronous wake sender");
+        }
+        return node_async_wake_sender(runtime, data());
     }
 
     TSOutputView NodeView::error_output(DateTime evaluation_time) const

--- a/tests/cpp/test_engine_control.cpp
+++ b/tests/cpp/test_engine_control.cpp
@@ -5,10 +5,21 @@
 #include <hgraph/lib/std/std_operators.h>
 #include <hgraph/lib/testing/check_output.h>
 #include <hgraph/lib/testing/eval_node.h>
+#include <hgraph/lib/testing/runtime_support.h>
 #include <hgraph/types/graph_wiring.h>
 #include <hgraph/types/static_node.h>
 
 #include <catch2/catch_test_macros.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <compare>
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <ostream>
+#include <thread>
 
 namespace
 {
@@ -39,7 +50,114 @@ namespace
             return signal;
         }
     };
+
+    struct AsyncWakeState
+    {
+        void install(AsyncNodeWakeSender value)
+        {
+            const std::lock_guard lock{mutex};
+            sender = value;
+        }
+
+        void evaluated()
+        {
+            {
+                const std::lock_guard lock{mutex};
+                ++evaluations;
+            }
+            changed.notify_all();
+        }
+
+        [[nodiscard]] bool wait_for(std::size_t count,
+                                    std::chrono::milliseconds timeout)
+        {
+            std::unique_lock lock{mutex};
+            return changed.wait_for(lock, timeout,
+                                    [&] { return evaluations >= count; });
+        }
+
+        void wake(std::size_t count)
+        {
+            AsyncNodeWakeSender value;
+            {
+                const std::lock_guard lock{mutex};
+                value = sender;
+            }
+            for (std::size_t index = 0; index < count; ++index) { value.wake(); }
+        }
+
+        [[nodiscard]] std::size_t count() const
+        {
+            const std::lock_guard lock{mutex};
+            return evaluations;
+        }
+
+        mutable std::mutex       mutex{};
+        std::condition_variable  changed{};
+        AsyncNodeWakeSender      sender{};
+        std::size_t              evaluations{};
+    };
+
+    struct AsyncWakeHandle
+    {
+        std::shared_ptr<AsyncWakeState> value{};
+
+        friend bool operator==(const AsyncWakeHandle &,
+                               const AsyncWakeHandle &) noexcept = default;
+        friend std::strong_ordering
+        operator<=>(const AsyncWakeHandle &lhs,
+                    const AsyncWakeHandle &rhs) noexcept
+        {
+            return reinterpret_cast<std::uintptr_t>(lhs.value.get()) <=>
+                   reinterpret_cast<std::uintptr_t>(rhs.value.get());
+        }
+    };
+
+    std::ostream &operator<<(std::ostream &stream,
+                             const AsyncWakeHandle &value)
+    {
+        return stream << "AsyncWakeHandle(" << value.value.get() << ')';
+    }
+
+    struct AsyncWakeProbe
+    {
+        static constexpr auto name = "async_node_wake_probe";
+
+        static void start(Scalar<"state", AsyncWakeHandle> state,
+                          AsyncNodeWakeSender sender,
+                          SingleShotScheduler scheduler)
+        {
+            state.value().value->install(sender);
+            scheduler.schedule_now();
+        }
+
+        static void eval(Scalar<"state", AsyncWakeHandle> state)
+        {
+            state.value().value->evaluated();
+        }
+    };
 }  // namespace
+
+namespace std
+{
+    template <>
+    struct hash<AsyncWakeHandle>
+    {
+        size_t operator()(const AsyncWakeHandle &value) const noexcept
+        {
+            return hash<const void *>{}(value.value.get());
+        }
+    };
+}  // namespace std
+
+namespace hgraph::static_schema_detail
+{
+    template <>
+    struct scalar_name<AsyncWakeHandle>
+    {
+        static constexpr std::string_view value{"tests::AsyncWakeHandle"};
+    };
+}  // namespace hgraph::static_schema_detail
 
 TEST_CASE("engine control: static nodes receive the native executor projection")
 {
@@ -56,6 +174,72 @@ TEST_CASE("stop_engine: the current cycle completes and later cycles do not run"
 
     CHECK_OUTPUT(eval_node<StopAfterFirstGraph>(values<bool>(true, true, true)),
                  {true, none, none});
+}
+
+TEST_CASE("engine control: async wakes schedule an ordinary node once at a root boundary")
+{
+    AsyncWakeHandle state{std::make_shared<AsyncWakeState>()};
+    Wiring wiring;
+    wire<AsyncWakeProbe>(wiring, state);
+
+    GraphExecutorBuilder builder;
+    const DateTime now = std::chrono::time_point_cast<std::chrono::microseconds>(
+        engine_clock::now());
+    builder.graph_builder(std::move(wiring).finish())
+        .mode(GraphExecutorMode::RealTime)
+        .start_time(now - std::chrono::milliseconds{1})
+        .end_time(now + std::chrono::seconds{5});
+    auto executor = builder.make_executor();
+    CHECK(executor.view().graph().schema()->push_source_nodes_end == 0);
+    CHECK(executor.view().graph().schema()->waits_for_async_node_wakes);
+
+    auto view = executor.view();
+    AsyncGraphExecutorRun run{view};
+    REQUIRE(state.value->wait_for(1, std::chrono::seconds{2}));
+    state.value->wake(8);
+    REQUIRE(state.value->wait_for(2, std::chrono::seconds{2}));
+    CHECK(state.value->count() == 2);
+    view.request_stop();
+    run.join();
+    state.value->wake(1);
+    CHECK(state.value->count() == 2);
+}
+
+TEST_CASE("engine control: async wake teardown synchronizes with callback threads")
+{
+    AsyncWakeHandle state{std::make_shared<AsyncWakeState>()};
+    Wiring wiring;
+    wire<AsyncWakeProbe>(wiring, state);
+
+    GraphExecutorBuilder builder;
+    const DateTime now = std::chrono::time_point_cast<std::chrono::microseconds>(
+        engine_clock::now());
+    builder.graph_builder(std::move(wiring).finish())
+        .mode(GraphExecutorMode::RealTime)
+        .start_time(now - std::chrono::milliseconds{1})
+        .end_time(now + std::chrono::seconds{5});
+    auto executor = builder.make_executor();
+    auto view     = executor.view();
+    AsyncGraphExecutorRun run{view};
+    REQUIRE(state.value->wait_for(1, std::chrono::seconds{2}));
+
+    std::atomic running{true};
+    std::thread callback([&] {
+        while (running.load(std::memory_order_relaxed))
+        {
+            state.value->wake(1);
+            std::this_thread::yield();
+        }
+    });
+    REQUIRE(state.value->wait_for(2, std::chrono::seconds{2}));
+    view.request_stop();
+    run.join();
+    running.store(false, std::memory_order_relaxed);
+    callback.join();
+
+    const auto evaluations = state.value->count();
+    state.value->wake(1);
+    CHECK(state.value->count() == evaluations);
 }
 
 namespace


### PR DESCRIPTION
## Summary

- add a public, copyable `AsyncNodeWakeSender` that callback-driven resources can use to request an ordinary node evaluation
- admit callback wakes at the root evaluation boundary, conflate duplicate requests, and wake real-time executors without adding work to graphs that do not opt in
- plan sender storage only for nodes that request the injectable, including nodes inside compiled child graphs
- synchronize sender teardown with concurrent callbacks so post-stop wakes are safe no-ops
- keep wiring-time owned scalar values explicitly owned while preserving the allocation-free borrowed scalar path used by node evaluation

This is the reusable core seam required by hgraph-fabric live subscriptions in #512. It is stacked on #531.

## Validation

- macOS fresh native preset: 1,607/1,607 tests passed
- macOS installed SDK consumer: passed
- Python 3.12 abi3 wheel installed into fresh Python 3.14: 2,123 passed, 9 skipped
- Linux GCC 13 warning-clean build: passed
- Linux native suite: 1,607/1,607 tests passed
- Linux Python 3.14 compatibility suite from abi3 wheel: 2,123 passed, 9 skipped
- ASan callback/shutdown lifecycle tests: passed with leak detection
