### PR TITLE
Implement Fabric subscription service runtime

### DIFF
--- a/extensions/fabric/CHANGELOG.md
+++ b/extensions/fabric/CHANGELOG.md
@@ -8,3 +8,6 @@
   publication state machine with schema locking and crash/index repair.
 - Add the native wiring-time dependency planner, explicit subscription handles,
   independent consistency forests, and hidden publisher lineage cuts.
+- Add the shared root Fabric service, Snapshot/Replay/Live subscription
+  sessions, service-owned publication and load paths, complete-revision live
+  cache ingestion, and the local Python memory-service host.

--- a/extensions/fabric/CMakeLists.txt
+++ b/extensions/fabric/CMakeLists.txt
@@ -32,6 +32,8 @@ add_library(hgraph_fabric
     src/planning.cpp
     src/publication.cpp
     src/resolution.cpp
+    src/service.cpp
+    src/subscription.cpp
     src/types.cpp
     src/value_builders.cpp
     src/impl/memory_notifier.cpp

--- a/extensions/fabric/README.md
+++ b/extensions/fabric/README.md
@@ -5,29 +5,44 @@
 It decouples recurring graph components through immutable, complete `Frame`
 versions and contiguous lineage revisions.
 
-The current implementation establishes the installed C++/Python operator and
+The current implementation provides the installed C++/Python operator and
 value contracts, canonical durable keys and metadata, run-scoped
-configuration, and broker-free memory notification. Its native publication
-state machine writes each Frame, wins the immutable revision slot, repairs the
-derived as-of/latest indexes, and only then advertises the accepted revision.
-Notifier failure leaves the accepted revision pending delivery so retry cannot
-change the durable winner. The wiring-time planner discovers subscriptions
-through direct and nested graph ownership, validates explicit dependency
-handles, partitions
-independent consistency forests, and wires one root coordinator with hidden
-lineage cuts. The ingress consistency resolver observes and repairs accepted
-heads, caches immutable revisions and Frames,
-indexes revision runs by output version, and selects the unique greatest
-newest-compatible cut. Its coordinator dynamically merges and splits
-consistency forests, isolates failed forests, prevents exposed root regression,
-and returns changed roots as one atomic graph-delivery batch together with the
-updated hidden lineage. Later RFC checkpoints connect that coordinator to
-subscription modes and Kafka.
+configuration, and broker-free memory notification. One lazy root
+`FabricServiceImpl` owns publication state, persistence access, live revision
+caches, replay/snapshot sessions, bounded queues and diagnostics. Client
+`subscribe_data` and `publish_data` operators only communicate with that
+service through hgraph service edges.
+
+The native publication state machine writes each Frame, wins the immutable
+revision slot, repairs the derived as-of/latest indexes, and only then
+advertises the accepted revision. Notifier failure leaves the accepted
+revision pending delivery so retry cannot change the durable winner. The
+wiring-time planner discovers subscriptions through direct and nested graph
+ownership, validates explicit dependency handles, partitions independent
+consistency forests, and wires hidden lineage signals to publication requests.
+
+The shared ingress coordinator supports all three wiring-time modes:
+
+* `Snapshot` emits one recursively bounded consistent image;
+* `Replay` walks durable as-of histories over the executor's half-open
+  interval using ordinary node scheduling; and
+* `Live` loads a durable initial image, then advances only when a complete
+  revision arrives on the ordinary notice edge.
+
+Complete live revision messages populate dependency indexes directly. Durable
+metadata is read for startup and explicit revision gaps; only a selected
+changed root causes its Frame to load. The live cache conflates by data id and
+is bounded. The Kafka adapter which supplies the production real-time
+push-source notice edge and reconnect reconciliation is the next RFC
+checkpoint; replay and snapshot never create a push source.
 
 Durable keys use a canonical reversible data-id segment and a portable
 1,024-byte whole-key limit shared with S3. The fabric prefix and encoded data
 id must leave room for the key category and fixed-width ordinal.
 
-Native consumers call `hgraph::fabric::register_fabric_operators()` and link
-`hgraph::fabric`. Python consumers import `hgraph_fabric`; importing the package
-registers the same native operator overloads and scalar enum.
+Native hosts install `FabricConfig` in `GlobalState`, call
+`hgraph::fabric::register_service()`, call
+`hgraph::fabric::register_fabric_operators()`, and link `hgraph::fabric`.
+Python consumers import `hgraph_fabric` and call
+`register_memory_fabric_service()` for the deterministic local host; importing
+the package registers the same native operators and scalar enum.

--- a/extensions/fabric/include/hgraph/fabric/fabric.h
+++ b/extensions/fabric/include/hgraph/fabric/fabric.h
@@ -9,6 +9,7 @@
 #include <hgraph/fabric/planning.h>
 #include <hgraph/fabric/publication.h>
 #include <hgraph/fabric/resolution.h>
+#include <hgraph/fabric/service.h>
 #include <hgraph/fabric/types.h>
 #include <hgraph/fabric/value_builders.h>
 

--- a/extensions/fabric/include/hgraph/fabric/resolution.h
+++ b/extensions/fabric/include/hgraph/fabric/resolution.h
@@ -152,6 +152,23 @@ public:
   resolve_forest(std::vector<Str> roots,
                  std::span<const ExposedRootVersion> exposed_roots = {});
 
+  /** Seed the immutable revision/output-version/dependency indexes from one
+      complete accepted notice. Missing earlier slots are loaded directly by
+      revision id; no latest/as-of discovery read is performed. */
+  void observe_accepted_revision(DataRevisionInput revision);
+
+  /** Resolve from the already observed cache. A previously unseen ancestry
+      id is recovered durably once, but cached heads are not polled again. */
+  [[nodiscard]] ForestResolution
+  resolve_forest_cached(std::vector<Str> roots,
+                        std::span<const ExposedRootVersion> exposed_roots = {});
+
+  /** Resolve only from revisions knowable at ``maximum_as_of``. The bound
+      applies recursively to roots and ordinary ancestry. */
+  [[nodiscard]] ForestResolution
+  resolve_forest_at(std::vector<Str> roots, DateTime maximum_as_of,
+                    std::span<const ExposedRootVersion> exposed_roots = {});
+
 private:
   struct Impl;
   std::unique_ptr<Impl> impl_;
@@ -186,9 +203,22 @@ public:
    */
   void observe_notice(Str data_id, DateTime noticed_at);
 
+  /** Populate the live resolver indexes from a complete accepted revision
+      carried on the graph notification edge. */
+  void observe_accepted_revision(DataRevisionInput revision);
+
   /** Resolve current accepted heads. MIN_DT omits notice latency for startup
       image calls which did not originate from a notice. */
   [[nodiscard]] CoordinationResult resolve(DateTime ready_at = MIN_DT);
+
+  /** Resolve a notice-driven update without polling durable heads already in
+      the cache. New ancestry and explicit revision gaps are still recovered. */
+  [[nodiscard]] CoordinationResult resolve_cached(DateTime ready_at = MIN_DT);
+
+  /** Resolve and atomically commit a historical cut using no revision later
+      than ``maximum_as_of``. */
+  [[nodiscard]] CoordinationResult resolve_at(DateTime maximum_as_of,
+                                              DateTime ready_at = MIN_DT);
 
 private:
   struct Impl;

--- a/extensions/fabric/include/hgraph/fabric/service.h
+++ b/extensions/fabric/include/hgraph/fabric/service.h
@@ -1,0 +1,104 @@
+#ifndef HGRAPH_FABRIC_SERVICE_H
+#define HGRAPH_FABRIC_SERVICE_H
+
+#include <hgraph/fabric/export.h>
+#include <hgraph/fabric/types.h>
+
+#include <hgraph/types/frame.h>
+#include <hgraph/types/graph_wiring.h>
+#include <hgraph/types/service_wiring.h>
+
+#include <string_view>
+
+namespace hgraph::fabric
+{
+inline constexpr std::string_view DEFAULT_SERVICE_PATH{"fabric"};
+
+/** One root update delivered by the shared Fabric service. A revision may
+    advance without ticking ``frame``; hidden publisher lineage still sees
+    the version/revision fields in that case. */
+using FabricIngressSignal = TSB<"hgraph.fabric::IngressSignal", Field<"frame", TS<Frame>>, Field<"version", TS<Int>>,
+                                Field<"revision", TS<Int>>>;
+
+using FabricPublicationRequest =
+    TSB<"hgraph.fabric::PublicationRequest", Field<"data_id", TS<Str>>, Field<"frame", TS<Frame>>,
+        Field<"dependencies", TSD<Str, TS<Int>>>, Field<"self_predecessor", TS<Int>>>;
+
+using FabricLoadResponse =
+    TSB<"hgraph.fabric::LoadResponse", Field<"data_id", TS<Str>>, Field<"version", TS<Int>>, Field<"frame", TS<Frame>>>;
+
+using FabricLoadRequest = TSB<"hgraph.fabric::LoadRequest", Field<"data_id", TS<Str>>, Field<"version", TS<Int>>>;
+
+struct FabricLiveSubscriptionService
+{
+    static constexpr std::string_view name{"fabric_live_subscription"};
+    using key_type = Str;
+    using value_schema = FabricIngressSignal;
+};
+
+struct FabricReplaySubscriptionService
+{
+    static constexpr std::string_view name{"fabric_replay_subscription"};
+    using key_type = Str;
+    using value_schema = FabricIngressSignal;
+};
+
+struct FabricSnapshotSubscriptionService
+{
+    static constexpr std::string_view name{"fabric_snapshot_subscription"};
+    using key_type = Str;
+    using value_schema = FabricIngressSignal;
+};
+
+/** Replyless publication requests from every publish_data client. */
+struct FabricPublicationService
+{
+    static constexpr std::string_view name{"fabric_publication"};
+    using request_schema = FabricPublicationRequest;
+};
+
+/** Complete accepted revisions arriving on an ordinary graph edge. The
+    optional Kafka adapter is the production implementation of this edge. */
+struct FabricNoticeService
+{
+    static constexpr std::string_view name{"fabric_notice"};
+    using request_schema = TS<DataRevision>;
+};
+
+/** Synchronous v1 load request/reply surface. The service owns persistence
+    access; a later asynchronous strategy can retain this contract. */
+struct FabricLoadService
+{
+    static constexpr std::string_view name{"fabric_load"};
+    using request_schema = FabricLoadRequest;
+    using response_schema = FabricLoadResponse;
+};
+
+struct FabricDiagnosticsService
+{
+    static constexpr std::string_view name{"fabric_diagnostics"};
+    using output_schema = TSD<Str, TS<Str>>;
+};
+
+/** Register one lazy root-graph FabricServiceImpl singleton. Configuration
+    is read from GlobalState during service start. This host operation is
+    intentionally separate from subscribe_data clients. */
+HGRAPH_FABRIC_EXPORT void register_service(Wiring &wiring, service::ServicePath path);
+HGRAPH_FABRIC_EXPORT void register_service(Wiring &wiring);
+
+/** Feed a complete accepted revision into the registered service through
+    the ordinary request edge. */
+HGRAPH_FABRIC_EXPORT void submit_notice(Wiring &wiring, Port<TS<DataRevision>> notice, service::ServicePath path);
+HGRAPH_FABRIC_EXPORT void submit_notice(Wiring &wiring, Port<TS<DataRevision>> notice);
+
+[[nodiscard]] HGRAPH_FABRIC_EXPORT Port<FabricLoadResponse> request_load(Wiring &wiring, Str data_id,
+                                                                         DataVersion version,
+                                                                         service::ServicePath path);
+[[nodiscard]] HGRAPH_FABRIC_EXPORT Port<FabricLoadResponse> request_load(Wiring &wiring, Str data_id,
+                                                                         DataVersion version);
+
+[[nodiscard]] HGRAPH_FABRIC_EXPORT Port<TSD<Str, TS<Str>>> diagnostics(Wiring &wiring, service::ServicePath path);
+[[nodiscard]] HGRAPH_FABRIC_EXPORT Port<TSD<Str, TS<Str>>> diagnostics(Wiring &wiring);
+} // namespace hgraph::fabric
+
+#endif // HGRAPH_FABRIC_SERVICE_H

--- a/extensions/fabric/python/hgraph_fabric/__init__.py
+++ b/extensions/fabric/python/hgraph_fabric/__init__.py
@@ -91,6 +91,20 @@ _publish_data = operator_function("hgraph.fabric.publish_data")
 _publish_data_explicit = operator_function(
     "hgraph.fabric._publish_data_explicit"
 )
+_register_memory_service = operator_function(
+    "hgraph.fabric.register_memory_service"
+)
+
+
+def register_memory_fabric_service(*, prefix: str = "fabric") -> None:
+    """Register one native Fabric service backed by process-local stores.
+
+    This is the deterministic local/test host. Production hosts install their
+    persistence and notification resources in ``GlobalState`` and register the
+    same native service contract from C++.
+    """
+
+    _register_memory_service(prefix)
 
 
 def subscribe_data(
@@ -235,5 +249,6 @@ __all__ = [
     "encode_latest_reference",
     "encode_revision",
     "publish_data",
+    "register_memory_fabric_service",
     "subscribe_data",
 ]

--- a/extensions/fabric/python/tests/test_distribution_audit.py
+++ b/extensions/fabric/python/tests/test_distribution_audit.py
@@ -30,6 +30,7 @@ def test_wheel_audit_accepts_platform_library_directories(
         "include/hgraph/fabric/planning.h": "",
         "include/hgraph/fabric/publication.h": "",
         "include/hgraph/fabric/resolution.h": "",
+        "include/hgraph/fabric/service.h": "",
         "include/hgraph/fabric/types.h": "",
         "include/hgraph/fabric/value_builders.h": "",
         f"{library_directory}/libhgraph_fabric.a": "",

--- a/extensions/fabric/python/tests/test_public_contracts.py
+++ b/extensions/fabric/python/tests/test_public_contracts.py
@@ -74,11 +74,12 @@ def test_python_codec_does_not_replace_an_unsupported_format_version():
 def test_python_public_operators_wire_through_native_registry():
     wiring = _hgraph.Wiring()
     with use_wiring(wiring):
+        hgf.register_memory_fabric_service()
         value = hgf.subscribe_data(
             "python/input", mode=hgf.SubscriptionMode.LIVE
         )
         hgf.publish_data("python/output", value)
-    wiring.build_services()
+    wiring.run()
 
 
 def test_python_operator_validation_is_wiring_time():
@@ -119,8 +120,7 @@ def test_explicit_dependency_selection_rejects_empty():
 
 
 def _finish_contract_wiring(wiring: _hgraph.Wiring) -> None:
-    with pytest.raises(RuntimeError, match="subscription checkpoints"):
-        wiring.run()
+    wiring.run()
 
 
 def test_python_planner_wires_direct_shared_conditional_and_nested_graphs():
@@ -132,6 +132,7 @@ def test_python_planner_wires_direct_shared_conditional_and_nested_graphs():
 
     wiring = _hgraph.Wiring()
     with use_wiring(wiring):
+        hgf.register_memory_fabric_service()
         direct = hgf.subscribe_data(
             "python/direct", mode=hgf.SubscriptionMode.LIVE
         )
@@ -160,6 +161,7 @@ def test_python_planner_wires_direct_shared_conditional_and_nested_graphs():
 def test_python_explicit_dependencies_use_the_native_planner():
     wiring = _hgraph.Wiring()
     with use_wiring(wiring):
+        hgf.register_memory_fabric_service()
         source = hgf.subscribe_data(
             "python/explicit-input", mode=hgf.SubscriptionMode.LIVE
         )
@@ -215,8 +217,9 @@ def test_python_operator_registration_survives_registry_reset():
     _hgraph.reset_registries()
     wiring = _hgraph.Wiring()
     with use_wiring(wiring):
+        hgf.register_memory_fabric_service()
         value = hgf.subscribe_data(
             "python/reset-input", mode=hgf.SubscriptionMode.LIVE
         )
         hgf.publish_data("python/reset-output", value)
-    wiring.build_services()
+    wiring.run()

--- a/extensions/fabric/src/impl/service_runtime.h
+++ b/extensions/fabric/src/impl/service_runtime.h
@@ -1,0 +1,190 @@
+#ifndef HGRAPH_FABRIC_IMPL_SERVICE_RUNTIME_H
+#define HGRAPH_FABRIC_IMPL_SERVICE_RUNTIME_H
+
+#include <hgraph/fabric/publication.h>
+#include <hgraph/fabric/resolution.h>
+#include <hgraph/fabric/service.h>
+
+#include <hgraph/runtime/node_scheduler.h>
+#include <hgraph/types/static_node.h>
+
+#include <compare>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <ostream>
+#include <string_view>
+#include <tuple>
+#include <vector>
+
+namespace hgraph::fabric::detail
+{
+struct SubscriptionSpec
+{
+    Str key{};
+    Str data_id{};
+    DateTime as_of{MIN_DT};
+
+    friend bool operator==(const SubscriptionSpec &, const SubscriptionSpec &) = default;
+};
+
+struct DeliveredRoot
+{
+    Str key{};
+    Str data_id{};
+    RevisionId revision{};
+    DataVersion output_version{};
+    std::optional<Frame> frame{};
+};
+
+struct DeliveryBatch
+{
+    std::vector<DeliveredRoot> roots{};
+};
+
+struct PublicationRequestInput
+{
+    Str data_id{};
+    Frame output{};
+    std::vector<DataDependencyInput> dependencies{};
+    std::optional<DataVersion> self_predecessor{};
+};
+
+struct FabricServicePlan
+{
+    std::vector<SubscriptionSpec> live{};
+    std::vector<SubscriptionSpec> replay{};
+    std::vector<SubscriptionSpec> snapshot{};
+
+    void add(SubscriptionSpec subscription, SubscriptionMode mode);
+};
+
+struct FabricServicePlanHandle
+{
+    std::shared_ptr<FabricServicePlan> value{};
+
+    friend bool operator==(const FabricServicePlanHandle &, const FabricServicePlanHandle &) noexcept = default;
+    friend std::strong_ordering operator<=>(const FabricServicePlanHandle &lhs,
+                                            const FabricServicePlanHandle &rhs) noexcept
+    {
+        return reinterpret_cast<std::uintptr_t>(lhs.value.get()) <=> reinterpret_cast<std::uintptr_t>(rhs.value.get());
+    }
+};
+
+inline std::ostream &operator<<(std::ostream &stream, const FabricServicePlanHandle &value)
+{
+    return stream << "FabricServicePlanHandle(" << value.value.get() << ')';
+}
+
+struct FabricPlannedLiveService
+{
+    static constexpr std::string_view name{"fabric_planned_live"};
+    using output_schema = TSD<Str, FabricIngressSignal>;
+};
+
+struct FabricPlannedReplayService
+{
+    static constexpr std::string_view name{"fabric_planned_replay"};
+    using output_schema = TSD<Str, FabricIngressSignal>;
+};
+
+struct FabricPlannedSnapshotService
+{
+    static constexpr std::string_view name{"fabric_planned_snapshot"};
+    using output_schema = TSD<Str, FabricIngressSignal>;
+};
+
+[[nodiscard]] FabricServicePlanHandle service_plan(Wiring &wiring, std::string_view path);
+void plan_subscription(Wiring &wiring, SubscriptionSpec subscription, SubscriptionMode mode, std::string_view path);
+
+class FabricServiceRuntime final
+{
+  public:
+    explicit FabricServiceRuntime(FabricServicePlanHandle plan);
+    ~FabricServiceRuntime();
+
+    FabricServiceRuntime(const FabricServiceRuntime &) = delete;
+    FabricServiceRuntime &operator=(const FabricServiceRuntime &) = delete;
+
+    void start(GlobalStateView global_state);
+    void stop() noexcept;
+    void configure_replay_window(DateTime start_time, DateTime end_time);
+
+    [[nodiscard]] std::optional<DeliveryBatch> snapshot(std::vector<SubscriptionSpec> subscriptions);
+    [[nodiscard]] std::optional<DeliveryBatch> planned_snapshot();
+    [[nodiscard]] std::optional<DeliveryBatch> replay(std::vector<SubscriptionSpec> subscriptions, DateTime now,
+                                                      NodeScheduler scheduler);
+    [[nodiscard]] std::optional<DeliveryBatch> planned_replay(DateTime now, NodeScheduler scheduler);
+    [[nodiscard]] std::optional<DeliveryBatch> live(std::vector<SubscriptionSpec> subscriptions,
+                                                    std::vector<DataRevisionInput> revisions, DateTime now);
+    [[nodiscard]] std::optional<DeliveryBatch> planned_live(std::vector<DataRevisionInput> revisions, DateTime now);
+
+    void publish(PublicationRequestInput request);
+    [[nodiscard]] std::vector<DataRevisionInput> advance_publications();
+    [[nodiscard]] bool publication_work_pending() const noexcept;
+
+    [[nodiscard]] std::optional<std::tuple<Str, DataVersion, Frame>> load(std::string_view data_id,
+                                                                          DataVersion version) const;
+    [[nodiscard]] std::vector<std::pair<Str, Str>> diagnostics() const;
+
+  private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+struct FabricServiceRuntimeHandle
+{
+    std::shared_ptr<FabricServiceRuntime> value{};
+
+    friend bool operator==(const FabricServiceRuntimeHandle &, const FabricServiceRuntimeHandle &) noexcept = default;
+    friend std::strong_ordering operator<=>(const FabricServiceRuntimeHandle &lhs,
+                                            const FabricServiceRuntimeHandle &rhs) noexcept
+    {
+        return reinterpret_cast<std::uintptr_t>(lhs.value.get()) <=> reinterpret_cast<std::uintptr_t>(rhs.value.get());
+    }
+};
+
+inline std::ostream &operator<<(std::ostream &stream, const FabricServiceRuntimeHandle &value)
+{
+    return stream << "FabricServiceRuntimeHandle(" << value.value.get() << ')';
+}
+
+[[nodiscard]] Str subscription_key(Str data_id, SubscriptionMode mode, DateTime as_of);
+[[nodiscard]] SubscriptionSpec decode_subscription_key(std::string_view key, SubscriptionMode mode);
+} // namespace hgraph::fabric::detail
+
+namespace std
+{
+template <> struct hash<hgraph::fabric::detail::FabricServiceRuntimeHandle>
+{
+    size_t operator()(const hgraph::fabric::detail::FabricServiceRuntimeHandle &value) const noexcept
+    {
+        return hash<const void *>{}(value.value.get());
+    }
+};
+
+template <> struct hash<hgraph::fabric::detail::FabricServicePlanHandle>
+{
+    size_t operator()(const hgraph::fabric::detail::FabricServicePlanHandle &value) const noexcept
+    {
+        return hash<const void *>{}(value.value.get());
+    }
+};
+} // namespace std
+
+namespace hgraph::static_schema_detail
+{
+template <> struct scalar_name<fabric::detail::FabricServiceRuntimeHandle>
+{
+    static constexpr std::string_view value{"hgraph.fabric.internal::ServiceRuntimeHandle"};
+};
+
+template <> struct scalar_name<fabric::detail::FabricServicePlanHandle>
+{
+    static constexpr std::string_view value{"hgraph.fabric.internal::ServicePlanHandle"};
+};
+} // namespace hgraph::static_schema_detail
+
+#endif // HGRAPH_FABRIC_IMPL_SERVICE_RUNTIME_H

--- a/extensions/fabric/src/operators.cpp
+++ b/extensions/fabric/src/operators.cpp
@@ -1,14 +1,19 @@
 #include <hgraph/fabric/operators.h>
 
 #include <hgraph/fabric/planning.h>
+#include <hgraph/fabric/service.h>
 #include <hgraph/fabric/value_builders.h>
+
+#include "impl/service_runtime.h"
 
 #include <hgraph/lib/std/operators/collection.h>
 #include <hgraph/lib/std/operators/container.h>
+#include <hgraph/lib/std/operators/conversion.h>
 #include <hgraph/lib/std/value_util.h>
 #include <hgraph/types/operator_dispatch.h>
 
 #include <algorithm>
+#include <map>
 #include <memory>
 #include <stdexcept>
 #include <tuple>
@@ -22,84 +27,72 @@ namespace hgraph::fabric
 {
     namespace
     {
-        using IngressSignal =
-            TSB<"hgraph.fabric::IngressSignal", Field<"version", TS<Int>>,
-                Field<"revision", TS<Int>>>;
-        using IngressSignals = TSD<Str, IngressSignal>;
-
         struct SubscribeDataPlanningSource
         {
             static constexpr auto name = "hgraph.fabric.subscribe_data.planned";
             using signature_args =
-                std::tuple<Scalar<"data_id", Str>,
-                           Scalar<"mode", SubscriptionMode>,
-                           Scalar<"as_of", DateTime>, Out<TS<Frame>>>;
+                std::tuple<In<"signal", FabricIngressSignal>, Scalar<"data_id", Str>,
+                           Scalar<"mode", SubscriptionMode>, Scalar<"as_of", DateTime>,
+                           Out<TS<Frame>>>;
 
-            static void start(Scalar<"data_id", Str>,
-                              Scalar<"mode", SubscriptionMode>,
-                              Scalar<"as_of", DateTime>)
+            /** O(Frame handle copy) per delivered version. The service has
+                already resolved consistency and performed durable loading. */
+            static void eval(In<"signal", FabricIngressSignal> signal, Out<TS<Frame>> out)
             {
-                throw std::logic_error(
-                    "hgraph.fabric.subscribe_data runtime is introduced by "
-                    "RFC 0026 subscription checkpoints");
+                const auto frame = signal.field<"frame">();
+                if (frame.modified() && frame.valid())
+                {
+                    out.set(frame.value());
+                }
             }
-
-            static void eval() {}
         };
 
-        /** One root endpoint for accepted lineage signals. Concrete memory and
-            Kafka ingress strategies replace this contract source in the
-            subscription checkpoints. */
-        struct IngressCoordinatorContractSource
-        {
-            static constexpr auto name = "hgraph.fabric.ingress_coordinator.contract";
-
-            static void start()
-            {
-                throw std::logic_error(
-                    "hgraph.fabric ingress runtime is introduced by RFC 0026 "
-                    "subscription checkpoints");
-            }
-
-            static void eval(Out<IngressSignals>) {}
-        };
-
-        struct PublishDataWithoutCutSink
+        struct PublishDataWithoutCutRequest
         {
             static constexpr auto name = "hgraph.fabric.publish_data.no_dependencies";
 
-            static void eval(In<"value", TS<Frame>>,
-                             Scalar<"data_id", Str>)
+            static void eval(In<"value", TS<Frame>> value, Scalar<"data_id", Str> data_id,
+                             Out<FabricPublicationRequest> out)
             {
-                throw std::logic_error(
-                    "hgraph.fabric.publish_data runtime wiring is introduced "
-                    "by RFC 0026 coordinator checkpoints");
+                out.field<"data_id">().set(data_id.value());
+                out.field<"frame">().set(value.value());
             }
         };
 
-        struct PublishDataWithCutSink
+        struct PublishDataWithCutRequest
         {
             static constexpr auto name = "hgraph.fabric.publish_data.with_cut";
 
-            static void eval(
-                In<"value", TS<Frame>>,
-                In<"cut", TSD<Str, IngressSignal>,
-                   InputActivity::Structural, InputValidity::Unchecked>,
-                Scalar<"data_id", Str>)
+            static void eval(In<"value", TS<Frame>, InputValidity::Unchecked> value,
+                             In<"cut", TSD<Str, FabricIngressSignal>, InputActivity::Structural,
+                                InputValidity::Unchecked>
+                                                    cut,
+                             Scalar<"data_id", Str> data_id, Out<FabricPublicationRequest> out)
             {
-                throw std::logic_error(
-                    "hgraph.fabric.publish_data runtime wiring is introduced "
-                    "by RFC 0026 coordinator checkpoints");
+                out.field<"data_id">().set(data_id.value());
+                if (value.modified() && value.valid())
+                {
+                    out.field<"frame">().set(value.value());
+                }
+                auto dependencies = out.field<"dependencies">();
+                for (const auto &[dependency_id, signal] : cut.valid_items())
+                {
+                    const auto version = signal.template field<"version">();
+                    if (version.valid())
+                    {
+                        dependencies.set(dependency_id.checked_as<Str>(), version.value());
+                    }
+                }
             }
         };
 
         struct SubscriptionDeclaration
         {
-            Str                                          data_id{};
-            SubscriptionMode                             mode{SubscriptionMode::Live};
-            DateTime                                     as_of{MIN_DT};
-            DelayedBindingWiringPort<TS<Frame>>          delayed{};
-            WiringPortRef                                output{};
+            Str                                 data_id{};
+            SubscriptionMode                    mode{SubscriptionMode::Live};
+            DateTime                            as_of{MIN_DT};
+            DelayedBindingWiringPort<TS<Frame>> delayed{};
+            WiringPortRef                       output{};
         };
 
         struct PublisherDeclaration
@@ -108,15 +101,17 @@ namespace hgraph::fabric
             WiringPortRef       value{};
             DependencySelection dependencies{DependencySelection::automatic()};
             std::vector<Str>    resolved_dependencies{};
-            bool                wired{false};
+            std::map<Str, std::pair<SubscriptionMode, DateTime>> resolved_subscription_policies{};
+            bool                                                 wired{false};
         };
 
         struct DeclarationState
         {
-            std::vector<SubscriptionDeclaration> subscriptions{};
-            std::vector<PublisherDeclaration>    publishers{};
-            std::optional<Port<IngressSignals>>  coordinator{};
-            bool                                 finalizer_registered{false};
+            std::vector<SubscriptionDeclaration>                 subscriptions{};
+            std::vector<PublisherDeclaration>                    publishers{};
+            std::map<Str, WiringPortRef>                         lineage_signals{};
+            std::map<Str, std::pair<SubscriptionMode, DateTime>> lineage_policies{};
+            bool                                                 finalizer_registered{false};
         };
 
         [[nodiscard]] NodeTypeRef subscribe_source_type()
@@ -131,21 +126,45 @@ namespace hgraph::fabric
             const Value &scalars = builder.scalars();
             if (!scalars.has_value())
             {
-                throw std::logic_error(
-                    "fabric subscription source has no scalar configuration");
+                throw std::logic_error("fabric subscription source has no scalar configuration");
             }
             return scalars.view().as_bundle().at("data_id").checked_as<Str>();
+        }
+
+        [[nodiscard]] std::pair<SubscriptionMode, DateTime>
+        source_policy(const NodeBuilder &builder)
+        {
+            const Value &scalars = builder.scalars();
+            if (!scalars.has_value())
+            {
+                throw std::logic_error("fabric subscription source has no scalar configuration");
+            }
+            const auto fields = scalars.view().as_bundle();
+            return {
+                fields.at("mode").checked_as<SubscriptionMode>(),
+                fields.at("as_of").checked_as<DateTime>(),
+            };
         }
 
         struct SourceCollection
         {
             std::unordered_set<const WiringInstance *> wiring_nodes{};
-            std::unordered_map<const GraphBuilder *,
-                               std::unordered_set<std::size_t>> compiled_nodes{};
-            std::vector<Str>                           data_ids{};
+            std::unordered_map<const GraphBuilder *, std::unordered_set<std::size_t>>
+                                                                 compiled_nodes{};
+            std::vector<Str>                                     data_ids{};
+            std::map<Str, std::pair<SubscriptionMode, DateTime>> policies{};
 
-            void add(Str data_id)
+            void add(const NodeBuilder &builder)
             {
+                Str        data_id = source_data_id(builder);
+                const auto policy = source_policy(builder);
+                const auto [found, inserted] = policies.emplace(data_id, policy);
+                if (!inserted && found->second != policy)
+                {
+                    throw std::invalid_argument(
+                        "fabric dependency discovery found one data id with "
+                        "multiple subscription policies");
+                }
                 if (std::ranges::find(data_ids, data_id) == data_ids.end())
                 {
                     data_ids.push_back(std::move(data_id));
@@ -153,47 +172,40 @@ namespace hgraph::fabric
             }
         };
 
-        void collect_compiled_node(const GraphBuilder &graph,
-                                   std::size_t node_index,
+        void collect_compiled_node(const GraphBuilder &graph, std::size_t node_index,
                                    SourceCollection &collection);
 
-        void collect_compiled_child(void *raw_collection,
-                                    ChildGraphInspectionView child)
+        void collect_compiled_child(void *raw_collection, ChildGraphInspectionView child)
         {
             if (child.graph == nullptr)
             {
-                throw std::logic_error(
-                    "fabric planner encountered an invalid child graph view");
+                throw std::logic_error("fabric planner encountered an invalid child graph view");
             }
             if (child.output_binding == nullptr ||
-                child.output_binding->kind ==
-                    NestedGraphOutputBinding::Kind::ParentInput)
+                child.output_binding->kind == NestedGraphOutputBinding::Kind::ParentInput)
             {
                 return;
             }
-            collect_compiled_node(
-                *child.graph, child.output_binding->source.node,
-                *static_cast<SourceCollection *>(raw_collection));
+            collect_compiled_node(*child.graph, child.output_binding->source.node,
+                                  *static_cast<SourceCollection *>(raw_collection));
         }
 
-        void collect_compiled_node(const GraphBuilder &graph,
-                                   std::size_t node_index,
+        void collect_compiled_node(const GraphBuilder &graph, std::size_t node_index,
                                    SourceCollection &collection)
         {
             if (node_index >= graph.node_count())
             {
-                throw std::logic_error(
-                    "fabric planner encountered an invalid child output node");
+                throw std::logic_error("fabric planner encountered an invalid child output node");
             }
             if (!collection.compiled_nodes[&graph].insert(node_index).second)
             {
                 return;
             }
-            const NodeTypeRef source_type = subscribe_source_type();
+            const NodeTypeRef  source_type = subscribe_source_type();
             const NodeBuilder &node = graph.nodes()[node_index];
             if (node.type() == source_type)
             {
-                collection.add(source_data_id(node));
+                collection.add(node);
                 return;
             }
             node.visit_child_graphs(&collection, &collect_compiled_child);
@@ -201,15 +213,13 @@ namespace hgraph::fabric
             {
                 if (edge.target_node == node_index)
                 {
-                    collect_compiled_node(
-                        graph, graph_edge_source_node(edge.source_node),
-                        collection);
+                    collect_compiled_node(graph, graph_edge_source_node(edge.source_node),
+                                          collection);
                 }
             }
         }
 
-        void collect_subscription_sources(const WiringPortRef &source,
-                                          SourceCollection &collection)
+        void collect_subscription_sources(const WiringPortRef &source, SourceCollection &collection)
         {
             using SourceKind = WiringPortRef::SourceKind;
             switch (source.source_kind())
@@ -236,15 +246,16 @@ namespace hgraph::fabric
                 case SourceKind::Peered:
                 {
                     const WiringInstance *node = source.peered_node();
-                    if (!collection.wiring_nodes.insert(node).second) { return; }
-                    if (node->definition ==
-                        std::type_index(typeid(SubscribeDataPlanningSource)))
+                    if (!collection.wiring_nodes.insert(node).second)
                     {
-                        collection.add(source_data_id(node->builder));
                         return;
                     }
-                    node->builder.visit_child_graphs(&collection,
-                                                     &collect_compiled_child);
+                    if (node->definition == std::type_index(typeid(SubscribeDataPlanningSource)))
+                    {
+                        collection.add(node->builder);
+                        return;
+                    }
+                    node->builder.visit_child_graphs(&collection, &collect_compiled_child);
                     for (const auto &input : node->inputs)
                     {
                         collect_subscription_sources(input.source, collection);
@@ -255,8 +266,7 @@ namespace hgraph::fabric
                     throw std::logic_error(
                         "fabric planner expected a materialised top-level source");
                 case SourceKind::Unbound:
-                    throw std::logic_error(
-                        "fabric planner encountered an unbound wiring source");
+                    throw std::logic_error("fabric planner encountered an unbound wiring source");
             }
         }
 
@@ -267,8 +277,7 @@ namespace hgraph::fabric
             return ids;
         }
 
-        [[nodiscard]] DependencyPlanInput build_plan(
-            const DeclarationState &state)
+        [[nodiscard]] DependencyPlanInput build_plan(const DeclarationState &state)
         {
             DependencyPlanInput plan;
             for (const auto &subscription : state.subscriptions)
@@ -277,8 +286,7 @@ namespace hgraph::fabric
             }
             for (const auto &publisher : state.publishers)
             {
-                plan.roots.insert(plan.roots.end(),
-                                  publisher.resolved_dependencies.begin(),
+                plan.roots.insert(plan.roots.end(), publisher.resolved_dependencies.begin(),
                                   publisher.resolved_dependencies.end());
                 plan.publishers.push_back(PlannedPublisherInput{
                     .data_id = publisher.data_id,
@@ -290,36 +298,84 @@ namespace hgraph::fabric
             plan.forests.reserve(plan.roots.size());
             for (const auto &root : plan.roots)
             {
-                plan.forests.push_back(
-                    ConsistencyForestInput{.roots = {root}});
+                plan.forests.push_back(ConsistencyForestInput{.roots = {root}});
             }
             return dependency_plan_input(make_dependency_plan(std::move(plan)).view());
         }
 
-        [[nodiscard]] WiringPortRef combine_cut(
-            Wiring &wiring, Port<IngressSignals> coordinator,
-            const std::vector<Str> &dependencies)
+        [[nodiscard]] Port<FabricIngressSignal> wire_subscription_signal(Wiring          &wiring,
+                                                                         const Str       &data_id,
+                                                                         SubscriptionMode mode,
+                                                                         DateTime         as_of)
+        {
+            const Str  key_value = detail::subscription_key(data_id, mode, as_of);
+            auto       key = wire<stdlib::const_, TS<Str>>(wiring, key_value);
+            const auto path = service::path(DEFAULT_SERVICE_PATH);
+            if (wiring.kind() == WiringKind::TopLevel)
+            {
+                detail::plan_subscription(wiring,
+                                          detail::SubscriptionSpec{
+                                              .key = key_value,
+                                              .data_id = data_id,
+                                              .as_of = as_of,
+                                          },
+                                          mode, DEFAULT_SERVICE_PATH);
+                switch (mode)
+                {
+                    case SubscriptionMode::Live:
+                        return wire<stdlib::getitem_>(
+                                   wiring, wire<detail::FabricPlannedLiveService>(wiring, path),
+                                   key)
+                            .template as<FabricIngressSignal>();
+                    case SubscriptionMode::Replay:
+                        return wire<stdlib::getitem_>(
+                                   wiring, wire<detail::FabricPlannedReplayService>(wiring, path),
+                                   key)
+                            .template as<FabricIngressSignal>();
+                    case SubscriptionMode::Snapshot:
+                        return wire<stdlib::getitem_>(
+                                   wiring, wire<detail::FabricPlannedSnapshotService>(wiring, path),
+                                   key)
+                            .template as<FabricIngressSignal>();
+                }
+                throw std::invalid_argument("unsupported fabric subscription mode");
+            }
+            switch (mode)
+            {
+                case SubscriptionMode::Live:
+                    return wire<FabricLiveSubscriptionService>(wiring, path, key);
+                case SubscriptionMode::Replay:
+                    return wire<FabricReplaySubscriptionService>(wiring, path, key);
+                case SubscriptionMode::Snapshot:
+                    return wire<FabricSnapshotSubscriptionService>(wiring, path, key);
+            }
+            throw std::invalid_argument("unsupported fabric subscription mode");
+        }
+
+        [[nodiscard]] WiringPortRef combine_cut(Wiring &wiring, const DeclarationState &state,
+                                                const std::vector<Str> &dependencies)
         {
             std::vector<WiringArg> args;
             args.reserve(dependencies.size() + 1);
             WiringArg keys;
             keys.kind = WiringArg::Kind::Scalar;
-            keys.scalar_value = stdlib::make_list<Str>(dependencies.begin(),
-                                                       dependencies.end());
+            keys.scalar_value = stdlib::make_list<Str>(dependencies.begin(), dependencies.end());
             keys.scalar_meta = keys.scalar_value.schema();
             args.push_back(std::move(keys));
 
             for (const auto &data_id : dependencies)
             {
-                auto signal = wire<stdlib::getitem_>(wiring, coordinator, data_id)
-                                  .as<IngressSignal>();
                 WiringArg value;
                 value.kind = WiringArg::Kind::TimeSeries;
-                value.port = signal.erased();
+                const auto signal = state.lineage_signals.find(data_id);
+                if (signal == state.lineage_signals.end())
+                {
+                    throw std::logic_error("fabric dependency has no subscription signal");
+                }
+                value.port = signal->second;
                 args.push_back(std::move(value));
             }
-            return wire_operator(wiring, "combine_tsd", args, true)
-                .output.erased();
+            return wire_operator(wiring, "combine_tsd", args, true).output.erased();
         }
 
         void finalize(DeclarationState &state, Wiring &wiring)
@@ -328,9 +384,21 @@ namespace hgraph::fabric
             {
                 if (!subscription.delayed.bound())
                 {
-                    auto source = wire<SubscribeDataPlanningSource>(
-                        wiring, subscription.data_id, subscription.mode,
-                        subscription.as_of);
+                    auto signal = wire_subscription_signal(wiring, subscription.data_id,
+                                                           subscription.mode, subscription.as_of);
+                    auto source =
+                        wire<SubscribeDataPlanningSource>(wiring, signal, subscription.data_id,
+                                                          subscription.mode, subscription.as_of);
+                    const auto policy = std::pair{subscription.mode, subscription.as_of};
+                    const auto [known_policy, inserted_policy] =
+                        state.lineage_policies.emplace(subscription.data_id, policy);
+                    if (!inserted_policy && known_policy->second != policy)
+                    {
+                        throw std::invalid_argument("fabric dependency discovery found one data id "
+                                                    "with "
+                                                    "multiple subscription policies");
+                    }
+                    state.lineage_signals.try_emplace(subscription.data_id, signal.erased());
                     subscription.delayed(source);
                 }
             }
@@ -344,23 +412,19 @@ namespace hgraph::fabric
                 }
                 else
                 {
-                    for (const auto &dependency :
-                         publisher.dependencies.dependencies())
+                    for (const auto &dependency : publisher.dependencies.dependencies())
                     {
                         if (dependency.root_identity() != wiring.identity())
                         {
-                            throw std::logic_error(
-                                "fabric explicit dependency belongs to another "
-                                "wired root");
+                            throw std::logic_error("fabric explicit dependency belongs to another "
+                                                   "wired root");
                         }
-                        collect_subscription_sources(dependency.source(),
-                                                     collection);
+                        collect_subscription_sources(dependency.source(), collection);
                     }
                 }
-                publisher.resolved_dependencies =
-                    canonical_ids(std::move(collection.data_ids));
-                if (std::ranges::find(publisher.resolved_dependencies,
-                                      publisher.data_id) !=
+                publisher.resolved_dependencies = canonical_ids(std::move(collection.data_ids));
+                publisher.resolved_subscription_policies = std::move(collection.policies);
+                if (std::ranges::find(publisher.resolved_dependencies, publisher.data_id) !=
                     publisher.resolved_dependencies.end())
                 {
                     throw std::invalid_argument(
@@ -369,55 +433,75 @@ namespace hgraph::fabric
                 }
             }
 
-            DependencyPlanInput plan = build_plan(state);
-            wiring.set_trait(DEPENDENCY_PLAN_TRAIT,
-                             make_dependency_plan(plan));
-
-            if (!plan.roots.empty() && !state.coordinator.has_value())
+            for (const auto &publisher : state.publishers)
             {
-                state.coordinator =
-                    wire<IngressCoordinatorContractSource>(wiring);
+                for (const auto &data_id : publisher.resolved_dependencies)
+                {
+                    const auto policy = publisher.resolved_subscription_policies.find(data_id);
+                    if (policy == publisher.resolved_subscription_policies.end())
+                    {
+                        throw std::logic_error("fabric dependency has no subscription policy");
+                    }
+                    const auto [known_policy, inserted_policy] =
+                        state.lineage_policies.emplace(data_id, policy->second);
+                    if (!inserted_policy && known_policy->second != policy->second)
+                    {
+                        throw std::invalid_argument("fabric dependency discovery found one data id "
+                                                    "with "
+                                                    "multiple subscription policies");
+                    }
+                    if (state.lineage_signals.contains(data_id))
+                    {
+                        continue;
+                    }
+                    auto signal = wire_subscription_signal(wiring, data_id, policy->second.first,
+                                                           policy->second.second);
+                    state.lineage_signals.emplace(data_id, signal.erased());
+                }
             }
+
+            DependencyPlanInput plan = build_plan(state);
+            wiring.set_trait(DEPENDENCY_PLAN_TRAIT, make_dependency_plan(plan));
+
             for (auto &publisher : state.publishers)
             {
-                if (publisher.wired) { continue; }
+                if (publisher.wired)
+                {
+                    continue;
+                }
                 Port<void> value{wiring, publisher.value};
                 if (publisher.resolved_dependencies.empty())
                 {
-                    wire<PublishDataWithoutCutSink>(wiring, value,
-                                                    publisher.data_id);
+                    auto request =
+                        wire<PublishDataWithoutCutRequest>(wiring, value, publisher.data_id);
+                    wire<FabricPublicationService>(wiring, service::path(DEFAULT_SERVICE_PATH),
+                                                   request);
                 }
                 else
                 {
-                    if (!state.coordinator.has_value())
-                    {
-                        throw std::logic_error(
-                            "fabric dependency plan has no ingress coordinator");
-                    }
-                    WiringPortRef cut = combine_cut(
-                        wiring, *state.coordinator,
-                        publisher.resolved_dependencies);
-                    wire<PublishDataWithCutSink>(wiring, value,
-                                                 Port<void>{wiring, cut},
-                                                 publisher.data_id);
+                    WiringPortRef cut = combine_cut(wiring, state, publisher.resolved_dependencies);
+                    auto          request = wire<PublishDataWithCutRequest>(
+                        wiring, value, Port<void>{wiring, cut}, publisher.data_id);
+                    wire<FabricPublicationService>(wiring, service::path(DEFAULT_SERVICE_PATH),
+                                                   request);
                 }
                 publisher.wired = true;
             }
+            wiring.build_services();
         }
 
-        [[nodiscard]] std::shared_ptr<DeclarationState> declarations(
-            Wiring &wiring)
+        [[nodiscard]] std::shared_ptr<DeclarationState> declarations(Wiring &wiring)
         {
             auto state = std::static_pointer_cast<DeclarationState>(
-                wiring.acquire_extension_state(
-                    std::type_index(typeid(DeclarationState)),
-                    [] { return std::make_shared<DeclarationState>(); }));
+                wiring.acquire_extension_state(std::type_index(typeid(DeclarationState)), []
+                                               { return std::make_shared<DeclarationState>(); }));
             if (!state->finalizer_registered)
             {
                 state->finalizer_registered = true;
                 std::weak_ptr<DeclarationState> weak = state;
                 wiring.register_pre_rank_finalizer(
-                    [weak](Wiring &target) {
+                    [weak](Wiring &target)
+                    {
                         if (const auto locked = weak.lock())
                         {
                             finalize(*locked, target);
@@ -427,8 +511,7 @@ namespace hgraph::fabric
             return state;
         }
 
-        void require_subscription_arguments(Str const &data_id,
-                                            SubscriptionMode mode,
+        void require_subscription_arguments(Str const &data_id, SubscriptionMode mode,
                                             DateTime as_of)
         {
             require_data_id(data_id);
@@ -438,8 +521,8 @@ namespace hgraph::fabric
                 case SubscriptionMode::Snapshot:
                     if (!supplied_as_of)
                     {
-                        throw std::invalid_argument(
-                            "hgraph.fabric.subscribe_data: Snapshot requires as_of");
+                        throw std::invalid_argument("hgraph.fabric.subscribe_data: "
+                                                    "Snapshot requires as_of");
                     }
                     return;
                 case SubscriptionMode::Live:
@@ -447,7 +530,8 @@ namespace hgraph::fabric
                     if (supplied_as_of)
                     {
                         throw std::invalid_argument(
-                            "hgraph.fabric.subscribe_data: as_of is valid only for Snapshot");
+                            "hgraph.fabric.subscribe_data: as_of is valid only for "
+                            "Snapshot");
                     }
                     return;
             }
@@ -455,20 +539,15 @@ namespace hgraph::fabric
                 "hgraph.fabric.subscribe_data: unsupported subscription mode");
         }
 
-        void record_publisher(Wiring &wiring, Str data_id,
-                              WiringPortRef value,
+        void record_publisher(Wiring &wiring, Str data_id, WiringPortRef value,
                               DependencySelection dependencies)
         {
             auto state = declarations(wiring);
-            if (std::ranges::any_of(
-                    state->publishers,
-                    [&](const PublisherDeclaration &publisher) {
-                        return publisher.data_id == data_id;
-                    }))
+            if (std::ranges::any_of(state->publishers, [&](const PublisherDeclaration &publisher)
+                                    { return publisher.data_id == data_id; }))
             {
-                throw std::invalid_argument(
-                    "hgraph.fabric.publish_data: data id already has a "
-                    "publisher in this wiring root");
+                throw std::invalid_argument("hgraph.fabric.publish_data: data id already has a "
+                                            "publisher in this wiring root");
             }
             state->publishers.push_back(PublisherDeclaration{
                 .data_id = std::move(data_id),
@@ -479,8 +558,7 @@ namespace hgraph::fabric
 
         struct SubscribeDataPlanningGraph
         {
-            static constexpr auto name =
-                "hgraph.fabric.subscribe_data.planning_graph";
+            static constexpr auto name = "hgraph.fabric.subscribe_data.planning_graph";
 
             static auto defaults()
             {
@@ -489,34 +567,29 @@ namespace hgraph::fabric
                 };
             }
 
-            static Port<TS<Frame>> compose(
-                Wiring &wiring, Scalar<"data_id", Str> data_id,
-                Scalar<"mode", SubscriptionMode> mode,
-                Scalar<"as_of", DateTime> as_of)
+            static Port<TS<Frame>> compose(Wiring &wiring, Scalar<"data_id", Str> data_id,
+                                           Scalar<"mode", SubscriptionMode> mode,
+                                           Scalar<"as_of", DateTime>        as_of)
             {
-                require_subscription_arguments(data_id.value(), mode.value(),
-                                               as_of.value());
+                require_subscription_arguments(data_id.value(), mode.value(), as_of.value());
                 auto delayed = delayed_binding<TS<Frame>>(wiring);
                 auto output = delayed();
-                declarations(wiring)->subscriptions.push_back(
-                    SubscriptionDeclaration{
-                        .data_id = data_id.value(),
-                        .mode = mode.value(),
-                        .as_of = as_of.value(),
-                        .delayed = delayed,
-                        .output = output.erased(),
-                    });
+                declarations(wiring)->subscriptions.push_back(SubscriptionDeclaration{
+                    .data_id = data_id.value(),
+                    .mode = mode.value(),
+                    .as_of = as_of.value(),
+                    .delayed = delayed,
+                    .output = output.erased(),
+                });
                 return output;
             }
         };
 
         struct PublishDataPlanningGraph
         {
-            static constexpr auto name =
-                "hgraph.fabric.publish_data.planning_graph";
+            static constexpr auto name = "hgraph.fabric.publish_data.planning_graph";
 
-            static void compose(Wiring &wiring,
-                                Scalar<"data_id", Str> data_id,
+            static void compose(Wiring &wiring, Scalar<"data_id", Str> data_id,
                                 NamedPort<"value", TS<Frame>> value)
             {
                 require_data_id(data_id.value());
@@ -526,36 +599,30 @@ namespace hgraph::fabric
         };
 
         using PublishDataExplicit =
-            Operator<"hgraph.fabric._publish_data_explicit",
-                     Scalar<"data_id", Str>, In<"value", TS<Frame>>,
-                     VarIn<"dependencies", TS<Frame>>>;
+            Operator<"hgraph.fabric._publish_data_explicit", Scalar<"data_id", Str>,
+                     In<"value", TS<Frame>>, VarIn<"dependencies", TS<Frame>>>;
 
         struct PublishDataExplicitPlanningGraph
         {
-            static constexpr auto name =
-                "hgraph.fabric.publish_data.explicit_planning_graph";
+            static constexpr auto name = "hgraph.fabric.publish_data.explicit_planning_graph";
 
-            static void compose(Wiring &wiring,
-                                Scalar<"data_id", Str> data_id,
-                                NamedPort<"value", TS<Frame>> value,
+            static void compose(Wiring &wiring, Scalar<"data_id", Str> data_id,
+                                NamedPort<"value", TS<Frame>>    value,
                                 VarIn<"dependencies", TS<Frame>> dependencies)
             {
                 if (dependencies.empty())
                 {
-                    throw std::invalid_argument(
-                        "explicit fabric dependencies must not be empty");
+                    throw std::invalid_argument("explicit fabric dependencies must not be empty");
                 }
                 std::vector<DependencyHandle> handles;
                 handles.reserve(dependencies.size());
                 for (const auto &dependency : dependencies)
                 {
-                    handles.push_back(dependency_handle(
-                        wiring, Port<TS<Frame>>{wiring, dependency}));
+                    handles.push_back(
+                        dependency_handle(wiring, Port<TS<Frame>>{wiring, dependency}));
                 }
-                record_publisher(
-                    wiring, data_id.value(), value.erased(),
-                    DependencySelection::explicit_dependencies(
-                        std::move(handles)));
+                record_publisher(wiring, data_id.value(), value.erased(),
+                                 DependencySelection::explicit_dependencies(std::move(handles)));
             }
         };
 
@@ -564,58 +631,42 @@ namespace hgraph::fabric
             register_fabric_types();
             register_graph_overload<SubscribeData, SubscribeDataPlanningGraph>();
             register_graph_overload<PublishData, PublishDataPlanningGraph>();
-            register_graph_overload<PublishDataExplicit,
-                                    PublishDataExplicitPlanningGraph>();
+            register_graph_overload<PublishDataExplicit, PublishDataExplicitPlanningGraph>();
         }
-    }  // namespace
+    } // namespace
 
     DependencyHandle::DependencyHandle(std::uint64_t root_identity, Str data_id,
                                        WiringPortRef source)
-        : root_identity_(root_identity), data_id_(std::move(data_id)),
-          source_(std::move(source))
+        : root_identity_(root_identity), data_id_(std::move(data_id)), source_(std::move(source))
     {
     }
 
-    std::uint64_t DependencyHandle::root_identity() const noexcept
-    {
-        return root_identity_;
-    }
+    std::uint64_t DependencyHandle::root_identity() const noexcept { return root_identity_; }
 
-    std::string_view DependencyHandle::data_id() const noexcept
-    {
-        return data_id_;
-    }
+    std::string_view DependencyHandle::data_id() const noexcept { return data_id_; }
 
-    const WiringPortRef &DependencyHandle::source() const noexcept
-    {
-        return source_;
-    }
+    const WiringPortRef &DependencyHandle::source() const noexcept { return source_; }
 
-    DependencySelection DependencySelection::automatic()
-    {
-        return DependencySelection{};
-    }
+    DependencySelection DependencySelection::automatic() { return DependencySelection{}; }
 
-    DependencySelection DependencySelection::explicit_dependencies(
-        std::vector<DependencyHandle> dependencies)
+    DependencySelection
+    DependencySelection::explicit_dependencies(std::vector<DependencyHandle> dependencies)
     {
         if (dependencies.empty())
         {
-            throw std::invalid_argument(
-                "explicit fabric dependencies must not be empty");
+            throw std::invalid_argument("explicit fabric dependencies must not be empty");
         }
         const std::uint64_t root = dependencies.front().root_identity();
         for (std::size_t index = 0; index < dependencies.size(); ++index)
         {
             if (dependencies[index].root_identity() != root)
             {
-                throw std::invalid_argument(
-                    "explicit fabric dependencies must belong to one wiring root");
+                throw std::invalid_argument("explicit fabric dependencies must "
+                                            "belong to one wiring root");
             }
             for (std::size_t previous = 0; previous < index; ++previous)
             {
-                if (dependencies[index].data_id() ==
-                    dependencies[previous].data_id())
+                if (dependencies[index].data_id() == dependencies[previous].data_id())
                 {
                     throw std::invalid_argument(
                         "explicit fabric dependency data ids must be unique");
@@ -623,50 +674,41 @@ namespace hgraph::fabric
             }
         }
         DependencySelection result;
-        result.automatic_    = false;
+        result.automatic_ = false;
         result.dependencies_ = std::move(dependencies);
         return result;
     }
 
-    bool DependencySelection::is_automatic() const noexcept
-    {
-        return automatic_;
-    }
+    bool DependencySelection::is_automatic() const noexcept { return automatic_; }
 
-    const std::vector<DependencyHandle> &
-    DependencySelection::dependencies() const noexcept
+    const std::vector<DependencyHandle> &DependencySelection::dependencies() const noexcept
     {
         return dependencies_;
     }
 
-    DependencyHandle dependency_handle(Wiring &wiring,
-                                       Port<TS<Frame>> subscription)
+    DependencyHandle dependency_handle(Wiring &wiring, Port<TS<Frame>> subscription)
     {
         if (subscription.wiring() != &wiring)
         {
-            throw std::invalid_argument(
-                "fabric dependency handle requires the same wiring root");
+            throw std::invalid_argument("fabric dependency handle requires the same wiring root");
         }
         for (const auto &declaration : declarations(wiring)->subscriptions)
         {
             if (declaration.output.same_source_as(subscription.erased()))
             {
-                return DependencyHandle{wiring.identity(), declaration.data_id,
-                                        declaration.output};
+                return DependencyHandle{wiring.identity(), declaration.data_id, declaration.output};
             }
         }
         throw std::invalid_argument(
             "fabric dependency handle requires a direct subscribe_data result");
     }
 
-    Port<TS<Frame>> subscribe_data(Wiring &wiring, Str data_id,
-                                   SubscriptionMode mode,
+    Port<TS<Frame>> subscribe_data(Wiring &wiring, Str data_id, SubscriptionMode mode,
                                    std::optional<DateTime> as_of)
     {
         const DateTime resolved_as_of = as_of.value_or(MIN_DT);
         require_subscription_arguments(data_id, mode, resolved_as_of);
-        return wire<SubscribeData, TS<Frame>>(wiring, data_id, mode,
-                                              resolved_as_of);
+        return wire<SubscribeData, TS<Frame>>(wiring, data_id, mode, resolved_as_of);
     }
 
     void publish_data(Wiring &wiring, Str data_id, Port<TS<Frame>> value,
@@ -675,26 +717,25 @@ namespace hgraph::fabric
         require_data_id(data_id);
         if (value.wiring() != &wiring)
         {
-            throw std::invalid_argument(
-                "hgraph.fabric.publish_data requires a value from the same wiring");
+            throw std::invalid_argument("hgraph.fabric.publish_data requires a "
+                                        "value from the same wiring");
         }
         for (const auto &dependency : dependencies.dependencies())
         {
             if (dependency.root_identity() != wiring.identity())
             {
                 throw std::invalid_argument(
-                    "explicit fabric dependency belongs to a different wiring root");
+                    "explicit fabric dependency belongs to a different wiring "
+                    "root");
             }
         }
         wire<PublishData>(wiring, data_id, value);
         if (!dependencies.is_automatic())
         {
             auto state = declarations(wiring);
-            if (state->publishers.empty() ||
-                state->publishers.back().data_id != data_id)
+            if (state->publishers.empty() || state->publishers.back().data_id != data_id)
             {
-                throw std::logic_error(
-                    "fabric publisher declaration was not recorded");
+                throw std::logic_error("fabric publisher declaration was not recorded");
             }
             state->publishers.back().dependencies = std::move(dependencies);
         }
@@ -706,4 +747,4 @@ namespace hgraph::fabric
         registry.register_installer("hgraph.fabric", &install_fabric_operators);
         registry.run_installers();
     }
-}  // namespace hgraph::fabric
+} // namespace hgraph::fabric

--- a/extensions/fabric/src/python_module.cpp
+++ b/extensions/fabric/src/python_module.cpp
@@ -1,7 +1,9 @@
+#include <hgraph/fabric/config.h>
 #include <hgraph/fabric/keys.h>
 #include <hgraph/fabric/metadata_codec.h>
 #include <hgraph/fabric/operators.h>
 #include <hgraph/fabric/resolution.h>
+#include <hgraph/fabric/service.h>
 #include <hgraph/fabric/value_builders.h>
 
 #include <hgraph/python/native_scalar_registration.h>
@@ -58,6 +60,39 @@ namespace
     }
 }  // namespace
 
+namespace hgraph::fabric
+{
+    namespace
+    {
+        struct RegisterMemoryFabricServiceOperator
+            : Operator<"hgraph.fabric.register_memory_service",
+                       Scalar<"prefix", Str>>
+        {
+        };
+
+        struct RegisterMemoryFabricServiceGraph
+        {
+            static constexpr auto name =
+                "hgraph.fabric.register_memory_service_impl";
+
+            static void compose(Wiring &wiring,
+                                Scalar<"prefix", Str> prefix)
+            {
+                if (fabric_config(wiring.global_state()).has_value())
+                {
+                    throw std::invalid_argument(
+                        "register_memory_fabric_service found an existing "
+                        "FabricConfig");
+                }
+                set_fabric_config(
+                    wiring.global_state(),
+                    make_memory_fabric_config(prefix.value()));
+                register_service(wiring);
+            }
+        };
+    }  // namespace
+}  // namespace hgraph::fabric
+
 NB_MODULE(_hgraph_fabric, module)
 {
     using namespace hgraph;
@@ -78,6 +113,8 @@ NB_MODULE(_hgraph_fabric, module)
     register_fabric_operators();
     OperatorRegistry::instance().register_installer(
         "hgraph.fabric.python_scalars", [mode] {
+            register_graph_overload<RegisterMemoryFabricServiceOperator,
+                                    RegisterMemoryFabricServiceGraph>();
             python_bridge::register_native_scalar_type<SubscriptionMode>(mode);
         });
     OperatorRegistry::instance().run_installers();

--- a/extensions/fabric/src/resolution.cpp
+++ b/extensions/fabric/src/resolution.cpp
@@ -121,6 +121,8 @@ struct ConsistencyResolver::Impl {
   ResolverMetrics metrics{};
   std::map<Str, DataVersion, IdLess> lower_bounds{};
   std::vector<ResolvedCut> maxima{};
+  DateTime maximum_as_of{MAX_DT};
+  bool cache_only{};
   bool saw_cycle{};
 
   explicit Impl(FabricConfig configured) : config(std::move(configured)) {
@@ -240,7 +242,8 @@ struct ConsistencyResolver::Impl {
     data.frames.emplace(revision.output_version, std::move(frame));
   }
 
-  void append(CachedData &data, DataRevisionInput revision) {
+  void append(CachedData &data, DataRevisionInput revision,
+              bool validate_durable_payload = true) {
     if (data.revisions.empty()) {
       if (revision.revision != 1) {
         throw CorruptHistory("fabric revision history does not start at one");
@@ -263,8 +266,10 @@ struct ConsistencyResolver::Impl {
       }
     }
 
-    validate_frame(data, revision);
-    repair_as_of(revision);
+    if (validate_durable_payload) {
+      validate_frame(data, revision);
+      repair_as_of(revision);
+    }
     data.output_index[revision.output_version].push_back(data.revisions.size());
     data.revisions.push_back(std::move(revision));
     ++metrics.revision_cache_misses;
@@ -298,6 +303,13 @@ struct ConsistencyResolver::Impl {
     if (!refreshed_this_call.emplace(data_id).second) {
       ++metrics.revision_cache_hits;
       return cache.find(data_id)->second;
+    }
+    if (cache_only) {
+      const auto cached = cache.find(data_id);
+      if (cached != cache.end() && !cached->second.revisions.empty()) {
+        ++metrics.revision_cache_hits;
+        return cached->second;
+      }
     }
     auto [entry, inserted] = cache.try_emplace(Str{data_id});
     auto &data = entry->second;
@@ -366,7 +378,10 @@ struct ConsistencyResolver::Impl {
       result.reserve(found->second.size());
       for (auto index = found->second.rbegin(); index != found->second.rend();
            ++index) {
-        result.push_back(&data.revisions[*index]);
+        const auto &revision = data.revisions[*index];
+        if (revision.as_of <= maximum_as_of) {
+          result.push_back(&revision);
+        }
       }
       return result;
     }
@@ -375,6 +390,9 @@ struct ConsistencyResolver::Impl {
     const auto lower = lower_bounds.find(data_id);
     for (auto revision = data.revisions.rbegin();
          revision != data.revisions.rend(); ++revision) {
+      if (revision->as_of > maximum_as_of) {
+        continue;
+      }
       if (lower != lower_bounds.end() &&
           revision->output_version < lower->second) {
         continue;
@@ -585,6 +603,7 @@ struct ConsistencyResolver::Impl {
     if (data == cache.end()) {
       throw std::logic_error("resolved root has no cached data");
     }
+    validate_frame(data->second, revision);
     const auto frame = data->second.frames.find(revision.output_version);
     if (frame == data->second.frames.end()) {
       throw std::logic_error("resolved root has no cached Frame");
@@ -593,10 +612,48 @@ struct ConsistencyResolver::Impl {
     return frame->second;
   }
 
+  void observe_revision(DataRevisionInput revision) {
+    Value canonical = make_data_revision(std::move(revision));
+    revision = data_revision_input(canonical.view());
+    auto [entry, inserted] = cache.try_emplace(revision.data_id);
+    static_cast<void>(inserted);
+    auto &data = entry->second;
+    if (revision.revision <= static_cast<RevisionId>(data.revisions.size())) {
+      const auto &cached =
+          data.revisions[static_cast<std::size_t>(revision.revision - 1)];
+      if (cached != revision) {
+        throw CorruptHistory(
+            "fabric accepted notice conflicts with its cached revision");
+      }
+      return;
+    }
+
+    RevisionId next = static_cast<RevisionId>(data.revisions.size() + 1);
+    while (next < revision.revision) {
+      const auto object = config.objects.get(
+          revision_key(config.prefix, revision.data_id, next));
+      if (!object.has_value()) {
+        throw CorruptHistory(
+            "fabric accepted notice has a missing revision gap: " +
+            revision.data_id + ":" + std::to_string(next));
+      }
+      append(data, decode_slot(revision.data_id, next, *object), false);
+      next = checked_increment(next, "revision id");
+    }
+    append(data, std::move(revision), false);
+  }
+
   ForestResolution resolve(std::vector<Str> roots,
-                           std::span<const ExposedRootVersion> exposed) {
+                           std::span<const ExposedRootVersion> exposed,
+                           DateTime as_of_limit, bool use_cached_heads) {
     canonicalise_ids(roots, "resolver roots");
+    if (as_of_limit != MAX_DT && as_of_limit <= MIN_DT) {
+      throw std::invalid_argument(
+          "fabric historical resolution requires a real as-of bound");
+    }
     metrics = {};
+    maximum_as_of = as_of_limit;
+    cache_only = use_cached_heads;
     lower_bounds.clear();
     refreshed_this_call.clear();
     maxima.clear();
@@ -687,7 +744,23 @@ ConsistencyResolver::operator=(ConsistencyResolver &&) noexcept = default;
 
 ForestResolution ConsistencyResolver::resolve_forest(
     std::vector<Str> roots, std::span<const ExposedRootVersion> exposed_roots) {
-  return impl_->resolve(std::move(roots), exposed_roots);
+  return impl_->resolve(std::move(roots), exposed_roots, MAX_DT, false);
+}
+
+void ConsistencyResolver::observe_accepted_revision(
+    DataRevisionInput revision) {
+  impl_->observe_revision(std::move(revision));
+}
+
+ForestResolution ConsistencyResolver::resolve_forest_cached(
+    std::vector<Str> roots, std::span<const ExposedRootVersion> exposed_roots) {
+  return impl_->resolve(std::move(roots), exposed_roots, MAX_DT, true);
+}
+
+ForestResolution ConsistencyResolver::resolve_forest_at(
+    std::vector<Str> roots, DateTime maximum_as_of,
+    std::span<const ExposedRootVersion> exposed_roots) {
+  return impl_->resolve(std::move(roots), exposed_roots, maximum_as_of, false);
 }
 
 struct ConsistencyCoordinator::Impl {
@@ -780,7 +853,8 @@ struct ConsistencyCoordinator::Impl {
     return true;
   }
 
-  [[nodiscard]] CoordinationResult resolve_all(DateTime ready_at) {
+  [[nodiscard]] CoordinationResult
+  resolve_all(DateTime ready_at, DateTime maximum_as_of, bool cached_only) {
     std::vector<std::vector<Str>> groups;
     groups.reserve(roots.size());
     for (const auto &root : roots) {
@@ -793,7 +867,15 @@ struct ConsistencyCoordinator::Impl {
       results.reserve(groups.size());
       for (const auto &group : groups) {
         const auto exposed_bounds = bounds(group);
-        results.push_back(resolver.resolve_forest(group, exposed_bounds));
+        if (maximum_as_of != MAX_DT) {
+          results.push_back(
+              resolver.resolve_forest_at(group, maximum_as_of, exposed_bounds));
+        } else if (cached_only) {
+          results.push_back(
+              resolver.resolve_forest_cached(group, exposed_bounds));
+        } else {
+          results.push_back(resolver.resolve_forest(group, exposed_bounds));
+        }
       }
       if (!merge_overlaps(groups, results)) {
         break;
@@ -887,7 +969,21 @@ void ConsistencyCoordinator::observe_notice(Str data_id, DateTime noticed_at) {
   impl_->observe(std::move(data_id), noticed_at);
 }
 
+void ConsistencyCoordinator::observe_accepted_revision(
+    DataRevisionInput revision) {
+  impl_->resolver.observe_accepted_revision(std::move(revision));
+}
+
 CoordinationResult ConsistencyCoordinator::resolve(DateTime ready_at) {
-  return impl_->resolve_all(ready_at);
+  return impl_->resolve_all(ready_at, MAX_DT, false);
+}
+
+CoordinationResult ConsistencyCoordinator::resolve_cached(DateTime ready_at) {
+  return impl_->resolve_all(ready_at, MAX_DT, true);
+}
+
+CoordinationResult ConsistencyCoordinator::resolve_at(DateTime maximum_as_of,
+                                                      DateTime ready_at) {
+  return impl_->resolve_all(ready_at, maximum_as_of, false);
 }
 } // namespace hgraph::fabric

--- a/extensions/fabric/src/service.cpp
+++ b/extensions/fabric/src/service.cpp
@@ -1,0 +1,463 @@
+#include <hgraph/fabric/service.h>
+
+#include "impl/service_runtime.h"
+
+#include <hgraph/fabric/value_builders.h>
+
+#include <hgraph/lib/std/operators/collection.h>
+#include <hgraph/lib/std/operators/conversion.h>
+#include <hgraph/runtime/executor.h>
+#include <hgraph/types/metadata/value_plan_factory.h>
+#include <hgraph/types/static_node.h>
+#include <hgraph/types/value/value_builder.h>
+
+#include <algorithm>
+#include <memory>
+#include <stdexcept>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace hgraph::fabric
+{
+namespace
+{
+using detail::DeliveryBatch;
+using detail::FabricServiceRuntimeHandle;
+using detail::PublicationRequestInput;
+using detail::SubscriptionSpec;
+
+[[nodiscard]] Value ingress_value(const detail::DeliveredRoot &root)
+{
+    BundleBuilder builder{
+        ValuePlanFactory::instance().type_for(schema_descriptor<FabricIngressSignal>::ts_meta()->value_schema)};
+    if (root.frame.has_value())
+    {
+        builder.set("frame", Value{*root.frame});
+    }
+    builder.set("version", Value{root.output_version});
+    builder.set("revision", Value{root.revision});
+    return builder.build();
+}
+
+void apply_delivery(DeliveryBatch delivery, Out<TSD<Str, FabricIngressSignal>> &out)
+{
+    auto mutation = out.begin_mutation(out.evaluation_time());
+    for (const auto &root : delivery.roots)
+    {
+        Value key{root.key};
+        Value update = ingress_value(root);
+        mutation.set(key.view(), update.view());
+    }
+}
+
+[[nodiscard]] std::vector<SubscriptionSpec> subscriptions(const TSSInputView &keys, SubscriptionMode mode)
+{
+    std::vector<SubscriptionSpec> result;
+    if (!keys.valid())
+    {
+        return result;
+    }
+    result.reserve(keys.size());
+    for (const ValueView key : keys.values())
+    {
+        result.push_back(detail::decode_subscription_key(key.checked_as<Str>(), mode));
+    }
+    return result;
+}
+
+template <typename Requests> void collect_revisions(const Requests &requests, std::vector<DataRevisionInput> &revisions)
+{
+    if (!requests.modified())
+    {
+        return;
+    }
+    for (const auto &[key, revision] : requests.modified_items())
+    {
+        static_cast<void>(key);
+        if (!revision.valid() || !revision.modified())
+        {
+            continue;
+        }
+        revisions.push_back(data_revision_input(revision.base().value()));
+    }
+}
+
+struct FabricLifecycleNode
+{
+    static constexpr auto name = "hgraph.fabric.service.lifecycle";
+    static constexpr bool schedule_on_start = true;
+    using signature_args = std::tuple<Scalar<"runtime", FabricServiceRuntimeHandle>, GlobalStateView, Out<TS<Bool>>>;
+
+    static void start(Scalar<"runtime", FabricServiceRuntimeHandle> runtime, GlobalStateView global_state)
+    {
+        runtime.value().value->start(global_state);
+    }
+
+    static void eval(Out<TS<Bool>> ready)
+    {
+        ready.set(true);
+    }
+
+    static void stop(Scalar<"runtime", FabricServiceRuntimeHandle> runtime)
+    {
+        runtime.value().value->stop();
+    }
+};
+
+struct FabricSnapshotNode
+{
+    static constexpr auto name = "hgraph.fabric.service.snapshot";
+
+    static void eval(In<"keys", TSS<Str>, InputValidity::Unchecked> keys,
+                     In<"ready", TS<Bool>, InputValidity::Unchecked>,
+                     Scalar<"runtime", FabricServiceRuntimeHandle> runtime, Out<TSD<Str, FabricIngressSignal>> out)
+    {
+        const auto &erased = static_cast<const TSSInputView &>(keys);
+        if (auto delivery = runtime.value().value->snapshot(subscriptions(erased, SubscriptionMode::Snapshot));
+            delivery.has_value())
+        {
+            apply_delivery(std::move(*delivery), out);
+        }
+    }
+};
+
+/** Planned root snapshots are independent of the keyed subscription
+    transport, so the initial image is produced at the exact graph
+    start. One evaluation performs one durable consistency resolve. */
+struct FabricPlannedSnapshotNode
+{
+    static constexpr auto name = "hgraph.fabric.service.snapshot.planned";
+
+    static void eval(In<"ready", TS<Bool>, InputValidity::Unchecked>,
+                     Scalar<"runtime", FabricServiceRuntimeHandle> runtime, Out<TSD<Str, FabricIngressSignal>> out)
+    {
+        if (auto delivery = runtime.value().value->planned_snapshot(); delivery.has_value())
+        {
+            apply_delivery(std::move(*delivery), out);
+        }
+    }
+};
+
+struct FabricReplayNode
+{
+    static constexpr auto name = "hgraph.fabric.service.replay";
+
+    static void start(Scalar<"runtime", FabricServiceRuntimeHandle> runtime, EngineControlView engine)
+    {
+        runtime.value().value->configure_replay_window(engine.start_time(), engine.end_time());
+    }
+
+    static void eval(In<"keys", TSS<Str>, InputValidity::Unchecked> keys,
+                     In<"ready", TS<Bool>, InputValidity::Unchecked>, DateTime now, NodeScheduler scheduler,
+                     Scalar<"runtime", FabricServiceRuntimeHandle> runtime, Out<TSD<Str, FabricIngressSignal>> out)
+    {
+        const auto &erased = static_cast<const TSSInputView &>(keys);
+        if (auto delivery =
+                runtime.value().value->replay(subscriptions(erased, SubscriptionMode::Replay), now, scheduler);
+            delivery.has_value())
+        {
+            apply_delivery(std::move(*delivery), out);
+        }
+    }
+};
+
+/** Planned root replay is an ordinary scheduled source. Per tick it
+    resolves one equal-as-of batch and schedules the next durable
+    history time; retained memory is the reachable revision history. */
+struct FabricPlannedReplayNode
+{
+    static constexpr auto name = "hgraph.fabric.service.replay.planned";
+
+    static void start(Scalar<"runtime", FabricServiceRuntimeHandle> runtime, EngineControlView engine)
+    {
+        runtime.value().value->configure_replay_window(engine.start_time(), engine.end_time());
+    }
+
+    static void eval(In<"ready", TS<Bool>, InputValidity::Unchecked>, DateTime now, NodeScheduler scheduler,
+                     Scalar<"runtime", FabricServiceRuntimeHandle> runtime, Out<TSD<Str, FabricIngressSignal>> out)
+    {
+        if (auto delivery = runtime.value().value->planned_replay(now, scheduler); delivery.has_value())
+        {
+            apply_delivery(std::move(*delivery), out);
+        }
+    }
+};
+
+struct FabricLiveNode
+{
+    static constexpr auto name = "hgraph.fabric.service.live";
+
+    static void eval(In<"keys", TSS<Str>, InputValidity::Unchecked> keys,
+                     In<"notices", TSD<Int, TS<DataRevision>>, InputValidity::Unchecked> notices,
+                     In<"ready", TS<Bool>, InputValidity::Unchecked>, DateTime now,
+                     Scalar<"runtime", FabricServiceRuntimeHandle> runtime, Out<TSD<Str, FabricIngressSignal>> out)
+    {
+        std::vector<DataRevisionInput> revisions;
+        collect_revisions(notices, revisions);
+        const auto &erased = static_cast<const TSSInputView &>(keys);
+        if (auto delivery =
+                runtime.value().value->live(subscriptions(erased, SubscriptionMode::Live), std::move(revisions), now);
+            delivery.has_value())
+        {
+            apply_delivery(std::move(*delivery), out);
+        }
+    }
+};
+
+/** Planned root Live ingress performs one durable startup resolve and
+    thereafter admits only complete revisions delivered by the notice
+    edge. Work is O(conflated notices plus affected resolver search). */
+struct FabricPlannedLiveNode
+{
+    static constexpr auto name = "hgraph.fabric.service.live.planned";
+
+    static void eval(In<"notices", TSD<Int, TS<DataRevision>>, InputValidity::Unchecked> notices,
+                     In<"ready", TS<Bool>, InputValidity::Unchecked>, DateTime now,
+                     Scalar<"runtime", FabricServiceRuntimeHandle> runtime, Out<TSD<Str, FabricIngressSignal>> out)
+    {
+        std::vector<DataRevisionInput> revisions;
+        collect_revisions(notices, revisions);
+        if (auto delivery = runtime.value().value->planned_live(std::move(revisions), now); delivery.has_value())
+        {
+            apply_delivery(std::move(*delivery), out);
+        }
+    }
+};
+
+[[nodiscard]] PublicationRequestInput publication_request(const TSBInputView &request)
+{
+    const auto data_id = request.field("data_id");
+    if (!data_id.valid())
+    {
+        throw std::invalid_argument("fabric publication request requires data_id");
+    }
+    PublicationRequestInput result{.data_id = data_id.value().checked_as<Str>()};
+
+    const auto frame = request.field("frame");
+    if (frame.valid() && frame.modified())
+    {
+        result.output = frame.value().checked_as<Frame>();
+    }
+
+    const auto dependency_field = request.field("dependencies");
+    const auto dependencies = dependency_field.as_dict();
+    if (dependencies.valid())
+    {
+        for (const auto &[dependency_id, version] : dependencies.valid_items())
+        {
+            if (!version.valid())
+            {
+                continue;
+            }
+            result.dependencies.push_back(DataDependencyInput{
+                .data_id = dependency_id.checked_as<Str>(),
+                .version = version.value().checked_as<Int>(),
+            });
+        }
+    }
+    const auto predecessor = request.field("self_predecessor");
+    if (predecessor.valid())
+    {
+        result.self_predecessor = predecessor.value().checked_as<Int>();
+    }
+    return result;
+}
+
+struct FabricPublicationNode
+{
+    static constexpr auto name = "hgraph.fabric.service.publication";
+
+    static void eval(In<"requests", TSD<Int, FabricPublicationRequest>, InputValidity::Unchecked> requests,
+                     In<"ready", TS<Bool>, InputValidity::Unchecked>, NodeScheduler scheduler,
+                     Scalar<"runtime", FabricServiceRuntimeHandle> runtime, Out<TSD<Str, TS<DataRevision>>> accepted)
+    {
+        if (requests.modified())
+        {
+            for (const auto &[request_id, request] : requests.modified_items())
+            {
+                static_cast<void>(request_id);
+                if (!request.valid())
+                {
+                    continue;
+                }
+                runtime.value().value->publish(publication_request(request));
+            }
+        }
+
+        auto mutation = accepted.begin_mutation(accepted.evaluation_time());
+        for (auto &revision : runtime.value().value->advance_publications())
+        {
+            Value key{revision.data_id};
+            Value value = make_data_revision(std::move(revision));
+            mutation.set(key.view(), value.view());
+        }
+        if (runtime.value().value->publication_work_pending())
+        {
+            scheduler.schedule(MIN_TD);
+        }
+    }
+};
+
+[[nodiscard]] Value load_response_value(Str data_id, DataVersion version, Frame frame)
+{
+    BundleBuilder builder{
+        ValuePlanFactory::instance().type_for(schema_descriptor<FabricLoadResponse>::ts_meta()->value_schema)};
+    builder.set("data_id", Value{std::move(data_id)});
+    builder.set("version", Value{version});
+    builder.set("frame", Value{std::move(frame)});
+    return builder.build();
+}
+
+struct FabricLoadNode
+{
+    static constexpr auto name = "hgraph.fabric.service.load";
+
+    static void eval(In<"requests", TSD<Int, FabricLoadRequest>, InputValidity::Unchecked> requests,
+                     In<"ready", TS<Bool>, InputValidity::Unchecked>,
+                     Scalar<"runtime", FabricServiceRuntimeHandle> runtime, Out<TSD<Int, FabricLoadResponse>> responses)
+    {
+        if (!requests.modified())
+        {
+            return;
+        }
+        auto mutation = responses.begin_mutation(responses.evaluation_time());
+        for (const auto &[request_id, request] : requests.modified_items())
+        {
+            if (!request.valid())
+            {
+                continue;
+            }
+            const auto requested_data_id = request.template field<"data_id">();
+            const auto requested_version = request.template field<"version">();
+            if (!requested_data_id.valid() || !requested_version.valid())
+            {
+                continue;
+            }
+            const auto loaded = runtime.value().value->load(requested_data_id.value(), requested_version.value());
+            if (!loaded.has_value())
+            {
+                continue;
+            }
+            auto [data_id, version, frame] = *loaded;
+            Value response = load_response_value(std::move(data_id), version, std::move(frame));
+            mutation.set(request_id, response.view());
+        }
+    }
+};
+
+struct FabricDiagnosticsNode
+{
+    static constexpr auto name = "hgraph.fabric.service.diagnostics";
+
+    static void eval(In<"ready", TS<Bool>>, Scalar<"runtime", FabricServiceRuntimeHandle> runtime,
+                     Out<TSD<Str, TS<Str>>> diagnostics)
+    {
+        auto mutation = diagnostics.begin_mutation(diagnostics.evaluation_time());
+        for (auto &[name, value] : runtime.value().value->diagnostics())
+        {
+            Value key{std::move(name)};
+            Value item{std::move(value)};
+            mutation.set(key.view(), item.view());
+        }
+    }
+};
+
+struct FabricServiceImpl
+{
+    static constexpr auto name = "hgraph.fabric.service_impl";
+
+    static void compose(Wiring &wiring, Scalar<"plan", detail::FabricServicePlanHandle> plan, Scalar<"path", Str> path)
+    {
+        const auto binding = service::path(path.value());
+        auto live_keys = service::impl_input<FabricLiveSubscriptionService>(wiring, binding);
+        auto replay_keys = service::impl_input<FabricReplaySubscriptionService>(wiring, binding);
+        auto snapshot_keys = service::impl_input<FabricSnapshotSubscriptionService>(wiring, binding);
+        auto publications = service::impl_input<FabricPublicationService>(wiring, binding);
+        auto notices = service::impl_input<FabricNoticeService>(wiring, binding);
+        auto loads = service::impl_input<FabricLoadService>(wiring, binding);
+
+        FabricServiceRuntimeHandle runtime{std::make_shared<detail::FabricServiceRuntime>(plan.value())};
+        auto ready = wire<FabricLifecycleNode>(wiring, runtime);
+        static_cast<void>(wire<FabricPublicationNode>(wiring, publications, ready, runtime));
+        auto snapshot = wire<FabricSnapshotNode>(wiring, snapshot_keys, ready, runtime);
+        auto replay = wire<FabricReplayNode>(wiring, replay_keys, ready, runtime);
+        auto live = wire<FabricLiveNode>(wiring, live_keys, notices, ready, runtime);
+        auto planned_snapshot = wire<FabricPlannedSnapshotNode>(wiring, ready, runtime);
+        auto planned_replay = wire<FabricPlannedReplayNode>(wiring, ready, runtime);
+        auto planned_live = wire<FabricPlannedLiveNode>(wiring, notices, ready, runtime);
+        auto loaded = wire<FabricLoadNode>(wiring, loads, ready, runtime);
+        auto diagnostic_values = wire<FabricDiagnosticsNode>(wiring, ready, runtime);
+
+        service::impl_output<FabricLiveSubscriptionService>(wiring, binding,
+                                                            live.template as<TSD<Str, FabricIngressSignal>>());
+        service::impl_output<FabricReplaySubscriptionService>(wiring, binding,
+                                                              replay.template as<TSD<Str, FabricIngressSignal>>());
+        service::impl_output<FabricSnapshotSubscriptionService>(wiring, binding,
+                                                                snapshot.template as<TSD<Str, FabricIngressSignal>>());
+        service::impl_output<detail::FabricPlannedLiveService>(
+            wiring, binding, planned_live.template as<TSD<Str, FabricIngressSignal>>());
+        service::impl_output<detail::FabricPlannedReplayService>(
+            wiring, binding, planned_replay.template as<TSD<Str, FabricIngressSignal>>());
+        service::impl_output<detail::FabricPlannedSnapshotService>(
+            wiring, binding, planned_snapshot.template as<TSD<Str, FabricIngressSignal>>());
+        service::impl_output<FabricLoadService>(wiring, binding, loaded.template as<TSD<Int, FabricLoadResponse>>());
+        service::impl_output<FabricDiagnosticsService>(wiring, binding,
+                                                       diagnostic_values.template as<TSD<Str, TS<Str>>>());
+    }
+};
+} // namespace
+
+void register_service(Wiring &wiring, service::ServicePath path)
+{
+    const auto plan = detail::service_plan(wiring, path.value);
+    service::register_services<FabricServiceImpl, FabricLiveSubscriptionService, FabricReplaySubscriptionService,
+                               FabricSnapshotSubscriptionService, detail::FabricPlannedLiveService,
+                               detail::FabricPlannedReplayService, detail::FabricPlannedSnapshotService,
+                               FabricPublicationService, FabricNoticeService, FabricLoadService,
+                               FabricDiagnosticsService>(wiring, std::move(path), plan);
+}
+
+void register_service(Wiring &wiring)
+{
+    register_service(wiring, service::path(DEFAULT_SERVICE_PATH));
+}
+
+void submit_notice(Wiring &wiring, Port<TS<DataRevision>> notice, service::ServicePath path)
+{
+    wire<FabricNoticeService>(wiring, std::move(path), notice);
+}
+
+void submit_notice(Wiring &wiring, Port<TS<DataRevision>> notice)
+{
+    submit_notice(wiring, std::move(notice), service::path(DEFAULT_SERVICE_PATH));
+}
+
+Port<FabricLoadResponse> request_load(Wiring &wiring, Str data_id, DataVersion version, service::ServicePath path)
+{
+    require_data_id(data_id);
+    if (version <= 0)
+    {
+        throw std::invalid_argument("fabric load version must be positive");
+    }
+    auto id = wire<stdlib::const_, TS<Str>>(wiring, std::move(data_id));
+    auto requested_version = wire<stdlib::const_, TS<Int>>(wiring, version);
+    auto request = stdlib::to_tsb<FabricLoadRequest>(wiring, id, requested_version);
+    return wire<FabricLoadService>(wiring, std::move(path), request);
+}
+
+Port<FabricLoadResponse> request_load(Wiring &wiring, Str data_id, DataVersion version)
+{
+    return request_load(wiring, std::move(data_id), version, service::path(DEFAULT_SERVICE_PATH));
+}
+
+Port<TSD<Str, TS<Str>>> diagnostics(Wiring &wiring, service::ServicePath path)
+{
+    return wire<FabricDiagnosticsService>(wiring, std::move(path));
+}
+
+Port<TSD<Str, TS<Str>>> diagnostics(Wiring &wiring)
+{
+    return diagnostics(wiring, service::path(DEFAULT_SERVICE_PATH));
+}
+} // namespace hgraph::fabric

--- a/extensions/fabric/src/subscription.cpp
+++ b/extensions/fabric/src/subscription.cpp
@@ -1,0 +1,802 @@
+#include "impl/service_runtime.h"
+
+#include <hgraph/fabric/config.h>
+#include <hgraph/fabric/keys.h>
+#include <hgraph/fabric/metadata_codec.h>
+#include <hgraph/fabric/value_builders.h>
+
+#include <hgraph/runtime/evaluation_clock.h>
+
+#include <algorithm>
+#include <charconv>
+#include <deque>
+#include <iterator>
+#include <map>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace hgraph::fabric::detail
+{
+namespace
+{
+inline constexpr char KEY_SEPARATOR{'\n'};
+
+struct IdLess
+{
+    using is_transparent = void;
+
+    [[nodiscard]] bool operator()(std::string_view lhs, std::string_view rhs) const noexcept
+    {
+        return canonical_data_id_less(lhs, rhs);
+    }
+};
+
+[[nodiscard]] DateTime wall_time() noexcept
+{
+    return std::chrono::time_point_cast<TimeDelta>(engine_clock::now());
+}
+
+[[nodiscard]] Int parse_integer(std::string_view text, std::string_view subject)
+{
+    Int value{};
+    const auto [end, error] = std::from_chars(text.data(), text.data() + text.size(), value);
+    if (error != std::errc{} || end != text.data() + text.size())
+    {
+        throw std::invalid_argument("invalid fabric " + std::string{subject});
+    }
+    return value;
+}
+
+[[nodiscard]] std::pair<Str, Int> split_key(std::string_view encoded, std::string_view subject)
+{
+    const auto separator = encoded.rfind(KEY_SEPARATOR);
+    if (separator == std::string_view::npos)
+    {
+        throw std::invalid_argument("invalid fabric " + std::string{subject});
+    }
+    Str data_id{encoded.substr(0, separator)};
+    require_data_id(data_id);
+    return {std::move(data_id), parse_integer(encoded.substr(separator + 1), subject)};
+}
+
+[[nodiscard]] std::vector<Str> roots_of(const std::vector<SubscriptionSpec> &subscriptions)
+{
+    std::vector<Str> roots;
+    roots.reserve(subscriptions.size());
+    for (const auto &subscription : subscriptions)
+    {
+        roots.push_back(subscription.data_id);
+    }
+    std::ranges::sort(roots, canonical_data_id_less);
+    roots.erase(std::ranges::unique(roots).begin(), roots.end());
+    return roots;
+}
+
+[[nodiscard]] std::vector<SubscriptionSpec> canonical_subscriptions(std::vector<SubscriptionSpec> subscriptions)
+{
+    std::ranges::sort(subscriptions,
+                      [](const SubscriptionSpec &lhs, const SubscriptionSpec &rhs) { return lhs.key < rhs.key; });
+    subscriptions.erase(std::ranges::unique(subscriptions, {}, &SubscriptionSpec::key).begin(), subscriptions.end());
+    return subscriptions;
+}
+
+struct RootBatch
+{
+    std::vector<RootUpdate> changed{};
+    std::vector<ResolvedRevision> selected{};
+};
+
+struct RuntimeCore
+{
+    FabricConfig config;
+    std::vector<Str> roots;
+    ConsistencyCoordinator coordinator;
+    std::map<Str, RevisionId, IdLess> emitted_revisions{};
+    std::set<Str, IdLess> observed{};
+
+    RuntimeCore(FabricConfig configured, std::vector<Str> configured_roots)
+        : config(std::move(configured)), roots(std::move(configured_roots)), coordinator(config, roots),
+          observed(roots.begin(), roots.end())
+    {
+    }
+
+    void observe(const CoordinationResult &result)
+    {
+        for (const auto &forest : result.forests)
+        {
+            observed.insert(forest.observed_data_ids.begin(), forest.observed_data_ids.end());
+            if (forest.cut.has_value())
+            {
+                for (const auto &revision : forest.cut->revisions)
+                {
+                    observed.insert(revision.data_id);
+                }
+            }
+        }
+    }
+
+    [[nodiscard]] std::optional<RootBatch> batch(CoordinationResult result)
+    {
+        for (const auto &forest : result.forests)
+        {
+            if (forest.status == ResolutionStatus::Corrupt || forest.status == ResolutionStatus::Ambiguous ||
+                forest.status == ResolutionStatus::Cyclic)
+            {
+                throw std::runtime_error("fabric subscription consistency failure for root '" + forest.roots.front() +
+                                         "': " + std::string{enum_name(forest.status)} + ": " + forest.diagnostic);
+            }
+        }
+        observe(result);
+
+        RootBatch batch;
+        batch.changed = std::move(result.changed_roots);
+        for (const auto &root : roots)
+        {
+            const auto selected = std::ranges::lower_bound(result.committed_lineage, root, canonical_data_id_less,
+                                                           &ResolvedRevision::data_id);
+            if (selected == result.committed_lineage.end() || selected->data_id != root)
+            {
+                continue;
+            }
+            const auto prior = emitted_revisions.find(root);
+            if (prior != emitted_revisions.end() && prior->second == selected->revision)
+            {
+                continue;
+            }
+            batch.selected.push_back(*selected);
+            emitted_revisions[root] = selected->revision;
+        }
+        if (batch.selected.empty())
+        {
+            return std::nullopt;
+        }
+        return batch;
+    }
+};
+
+[[nodiscard]] std::optional<DeliveryBatch> deliver(RootBatch batch, const std::vector<SubscriptionSpec> &subscriptions)
+{
+    std::map<Str, Frame, IdLess> frames;
+    for (auto &root : batch.changed)
+    {
+        frames.emplace(root.data_id, std::move(root.frame));
+    }
+
+    DeliveryBatch delivery;
+    for (const auto &selected : batch.selected)
+    {
+        for (const auto &subscription : subscriptions)
+        {
+            if (subscription.data_id != selected.data_id)
+            {
+                continue;
+            }
+            std::optional<Frame> frame;
+            if (const auto found = frames.find(selected.data_id); found != frames.end())
+            {
+                frame = found->second;
+            }
+            delivery.roots.push_back(DeliveredRoot{
+                .key = subscription.key,
+                .data_id = subscription.data_id,
+                .revision = selected.revision,
+                .output_version = selected.output_version,
+                .frame = std::move(frame),
+            });
+        }
+    }
+    if (delivery.roots.empty())
+    {
+        return std::nullopt;
+    }
+    return delivery;
+}
+
+struct SnapshotGroup
+{
+    std::vector<SubscriptionSpec> subscriptions{};
+    std::unique_ptr<RuntimeCore> core{};
+    bool complete{};
+};
+
+struct SnapshotSession
+{
+    std::vector<SubscriptionSpec> subscriptions{};
+    std::map<DateTime, SnapshotGroup> groups{};
+
+    void configure(const FabricConfig &config, std::vector<SubscriptionSpec> requested)
+    {
+        requested = canonical_subscriptions(std::move(requested));
+        if (requested == subscriptions)
+        {
+            return;
+        }
+        subscriptions = std::move(requested);
+        groups.clear();
+        for (const auto &subscription : subscriptions)
+        {
+            auto &group = groups[subscription.as_of];
+            group.subscriptions.push_back(subscription);
+        }
+        for (auto &[as_of, group] : groups)
+        {
+            static_cast<void>(as_of);
+            group.core = std::make_unique<RuntimeCore>(config, roots_of(group.subscriptions));
+        }
+    }
+
+    [[nodiscard]] std::optional<DeliveryBatch> evaluate()
+    {
+        DeliveryBatch combined;
+        for (auto &[as_of, group] : groups)
+        {
+            if (group.complete)
+            {
+                continue;
+            }
+            group.complete = true;
+            auto batch = group.core->batch(group.core->coordinator.resolve_at(as_of));
+            if (!batch.has_value())
+            {
+                continue;
+            }
+            auto delivery = deliver(std::move(*batch), group.subscriptions);
+            if (!delivery.has_value())
+            {
+                continue;
+            }
+            combined.roots.insert(combined.roots.end(), std::make_move_iterator(delivery->roots.begin()),
+                                  std::make_move_iterator(delivery->roots.end()));
+        }
+        if (combined.roots.empty())
+        {
+            return std::nullopt;
+        }
+        return combined;
+    }
+};
+
+struct ReplaySession
+{
+    FabricConfig config{};
+    std::vector<SubscriptionSpec> subscriptions{};
+    std::unique_ptr<RuntimeCore> core{};
+    DateTime start_time{MIN_DT};
+    DateTime end_time{MAX_DT};
+    std::optional<DateTime> cursor{};
+    std::map<Str, std::vector<DateTime>, IdLess> histories{};
+
+    void configure(const FabricConfig &configured, std::vector<SubscriptionSpec> requested)
+    {
+        requested = canonical_subscriptions(std::move(requested));
+        if (requested == subscriptions && core)
+        {
+            return;
+        }
+        config = configured;
+        subscriptions = std::move(requested);
+        histories.clear();
+        core = subscriptions.empty() ? nullptr : std::make_unique<RuntimeCore>(config, roots_of(subscriptions));
+        cursor = core ? std::optional<DateTime>{start_time} : std::nullopt;
+    }
+
+    [[nodiscard]] const std::vector<DateTime> &history(const Str &data_id)
+    {
+        auto [entry, inserted] = histories.try_emplace(data_id);
+        if (!inserted)
+        {
+            return entry->second;
+        }
+
+        const std::string category = as_of_key_prefix(config.prefix, data_id);
+        const std::string prefix = category + "/";
+        std::optional<std::string> cursor;
+        for (;;)
+        {
+            const auto page = config.objects.list(
+                prefix, cursor.has_value() ? std::optional<std::string_view>{*cursor} : std::nullopt, 1000);
+            for (const auto &object : page.objects)
+            {
+                if (!object.key.starts_with(prefix))
+                {
+                    throw std::runtime_error("fabric as-of listing escaped its data id");
+                }
+                entry->second.emplace_back(
+                    TimeDelta{decode_fabric_ordinal(std::string_view{object.key}.substr(prefix.size()))});
+            }
+            if (!page.next_start_after.has_value())
+            {
+                break;
+            }
+            cursor = page.next_start_after;
+        }
+        return entry->second;
+    }
+
+    [[nodiscard]] std::optional<DateTime> next_after(DateTime now)
+    {
+        std::optional<DateTime> next;
+        for (const auto &data_id : core->observed)
+        {
+            const auto &times = history(data_id);
+            const auto found = std::ranges::upper_bound(times, now);
+            if (found == times.end() || *found >= end_time)
+            {
+                continue;
+            }
+            if (!next.has_value() || *found < *next)
+            {
+                next = *found;
+            }
+        }
+        return next;
+    }
+
+    [[nodiscard]] std::optional<DeliveryBatch> evaluate(DateTime now, NodeScheduler scheduler)
+    {
+        if (!core)
+        {
+            return std::nullopt;
+        }
+        const DateTime logical_time = cursor.value_or(now);
+        if (logical_time >= end_time)
+        {
+            return std::nullopt;
+        }
+        auto result = core->coordinator.resolve_at(logical_time);
+        core->observe(result);
+        cursor = next_after(logical_time);
+        if (cursor.has_value())
+        {
+            if (*cursor > now)
+            {
+                scheduler.schedule(*cursor);
+            }
+            else
+            {
+                scheduler.schedule(MIN_TD);
+            }
+        }
+        auto batch = core->batch(std::move(result));
+        return batch.has_value() ? deliver(std::move(*batch), subscriptions) : std::nullopt;
+    }
+};
+
+struct LiveSession
+{
+    struct CachedNotice
+    {
+        DataRevisionInput revision{};
+        DateTime noticed_at{MIN_DT};
+    };
+
+    FabricConfig config{};
+    std::vector<SubscriptionSpec> subscriptions{};
+    std::unique_ptr<RuntimeCore> core{};
+    std::map<Str, CachedNotice, IdLess> notice_cache{};
+    std::map<Str, RevisionId, IdLess> admitted{};
+    bool startup{true};
+
+    void configure(const FabricConfig &configured, std::vector<SubscriptionSpec> requested)
+    {
+        requested = canonical_subscriptions(std::move(requested));
+        if (requested == subscriptions && core)
+        {
+            return;
+        }
+        config = configured;
+        subscriptions = std::move(requested);
+        core = subscriptions.empty() ? nullptr : std::make_unique<RuntimeCore>(config, roots_of(subscriptions));
+        admitted.clear();
+        startup = true;
+    }
+
+    [[nodiscard]] std::optional<DeliveryBatch> evaluate(std::vector<DataRevisionInput> revisions, DateTime now)
+    {
+        DeliveryBatch combined;
+        for (auto &revision : revisions)
+        {
+            auto found = notice_cache.find(revision.data_id);
+            if (found == notice_cache.end())
+            {
+                if (notice_cache.size() >= 4096)
+                {
+                    throw std::overflow_error("fabric live notice cache is full");
+                }
+                Str data_id = revision.data_id;
+                notice_cache.emplace(std::move(data_id), CachedNotice{std::move(revision), now});
+            }
+            else if (found->second.revision.revision < revision.revision)
+            {
+                found->second = CachedNotice{std::move(revision), now};
+            }
+            else if (found->second.revision.revision == revision.revision && found->second.revision != revision)
+            {
+                throw std::runtime_error("fabric live notice conflicts with its cached revision");
+            }
+        }
+
+        if (!core)
+        {
+            return std::nullopt;
+        }
+        if (startup)
+        {
+            auto initial = core->batch(core->coordinator.resolve(now));
+            if (initial.has_value())
+            {
+                if (auto values = deliver(std::move(*initial), subscriptions); values.has_value())
+                {
+                    combined = std::move(*values);
+                }
+            }
+            startup = false;
+        }
+
+        for (;;)
+        {
+            bool admitted_any{};
+            for (;;)
+            {
+                bool admitted_this_pass{};
+                for (const auto &[data_id, cached] : notice_cache)
+                {
+                    if (!core->observed.contains(data_id))
+                    {
+                        continue;
+                    }
+                    const auto prior = admitted.find(data_id);
+                    if (prior != admitted.end() && prior->second >= cached.revision.revision)
+                    {
+                        continue;
+                    }
+                    core->coordinator.observe_accepted_revision(cached.revision);
+                    core->coordinator.observe_notice(data_id, cached.noticed_at);
+                    admitted[data_id] = cached.revision.revision;
+                    for (const auto &dependency : cached.revision.dependencies)
+                    {
+                        core->observed.insert(dependency.data_id);
+                    }
+                    admitted_this_pass = true;
+                    admitted_any = true;
+                }
+                if (!admitted_this_pass)
+                {
+                    break;
+                }
+            }
+            if (!admitted_any)
+            {
+                break;
+            }
+            auto update = core->batch(core->coordinator.resolve_cached(now));
+            if (update.has_value())
+            {
+                if (auto values = deliver(std::move(*update), subscriptions); values.has_value())
+                {
+                    combined.roots.insert(combined.roots.end(), std::make_move_iterator(values->roots.begin()),
+                                          std::make_move_iterator(values->roots.end()));
+                }
+            }
+        }
+        if (combined.roots.empty())
+        {
+            return std::nullopt;
+        }
+        return combined;
+    }
+};
+} // namespace
+
+struct FabricServiceRuntime::Impl
+{
+    FabricServicePlanHandle plan{};
+    std::optional<FabricConfig> config{};
+    SnapshotSession snapshot{};
+    SnapshotSession planned_snapshot{};
+    ReplaySession replay{};
+    ReplaySession planned_replay{};
+    LiveSession live{};
+    LiveSession planned_live{};
+    std::map<Str, std::unique_ptr<PublisherStateMachine>, IdLess> publishers{};
+    std::map<Str, std::deque<PublicationRequestInput>, IdLess> publication_queues{};
+    std::map<Str, RevisionId, IdLess> advertised{};
+    bool running{};
+
+    [[nodiscard]] FabricConfig &configured()
+    {
+        if (!running || !config.has_value())
+        {
+            throw std::logic_error("fabric service runtime is not started");
+        }
+        return *config;
+    }
+
+    void begin_next(std::string_view data_id)
+    {
+        auto queue = publication_queues.find(data_id);
+        if (queue == publication_queues.end() || queue->second.empty())
+        {
+            return;
+        }
+        auto machine = publishers.find(data_id);
+        if (machine == publishers.end())
+        {
+            machine =
+                publishers.emplace(Str{data_id}, std::make_unique<PublisherStateMachine>(configured(), Str{data_id}))
+                    .first;
+        }
+        if (!publication_terminal(machine->second->state()) && machine->second->state() != PublicationState::Idle)
+        {
+            return;
+        }
+
+        PublicationRequestInput request = std::move(queue->second.front());
+        queue->second.pop_front();
+        machine->second->begin(PublicationInput{
+            .output = std::move(request.output),
+            .dependencies = std::move(request.dependencies),
+            .self_predecessor = request.self_predecessor,
+            .system_time = wall_time(),
+        });
+    }
+};
+
+FabricServiceRuntime::FabricServiceRuntime(FabricServicePlanHandle plan) : impl_(std::make_unique<Impl>())
+{
+    if (!plan.value)
+    {
+        throw std::invalid_argument("fabric service runtime requires a wiring plan");
+    }
+    impl_->plan = std::move(plan);
+}
+
+FabricServiceRuntime::~FabricServiceRuntime()
+{
+    stop();
+}
+
+void FabricServiceRuntime::start(GlobalStateView global_state)
+{
+    if (impl_->running)
+    {
+        throw std::logic_error("fabric service runtime started twice");
+    }
+    impl_->config = fabric_config(global_state);
+    if (!impl_->config.has_value())
+    {
+        throw std::logic_error("hgraph.fabric service requires FabricConfig in GlobalState");
+    }
+    require_valid_config(*impl_->config);
+    impl_->running = true;
+}
+
+void FabricServiceRuntime::stop() noexcept
+{
+    if (!impl_)
+    {
+        return;
+    }
+    impl_->running = false;
+    impl_->publishers.clear();
+    impl_->publication_queues.clear();
+    impl_->advertised.clear();
+    impl_->snapshot = {};
+    impl_->planned_snapshot = {};
+    impl_->replay = {};
+    impl_->planned_replay = {};
+    impl_->live = {};
+    impl_->planned_live = {};
+    impl_->config.reset();
+}
+
+void FabricServiceRuntime::configure_replay_window(DateTime start_time, DateTime end_time)
+{
+    impl_->replay.start_time = start_time;
+    impl_->replay.end_time = end_time;
+    impl_->planned_replay.start_time = start_time;
+    impl_->planned_replay.end_time = end_time;
+}
+
+std::optional<DeliveryBatch> FabricServiceRuntime::snapshot(std::vector<SubscriptionSpec> subscriptions)
+{
+    impl_->snapshot.configure(impl_->configured(), std::move(subscriptions));
+    return impl_->snapshot.evaluate();
+}
+
+std::optional<DeliveryBatch> FabricServiceRuntime::planned_snapshot()
+{
+    impl_->planned_snapshot.configure(impl_->configured(), impl_->plan.value->snapshot);
+    return impl_->planned_snapshot.evaluate();
+}
+
+std::optional<DeliveryBatch> FabricServiceRuntime::replay(std::vector<SubscriptionSpec> subscriptions, DateTime now,
+                                                          NodeScheduler scheduler)
+{
+    impl_->replay.configure(impl_->configured(), std::move(subscriptions));
+    return impl_->replay.evaluate(now, scheduler);
+}
+
+std::optional<DeliveryBatch> FabricServiceRuntime::planned_replay(DateTime now, NodeScheduler scheduler)
+{
+    impl_->planned_replay.configure(impl_->configured(), impl_->plan.value->replay);
+    return impl_->planned_replay.evaluate(now, scheduler);
+}
+
+std::optional<DeliveryBatch> FabricServiceRuntime::live(std::vector<SubscriptionSpec> subscriptions,
+                                                        std::vector<DataRevisionInput> revisions, DateTime now)
+{
+    impl_->live.configure(impl_->configured(), std::move(subscriptions));
+    return impl_->live.evaluate(std::move(revisions), now);
+}
+
+std::optional<DeliveryBatch> FabricServiceRuntime::planned_live(std::vector<DataRevisionInput> revisions, DateTime now)
+{
+    impl_->planned_live.configure(impl_->configured(), impl_->plan.value->live);
+    return impl_->planned_live.evaluate(std::move(revisions), now);
+}
+
+void FabricServiceRuntime::publish(PublicationRequestInput request)
+{
+    require_data_id(request.data_id);
+    auto &queue = impl_->publication_queues[request.data_id];
+    if (queue.size() >= 1024)
+    {
+        throw std::overflow_error("fabric publication queue is full");
+    }
+    const Str data_id = request.data_id;
+    queue.push_back(std::move(request));
+    impl_->begin_next(data_id);
+}
+
+std::vector<DataRevisionInput> FabricServiceRuntime::advance_publications()
+{
+    std::vector<DataRevisionInput> accepted;
+    for (auto &[data_id, machine] : impl_->publishers)
+    {
+        for (std::size_t step = 0; step < 16; ++step)
+        {
+            const PublicationState before = machine->state();
+            const PublicationState after = machine->advance();
+            if (publication_terminal(after))
+            {
+                break;
+            }
+            if (after == before && after == PublicationState::NotificationPending)
+            {
+                break;
+            }
+        }
+        if (machine->state() == PublicationState::Published)
+        {
+            const auto revision = machine->accepted_revision();
+            if (revision.has_value() && impl_->advertised[data_id] < revision->revision)
+            {
+                impl_->advertised[data_id] = revision->revision;
+                accepted.push_back(*revision);
+            }
+        }
+        impl_->begin_next(data_id);
+    }
+    return accepted;
+}
+
+bool FabricServiceRuntime::publication_work_pending() const noexcept
+{
+    if (!impl_->running)
+    {
+        return false;
+    }
+    if (std::ranges::any_of(impl_->publication_queues, [](const auto &item) { return !item.second.empty(); }))
+    {
+        return true;
+    }
+    return std::ranges::any_of(impl_->publishers,
+                               [](const auto &item) { return !publication_terminal(item.second->state()); });
+}
+
+std::optional<std::tuple<Str, DataVersion, Frame>> FabricServiceRuntime::load(std::string_view requested_data_id,
+                                                                              DataVersion version) const
+{
+    if (!impl_->running || !impl_->config.has_value())
+    {
+        throw std::logic_error("fabric service runtime is not started");
+    }
+    Str data_id{requested_data_id};
+    require_data_id(data_id);
+    if (version <= 0)
+    {
+        throw std::invalid_argument("fabric load version must be positive");
+    }
+    Frame frame = impl_->config->frames.read(data_version_key(impl_->config->prefix, data_id, version));
+    if (!frame.has_value())
+    {
+        return std::nullopt;
+    }
+    return std::tuple<Str, DataVersion, Frame>{std::move(data_id), version, std::move(frame)};
+}
+
+std::vector<std::pair<Str, Str>> FabricServiceRuntime::diagnostics() const
+{
+    return {
+        {"lifecycle", impl_->running ? "running" : "stopped"},
+        {"publishers", std::to_string(impl_->publishers.size())},
+    };
+}
+
+Str subscription_key(Str data_id, SubscriptionMode mode, DateTime as_of)
+{
+    require_data_id(data_id);
+    if (mode != SubscriptionMode::Snapshot)
+    {
+        return data_id;
+    }
+    return data_id + KEY_SEPARATOR + std::to_string(as_of.time_since_epoch().count());
+}
+
+SubscriptionSpec decode_subscription_key(std::string_view key, SubscriptionMode mode)
+{
+    if (mode != SubscriptionMode::Snapshot)
+    {
+        Str data_id{key};
+        require_data_id(data_id);
+        return SubscriptionSpec{.key = data_id, .data_id = std::move(data_id)};
+    }
+    auto [data_id, micros] = split_key(key, "snapshot subscription key");
+    return SubscriptionSpec{
+        .key = Str{key},
+        .data_id = std::move(data_id),
+        .as_of = DateTime{TimeDelta{micros}},
+    };
+}
+
+void FabricServicePlan::add(SubscriptionSpec subscription, SubscriptionMode mode)
+{
+    auto *target = [&]() -> std::vector<SubscriptionSpec> * {
+        switch (mode)
+        {
+        case SubscriptionMode::Live:
+            return &live;
+        case SubscriptionMode::Replay:
+            return &replay;
+        case SubscriptionMode::Snapshot:
+            return &snapshot;
+        }
+        throw std::invalid_argument("unsupported fabric planned subscription mode");
+    }();
+    const auto found = std::ranges::find(*target, subscription.key, &SubscriptionSpec::key);
+    if (found != target->end())
+    {
+        if (*found != subscription)
+        {
+            throw std::invalid_argument("fabric planned subscription key has conflicting policy");
+        }
+        return;
+    }
+    target->push_back(std::move(subscription));
+}
+
+FabricServicePlanHandle service_plan(Wiring &wiring, std::string_view path)
+{
+    struct PlanRegistry
+    {
+        std::map<Str, FabricServicePlanHandle> paths{};
+    };
+    auto registry = std::static_pointer_cast<PlanRegistry>(wiring.acquire_extension_state(
+        std::type_index(typeid(PlanRegistry)), [] { return std::make_shared<PlanRegistry>(); }));
+    auto [found, inserted] = registry->paths.try_emplace(Str{path});
+    if (inserted)
+    {
+        found->second.value = std::make_shared<FabricServicePlan>();
+    }
+    return found->second;
+}
+
+void plan_subscription(Wiring &wiring, SubscriptionSpec subscription, SubscriptionMode mode, std::string_view path)
+{
+    service_plan(wiring, path).value->add(std::move(subscription), mode);
+}
+
+} // namespace hgraph::fabric::detail

--- a/extensions/fabric/tests/CMakeLists.txt
+++ b/extensions/fabric/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(hgraph_fabric_tests
     test_public_contracts.cpp
     test_publication.cpp
     test_resolution.cpp
+    test_subscription.cpp
 )
 target_link_libraries(hgraph_fabric_tests
     PRIVATE hgraph::fabric Catch2::Catch2WithMain)

--- a/extensions/fabric/tests/test_public_contracts.cpp
+++ b/extensions/fabric/tests/test_public_contracts.cpp
@@ -84,6 +84,7 @@ namespace
 
         static void compose(hg::Wiring &wiring)
         {
+            hgf::register_service(wiring);
             auto source = hgf::subscribe_data(
                 wiring, "input", hgf::SubscriptionMode::Live);
             auto dependency = hgf::dependency_handle(wiring, source);
@@ -101,6 +102,7 @@ namespace
 
         static void compose(hg::Wiring &wiring)
         {
+            hgf::register_service(wiring);
             auto first = hgf::subscribe_data(
                 wiring, "input-a", hgf::SubscriptionMode::Live);
             auto second = hgf::subscribe_data(
@@ -117,6 +119,7 @@ namespace
 
         static void compose(hg::Wiring &wiring)
         {
+            hgf::register_service(wiring);
             auto first = hgf::subscribe_data(
                 wiring, "input", hgf::SubscriptionMode::Live);
             auto second = hgf::subscribe_data(
@@ -139,6 +142,7 @@ namespace
     {
         static void compose(hg::Wiring &wiring)
         {
+            hgf::register_service(wiring);
             auto source = hgf::subscribe_data(
                 wiring, "shared", hgf::SubscriptionMode::Live);
             hgf::publish_data(wiring, "left", source);
@@ -177,6 +181,7 @@ namespace
     {
         static void compose(hg::Wiring &wiring)
         {
+            hgf::register_service(wiring);
             auto source = hg::nested_<NestedSubscriptionGraph>(wiring);
             hgf::publish_data(wiring, "nested-output", source);
         }
@@ -186,6 +191,7 @@ namespace
     {
         static void compose(hg::Wiring &wiring)
         {
+            hgf::register_service(wiring);
             auto source = hg::nested_<NestedSubscriptionWithSideEffectGraph>(wiring);
             hgf::publish_data(wiring, "nested-side-effect-output", source);
         }
@@ -195,6 +201,7 @@ namespace
     {
         static void compose(hg::Wiring &wiring)
         {
+            hgf::register_service(wiring);
             auto left = hgf::subscribe_data(
                 wiring, "conditional-a", hgf::SubscriptionMode::Live);
             auto right = hgf::subscribe_data(
@@ -212,6 +219,7 @@ namespace
     {
         static void compose(hg::Wiring &wiring)
         {
+            hgf::register_service(wiring);
             auto dependency = hgf::subscribe_data(
                 wiring, "declared-only", hgf::SubscriptionMode::Live);
             auto value = hg::wire<NeverFrameSource>(wiring);
@@ -226,6 +234,7 @@ namespace
     {
         static void compose(hg::Wiring &wiring)
         {
+            hgf::register_service(wiring);
             auto a = hgf::subscribe_data(
                 wiring, "a", hgf::SubscriptionMode::Live);
             auto b = hgf::subscribe_data(
@@ -246,6 +255,7 @@ namespace
     {
         static void compose(hg::Wiring &wiring)
         {
+            hgf::register_service(wiring);
             hgf::publish_data(wiring, "independent-output",
                               hg::wire<NeverFrameSource>(wiring));
         }
@@ -439,14 +449,16 @@ TEST_CASE("fabric planner partitions independent consistency forests")
                               {{"a"}}, {{"b"}}, {{"x"}}});
 }
 
-TEST_CASE("fabric planner wires one coordinator and hidden lineage cuts")
+TEST_CASE("fabric planner wires shared service clients and hidden lineage cuts")
 {
     hg::stdlib::register_standard_operators();
     hgf::register_fabric_operators();
 
     const auto dependent = hg::build_graph<IndependentForestsGraph>();
     CHECK(count_semantic_node(
-              dependent, "hgraph.fabric.ingress_coordinator.contract") == 1);
+              dependent, "hgraph.fabric.service.lifecycle") == 1);
+    CHECK(count_semantic_node(
+              dependent, "hgraph.fabric.ingress_coordinator.contract") == 0);
     CHECK(count_semantic_node(
               dependent, "hgraph.fabric.publish_data.with_cut") == 2);
     CHECK(count_semantic_node(

--- a/extensions/fabric/tests/test_subscription.cpp
+++ b/extensions/fabric/tests/test_subscription.cpp
@@ -1,0 +1,766 @@
+#include <hgraph/fabric/fabric.h>
+
+#include <hgraph/lib/std/operators/conversion.h>
+#include <hgraph/lib/std/operators/registration.h>
+#include <hgraph/lib/testing/runtime_support.h>
+#include <hgraph/runtime/runtime.h>
+#include <hgraph/types/static_node.h>
+
+#include <arrow/array.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string_view>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace
+{
+namespace hg = hgraph;
+namespace hgf = hgraph::fabric;
+namespace hgps = hgraph::persistence::store;
+
+constexpr hg::DateTime BASE_TIME{hg::TimeDelta{1'800'000'000'000'000}};
+
+std::vector<std::pair<hg::DateTime, std::int64_t>> observed_frames{};
+std::vector<std::tuple<hg::DateTime, hg::Str, std::int64_t>> observed_tagged_frames{};
+
+struct IoCounters
+{
+    std::size_t object_puts{};
+    std::size_t object_gets{};
+    std::size_t object_lists{};
+    std::size_t object_compares{};
+    std::size_t frame_writes{};
+    std::size_t frame_reads{};
+    std::size_t frame_contains{};
+
+    void reset() noexcept
+    {
+        *this = {};
+    }
+};
+
+struct CountingObjectContext
+{
+    hgps::ObjectStore store{};
+    std::shared_ptr<IoCounters> counters{};
+};
+
+struct CountingFrameContext
+{
+    hgps::FrameStore store{};
+    std::shared_ptr<IoCounters> counters{};
+};
+
+[[nodiscard]] const hgps::ObjectStoreOps &counting_object_ops()
+{
+    static const hgps::ObjectStoreOps ops{
+        [](void *context, std::string_view key, std::span<const std::byte> data) {
+            auto &counting = *static_cast<CountingObjectContext *>(context);
+            ++counting.counters->object_puts;
+            return counting.store.put_immutable(key, data);
+        },
+        [](void *context, std::string_view key) {
+            auto &counting = *static_cast<CountingObjectContext *>(context);
+            ++counting.counters->object_gets;
+            return counting.store.get(key);
+        },
+        [](void *context, std::string_view prefix, std::optional<std::string_view> start_after, std::size_t limit) {
+            auto &counting = *static_cast<CountingObjectContext *>(context);
+            ++counting.counters->object_lists;
+            return counting.store.list(prefix, start_after, limit);
+        },
+        [](void *context, std::string_view key, std::optional<std::string_view> expected,
+           std::span<const std::byte> desired) {
+            auto &counting = *static_cast<CountingObjectContext *>(context);
+            ++counting.counters->object_compares;
+            return counting.store.compare_exchange_ref(key, expected, desired);
+        },
+        [](void *context) { static_cast<CountingObjectContext *>(context)->store.clear(); },
+    };
+    return ops;
+}
+
+[[nodiscard]] const hgps::FrameStoreOps &counting_frame_ops()
+{
+    static const hgps::FrameStoreOps ops{
+        [](void *context, std::string_view key, hg::Frame value, std::optional<hgps::Compression> compression) {
+            auto &counting = *static_cast<CountingFrameContext *>(context);
+            ++counting.counters->frame_writes;
+            counting.store.write(key, std::move(value), compression);
+        },
+        [](void *context, std::string_view key) {
+            auto &counting = *static_cast<CountingFrameContext *>(context);
+            ++counting.counters->frame_reads;
+            return counting.store.read(key);
+        },
+        [](void *context, std::string_view key) {
+            auto &counting = *static_cast<CountingFrameContext *>(context);
+            ++counting.counters->frame_contains;
+            return counting.store.contains(key);
+        },
+        [](void *context) { static_cast<CountingFrameContext *>(context)->store.clear(); },
+    };
+    return ops;
+}
+
+[[nodiscard]] hgf::FabricConfig counting_config(const hgf::FabricConfig &base, std::shared_ptr<IoCounters> counters)
+{
+    hgf::FabricConfig result = base;
+    result.objects = hgps::ObjectStore{std::make_shared<CountingObjectContext>(CountingObjectContext{
+                                           .store = base.objects,
+                                           .counters = counters,
+                                       }),
+                                       counting_object_ops()};
+    result.frames = hgps::FrameStore{std::make_shared<CountingFrameContext>(CountingFrameContext{
+                                         .store = base.frames,
+                                         .counters = std::move(counters),
+                                     }),
+                                     counting_frame_ops()};
+    return result;
+}
+
+[[nodiscard]] hg::Frame frame(std::int64_t value)
+{
+    arrow::Int64Builder builder;
+    if (!builder.Append(value).ok())
+    {
+        throw std::runtime_error("failed to append test Frame value");
+    }
+    auto array = builder.Finish();
+    if (!array.ok())
+    {
+        throw std::runtime_error("failed to finish test Frame value");
+    }
+    return hg::Frame{
+        arrow::Table::Make(arrow::schema({arrow::field("value", arrow::int64())}), {std::move(array).ValueOrDie()})};
+}
+
+[[nodiscard]] std::int64_t frame_value(const hg::Frame &value)
+{
+    if (!value.has_value() || value.table->num_rows() != 1)
+    {
+        throw std::runtime_error("test Frame is not a one-row value");
+    }
+    const auto values = std::static_pointer_cast<arrow::Int64Array>(value.table->column(0)->chunk(0));
+    return values->Value(0);
+}
+
+[[nodiscard]] hgf::DataRevisionInput seed(const hgf::FabricConfig &config, hg::Str data_id, hgf::RevisionId revision,
+                                          hgf::DataVersion output_version, hg::DateTime as_of,
+                                          std::vector<hgf::DataDependencyInput> dependencies = {})
+{
+    const std::string data_key = hgf::data_version_key(config.prefix, data_id, output_version);
+    if (!config.frames.contains(data_key))
+    {
+        config.frames.write(data_key, frame(output_version));
+    }
+    hg::Value value = hgf::make_data_revision(hgf::DataRevisionInput{
+        .data_id = std::move(data_id),
+        .revision = revision,
+        .output_version = output_version,
+        .dependencies = std::move(dependencies),
+        .as_of = as_of,
+    });
+    const hgf::DataRevisionInput decoded = hgf::data_revision_input(value.view());
+    const auto revision_result = config.objects.put_immutable(
+        hgf::revision_key(config.prefix, decoded.data_id, revision), hgf::encode_revision(value.view()));
+    if (revision_result.status == hgps::ImmutableWriteStatus::Conflict)
+    {
+        throw std::runtime_error("test revision conflicted");
+    }
+    const auto as_of_result =
+        config.objects.put_immutable(hgf::as_of_key(config.prefix, decoded.data_id, as_of),
+                                     hgf::encode_revision_reference(hgf::MetadataObjectKind::AsOf, revision));
+    if (as_of_result.status == hgps::ImmutableWriteStatus::Conflict)
+    {
+        throw std::runtime_error("test as-of index conflicted");
+    }
+    const std::string latest_key = hgf::latest_key(config.prefix, decoded.data_id);
+    const auto current = config.objects.get(latest_key);
+    const auto latest = config.objects.compare_exchange_ref(
+        latest_key, current.has_value() ? std::optional<std::string_view>{current->version_token} : std::nullopt,
+        hgf::encode_revision_reference(hgf::MetadataObjectKind::Latest, revision));
+    if (!latest.exchanged)
+    {
+        throw std::runtime_error("test latest index update lost a race");
+    }
+    return decoded;
+}
+
+struct CaptureFrame
+{
+    static constexpr auto name = "hgraph.fabric.test.capture_frame";
+
+    static void eval(hg::DateTime now, hg::In<"value", hg::TS<hg::Frame>> value)
+    {
+        observed_frames.emplace_back(now, frame_value(value.value()));
+    }
+};
+
+struct CaptureTaggedFrame
+{
+    static constexpr auto name = "hgraph.fabric.test.capture_tagged_frame";
+
+    static void eval(hg::DateTime now, hg::In<"value", hg::TS<hg::Frame>> value, hg::Scalar<"label", hg::Str> label)
+    {
+        observed_tagged_frames.emplace_back(now, label.value(), frame_value(value.value()));
+    }
+};
+
+struct SnapshotGraph
+{
+    static constexpr auto name = "hgraph.fabric.test.snapshot";
+
+    static void compose(hg::Wiring &wiring)
+    {
+        hgf::register_service(wiring);
+        auto value =
+            hgf::subscribe_data(wiring, "prices", hgf::SubscriptionMode::Snapshot, BASE_TIME + hg::TimeDelta{2});
+        static_cast<void>(hg::wire<CaptureFrame>(wiring, value));
+    }
+};
+
+struct ReplayGraph
+{
+    static constexpr auto name = "hgraph.fabric.test.replay";
+
+    static void compose(hg::Wiring &wiring)
+    {
+        hgf::register_service(wiring);
+        auto value = hgf::subscribe_data(wiring, "prices", hgf::SubscriptionMode::Replay);
+        static_cast<void>(hg::wire<CaptureFrame>(wiring, value));
+    }
+};
+
+struct EqualTimeReplayGraph
+{
+    static constexpr auto name = "hgraph.fabric.test.equal_time_replay";
+
+    static void compose(hg::Wiring &wiring)
+    {
+        hgf::register_service(wiring);
+        auto left = hgf::subscribe_data(wiring, "left", hgf::SubscriptionMode::Replay);
+        auto right = hgf::subscribe_data(wiring, "right", hgf::SubscriptionMode::Replay);
+        static_cast<void>(hg::wire<CaptureTaggedFrame>(wiring, left, hg::Str{"left"}));
+        static_cast<void>(hg::wire<CaptureTaggedFrame>(wiring, right, hg::Str{"right"}));
+    }
+};
+
+struct DynamicAncestryReplayGraph
+{
+    static constexpr auto name = "hgraph.fabric.test.dynamic_ancestry_replay";
+
+    static void compose(hg::Wiring &wiring)
+    {
+        hgf::register_service(wiring);
+        auto value = hgf::subscribe_data(wiring, "derived", hgf::SubscriptionMode::Replay);
+        static_cast<void>(hg::wire<CaptureFrame>(wiring, value));
+    }
+};
+
+struct RecursiveSnapshotGraph
+{
+    static constexpr auto name = "hgraph.fabric.test.recursive_snapshot";
+
+    static void compose(hg::Wiring &wiring)
+    {
+        hgf::register_service(wiring);
+        auto value =
+            hgf::subscribe_data(wiring, "derived", hgf::SubscriptionMode::Snapshot, BASE_TIME + hg::TimeDelta{5});
+        static_cast<void>(hg::wire<CaptureFrame>(wiring, value));
+    }
+};
+
+struct LiveNoticeSource
+{
+    static constexpr auto name = "hgraph.fabric.test.live_notice";
+    static constexpr bool schedule_on_start = true;
+
+    static void eval(hg::GlobalStateView global_state, hg::NodeScheduler scheduler, hg::State<hg::Int> phase,
+                     hg::Out<hg::TS<hgf::DataRevision>> out)
+    {
+        if (phase.get() == hg::Int{0})
+        {
+            phase.set(hg::Int{1});
+            scheduler.schedule(hg::TimeDelta{5});
+            return;
+        }
+        if (phase.get() != hg::Int{1})
+        {
+            return;
+        }
+        const auto config = hgf::fabric_config(global_state);
+        if (!config.has_value())
+        {
+            throw std::logic_error("test live source has no FabricConfig");
+        }
+        const auto revision = seed(*config, "prices", 2, 2, BASE_TIME + hg::TimeDelta{2});
+        hg::Value value = hgf::make_data_revision(revision);
+        out.apply(value.view());
+        phase.set(hg::Int{2});
+    }
+};
+
+struct LiveGraph
+{
+    static constexpr auto name = "hgraph.fabric.test.live";
+
+    static void compose(hg::Wiring &wiring)
+    {
+        hgf::register_service(wiring);
+        auto value = hgf::subscribe_data(wiring, "prices", hgf::SubscriptionMode::Live);
+        auto notice = hg::wire<LiveNoticeSource>(wiring);
+        hgf::submit_notice(wiring, notice, hg::service::path(hgf::DEFAULT_SERVICE_PATH));
+        static_cast<void>(hg::wire<CaptureFrame>(wiring, value));
+    }
+};
+
+std::optional<hgf::FabricConfig> notice_seed_config{};
+std::shared_ptr<IoCounters> notice_io_counters{};
+std::vector<hgf::DataRevisionInput> notice_specs{};
+
+template <std::size_t Index, std::int64_t Delay, bool ResetCounters, std::size_t SeedCount = 1>
+struct CountingNoticeSource
+{
+    static constexpr auto name = "hgraph.fabric.test.counting_notice";
+    static constexpr bool schedule_on_start = true;
+
+    static void eval(hg::NodeScheduler scheduler, hg::State<hg::Int> phase, hg::Out<hg::TS<hgf::DataRevision>> out)
+    {
+        if (phase.get() == hg::Int{0})
+        {
+            phase.set(hg::Int{1});
+            scheduler.schedule(hg::TimeDelta{Delay});
+            return;
+        }
+        if (phase.get() != hg::Int{1})
+        {
+            return;
+        }
+        if (!notice_seed_config.has_value() || Index + SeedCount > notice_specs.size())
+        {
+            throw std::logic_error("counting notice source is not configured");
+        }
+        std::optional<hgf::DataRevisionInput> revision;
+        for (std::size_t offset = 0; offset < SeedCount; ++offset)
+        {
+            auto spec = notice_specs[Index + offset];
+            revision = seed(*notice_seed_config, std::move(spec.data_id), spec.revision, spec.output_version,
+                            spec.as_of, std::move(spec.dependencies));
+        }
+        if constexpr (ResetCounters)
+        {
+            if (!notice_io_counters)
+            {
+                throw std::logic_error("counting notice source has no counters");
+            }
+            notice_io_counters->reset();
+        }
+        hg::Value value = hgf::make_data_revision(std::move(*revision));
+        out.apply(value.view());
+        phase.set(hg::Int{2});
+    }
+};
+
+struct CompleteNoticeGraph
+{
+    static constexpr auto name = "hgraph.fabric.test.complete_notice";
+
+    static void compose(hg::Wiring &wiring)
+    {
+        hgf::register_service(wiring);
+        auto value = hgf::subscribe_data(wiring, "prices", hgf::SubscriptionMode::Live);
+        hgf::submit_notice(wiring, hg::wire<CountingNoticeSource<0, 5, true>>(wiring));
+        static_cast<void>(hg::wire<CaptureFrame>(wiring, value));
+    }
+};
+
+struct CachedAncestryNoticeGraph
+{
+    static constexpr auto name = "hgraph.fabric.test.cached_ancestry_notice";
+
+    static void compose(hg::Wiring &wiring)
+    {
+        hgf::register_service(wiring);
+        auto value = hgf::subscribe_data(wiring, "z-root", hgf::SubscriptionMode::Live);
+        hgf::submit_notice(wiring, hg::wire<CountingNoticeSource<0, 3, true>>(wiring));
+        hgf::submit_notice(wiring, hg::wire<CountingNoticeSource<1, 5, false>>(wiring));
+        static_cast<void>(hg::wire<CaptureFrame>(wiring, value));
+    }
+};
+
+struct GapNoticeGraph
+{
+    static constexpr auto name = "hgraph.fabric.test.gap_notice";
+
+    static void compose(hg::Wiring &wiring)
+    {
+        hgf::register_service(wiring);
+        auto value = hgf::subscribe_data(wiring, "prices", hgf::SubscriptionMode::Live);
+        hgf::submit_notice(wiring, hg::wire<CountingNoticeSource<0, 5, true, 2>>(wiring));
+        static_cast<void>(hg::wire<CaptureFrame>(wiring, value));
+    }
+};
+
+struct PublishedFrameSource
+{
+    static constexpr auto name = "hgraph.fabric.test.published_frame";
+    static constexpr bool schedule_on_start = true;
+
+    static void eval(hg::Out<hg::TS<hg::Frame>> out)
+    {
+        out.set(frame(71));
+    }
+};
+
+struct PublicationGraph
+{
+    static constexpr auto name = "hgraph.fabric.test.publication";
+
+    static void compose(hg::Wiring &wiring)
+    {
+        hgf::register_service(wiring);
+        hgf::publish_data(wiring, "published", hg::wire<PublishedFrameSource>(wiring));
+    }
+};
+
+struct CaptureLoad
+{
+    static constexpr auto name = "hgraph.fabric.test.capture_load";
+
+    static void eval(hg::DateTime now, hg::In<"loaded", hgf::FabricLoadResponse> loaded)
+    {
+        const auto value = loaded.template field<"frame">();
+        if (value.modified() && value.valid())
+        {
+            observed_frames.emplace_back(now, frame_value(value.value()));
+        }
+    }
+};
+
+struct LoadGraph
+{
+    static constexpr auto name = "hgraph.fabric.test.load";
+
+    static void compose(hg::Wiring &wiring)
+    {
+        hgf::register_service(wiring);
+        static_cast<void>(hg::wire<CaptureLoad>(wiring, hgf::request_load(wiring, "prices", 2)));
+    }
+};
+
+[[nodiscard]] hg::GraphExecutorValue run(hg::GraphBuilder graph, const hgf::FabricConfig &config, hg::DateTime start,
+                                         hg::DateTime end)
+{
+    hgf::set_fabric_config(graph.global_state(), config);
+    return hg::testing::run_graph(std::move(graph), start, end);
+}
+} // namespace
+
+TEST_CASE("snapshot loads one consistent image at the requested as-of")
+{
+    hg::stdlib::register_standard_operators();
+    hgf::register_fabric_operators();
+    auto config = hgf::make_memory_fabric_config("tests/subscription/snapshot");
+    static_cast<void>(seed(config, "prices", 1, 1, BASE_TIME + hg::TimeDelta{1}));
+    static_cast<void>(seed(config, "prices", 2, 2, BASE_TIME + hg::TimeDelta{2}));
+    static_cast<void>(seed(config, "prices", 3, 3, BASE_TIME + hg::TimeDelta{3}));
+    observed_frames.clear();
+
+    static_cast<void>(run(hg::build_graph<SnapshotGraph>(), config, BASE_TIME, BASE_TIME + hg::TimeDelta{5}));
+
+    REQUIRE(observed_frames.size() == 1);
+    CHECK(observed_frames.front().first == BASE_TIME);
+    CHECK(observed_frames.front().second == 2);
+}
+
+TEST_CASE("snapshot applies its as-of bound through transitive ancestry")
+{
+    hg::stdlib::register_standard_operators();
+    hgf::register_fabric_operators();
+    auto config = hgf::make_memory_fabric_config("tests/subscription/snapshot-ancestry");
+    static_cast<void>(seed(config, "base", 1, 1, BASE_TIME + hg::TimeDelta{1}));
+    static_cast<void>(seed(config, "middle", 1, 1, BASE_TIME + hg::TimeDelta{2}, {{"base", 1}}));
+    static_cast<void>(seed(config, "derived", 1, 1, BASE_TIME + hg::TimeDelta{3}, {{"middle", 1}}));
+    static_cast<void>(seed(config, "derived", 2, 2, BASE_TIME + hg::TimeDelta{5}, {{"middle", 2}}));
+    static_cast<void>(seed(config, "base", 2, 2, BASE_TIME + hg::TimeDelta{6}));
+    static_cast<void>(seed(config, "middle", 2, 2, BASE_TIME + hg::TimeDelta{7}, {{"base", 2}}));
+    observed_frames.clear();
+
+    const auto graph_start = BASE_TIME + hg::TimeDelta{20};
+    static_cast<void>(
+        run(hg::build_graph<RecursiveSnapshotGraph>(), config, graph_start, graph_start + hg::TimeDelta{5}));
+
+    REQUIRE(observed_frames.size() == 1);
+    CHECK(observed_frames.front().first == graph_start);
+    CHECK(observed_frames.front().second == 1);
+}
+
+TEST_CASE("replay emits ordered as-of images over a half-open run interval")
+{
+    hg::stdlib::register_standard_operators();
+    hgf::register_fabric_operators();
+    auto config = hgf::make_memory_fabric_config("tests/subscription/replay");
+    static_cast<void>(seed(config, "prices", 1, 1, BASE_TIME + hg::TimeDelta{10}));
+    static_cast<void>(seed(config, "prices", 2, 2, BASE_TIME + hg::TimeDelta{20}));
+    static_cast<void>(seed(config, "prices", 3, 3, BASE_TIME + hg::TimeDelta{30}));
+    observed_frames.clear();
+
+    static_cast<void>(
+        run(hg::build_graph<ReplayGraph>(), config, BASE_TIME + hg::TimeDelta{15}, BASE_TIME + hg::TimeDelta{30}));
+
+    REQUIRE(observed_frames.size() == 2);
+    CHECK(observed_frames[0].first == BASE_TIME + hg::TimeDelta{15});
+    CHECK(observed_frames[0].second == 1);
+    CHECK(observed_frames[1].first == BASE_TIME + hg::TimeDelta{20});
+    CHECK(observed_frames[1].second == 2);
+}
+
+TEST_CASE("replay from MIN_ST begins at the first durable publication")
+{
+    hg::stdlib::register_standard_operators();
+    hgf::register_fabric_operators();
+    auto config = hgf::make_memory_fabric_config("tests/subscription/replay-min-start");
+    static_cast<void>(seed(config, "prices", 1, 1, hg::MIN_ST + hg::TimeDelta{2}));
+    observed_frames.clear();
+
+    static_cast<void>(run(hg::build_graph<ReplayGraph>(), config, hg::MIN_ST, hg::MIN_ST + hg::TimeDelta{5}));
+
+    REQUIRE(observed_frames.size() == 1);
+    CHECK(observed_frames.front().first == hg::MIN_ST + hg::TimeDelta{2});
+    CHECK(observed_frames.front().second == 1);
+}
+
+TEST_CASE("replay batches equal as-of timestamps across direct roots")
+{
+    hg::stdlib::register_standard_operators();
+    hgf::register_fabric_operators();
+    auto config = hgf::make_memory_fabric_config("tests/subscription/replay-equal-time");
+    const auto published_at = BASE_TIME + hg::TimeDelta{10};
+    static_cast<void>(seed(config, "left", 1, 1, published_at));
+    static_cast<void>(seed(config, "right", 1, 1, published_at));
+    observed_tagged_frames.clear();
+
+    static_cast<void>(run(hg::build_graph<EqualTimeReplayGraph>(), config, BASE_TIME + hg::TimeDelta{1},
+                          BASE_TIME + hg::TimeDelta{20}));
+
+    REQUIRE(observed_tagged_frames.size() == 2);
+    CHECK(std::get<0>(observed_tagged_frames[0]) == published_at);
+    CHECK(std::get<0>(observed_tagged_frames[1]) == published_at);
+    std::map<hg::Str, std::int64_t> values;
+    for (const auto &[time, label, value] : observed_tagged_frames)
+    {
+        static_cast<void>(time);
+        values.emplace(label, value);
+    }
+    CHECK((values == std::map<hg::Str, std::int64_t>{{"left", 1}, {"right", 1}}));
+}
+
+TEST_CASE("replay follows dynamically introduced transitive ancestry")
+{
+    hg::stdlib::register_standard_operators();
+    hgf::register_fabric_operators();
+    auto config = hgf::make_memory_fabric_config("tests/subscription/replay-ancestry");
+    static_cast<void>(seed(config, "base", 1, 1, BASE_TIME + hg::TimeDelta{5}));
+    static_cast<void>(seed(config, "middle", 1, 1, BASE_TIME + hg::TimeDelta{7}, {{"base", 1}}));
+    static_cast<void>(seed(config, "derived", 1, 1, BASE_TIME + hg::TimeDelta{10}, {{"middle", 1}}));
+    static_cast<void>(seed(config, "base", 2, 2, BASE_TIME + hg::TimeDelta{15}));
+    static_cast<void>(seed(config, "middle", 2, 2, BASE_TIME + hg::TimeDelta{20}, {{"base", 2}}));
+    static_cast<void>(seed(config, "derived", 2, 2, BASE_TIME + hg::TimeDelta{30}, {{"middle", 2}}));
+    observed_frames.clear();
+
+    static_cast<void>(run(hg::build_graph<DynamicAncestryReplayGraph>(), config, BASE_TIME + hg::TimeDelta{1},
+                          BASE_TIME + hg::TimeDelta{40}));
+
+    REQUIRE(observed_frames.size() == 2);
+    CHECK(observed_frames[0].first == BASE_TIME + hg::TimeDelta{10});
+    CHECK(observed_frames[0].second == 1);
+    CHECK(observed_frames[1].first == BASE_TIME + hg::TimeDelta{30});
+    CHECK(observed_frames[1].second == 2);
+}
+
+TEST_CASE("live starts from durable state and advances only from notice ticks")
+{
+    hg::stdlib::register_standard_operators();
+    hgf::register_fabric_operators();
+    auto config = hgf::make_memory_fabric_config("tests/subscription/live");
+    static_cast<void>(seed(config, "prices", 1, 1, BASE_TIME + hg::TimeDelta{1}));
+    observed_frames.clear();
+
+    static_cast<void>(
+        run(hg::build_graph<LiveGraph>(), config, BASE_TIME + hg::TimeDelta{1}, BASE_TIME + hg::TimeDelta{10}));
+
+    REQUIRE(observed_frames.size() == 2);
+    CHECK(observed_frames[0].first == BASE_TIME + hg::TimeDelta{1});
+    CHECK(observed_frames[0].second == 1);
+    CHECK(observed_frames[1].first == BASE_TIME + hg::TimeDelta{6});
+    CHECK(observed_frames[1].second == 2);
+}
+
+TEST_CASE("complete live notices avoid metadata reads and load only the "
+          "selected Frame")
+{
+    hg::stdlib::register_standard_operators();
+    hgf::register_fabric_operators();
+    auto base = hgf::make_memory_fabric_config("tests/subscription/complete-notice");
+    static_cast<void>(seed(base, "prices", 1, 1, BASE_TIME + hg::TimeDelta{1}));
+    auto counters = std::make_shared<IoCounters>();
+    auto observed_config = counting_config(base, counters);
+    notice_seed_config = base;
+    notice_io_counters = counters;
+    notice_specs = {hgf::DataRevisionInput{
+        .data_id = "prices",
+        .revision = 2,
+        .output_version = 2,
+        .as_of = BASE_TIME + hg::TimeDelta{2},
+    }};
+    observed_frames.clear();
+
+    static_cast<void>(run(hg::build_graph<CompleteNoticeGraph>(), observed_config, BASE_TIME + hg::TimeDelta{1},
+                          BASE_TIME + hg::TimeDelta{10}));
+
+    REQUIRE(observed_frames.size() == 2);
+    CHECK(observed_frames.back().second == 2);
+    CHECK(counters->object_gets == 0);
+    CHECK(counters->object_lists == 0);
+    CHECK(counters->object_puts == 0);
+    CHECK(counters->object_compares == 0);
+    CHECK(counters->frame_reads == 1);
+    notice_specs.clear();
+    notice_seed_config.reset();
+    notice_io_counters.reset();
+}
+
+TEST_CASE("live gap recovery reads only missing metadata and the selected Frame")
+{
+    hg::stdlib::register_standard_operators();
+    hgf::register_fabric_operators();
+    auto base = hgf::make_memory_fabric_config("tests/subscription/notice-gap");
+    static_cast<void>(seed(base, "prices", 1, 1, BASE_TIME + hg::TimeDelta{1}));
+    auto counters = std::make_shared<IoCounters>();
+    auto observed_config = counting_config(base, counters);
+    notice_seed_config = base;
+    notice_io_counters = counters;
+    notice_specs = {
+        hgf::DataRevisionInput{
+            .data_id = "prices",
+            .revision = 2,
+            .output_version = 2,
+            .as_of = BASE_TIME + hg::TimeDelta{2},
+        },
+        hgf::DataRevisionInput{
+            .data_id = "prices",
+            .revision = 3,
+            .output_version = 3,
+            .as_of = BASE_TIME + hg::TimeDelta{3},
+        },
+    };
+    observed_frames.clear();
+
+    static_cast<void>(run(hg::build_graph<GapNoticeGraph>(), observed_config, BASE_TIME + hg::TimeDelta{1},
+                          BASE_TIME + hg::TimeDelta{10}));
+
+    REQUIRE(observed_frames.size() == 2);
+    CHECK(observed_frames.back().second == 3);
+    CHECK(counters->object_gets == 1);
+    CHECK(counters->object_lists == 0);
+    CHECK(counters->object_puts == 0);
+    CHECK(counters->object_compares == 0);
+    CHECK(counters->frame_reads == 1);
+    notice_specs.clear();
+    notice_seed_config.reset();
+    notice_io_counters.reset();
+}
+
+TEST_CASE("live admits cached dependency notices before durable fallback")
+{
+    hg::stdlib::register_standard_operators();
+    hgf::register_fabric_operators();
+    auto base = hgf::make_memory_fabric_config("tests/subscription/cached-ancestry");
+    static_cast<void>(seed(base, "z-root", 1, 1, BASE_TIME + hg::TimeDelta{1}));
+    auto counters = std::make_shared<IoCounters>();
+    auto observed_config = counting_config(base, counters);
+    notice_seed_config = base;
+    notice_io_counters = counters;
+    notice_specs = {
+        hgf::DataRevisionInput{
+            .data_id = "a-ancestor",
+            .revision = 1,
+            .output_version = 1,
+            .as_of = BASE_TIME + hg::TimeDelta{2},
+        },
+        hgf::DataRevisionInput{
+            .data_id = "z-root",
+            .revision = 2,
+            .output_version = 2,
+            .dependencies = {{"a-ancestor", 1}},
+            .as_of = BASE_TIME + hg::TimeDelta{3},
+        },
+    };
+    observed_frames.clear();
+
+    static_cast<void>(run(hg::build_graph<CachedAncestryNoticeGraph>(), observed_config, BASE_TIME + hg::TimeDelta{1},
+                          BASE_TIME + hg::TimeDelta{10}));
+
+    REQUIRE(observed_frames.size() == 2);
+    CHECK(observed_frames.back().second == 2);
+    CHECK(counters->object_gets == 0);
+    CHECK(counters->object_lists == 0);
+    CHECK(counters->frame_reads == 1);
+    notice_specs.clear();
+    notice_seed_config.reset();
+    notice_io_counters.reset();
+}
+
+TEST_CASE("snapshot and replay service graphs contain no push sources")
+{
+    hg::stdlib::register_standard_operators();
+    hgf::register_fabric_operators();
+    const auto snapshot = hg::build_graph<SnapshotGraph>();
+    const auto replay = hg::build_graph<ReplayGraph>();
+    CHECK(snapshot.root_type().schema()->push_source_nodes_end == 0);
+    CHECK(replay.root_type().schema()->push_source_nodes_end == 0);
+}
+
+TEST_CASE("publish_data routes through the singleton service publication state")
+{
+    hg::stdlib::register_standard_operators();
+    hgf::register_fabric_operators();
+    auto config = hgf::make_memory_fabric_config("tests/subscription/publication");
+    static_cast<void>(run(hg::build_graph<PublicationGraph>(), config, BASE_TIME, BASE_TIME + hg::TimeDelta{5}));
+
+    const auto latest = config.objects.get(hgf::latest_key(config.prefix, "published"));
+    REQUIRE(latest.has_value());
+    CHECK(hgf::decode_revision_reference(hgf::MetadataObjectKind::Latest, latest->data) == 1);
+    const auto revision_object = config.objects.get(hgf::revision_key(config.prefix, "published", 1));
+    REQUIRE(revision_object.has_value());
+    const auto revision = hgf::data_revision_input(hgf::decode_revision(revision_object->data).view());
+    const auto stored = config.frames.read(hgf::data_version_key(config.prefix, "published", revision.output_version));
+    REQUIRE(stored.has_value());
+    CHECK(frame_value(stored) == 71);
+}
+
+TEST_CASE("request_load uses the service-owned persistence resource")
+{
+    hg::stdlib::register_standard_operators();
+    hgf::register_fabric_operators();
+    auto config = hgf::make_memory_fabric_config("tests/subscription/load");
+    static_cast<void>(seed(config, "prices", 1, 2, BASE_TIME + hg::TimeDelta{1}));
+    observed_frames.clear();
+
+    static_cast<void>(run(hg::build_graph<LoadGraph>(), config, BASE_TIME, BASE_TIME + hg::TimeDelta{5}));
+
+    REQUIRE(observed_frames.size() == 1);
+    CHECK(observed_frames.front().second == 2);
+}


### PR DESCRIPTION
## Summary

- add the graph-owned Fabric service runtime as one lazy singleton implementing subscription, publication, load, and diagnostics contracts
- wire explicit Snapshot, Replay, and Live subscription modes through ordinary graph nodes
- ingest complete revision notices directly into the consistency resolver, use persistence only for targeted metadata gaps, and load only selected Frame versions
- add service-owned publication queues and synchronous request/reply loading without external access to the running graph
- expose the same native path to Python and document the runtime behavior

This is stacked on #535 and advances checkpoint 5 of #512. The production Kafka-to-`push_source_node` ingress remains the next transport checkpoint.

## Design constraints

- no `AsyncNotifier` or direct external graph notification
- no simulated push-source path; push sources remain real-time only
- Snapshot and Replay are deterministic scheduled sources
- Live is an ordinary notice-driven graph path
- complete revision messages avoid repeated metadata reads
- live notices are bounded and conflated; replay remains lossless

## Validation

- macOS: fresh full native suite, 1604/1604 passed
- macOS: stable-ABI wheel installed into Python 3.14, 2122 passed, 10 skipped
- macOS: Fabric Python extension tests, 15 passed
- macOS: installed-SDK C++ consumer, 1/1 passed
- Linux GCC 14: fresh full native suite, 1604/1604 passed
- Linux Python 3.14 with Polars rtcompat: 2122 passed, 10 skipped
- Linux: Fabric Python extension tests, 15 passed
- Linux: installed-SDK C++ consumer, 1/1 passed
- Linux GCC 14 ASan with Arrow system allocator: 41 cases / 1622 assertions passed
