### PR TITLE
Add Kafka-backed fabric notifier

### DIFF
--- a/extensions/fabric/CMakeLists.txt
+++ b/extensions/fabric/CMakeLists.txt
@@ -10,6 +10,9 @@ option(HGRAPH_FABRIC_BUILD_PYTHON "Build the optional Python authoring bridge" O
 option(HGRAPH_FABRIC_WARNINGS_AS_ERRORS
     "Treat hgraph-fabric compiler warnings as errors"
     ${HGRAPH_WARNINGS_AS_ERRORS})
+option(HGRAPH_FABRIC_BUILD_KAFKA_NOTIFIER
+    "Build the optional production hgraph-kafka notifier adapter"
+    ${HGRAPH_BUILD_KAFKA_EXTENSION})
 
 if(HGRAPH_FABRIC_BUILD_PYTHON)
     find_package(Python 3.12 COMPONENTS
@@ -68,6 +71,42 @@ else()
     endif()
 endif()
 
+if(HGRAPH_FABRIC_BUILD_KAFKA_NOTIFIER)
+    if(NOT TARGET hgraph::kafka)
+        find_package(hgraph-kafka CONFIG REQUIRED)
+    endif()
+    add_library(hgraph_fabric_kafka src/kafka_notifier.cpp)
+    add_library(hgraph::fabric_kafka ALIAS hgraph_fabric_kafka)
+    get_target_property(HGRAPH_FABRIC_KAFKA_LIBRARY_TYPE hgraph_fabric_kafka TYPE)
+    if(HGRAPH_FABRIC_KAFKA_LIBRARY_TYPE STREQUAL "STATIC_LIBRARY")
+        target_compile_definitions(hgraph_fabric_kafka
+            PUBLIC HGRAPH_FABRIC_KAFKA_STATIC_DEFINE)
+    endif()
+    target_compile_features(hgraph_fabric_kafka PUBLIC cxx_std_23)
+    target_link_libraries(hgraph_fabric_kafka
+        PUBLIC hgraph::fabric hgraph::kafka)
+    target_include_directories(hgraph_fabric_kafka
+        PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    )
+    set_target_properties(hgraph_fabric_kafka PROPERTIES
+        EXPORT_NAME fabric_kafka
+        POSITION_INDEPENDENT_CODE ON
+    )
+    if(MSVC)
+        target_compile_options(hgraph_fabric_kafka PRIVATE /W4 /permissive-)
+        if(HGRAPH_FABRIC_WARNINGS_AS_ERRORS)
+            target_compile_options(hgraph_fabric_kafka PRIVATE /WX)
+        endif()
+    else()
+        target_compile_options(hgraph_fabric_kafka PRIVATE -Wall -Wextra -Wpedantic)
+        if(HGRAPH_FABRIC_WARNINGS_AS_ERRORS)
+            target_compile_options(hgraph_fabric_kafka PRIVATE -Werror)
+        endif()
+    endif()
+endif()
+
 if(BUILD_TESTING)
     add_subdirectory(tests)
 endif()
@@ -100,6 +139,15 @@ install(TARGETS hgraph_fabric
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
+if(TARGET hgraph_fabric_kafka)
+    install(TARGETS hgraph_fabric_kafka
+        EXPORT hgraphFabricTargets
+        COMPONENT Development
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+endif()
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     COMPONENT Development FILES_MATCHING PATTERN "*.h")
 

--- a/extensions/fabric/cmake/hgraph-fabricConfig.cmake.in
+++ b/extensions/fabric/cmake/hgraph-fabricConfig.cmake.in
@@ -3,6 +3,9 @@
 include(CMakeFindDependencyMacro)
 find_dependency(hgraph CONFIG)
 find_dependency(hgraph-persistence CONFIG)
+if("@HGRAPH_FABRIC_BUILD_KAFKA_NOTIFIER@")
+    find_dependency(hgraph-kafka CONFIG)
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/hgraphFabricTargets.cmake")
 

--- a/extensions/fabric/include/hgraph/fabric/kafka_export.h
+++ b/extensions/fabric/include/hgraph/fabric/kafka_export.h
@@ -1,0 +1,16 @@
+#ifndef HGRAPH_FABRIC_KAFKA_EXPORT_H
+#define HGRAPH_FABRIC_KAFKA_EXPORT_H
+
+#if defined(HGRAPH_FABRIC_KAFKA_STATIC_DEFINE)
+    #define HGRAPH_FABRIC_KAFKA_EXPORT
+#elif defined(_WIN32)
+    #if defined(hgraph_fabric_kafka_EXPORTS)
+        #define HGRAPH_FABRIC_KAFKA_EXPORT __declspec(dllexport)
+    #else
+        #define HGRAPH_FABRIC_KAFKA_EXPORT __declspec(dllimport)
+    #endif
+#else
+    #define HGRAPH_FABRIC_KAFKA_EXPORT __attribute__((visibility("default")))
+#endif
+
+#endif  // HGRAPH_FABRIC_KAFKA_EXPORT_H

--- a/extensions/fabric/include/hgraph/fabric/kafka_notifier.h
+++ b/extensions/fabric/include/hgraph/fabric/kafka_notifier.h
@@ -1,0 +1,53 @@
+#ifndef HGRAPH_FABRIC_KAFKA_NOTIFIER_H
+#define HGRAPH_FABRIC_KAFKA_NOTIFIER_H
+
+#include <hgraph/fabric/kafka_export.h>
+#include <hgraph/fabric/notifier.h>
+
+#include <hgraph/kafka/service.h>
+#include <hgraph/types/value/value.h>
+
+namespace hgraph::fabric
+{
+    /** Wiring-time configuration for the production Kafka wake-up path.
+
+        One graph consumes the complete topic independently and explicitly
+        commits only notices which Fabric has validated (or deliberately
+        filtered/superseded). Queues remain bounded; persistence is always the
+        authoritative state source. */
+    struct KafkaNotifierConfig
+    {
+        Str topic{};
+        Str group_id{};
+        Str sharing_identity{};
+        Int pending_data_id_limit{10'000};
+        Int outbound_record_limit{10'000};
+        Int commit_partition_limit{1'000};
+    };
+
+    /** Validate the strict RFC 0026 Kafka service profile. */
+    HGRAPH_FABRIC_KAFKA_EXPORT void
+    require_kafka_fabric_profile(ValueView service_config);
+
+    /** Compose a Fabric notifier over an already registered public Kafka
+        service. The returned owning handle must be installed in FabricConfig
+        for this wiring root before graph execution.
+
+        The adapter retains O(outbound_record_limit + pending_data_id_limit +
+        commit_partition_limit) transport state. Callback work is O(log N) per
+        affected data id/partition; each internal source evaluation emits at
+        most one record or cursor and schedules another cycle for backlog. */
+    [[nodiscard]] HGRAPH_FABRIC_KAFKA_EXPORT Notifier
+    wire_kafka_notifier(Wiring &wiring, service::ServicePath service_path,
+                        KafkaNotifierConfig config);
+
+    /** Validate and register the public Kafka service, then compose the Fabric
+        notifier over it. This is the normal production entry point. */
+    [[nodiscard]] HGRAPH_FABRIC_KAFKA_EXPORT Notifier
+    register_kafka_notifier(Wiring &wiring,
+                            service::ServicePath service_path,
+                            Value kafka_service_config,
+                            KafkaNotifierConfig config);
+}  // namespace hgraph::fabric
+
+#endif  // HGRAPH_FABRIC_KAFKA_NOTIFIER_H

--- a/extensions/fabric/include/hgraph/fabric/notifier.h
+++ b/extensions/fabric/include/hgraph/fabric/notifier.h
@@ -7,6 +7,7 @@
 #include <hgraph/types/primitive_types.h>
 
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -17,6 +18,9 @@ namespace hgraph::fabric
     {
         Str                                     data_id{};
         persistence::store::ObjectBytes         revision{};
+        /** Transport-private receipt used to acknowledge one conflated wake-up.
+            Zero denotes an in-process/no-ack notification. */
+        std::uint64_t                           receipt{};
 
         friend bool operator==(const RevisionNotification &,
                                const RevisionNotification &) = default;
@@ -27,6 +31,29 @@ namespace hgraph::fabric
         Pending,
         Delivered,
         Failed,
+    };
+
+    enum class NotificationSubscriptionState
+    {
+        Starting,
+        Recovering,
+        Live,
+        Retrying,
+        Stopped,
+        Failed,
+    };
+
+    struct NotificationSubscriptionStatus
+    {
+        NotificationSubscriptionState state{
+            NotificationSubscriptionState::Starting};
+        /** Monotonic transition generation. A new Live generation requires a
+            durable-head reconciliation before normal wake processing resumes. */
+        std::uint64_t generation{};
+        Str           message{};
+
+        friend bool operator==(const NotificationSubscriptionStatus &,
+                               const NotificationSubscriptionStatus &) = default;
     };
 
     struct NotificationDeliveryResult
@@ -74,6 +101,9 @@ namespace hgraph::fabric
     {
         std::optional<RevisionNotification> (*try_pop)(void *context);
         std::size_t (*pending)(void *context) noexcept;
+        NotificationSubscriptionStatus (*status)(void *context);
+        void (*acknowledge)(void *context,
+                            const RevisionNotification &notification);
         void (*set_waker)(void *context, std::function<void()> waker);
         void (*close)(void *context) noexcept;
     };
@@ -97,6 +127,10 @@ namespace hgraph::fabric
 
         [[nodiscard]] std::optional<RevisionNotification> try_pop() const;
         [[nodiscard]] std::size_t pending() const noexcept;
+        [[nodiscard]] NotificationSubscriptionStatus status() const;
+        /** Acknowledge durable validation (or deliberate dynamic filtering) of
+            a delivered wake-up. Memory notifications make this a no-op. */
+        void acknowledge(const RevisionNotification &notification) const;
         /** Install or replace the wake callback used when a data id first
             becomes pending. Passing an empty callback disables wake-ups.
             Concrete notifiers invoke it without holding their queue lock. */

--- a/extensions/fabric/src/impl/memory_notifier.cpp
+++ b/extensions/fabric/src/impl/memory_notifier.cpp
@@ -77,6 +77,22 @@ namespace hgraph::fabric
                     const std::scoped_lock lock{subscription.mutex};
                     return subscription.closed ? 0 : subscription.pending.size();
                 },
+                [](void *context) {
+                    if (context == nullptr)
+                    {
+                        return NotificationSubscriptionStatus{
+                            NotificationSubscriptionState::Stopped, 0, {}};
+                    }
+                    auto &subscription =
+                        *static_cast<MemorySubscription *>(context);
+                    const std::scoped_lock lock{subscription.mutex};
+                    return NotificationSubscriptionStatus{
+                        subscription.closed
+                            ? NotificationSubscriptionState::Stopped
+                            : NotificationSubscriptionState::Live,
+                        1, {}};
+                },
+                [](void *, const RevisionNotification &) {},
                 [](void *context, std::function<void()> waker) {
                     if (context == nullptr) { return; }
                     auto &subscription = *static_cast<MemorySubscription *>(context);

--- a/extensions/fabric/src/kafka_notifier.cpp
+++ b/extensions/fabric/src/kafka_notifier.cpp
@@ -1,0 +1,1053 @@
+#include <hgraph/fabric/kafka_notifier.h>
+
+#include <hgraph/fabric/metadata_codec.h>
+#include <hgraph/fabric/types.h>
+#include <hgraph/fabric/value_builders.h>
+
+#include <hgraph/kafka/value_builders.h>
+#include <hgraph/lib/std/operators/conversion.h>
+#include <hgraph/runtime/executor.h>
+#include <hgraph/types/metadata/type_registry.h>
+#include <hgraph/types/static_node.h>
+
+#include <algorithm>
+#include <compare>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <ostream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace hgraph::fabric::detail
+{
+    namespace
+    {
+        struct IdLess
+        {
+            using is_transparent = void;
+
+            [[nodiscard]] bool operator()(std::string_view lhs,
+                                          std::string_view rhs) const noexcept
+            {
+                return canonical_data_id_less(lhs, rhs);
+            }
+        };
+
+        struct DeliveryState
+        {
+            std::mutex                 mutex{};
+            NotificationDeliveryResult result{};
+        };
+
+        struct PartitionIdentity
+        {
+            Str subscription_identity{};
+            Int assignment_generation{};
+            Str topic{};
+            Int partition{};
+
+            friend auto operator<=>(const PartitionIdentity &,
+                                    const PartitionIdentity &) = default;
+        };
+
+        struct Receipt
+        {
+            std::uint64_t receipt{};
+            Int           next_offset{};
+        };
+
+        struct PartitionProgress
+        {
+            Int                            greatest_seen_next_offset{-1};
+            Int                            greatest_queued_next_offset{-1};
+            std::map<Str, Receipt, IdLess> outstanding{};
+        };
+    }  // namespace
+
+    class KafkaNotifierBridge;
+
+    struct KafkaNotifierBridgeHandle
+    {
+        std::shared_ptr<KafkaNotifierBridge> value{};
+
+        friend bool operator==(const KafkaNotifierBridgeHandle &,
+                               const KafkaNotifierBridgeHandle &) noexcept = default;
+        friend std::strong_ordering
+        operator<=>(const KafkaNotifierBridgeHandle &lhs,
+                    const KafkaNotifierBridgeHandle &rhs) noexcept
+        {
+            return reinterpret_cast<std::uintptr_t>(lhs.value.get()) <=>
+                   reinterpret_cast<std::uintptr_t>(rhs.value.get());
+        }
+    };
+
+    inline std::ostream &operator<<(std::ostream &stream,
+                                    const KafkaNotifierBridgeHandle &value)
+    {
+        return stream << "KafkaNotifierBridgeHandle(" << value.value.get() << ')';
+    }
+
+    struct KafkaNotificationSubscriber
+    {
+        struct PendingNotice
+        {
+            RevisionId          revision{};
+            RevisionNotification notification{};
+        };
+
+        explicit KafkaNotificationSubscriber(
+            std::weak_ptr<KafkaNotifierBridge> configured_owner)
+            : owner(std::move(configured_owner))
+        {
+        }
+
+        mutable std::mutex mutex{};
+        std::weak_ptr<KafkaNotifierBridge> owner{};
+        bool closed{};
+        std::deque<Str> order{};
+        std::map<Str, PendingNotice, IdLess> pending{};
+        NotificationSubscriptionStatus transport{};
+        std::function<void()> waker{};
+    };
+
+    class KafkaNotifierBridge final
+        : public std::enable_shared_from_this<KafkaNotifierBridge>
+    {
+      public:
+        explicit KafkaNotifierBridge(KafkaNotifierConfig configured)
+            : config_(std::move(configured))
+        {
+        }
+
+        ~KafkaNotifierBridge()
+        {
+            const std::scoped_lock lock{mutex_};
+            fail_deliveries_locked("fabric Kafka notifier was destroyed");
+        }
+
+        [[nodiscard]] NotificationSubscription subscribe();
+        [[nodiscard]] NotificationDelivery publish(RevisionNotification notification);
+
+        void prepare_subscription()
+        {
+            const std::scoped_lock lock{mutex_};
+            if (!subscriber_)
+            {
+                subscriber_ = std::make_shared<KafkaNotificationSubscriber>(
+                    weak_from_this());
+            }
+        }
+
+        void attach_publish_source(AsyncNodeWakeSender sender)
+        {
+            std::function<void()> wake;
+            {
+                const std::scoped_lock lock{mutex_};
+                publish_sender_ = std::move(sender);
+                publish_active_ = true;
+                if (!outbound_.empty())
+                {
+                    wake = [sender = publish_sender_] { sender.wake(); };
+                }
+            }
+            if (wake) { wake(); }
+        }
+
+        void detach_publish_source() noexcept
+        {
+            const std::scoped_lock lock{mutex_};
+            publish_active_ = false;
+            publish_sender_ = {};
+            fail_deliveries_locked("fabric Kafka publish source stopped");
+            outbound_.clear();
+        }
+
+        void attach_commit_source(AsyncNodeWakeSender sender)
+        {
+            std::function<void()> wake;
+            {
+                const std::scoped_lock lock{mutex_};
+                commit_sender_ = std::move(sender);
+                commit_active_ = true;
+                if (!commits_.empty())
+                {
+                    wake = [sender = commit_sender_] { sender.wake(); };
+                }
+            }
+            if (wake) { wake(); }
+        }
+
+        void detach_commit_source() noexcept
+        {
+            const std::scoped_lock lock{mutex_};
+            commit_active_ = false;
+            commit_sender_ = {};
+            commits_.clear();
+        }
+
+        [[nodiscard]] std::optional<Value> pop_publish()
+        {
+            const std::scoped_lock lock{mutex_};
+            if (outbound_.empty()) { return std::nullopt; }
+            Value value = std::move(outbound_.front());
+            outbound_.pop_front();
+            return value;
+        }
+
+        [[nodiscard]] std::size_t pending_publish() const noexcept
+        {
+            const std::scoped_lock lock{mutex_};
+            return outbound_.size();
+        }
+
+        [[nodiscard]] std::optional<Value> pop_commit()
+        {
+            const std::scoped_lock lock{mutex_};
+            if (commits_.empty()) { return std::nullopt; }
+            auto item = commits_.begin();
+            Value value = std::move(item->second);
+            commits_.erase(item);
+            return value;
+        }
+
+        [[nodiscard]] std::size_t pending_commit() const noexcept
+        {
+            const std::scoped_lock lock{mutex_};
+            return commits_.size();
+        }
+
+        void delivery(ValueView report)
+        {
+            const auto fields = report.as_bundle();
+            const Str token = fields.at("user_token").checked_as<Str>();
+            std::shared_ptr<DeliveryState> state;
+            {
+                const std::scoped_lock lock{mutex_};
+                const auto found = deliveries_.find(token);
+                if (found == deliveries_.end()) { return; }
+                state = std::move(found->second);
+                deliveries_.erase(found);
+            }
+            const auto status =
+                fields.at("status").checked_as<kafka::KafkaDeliveryStatus>();
+            NotificationDeliveryResult result;
+            result.status = status == kafka::KafkaDeliveryStatus::Delivered
+                                ? NotificationDeliveryStatus::Delivered
+                                : NotificationDeliveryStatus::Failed;
+            result.message = fields.at("message").has_value()
+                                 ? fields.at("message").checked_as<Str>()
+                                 : Str{};
+            if (result.status == NotificationDeliveryStatus::Failed &&
+                result.message.empty())
+            {
+                result.message = "Kafka delivery status " +
+                                 std::string{kafka::detail::enum_name(status)};
+            }
+            const std::scoped_lock lock{state->mutex};
+            state->result = std::move(result);
+        }
+
+        void ingest(ValueView record, ValueView cursor)
+        {
+            const auto record_fields = record.as_bundle();
+            const auto cursor_fields = cursor.as_bundle();
+            if (!record_fields.at("key").has_value() ||
+                !record_fields.at("value").has_value())
+            {
+                fail_subscription(
+                    "fabric Kafka notice requires non-null key and value");
+                return;
+            }
+            const Str data_id =
+                record_fields.at("key").checked_as<Bytes>().data;
+            const Bytes payload =
+                record_fields.at("value").checked_as<Bytes>();
+            try
+            {
+                require_data_id(data_id);
+                persistence::store::ObjectBytes encoded(payload.data.size());
+                std::ranges::transform(payload.data, encoded.begin(),
+                                       [](char value) {
+                                           return static_cast<std::byte>(value);
+                                       });
+                const DataRevisionInput decoded =
+                    data_revision_input(decode_revision(encoded).view());
+                if (decoded.data_id != data_id)
+                {
+                    throw std::invalid_argument(
+                        "Kafka record key does not match revision data id");
+                }
+
+                std::shared_ptr<KafkaNotificationSubscriber> subscriber;
+                RevisionNotification notification{
+                    .data_id = data_id,
+                    .revision = std::move(encoded),
+                };
+                bool stale{};
+                {
+                    const std::scoped_lock lock{mutex_};
+                    const PartitionIdentity identity{
+                        cursor_fields.at("subscription_identity").checked_as<Str>(),
+                        cursor_fields.at("assignment_generation").checked_as<Int>(),
+                        cursor_fields.at("topic").checked_as<Str>(),
+                        cursor_fields.at("partition").checked_as<Int>(),
+                    };
+                    const Int next_offset =
+                        cursor_fields.at("next_offset").checked_as<Int>();
+                    subscriber = subscriber_;
+                    if (!subscriber)
+                    {
+                        subscriber = std::make_shared<KafkaNotificationSubscriber>(
+                            weak_from_this());
+                        subscriber_ = subscriber;
+                    }
+                    if (!partitions_.contains(identity) &&
+                        partitions_.size() >= static_cast<std::size_t>(
+                                                  config_.commit_partition_limit))
+                    {
+                        throw std::runtime_error(
+                            "fabric Kafka commit partition limit exceeded");
+                    }
+                    auto &partition = partitions_[identity];
+                    partition.greatest_seen_next_offset = std::max(
+                        partition.greatest_seen_next_offset, next_offset);
+                    const auto newest = newest_revision_.find(data_id);
+                    if (newest != newest_revision_.end() &&
+                        decoded.revision < newest->second)
+                    {
+                        stale = true;
+                    }
+                    else
+                    {
+                        if (newest == newest_revision_.end() &&
+                            newest_revision_.size() >=
+                                static_cast<std::size_t>(
+                                    config_.pending_data_id_limit))
+                        {
+                            throw std::runtime_error(
+                                "fabric Kafka pending data-id limit exceeded");
+                        }
+                        if (const auto prior =
+                                partition.outstanding.find(data_id);
+                            prior != partition.outstanding.end())
+                        {
+                            receipts_.erase(prior->second.receipt);
+                        }
+                        newest_revision_[data_id] = decoded.revision;
+                        notification.receipt = next_receipt_++;
+                        partition.outstanding[data_id] =
+                            Receipt{notification.receipt, next_offset};
+                        receipts_[notification.receipt] =
+                            std::pair{identity, data_id};
+                    }
+                    recompute_commit_locked(identity, partition);
+                }
+                if (stale) { return; }
+
+                std::function<void()> wake;
+                std::optional<RevisionNotification> acknowledge_after_unlock;
+                {
+                    const std::scoped_lock lock{subscriber->mutex};
+                    if (subscriber->closed)
+                    {
+                        acknowledge_after_unlock = notification;
+                    }
+                    else
+                    {
+                        auto [entry, inserted] = subscriber->pending.try_emplace(
+                            data_id,
+                            KafkaNotificationSubscriber::PendingNotice{
+                                decoded.revision, notification});
+                        if (inserted)
+                        {
+                            subscriber->order.push_back(data_id);
+                            wake = subscriber->waker;
+                        }
+                        else if (decoded.revision >= entry->second.revision)
+                        {
+                            acknowledge_after_unlock =
+                                std::move(entry->second.notification);
+                            entry->second = {
+                                decoded.revision, std::move(notification)};
+                        }
+                        else
+                        {
+                            acknowledge_after_unlock = std::move(notification);
+                        }
+                    }
+                }
+                if (acknowledge_after_unlock.has_value())
+                {
+                    acknowledge(*acknowledge_after_unlock);
+                }
+                if (wake) { wake(); }
+            }
+            catch (const std::exception &error)
+            {
+                fail_subscription(error.what());
+            }
+        }
+
+        void transition(kafka::KafkaSubscriptionState state)
+        {
+            const NotificationSubscriptionState mapped = [&] {
+                switch (state)
+                {
+                    case kafka::KafkaSubscriptionState::Starting:
+                        return NotificationSubscriptionState::Starting;
+                    case kafka::KafkaSubscriptionState::Recovering:
+                        return NotificationSubscriptionState::Recovering;
+                    case kafka::KafkaSubscriptionState::Live:
+                    case kafka::KafkaSubscriptionState::BoundedComplete:
+                        return NotificationSubscriptionState::Live;
+                    case kafka::KafkaSubscriptionState::Retrying:
+                        return NotificationSubscriptionState::Retrying;
+                    case kafka::KafkaSubscriptionState::Stopped:
+                        return NotificationSubscriptionState::Stopped;
+                    case kafka::KafkaSubscriptionState::Failed:
+                        return NotificationSubscriptionState::Failed;
+                }
+                return NotificationSubscriptionState::Failed;
+            }();
+            if (mapped == NotificationSubscriptionState::Starting ||
+                mapped == NotificationSubscriptionState::Recovering ||
+                mapped == NotificationSubscriptionState::Retrying)
+            {
+                // Assignment generations invalidate old cursor identities. A
+                // recovered consumer replays from the last durable commit,
+                // while LiveStrategy reconciles persistence on the next Live
+                // generation before accepting normal wake processing.
+                reset_ingress_tracking();
+            }
+            if (mapped == NotificationSubscriptionState::Failed)
+            {
+                fail_subscription("fabric Kafka subscription failed");
+                return;
+            }
+            update_status(mapped, {});
+        }
+
+        void event(ValueView event)
+        {
+            const auto fields = event.as_bundle();
+            const bool fatal = fields.at("fatal").checked_as<Bool>();
+            const auto severity =
+                fields.at("severity").checked_as<kafka::KafkaSeverity>();
+            if (fatal || severity == kafka::KafkaSeverity::Fatal)
+            {
+                fail_subscription(fields.at("message").checked_as<Str>());
+            }
+        }
+
+        void fail(std::string_view message) { fail_subscription(message); }
+
+        void acknowledge(const RevisionNotification &notification)
+        {
+            if (notification.receipt == 0) { return; }
+            const std::scoped_lock lock{mutex_};
+            const auto receipt = receipts_.find(notification.receipt);
+            if (receipt == receipts_.end()) { return; }
+            const PartitionIdentity identity = receipt->second.first;
+            const Str data_id = receipt->second.second;
+            receipts_.erase(receipt);
+            const auto progress = partitions_.find(identity);
+            if (progress == partitions_.end()) { return; }
+            const auto outstanding = progress->second.outstanding.find(data_id);
+            if (outstanding != progress->second.outstanding.end() &&
+                outstanding->second.receipt == notification.receipt)
+            {
+                progress->second.outstanding.erase(outstanding);
+                newest_revision_.erase(data_id);
+            }
+            recompute_commit_locked(identity, progress->second);
+        }
+
+        void close_subscriber(KafkaNotificationSubscriber *subscriber) noexcept
+        {
+            {
+                const std::scoped_lock lock{subscriber->mutex};
+                if (subscriber->closed) { return; }
+                subscriber->closed = true;
+                subscriber->pending.clear();
+                subscriber->order.clear();
+                subscriber->waker = {};
+                subscriber->transport.state =
+                    NotificationSubscriptionState::Stopped;
+                ++subscriber->transport.generation;
+            }
+            const std::scoped_lock lock{mutex_};
+            if (const auto &current = subscriber_;
+                current && current.get() == subscriber)
+            {
+                subscriber_.reset();
+                subscriber_claimed_ = false;
+                partitions_.clear();
+                receipts_.clear();
+                commits_.clear();
+                newest_revision_.clear();
+            }
+        }
+
+      private:
+        void reset_ingress_tracking()
+        {
+            std::shared_ptr<KafkaNotificationSubscriber> subscriber;
+            {
+                const std::scoped_lock lock{mutex_};
+                subscriber = subscriber_;
+                partitions_.clear();
+                receipts_.clear();
+                commits_.clear();
+                newest_revision_.clear();
+            }
+            if (!subscriber) { return; }
+            const std::scoped_lock lock{subscriber->mutex};
+            if (subscriber->closed) { return; }
+            subscriber->pending.clear();
+            subscriber->order.clear();
+        }
+
+        void update_status(NotificationSubscriptionState state, Str message)
+        {
+            std::shared_ptr<KafkaNotificationSubscriber> subscriber;
+            {
+                const std::scoped_lock lock{mutex_};
+                if (!fatal_message_.empty())
+                {
+                    state = NotificationSubscriptionState::Failed;
+                    message = fatal_message_;
+                }
+                subscriber = subscriber_;
+            }
+            if (!subscriber) { return; }
+            std::function<void()> wake;
+            {
+                const std::scoped_lock lock{subscriber->mutex};
+                if (subscriber->closed) { return; }
+                if (subscriber->transport.state != state ||
+                    subscriber->transport.message != message)
+                {
+                    subscriber->transport = {
+                        state, subscriber->transport.generation + 1,
+                        std::move(message)};
+                    wake = subscriber->waker;
+                }
+            }
+            if (wake) { wake(); }
+        }
+
+        void fail_subscription(std::string_view message)
+        {
+            {
+                const std::scoped_lock lock{mutex_};
+                if (fatal_message_.empty()) { fatal_message_ = Str{message}; }
+            }
+            update_status(NotificationSubscriptionState::Failed, Str{message});
+        }
+
+        void fail_deliveries_locked(std::string_view message) noexcept
+        {
+            for (auto &[token, state] : deliveries_)
+            {
+                static_cast<void>(token);
+                const std::scoped_lock state_lock{state->mutex};
+                state->result = {NotificationDeliveryStatus::Failed,
+                                 Str{message}};
+            }
+            deliveries_.clear();
+        }
+
+        void recompute_commit_locked(const PartitionIdentity &identity,
+                                     PartitionProgress &progress)
+        {
+            Int next_offset = progress.greatest_seen_next_offset;
+            if (!progress.outstanding.empty())
+            {
+                next_offset = std::ranges::min_element(
+                                  progress.outstanding, {},
+                                  [](const auto &item) {
+                                      return item.second.next_offset;
+                                  })
+                                  ->second.next_offset -
+                              1;
+            }
+            if (next_offset <= progress.greatest_queued_next_offset ||
+                next_offset < 0)
+            {
+                return;
+            }
+            commits_[identity] = kafka::make_cursor(
+                identity.subscription_identity,
+                identity.assignment_generation, identity.topic,
+                identity.partition, next_offset);
+            progress.greatest_queued_next_offset = next_offset;
+            if (commit_active_ && commit_sender_.valid())
+            {
+                commit_sender_.wake();
+            }
+        }
+
+        KafkaNotifierConfig config_;
+        mutable std::mutex mutex_{};
+        std::shared_ptr<KafkaNotificationSubscriber> subscriber_{};
+        std::deque<Value> outbound_{};
+        std::map<Str, std::shared_ptr<DeliveryState>> deliveries_{};
+        std::map<PartitionIdentity, PartitionProgress> partitions_{};
+        std::map<std::uint64_t, std::pair<PartitionIdentity, Str>> receipts_{};
+        std::map<PartitionIdentity, Value> commits_{};
+        std::map<Str, RevisionId, IdLess> newest_revision_{};
+        Str fatal_message_{};
+        std::uint64_t next_delivery_{};
+        std::uint64_t next_receipt_{1};
+        AsyncNodeWakeSender publish_sender_{};
+        AsyncNodeWakeSender commit_sender_{};
+        bool publish_active_{};
+        bool commit_active_{};
+        bool subscriber_claimed_{};
+    };
+}  // namespace hgraph::fabric::detail
+
+namespace std
+{
+    template <>
+    struct hash<hgraph::fabric::detail::KafkaNotifierBridgeHandle>
+    {
+        size_t operator()(
+            const hgraph::fabric::detail::KafkaNotifierBridgeHandle &value) const noexcept
+        {
+            return hash<const void *>{}(value.value.get());
+        }
+    };
+}  // namespace std
+
+namespace hgraph::static_schema_detail
+{
+    template <>
+    struct scalar_name<fabric::detail::KafkaNotifierBridgeHandle>
+    {
+        static constexpr std::string_view value{
+            "hgraph.fabric.internal::KafkaNotifierBridgeHandle"};
+    };
+}  // namespace hgraph::static_schema_detail
+
+namespace hgraph::fabric
+{
+    namespace
+    {
+        using detail::DeliveryState;
+        using detail::KafkaNotificationSubscriber;
+        using detail::KafkaNotifierBridge;
+        using detail::KafkaNotifierBridgeHandle;
+
+        [[nodiscard]] const NotificationDeliveryOps &delivery_ops() noexcept
+        {
+            static const NotificationDeliveryOps ops{
+                [](void *context) {
+                    auto &state = *static_cast<DeliveryState *>(context);
+                    const std::scoped_lock lock{state.mutex};
+                    return state.result;
+                },
+            };
+            return ops;
+        }
+
+        [[nodiscard]] const NotificationSubscriptionOps &
+        subscription_ops() noexcept
+        {
+            static const NotificationSubscriptionOps ops{
+                [](void *context) -> std::optional<RevisionNotification> {
+                    auto &subscriber =
+                        *static_cast<KafkaNotificationSubscriber *>(context);
+                    const std::scoped_lock lock{subscriber.mutex};
+                    if (subscriber.closed || subscriber.order.empty())
+                    {
+                        return std::nullopt;
+                    }
+                    Str data_id = std::move(subscriber.order.front());
+                    subscriber.order.pop_front();
+                    auto found = subscriber.pending.find(data_id);
+                    RevisionNotification result =
+                        std::move(found->second.notification);
+                    subscriber.pending.erase(found);
+                    return result;
+                },
+                [](void *context) noexcept -> std::size_t {
+                    if (context == nullptr) { return 0; }
+                    auto &subscriber =
+                        *static_cast<KafkaNotificationSubscriber *>(context);
+                    const std::scoped_lock lock{subscriber.mutex};
+                    return subscriber.closed ? 0 : subscriber.pending.size();
+                },
+                [](void *context) {
+                    if (context == nullptr)
+                    {
+                        return NotificationSubscriptionStatus{
+                            NotificationSubscriptionState::Stopped, 0, {}};
+                    }
+                    auto &subscriber =
+                        *static_cast<KafkaNotificationSubscriber *>(context);
+                    const std::scoped_lock lock{subscriber.mutex};
+                    return subscriber.transport;
+                },
+                [](void *context,
+                   const RevisionNotification &notification) {
+                    if (context == nullptr) { return; }
+                    auto &subscriber =
+                        *static_cast<KafkaNotificationSubscriber *>(context);
+                    if (const auto owner = subscriber.owner.lock())
+                    {
+                        owner->acknowledge(notification);
+                    }
+                },
+                [](void *context, std::function<void()> waker) {
+                    if (context == nullptr) { return; }
+                    auto &subscriber =
+                        *static_cast<KafkaNotificationSubscriber *>(context);
+                    std::function<void()> wake;
+                    {
+                        const std::scoped_lock lock{subscriber.mutex};
+                        if (subscriber.closed) { return; }
+                        subscriber.waker = std::move(waker);
+                        if (!subscriber.pending.empty() ||
+                            subscriber.transport.generation != 0)
+                        {
+                            wake = subscriber.waker;
+                        }
+                    }
+                    if (wake) { wake(); }
+                },
+                [](void *context) noexcept {
+                    if (context == nullptr) { return; }
+                    auto &subscriber =
+                        *static_cast<KafkaNotificationSubscriber *>(context);
+                    if (const auto owner = subscriber.owner.lock())
+                    {
+                        owner->close_subscriber(&subscriber);
+                    }
+                },
+            };
+            return ops;
+        }
+
+        [[nodiscard]] const NotifierOps &notifier_ops() noexcept
+        {
+            static const NotifierOps ops{
+                [](void *context) {
+                    return static_cast<KafkaNotifierBridge *>(context)->subscribe();
+                },
+                [](void *context, RevisionNotification notification) {
+                    return static_cast<KafkaNotifierBridge *>(context)->publish(
+                        std::move(notification));
+                },
+            };
+            return ops;
+        }
+
+        struct KafkaPublishQueueSource
+        {
+            static constexpr auto name =
+                "hgraph.fabric.kafka.publish_queue";
+
+            static void start(Scalar<"bridge", KafkaNotifierBridgeHandle> bridge,
+                              AsyncNodeWakeSender sender)
+            {
+                bridge.value().value->attach_publish_source(std::move(sender));
+            }
+
+            static void eval(
+                Scalar<"bridge", KafkaNotifierBridgeHandle> bridge,
+                SingleShotScheduler scheduler,
+                Out<TS<kafka::KafkaProduceRecord>> out)
+            {
+                if (auto value = bridge.value().value->pop_publish())
+                {
+                    out.apply(value->view());
+                }
+                if (bridge.value().value->pending_publish() != 0)
+                {
+                    scheduler.schedule(MIN_TD);
+                }
+            }
+
+            static void stop(Scalar<"bridge", KafkaNotifierBridgeHandle> bridge)
+            {
+                bridge.value().value->detach_publish_source();
+            }
+        };
+
+        struct KafkaDeliverySink
+        {
+            static constexpr auto name = "hgraph.fabric.kafka.delivery";
+
+            static void eval(
+                In<"report", TS<kafka::KafkaDeliveryReport>,
+                   InputValidity::Unchecked> report,
+                Scalar<"bridge", KafkaNotifierBridgeHandle> bridge)
+            {
+                if (report.valid() && report.modified())
+                {
+                    bridge.value().value->delivery(report.base().value());
+                }
+            }
+        };
+
+        struct KafkaCommitQueueSource
+        {
+            static constexpr auto name = "hgraph.fabric.kafka.commit_queue";
+
+            static void start(Scalar<"bridge", KafkaNotifierBridgeHandle> bridge,
+                              AsyncNodeWakeSender sender)
+            {
+                bridge.value().value->attach_commit_source(std::move(sender));
+            }
+
+            static void eval(Scalar<"bridge", KafkaNotifierBridgeHandle> bridge,
+                             SingleShotScheduler scheduler,
+                             Out<TS<kafka::KafkaCursor>> out)
+            {
+                if (auto value = bridge.value().value->pop_commit())
+                {
+                    out.apply(value->view());
+                }
+                if (bridge.value().value->pending_commit() != 0)
+                {
+                    scheduler.schedule(MIN_TD);
+                }
+            }
+
+            static void stop(Scalar<"bridge", KafkaNotifierBridgeHandle> bridge)
+            {
+                bridge.value().value->detach_commit_source();
+            }
+        };
+
+        struct KafkaSubscriptionSink
+        {
+            static constexpr auto name = "hgraph.fabric.kafka.subscription";
+
+            static void eval(
+                In<"subscription", kafka::KafkaSubscriptionOutput,
+                   InputValidity::Unchecked> subscription,
+                Scalar<"bridge", KafkaNotifierBridgeHandle> bridge)
+            {
+                const auto state = subscription.template field<"state">();
+                if (state.valid() && state.modified())
+                {
+                    bridge.value().value->transition(state.value());
+                }
+                const auto record = subscription.template field<"record">();
+                if (!record.valid() || !record.modified()) { return; }
+                const auto cursor = subscription.template field<"cursor">();
+                if (!cursor.valid() || !cursor.modified())
+                {
+                    bridge.value().value->fail(
+                        "fabric Kafka record arrived without its cursor");
+                    return;
+                }
+                bridge.value().value->ingest(record.base().value(),
+                                             cursor.base().value());
+            }
+        };
+
+        struct KafkaEventSink
+        {
+            static constexpr auto name = "hgraph.fabric.kafka.event";
+
+            static void eval(
+                In<"event", TS<kafka::KafkaEvent>, InputValidity::Unchecked> event,
+                Scalar<"bridge", KafkaNotifierBridgeHandle> bridge)
+            {
+                if (event.valid() && event.modified())
+                {
+                    bridge.value().value->event(event.base().value());
+                }
+            }
+        };
+    }  // namespace
+
+    NotificationSubscription KafkaNotifierBridge::subscribe()
+    {
+        std::shared_ptr<KafkaNotificationSubscriber> subscriber;
+        Str fatal_message;
+        {
+            const std::scoped_lock lock{mutex_};
+            if (subscriber_claimed_)
+            {
+                throw std::logic_error(
+                    "fabric Kafka notifier supports one live ingress coordinator");
+            }
+            if (!subscriber_)
+            {
+                subscriber_ = std::make_shared<KafkaNotificationSubscriber>(
+                    weak_from_this());
+            }
+            subscriber = subscriber_;
+            fatal_message = fatal_message_;
+            subscriber_claimed_ = true;
+        }
+        if (!fatal_message.empty())
+        {
+            const std::scoped_lock lock{subscriber->mutex};
+            subscriber->transport = {
+                NotificationSubscriptionState::Failed, 1,
+                std::move(fatal_message)};
+        }
+        return NotificationSubscription{std::move(subscriber),
+                                        subscription_ops()};
+    }
+
+    NotificationDelivery KafkaNotifierBridge::publish(
+        RevisionNotification notification)
+    {
+        auto delivery = std::make_shared<DeliveryState>();
+        AsyncNodeWakeSender sender;
+        {
+            const std::scoped_lock lock{mutex_};
+            if (deliveries_.size() >= static_cast<std::size_t>(
+                                          config_.outbound_record_limit))
+            {
+                delivery->result = {
+                    NotificationDeliveryStatus::Failed,
+                    "fabric Kafka outbound record limit exceeded"};
+                return NotificationDelivery{std::move(delivery), delivery_ops()};
+            }
+            const Str token = "fabric-" + std::to_string(next_delivery_++);
+            std::string payload(notification.revision.size(), '\0');
+            std::ranges::transform(notification.revision, payload.begin(),
+                                   [](std::byte value) {
+                                       return static_cast<char>(value);
+                                   });
+            outbound_.push_back(kafka::make_produce_record(
+                Bytes{std::move(payload)}, Bytes{notification.data_id}, {},
+                std::nullopt, std::nullopt, token));
+            deliveries_[token] = delivery;
+            if (publish_active_) { sender = publish_sender_; }
+        }
+        if (sender.valid()) { sender.wake(); }
+        return NotificationDelivery{std::move(delivery), delivery_ops()};
+    }
+
+    void require_kafka_fabric_profile(ValueView service_config)
+    {
+        if (service_config.schema() !=
+            scalar_descriptor<kafka::KafkaServiceConfig>::value_meta())
+        {
+            throw std::invalid_argument(
+                "fabric Kafka notifier requires KafkaServiceConfig");
+        }
+        const auto fields = service_config.as_bundle();
+        const auto consumer = fields.at("consumer_defaults").as_bundle();
+        const auto producer = fields.at("producer").as_bundle();
+        if (!producer.at("idempotent").checked_as<Bool>())
+        {
+            throw std::invalid_argument(
+                "fabric Kafka notifier requires an idempotent producer");
+        }
+        const Str acknowledgements =
+            producer.at("acknowledgements").checked_as<Str>();
+        if (acknowledgements != "all" && acknowledgements != "-1")
+        {
+            throw std::invalid_argument(
+                "fabric Kafka notifier requires acknowledgements=all or -1");
+        }
+        if (consumer.at("inbound_overflow")
+                .checked_as<kafka::KafkaOverflowAction>() ==
+            kafka::KafkaOverflowAction::Drop)
+        {
+            throw std::invalid_argument(
+                "fabric Kafka notifier forbids dropping inbound records");
+        }
+        if (producer.at("overflow").checked_as<kafka::KafkaOverflowAction>() ==
+                kafka::KafkaOverflowAction::Drop ||
+            producer.at("stage_overflow")
+                    .checked_as<kafka::KafkaOverflowAction>() ==
+                kafka::KafkaOverflowAction::Drop)
+        {
+            throw std::invalid_argument(
+                "fabric Kafka notifier forbids dropping outbound records");
+        }
+    }
+
+    Notifier wire_kafka_notifier(Wiring &wiring,
+                                 service::ServicePath service_path,
+                                 KafkaNotifierConfig config)
+    {
+        if (config.topic.empty())
+        {
+            throw std::invalid_argument(
+                "fabric Kafka notifier requires a topic");
+        }
+        if (config.group_id.empty())
+        {
+            throw std::invalid_argument(
+                "fabric Kafka notifier requires a group id");
+        }
+        if (config.pending_data_id_limit <= 0 ||
+            config.outbound_record_limit <= 0 ||
+            config.commit_partition_limit <= 0)
+        {
+            throw std::invalid_argument(
+                "fabric Kafka notifier queue limits must be positive");
+        }
+        if (config.sharing_identity.empty())
+        {
+            config.sharing_identity = "fabric:" + config.topic;
+        }
+
+        auto bridge = std::make_shared<KafkaNotifierBridge>(config);
+        bridge->prepare_subscription();
+        KafkaNotifierBridgeHandle handle{bridge};
+
+        auto publish_source = wire<KafkaPublishQueueSource>(wiring, handle)
+                                  .as<TS<kafka::KafkaProduceRecord>>();
+        auto delivery = kafka::publish(
+            wiring, service_path,
+            kafka::publish_request(wiring, config.topic, publish_source));
+        wire<KafkaDeliverySink>(wiring, delivery, handle);
+
+        auto subscription_key =
+            kafka::subscription_key()
+                .topics({config.topic})
+                .group_id(config.group_id)
+                .assignment_mode(kafka::KafkaAssignmentMode::Independent)
+                .start(kafka::make_start_position(
+                    kafka::KafkaStartPositionKind::Committed,
+                    kafka::KafkaOffsetFallback::Earliest))
+                .stop(kafka::make_stop_position(
+                    kafka::KafkaStopPositionKind::GraphLifetime))
+                .commit_mode(kafka::KafkaCommitMode::Explicit)
+                .recovery_clock(kafka::KafkaRecoveryClock::Arrival)
+                .merge_policy(kafka::KafkaMergePolicy::Partition)
+                .sharing_identity(config.sharing_identity)
+                .build();
+        auto key = wire<stdlib::const_, TS<kafka::KafkaSubscriptionKey>>(
+            wiring, std::move(subscription_key));
+        auto subscription = kafka::subscribe(wiring, service_path, key);
+        wire<KafkaSubscriptionSink>(wiring, subscription, handle);
+
+        auto commit_source = wire<KafkaCommitQueueSource>(wiring, handle)
+                                 .as<TS<kafka::KafkaCursor>>();
+        kafka::commit(wiring, service_path, commit_source);
+        wire<KafkaEventSink>(wiring, kafka::events(wiring, service_path), handle);
+
+        return Notifier{std::move(bridge), notifier_ops()};
+    }
+
+    Notifier register_kafka_notifier(Wiring &wiring,
+                                     service::ServicePath service_path,
+                                     Value kafka_service_config,
+                                     KafkaNotifierConfig config)
+    {
+        require_kafka_fabric_profile(kafka_service_config.view());
+        kafka::register_service(wiring, service_path,
+                                std::move(kafka_service_config));
+        return wire_kafka_notifier(wiring, std::move(service_path),
+                                   std::move(config));
+    }
+}  // namespace hgraph::fabric

--- a/extensions/fabric/src/notifier.cpp
+++ b/extensions/fabric/src/notifier.cpp
@@ -16,6 +16,16 @@ namespace hgraph::fabric
         }
 
         [[nodiscard]] std::size_t empty_pending(void *) noexcept { return 0; }
+        [[nodiscard]] NotificationSubscriptionStatus
+        empty_status(void *)
+        {
+            return {NotificationSubscriptionState::Stopped, 0,
+                    "fabric notification subscription is not configured"};
+        }
+        void empty_acknowledge(void *,
+                               const RevisionNotification &)
+        {
+        }
         void empty_set_waker(void *, std::function<void()>) {}
         void empty_close(void *) noexcept {}
 
@@ -95,6 +105,8 @@ namespace hgraph::fabric
         static const NotificationSubscriptionOps ops{
             &empty_try_pop,
             &empty_pending,
+            &empty_status,
+            &empty_acknowledge,
             &empty_set_waker,
             &empty_close,
         };
@@ -108,6 +120,7 @@ namespace hgraph::fabric
         : context_(std::move(context)), ops_(ops)
     {
         if (!context_ || ops_.try_pop == nullptr || ops_.pending == nullptr ||
+            ops_.status == nullptr || ops_.acknowledge == nullptr ||
             ops_.set_waker == nullptr || ops_.close == nullptr)
         {
             throw std::invalid_argument(
@@ -146,6 +159,18 @@ namespace hgraph::fabric
     std::size_t NotificationSubscription::pending() const noexcept
     {
         return ops_.pending(context_.get());
+    }
+
+    NotificationSubscriptionStatus
+    NotificationSubscription::status() const
+    {
+        return ops_.status(context_.get());
+    }
+
+    void NotificationSubscription::acknowledge(
+        const RevisionNotification &notification) const
+    {
+        ops_.acknowledge(context_.get(), notification);
     }
 
     void NotificationSubscription::set_waker(std::function<void()> waker) const

--- a/extensions/fabric/src/subscription.cpp
+++ b/extensions/fabric/src/subscription.cpp
@@ -337,6 +337,7 @@ namespace hgraph::fabric::detail
             struct PendingProposal
             {
                 RevisionId                           revision{};
+                RevisionNotification                 notification{};
                 DateTime                             noticed_at{MIN_DT};
                 DateTime                             next_attempt{MIN_DT};
                 TimeDelta                            backoff{std::chrono::milliseconds{1}};
@@ -352,6 +353,7 @@ namespace hgraph::fabric::detail
             std::map<Str, PendingProposal, IdLess>   pending{};
             bool                                     startup{true};
             bool                                     wall_clock{};
+            std::optional<std::uint64_t>              reconciled_live_generation{};
 
             LiveStrategy(FabricConfig config, std::vector<Str> roots,
                          bool use_wall_clock)
@@ -374,19 +376,27 @@ namespace hgraph::fabric::detail
                 {
                     if (!core.observed.contains(notification->data_id))
                     {
+                        subscription.acknowledge(*notification);
                         continue;
                     }
                     const Value decoded = decode_revision(notification->revision);
                     const DataRevisionInput revision =
                         data_revision_input(decoded.view());
-                    auto found = pending.find(notification->data_id);
+                    const Str data_id = notification->data_id;
+                    auto found = pending.find(data_id);
                     if (found != pending.end() &&
                         found->second.revision > revision.revision)
                     {
+                        subscription.acknowledge(*notification);
                         continue;
                     }
-                    pending[notification->data_id] = PendingProposal{
+                    if (found != pending.end())
+                    {
+                        subscription.acknowledge(found->second.notification);
+                    }
+                    pending[data_id] = PendingProposal{
                         .revision = revision.revision,
+                        .notification = std::move(*notification),
                         .noticed_at = now,
                         .next_attempt = now,
                     };
@@ -428,6 +438,7 @@ namespace hgraph::fabric::detail
                     }
                     core.coordinator.observe_notice(item->first,
                                                     item->second.noticed_at);
+                    subscription.acknowledge(item->second.notification);
                     item = pending.erase(item);
                     admitted = true;
                 }
@@ -471,6 +482,16 @@ namespace hgraph::fabric::detail
             [[nodiscard]] std::optional<IngressBatch>
             evaluate(DateTime now, NodeScheduler scheduler)
             {
+                const NotificationSubscriptionStatus transport =
+                    subscription.status();
+                if (transport.state == NotificationSubscriptionState::Failed)
+                {
+                    throw std::runtime_error(
+                        transport.message.empty()
+                            ? "fabric notification subscription failed"
+                            : "fabric notification subscription failed: " +
+                                  transport.message);
+                }
                 std::optional<IngressBatch> batch;
                 if (startup)
                 {
@@ -482,8 +503,12 @@ namespace hgraph::fabric::detail
                 }
                 drain(now);
                 const bool admitted = admit(now);
+                const bool reconcile =
+                    transport.state == NotificationSubscriptionState::Live &&
+                    (!reconciled_live_generation.has_value() ||
+                     *reconciled_live_generation != transport.generation);
 
-                if (admitted)
+                if (admitted || reconcile)
                 {
                     if (auto update = core.batch(core.coordinator.resolve(now));
                         update.has_value())
@@ -494,6 +519,10 @@ namespace hgraph::fabric::detail
                             std::make_move_iterator(update->roots.begin()),
                             std::make_move_iterator(update->roots.end()));
                     }
+                }
+                if (reconcile)
+                {
+                    reconciled_live_generation = transport.generation;
                 }
                 startup = false;
                 schedule_retry(now, scheduler);

--- a/extensions/fabric/test_package/CMakeLists.txt
+++ b/extensions/fabric/test_package/CMakeLists.txt
@@ -8,7 +8,13 @@ find_package(hgraph-fabric CONFIG REQUIRED)
 
 add_executable(hgraph_fabric_consumer main.cpp)
 target_compile_features(hgraph_fabric_consumer PRIVATE cxx_std_23)
-target_link_libraries(hgraph_fabric_consumer PRIVATE hgraph::fabric)
+if(TARGET hgraph::fabric_kafka)
+    target_link_libraries(hgraph_fabric_consumer PRIVATE hgraph::fabric_kafka)
+    target_compile_definitions(hgraph_fabric_consumer PRIVATE
+        HGRAPH_FABRIC_CONSUMER_HAS_KAFKA=1)
+else()
+    target_link_libraries(hgraph_fabric_consumer PRIVATE hgraph::fabric)
+endif()
 
 if(TARGET hgraph::nanobind AND NOT TARGET Python::Python)
     find_package(Python 3.12 COMPONENTS Interpreter Development.Embed REQUIRED)

--- a/extensions/fabric/test_package/main.cpp
+++ b/extensions/fabric/test_package/main.cpp
@@ -1,4 +1,9 @@
 #include <hgraph/fabric/fabric.h>
+#if defined(HGRAPH_FABRIC_CONSUMER_HAS_KAFKA)
+#include <hgraph/fabric/kafka_notifier.h>
+#include <hgraph/kafka/testing/fake_broker.h>
+#include <hgraph/kafka/value_builders.h>
+#endif
 
 #include <hgraph/lib/std/operators/registration.h>
 #include <hgraph/types/graph_wiring.h>
@@ -20,6 +25,32 @@ namespace
             hgf::publish_data(wiring, "installed/output", input);
         }
     };
+
+#if defined(HGRAPH_FABRIC_CONSUMER_HAS_KAFKA)
+    hg::Value installed_kafka_config{};
+    hg::kafka::testing::FakeBrokerPtr installed_kafka_broker{};
+    hgf::Notifier installed_kafka_notifier{};
+
+    struct InstalledKafkaFabricGraph
+    {
+        static constexpr auto name =
+            "installed_hgraph_fabric_kafka_consumer";
+
+        static void compose(hg::Wiring &wiring)
+        {
+            const auto path = hg::service::path("installed-fabric-kafka");
+            hg::kafka::testing::register_fake_service(
+                wiring, path, installed_kafka_config.clone(),
+                installed_kafka_broker);
+            installed_kafka_notifier = hgf::wire_kafka_notifier(
+                wiring, path,
+                hgf::KafkaNotifierConfig{
+                    .topic = "installed-fabric-notices",
+                    .group_id = "installed-fabric-consumer",
+                });
+        }
+    };
+#endif
 }  // namespace
 
 int main()
@@ -78,14 +109,37 @@ int main()
         return 5;
     }
 
-    auto graph = hg::build_graph<InstalledFabricGraph>();
-    const auto plan = hgf::dependency_plan_input(
-        graph.traits().get(hgf::DEPENDENCY_PLAN_TRAIT));
-    return plan == hgf::DependencyPlanInput{
-                       .roots = {"installed/input"},
-                       .publishers = {{"installed/output", {"installed/input"}}},
-                       .forests = {{{"installed/input"}}},
-                   }
-               ? 0
-               : 6;
+    {
+        auto graph = hg::build_graph<InstalledFabricGraph>();
+        const auto plan = hgf::dependency_plan_input(
+            graph.traits().get(hgf::DEPENDENCY_PLAN_TRAIT));
+        if (plan != hgf::DependencyPlanInput{
+                        .roots = {"installed/input"},
+                        .publishers = {
+                            {"installed/output", {"installed/input"}}},
+                        .forests = {{{"installed/input"}}},
+                    })
+        {
+            return 6;
+        }
+    }
+
+#if defined(HGRAPH_FABRIC_CONSUMER_HAS_KAFKA)
+    installed_kafka_config =
+        hg::kafka::service_config()
+            .bootstrap_servers({"localhost:9092"})
+            .client_id("installed-fabric-consumer")
+            .build();
+    hgf::require_kafka_fabric_profile(installed_kafka_config.view());
+    installed_kafka_broker =
+        std::make_shared<hg::kafka::testing::FakeBroker>();
+    {
+        auto graph = hg::build_graph<InstalledKafkaFabricGraph>();
+        if (!installed_kafka_notifier) { return 7; }
+    }
+    installed_kafka_notifier.reset();
+    installed_kafka_broker.reset();
+    installed_kafka_config = {};
+#endif
+    return 0;
 }

--- a/extensions/fabric/tests/CMakeLists.txt
+++ b/extensions/fabric/tests/CMakeLists.txt
@@ -18,8 +18,14 @@ add_executable(hgraph_fabric_tests
     test_resolution.cpp
     test_subscription.cpp
 )
-target_link_libraries(hgraph_fabric_tests
-    PRIVATE hgraph::fabric Catch2::Catch2WithMain)
+if(TARGET hgraph::fabric_kafka)
+    target_sources(hgraph_fabric_tests PRIVATE test_kafka_notifier.cpp)
+    target_link_libraries(hgraph_fabric_tests
+        PRIVATE hgraph::fabric_kafka Catch2::Catch2WithMain)
+else()
+    target_link_libraries(hgraph_fabric_tests
+        PRIVATE hgraph::fabric Catch2::Catch2WithMain)
+endif()
 target_compile_features(hgraph_fabric_tests PRIVATE cxx_std_23)
 target_compile_definitions(hgraph_fabric_tests PRIVATE
     HGRAPH_FABRIC_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/fixtures")

--- a/extensions/fabric/tests/test_kafka_notifier.cpp
+++ b/extensions/fabric/tests/test_kafka_notifier.cpp
@@ -1,0 +1,705 @@
+#include <hgraph/fabric/kafka_notifier.h>
+#include <hgraph/fabric/metadata_codec.h>
+#include <hgraph/fabric/value_builders.h>
+
+#include <hgraph/kafka/testing/fake_broker.h>
+#include <hgraph/kafka/testing/mock_cluster.h>
+#include <hgraph/kafka/value_builders.h>
+#include <hgraph/lib/std/operators/registration.h>
+#include <hgraph/lib/testing/runtime_support.h>
+#include <hgraph/runtime/runtime.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdlib>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <thread>
+#include <utility>
+
+namespace
+{
+    namespace hg  = hgraph;
+    namespace hgf = hgraph::fabric;
+    namespace hgk = hgraph::kafka;
+
+    using namespace std::chrono_literals;
+
+    inline hg::Value service_config{};
+    inline hgk::testing::FakeBrokerPtr broker{};
+    inline hgf::Notifier notifier{};
+    inline hgf::KafkaNotifierConfig notifier_config{};
+
+    [[nodiscard]] hg::GraphExecutorValue start_realtime(
+        hg::GraphBuilder builder,
+        hg::TimeDelta duration = hg::TimeDelta{5'000'000})
+    {
+        const hg::DateTime start = hg::testing::wall_now();
+        hg::GraphExecutorBuilder executor_builder;
+        executor_builder.graph_builder(std::move(builder))
+            .mode(hg::GraphExecutorMode::RealTime)
+            .start_time(start)
+            .end_time(start + duration);
+        return executor_builder.make_executor();
+    }
+
+    template <typename Predicate>
+    [[nodiscard]] bool wait_until(Predicate &&predicate,
+                                  std::chrono::milliseconds timeout = 2s)
+    {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (std::chrono::steady_clock::now() < deadline)
+        {
+            if (std::invoke(predicate)) { return true; }
+            std::this_thread::sleep_for(1ms);
+        }
+        return std::invoke(predicate);
+    }
+
+    [[nodiscard]] hgraph::persistence::store::ObjectBytes notice_bytes(
+        hg::Str data_id, hgf::RevisionId revision,
+        hgf::DataVersion version = 0)
+    {
+        if (version == 0) { version = revision; }
+        hg::Value value = hgf::make_data_revision(hgf::DataRevisionInput{
+            .data_id = std::move(data_id),
+            .revision = revision,
+            .output_version = version,
+            .as_of = hg::DateTime{hg::TimeDelta{
+                1'900'000'000'000'000 + revision}},
+        });
+        return hgf::encode_revision(value.view());
+    }
+
+    [[nodiscard]] hg::Bytes bytes(
+        const hgraph::persistence::store::ObjectBytes &value)
+    {
+        std::string result(value.size(), '\0');
+        std::ranges::transform(value, result.begin(), [](std::byte item) {
+            return static_cast<char>(item);
+        });
+        return hg::Bytes{std::move(result)};
+    }
+
+    [[nodiscard]] hg::Value subscription_key()
+    {
+        return hgk::subscription_key()
+            .topics({notifier_config.topic})
+            .group_id(notifier_config.group_id)
+            .assignment_mode(hgk::KafkaAssignmentMode::Independent)
+            .start(hgk::make_start_position(
+                hgk::KafkaStartPositionKind::Committed,
+                hgk::KafkaOffsetFallback::Earliest))
+            .stop(hgk::make_stop_position(
+                hgk::KafkaStopPositionKind::GraphLifetime))
+            .commit_mode(hgk::KafkaCommitMode::Explicit)
+            .recovery_clock(hgk::KafkaRecoveryClock::Arrival)
+            .merge_policy(hgk::KafkaMergePolicy::Partition)
+            .sharing_identity(notifier_config.sharing_identity)
+            .build();
+    }
+
+    void emit(hg::Str data_id, hgf::RevisionId revision, hg::Int offset,
+              hgk::KafkaSubscriptionState state =
+                  hgk::KafkaSubscriptionState::Live,
+              hgf::DataVersion version = 0)
+    {
+        auto encoded = notice_bytes(data_id, revision, version);
+        broker->emit_subscription(
+            subscription_key(),
+            hgk::make_record(notifier_config.topic, 0, offset,
+                             bytes(encoded), hg::Bytes{data_id}),
+            hgk::make_cursor(notifier_config.sharing_identity, 1,
+                             notifier_config.topic, 0, offset + 1),
+            state);
+    }
+
+    [[nodiscard]] hg::Int revision_of(
+        const hgf::RevisionNotification &notification)
+    {
+        return hgf::data_revision_input(
+                   hgf::decode_revision(notification.revision).view())
+            .revision;
+    }
+
+    struct KafkaNotifierGraph
+    {
+        static constexpr auto name = "hgraph.fabric.test.kafka_notifier";
+
+        static void compose(hg::Wiring &wiring)
+        {
+            const auto path = hg::service::path("fabric-kafka");
+            hgk::testing::register_fake_service(
+                wiring, path, service_config.clone(), broker);
+            notifier = hgf::wire_kafka_notifier(wiring, path,
+                                                notifier_config);
+        }
+    };
+
+    struct ProductionKafkaNotifierGraph
+    {
+        static constexpr auto name =
+            "hgraph.fabric.test.production_kafka_notifier";
+
+        static void compose(hg::Wiring &wiring)
+        {
+            notifier = hgf::register_kafka_notifier(
+                wiring, hg::service::path("fabric-kafka-production"),
+                service_config.clone(), notifier_config);
+        }
+    };
+
+    struct RunningNotifier
+    {
+        RunningNotifier()
+        {
+            hg::stdlib::register_standard_operators();
+            broker = std::make_shared<hgk::testing::FakeBroker>();
+            notifier = {};
+            service_config = hgk::service_config()
+                                 .bootstrap_servers({"localhost:9092"})
+                                 .client_id("fabric-kafka-test")
+                                 .build();
+            notifier_config = {
+                .topic = "fabric-notices",
+                .group_id = "fabric-notices-test",
+                .sharing_identity = "fabric-notices-test",
+                .pending_data_id_limit = 4,
+                .outbound_record_limit = 4,
+                .commit_partition_limit = 4,
+            };
+            executor = start_realtime(hg::build_graph<KafkaNotifierGraph>());
+            subscription = notifier.subscribe();
+            view = executor.view();
+            runner.emplace(view);
+            REQUIRE(broker->wait_until_attached(2s));
+            REQUIRE(broker->wait_for_subscription_updates(1, 2s));
+        }
+
+        ~RunningNotifier()
+        {
+            subscription.close();
+            view.request_stop();
+            if (runner.has_value()) { runner->join(); }
+            notifier.reset();
+            broker.reset();
+            service_config = {};
+        }
+
+        hg::GraphExecutorValue executor{};
+        hgf::NotificationSubscription subscription{};
+        hg::GraphExecutorView view{};
+        std::optional<hg::testing::AsyncGraphExecutorRun> runner{};
+    };
+
+    struct RunningProductionNotifier
+    {
+        RunningProductionNotifier()
+        {
+            hg::stdlib::register_standard_operators();
+            notifier = {};
+            executor = start_realtime(
+                hg::build_graph<ProductionKafkaNotifierGraph>(),
+                hg::TimeDelta{15'000'000});
+            subscription = notifier.subscribe();
+            view = executor.view();
+            runner.emplace(view);
+        }
+
+        ~RunningProductionNotifier()
+        {
+            subscription.close();
+            view.request_stop();
+            if (runner.has_value()) { runner->join(); }
+            notifier.reset();
+        }
+
+        [[nodiscard]] bool wait_for_live()
+        {
+            return wait_until(
+                [&] {
+                    return subscription.status().state ==
+                           hgf::NotificationSubscriptionState::Live;
+                },
+                10s);
+        }
+
+        [[nodiscard]] std::optional<hgf::RevisionNotification>
+        wait_for_revision(hgf::RevisionId expected)
+        {
+            std::optional<hgf::RevisionNotification> result;
+            const bool found = wait_until(
+                [&] {
+                    while (auto candidate = subscription.try_pop())
+                    {
+                        if (revision_of(*candidate) == expected)
+                        {
+                            result = std::move(*candidate);
+                            return true;
+                        }
+                        subscription.acknowledge(*candidate);
+                    }
+                    return false;
+                },
+                10s);
+            return found ? std::move(result) : std::nullopt;
+        }
+
+        hg::GraphExecutorValue executor{};
+        hgf::NotificationSubscription subscription{};
+        hg::GraphExecutorView view{};
+        std::optional<hg::testing::AsyncGraphExecutorRun> runner{};
+    };
+}  // namespace
+
+TEST_CASE("Kafka fabric profile requires non-lossy idempotent transport")
+{
+    const hg::Value valid = hgk::service_config()
+                                .bootstrap_servers({"localhost:9092"})
+                                .client_id("fabric-profile")
+                                .build();
+    REQUIRE_NOTHROW(hgf::require_kafka_fabric_profile(valid.view()));
+
+    const hg::Value non_idempotent =
+        hgk::service_config()
+            .bootstrap_servers({"localhost:9092"})
+            .client_id("fabric-profile")
+            .idempotent_producer(false)
+            .build();
+    REQUIRE_THROWS_WITH(
+        hgf::require_kafka_fabric_profile(non_idempotent.view()),
+        Catch::Matchers::ContainsSubstring("idempotent"));
+
+    const hg::Value lossy =
+        hgk::service_config()
+            .bootstrap_servers({"localhost:9092"})
+            .client_id("fabric-profile")
+            .inbound_overflow(hgk::KafkaOverflowAction::Drop)
+            .build();
+    REQUIRE_THROWS_WITH(
+        hgf::require_kafka_fabric_profile(lossy.view()),
+        Catch::Matchers::ContainsSubstring("dropping inbound"));
+}
+
+TEST_CASE("Kafka notifier publishes the complete revision and correlates delivery")
+{
+    RunningNotifier running;
+    const auto payload = notice_bytes("prices", 7, 41);
+    auto delivery = notifier.publish({"prices", payload});
+
+    REQUIRE(broker->wait_for_publications(1, 2s));
+    REQUIRE(wait_until([&] {
+        return delivery.poll().status !=
+               hgf::NotificationDeliveryStatus::Pending;
+    }));
+    REQUIRE(delivery.poll().status ==
+            hgf::NotificationDeliveryStatus::Delivered);
+
+    const auto publications = broker->published_records();
+    REQUIRE(publications.size() == 1);
+    const auto record = publications.front().record.view().as_bundle();
+    REQUIRE(record.at("key").checked_as<hg::Bytes>() == hg::Bytes{"prices"});
+    REQUIRE(record.at("value").checked_as<hg::Bytes>() == bytes(payload));
+}
+
+TEST_CASE("Kafka notifier bounds delivery correlation before graph startup")
+{
+    hg::stdlib::register_standard_operators();
+    broker = std::make_shared<hgk::testing::FakeBroker>();
+    service_config = hgk::service_config()
+                         .bootstrap_servers({"localhost:9092"})
+                         .client_id("fabric-kafka-bound")
+                         .build();
+    notifier_config = {
+        .topic = "fabric-notices",
+        .group_id = "fabric-notices-bound",
+        .sharing_identity = "fabric-notices-bound",
+        .pending_data_id_limit = 4,
+        .outbound_record_limit = 1,
+        .commit_partition_limit = 4,
+    };
+
+    auto executor = start_realtime(hg::build_graph<KafkaNotifierGraph>());
+    auto first = notifier.publish({"prices", notice_bytes("prices", 1)});
+    auto rejected = notifier.publish({"positions", notice_bytes("positions", 1)});
+    REQUIRE(first.poll().status == hgf::NotificationDeliveryStatus::Pending);
+    REQUIRE(rejected.poll().status == hgf::NotificationDeliveryStatus::Failed);
+    REQUIRE_THAT(rejected.poll().message,
+                 Catch::Matchers::ContainsSubstring("outbound record limit"));
+
+    notifier.reset();
+    executor = {};
+    REQUIRE(first.poll().status == hgf::NotificationDeliveryStatus::Failed);
+    broker.reset();
+    service_config = {};
+}
+
+TEST_CASE("Kafka notifier retains notices before Fabric claims live ingress")
+{
+    hg::stdlib::register_standard_operators();
+    broker = std::make_shared<hgk::testing::FakeBroker>();
+    service_config = hgk::service_config()
+                         .bootstrap_servers({"localhost:9092"})
+                         .client_id("fabric-kafka-startup-race")
+                         .build();
+    notifier_config = {
+        .topic = "fabric-notices",
+        .group_id = "fabric-notices-startup-race",
+        .sharing_identity = "fabric-notices-startup-race",
+        .pending_data_id_limit = 4,
+        .outbound_record_limit = 4,
+        .commit_partition_limit = 4,
+    };
+
+    auto executor = start_realtime(hg::build_graph<KafkaNotifierGraph>());
+    auto view = executor.view();
+    hg::testing::AsyncGraphExecutorRun runner{view};
+    REQUIRE(broker->wait_for_subscription_updates(1, 2s));
+    emit("prices", 1, 0);
+    REQUIRE(wait_until([&] {
+        const auto commits = broker->committed_cursors();
+        return !commits.empty() &&
+               commits.back()
+                       .view()
+                       .as_bundle()
+                       .at("next_offset")
+                       .checked_as<hg::Int>() == 0;
+    }));
+
+    auto subscription = notifier.subscribe();
+    REQUIRE(subscription.pending() == 1);
+    REQUIRE(subscription.status().state ==
+            hgf::NotificationSubscriptionState::Live);
+    auto retained = subscription.try_pop();
+    REQUIRE(retained.has_value());
+    REQUIRE(revision_of(*retained) == 1);
+    subscription.acknowledge(*retained);
+    REQUIRE(wait_until([&] {
+        const auto commits = broker->committed_cursors();
+        return !commits.empty() &&
+               commits.back()
+                       .view()
+                       .as_bundle()
+                       .at("next_offset")
+                       .checked_as<hg::Int>() == 1;
+    }));
+
+    subscription.close();
+    view.request_stop();
+    runner.join();
+    notifier.reset();
+    broker.reset();
+    service_config = {};
+}
+
+TEST_CASE("Kafka notifier conflates by newest revision and commits only acknowledgements")
+{
+    RunningNotifier running;
+
+    emit("prices", 2, 0, hgk::KafkaSubscriptionState::Recovering);
+    REQUIRE(wait_until([&] { return running.subscription.pending() == 1; }));
+    REQUIRE(running.subscription.status().state ==
+            hgf::NotificationSubscriptionState::Recovering);
+
+    emit("prices", 3, 1);
+    emit("prices", 2, 2);
+    // A second key is a FIFO transport barrier proving that the stale record
+    // has reached the adapter before the test acknowledges the winner.
+    emit("positions", 1, 3);
+    REQUIRE(wait_until([&] { return running.subscription.pending() == 2; }));
+    REQUIRE(wait_until([&] {
+        return running.subscription.status().state ==
+               hgf::NotificationSubscriptionState::Live;
+    }));
+    REQUIRE(wait_until([&] {
+        const auto commits = broker->committed_cursors();
+        return !commits.empty() &&
+               commits.back()
+                       .view()
+                       .as_bundle()
+                       .at("next_offset")
+                       .checked_as<hg::Int>() == 1;
+    }));
+
+    auto notification = running.subscription.try_pop();
+    REQUIRE(notification.has_value());
+    REQUIRE(revision_of(*notification) == 3);
+    REQUIRE(running.subscription.pending() == 1);
+
+    const auto before_ack = broker->committed_cursors();
+    REQUIRE(before_ack.back()
+                .view()
+                .as_bundle()
+                .at("next_offset")
+                .checked_as<hg::Int>() == 1);
+
+    running.subscription.acknowledge(*notification);
+    const bool committed = wait_until([&] {
+        const auto commits = broker->committed_cursors();
+        return !commits.empty() &&
+               commits.back()
+                       .view()
+                       .as_bundle()
+                       .at("next_offset")
+                       .checked_as<hg::Int>() == 3;
+    });
+    std::vector<hg::Int> committed_offsets;
+    for (const auto &cursor : broker->committed_cursors())
+    {
+        committed_offsets.push_back(cursor.view()
+                                        .as_bundle()
+                                        .at("next_offset")
+                                        .checked_as<hg::Int>());
+    }
+    CAPTURE(committed_offsets);
+    REQUIRE(committed);
+
+    auto barrier = running.subscription.try_pop();
+    REQUIRE(barrier.has_value());
+    REQUIRE(barrier->data_id == "positions");
+    running.subscription.acknowledge(*barrier);
+}
+
+TEST_CASE("Kafka notifier clears obsolete receipts when the consumer recovers")
+{
+    RunningNotifier running;
+
+    emit("prices", 2, 0);
+    REQUIRE(wait_until([&] { return running.subscription.pending() == 1; }));
+    const auto prior_generation = running.subscription.status().generation;
+
+    emit("positions", 1, 1, hgk::KafkaSubscriptionState::Retrying);
+    REQUIRE(wait_until([&] {
+        return running.subscription.status().state ==
+               hgf::NotificationSubscriptionState::Retrying;
+    }));
+    REQUIRE(running.subscription.pending() == 1);
+
+    emit("positions", 2, 2);
+    REQUIRE(wait_until([&] {
+        return running.subscription.status().state ==
+                   hgf::NotificationSubscriptionState::Live &&
+               running.subscription.status().generation > prior_generation;
+    }));
+    auto recovered = running.subscription.try_pop();
+    REQUIRE(recovered.has_value());
+    REQUIRE(recovered->data_id == "positions");
+    REQUIRE(revision_of(*recovered) == 2);
+    running.subscription.acknowledge(*recovered);
+}
+
+TEST_CASE("Kafka notifier fails closed at its distinct pending-id bound")
+{
+    RunningNotifier running;
+    notifier_config.pending_data_id_limit = 1;
+    // Rebuild because the wiring-time limits are already captured by the
+    // running adapter.
+    running.subscription.close();
+    running.view.request_stop();
+    running.runner->join();
+    running.runner.reset();
+    notifier.reset();
+
+    broker = std::make_shared<hgk::testing::FakeBroker>();
+    running.executor = start_realtime(hg::build_graph<KafkaNotifierGraph>());
+    running.subscription = notifier.subscribe();
+    running.view = running.executor.view();
+    running.runner.emplace(running.view);
+    REQUIRE(broker->wait_for_subscription_updates(1, 2s));
+
+    emit("prices", 1, 0);
+    emit("positions", 1, 1);
+    REQUIRE(wait_until([&] {
+        return running.subscription.status().state ==
+               hgf::NotificationSubscriptionState::Failed;
+    }));
+    REQUIRE_THAT(running.subscription.status().message,
+                 Catch::Matchers::ContainsSubstring("pending data-id limit"));
+}
+
+TEST_CASE("Kafka notifier exposes fatal transport diagnostics as typed status")
+{
+    RunningNotifier running;
+    broker->emit_event(hgk::make_event(
+        hgk::KafkaSeverity::Fatal, "consumer", "poll", "fabric-kafka",
+        "broker authentication failed", 29, false, true));
+
+    REQUIRE(wait_until([&] {
+        return running.subscription.status().state ==
+               hgf::NotificationSubscriptionState::Failed;
+    }));
+    REQUIRE_THAT(running.subscription.status().message,
+                 Catch::Matchers::ContainsSubstring(
+                     "broker authentication failed"));
+
+    emit("prices", 1, 0);
+    REQUIRE(wait_until([&] { return running.subscription.pending() == 1; }));
+    REQUIRE(running.subscription.status().state ==
+            hgf::NotificationSubscriptionState::Failed);
+    REQUIRE_THAT(running.subscription.status().message,
+                 Catch::Matchers::ContainsSubstring(
+                     "broker authentication failed"));
+}
+
+TEST_CASE("production Kafka notifier recovers and resumes after graph restart")
+{
+    hgk::testing::MockCluster cluster;
+    cluster.create_topic("fabric-production-notices");
+    cluster.fail_next_fetch(hgk::testing::MockConsumeError::Retriable);
+    service_config =
+        hgk::service_config()
+            .bootstrap_servers({cluster.bootstrap_servers()})
+            .client_id("fabric-production-notifier")
+            .consumer_failure_policy(hgk::KafkaFailurePolicy::Report)
+            .build();
+    notifier_config = {
+        .topic = "fabric-production-notices",
+        .group_id = "fabric-production-notifier",
+        .sharing_identity = "fabric-production-notifier",
+        .pending_data_id_limit = 16,
+        .outbound_record_limit = 16,
+        .commit_partition_limit = 4,
+    };
+
+    {
+        RunningProductionNotifier running;
+        REQUIRE(running.wait_for_live());
+        REQUIRE(running.subscription.status().generation > 0);
+
+        const auto first_bytes = notice_bytes("prices", 1);
+        auto delivery = notifier.publish({"prices", first_bytes});
+        REQUIRE(wait_until(
+            [&] {
+                return delivery.poll().status !=
+                       hgf::NotificationDeliveryStatus::Pending;
+            },
+            10s));
+        REQUIRE(delivery.poll().status ==
+                hgf::NotificationDeliveryStatus::Delivered);
+        auto first = running.wait_for_revision(1);
+        REQUIRE(first.has_value());
+        running.subscription.acknowledge(*first);
+        std::this_thread::sleep_for(100ms);
+    }
+
+    {
+        RunningProductionNotifier running;
+        REQUIRE(running.wait_for_live());
+
+        const auto second_bytes = notice_bytes("prices", 2);
+        auto delivery = notifier.publish({"prices", second_bytes});
+        REQUIRE(wait_until(
+            [&] {
+                return delivery.poll().status !=
+                       hgf::NotificationDeliveryStatus::Pending;
+            },
+            10s));
+        REQUIRE(delivery.poll().status ==
+                hgf::NotificationDeliveryStatus::Delivered);
+        auto second = running.wait_for_revision(2);
+        REQUIRE(second.has_value());
+        running.subscription.acknowledge(*second);
+    }
+
+    notifier.reset();
+    service_config = {};
+}
+
+TEST_CASE("production Kafka notifier surfaces permanent delivery failure")
+{
+    hgk::testing::MockCluster cluster;
+    cluster.create_topic("fabric-production-failure");
+    cluster.fail_next_produce(hgk::testing::MockProduceError::Permanent);
+    service_config =
+        hgk::service_config()
+            .bootstrap_servers({cluster.bootstrap_servers()})
+            .client_id("fabric-production-failure")
+            .producer_failure_policy(hgk::KafkaFailurePolicy::Report)
+            .build();
+    notifier_config = {
+        .topic = "fabric-production-failure",
+        .group_id = "fabric-production-failure",
+        .sharing_identity = "fabric-production-failure",
+        .pending_data_id_limit = 4,
+        .outbound_record_limit = 4,
+        .commit_partition_limit = 4,
+    };
+
+    {
+        RunningProductionNotifier running;
+        REQUIRE(running.wait_for_live());
+        auto delivery = notifier.publish(
+            {"prices", notice_bytes("prices", 1)});
+        REQUIRE(wait_until(
+            [&] {
+                return delivery.poll().status !=
+                       hgf::NotificationDeliveryStatus::Pending;
+            },
+            10s));
+        REQUIRE(delivery.poll().status ==
+                hgf::NotificationDeliveryStatus::Failed);
+        REQUIRE_FALSE(delivery.poll().message.empty());
+        REQUIRE(running.subscription.pending() == 0);
+    }
+
+    notifier.reset();
+    service_config = {};
+}
+
+TEST_CASE("production Kafka notifier round-trips through an external broker")
+{
+    const char *bootstrap =
+        std::getenv("HGRAPH_FABRIC_KAFKA_INTEGRATION_BOOTSTRAP");
+    const char *topic = std::getenv("HGRAPH_FABRIC_KAFKA_INTEGRATION_TOPIC");
+    if (bootstrap == nullptr && topic == nullptr) { return; }
+
+    REQUIRE(bootstrap != nullptr);
+    REQUIRE(topic != nullptr);
+    const hg::Str topic_name{topic};
+    const hg::Str identity =
+        hg::Str{"hgraph-fabric-integration-"} + topic_name;
+    service_config =
+        hgk::service_config()
+            .bootstrap_servers({hg::Str{bootstrap}})
+            .client_id("hgraph-fabric-real-broker")
+            .build();
+    notifier_config = {
+        .topic = topic_name,
+        .group_id = identity,
+        .sharing_identity = identity,
+        .pending_data_id_limit = 16,
+        .outbound_record_limit = 16,
+        .commit_partition_limit = 16,
+    };
+
+    const auto revision = static_cast<hgf::RevisionId>(
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch())
+            .count());
+    {
+        RunningProductionNotifier running;
+        REQUIRE(running.wait_for_live());
+        auto delivery = notifier.publish(
+            {"prices", notice_bytes("prices", revision)});
+        REQUIRE(wait_until(
+            [&] {
+                return delivery.poll().status !=
+                       hgf::NotificationDeliveryStatus::Pending;
+            },
+            10s));
+        REQUIRE(delivery.poll().status ==
+                hgf::NotificationDeliveryStatus::Delivered);
+        auto received = running.wait_for_revision(revision);
+        REQUIRE(received.has_value());
+        running.subscription.acknowledge(*received);
+        std::this_thread::sleep_for(100ms);
+    }
+
+    notifier.reset();
+    service_config = {};
+}

--- a/extensions/fabric/tests/test_subscription.cpp
+++ b/extensions/fabric/tests/test_subscription.cpp
@@ -182,6 +182,87 @@ namespace hgraph::fabric::test_detail
         };
         return Notifier{gate, ops};
     }
+
+    struct ControlledSubscription
+    {
+        void transition(NotificationSubscriptionState state)
+        {
+            std::function<void()> notify;
+            {
+                const std::scoped_lock lock{mutex};
+                status = {state, status.generation + 1, {}};
+                notify = waker;
+            }
+            if (notify) { notify(); }
+        }
+
+        mutable std::mutex mutex{};
+        NotificationSubscriptionStatus status{};
+        std::function<void()> waker{};
+        bool closed{};
+    };
+
+    struct ControlledNotifier
+    {
+        std::shared_ptr<ControlledSubscription> subscription{};
+        Notifier memory{make_memory_notifier()};
+    };
+
+    [[nodiscard]] const NotificationSubscriptionOps &
+    controlled_subscription_ops()
+    {
+        static const NotificationSubscriptionOps ops{
+            [](void *) -> std::optional<RevisionNotification> {
+                return std::nullopt;
+            },
+            [](void *) noexcept -> std::size_t { return 0; },
+            [](void *context) {
+                auto &subscription =
+                    *static_cast<ControlledSubscription *>(context);
+                const std::scoped_lock lock{subscription.mutex};
+                return subscription.status;
+            },
+            [](void *, const RevisionNotification &) {},
+            [](void *context, std::function<void()> waker) {
+                auto &subscription =
+                    *static_cast<ControlledSubscription *>(context);
+                const std::scoped_lock lock{subscription.mutex};
+                subscription.waker = std::move(waker);
+            },
+            [](void *context) noexcept {
+                auto &subscription =
+                    *static_cast<ControlledSubscription *>(context);
+                const std::scoped_lock lock{subscription.mutex};
+                subscription.closed = true;
+                subscription.waker = {};
+                subscription.status.state =
+                    NotificationSubscriptionState::Stopped;
+                ++subscription.status.generation;
+                subscription.status.message.clear();
+            },
+        };
+        return ops;
+    }
+
+    [[nodiscard]] Notifier controlled_notifier(
+        const std::shared_ptr<ControlledSubscription> &subscription)
+    {
+        static const NotifierOps ops{
+            [](void *context) {
+                auto &owner = *static_cast<ControlledNotifier *>(context);
+                return NotificationSubscription{owner.subscription,
+                                                controlled_subscription_ops()};
+            },
+            [](void *context, RevisionNotification notification) {
+                return static_cast<ControlledNotifier *>(context)
+                    ->memory.publish(std::move(notification));
+            },
+        };
+        return Notifier{
+            std::make_shared<ControlledNotifier>(
+                ControlledNotifier{subscription, make_memory_notifier()}),
+            ops};
+    }
 }  // namespace hgraph::fabric::test_detail
 
 namespace std
@@ -567,6 +648,75 @@ TEST_CASE("slow live clients conflate and skip stale out-of-order notices")
     view.request_stop();
     run.join();
     CHECK(values(capture) == std::vector<std::int64_t>{1, 2, 4});
+}
+
+TEST_CASE("live notifications select the immutable winner over a losing payload")
+{
+    const auto now = std::chrono::time_point_cast<std::chrono::microseconds>(
+        hg::engine_clock::now());
+    auto config = hgf::make_memory_fabric_config(
+        "tests/subscription/durable-winner");
+    seed(config, "data", 1, 1, now - std::chrono::seconds{2});
+
+    detail::CaptureHandle capture{std::make_shared<detail::CaptureState>()};
+    auto executor = make_executor(
+        config, hgf::SubscriptionMode::Live,
+        hg::GraphExecutorMode::RealTime, now - std::chrono::milliseconds{1},
+        now + std::chrono::seconds{5}, capture);
+    auto view = executor.view();
+    hg::testing::AsyncGraphExecutorRun run{view};
+    REQUIRE(capture.value->wait_for(1, std::chrono::seconds{2}));
+
+    static_cast<void>(seed(config, "data", 2, 2,
+                           now - std::chrono::seconds{1}));
+    const auto losing_value = hgf::make_data_revision(
+        hgf::DataRevisionInput{
+            .data_id = "data",
+            .revision = 2,
+            .output_version = 99,
+            .as_of = now - std::chrono::seconds{1},
+        });
+    const auto losing_payload = hgf::encode_revision(losing_value.view());
+    REQUIRE(config.notifications.publish({"data", losing_payload})
+                .poll()
+                .status == hgf::NotificationDeliveryStatus::Delivered);
+
+    REQUIRE(capture.value->wait_for(2, std::chrono::seconds{2}));
+    view.request_stop();
+    run.join();
+    CHECK(values(capture) == std::vector<std::int64_t>{1, 2});
+}
+
+TEST_CASE("live reconciles durable heads after each recovered transport generation")
+{
+    const auto now = std::chrono::time_point_cast<std::chrono::microseconds>(
+        hg::engine_clock::now());
+    auto config = hgf::make_memory_fabric_config(
+        "tests/subscription/reconnect-reconcile");
+    auto transport =
+        std::make_shared<detail::ControlledSubscription>();
+    config.notifications = detail::controlled_notifier(transport);
+    seed(config, "data", 1, 1, now - std::chrono::seconds{2});
+
+    detail::CaptureHandle capture{std::make_shared<detail::CaptureState>()};
+    auto executor = make_executor(
+        config, hgf::SubscriptionMode::Live,
+        hg::GraphExecutorMode::RealTime, now - std::chrono::milliseconds{1},
+        now + std::chrono::seconds{5}, capture);
+    auto view = executor.view();
+    hg::testing::AsyncGraphExecutorRun run{view};
+    REQUIRE(capture.value->wait_for(1, std::chrono::seconds{2}));
+
+    static_cast<void>(seed(config, "data", 2, 2,
+                           now - std::chrono::seconds{1}));
+    transport->transition(hgf::NotificationSubscriptionState::Recovering);
+    CHECK_FALSE(capture.value->wait_for(2, std::chrono::milliseconds{20}));
+    transport->transition(hgf::NotificationSubscriptionState::Live);
+
+    REQUIRE(capture.value->wait_for(2, std::chrono::seconds{2}));
+    view.request_stop();
+    run.join();
+    CHECK(values(capture) == std::vector<std::int64_t>{1, 2});
 }
 
 TEST_CASE("live retains an ahead proposal when a stale notice follows")


### PR DESCRIPTION
Part of #512.

## Summary

- add the optional installed `hgraph::fabric_kafka` adapter over the public hgraph-kafka service API
- enforce the non-lossy idempotent Fabric profile and correlate publisher delivery before durable revision publication
- reserve ingress before image loading, conflate per data id, validate before explicit offset acknowledgement, and reconcile durable heads on every recovered Live generation
- surface typed lifecycle/failure status and bound outbound, pending-id, receipt, and partition state
- cover fake-broker races/failures, librdkafka protocol recovery, installed SDK consumption, and opt-in external-broker restart conformance

## Validation

- macOS fresh native: 1,607/1,607
- macOS Python 3.14 from Python 3.12 abi3 wheel: 2,122 passed, 10 skipped
- installed C++ `hgraph::fabric_kafka` consumer: 1/1
- external Redpanda broker: round trip passed before and after broker restart
- Linux GCC 13 fresh native: 1,607/1,607
- Linux Python 3.14 with Polars rtcompat: 2,122 passed, 10 skipped
- Linux ASan Fabric suite: 1,862 assertions in 56 cases

Stacked on #533.