### PR TITLE
Implement fabric subscription modes

### DIFF
--- a/extensions/fabric/CMakeLists.txt
+++ b/extensions/fabric/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(hgraph_fabric
     src/planning.cpp
     src/publication.cpp
     src/resolution.cpp
+    src/subscription.cpp
     src/types.cpp
     src/value_builders.cpp
     src/impl/memory_notifier.cpp

--- a/extensions/fabric/include/hgraph/fabric/notifier.h
+++ b/extensions/fabric/include/hgraph/fabric/notifier.h
@@ -7,6 +7,7 @@
 #include <hgraph/types/primitive_types.h>
 
 #include <cstddef>
+#include <functional>
 #include <memory>
 #include <optional>
 
@@ -73,6 +74,7 @@ namespace hgraph::fabric
     {
         std::optional<RevisionNotification> (*try_pop)(void *context);
         std::size_t (*pending)(void *context) noexcept;
+        void (*set_waker)(void *context, std::function<void()> waker);
         void (*close)(void *context) noexcept;
     };
 
@@ -95,6 +97,10 @@ namespace hgraph::fabric
 
         [[nodiscard]] std::optional<RevisionNotification> try_pop() const;
         [[nodiscard]] std::size_t pending() const noexcept;
+        /** Install or replace the wake callback used when a data id first
+            becomes pending. Passing an empty callback disables wake-ups.
+            Concrete notifiers invoke it without holding their queue lock. */
+        void set_waker(std::function<void()> waker) const;
         void close() noexcept;
         [[nodiscard]] explicit operator bool() const noexcept;
 

--- a/extensions/fabric/include/hgraph/fabric/resolution.h
+++ b/extensions/fabric/include/hgraph/fabric/resolution.h
@@ -152,6 +152,12 @@ public:
   resolve_forest(std::vector<Str> roots,
                  std::span<const ExposedRootVersion> exposed_roots = {});
 
+  /** Resolve only from revisions which were knowable at ``maximum_as_of``.
+      The bound applies recursively to roots and all ordinary ancestry. */
+  [[nodiscard]] ForestResolution resolve_forest_at(
+      std::vector<Str> roots, DateTime maximum_as_of,
+      std::span<const ExposedRootVersion> exposed_roots = {});
+
 private:
   struct Impl;
   std::unique_ptr<Impl> impl_;
@@ -189,6 +195,12 @@ public:
   /** Resolve current accepted heads. MIN_DT omits notice latency for startup
       image calls which did not originate from a notice. */
   [[nodiscard]] CoordinationResult resolve(DateTime ready_at = MIN_DT);
+
+  /** Resolve and atomically commit a historical cut using no revision later
+      than ``maximum_as_of``. ``ready_at`` is independently used for latency
+      accounting and may remain MIN_DT for replay and snapshot. */
+  [[nodiscard]] CoordinationResult resolve_at(DateTime maximum_as_of,
+                                               DateTime ready_at = MIN_DT);
 
 private:
   struct Impl;

--- a/extensions/fabric/python/hgraph_fabric/__init__.py
+++ b/extensions/fabric/python/hgraph_fabric/__init__.py
@@ -23,6 +23,7 @@ RevisionId = int
 SubscriptionMode = _native.SubscriptionMode
 FabricSubscriptionMode = SubscriptionMode
 ResolutionStatus = _native.ResolutionStatus
+_MemoryFabricFixture = _native._MemoryFabricFixture
 
 
 @dataclass(frozen=True)

--- a/extensions/fabric/python/tests/test_public_contracts.py
+++ b/extensions/fabric/python/tests/test_public_contracts.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import _hgraph
+import hgraph as hg
 import pytest
 
 import hgraph_fabric as hgf
@@ -110,8 +111,66 @@ def test_explicit_dependency_selection_rejects_empty():
 
 
 def _finish_contract_wiring(wiring: _hgraph.Wiring) -> None:
-    with pytest.raises(RuntimeError, match="subscription checkpoints"):
+    with pytest.raises(RuntimeError, match="requires FabricConfig"):
         wiring.run()
+
+
+def _runtime_revision(
+    revision: int,
+    output_version: int,
+    as_of: datetime,
+) -> hgf.DataRevision:
+    return hgf.DataRevision(
+        format_version=1,
+        data_id="python/runtime",
+        revision=revision,
+        output_version=output_version,
+        dependencies=(),
+        self_predecessor=None,
+        as_of=as_of,
+    )
+
+
+def test_python_subscription_modes_execute_the_native_runtime_strategies():
+    base = datetime(2026, 1, 1)
+    fixture = hgf._MemoryFabricFixture("python/subscription-runtime")
+    for revision in (
+        _runtime_revision(1, 1, base + timedelta(microseconds=1)),
+        _runtime_revision(2, 2, base + timedelta(microseconds=2)),
+        _runtime_revision(3, 3, base + timedelta(microseconds=3)),
+    ):
+        fixture.seed(hgf.encode_revision(revision))
+
+    @graph
+    def replay_subscription() -> TS[Frame]:
+        return hgf.subscribe_data(
+            "python/runtime", mode=hgf.SubscriptionMode.REPLAY
+        )
+
+    @graph
+    def snapshot_subscription() -> TS[Frame]:
+        return hgf.subscribe_data(
+            "python/runtime",
+            mode=hgf.SubscriptionMode.SNAPSHOT,
+            as_of=base + timedelta(microseconds=2),
+        )
+
+    with hg.GlobalState() as state:
+        fixture.install(state._impl)
+        replay = hg.run_graph(
+            replay_subscription,
+            start_time=base + timedelta(microseconds=1),
+            end_time=base + timedelta(microseconds=3),
+        )
+        snapshot = hg.run_graph(snapshot_subscription)
+
+    assert [value.get_column("value")[0] for _, value in replay] == [1, 2]
+    assert [when for when, _ in replay] == [
+        base + timedelta(microseconds=1),
+        base + timedelta(microseconds=2),
+    ]
+    assert [value.get_column("value")[0] for _, value in snapshot] == [2]
+    assert snapshot[0][0] == hg.MIN_ST
 
 
 def test_python_planner_wires_direct_shared_conditional_and_nested_graphs():

--- a/extensions/fabric/src/impl/memory_notifier.cpp
+++ b/extensions/fabric/src/impl/memory_notifier.cpp
@@ -1,7 +1,10 @@
+#include <hgraph/fabric/metadata_codec.h>
 #include <hgraph/fabric/notifier.h>
+#include <hgraph/fabric/value_builders.h>
 
 #include <algorithm>
 #include <deque>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <unordered_map>
@@ -14,10 +17,17 @@ namespace hgraph::fabric
     {
         struct MemorySubscription
         {
+            struct PendingNotice
+            {
+                RevisionId revision{};
+                persistence::store::ObjectBytes payload{};
+            };
+
             mutable std::mutex mutex{};
             bool closed{};
             std::deque<Str> order{};
-            std::unordered_map<Str, persistence::store::ObjectBytes> pending{};
+            std::unordered_map<Str, PendingNotice> pending{};
+            std::function<void()> waker{};
         };
 
         struct MemoryNotifier
@@ -56,7 +66,7 @@ namespace hgraph::fabric
                     auto found = subscription.pending.find(data_id);
                     RevisionNotification result{
                         .data_id = std::move(data_id),
-                        .revision = std::move(found->second),
+                        .revision = std::move(found->second.payload),
                     };
                     subscription.pending.erase(found);
                     return result;
@@ -67,6 +77,21 @@ namespace hgraph::fabric
                     const std::scoped_lock lock{subscription.mutex};
                     return subscription.closed ? 0 : subscription.pending.size();
                 },
+                [](void *context, std::function<void()> waker) {
+                    if (context == nullptr) { return; }
+                    auto &subscription = *static_cast<MemorySubscription *>(context);
+                    std::function<void()> notify;
+                    {
+                        const std::scoped_lock lock{subscription.mutex};
+                        if (subscription.closed) { return; }
+                        subscription.waker = std::move(waker);
+                        if (!subscription.pending.empty())
+                        {
+                            notify = subscription.waker;
+                        }
+                    }
+                    if (notify) { notify(); }
+                },
                 [](void *context) noexcept {
                     if (context == nullptr) { return; }
                     auto &subscription = *static_cast<MemorySubscription *>(context);
@@ -74,6 +99,7 @@ namespace hgraph::fabric
                     subscription.closed = true;
                     subscription.order.clear();
                     subscription.pending.clear();
+                    subscription.waker = {};
                 },
             };
             return ops;
@@ -99,6 +125,10 @@ namespace hgraph::fabric
                 },
                 [](void *context, RevisionNotification notification) {
                     auto &owner = *static_cast<MemoryNotifier *>(context);
+                    const RevisionId proposed_revision =
+                        data_revision_input(
+                            decode_revision(notification.revision).view())
+                            .revision;
                     std::vector<std::shared_ptr<MemorySubscription>> subscribers;
                     {
                         const std::scoped_lock lock{owner.mutex};
@@ -116,15 +146,28 @@ namespace hgraph::fabric
                     }
                     for (const auto &subscription : subscribers)
                     {
-                        const std::scoped_lock lock{subscription->mutex};
-                        if (subscription->closed) { continue; }
-                        auto [entry, inserted] = subscription->pending.try_emplace(
-                            notification.data_id, notification.revision);
-                        if (inserted)
+                        std::function<void()> waker;
                         {
-                            subscription->order.push_back(notification.data_id);
+                            const std::scoped_lock lock{subscription->mutex};
+                            if (subscription->closed) { continue; }
+                            auto [entry, inserted] = subscription->pending.try_emplace(
+                                notification.data_id,
+                                MemorySubscription::PendingNotice{
+                                    proposed_revision,
+                                    notification.revision});
+                            if (inserted)
+                            {
+                                subscription->order.push_back(notification.data_id);
+                                waker = subscription->waker;
+                            }
+                            else if (proposed_revision >= entry->second.revision)
+                            {
+                                entry->second = MemorySubscription::PendingNotice{
+                                    proposed_revision,
+                                    notification.revision};
+                            }
                         }
-                        else { entry->second = notification.revision; }
+                        if (waker) { waker(); }
                     }
                     return NotificationDelivery{
                         std::make_shared<ImmediateDelivery>(), delivery_ops()};

--- a/extensions/fabric/src/impl/subscription_runtime.h
+++ b/extensions/fabric/src/impl/subscription_runtime.h
@@ -1,0 +1,228 @@
+#ifndef HGRAPH_FABRIC_IMPL_SUBSCRIPTION_RUNTIME_H
+#define HGRAPH_FABRIC_IMPL_SUBSCRIPTION_RUNTIME_H
+
+#include <hgraph/fabric/operators.h>
+#include <hgraph/fabric/resolution.h>
+
+#include <hgraph/runtime/node_scheduler.h>
+#include <hgraph/types/static_node.h>
+
+#include <compare>
+#include <cstdint>
+#include <memory>
+#include <ostream>
+#include <span>
+#include <vector>
+
+namespace hgraph::fabric::detail
+{
+    using IngressSignal =
+        TSB<"hgraph.fabric::IngressSignal", Field<"frame", TS<Frame>>,
+            Field<"version", TS<Int>>, Field<"revision", TS<Int>>>;
+    using IngressSignals = TSD<Str, IngressSignal>;
+
+    /** The marked source remains visible to the wiring-time dependency walker,
+        while its evaluation path only projects a changed atomic Frame.
+
+        Per tick: O(1) with one shared Arrow-table handle copy; no retained
+        history and no REF allocation. */
+    struct SubscribeDataRuntimeSource
+    {
+        static constexpr auto name = "hgraph.fabric.subscribe_data.planned";
+        using signature_args =
+            std::tuple<In<"signal", IngressSignal, InputActivity::Active,
+                          InputValidity::Unchecked>,
+                       Scalar<"data_id", Str>, Scalar<"mode", SubscriptionMode>,
+                       Scalar<"as_of", DateTime>, Out<TS<Frame>>>;
+
+        static void eval(
+            In<"signal", IngressSignal, InputActivity::Active,
+               InputValidity::Unchecked> signal,
+            Out<TS<Frame>> out)
+        {
+            const auto frame = signal.template field<"frame">();
+            if (frame.modified()) { out.set(frame.value()); }
+        }
+    };
+
+    class IngressBridge;
+
+    struct IngressBridgeHandle
+    {
+        std::shared_ptr<IngressBridge> value{};
+
+        friend bool operator==(const IngressBridgeHandle &,
+                               const IngressBridgeHandle &) noexcept = default;
+        friend std::strong_ordering
+        operator<=>(const IngressBridgeHandle &lhs,
+                    const IngressBridgeHandle &rhs) noexcept
+        {
+            return reinterpret_cast<std::uintptr_t>(lhs.value.get()) <=>
+                   reinterpret_cast<std::uintptr_t>(rhs.value.get());
+        }
+    };
+
+    inline std::ostream &operator<<(std::ostream &stream,
+                                    const IngressBridgeHandle &value)
+    {
+        return stream << "IngressBridgeHandle(" << value.value.get() << ')';
+    }
+
+    class IngressBridge final
+        : public std::enable_shared_from_this<IngressBridge>
+    {
+      public:
+        explicit IngressBridge(std::vector<Str> roots);
+        ~IngressBridge();
+
+        IngressBridge(const IngressBridge &) = delete;
+        IngressBridge &operator=(const IngressBridge &) = delete;
+
+        void start(SubscriptionMode requested_mode, DateTime as_of,
+                   EngineControlView engine, GlobalStateView global_state,
+                   AsyncNodeWakeSender wake_sender);
+        void evaluate(DateTime now, NodeScheduler scheduler,
+                      Out<IngressSignals> &out);
+        void stop() noexcept;
+
+        /** Thread-safe wake path used by concrete notification strategies. */
+        void wake();
+
+      private:
+        struct Impl;
+        std::unique_ptr<Impl> impl_;
+    };
+
+    template <SubscriptionMode Mode>
+    struct IngressCoordinatorNode
+    {
+        /** Cold ingress node, scheduled only for startup, replay entries,
+            notifier wakes, or a retained proposal retry. Per evaluation it
+            performs O(P) pending-proposal work plus the resolver cost
+            documented by ConsistencyResolver; retained storage is O(P + R)
+            for pending ids and cached accepted history. */
+        static constexpr auto name = [] {
+            if constexpr (Mode == SubscriptionMode::Auto)
+                return "hgraph.fabric.ingress.auto";
+            if constexpr (Mode == SubscriptionMode::Live)
+                return "hgraph.fabric.ingress.live";
+            if constexpr (Mode == SubscriptionMode::Replay)
+                return "hgraph.fabric.ingress.replay";
+            return "hgraph.fabric.ingress.snapshot";
+        }();
+
+        static void start(Scalar<"bridge", IngressBridgeHandle> bridge,
+                          Scalar<"as_of", DateTime> as_of,
+                          EngineControlView engine, GlobalStateView global_state,
+                          AsyncNodeWakeSender wake_sender,
+                          SingleShotScheduler scheduler)
+        {
+            bridge.value().value->start(Mode, as_of.value(), engine,
+                                        global_state, wake_sender);
+            scheduler.schedule_now();
+        }
+
+        static void eval(
+            Scalar<"bridge", IngressBridgeHandle> bridge, DateTime now,
+            Scalar<"as_of", DateTime>, NodeScheduler scheduler,
+            Out<IngressSignals> out)
+        {
+            bridge.value().value->evaluate(now, scheduler, out);
+        }
+
+        static void stop(Scalar<"bridge", IngressBridgeHandle> bridge)
+        {
+            bridge.value().value->stop();
+        }
+    };
+
+    template <>
+    struct IngressCoordinatorNode<SubscriptionMode::Replay>
+    {
+        static constexpr auto name = "hgraph.fabric.ingress.replay";
+
+        static void start(Scalar<"bridge", IngressBridgeHandle> bridge,
+                          Scalar<"as_of", DateTime> as_of,
+                          EngineControlView engine,
+                          GlobalStateView global_state,
+                          SingleShotScheduler scheduler)
+        {
+            bridge.value().value->start(SubscriptionMode::Replay,
+                                        as_of.value(), engine, global_state,
+                                        AsyncNodeWakeSender{});
+            scheduler.schedule_now();
+        }
+
+        static void eval(
+            Scalar<"bridge", IngressBridgeHandle> bridge, DateTime now,
+            Scalar<"as_of", DateTime>, NodeScheduler scheduler,
+            Out<IngressSignals> out)
+        {
+            bridge.value().value->evaluate(now, scheduler, out);
+        }
+
+        static void stop(Scalar<"bridge", IngressBridgeHandle> bridge)
+        {
+            bridge.value().value->stop();
+        }
+    };
+
+    template <>
+    struct IngressCoordinatorNode<SubscriptionMode::Snapshot>
+    {
+        static constexpr auto name = "hgraph.fabric.ingress.snapshot";
+
+        static void start(Scalar<"bridge", IngressBridgeHandle> bridge,
+                          Scalar<"as_of", DateTime> as_of,
+                          EngineControlView engine,
+                          GlobalStateView global_state,
+                          SingleShotScheduler scheduler)
+        {
+            bridge.value().value->start(SubscriptionMode::Snapshot,
+                                        as_of.value(), engine, global_state,
+                                        AsyncNodeWakeSender{});
+            scheduler.schedule_now();
+        }
+
+        static void eval(Scalar<"bridge", IngressBridgeHandle> bridge,
+                         DateTime now, Scalar<"as_of", DateTime>,
+                         Out<IngressSignals> out)
+        {
+            bridge.value().value->evaluate(now, NodeScheduler{}, out);
+        }
+
+        static void stop(Scalar<"bridge", IngressBridgeHandle> bridge)
+        {
+            bridge.value().value->stop();
+        }
+    };
+
+    [[nodiscard]] Port<IngressSignals>
+    wire_ingress_group(Wiring &wiring, std::vector<Str> roots,
+                       SubscriptionMode mode, DateTime as_of);
+}  // namespace hgraph::fabric::detail
+
+namespace std
+{
+    template <>
+    struct hash<hgraph::fabric::detail::IngressBridgeHandle>
+    {
+        size_t operator()(
+            const hgraph::fabric::detail::IngressBridgeHandle &value) const noexcept
+        {
+            return hash<const void *>{}(value.value.get());
+        }
+    };
+}  // namespace std
+
+namespace hgraph::static_schema_detail
+{
+    template <>
+    struct scalar_name<fabric::detail::IngressBridgeHandle>
+    {
+        static constexpr std::string_view value{
+            "hgraph.fabric.internal::IngressBridgeHandle"};
+    };
+}  // namespace hgraph::static_schema_detail
+
+#endif  // HGRAPH_FABRIC_IMPL_SUBSCRIPTION_RUNTIME_H

--- a/extensions/fabric/src/notifier.cpp
+++ b/extensions/fabric/src/notifier.cpp
@@ -16,6 +16,7 @@ namespace hgraph::fabric
         }
 
         [[nodiscard]] std::size_t empty_pending(void *) noexcept { return 0; }
+        void empty_set_waker(void *, std::function<void()>) {}
         void empty_close(void *) noexcept {}
 
         [[nodiscard]] NotificationSubscription empty_subscribe(void *)
@@ -94,6 +95,7 @@ namespace hgraph::fabric
         static const NotificationSubscriptionOps ops{
             &empty_try_pop,
             &empty_pending,
+            &empty_set_waker,
             &empty_close,
         };
         return ops;
@@ -106,7 +108,7 @@ namespace hgraph::fabric
         : context_(std::move(context)), ops_(ops)
     {
         if (!context_ || ops_.try_pop == nullptr || ops_.pending == nullptr ||
-            ops_.close == nullptr)
+            ops_.set_waker == nullptr || ops_.close == nullptr)
         {
             throw std::invalid_argument(
                 "fabric notification subscription requires complete operations");
@@ -144,6 +146,11 @@ namespace hgraph::fabric
     std::size_t NotificationSubscription::pending() const noexcept
     {
         return ops_.pending(context_.get());
+    }
+
+    void NotificationSubscription::set_waker(std::function<void()> waker) const
+    {
+        ops_.set_waker(context_.get(), std::move(waker));
     }
 
     void NotificationSubscription::close() noexcept

--- a/extensions/fabric/src/operators.cpp
+++ b/extensions/fabric/src/operators.cpp
@@ -3,13 +3,17 @@
 #include <hgraph/fabric/planning.h>
 #include <hgraph/fabric/value_builders.h>
 
+#include "impl/subscription_runtime.h"
+
 #include <hgraph/lib/std/operators/collection.h>
 #include <hgraph/lib/std/operators/container.h>
 #include <hgraph/lib/std/value_util.h>
 #include <hgraph/types/operator_dispatch.h>
 
 #include <algorithm>
+#include <map>
 #include <memory>
+#include <set>
 #include <stdexcept>
 #include <tuple>
 #include <typeindex>
@@ -22,47 +26,8 @@ namespace hgraph::fabric
 {
     namespace
     {
-        using IngressSignal =
-            TSB<"hgraph.fabric::IngressSignal", Field<"version", TS<Int>>,
-                Field<"revision", TS<Int>>>;
-        using IngressSignals = TSD<Str, IngressSignal>;
-
-        struct SubscribeDataPlanningSource
-        {
-            static constexpr auto name = "hgraph.fabric.subscribe_data.planned";
-            using signature_args =
-                std::tuple<Scalar<"data_id", Str>,
-                           Scalar<"mode", SubscriptionMode>,
-                           Scalar<"as_of", DateTime>, Out<TS<Frame>>>;
-
-            static void start(Scalar<"data_id", Str>,
-                              Scalar<"mode", SubscriptionMode>,
-                              Scalar<"as_of", DateTime>)
-            {
-                throw std::logic_error(
-                    "hgraph.fabric.subscribe_data runtime is introduced by "
-                    "RFC 0026 subscription checkpoints");
-            }
-
-            static void eval() {}
-        };
-
-        /** One root endpoint for accepted lineage signals. Concrete memory and
-            Kafka ingress strategies replace this contract source in the
-            subscription checkpoints. */
-        struct IngressCoordinatorContractSource
-        {
-            static constexpr auto name = "hgraph.fabric.ingress_coordinator.contract";
-
-            static void start()
-            {
-                throw std::logic_error(
-                    "hgraph.fabric ingress runtime is introduced by RFC 0026 "
-                    "subscription checkpoints");
-            }
-
-            static void eval(Out<IngressSignals>) {}
-        };
+        using detail::IngressSignal;
+        using detail::IngressSignals;
 
         struct PublishDataWithoutCutSink
         {
@@ -108,6 +73,8 @@ namespace hgraph::fabric
             WiringPortRef       value{};
             DependencySelection dependencies{DependencySelection::automatic()};
             std::vector<Str>    resolved_dependencies{};
+            std::map<Str, std::pair<SubscriptionMode, DateTime>>
+                resolved_subscription_policies{};
             bool                wired{false};
         };
 
@@ -122,7 +89,7 @@ namespace hgraph::fabric
         [[nodiscard]] NodeTypeRef subscribe_source_type()
         {
             NodeBuilder builder;
-            builder.implementation<SubscribeDataPlanningSource>();
+            builder.implementation<detail::SubscribeDataRuntimeSource>();
             return builder.type();
         }
 
@@ -137,15 +104,35 @@ namespace hgraph::fabric
             return scalars.view().as_bundle().at("data_id").checked_as<Str>();
         }
 
+        [[nodiscard]] std::pair<SubscriptionMode, DateTime>
+        source_policy(const NodeBuilder &builder)
+        {
+            const auto scalars = builder.scalars().view().as_bundle();
+            return {
+                scalars.at("mode").checked_as<SubscriptionMode>(),
+                scalars.at("as_of").checked_as<DateTime>(),
+            };
+        }
+
         struct SourceCollection
         {
             std::unordered_set<const WiringInstance *> wiring_nodes{};
             std::unordered_map<const GraphBuilder *,
                                std::unordered_set<std::size_t>> compiled_nodes{};
             std::vector<Str>                           data_ids{};
+            std::map<Str, std::pair<SubscriptionMode, DateTime>> policies{};
 
-            void add(Str data_id)
+            void add(const NodeBuilder &builder)
             {
+                Str data_id = source_data_id(builder);
+                const auto policy = source_policy(builder);
+                const auto [found, inserted] = policies.emplace(data_id, policy);
+                if (!inserted && found->second != policy)
+                {
+                    throw std::invalid_argument(
+                        "fabric dependency discovery found one data id with "
+                        "multiple subscription policies");
+                }
                 if (std::ranges::find(data_ids, data_id) == data_ids.end())
                 {
                     data_ids.push_back(std::move(data_id));
@@ -193,7 +180,7 @@ namespace hgraph::fabric
             const NodeBuilder &node = graph.nodes()[node_index];
             if (node.type() == source_type)
             {
-                collection.add(source_data_id(node));
+                collection.add(node);
                 return;
             }
             node.visit_child_graphs(&collection, &collect_compiled_child);
@@ -238,9 +225,9 @@ namespace hgraph::fabric
                     const WiringInstance *node = source.peered_node();
                     if (!collection.wiring_nodes.insert(node).second) { return; }
                     if (node->definition ==
-                        std::type_index(typeid(SubscribeDataPlanningSource)))
+                        std::type_index(typeid(detail::SubscribeDataRuntimeSource)))
                     {
-                        collection.add(source_data_id(node->builder));
+                        collection.add(node->builder);
                         return;
                     }
                     node->builder.visit_child_graphs(&collection,
@@ -322,17 +309,180 @@ namespace hgraph::fabric
                 .output.erased();
         }
 
-        void finalize(DeclarationState &state, Wiring &wiring)
+        struct SubscriptionPolicy
         {
+            SubscriptionMode mode{SubscriptionMode::Auto};
+            DateTime         as_of{MIN_DT};
+
+            friend auto operator<=>(const SubscriptionPolicy &,
+                                    const SubscriptionPolicy &) = default;
+        };
+
+        [[nodiscard]] Port<IngressSignals> combine_signal_ports(
+            Wiring &wiring, const std::map<Str, WiringPortRef> &signals)
+        {
+            if (signals.empty())
+            {
+                throw std::invalid_argument(
+                    "fabric ingress combination requires at least one signal");
+            }
+            std::vector<WiringArg> args;
+            args.reserve(signals.size() + 1);
+            WiringArg keys;
+            keys.kind = WiringArg::Kind::Scalar;
+            std::vector<Str> data_ids;
+            data_ids.reserve(signals.size());
+            for (const auto &[data_id, signal] : signals)
+            {
+                static_cast<void>(signal);
+                data_ids.push_back(data_id);
+            }
+            keys.scalar_value = stdlib::make_list<Str>(data_ids.begin(),
+                                                       data_ids.end());
+            keys.scalar_meta = keys.scalar_value.schema();
+            args.push_back(std::move(keys));
+            for (const auto &[data_id, signal] : signals)
+            {
+                static_cast<void>(data_id);
+                WiringArg value;
+                value.kind = WiringArg::Kind::TimeSeries;
+                value.port = signal;
+                args.push_back(std::move(value));
+            }
+            return Port<IngressSignals>{
+                wiring,
+                wire_operator(wiring, "combine_tsd", args, true)
+                    .output.erased()};
+        }
+
+        [[nodiscard]] Port<IngressSignals> wire_subscription_ingress(
+            DeclarationState &state, Wiring &wiring)
+        {
+            std::map<SubscriptionPolicy, std::vector<std::size_t>> groups;
+            std::map<Str, SubscriptionPolicy> policies_by_data_id;
+            for (std::size_t index = 0; index < state.subscriptions.size();
+                 ++index)
+            {
+                const auto &subscription = state.subscriptions[index];
+                const SubscriptionPolicy policy{subscription.mode,
+                                                subscription.as_of};
+                const auto [found, inserted] = policies_by_data_id.emplace(
+                    subscription.data_id, policy);
+                if (!inserted && found->second != policy)
+                {
+                    throw std::invalid_argument(
+                        "hgraph.fabric.subscribe_data: one data id cannot use "
+                        "multiple subscription policies in the same wiring root");
+                }
+                groups[policy].push_back(index);
+            }
+
+            std::map<SubscriptionPolicy, Port<IngressSignals>> group_outputs;
+            for (const auto &[policy, indexes] : groups)
+            {
+                std::vector<Str> roots;
+                roots.reserve(indexes.size());
+                for (const auto index : indexes)
+                {
+                    roots.push_back(state.subscriptions[index].data_id);
+                }
+                group_outputs.emplace(
+                    policy, detail::wire_ingress_group(
+                                wiring, canonical_ids(std::move(roots)),
+                                policy.mode, policy.as_of));
+            }
+
+            std::map<Str, WiringPortRef> signals;
             for (auto &subscription : state.subscriptions)
             {
+                const SubscriptionPolicy policy{subscription.mode,
+                                                subscription.as_of};
+                const auto group = group_outputs.find(policy);
+                if (group == group_outputs.end())
+                {
+                    throw std::logic_error(
+                        "fabric subscription policy group was not wired");
+                }
+                auto signal = wire<stdlib::getitem_>(
+                                  wiring, group->second, subscription.data_id)
+                                  .as<IngressSignal>();
                 if (!subscription.delayed.bound())
                 {
-                    auto source = wire<SubscribeDataPlanningSource>(
-                        wiring, subscription.data_id, subscription.mode,
-                        subscription.as_of);
+                    auto source = wire<detail::SubscribeDataRuntimeSource>(
+                        wiring, signal, subscription.data_id,
+                        subscription.mode, subscription.as_of);
                     subscription.delayed(source);
                 }
+                signals.try_emplace(subscription.data_id, signal.erased());
+            }
+
+            return combine_signal_ports(wiring, signals);
+        }
+
+        [[nodiscard]] Port<IngressSignals> wire_discovered_ingress(
+            Wiring &wiring,
+            const std::map<Str, std::pair<SubscriptionMode, DateTime>> &policies)
+        {
+            std::map<SubscriptionPolicy, std::vector<Str>> groups;
+            for (const auto &[data_id, policy] : policies)
+            {
+                groups[SubscriptionPolicy{policy.first, policy.second}]
+                    .push_back(data_id);
+            }
+            std::map<Str, WiringPortRef> signals;
+            for (auto &[policy, roots] : groups)
+            {
+                auto output = detail::wire_ingress_group(
+                    wiring, canonical_ids(std::move(roots)), policy.mode,
+                    policy.as_of);
+                for (const auto &[data_id, selected_policy] : policies)
+                {
+                    if (selected_policy !=
+                        std::pair{policy.mode, policy.as_of})
+                    {
+                        continue;
+                    }
+                    signals.emplace(
+                        data_id,
+                        wire<stdlib::getitem_>(wiring, output, data_id)
+                            .as<IngressSignal>()
+                            .erased());
+                }
+            }
+            return combine_signal_ports(wiring, signals);
+        }
+
+        [[nodiscard]] Port<IngressSignals> merge_ingress(
+            Wiring &wiring, Port<IngressSignals> first,
+            std::span<const Str> first_ids, Port<IngressSignals> second,
+            const std::map<Str, std::pair<SubscriptionMode, DateTime>> &second_ids)
+        {
+            std::map<Str, WiringPortRef> signals;
+            for (const auto &data_id : first_ids)
+            {
+                signals.emplace(
+                    data_id,
+                    wire<stdlib::getitem_>(wiring, first, data_id)
+                        .as<IngressSignal>()
+                        .erased());
+            }
+            for (const auto &[data_id, policy] : second_ids)
+            {
+                static_cast<void>(policy);
+                signals.emplace(
+                    data_id,
+                    wire<stdlib::getitem_>(wiring, second, data_id)
+                        .as<IngressSignal>()
+                        .erased());
+            }
+            return combine_signal_ports(wiring, signals);
+        }
+
+        void finalize(DeclarationState &state, Wiring &wiring)
+        {
+            if (!state.subscriptions.empty() && !state.coordinator.has_value())
+            {
+                state.coordinator = wire_subscription_ingress(state, wiring);
             }
 
             for (auto &publisher : state.publishers)
@@ -359,6 +509,8 @@ namespace hgraph::fabric
                 }
                 publisher.resolved_dependencies =
                     canonical_ids(std::move(collection.data_ids));
+                publisher.resolved_subscription_policies =
+                    std::move(collection.policies);
                 if (std::ranges::find(publisher.resolved_dependencies,
                                       publisher.data_id) !=
                     publisher.resolved_dependencies.end())
@@ -369,15 +521,47 @@ namespace hgraph::fabric
                 }
             }
 
+            std::set<Str, decltype(&canonical_data_id_less)> direct_ids{
+                &canonical_data_id_less};
+            for (const auto &subscription : state.subscriptions)
+            {
+                direct_ids.insert(subscription.data_id);
+            }
+            std::map<Str, std::pair<SubscriptionMode, DateTime>> missing;
+            for (const auto &publisher : state.publishers)
+            {
+                for (const auto &[data_id, policy] :
+                     publisher.resolved_subscription_policies)
+                {
+                    if (direct_ids.contains(data_id)) { continue; }
+                    const auto [found, inserted] = missing.emplace(data_id, policy);
+                    if (!inserted && found->second != policy)
+                    {
+                        throw std::invalid_argument(
+                            "fabric dependency discovery found conflicting "
+                            "subscription policies for one data id");
+                    }
+                }
+            }
+            if (!missing.empty())
+            {
+                auto discovered = wire_discovered_ingress(wiring, missing);
+                if (state.coordinator.has_value())
+                {
+                    std::vector<Str> ids{direct_ids.begin(), direct_ids.end()};
+                    state.coordinator = merge_ingress(
+                        wiring, *state.coordinator, ids, discovered, missing);
+                }
+                else
+                {
+                    state.coordinator = discovered;
+                }
+            }
+
             DependencyPlanInput plan = build_plan(state);
             wiring.set_trait(DEPENDENCY_PLAN_TRAIT,
                              make_dependency_plan(plan));
 
-            if (!plan.roots.empty() && !state.coordinator.has_value())
-            {
-                state.coordinator =
-                    wire<IngressCoordinatorContractSource>(wiring);
-            }
             for (auto &publisher : state.publishers)
             {
                 if (publisher.wired) { continue; }

--- a/extensions/fabric/src/python_module.cpp
+++ b/extensions/fabric/src/python_module.cpp
@@ -1,9 +1,11 @@
+#include <hgraph/fabric/config.h>
 #include <hgraph/fabric/keys.h>
 #include <hgraph/fabric/metadata_codec.h>
 #include <hgraph/fabric/operators.h>
 #include <hgraph/fabric/resolution.h>
 #include <hgraph/fabric/value_builders.h>
 
+#include <hgraph/runtime/global_state.h>
 #include <hgraph/python/native_scalar_registration.h>
 #include <hgraph/types/operator_dispatch.h>
 
@@ -29,6 +31,17 @@ namespace nb = nanobind;
 
 namespace
 {
+    struct MemoryFabricFixture
+    {
+        explicit MemoryFabricFixture(hgraph::Str prefix)
+            : config(hgraph::fabric::make_memory_fabric_config(
+                  std::move(prefix)))
+        {
+        }
+
+        hgraph::fabric::FabricConfig config;
+    };
+
     [[nodiscard]] nb::bytes to_python_bytes(
         const hgraph::persistence::store::ObjectBytes &value)
     {
@@ -82,6 +95,61 @@ NB_MODULE(_hgraph_fabric, module)
             python_bridge::register_native_scalar_type<SubscriptionMode>(mode);
         });
     OperatorRegistry::instance().run_installers();
+
+    nb::class_<MemoryFabricFixture>(module, "_MemoryFabricFixture")
+        .def(nb::init<Str>(), nb::arg("prefix"))
+        .def(
+            "install",
+            [](MemoryFabricFixture &self, nb::handle state) {
+                set_fabric_config(nb::cast<GlobalState &>(state).view(),
+                                  self.config);
+            },
+            nb::arg("global_state"))
+        .def(
+            "seed",
+            [](MemoryFabricFixture &self, const nb::bytes &encoded) {
+                const DataRevisionInput revision = data_revision_input(
+                    decode_revision(bytes_view(encoded)).view());
+                const std::string frame_key = data_version_key(
+                    self.config.prefix, revision.data_id,
+                    revision.output_version);
+                if (!self.config.frames.contains(frame_key))
+                {
+                    self.config.frames.write(
+                        frame_key, fixture_frame(revision.output_version));
+                }
+                const auto stored = self.config.objects.put_immutable(
+                    revision_key(self.config.prefix, revision.data_id,
+                                 revision.revision),
+                    encode_revision(make_data_revision(revision).view()));
+                if (stored.status !=
+                        persistence::store::ImmutableWriteStatus::Created &&
+                    stored.status !=
+                        persistence::store::ImmutableWriteStatus::Unchanged)
+                {
+                    throw std::invalid_argument(
+                        "fabric fixture revision slot conflicts");
+                }
+            },
+            nb::arg("encoded_revision"))
+        .def(
+            "notify",
+            [](MemoryFabricFixture &self, const nb::bytes &encoded) {
+                auto payload = persistence::store::ObjectBytes{
+                    bytes_view(encoded).begin(), bytes_view(encoded).end()};
+                const DataRevisionInput revision = data_revision_input(
+                    decode_revision(payload).view());
+                const auto delivery = self.config.notifications.publish(
+                    {.data_id = revision.data_id,
+                     .revision = std::move(payload)});
+                const auto result = delivery.poll();
+                if (result.status != NotificationDeliveryStatus::Delivered)
+                {
+                    throw std::runtime_error(
+                        "fabric fixture notification was not delivered");
+                }
+            },
+            nb::arg("encoded_revision"));
 
     module.def(
         "_encode_revision",

--- a/extensions/fabric/src/resolution.cpp
+++ b/extensions/fabric/src/resolution.cpp
@@ -121,6 +121,7 @@ struct ConsistencyResolver::Impl {
   ResolverMetrics metrics{};
   std::map<Str, DataVersion, IdLess> lower_bounds{};
   std::vector<ResolvedCut> maxima{};
+  DateTime maximum_as_of{MAX_DT};
   bool saw_cycle{};
 
   explicit Impl(FabricConfig configured) : config(std::move(configured)) {
@@ -366,7 +367,10 @@ struct ConsistencyResolver::Impl {
       result.reserve(found->second.size());
       for (auto index = found->second.rbegin(); index != found->second.rend();
            ++index) {
-        result.push_back(&data.revisions[*index]);
+        const auto &revision = data.revisions[*index];
+        if (revision.as_of <= maximum_as_of) {
+          result.push_back(&revision);
+        }
       }
       return result;
     }
@@ -375,6 +379,9 @@ struct ConsistencyResolver::Impl {
     const auto lower = lower_bounds.find(data_id);
     for (auto revision = data.revisions.rbegin();
          revision != data.revisions.rend(); ++revision) {
+      if (revision->as_of > maximum_as_of) {
+        continue;
+      }
       if (lower != lower_bounds.end() &&
           revision->output_version < lower->second) {
         continue;
@@ -594,9 +601,15 @@ struct ConsistencyResolver::Impl {
   }
 
   ForestResolution resolve(std::vector<Str> roots,
-                           std::span<const ExposedRootVersion> exposed) {
+                           std::span<const ExposedRootVersion> exposed,
+                           DateTime as_of_limit) {
     canonicalise_ids(roots, "resolver roots");
+    if (as_of_limit <= MIN_DT) {
+      throw std::invalid_argument(
+          "fabric historical resolution requires a real as-of bound");
+    }
     metrics = {};
+    maximum_as_of = as_of_limit;
     lower_bounds.clear();
     refreshed_this_call.clear();
     maxima.clear();
@@ -687,7 +700,13 @@ ConsistencyResolver::operator=(ConsistencyResolver &&) noexcept = default;
 
 ForestResolution ConsistencyResolver::resolve_forest(
     std::vector<Str> roots, std::span<const ExposedRootVersion> exposed_roots) {
-  return impl_->resolve(std::move(roots), exposed_roots);
+  return impl_->resolve(std::move(roots), exposed_roots, MAX_DT);
+}
+
+ForestResolution ConsistencyResolver::resolve_forest_at(
+    std::vector<Str> roots, DateTime maximum_as_of,
+    std::span<const ExposedRootVersion> exposed_roots) {
+  return impl_->resolve(std::move(roots), exposed_roots, maximum_as_of);
 }
 
 struct ConsistencyCoordinator::Impl {
@@ -780,7 +799,8 @@ struct ConsistencyCoordinator::Impl {
     return true;
   }
 
-  [[nodiscard]] CoordinationResult resolve_all(DateTime ready_at) {
+  [[nodiscard]] CoordinationResult resolve_all(DateTime ready_at,
+                                                DateTime maximum_as_of) {
     std::vector<std::vector<Str>> groups;
     groups.reserve(roots.size());
     for (const auto &root : roots) {
@@ -793,7 +813,10 @@ struct ConsistencyCoordinator::Impl {
       results.reserve(groups.size());
       for (const auto &group : groups) {
         const auto exposed_bounds = bounds(group);
-        results.push_back(resolver.resolve_forest(group, exposed_bounds));
+        results.push_back(maximum_as_of == MAX_DT
+                              ? resolver.resolve_forest(group, exposed_bounds)
+                              : resolver.resolve_forest_at(
+                                    group, maximum_as_of, exposed_bounds));
       }
       if (!merge_overlaps(groups, results)) {
         break;
@@ -888,6 +911,11 @@ void ConsistencyCoordinator::observe_notice(Str data_id, DateTime noticed_at) {
 }
 
 CoordinationResult ConsistencyCoordinator::resolve(DateTime ready_at) {
-  return impl_->resolve_all(ready_at);
+  return impl_->resolve_all(ready_at, MAX_DT);
+}
+
+CoordinationResult ConsistencyCoordinator::resolve_at(DateTime maximum_as_of,
+                                                      DateTime ready_at) {
+  return impl_->resolve_all(ready_at, maximum_as_of);
 }
 } // namespace hgraph::fabric

--- a/extensions/fabric/src/subscription.cpp
+++ b/extensions/fabric/src/subscription.cpp
@@ -1,0 +1,662 @@
+#include "impl/subscription_runtime.h"
+
+#include <hgraph/fabric/config.h>
+#include <hgraph/fabric/keys.h>
+#include <hgraph/fabric/metadata_codec.h>
+#include <hgraph/fabric/value_builders.h>
+
+#include <hgraph/types/metadata/type_registry.h>
+
+#include <algorithm>
+#include <iterator>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <set>
+#include <stdexcept>
+#include <utility>
+
+namespace hgraph::fabric::detail
+{
+    namespace
+    {
+        struct IdLess
+        {
+            using is_transparent = void;
+
+            [[nodiscard]] bool operator()(std::string_view lhs,
+                                          std::string_view rhs) const noexcept
+            {
+                return canonical_data_id_less(lhs, rhs);
+            }
+        };
+
+        struct IngressRootUpdate
+        {
+            Str                  data_id{};
+            RevisionId           revision{};
+            DataVersion          output_version{};
+            std::optional<Frame> frame{};
+        };
+
+        struct IngressBatch
+        {
+            std::vector<IngressRootUpdate> roots{};
+        };
+
+        struct RuntimeCore
+        {
+            FabricConfig                              config;
+            std::vector<Str>                          roots;
+            ConsistencyCoordinator                    coordinator;
+            std::map<Str, RevisionId, IdLess>         emitted_revisions{};
+            std::set<Str, IdLess>                     observed{};
+
+            RuntimeCore(FabricConfig configured, std::vector<Str> configured_roots)
+                : config(std::move(configured)), roots(std::move(configured_roots)),
+                  coordinator(config, roots), observed(roots.begin(), roots.end())
+            {
+            }
+
+            void observe(const CoordinationResult &result)
+            {
+                for (const auto &forest : result.forests)
+                {
+                    observed.insert(forest.observed_data_ids.begin(),
+                                    forest.observed_data_ids.end());
+                }
+            }
+
+            [[nodiscard]] std::optional<IngressBatch>
+            batch(CoordinationResult result)
+            {
+                for (const auto &forest : result.forests)
+                {
+                    if (forest.status == ResolutionStatus::Corrupt ||
+                        forest.status == ResolutionStatus::Ambiguous ||
+                        forest.status == ResolutionStatus::Cyclic)
+                    {
+                        throw std::runtime_error(
+                            "fabric subscription consistency failure for root '" +
+                            forest.roots.front() + "': " +
+                            std::string{enum_name(forest.status)} + ": " +
+                            forest.diagnostic);
+                    }
+                }
+                observe(result);
+                std::map<Str, Frame, IdLess> changed;
+                for (auto &root : result.changed_roots)
+                {
+                    changed.emplace(root.data_id, std::move(root.frame));
+                }
+
+                IngressBatch batch;
+                for (const auto &root : roots)
+                {
+                    const auto selected = std::ranges::lower_bound(
+                        result.committed_lineage, root, canonical_data_id_less,
+                        &ResolvedRevision::data_id);
+                    if (selected == result.committed_lineage.end() ||
+                        selected->data_id != root)
+                    {
+                        continue;
+                    }
+                    const auto prior = emitted_revisions.find(root);
+                    if (prior != emitted_revisions.end() &&
+                        prior->second == selected->revision)
+                    {
+                        continue;
+                    }
+
+                    std::optional<Frame> frame;
+                    if (auto value = changed.find(root); value != changed.end())
+                    {
+                        frame = std::move(value->second);
+                    }
+                    batch.roots.push_back(IngressRootUpdate{
+                        .data_id = root,
+                        .revision = selected->revision,
+                        .output_version = selected->output_version,
+                        .frame = std::move(frame),
+                    });
+                    emitted_revisions[root] = selected->revision;
+                }
+                if (batch.roots.empty()) { return std::nullopt; }
+                return batch;
+            }
+        };
+
+        struct StrategyOps
+        {
+            void (*start)(void *context, std::weak_ptr<IngressBridge> bridge);
+            std::optional<IngressBatch> (*evaluate)(void *context, DateTime now,
+                                                    NodeScheduler scheduler);
+            void (*stop)(void *context) noexcept;
+            void (*destroy)(void *context) noexcept;
+        };
+
+        void empty_start(void *, std::weak_ptr<IngressBridge>) {}
+        std::optional<IngressBatch> empty_evaluate(void *, DateTime,
+                                                   NodeScheduler)
+        {
+            return std::nullopt;
+        }
+        void empty_stop(void *) noexcept {}
+        void empty_destroy(void *) noexcept {}
+
+        [[nodiscard]] const StrategyOps &empty_strategy_ops() noexcept
+        {
+            static const StrategyOps ops{
+                &empty_start, &empty_evaluate, &empty_stop, &empty_destroy};
+            return ops;
+        }
+
+        class ErasedStrategy final
+        {
+          public:
+            ErasedStrategy() noexcept = default;
+
+            template <typename T>
+            explicit ErasedStrategy(std::unique_ptr<T> value)
+                : context_(value.release()), ops_(&ops_for<T>())
+            {
+            }
+
+            ErasedStrategy(const ErasedStrategy &) = delete;
+            ErasedStrategy &operator=(const ErasedStrategy &) = delete;
+
+            ErasedStrategy(ErasedStrategy &&other) noexcept
+                : context_(std::exchange(other.context_, nullptr)),
+                  ops_(std::exchange(other.ops_, &empty_strategy_ops()))
+            {
+            }
+
+            ErasedStrategy &operator=(ErasedStrategy &&other) noexcept
+            {
+                if (this != &other)
+                {
+                    reset();
+                    context_ = std::exchange(other.context_, nullptr);
+                    ops_ = std::exchange(other.ops_, &empty_strategy_ops());
+                }
+                return *this;
+            }
+
+            ~ErasedStrategy() { reset(); }
+
+            void start(std::weak_ptr<IngressBridge> bridge) const
+            {
+                ops_->start(context_, std::move(bridge));
+            }
+
+            [[nodiscard]] std::optional<IngressBatch>
+            evaluate(DateTime now, NodeScheduler scheduler) const
+            {
+                return ops_->evaluate(context_, now, scheduler);
+            }
+
+            void stop() const noexcept { ops_->stop(context_); }
+
+            void reset() noexcept
+            {
+                ops_->destroy(context_);
+                context_ = nullptr;
+                ops_ = &empty_strategy_ops();
+            }
+
+          private:
+            template <typename T>
+            [[nodiscard]] static const StrategyOps &ops_for() noexcept
+            {
+                static const StrategyOps ops{
+                    [](void *context, std::weak_ptr<IngressBridge> bridge) {
+                        static_cast<T *>(context)->start(std::move(bridge));
+                    },
+                    [](void *context, DateTime now, NodeScheduler scheduler) {
+                        return static_cast<T *>(context)->evaluate(now, scheduler);
+                    },
+                    [](void *context) noexcept {
+                        static_cast<T *>(context)->stop();
+                    },
+                    [](void *context) noexcept { delete static_cast<T *>(context); },
+                };
+                return ops;
+            }
+
+            void              *context_{};
+            const StrategyOps *ops_{&empty_strategy_ops()};
+        };
+
+        struct SnapshotStrategy
+        {
+            RuntimeCore core;
+            DateTime    as_of;
+            bool        complete{};
+
+            SnapshotStrategy(FabricConfig config, std::vector<Str> roots,
+                             DateTime configured_as_of)
+                : core(std::move(config), std::move(roots)),
+                  as_of(configured_as_of)
+            {
+            }
+
+            void start(std::weak_ptr<IngressBridge>) {}
+
+            [[nodiscard]] std::optional<IngressBatch>
+            evaluate(DateTime, NodeScheduler)
+            {
+                if (complete) { return std::nullopt; }
+                complete = true;
+                return core.batch(core.coordinator.resolve_at(as_of));
+            }
+
+            void stop() noexcept { complete = true; }
+        };
+
+        struct ReplayStrategy
+        {
+            RuntimeCore                              core;
+            DateTime                                 end_time;
+            std::map<Str, std::vector<DateTime>, IdLess> histories{};
+
+            ReplayStrategy(FabricConfig config, std::vector<Str> roots,
+                           DateTime configured_end)
+                : core(std::move(config), std::move(roots)),
+                  end_time(configured_end)
+            {
+            }
+
+            void start(std::weak_ptr<IngressBridge>) {}
+
+            [[nodiscard]] const std::vector<DateTime> &history(const Str &data_id)
+            {
+                auto [entry, inserted] = histories.try_emplace(data_id);
+                if (!inserted) { return entry->second; }
+
+                const std::string category = as_of_key_prefix(
+                    core.config.prefix, data_id);
+                const std::string prefix = category + "/";
+                std::optional<std::string> cursor;
+                for (;;)
+                {
+                    const auto page = core.config.objects.list(
+                        prefix,
+                        cursor.has_value()
+                            ? std::optional<std::string_view>{*cursor}
+                            : std::nullopt,
+                        1000);
+                    for (const auto &object : page.objects)
+                    {
+                        if (!object.key.starts_with(prefix))
+                        {
+                            throw std::runtime_error(
+                                "fabric as-of listing escaped its data id");
+                        }
+                        const auto encoded = std::string_view{object.key}.substr(
+                            prefix.size());
+                        entry->second.emplace_back(TimeDelta{
+                            decode_fabric_ordinal(encoded)});
+                    }
+                    if (!page.next_start_after.has_value()) { break; }
+                    cursor = page.next_start_after;
+                }
+                return entry->second;
+            }
+
+            [[nodiscard]] std::optional<DateTime> next_after(DateTime now)
+            {
+                std::optional<DateTime> next;
+                for (const auto &data_id : core.observed)
+                {
+                    const auto &times = history(data_id);
+                    const auto found = std::ranges::upper_bound(times, now);
+                    if (found == times.end() || *found >= end_time) { continue; }
+                    if (!next.has_value() || *found < *next) { next = *found; }
+                }
+                return next;
+            }
+
+            [[nodiscard]] std::optional<IngressBatch>
+            evaluate(DateTime now, NodeScheduler scheduler)
+            {
+                if (now >= end_time) { return std::nullopt; }
+                auto result = core.coordinator.resolve_at(now);
+                core.observe(result);
+                if (const auto next = next_after(now); next.has_value())
+                {
+                    scheduler.schedule(*next);
+                }
+                return core.batch(std::move(result));
+            }
+
+            void stop() noexcept {}
+        };
+
+        struct LiveStrategy
+        {
+            struct PendingProposal
+            {
+                RevisionId                           revision{};
+                DateTime                             noticed_at{MIN_DT};
+                DateTime                             next_attempt{MIN_DT};
+                TimeDelta                            backoff{std::chrono::milliseconds{1}};
+            };
+
+            static constexpr TimeDelta MAX_BACKOFF{
+                std::chrono::seconds{1}};
+            static constexpr std::string_view RETRY_TAG{
+                "fabric-storage-retry"};
+
+            RuntimeCore                              core;
+            NotificationSubscription                 subscription{};
+            std::map<Str, PendingProposal, IdLess>   pending{};
+            bool                                     startup{true};
+            bool                                     wall_clock{};
+
+            LiveStrategy(FabricConfig config, std::vector<Str> roots,
+                         bool use_wall_clock)
+                : core(std::move(config), std::move(roots)),
+                  wall_clock(use_wall_clock)
+            {
+            }
+
+            void start(std::weak_ptr<IngressBridge> bridge)
+            {
+                subscription = core.config.notifications.subscribe();
+                subscription.set_waker([bridge = std::move(bridge)] {
+                    if (const auto owner = bridge.lock()) { owner->wake(); }
+                });
+            }
+
+            void drain(DateTime now)
+            {
+                while (auto notification = subscription.try_pop())
+                {
+                    if (!core.observed.contains(notification->data_id))
+                    {
+                        continue;
+                    }
+                    const Value decoded = decode_revision(notification->revision);
+                    const DataRevisionInput revision =
+                        data_revision_input(decoded.view());
+                    auto found = pending.find(notification->data_id);
+                    if (found != pending.end() &&
+                        found->second.revision > revision.revision)
+                    {
+                        continue;
+                    }
+                    pending[notification->data_id] = PendingProposal{
+                        .revision = revision.revision,
+                        .noticed_at = now,
+                        .next_attempt = now,
+                    };
+                }
+            }
+
+            [[nodiscard]] bool admit(DateTime now)
+            {
+                bool admitted{};
+                for (auto item = pending.begin(); item != pending.end();)
+                {
+                    if (item->second.next_attempt > now)
+                    {
+                        ++item;
+                        continue;
+                    }
+                    const auto slot = core.config.objects.get(revision_key(
+                        core.config.prefix, item->first,
+                        item->second.revision));
+                    if (!slot.has_value())
+                    {
+                        item->second.next_attempt = now + item->second.backoff;
+                        item->second.backoff = std::min(
+                            item->second.backoff * 2, MAX_BACKOFF);
+                        ++item;
+                        continue;
+                    }
+
+                    // Decode the durable winner. A different proposal payload is
+                    // deliberately ignored: immutable persistence is authoritative.
+                    const Value winner = decode_revision(slot->data);
+                    const DataRevisionInput accepted =
+                        data_revision_input(winner.view());
+                    if (accepted.data_id != item->first ||
+                        accepted.revision != item->second.revision)
+                    {
+                        throw std::runtime_error(
+                            "fabric notification references a malformed durable slot");
+                    }
+                    core.coordinator.observe_notice(item->first,
+                                                    item->second.noticed_at);
+                    item = pending.erase(item);
+                    admitted = true;
+                }
+                return admitted;
+            }
+
+            void schedule_retry(DateTime now, NodeScheduler scheduler)
+            {
+                std::optional<DateTime> next;
+                for (const auto &[data_id, proposal] : pending)
+                {
+                    static_cast<void>(data_id);
+                    if (!next.has_value() || proposal.next_attempt < *next)
+                    {
+                        next = proposal.next_attempt;
+                    }
+                }
+                if (!next.has_value())
+                {
+                    if (scheduler.has_tag(RETRY_TAG))
+                    {
+                        scheduler.un_schedule(std::string{RETRY_TAG});
+                    }
+                    return;
+                }
+
+                if (scheduler.tag_is_scheduled_now(std::string{RETRY_TAG}))
+                {
+                    static_cast<void>(
+                        scheduler.pop_tag(std::string{RETRY_TAG}));
+                }
+                if (!scheduler.has_tag(RETRY_TAG) ||
+                    *next < scheduler.tag_time(RETRY_TAG))
+                {
+                    const DateTime target = std::max(*next, now + MIN_TD);
+                    scheduler.schedule(target, std::string{RETRY_TAG},
+                                       wall_clock);
+                }
+            }
+
+            [[nodiscard]] std::optional<IngressBatch>
+            evaluate(DateTime now, NodeScheduler scheduler)
+            {
+                std::optional<IngressBatch> batch;
+                if (startup)
+                {
+                    // Establish the durable image and therefore its dynamic
+                    // ancestry before filtering notices accumulated during
+                    // startup. This is the in-process form of the RFC no-gap
+                    // subscription-before-image handoff.
+                    batch = core.batch(core.coordinator.resolve(now));
+                }
+                drain(now);
+                const bool admitted = admit(now);
+
+                if (admitted)
+                {
+                    if (auto update = core.batch(core.coordinator.resolve(now));
+                        update.has_value())
+                    {
+                        if (!batch.has_value()) { batch.emplace(); }
+                        batch->roots.insert(
+                            batch->roots.end(),
+                            std::make_move_iterator(update->roots.begin()),
+                            std::make_move_iterator(update->roots.end()));
+                    }
+                }
+                startup = false;
+                schedule_retry(now, scheduler);
+                return batch;
+            }
+
+            void stop() noexcept
+            {
+                subscription.close();
+                pending.clear();
+            }
+        };
+
+        [[nodiscard]] ErasedStrategy make_strategy(
+            SubscriptionMode mode, DateTime as_of, EngineControlView engine,
+            FabricConfig config, const std::vector<Str> &roots)
+        {
+            switch (mode)
+            {
+                case SubscriptionMode::Snapshot:
+                    return ErasedStrategy{std::make_unique<SnapshotStrategy>(
+                        std::move(config), roots, as_of)};
+                case SubscriptionMode::Replay:
+                    return ErasedStrategy{std::make_unique<ReplayStrategy>(
+                        std::move(config), roots, engine.end_time())};
+                case SubscriptionMode::Live:
+                    return ErasedStrategy{std::make_unique<LiveStrategy>(
+                        std::move(config), roots,
+                        engine.mode() == GraphExecutorMode::RealTime)};
+                case SubscriptionMode::Auto:
+                    break;
+            }
+            throw std::invalid_argument(
+                "fabric ingress strategy must be resolved before construction");
+        }
+    }  // namespace
+
+    struct IngressBridge::Impl
+    {
+        explicit Impl(std::vector<Str> configured_roots)
+            : roots(std::move(configured_roots))
+        {
+            std::ranges::sort(roots, canonical_data_id_less);
+            roots.erase(std::ranges::unique(roots).begin(), roots.end());
+            if (roots.empty())
+            {
+                throw std::invalid_argument(
+                    "fabric ingress bridge requires at least one root");
+            }
+            for (const auto &root : roots) { require_data_id(root); }
+        }
+
+        std::vector<Str> roots{};
+        std::mutex mutex{};
+        AsyncNodeWakeSender wake_sender{};
+        bool active{};
+        ErasedStrategy strategy{};
+    };
+
+    IngressBridge::IngressBridge(std::vector<Str> roots)
+        : impl_(std::make_unique<Impl>(std::move(roots)))
+    {
+    }
+
+    IngressBridge::~IngressBridge() { stop(); }
+
+    void IngressBridge::start(SubscriptionMode requested_mode, DateTime as_of,
+                              EngineControlView engine,
+                              GlobalStateView global_state,
+                              AsyncNodeWakeSender wake_sender)
+    {
+        const auto configured = fabric_config(global_state);
+        if (!configured.has_value())
+        {
+            throw std::logic_error(
+                "hgraph.fabric.subscribe_data requires FabricConfig in GlobalState");
+        }
+        SubscriptionMode resolved = requested_mode;
+        if (resolved == SubscriptionMode::Auto)
+        {
+            resolved = engine.mode() == GraphExecutorMode::RealTime
+                           ? configured->default_real_time
+                           : configured->default_simulation;
+        }
+        {
+            const std::scoped_lock lock{impl_->mutex};
+            if (resolved == SubscriptionMode::Live && !wake_sender.valid())
+            {
+                throw std::logic_error(
+                    "fabric ingress requires a live async node wake sender");
+            }
+            impl_->wake_sender = wake_sender;
+            impl_->active = resolved == SubscriptionMode::Live;
+        }
+        impl_->strategy = make_strategy(resolved, as_of, engine, *configured,
+                                        impl_->roots);
+        impl_->strategy.start(weak_from_this());
+    }
+
+    void IngressBridge::evaluate(DateTime now, NodeScheduler scheduler,
+                                 Out<IngressSignals> &out)
+    {
+        const auto batch = impl_->strategy.evaluate(now, scheduler);
+        if (!batch.has_value()) { return; }
+        for (const auto &root : batch->roots)
+        {
+            auto signal = out[root.data_id];
+            if (root.frame.has_value())
+            {
+                signal.template field<"frame">().set(*root.frame);
+            }
+            signal.template field<"version">().set(root.output_version);
+            signal.template field<"revision">().set(root.revision);
+        }
+    }
+
+    void IngressBridge::stop() noexcept
+    {
+        if (!impl_) { return; }
+        {
+            const std::scoped_lock lock{impl_->mutex};
+            impl_->active = false;
+        }
+        impl_->strategy.stop();
+        impl_->strategy.reset();
+        const std::scoped_lock lock{impl_->mutex};
+        impl_->wake_sender = {};
+    }
+
+    void IngressBridge::wake()
+    {
+        AsyncNodeWakeSender sender;
+        {
+            const std::scoped_lock lock{impl_->mutex};
+            if (!impl_->active || !impl_->wake_sender.valid()) { return; }
+            sender = impl_->wake_sender;
+        }
+        sender.wake();
+    }
+
+    Port<IngressSignals> wire_ingress_group(Wiring &wiring,
+                                             std::vector<Str> roots,
+                                             SubscriptionMode mode,
+                                             DateTime as_of)
+    {
+        IngressBridgeHandle bridge{
+            std::make_shared<IngressBridge>(std::move(roots))};
+
+        switch (mode)
+        {
+            case SubscriptionMode::Auto:
+                return wire<IngressCoordinatorNode<SubscriptionMode::Auto>>(
+                    wiring, bridge, as_of);
+            case SubscriptionMode::Live:
+                return wire<IngressCoordinatorNode<SubscriptionMode::Live>>(
+                    wiring, bridge, as_of);
+            case SubscriptionMode::Replay:
+                return wire<IngressCoordinatorNode<SubscriptionMode::Replay>>(
+                    wiring, bridge, as_of);
+            case SubscriptionMode::Snapshot:
+                return wire<IngressCoordinatorNode<SubscriptionMode::Snapshot>>(
+                    wiring, bridge, as_of);
+        }
+        throw std::invalid_argument("unsupported fabric subscription mode");
+    }
+}  // namespace hgraph::fabric::detail

--- a/extensions/fabric/tests/CMakeLists.txt
+++ b/extensions/fabric/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(hgraph_fabric_tests
     test_public_contracts.cpp
     test_publication.cpp
     test_resolution.cpp
+    test_subscription.cpp
 )
 target_link_libraries(hgraph_fabric_tests
     PRIVATE hgraph::fabric Catch2::Catch2WithMain)

--- a/extensions/fabric/tests/test_public_contracts.cpp
+++ b/extensions/fabric/tests/test_public_contracts.cpp
@@ -320,6 +320,8 @@ TEST_CASE("memory notifier fans out and conflates each data id")
     auto notifier = hgf::make_memory_notifier();
     auto first = notifier.subscribe();
     auto second = notifier.subscribe();
+    std::size_t wakes{};
+    first.set_waker([&] { ++wakes; });
 
     CHECK(notifier.publish({"a", notice("a", 1)}).poll().status ==
           hgf::NotificationDeliveryStatus::Delivered);
@@ -327,6 +329,7 @@ TEST_CASE("memory notifier fans out and conflates each data id")
           hgf::NotificationDeliveryStatus::Delivered);
     CHECK(notifier.publish({"a", notice("a", 2)}).poll().status ==
           hgf::NotificationDeliveryStatus::Delivered);
+    CHECK(wakes == 2);
     CHECK_THROWS_AS(notifier.publish({"a", notice("different", 1)}),
                     std::invalid_argument);
 
@@ -440,7 +443,7 @@ TEST_CASE("fabric planner wires one coordinator and hidden lineage cuts")
 
     const auto dependent = hg::build_graph<IndependentForestsGraph>();
     CHECK(count_semantic_node(
-              dependent, "hgraph.fabric.ingress_coordinator.contract") == 1);
+              dependent, "hgraph.fabric.ingress.auto") == 1);
     CHECK(count_semantic_node(
               dependent, "hgraph.fabric.publish_data.with_cut") == 2);
     CHECK(count_semantic_node(

--- a/extensions/fabric/tests/test_resolution.cpp
+++ b/extensions/fabric/tests/test_resolution.cpp
@@ -35,7 +35,8 @@ void seed(const hgf::FabricConfig &config, std::string data_id,
           hgf::RevisionId revision, hgf::DataVersion output_version,
           std::vector<hgf::DataDependencyInput> dependencies = {},
           std::optional<hgf::DataVersion> self_predecessor = {},
-          std::string field = "value", bool write_frame = true) {
+          std::string field = "value", bool write_frame = true,
+          std::optional<hg::DateTime> as_of = {}) {
   const std::string frame_key =
       hgf::data_version_key(config.prefix, data_id, output_version);
   if (write_frame && !config.frames.contains(frame_key)) {
@@ -47,7 +48,7 @@ void seed(const hgf::FabricConfig &config, std::string data_id,
       .output_version = output_version,
       .dependencies = std::move(dependencies),
       .self_predecessor = self_predecessor,
-      .as_of = BASE_TIME + hg::TimeDelta{revision},
+      .as_of = as_of.value_or(BASE_TIME + hg::TimeDelta{revision}),
   });
   const auto decoded = hgf::data_revision_input(value.view());
   REQUIRE(config.objects
@@ -294,6 +295,29 @@ TEST_CASE("root versions never regress below an exposed cut") {
   REQUIRE(result.status == hgf::ResolutionStatus::Unchanged);
   CHECK(selection(result, "A").output_version == 2);
   CHECK(result.changed_roots.empty());
+}
+
+TEST_CASE("historical resolution applies the as-of bound recursively") {
+  auto config = hgf::make_memory_fabric_config("tests/resolution/as-of");
+  seed(config, "P", 1, 1, {}, {}, "value", true,
+       BASE_TIME + hg::TimeDelta{1});
+  seed(config, "P", 2, 2, {}, {}, "value", true,
+       BASE_TIME + hg::TimeDelta{4});
+  seed(config, "A", 1, 1, {{"P", 1}}, {}, "value", true,
+       BASE_TIME + hg::TimeDelta{2});
+  seed(config, "A", 2, 2, {{"P", 2}}, {}, "value", true,
+       BASE_TIME + hg::TimeDelta{5});
+
+  hgf::ConsistencyResolver resolver{config};
+  const auto historical = resolver.resolve_forest_at(
+      {"A"}, BASE_TIME + hg::TimeDelta{3});
+  REQUIRE(historical.status == hgf::ResolutionStatus::Ready);
+  CHECK(selection(historical, "A").revision == 1);
+  CHECK(selection(historical, "P").revision == 1);
+
+  hgf::ConsistencyResolver pending{config};
+  CHECK(pending.resolve_forest_at({"A"}, BASE_TIME + hg::TimeDelta{1})
+            .status == hgf::ResolutionStatus::Pending);
 }
 
 TEST_CASE("coordinator measures conflated notice to ready latency") {

--- a/extensions/fabric/tests/test_subscription.cpp
+++ b/extensions/fabric/tests/test_subscription.cpp
@@ -1,0 +1,669 @@
+#include <hgraph/fabric/fabric.h>
+
+#include <hgraph/lib/std/operators/impl/record_replay_memory_impl.h>
+#include <hgraph/lib/std/operators/registration.h>
+#include <hgraph/lib/testing/runtime_support.h>
+#include <hgraph/types/subgraph_wiring.h>
+
+#include <arrow/api.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <vector>
+
+namespace hgraph::fabric::test_detail
+{
+    struct CapturedFrame
+    {
+        DateTime evaluation_time{MIN_DT};
+        Frame    frame{};
+    };
+
+    struct CaptureState
+    {
+        void push(DateTime now, Frame frame)
+        {
+            std::unique_lock lock{mutex};
+            values.push_back({now, std::move(frame)});
+            if (block_at.has_value() && values.size() == *block_at)
+            {
+                blocked = true;
+                changed.notify_all();
+                changed.wait(lock, [&] { return released; });
+            }
+            lock.unlock();
+            changed.notify_all();
+        }
+
+        void block_on(std::size_t count)
+        {
+            const std::lock_guard lock{mutex};
+            block_at = count;
+        }
+
+        [[nodiscard]] bool wait_until_blocked(
+            std::chrono::milliseconds timeout)
+        {
+            std::unique_lock lock{mutex};
+            return changed.wait_for(lock, timeout, [&] { return blocked; });
+        }
+
+        void release()
+        {
+            {
+                const std::lock_guard lock{mutex};
+                released = true;
+            }
+            changed.notify_all();
+        }
+
+        [[nodiscard]] bool wait_for(std::size_t count,
+                                    std::chrono::milliseconds timeout)
+        {
+            std::unique_lock lock{mutex};
+            return changed.wait_for(lock, timeout,
+                                    [&] { return values.size() >= count; });
+        }
+
+        [[nodiscard]] std::vector<CapturedFrame> snapshot() const
+        {
+            const std::lock_guard lock{mutex};
+            return values;
+        }
+
+        mutable std::mutex       mutex{};
+        std::condition_variable  changed{};
+        std::vector<CapturedFrame> values{};
+        std::optional<std::size_t> block_at{};
+        bool                       blocked{};
+        bool                       released{};
+    };
+
+    struct CaptureHandle
+    {
+        std::shared_ptr<CaptureState> value{};
+
+        friend bool operator==(const CaptureHandle &,
+                               const CaptureHandle &) noexcept = default;
+        friend std::strong_ordering operator<=>(const CaptureHandle &lhs,
+                                                const CaptureHandle &rhs) noexcept
+        {
+            return reinterpret_cast<std::uintptr_t>(lhs.value.get()) <=>
+                   reinterpret_cast<std::uintptr_t>(rhs.value.get());
+        }
+    };
+
+    inline std::ostream &operator<<(std::ostream &stream,
+                                    const CaptureHandle &value)
+    {
+        return stream << "CaptureHandle(" << value.value.get() << ')';
+    }
+
+    struct CaptureFrameSink
+    {
+        static constexpr auto name = "hgraph.fabric.test.capture_frame";
+
+        static void eval(In<"value", TS<Frame>> value,
+                         Scalar<"capture", CaptureHandle> capture,
+                         DateTime now)
+        {
+            capture.value().value->push(now, value.value());
+        }
+    };
+
+    struct NestedLiveSubscription
+    {
+        static Port<TS<Frame>> compose(Wiring &wiring)
+        {
+            return subscribe_data(wiring, "nested-live",
+                                  SubscriptionMode::Live);
+        }
+    };
+
+    struct SubscribeGate
+    {
+        explicit SubscribeGate(Notifier configured)
+            : inner(std::move(configured))
+        {
+        }
+
+        NotificationSubscription subscribe()
+        {
+            auto result = inner.subscribe();
+            std::unique_lock lock{mutex};
+            subscribed = true;
+            changed.notify_all();
+            changed.wait(lock, [&] { return released; });
+            return result;
+        }
+
+        [[nodiscard]] bool wait_until_subscribed(
+            std::chrono::milliseconds timeout)
+        {
+            std::unique_lock lock{mutex};
+            return changed.wait_for(lock, timeout,
+                                    [&] { return subscribed; });
+        }
+
+        void release()
+        {
+            {
+                const std::lock_guard lock{mutex};
+                released = true;
+            }
+            changed.notify_all();
+        }
+
+        Notifier                 inner{};
+        std::mutex               mutex{};
+        std::condition_variable  changed{};
+        bool                     subscribed{};
+        bool                     released{};
+    };
+
+    [[nodiscard]] Notifier gated_notifier(
+        const std::shared_ptr<SubscribeGate> &gate)
+    {
+        static const NotifierOps ops{
+            [](void *context) {
+                return static_cast<SubscribeGate *>(context)->subscribe();
+            },
+            [](void *context, RevisionNotification notification) {
+                return static_cast<SubscribeGate *>(context)->inner.publish(
+                    std::move(notification));
+            },
+        };
+        return Notifier{gate, ops};
+    }
+}  // namespace hgraph::fabric::test_detail
+
+namespace std
+{
+    template <>
+    struct hash<hgraph::fabric::test_detail::CaptureHandle>
+    {
+        size_t operator()(
+            const hgraph::fabric::test_detail::CaptureHandle &value) const noexcept
+        {
+            return hash<const void *>{}(value.value.get());
+        }
+    };
+}  // namespace std
+
+namespace hgraph::static_schema_detail
+{
+    template <>
+    struct scalar_name<fabric::test_detail::CaptureHandle>
+    {
+        static constexpr std::string_view value{
+            "hgraph.fabric.test::CaptureHandle"};
+    };
+}  // namespace hgraph::static_schema_detail
+
+namespace
+{
+    namespace hg = hgraph;
+    namespace hgf = hgraph::fabric;
+    namespace detail = hgraph::fabric::test_detail;
+    namespace hgps = hgraph::persistence::store;
+
+    constexpr hg::DateTime BASE_TIME{
+        hg::TimeDelta{1'900'000'000'000'000}};
+
+    [[nodiscard]] hg::Frame frame(std::int64_t value)
+    {
+        arrow::Int64Builder builder;
+        REQUIRE(builder.Append(value).ok());
+        auto array = builder.Finish();
+        REQUIRE(array.ok());
+        return hg::Frame{arrow::Table::Make(
+            arrow::schema({arrow::field("value", arrow::int64())}),
+            {std::move(array).ValueOrDie()})};
+    }
+
+    [[nodiscard]] std::int64_t value_of(const hg::Frame &value)
+    {
+        REQUIRE(value.has_value());
+        const auto array = std::static_pointer_cast<arrow::Int64Array>(
+            value.table->column(0)->chunk(0));
+        return array->Value(0);
+    }
+
+    hgps::ObjectBytes seed(
+        const hgf::FabricConfig &config, std::string data_id,
+        hgf::RevisionId revision, hgf::DataVersion output_version,
+        hg::DateTime as_of,
+        std::vector<hgf::DataDependencyInput> dependencies = {},
+        bool write_slot = true)
+    {
+        const std::string frame_key = hgf::data_version_key(
+            config.prefix, data_id, output_version);
+        if (!config.frames.contains(frame_key))
+        {
+            config.frames.write(frame_key, frame(output_version));
+        }
+        const auto encoded_value = hgf::make_data_revision(
+            hgf::DataRevisionInput{
+                .data_id = data_id,
+                .revision = revision,
+                .output_version = output_version,
+                .dependencies = std::move(dependencies),
+                .as_of = as_of,
+            });
+        auto encoded = hgf::encode_revision(encoded_value.view());
+        if (write_slot)
+        {
+            REQUIRE(config.objects
+                        .put_immutable(hgf::revision_key(
+                                           config.prefix, data_id, revision),
+                                       encoded)
+                        .status == hgps::ImmutableWriteStatus::Created);
+        }
+        return encoded;
+    }
+
+    [[nodiscard]] hg::GraphExecutorValue make_executor(
+        const hgf::FabricConfig &config, hgf::SubscriptionMode subscription_mode,
+        hg::GraphExecutorMode executor_mode, hg::DateTime start,
+        hg::DateTime end, detail::CaptureHandle capture,
+        std::optional<hg::DateTime> as_of = {}, bool nested = false)
+    {
+        hg::stdlib::register_standard_operators();
+        hgf::register_fabric_operators();
+        hg::Wiring wiring;
+        hgf::set_fabric_config(wiring.global_state(), config);
+        hg::Port<hg::TS<hg::Frame>> source = nested
+            ? hg::nested_<detail::NestedLiveSubscription>(wiring)
+            : hgf::subscribe_data(wiring, nested ? "nested-live" : "data",
+                                  subscription_mode, as_of);
+        hg::wire<detail::CaptureFrameSink>(wiring, source, capture);
+
+        hg::GraphExecutorBuilder builder;
+        builder.graph_builder(std::move(wiring).finish())
+            .mode(executor_mode)
+            .start_time(start)
+            .end_time(end);
+        return builder.make_executor();
+    }
+
+    [[nodiscard]] std::vector<std::int64_t>
+    values(const detail::CaptureHandle &capture)
+    {
+        std::vector<std::int64_t> result;
+        for (const auto &item : capture.value->snapshot())
+        {
+            result.push_back(value_of(item.frame));
+        }
+        return result;
+    }
+}  // namespace
+
+TEST_CASE("snapshot emits one recursively bounded image at graph start")
+{
+    auto config = hgf::make_memory_fabric_config("tests/subscription/snapshot");
+    seed(config, "P", 1, 1, BASE_TIME + hg::TimeDelta{1});
+    seed(config, "P", 2, 2, BASE_TIME + hg::TimeDelta{4});
+    seed(config, "data", 1, 1, BASE_TIME + hg::TimeDelta{2}, {{"P", 1}});
+    seed(config, "data", 2, 2, BASE_TIME + hg::TimeDelta{5}, {{"P", 2}});
+
+    detail::CaptureHandle capture{std::make_shared<detail::CaptureState>()};
+    auto executor = make_executor(
+        config, hgf::SubscriptionMode::Snapshot,
+        hg::GraphExecutorMode::Simulation, BASE_TIME + hg::TimeDelta{10},
+        BASE_TIME + hg::TimeDelta{12}, capture,
+        BASE_TIME + hg::TimeDelta{3});
+    CHECK_FALSE(executor.view().graph().schema()->waits_for_async_node_wakes);
+    executor.view().run();
+
+    REQUIRE(values(capture) == std::vector<std::int64_t>{1});
+    CHECK(capture.value->snapshot().front().evaluation_time ==
+          BASE_TIME + hg::TimeDelta{10});
+}
+
+TEST_CASE("subscription surfaces corrupt accepted storage as a node failure")
+{
+    auto config = hgf::make_memory_fabric_config(
+        "tests/subscription/corrupt");
+    const auto revision = hgf::make_data_revision(hgf::DataRevisionInput{
+        .data_id = "data",
+        .revision = 1,
+        .output_version = 1,
+        .as_of = BASE_TIME + hg::TimeDelta{1},
+    });
+    REQUIRE(config.objects
+                .put_immutable(
+                    hgf::revision_key(config.prefix, "data", 1),
+                    hgf::encode_revision(revision.view()))
+                .status == hgps::ImmutableWriteStatus::Created);
+
+    detail::CaptureHandle capture{std::make_shared<detail::CaptureState>()};
+    auto executor = make_executor(
+        config, hgf::SubscriptionMode::Snapshot,
+        hg::GraphExecutorMode::Simulation, BASE_TIME + hg::TimeDelta{2},
+        BASE_TIME + hg::TimeDelta{3}, capture,
+        BASE_TIME + hg::TimeDelta{2});
+    CHECK_THROWS_WITH(
+        executor.view().run(),
+        Catch::Matchers::ContainsSubstring("Corrupt") &&
+            Catch::Matchers::ContainsSubstring("missing durable Frame"));
+}
+
+TEST_CASE("replay is seeded at start and excludes the end time")
+{
+    auto config = hgf::make_memory_fabric_config("tests/subscription/replay");
+    seed(config, "data", 1, 1, BASE_TIME + hg::TimeDelta{1});
+    seed(config, "data", 2, 2, BASE_TIME + hg::TimeDelta{2});
+    seed(config, "data", 3, 3, BASE_TIME + hg::TimeDelta{3});
+    seed(config, "data", 4, 4, BASE_TIME + hg::TimeDelta{5});
+
+    detail::CaptureHandle capture{std::make_shared<detail::CaptureState>()};
+    auto executor = make_executor(
+        config, hgf::SubscriptionMode::Replay,
+        hg::GraphExecutorMode::Simulation, BASE_TIME + hg::TimeDelta{2},
+        BASE_TIME + hg::TimeDelta{5}, capture);
+    CHECK_FALSE(executor.view().graph().schema()->waits_for_async_node_wakes);
+    executor.view().run();
+
+    CHECK(values(capture) == std::vector<std::int64_t>{2, 3});
+    const auto observed = capture.value->snapshot();
+    REQUIRE(observed.size() == 2);
+    CHECK(observed[0].evaluation_time == BASE_TIME + hg::TimeDelta{2});
+    CHECK(observed[1].evaluation_time == BASE_TIME + hg::TimeDelta{3});
+}
+
+TEST_CASE("replay advances hidden lineage without copying an unchanged Frame")
+{
+    auto config = hgf::make_memory_fabric_config(
+        "tests/subscription/input-only");
+    seed(config, "P", 1, 1, BASE_TIME + hg::TimeDelta{1});
+    seed(config, "P", 2, 2, BASE_TIME + hg::TimeDelta{2});
+    seed(config, "data", 1, 1, BASE_TIME + hg::TimeDelta{1}, {{"P", 1}});
+    seed(config, "data", 2, 1, BASE_TIME + hg::TimeDelta{2}, {{"P", 2}});
+
+    detail::CaptureHandle capture{std::make_shared<detail::CaptureState>()};
+    auto executor = make_executor(
+        config, hgf::SubscriptionMode::Replay,
+        hg::GraphExecutorMode::Simulation, BASE_TIME + hg::TimeDelta{1},
+        BASE_TIME + hg::TimeDelta{3}, capture);
+    executor.view().run();
+
+    CHECK(values(capture) == std::vector<std::int64_t>{1});
+}
+
+TEST_CASE("replay from MIN_ST opens dynamic ancestry without a future seed")
+{
+    auto config = hgf::make_memory_fabric_config("tests/subscription/min-st");
+    seed(config, "A", 1, 1, BASE_TIME + hg::TimeDelta{1});
+    seed(config, "B", 1, 1, BASE_TIME + hg::TimeDelta{2});
+    seed(config, "data", 1, 1, BASE_TIME + hg::TimeDelta{1}, {{"A", 1}});
+    seed(config, "data", 2, 2, BASE_TIME + hg::TimeDelta{3}, {{"B", 1}});
+
+    detail::CaptureHandle capture{std::make_shared<detail::CaptureState>()};
+    auto executor = make_executor(
+        config, hgf::SubscriptionMode::Replay,
+        hg::GraphExecutorMode::Simulation, hg::MIN_ST,
+        BASE_TIME + hg::TimeDelta{4}, capture);
+    executor.view().run();
+
+    CHECK(values(capture) == std::vector<std::int64_t>{1, 2});
+}
+
+TEST_CASE("replay batches equal as-of timestamps across dynamic ancestry")
+{
+    auto config = hgf::make_memory_fabric_config(
+        "tests/subscription/equal-as-of");
+    seed(config, "P", 1, 1, BASE_TIME + hg::TimeDelta{1});
+    seed(config, "data", 1, 1, BASE_TIME + hg::TimeDelta{1}, {{"P", 1}});
+    seed(config, "P", 2, 2, BASE_TIME + hg::TimeDelta{2});
+    seed(config, "data", 2, 2, BASE_TIME + hg::TimeDelta{2}, {{"P", 2}});
+
+    detail::CaptureHandle capture{std::make_shared<detail::CaptureState>()};
+    auto executor = make_executor(
+        config, hgf::SubscriptionMode::Replay,
+        hg::GraphExecutorMode::Simulation, BASE_TIME + hg::TimeDelta{1},
+        BASE_TIME + hg::TimeDelta{3}, capture);
+    executor.view().run();
+
+    CHECK(values(capture) == std::vector<std::int64_t>{1, 2});
+    const auto observed = capture.value->snapshot();
+    REQUIRE(observed.size() == 2);
+    CHECK(observed[1].evaluation_time == BASE_TIME + hg::TimeDelta{2});
+}
+
+TEST_CASE("replay emits a held cut when its dependency becomes knowable")
+{
+    auto config = hgf::make_memory_fabric_config(
+        "tests/subscription/held-cut");
+    seed(config, "P", 1, 1, BASE_TIME + hg::TimeDelta{1});
+    seed(config, "data", 1, 1, BASE_TIME + hg::TimeDelta{1}, {{"P", 1}});
+    seed(config, "data", 2, 2, BASE_TIME + hg::TimeDelta{2}, {{"P", 2}});
+    seed(config, "P", 2, 2, BASE_TIME + hg::TimeDelta{3});
+
+    detail::CaptureHandle capture{std::make_shared<detail::CaptureState>()};
+    auto executor = make_executor(
+        config, hgf::SubscriptionMode::Replay,
+        hg::GraphExecutorMode::Simulation, BASE_TIME + hg::TimeDelta{1},
+        BASE_TIME + hg::TimeDelta{4}, capture);
+    executor.view().run();
+
+    CHECK(values(capture) == std::vector<std::int64_t>{1, 2});
+    const auto observed = capture.value->snapshot();
+    REQUIRE(observed.size() == 2);
+    CHECK(observed[1].evaluation_time == BASE_TIME + hg::TimeDelta{3});
+}
+
+TEST_CASE("Auto selects replay once for a simulation run")
+{
+    auto config = hgf::make_memory_fabric_config("tests/subscription/auto");
+    seed(config, "data", 1, 1, BASE_TIME + hg::TimeDelta{1});
+    seed(config, "data", 2, 2, BASE_TIME + hg::TimeDelta{2});
+
+    detail::CaptureHandle capture{std::make_shared<detail::CaptureState>()};
+    auto executor = make_executor(
+        config, hgf::SubscriptionMode::Auto,
+        hg::GraphExecutorMode::Simulation, BASE_TIME + hg::TimeDelta{1},
+        BASE_TIME + hg::TimeDelta{3}, capture);
+    executor.view().run();
+    CHECK(values(capture) == std::vector<std::int64_t>{1, 2});
+}
+
+TEST_CASE("Auto honours the configured simulation strategy once in start")
+{
+    auto config = hgf::make_memory_fabric_config(
+        "tests/subscription/auto-live", hgf::SubscriptionMode::Live,
+        hgf::SubscriptionMode::Live);
+    seed(config, "data", 1, 1, BASE_TIME + hg::TimeDelta{1});
+    seed(config, "data", 2, 2, BASE_TIME + hg::TimeDelta{2});
+
+    detail::CaptureHandle capture{std::make_shared<detail::CaptureState>()};
+    auto executor = make_executor(
+        config, hgf::SubscriptionMode::Auto,
+        hg::GraphExecutorMode::Simulation, BASE_TIME + hg::TimeDelta{1},
+        BASE_TIME + hg::TimeDelta{3}, capture);
+    executor.view().run();
+
+    CHECK(values(capture) == std::vector<std::int64_t>{2});
+}
+
+TEST_CASE("live subscribes before loading and emits the raced durable image")
+{
+    const auto now = std::chrono::time_point_cast<std::chrono::microseconds>(
+        hg::engine_clock::now());
+    auto config = hgf::make_memory_fabric_config(
+        "tests/subscription/startup-race");
+    auto gate = std::make_shared<detail::SubscribeGate>(config.notifications);
+    config.notifications = detail::gated_notifier(gate);
+    seed(config, "P", 1, 1, now - std::chrono::seconds{3});
+    seed(config, "data", 1, 1, now - std::chrono::seconds{3}, {{"P", 1}});
+
+    detail::CaptureHandle capture{std::make_shared<detail::CaptureState>()};
+    auto executor = make_executor(
+        config, hgf::SubscriptionMode::Live,
+        hg::GraphExecutorMode::RealTime, now - std::chrono::milliseconds{1},
+        now + std::chrono::seconds{5}, capture);
+    CHECK(executor.view().graph().schema()->waits_for_async_node_wakes);
+    auto view = executor.view();
+    hg::testing::AsyncGraphExecutorRun run{view};
+    REQUIRE(gate->wait_until_subscribed(std::chrono::seconds{2}));
+
+    const auto parent = seed(config, "P", 2, 2,
+                             now - std::chrono::seconds{2});
+    const auto root = seed(config, "data", 2, 2,
+                           now - std::chrono::seconds{2}, {{"P", 2}});
+    REQUIRE(config.notifications.publish({"P", parent}).poll().status ==
+            hgf::NotificationDeliveryStatus::Delivered);
+    REQUIRE(config.notifications.publish({"data", root}).poll().status ==
+            hgf::NotificationDeliveryStatus::Delivered);
+    gate->release();
+
+    REQUIRE(capture.value->wait_for(1, std::chrono::seconds{2}));
+    view.request_stop();
+    run.join();
+    CHECK(values(capture) == std::vector<std::int64_t>{2});
+}
+
+TEST_CASE("slow live clients conflate and skip stale out-of-order notices")
+{
+    const auto now = std::chrono::time_point_cast<std::chrono::microseconds>(
+        hg::engine_clock::now());
+    auto config = hgf::make_memory_fabric_config(
+        "tests/subscription/slow-client");
+    seed(config, "data", 1, 1, now - std::chrono::seconds{4});
+
+    detail::CaptureHandle capture{std::make_shared<detail::CaptureState>()};
+    capture.value->block_on(2);
+    auto executor = make_executor(
+        config, hgf::SubscriptionMode::Live,
+        hg::GraphExecutorMode::RealTime, now - std::chrono::milliseconds{1},
+        now + std::chrono::seconds{5}, capture);
+    auto view = executor.view();
+    hg::testing::AsyncGraphExecutorRun run{view};
+    REQUIRE(capture.value->wait_for(1, std::chrono::seconds{2}));
+
+    const auto second = seed(config, "data", 2, 2,
+                             now - std::chrono::seconds{3});
+    REQUIRE(config.notifications.publish({"data", second}).poll().status ==
+            hgf::NotificationDeliveryStatus::Delivered);
+    REQUIRE(capture.value->wait_until_blocked(std::chrono::seconds{2}));
+
+    const auto third = seed(config, "data", 3, 3,
+                            now - std::chrono::seconds{2});
+    const auto fourth = seed(config, "data", 4, 4,
+                             now - std::chrono::seconds{1});
+    REQUIRE(config.notifications.publish({"data", fourth}).poll().status ==
+            hgf::NotificationDeliveryStatus::Delivered);
+    REQUIRE(config.notifications.publish({"data", third}).poll().status ==
+            hgf::NotificationDeliveryStatus::Delivered);
+    capture.value->release();
+
+    REQUIRE(capture.value->wait_for(3, std::chrono::seconds{2}));
+    view.request_stop();
+    run.join();
+    CHECK(values(capture) == std::vector<std::int64_t>{1, 2, 4});
+}
+
+TEST_CASE("live retains an ahead proposal when a stale notice follows")
+{
+    const auto now = std::chrono::time_point_cast<std::chrono::microseconds>(
+        hg::engine_clock::now());
+    auto config = hgf::make_memory_fabric_config(
+        "tests/subscription/ahead-conflation");
+    seed(config, "data", 1, 1, now - std::chrono::seconds{4});
+
+    detail::CaptureHandle capture{std::make_shared<detail::CaptureState>()};
+    capture.value->block_on(1);
+    auto executor = make_executor(
+        config, hgf::SubscriptionMode::Live,
+        hg::GraphExecutorMode::RealTime, now - std::chrono::milliseconds{1},
+        now + std::chrono::seconds{5}, capture);
+    auto view = executor.view();
+    hg::testing::AsyncGraphExecutorRun run{view};
+    REQUIRE(capture.value->wait_until_blocked(std::chrono::seconds{2}));
+
+    const auto ahead = seed(config, "data", 3, 3,
+                            now - std::chrono::seconds{2}, {}, false);
+    const auto stale = seed(config, "data", 2, 2,
+                            now - std::chrono::seconds{3});
+    REQUIRE(config.notifications.publish({"data", ahead}).poll().status ==
+            hgf::NotificationDeliveryStatus::Delivered);
+    REQUIRE(config.notifications.publish({"data", stale}).poll().status ==
+            hgf::NotificationDeliveryStatus::Delivered);
+    capture.value->release();
+    CHECK_FALSE(capture.value->wait_for(2, std::chrono::milliseconds{20}));
+
+    REQUIRE(config.objects
+                .put_immutable(hgf::revision_key(config.prefix, "data", 3),
+                               ahead)
+                .status == hgps::ImmutableWriteStatus::Created);
+    REQUIRE(capture.value->wait_for(2, std::chrono::seconds{2}));
+    view.request_stop();
+    run.join();
+
+    CHECK(values(capture) == std::vector<std::int64_t>{1, 3});
+}
+
+TEST_CASE("Auto selects live once and retries an ahead-of-storage notice")
+{
+    const auto now = std::chrono::time_point_cast<std::chrono::microseconds>(
+        hg::engine_clock::now());
+    auto config = hgf::make_memory_fabric_config("tests/subscription/live");
+    seed(config, "data", 1, 1, now - std::chrono::seconds{2});
+
+    detail::CaptureHandle capture{std::make_shared<detail::CaptureState>()};
+    auto executor = make_executor(
+        config, hgf::SubscriptionMode::Auto,
+        hg::GraphExecutorMode::RealTime, now - std::chrono::milliseconds{1},
+        now + std::chrono::seconds{5}, capture);
+    auto view = executor.view();
+    hg::testing::AsyncGraphExecutorRun run{view};
+    REQUIRE(capture.value->wait_for(1, std::chrono::seconds{2}));
+
+    const auto proposal = seed(config, "data", 2, 2,
+                               now - std::chrono::seconds{1}, {}, false);
+    REQUIRE(config.notifications.publish({"data", proposal}).poll().status ==
+            hgf::NotificationDeliveryStatus::Delivered);
+    CHECK_FALSE(capture.value->wait_for(2, std::chrono::milliseconds{20}));
+    REQUIRE(config.objects
+                .put_immutable(hgf::revision_key(config.prefix, "data", 2),
+                               proposal)
+                .status == hgps::ImmutableWriteStatus::Created);
+    REQUIRE(capture.value->wait_for(2, std::chrono::seconds{2}));
+    view.request_stop();
+    run.join();
+
+    CHECK(values(capture) == std::vector<std::int64_t>{1, 2});
+}
+
+TEST_CASE("live notification wake crosses a nested graph boundary")
+{
+    const auto now = std::chrono::time_point_cast<std::chrono::microseconds>(
+        hg::engine_clock::now());
+    auto config = hgf::make_memory_fabric_config("tests/subscription/nested");
+    seed(config, "nested-live", 1, 1, now - std::chrono::seconds{2});
+
+    detail::CaptureHandle capture{std::make_shared<detail::CaptureState>()};
+    auto executor = make_executor(
+        config, hgf::SubscriptionMode::Live,
+        hg::GraphExecutorMode::RealTime, now - std::chrono::milliseconds{1},
+        now + std::chrono::seconds{5}, capture, {}, true);
+    auto view = executor.view();
+    hg::testing::AsyncGraphExecutorRun run{view};
+    REQUIRE(capture.value->wait_for(1, std::chrono::seconds{2}));
+
+    const auto revision = seed(config, "nested-live", 2, 2,
+                               now - std::chrono::seconds{1});
+    REQUIRE(config.notifications.publish({"nested-live", revision}).poll().status ==
+            hgf::NotificationDeliveryStatus::Delivered);
+    REQUIRE(capture.value->wait_for(2, std::chrono::seconds{2}));
+    view.request_stop();
+    run.join();
+
+    CHECK(values(capture) == std::vector<std::int64_t>{1, 2});
+}


### PR DESCRIPTION
## Summary

- implement one-shot Snapshot images and half-open Replay from durable as-of indexes
- implement Live subscription-before-image startup, local per-data-id conflation, and slow-client skipping
- retain one newest ahead-of-storage proposal per data id and retry it with bounded backoff until its immutable winning slot validates
- make durable persistence authoritative when a losing proposal payload differs from the accepted slot
- select Auto once during source start from `EngineControlView` and run concrete erased strategies without per-tick mode dispatch
- expose the same operators and runtime behavior through the Python adapter

This completes checkpoint 5 of #512 and is stacked on #532.

## Validation

- macOS native suite: 1,607/1,607 tests passed
- macOS installed SDK consumer, including Fabric probe: passed
- macOS Python 3.14 compatibility suite from Python-3.12-built abi3 wheel: 2,123 passed, 9 skipped
- macOS installed Fabric Python suite: 16/16 passed
- Linux GCC 13 warning-clean build: passed
- Linux native suite: 1,607/1,607 tests passed
- Linux Python 3.14 compatibility suite from Python-3.12-built abi3 wheel: 2,123 passed, 9 skipped
- Linux installed Fabric Python suite: 16/16 passed
