### PR TITLE
Bound Fabric queues and type diagnostics

### DIFF
--- a/extensions/fabric/CHANGELOG.md
+++ b/extensions/fabric/CHANGELOG.md
@@ -22,3 +22,6 @@
 - Add restartable real-broker conformance for startup handoff, retriable
   delivery failure, reconnect recovery, bounded queue profiles, and keyed
   partition ordering.
+- Add typed, path-addressed transport/store event diagnostics and executable
+  hard-bound coverage for stalled publication, live-notice, delivery, and
+  diagnostic queues.

--- a/extensions/fabric/README.md
+++ b/extensions/fabric/README.md
@@ -112,8 +112,9 @@ profiles, and conflicting service registration never fall back to memory.
 
 ## Operations
 
-The `diagnostics()` service publishes string values under stable metric names.
-Important groups are:
+The `diagnostics()` service publishes a bundle with `metrics` and `events`.
+Metrics remain string values under stable names so lifecycle values and
+counters share one map. Important groups are:
 
 * `resolution.*`: calls, forest outcomes, cache hits/misses, examined revisions
   and edges, candidate selections, backtracking depth, and notice-to-ready
@@ -121,9 +122,14 @@ Important groups are:
 * `publication.*`: current queue occupancy and its per-data-id bound;
 * `live.*`: conflated notice occupancy and its per-session bound;
 * `transport.notification.*`: pending, delivered, retried, failed, and stale
-  correlated delivery reports; and
-* `transport.<component>.<category>`: the latest typed Kafka lifecycle or
-  delivery event, including whether it is retriable or fatal.
+  correlated delivery reports.
+
+Events are keyed by `<component>.<category>` and retain typed `component`,
+`category`, `message`, `retriable`, `fatal`, and `occurrences` fields. Repeated
+events conflate at that path without losing their count. Kafka lifecycle and
+delivery events use their native component/category and severity; synchronous
+store reads and publication boundaries report `store.*` failures before the
+original graph error is rethrown.
 
 The root service logs one `info` record at successful start and one at stop,
 including the canonical service path so multiple Fabric services can be
@@ -138,7 +144,9 @@ durable-head reconciliation.
 All queues are bounded. Publication accepts at most 1,024 waiting requests per
 data id, each live session retains at most 4,096 conflated data ids, and the
 graph transport retains at most 1,024 correlated deliveries with at most eight
-retries. Hitting a bound is an explicit failure, never silent data loss.
+retries. Diagnostic events retain at most 256 distinct paths; additional
+paths conflate into `diagnostics.capacity` with an occurrence count. Hitting a
+work queue bound is an explicit failure, never silent data loss.
 
 V1 retention is intentionally unbounded: one complete Frame per output tick,
 plus one small revision and as-of entry for each accepted input/output tuple.

--- a/extensions/fabric/include/hgraph/fabric/service.h
+++ b/extensions/fabric/include/hgraph/fabric/service.h
@@ -8,11 +8,17 @@
 #include <hgraph/types/graph_wiring.h>
 #include <hgraph/types/service_wiring.h>
 
+#include <cstddef>
 #include <string_view>
 
 namespace hgraph::fabric
 {
 inline constexpr std::string_view DEFAULT_SERVICE_PATH{"fabric"};
+inline constexpr std::size_t FABRIC_PUBLICATION_QUEUE_LIMIT_PER_DATA_ID{1024U};
+inline constexpr std::size_t FABRIC_LIVE_NOTICE_LIMIT_PER_SESSION{4096U};
+inline constexpr std::size_t FABRIC_NOTIFICATION_REQUEST_LIMIT{1024U};
+inline constexpr std::size_t FABRIC_NOTIFICATION_RETRY_LIMIT{8U};
+inline constexpr std::size_t FABRIC_DIAGNOSTIC_EVENT_LIMIT{256U};
 
 /** Select where accepted revision notifications are delivered. Configured
     uses the Notifier stored in FabricConfig. GraphTransport exposes requests
@@ -53,6 +59,13 @@ using FabricTransportControl =
 using FabricTransportEvent =
     TSB<"hgraph.fabric::TransportEvent", Field<"component", TS<Str>>, Field<"category", TS<Str>>,
         Field<"message", TS<Str>>, Field<"retriable", TS<Bool>>, Field<"fatal", TS<Bool>>>;
+
+/** Stable metrics plus typed, path-addressed events. Metrics remain strings
+    so counters and lifecycle values can share one map; events preserve
+    component, category, severity and repeat count as native scalar fields. */
+using FabricDiagnostics =
+    TSB<"hgraph.fabric::Diagnostics", Field<"metrics", TSD<Str, TS<Str>>>,
+        Field<"events", TSD<Str, TS<FabricDiagnosticEvent>>>>;
 
 struct FabricLiveSubscriptionService
 {
@@ -129,7 +142,7 @@ struct FabricLoadService
 struct FabricDiagnosticsService
 {
     static constexpr std::string_view name{"fabric_diagnostics"};
-    using output_schema = TSD<Str, TS<Str>>;
+    using output_schema = FabricDiagnostics;
 };
 
 /** Register one lazy root-graph FabricServiceImpl singleton. Configuration
@@ -161,8 +174,9 @@ HGRAPH_FABRIC_EXPORT void submit_transport_event(Wiring &wiring, Port<FabricTran
 [[nodiscard]] HGRAPH_FABRIC_EXPORT Port<FabricLoadResponse> request_load(Wiring &wiring, Str data_id,
                                                                          DataVersion version);
 
-[[nodiscard]] HGRAPH_FABRIC_EXPORT Port<TSD<Str, TS<Str>>> diagnostics(Wiring &wiring, service::ServicePath path);
-[[nodiscard]] HGRAPH_FABRIC_EXPORT Port<TSD<Str, TS<Str>>> diagnostics(Wiring &wiring);
+[[nodiscard]] HGRAPH_FABRIC_EXPORT Port<FabricDiagnostics> diagnostics(Wiring &wiring,
+                                                                        service::ServicePath path);
+[[nodiscard]] HGRAPH_FABRIC_EXPORT Port<FabricDiagnostics> diagnostics(Wiring &wiring);
 } // namespace hgraph::fabric
 
 namespace hgraph::static_schema_detail

--- a/extensions/fabric/include/hgraph/fabric/types.h
+++ b/extensions/fabric/include/hgraph/fabric/types.h
@@ -61,6 +61,15 @@ namespace hgraph::fabric
                Field<"dependencies", HomogeneousTuple<DataDependency>>,
                Field<"self_predecessor", Int>, Field<"as_of", DateTime>>;
 
+    /** One path-addressed operational event retained by the root Fabric
+        service. Boolean severity fields remain machine-readable across
+        transport implementations; ``occurrences`` counts conflated repeats. */
+    using FabricDiagnosticEvent =
+        Bundle<"hgraph.fabric::DiagnosticEvent", Field<"component", Str>,
+               Field<"category", Str>, Field<"message", Str>,
+               Field<"retriable", Bool>, Field<"fatal", Bool>,
+               Field<"occurrences", Int>>;
+
     struct DataDependencyInput
     {
         Str         data_id{};
@@ -82,6 +91,19 @@ namespace hgraph::fabric
 
         friend bool operator==(const DataRevisionInput &,
                                const DataRevisionInput &) = default;
+    };
+
+    struct FabricDiagnosticEventInput
+    {
+        Str  component{};
+        Str  category{};
+        Str  message{};
+        Bool retriable{};
+        Bool fatal{};
+        Int  occurrences{};
+
+        friend bool operator==(const FabricDiagnosticEventInput &,
+                               const FabricDiagnosticEventInput &) = default;
     };
 
     /** Validate one logical data id. Data ids are non-empty UTF-8 strings,

--- a/extensions/fabric/src/impl/service_runtime.h
+++ b/extensions/fabric/src/impl/service_runtime.h
@@ -158,6 +158,7 @@ class FabricServiceRuntime final
     [[nodiscard]] std::optional<std::tuple<Str, DataVersion, Frame>> load(std::string_view data_id,
                                                                           DataVersion version) const;
     [[nodiscard]] std::vector<std::pair<Str, Str>> diagnostics() const;
+    [[nodiscard]] std::vector<std::pair<Str, FabricDiagnosticEventInput>> events() const;
     void observe_transport_event(TransportEventInput event);
 
   private:

--- a/extensions/fabric/src/impl/service_runtime.h
+++ b/extensions/fabric/src/impl/service_runtime.h
@@ -157,6 +157,11 @@ class FabricServiceRuntime final
 
     [[nodiscard]] std::optional<std::tuple<Str, DataVersion, Frame>> load(std::string_view data_id,
                                                                           DataVersion version) const;
+    /** Monotonic graph-thread sequence advanced whenever an internal
+        diagnostic event is recorded. Service nodes project changes onto an
+        ordinary time-series edge so diagnostics consumers are scheduled
+        without allowing the runtime to address the graph directly. */
+    [[nodiscard]] Int diagnostic_revision() const noexcept;
     [[nodiscard]] std::vector<std::pair<Str, Str>> diagnostics() const;
     [[nodiscard]] std::vector<std::pair<Str, FabricDiagnosticEventInput>> events() const;
     void observe_transport_event(TransportEventInput event);

--- a/extensions/fabric/src/service.cpp
+++ b/extensions/fabric/src/service.cpp
@@ -5,12 +5,14 @@
 #include <hgraph/fabric/value_builders.h>
 
 #include <hgraph/lib/std/operators/collection.h>
+#include <hgraph/lib/std/operators/container.h>
 #include <hgraph/lib/std/operators/conversion.h>
 #include <hgraph/runtime/executor.h>
 #include <hgraph/runtime/logger.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/static_node.h>
 #include <hgraph/types/value/value_builder.h>
+#include <hgraph/util/scope.h>
 
 #include <algorithm>
 #include <memory>
@@ -31,6 +33,34 @@ using detail::PublicationRequestInput;
 using detail::SubscriptionSpec;
 using detail::TransportControlInput;
 using detail::TransportEventInput;
+
+template <typename ValueSchema>
+using FabricServiceNodeResult =
+    UnNamedTSB<Field<"value", ValueSchema>, Field<"diagnostics_changed", TS<Int>>>;
+
+void emit_diagnostic_change(Int before, const FabricServiceRuntimeHandle &runtime,
+                            const Out<TS<Int>> &diagnostics_changed)
+{
+    const Int after = runtime.value->diagnostic_revision();
+    if (after != before)
+    {
+        diagnostics_changed.set(after);
+    }
+}
+
+template <typename ValueSchema>
+[[nodiscard]] Port<ValueSchema> service_result_value(Wiring &wiring,
+                                                     Port<FabricServiceNodeResult<ValueSchema>> result)
+{
+    return wire<stdlib::getattr_>(wiring, result, Str{"value"}).template as<ValueSchema>();
+}
+
+template <typename ValueSchema>
+[[nodiscard]] Port<TS<Int>> service_result_diagnostics(Wiring &wiring,
+                                                       Port<FabricServiceNodeResult<ValueSchema>> result)
+{
+    return wire<stdlib::getattr_>(wiring, result, Str{"diagnostics_changed"}).template as<TS<Int>>();
+}
 
 [[nodiscard]] Value ingress_value(const detail::DeliveredRoot &root)
 {
@@ -179,14 +209,21 @@ struct FabricSnapshotNode
 
     static void eval(In<"keys", TSS<Str>, InputValidity::Unchecked> keys,
                      In<"ready", TS<Bool>, InputValidity::Unchecked>,
-                     Scalar<"runtime", FabricServiceRuntimeHandle> runtime, Out<TSD<Str, FabricIngressSignal>> out)
+                     Scalar<"runtime", FabricServiceRuntimeHandle> runtime,
+                     Out<FabricServiceNodeResult<TSD<Str, FabricIngressSignal>>> result)
     {
+        auto out = result.template field<"value">();
+        auto diagnostics_changed = result.template field<"diagnostics_changed">();
+        const Int before = runtime.value().value->diagnostic_revision();
+        UnwindCleanupGuard diagnostic_change{
+            [&] { emit_diagnostic_change(before, runtime.value(), diagnostics_changed); }};
         const auto &erased = static_cast<const TSSInputView &>(keys);
         if (auto delivery = runtime.value().value->snapshot(subscriptions(erased, SubscriptionMode::Snapshot));
             delivery.has_value())
         {
             apply_delivery(std::move(*delivery), out);
         }
+        diagnostic_change.complete();
     }
 };
 
@@ -198,12 +235,19 @@ struct FabricPlannedSnapshotNode
     static constexpr auto name = "hgraph.fabric.service.snapshot.planned";
 
     static void eval(In<"ready", TS<Bool>, InputValidity::Unchecked>,
-                     Scalar<"runtime", FabricServiceRuntimeHandle> runtime, Out<TSD<Str, FabricIngressSignal>> out)
+                     Scalar<"runtime", FabricServiceRuntimeHandle> runtime,
+                     Out<FabricServiceNodeResult<TSD<Str, FabricIngressSignal>>> result)
     {
+        auto out = result.template field<"value">();
+        auto diagnostics_changed = result.template field<"diagnostics_changed">();
+        const Int before = runtime.value().value->diagnostic_revision();
+        UnwindCleanupGuard diagnostic_change{
+            [&] { emit_diagnostic_change(before, runtime.value(), diagnostics_changed); }};
         if (auto delivery = runtime.value().value->planned_snapshot(); delivery.has_value())
         {
             apply_delivery(std::move(*delivery), out);
         }
+        diagnostic_change.complete();
     }
 };
 
@@ -218,8 +262,14 @@ struct FabricReplayNode
 
     static void eval(In<"keys", TSS<Str>, InputValidity::Unchecked> keys,
                      In<"ready", TS<Bool>, InputValidity::Unchecked>, DateTime now, NodeScheduler scheduler,
-                     Scalar<"runtime", FabricServiceRuntimeHandle> runtime, Out<TSD<Str, FabricIngressSignal>> out)
+                     Scalar<"runtime", FabricServiceRuntimeHandle> runtime,
+                     Out<FabricServiceNodeResult<TSD<Str, FabricIngressSignal>>> result)
     {
+        auto out = result.template field<"value">();
+        auto diagnostics_changed = result.template field<"diagnostics_changed">();
+        const Int before = runtime.value().value->diagnostic_revision();
+        UnwindCleanupGuard diagnostic_change{
+            [&] { emit_diagnostic_change(before, runtime.value(), diagnostics_changed); }};
         const auto &erased = static_cast<const TSSInputView &>(keys);
         if (auto delivery =
                 runtime.value().value->replay(subscriptions(erased, SubscriptionMode::Replay), now, scheduler);
@@ -227,6 +277,7 @@ struct FabricReplayNode
         {
             apply_delivery(std::move(*delivery), out);
         }
+        diagnostic_change.complete();
     }
 };
 
@@ -243,12 +294,19 @@ struct FabricPlannedReplayNode
     }
 
     static void eval(In<"ready", TS<Bool>, InputValidity::Unchecked>, DateTime now, NodeScheduler scheduler,
-                     Scalar<"runtime", FabricServiceRuntimeHandle> runtime, Out<TSD<Str, FabricIngressSignal>> out)
+                     Scalar<"runtime", FabricServiceRuntimeHandle> runtime,
+                     Out<FabricServiceNodeResult<TSD<Str, FabricIngressSignal>>> result)
     {
+        auto out = result.template field<"value">();
+        auto diagnostics_changed = result.template field<"diagnostics_changed">();
+        const Int before = runtime.value().value->diagnostic_revision();
+        UnwindCleanupGuard diagnostic_change{
+            [&] { emit_diagnostic_change(before, runtime.value(), diagnostics_changed); }};
         if (auto delivery = runtime.value().value->planned_replay(now, scheduler); delivery.has_value())
         {
             apply_delivery(std::move(*delivery), out);
         }
+        diagnostic_change.complete();
     }
 };
 
@@ -261,8 +319,14 @@ struct FabricLiveNode
                      In<"controls", TSD<Int, FabricTransportControl>, InputValidity::Unchecked> controls,
                      In<"ready", TS<Bool>, InputValidity::Unchecked>, DateTime now,
                      Scalar<"notification_mode", FabricNotificationMode> notification_mode,
-                     Scalar<"runtime", FabricServiceRuntimeHandle> runtime, Out<TSD<Str, FabricIngressSignal>> out)
+                     Scalar<"runtime", FabricServiceRuntimeHandle> runtime,
+                     Out<FabricServiceNodeResult<TSD<Str, FabricIngressSignal>>> result)
     {
+        auto out = result.template field<"value">();
+        auto diagnostics_changed = result.template field<"diagnostics_changed">();
+        const Int before = runtime.value().value->diagnostic_revision();
+        UnwindCleanupGuard diagnostic_change{
+            [&] { emit_diagnostic_change(before, runtime.value(), diagnostics_changed); }};
         const auto control = transport_control(controls);
         if (notification_mode.value() == FabricNotificationMode::GraphTransport)
         {
@@ -272,6 +336,7 @@ struct FabricLiveNode
             }
             if (!control.has_value() || !control->ready)
             {
+                diagnostic_change.complete();
                 return;
             }
         }
@@ -285,6 +350,7 @@ struct FabricLiveNode
         {
             apply_delivery(std::move(*delivery), out);
         }
+        diagnostic_change.complete();
     }
 };
 
@@ -299,8 +365,14 @@ struct FabricPlannedLiveNode
                      In<"controls", TSD<Int, FabricTransportControl>, InputValidity::Unchecked> controls,
                      In<"ready", TS<Bool>, InputValidity::Unchecked>, DateTime now,
                      Scalar<"notification_mode", FabricNotificationMode> notification_mode,
-                     Scalar<"runtime", FabricServiceRuntimeHandle> runtime, Out<TSD<Str, FabricIngressSignal>> out)
+                     Scalar<"runtime", FabricServiceRuntimeHandle> runtime,
+                     Out<FabricServiceNodeResult<TSD<Str, FabricIngressSignal>>> result)
     {
+        auto out = result.template field<"value">();
+        auto diagnostics_changed = result.template field<"diagnostics_changed">();
+        const Int before = runtime.value().value->diagnostic_revision();
+        UnwindCleanupGuard diagnostic_change{
+            [&] { emit_diagnostic_change(before, runtime.value(), diagnostics_changed); }};
         const auto control = transport_control(controls);
         if (notification_mode.value() == FabricNotificationMode::GraphTransport)
         {
@@ -310,6 +382,7 @@ struct FabricPlannedLiveNode
             }
             if (!control.has_value() || !control->ready)
             {
+                diagnostic_change.complete();
                 return;
             }
         }
@@ -321,6 +394,7 @@ struct FabricPlannedLiveNode
         {
             apply_delivery(std::move(*delivery), out);
         }
+        diagnostic_change.complete();
     }
 };
 
@@ -371,8 +445,14 @@ struct FabricPublicationNode
                      In<"deliveries", TSD<Int, FabricNotificationDelivery>, InputValidity::Unchecked> deliveries,
                      In<"ready", TS<Bool>, InputValidity::Unchecked>, NodeScheduler scheduler,
                      Scalar<"runtime", FabricServiceRuntimeHandle> runtime,
-                     Scalar<"bridge", GraphNotificationBridgeHandle> bridge, Out<TS<DataRevision>> notifications)
+                     Scalar<"bridge", GraphNotificationBridgeHandle> bridge,
+                     Out<FabricServiceNodeResult<TS<DataRevision>>> result)
     {
+        auto notifications = result.template field<"value">();
+        auto diagnostics_changed = result.template field<"diagnostics_changed">();
+        const Int before = runtime.value().value->diagnostic_revision();
+        UnwindCleanupGuard diagnostic_change{
+            [&] { emit_diagnostic_change(before, runtime.value(), diagnostics_changed); }};
         apply_delivery_reports(deliveries, bridge.value());
         if (requests.modified())
         {
@@ -401,6 +481,7 @@ struct FabricPublicationNode
         {
             scheduler.schedule(MIN_TD);
         }
+        diagnostic_change.complete();
     }
 };
 
@@ -420,10 +501,17 @@ struct FabricLoadNode
 
     static void eval(In<"requests", TSD<Int, FabricLoadRequest>, InputValidity::Unchecked> requests,
                      In<"ready", TS<Bool>, InputValidity::Unchecked>,
-                     Scalar<"runtime", FabricServiceRuntimeHandle> runtime, Out<TSD<Int, FabricLoadResponse>> responses)
+                     Scalar<"runtime", FabricServiceRuntimeHandle> runtime,
+                     Out<FabricServiceNodeResult<TSD<Int, FabricLoadResponse>>> result)
     {
+        auto responses = result.template field<"value">();
+        auto diagnostics_changed = result.template field<"diagnostics_changed">();
+        const Int before = runtime.value().value->diagnostic_revision();
+        UnwindCleanupGuard diagnostic_change{
+            [&] { emit_diagnostic_change(before, runtime.value(), diagnostics_changed); }};
         if (!requests.modified())
         {
+            diagnostic_change.complete();
             return;
         }
         auto mutation = responses.begin_mutation(responses.evaluation_time());
@@ -448,6 +536,7 @@ struct FabricLoadNode
             Value response = load_response_value(std::move(data_id), version, std::move(frame));
             mutation.set(request_id, response.view());
         }
+        diagnostic_change.complete();
     }
 };
 
@@ -455,11 +544,20 @@ struct FabricDiagnosticsNode
 {
     static constexpr auto name = "hgraph.fabric.service.diagnostics";
 
-    /** Runs only when service lifecycle or transport-event inputs tick. Work is
-        O(stable metric count + retained distinct event paths), with event paths
-        bounded by ``FABRIC_DIAGNOSTIC_EVENT_LIMIT``. */
+    /** Runs only when service lifecycle, transport events, or explicit
+        internal-diagnostic edges tick. Work is O(stable metric count +
+        retained distinct event paths), with event paths bounded by
+        ``FABRIC_DIAGNOSTIC_EVENT_LIMIT``. */
     static void eval(In<"events", TSD<Int, FabricTransportEvent>, InputValidity::Unchecked> events,
-                     In<"ready", TS<Bool>>, Scalar<"runtime", FabricServiceRuntimeHandle> runtime,
+                     In<"ready", TS<Bool>>, In<"publication_change", TS<Int>, InputValidity::Unchecked>,
+                     In<"snapshot_change", TS<Int>, InputValidity::Unchecked>,
+                     In<"planned_snapshot_change", TS<Int>, InputValidity::Unchecked>,
+                     In<"replay_change", TS<Int>, InputValidity::Unchecked>,
+                     In<"planned_replay_change", TS<Int>, InputValidity::Unchecked>,
+                     In<"live_change", TS<Int>, InputValidity::Unchecked>,
+                     In<"planned_live_change", TS<Int>, InputValidity::Unchecked>,
+                     In<"load_change", TS<Int>, InputValidity::Unchecked>,
+                     Scalar<"runtime", FabricServiceRuntimeHandle> runtime,
                      Scalar<"bridge", GraphNotificationBridgeHandle> bridge,
                      Out<FabricDiagnostics> diagnostics)
     {
@@ -556,15 +654,34 @@ struct FabricServiceImpl
         FabricServiceRuntimeHandle runtime{
             std::make_shared<detail::FabricServiceRuntime>(plan.value(), std::move(notification_override))};
         auto ready = wire<FabricLifecycleNode>(wiring, runtime, path.value());
-        auto notification_requests = wire<FabricPublicationNode>(wiring, publications, deliveries, ready, runtime, bridge);
-        auto snapshot = wire<FabricSnapshotNode>(wiring, snapshot_keys, ready, runtime);
-        auto replay = wire<FabricReplayNode>(wiring, replay_keys, ready, runtime);
-        auto live = wire<FabricLiveNode>(wiring, live_keys, notices, controls, ready, notification_mode.value(), runtime);
-        auto planned_snapshot = wire<FabricPlannedSnapshotNode>(wiring, ready, runtime);
-        auto planned_replay = wire<FabricPlannedReplayNode>(wiring, ready, runtime);
-        auto planned_live = wire<FabricPlannedLiveNode>(wiring, notices, controls, ready, notification_mode.value(), runtime);
-        auto loaded = wire<FabricLoadNode>(wiring, loads, ready, runtime);
-        auto diagnostic_values = wire<FabricDiagnosticsNode>(wiring, events, ready, runtime, bridge);
+        auto publication_result =
+            wire<FabricPublicationNode>(wiring, publications, deliveries, ready, runtime, bridge);
+        auto snapshot_result = wire<FabricSnapshotNode>(wiring, snapshot_keys, ready, runtime);
+        auto replay_result = wire<FabricReplayNode>(wiring, replay_keys, ready, runtime);
+        auto live_result =
+            wire<FabricLiveNode>(wiring, live_keys, notices, controls, ready, notification_mode.value(), runtime);
+        auto planned_snapshot_result = wire<FabricPlannedSnapshotNode>(wiring, ready, runtime);
+        auto planned_replay_result = wire<FabricPlannedReplayNode>(wiring, ready, runtime);
+        auto planned_live_result =
+            wire<FabricPlannedLiveNode>(wiring, notices, controls, ready, notification_mode.value(), runtime);
+        auto load_result = wire<FabricLoadNode>(wiring, loads, ready, runtime);
+
+        auto notification_requests = service_result_value(wiring, publication_result);
+        auto snapshot = service_result_value(wiring, snapshot_result);
+        auto replay = service_result_value(wiring, replay_result);
+        auto live = service_result_value(wiring, live_result);
+        auto planned_snapshot = service_result_value(wiring, planned_snapshot_result);
+        auto planned_replay = service_result_value(wiring, planned_replay_result);
+        auto planned_live = service_result_value(wiring, planned_live_result);
+        auto loaded = service_result_value(wiring, load_result);
+        auto diagnostic_values = wire<FabricDiagnosticsNode>(
+            wiring, events, ready, service_result_diagnostics(wiring, publication_result),
+            service_result_diagnostics(wiring, snapshot_result),
+            service_result_diagnostics(wiring, planned_snapshot_result),
+            service_result_diagnostics(wiring, replay_result),
+            service_result_diagnostics(wiring, planned_replay_result),
+            service_result_diagnostics(wiring, live_result), service_result_diagnostics(wiring, planned_live_result),
+            service_result_diagnostics(wiring, load_result), runtime, bridge);
 
         service::impl_output<FabricLiveSubscriptionService>(wiring, binding,
                                                             live.template as<TSD<Str, FabricIngressSignal>>());

--- a/extensions/fabric/src/service.cpp
+++ b/extensions/fabric/src/service.cpp
@@ -455,10 +455,13 @@ struct FabricDiagnosticsNode
 {
     static constexpr auto name = "hgraph.fabric.service.diagnostics";
 
+    /** Runs only when service lifecycle or transport-event inputs tick. Work is
+        O(stable metric count + retained distinct event paths), with event paths
+        bounded by ``FABRIC_DIAGNOSTIC_EVENT_LIMIT``. */
     static void eval(In<"events", TSD<Int, FabricTransportEvent>, InputValidity::Unchecked> events,
                      In<"ready", TS<Bool>>, Scalar<"runtime", FabricServiceRuntimeHandle> runtime,
                      Scalar<"bridge", GraphNotificationBridgeHandle> bridge,
-                     Out<TSD<Str, TS<Str>>> diagnostics)
+                     Out<FabricDiagnostics> diagnostics)
     {
         if (events.modified())
         {
@@ -487,7 +490,8 @@ struct FabricDiagnosticsNode
                 });
             }
         }
-        auto mutation = diagnostics.begin_mutation(diagnostics.evaluation_time());
+        auto metrics = diagnostics.template field<"metrics">();
+        auto mutation = metrics.begin_mutation(metrics.evaluation_time());
         for (auto &[name, value] : runtime.value().value->diagnostics())
         {
             Value key{std::move(name)};
@@ -502,6 +506,23 @@ struct FabricDiagnosticsNode
                 Value item{std::move(value)};
                 mutation.set(key.view(), item.view());
             }
+        }
+
+        auto diagnostic_events = diagnostics.template field<"events">();
+        auto event_mutation = diagnostic_events.begin_mutation(diagnostic_events.evaluation_time());
+        for (auto &[path, event] : runtime.value().value->events())
+        {
+            BundleBuilder builder{ValuePlanFactory::instance().type_for(
+                scalar_descriptor<FabricDiagnosticEvent>::value_meta())};
+            builder.set("component", Value{std::move(event.component)});
+            builder.set("category", Value{std::move(event.category)});
+            builder.set("message", Value{std::move(event.message)});
+            builder.set("retriable", Value{event.retriable});
+            builder.set("fatal", Value{event.fatal});
+            builder.set("occurrences", Value{event.occurrences});
+            Value key{std::move(path)};
+            Value item = builder.build();
+            event_mutation.set(key.view(), item.view());
         }
     }
 };
@@ -559,7 +580,7 @@ struct FabricServiceImpl
             wiring, binding, planned_snapshot.template as<TSD<Str, FabricIngressSignal>>());
         service::impl_output<FabricLoadService>(wiring, binding, loaded.template as<TSD<Int, FabricLoadResponse>>());
         service::impl_output<FabricDiagnosticsService>(wiring, binding,
-                                                       diagnostic_values.template as<TSD<Str, TS<Str>>>());
+                                                       diagnostic_values.template as<FabricDiagnostics>());
         service::impl_output<FabricNotificationRequestService>(wiring, binding,
                                                                notification_requests.template as<TS<DataRevision>>());
     }
@@ -641,12 +662,12 @@ Port<FabricLoadResponse> request_load(Wiring &wiring, Str data_id, DataVersion v
     return request_load(wiring, std::move(data_id), version, service::path(DEFAULT_SERVICE_PATH));
 }
 
-Port<TSD<Str, TS<Str>>> diagnostics(Wiring &wiring, service::ServicePath path)
+Port<FabricDiagnostics> diagnostics(Wiring &wiring, service::ServicePath path)
 {
     return wire<FabricDiagnosticsService>(wiring, std::move(path));
 }
 
-Port<TSD<Str, TS<Str>>> diagnostics(Wiring &wiring)
+Port<FabricDiagnostics> diagnostics(Wiring &wiring)
 {
     return diagnostics(wiring, service::path(DEFAULT_SERVICE_PATH));
 }

--- a/extensions/fabric/src/service_transport.cpp
+++ b/extensions/fabric/src/service_transport.cpp
@@ -33,9 +33,6 @@ struct GraphNotificationBridge::Impl
     Key key{};
   };
 
-  static constexpr std::size_t REQUEST_LIMIT{1024};
-  static constexpr std::size_t RETRY_LIMIT{8};
-
   mutable std::mutex mutex{};
   std::map<Key, RequestState> requests{};
   std::deque<Key> outgoing{};
@@ -65,7 +62,7 @@ struct GraphNotificationBridge::Impl
               "fabric graph notification conflicts with an in-flight request");
         }
       } else {
-        if (self.requests.size() >= REQUEST_LIMIT) {
+        if (self.requests.size() >= FABRIC_NOTIFICATION_REQUEST_LIMIT) {
           throw std::overflow_error("fabric graph notification queue is full");
         }
         self.requests.emplace(
@@ -139,7 +136,8 @@ struct GraphNotificationBridge::Impl
       ++delivered;
       return;
     }
-    if (delivery.retriable && state.retries < RETRY_LIMIT) {
+    if (delivery.retriable &&
+        state.retries < FABRIC_NOTIFICATION_RETRY_LIMIT) {
       ++state.retries;
       ++retried;
       state.message = std::move(delivery.message);

--- a/extensions/fabric/src/subscription.cpp
+++ b/extensions/fabric/src/subscription.cpp
@@ -633,6 +633,7 @@ struct FabricServiceRuntime::Impl
     std::map<Str, RevisionId, IdLess> advertised{};
     std::optional<Notifier> notification_override{};
     std::map<Str, FabricDiagnosticEventInput, IdLess> events{};
+    Int diagnostic_revision{};
     bool graph_notifications{};
     bool running{};
 
@@ -671,6 +672,10 @@ struct FabricServiceRuntime::Impl
         if (found->second.occurrences < std::numeric_limits<Int>::max())
         {
             ++found->second.occurrences;
+        }
+        if (diagnostic_revision < std::numeric_limits<Int>::max())
+        {
+            ++diagnostic_revision;
         }
     }
 
@@ -948,6 +953,11 @@ std::optional<std::tuple<Str, DataVersion, Frame>> FabricServiceRuntime::load(st
         return std::nullopt;
     }
     return std::tuple<Str, DataVersion, Frame>{std::move(data_id), version, std::move(frame)};
+}
+
+Int FabricServiceRuntime::diagnostic_revision() const noexcept
+{
+    return impl_->diagnostic_revision;
 }
 
 std::vector<std::pair<Str, Str>> FabricServiceRuntime::diagnostics() const

--- a/extensions/fabric/src/subscription.cpp
+++ b/extensions/fabric/src/subscription.cpp
@@ -11,6 +11,7 @@
 #include <charconv>
 #include <deque>
 #include <iterator>
+#include <limits>
 #include <map>
 #include <set>
 #include <stdexcept>
@@ -520,7 +521,7 @@ struct LiveSession
             auto found = notice_cache.find(revision.data_id);
             if (found == notice_cache.end())
             {
-                if (notice_cache.size() >= 4096)
+                if (notice_cache.size() >= FABRIC_LIVE_NOTICE_LIMIT_PER_SESSION)
                 {
                     throw std::overflow_error("fabric live notice cache is full");
                 }
@@ -631,9 +632,61 @@ struct FabricServiceRuntime::Impl
     std::map<Str, std::deque<PublicationRequestInput>, IdLess> publication_queues{};
     std::map<Str, RevisionId, IdLess> advertised{};
     std::optional<Notifier> notification_override{};
-    std::map<Str, Str, IdLess> transport_diagnostics{};
+    std::map<Str, FabricDiagnosticEventInput, IdLess> events{};
     bool graph_notifications{};
     bool running{};
+
+    void record_event(Str component, Str category, Str message, Bool retriable, Bool fatal)
+    {
+        Str path = component + "." + category;
+        auto found = events.find(path);
+        if (found == events.end() && events.size() >= FABRIC_DIAGNOSTIC_EVENT_LIMIT - 1U)
+        {
+            path = "diagnostics.capacity";
+            component = "diagnostics";
+            category = "capacity";
+            message = "additional Fabric diagnostic paths were conflated at the configured limit";
+            retriable = false;
+            fatal = false;
+            found = events.find(path);
+        }
+        if (found == events.end())
+        {
+            found = events
+                        .emplace(path, FabricDiagnosticEventInput{
+                                           .component = std::move(component),
+                                           .category = std::move(category),
+                                           .message = std::move(message),
+                                           .retriable = retriable,
+                                           .fatal = fatal,
+                                       })
+                        .first;
+        }
+        else
+        {
+            found->second.message = std::move(message);
+            found->second.retriable = retriable;
+            found->second.fatal = fatal;
+        }
+        if (found->second.occurrences < std::numeric_limits<Int>::max())
+        {
+            ++found->second.occurrences;
+        }
+    }
+
+    template <typename Operation>
+    decltype(auto) with_failure_diagnostic(Str component, Str category, Operation &&operation)
+    {
+        try
+        {
+            return std::forward<Operation>(operation)();
+        }
+        catch (const std::exception &error)
+        {
+            record_event(std::move(component), std::move(category), error.what(), false, true);
+            throw;
+        }
+    }
 
     [[nodiscard]] FabricConfig &configured()
     {
@@ -726,7 +779,7 @@ void FabricServiceRuntime::stop() noexcept
     impl_->planned_replay = {};
     impl_->live = {};
     impl_->planned_live = {};
-    impl_->transport_diagnostics.clear();
+    impl_->events.clear();
     impl_->config.reset();
 }
 
@@ -740,49 +793,61 @@ void FabricServiceRuntime::configure_replay_window(DateTime start_time, DateTime
 
 std::optional<DeliveryBatch> FabricServiceRuntime::snapshot(std::vector<SubscriptionSpec> subscriptions)
 {
-    impl_->snapshot.configure(impl_->configured(), std::move(subscriptions));
-    return impl_->snapshot.evaluate();
+    return impl_->with_failure_diagnostic("store", "snapshot", [&] {
+        impl_->snapshot.configure(impl_->configured(), std::move(subscriptions));
+        return impl_->snapshot.evaluate();
+    });
 }
 
 std::optional<DeliveryBatch> FabricServiceRuntime::planned_snapshot()
 {
-    impl_->planned_snapshot.configure(impl_->configured(), impl_->plan.value->snapshot);
-    return impl_->planned_snapshot.evaluate();
+    return impl_->with_failure_diagnostic("store", "snapshot", [&] {
+        impl_->planned_snapshot.configure(impl_->configured(), impl_->plan.value->snapshot);
+        return impl_->planned_snapshot.evaluate();
+    });
 }
 
 std::optional<DeliveryBatch> FabricServiceRuntime::replay(std::vector<SubscriptionSpec> subscriptions, DateTime now,
                                                           NodeScheduler scheduler)
 {
-    impl_->replay.configure(impl_->configured(), std::move(subscriptions));
-    return impl_->replay.evaluate(now, scheduler);
+    return impl_->with_failure_diagnostic("store", "replay", [&] {
+        impl_->replay.configure(impl_->configured(), std::move(subscriptions));
+        return impl_->replay.evaluate(now, scheduler);
+    });
 }
 
 std::optional<DeliveryBatch> FabricServiceRuntime::planned_replay(DateTime now, NodeScheduler scheduler)
 {
-    impl_->planned_replay.configure(impl_->configured(), impl_->plan.value->replay);
-    return impl_->planned_replay.evaluate(now, scheduler);
+    return impl_->with_failure_diagnostic("store", "replay", [&] {
+        impl_->planned_replay.configure(impl_->configured(), impl_->plan.value->replay);
+        return impl_->planned_replay.evaluate(now, scheduler);
+    });
 }
 
 std::optional<DeliveryBatch> FabricServiceRuntime::live(std::vector<SubscriptionSpec> subscriptions,
                                                         std::vector<DataRevisionInput> revisions, DateTime now,
                                                         bool reconcile)
 {
-    impl_->live.configure(impl_->configured(), std::move(subscriptions));
-    return impl_->live.evaluate(std::move(revisions), now, reconcile);
+    return impl_->with_failure_diagnostic("fabric", "live", [&] {
+        impl_->live.configure(impl_->configured(), std::move(subscriptions));
+        return impl_->live.evaluate(std::move(revisions), now, reconcile);
+    });
 }
 
 std::optional<DeliveryBatch> FabricServiceRuntime::planned_live(std::vector<DataRevisionInput> revisions, DateTime now,
                                                                 bool reconcile)
 {
-    impl_->planned_live.configure(impl_->configured(), impl_->plan.value->live);
-    return impl_->planned_live.evaluate(std::move(revisions), now, reconcile);
+    return impl_->with_failure_diagnostic("fabric", "live", [&] {
+        impl_->planned_live.configure(impl_->configured(), impl_->plan.value->live);
+        return impl_->planned_live.evaluate(std::move(revisions), now, reconcile);
+    });
 }
 
 void FabricServiceRuntime::publish(PublicationRequestInput request)
 {
     require_data_id(request.data_id);
     auto &queue = impl_->publication_queues[request.data_id];
-    if (queue.size() >= 1024)
+    if (queue.size() >= FABRIC_PUBLICATION_QUEUE_LIMIT_PER_DATA_ID)
     {
         throw std::overflow_error("fabric publication queue is full");
     }
@@ -799,7 +864,19 @@ std::vector<DataRevisionInput> FabricServiceRuntime::advance_publications()
         for (std::size_t step = 0; step < 16; ++step)
         {
             const PublicationState before = machine->state();
-            const PublicationState after = machine->advance();
+            PublicationState after{};
+            try
+            {
+                after = machine->advance();
+            }
+            catch (const std::exception &error)
+            {
+                const bool transport = before == PublicationState::LatestDurable ||
+                                       before == PublicationState::NotificationPending;
+                impl_->record_event(transport ? "transport" : "store",
+                                    transport ? "notification" : "publication", error.what(), false, true);
+                throw;
+            }
             if (publication_terminal(after))
             {
                 break;
@@ -853,9 +930,21 @@ std::optional<std::tuple<Str, DataVersion, Frame>> FabricServiceRuntime::load(st
     {
         throw std::invalid_argument("fabric load version must be positive");
     }
-    Frame frame = impl_->config->frames.read(data_version_key(impl_->config->prefix, data_id, version));
+    Frame frame;
+    try
+    {
+        frame = impl_->config->frames.read(data_version_key(impl_->config->prefix, data_id, version));
+    }
+    catch (const std::exception &error)
+    {
+        impl_->record_event("store", "frame.read", error.what(), false, true);
+        throw;
+    }
     if (!frame.has_value())
     {
+        impl_->record_event("store", "frame.missing",
+                            "requested Fabric Frame is not present: " + data_id + ":" + std::to_string(version),
+                            false, false);
         return std::nullopt;
     }
     return std::tuple<Str, DataVersion, Frame>{std::move(data_id), version, std::move(frame)};
@@ -884,9 +973,9 @@ std::vector<std::pair<Str, Str>> FabricServiceRuntime::diagnostics() const
         {"lifecycle", impl_->running ? "running" : "stopped"},
         {"publishers", std::to_string(impl_->publishers.size())},
         {"publication.queued", std::to_string(publication_queued)},
-        {"publication.queue_limit_per_data_id", "1024"},
+        {"publication.queue_limit_per_data_id", std::to_string(FABRIC_PUBLICATION_QUEUE_LIMIT_PER_DATA_ID)},
         {"live.notices", std::to_string(live_notices)},
-        {"live.notice_limit_per_session", "4096"},
+        {"live.notice_limit_per_session", std::to_string(FABRIC_LIVE_NOTICE_LIMIT_PER_SESSION)},
         {"resolution.calls", std::to_string(metrics.calls)},
         {"resolution.forests.ready", std::to_string(metrics.forests_ready)},
         {"resolution.forests.unchanged",
@@ -927,16 +1016,18 @@ std::vector<std::pair<Str, Str>> FabricServiceRuntime::diagnostics() const
         {"resolution.notice_to_ready.microseconds_total",
          std::to_string(metrics.notice_to_ready_total)},
     };
-    result.insert(result.end(), impl_->transport_diagnostics.begin(), impl_->transport_diagnostics.end());
     return result;
+}
+
+std::vector<std::pair<Str, FabricDiagnosticEventInput>> FabricServiceRuntime::events() const
+{
+    return {impl_->events.begin(), impl_->events.end()};
 }
 
 void FabricServiceRuntime::observe_transport_event(TransportEventInput event)
 {
-    const Str key = "transport." + event.component + "." + event.category;
-    Str value = event.fatal ? "fatal: " : (event.retriable ? "retriable: " : "info: ");
-    value += event.message;
-    impl_->transport_diagnostics.insert_or_assign(key, std::move(value));
+    impl_->record_event(std::move(event.component), std::move(event.category), std::move(event.message),
+                        event.retriable, event.fatal);
 }
 
 Str subscription_key(Str data_id, SubscriptionMode mode, DateTime as_of)

--- a/extensions/fabric/src/types.cpp
+++ b/extensions/fabric/src/types.cpp
@@ -114,6 +114,7 @@ namespace hgraph::fabric
         static_cast<void>(scalar_descriptor<SubscriptionMode>::value_meta());
         static_cast<void>(scalar_descriptor<DataDependency>::value_meta());
         static_cast<void>(scalar_descriptor<DataRevision>::value_meta());
+        static_cast<void>(scalar_descriptor<FabricDiagnosticEvent>::value_meta());
         static_cast<void>(scalar_descriptor<PlannedPublisher>::value_meta());
         static_cast<void>(scalar_descriptor<ConsistencyForest>::value_meta());
         static_cast<void>(scalar_descriptor<DependencyPlan>::value_meta());

--- a/extensions/fabric/test_package/main.cpp
+++ b/extensions/fabric/test_package/main.cpp
@@ -20,9 +20,11 @@ namespace
 
         static void compose(hg::Wiring &wiring)
         {
+            hgf::register_service(wiring);
             auto input = hgf::subscribe_data(
                 wiring, "installed/input", hgf::SubscriptionMode::Live);
             hgf::publish_data(wiring, "installed/output", input);
+            static_cast<void>(hgf::diagnostics(wiring));
         }
     };
 }  // namespace

--- a/extensions/fabric/tests/test_kafka.cpp
+++ b/extensions/fabric/tests/test_kafka.cpp
@@ -26,6 +26,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <span>
 #include <stdexcept>
 #include <string>
@@ -53,6 +54,7 @@ hg::Str actual_topic{};
 std::filesystem::path actual_control_dir{};
 std::vector<std::int64_t> actual_live_values{};
 std::map<hg::Str, hg::Str> actual_diagnostics{};
+std::map<hg::Str, hgf::FabricDiagnosticEventInput> actual_events{};
 
 struct ActualBrokerRecord {
   hg::Int partition{};
@@ -270,10 +272,25 @@ struct CaptureActualDiagnostics {
   static constexpr auto name =
       "hgraph.fabric.kafka.test.actual_diagnostics_capture";
 
-  static void eval(hg::In<"values", hg::TSD<hg::Str, hg::TS<hg::Str>>> values) {
-    for (const auto &[key, value] : values.valid_items()) {
+  static void eval(hg::In<"values", hgf::FabricDiagnostics> values) {
+    const auto metrics = values.template field<"metrics">();
+    for (const auto &[key, value] : metrics.valid_items()) {
       actual_diagnostics.insert_or_assign(key.checked_as<hg::Str>(),
                                           value.value());
+    }
+    const auto events = values.template field<"events">();
+    for (const auto &[key, value] : events.valid_items()) {
+      const auto fields = value.base().value().as_bundle();
+      actual_events.insert_or_assign(
+          key.checked_as<hg::Str>(),
+          hgf::FabricDiagnosticEventInput{
+              .component = fields.at("component").checked_as<hg::Str>(),
+              .category = fields.at("category").checked_as<hg::Str>(),
+              .message = fields.at("message").checked_as<hg::Str>(),
+              .retriable = fields.at("retriable").checked_as<hg::Bool>(),
+              .fatal = fields.at("fatal").checked_as<hg::Bool>(),
+              .occurrences = fields.at("occurrences").checked_as<hg::Int>(),
+          });
     }
   }
 };
@@ -547,6 +564,7 @@ TEST_CASE("manual Kafka assignment recovers after every broker disconnects") {
                             .build();
   actual_live_values.clear();
   actual_diagnostics.clear();
+  actual_events.clear();
 
   auto graph = hg::build_graph<ActualBrokerGraph>();
   hgf::set_fabric_config(graph.global_state(), config);
@@ -659,6 +677,7 @@ TEST_CASE("actual broker preserves Fabric recovery, retry, and ordering",
 
   actual_live_values.clear();
   actual_diagnostics.clear();
+  actual_events.clear();
   auto graph = hg::build_graph<ActualBrokerGraph>();
   hgf::set_fabric_config(graph.global_state(), config);
   const hg::DateTime start = hg::testing::wall_now();
@@ -723,6 +742,10 @@ TEST_CASE("actual broker preserves Fabric recovery, retry, and ordering",
   CHECK(actual_diagnostics.at("publication.queue_limit_per_data_id") == "1024");
   CHECK(actual_diagnostics.at("live.notice_limit_per_session") == "4096");
   CHECK(actual_diagnostics.at("transport.notification.retried") != "0");
+  const auto retriable = std::ranges::find_if(
+      actual_events, [](const auto &entry) { return entry.second.retriable; });
+  REQUIRE(retriable != actual_events.end());
+  CHECK_FALSE(retriable->second.fatal);
 
   actual_audit_key =
       hgk::subscription_key()

--- a/extensions/fabric/tests/test_subscription.cpp
+++ b/extensions/fabric/tests/test_subscription.cpp
@@ -38,6 +38,7 @@ constexpr hg::DateTime BASE_TIME{hg::TimeDelta{1'800'000'000'000'000}};
 
 std::vector<std::pair<hg::DateTime, std::int64_t>> observed_frames{};
 std::vector<std::tuple<hg::DateTime, hg::Str, std::int64_t>> observed_tagged_frames{};
+std::map<hg::Str, hgf::FabricDiagnosticEventInput> observed_diagnostic_events{};
 
 struct CapturedLog
 {
@@ -490,6 +491,45 @@ struct LoadGraph
     }
 };
 
+struct CaptureDiagnostics
+{
+    static constexpr auto name = "hgraph.fabric.test.capture_diagnostics";
+
+    static void eval(hg::In<"values", hgf::FabricDiagnostics> values)
+    {
+        for (const auto &[path, event] : values.template field<"events">().modified_items())
+        {
+            if (!event.valid())
+            {
+                continue;
+            }
+            const auto fields = event.base().value().as_bundle();
+            observed_diagnostic_events.insert_or_assign(
+                path.checked_as<hg::Str>(),
+                hgf::FabricDiagnosticEventInput{
+                    .component = fields.at("component").checked_as<hg::Str>(),
+                    .category = fields.at("category").checked_as<hg::Str>(),
+                    .message = fields.at("message").checked_as<hg::Str>(),
+                    .retriable = fields.at("retriable").checked_as<hg::Bool>(),
+                    .fatal = fields.at("fatal").checked_as<hg::Bool>(),
+                    .occurrences = fields.at("occurrences").checked_as<hg::Int>(),
+                });
+        }
+    }
+};
+
+struct MissingLoadDiagnosticsGraph
+{
+    static constexpr auto name = "hgraph.fabric.test.missing_load_diagnostics";
+
+    static void compose(hg::Wiring &wiring)
+    {
+        hgf::register_service(wiring);
+        static_cast<void>(hgf::request_load(wiring, "missing", 1));
+        static_cast<void>(hg::wire<CaptureDiagnostics>(wiring, hgf::diagnostics(wiring)));
+    }
+};
+
 [[nodiscard]] hg::GraphExecutorValue run(hg::GraphBuilder graph, const hgf::FabricConfig &config, hg::DateTime start,
                                          hg::DateTime end)
 {
@@ -814,6 +854,25 @@ TEST_CASE("request_load uses the service-owned persistence resource")
 
     REQUIRE(observed_frames.size() == 1);
     CHECK(observed_frames.front().second == 2);
+}
+
+TEST_CASE("service diagnostics tick when an internal load records an event")
+{
+    hg::stdlib::register_standard_operators();
+    hgf::register_fabric_operators();
+    auto config = hgf::make_memory_fabric_config("tests/subscription/load-diagnostics");
+    observed_diagnostic_events.clear();
+
+    static_cast<void>(
+        run(hg::build_graph<MissingLoadDiagnosticsGraph>(), config, BASE_TIME, BASE_TIME + hg::TimeDelta{5}));
+
+    REQUIRE(observed_diagnostic_events.contains("store.frame.missing"));
+    const auto &event = observed_diagnostic_events.at("store.frame.missing");
+    CHECK(event.component == "store");
+    CHECK(event.category == "frame.missing");
+    CHECK_FALSE(event.retriable);
+    CHECK_FALSE(event.fatal);
+    CHECK(event.occurrences == 1);
 }
 
 TEST_CASE("service diagnostics expose resolver work and bounded queue usage")

--- a/extensions/fabric/tests/test_subscription.cpp
+++ b/extensions/fabric/tests/test_subscription.cpp
@@ -848,6 +848,124 @@ TEST_CASE("service diagnostics expose resolver work and bounded queue usage")
     CHECK(std::stoull(diagnostics.at("resolution.frame_cache.misses")) >= 1);
 }
 
+TEST_CASE("service diagnostics retain typed transport and store events")
+{
+    auto config = hgf::make_memory_fabric_config("tests/subscription/typed-failures");
+    hgf::detail::FabricServicePlanHandle plan{
+        std::make_shared<hgf::detail::FabricServicePlan>()};
+    hgf::detail::FabricServiceRuntime runtime{std::move(plan)};
+    hg::GlobalContext context;
+    hgf::set_fabric_config(context.state().view(), config);
+    runtime.start(context.state().view());
+
+    CHECK_FALSE(runtime.load("missing", 1).has_value());
+    runtime.observe_transport_event(hgf::detail::TransportEventInput{
+        .component = "kafka",
+        .category = "disconnect",
+        .message = "broker unavailable",
+        .retriable = true,
+    });
+
+    const auto values = runtime.events();
+    const std::map<hg::Str, hgf::FabricDiagnosticEventInput> events{values.begin(), values.end()};
+    REQUIRE(events.contains("store.frame.missing"));
+    CHECK(events.at("store.frame.missing").component == "store");
+    CHECK_FALSE(events.at("store.frame.missing").retriable);
+    CHECK_FALSE(events.at("store.frame.missing").fatal);
+    REQUIRE(events.contains("kafka.disconnect"));
+    CHECK(events.at("kafka.disconnect").message == "broker unavailable");
+    CHECK(events.at("kafka.disconnect").retriable);
+    CHECK_FALSE(events.at("kafka.disconnect").fatal);
+    CHECK(events.at("kafka.disconnect").occurrences == 1);
+}
+
+TEST_CASE("stalled service queues and diagnostic paths enforce hard bounds")
+{
+    SECTION("publication requests")
+    {
+        auto config = hgf::make_memory_fabric_config("tests/subscription/publication-bound");
+        hgf::detail::FabricServicePlanHandle plan{
+            std::make_shared<hgf::detail::FabricServicePlan>()};
+        hgf::detail::FabricServiceRuntime runtime{std::move(plan)};
+        hg::GlobalContext context;
+        hgf::set_fabric_config(context.state().view(), config);
+        runtime.start(context.state().view());
+
+        runtime.publish(hgf::detail::PublicationRequestInput{.data_id = "stalled"});
+        for (std::size_t index = 0; index < hgf::FABRIC_PUBLICATION_QUEUE_LIMIT_PER_DATA_ID; ++index)
+        {
+            runtime.publish(hgf::detail::PublicationRequestInput{.data_id = "stalled"});
+        }
+        CHECK_THROWS_AS(runtime.publish(hgf::detail::PublicationRequestInput{.data_id = "stalled"}),
+                        std::overflow_error);
+        const auto values = runtime.diagnostics();
+        const std::map<hg::Str, hg::Str> metrics{values.begin(), values.end()};
+        CHECK(std::stoull(metrics.at("publication.queued")) ==
+              hgf::FABRIC_PUBLICATION_QUEUE_LIMIT_PER_DATA_ID);
+    }
+
+    SECTION("live notices")
+    {
+        auto config = hgf::make_memory_fabric_config("tests/subscription/live-bound");
+        hgf::detail::FabricServicePlanHandle plan{
+            std::make_shared<hgf::detail::FabricServicePlan>()};
+        hgf::detail::FabricServiceRuntime runtime{std::move(plan)};
+        hg::GlobalContext context;
+        hgf::set_fabric_config(context.state().view(), config);
+        runtime.start(context.state().view());
+
+        std::vector<hgf::DataRevisionInput> revisions;
+        revisions.reserve(hgf::FABRIC_LIVE_NOTICE_LIMIT_PER_SESSION);
+        for (std::size_t index = 0; index < hgf::FABRIC_LIVE_NOTICE_LIMIT_PER_SESSION; ++index)
+        {
+            revisions.push_back(hgf::DataRevisionInput{
+                .data_id = "notice-" + std::to_string(index),
+                .revision = 1,
+                .output_version = 1,
+                .as_of = BASE_TIME,
+            });
+        }
+        CHECK_FALSE(runtime.live({}, std::move(revisions), BASE_TIME).has_value());
+        CHECK_THROWS_AS(runtime.live({}, {hgf::DataRevisionInput{
+                                              .data_id = "notice-overflow",
+                                              .revision = 1,
+                                              .output_version = 1,
+                                              .as_of = BASE_TIME,
+                                          }},
+                                     BASE_TIME),
+                        std::overflow_error);
+        const auto values = runtime.diagnostics();
+        const std::map<hg::Str, hg::Str> metrics{values.begin(), values.end()};
+        CHECK(std::stoull(metrics.at("live.notices")) == hgf::FABRIC_LIVE_NOTICE_LIMIT_PER_SESSION);
+    }
+
+    SECTION("diagnostic paths")
+    {
+        auto config = hgf::make_memory_fabric_config("tests/subscription/diagnostic-bound");
+        hgf::detail::FabricServicePlanHandle plan{
+            std::make_shared<hgf::detail::FabricServicePlan>()};
+        hgf::detail::FabricServiceRuntime runtime{std::move(plan)};
+        hg::GlobalContext context;
+        hgf::set_fabric_config(context.state().view(), config);
+        runtime.start(context.state().view());
+
+        for (std::size_t index = 0; index < hgf::FABRIC_DIAGNOSTIC_EVENT_LIMIT + 20U; ++index)
+        {
+            runtime.observe_transport_event(hgf::detail::TransportEventInput{
+                .component = "kafka",
+                .category = "category-" + std::to_string(index),
+                .message = "failure",
+                .retriable = true,
+            });
+        }
+        const auto values = runtime.events();
+        const std::map<hg::Str, hgf::FabricDiagnosticEventInput> events{values.begin(), values.end()};
+        CHECK(events.size() == hgf::FABRIC_DIAGNOSTIC_EVENT_LIMIT);
+        REQUIRE(events.contains("diagnostics.capacity"));
+        CHECK(events.at("diagnostics.capacity").occurrences == 21);
+    }
+}
+
 TEST_CASE("graph notification bridge retries with stable revision correlation")
 {
     hgf::detail::GraphNotificationBridge bridge;
@@ -886,4 +1004,35 @@ TEST_CASE("graph notification bridge retries with stable revision correlation")
     CHECK(diagnostics.at("transport.notification.pending") == "0");
     CHECK(diagnostics.at("transport.notification.retried") == "1");
     CHECK(diagnostics.at("transport.notification.delivered") == "1");
+}
+
+TEST_CASE("stalled graph notification delivery queue enforces its hard bound")
+{
+    hgf::detail::GraphNotificationBridge bridge;
+    auto notifier = bridge.notifier();
+    for (std::size_t index = 0; index < hgf::FABRIC_NOTIFICATION_REQUEST_LIMIT; ++index)
+    {
+        const auto revision = hgf::make_data_revision(hgf::DataRevisionInput{
+            .data_id = "stalled",
+            .revision = static_cast<hgf::RevisionId>(index + 1U),
+            .output_version = 1,
+            .as_of = BASE_TIME + hg::TimeDelta{static_cast<hg::TimeDelta::rep>(index + 1U)},
+        });
+        static_cast<void>(notifier.publish(
+            hgf::RevisionNotification{"stalled", hgf::encode_revision(revision.view())}));
+    }
+    const auto overflow = hgf::make_data_revision(hgf::DataRevisionInput{
+        .data_id = "stalled",
+        .revision = static_cast<hgf::RevisionId>(hgf::FABRIC_NOTIFICATION_REQUEST_LIMIT + 1U),
+        .output_version = 1,
+        .as_of = BASE_TIME + hg::TimeDelta{
+                               static_cast<hg::TimeDelta::rep>(hgf::FABRIC_NOTIFICATION_REQUEST_LIMIT + 1U)},
+    });
+    CHECK_THROWS_AS(notifier.publish(
+                        hgf::RevisionNotification{"stalled", hgf::encode_revision(overflow.view())}),
+                    std::overflow_error);
+    const auto values = bridge.diagnostics();
+    const std::map<hg::Str, hg::Str> diagnostics{values.begin(), values.end()};
+    CHECK(std::stoull(diagnostics.at("transport.notification.pending")) ==
+          hgf::FABRIC_NOTIFICATION_REQUEST_LIMIT);
 }

--- a/extensions/fabric/tests/test_subscription.cpp
+++ b/extensions/fabric/tests/test_subscription.cpp
@@ -497,7 +497,8 @@ struct CaptureDiagnostics
 
     static void eval(hg::In<"values", hgf::FabricDiagnostics> values)
     {
-        for (const auto &[path, event] : values.template field<"events">().modified_items())
+        const auto events = values.template field<"events">();
+        for (const auto &[path, event] : events.modified_items())
         {
             if (!event.valid())
             {

--- a/extensions/kafka/include/hgraph/kafka/testing/mock_cluster.h
+++ b/extensions/kafka/include/hgraph/kafka/testing/mock_cluster.h
@@ -41,6 +41,8 @@ public:
                    std::optional<DateTime> timestamp = std::nullopt);
   void fail_next_produce(MockProduceError error, std::size_t count = 1);
   void fail_next_fetch(MockConsumeError error, std::size_t count = 1);
+  /** Make committed-offset discovery observe a transient coordinator outage. */
+  void fail_next_committed_offset_fetch(std::size_t count = 1);
   /** Disconnect every broker without discarding broker state. */
   void stop_brokers();
   /** Accept connections again after stop_brokers(). */

--- a/extensions/kafka/src/librdkafka_service.cpp
+++ b/extensions/kafka/src/librdkafka_service.cpp
@@ -354,7 +354,11 @@ using KafkaConfPtr = std::unique_ptr<rd_kafka_conf_t, KafkaConfDeleter>;
   case RD_KAFKA_RESP_ERR__MSG_TIMED_OUT:
   case RD_KAFKA_RESP_ERR__TRANSPORT:
   case RD_KAFKA_RESP_ERR__ALL_BROKERS_DOWN:
+  case RD_KAFKA_RESP_ERR__WAIT_COORD:
   case RD_KAFKA_RESP_ERR_REQUEST_TIMED_OUT:
+  case RD_KAFKA_RESP_ERR_COORDINATOR_LOAD_IN_PROGRESS:
+  case RD_KAFKA_RESP_ERR_COORDINATOR_NOT_AVAILABLE:
+  case RD_KAFKA_RESP_ERR_NOT_COORDINATOR:
   case RD_KAFKA_RESP_ERR_NOT_ENOUGH_REPLICAS:
   case RD_KAFKA_RESP_ERR_NOT_ENOUGH_REPLICAS_AFTER_APPEND:
   case RD_KAFKA_RESP_ERR_NETWORK_EXCEPTION:
@@ -2015,7 +2019,22 @@ void ConsumerSession::resolve_start_positions(
     }
   }
   if (spec_.start_kind == KafkaStartPositionKind::Committed) {
-    const auto error = rd_kafka_committed(consumer, partitions, 5'000);
+    // A newly started broker may acknowledge topic traffic before its group
+    // coordinator is ready.  Committed-offset discovery is a startup/recovery
+    // operation, so retry coordinator transitions within the existing
+    // five-second resolution budget instead of terminating the subscription.
+    const auto deadline = std::chrono::steady_clock::now() +
+                          std::chrono::milliseconds{5'000};
+    rd_kafka_resp_err_t error{};
+    do {
+      error = rd_kafka_committed(consumer, partitions, 500);
+      if (error == RD_KAFKA_RESP_ERR_NO_ERROR || !retriable_error(error) ||
+          stopping_.load(std::memory_order_relaxed) ||
+          std::chrono::steady_clock::now() >= deadline) {
+        break;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds{50});
+    } while (true);
     if (error != RD_KAFKA_RESP_ERR_NO_ERROR) {
       throw std::runtime_error(
           Str{"Unable to resolve committed Kafka offsets: "} +

--- a/extensions/kafka/src/testing/mock_cluster.cpp
+++ b/extensions/kafka/src/testing/mock_cluster.cpp
@@ -212,6 +212,21 @@ void MockCluster::fail_next_fetch(MockConsumeError error, std::size_t count) {
                                           responses.data());
 }
 
+void MockCluster::fail_next_committed_offset_fetch(std::size_t count) {
+  if (count == 0) {
+    return;
+  }
+  if (count > static_cast<std::size_t>(std::numeric_limits<int>::max())) {
+    throw std::invalid_argument("Kafka mock failure count is out of range");
+  }
+  std::vector<rd_kafka_resp_err_t> responses(
+      count, RD_KAFKA_RESP_ERR_COORDINATOR_NOT_AVAILABLE);
+  // OffsetFetch is Kafka protocol API key 9.  This reproduces the startup
+  // window in which topic traffic is available before the group coordinator.
+  rd_kafka_mock_push_request_errors_array(impl_->cluster, 9, responses.size(),
+                                          responses.data());
+}
+
 void MockCluster::stop_brokers() {
   const auto error = rd_kafka_mock_broker_set_down(impl_->cluster, -1);
   if (error != RD_KAFKA_RESP_ERR_NO_ERROR) {

--- a/extensions/kafka/tests/test_service.cpp
+++ b/extensions/kafka/tests/test_service.cpp
@@ -1894,6 +1894,32 @@ void test_independent_assignment_reads_every_partition() {
           "independent assignment did not read every selected topic partition");
 }
 
+void test_committed_start_retries_coordinator_initialization() {
+  MockCluster cluster;
+  cluster.create_topic(Str{"typed-coordinator-startup"});
+  cluster.seed_record(Str{"typed-coordinator-startup"}, Bytes{"available"});
+  cluster.fail_next_committed_offset_fetch(2);
+  production_config = hgraph::kafka::service_config()
+                          .bootstrap_servers({cluster.bootstrap_servers()})
+                          .client_id(Str{"typed-coordinator-startup-subscriber"})
+                          .build();
+  subscription_key =
+      hgraph::kafka::subscription_key()
+          .topics({Str{"typed-coordinator-startup"}})
+          .group_id(Str{"typed-coordinator-startup-group"})
+          .assignment_mode(KafkaAssignmentMode::Independent)
+          .start(make_start_position(KafkaStartPositionKind::Committed,
+                                     KafkaOffsetFallback::Earliest))
+          .stop(make_stop_position(KafkaStopPositionKind::Snapshot))
+          .sharing_identity(Str{"typed-coordinator-startup-subscription"})
+          .build();
+  run_bounded_subscription();
+
+  require(bounded_payloads == std::vector<Str>{Str{"available"}},
+          "a transient group-coordinator startup response terminated the "
+          "committed subscription");
+}
+
 void test_commit_modes_and_monotonic_explicit_commits() {
   {
     MockCluster cluster;
@@ -2481,6 +2507,7 @@ int main() {
     test_timestamp_and_graph_start_positions();
     test_pattern_committed_fallback_and_key_filter();
     test_independent_assignment_reads_every_partition();
+    test_committed_start_retries_coordinator_initialization();
     test_commit_modes_and_monotonic_explicit_commits();
     test_record_time_recovery_is_deterministically_merged();
     test_record_time_recovery_hands_off_before_live_records();

--- a/include/hgraph/types/static_node.h
+++ b/include/hgraph/types/static_node.h
@@ -42,6 +42,7 @@
 #include <tuple>
 #include <type_traits>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace hgraph
@@ -1683,23 +1684,26 @@ namespace hgraph
         static constexpr auto field_name = Name;
 
         /** Supplied directly (graph ``compose`` parameter / wiring-time value). */
-        explicit Scalar(TValue value) : owned_(std::move(value)) {}
+        explicit Scalar(TValue value)
+            : storage_(std::in_place_index<0>, std::move(value))
+        {
+        }
 
         /** Borrow from the immutable node scalar storage (node hook path). */
         explicit Scalar(const ValueView &view)
-            : borrowed_(std::addressof(view.template checked_as<TValue>()))
+            : storage_(std::in_place_index<1>,
+                       std::addressof(view.template checked_as<TValue>()))
         {
         }
 
         /** The configured value of this scalar input. */
         [[nodiscard]] const value_type &value() const noexcept
         {
-            return borrowed_ != nullptr ? *borrowed_ : *owned_;
+            return storage_.index() == 0 ? std::get<0>(storage_) : *std::get<1>(storage_);
         }
 
       private:
-        std::optional<TValue> owned_{};
-        const TValue        *borrowed_{nullptr};
+        std::variant<TValue, const TValue *> storage_;
     };
 
     /**


### PR DESCRIPTION
## Summary

- expose stable Fabric metrics separately from typed, path-addressed operational events
- conflate repeated and excess diagnostic paths while preserving occurrence counts
- publish and enforce hard bounds for publication, live-notice, and graph-delivery queues
- exercise the public diagnostics schema through the installed C++ SDK consumer

## Validation

- fresh macOS native suite: 1,605 passed
- Python 3.12 stable-ABI wheel installed under Python 3.14: 2,122 passed, 10 skipped
- focused Fabric and Kafka suites: passed
- installed Fabric SDK consumer: passed
- real Redpanda outage/restart conformance: 23 assertions passed

Stacked on #539. Advances #512.