### PR TITLE
Implement RFC 0027 push-source queue models

### DIFF
--- a/.agents/skills/hgraph-realtime-adaptors/SKILL.md
+++ b/.agents/skills/hgraph-realtime-adaptors/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: hgraph-realtime-adaptors
+description: Implement or review C++-first hgraph real-time adaptors and service implementations that bridge external threads, callbacks, or event loops through push sources and sink nodes. Use for sender admission and backpressure, start/stop task ownership, service_impl resource sharing, real-time versus simulation wiring, protocol acknowledgements, or native/Python adaptor lifecycle tests.
+---
+
+# HGraph Real-Time Adaptors
+
+Build asynchronous boundaries that preserve the graph's real-time execution,
+ownership, and lifecycle rules.
+
+## Establish the boundary
+
+1. Read the current repository's `AGENTS.md`, the relevant adaptor or service
+   interfaces and implementations, and their tests before editing.
+2. In the hgraph core checkout, also read
+   `docs/source/developer_guide/real_time_adaptors.rst`,
+   `docs/source/developer_guide/services.rst`, and the push-source section of
+   `docs/source/user_guide/cpp/authoring_nodes.rst`.
+3. In a downstream project, use its extension layout and the public APIs and
+   documentation of its pinned hgraph version. Do not assume core sources are
+   available or promote domain-specific policy into core without the required
+   RFC and evidence.
+4. Classify the implementation before choosing nodes:
+   - A simple source-only adaptor uses one push source with lifecycle state.
+   - A bidirectional or multi-interface adaptor uses a `service_impl` composed
+     from push sources, sink nodes, and one graph-scoped task/resource.
+   - Simulation uses a distinct scheduled or pull-source implementation
+     selected at wiring time; it never uses a simulated push source.
+
+Keep implementation logic in node `eval` and graph `compose` methods. Extract
+a helper only for a well-defined operation or genuinely shared logic.
+
+## Enter the graph only through the sender
+
+External threads, callbacks, and event loops may retain `PushSourceSender`.
+They must not retain or access the graph or executor, schedule nodes, or invoke
+evaluation directly.
+
+Treat the sender as opaque. Its selected policy owns queue or conflating
+storage, locks, condition variables, receiver lifetime, and executor wake-up.
+The sender stores work first and then marks push work pending and notifies the
+real-time executor. Do not reproduce or expose those internals in an adaptor.
+
+Choose admission deliberately:
+
+- `try_send(value) -> bool` never waits. Use it only with an explicit plan for
+  `false`, such as pausing upstream reads while continuing protocol
+  heartbeats. Never ignore refusal when it would lose data.
+- `send_blocking(value) -> bool` waits for bounded capacity and returns
+  `false` only if the receiver stops before admission. It may be discarded
+  when the adaptor's stop path already ends the producer.
+- Python maps its sender call to blocking admission and must release the GIL
+  while waiting.
+
+Admission is not processing confirmation. Dequeue only means the graph has
+started processing the buffered value.
+
+## Own simple adaptor lifecycle in the push source
+
+For a source-only adaptor:
+
+1. Store the external task, stop mechanism, and thread handles in node
+   `State`.
+2. In `start`, receive the framework-created sender, construct the task with
+   it, and start the task's threads.
+3. In `stop`, request shutdown, wake task-owned waits, and join every thread
+   started by `start`.
+4. Make stop safe after partial start. Use the existing guards from
+   `hgraph/util/scope.h` for rollback and cleanup.
+
+Do not capture call-scoped Python time-series, `STATE`, scheduler, node, or
+global-state wrappers in an external thread. Copy task-owned configuration and
+retain only the sender and the task's own data.
+
+## Compose bidirectional adaptors as services
+
+Use `service_impl` as the graph-scoped singleton for a shared external
+resource. Compose it from:
+
+- one or more push sources receiving asynchronous results;
+- sink nodes sending graph requests or commands to the task;
+- service/adaptor boundary nodes exposing the public interfaces; and
+- one central task/resource instance shared by those nodes.
+
+Use one push source per independently ordered result stream. When related
+result types require one order, carry a discriminated envelope through one
+sender and demultiplex it in the graph.
+
+Prefer graph-scoped `GlobalState` resource ownership when several nodes need
+the task. If one push source is the natural owner, it may lazily construct the
+task and expose passive access to sinks, but that passive connection is a graph
+edge and can delay inputs. Make one node responsible for starting the shared
+task and one corresponding stop path responsible for stopping and joining it.
+Never substitute a process global for graph-scoped ownership.
+
+Use the compute/sink-node skill for the concrete sink lifecycle and hot path,
+the graph skill for composition, and the operator skill when type or policy
+selection should be resolved through overloads.
+
+## Provide simulation by wiring a different implementation
+
+Push sources are real-time-root-only. There is no simulation-capable push
+source and no external thread may wake a simulation executor.
+
+When simulation is supported, inspect the wiring context's run mode and select
+an ordinary scheduled or pull-source implementation. Historical Kafka replay,
+for example, reads the stored log from a pull source instead of running a live
+consumer task. Keep live and replay implementations behind the same public
+service interfaces.
+
+## Confirm protocols downstream
+
+Never acknowledge or commit because enqueue succeeded. When a protocol needs
+confirmation after graph processing:
+
+1. carry the correlation key, cursor, or offset with the input;
+2. emit it from the point that defines successful processing; and
+3. wire a sink node that performs the acknowledgement or commit.
+
+Kafka transactional processing must therefore commit from a confirmation that
+flows through the graph, not from the callback that buffered the record.
+
+## Validate lifecycle, refusal, and ordering
+
+Test through public wiring interfaces with equivalent C++ coverage for every
+Python-visible behavior. Cover:
+
+- exactly one task construction, orderly stop request, and thread join;
+- stop while a producer is blocked, with `false` returned and no deadlock;
+- retained/default/moved-from senders remaining inert after teardown;
+- the explicit producer response to `try_send` refusal;
+- concurrent producers and the selected FIFO, burst, or conflating semantics;
+- executor wake only after accepted work is stored;
+- acknowledgement only after the explicit confirmation sink; and
+- simulation selecting a scheduled or pull source with no producer thread.
+
+Run the repository acceptance gates from `AGENTS.md`; for cross-thread
+lifetime changes, also use the required Linux validation and ASan/TSan where
+applicable.

--- a/.agents/skills/hgraph-realtime-adaptors/agents/openai.yaml
+++ b/.agents/skills/hgraph-realtime-adaptors/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "HGraph Real-Time Adaptors"
+  short_description: "Build lifecycle-safe asynchronous HGraph adaptors"
+  default_prompt: "Use $hgraph-realtime-adaptors to implement or review this HGraph real-time adaptor."

--- a/docs/source/developer_guide/index.rst
+++ b/docs/source/developer_guide/index.rst
@@ -25,6 +25,7 @@ These pages describe *how the runtime is built*. For how to write programs with 
    error_handling
    mesh
    services
+   real_time_adaptors
    operators
    writing_nodes
    parity_matrix

--- a/docs/source/developer_guide/real_time_adaptors.rst
+++ b/docs/source/developer_guide/real_time_adaptors.rst
@@ -1,0 +1,169 @@
+Real-time adaptors
+==================
+
+This page defines the lifecycle and threading pattern for connecting an
+external asynchronous process to an hgraph real-time graph.  The external
+process may use threads, callbacks, or an event loop, but it enters the graph
+only through a push-source sender.  It must not retain a graph or executor
+object and must never schedule or evaluate graph nodes directly.
+
+The sender boundary
+-------------------
+
+``PushSourceSender`` is the complete producer-facing boundary.  Its internals
+own the selected queue or conflating representation, synchronization, receiver
+lifetime, and the projection onto the real-time executor's wake machinery.
+Those details are not exposed to adaptor code.
+
+Admission has this ordering:
+
+1. the selected sender policy validates and queues or applies the value under
+   its own synchronization;
+2. the policy reports whether the accepted value made push work pending; and
+3. the sender marks push work pending and notifies the real-time executor.
+
+The executor checks the pending state to decide whether to evaluate the root
+graph's push-source prefix.  The notification also wakes an executor waiting
+for its next scheduled time.  Work is always stored before notification, so a
+woken executor can observe it.
+
+The queue policy owns its producer/consumer safety.  The basic FIFO policy
+uses a mutex.  A bounded queue also uses a condition variable: blocking sends
+wait without holding the queue lock, dequeue notifies available capacity, and
+stop makes the queue non-accepting and wakes every waiter before producer
+threads are joined.
+
+The sender exposes two admission choices:
+
+``try_send(value) -> bool``
+   Never waits.  ``False`` means capacity was unavailable or the receiver had
+   stopped.  Use it only when the producer has an explicit refusal plan, such
+   as pausing upstream reads while continuing to serve protocol heartbeats.
+   Ignoring ``False`` loses the value.
+
+``send_blocking(value) -> bool``
+   Waits for bounded capacity.  ``False`` means the receiver stopped before
+   admission.  A producer may discard this result when its stop lifecycle
+   already requests task shutdown.  Python releases the GIL for the native
+   wait.
+
+Neither result means the graph processed the value.  Admission is buffering,
+and dequeue only means processing has begun.
+
+Simple source adaptors
+----------------------
+
+A source-only adaptor consists of one push source whose lifecycle owns the
+external task:
+
+* node ``State`` holds the task, its stop mechanism, and its thread handles;
+* ``start`` receives the framework-created sender, constructs the task with
+  that sender, and starts its threads; and
+* ``stop`` requests task shutdown, wakes any task-owned waits, and joins every
+  thread started by ``start``.
+
+The stop path must tolerate partial start.  If construction or thread start
+can fail after acquiring resources, use the existing scope guards from
+``hgraph/util/scope.h`` to roll back the completed steps.
+
+Python ``@push_queue`` uses the same model:
+
+.. code-block:: python
+
+   @push_queue(TS[Event])
+   def events(sender, config: Config, state: STATE = None):
+       state.task = EventTask(config, sender)
+       state.task.start()
+
+   @events.stop
+   def stop_events(config: Config, state: STATE = None):
+       state.task.request_stop()
+       state.task.join()
+
+Do not capture a call-scoped Python ``STATE`` or time-series wrapper in the
+worker.  Copy the task-owned values needed by the worker during ``start`` and
+store the task itself in state for ``stop``.
+
+Bidirectional and multi-interface adaptors
+------------------------------------------
+
+An adaptor that both receives asynchronous results and consumes graph inputs
+is a service implementation, not a push source plus an unrelated external
+object.  Register the ``service_impl`` once for its graph path so it is the
+graph-scoped singleton responsible for the external resource.
+
+The implementation composes:
+
+* one or more push sources for asynchronous responses entering the graph;
+* sink nodes for requests or commands leaving the graph;
+* the ordinary service or adaptor boundary nodes for its public interfaces;
+  and
+* one central task/resource instance shared by those nodes.
+
+Use one push source for each independently ordered response stream.  Combine
+related result kinds into a discriminated envelope on one sender when they
+must preserve a single external order; demultiplex the envelope with ordinary
+graph nodes.
+
+Prefer a graph-scoped resource held through ``GlobalState`` when several
+source and sink nodes need the task.  When exactly one push source is the
+natural resource owner, it may lazily construct the task in its state and
+expose passive access to the sinks.  That connection is a real graph edge and
+can delay inputs; choose it only when the resulting ordering is intended.
+Never introduce a process global for a resource whose configuration and
+lifetime belong to one graph execution.
+
+One node, preferably the resource-owning push source, is responsible for
+creating and starting the shared task.  One corresponding stop path requests
+shutdown and joins it.  Sink-node stop hooks must not independently destroy a
+resource still used by response callbacks.
+
+Simulation specializations
+--------------------------
+
+Push sources belong only to real-time root graphs.  There is no simulated push
+source and no external thread that is allowed to wake a simulation executor.
+
+An adaptor that supports simulation supplies a separate native wiring-time
+implementation selected from the wiring context's run mode.  Historical data
+is produced by ordinary scheduled or pull-source nodes so graph time alone
+controls replay.  For example, a Kafka real-time implementation consumes the
+broker on an external task and sends records through a push source, while its
+simulation implementation replays a stored log through a pull source.
+
+Keep both implementations behind the same service interfaces.  Client graphs
+should not need to know whether the service is live or replayed.
+
+Protocol confirmation and commits
+---------------------------------
+
+Never acknowledge, commit, or release protocol work merely because
+``try_send`` or ``send_blocking`` accepted it.  Enqueueing proves only that the
+graph can receive the buffered value.
+
+When a protocol requires confirmation after successful graph processing,
+carry a correlation key, cursor, or offset with the data.  Emit that identity
+at the point in the graph that defines successful processing and connect it to
+a service sink that performs the acknowledgement or commit.  Kafka
+transactional processing therefore commits from a confirmation flowing
+through the graph, not from the consumer callback that enqueued the record.
+
+Validation
+----------
+
+Test the adaptor through its public wiring interfaces in both C++ and Python
+where Python exposure exists.  At minimum cover:
+
+* start constructs one task and stop requests shutdown and joins it;
+* stop while a producer is blocked returns ``false`` without deadlock;
+* retained senders are inert after graph teardown;
+* ``try_send`` refusal follows the documented producer flow-control path;
+* several producer threads preserve the selected sender policy's semantics;
+* the graph wakes and evaluates only after accepted work is available;
+* protocol acknowledgement occurs only after the explicit confirmation sink;
+  and
+* simulation selects the scheduled or pull-source implementation and creates
+  no producer thread.
+
+See :doc:`services` for service materialization and graph-boundary wiring, and
+:doc:`../user_guide/cpp/authoring_nodes` for the public push-source APIs.

--- a/docs/source/developer_guide/services.rst
+++ b/docs/source/developer_guide/services.rst
@@ -547,6 +547,10 @@ implementation can serve **multiple interfaces** via
 ``register_adaptors<Impl, Interfaces…>(w, path)`` — e.g. a sink-only interface
 in, a source-only interface out:
 
+The task ownership, sender admission, stop/join, simulation specialization,
+and protocol-confirmation rules for such an implementation are defined in
+:doc:`real_time_adaptors`.
+
 .. code-block:: cpp
 
    struct MultiAdaptorImpl

--- a/docs/source/reference/authoring_api.rst
+++ b/docs/source/reference/authoring_api.rst
@@ -120,7 +120,10 @@ Authoring decorators
 
    The decorated start hook receives a thread-safe ``sender(value)`` callable
    as its first argument. It may retain that sender and invoke it from any
-   Python thread while the graph is running.
+   Python thread while the graph is running. The sender returns ``True`` when
+   the value was accepted and ``False`` when the receiver has stopped. A stop
+   hook registered with ``@source.stop`` should request producer shutdown and
+   join its threads.
 
    :param tp: Output time-series type, such as ``TS[int]``.
    :param overloads: Operator contract whose overload set should include this

--- a/docs/source/reference/authoring_api.rst
+++ b/docs/source/reference/authoring_api.rst
@@ -114,7 +114,7 @@ Authoring decorators
    :return: A generator decorator or the decorated source.
 
 
-.. py:function:: hgraph.push_queue(tp, overloads=None, resolvers=None, requires=None, label=None, deprecated=False, *, conflate=False)
+.. py:function:: hgraph.push_queue(tp, overloads=None, resolvers=None, requires=None, label=None, deprecated=False, *, conflate=False, burst=False, max_pending=None)
 
    Decorate an external callback source for real-time graph execution.
 
@@ -132,8 +132,14 @@ Authoring decorators
    :param label: Diagnostic label used in the wired graph.
    :param deprecated: ``True`` or a message string to emit a deprecation
        warning when the source is wired.
-   :param conflate: Retain only the latest pending value when producers run
-       ahead of graph evaluation.
+   :param conflate: Merge pending deltas into one current-state update when
+       producers run ahead of graph evaluation.
+   :param burst: Deliver all scalar values pending at evaluation as one
+       homogeneous tuple. The output must be ``TS[tuple[SCALAR, ...]]``;
+       sender calls accept one ``SCALAR`` at a time.
+   :param max_pending: Optional positive queue capacity. At capacity the
+       Python sender waits without holding the GIL until graph evaluation
+       dequeues work. Not supported with ``conflate=True``.
    :return: A push-queue decorator.
 
 

--- a/docs/source/rfc/rfc_0027_bounded_push_source_queues.rst
+++ b/docs/source/rfc/rfc_0027_bounded_push_source_queues.rst
@@ -378,9 +378,11 @@ Threading:
 * several producer threads may share one sender.  Both entry points are
   safe under the queue mutex.
 
-``send_blocking`` must never be called from the graph evaluation thread.  A
-debug assertion compares against the executor's evaluation thread id; release
-builds do not pay for the check.
+``send_blocking`` must never wait on the graph evaluation thread.  The queue
+captures its consumer thread at start and rejects a full-queue call from that
+thread before entering the condition-variable wait.  An immediately
+admissible call remains legal during a start callback, preserving existing
+unbounded start-hook behaviour.
 
 The sender remains a non-templated, type-erased facade.  The selected policy
 validates each admitted ``Value`` against its sender schema.  Queue and
@@ -594,22 +596,15 @@ Passing a tuple to the sender
    scalar per call so the graph's evaluation cadence defines the opportunistic
    batch boundary.
 
-Unresolved questions
---------------------
+Deferred questions
+------------------
 
-1. **``send_blocking`` on stop.**  This RFC proposes throwing
-   ``PushSourceStopped`` both when called on a stopped node and when stop
-   arrives during the wait.  The alternative is to return silently, matching
-   today's discard.  Throwing is chosen because a discarded message is a
-   silent failure.  The cost is that a clean shutdown racing an in-flight send
-   produces an exception on a normal path.  Resolve before implementation.
-
-2. **Control-lane headroom.**  Some transports must guarantee that a lifecycle
+1. **Control-lane headroom.**  Some transports must guarantee that a lifecycle
    record cannot be starved by a full payload queue.  With one queue this is
    reserved headroom rather than a second lane.  It remains downstream until
    the migrations establish a shared domain-independent requirement.
 
-3. **Two-phase reserve.**  Some producers reserve capacity before performing
+2. **Two-phase reserve.**  Some producers reserve capacity before performing
    work so its resulting control record always has somewhere to land.  This is
    deferred until multiple migrations establish a shared contract.
 
@@ -694,7 +689,27 @@ Compatibility
 Implementation status
 ---------------------
 
-Not started.  This RFC is ``Proposed`` and contains no implementation.
+Stages 1 and 2 are implemented on the RFC implementation branch.  The native
+sender exposes ``try_send`` and ``send_blocking`` through a shared lifecycle
+control, bounded FIFO admission releases capacity at dequeue, stop wakes and
+quiesces blocked producers, and burst reuses that admission queue while
+materialising all detached values into a homogeneous tuple.  Burst
+materialisation moves owning values into an adopted list buffer and uses its
+preselected binding; it performs no per-tick schema lookup or avoidable second
+payload copy.
+
+Python ``push_queue`` exposes ``burst`` and ``max_pending`` and maps its sender
+to native blocking admission with the GIL released.  Native and Python tests
+cover capacity refusal/release, stop and retained-sender safety, concurrent
+producers, burst FIFO/batch boundaries, invalid schemas and option validation,
+and Python blocking behaviour.  The installed-SDK fixture exercises bounded
+queue and burst factories through public headers.
+
+Stage 3 remains the pair of separate downstream migration pull requests.  The
+downstream before/after latency and allocation measurements required for
+``Accepted`` status will be recorded when those duplicate queues are removed.
+Until the implementation and conformance tests merge, this RFC remains
+``Proposed`` as required by RFC 0000.
 
 References
 ----------

--- a/docs/source/rfc/rfc_0027_bounded_push_source_queues.rst
+++ b/docs/source/rfc/rfc_0027_bounded_push_source_queues.rst
@@ -23,12 +23,13 @@ Replace the sender's ``void send(Value)`` with an explicit pair:
 .. code-block:: cpp
 
    [[nodiscard]] bool try_send(Value value) const;
-   void               send_blocking(Value value) const;
+   bool               send_blocking(Value value) const;
 
 ``try_send`` returns ``false`` when the selected policy cannot accept the
-value.  ``send_blocking`` waits until it can, or until the node stops.  Capacity
-is a count of admitted elements; there is no byte accounting in the core
-contract.
+value.  ``send_blocking`` waits until it can and returns ``true``, or returns
+``false`` if the receiver stops before admission.  Its result may be discarded
+when a producer has no stop-specific action.  Capacity is a count of admitted
+elements; there is no byte accounting in the core contract.
 
 The push-source node then *is* the queue.  A service implementation uses one
 push source to carry every value its adaptor returns to the graph, in one
@@ -128,7 +129,7 @@ Sender
    class HGRAPH_EXPORT PushSourceSender
    {
      public:
-       PushSourceSender() noexcept = default;
+       PushSourceSender() noexcept;
 
        [[nodiscard]] bool valid() const noexcept;
        [[nodiscard]] const TypeRealizationSnapshot *type_realization() const noexcept;
@@ -143,13 +144,12 @@ Sender
 
        /** Enqueue, waiting for capacity if necessary.
         *
-        * Must not be called from the graph evaluation thread. Throws
-        * ``PushSourceStopped`` if the node is not accepting when called, or
-        * becomes non-accepting while waiting. */
-       void send_blocking(Value value) const;
+        * Returns false only when the node stops before admission. Must not be
+        * called from the graph evaluation thread when it would wait. */
+       bool send_blocking(Value value) const;
 
        template <typename T> [[nodiscard]] bool try_send(T &&value) const;
-       template <typename T> void send_blocking(T &&value) const;
+       template <typename T> bool send_blocking(T &&value) const;
    };
 
 ``void send(Value)`` is removed rather than deprecated.  It has few call sites
@@ -261,7 +261,7 @@ longer belong to the sender queue.
        *ts_type<TS<HomogeneousTuple<Int>>>(), 256);
 
    // Both calls contribute scalar elements to a later tuple-valued tick.
-   static_cast<void>(sender.try_send(Int{1}));
+   sender.send_blocking(Int{1});
    sender.send_blocking(Int{2});
 
 Protocol acknowledgements
@@ -281,37 +281,54 @@ not change capacity in the push-source queue.
 Usage model
 ~~~~~~~~~~~
 
-A service implementation uses **one** push source for everything its adaptor
-returns to the graph.  The sender schema is a discriminated envelope; the
-implementation demultiplexes it into its several service outputs with ordinary
-graph nodes.
+A service implementation uses one push source for each independently ordered
+asynchronous result stream.  When several related result kinds require one
+order, their sender schema is a discriminated envelope and the implementation
+demultiplexes it with ordinary graph nodes.  A service implementation may own
+more than one push source when the external streams are genuinely independent.
 
 This is the point of the design rather than an incidental economy.  One queue
 is one order, so values that are related — a record and the state change that
 explains it, a delivery failure and its event — arrive in the order the adaptor
 produced them.  Several push sources cannot promise that at any price.
 
-The core does not enforce one push source per implementation; it is the
-documented pattern, and the extension migrations below follow it.
+The core does not expose the sender's queue, lock, condition variable, executor
+notification, or selected policy to the service implementation.  Adaptors only
+retain the sender and use its admission operations.
 
 Python contract
 ---------------
 
-``PySender`` gains no boolean.  Python has no established way to express a
-refused send in the ``push_queue`` protocol today, so its bound ``send`` method
-continues to be passed to the start callback as ``sender(value)`` and maps to
-native ``send_blocking``:
+``PySender.send`` maps to native ``send_blocking`` and returns its boolean
+admission result:
 
 .. code-block:: python
 
    @push_queue(TS[int])
-   def my_source(sender: Callable[[int], None]):
-       sender(1)          # blocks if the queue is full
+   def my_source(sender: Callable[[int], bool]):
+       accepted = sender(1)  # blocks if full; false only after receiver stop
 
 ``PySender::send`` already releases the GIL around the native call
 (``python/py_carriers.h``), so blocking there does not stall the interpreter.
-A stopped node raises ``RuntimeError`` from the same call, replacing the
-current silent discard.
+A stopped node returns ``False``.  The common producer loop may discard this
+result because its stop callback requests task shutdown; a producer that needs
+different shutdown behaviour can inspect it.  Internal sender lifecycle or
+queue implementation types are not exposed to Python.
+
+``@push_queue`` also supports a lifecycle stop hook.  The start hook constructs
+and starts an external task or worker thread and stores it in ``STATE``; the
+stop hook requests shutdown and joins it:
+
+.. code-block:: python
+
+   @push_queue(TS[int])
+   def my_source(sender, state: STATE = None):
+       state.task = start_task(sender)
+
+   @my_source.stop
+   def stop_my_source(state: STATE = None):
+       state.task.request_stop()
+       state.task.join()
 
 ``@push_queue`` gains optional ``max_pending`` and ``burst`` keyword arguments:
 
@@ -384,11 +401,23 @@ thread before entering the condition-variable wait.  An immediately
 admissible call remains legal during a start callback, preserving existing
 unbounded start-hook behaviour.
 
-The sender remains a non-templated, type-erased facade.  The selected policy
-validates each admitted ``Value`` against its sender schema.  Queue and
-conflating policies therefore continue to accept the output delta schema;
-burst accepts the element schema derived from its output tuple.  There is no
-per-send or per-evaluation registry lookup.
+The sender remains a non-templated, type-erased facade.  Its private, non-null
+operations table dispatches either to the live control block or to a canonical
+stopped sentinel; default and moved-from senders therefore return ``false``
+without branches at call sites.  The selected policy validates each admitted
+``Value`` against its sender schema.  Queue and conflating policies therefore
+continue to accept the output delta schema; burst accepts the element schema
+derived from its output tuple.  There is no per-send or per-evaluation registry
+lookup.
+
+The control block holds the sender's internal executor projection.  A policy
+first queues or applies the value under its own synchronization and returns
+whether executor wake-up is required.  Only after successful admission does
+the sender mark push work pending and notify the real-time executor's condition
+variable.  The executor consults that pending state to decide whether to run
+the push-source prefix in the next cycle; the same notification wakes an
+executor waiting for its next scheduled time.  External producer code never
+receives the executor projection or invokes the graph directly.
 
 The ``Burst`` selection uses the queue storage, admission operations, and
 condition-variable machinery unchanged.  Only its ``emit_next`` operation is
@@ -417,12 +446,11 @@ operations that have entered policy storage.  Stop proceeds in this order:
 5. detach the control from node and executor storage before either is
    destroyed.
 
-After step 1, ``try_send`` returns ``false`` and ``send_blocking`` throws
-``PushSourceStopped`` without accessing node storage.  ``valid()`` means the
-control is attached to a running, accepting policy, rather than merely holding
-a non-null historical pointer.  This is one small, explicit erased-ownership
-boundary per push source; payload and queue storage remain owned by the node's
-planned storage.
+After step 1, both sender operations return ``false`` without accessing node
+storage.  ``valid()`` means the control is attached to a running, accepting
+policy, rather than merely holding a non-null historical pointer.  This is one
+small, explicit erased-ownership boundary per push source; payload and queue
+storage remain owned by the node's planned storage.
 
 Performance and memory
 ----------------------
@@ -468,8 +496,8 @@ Source compatibility
 
 Behavioural compatibility
    Default ``max_pending == 0`` preserves today's queue semantics.  The one
-   visible change for existing users is that a Python ``sender(value)`` after
-   stop now raises instead of silently discarding.
+   visible change for existing users is that Python ``sender(value)`` returns
+   a boolean; after stop it returns ``False`` instead of silently discarding.
    ``burst=False`` is the default, so existing Python output schemas and sender
    payload types are unchanged.
 
@@ -655,7 +683,10 @@ Behaviour
      under TSAN and ASan.
    * ``max_pending == 0`` reproduces today's unbounded behaviour, including the
      existing real-time execution tests unchanged.
-   * A stopped node's Python ``sender(value)`` raises rather than discarding.
+   * A stopped node's native and Python blocking send returns ``false`` rather
+     than exposing a sender-internal exception.
+   * Python blocking admission releases the GIL, and a ``@push_queue`` stop
+     hook can request task shutdown and join its thread using shared ``STATE``.
    * Burst rejects every output except ``TS[tuple[SCALAR, ...]]`` and rejects a
      sender value whose schema is not ``SCALAR``.
    * Burst uses the same bounded and unbounded enqueue path as ordinary queue
@@ -698,12 +729,14 @@ materialisation moves owning values into an adopted list buffer and uses its
 preselected binding; it performs no per-tick schema lookup or avoidable second
 payload copy.
 
-Python ``push_queue`` exposes ``burst`` and ``max_pending`` and maps its sender
-to native blocking admission with the GIL released.  Native and Python tests
-cover capacity refusal/release, stop and retained-sender safety, concurrent
-producers, burst FIFO/batch boundaries, invalid schemas and option validation,
-and Python blocking behaviour.  The installed-SDK fixture exercises bounded
-queue and burst factories through public headers.
+Python ``push_queue`` exposes ``burst`` and ``max_pending``, maps its sender to
+native boolean blocking admission with the GIL released, and provides a stop
+hook for task shutdown and thread joining through shared ``STATE``.  Native
+and Python tests cover capacity refusal/release, stop and retained-sender
+safety, concurrent producers, burst FIFO/batch boundaries, invalid schemas and
+option validation, Python blocking behaviour, and start/stop task lifecycle.
+The installed-SDK fixture exercises bounded queue and burst factories through
+public headers.
 
 Stage 3 remains the pair of separate downstream migration pull requests.  The
 downstream before/after latency and allocation measurements required for

--- a/docs/source/specification/10_DATA_SOURCES.md
+++ b/docs/source/specification/10_DATA_SOURCES.md
@@ -356,7 +356,7 @@ Push queues enable asynchronous external data injection with thread-safe semanti
 
 ```python
 @push_queue(TS[str])
-def my_message_sender(sender: Callable[[str], None], values: tuple[str, ...]):
+def my_message_sender(sender: Callable[[str], bool], values: tuple[str, ...]):
     """
     The sender callable is provided by the runtime.
     Call sender(value) from any thread to inject data into the graph.
@@ -380,7 +380,7 @@ from typing import Callable
 from datetime import timedelta
 from hgraph import push_queue, TS, graph, evaluate_graph, GraphConfiguration, EvaluationMode, debug_print, if_true, stop_engine
 
-def _user_input(sender: Callable[[str], None]):
+def _user_input(sender: Callable[[str], bool]):
     while True:
         s = sys.stdin.readline().strip("\n")
         sender(s)
@@ -388,7 +388,7 @@ def _user_input(sender: Callable[[str], None]):
             break
 
 @push_queue(TS[str])
-def user_input(sender: Callable[[str], None]):
+def user_input(sender: Callable[[str], bool]):
     threading.Thread(target=_user_input, args=(sender,)).start()
 
 @graph
@@ -405,13 +405,13 @@ evaluate_graph(main, GraphConfiguration(run_mode=EvaluationMode.REAL_TIME, end_t
 ```python
 # From hgraph_unit_tests/nodes/test_push_queue.py
 def test_push_queue():
-    def _sender(sender: Callable[[str], None], values: [str]):
+    def _sender(sender: Callable[[str], bool], values: [str]):
         for value in values:
             sender(value)
             time.sleep(0.1)
 
     @push_queue(TS[str])
-    def my_message_sender(sender: Callable[[str], None], values: tuple[str, ...]):
+    def my_message_sender(sender: Callable[[str], bool], values: tuple[str, ...]):
         threading.Thread(target=_sender, args=(sender, values)).start()
 
     @graph
@@ -434,12 +434,12 @@ Collect multiple values into tuples before sending:
 ```python
 # From hgraph_unit_tests/nodes/test_push_queue.py
 def test_batch_push_queue():
-    def _sender(sender: Callable[[str], None], values: [str]):
+    def _sender(sender: Callable[[str], bool], values: [str]):
         for value in values:
             sender(value)
 
     @push_queue(TS[Tuple[str, ...]])
-    def my_message_sender(sender: Callable[[str], None], values: tuple[str, ...], batch: bool = True):
+    def my_message_sender(sender: Callable[[str], bool], values: tuple[str, ...], batch: bool = True):
         threading.Thread(target=_sender, args=(sender, values)).start()
 
     @graph
@@ -463,12 +463,12 @@ Skip intermediate values, only forward final state changes:
 ```python
 # From hgraph_unit_tests/nodes/test_push_queue.py
 def test_elide_push_queue():
-    def _sender(sender: Callable[[str], None], values: [str]):
+    def _sender(sender: Callable[[str], bool], values: [str]):
         for value in values:
             sender(value)
 
     @push_queue(TS[str])
-    def my_message_sender(sender: Callable[[str], None], values: tuple[str, ...], elide: bool = True):
+    def my_message_sender(sender: Callable[[str], bool], values: tuple[str, ...], elide: bool = True):
         threading.Thread(target=_sender, args=(sender, values)).start()
 
     @graph
@@ -492,13 +492,13 @@ For multi-keyed data streams:
 ```python
 # From hgraph_unit_tests/nodes/test_push_queue.py
 def test_tsd_push_queue():
-    def _sender(sender: Callable[[str, float], None], values: Tuple[dict[str, float]]):
+    def _sender(sender: Callable[[str, float], bool], values: Tuple[dict[str, float]]):
         for value in values:
             sender(value)
             time.sleep(0.01)
 
     @push_queue(TSD[str, TS[float]])
-    def my_message_sender(sender: Callable[[str, float], None], values: tuple[dict[str, float], ...]):
+    def my_message_sender(sender: Callable[[str, float], bool], values: tuple[dict[str, float], ...]):
         threading.Thread(target=_sender, args=(sender, values)).start()
 
     @graph
@@ -525,11 +525,11 @@ from typing import Callable
 from threading import Thread, Event
 
 @push_queue(TS[bytes])
-def _message_subscriber_queue(sender: Callable[[SCALAR], None] = None, *, topic: str):
+def _message_subscriber_queue(sender: Callable[[SCALAR], bool] = None, *, topic: str):
     KafkaMessageState.instance().set_subscriber_sender(topic, sender)
 
 class KafkaConsumerThread(Thread):
-    def __init__(self, topic, consumer: KafkaConsumer, sender: Callable[[bytes], None]):
+    def __init__(self, topic, consumer: KafkaConsumer, sender: Callable[[bytes], bool]):
         super().__init__()
         self.topic = topic
         self.consumer = consumer
@@ -1161,4 +1161,3 @@ HGraph's data source system provides:
 7. **Mode selection** for simulation vs real-time execution
 
 The separation of pull and push sources ensures that simulation mode remains deterministic while real-time mode can handle external events. The record/replay system enables reproducible testing and back-testing of live systems.
-

--- a/docs/source/user_guide/concepts/node_based_computation.rst
+++ b/docs/source/user_guide/concepts/node_based_computation.rst
@@ -112,7 +112,7 @@ is called during the start life-cycle. It takes at least one input, the sender, 
 ::
 
     @push_queue(TS[bool])
-    def my_message_sender(sender: Callable[[SCALAR], None]):
+    def my_message_sender(sender: Callable[[SCALAR], bool]):
         ...
 
 The ``push_queue`` takes the output type, as a parameter, then the function is
@@ -444,4 +444,3 @@ This is more intrusive and requires you to wire the component into your graph in
 be available.
 
 For more information see :doc:`../tools/inspector`.
-

--- a/docs/source/user_guide/cpp/authoring_nodes.rst
+++ b/docs/source/user_guide/cpp/authoring_nodes.rst
@@ -280,20 +280,52 @@ specialized node/builder rather than the ordinary static-node
 (``runtime/push_source_node.h``) owns the message storage, hands a thread-safe
 ``PushSourceSender`` to user code during ``start``, and delivers values through
 the normal node evaluation path when the real-time engine is woken by queued
-messages. Two delivery policies exist — **Queue** (FIFO; drains one value per
-engine cycle) and **Conflating** (a delta-merging accumulator; delivers the
-merged state). Ordinary asynchronous push sources require a **real-time root
-graph** (they are rejected in simulation mode and inside nested graphs):
+messages. Three wiring-time delivery policies exist:
+
+* **Queue** is FIFO and drains one value per engine cycle. It is unbounded by
+  default, or bounded by a non-zero ``max_pending`` element count.
+* **Burst** uses the same FIFO admission queue but drains every value pending
+  at evaluation into one ``TS<HomogeneousTuple<T>>`` tick. Its sender accepts
+  one ``T`` at a time; it introduces neither a timer nor a target batch size.
+* **Conflating** merges pending deltas into current state and delivers the
+  merged result.
+
+Ordinary asynchronous push sources require a **real-time root graph** (they
+are rejected in simulation mode and inside nested graphs):
 
 .. code-block:: cpp
 
    // Runtime builder — see tests/cpp/test_realtime_execution.cpp
    graph_builder.add_node(make_push_source_node(
        *ts_int,                                            // output schema: TS<Int>
-       make_push_source_queue_policy(*ts_int->value_schema),
+       make_push_source_queue_policy(*ts_int, 256),          // bounded FIFO
        [](PushSourceSender sender) {
            // runs at start; hand `sender` to a producer thread.
-           // sender.send(Int{42}) enqueues a value and wakes the executor.
+           // Refuse without waiting when full:
+           if (!sender.try_send(Int{42})) { /* producer flow control */ }
+           // Or wait for graph dequeue to release capacity:
+           sender.send_blocking(Int{43});
+       }));
+
+``try_send`` returns ``false`` at capacity or after stop. ``send_blocking``
+waits on bounded capacity and throws ``PushSourceStopped`` if the graph stops;
+it must not wait on the graph evaluation thread. Dequeueing releases capacity
+immediately — protocol acknowledgement, when required, is an explicit sink
+node rather than part of sender admission.
+
+Burst selects only delivery; admission remains the same bounded or unbounded
+FIFO queue:
+
+.. code-block:: cpp
+
+   const auto *ts_batch = ts_type<TS<HomogeneousTuple<Int>>>();
+   graph_builder.add_node(make_push_source_node(
+       *ts_batch,
+       make_push_source_burst_policy(*ts_batch, 256),
+       [](PushSourceSender sender) {
+           // Each call admits one Int. Evaluation emits tuple<Int, ...>.
+           static_cast<void>(sender.try_send(Int{1}));
+           static_cast<void>(sender.try_send(Int{2}));
        }));
 
 Push sources are always real-time-only. Deterministic replay and simulation
@@ -305,6 +337,10 @@ derived solely from graph time, never producer-thread timing.
    @push_queue(TS[int])
    def from_queue(sender: Callable[[int], None]):
        ...  # register `sender`; call sender(value) from another thread to inject ticks
+
+   @push_queue(TS[tuple[int, ...]], burst=True, max_pending=256)
+   def from_burst(sender: Callable[[int], None]):
+       ...  # sender(value) blocks without holding the GIL when at capacity
 
 A static-node authoring shape (a sender parameter on ``start`` plus a
 message-application hook) is still **planned**. The important runtime

--- a/docs/source/user_guide/cpp/authoring_nodes.rst
+++ b/docs/source/user_guide/cpp/authoring_nodes.rst
@@ -308,10 +308,13 @@ are rejected in simulation mode and inside nested graphs):
        }));
 
 ``try_send`` returns ``false`` at capacity or after stop. ``send_blocking``
-waits on bounded capacity and throws ``PushSourceStopped`` if the graph stops;
-it must not wait on the graph evaluation thread. Dequeueing releases capacity
-immediately — protocol acknowledgement, when required, is an explicit sink
-node rather than part of sender admission.
+waits on bounded capacity and returns ``false`` if the graph stops before
+admission; its result may be discarded when the producer has no special stop
+action. It must not wait on the graph evaluation thread. The sender owns the
+queue synchronization and notifies the real-time executor only after a value
+has been queued. Dequeueing releases capacity immediately — protocol
+acknowledgement, when required, is an explicit sink node downstream rather
+than part of sender admission.
 
 Burst selects only delivery; admission remains the same bounded or unbounded
 FIFO queue:
@@ -324,8 +327,8 @@ FIFO queue:
        make_push_source_burst_policy(*ts_batch, 256),
        [](PushSourceSender sender) {
            // Each call admits one Int. Evaluation emits tuple<Int, ...>.
-           static_cast<void>(sender.try_send(Int{1}));
-           static_cast<void>(sender.try_send(Int{2}));
+           sender.send_blocking(Int{1});
+           sender.send_blocking(Int{2});
        }));
 
 Push sources are always real-time-only. Deterministic replay and simulation
@@ -335,12 +338,22 @@ derived solely from graph time, never producer-thread timing.
 .. code-block:: python
 
    @push_queue(TS[int])
-   def from_queue(sender: Callable[[int], None]):
-       ...  # register `sender`; call sender(value) from another thread to inject ticks
+   def from_queue(sender: Callable[[int], bool], state: STATE = None):
+       state.task = start_external_task(sender)
+
+   @from_queue.stop
+   def stop_from_queue(state: STATE = None):
+       state.task.request_stop()
+       state.task.join()
 
    @push_queue(TS[tuple[int, ...]], burst=True, max_pending=256)
-   def from_burst(sender: Callable[[int], None]):
-       ...  # sender(value) blocks without holding the GIL when at capacity
+   def from_burst(sender: Callable[[int], bool]):
+       ...  # register `sender`; call sender(value) from another thread to inject ticks
+
+Python ``sender(value)`` blocks without holding the GIL when at capacity and
+returns ``False`` after the receiver has stopped. Start owns construction of
+the producer task; the stop hook requests shutdown and joins every thread it
+started.
 
 A static-node authoring shape (a sender parameter on ``start`` plus a
 message-application hook) is still **planned**. The important runtime

--- a/docs/source/user_guide/python/quick_start/node.rst
+++ b/docs/source/user_guide/python/quick_start/node.rst
@@ -44,7 +44,7 @@ method in Python is to use the ``push_queue`` decorator. This is shown below:
 
     from hgraph import push_queue, TS
 
-    def _user_input(sender: Callable[[str], None]):
+    def _user_input(sender: Callable[[str], bool]):
         while True:
             s = sys.stdin.readline().strip("\n")
             sender(s)
@@ -52,7 +52,7 @@ method in Python is to use the ``push_queue`` decorator. This is shown below:
                 break
 
     @push_queue(TS[str])
-    def my_push_queue(sender: Callable[[str], None]) -> TS[str]:
+    def my_push_queue(sender: Callable[[str], bool]) -> TS[str]:
         threading.Thread(target=_user_input, args=(sender,)).start()
 
 The function accepts at least one parameter, namely the sender. This is a callable
@@ -110,6 +110,5 @@ consuming ticks in a graph and forms the leaves in the DAG.
 Here the sink node takes the value and prints it out. In all cases, no further ticks
 are produced. Once all the scheduled nodes have been processed, the graph evaluation cycle is marked as complete
 and the next cycle is started (or we will wait until we are ready to start the next cycle).
-
 
 

--- a/extensions/kafka/src/detail/service_bridge.h
+++ b/extensions/kafka/src/detail/service_bridge.h
@@ -101,9 +101,7 @@ public:
         wake = state.sender;
       }
     }
-    if (wake.valid()) {
-      wake.send_blocking(generation);
-    }
+    static_cast<void>(wake.try_send(generation));
   }
 
   /** Start queue admission. Real-time services require all queue-owned push
@@ -201,9 +199,7 @@ public:
         wake = state.sender;
       }
     }
-    if (wake.valid()) {
-      wake.send_blocking(generation);
-    }
+    static_cast<void>(wake.try_send(generation));
   }
 
   void finish_record_time_recovery() {
@@ -480,9 +476,7 @@ public:
         wake = state.sender;
       }
     }
-    if (wake.valid()) {
-      wake.send_blocking(generation);
-    }
+    static_cast<void>(wake.try_send(generation));
     return true;
   }
 
@@ -554,9 +548,7 @@ private:
         wake = state.sender;
       }
     }
-    if (wake.valid()) {
-      wake.send_blocking(generation);
-    }
+    static_cast<void>(wake.try_send(generation));
     return true;
   }
   struct QueuedValue {

--- a/extensions/kafka/src/detail/service_bridge.h
+++ b/extensions/kafka/src/detail/service_bridge.h
@@ -102,7 +102,7 @@ public:
       }
     }
     if (wake.valid()) {
-      wake.send(generation);
+      wake.send_blocking(generation);
     }
   }
 
@@ -202,7 +202,7 @@ public:
       }
     }
     if (wake.valid()) {
-      wake.send(generation);
+      wake.send_blocking(generation);
     }
   }
 
@@ -481,7 +481,7 @@ public:
       }
     }
     if (wake.valid()) {
-      wake.send(generation);
+      wake.send_blocking(generation);
     }
     return true;
   }
@@ -555,7 +555,7 @@ private:
       }
     }
     if (wake.valid()) {
-      wake.send(generation);
+      wake.send_blocking(generation);
     }
     return true;
   }

--- a/extensions/kafka/src/detail/service_bridge.h
+++ b/extensions/kafka/src/detail/service_bridge.h
@@ -101,7 +101,7 @@ public:
         wake = state.sender;
       }
     }
-    static_cast<void>(wake.try_send(generation));
+    wake.send_blocking(generation);
   }
 
   /** Start queue admission. Real-time services require all queue-owned push
@@ -199,7 +199,7 @@ public:
         wake = state.sender;
       }
     }
-    static_cast<void>(wake.try_send(generation));
+    wake.send_blocking(generation);
   }
 
   void finish_record_time_recovery() {
@@ -476,7 +476,7 @@ public:
         wake = state.sender;
       }
     }
-    static_cast<void>(wake.try_send(generation));
+    wake.send_blocking(generation);
     return true;
   }
 
@@ -548,7 +548,7 @@ private:
         wake = state.sender;
       }
     }
-    static_cast<void>(wake.try_send(generation));
+    wake.send_blocking(generation);
     return true;
   }
   struct QueuedValue {

--- a/extensions/kafka/tests/CMakeLists.txt
+++ b/extensions/kafka/tests/CMakeLists.txt
@@ -4,6 +4,8 @@ add_executable(hgraph_kafka_tests
 
 target_compile_features(hgraph_kafka_tests PRIVATE cxx_std_23)
 target_link_libraries(hgraph_kafka_tests PRIVATE hgraph::kafka)
+target_include_directories(hgraph_kafka_tests
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 
 if(MSVC)
     target_compile_options(hgraph_kafka_tests PRIVATE /W4 /permissive-)

--- a/extensions/kafka/tests/test_service.cpp
+++ b/extensions/kafka/tests/test_service.cpp
@@ -1,3 +1,5 @@
+#include "detail/service_bridge.h"
+
 #include <hgraph/kafka/service.h>
 #include <hgraph/kafka/testing/fake_broker.h>
 #include <hgraph/kafka/testing/mock_cluster.h>
@@ -38,6 +40,45 @@ void require(bool condition, std::string message) {
   if (!condition) {
     throw std::runtime_error(std::move(message));
   }
+}
+
+void test_bridge_wake_handles_graph_teardown() {
+  const auto *ts_int = ts_type<TS<Int>>();
+  PushSourceSender sender;
+  GraphBuilder builder;
+  builder.add_node(make_push_source_node(
+      *ts_int, make_push_source_conflating_policy(*ts_int),
+      [&sender](PushSourceSender started) { sender = std::move(started); }));
+
+  const DateTime start = wall_now();
+  GraphExecutorBuilder executor_builder;
+  executor_builder.graph_builder(std::move(builder))
+      .mode(GraphExecutorMode::RealTime)
+      .start_time(start)
+      .end_time(start + TimeDelta{1'000'000});
+  auto executor = executor_builder.make_executor();
+  auto graph = executor.view().graph();
+  graph.start(start);
+
+  hgraph::kafka::detail::ServiceBridge bridge{{4, 4096}, {4, 4096},
+                                               {4, 4096}};
+  bridge.attach(hgraph::kafka::detail::OutputChannel::Subscription, sender);
+  bridge.attach(hgraph::kafka::detail::OutputChannel::Delivery, sender);
+  bridge.attach(hgraph::kafka::detail::OutputChannel::Event, sender);
+  bridge.start();
+  graph.stop(start);
+
+  // Broker callbacks can enqueue after graph teardown has closed the retained
+  // sender but before service teardown disables bridge admission. Exercise
+  // both the retained stopped sender and the outstanding-notification path.
+  using hgraph::kafka::detail::OutputChannel;
+  require(bridge.push(OutputChannel::Event, Value{Int{1}}, sizeof(Int)),
+          "a Kafka bridge push racing graph teardown was rejected");
+  require(bridge.push(OutputChannel::Event, Value{Int{2}}, sizeof(Int)),
+          "a Kafka bridge push with an outstanding wake was rejected");
+  require(bridge.pending(OutputChannel::Event) == 2,
+          "teardown-racing Kafka values were not retained");
+  bridge.stop();
 }
 
 template <typename Fn> void require_invalid(Fn &&fn, std::string message) {
@@ -2481,6 +2522,7 @@ void test_real_broker_publish_subscribe_and_commit_round_trip() {
 int main() {
   try {
     hgraph::stdlib::register_standard_operators();
+    test_bridge_wake_handles_graph_teardown();
     const auto release_state = hgraph::make_scope_exit(release_test_state);
     initialize_values();
     test_public_value_validation_and_producer_configuration();

--- a/extensions/kafka/tests/test_service.cpp
+++ b/extensions/kafka/tests/test_service.cpp
@@ -1803,16 +1803,16 @@ void test_subscription_removal_and_readd_uses_a_fresh_assignment_generation() {
   require(commit_sender.has_value(),
           "dynamic Kafka commit push source did not start");
 
-  sender->send(first.clone());
+  sender->send_blocking(first.clone());
   require(subscription_generations.await(1),
           "first subscription assignment did not produce a cursor");
-  sender->send(second.clone());
+  sender->send_blocking(second.clone());
   require(subscription_generations.await(2),
           "replacement subscription assignment did not produce a cursor");
-  sender->send(first.clone());
+  sender->send_blocking(first.clone());
   require(subscription_generations.await(3),
           "re-added subscription assignment did not produce a cursor");
-  commit_sender->send(first_readded_cursor.clone());
+  commit_sender->send_blocking(first_readded_cursor.clone());
   require(stale_commit_events.await(1), "a cursor from the removed assignment "
                                         "was not rejected with a typed event");
 

--- a/extensions/web/src/detail/service_bridge.h
+++ b/extensions/web/src/detail/service_bridge.h
@@ -103,9 +103,7 @@ public:
         wake = state.sender;
       }
     }
-    if (wake.valid()) {
-      wake.send_blocking(generation);
-    }
+    static_cast<void>(wake.try_send(generation));
   }
 
   void start() {
@@ -196,9 +194,7 @@ public:
         wake = state.sender;
       }
     }
-    if (wake.valid()) {
-      wake.send_blocking(generation);
-    }
+    static_cast<void>(wake.try_send(generation));
   }
 
   [[nodiscard]] std::optional<Value> pop(std::size_t channel) {
@@ -344,9 +340,7 @@ public:
         notify = true;
       }
     }
-    if (wake.valid()) {
-      wake.send_blocking(generation);
-    }
+    static_cast<void>(wake.try_send(generation));
     if (notify) {
       deliver_watermark(channel);
     }
@@ -493,9 +487,7 @@ private:
         notify = true;
       }
     }
-    if (wake.valid()) {
-      wake.send_blocking(generation);
-    }
+    static_cast<void>(wake.try_send(generation));
     if (notify) {
       deliver_watermark(channel);
     }

--- a/extensions/web/src/detail/service_bridge.h
+++ b/extensions/web/src/detail/service_bridge.h
@@ -104,7 +104,7 @@ public:
       }
     }
     if (wake.valid()) {
-      wake.send(generation);
+      wake.send_blocking(generation);
     }
   }
 
@@ -197,7 +197,7 @@ public:
       }
     }
     if (wake.valid()) {
-      wake.send(generation);
+      wake.send_blocking(generation);
     }
   }
 
@@ -345,7 +345,7 @@ public:
       }
     }
     if (wake.valid()) {
-      wake.send(generation);
+      wake.send_blocking(generation);
     }
     if (notify) {
       deliver_watermark(channel);
@@ -494,7 +494,7 @@ private:
       }
     }
     if (wake.valid()) {
-      wake.send(generation);
+      wake.send_blocking(generation);
     }
     if (notify) {
       deliver_watermark(channel);

--- a/extensions/web/src/detail/service_bridge.h
+++ b/extensions/web/src/detail/service_bridge.h
@@ -103,7 +103,7 @@ public:
         wake = state.sender;
       }
     }
-    static_cast<void>(wake.try_send(generation));
+    wake.send_blocking(generation);
   }
 
   void start() {
@@ -194,7 +194,7 @@ public:
         wake = state.sender;
       }
     }
-    static_cast<void>(wake.try_send(generation));
+    wake.send_blocking(generation);
   }
 
   [[nodiscard]] std::optional<Value> pop(std::size_t channel) {
@@ -340,7 +340,7 @@ public:
         notify = true;
       }
     }
-    static_cast<void>(wake.try_send(generation));
+    wake.send_blocking(generation);
     if (notify) {
       deliver_watermark(channel);
     }
@@ -487,7 +487,7 @@ private:
         notify = true;
       }
     }
-    static_cast<void>(wake.try_send(generation));
+    wake.send_blocking(generation);
     if (notify) {
       deliver_watermark(channel);
     }

--- a/extensions/web/tests/test_bridge.cpp
+++ b/extensions/web/tests/test_bridge.cpp
@@ -9,6 +9,11 @@
 
 #include <hgraph/web/types.h>
 
+#include <hgraph/lib/std/standard_types.h>
+#include <hgraph/lib/testing/runtime_support.h>
+#include <hgraph/runtime/runtime.h>
+#include <hgraph/types/static_schema.h>
+
 #include <array>
 #include <cstddef>
 #include <iostream>
@@ -61,6 +66,42 @@ void test_reservation_calls_after_stop_are_inert() {
           "a stopped bridge accumulated accounting");
 }
 
+void test_wake_delivery_handles_graph_teardown() {
+  const auto *ts_int = ts_type<TS<Int>>();
+  PushSourceSender sender;
+  GraphBuilder builder;
+  builder.add_node(make_push_source_node(
+      *ts_int, make_push_source_conflating_policy(*ts_int),
+      [&sender](PushSourceSender started) { sender = std::move(started); }));
+
+  const DateTime start = hgraph::testing::wall_now();
+  GraphExecutorBuilder executor_builder;
+  executor_builder.graph_builder(std::move(builder))
+      .mode(GraphExecutorMode::RealTime)
+      .start_time(start)
+      .end_time(start + TimeDelta{1'000'000});
+  auto executor = executor_builder.make_executor();
+  auto graph = executor.view().graph();
+  graph.start(start);
+
+  BoundedBridge<1> bridge{small_limits()};
+  bridge.attach(0, sender);
+  bridge.start();
+  graph.stop(start);
+
+  // Transport callbacks can enqueue after graph teardown has closed the
+  // retained sender but before bridge teardown disables admission. The first
+  // push exercises the retained stopped sender; the second needs no new
+  // notification because a wake is already outstanding.
+  require(bridge.push(0, Value{Int{1}}, sizeof(Int)),
+          "a bridge push racing graph teardown was rejected");
+  require(bridge.push(0, Value{Int{2}}, sizeof(Int)),
+          "a bridge push with an outstanding wake was rejected");
+  require(bridge.pending(0) == 2,
+          "teardown-racing bridge values were not retained");
+  bridge.stop();
+}
+
 } // namespace
 
 int main() {
@@ -68,6 +109,7 @@ int main() {
     register_web_types();
     test_late_push_reserved_is_rejected_not_thrown();
     test_reservation_calls_after_stop_are_inert();
+    test_wake_delivery_handles_graph_teardown();
   } catch (const std::exception &error) {
     std::cerr << "hgraph_web_bridge_tests failed: " << error.what() << "\n";
     return 1;

--- a/include/hgraph/runtime/push_source_node.h
+++ b/include/hgraph/runtime/push_source_node.h
@@ -20,6 +20,7 @@ namespace hgraph
     {
         struct PushSourcePolicyOps;
         struct PushSourcePolicyAccess;
+        struct PushSourceSenderOps;
         class PushSourceSenderControl;
     }
 
@@ -72,25 +73,23 @@ namespace hgraph
         };
     }
 
-    /** Raised when blocking admission cannot complete because the source is
-     * not running or its graph is stopping. */
-    class HGRAPH_EXPORT PushSourceStopped : public std::runtime_error
-    {
-      public:
-        PushSourceStopped();
-    };
-
     /**
      * Sender handed to push-source user code during node start.
      *
      * The sender is a copyable handle onto a lifetime-safe control block for
      * the owning node's policy storage. Admission marks the root real-time
-     * executor only when the policy accepts a ready update.
+     * executor only after the policy accepts a ready update. Its policy and
+     * synchronization remain internal; default and moved-from handles bind a
+     * canonical stopped sentinel.
      */
     class HGRAPH_EXPORT PushSourceSender
     {
       public:
-        PushSourceSender() noexcept = default;
+        PushSourceSender() noexcept;
+        PushSourceSender(const PushSourceSender &) noexcept = default;
+        PushSourceSender &operator=(const PushSourceSender &) noexcept = default;
+        PushSourceSender(PushSourceSender &&other) noexcept;
+        PushSourceSender &operator=(PushSourceSender &&other) noexcept;
 
         [[nodiscard]] bool valid() const noexcept;
         [[nodiscard]] const TypeRealizationSnapshot *type_realization() const noexcept;
@@ -99,10 +98,11 @@ namespace hgraph
          * when the source is not accepting values. */
         [[nodiscard]] bool try_send(Value value) const;
 
-        /** Wait for admission when a bounded queue is full. This must not
-         * wait on the graph evaluation thread. Throws ``PushSourceStopped``
-         * when the source stops before admission. */
-        void send_blocking(Value value) const;
+        /** Wait for admission when a bounded queue is full. Returns false
+         * only when the source stops before admission. The result may be
+         * discarded when the producer has no stop-specific action. This must
+         * not wait on the graph evaluation thread. */
+        bool send_blocking(Value value) const;
 
         template <typename T>
         [[nodiscard]] bool try_send(T &&value) const
@@ -111,9 +111,9 @@ namespace hgraph
         }
 
         template <typename T>
-        void send_blocking(T &&value) const
+        bool send_blocking(T &&value) const
         {
-            send_blocking(Value{std::forward<T>(value)});
+            return send_blocking(Value{std::forward<T>(value)});
         }
 
       private:
@@ -122,6 +122,7 @@ namespace hgraph
         explicit PushSourceSender(
             std::shared_ptr<detail::PushSourceSenderControl> control) noexcept;
 
+        const detail::PushSourceSenderOps                  *ops_;
         std::shared_ptr<detail::PushSourceSenderControl> control_{};
     };
 

--- a/include/hgraph/runtime/push_source_node.h
+++ b/include/hgraph/runtime/push_source_node.h
@@ -3,8 +3,11 @@
 
 #include <hgraph/runtime/executor.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <memory>
+#include <stdexcept>
 #include <utility>
 
 namespace hgraph
@@ -17,13 +20,14 @@ namespace hgraph
     {
         struct PushSourcePolicyOps;
         struct PushSourcePolicyAccess;
-        struct PushSourcePolicyStorageRef;
+        class PushSourceSenderControl;
     }
 
     enum class PushSourcePolicyKind : std::uint8_t
     {
         Queue,
         Conflating,
+        Burst,
     };
 
     class HGRAPH_EXPORT PushSourcePolicy
@@ -37,7 +41,7 @@ namespace hgraph
 
       private:
         friend struct detail::PushSourcePolicyAccess;
-        friend struct detail::PushSourcePolicyStorageRef;
+        friend class detail::PushSourceSenderControl;
 
         PushSourcePolicy(const detail::PushSourcePolicyOps *ops, const void *context) noexcept;
 
@@ -47,17 +51,6 @@ namespace hgraph
 
     namespace detail
     {
-        struct PushSourcePolicyStorageRef
-        {
-            PushSourcePolicy   policy{};
-            void              *storage{nullptr};
-            PushQueueEngineView push_engine{};
-            const TypeRealizationSnapshot *type_realization{nullptr};
-
-            [[nodiscard]] bool bound() const noexcept;
-            void send(Value value) const;
-        };
-
         struct PushSourcePolicyAccess
         {
             [[nodiscard]] static PushSourcePolicy make_policy(
@@ -66,10 +59,7 @@ namespace hgraph
             [[nodiscard]] static const MemoryUtils::StoragePlan &storage_plan(
                 const PushSourcePolicy &policy);
             [[nodiscard]] static PushSourceSender make_sender(
-                PushSourcePolicy policy,
-                void *storage,
-                PushQueueEngineView push_engine,
-                const TypeRealizationSnapshot *type_realization) noexcept;
+                std::shared_ptr<PushSourceSenderControl> control) noexcept;
             static void start(const PushSourcePolicy &policy,
                               void *storage,
                               const TSValueTypeMetaData &output_schema);
@@ -82,12 +72,20 @@ namespace hgraph
         };
     }
 
+    /** Raised when blocking admission cannot complete because the source is
+     * not running or its graph is stopping. */
+    class HGRAPH_EXPORT PushSourceStopped : public std::runtime_error
+    {
+      public:
+        PushSourceStopped();
+    };
+
     /**
      * Sender handed to push-source user code during node start.
      *
-     * The sender is a lightweight handle onto the owning node's policy storage.
-     * Sending copies/moves an owned value into the policy and marks the root
-     * real-time executor when the policy accepts a ready update.
+     * The sender is a copyable handle onto a lifetime-safe control block for
+     * the owning node's policy storage. Admission marks the root real-time
+     * executor only when the policy accepts a ready update.
      */
     class HGRAPH_EXPORT PushSourceSender
     {
@@ -97,20 +95,34 @@ namespace hgraph
         [[nodiscard]] bool valid() const noexcept;
         [[nodiscard]] const TypeRealizationSnapshot *type_realization() const noexcept;
 
-        void send(Value value) const;
+        /** Attempt admission without waiting. Returns false at capacity or
+         * when the source is not accepting values. */
+        [[nodiscard]] bool try_send(Value value) const;
+
+        /** Wait for admission when a bounded queue is full. This must not
+         * wait on the graph evaluation thread. Throws ``PushSourceStopped``
+         * when the source stops before admission. */
+        void send_blocking(Value value) const;
 
         template <typename T>
-        void send(T &&value) const
+        [[nodiscard]] bool try_send(T &&value) const
         {
-            send(Value{std::forward<T>(value)});
+            return try_send(Value{std::forward<T>(value)});
+        }
+
+        template <typename T>
+        void send_blocking(T &&value) const
+        {
+            send_blocking(Value{std::forward<T>(value)});
         }
 
       private:
         friend struct detail::PushSourcePolicyAccess;
 
-        explicit PushSourceSender(detail::PushSourcePolicyStorageRef policy_storage) noexcept;
+        explicit PushSourceSender(
+            std::shared_ptr<detail::PushSourceSenderControl> control) noexcept;
 
-        detail::PushSourcePolicyStorageRef policy_storage_{};
+        std::shared_ptr<detail::PushSourceSenderControl> control_{};
     };
 
     using PushSourceStartCallback = std::function<void(PushSourceSender)>;
@@ -134,7 +146,7 @@ namespace hgraph
         const ValueTypeMetaData &sender_schema);
 
     [[nodiscard]] HGRAPH_EXPORT PushSourcePolicy make_push_source_queue_policy(
-        const ValueTypeMetaData &sender_schema);
+        const ValueTypeMetaData &sender_schema, std::size_t max_pending = 0);
 
     [[nodiscard]] HGRAPH_EXPORT PushSourcePolicy make_push_source_conflating_policy(
         const ValueTypeMetaData &sender_schema);
@@ -149,7 +161,12 @@ namespace hgraph
         const ValueTypeMetaData *authored_schema);
 
     [[nodiscard]] HGRAPH_EXPORT PushSourcePolicy make_push_source_queue_policy(
-        const TSValueTypeMetaData &output_schema);
+        const TSValueTypeMetaData &output_schema, std::size_t max_pending = 0);
+
+    /** Queue individual scalar values and deliver all pending values as one
+     * homogeneous variadic tuple per graph evaluation. */
+    [[nodiscard]] HGRAPH_EXPORT PushSourcePolicy make_push_source_burst_policy(
+        const TSValueTypeMetaData &output_schema, std::size_t max_pending = 0);
 
     [[nodiscard]] HGRAPH_EXPORT PushSourcePolicy make_push_source_conflating_policy(
         const TSValueTypeMetaData &output_schema);

--- a/include/hgraph/types/value/compact_storage.h
+++ b/include/hgraph/types/value/compact_storage.h
@@ -27,6 +27,8 @@
 
 namespace hgraph
 {
+    class ListBuilder;
+
     /**
      * Compact, immutable-after-construction storage shapes for the value
      * layer's container kinds. See *Allocation, Plans and Ops > Scalar
@@ -485,6 +487,19 @@ namespace hgraph
         }
 
       private:
+        friend class ListBuilder;
+
+        struct AdoptElementsTag
+        {
+        };
+
+        ListStorage(AdoptElementsTag, const ValueTypeRef &element_binding,
+                    void *bytes, std::size_t size, std::vector<bool> validity) noexcept
+            : bytes_{bytes}, size_{size}, element_binding_{element_binding},
+              validity_{std::move(validity)}
+        {
+        }
+
         void clear() noexcept
         {
             if (element_binding_ == nullptr) { return; }

--- a/include/hgraph/types/value/value_builder.h
+++ b/include/hgraph/types/value/value_builder.h
@@ -34,9 +34,9 @@ namespace hgraph
      *
      * Each builder is single-use. The accumulated elements live in a
      * type-erased contiguous buffer driven by the bound element plan;
-     * ``build_storage()`` copies them into a freshly-constructed
-     * compact storage of the now-known size and the builder's buffer
-     * is reset.
+     * ``build_storage()`` transfers that buffer into compact storage and
+     * resets the builder. Owning ``Value`` inputs can likewise be moved into
+     * the accumulator, avoiding another payload copy during materialisation.
      */
 
     namespace builder_detail
@@ -52,6 +52,13 @@ namespace hgraph
         class ElementAccumulator
         {
           public:
+            struct ReleasedElements
+            {
+                void             *bytes{nullptr};
+                std::size_t       size{0};
+                std::vector<bool> validity{};
+            };
+
             explicit ElementAccumulator(const MemoryUtils::StoragePlan &plan) : plan_{&plan} {}
 
             ElementAccumulator(const ElementAccumulator &)            = delete;
@@ -123,6 +130,45 @@ namespace hgraph
                 rollback.release();
             }
 
+            /** Append by transferring an owning value into the accumulator.
+                Exact bindings use the storage plan's move constructor;
+                compatible representations use their erased move-assignment
+                operation. */
+            void push_back_from(const ValueTypeRef &target, Value &&source)
+            {
+                if (!source.has_value())
+                {
+                    throw std::invalid_argument("container builder requires a live source value");
+                }
+                if (target.plan() != plan_)
+                {
+                    throw std::logic_error("container builder target binding does not match its accumulator plan");
+                }
+                const auto source_binding = source.binding();
+                if (!source_binding || !target.ops_ref().accepts_source(target, source_binding))
+                {
+                    throw std::invalid_argument(
+                        "container builder target binding does not accept its source binding");
+                }
+                if (size_ == capacity_) { grow(std::max<std::size_t>(capacity_ * 2, 8)); }
+                void *destination = slot_address(size_);
+                if (target == source_binding)
+                {
+                    plan_->move_construct(destination, const_cast<void *>(source.view().data()));
+                }
+                else
+                {
+                    plan_->default_construct(destination);
+                    auto rollback = make_scope_exit([&]() noexcept { plan_->destroy(destination); });
+                    target.ops_ref().move_assign_from(
+                        target, destination, source_binding,
+                        const_cast<void *>(source.view().data()));
+                    rollback.release();
+                }
+                if (!validity_.empty()) { validity_.push_back(true); }
+                ++size_;
+            }
+
             /** Append a default-constructed HOLE (element validity): the slot
                 is live memory but reads report it unset. The first hole sizes
                 the (otherwise-empty, dense) validity bitset. */
@@ -158,6 +204,28 @@ namespace hgraph
                     .stride = plan_->layout.size,
                     .plan   = plan_,
                 };
+            }
+
+            [[nodiscard]] ReleasedElements release()
+            {
+                // Compact storage promises an exact-size allocation. Shrink by
+                // moving elements when geometric accumulation left headroom.
+                if (size_ == 0)
+                {
+                    clear();
+                    return {};
+                }
+                if (capacity_ != size_) { grow(size_); }
+                ReleasedElements result{
+                    .bytes = bytes_,
+                    .size = size_,
+                    .validity = std::move(validity_),
+                };
+                bytes_ = nullptr;
+                capacity_ = 0;
+                size_ = 0;
+                validity_.clear();
+                return result;
             }
 
             void clear() noexcept
@@ -281,6 +349,13 @@ namespace hgraph
             accumulator_.push_back_from(element_binding_, value);
         }
 
+        /** Append by moving an owning value into the result buffer. */
+        void push_back(Value &&value)
+        {
+            ensure_not_built();
+            accumulator_.push_back_from(element_binding_, std::move(value));
+        }
+
         /** Append an UNSET element (a hole) - element validity. */
         void push_back_unset()
         {
@@ -300,8 +375,10 @@ namespace hgraph
         [[nodiscard]] ListStorage build_storage()
         {
             ensure_not_built();
-            ListStorage storage{element_binding_, accumulator_.as_span(), accumulator_.validity()};
-            accumulator_.clear();
+            auto elements = accumulator_.release();
+            ListStorage storage{
+                ListStorage::AdoptElementsTag{}, element_binding_, elements.bytes,
+                elements.size, std::move(elements.validity)};
             built_ = true;
             return storage;
         }

--- a/python/hgraph/_wiring/_node.py
+++ b/python/hgraph/_wiring/_node.py
@@ -1301,7 +1301,8 @@ class _PushQueue:
     """hgraph's @push_queue: the wrapped function is the node's START
     lifecycle hook - called with the sender callable as its first argument
     (plus any wiring-time scalars as kwargs) once the real-time graph is
-    running. sender(value) is thread-safe from any Python thread."""
+    running. sender(value) is thread-safe from any Python thread. A stop hook
+    may be registered with ``@source.stop`` to stop and join producer tasks."""
 
     def __init__(self, fn, tp, conflate, burst, max_pending, *, resolvers=None, requires=None,
                  label=None, deprecated=False):
@@ -1352,6 +1353,34 @@ class _PushQueue:
         self._requires = requires
         self._label = label
         self._deprecated = deprecated
+        self._stop_fn = None
+
+    def _stop_annotation(self, parameter):
+        for fn_parameter in list(
+                inspect.signature(self.fn, eval_str=True).parameters.values())[1:]:
+            if fn_parameter.name == parameter.name:
+                return fn_parameter.annotation
+        return parameter.annotation
+
+    def stop(self, fn):
+        for parameter in inspect.signature(fn, eval_str=True).parameters.values():
+            annotation = self._stop_annotation(parameter)
+            injectable = (
+                annotation in _INJECTABLE_MARKERS
+                or isinstance(annotation, _StateExpr)
+            )
+            if injectable:
+                if parameter.default is not None:
+                    raise TypeError(
+                        f"injectable parameter '{parameter.name}' of "
+                        f"'{self.__name__}.stop' must default to None")
+                continue
+            if _is_time_series_annotation(annotation):
+                raise TypeError(
+                    f"@{self.__name__}.stop supports wiring-time scalars "
+                    "and injectables only")
+        self._stop_fn = fn
+        return fn
 
     @property
     def signature(self):
@@ -1385,11 +1414,42 @@ class _PushQueue:
             factory if name is None else bound_call.arguments[name]
             for name, factory in self._scalar_specs
         ]
+        stop_layout = []
+        stop_scalars = []
+        stop_keyword_names = []
+        if self._stop_fn is not None:
+            for parameter in inspect.signature(
+                    self._stop_fn, eval_str=True).parameters.values():
+                annotation = self._stop_annotation(parameter)
+                if isinstance(annotation, _StateExpr):
+                    stop_layout.append("Q")
+                    stop_scalars.append(annotation.factory)
+                elif (marker := _INJECTABLE_MARKERS.get(annotation)) is not None:
+                    stop_layout.append(marker)
+                else:
+                    if parameter.name in bound_call.arguments:
+                        value = bound_call.arguments[parameter.name]
+                    elif parameter.default is not inspect.Parameter.empty:
+                        value = parameter.default
+                    else:
+                        raise TypeError(
+                            f"{self.__name__}.stop: scalar '{parameter.name}' "
+                            "is not supplied by the push_queue call")
+                    stop_layout.append("s")
+                    stop_scalars.append(value)
+                if parameter.kind is inspect.Parameter.KEYWORD_ONLY:
+                    stop_keyword_names.append(parameter.name)
+        stop_config = "".join(stop_layout)
+        if stop_keyword_names:
+            stop_config += "|" + ",".join(stop_keyword_names)
 
         port, _sender = w.push_source(
             _unwrap(out_tp), self.conflate, self.burst, self.max_pending,
             _hgraph.node_ref(self.fn),
-            self._config, _hgraph.any_list(scalars),
+            self._config,
+            _hgraph.node_ref(self._stop_fn or self.fn),
+            self._stop_fn is not None, stop_config, len(scalars),
+            _hgraph.any_list(scalars + stop_scalars),
             self._label or self.__name__)
         return WiringPort(port)
 
@@ -1401,7 +1461,10 @@ def push_queue(tp, overloads=None, resolvers=None, requires=None, label=None,
 
     The decorated start hook receives a thread-safe ``sender(value)`` callable
     as its first argument. It may retain that sender and invoke it from any
-    Python thread while the graph is running.
+    Python thread while the graph is running. The sender returns ``True`` when
+    the value was accepted and ``False`` when the receiver has stopped. A stop
+    hook registered with ``@source.stop`` should request producer shutdown and
+    join its threads.
 
     :param tp: Output time-series type, such as ``TS[int]``.
     :param overloads: Operator contract whose overload set should include this

--- a/python/hgraph/_wiring/_node.py
+++ b/python/hgraph/_wiring/_node.py
@@ -1303,11 +1303,13 @@ class _PushQueue:
     (plus any wiring-time scalars as kwargs) once the real-time graph is
     running. sender(value) is thread-safe from any Python thread."""
 
-    def __init__(self, fn, tp, conflate, *, resolvers=None, requires=None,
+    def __init__(self, fn, tp, conflate, burst, max_pending, *, resolvers=None, requires=None,
                  label=None, deprecated=False):
         self.fn = fn
         self.tp = tp
         self.conflate = conflate
+        self.burst = burst
+        self.max_pending = max_pending
         self.__name__ = fn.__name__
         signature, self._default_type_var = _default_type_var_of(
             inspect.signature(fn, eval_str=True))
@@ -1385,14 +1387,16 @@ class _PushQueue:
         ]
 
         port, _sender = w.push_source(
-            _unwrap(out_tp), self.conflate, _hgraph.node_ref(self.fn),
+            _unwrap(out_tp), self.conflate, self.burst, self.max_pending,
+            _hgraph.node_ref(self.fn),
             self._config, _hgraph.any_list(scalars),
             self._label or self.__name__)
         return WiringPort(port)
 
 
 def push_queue(tp, overloads=None, resolvers=None, requires=None, label=None,
-               deprecated=False, *, conflate=False):
+               deprecated=False, *, conflate=False, burst=False,
+               max_pending=None):
     """Decorate an external callback source for real-time graph execution.
 
     The decorated start hook receives a thread-safe ``sender(value)`` callable
@@ -1409,13 +1413,29 @@ def push_queue(tp, overloads=None, resolvers=None, requires=None, label=None,
     :param label: Diagnostic label used in the wired graph.
     :param deprecated: ``True`` or a message string to emit a deprecation
         warning when the source is wired.
-    :param conflate: Retain only the latest pending value when producers run
-        ahead of graph evaluation.
+    :param conflate: Merge pending deltas into one current-state update when
+        producers run ahead of graph evaluation.
+    :param burst: Deliver all scalar values pending at evaluation as one
+        homogeneous tuple. The output must be ``TS[tuple[SCALAR, ...]]``;
+        sender calls accept one ``SCALAR`` at a time.
+    :param max_pending: Optional positive queue capacity. At capacity the
+        Python sender waits without holding the GIL until graph evaluation
+        dequeues work. Not supported with ``conflate=True``.
     :return: A push-queue decorator.
     """
     def decorator(fn):
+        if conflate and burst:
+            raise TypeError("push_queue conflate and burst are mutually exclusive")
+        if conflate and max_pending is not None:
+            raise TypeError("push_queue max_pending is not supported with conflate")
+        if max_pending is not None:
+            if isinstance(max_pending, bool) or not isinstance(max_pending, int):
+                raise TypeError("push_queue max_pending must be a positive integer or None")
+            if max_pending <= 0:
+                raise ValueError("push_queue max_pending must be greater than zero")
         wrapped = _PushQueue(
-            fn, tp, conflate, resolvers=resolvers, requires=requires,
+            fn, tp, conflate, burst, max_pending,
+            resolvers=resolvers, requires=requires,
             label=label, deprecated=deprecated)
         if overloads is not None:
             _register_overload(overloads, wrapped, requires)

--- a/python/hgraph/adaptors/delta/delta_adaptor_raw.py
+++ b/python/hgraph/adaptors/delta/delta_adaptor_raw.py
@@ -144,7 +144,14 @@ def delta_read_adaptor_raw_impl(
 
     @send_query.stop
     def stop_send_query(request_id: TS[int], _state: STATE = None):
-        sender_ref["sender"]({request_id.value: __import__("hgraph").REMOVE})
+        try:
+            sender_ref["sender"]({request_id.value: __import__("hgraph").REMOVE})
+        except RuntimeError as error:
+            # A mapped child can stop after its push source during whole-graph
+            # teardown. The removal is then unobservable, and the push-source
+            # sender intentionally reports that it no longer accepts values.
+            if str(error) != "Push source is not accepting values":
+                raise
 
     map_(
         lambda key, table, columns, filters, sort, credentials, executor:

--- a/python/hgraph/adaptors/delta/delta_adaptor_raw.py
+++ b/python/hgraph/adaptors/delta/delta_adaptor_raw.py
@@ -144,14 +144,10 @@ def delta_read_adaptor_raw_impl(
 
     @send_query.stop
     def stop_send_query(request_id: TS[int], _state: STATE = None):
-        try:
-            sender_ref["sender"]({request_id.value: __import__("hgraph").REMOVE})
-        except RuntimeError as error:
-            # A mapped child can stop after its push source during whole-graph
-            # teardown. The removal is then unobservable, and the push-source
-            # sender intentionally reports that it no longer accepts values.
-            if str(error) != "Push source is not accepting values":
-                raise
+        # A mapped child can stop after its push source during whole-graph
+        # teardown. The removal is then unobservable, so the sender's false
+        # result can be discarded here.
+        sender_ref["sender"]({request_id.value: __import__("hgraph").REMOVE})
 
     map_(
         lambda key, table, columns, filters, sort, credentials, executor:

--- a/python/py_carriers.h
+++ b/python/py_carriers.h
@@ -12,6 +12,8 @@
 
 #include "module_internal.h"
 
+#include <atomic>
+
 #include <hgraph/lib/std/std_operators.h>
 #include <hgraph/types/time_series/ts_output/alternative.h>
 #include <hgraph/types/wired_fn.h>
@@ -127,7 +129,9 @@ namespace hgraph::python_bridge
     {
         PushSourceSender           sender{};
         const TSValueTypeMetaData *schema{nullptr};
+        const ValueTypeMetaData   *sender_value_schema{nullptr};
         const TypeRealizationSnapshot *type_realization{nullptr};
+        std::atomic_bool           started_once{false};
     };
 
     struct PySender
@@ -138,12 +142,18 @@ namespace hgraph::python_bridge
         {
             if (slot == nullptr || !slot->sender.valid())
             {
+                if (slot != nullptr && slot->started_once.load(std::memory_order_acquire))
+                {
+                    throw PushSourceStopped{};
+                }
                 throw std::logic_error("push sender is not started yet (the graph must be running)");
             }
             TypeRealizationScope realization_scope{slot->type_realization};
-            Value value = py_to_delta(object, slot->schema);
+            Value value = slot->sender_value_schema != nullptr
+                              ? py_to_value_as(object, slot->sender_value_schema)
+                              : py_to_delta(object, slot->schema);
             nb::gil_scoped_release release;
-            slot->sender.send(std::move(value));
+            slot->sender.send_blocking(std::move(value));
         }
     };
 

--- a/python/py_carriers.h
+++ b/python/py_carriers.h
@@ -138,13 +138,13 @@ namespace hgraph::python_bridge
     {
         std::shared_ptr<PySenderSlot> slot;
 
-        void send(nb::handle object) const
+        [[nodiscard]] bool send(nb::handle object) const
         {
             if (slot == nullptr || !slot->sender.valid())
             {
                 if (slot != nullptr && slot->started_once.load(std::memory_order_acquire))
                 {
-                    throw PushSourceStopped{};
+                    return false;
                 }
                 throw std::logic_error("push sender is not started yet (the graph must be running)");
             }
@@ -153,7 +153,7 @@ namespace hgraph::python_bridge
                               ? py_to_value_as(object, slot->sender_value_schema)
                               : py_to_delta(object, slot->schema);
             nb::gil_scoped_release release;
-            slot->sender.send_blocking(std::move(value));
+            return slot->sender.send_blocking(std::move(value));
         }
     };
 

--- a/python/py_nodes.cpp
+++ b/python/py_nodes.cpp
@@ -578,8 +578,9 @@ void py_assemble_lifecycle_args(std::string_view layout,
                                 EngineControlView engine,
                                 const PyTsLease &lease, const NodeView &node,
                                 nb::list &call_args,
-                                const TSInputView *inputs = nullptr) {
-  std::size_t scalar_index = 0;
+                                const TSInputView *inputs = nullptr,
+                                std::size_t scalar_offset = 0) {
+  std::size_t scalar_index = scalar_offset;
   auto scalar_list =
       scalars.valid() ? std::optional{scalars.as_list()} : std::nullopt;
   for (const char kind : layout) {
@@ -1605,8 +1606,46 @@ void py_call_push_queue_start(nb::handle fn, std::string_view config,
   });
 }
 
-void py_release_push_queue_state(const NodeView &node) {
+void py_call_push_queue_stop(nb::handle fn, bool enabled,
+                             std::string_view config,
+                             std::size_t scalar_offset,
+                             const ValueView &scalars,
+                             const NodeView &node) {
   State<PyStateRef> state{node.state()};
+  auto release = UnwindCleanupGuard([&] { py_release_state(state); });
+  if (enabled) {
+    NodeScheduler scheduler;
+    if (node.has_scheduler()) {
+      auto executor = node.graph().executor();
+      const bool supports_wall_clock =
+          executor.valid() &&
+          executor.schema()->mode == GraphExecutorMode::RealTime;
+      scheduler = NodeScheduler{
+          node.scheduler_state(), node.graph_value(), node.node_index(),
+          executor.evaluation_clock().evaluation_time(), node.started(),
+          node.evaluation_clock(), supports_wall_clock};
+    }
+    const auto engine = node.graph().executor().engine_control();
+    translate_python_error([&] {
+      const auto shape = parse_py_call_shape(config);
+      nb::list call_args;
+      auto lease = py_ts_lease_for_node(state);
+      auto invalid = UnwindCleanupGuard([&] { lease.invalidate(); });
+      nb::object runtime_state = py_runtime_global_state_for_call(
+          shape.layout, node.global_state(), lease, state.get().call_lease);
+      py_assemble_lifecycle_args(
+          shape.layout, scalars, &state, nullptr,
+          engine.evaluation_clock().evaluation_time(), scheduler,
+          runtime_state, engine, lease, node, call_args, nullptr,
+          scalar_offset);
+      auto call_kwargs = py_peel_kwargs(call_args, shape.kw_names);
+      (void)py_call_with_contexts(nb::borrow(fn), call_args, std::nullopt,
+                                  std::move(call_kwargs));
+      invalid.release();
+      lease.invalidate();
+    });
+  }
+  release.release();
   py_release_state(state);
 }
 } // namespace hgraph::python_bridge

--- a/python/py_runtime.h
+++ b/python/py_runtime.h
@@ -33,7 +33,11 @@ namespace hgraph::python_bridge
                                   const NodeView &node,
                                   DateTime evaluation_time);
 
-    void py_release_push_queue_state(const NodeView &node);
+    void py_call_push_queue_stop(nb::handle fn, bool enabled,
+                                 std::string_view config,
+                                 std::size_t scalar_offset,
+                                 const ValueView &scalars,
+                                 const NodeView &node);
 
     /** Copy a window's evaluation timestamps into the value layer's standard
         NumPy-compatible one-dimensional buffer.  The scalar binding owns the

--- a/python/py_wiring.cpp
+++ b/python/py_wiring.cpp
@@ -1325,7 +1325,9 @@ namespace hgraph::python_bridge
              nb::arg("_on_prepared") = nb::none())
         .def("push_source", &PyWiring::push_source, nb::arg("ts_type"), nb::arg("conflate") = false,
              nb::arg("burst") = false, nb::arg("max_pending") = nb::none(),
-             nb::arg("fn"), nb::arg("config"), nb::arg("scalars"),
+             nb::arg("fn"), nb::arg("config"), nb::arg("stop_fn"),
+             nb::arg("stop_enabled"), nb::arg("stop_config"),
+             nb::arg("stop_scalar_offset"), nb::arg("scalars"),
              nb::arg("node_label") = nb::none());
 
     m.def(

--- a/python/py_wiring.cpp
+++ b/python/py_wiring.cpp
@@ -1324,6 +1324,7 @@ namespace hgraph::python_bridge
              nb::arg("snapshot") = false,
              nb::arg("_on_prepared") = nb::none())
         .def("push_source", &PyWiring::push_source, nb::arg("ts_type"), nb::arg("conflate") = false,
+             nb::arg("burst") = false, nb::arg("max_pending") = nb::none(),
              nb::arg("fn"), nb::arg("config"), nb::arg("scalars"),
              nb::arg("node_label") = nb::none());
 

--- a/python/py_wiring.h
+++ b/python/py_wiring.h
@@ -420,17 +420,37 @@ namespace hgraph::python_bridge
             return run;
         }
 
-        [[nodiscard]] nb::tuple push_source(PyTsType ts_type, bool conflate,
+        [[nodiscard]] nb::tuple push_source(PyTsType ts_type, bool conflate, bool burst,
+                                            std::optional<std::size_t> max_pending,
                                             PyNodeHandle fn,
                                             std::string config,
                                             PyScalarValue scalars,
                                             std::optional<std::string> node_label)
         {
             ensure_open();
-            auto slot     = std::make_shared<PySenderSlot>();
-            slot->schema  = ts_type.meta;
-            auto policy   = conflate ? make_push_source_conflating_policy(*ts_type.meta)
-                                     : make_push_source_queue_policy(*ts_type.meta);
+            if (conflate && burst)
+            {
+                throw std::invalid_argument("push_queue conflate and burst are mutually exclusive");
+            }
+            if (conflate && max_pending.has_value())
+            {
+                throw std::invalid_argument("push_queue max_pending is not supported with conflate");
+            }
+            if (max_pending.has_value() && *max_pending == 0)
+            {
+                throw std::invalid_argument("push_queue max_pending must be greater than zero");
+            }
+
+            auto policy = burst
+                              ? make_push_source_burst_policy(
+                                    *ts_type.meta, max_pending.value_or(0))
+                              : conflate
+                                    ? make_push_source_conflating_policy(*ts_type.meta)
+                                    : make_push_source_queue_policy(
+                                          *ts_type.meta, max_pending.value_or(0));
+            auto slot = std::make_shared<PySenderSlot>();
+            slot->schema = ts_type.meta;
+            slot->sender_value_schema = burst ? &policy.sender_schema() : nullptr;
             const bool uses_scheduler = config.find('d') != std::string::npos;
             const bool uses_global_state = config.find('g') != std::string::npos;
             const bool uses_evaluation_clock =
@@ -443,6 +463,7 @@ namespace hgraph::python_bridge
                         DateTime evaluation_time) {
                         slot->sender = std::move(sender);
                         slot->type_realization = slot->sender.type_realization();
+                        slot->started_once.store(true, std::memory_order_release);
                         py_call_push_queue_start(
                             fn.record->fn, config, view.scalars(),
                             PySender{slot}, view, evaluation_time);

--- a/python/py_wiring.h
+++ b/python/py_wiring.h
@@ -424,6 +424,10 @@ namespace hgraph::python_bridge
                                             std::optional<std::size_t> max_pending,
                                             PyNodeHandle fn,
                                             std::string config,
+                                            PyNodeHandle stop_fn,
+                                            bool stop_enabled,
+                                            std::string stop_config,
+                                            std::size_t stop_scalar_offset,
                                             PyScalarValue scalars,
                                             std::optional<std::string> node_label)
         {
@@ -452,9 +456,12 @@ namespace hgraph::python_bridge
             slot->schema = ts_type.meta;
             slot->sender_value_schema = burst ? &policy.sender_schema() : nullptr;
             const bool uses_scheduler = config.find('d') != std::string::npos;
-            const bool uses_global_state = config.find('g') != std::string::npos;
+            const bool stop_uses_scheduler = stop_config.find('d') != std::string::npos;
+            const bool uses_global_state = config.find('g') != std::string::npos ||
+                                           stop_config.find('g') != std::string::npos;
             const bool uses_evaluation_clock =
-                config.find_first_of("cde") != std::string::npos;
+                config.find_first_of("cde") != std::string::npos ||
+                stop_config.find_first_of("cde") != std::string::npos;
             NodeBuilder builder = make_push_source_node_with_view(
                 *ts_type.meta, std::move(policy),
                 PushSourceNodeExtension{
@@ -468,12 +475,15 @@ namespace hgraph::python_bridge
                             fn.record->fn, config, view.scalars(),
                             PySender{slot}, view, evaluation_time);
                     },
-                    .on_stop = [](const NodeView &view) {
-                        py_release_push_queue_state(view);
+                    .on_stop = [stop_fn, stop_enabled, stop_config,
+                                stop_scalar_offset](const NodeView &view) {
+                        py_call_push_queue_stop(
+                            stop_fn.record->fn, stop_enabled, stop_config,
+                            stop_scalar_offset, view.scalars(), view);
                     },
                     .state_schema = scalar_descriptor<PyStateRef>::value_meta(),
                     .scalar_schema = scalars.value.schema(),
-                    .uses_scheduler = uses_scheduler,
+                    .uses_scheduler = uses_scheduler || stop_uses_scheduler,
                     .uses_global_state = uses_global_state,
                     .uses_evaluation_clock = uses_evaluation_clock,
                     .uses_python_values = true,

--- a/python/tests/test_push_source_queues.py
+++ b/python/tests/test_push_source_queues.py
@@ -18,9 +18,9 @@ def test_burst_push_queue_delivers_pending_scalars_as_one_tuple():
 
     @hg.push_queue(TS[tuple[int, ...]], burst=True, max_pending=3)
     def source(sender):
-        sender(1)
-        sender(2)
-        sender(3)
+        assert sender(1) is True
+        assert sender(2) is True
+        assert sender(3) is True
 
     @hg.sink_node
     def collect(value: TS[tuple[int, ...]]) -> None:
@@ -67,7 +67,7 @@ def test_bounded_burst_python_sender_releases_gil_while_waiting_for_dequeue():
     assert observed == [(1,), (2,)]
 
 
-def test_python_sender_raises_after_graph_stop():
+def test_python_sender_returns_false_after_graph_stop():
     retained = []
 
     @hg.push_queue(TS[int])
@@ -80,8 +80,43 @@ def test_python_sender_raises_after_graph_stop():
 
     _run(app, seconds=0.1)
     assert len(retained) == 1
-    with pytest.raises(RuntimeError, match="not accepting"):
-        retained[0](1)
+    assert retained[0](1) is False
+
+
+def test_push_queue_stop_hook_shares_state_and_joins_worker():
+    started = threading.Event()
+    finished = threading.Event()
+    lifecycle = []
+
+    @hg.push_queue(TS[int])
+    def source(sender, label: str, state: hg.STATE = None):
+        stop_requested = threading.Event()
+        state.stop_requested = stop_requested
+
+        def run():
+            started.set()
+            stop_requested.wait()
+            finished.set()
+
+        state.worker = threading.Thread(target=run)
+        state.worker.start()
+        lifecycle.append(("start", label))
+
+    @source.stop
+    def stop_source(label: str, state: hg.STATE = None):
+        state.stop_requested.set()
+        state.worker.join(timeout=1.0)
+        lifecycle.append(("stop", label))
+
+    @graph
+    def app() -> None:
+        source("worker")
+
+    _run(app, seconds=0.1)
+
+    assert started.is_set()
+    assert finished.is_set()
+    assert lifecycle == [("start", "worker"), ("stop", "worker")]
 
 
 def test_push_queue_rejects_incompatible_policy_options():

--- a/python/tests/test_push_source_queues.py
+++ b/python/tests/test_push_source_queues.py
@@ -1,0 +1,117 @@
+import datetime
+import threading
+
+import pytest
+
+import hgraph as hg
+from hgraph import TS, graph
+
+
+def _run(g, seconds=0.5):
+    end = datetime.datetime.now(datetime.UTC).replace(tzinfo=None) + datetime.timedelta(
+        seconds=seconds)
+    hg.run_graph(g, end_time=end, run_mode=hg.EvaluationMode.REAL_TIME)
+
+
+def test_burst_push_queue_delivers_pending_scalars_as_one_tuple():
+    observed = []
+
+    @hg.push_queue(TS[tuple[int, ...]], burst=True, max_pending=3)
+    def source(sender):
+        sender(1)
+        sender(2)
+        sender(3)
+
+    @hg.sink_node
+    def collect(value: TS[tuple[int, ...]]) -> None:
+        observed.append(value.value)
+
+    @graph
+    def app() -> None:
+        collect(source())
+
+    _run(app)
+    assert observed == [(1, 2, 3)]
+
+
+def test_bounded_burst_python_sender_releases_gil_while_waiting_for_dequeue():
+    observed = []
+    workers = []
+    completed = threading.Event()
+
+    @hg.push_queue(TS[tuple[int, ...]], burst=True, max_pending=1)
+    def source(sender):
+        sender(1)
+
+        def send_second():
+            sender(2)
+            completed.set()
+
+        worker = threading.Thread(target=send_second)
+        workers.append(worker)
+        worker.start()
+
+    @hg.sink_node
+    def collect(value: TS[tuple[int, ...]]) -> None:
+        observed.append(value.value)
+
+    @graph
+    def app() -> None:
+        collect(source())
+
+    _run(app)
+    for worker in workers:
+        worker.join(timeout=1.0)
+
+    assert completed.is_set()
+    assert observed == [(1,), (2,)]
+
+
+def test_python_sender_raises_after_graph_stop():
+    retained = []
+
+    @hg.push_queue(TS[int])
+    def source(sender):
+        retained.append(sender)
+
+    @graph
+    def app() -> None:
+        source()
+
+    _run(app, seconds=0.1)
+    assert len(retained) == 1
+    with pytest.raises(RuntimeError, match="not accepting"):
+        retained[0](1)
+
+
+def test_push_queue_rejects_incompatible_policy_options():
+    with pytest.raises(TypeError, match="mutually exclusive"):
+        @hg.push_queue(TS[int], conflate=True, burst=True)
+        def conflated_burst(sender):
+            pass
+
+    with pytest.raises(TypeError, match="not supported with conflate"):
+        @hg.push_queue(TS[int], conflate=True, max_pending=1)
+        def bounded_conflated(sender):
+            pass
+
+    with pytest.raises(ValueError, match="greater than zero"):
+        @hg.push_queue(TS[int], max_pending=0)
+        def zero_capacity(sender):
+            pass
+
+    with pytest.raises(TypeError, match="positive integer"):
+        @hg.push_queue(TS[int], max_pending=True)
+        def boolean_capacity(sender):
+            pass
+
+    @hg.push_queue(TS[int], burst=True)
+    def invalid_burst(sender):
+        pass
+
+    @graph
+    def invalid_app() -> None:
+        invalid_burst()
+
+    with pytest.raises(ValueError, match=r"TS\[tuple\[SCALAR, \.\.\.\]\]"):
+        _run(invalid_app, seconds=0.1)

--- a/python/tests/test_signature_compatibility.py
+++ b/python/tests/test_signature_compatibility.py
@@ -33,7 +33,7 @@ def test_shared_callable_signatures_match_python_authoring_surface():
     )
     assert _parameters(hg.push_queue) == (
         "tp", "overloads", "resolvers", "requires", "label", "deprecated",
-        "conflate",
+        "conflate", "burst", "max_pending",
     )
     assert _parameters(hg.feedback) == ("tp_or_wp", "default")
     assert tuple(inspect.signature(hg.dispatch_).parameters)[:2] == (

--- a/src/hgraph/runtime/push_source_node.cpp
+++ b/src/hgraph/runtime/push_source_node.cpp
@@ -50,6 +50,17 @@ namespace hgraph
                                               const void *storage) noexcept = nullptr;
         };
 
+        /** Private sender facade dispatch. The public handle retains erased
+         * ownership separately and always binds a non-null table. */
+        struct PushSourceSenderOps
+        {
+            bool (*valid_impl)(const void *control) noexcept = nullptr;
+            const TypeRealizationSnapshot *(*type_realization_impl)(
+                const void *control) noexcept = nullptr;
+            bool (*try_send_impl)(void *control, Value value) = nullptr;
+            bool (*send_blocking_impl)(void *control, Value value) = nullptr;
+        };
+
         struct PushSourceQueuePop
         {
             Value value{};
@@ -392,28 +403,29 @@ namespace hgraph
                 return result.accepted;
             }
 
-            void send_blocking(Value value)
+            [[nodiscard]] bool send_blocking(Value value)
             {
                 if (!enter())
                 {
-                    throw PushSourceStopped{};
+                    return false;
                 }
                 auto leave_call = make_scope_exit([this] { leave(); });
                 if (push_engine_.stop_requested())
                 {
-                    throw PushSourceStopped{};
+                    return false;
                 }
 
                 const PushSourceSendResult result =
                     policy_.ops_->send_blocking_impl(policy_.context_, storage_, std::move(value));
                 if (!result.accepted)
                 {
-                    throw PushSourceStopped{};
+                    return false;
                 }
                 if (result.wake_required)
                 {
                     push_engine_.mark_push_update_pending();
                 }
+                return true;
             }
 
             void begin_close() noexcept
@@ -533,6 +545,68 @@ namespace hgraph
                 .send_blocking_impl = &default_policy_send_blocking,
                 .emit_next_impl = &default_policy_emit_next,
                 .pending_items_impl = &default_policy_pending_items,
+            };
+            return ops;
+        }
+
+        [[nodiscard]] bool stopped_sender_valid(const void *) noexcept
+        {
+            return false;
+        }
+
+        [[nodiscard]] const TypeRealizationSnapshot *stopped_sender_type_realization(
+            const void *) noexcept
+        {
+            return nullptr;
+        }
+
+        [[nodiscard]] bool stopped_sender_send(void *, Value)
+        {
+            return false;
+        }
+
+        [[nodiscard]] const detail::PushSourceSenderOps &stopped_sender_ops() noexcept
+        {
+            static constexpr detail::PushSourceSenderOps ops{
+                .valid_impl = &stopped_sender_valid,
+                .type_realization_impl = &stopped_sender_type_realization,
+                .try_send_impl = &stopped_sender_send,
+                .send_blocking_impl = &stopped_sender_send,
+            };
+            return ops;
+        }
+
+        [[nodiscard]] bool active_sender_valid(const void *control) noexcept
+        {
+            return static_cast<const detail::PushSourceSenderControl *>(control)->valid();
+        }
+
+        [[nodiscard]] const TypeRealizationSnapshot *active_sender_type_realization(
+            const void *control) noexcept
+        {
+            return static_cast<const detail::PushSourceSenderControl *>(control)
+                ->type_realization();
+        }
+
+        [[nodiscard]] bool active_sender_try_send(void *control, Value value)
+        {
+            return static_cast<detail::PushSourceSenderControl *>(control)
+                ->try_send(std::move(value));
+        }
+
+        [[nodiscard]] bool active_sender_send_blocking(void *control, Value value)
+        {
+            return static_cast<detail::PushSourceSenderControl *>(control)
+                ->send_blocking(std::move(value));
+        }
+
+        [[nodiscard]] const detail::PushSourceSenderOps &active_sender_ops() noexcept
+        {
+            static constexpr detail::PushSourceSenderOps ops{
+                .valid_impl = &active_sender_valid,
+                .type_realization_impl = &active_sender_type_realization,
+                .try_send_impl = &active_sender_try_send,
+                .send_blocking_impl = &active_sender_send_blocking,
             };
             return ops;
         }
@@ -948,38 +1022,50 @@ namespace hgraph
         return policy.ops_->pending_items_impl(policy.context_, storage);
     }
 
-    PushSourceStopped::PushSourceStopped()
-        : std::runtime_error{"Push source is not accepting values"}
+    PushSourceSender::PushSourceSender() noexcept
+        : ops_(&stopped_sender_ops())
     {
     }
 
     PushSourceSender::PushSourceSender(std::shared_ptr<detail::PushSourceSenderControl> control) noexcept
-        : control_(std::move(control))
+        : ops_(&active_sender_ops()), control_(std::move(control))
     {
+    }
+
+    PushSourceSender::PushSourceSender(PushSourceSender &&other) noexcept
+        : ops_(std::exchange(other.ops_, &stopped_sender_ops())),
+          control_(std::move(other.control_))
+    {
+    }
+
+    PushSourceSender &PushSourceSender::operator=(PushSourceSender &&other) noexcept
+    {
+        if (this != &other)
+        {
+            control_ = std::move(other.control_);
+            ops_ = std::exchange(other.ops_, &stopped_sender_ops());
+        }
+        return *this;
     }
 
     bool PushSourceSender::valid() const noexcept
     {
-        return control_ != nullptr && control_->valid();
+        return ops_->valid_impl(control_.get());
     }
 
     const TypeRealizationSnapshot *PushSourceSender::type_realization() const noexcept
     {
-        return control_ != nullptr ? control_->type_realization() : nullptr;
+        return ops_->type_realization_impl(control_.get());
     }
 
     bool PushSourceSender::try_send(Value value) const
     {
-        return control_ != nullptr && control_->try_send(std::move(value));
+        return ops_->try_send_impl(control_.get(), std::move(value));
     }
 
-    void PushSourceSender::send_blocking(Value value) const
+    bool PushSourceSender::send_blocking(Value value) const
     {
-        if (control_ == nullptr)
-        {
-            throw PushSourceStopped{};
-        }
-        control_->send_blocking(std::move(value));
+        return ops_->send_blocking_impl(control_.get(), std::move(value));
     }
 
     PushSourcePolicy make_push_source_policy(PushSourcePolicyKind kind,

--- a/src/hgraph/runtime/push_source_node.cpp
+++ b/src/hgraph/runtime/push_source_node.cpp
@@ -3,15 +3,18 @@
 #include <hgraph/runtime/executor.h>
 #include <hgraph/types/time_series/ts_delta.h>
 #include <hgraph/types/time_series/ts_output.h>
+#include <hgraph/types/value/value_builder.h>
 #include <hgraph/util/scope.h>
 
 #include <array>
+#include <condition_variable>
 #include <cstddef>
 #include <deque>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <stdexcept>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -21,23 +24,30 @@ namespace hgraph
     {
         const DateTime push_conflation_time{MIN_ST};
 
+        struct PushSourceSendResult
+        {
+            bool accepted{false};
+            bool wake_required{false};
+        };
+
         struct PushSourcePolicyOps
         {
             const MemoryUtils::StoragePlan *storage_plan{nullptr};
 
             const ValueTypeMetaData &(*sender_schema_impl)(const void *context) = nullptr;
             bool (*output_compatible_impl)(const void *context,
-                                                         const TSValueTypeMetaData &output_schema) = nullptr;
-            void (*start_impl)(const void *context,
-                               void *storage,
+                                           const TSValueTypeMetaData &output_schema) = nullptr;
+            void (*start_impl)(const void *context, void *storage,
                                const TSValueTypeMetaData &output_schema) = nullptr;
             void (*stop_impl)(const void *context, void *storage) = nullptr;
-            bool (*send_impl)(const void *context, void *storage, Value value) = nullptr;
-            bool (*emit_next_impl)(const void *context,
-                                                 void *storage,
-                                                 const TSOutputView &output) = nullptr;
+            PushSourceSendResult (*try_send_impl)(const void *context, void *storage,
+                                                  Value value) = nullptr;
+            PushSourceSendResult (*send_blocking_impl)(const void *context, void *storage,
+                                                       Value value) = nullptr;
+            bool (*emit_next_impl)(const void *context, void *storage,
+                                   const TSOutputView &output) = nullptr;
             std::size_t (*pending_items_impl)(const void *context,
-                                             const void *storage) noexcept = nullptr;
+                                              const void *storage) noexcept = nullptr;
         };
 
         struct PushSourceQueuePop
@@ -53,8 +63,8 @@ namespace hgraph
             /** The AUTHORED counterpart, equal to ``sender_schema`` unless the
                 output contains a ``TSD`` (see ``authored_delta_schema``). */
             const ValueTypeMetaData *authored_schema{nullptr};
+            std::size_t              max_pending{0};
         };
-
 
         /**
          * A pushed delta may be OBSERVED or AUTHORED.
@@ -75,44 +85,89 @@ namespace hgraph
 
         struct QueuePolicyStorage
         {
-            void start()
+            void start(const PushSourcePolicyContext &context,
+                       const TSValueTypeMetaData *burst_output_schema = nullptr)
             {
                 std::lock_guard lock{mutex};
-                accepting = true;
                 values.clear();
+                max_pending          = context.max_pending;
+                burst_element_binding = {};
+                burst_value_binding   = {};
+                if (burst_output_schema != nullptr)
+                {
+                    burst_element_binding =
+                        ValuePlanFactory::instance().type_for(context.sender_schema);
+                    burst_value_binding = compact_list_type(
+                        burst_element_binding, *burst_output_schema->value_schema);
+                }
+                consumer_thread = std::this_thread::get_id();
+                accepting       = true;
             }
 
             void stop()
             {
-                std::lock_guard lock{mutex};
-                accepting = false;
-                values.clear();
+                {
+                    std::lock_guard lock{mutex};
+                    accepting = false;
+                    values.clear();
+                    burst_element_binding = {};
+                    burst_value_binding = {};
+                    consumer_thread = {};
+                }
+                capacity_available.notify_all();
             }
 
-            [[nodiscard]] bool send(const PushSourcePolicyContext &context, Value value)
+            [[nodiscard]] PushSourceSendResult try_send(
+                const PushSourcePolicyContext &context, Value value)
             {
                 std::lock_guard lock{mutex};
-                if (!accepting) { return false; }
-                if (!value.has_value())
+                if (!accepting)
                 {
-                    throw std::invalid_argument("PushSourceSender requires a live value payload");
+                    return {};
                 }
-                const auto &value_schema = *value.schema();
-                if (context.sender_schema == nullptr ||
-                    !push_value_schema_acceptable(context, value_schema))
+                validate(context, value);
+                if (full())
                 {
-                    throw std::invalid_argument(
-                        "PushSourceSender value schema does not match the push-source sender schema");
+                    return {};
                 }
 
+                const bool was_empty = values.empty();
                 values.push_back(std::move(value));
-                return true;
+                return {.accepted = true, .wake_required = was_empty};
+            }
+
+            [[nodiscard]] PushSourceSendResult send_blocking(
+                const PushSourcePolicyContext &context, Value value)
+            {
+                std::unique_lock lock{mutex};
+                if (!accepting)
+                {
+                    return {};
+                }
+                validate(context, value);
+                if (full() && consumer_thread == std::this_thread::get_id())
+                {
+                    throw std::logic_error("PushSourceSender::send_blocking cannot wait on "
+                                           "the graph evaluation thread");
+                }
+                capacity_available.wait(lock, [this] { return !accepting || !full(); });
+                if (!accepting)
+                {
+                    return {};
+                }
+
+                const bool was_empty = values.empty();
+                values.push_back(std::move(value));
+                return {.accepted = true, .wake_required = was_empty};
             }
 
             [[nodiscard]] std::optional<PushSourceQueuePop> try_pop()
             {
-                std::lock_guard lock{mutex};
-                if (values.empty()) { return std::nullopt; }
+                std::unique_lock lock{mutex};
+                if (values.empty())
+                {
+                    return std::nullopt;
+                }
 
                 PushSourceQueuePop result{
                     .value = std::move(values.front()),
@@ -120,6 +175,46 @@ namespace hgraph
                 };
                 values.pop_front();
                 result.more_pending = !values.empty();
+                lock.unlock();
+                capacity_available.notify_one();
+                return result;
+            }
+
+            [[nodiscard]] std::deque<Value> take_all()
+            {
+                std::deque<Value> result;
+                {
+                    std::lock_guard lock{mutex};
+                    result.swap(values);
+                }
+                if (!result.empty())
+                {
+                    capacity_available.notify_all();
+                }
+                return result;
+            }
+
+            [[nodiscard]] Value make_burst(std::deque<Value> values) const
+            {
+                if (values.empty())
+                {
+                    return {};
+                }
+                if (!burst_element_binding || !burst_value_binding)
+                {
+                    throw std::logic_error("Burst push-source queue is not initialized");
+                }
+
+                ListBuilder builder{burst_element_binding, *burst_value_binding.schema()};
+                for (Value &value : values)
+                {
+                    builder.push_back(std::move(value));
+                }
+                ListStorage storage = builder.build_storage();
+                Value result{burst_value_binding};
+                burst_value_binding.ops_ref().move_assign_from(
+                    burst_value_binding, const_cast<void *>(result.view().data()),
+                    burst_value_binding, &storage);
                 return result;
             }
 
@@ -129,9 +224,35 @@ namespace hgraph
                 return values.size();
             }
 
-            mutable std::mutex mutex{};
-            std::deque<Value>  values{};
-            bool               accepting{false};
+          private:
+            [[nodiscard]] bool full() const noexcept
+            {
+                return max_pending != 0 && values.size() >= max_pending;
+            }
+
+            static void validate(const PushSourcePolicyContext &context, const Value &value)
+            {
+                if (!value.has_value())
+                {
+                    throw std::invalid_argument("PushSourceSender requires a live value payload");
+                }
+                const auto &value_schema = *value.schema();
+                if (context.sender_schema == nullptr ||
+                    !push_value_schema_acceptable(context, value_schema))
+                {
+                    throw std::invalid_argument("PushSourceSender value schema does not "
+                                                "match the push-source sender schema");
+                }
+            }
+
+            mutable std::mutex      mutex{};
+            std::condition_variable capacity_available{};
+            std::deque<Value>       values{};
+            ValueTypeRef            burst_element_binding{};
+            ValueTypeRef            burst_value_binding{};
+            std::size_t             max_pending{0};
+            std::thread::id         consumer_thread{};
+            bool                    accepting{false};
         };
 
         struct ConflatingPolicyStorage
@@ -156,10 +277,14 @@ namespace hgraph
                 next_mutation_time = MIN_ST;
             }
 
-            [[nodiscard]] bool send(const PushSourcePolicyContext &context, Value value)
+            [[nodiscard]] PushSourceSendResult try_send(
+                const PushSourcePolicyContext &context, Value value)
             {
                 std::lock_guard lock{mutex};
-                if (!accepting) { return false; }
+                if (!accepting)
+                {
+                    return {};
+                }
                 if (!value.has_value())
                 {
                     throw std::invalid_argument("PushSourceSender requires a live value payload");
@@ -168,21 +293,34 @@ namespace hgraph
                 if (context.sender_schema == nullptr ||
                     !push_value_schema_acceptable(context, value_schema))
                 {
-                    throw std::invalid_argument(
-                        "PushSourceSender value schema does not match the push-source sender schema");
+                    throw std::invalid_argument("PushSourceSender value schema does not "
+                                                "match the push-source sender schema");
                 }
 
                 const DateTime mutation_time = next_mutation_time;
                 next_mutation_time += MIN_TD;
+                const bool was_pending = pending;
                 apply_delta(accumulator.view(mutation_time), value.view());
                 pending = pending || accumulator.view(mutation_time).modified();
-                return pending;
+                return {
+                    .accepted = true,
+                    .wake_required = pending && !was_pending,
+                };
+            }
+
+            [[nodiscard]] PushSourceSendResult send_blocking(
+                const PushSourcePolicyContext &context, Value value)
+            {
+                return try_send(context, std::move(value));
             }
 
             [[nodiscard]] std::optional<TSOutput> take_accumulated()
             {
                 std::lock_guard lock{mutex};
-                if (!pending) { return std::nullopt; }
+                if (!pending)
+                {
+                    return std::nullopt;
+                }
 
                 std::optional<TSOutput> result{std::move(accumulator)};
                 accumulator = TSOutput{*output_schema};
@@ -204,11 +342,137 @@ namespace hgraph
             bool                        accepting{false};
             bool                        pending{false};
         };
+
+        /** Shared lifetime boundary between retained producer handles and the
+         * graph-owned policy storage. Closing prevents new calls; graph stop
+         * then wakes policy waiters and waits for entered calls before node
+         * storage can be destroyed. */
+        class PushSourceSenderControl
+        {
+          public:
+            PushSourceSenderControl(PushSourcePolicy policy, void *storage,
+                                    PushQueueEngineView push_engine,
+                                    const TypeRealizationSnapshot *type_realization) noexcept
+                : policy_{policy}, storage_{storage}, push_engine_{std::move(push_engine)},
+                  type_realization_{type_realization}
+            {
+            }
+
+            [[nodiscard]] bool valid() const noexcept
+            {
+                std::lock_guard lock{mutex_};
+                return !closing_ && storage_ != nullptr && push_engine_.valid() &&
+                       !push_engine_.stop_requested();
+            }
+
+            [[nodiscard]] const TypeRealizationSnapshot *type_realization() const noexcept
+            {
+                std::lock_guard lock{mutex_};
+                return !closing_ && storage_ != nullptr ? type_realization_ : nullptr;
+            }
+
+            [[nodiscard]] bool try_send(Value value)
+            {
+                if (!enter())
+                {
+                    return false;
+                }
+                auto leave_call = make_scope_exit([this] { leave(); });
+                if (push_engine_.stop_requested())
+                {
+                    return false;
+                }
+
+                const PushSourceSendResult result =
+                    policy_.ops_->try_send_impl(policy_.context_, storage_, std::move(value));
+                if (result.accepted && result.wake_required)
+                {
+                    push_engine_.mark_push_update_pending();
+                }
+                return result.accepted;
+            }
+
+            void send_blocking(Value value)
+            {
+                if (!enter())
+                {
+                    throw PushSourceStopped{};
+                }
+                auto leave_call = make_scope_exit([this] { leave(); });
+                if (push_engine_.stop_requested())
+                {
+                    throw PushSourceStopped{};
+                }
+
+                const PushSourceSendResult result =
+                    policy_.ops_->send_blocking_impl(policy_.context_, storage_, std::move(value));
+                if (!result.accepted)
+                {
+                    throw PushSourceStopped{};
+                }
+                if (result.wake_required)
+                {
+                    push_engine_.mark_push_update_pending();
+                }
+            }
+
+            void begin_close() noexcept
+            {
+                std::lock_guard lock{mutex_};
+                closing_ = true;
+            }
+
+            void wait_for_quiescence() noexcept
+            {
+                std::unique_lock lock{mutex_};
+                quiescent_.wait(lock, [this] { return active_calls_ == 0; });
+            }
+
+            void detach() noexcept
+            {
+                std::lock_guard lock{mutex_};
+                storage_ = nullptr;
+                push_engine_ = {};
+                type_realization_ = nullptr;
+            }
+
+          private:
+            [[nodiscard]] bool enter() noexcept
+            {
+                std::lock_guard lock{mutex_};
+                if (closing_ || storage_ == nullptr)
+                {
+                    return false;
+                }
+                ++active_calls_;
+                return true;
+            }
+
+            void leave() noexcept
+            {
+                std::lock_guard lock{mutex_};
+                if (--active_calls_ == 0)
+                {
+                    quiescent_.notify_all();
+                }
+            }
+
+            mutable std::mutex      mutex_{};
+            std::condition_variable quiescent_{};
+            PushSourcePolicy        policy_{};
+            void                   *storage_{nullptr};
+            PushQueueEngineView     push_engine_{};
+            const TypeRealizationSnapshot *type_realization_{nullptr};
+            std::size_t              active_calls_{0};
+            bool                     closing_{false};
+        };
     }  // namespace detail
 
     namespace
     {
         constexpr std::string_view push_source_policy_field_name{"push_source_policy"};
+        constexpr std::string_view push_source_sender_control_field_name{
+            "push_source_sender_control"};
 
         [[noreturn]] void throw_unconfigured_policy()
         {
@@ -234,7 +498,14 @@ namespace hgraph
         {
         }
 
-        [[nodiscard]] bool default_policy_send(const void *, void *, Value)
+        [[nodiscard]] detail::PushSourceSendResult default_policy_try_send(
+            const void *, void *, Value)
+        {
+            throw_unconfigured_policy();
+        }
+
+        [[nodiscard]] detail::PushSourceSendResult default_policy_send_blocking(
+            const void *, void *, Value)
         {
             throw_unconfigured_policy();
         }
@@ -258,7 +529,8 @@ namespace hgraph
                 .output_compatible_impl = &default_output_compatible_impl,
                 .start_impl = &default_policy_start,
                 .stop_impl = &default_policy_stop,
-                .send_impl = &default_policy_send,
+                .try_send_impl = &default_policy_try_send,
+                .send_blocking_impl = &default_policy_send_blocking,
                 .emit_next_impl = &default_policy_emit_next,
                 .pending_items_impl = &default_policy_pending_items,
             };
@@ -277,12 +549,15 @@ namespace hgraph
         }
 
         [[nodiscard]] const detail::PushSourcePolicyContext &register_policy_context(
-            const ValueTypeMetaData &sender_schema, const ValueTypeMetaData *authored_schema)
+            const ValueTypeMetaData &sender_schema,
+            const ValueTypeMetaData *authored_schema,
+            std::size_t max_pending)
         {
             auto context = std::make_unique<detail::PushSourcePolicyContext>(
                 detail::PushSourcePolicyContext{
                     .sender_schema  = &sender_schema,
-                    .authored_schema = authored_schema != nullptr ? authored_schema : &sender_schema});
+                    .authored_schema = authored_schema != nullptr ? authored_schema : &sender_schema,
+                    .max_pending = max_pending});
             const auto *result = context.get();
             policy_contexts().push_back(std::move(context));
             return *result;
@@ -293,15 +568,33 @@ namespace hgraph
             return *policy_context(context).sender_schema;
         }
 
-        [[nodiscard]] bool delta_output_compatible(const void *context,
-                                                   const TSValueTypeMetaData &output_schema)
+        [[nodiscard]] bool delta_output_compatible(
+            const void *context, const TSValueTypeMetaData &output_schema)
         {
             return output_schema.delta_value_schema == policy_context(context).sender_schema;
         }
 
-        void queue_policy_start(const void *, void *storage, const TSValueTypeMetaData &)
+        [[nodiscard]] bool burst_output_compatible(
+            const void *context, const TSValueTypeMetaData &output_schema)
         {
-            MemoryUtils::cast<detail::QueuePolicyStorage>(storage)->start();
+            const auto *value_schema = output_schema.value_schema;
+            return output_schema.kind == TSTypeKind::TS && value_schema != nullptr &&
+                   value_schema->try_value_kind() == ValueTypeKind::List &&
+                   value_schema->fixed_size == 0 && value_schema->is_variadic_tuple() &&
+                   !value_schema->is_mutable() && !value_schema->is_nullable() &&
+                   value_schema->element_type == policy_context(context).sender_schema;
+        }
+
+        void queue_policy_start(const void *context, void *storage, const TSValueTypeMetaData &)
+        {
+            MemoryUtils::cast<detail::QueuePolicyStorage>(storage)->start(policy_context(context));
+        }
+
+        void burst_policy_start(
+            const void *context, void *storage,
+            const TSValueTypeMetaData &output_schema)
+        {
+            MemoryUtils::cast<detail::QueuePolicyStorage>(storage)->start(policy_context(context), &output_schema);
         }
 
         void queue_policy_stop(const void *, void *storage)
@@ -309,22 +602,45 @@ namespace hgraph
             MemoryUtils::cast<detail::QueuePolicyStorage>(storage)->stop();
         }
 
-        [[nodiscard]] bool queue_policy_send(const void *context, void *storage, Value value)
+        [[nodiscard]] detail::PushSourceSendResult queue_policy_try_send(
+            const void *context, void *storage, Value value)
         {
-            return MemoryUtils::cast<detail::QueuePolicyStorage>(storage)->send(
-                policy_context(context),
-                std::move(value));
+            return MemoryUtils::cast<detail::QueuePolicyStorage>(storage)->try_send(
+                policy_context(context), std::move(value));
         }
 
-        [[nodiscard]] bool queue_policy_emit_next(const void *,
-                                                  void *storage,
-                                                  const TSOutputView &output)
+        [[nodiscard]] detail::PushSourceSendResult queue_policy_send_blocking(
+            const void *context, void *storage, Value value)
+        {
+            return MemoryUtils::cast<detail::QueuePolicyStorage>(storage)->send_blocking(
+                policy_context(context), std::move(value));
+        }
+
+        [[nodiscard]] bool queue_policy_emit_next(
+            const void *, void *storage, const TSOutputView &output)
         {
             auto item = MemoryUtils::cast<detail::QueuePolicyStorage>(storage)->try_pop();
-            if (!item.has_value()) { return false; }
+            if (!item.has_value())
+            {
+                return false;
+            }
 
             apply_delta(output, item->value.view());
             return item->more_pending;
+        }
+
+        [[nodiscard]] bool burst_policy_emit_next(
+            const void *, void *storage, const TSOutputView &output)
+        {
+            auto *queue = MemoryUtils::cast<detail::QueuePolicyStorage>(storage);
+            auto values = queue->take_all();
+            if (values.empty())
+            {
+                return false;
+            }
+
+            apply_current_value(output, queue->make_burst(std::move(values)).view());
+            return false;
         }
 
         [[nodiscard]] std::size_t queue_policy_pending_items(
@@ -344,19 +660,28 @@ namespace hgraph
             MemoryUtils::cast<detail::ConflatingPolicyStorage>(storage)->stop();
         }
 
-        [[nodiscard]] bool conflating_policy_send(const void *context, void *storage, Value value)
+        [[nodiscard]] detail::PushSourceSendResult conflating_policy_try_send(
+            const void *context, void *storage, Value value)
         {
-            return MemoryUtils::cast<detail::ConflatingPolicyStorage>(storage)->send(
-                policy_context(context),
-                std::move(value));
+            return MemoryUtils::cast<detail::ConflatingPolicyStorage>(storage)->try_send(
+                policy_context(context), std::move(value));
         }
 
-        [[nodiscard]] bool conflating_policy_emit_next(const void *,
-                                                       void *storage,
-                                                       const TSOutputView &output)
+        [[nodiscard]] detail::PushSourceSendResult conflating_policy_send_blocking(
+            const void *context, void *storage, Value value)
+        {
+            return MemoryUtils::cast<detail::ConflatingPolicyStorage>(storage)->send_blocking(
+                policy_context(context), std::move(value));
+        }
+
+        [[nodiscard]] bool conflating_policy_emit_next(
+            const void *, void *storage, const TSOutputView &output)
         {
             auto accumulated = MemoryUtils::cast<detail::ConflatingPolicyStorage>(storage)->take_accumulated();
-            if (!accumulated.has_value()) { return false; }
+            if (!accumulated.has_value())
+            {
+                return false;
+            }
 
             apply_current_value(output, accumulated->view(detail::push_conflation_time).value());
             return false;
@@ -377,7 +702,8 @@ namespace hgraph
                 .output_compatible_impl = &delta_output_compatible,
                 .start_impl = &queue_policy_start,
                 .stop_impl = &queue_policy_stop,
-                .send_impl = &queue_policy_send,
+                .try_send_impl = &queue_policy_try_send,
+                .send_blocking_impl = &queue_policy_send_blocking,
                 .emit_next_impl = &queue_policy_emit_next,
                 .pending_items_impl = &queue_policy_pending_items,
             };
@@ -392,9 +718,26 @@ namespace hgraph
                 .output_compatible_impl = &delta_output_compatible,
                 .start_impl = &conflating_policy_start,
                 .stop_impl = &conflating_policy_stop,
-                .send_impl = &conflating_policy_send,
+                .try_send_impl = &conflating_policy_try_send,
+                .send_blocking_impl = &conflating_policy_send_blocking,
                 .emit_next_impl = &conflating_policy_emit_next,
                 .pending_items_impl = &conflating_policy_pending_items,
+            };
+            return ops;
+        }
+
+        [[nodiscard]] const detail::PushSourcePolicyOps &burst_policy_ops()
+        {
+            static const detail::PushSourcePolicyOps ops{
+                .storage_plan = &MemoryUtils::plan_for<detail::QueuePolicyStorage>(),
+                .sender_schema_impl = &sender_schema_impl,
+                .output_compatible_impl = &burst_output_compatible,
+                .start_impl = &burst_policy_start,
+                .stop_impl = &queue_policy_stop,
+                .try_send_impl = &queue_policy_try_send,
+                .send_blocking_impl = &queue_policy_send_blocking,
+                .emit_next_impl = &burst_policy_emit_next,
+                .pending_items_impl = &queue_policy_pending_items,
             };
             return ops;
         }
@@ -404,6 +747,7 @@ namespace hgraph
             const TSValueTypeMetaData *output_schema{nullptr};
             PushSourcePolicy           policy{};
             std::size_t                policy_storage_offset{0};
+            std::size_t                sender_control_storage_offset{0};
             PushSourceStartViewCallback on_start{};
             std::function<void(const NodeView &)> on_stop{};
         };
@@ -418,6 +762,7 @@ namespace hgraph
             const TSValueTypeMetaData &output_schema,
             PushSourcePolicy policy,
             std::size_t policy_storage_offset,
+            std::size_t sender_control_storage_offset,
             PushSourceStartViewCallback on_start,
             std::function<void(const NodeView &)> on_stop)
         {
@@ -425,6 +770,7 @@ namespace hgraph
                 .output_schema = &output_schema,
                 .policy = policy,
                 .policy_storage_offset = policy_storage_offset,
+                .sender_control_storage_offset = sender_control_storage_offset,
                 .on_start = std::move(on_start),
                 .on_stop = std::move(on_stop),
             });
@@ -444,6 +790,13 @@ namespace hgraph
             return MemoryUtils::advance(memory, context.policy_storage_offset);
         }
 
+        [[nodiscard]] std::shared_ptr<detail::PushSourceSenderControl> &
+        sender_control_storage(const PushSourceNodeContext &context, void *memory)
+        {
+            return *MemoryUtils::cast<std::shared_ptr<detail::PushSourceSenderControl>>(
+                MemoryUtils::advance(memory, context.sender_control_storage_offset));
+        }
+
         [[nodiscard]] NodeInspectionMetrics push_source_inspection_metrics(
             const void *raw_context, const void *memory) noexcept
         {
@@ -454,21 +807,29 @@ namespace hgraph
             };
         }
 
-        void push_source_start(const PushSourceNodeContext &context, const NodeView &view,
-                               DateTime evaluation_time)
+        void push_source_start(const PushSourceNodeContext &context,
+                               const NodeView &view, DateTime evaluation_time)
         {
             void *storage = policy_storage(context, view.data());
+            auto &control = sender_control_storage(context, view.data());
             detail::PushSourcePolicyAccess::start(context.policy, storage, *context.output_schema);
             auto rollback = UnwindCleanupGuard([&] {
+                if (control) { control->begin_close(); }
                 detail::PushSourcePolicyAccess::stop(context.policy, storage);
+                if (control)
+                {
+                    control->wait_for_quiescence();
+                    control->detach();
+                    control.reset();
+                }
             });
+            control = std::make_shared<detail::PushSourceSenderControl>(
+                context.policy, storage, view.graph().root().executor().push_queue_engine(),
+                view.graph().type_realization());
             if (context.on_start)
             {
-                context.on_start(detail::PushSourcePolicyAccess::make_sender(
-                    context.policy,
-                    storage,
-                    view.graph().root().executor().push_queue_engine(),
-                    view.graph().type_realization()), view, evaluation_time);
+                context.on_start(detail::PushSourcePolicyAccess::make_sender(control),
+                                 view, evaluation_time);
             }
             rollback.release();
         }
@@ -477,9 +838,7 @@ namespace hgraph
         {
             void *storage = policy_storage(context, view.data());
             const bool more_pending = detail::PushSourcePolicyAccess::emit_next(
-                context.policy,
-                storage,
-                view.output(evaluation_time));
+                context.policy, storage, view.output(evaluation_time));
             if (more_pending)
             {
                 view.graph().root().executor().push_queue_engine().mark_push_update_pending();
@@ -488,17 +847,34 @@ namespace hgraph
 
         void push_source_stop(const PushSourceNodeContext &context, const NodeView &view)
         {
+            auto &control_slot = sender_control_storage(context, view.data());
+            auto control = control_slot;
+            if (control)
+            {
+                control->begin_close();
+            }
             detail::PushSourcePolicyAccess::stop(context.policy, policy_storage(context, view.data()));
-            if (context.on_stop) { context.on_stop(view); }
+            if (control)
+            {
+                control->wait_for_quiescence();
+            }
+            auto detach = make_scope_exit([&] {
+                if (control) { control->detach(); }
+                control_slot.reset();
+            });
+            if (context.on_stop)
+            {
+                context.on_stop(view);
+            }
         }
 
         [[nodiscard]] PushSourcePolicy make_policy(const detail::PushSourcePolicyOps &ops,
                                                    const ValueTypeMetaData &sender_schema,
-                                                   const ValueTypeMetaData *authored_schema)
+                                                   const ValueTypeMetaData *authored_schema,
+                                                   std::size_t max_pending = 0)
         {
             return detail::PushSourcePolicyAccess::make_policy(
-                &ops,
-                &register_policy_context(sender_schema, authored_schema));
+                &ops, &register_policy_context(sender_schema, authored_schema, max_pending));
         }
     }  // namespace
 
@@ -529,24 +905,8 @@ namespace hgraph
         return ops_->output_compatible_impl(context_, output_schema);
     }
 
-    bool detail::PushSourcePolicyStorageRef::bound() const noexcept
-    {
-        return storage != nullptr;
-    }
-
-    void detail::PushSourcePolicyStorageRef::send(Value value) const
-    {
-        if (!bound()) { throw std::logic_error("PushSourceSender requires live push-source policy storage"); }
-        if (push_engine.stop_requested()) { return; }
-        if (policy.ops_->send_impl(policy.context_, storage, std::move(value)))
-        {
-            push_engine.mark_push_update_pending();
-        }
-    }
-
     PushSourcePolicy detail::PushSourcePolicyAccess::make_policy(
-        const PushSourcePolicyOps *ops,
-        const void *context) noexcept
+        const PushSourcePolicyOps *ops, const void *context) noexcept
     {
         return PushSourcePolicy{ops, context};
     }
@@ -558,17 +918,9 @@ namespace hgraph
     }
 
     PushSourceSender detail::PushSourcePolicyAccess::make_sender(
-        PushSourcePolicy policy,
-        void *storage,
-        PushQueueEngineView push_engine,
-        const TypeRealizationSnapshot *type_realization) noexcept
+        std::shared_ptr<PushSourceSenderControl> control) noexcept
     {
-        return PushSourceSender{PushSourcePolicyStorageRef{
-            .policy = policy,
-            .storage = storage,
-            .push_engine = std::move(push_engine),
-            .type_realization = type_realization,
-        }};
+        return PushSourceSender{std::move(control)};
     }
 
     void detail::PushSourcePolicyAccess::start(const PushSourcePolicy &policy,
@@ -590,30 +942,44 @@ namespace hgraph
         return policy.ops_->emit_next_impl(policy.context_, storage, output);
     }
 
-    std::size_t detail::PushSourcePolicyAccess::pending_items(
-        const PushSourcePolicy &policy, const void *storage) noexcept
+    std::size_t detail::PushSourcePolicyAccess::pending_items(const PushSourcePolicy &policy,
+                                                              const void *storage) noexcept
     {
         return policy.ops_->pending_items_impl(policy.context_, storage);
     }
 
-    PushSourceSender::PushSourceSender(detail::PushSourcePolicyStorageRef policy_storage) noexcept
-        : policy_storage_(policy_storage)
+    PushSourceStopped::PushSourceStopped()
+        : std::runtime_error{"Push source is not accepting values"}
+    {
+    }
+
+    PushSourceSender::PushSourceSender(std::shared_ptr<detail::PushSourceSenderControl> control) noexcept
+        : control_(std::move(control))
     {
     }
 
     bool PushSourceSender::valid() const noexcept
     {
-        return policy_storage_.bound();
+        return control_ != nullptr && control_->valid();
     }
 
     const TypeRealizationSnapshot *PushSourceSender::type_realization() const noexcept
     {
-        return policy_storage_.type_realization;
+        return control_ != nullptr ? control_->type_realization() : nullptr;
     }
 
-    void PushSourceSender::send(Value value) const
+    bool PushSourceSender::try_send(Value value) const
     {
-        policy_storage_.send(std::move(value));
+        return control_ != nullptr && control_->try_send(std::move(value));
+    }
+
+    void PushSourceSender::send_blocking(Value value) const
+    {
+        if (control_ == nullptr)
+        {
+            throw PushSourceStopped{};
+        }
+        control_->send_blocking(std::move(value));
     }
 
     PushSourcePolicy make_push_source_policy(PushSourcePolicyKind kind,
@@ -632,19 +998,42 @@ namespace hgraph
                 return make_policy(queue_policy_ops(), sender_schema, authored_schema);
             case PushSourcePolicyKind::Conflating:
                 return make_policy(conflating_policy_ops(), sender_schema, authored_schema);
+            case PushSourcePolicyKind::Burst:
+                throw std::invalid_argument(
+                    "Burst push-source policy requires a complete "
+                    "TS[tuple[SCALAR, ...]] output schema");
         }
         throw std::invalid_argument("Unknown push-source policy kind");
     }
 
-    PushSourcePolicy make_push_source_queue_policy(const ValueTypeMetaData &sender_schema)
+    PushSourcePolicy make_push_source_queue_policy(
+        const ValueTypeMetaData &sender_schema, std::size_t max_pending)
     {
-        return make_push_source_policy(PushSourcePolicyKind::Queue, sender_schema, nullptr);
+        return make_policy(queue_policy_ops(), sender_schema, nullptr, max_pending);
     }
 
-    PushSourcePolicy make_push_source_queue_policy(const TSValueTypeMetaData &output_schema)
+    PushSourcePolicy make_push_source_queue_policy(
+        const TSValueTypeMetaData &output_schema, std::size_t max_pending)
     {
-        return make_push_source_policy(PushSourcePolicyKind::Queue, *output_schema.delta_value_schema,
-                                       output_schema.authored_delta_schema);
+        return make_policy(
+            queue_policy_ops(), *output_schema.delta_value_schema,
+            output_schema.authored_delta_schema, max_pending);
+    }
+
+    PushSourcePolicy make_push_source_burst_policy(
+        const TSValueTypeMetaData &output_schema, std::size_t max_pending)
+    {
+        const auto *value_schema = output_schema.value_schema;
+        if (output_schema.kind != TSTypeKind::TS || value_schema == nullptr ||
+            value_schema->try_value_kind() != ValueTypeKind::List ||
+            value_schema->fixed_size != 0 || !value_schema->is_variadic_tuple() ||
+            value_schema->is_mutable() || value_schema->is_nullable() ||
+            value_schema->element_type == nullptr)
+        {
+            throw std::invalid_argument("Burst push source requires TS[tuple[SCALAR, ...]] output");
+        }
+        return make_policy(
+            burst_policy_ops(), *value_schema->element_type, nullptr, max_pending);
     }
 
     PushSourcePolicy make_push_source_conflating_policy(const ValueTypeMetaData &sender_schema)
@@ -688,12 +1077,17 @@ namespace hgraph
                     push_source_policy_field_name,
                     &detail::PushSourcePolicyAccess::storage_plan(policy),
                 },
+                NodeStorageField{
+                    push_source_sender_control_field_name,
+                    &MemoryUtils::plan_for<std::shared_ptr<detail::PushSourceSenderControl>>(),
+                },
             };
             const auto &plan = node_storage_plan_for(schema, fields);
             const auto *context = &register_push_source_node_context(
                 output_schema,
                 policy,
                 plan.component(push_source_policy_field_name).offset,
+                plan.component(push_source_sender_control_field_name).offset,
                 std::move(extension.on_start),
                 std::move(extension.on_stop));
 
@@ -718,10 +1112,11 @@ namespace hgraph
         }
     }  // namespace
 
-    NodeBuilder make_push_source_node(const TSValueTypeMetaData &output_schema,
-                                      PushSourcePolicy policy,
-                                      PushSourceStartCallback on_start,
-                                      bool requires_phase_runner)
+    NodeBuilder make_push_source_node(
+        const TSValueTypeMetaData &output_schema,
+        PushSourcePolicy policy,
+        PushSourceStartCallback on_start,
+        bool requires_phase_runner)
     {
         return make_push_source_node_impl(
             output_schema, std::move(policy),
@@ -745,8 +1140,9 @@ namespace hgraph
             requires_phase_runner);
     }
 
-    NodeBuilder make_push_source_node(const TSValueTypeMetaData &output_schema,
-                                      PushSourceStartCallback on_start)
+    NodeBuilder make_push_source_node(
+        const TSValueTypeMetaData &output_schema,
+        PushSourceStartCallback on_start)
     {
         return make_push_source_node(
             output_schema,

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -200,6 +200,7 @@ hgraph_add_test_objects(hgraph_runtime_test_objects
     test_graph_diagnostics.cpp
     test_logger.cpp
     test_node_scheduler.cpp
+    test_push_source_queues.cpp
     test_realtime_execution.cpp
     test_ref_executor.cpp
     test_registry_snapshot.cpp

--- a/tests/cpp/test_compact_storage.cpp
+++ b/tests/cpp/test_compact_storage.cpp
@@ -118,6 +118,26 @@ TEST_CASE("ListBuilder: works with non-trivial element types (std::string)")
     REQUIRE(as_const<std::string>(storage.element_at(2)) == "gamma");
 }
 
+TEST_CASE("ListBuilder: transfers owning non-trivial values into ListStorage")
+{
+    using namespace hgraph;
+    auto       &registry = TypeRegistry::instance();
+    (void)registry.register_scalar<std::string>("string");
+    const auto binding = registry.scalar_type<std::string>();
+    REQUIRE(binding != nullptr);
+
+    Value first{std::string{"alpha"}};
+    Value second{std::string{"beta"}};
+    ListBuilder builder{binding};
+    builder.push_back(std::move(first));
+    builder.push_back(std::move(second));
+    auto storage = builder.build_storage();
+
+    REQUIRE(storage.size() == 2);
+    CHECK(as_const<std::string>(storage.element_at(0)) == "alpha");
+    CHECK(as_const<std::string>(storage.element_at(1)) == "beta");
+}
+
 TEST_CASE("compact containers expose raw, index, and recursive payload metrics", "[memory]")
 {
     using namespace hgraph;

--- a/tests/cpp/test_push_source_queues.cpp
+++ b/tests/cpp/test_push_source_queues.cpp
@@ -11,7 +11,6 @@
 #include <atomic>
 #include <chrono>
 #include <cstddef>
-#include <exception>
 #include <future>
 #include <thread>
 #include <vector>
@@ -114,7 +113,7 @@ TEST_CASE("bounded push-source queue refuses at capacity and releases on dequeue
     CHECK(observed == expected);
 }
 
-TEST_CASE("blocking push-source sender wakes with PushSourceStopped on stop")
+TEST_CASE("blocking push-source sender returns false when stopped")
 {
     using namespace hgraph;
 
@@ -137,19 +136,12 @@ TEST_CASE("blocking push-source sender wakes with PushSourceStopped on stop")
     REQUIRE(sender.try_send(Int{1}));
     std::promise<void> attempted;
     auto attempted_future = attempted.get_future();
-    std::atomic_bool stopped{false};
+    std::atomic_bool accepted{true};
     std::thread blocked(
         [&]
         {
             attempted.set_value();
-            try
-            {
-                sender.send_blocking(Int{2});
-            }
-            catch (const PushSourceStopped &)
-            {
-                stopped = true;
-            }
+            accepted = sender.send_blocking(Int{2});
         });
     attempted_future.wait();
     std::this_thread::sleep_for(std::chrono::milliseconds{10});
@@ -157,15 +149,21 @@ TEST_CASE("blocking push-source sender wakes with PushSourceStopped on stop")
     graph.stop(start_time);
     blocked.join();
 
-    CHECK(stopped);
+    CHECK_FALSE(accepted);
     CHECK_FALSE(sender.valid());
     CHECK_FALSE(sender.try_send(Int{3}));
-    CHECK_THROWS_AS(sender.send_blocking(Int{4}), PushSourceStopped);
+    CHECK_FALSE(sender.send_blocking(Int{4}));
 }
 
-TEST_CASE("non-blocking push-source wake tolerates concurrent graph stop")
+TEST_CASE("default and moved-from push-source senders use the stopped sentinel")
 {
     using namespace hgraph;
+
+    PushSourceSender stopped;
+    CHECK_FALSE(stopped.valid());
+    CHECK(stopped.type_realization() == nullptr);
+    CHECK_FALSE(stopped.try_send(Int{1}));
+    CHECK_FALSE(stopped.send_blocking(Int{2}));
 
     const auto *ts_int = ts_type<TS<Int>>();
     PushSourceSender sender;
@@ -184,34 +182,17 @@ TEST_CASE("non-blocking push-source wake tolerates concurrent graph stop")
     auto graph = executor.view().graph();
     graph.start(start_time);
 
-    std::promise<void> entered;
-    auto entered_future = entered.get_future();
-    bool stopped_without_throwing{false};
-    std::exception_ptr failure;
-    std::thread producer(
-        [&]
-        {
-            entered.set_value();
-            try
-            {
-                while (sender.try_send(Int{1}))
-                {
-                    std::this_thread::yield();
-                }
-                stopped_without_throwing = true;
-            }
-            catch (...)
-            {
-                failure = std::current_exception();
-            }
-        });
+    REQUIRE(sender.valid());
+    PushSourceSender live{std::move(sender)};
+    CHECK_FALSE(sender.valid());
+    CHECK_FALSE(sender.try_send(Int{3}));
+    CHECK_FALSE(sender.send_blocking(Int{4}));
+    CHECK(live.try_send(Int{5}));
 
-    entered_future.wait();
     graph.stop(start_time);
-    producer.join();
-
-    CHECK(failure == nullptr);
-    CHECK(stopped_without_throwing);
+    CHECK_FALSE(live.valid());
+    CHECK_FALSE(live.try_send(Int{6}));
+    CHECK_FALSE(live.send_blocking(Int{7}));
 }
 
 TEST_CASE("blocking push-source sender refuses to wait on the evaluation thread")

--- a/tests/cpp/test_push_source_queues.cpp
+++ b/tests/cpp/test_push_source_queues.cpp
@@ -11,6 +11,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstddef>
+#include <exception>
 #include <future>
 #include <thread>
 #include <vector>
@@ -160,6 +161,57 @@ TEST_CASE("blocking push-source sender wakes with PushSourceStopped on stop")
     CHECK_FALSE(sender.valid());
     CHECK_FALSE(sender.try_send(Int{3}));
     CHECK_THROWS_AS(sender.send_blocking(Int{4}), PushSourceStopped);
+}
+
+TEST_CASE("non-blocking push-source wake tolerates concurrent graph stop")
+{
+    using namespace hgraph;
+
+    const auto *ts_int = ts_type<TS<Int>>();
+    PushSourceSender sender;
+    GraphBuilder builder;
+    builder.add_node(make_push_source_node(
+        *ts_int, make_push_source_conflating_policy(*ts_int),
+        [&sender](PushSourceSender started) { sender = std::move(started); }));
+
+    const DateTime start_time = hgraph::testing::wall_now();
+    GraphExecutorBuilder executor_builder;
+    executor_builder.graph_builder(std::move(builder))
+        .mode(GraphExecutorMode::RealTime)
+        .start_time(start_time)
+        .end_time(start_time + TimeDelta{1'000'000});
+    auto executor = executor_builder.make_executor();
+    auto graph = executor.view().graph();
+    graph.start(start_time);
+
+    std::promise<void> entered;
+    auto entered_future = entered.get_future();
+    bool stopped_without_throwing{false};
+    std::exception_ptr failure;
+    std::thread producer(
+        [&]
+        {
+            entered.set_value();
+            try
+            {
+                while (sender.try_send(Int{1}))
+                {
+                    std::this_thread::yield();
+                }
+                stopped_without_throwing = true;
+            }
+            catch (...)
+            {
+                failure = std::current_exception();
+            }
+        });
+
+    entered_future.wait();
+    graph.stop(start_time);
+    producer.join();
+
+    CHECK(failure == nullptr);
+    CHECK(stopped_without_throwing);
 }
 
 TEST_CASE("blocking push-source sender refuses to wait on the evaluation thread")

--- a/tests/cpp/test_push_source_queues.cpp
+++ b/tests/cpp/test_push_source_queues.cpp
@@ -1,0 +1,332 @@
+#include <hgraph/lib/std/standard_types.h>
+#include <hgraph/lib/testing/runtime_support.h>
+#include <hgraph/runtime/runtime.h>
+#include <hgraph/types/metadata/type_registry.h>
+#include <hgraph/types/static_schema.h>
+#include <hgraph/types/type_resolution.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <future>
+#include <thread>
+#include <vector>
+
+namespace
+{
+    using namespace hgraph;
+
+    [[nodiscard]] NodeBuilder collecting_tuple_sink(const TSValueTypeMetaData &input_schema,
+                                                    const TSValueTypeMetaData &input_ts,
+                                                    std::vector<std::vector<Int>> &observed,
+                                                    std::size_t stop_after_count = 1)
+    {
+        NodeTypeMetaData schema;
+        schema.display_name = "collecting_tuple_sink";
+        schema.input_schema = &input_schema;
+        schema.node_kind = NodeKind::Sink;
+
+        NodeCallbacks callbacks;
+        callbacks.evaluate = [&observed, stop_after_count](const NodeView &view, DateTime evaluation_time)
+        {
+            auto root = view.input(evaluation_time);
+            auto bundle = root.as_bundle();
+            auto tuple = bundle[0].value().as_list();
+            std::vector<Int> values;
+            values.reserve(tuple.size());
+            for (std::size_t index = 0; index < tuple.size(); ++index)
+            {
+                values.push_back(tuple[index].checked_as<Int>());
+            }
+            observed.push_back(std::move(values));
+            if (observed.size() >= stop_after_count)
+            {
+                view.graph().executor().request_stop();
+            }
+        };
+
+        return NodeBuilder::native(std::move(schema), std::move(callbacks),
+                                   hgraph::testing::single_input_endpoint(input_schema, input_ts));
+    }
+
+    void connect_source_to_sink(GraphBuilder &builder)
+    {
+        builder.add_edge(GraphEdge{
+            .source_node = make_graph_edge_source(0),
+            .source_path = {},
+            .target_node = 1,
+            .target_path = {0},
+        });
+    }
+} // namespace
+
+TEST_CASE("bounded push-source queue refuses at capacity and releases on dequeue")
+{
+    using namespace hgraph;
+
+    const auto *ts_int = ts_type<TS<Int>>();
+    const auto *input_schema = hgraph::testing::single_input_schema(*ts_int);
+    std::vector<Int> observed;
+    std::thread producer;
+    std::atomic_bool blocking_send_completed{false};
+
+    PushSourceNodeExtension extension;
+    extension.on_start = [&](PushSourceSender sender, const NodeView &, DateTime)
+    {
+        REQUIRE(sender.try_send(Int{1}));
+        CHECK_FALSE(sender.try_send(Int{99}));
+        producer = std::thread(
+            [sender, &blocking_send_completed]
+            {
+                sender.send_blocking(Int{2});
+                blocking_send_completed = true;
+            });
+    };
+    extension.on_stop = [&](const NodeView &)
+    {
+        if (producer.joinable())
+        {
+            producer.join();
+        }
+    };
+
+    GraphBuilder builder;
+    builder.add_node(
+        make_push_source_node_with_view(*ts_int, make_push_source_queue_policy(*ts_int, 1), std::move(extension)));
+    builder.add_node(hgraph::testing::collecting_scalar_sink<Int>(*input_schema, *ts_int, observed, 2));
+    connect_source_to_sink(builder);
+
+    const DateTime start_time = hgraph::testing::wall_now();
+    GraphExecutorBuilder executor_builder;
+    executor_builder.graph_builder(std::move(builder))
+        .mode(GraphExecutorMode::RealTime)
+        .start_time(start_time)
+        .end_time(start_time + TimeDelta{1'000'000});
+    auto executor = executor_builder.make_executor();
+    executor.view().run();
+
+    CHECK(blocking_send_completed);
+    const std::vector<Int> expected{Int{1}, Int{2}};
+    CHECK(observed == expected);
+}
+
+TEST_CASE("blocking push-source sender wakes with PushSourceStopped on stop")
+{
+    using namespace hgraph;
+
+    const auto *ts_int = ts_type<TS<Int>>();
+    PushSourceSender sender;
+    GraphBuilder builder;
+    builder.add_node(make_push_source_node(*ts_int, make_push_source_queue_policy(*ts_int, 1),
+                                           [&sender](PushSourceSender started) { sender = std::move(started); }));
+
+    const DateTime start_time = hgraph::testing::wall_now();
+    GraphExecutorBuilder executor_builder;
+    executor_builder.graph_builder(std::move(builder))
+        .mode(GraphExecutorMode::RealTime)
+        .start_time(start_time)
+        .end_time(start_time + TimeDelta{1'000'000});
+    auto executor = executor_builder.make_executor();
+    auto graph = executor.view().graph();
+    graph.start(start_time);
+
+    REQUIRE(sender.try_send(Int{1}));
+    std::promise<void> attempted;
+    auto attempted_future = attempted.get_future();
+    std::atomic_bool stopped{false};
+    std::thread blocked(
+        [&]
+        {
+            attempted.set_value();
+            try
+            {
+                sender.send_blocking(Int{2});
+            }
+            catch (const PushSourceStopped &)
+            {
+                stopped = true;
+            }
+        });
+    attempted_future.wait();
+    std::this_thread::sleep_for(std::chrono::milliseconds{10});
+
+    graph.stop(start_time);
+    blocked.join();
+
+    CHECK(stopped);
+    CHECK_FALSE(sender.valid());
+    CHECK_FALSE(sender.try_send(Int{3}));
+    CHECK_THROWS_AS(sender.send_blocking(Int{4}), PushSourceStopped);
+}
+
+TEST_CASE("blocking push-source sender refuses to wait on the evaluation thread")
+{
+    using namespace hgraph;
+
+    const auto *ts_int = ts_type<TS<Int>>();
+    bool rejected_wait{false};
+    GraphBuilder builder;
+    builder.add_node(make_push_source_node(*ts_int, make_push_source_queue_policy(*ts_int, 1),
+                                           [&rejected_wait](PushSourceSender sender)
+                                           {
+                                               sender.send_blocking(Int{1});
+                                               try
+                                               {
+                                                   sender.send_blocking(Int{2});
+                                               }
+                                               catch (const std::logic_error &error)
+                                               {
+                                                   rejected_wait = std::string_view{error.what()}.contains(
+                                                       "graph evaluation thread");
+                                               }
+                                           }));
+
+    const DateTime start_time = hgraph::testing::wall_now();
+    GraphExecutorBuilder executor_builder;
+    executor_builder.graph_builder(std::move(builder))
+        .mode(GraphExecutorMode::RealTime)
+        .start_time(start_time)
+        .end_time(start_time + TimeDelta{1'000'000});
+    auto executor = executor_builder.make_executor();
+    auto graph = executor.view().graph();
+    graph.start(start_time);
+    graph.stop(start_time);
+
+    CHECK(rejected_wait);
+}
+
+TEST_CASE("burst delivery shares queue admission and emits one pending tuple")
+{
+    using namespace hgraph;
+
+    const auto *ts_tuple = ts_type<TS<HomogeneousTuple<Int>>>();
+    const auto *input_schema = hgraph::testing::single_input_schema(*ts_tuple);
+    std::vector<std::vector<Int>> observed;
+    std::thread producer;
+    std::atomic_bool blocking_send_completed{false};
+    bool refused{false};
+
+    PushSourceNodeExtension extension;
+    extension.on_start = [&](PushSourceSender sender, const NodeView &, DateTime)
+    {
+        sender.send_blocking(Int{1});
+        sender.send_blocking(Int{2});
+        sender.send_blocking(Int{3});
+        refused = !sender.try_send(Int{4});
+        CHECK_THROWS_AS(sender.try_send(Str{"wrong schema"}), std::invalid_argument);
+        producer = std::thread(
+            [sender, &blocking_send_completed]
+            {
+                sender.send_blocking(Int{4});
+                blocking_send_completed = true;
+            });
+    };
+    extension.on_stop = [&](const NodeView &)
+    {
+        if (producer.joinable())
+        {
+            producer.join();
+        }
+    };
+
+    GraphBuilder builder;
+    builder.add_node(
+        make_push_source_node_with_view(*ts_tuple, make_push_source_burst_policy(*ts_tuple, 3), std::move(extension)));
+    builder.add_node(collecting_tuple_sink(*input_schema, *ts_tuple, observed, 2));
+    connect_source_to_sink(builder);
+
+    const DateTime start_time = hgraph::testing::wall_now();
+    GraphExecutorBuilder executor_builder;
+    executor_builder.graph_builder(std::move(builder))
+        .mode(GraphExecutorMode::RealTime)
+        .start_time(start_time)
+        .end_time(start_time + TimeDelta{1'000'000});
+    auto executor = executor_builder.make_executor();
+    executor.view().run();
+
+    CHECK(refused);
+    CHECK(blocking_send_completed);
+    REQUIRE(observed.size() == 2);
+    const std::vector<Int> expected_first{Int{1}, Int{2}, Int{3}};
+    const std::vector<Int> expected_second{Int{4}};
+    CHECK(observed[0] == expected_first);
+    CHECK(observed[1] == expected_second);
+}
+
+TEST_CASE("burst policy rejects non-variadic-tuple output schemas")
+{
+    using namespace hgraph;
+
+    auto &registry = TypeRegistry::instance();
+    const auto *integer = scalar_descriptor<Int>::value_meta();
+    CHECK_THROWS_AS(make_push_source_burst_policy(*registry.ts(integer)), std::invalid_argument);
+    CHECK_THROWS_AS(make_push_source_burst_policy(*registry.ts(registry.list(integer))), std::invalid_argument);
+    CHECK_THROWS_AS(make_push_source_burst_policy(*registry.ts(registry.list(integer, 2))), std::invalid_argument);
+    CHECK_THROWS_AS(make_push_source_policy(PushSourcePolicyKind::Burst, *integer), std::invalid_argument);
+}
+
+TEST_CASE("push-source sender supports concurrent producers")
+{
+    using namespace hgraph;
+
+    constexpr std::size_t producer_count = 4;
+    constexpr std::size_t values_per_producer = 32;
+    constexpr std::size_t total_values = producer_count * values_per_producer;
+
+    const auto *ts_int = ts_type<TS<Int>>();
+    const auto *input_schema = hgraph::testing::single_input_schema(*ts_int);
+    std::vector<Int> observed;
+    std::vector<std::thread> producers;
+
+    PushSourceNodeExtension extension;
+    extension.on_start = [&](PushSourceSender sender, const NodeView &, DateTime)
+    {
+        producers.reserve(producer_count);
+        for (std::size_t producer = 0; producer < producer_count; ++producer)
+        {
+            producers.emplace_back(
+                [sender, producer]
+                {
+                    for (std::size_t index = 0; index < values_per_producer; ++index)
+                    {
+                        sender.send_blocking(Int{static_cast<std::int64_t>(producer * values_per_producer + index)});
+                    }
+                });
+        }
+    };
+    extension.on_stop = [&](const NodeView &)
+    {
+        for (auto &producer : producers)
+        {
+            if (producer.joinable())
+            {
+                producer.join();
+            }
+        }
+    };
+
+    GraphBuilder builder;
+    builder.add_node(
+        make_push_source_node_with_view(*ts_int, make_push_source_queue_policy(*ts_int, 16), std::move(extension)));
+    builder.add_node(hgraph::testing::collecting_scalar_sink<Int>(*input_schema, *ts_int, observed, total_values));
+    connect_source_to_sink(builder);
+
+    const DateTime start_time = hgraph::testing::wall_now();
+    GraphExecutorBuilder executor_builder;
+    executor_builder.graph_builder(std::move(builder))
+        .mode(GraphExecutorMode::RealTime)
+        .start_time(start_time)
+        .end_time(start_time + TimeDelta{2'000'000});
+    auto executor = executor_builder.make_executor();
+    executor.view().run();
+
+    REQUIRE(observed.size() == total_values);
+    std::ranges::sort(observed);
+    for (std::size_t index = 0; index < total_values; ++index)
+    {
+        CHECK(observed[index] == Int{static_cast<std::int64_t>(index)});
+    }
+}

--- a/tests/cpp/test_realtime_execution.cpp
+++ b/tests/cpp/test_realtime_execution.cpp
@@ -1139,7 +1139,7 @@ TEST_CASE("push source sender reports values refused during and after graph shut
     const auto check_policy = [&](PushSourcePolicy policy) {
         PushSourceSender sender;
         bool stop_try_accepted{true};
-        bool stop_blocking_threw{false};
+        bool stop_blocking_accepted{true};
         GraphBuilder graph_builder;
         graph_builder.add_node(make_push_source_node(
             *ts_int,
@@ -1150,14 +1150,7 @@ TEST_CASE("push source sender reports values refused during and after graph shut
         NodeCallbacks stop_sender_callbacks;
         stop_sender_callbacks.stop = [&](const NodeView &, DateTime) {
             stop_try_accepted = sender.try_send(Int{41});
-            try
-            {
-                sender.send_blocking(Int{41});
-            }
-            catch (const PushSourceStopped &)
-            {
-                stop_blocking_threw = true;
-            }
+            stop_blocking_accepted = sender.send_blocking(Int{41});
         };
         graph_builder.add_node(NodeBuilder::native(
             std::move(stop_sender_schema), std::move(stop_sender_callbacks)));
@@ -1179,9 +1172,9 @@ TEST_CASE("push source sender reports values refused during and after graph shut
         runner.join();
 
         CHECK_FALSE(stop_try_accepted);
-        CHECK(stop_blocking_threw);
+        CHECK_FALSE(stop_blocking_accepted);
         CHECK_FALSE(sender.try_send(Int{42}));
-        CHECK_THROWS_AS(sender.send_blocking(Int{42}), PushSourceStopped);
+        CHECK_FALSE(sender.send_blocking(Int{42}));
     };
 
     SECTION("queue policy") { check_policy(make_push_source_queue_policy(*int_meta)); }

--- a/tests/cpp/test_realtime_execution.cpp
+++ b/tests/cpp/test_realtime_execution.cpp
@@ -697,7 +697,7 @@ TEST_CASE("real-time executor evaluates root push queues after pending update si
 
     std::this_thread::sleep_for(std::chrono::milliseconds{20});
     REQUIRE(sender.valid());
-    sender.send(Int{42});
+    sender.send_blocking(Int{42});
     runner.join();
 
     CHECK(sink_eval_count == 1);
@@ -728,8 +728,8 @@ TEST_CASE("push source exposes pending work through the data-only inspection con
     graph.start(start_time);
     REQUIRE(sender.valid());
 
-    sender.send(Int{41});
-    sender.send(Int{42});
+    sender.send_blocking(Int{41});
+    sender.send_blocking(Int{42});
     REQUIRE(graph.node_at(0).inspection_metrics().pending_items.has_value());
     CHECK(*graph.node_at(0).inspection_metrics().pending_items == 2);
 
@@ -822,8 +822,8 @@ TEST_CASE("real-time push source drains multiple queued values across cycles")
 
     std::this_thread::sleep_for(std::chrono::milliseconds{20});
     REQUIRE(sender.valid());
-    sender.send(Int{1});
-    sender.send(Int{2});
+    sender.send_blocking(Int{1});
+    sender.send_blocking(Int{2});
     runner.join();
 
     REQUIRE(observed_values.size() == 2);
@@ -849,8 +849,8 @@ TEST_CASE("real-time push source applies queued collection deltas in order")
     graph_builder.add_node(make_push_source_node(
         *tsd_int,
         [](PushSourceSender sender) {
-            sender.send(dict_delta<Str, TS<Int>>({{"a"s, Int{1}}, {"b"s, Int{2}}}));
-            sender.send(dict_delta<Str, TS<Int>>({{"a"s, Int{3}}}, {"b"s}));
+            sender.send_blocking(dict_delta<Str, TS<Int>>({{"a"s, Int{1}}, {"b"s, Int{2}}}));
+            sender.send_blocking(dict_delta<Str, TS<Int>>({{"a"s, Int{3}}}, {"b"s}));
         }));
 
     NodeTypeMetaData sink_schema;
@@ -964,8 +964,8 @@ TEST_CASE("real-time push source moves external polymorphic keys into graph pool
 
         std::this_thread::sleep_for(std::chrono::milliseconds{20});
         REQUIRE(sender.valid());
-        sender.send(initial_delta);
-        sender.send(update_delta);
+        sender.send_blocking(initial_delta);
+        sender.send_blocking(update_delta);
         runner.join();
 
         const auto pools = view.graph().compound_scalar_storage().inspect();
@@ -1003,8 +1003,8 @@ TEST_CASE("real-time conflating push source emits only the latest pending value"
         *ts_int,
         make_push_source_conflating_policy(*ts_int->value_schema),
         [](PushSourceSender sender) {
-            sender.send(Int{1});
-            sender.send(Int{2});
+            sender.send_blocking(Int{1});
+            sender.send_blocking(Int{2});
         }));
     graph_builder.add_node(hgraph::testing::recording_scalar_sink<Int>(
         *input_schema,
@@ -1053,9 +1053,9 @@ TEST_CASE("real-time conflating push source applies collection deltas before emi
         *tsd_int,
         make_push_source_conflating_policy(*tsd_int->delta_value_schema),
         [](PushSourceSender sender) {
-            sender.send(dict_delta<Str, TS<Int>>({{"a"s, Int{1}}}));
-            sender.send(dict_delta<Str, TS<Int>>({{"b"s, Int{2}}}));
-            sender.send(dict_delta<Str, TS<Int>>({{"a"s, Int{3}}}));
+            sender.send_blocking(dict_delta<Str, TS<Int>>({{"a"s, Int{1}}}));
+            sender.send_blocking(dict_delta<Str, TS<Int>>({{"b"s, Int{2}}}));
+            sender.send_blocking(dict_delta<Str, TS<Int>>({{"a"s, Int{3}}}));
         }));
     graph_builder.add_node(hgraph::testing::recording_value_sink(
         *input_schema,
@@ -1123,12 +1123,12 @@ TEST_CASE("push source policy validates output shape and sender payload schema s
 
     std::this_thread::sleep_for(std::chrono::milliseconds{20});
     REQUIRE(sender.valid());
-    CHECK_THROWS_AS(sender.send(Str{"wrong-schema"}), std::invalid_argument);
+    CHECK_THROWS_AS(sender.send_blocking(Str{"wrong-schema"}), std::invalid_argument);
     view.request_stop();
     runner.join();
 }
 
-TEST_CASE("push source sender ignores values after graph shutdown")
+TEST_CASE("push source sender reports values refused during and after graph shutdown")
 {
     using namespace hgraph;
 
@@ -1138,6 +1138,8 @@ TEST_CASE("push source sender ignores values after graph shutdown")
 
     const auto check_policy = [&](PushSourcePolicy policy) {
         PushSourceSender sender;
+        bool stop_try_accepted{true};
+        bool stop_blocking_threw{false};
         GraphBuilder graph_builder;
         graph_builder.add_node(make_push_source_node(
             *ts_int,
@@ -1146,7 +1148,17 @@ TEST_CASE("push source sender ignores values after graph shutdown")
         NodeTypeMetaData stop_sender_schema;
         stop_sender_schema.display_name = "send_during_stop";
         NodeCallbacks stop_sender_callbacks;
-        stop_sender_callbacks.stop = [&sender](const NodeView &, DateTime) { sender.send(Int{41}); };
+        stop_sender_callbacks.stop = [&](const NodeView &, DateTime) {
+            stop_try_accepted = sender.try_send(Int{41});
+            try
+            {
+                sender.send_blocking(Int{41});
+            }
+            catch (const PushSourceStopped &)
+            {
+                stop_blocking_threw = true;
+            }
+        };
         graph_builder.add_node(NodeBuilder::native(
             std::move(stop_sender_schema), std::move(stop_sender_callbacks)));
 
@@ -1166,7 +1178,10 @@ TEST_CASE("push source sender ignores values after graph shutdown")
         view.request_stop();
         runner.join();
 
-        CHECK_NOTHROW(sender.send(Int{42}));
+        CHECK_FALSE(stop_try_accepted);
+        CHECK(stop_blocking_threw);
+        CHECK_FALSE(sender.try_send(Int{42}));
+        CHECK_THROWS_AS(sender.send_blocking(Int{42}), PushSourceStopped);
     };
 
     SECTION("queue policy") { check_policy(make_push_source_queue_policy(*int_meta)); }

--- a/tests/cpp/test_service_push_sources.cpp
+++ b/tests/cpp/test_service_push_sources.cpp
@@ -401,7 +401,7 @@ TEST_CASE("service push sources: a reference service implementation owns a root 
     AsyncGraphExecutorRun runner{view};
     auto sender = ticks_sender.await();
     REQUIRE(sender.has_value());
-    sender->send(Int{42});
+    sender->send_blocking(Int{42});
     runner.join();
 
     CHECK(observed == std::vector<Int>{Int{42}});
@@ -427,8 +427,8 @@ TEST_CASE("service push sources: two implementations contribute two push sources
     auto alt_ticks = alt_ticks_sender.await();
     REQUIRE(ticks.has_value());
     REQUIRE(alt_ticks.has_value());
-    ticks->send(Int{40});
-    alt_ticks->send(Int{2});
+    ticks->send_blocking(Int{40});
+    alt_ticks->send_blocking(Int{2});
     runner.join();
 
     REQUIRE(observed.size() == 1);
@@ -448,7 +448,7 @@ TEST_CASE("service push sources: a subscription service implementation owns a ro
     AsyncGraphExecutorRun runner{view};
     auto sender = quotes_sender.await();
     REQUIRE(sender.has_value());
-    sender->send(Int{99});
+    sender->send_blocking(Int{99});
     runner.join();
 
     CHECK(observed == std::vector<Int>{Int{99}});
@@ -467,7 +467,7 @@ TEST_CASE("service push sources: a request/reply service implementation owns a r
     AsyncGraphExecutorRun runner{view};
     auto sender = replies_sender.await();
     REQUIRE(sender.has_value());
-    sender->send(Int{55});
+    sender->send_blocking(Int{55});
     runner.join();
 
     CHECK(observed == std::vector<Int>{Int{55}});
@@ -486,7 +486,7 @@ TEST_CASE("service push sources: an adaptor implementation owns a root push sour
     AsyncGraphExecutorRun runner{view};
     auto sender = adaptor_sender.await();
     REQUIRE(sender.has_value());
-    sender->send(Int{13});
+    sender->send_blocking(Int{13});
     runner.join();
 
     CHECK(observed == std::vector<Int>{Int{13}});

--- a/tests/install_consumer/main.cpp
+++ b/tests/install_consumer/main.cpp
@@ -107,6 +107,50 @@ namespace
         &apply_consumer_table,
     };
 
+    void check_push_source_queue_contract()
+    {
+        using namespace hgraph;
+
+        auto &registry = TypeRegistry::instance();
+        const auto *integer = scalar_descriptor<Int>::value_meta();
+        const auto *ts_int = registry.ts(integer);
+        const auto *ts_tuple = registry.ts(registry.list(integer, 0, true));
+
+        const auto check_capacity = [](const TSValueTypeMetaData &output_schema,
+                                       PushSourcePolicy policy) {
+            PushSourceSender sender;
+            GraphBuilder graph_builder;
+            graph_builder.add_node(make_push_source_node(
+                output_schema, std::move(policy),
+                [&sender](PushSourceSender started) {
+                    sender = std::move(started);
+                }));
+
+            GraphExecutorBuilder executor_builder;
+            executor_builder.graph_builder(std::move(graph_builder))
+                .mode(GraphExecutorMode::RealTime)
+                .start_time(MIN_ST)
+                .end_time(MIN_ST + TimeDelta{1});
+            auto executor = executor_builder.make_executor();
+            auto graph = executor.view().graph();
+            graph.start(MIN_ST);
+            if (!sender.try_send(Int{1}) || sender.try_send(Int{2}))
+            {
+                throw std::runtime_error(
+                    "installed bounded push-source sender does not report capacity");
+            }
+            graph.stop(MIN_ST);
+            if (sender.valid() || sender.try_send(Int{3}))
+            {
+                throw std::runtime_error(
+                    "installed push-source sender remains valid after stop");
+            }
+        };
+
+        check_capacity(*ts_int, make_push_source_queue_policy(*ts_int, 1));
+        check_capacity(*ts_tuple, make_push_source_burst_policy(*ts_tuple, 1));
+    }
+
     // ------------------------------------------------------------------
     // A trivial EXTERNAL record/replay backend (RFC 0025 checkpoint 3):
     // registers overloads of the core operator markers through public
@@ -517,6 +561,7 @@ int main()
     }
 
     check_probe_backend_round_trip();
+    check_push_source_queue_contract();
     hgraph_install_consumer::check_fabric_core_extension_seam();
 
     return 0;


### PR DESCRIPTION
## Summary

- keep queue admission, stopped-state behavior, policy dispatch, synchronization, and executor notification inside the type-erased `PushSourceSender` contract
- queue or conflate work before marking the root executor push-pending and notifying its condition variable; adaptors never access the graph or executor directly
- expose `try_send(T&&) -> bool` and `send_blocking(T&&) -> bool`; blocking waits only for bounded capacity, returns `false` when the receiver stops, and releases the Python GIL
- use a canonical stopped ops-table sentinel for default and moved-from senders instead of nullable guards or a separate wake wrapper
- support unbounded and bounded FIFO queues, conflation, and queue-backed burst delivery to homogeneous tuples
- make Python `@push_queue` support a stop hook sharing lifecycle state with start, so producer tasks can be requested to stop and their threads joined
- make web and Kafka bridges enqueue their own work first and then issue an unconditional blocking sender notification; a teardown refusal is intentionally discardable and never escapes as an exception
- document simple push adaptors, graph-singleton `service_impl` adaptors with push/sink interfaces, simulation-specific pull/source wiring, and downstream acknowledgement/commit sinks
- add the reusable `hgraph-realtime-adaptors` development skill; the existing `.claude/skills` link exposes it to Claude as well

Implements the core stages of RFC 0027 from #548. Protocol acknowledgement remains deliberately outside the sender contract: enqueueing proves only that data was buffered, while acknowledgement or transactional commit must flow through the graph after processing.

## Validation

- macOS clean native build: 1,616/1,616 tests passed
- macOS stable-ABI wheel built with Python 3.12, installed into a fresh Python 3.14 environment: 2,128 passed, 10 skipped
- GCC 14.2 Linux clean native build: 1,616/1,616 tests passed
- GCC 14.2 Linux stable-ABI wheel built with Python 3.12, installed into a fresh Python 3.14 environment with the VM-compatible Polars runtime: 2,128 passed, 10 skipped
- generated API inventory: 11/11 tests passed
- Sphinx warnings-as-errors build passed
- real-time adaptor skill validation passed
