### PR TITLE
Keep the node evaluator hot path compact

### DIFF
--- a/include/hgraph/runtime/node.h
+++ b/include/hgraph/runtime/node.h
@@ -109,6 +109,11 @@ namespace hgraph
         // through the Python object boundary. Wiring uses this to request
         // output-local Python-aware storage from upstream producers.
         bool     uses_python_values{false};
+        // Reserved ABI byte. Behaviour bit 4 was briefly assigned to a
+        // simulation push-source exception; push sources are now uniformly
+        // real-time-only, but retaining this byte preserves the offsets of
+        // the hot metadata fields which follow it.
+        std::uint8_t reserved_behaviour_bit_4{0};
         // True when this node requires the embedding phase runner during
         // start, evaluation, or stop. Nested-node builders propagate the flag
         // from their child graph plans so a root executor can select its

--- a/src/hgraph/runtime/node.cpp
+++ b/src/hgraph/runtime/node.cpp
@@ -921,16 +921,20 @@ namespace hgraph
             const bool          scheduled_now = scheduler != nullptr && !scheduler->events.empty() &&
                                        scheduler->events.begin()->first == evaluation_time;
 
-            bool do_eval = callbacks(context).input_validity_in_evaluate
-                               ? true
-                               : ready_to_evaluate(view, evaluation_time);
+            const bool do_eval = callbacks(context).input_validity_in_evaluate ||
+                                 !runtime.layout.has_input() ||
+                                 ready_to_evaluate(view, evaluation_time);
 
             if (do_eval)
             {
                 if (callbacks(context).evaluate)
                 {
-                    const NodeTypeMetaData *schema = view.schema();
-                    const bool capture = schema != nullptr && schema->captures_errors && runtime.layout.has_error_output();
+                    bool capture = false;
+                    if (runtime.layout.has_error_output())
+                    {
+                        const NodeTypeMetaData *schema = view.schema();
+                        capture = schema != nullptr && schema->captures_errors;
+                    }
                     if (capture)
                     {
                         static_cast<void>(fallback_on_exception(false,
@@ -1005,6 +1009,8 @@ namespace hgraph
                    lhs.uses_global_state == rhs.uses_global_state &&
                    lhs.uses_evaluation_clock == rhs.uses_evaluation_clock &&
                    lhs.uses_python_values == rhs.uses_python_values &&
+                   lhs.reserved_behaviour_bit_4 ==
+                       rhs.reserved_behaviour_bit_4 &&
                    lhs.requires_phase_runner == rhs.requires_phase_runner &&
                    lhs.schedule_on_start == rhs.schedule_on_start &&
                    lhs.captures_errors == rhs.captures_errors &&


### PR DESCRIPTION
## Summary

- preserve the hot NodeTypeMetaData layout after removing the rejected simulation push-source behavior flag by retaining an explicit reserved ABI byte
- skip generic input-readiness traversal for inputless nodes
- avoid the schema lookup on ordinary nodes which have no error output
- include the reserved metadata byte in equality without changing node semantics

This is the generic core prerequisite for RFC 0026's no-regression acceptance evidence; it contains no Fabric dependency or policy.

## Performance evidence

On the controlled GCC 14.2 Release comparison, all ordinary graph paths remained within the five-percent gate: native evaluation -1.38%, profiler disabled/enabled -5.90%/-1.87%, small graph construction -2.38%, nested scheduled scan +2.58%, dynamic TSL map +1.74%, and map-reduce +0.83%. Sparse TSD graph paths improved 17.55-19.80%.

## Validation

- macOS fresh native suite: 1,605/1,605
- macOS Python 3.14 compatibility suite from the Python 3.12 abi3 wheel: 2,122 passed, 10 skipped
- Linux GCC 14 fresh native suite: 1,605/1,605
- Linux GCC 14 Python 3.14 compatibility suite with Polars rtcompat: 2,122 passed, 10 skipped
- Linux GCC 14 ASan runtime, Kafka, Fabric, and Fabric Kafka targets
