### PR TITLE
Test Fabric Kafka broker outage recovery

### DIFF
--- a/.github/workflows/native-cpp.yml
+++ b/.github/workflows/native-cpp.yml
@@ -80,6 +80,12 @@ jobs:
         run: cmake --build build-native --parallel ${{ matrix.parallel }}
       - name: Run native C++ tests
         run: ctest --test-dir build-native --output-on-failure --parallel ${{ matrix.parallel }}
+      - name: Run restartable Kafka broker conformance
+        if: runner.os == 'Linux'
+        run: >-
+          python3 extensions/fabric/tools/run_kafka_broker_conformance.py
+          --test-executable
+          build-native/extensions/fabric/tests/hgraph_fabric_kafka_tests
       - name: HTTP/2 conformance (h2spec)
         if: runner.os == 'Linux'
         shell: bash

--- a/extensions/fabric/CHANGELOG.md
+++ b/extensions/fabric/CHANGELOG.md
@@ -19,3 +19,6 @@
   publication race, resolver/cache and bounded-queue diagnostics, service
   lifecycle logs, installed wheel SDK consumers, dependency-first Windows DLL
   setup, release artifacts, and production operating guidance.
+- Add restartable real-broker conformance for startup handoff, retriable
+  delivery failure, reconnect recovery, bounded queue profiles, and keyed
+  partition ordering.

--- a/extensions/fabric/README.md
+++ b/extensions/fabric/README.md
@@ -151,3 +151,21 @@ uses a new data id (for example `prices/v2`), runs old and new producers during
 the consumer migration, then retires the old id only under an explicit
 retention plan. Fabric does not reinterpret or transparently migrate stored
 Frames.
+
+## Broker conformance
+
+The deterministic suite uses librdkafka's mock cluster and the graph-native
+fake service for exact failure injection. Linux CI additionally runs a pinned
+single-node Redpanda broker, stops it while a live graph is running, accepts a
+new durable revision during the outage, observes a retriable delivery failure,
+then restarts the same broker. The test verifies startup image/notice
+de-duplication, reconnect reconciliation, explicit retry, same-key partition
+ordering, and operation with deliberately small non-dropping ingress/outbound
+queues.
+
+Run the same scenario locally against Docker with:
+
+```sh
+python3 extensions/fabric/tools/run_kafka_broker_conformance.py \
+  --test-executable build/extensions/fabric/tests/hgraph_fabric_kafka_tests
+```

--- a/extensions/fabric/tests/test_kafka.cpp
+++ b/extensions/fabric/tests/test_kafka.cpp
@@ -1,10 +1,12 @@
 #include <hgraph/fabric/fabric.h>
 #include <hgraph/fabric/kafka.h>
 
+#include <hgraph/kafka/service.h>
 #include <hgraph/kafka/testing/fake_broker.h>
 #include <hgraph/kafka/testing/mock_cluster.h>
 #include <hgraph/kafka/value_builders.h>
 
+#include <hgraph/lib/std/operators/conversion.h>
 #include <hgraph/lib/std/operators/registration.h>
 #include <hgraph/lib/testing/runtime_support.h>
 #include <hgraph/runtime/runtime.h>
@@ -18,9 +20,16 @@
 
 #include <chrono>
 #include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <map>
 #include <memory>
+#include <optional>
+#include <span>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace {
@@ -36,6 +45,48 @@ std::int64_t observed_value{};
 std::size_t observed_count{};
 hgk::testing::FakeBrokerPtr fake_broker{};
 std::vector<std::int64_t> observed_sequence{};
+hg::Value actual_kafka_config{};
+hg::Value actual_notice_record{};
+hg::Value actual_delivery_report{};
+hg::Value actual_audit_key{};
+hg::Str actual_topic{};
+std::filesystem::path actual_control_dir{};
+std::vector<std::int64_t> actual_live_values{};
+std::map<hg::Str, hg::Str> actual_diagnostics{};
+
+struct ActualBrokerRecord {
+  hg::Int partition{};
+  hg::Int offset{};
+  hg::Bytes key{};
+  hgf::DataRevisionInput revision{};
+};
+
+std::vector<ActualBrokerRecord> actual_broker_records{};
+
+[[nodiscard]] std::filesystem::path marker(std::string_view name) {
+  return actual_control_dir / name;
+}
+
+void write_marker(std::string_view name) {
+  std::ofstream output{marker(name), std::ios::trunc};
+  if (!output) {
+    throw std::runtime_error("failed to write Fabric broker test marker");
+  }
+  output << name << '\n';
+}
+
+template <typename Predicate>
+[[nodiscard]] bool wait_until(Predicate &&predicate,
+                              std::chrono::steady_clock::duration timeout) {
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (std::forward<Predicate>(predicate)()) {
+      return true;
+    }
+    std::this_thread::sleep_for(10ms);
+  }
+  return std::forward<Predicate>(predicate)();
+}
 
 [[nodiscard]] hg::Frame frame(std::int64_t value) {
   arrow::Int64Builder builder;
@@ -132,6 +183,162 @@ struct CaptureLiveSequence {
     if (observed_sequence.size() == 2) {
       node.graph().executor().request_stop();
     }
+  }
+};
+
+struct ActualNoticeSource {
+  static constexpr auto name = "hgraph.fabric.kafka.test.actual_notice";
+  static constexpr bool schedule_on_start = true;
+
+  static void eval(hg::Out<hg::TS<hgk::KafkaProduceRecord>> out) {
+    out.apply(actual_notice_record.view());
+  }
+};
+
+struct CaptureActualDelivery {
+  static constexpr auto name = "hgraph.fabric.kafka.test.actual_delivery";
+
+  static void eval(hg::NodeView node,
+                   hg::In<"report", hg::TS<hgk::KafkaDeliveryReport>> report) {
+    actual_delivery_report = report.base().value().clone();
+    node.graph().executor().request_stop();
+  }
+};
+
+struct ActualNoticeGraph {
+  static constexpr auto name = "hgraph.fabric.kafka.test.actual_notice_graph";
+
+  static void compose(hg::Wiring &wiring) {
+    const auto path = hg::service::path("fabric-broker-seed-kafka");
+    hgk::register_service(wiring, path, actual_kafka_config.clone(),
+                          hgk::KafkaServiceMode::RealTime);
+    auto request = hgk::publish_request(wiring, actual_topic,
+                                        hg::wire<ActualNoticeSource>(wiring));
+    static_cast<void>(hg::wire<CaptureActualDelivery>(
+        wiring, hgk::publish(wiring, path, request)));
+  }
+};
+
+struct ActualBrokerFrameSource {
+  static constexpr auto name = "hgraph.fabric.kafka.test.actual_frame";
+  static constexpr bool schedule_on_start = true;
+
+  static void eval(hg::NodeScheduler scheduler, hg::State<hg::Bool> emitted,
+                   hg::Out<hg::TS<hg::Frame>> out) {
+    if (emitted.get()) {
+      return;
+    }
+    if (!std::filesystem::exists(marker("broker-stopped"))) {
+      scheduler.schedule(hg::TimeDelta{10'000});
+      return;
+    }
+    out.set(frame(2));
+    emitted.set(true);
+  }
+};
+
+struct CaptureActualLiveFrame {
+  static constexpr auto name = "hgraph.fabric.kafka.test.actual_live_capture";
+
+  static void eval(hg::NodeView node,
+                   hg::In<"value", hg::TS<hg::Frame>> value) {
+    const auto observed = frame_value(value.value());
+    actual_live_values.push_back(observed);
+    if (actual_live_values.size() == 1) {
+      write_marker("initial-ready");
+    }
+    if (observed == 2) {
+      write_marker("live-complete");
+      node.graph().executor().request_stop();
+    }
+  }
+};
+
+struct CaptureActualKafkaEvent {
+  static constexpr auto name = "hgraph.fabric.kafka.test.actual_event_capture";
+
+  static void eval(hg::In<"event", hg::TS<hgk::KafkaEvent>> event) {
+    const auto fields = event.base().value().as_bundle();
+    if (fields.at("category").checked_as<hg::Str>() == "delivery" &&
+        fields.at("retriable").checked_as<hg::Bool>()) {
+      write_marker("delivery-failed-retriable");
+    }
+  }
+};
+
+struct CaptureActualDiagnostics {
+  static constexpr auto name =
+      "hgraph.fabric.kafka.test.actual_diagnostics_capture";
+
+  static void eval(hg::In<"values", hg::TSD<hg::Str, hg::TS<hg::Str>>> values) {
+    for (const auto &[key, value] : values.valid_items()) {
+      actual_diagnostics.insert_or_assign(key.checked_as<hg::Str>(),
+                                          value.value());
+    }
+  }
+};
+
+struct ActualBrokerGraph {
+  static constexpr auto name = "hgraph.fabric.kafka.test.actual_broker_graph";
+
+  static void compose(hg::Wiring &wiring) {
+    hgf::register_kafka_transport(wiring, actual_topic,
+                                  "fabric-broker-conformance",
+                                  actual_kafka_config.clone());
+    auto subscribed =
+        hgf::subscribe_data(wiring, "prices", hgf::SubscriptionMode::Live);
+    hgf::publish_data(wiring, "prices",
+                      hg::wire<ActualBrokerFrameSource>(wiring));
+    static_cast<void>(hg::wire<CaptureActualLiveFrame>(wiring, subscribed));
+    static_cast<void>(hg::wire<CaptureActualKafkaEvent>(
+        wiring, hgk::events(wiring, hg::service::path(
+                                        hgf::DEFAULT_KAFKA_SERVICE_PATH))));
+    static_cast<void>(
+        hg::wire<CaptureActualDiagnostics>(wiring, hgf::diagnostics(wiring)));
+  }
+};
+
+struct CaptureActualBrokerRecords {
+  static constexpr auto name = "hgraph.fabric.kafka.test.actual_record_capture";
+
+  static void eval(hg::NodeView node,
+                   hg::In<"subscription", hgk::KafkaSubscriptionOutput,
+                          hg::InputValidity::Unchecked>
+                       subscription) {
+    auto record = subscription.template field<"record">();
+    if (record.valid() && record.modified()) {
+      const auto fields = record.base().value().as_bundle();
+      const auto payload = fields.at("value").checked_as<hg::Bytes>();
+      actual_broker_records.push_back(ActualBrokerRecord{
+          .partition = fields.at("partition").checked_as<hg::Int>(),
+          .offset = fields.at("offset").checked_as<hg::Int>(),
+          .key = fields.at("key").checked_as<hg::Bytes>(),
+          .revision = hgf::data_revision_input(
+              hgf::decode_revision(
+                  std::as_bytes(
+                      std::span{payload.data.data(), payload.data.size()}))
+                  .view()),
+      });
+    }
+    auto state = subscription.template field<"state">();
+    if (state.valid() && state.modified() &&
+        state.value() == hgk::KafkaSubscriptionState::BoundedComplete) {
+      node.graph().executor().request_stop();
+    }
+  }
+};
+
+struct ActualBrokerAuditGraph {
+  static constexpr auto name = "hgraph.fabric.kafka.test.actual_audit_graph";
+
+  static void compose(hg::Wiring &wiring) {
+    const auto path = hg::service::path("fabric-broker-audit-kafka");
+    hgk::register_service(wiring, path, actual_kafka_config.clone(),
+                          hgk::KafkaServiceMode::RealTime);
+    auto key = hg::wire<hg::stdlib::const_, hg::TS<hgk::KafkaSubscriptionKey>>(
+        wiring, actual_audit_key.clone());
+    static_cast<void>(hg::wire<CaptureActualBrokerRecords>(
+        wiring, hgk::subscribe(wiring, path, key)));
   }
 };
 
@@ -309,4 +516,252 @@ TEST_CASE("Kafka lifecycle establishes the durable image before "
   CHECK(fake_broker->wait_until_detached(2s));
   fake_broker.reset();
   kafka_config = {};
+}
+
+TEST_CASE("manual Kafka assignment recovers after every broker disconnects") {
+  hg::stdlib::register_standard_operators();
+  hgf::register_fabric_operators();
+  hgk::register_kafka_types();
+
+  hgk::testing::MockCluster cluster{1};
+  const hg::Str topic{"hgraph-fabric-manual-reconnect"};
+  cluster.create_topic(topic, 1, 1);
+  auto config = hgf::make_memory_fabric_config("tests/kafka-manual-reconnect");
+  const auto first = seed(config, 1, 1);
+  cluster.seed_record(topic, revision_bytes(first), hg::Bytes{"prices"});
+
+  actual_topic = topic;
+  actual_control_dir =
+      std::filesystem::temp_directory_path() /
+      ("hgraph-fabric-kafka-reconnect-" +
+       std::to_string(
+           std::chrono::steady_clock::now().time_since_epoch().count()));
+  std::filesystem::create_directories(actual_control_dir);
+  actual_kafka_config = hgk::service_config()
+                            .bootstrap_servers({cluster.bootstrap_servers()})
+                            .client_id("hgraph-fabric-manual-reconnect")
+                            .ingress_limits(8, 1024 * 1024)
+                            .outbound_limits(2, 1024 * 1024)
+                            .shutdown_drain_timeout(2s)
+                            .producer_option("message.timeout.ms", "750")
+                            .build();
+  actual_live_values.clear();
+  actual_diagnostics.clear();
+
+  auto graph = hg::build_graph<ActualBrokerGraph>();
+  hgf::set_fabric_config(graph.global_state(), config);
+  const hg::DateTime start = hg::testing::wall_now();
+  hg::GraphExecutorBuilder builder;
+  builder.graph_builder(std::move(graph))
+      .mode(hg::GraphExecutorMode::RealTime)
+      .start_time(start)
+      .end_time(start + hg::TimeDelta{20'000'000});
+  auto executor = builder.make_executor();
+  auto view = executor.view();
+  hg::testing::AsyncGraphExecutorRun runner{view};
+
+  if (!wait_until(
+          [] { return std::filesystem::exists(marker("initial-ready")); },
+          5s)) {
+    view.request_stop();
+    runner.join();
+    FAIL("mock broker subscription did not expose the initial image");
+  }
+  cluster.stop_brokers();
+  write_marker("broker-stopped");
+  const bool second_is_durable = wait_until(
+      [&config] {
+        const auto latest =
+            config.objects.get(hgf::latest_key(config.prefix, "prices"));
+        return latest.has_value() &&
+               hgf::decode_revision_reference(hgf::MetadataObjectKind::Latest,
+                                              latest->data) == 2;
+      },
+      5s);
+  if (!second_is_durable ||
+      !wait_until(
+          [] {
+            return std::filesystem::exists(marker("delivery-failed-retriable"));
+          },
+          5s)) {
+    cluster.start_brokers();
+    write_marker("broker-restarted");
+    view.request_stop();
+    runner.join();
+    FAIL("mock outage did not retain a retriable durable publication");
+  }
+  write_marker("publication-durable");
+  cluster.start_brokers();
+  write_marker("broker-restarted");
+  runner.join();
+
+  CHECK((actual_live_values == std::vector<std::int64_t>{1, 2}));
+  CHECK(std::filesystem::exists(marker("live-complete")));
+  std::error_code ignored;
+  std::filesystem::remove_all(actual_control_dir, ignored);
+  actual_kafka_config = {};
+}
+
+TEST_CASE("actual broker preserves Fabric recovery, retry, and ordering",
+          "[.kafka-broker]") {
+  const char *bootstrap =
+      std::getenv("HGRAPH_FABRIC_KAFKA_INTEGRATION_BOOTSTRAP");
+  const char *topic = std::getenv("HGRAPH_FABRIC_KAFKA_INTEGRATION_TOPIC");
+  const char *control =
+      std::getenv("HGRAPH_FABRIC_KAFKA_INTEGRATION_CONTROL_DIR");
+  if (bootstrap == nullptr && topic == nullptr && control == nullptr) {
+    SKIP("run through run_kafka_broker_conformance.py");
+  }
+  REQUIRE(bootstrap != nullptr);
+  REQUIRE(topic != nullptr);
+  REQUIRE(control != nullptr);
+
+  hg::stdlib::register_standard_operators();
+  hgf::register_fabric_operators();
+  hgk::register_kafka_types();
+
+  actual_topic = topic;
+  actual_control_dir = control;
+  std::filesystem::create_directories(actual_control_dir);
+  actual_kafka_config = hgk::service_config()
+                            .bootstrap_servers({bootstrap})
+                            .client_id("hgraph-fabric-broker-conformance")
+                            .ingress_limits(8, 1024 * 1024)
+                            .outbound_limits(2, 1024 * 1024)
+                            .shutdown_drain_timeout(2s)
+                            .common_option("reconnect.backoff.ms", "100")
+                            .common_option("reconnect.backoff.max.ms", "500")
+                            .producer_option("message.timeout.ms", "1500")
+                            .build();
+
+  auto config = hgf::make_memory_fabric_config("tests/actual-kafka-broker");
+  const auto first = seed(config, 1, 1);
+  actual_notice_record = hgk::make_produce_record(
+      revision_bytes(first), hg::Bytes{"prices"}, {}, std::nullopt,
+      std::nullopt, "fabric-broker-seed");
+  actual_delivery_report = {};
+
+  {
+    const hg::DateTime start = hg::testing::wall_now();
+    hg::GraphExecutorBuilder builder;
+    builder.graph_builder(hg::build_graph<ActualNoticeGraph>())
+        .mode(hg::GraphExecutorMode::RealTime)
+        .start_time(start)
+        .end_time(start + hg::TimeDelta{15'000'000});
+    builder.make_executor().view().run();
+  }
+  REQUIRE(actual_delivery_report.view().data() != nullptr);
+  CHECK(actual_delivery_report.view()
+            .as_bundle()
+            .at("status")
+            .checked_as<hgk::KafkaDeliveryStatus>() ==
+        hgk::KafkaDeliveryStatus::Delivered);
+
+  actual_live_values.clear();
+  actual_diagnostics.clear();
+  auto graph = hg::build_graph<ActualBrokerGraph>();
+  hgf::set_fabric_config(graph.global_state(), config);
+  const hg::DateTime start = hg::testing::wall_now();
+  hg::GraphExecutorBuilder builder;
+  builder.graph_builder(std::move(graph))
+      .mode(hg::GraphExecutorMode::RealTime)
+      .start_time(start)
+      .end_time(start + hg::TimeDelta{45'000'000});
+  auto executor = builder.make_executor();
+  auto view = executor.view();
+  hg::testing::AsyncGraphExecutorRun runner{view};
+
+  if (!wait_until(
+          [] { return std::filesystem::exists(marker("initial-ready")); },
+          20s)) {
+    view.request_stop();
+    runner.join();
+    FAIL("Fabric did not expose its durable image after broker subscription");
+  }
+  if (!wait_until(
+          [] { return std::filesystem::exists(marker("broker-stopped")); },
+          20s)) {
+    view.request_stop();
+    runner.join();
+    FAIL("broker controller did not stop the broker");
+  }
+  const bool second_is_durable = wait_until(
+      [&config] {
+        const auto latest =
+            config.objects.get(hgf::latest_key(config.prefix, "prices"));
+        return latest.has_value() &&
+               hgf::decode_revision_reference(hgf::MetadataObjectKind::Latest,
+                                              latest->data) == 2;
+      },
+      20s);
+  if (!second_is_durable) {
+    view.request_stop();
+    runner.join();
+    FAIL("Fabric did not durably accept the outage publication");
+  }
+  write_marker("publication-durable");
+  if (!wait_until(
+          [] {
+            return std::filesystem::exists(marker("delivery-failed-retriable"));
+          },
+          20s)) {
+    view.request_stop();
+    runner.join();
+    FAIL("Kafka did not report a retriable delivery failure during outage");
+  }
+  if (!wait_until(
+          [] { return std::filesystem::exists(marker("broker-restarted")); },
+          20s)) {
+    view.request_stop();
+    runner.join();
+    FAIL("broker controller did not restart the broker");
+  }
+  runner.join();
+
+  CHECK((actual_live_values == std::vector<std::int64_t>{1, 2}));
+  CHECK(std::filesystem::exists(marker("live-complete")));
+  CHECK(actual_diagnostics.at("publication.queue_limit_per_data_id") == "1024");
+  CHECK(actual_diagnostics.at("live.notice_limit_per_session") == "4096");
+  CHECK(actual_diagnostics.at("transport.notification.retried") != "0");
+
+  actual_audit_key =
+      hgk::subscription_key()
+          .topics({actual_topic})
+          .group_id("fabric-broker-audit")
+          .assignment_mode(hgk::KafkaAssignmentMode::Independent)
+          .start(
+              hgk::make_start_position(hgk::KafkaStartPositionKind::Earliest))
+          .stop(hgk::make_stop_position(hgk::KafkaStopPositionKind::Snapshot))
+          .sharing_identity("fabric-broker-audit")
+          .build();
+  actual_broker_records.clear();
+  {
+    const hg::DateTime audit_start = hg::testing::wall_now();
+    hg::GraphExecutorBuilder audit_builder;
+    audit_builder.graph_builder(hg::build_graph<ActualBrokerAuditGraph>())
+        .mode(hg::GraphExecutorMode::RealTime)
+        .start_time(audit_start)
+        .end_time(audit_start + hg::TimeDelta{20'000'000});
+    audit_builder.make_executor().view().run();
+  }
+
+  REQUIRE(actual_broker_records.size() >= 2);
+  CHECK(actual_broker_records.front().revision.revision == 1);
+  CHECK(actual_broker_records.back().revision.revision == 2);
+  for (std::size_t index = 0; index < actual_broker_records.size(); ++index) {
+    const auto &record = actual_broker_records[index];
+    CHECK(record.key.data == "prices");
+    CHECK(record.revision.data_id == "prices");
+    CHECK(record.partition == actual_broker_records.front().partition);
+    if (index > 0) {
+      CHECK(record.offset > actual_broker_records[index - 1].offset);
+      CHECK(record.revision.revision >=
+            actual_broker_records[index - 1].revision.revision);
+    }
+  }
+
+  actual_kafka_config = {};
+  actual_notice_record = {};
+  actual_delivery_report = {};
+  actual_audit_key = {};
 }

--- a/extensions/fabric/tools/run_kafka_broker_conformance.py
+++ b/extensions/fabric/tools/run_kafka_broker_conformance.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Run the hidden Fabric conformance case against a restartable real broker."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import secrets
+import subprocess
+import sys
+import tempfile
+import time
+
+
+DEFAULT_IMAGE = (
+    "docker.redpanda.com/redpandadata/redpanda@"
+    "sha256:9a47c1f8d6736f98fa2616f6f0b715c051cb0bdac1a1176e38321bf45a5b572d"
+)
+
+
+def run(*command: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, check=check, text=True, capture_output=True)
+
+
+def wait_until(predicate, process: subprocess.Popen[str] | None, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        if process is not None and process.poll() is not None:
+            raise RuntimeError(f"conformance executable exited with {process.returncode}")
+        time.sleep(0.1)
+    raise TimeoutError("timed out waiting for broker conformance phase")
+
+
+def broker_ready(container: str) -> bool:
+    result = run(
+        "docker",
+        "exec",
+        container,
+        "rpk",
+        "topic",
+        "list",
+        "--brokers",
+        "127.0.0.1:9092",
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--test-executable", type=Path, required=True)
+    parser.add_argument("--image", default=DEFAULT_IMAGE)
+    parser.add_argument("--port", type=int, default=19092)
+    args = parser.parse_args()
+
+    executable = args.test_executable.resolve()
+    if not executable.is_file():
+        parser.error(f"test executable does not exist: {executable}")
+
+    suffix = secrets.token_hex(4)
+    container = f"hgraph-fabric-redpanda-{suffix}"
+    topic = f"hgraph-fabric-conformance-{suffix}"
+    with tempfile.TemporaryDirectory(prefix="hgraph-fabric-kafka-") as directory:
+        control = Path(directory)
+        output_path = control / "test-output.log"
+        test_process: subprocess.Popen[str] | None = None
+        try:
+            run(
+                "docker",
+                "run",
+                "--detach",
+                "--name",
+                container,
+                "--hostname",
+                container,
+                "--publish",
+                f"{args.port}:{args.port}",
+                args.image,
+                "redpanda",
+                "start",
+                "--mode",
+                "dev-container",
+                "--smp",
+                "1",
+                "--memory",
+                "512M",
+                "--reserve-memory",
+                "0M",
+                "--check=false",
+                "--kafka-addr",
+                f"internal://0.0.0.0:9092,external://0.0.0.0:{args.port}",
+                "--advertise-kafka-addr",
+                f"internal://{container}:9092,external://127.0.0.1:{args.port}",
+            )
+            wait_until(lambda: broker_ready(container), None, 45.0)
+            run(
+                "docker",
+                "exec",
+                container,
+                "rpk",
+                "topic",
+                "create",
+                topic,
+                "--partitions",
+                "3",
+                "--brokers",
+                "127.0.0.1:9092",
+            )
+
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "HGRAPH_FABRIC_KAFKA_INTEGRATION_BOOTSTRAP": f"127.0.0.1:{args.port}",
+                    "HGRAPH_FABRIC_KAFKA_INTEGRATION_TOPIC": topic,
+                    "HGRAPH_FABRIC_KAFKA_INTEGRATION_CONTROL_DIR": str(control),
+                }
+            )
+            with output_path.open("w", encoding="utf-8") as output:
+                test_process = subprocess.Popen(
+                    [str(executable), "[kafka-broker]"],
+                    env=environment,
+                    stdout=output,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                )
+
+                wait_until(lambda: (control / "initial-ready").exists(), test_process, 30.0)
+                run("docker", "stop", "--time", "2", container)
+                (control / "broker-stopped").write_text("stopped\n", encoding="utf-8")
+
+                wait_until(
+                    lambda: (control / "publication-durable").exists(),
+                    test_process,
+                    30.0,
+                )
+                wait_until(
+                    lambda: (control / "delivery-failed-retriable").exists(),
+                    test_process,
+                    30.0,
+                )
+
+                run("docker", "start", container)
+                wait_until(lambda: broker_ready(container), test_process, 45.0)
+                (control / "broker-restarted").write_text("restarted\n", encoding="utf-8")
+                try:
+                    return_code = test_process.wait(timeout=45.0)
+                except subprocess.TimeoutExpired:
+                    test_process.terminate()
+                    test_process.wait(timeout=10.0)
+                    raise TimeoutError("Fabric conformance executable did not finish")
+
+            if return_code != 0:
+                raise RuntimeError(f"conformance executable exited with {return_code}")
+            print(output_path.read_text(encoding="utf-8"), end="")
+            return 0
+        except Exception as error:
+            print(f"Fabric Kafka broker conformance failed: {error}", file=sys.stderr)
+            if output_path.exists():
+                print(output_path.read_text(encoding="utf-8"), file=sys.stderr)
+            logs = run("docker", "logs", "--tail", "200", container, check=False)
+            if logs.stdout:
+                print(logs.stdout, file=sys.stderr)
+            if logs.stderr:
+                print(logs.stderr, file=sys.stderr)
+            return 1
+        finally:
+            if test_process is not None and test_process.poll() is None:
+                test_process.terminate()
+                try:
+                    test_process.wait(timeout=10.0)
+                except subprocess.TimeoutExpired:
+                    test_process.kill()
+                    test_process.wait()
+            run("docker", "rm", "--force", container, check=False)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/extensions/kafka/CHANGELOG.md
+++ b/extensions/kafka/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Rebuild manual/independent assignments as a new recovery generation after a
+  broker disconnect, allowing live consumers to resume from committed offsets
+  and exposing `Retrying` -> `Recovering` -> `Live` lifecycle transitions.
 - Preserve bounded deterministic Kafka recovery in simulation through an
   ordinary scheduled service graph, while keeping live queue ingress on
   real-time-only root push sources.

--- a/extensions/kafka/include/hgraph/kafka/testing/mock_cluster.h
+++ b/extensions/kafka/include/hgraph/kafka/testing/mock_cluster.h
@@ -41,6 +41,10 @@ public:
                    std::optional<DateTime> timestamp = std::nullopt);
   void fail_next_produce(MockProduceError error, std::size_t count = 1);
   void fail_next_fetch(MockConsumeError error, std::size_t count = 1);
+  /** Disconnect every broker without discarding broker state. */
+  void stop_brokers();
+  /** Accept connections again after stop_brokers(). */
+  void start_brokers();
 
 private:
   struct Impl;

--- a/extensions/kafka/python/tests/test_packaging.py
+++ b/extensions/kafka/python/tests/test_packaging.py
@@ -130,6 +130,8 @@ def test_ci_builds_and_tests_separate_kafka_artifacts():
     assert "python -m pytest extensions/kafka/python/tests -q" in wheel_workflows
     assert "-DHGRAPH_BUILD_KAFKA_EXTENSION=ON" in native_workflow
     assert "Build and test installed Kafka consumer" in native_workflow
+    assert "run_kafka_broker_conformance.py" in native_workflow
+    assert "hgraph_fabric_kafka_tests" in native_workflow
     assert '      - "*.*.*"' in release_workflow
     assert "hgraph-kafka-v_" not in release_workflow
     assert "pattern: kafka-distribution-*" in wheel_workflows

--- a/extensions/kafka/src/librdkafka_service.cpp
+++ b/extensions/kafka/src/librdkafka_service.cpp
@@ -672,6 +672,8 @@ private:
                              void *opaque) noexcept;
 
   void run() noexcept;
+  [[nodiscard]] bool uses_manual_assignment() const noexcept;
+  void poll_manual_reconnect(rd_kafka_t *consumer);
   void configure_assignment(rd_kafka_t *consumer, rd_kafka_resp_err_t error,
                             rd_kafka_topic_partition_list_t *partitions);
   void handle_poll_error(rd_kafka_resp_err_t error, const char *message);
@@ -705,12 +707,15 @@ private:
   Value key_{};
   SubscriptionSpec spec_{};
   std::atomic<bool> stopping_{};
+  std::atomic<bool> reconnect_requested_{};
   std::thread thread_{};
   std::mutex commands_mutex_{};
   std::deque<Value> commits_{};
   Int assignment_generation_{};
   bool recovering_{};
   bool live_{};
+  bool reconnecting_{};
+  std::chrono::steady_clock::time_point reconnect_probe_after_{};
   std::vector<PositionBoundary> recovery_ends_{};
   std::vector<PositionBoundary> stop_ends_{};
   std::vector<PositionBoundary> assignment_starts_{};
@@ -1591,17 +1596,20 @@ void ConsumerSession::error_callback(rd_kafka_t *, int error, const char *,
   if (!session) {
     return;
   }
+  const auto kafka_error = static_cast<rd_kafka_resp_err_t>(error);
+  const bool retriable = retriable_error(kafka_error);
   session->owner_.emit_event(
       error == RD_KAFKA_RESP_ERR__FATAL ? KafkaSeverity::Fatal
                                         : KafkaSeverity::Error,
-      Str{"consumer"}, Str{"client_error"}, error,
-      retriable_error(static_cast<rd_kafka_resp_err_t>(error)),
-      error == RD_KAFKA_RESP_ERR__FATAL,
-      Str{rd_kafka_err2str(static_cast<rd_kafka_resp_err_t>(error))},
+      Str{"consumer"}, Str{"client_error"}, error, retriable,
+      error == RD_KAFKA_RESP_ERR__FATAL, Str{rd_kafka_err2str(kafka_error)},
       session->spec_.identity, {},
       error == RD_KAFKA_RESP_ERR__FATAL &&
           session->owner_.config().consumer_failure_policy ==
               KafkaFailurePolicy::StopGraph);
+  if (retriable && session->uses_manual_assignment()) {
+    session->reconnect_requested_.store(true, std::memory_order_release);
+  }
   if (error == RD_KAFKA_RESP_ERR__FATAL) {
     session->failed_ = true;
     session->stopping_ = true;
@@ -1729,6 +1737,7 @@ void ConsumerSession::run() noexcept {
     }
 
     while (!stopping_) {
+      poll_manual_reconnect(consumer);
       process_commits(consumer);
       update_flow_control(consumer);
       check_positions(consumer);
@@ -1803,7 +1812,66 @@ void ConsumerSession::handle_poll_error(rd_kafka_resp_err_t error,
     failed_ = true;
     stopping_ = true;
     complete_preload(message);
+  } else if (uses_manual_assignment()) {
+    reconnect_requested_.store(true, std::memory_order_release);
   }
+}
+
+bool ConsumerSession::uses_manual_assignment() const noexcept {
+  return spec_.selector == KafkaSelectorKind::Partitions ||
+         spec_.assignment_mode == KafkaAssignmentMode::Independent;
+}
+
+void ConsumerSession::poll_manual_reconnect(rd_kafka_t *consumer) {
+  // Normal polling pays one atomic load. Metadata probing and assignment
+  // reconstruction occur only after a manual assignment loses connectivity.
+  if (!reconnecting_ && !reconnect_requested_.load(std::memory_order_acquire)) {
+    return;
+  }
+  if (reconnect_requested_.exchange(false, std::memory_order_acq_rel) &&
+      !reconnecting_) {
+    reconnecting_ = true;
+    recovering_ = false;
+    live_ = false;
+    emit_state(KafkaSubscriptionState::Retrying);
+    reconnect_probe_after_ = std::chrono::steady_clock::time_point{};
+  }
+  if (!reconnecting_ ||
+      std::chrono::steady_clock::now() < reconnect_probe_after_) {
+    return;
+  }
+  reconnect_probe_after_ =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds{250};
+
+  const rd_kafka_metadata_t *metadata{};
+  const auto metadata_error =
+      rd_kafka_metadata(consumer, 0, nullptr, &metadata, 100);
+  if (metadata_error != RD_KAFKA_RESP_ERR_NO_ERROR || metadata == nullptr) {
+    if (metadata) {
+      rd_kafka_metadata_destroy(metadata);
+    }
+    return;
+  }
+  rd_kafka_metadata_destroy(metadata);
+
+  rd_kafka_topic_partition_list_t *partitions{};
+  if (rd_kafka_assignment(consumer, &partitions) !=
+          RD_KAFKA_RESP_ERR_NO_ERROR ||
+      partitions == nullptr || partitions->cnt == 0) {
+    if (partitions) {
+      rd_kafka_topic_partition_list_destroy(partitions);
+    }
+    return;
+  }
+  try {
+    configure_assignment(consumer, RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS,
+                         partitions);
+    reconnecting_ = false;
+  } catch (const std::exception &exception) {
+    owner_.emit_event(KafkaSeverity::Error, Str{"consumer"}, Str{"reconnect"},
+                      0, true, false, exception.what(), spec_.identity);
+  }
+  rd_kafka_topic_partition_list_destroy(partitions);
 }
 
 void ConsumerSession::configure_assignment(

--- a/extensions/kafka/src/testing/mock_cluster.cpp
+++ b/extensions/kafka/src/testing/mock_cluster.cpp
@@ -211,4 +211,20 @@ void MockCluster::fail_next_fetch(MockConsumeError error, std::size_t count) {
   rd_kafka_mock_push_request_errors_array(impl_->cluster, 1, responses.size(),
                                           responses.data());
 }
+
+void MockCluster::stop_brokers() {
+  const auto error = rd_kafka_mock_broker_set_down(impl_->cluster, -1);
+  if (error != RD_KAFKA_RESP_ERR_NO_ERROR) {
+    throw std::runtime_error(Str{"Unable to stop mock Kafka brokers: "} +
+                             rd_kafka_err2str(error));
+  }
+}
+
+void MockCluster::start_brokers() {
+  const auto error = rd_kafka_mock_broker_set_up(impl_->cluster, -1);
+  if (error != RD_KAFKA_RESP_ERR_NO_ERROR) {
+    throw std::runtime_error(Str{"Unable to start mock Kafka brokers: "} +
+                             rd_kafka_err2str(error));
+  }
+}
 } // namespace hgraph::kafka::testing


### PR DESCRIPTION
## Summary

- add deterministic mock-cluster and pinned Redpanda outage/restart conformance for the graph-native Fabric Kafka path
- recover consumers after retriable broker failures while preserving explicit and independent partition assignments
- verify durable-before-notify ordering, correlated delivery retry, bounded queue diagnostics, and keyed partition ordering
- run the real-broker conformance harness in Linux native validation

Stacked on #538 and contributes the broker-conformance checkpoint for #512.

## Validation

- macOS fresh native suite: 1605/1605 passed
- macOS Python 3.14 non-WIP suite from a Python 3.12 abi3 wheel: 2122 passed, 10 skipped
- Ubuntu GCC 14 fresh native suite: 1605/1605 passed
- Ubuntu Python 3.14 non-WIP suite with Polars rtcompat: 2122 passed, 10 skipped
- Ubuntu GCC 14 ASan focused Kafka/Fabric suites passed
- pinned Redpanda outage/restart conformance: 21 assertions passed
- post-rebase focused Fabric Kafka C++ and Kafka packaging tests passed