### PR TITLE
Fix Persistence wheel dependency RUNPATH

### DIFF
--- a/extensions/persistence/CMakeLists.txt
+++ b/extensions/persistence/CMakeLists.txt
@@ -223,6 +223,20 @@ if(HGRAPH_PERSISTENCE_BUILD_PYTHON)
         message(FATAL_ERROR
             "HGRAPH_PERSISTENCE_BUILD_PYTHON requires a Python-enabled installed hgraph SDK")
     endif()
+    # The bridge's RUNPATH locates libhgraph_persistence, but ELF RUNPATH is
+    # not inherited when that library resolves its own Arrow/Parquet and core
+    # dependencies.  Give the shared implementation library an explicit
+    # package-relative path as well; otherwise an isolated Linux wheel import
+    # depends on some earlier module having loaded libparquet globally.
+    if(BUILD_SHARED_LIBS)
+        if(APPLE)
+            set_target_properties(hgraph_persistence PROPERTIES
+                INSTALL_RPATH "@loader_path;@loader_path/../pyarrow")
+        elseif(UNIX)
+            set_target_properties(hgraph_persistence PROPERTIES
+                INSTALL_RPATH "$ORIGIN;$ORIGIN/../pyarrow")
+        endif()
+    endif()
     hgraph_add_python_module(_hgraph_persistence STABLE_ABI NOMINSIZE src/python_module.cpp)
     target_link_libraries(_hgraph_persistence PRIVATE hgraph::persistence)
     # One more `../` than hgraph_add_python_module's default: the module

--- a/extensions/persistence/python/tests/test_distribution_audit.py
+++ b/extensions/persistence/python/tests/test_distribution_audit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import zipfile
@@ -9,6 +10,20 @@ import pytest
 
 PERSISTENCE_ROOT = Path(__file__).resolve().parents[2]
 AUDIT_SCRIPT = PERSISTENCE_ROOT / "tools/audit_distribution.py"
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux wheel RUNPATH regression")
+def test_installed_bridge_imports_in_a_clean_process():
+    environment = os.environ.copy()
+    environment.pop("LD_LIBRARY_PATH", None)
+    result = subprocess.run(
+        [sys.executable, "-I", "-c", "import hgraph_persistence"],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 @pytest.mark.parametrize("library_directory", ["lib", "lib64"])


### PR DESCRIPTION
## Summary

- give the shared Persistence implementation library its own package-relative Arrow/Parquet runtime path
- cover isolated Linux wheel imports in a clean subprocess without `LD_LIBRARY_PATH`
- prevent Fabric imports from depending on Parquet having been loaded globally by an earlier test

This is a focused acceptance fix discovered while completing RFC 0026 issue #512.

## Validation

- GCC 14.2 Persistence abi3 wheel build with Python 3.12
- wheel distribution audit
- isolated Python 3.14 `import hgraph_persistence` with `LD_LIBRARY_PATH` removed
- Persistence Python suite: 83 passed
- Fabric Python suite: 16 passed
- `readelf` confirms `libhgraph_persistence.so` RUNPATH is `$ORIGIN:$ORIGIN/../pyarrow`
