### PR TITLE
Use burst ingress for web and Kafka adaptors

### DIFF
--- a/docs/source/rfc/rfc_0015_kafka_extension_api.rst
+++ b/docs/source/rfc/rfc_0015_kafka_extension_api.rst
@@ -63,20 +63,24 @@ Live Kafka ingress is real-time-only.  One standard unbounded burst push source
 carries discriminated, fully owned transport envelopes for subscription
 values, delivery reports, and service events.  Each sender call admits one
 envelope; one source evaluation transfers all currently pending envelopes as
-an ordered tuple.  The subscription scheduler retains only its required
-timestamp/recovery ordering.  Delivery reports are grouped by a stateless
-classifier and flow through standard ``collect`` and mapped ``emit`` operators;
-the scalar event stream uses standard ``emit`` directly.  This distributes
-independent keys in one public tick, preserves same-key FIFO over later cycles,
-and keeps graph-stop and commit-on-delivery policy on graph.  There is no extension-owned
-cross-thread ingress queue, conflated wake token, or drain node in front of the
-graph.
+an ordered tuple.  One Kafka-specific graph emit classifies that burst into a
+structural service bundle: keyed subscription and delivery lanes plus a scalar
+service-event lane.  Independent keys are emitted together as keyed deltas;
+only a repeated key, a later scalar event, or timestamp/recovery ordering is
+retained for a later engine cycle.  Standard field projection and ``map_`` then
+give each service lane its public shape.  This preserves same-key FIFO without
+head-of-line blocking across independent keys or services, and keeps graph-stop
+and commit-on-delivery policy on graph.  There is no extension-owned
+cross-thread ingress queue, conflated wake token, or opaque service projection
+or drain object in front of the graph.
 
 No push source is permitted in simulation.  The simulation specialization
 performs a finite bounded read without a worker thread, retains the resulting
 history in graph-owned replay state, and schedules it at the recorded Kafka
-timestamps.  Subscription records sharing one timestamp are applied in one
-keyed mutation so exact simulated time is preserved.
+timestamps.  Replay feeds the same graph emit and mapped service projections as
+live ingress.  Independent subscription records sharing one timestamp are
+applied in one keyed mutation so exact simulated time is preserved; a collision
+on one subscription key is released on the following engine cycle.
 
 Motivation
 ----------
@@ -1047,9 +1051,10 @@ Public C++ and extension boundary
 * One ``KafkaServiceImpl`` materializes for one demanded path and configuration;
   duplicate registration at that path is rejected.
 * Its graph-to-Kafka edges are distinct sink nodes over ``impl_input``.
-  Real-time Kafka-to-graph values use one burst root push source and ordinary
-  projection nodes; bounded simulation recovery uses a scheduled replay node.
-  Both are published through ``impl_output``.
+  Real-time Kafka-to-graph values use one burst root push source, one structural
+  service emit, and mapped projection graphs; bounded simulation recovery uses
+  a scheduled replay node feeding the same emit and projections.  Both are
+  published through ``impl_output``.
 * The real-time/simulation implementation is selected at wiring time.  A
   simulation graph contains no push source and accepts only deterministic,
   bounded record-time subscriptions.

--- a/docs/source/rfc/rfc_0015_kafka_extension_api.rst
+++ b/docs/source/rfc/rfc_0015_kafka_extension_api.rst
@@ -63,10 +63,12 @@ Live Kafka ingress is real-time-only.  One standard unbounded burst push source
 carries discriminated, fully owned transport envelopes for subscription
 values, delivery reports, and service events.  Each sender call admits one
 envelope; one source evaluation transfers all currently pending envelopes as
-an ordered tuple.  Ordinary graph nodes distribute independent subscription
-keys and delivery reports in one public tick, preserve same-key FIFO by
-unrolling collisions over later cycles, unroll the scalar event stream, and
-apply graph-stop and commit-on-delivery policy.  There is no extension-owned
+an ordered tuple.  The subscription scheduler retains only its required
+timestamp/recovery ordering.  Delivery reports are grouped by a stateless
+classifier and flow through standard ``collect`` and mapped ``emit`` operators;
+the scalar event stream uses standard ``emit`` directly.  This distributes
+independent keys in one public tick, preserves same-key FIFO over later cycles,
+and keeps graph-stop and commit-on-delivery policy on graph.  There is no extension-owned
 cross-thread ingress queue, conflated wake token, or drain node in front of the
 graph.
 
@@ -712,9 +714,10 @@ The native default promises:
   are emitted in arrival order on consecutive ``MIN_TD`` cycles.
 
 Delivery reports for distinct request ids distribute together as one keyed
-mutation.  Repeated reports for one id retain FIFO order over later cycles,
-just like repeated subscription values for one key.  Service events are scalar
-and are unrolled in FIFO order, one per graph cycle.  The discriminated tuple
+mutation.  Repeated reports for one id retain FIFO order over later cycles via
+one standard ``emit`` node per mapped request id, just like repeated
+subscription values for one key.  Service events are scalar and use standard
+``emit`` to unroll in FIFO order, one per graph cycle.  The discriminated tuple
 preserves admission order for projection, but no public total order is promised
 between independent subscription keys, delivery reports, and service events.
 
@@ -981,8 +984,9 @@ small records, large records, headers, several partitions, several graph
 clients, and two concurrent pure-C++ engines.
 
 The real-time ingress policy is explicitly the standard unbounded burst queue
-rather than a hidden extension queue.  The graph retains only same-key or
-scalar collisions that cannot share one public tick.  Capacity may be
+rather than a hidden extension queue.  Standard graph operators retain the
+same-key or scalar work that cannot share one public tick; the adaptor has no
+second projection queue.  Capacity may be
 introduced later only by selecting the core bounded policy with a documented
 refusal path.  The extension should expose data-only inspection views rather
 than requiring debuggers to decode librdkafka or STL layouts.
@@ -1151,7 +1155,8 @@ Implementation status
 The native extension, service interfaces, fake transport, librdkafka runtime,
 and Python authoring bridge are implemented.  The RFC 0027 migration described
 in step 6 is included in the current implementation: real-time ingress uses the
-standard burst push source and simulation uses graph-owned scheduled replay.
+standard burst push source, delivery/scalar unrolling uses standard graph
+composition, and simulation uses graph-owned scheduled replay.
 This RFC remains ``Proposed`` until the remaining performance, sanitizer,
 installed-package, and compatibility-transition evidence satisfies the
 acceptance criteria above.

--- a/docs/source/rfc/rfc_0015_kafka_extension_api.rst
+++ b/docs/source/rfc/rfc_0015_kafka_extension_api.rst
@@ -59,12 +59,16 @@ the same native extension and preserve the released ``KafkaMessage``, replay,
 ``recovered``, flush, and legacy cross-partition ordering behavior.  New code
 does not depend on magic ``msg``/``recovered`` parameter names.
 
-Live Kafka ingress is real-time-only.  One standard FIFO push source carries a
-discriminated, fully owned transport envelope for subscription values,
-delivery reports, and service events.  Ordinary graph nodes project that
-ordered stream into the public service outputs and apply graph-stop and
-commit-on-delivery policy.  There is no extension-owned ingress queue,
-conflated wake token, or drain node in front of the graph.
+Live Kafka ingress is real-time-only.  One standard unbounded burst push source
+carries discriminated, fully owned transport envelopes for subscription
+values, delivery reports, and service events.  Each sender call admits one
+envelope; one source evaluation transfers all currently pending envelopes as
+an ordered tuple.  Ordinary graph nodes distribute independent subscription
+keys and delivery reports in one public tick, preserve same-key FIFO by
+unrolling collisions over later cycles, unroll the scalar event stream, and
+apply graph-stop and commit-on-delivery policy.  There is no extension-owned
+cross-thread ingress queue, conflated wake token, or drain node in front of the
+graph.
 
 No push source is permitted in simulation.  The simulation specialization
 performs a finite bounded read without a worker thread, retains the resulting
@@ -638,7 +642,7 @@ The graph-local runtime resource owns:
 * one shared producer and poll thread for the path's producer configuration;
 * one consumer owner thread per consumer session;
 * a session registry keyed by the complete semantic subscription identity;
-* the standard push-source sender used for ordered real-time ingress;
+* the standard burst push-source sender used for real-time ingress;
 * the bounded, record-counted simulation recovery and producer staging state;
 * explicit start, accepting, stopping, and stopped states.
 
@@ -664,10 +668,11 @@ Queue ownership and capacity
 RFC 0027 makes the push-source node the cross-thread queue.  Kafka therefore
 does not duplicate its storage, locking, wake generation, or receiver-lifetime
 logic.  A consumer callback constructs one owned ``KafkaTransportEvent`` and
-calls ``send_blocking`` on the unbounded FIFO policy selected by the service
-graph.  The send cannot wait for capacity; ``false`` means only that graph
-teardown closed the receiver.  Storage is updated before the sender wakes the
-real-time executor.
+calls ``send_blocking`` on the unbounded burst policy selected by the service
+graph.  The scalar call moves one envelope into the queue; dequeue produces a
+tuple containing all work pending at that point.  The send cannot wait for
+capacity; ``false`` means only that graph teardown closed the receiver.
+Storage is updated before the sender wakes the real-time executor.
 
 The public Kafka configuration has record counts, not byte limits.  The
 consumer record limit bounds finite recovery retained before replay; the
@@ -700,9 +705,18 @@ The native default promises:
 
 * record offset order within each Kafka partition;
 * no invented total order across partitions;
-* worker/poll arrival order for records already classified as live; and
-* one hgraph tick per record, with no conflation unless the user wires an
-  explicit conflating graph operation.
+* worker/poll arrival order for records already classified as live on the same
+  subscription key; and
+* one keyed modification per record, with no conflation: distinct subscription
+  keys pending in one burst tick together, while repeated values for one key
+  are emitted in arrival order on consecutive ``MIN_TD`` cycles.
+
+Delivery reports for distinct request ids distribute together as one keyed
+mutation.  Repeated reports for one id retain FIFO order over later cycles,
+just like repeated subscription values for one key.  Service events are scalar
+and are unrolled in FIFO order, one per graph cycle.  The discriminated tuple
+preserves admission order for projection, but no public total order is promised
+between independent subscription keys, delivery reports, and service events.
 
 Record timestamp is metadata.  A live record's evaluation time is the graph
 cycle in which the transport projection emits it; its Kafka timestamp does
@@ -954,7 +968,7 @@ The native hot path must avoid Python and minimise copies:
 
 * librdkafka payloads are copied or retained exactly once into an owned
   cross-thread record according to the chosen safe lifetime strategy;
-* the standard push-source queue retains transport envelopes by move;
+* the standard burst push-source queue retains transport envelopes by move;
 * graph-thread publication moves into the native time-series value;
 * codecs run after transport unless a native codec explicitly opts into safe
   off-thread decoding; and
@@ -966,11 +980,12 @@ recovery throughput, and shutdown drain time.  Measurements cover
 small records, large records, headers, several partitions, several graph
 clients, and two concurrent pure-C++ engines.
 
-The real-time ingress policy is explicitly the standard unbounded FIFO rather
-than a hidden extension queue.  Capacity may be introduced later only by
-selecting the core bounded policy with a documented refusal path.  The
-extension should expose data-only inspection views rather than requiring
-debuggers to decode librdkafka or STL layouts.
+The real-time ingress policy is explicitly the standard unbounded burst queue
+rather than a hidden extension queue.  The graph retains only same-key or
+scalar collisions that cannot share one public tick.  Capacity may be
+introduced later only by selecting the core bounded policy with a documented
+refusal path.  The extension should expose data-only inspection views rather
+than requiring debuggers to decode librdkafka or STL layouts.
 
 Alternatives considered
 -----------------------
@@ -1028,7 +1043,7 @@ Public C++ and extension boundary
 * One ``KafkaServiceImpl`` materializes for one demanded path and configuration;
   duplicate registration at that path is rejected.
 * Its graph-to-Kafka edges are distinct sink nodes over ``impl_input``.
-  Real-time Kafka-to-graph values use one ordered root push source and ordinary
+  Real-time Kafka-to-graph values use one burst root push source and ordinary
   projection nodes; bounded simulation recovery uses a scheduled replay node.
   Both are published through ``impl_output``.
 * The real-time/simulation implementation is selected at wiring time.  A
@@ -1136,8 +1151,8 @@ Implementation status
 The native extension, service interfaces, fake transport, librdkafka runtime,
 and Python authoring bridge are implemented.  The RFC 0027 migration described
 in step 6 is included in the current implementation: real-time ingress uses the
-standard push source and simulation uses graph-owned scheduled replay.  This
-RFC remains ``Proposed`` until the remaining performance, sanitizer,
+standard burst push source and simulation uses graph-owned scheduled replay.
+This RFC remains ``Proposed`` until the remaining performance, sanitizer,
 installed-package, and compatibility-transition evidence satisfies the
 acceptance criteria above.
 

--- a/docs/source/rfc/rfc_0015_kafka_extension_api.rst
+++ b/docs/source/rfc/rfc_0015_kafka_extension_api.rst
@@ -65,14 +65,15 @@ values, delivery reports, and service events.  Each sender call admits one
 envelope; one source evaluation transfers all currently pending envelopes as
 an ordered tuple.  One Kafka-specific graph emit classifies that burst into a
 structural service bundle: keyed subscription and delivery lanes plus a scalar
-service-event lane.  Independent keys are emitted together as keyed deltas;
-only a repeated key, a later scalar event, or timestamp/recovery ordering is
-retained for a later engine cycle.  Standard field projection and ``map_`` then
-give each service lane its public shape.  This preserves same-key FIFO without
-head-of-line blocking across independent keys or services, and keeps graph-stop
-and commit-on-delivery policy on graph.  There is no extension-owned
-cross-thread ingress queue, conflated wake token, or opaque service projection
-or drain object in front of the graph.
+service-event lane.  The emit walks one ordered pending queue and delegates its
+collision-free prefix into that bundle.  Independent keys can therefore share
+a keyed delta, but the first repeated key, second scalar event, or
+timestamp/recovery constraint stops the walk; the front event resumes on the
+next applicable engine cycle.  No later event may overtake that boundary.
+Standard field projection and ``map_`` then give each service lane its public
+shape and keep graph-stop and commit-on-delivery policy on graph.  There is no
+extension-owned cross-thread ingress queue, conflated wake token, or opaque
+service projection or drain object in front of the graph.
 
 No push source is permitted in simulation.  The simulation specialization
 performs a finite bounded read without a worker thread, retains the resulting
@@ -988,9 +989,9 @@ small records, large records, headers, several partitions, several graph
 clients, and two concurrent pure-C++ engines.
 
 The real-time ingress policy is explicitly the standard unbounded burst queue
-rather than a hidden extension queue.  Standard graph operators retain the
-same-key or scalar work that cannot share one public tick; the adaptor has no
-second projection queue.  Capacity may be
+rather than a hidden extension queue.  The Kafka graph emit has one ordered
+pending queue for work that cannot enter the current output tick; it does not
+create a queue per projected service lane.  Capacity may be
 introduced later only by selecting the core bounded policy with a documented
 refusal path.  The extension should expose data-only inspection views rather
 than requiring debuggers to decode librdkafka or STL layouts.

--- a/docs/source/rfc/rfc_0024_web_extension_api.rst
+++ b/docs/source/rfc/rfc_0024_web_extension_api.rst
@@ -425,9 +425,9 @@ The primary operations are:
    mechanism converts live route keys to the implementation's
    ``TSS[WebRoute]``; the transport compiles the table and delivers each
    matched request on its route's stream. Distinct routes tick in the same
-   cycle; multiple pending requests on ONE route are delivered from the
-   standard FIFO push source one per engine cycle. A batched nested-TSD
-   delivery shape is the identified follow-up
+   cycle; the burst projection retains multiple pending requests on ONE route
+   and delivers them in FIFO order one per engine cycle. A batched nested-TSD
+   delivery shape remains the identified follow-up
    if pacing proves limiting on very hot routes.
 
 ``wire<HttpRespondService>(w, path, HttpRespondRequest)``
@@ -514,15 +514,17 @@ registry, and that holds no graph state.
   ``curl_multi_poll`` and woken by ``curl_multi_wakeup`` when the graph
   stages a submission.  WebSocket handles join the same loop; all
   ``curl_ws_send``/``curl_ws_recv`` calls happen on this thread.
-* **Graph transport**: one bounded standard FIFO push source carries the fully
+* **Graph transport**: one bounded standard burst push source carries the fully
   owned event envelopes for each independently ordered logical channel. A
   server has request, WS-ingress, response-delivery, WS-send-delivery, event,
   and statistics sources; a client has response, WS-ingress, send-delivery,
   event, and statistics sources. Ordinary graph nodes project each source onto
-  its service output. FIFO is preserved within each channel, while independent
-  channels may advance in the same engine cycle and cannot head-of-line block
-  one another. No public contract requires a total order across those service
-  outputs.
+  its service output. Within a keyed output, distinct keys pending in a burst
+  advance together and same-key collisions are retained in arrival order for
+  later ``MIN_TD`` cycles. Scalar event outputs are unrolled in FIFO order;
+  statistics use the latest sample. Independent channels may advance in the
+  same engine cycle and cannot head-of-line block one another. No public
+  contract requires a total order across those service outputs.
   The graph-to-runtime direction consists of purpose-specific sink nodes for
   route/key deltas, responses, calls, and WebSocket sends. A graph-scoped
   admission budget retains the web-specific per-channel byte limits,
@@ -532,13 +534,15 @@ registry, and that holds no graph state.
   capacity, so a successful domain admission cannot later fail because its
   core queue is full. Statistics allow
   one pending sample; additional periodic samples are self-superseding and are
-  refused until the graph dequeues it, after which the next sample reports the
+  refused until the graph projects it, after which the next sample reports the
   current state. Each active route or WebSocket client key also has a
   graph-owned lifetime generation. The external task stamps that generation on
   routed ingress, and the graph projection accepts it only while the same
   generation remains active. A queued event can therefore neither recreate a
-  removed output key nor cross a rapid remove/re-add boundary; the channel
-  queue remains the sole owner of event ordering and storage.
+  removed output key nor cross a rapid remove/re-add boundary. Same-key
+  collisions which cannot share a TSD tick are held by graph-thread projection
+  state and remain charged to the admission budget until applied or discarded.
+  The push source remains the sole cross-thread value queue.
 * No worker thread calls ``EvaluationEngineApi``, mutates a time series, or
   retains a borrowed graph value.  ``PushSourceSender`` is the only
   cross-thread runtime boundary; off-thread value construction runs under
@@ -632,10 +636,13 @@ Ordering and time
   ``Date`` headers and payload timestamps are metadata.
 * Multiple requests pending on one route are delivered on consecutive
   ``MIN_TD`` cycles in arrival order.
-* FIFO ordering is scoped to one logical channel. HTTP ingress, WebSocket
-  ingress, delivery reports, diagnostics, and statistics are independent
-  service outputs: they may tick in the same cycle and a backlog in one does
-  not delay another.
+* Distinct route, WebSocket, or delivery-report keys pending in one channel
+  burst are distributed in the same keyed tick. Same-key arrival order remains
+  FIFO. Diagnostics are scalar and unroll one per cycle; statistics are
+  current-state samples and the latest sample in a burst wins.
+* HTTP ingress, WebSocket ingress, delivery reports, diagnostics, and
+  statistics are independent service outputs: they may tick in the same cycle
+  and a backlog in one does not delay another.
 * Route/key removal invalidates all ingress already queued for that subscription
   lifetime. Re-adding an equal key creates a new lifetime; old HTTP requests,
   server WebSocket events/frames, and client WebSocket events/frames are not
@@ -1014,12 +1021,13 @@ A per-request adaptor-duplex endpoint per route
    routes dynamic data instead of requiring a new wiring-time route
    enumeration mechanism.
 
-One standard push source per logical channel
+One standard burst push source per logical channel
    Selected. RFC 0027 removes the private value queues and wake-only nodes; it
    does not require unrelated service outputs to share one FIFO. HTTP ingress,
    WebSocket ingress, delivery reports, diagnostics, and statistics have no
-   public cross-channel ordering contract, so separate standard sources retain
-   FIFO where it is meaningful and avoid head-of-line blocking across domains.
+   public cross-channel ordering contract, so separate burst sources retain
+   per-key or scalar FIFO where it is meaningful, distribute distinct keyed
+   work, and avoid head-of-line blocking across domains.
    The sources share one graph-scoped runtime and admission budget and require
    no private queue or drain node.
 
@@ -1126,9 +1134,9 @@ Implementation plan
 7. Land HTTP/2 server activation (``nghttp2_session.cpp``) in a v1.x
    release behind the already-shipped seam.
 8. Migrate server, client, and fake transports to RFC 0027: one standard
-   bounded push source per independently ordered channel, graph projection and
-   command sink nodes, no private ``Value`` queue, and a separate real-time
-   wiring path.
+   bounded burst push source per independently ordered channel, graph
+   projection and command sink nodes, no private cross-thread ``Value`` queue,
+   and a separate real-time wiring path.
 
 Implementation status
 ---------------------
@@ -1143,9 +1151,10 @@ sealed seam per the activation plan above.
 
 The RFC 0027 web migration is also implemented: the former private per-channel
 value deques, wake-only push sources, and drain nodes are removed. One standard
-bounded push source per logical channel now owns asynchronous value storage and
-executor notification; web retains only data-free byte/reservation accounting
-and protocol policy.
+bounded burst push source per logical channel now owns asynchronous
+cross-thread value storage and executor notification; web retains
+byte/reservation accounting and graph-thread same-key projection spill so that
+public TSD keys can distribute without conflating collisions.
 Live and callback-driven fake implementations reject simulation wiring.
 
 References

--- a/docs/source/rfc/rfc_0024_web_extension_api.rst
+++ b/docs/source/rfc/rfc_0024_web_extension_api.rst
@@ -425,8 +425,9 @@ The primary operations are:
    mechanism converts live route keys to the implementation's
    ``TSS[WebRoute]``; the transport compiles the table and delivers each
    matched request on its route's stream. Distinct routes tick in the same
-   cycle; the burst projection retains multiple pending requests on ONE route
-   and delivers them in FIFO order one per engine cycle. A batched nested-TSD
+   cycle; a keyed ``collect`` followed by ``map_(emit, ...)`` retains multiple
+   pending requests on ONE route and delivers them in FIFO order one per
+   engine cycle. A batched nested-TSD
    delivery shape remains the identified follow-up
    if pacing proves limiting on very hot routes.
 
@@ -518,13 +519,15 @@ registry, and that holds no graph state.
   owned event envelopes for each independently ordered logical channel. A
   server has request, WS-ingress, response-delivery, WS-send-delivery, event,
   and statistics sources; a client has response, WS-ingress, send-delivery,
-  event, and statistics sources. Ordinary graph nodes project each source onto
-  its service output. Within a keyed output, distinct keys pending in a burst
-  advance together and same-key collisions are retained in arrival order for
-  later ``MIN_TD`` cycles. Scalar event outputs are unrolled in FIFO order;
-  statistics use the latest sample. Independent channels may advance in the
-  same engine cycle and cannot head-of-line block one another. No public
-  contract requires a total order across those service outputs.
+  event, and statistics sources. A small stateless classifier groups keyed
+  bursts, then the standard ``collect``, ``map_``, and ``emit`` operators
+  project them onto the service outputs. Distinct keys pending in a burst
+  advance together; each mapped ``emit`` retains same-key collisions in FIFO
+  order for later ``MIN_TD`` cycles. Scalar event outputs use standard
+  ``emit`` directly, while statistics select the latest sample. Independent
+  channels may advance in the same engine cycle and cannot head-of-line block
+  one another. No public contract requires a total order across those service
+  outputs.
   The graph-to-runtime direction consists of purpose-specific sink nodes for
   route/key deltas, responses, calls, and WebSocket sends. A graph-scoped
   admission budget retains the web-specific per-channel byte limits,
@@ -534,15 +537,16 @@ registry, and that holds no graph state.
   capacity, so a successful domain admission cannot later fail because its
   core queue is full. Statistics allow
   one pending sample; additional periodic samples are self-superseding and are
-  refused until the graph projects it, after which the next sample reports the
+  refused until the graph receives it, after which the next sample reports the
   current state. Each active route or WebSocket client key also has a
   graph-owned lifetime generation. The external task stamps that generation on
   routed ingress, and the graph projection accepts it only while the same
   generation remains active. A queued event can therefore neither recreate a
-  removed output key nor cross a rapid remove/re-add boundary. Same-key
-  collisions which cannot share a TSD tick are held by graph-thread projection
-  state and remain charged to the admission budget until applied or discarded.
-  The push source remains the sole cross-thread value queue.
+  removed output key nor cross a rapid remove/re-add boundary. Domain record
+  and byte admission is released by a graph sink when the burst is taken from
+  the boundary queue. Any later same-key buffering belongs to standard graph
+  operators and is processing state, not transport admission or protocol
+  acknowledgement. The push source remains the sole cross-thread value queue.
 * No worker thread calls ``EvaluationEngineApi``, mutates a time series, or
   retains a borrowed graph value.  ``PushSourceSender`` is the only
   cross-thread runtime boundary; off-thread value construction runs under
@@ -555,11 +559,16 @@ Flow control and bounded memory
 -------------------------------
 
 Each standard push-source queue is bounded in records, and the web admission
-budget bounds its logical channel in records and bytes. At the configured high
+budget reserves its logical channel in records and bytes until the burst enters
+graph processing. At the configured high
 watermark (default 80%) the transport stops issuing socket reads — HTTP/1.1
 backpressure propagates naturally through TCP; the client pauses transfers
 with ``curl_easy_pause``; the future h2 session withholds window updates —
 and resumes below the low watermark (default 50%).
+These limits bound transport admission and reservation memory, not work that
+has already entered the graph.  A mapped ``emit`` queue is ordinary graph
+processing state; its size therefore follows the arrival-rate/processing-rate
+relationship rather than the transport byte budget.
 
 Server ingress admission is reservation-based, so payload memory outside
 the standard queue is bounded by the same domain limits. An HTTP
@@ -1150,11 +1159,12 @@ surface, and ``hgraph_web.compat`` — which now serves the released
 sealed seam per the activation plan above.
 
 The RFC 0027 web migration is also implemented: the former private per-channel
-value deques, wake-only push sources, and drain nodes are removed. One standard
-bounded burst push source per logical channel now owns asynchronous
-cross-thread value storage and executor notification; web retains
-byte/reservation accounting and graph-thread same-key projection spill so that
-public TSD keys can distribute without conflating collisions.
+value deques, wake-only push sources, projection schedules, and drain nodes are
+removed. One standard bounded burst push source per logical channel now owns
+asynchronous cross-thread value storage and executor notification; web retains
+only byte/reservation accounting until graph handoff. Standard ``collect`` and
+mapped ``emit`` composition distributes public TSD keys without conflating
+same-key collisions.
 Live and callback-driven fake implementations reject simulation wiring.
 
 References

--- a/docs/source/rfc/rfc_0027_bounded_push_source_queues.rst
+++ b/docs/source/rfc/rfc_0027_bounded_push_source_queues.rst
@@ -739,14 +739,17 @@ The installed-SDK fixture exercises bounded queue and burst factories through
 public headers.
 
 Stage 3 is implemented for both extensions. Kafka uses one FIFO push source
-for its ordered transport envelope, graph nodes project public service outputs,
-graph sinks issue commands and commits, byte-capacity configuration is removed, and
-simulation uses a scheduled replay node without a worker or push source. Web
-uses one FIFO push source per server/client runtime, graph nodes project its
-discriminated event envelope, graph sinks issue transport commands, and its
-former value queues, wake sources, and drain nodes are removed. Web retains
-only data-free domain byte/reservation accounting; callback-driven live and
-fake transports reject simulation wiring. Downstream before/after latency and
+for its ordered transport envelope; a stateless classifier plus standard
+``collect``/mapped ``emit`` handles delivery reports, standard ``emit`` handles
+scalar events, graph sinks issue commands and commits, byte-capacity
+configuration is removed, and simulation uses a scheduled replay node without
+a worker or push source. Web uses one bounded FIFO burst source per independently
+ordered channel; stateless grouping plus standard ``collect``/mapped ``emit``
+handles keyed outputs and standard ``emit`` handles scalar events. Its former
+value queues, wake sources, projection schedules, and drain nodes are removed.
+Web retains only data-free domain byte/reservation accounting until graph
+handoff; callback-driven live and fake transports reject simulation wiring.
+Downstream before/after latency and
 allocation measurements remain outstanding before ``Accepted`` status can be
 recorded.
 Until the implementation and conformance tests merge, this RFC remains

--- a/docs/source/user_guide/adaptors/kafka.rst
+++ b/docs/source/user_guide/adaptors/kafka.rst
@@ -53,10 +53,19 @@ use another path when those settings must differ.
 
 The actual Kafka clients and their worker threads are owned by the graph and
 joined when it stops.  There is no Python or C++ Kafka manager to construct,
-poll, or close outside the graph.  In real time, callbacks send one internal
-ordered envelope stream through a standard FIFO push source; ordinary graph
-nodes project that stream into the public subscription, delivery, and event
-outputs.  Kafka owns no second ingress queue or wake-token protocol.
+poll, or close outside the graph.  In real time, callbacks send scalar
+envelopes through one standard unbounded burst push source.  A graph cycle
+receives the pending envelopes as an ordered tuple; ordinary graph nodes
+project it into the public subscription, delivery, and event outputs.  Kafka
+owns no second cross-thread ingress queue or wake-token protocol.
+
+Distinct subscription keys in one burst tick together.  Repeated records for
+one subscription keep FIFO order and are unrolled over consecutive ``MIN_TD``
+cycles, so no record is conflated.  Delivery reports for distinct request ids
+distribute in one keyed tick; repeated reports for one id are likewise
+FIFO-unrolled.  The scalar service-event output remains FIFO and emits one
+event per graph cycle.  There is no public total order between these
+independent outputs.
 
 The essential data flow is:
 
@@ -371,7 +380,7 @@ options through deployment configuration.
    )
 
 The ingress record limit bounds finite recovery retained before replay; live
-real-time ingress uses the service's standard unbounded FIFO push source and
+real-time ingress uses the service's standard unbounded burst push source and
 has no byte-capacity setting.  Recovery overflow may ``FAIL`` or ``DROP``; it
 cannot stage.  Outbound overflow may ``FAIL``, ``DROP``, or ``STAGE`` in a
 record-counted queue, whose own overflow action must be ``FAIL`` or ``DROP``.

--- a/docs/source/user_guide/adaptors/kafka.rst
+++ b/docs/source/user_guide/adaptors/kafka.rst
@@ -56,7 +56,9 @@ joined when it stops.  There is no Python or C++ Kafka manager to construct,
 poll, or close outside the graph.  In real time, callbacks send scalar
 envelopes through one standard unbounded burst push source.  A graph cycle
 receives the pending envelopes as an ordered tuple; ordinary graph nodes
-project it into the public subscription, delivery, and event outputs.  Kafka
+project it into the public subscription, delivery, and event outputs.  Delivery
+reports use standard ``collect`` plus mapped ``emit`` composition, and scalar
+events use standard ``emit`` directly.  Kafka
 owns no second cross-thread ingress queue or wake-token protocol.
 
 Distinct subscription keys in one burst tick together.  Repeated records for

--- a/docs/source/user_guide/adaptors/web.rst
+++ b/docs/source/user_guide/adaptors/web.rst
@@ -61,10 +61,13 @@ root push sources, and the graph reaches the sockets only through sink
 nodes — evaluation itself stays single-threaded, with the bounded boundary
 queues (and their short handoff locks) as the only cross-thread
 touchpoints.  Each independently ordered service-output channel has its own
-FIFO push source: HTTP ingress cannot sit behind a WebSocket, delivery-report,
-diagnostic, or statistics backlog.  FIFO is guaranteed within a channel; no
-total order is invented across channels, and active channels may tick in the
-same engine cycle.  A request
+burst push source: HTTP ingress cannot sit behind a WebSocket, delivery-report,
+diagnostic, or statistics backlog.  Distinct route, connection, or request-id
+keys pending in one burst tick together; repeated values for one key retain
+FIFO order over consecutive ``MIN_TD`` cycles.  Scalar diagnostic streams are
+unrolled one event per cycle, while statistics use the latest sample.  No total
+order is invented across channels, and active channels may tick in the same
+engine cycle.  A request
 that a same-cycle handler can answer dispatches its response in that same
 engine cycle; there is no per-request feedback cycle.
 

--- a/docs/source/user_guide/adaptors/web.rst
+++ b/docs/source/user_guide/adaptors/web.rst
@@ -64,8 +64,9 @@ touchpoints.  Each independently ordered service-output channel has its own
 burst push source: HTTP ingress cannot sit behind a WebSocket, delivery-report,
 diagnostic, or statistics backlog.  Distinct route, connection, or request-id
 keys pending in one burst tick together; repeated values for one key retain
-FIFO order over consecutive ``MIN_TD`` cycles.  Scalar diagnostic streams are
-unrolled one event per cycle, while statistics use the latest sample.  No total
+FIFO order over consecutive ``MIN_TD`` cycles.  The keyed paths use standard
+``collect`` plus mapped ``emit`` graph composition; scalar diagnostic streams
+use standard ``emit`` directly, while statistics use the latest sample.  No total
 order is invented across channels, and active channels may tick in the same
 engine cycle.  A request
 that a same-cycle handler can answer dispatches its response in that same
@@ -389,9 +390,12 @@ Flow control and memory bounds
 Every boundary queue is bounded in **records and bytes**, and the byte
 accounting is real: a request's admission is *reserved* against
 ``ingress_byte_limit`` before its body is even read off the socket, so a
-flood cannot make the graph retain more than you configured — the excess
-stays in the kernel (HTTP/1.1 and WebSocket via paused reads, HTTP/2 via
-withheld per-stream flow-control window).  At the configured watermarks
+flood cannot make the transport boundary retain more than you configured —
+the excess stays in the kernel (HTTP/1.1 and WebSocket via paused reads,
+HTTP/2 via withheld per-stream flow-control window).  Capacity is released
+when a burst enters graph processing; any later mapped ``emit`` backlog is
+ordinary graph state and is not charged to the transport budget.  At the
+configured watermarks
 (``watermark_high_pct`` / ``watermark_low_pct``) socket reads pause and
 resume; at the hard limit the ``inbound_overflow`` policy applies:
 

--- a/extensions/kafka/CHANGELOG.md
+++ b/extensions/kafka/CHANGELOG.md
@@ -5,9 +5,11 @@
 - Rebuild manual/independent assignments as a new recovery generation after a
   broker disconnect, allowing live consumers to resume from committed offsets
   and exposing `Retrying` -> `Recovering` -> `Live` lifecycle transitions.
-- Route all real-time results through one ordered standard-FIFO push source,
-  with subscription, delivery, event, stop-policy, and delivery-commit logic
-  implemented by graph nodes and sinks rather than a private bridge queue.
+- Route all real-time results through one standard unbounded burst push source.
+  Graph projections distribute distinct subscription keys and delivery ids in
+  one tick, unroll same-key and scalar-event collisions in FIFO order, and keep
+  stop-policy and delivery-commit logic on graph rather than in a private
+  bridge queue.
 - Preserve bounded deterministic Kafka recovery in simulation through an
   ordinary scheduled service graph with no push source or consumer worker.
 - Replay recovered records at their Kafka timestamps across all subscriptions

--- a/extensions/kafka/CHANGELOG.md
+++ b/extensions/kafka/CHANGELOG.md
@@ -7,9 +7,10 @@
   and exposing `Retrying` -> `Recovering` -> `Live` lifecycle transitions.
 - Route all real-time results through one standard unbounded burst push source.
   Graph projections distribute distinct subscription keys and delivery ids in
-  one tick, unroll same-key and scalar-event collisions in FIFO order, and keep
-  stop-policy and delivery-commit logic on graph rather than in a private
-  bridge queue.
+  one tick; delivery reports use standard `collect` plus mapped `emit`, scalar
+  events use standard `emit`, and only Kafka timestamp/recovery ordering keeps
+  a specialised scheduler. Stop-policy and delivery-commit logic remain on
+  graph rather than in a private bridge queue.
 - Preserve bounded deterministic Kafka recovery in simulation through an
   ordinary scheduled service graph with no push source or consumer worker.
 - Replay recovered records at their Kafka timestamps across all subscriptions

--- a/extensions/kafka/src/detail/service_transport.h
+++ b/extensions/kafka/src/detail/service_transport.h
@@ -21,6 +21,8 @@
 #include <span>
 #include <string_view>
 #include <typeindex>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -83,8 +85,7 @@ inline std::ostream &operator<<(std::ostream &stream,
   return stream << "KafkaTransportBindingsHandle(" << value.value.get() << ')';
 }
 
-[[nodiscard]] inline KafkaTransportBindingsHandle
-make_transport_bindings() {
+[[nodiscard]] inline KafkaTransportBindingsHandle make_transport_bindings() {
   auto &factory = ValuePlanFactory::instance();
   return KafkaTransportBindingsHandle{
       std::make_shared<const KafkaTransportBindings>(KafkaTransportBindings{
@@ -144,6 +145,56 @@ public:
     Value value = std::move(values_.front());
     values_.pop_front();
     return value;
+  }
+
+  /** Detaches the next graph-visible cohort. Explicit recovery timestamps
+   * remain atomic; live events without timestamps release at most one event
+   * per subscription key so independent subscriptions can advance together.
+   * Cost is O(N) for N queued subscription events. */
+  [[nodiscard]] std::vector<Value> pop_ready_cohort() {
+    std::vector<Value> result;
+    if (values_.empty()) {
+      return result;
+    }
+    const auto cohort_time = evaluation_time(values_.front().view());
+    if (cohort_time.has_value()) {
+      while (!values_.empty() &&
+             evaluation_time(values_.front().view()) == cohort_time) {
+        result.push_back(pop());
+      }
+      return result;
+    }
+
+    struct Hash {
+      [[nodiscard]] std::size_t operator()(const Value &value) const {
+        return value.hash();
+      }
+    };
+    struct Equal {
+      [[nodiscard]] bool operator()(const Value &lhs, const Value &rhs) const {
+        return lhs.equals(rhs.view());
+      }
+    };
+    std::unordered_set<Value, Hash, Equal> emitted;
+    std::deque<Value> remaining;
+    while (!values_.empty()) {
+      Value value = pop();
+      if (evaluation_time(value.view()).has_value()) {
+        remaining.push_back(std::move(value));
+        while (!values_.empty()) {
+          remaining.push_back(pop());
+        }
+        break;
+      }
+      const auto key = value.view().as_bundle().at("subscription_key");
+      if (emitted.emplace(key).second) {
+        result.push_back(std::move(value));
+      } else {
+        remaining.push_back(std::move(value));
+      }
+    }
+    values_.swap(remaining);
+    return result;
   }
 
   [[nodiscard]] bool empty() const noexcept { return values_.empty(); }
@@ -209,17 +260,106 @@ struct SubscriptionEventScheduleHandle {
   }
 };
 
+/** Graph-thread spill used when one burst contains several delivery reports
+ * for the same service request id. Distinct ids never enter this state. Drain
+ * cost is O(P) for P pending ids; retained memory is O(C) for collisions. */
+class DeliveryEventSchedule {
+public:
+  template <typename Apply>
+  void drain(std::unordered_set<Int> &emitted, Apply &&apply) {
+    for (auto entry = values_.begin(); entry != values_.end();) {
+      auto &queue = entry->second;
+      Value event = std::move(queue.front());
+      queue.pop_front();
+      apply(event.view());
+      emitted.emplace(entry->first);
+      if (queue.empty()) {
+        entry = values_.erase(entry);
+      } else {
+        ++entry;
+      }
+    }
+  }
+
+  void defer(Int request_id, const ValueView &event) {
+    values_[request_id].emplace_back(event);
+  }
+
+  [[nodiscard]] bool empty() const noexcept { return values_.empty(); }
+
+private:
+  std::unordered_map<Int, std::deque<Value>> values_{};
+};
+
+struct DeliveryEventScheduleHandle {
+  std::shared_ptr<DeliveryEventSchedule> value{};
+
+  friend bool
+  operator==(const DeliveryEventScheduleHandle &,
+             const DeliveryEventScheduleHandle &) noexcept = default;
+  friend std::strong_ordering
+  operator<=>(const DeliveryEventScheduleHandle &lhs,
+              const DeliveryEventScheduleHandle &rhs) noexcept {
+    return reinterpret_cast<std::uintptr_t>(lhs.value.get()) <=>
+           reinterpret_cast<std::uintptr_t>(rhs.value.get());
+  }
+};
+
+/** Graph-thread FIFO used only when a burst contains several scalar service
+ * events. Cost is O(1) to emit and retain each event; memory is O(E) for E
+ * events awaiting their own ticks. */
+class KafkaEventSchedule {
+public:
+  void defer(const ValueView &event) { values_.emplace_back(event); }
+
+  [[nodiscard]] std::optional<Value> pop() {
+    if (values_.empty()) {
+      return std::nullopt;
+    }
+    Value value = std::move(values_.front());
+    values_.pop_front();
+    return value;
+  }
+
+  [[nodiscard]] bool empty() const noexcept { return values_.empty(); }
+
+private:
+  std::deque<Value> values_{};
+};
+
+struct KafkaEventScheduleHandle {
+  std::shared_ptr<KafkaEventSchedule> value{};
+
+  friend bool operator==(const KafkaEventScheduleHandle &,
+                         const KafkaEventScheduleHandle &) noexcept = default;
+  friend std::strong_ordering
+  operator<=>(const KafkaEventScheduleHandle &lhs,
+              const KafkaEventScheduleHandle &rhs) noexcept {
+    return reinterpret_cast<std::uintptr_t>(lhs.value.get()) <=>
+           reinterpret_cast<std::uintptr_t>(rhs.value.get());
+  }
+};
+
 inline std::ostream &operator<<(std::ostream &stream,
                                 const SubscriptionEventScheduleHandle &value) {
   return stream << "SubscriptionEventScheduleHandle(" << value.value.get()
                 << ')';
 }
 
+inline std::ostream &operator<<(std::ostream &stream,
+                                const DeliveryEventScheduleHandle &value) {
+  return stream << "DeliveryEventScheduleHandle(" << value.value.get() << ')';
+}
+
+inline std::ostream &operator<<(std::ostream &stream,
+                                const KafkaEventScheduleHandle &value) {
+  return stream << "KafkaEventScheduleHandle(" << value.value.get() << ')';
+}
+
 } // namespace hgraph::kafka::detail
 
 namespace std {
-template <>
-struct hash<hgraph::kafka::detail::KafkaTransportBindingsHandle> {
+template <> struct hash<hgraph::kafka::detail::KafkaTransportBindingsHandle> {
   size_t operator()(const hgraph::kafka::detail::KafkaTransportBindingsHandle
                         &value) const noexcept {
     return hash<const void *>{}(value.value.get());
@@ -229,6 +369,20 @@ struct hash<hgraph::kafka::detail::KafkaTransportBindingsHandle> {
 template <>
 struct hash<hgraph::kafka::detail::SubscriptionEventScheduleHandle> {
   size_t operator()(const hgraph::kafka::detail::SubscriptionEventScheduleHandle
+                        &value) const noexcept {
+    return hash<const void *>{}(value.value.get());
+  }
+};
+
+template <> struct hash<hgraph::kafka::detail::DeliveryEventScheduleHandle> {
+  size_t operator()(const hgraph::kafka::detail::DeliveryEventScheduleHandle
+                        &value) const noexcept {
+    return hash<const void *>{}(value.value.get());
+  }
+};
+
+template <> struct hash<hgraph::kafka::detail::KafkaEventScheduleHandle> {
+  size_t operator()(const hgraph::kafka::detail::KafkaEventScheduleHandle
                         &value) const noexcept {
     return hash<const void *>{}(value.value.get());
   }
@@ -244,6 +398,16 @@ template <> struct scalar_name<kafka::detail::KafkaTransportBindingsHandle> {
 template <> struct scalar_name<kafka::detail::SubscriptionEventScheduleHandle> {
   static constexpr std::string_view value{
       "hgraph.kafka.internal::SubscriptionEventScheduleHandle"};
+};
+
+template <> struct scalar_name<kafka::detail::DeliveryEventScheduleHandle> {
+  static constexpr std::string_view value{
+      "hgraph.kafka.internal::DeliveryEventScheduleHandle"};
+};
+
+template <> struct scalar_name<kafka::detail::KafkaEventScheduleHandle> {
+  static constexpr std::string_view value{
+      "hgraph.kafka.internal::KafkaEventScheduleHandle"};
 };
 } // namespace hgraph::static_schema_detail
 
@@ -293,65 +457,70 @@ transport_event(const KafkaTransportBindings &bindings,
                          std::move(fields));
 }
 
-[[nodiscard]] inline Value recovery_barrier_transport_event(
-    const KafkaTransportBindings &bindings) {
+[[nodiscard]] inline Value
+recovery_barrier_transport_event(const KafkaTransportBindings &bindings) {
   return transport_event(bindings, KafkaTransportEventKind::RecoveryBarrier,
                          {});
 }
 
-[[nodiscard]] inline Value subscription_removed_transport_event(
-    const KafkaTransportBindings &bindings, Value key) {
+[[nodiscard]] inline Value
+subscription_removed_transport_event(const KafkaTransportBindings &bindings,
+                                     Value key) {
   return transport_event(bindings, KafkaTransportEventKind::Subscription,
                          {{"subscription_key", std::move(key)},
                           {"removed", transport_atomic(Bool{true})}});
 }
 
-[[nodiscard]] inline Value delivery_transport_event(
-    const KafkaTransportBindings &bindings, Int request_id, Value report) {
+[[nodiscard]] inline Value
+delivery_transport_event(const KafkaTransportBindings &bindings, Int request_id,
+                         Value report) {
   return transport_event(bindings, KafkaTransportEventKind::Delivery,
                          {{"request_id", transport_atomic(request_id)},
                           {"report", std::move(report)}});
 }
 
-[[nodiscard]] inline Value service_transport_event(
-    const KafkaTransportBindings &bindings, Value event,
-    Bool stop_graph = false) {
+[[nodiscard]] inline Value
+service_transport_event(const KafkaTransportBindings &bindings, Value event,
+                        Bool stop_graph = false) {
   return transport_event(bindings, KafkaTransportEventKind::Event,
                          {{"event", std::move(event)},
                           {"stop_graph", transport_atomic(stop_graph)}});
 }
 
 /** Runtime demultiplexing cannot be expressed as a wiring-time graph because
- *  the envelope kind and recovery timestamp arrive on each tick. This compute
- *  node activates on every transport envelope, retains only the ordered
- *  subscription schedule, and emits keyed subscription mutations. Insertion
- *  is O(n) in queued subscription events and equal-timestamp cohort projection
- *  is O(B) for cohort size B; retained memory is O(n). State is ephemeral
- *  ingress state and is discarded at stop. */
+ * the envelope kind and recovery timestamp arrive in each burst. This compute
+ * node retains the ordered subscription schedule and emits one event per
+ * independent subscription key in a live cycle, while explicit same-time
+ * recovery cohorts remain atomic. Insertion and live cohort selection are
+ * O(n) in queued subscription events; projection is O(B) for emitted cohort
+ * size B and retained memory is O(n). State is ephemeral ingress state and is
+ * discarded at stop. */
 struct SubscriptionProjectionNode {
   static constexpr auto name = "kafka_subscription_projection";
 
-  static void
-  start(Scalar<"bindings", KafkaTransportBindingsHandle> bindings,
-        State<SubscriptionEventScheduleHandle> state) {
+  static void start(Scalar<"bindings", KafkaTransportBindingsHandle> bindings,
+                    State<SubscriptionEventScheduleHandle> state) {
     state.set(SubscriptionEventScheduleHandle{
         std::make_shared<SubscriptionEventSchedule>(*bindings.value().value)});
   }
 
   static void
-  eval(In<"transport", TS<KafkaTransportEvent>> transport,
+  eval(In<"transport", TS<KafkaTransportEventBatch>> transport,
        Scalar<"bindings", KafkaTransportBindingsHandle>,
        State<SubscriptionEventScheduleHandle> state,
        SingleShotScheduler scheduler,
        Out<TSD<KafkaSubscriptionKey, KafkaSubscriptionOutput>> out) {
     auto schedule = state.get().value;
     if (transport.modified()) {
-      const auto fields = transport.base().value().as_bundle();
-      const auto kind = fields.at("kind").checked_as<KafkaTransportEventKind>();
-      if (kind == KafkaTransportEventKind::Subscription) {
-        schedule->push(transport.base().value().clone());
-      } else if (kind == KafkaTransportEventKind::RecoveryBarrier) {
-        schedule->release_recovery();
+      for (const auto event : transport.base().value().as_list()) {
+        const auto fields = event.as_bundle();
+        const auto kind =
+            fields.at("kind").checked_as<KafkaTransportEventKind>();
+        if (kind == KafkaTransportEventKind::Subscription) {
+          schedule->push(event.clone());
+        } else if (kind == KafkaTransportEventKind::RecoveryBarrier) {
+          schedule->release_recovery();
+        }
       }
     }
 
@@ -398,48 +567,102 @@ struct SubscriptionProjectionNode {
       mutation.set(fields.at("subscription_key"), value.view());
     };
 
-    apply_event(schedule->pop());
-    while (next_time.has_value() && schedule->next_time() == next_time) {
-      apply_event(schedule->pop());
+    for (const auto &event : schedule->pop_ready_cohort()) {
+      apply_event(event);
     }
     schedule_following();
   }
 };
 
-/** Stateless runtime projection for delivery envelopes. It activates on every
- *  transport tick, emits only delivery events, and costs O(1) per tick. */
+/** Runtime projection for delivery envelopes. Distinct request ids tick
+ * together; same-id collisions retain FIFO order. Cost is O(B + P) per tick
+ * for burst size B and P pending ids; retained memory is O(C) for collisions.
+ * State is ephemeral ingress state and is discarded at stop. */
 struct DeliveryProjectionNode {
   static constexpr auto name = "kafka_delivery_projection";
 
-  static void eval(In<"transport", TS<KafkaTransportEvent>> transport,
+  static void start(State<DeliveryEventScheduleHandle> state) {
+    state.set(
+        DeliveryEventScheduleHandle{std::make_shared<DeliveryEventSchedule>()});
+  }
+
+  static void eval(In<"transport", TS<KafkaTransportEventBatch>> transport,
+                   State<DeliveryEventScheduleHandle> state,
+                   SingleShotScheduler scheduler,
                    Out<TSD<Int, TS<KafkaDeliveryReport>>> out) {
-    const auto fields = transport.base().value().as_bundle();
-    if (fields.at("kind").checked_as<KafkaTransportEventKind>() !=
-        KafkaTransportEventKind::Delivery) {
-      return;
-    }
+    auto schedule = state.get().value;
     auto mutation = out.begin_mutation(out.evaluation_time());
-    mutation.set(fields.at("request_id"), fields.at("report"));
+    std::unordered_set<Int> emitted;
+    const auto apply_event = [&](const ValueView &event) {
+      const auto fields = event.as_bundle();
+      mutation.set(fields.at("request_id"), fields.at("report"));
+    };
+    schedule->drain(emitted, apply_event);
+    if (transport.modified()) {
+      for (const auto event : transport.base().value().as_list()) {
+        const auto fields = event.as_bundle();
+        if (fields.at("kind").checked_as<KafkaTransportEventKind>() !=
+            KafkaTransportEventKind::Delivery) {
+          continue;
+        }
+        const Int request_id = fields.at("request_id").checked_as<Int>();
+        if (emitted.emplace(request_id).second) {
+          apply_event(event);
+        } else {
+          schedule->defer(request_id, event);
+        }
+      }
+    }
+    if (!schedule->empty()) {
+      scheduler.schedule(MIN_TD);
+    }
   }
 };
 
-/** Stateless runtime projection for service-event envelopes. It activates on
- *  every transport tick, emits only service events, and applies stop policy on
- *  the graph thread. Cost is O(1) per tick. */
+/** Runtime projection for scalar service-event output. A burst is scanned in
+ * O(B), the first event is emitted, and remaining events are retained in FIFO
+ * order using O(E) memory until their individual ticks. */
 struct EventProjectionNode {
   static constexpr auto name = "kafka_event_projection";
 
-  static void eval(In<"transport", TS<KafkaTransportEvent>> transport,
-                   EngineControlView engine, Out<TS<KafkaEvent>> out) {
-    const auto fields = transport.base().value().as_bundle();
-    if (fields.at("kind").checked_as<KafkaTransportEventKind>() !=
-        KafkaTransportEventKind::Event) {
-      return;
+  static void start(State<KafkaEventScheduleHandle> state) {
+    state.set(KafkaEventScheduleHandle{std::make_shared<KafkaEventSchedule>()});
+  }
+
+  static void eval(In<"transport", TS<KafkaTransportEventBatch>> transport,
+                   State<KafkaEventScheduleHandle> state,
+                   SingleShotScheduler scheduler, EngineControlView engine,
+                   Out<TS<KafkaEvent>> out) {
+    auto schedule = state.get().value;
+    bool emitted = false;
+    const auto apply_event = [&](const ValueView &event) {
+      const auto fields = event.as_bundle();
+      out.apply(fields.at("event"));
+      const auto stop_graph = fields.at("stop_graph");
+      if (stop_graph.data() != nullptr && stop_graph.checked_as<Bool>()) {
+        engine.request_stop();
+      }
+      emitted = true;
+    };
+    if (auto pending = schedule->pop()) {
+      apply_event(pending->view());
     }
-    out.apply(fields.at("event"));
-    const auto stop_graph = fields.at("stop_graph");
-    if (stop_graph.data() != nullptr && stop_graph.checked_as<Bool>()) {
-      engine.request_stop();
+    if (transport.modified()) {
+      for (const auto event : transport.base().value().as_list()) {
+        const auto fields = event.as_bundle();
+        if (fields.at("kind").checked_as<KafkaTransportEventKind>() !=
+            KafkaTransportEventKind::Event) {
+          continue;
+        }
+        if (emitted) {
+          schedule->defer(event);
+        } else {
+          apply_event(event);
+        }
+      }
+    }
+    if (!schedule->empty()) {
+      scheduler.schedule(MIN_TD);
     }
   }
 };
@@ -450,9 +673,8 @@ struct EventProjectionNode {
 struct SimulationSubscriptionProjectionNode {
   static constexpr auto name = "kafka_simulation_subscription_projection";
 
-  static void
-  start(Scalar<"bindings", KafkaTransportBindingsHandle> bindings,
-        State<SubscriptionEventScheduleHandle> state) {
+  static void start(Scalar<"bindings", KafkaTransportBindingsHandle> bindings,
+                    State<SubscriptionEventScheduleHandle> state) {
     state.set(SubscriptionEventScheduleHandle{
         std::make_shared<SubscriptionEventSchedule>(*bindings.value().value)});
   }
@@ -560,7 +782,7 @@ struct ServiceOutputs {
 };
 
 [[nodiscard]] inline ServiceOutputs
-wire_service_outputs(Wiring &w, Port<TS<KafkaTransportEvent>> transport,
+wire_service_outputs(Wiring &w, Port<TS<KafkaTransportEventBatch>> transport,
                      KafkaTransportBindingsHandle bindings) {
   return ServiceOutputs{
       wire<SubscriptionProjectionNode>(w, transport, bindings)
@@ -586,18 +808,18 @@ wire_simulation_service_outputs(Wiring &w,
 }
 
 template <typename Tag>
-[[nodiscard]] Port<TS<KafkaTransportEvent>>
+[[nodiscard]] Port<TS<KafkaTransportEventBatch>>
 wire_transport_source(Wiring &w, PushSourceStartViewCallback on_start,
                       std::function<void(const NodeView &)> on_stop) {
-  const auto *schema = ts_type<TS<KafkaTransportEvent>>();
+  const auto *schema = ts_type<TS<KafkaTransportEventBatch>>();
   PushSourceNodeExtension extension{
       .on_start = std::move(on_start),
       .on_stop = std::move(on_stop),
   };
-  return Port<TS<KafkaTransportEvent>>{
+  return Port<TS<KafkaTransportEventBatch>>{
       w, w.add_unique_node(std::type_index(typeid(Tag)),
                            make_push_source_node_with_view(
-                               *schema, make_push_source_queue_policy(*schema),
+                               *schema, make_push_source_burst_policy(*schema),
                                std::move(extension)),
                            std::span<const WiringPortRef>{}, Value{})};
 }

--- a/extensions/kafka/src/detail/service_transport.h
+++ b/extensions/kafka/src/detail/service_transport.h
@@ -4,11 +4,8 @@
 #include <hgraph/kafka/service.h>
 
 #include <hgraph/lib/std/operators/container.h>
-#include <hgraph/lib/std/operators/conversion.h>
 #include <hgraph/lib/std/operators/higher_order.h>
-#include <hgraph/lib/std/value_util.h>
 #include <hgraph/runtime/push_source_node.h>
-#include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/static_node.h>
 #include <hgraph/types/value/value_builder.h>
@@ -25,7 +22,6 @@
 #include <span>
 #include <string_view>
 #include <typeindex>
-#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -63,28 +59,15 @@ using KafkaTransportEvent =
            Field<"report", KafkaDeliveryReport>, Field<"event", KafkaEvent>,
            Field<"stop_graph", Bool>>;
 using KafkaTransportEventBatch = HomogeneousTuple<KafkaTransportEvent>;
-using SequencedKafkaTransportBatch =
-    Bundle<"hgraph.kafka.internal::SequencedKafkaTransportBatch",
-           Field<"sequence", DateTime>,
-           Field<"events", KafkaTransportEventBatch>>;
-using KafkaDeliveryTransportBatches =
-    Map<Int, SequencedKafkaTransportBatch>;
-
-struct KafkaKeyedBatchBindings {
-  ValueTypeRef key{};
-  ValueTypeRef event{};
-  ValueTypeRef event_batch{};
-  ValueTypeRef sequenced_batch{};
-  ValueTypeRef batch_map{};
-
-  friend bool operator==(const KafkaKeyedBatchBindings &,
-                         const KafkaKeyedBatchBindings &) noexcept = default;
-};
+using KafkaTransportStreams = TSB<
+    "hgraph.kafka.internal::KafkaTransportStreams",
+    Field<"subscriptions", TSD<KafkaSubscriptionKey, TS<KafkaTransportEvent>>>,
+    Field<"deliveries", TSD<Int, TS<KafkaTransportEvent>>>,
+    Field<"events", TS<KafkaTransportEvent>>>;
 
 struct KafkaTransportBindings {
   ValueTypeRef event{};
   ValueTypeRef batch{};
-  ValueTypeRef subscription_output{};
 };
 
 struct KafkaTransportBindingsHandle {
@@ -114,184 +97,45 @@ inline std::ostream &operator<<(std::ostream &stream,
               scalar_descriptor<KafkaTransportEvent>::value_meta()),
           factory.type_for(
               scalar_descriptor<KafkaTransportEventBatch>::value_meta()),
-          factory.type_for(schema_descriptor<KafkaSubscriptionOutput>::ts_meta()
-                               ->value_schema),
       })};
 }
 
-class SubscriptionEventSchedule {
-public:
-  explicit SubscriptionEventSchedule(KafkaTransportBindings bindings)
-      : bindings_{std::move(bindings)} {}
+struct OwnedValueHash {
+  using is_transparent = void;
 
-  void push(Value value) {
-    const auto recovery = value.view().as_bundle().at("recovery");
-    if (recovery.data() != nullptr && recovery.checked_as<Bool>()) {
-      recovery_blocked_ = true;
-    }
-    if (!evaluation_time(value.view()).has_value()) {
-      const auto fields = value.view().as_bundle();
-      const auto key = fields.at("subscription_key");
-      const auto predecessor = std::find_if(
-          values_.rbegin(), values_.rend(), [&](const Value &item) {
-            return item.view().as_bundle().at("subscription_key").equals(key);
-          });
-      if (predecessor != values_.rend()) {
-        const auto predecessor_time = evaluation_time(predecessor->view());
-        if (predecessor_time.has_value()) {
-          value = with_evaluation_time(std::move(value),
-                                       *predecessor_time + MIN_TD);
-        }
-      }
-    }
-    const auto position =
-        std::upper_bound(values_.begin(), values_.end(), value,
-                         [](const Value &lhs, const Value &rhs) {
-                           const auto lhs_time = evaluation_time(lhs.view());
-                           const auto rhs_time = evaluation_time(rhs.view());
-                           if (!lhs_time.has_value()) {
-                             return rhs_time.has_value();
-                           }
-                           return rhs_time.has_value() && *lhs_time < *rhs_time;
-                         });
-    values_.insert(position, std::move(value));
+  [[nodiscard]] std::size_t operator()(const Value &value) const {
+    return value.hash();
   }
 
-  [[nodiscard]] std::optional<DateTime> next_time() const {
-    return values_.empty() ? std::nullopt
-                           : evaluation_time(values_.front().view());
-  }
-
-  [[nodiscard]] Value pop() {
-    Value value = std::move(values_.front());
-    values_.pop_front();
-    return value;
-  }
-
-  /** Detaches the next graph-visible cohort. Explicit recovery timestamps
-   * remain atomic; live events without timestamps release at most one event
-   * per subscription key so independent subscriptions can advance together.
-   * Cost is O(N) for N queued subscription events. */
-  [[nodiscard]] std::vector<Value> pop_ready_cohort() {
-    std::vector<Value> result;
-    if (values_.empty()) {
-      return result;
-    }
-    const auto cohort_time = evaluation_time(values_.front().view());
-    if (cohort_time.has_value()) {
-      while (!values_.empty() &&
-             evaluation_time(values_.front().view()) == cohort_time) {
-        result.push_back(pop());
-      }
-      return result;
-    }
-
-    struct Hash {
-      [[nodiscard]] std::size_t operator()(const Value &value) const {
-        return value.hash();
-      }
-    };
-    struct Equal {
-      [[nodiscard]] bool operator()(const Value &lhs, const Value &rhs) const {
-        return lhs.equals(rhs.view());
-      }
-    };
-    std::unordered_set<Value, Hash, Equal> emitted;
-    std::deque<Value> remaining;
-    while (!values_.empty()) {
-      Value value = pop();
-      if (evaluation_time(value.view()).has_value()) {
-        remaining.push_back(std::move(value));
-        while (!values_.empty()) {
-          remaining.push_back(pop());
-        }
-        break;
-      }
-      const auto key = value.view().as_bundle().at("subscription_key");
-      if (emitted.emplace(key).second) {
-        result.push_back(std::move(value));
-      } else {
-        remaining.push_back(std::move(value));
-      }
-    }
-    values_.swap(remaining);
-    return result;
-  }
-
-  [[nodiscard]] bool empty() const noexcept { return values_.empty(); }
-
-  [[nodiscard]] bool recovery_blocked() const {
-    if (!recovery_blocked_ || values_.empty()) {
-      return false;
-    }
-    const auto recovery = values_.front().view().as_bundle().at("recovery");
-    return recovery.data() != nullptr && recovery.checked_as<Bool>();
-  }
-
-  void release_recovery() noexcept { recovery_blocked_ = false; }
-
-  [[nodiscard]] const ValueTypeRef &subscription_output_binding() const {
-    return bindings_.subscription_output;
-  }
-
-private:
-  [[nodiscard]] Value with_evaluation_time(Value value, DateTime time) const {
-    BundleBuilder builder{bindings_.event};
-    const auto fields = value.view().as_bundle();
-    for (const auto name :
-         {std::string_view{"kind"}, std::string_view{"subscription_key"},
-          std::string_view{"record"}, std::string_view{"cursor"},
-          std::string_view{"state"}, std::string_view{"removed"},
-          std::string_view{"recovery"}, std::string_view{"request_id"},
-          std::string_view{"report"}, std::string_view{"event"},
-          std::string_view{"stop_graph"}}) {
-      const auto field = fields.at(name);
-      if (field.data() != nullptr) {
-        builder.set(name, field.clone());
-      }
-    }
-    builder.set("evaluation_time", Value{time});
-    return builder.build();
-  }
-
-  [[nodiscard]] static std::optional<DateTime>
-  evaluation_time(const ValueView &value) {
-    const auto field = value.as_bundle().at("evaluation_time");
-    return field.data() == nullptr
-               ? std::nullopt
-               : std::optional<DateTime>{field.checked_as<DateTime>()};
-  }
-
-  std::deque<Value> values_{};
-  bool recovery_blocked_{};
-  KafkaTransportBindings bindings_{};
-};
-
-struct SubscriptionEventScheduleHandle {
-  std::shared_ptr<SubscriptionEventSchedule> value{};
-
-  friend bool
-  operator==(const SubscriptionEventScheduleHandle &,
-             const SubscriptionEventScheduleHandle &) noexcept = default;
-  friend std::strong_ordering
-  operator<=>(const SubscriptionEventScheduleHandle &lhs,
-              const SubscriptionEventScheduleHandle &rhs) noexcept {
-    return reinterpret_cast<std::uintptr_t>(lhs.value.get()) <=>
-           reinterpret_cast<std::uintptr_t>(rhs.value.get());
+  [[nodiscard]] std::size_t operator()(const ValueView &value) const {
+    return value.hash();
   }
 };
 
-inline std::ostream &operator<<(std::ostream &stream,
-                                const SubscriptionEventScheduleHandle &value) {
-  return stream << "SubscriptionEventScheduleHandle(" << value.value.get()
-                << ')';
-}
+struct OwnedValueEqual {
+  using is_transparent = void;
 
-inline std::ostream &operator<<(std::ostream &stream,
-                                const KafkaKeyedBatchBindings &value) {
-  return stream << "KafkaKeyedBatchBindings(" << value.batch_map.schema()
-                << ')';
-}
+  [[nodiscard]] bool operator()(const Value &lhs, const Value &rhs) const {
+    return lhs.equals(rhs.view());
+  }
+
+  [[nodiscard]] bool operator()(const Value &lhs, const ValueView &rhs) const {
+    return lhs.equals(rhs);
+  }
+
+  [[nodiscard]] bool operator()(const ValueView &lhs, const Value &rhs) const {
+    return rhs.equals(lhs);
+  }
+};
+
+struct KafkaTransportEmitState {
+  ValueTypeRef event_binding{};
+  std::deque<Value> subscriptions{};
+  std::deque<Value> deliveries{};
+  std::deque<Value> events{};
+  std::unordered_set<Value, OwnedValueHash, OwnedValueEqual> emitted_keys{};
+  bool recovery_blocked{};
+};
 
 } // namespace hgraph::kafka::detail
 
@@ -303,25 +147,6 @@ template <> struct hash<hgraph::kafka::detail::KafkaTransportBindingsHandle> {
   }
 };
 
-template <>
-struct hash<hgraph::kafka::detail::SubscriptionEventScheduleHandle> {
-  size_t operator()(const hgraph::kafka::detail::SubscriptionEventScheduleHandle
-                        &value) const noexcept {
-    return hash<const void *>{}(value.value.get());
-  }
-};
-
-template <> struct hash<hgraph::kafka::detail::KafkaKeyedBatchBindings> {
-  size_t operator()(const hgraph::kafka::detail::KafkaKeyedBatchBindings
-                        &value) const noexcept {
-    size_t result = hash<hgraph::ValueTypeRef>{}(value.key);
-    result ^= hash<hgraph::ValueTypeRef>{}(value.event) + 0x9e3779b9U +
-              (result << 6U) + (result >> 2U);
-    result ^= hash<hgraph::ValueTypeRef>{}(value.batch_map) + 0x9e3779b9U +
-              (result << 6U) + (result >> 2U);
-    return result;
-  }
-};
 } // namespace std
 
 namespace hgraph::static_schema_detail {
@@ -330,14 +155,9 @@ template <> struct scalar_name<kafka::detail::KafkaTransportBindingsHandle> {
       "hgraph.kafka.internal::KafkaTransportBindingsHandle"};
 };
 
-template <> struct scalar_name<kafka::detail::SubscriptionEventScheduleHandle> {
+template <> struct scalar_name<kafka::detail::KafkaTransportEmitState> {
   static constexpr std::string_view value{
-      "hgraph.kafka.internal::SubscriptionEventScheduleHandle"};
-};
-
-template <> struct scalar_name<kafka::detail::KafkaKeyedBatchBindings> {
-  static constexpr std::string_view value{
-      "hgraph.kafka.internal::KafkaKeyedBatchBindings"};
+      "hgraph.kafka.internal::KafkaTransportEmitState"};
 };
 } // namespace hgraph::static_schema_detail
 
@@ -417,160 +237,259 @@ service_transport_event(const KafkaTransportBindings &bindings, Value event,
                           {"stop_graph", transport_atomic(stop_graph)}});
 }
 
-/** Runtime demultiplexing cannot be expressed as a wiring-time graph because
- * the envelope kind and recovery timestamp arrive in each burst. This compute
- * node retains the ordered subscription schedule and emits one event per
- * independent subscription key in a live cycle, while explicit same-time
- * recovery cohorts remain atomic. Insertion and live cohort selection are
- * O(n) in queued subscription events; projection is O(B) for emitted cohort
- * size B and retained memory is O(n). State is ephemeral ingress state and is
- * discarded at stop. */
-struct SubscriptionProjectionNode {
-  static constexpr auto name = "kafka_subscription_projection";
+/** Splits one Kafka burst into graph-visible service lanes. Runtime envelope
+ * kinds cannot be selected at wiring time, so this is the one Kafka-specific
+ * emit primitive. Independent subscription keys and delivery request ids are
+ * emitted together as keyed deltas; a repeated key is retained for the next
+ * engine cycle so its event order remains observable. Scalar service events
+ * remain FIFO and release one per cycle. Timestamped recovery events release
+ * when due and remain blocked until their recovery barrier arrives.
+ *
+ * Normal live classification and draining are O(B + Q), where B is the
+ * incoming burst and Q is retained work examined for the current lanes.
+ * Sorted timestamp recovery insertion is O(Bs * Qs) worst-case for Bs new and
+ * Qs retained subscription events. Retained memory is O(Q). State is
+ * ephemeral ingress sequencing state and is discarded at stop. */
+struct KafkaTransportEmitNode {
+  static constexpr auto name = "kafka_transport_emit";
 
   static void start(Scalar<"bindings", KafkaTransportBindingsHandle> bindings,
-                    State<SubscriptionEventScheduleHandle> state) {
-    state.set(SubscriptionEventScheduleHandle{
-        std::make_shared<SubscriptionEventSchedule>(*bindings.value().value)});
+                    State<KafkaTransportEmitState> state) {
+    state.modify().event_binding = bindings.value().value->event;
   }
 
   static void
-  eval(In<"transport", TS<KafkaTransportEventBatch>> transport,
+  eval(In<"transport", TS<KafkaTransportEventBatch>, InputValidity::Unchecked>
+           transport,
        Scalar<"bindings", KafkaTransportBindingsHandle>,
-       State<SubscriptionEventScheduleHandle> state,
-       SingleShotScheduler scheduler,
-       Out<TSD<KafkaSubscriptionKey, KafkaSubscriptionOutput>> out) {
-    auto schedule = state.get().value;
-    if (transport.modified()) {
-      const auto events = transport.base().value().as_list();
-      for (std::size_t index = 0; index != events.size(); ++index) {
-        const auto event = events.at(index);
-        const auto fields = event.as_bundle();
-        const auto kind =
-            fields.at("kind").checked_as<KafkaTransportEventKind>();
-        if (kind == KafkaTransportEventKind::Subscription) {
-          schedule->push(event.clone());
-        } else if (kind == KafkaTransportEventKind::RecoveryBarrier) {
-          schedule->release_recovery();
-        }
-      }
-    }
-
-    if (schedule->recovery_blocked()) {
-      return;
-    }
-    if (schedule->empty()) {
-      return;
-    }
-
-    const auto next_time = schedule->next_time();
-    if (next_time.has_value() && *next_time > scheduler.now()) {
-      scheduler.schedule(*next_time);
-      return;
-    }
-    const auto schedule_following = [&] {
-      const auto following_time = schedule->next_time();
-      if (following_time.has_value() && *following_time > scheduler.now()) {
-        scheduler.schedule(*following_time);
-      } else if (!schedule->empty()) {
-        scheduler.schedule(MIN_TD);
-      }
+       State<KafkaTransportEmitState> state, SingleShotScheduler scheduler,
+       Out<KafkaTransportStreams> out) {
+    auto &current = state.modify();
+    const auto evaluation_time =
+        [](const ValueView &value) -> std::optional<DateTime> {
+      const auto field = value.as_bundle().at("evaluation_time");
+      return field.data() == nullptr
+                 ? std::nullopt
+                 : std::optional<DateTime>{field.checked_as<DateTime>()};
     };
-
-    auto mutation = out.begin_mutation(out.evaluation_time());
-    const auto apply_event = [&](const Value &event) {
-      const auto fields = event.view().as_bundle();
-      const auto removed = fields.at("removed");
-      if (removed.data() != nullptr && removed.checked_as<Bool>()) {
-        static_cast<void>(mutation.erase(fields.at("subscription_key")));
-        return;
-      }
-
-      BundleBuilder update{schedule->subscription_output_binding()};
+    const auto with_evaluation_time = [&](const ValueView &value,
+                                          DateTime time) {
+      BundleBuilder builder{current.event_binding};
+      const auto fields = value.as_bundle();
       for (const auto name :
-           {std::string_view{"record"}, std::string_view{"cursor"},
-            std::string_view{"state"}}) {
+           {std::string_view{"kind"}, std::string_view{"subscription_key"},
+            std::string_view{"record"}, std::string_view{"cursor"},
+            std::string_view{"state"}, std::string_view{"removed"},
+            std::string_view{"recovery"}, std::string_view{"request_id"},
+            std::string_view{"report"}, std::string_view{"event"},
+            std::string_view{"stop_graph"}}) {
         const auto field = fields.at(name);
         if (field.data() != nullptr) {
-          update.set(name, field.clone());
+          builder.set(name, field.clone());
         }
       }
-      const Value value = update.build();
-      mutation.set(fields.at("subscription_key"), value.view());
+      builder.set("evaluation_time", Value{time});
+      return builder.build();
     };
 
-    for (const auto &event : schedule->pop_ready_cohort()) {
-      apply_event(event);
+    if (transport.modified() && transport.valid()) {
+      const auto incoming = transport.base().value().as_list();
+      for (std::size_t index = 0; index != incoming.size(); ++index) {
+        const auto value = incoming.at(index);
+        const auto fields = value.as_bundle();
+        switch (fields.at("kind").checked_as<KafkaTransportEventKind>()) {
+        case KafkaTransportEventKind::Subscription: {
+          Value event = value.clone();
+          auto event_time = evaluation_time(value);
+          const auto recovery = fields.at("recovery");
+          if (recovery.data() != nullptr && recovery.checked_as<Bool>()) {
+            current.recovery_blocked = true;
+          }
+          // The ordered queue stores all live values before timestamped
+          // recovery. Avoid a predecessor scan on the normal live hot path
+          // when its tail proves that no timestamped value is retained.
+          const bool has_timestamped_tail =
+              !current.subscriptions.empty() &&
+              evaluation_time(current.subscriptions.back().view()).has_value();
+          if (!event_time.has_value() && has_timestamped_tail) {
+            const auto key = fields.at("subscription_key");
+            const auto predecessor = std::find_if(
+                current.subscriptions.rbegin(), current.subscriptions.rend(),
+                [&](const Value &candidate) {
+                  return candidate.view()
+                      .as_bundle()
+                      .at("subscription_key")
+                      .equals(key);
+                });
+            if (predecessor != current.subscriptions.rend()) {
+              const auto predecessor_time =
+                  evaluation_time(predecessor->view());
+              if (predecessor_time.has_value()) {
+                event = with_evaluation_time(event.view(),
+                                             *predecessor_time + MIN_TD);
+                event_time = *predecessor_time + MIN_TD;
+              }
+            }
+          }
+          if (!event_time.has_value() && !has_timestamped_tail) {
+            current.subscriptions.push_back(std::move(event));
+            break;
+          }
+          const auto position = std::upper_bound(
+              current.subscriptions.begin(), current.subscriptions.end(), event,
+              [&](const Value &lhs, const Value &rhs) {
+                const auto lhs_time = evaluation_time(lhs.view());
+                const auto rhs_time = evaluation_time(rhs.view());
+                if (!lhs_time.has_value()) {
+                  return rhs_time.has_value();
+                }
+                return rhs_time.has_value() && *lhs_time < *rhs_time;
+              });
+          current.subscriptions.insert(position, std::move(event));
+          break;
+        }
+        case KafkaTransportEventKind::Delivery:
+          current.deliveries.emplace_back(value);
+          break;
+        case KafkaTransportEventKind::Event:
+          current.events.emplace_back(value);
+          break;
+        case KafkaTransportEventKind::RecoveryBarrier:
+          current.recovery_blocked = false;
+          break;
+        }
+      }
     }
-    schedule_following();
+
+    const auto subscription_is_blocked = [&] {
+      if (!current.recovery_blocked || current.subscriptions.empty()) {
+        return false;
+      }
+      const auto recovery =
+          current.subscriptions.front().view().as_bundle().at("recovery");
+      return recovery.data() != nullptr && recovery.checked_as<Bool>();
+    };
+
+    if (!current.subscriptions.empty() && !subscription_is_blocked()) {
+      const auto cohort_time =
+          evaluation_time(current.subscriptions.front().view());
+      if (!cohort_time.has_value() || *cohort_time <= scheduler.now()) {
+        auto subscriptions = out.template field<"subscriptions">();
+        auto mutation =
+            subscriptions.begin_mutation(subscriptions.evaluation_time());
+        auto &emitted = current.emitted_keys;
+        emitted.clear();
+        std::deque<Value> remaining;
+        while (!current.subscriptions.empty()) {
+          Value event = std::move(current.subscriptions.front());
+          current.subscriptions.pop_front();
+          const auto event_time = evaluation_time(event.view());
+          const bool outside_cohort = cohort_time.has_value()
+                                          ? event_time != cohort_time
+                                          : event_time.has_value();
+          if (outside_cohort) {
+            remaining.push_back(std::move(event));
+            while (!current.subscriptions.empty()) {
+              remaining.push_back(std::move(current.subscriptions.front()));
+              current.subscriptions.pop_front();
+            }
+            break;
+          }
+          const auto fields = event.view().as_bundle();
+          const auto key = fields.at("subscription_key");
+          if (!emitted.emplace(key).second) {
+            remaining.push_back(std::move(event));
+            continue;
+          }
+          const auto removed = fields.at("removed");
+          if (removed.data() != nullptr && removed.checked_as<Bool>()) {
+            static_cast<void>(mutation.erase(key));
+          } else {
+            mutation.set(key, event.view());
+          }
+        }
+        current.subscriptions.swap(remaining);
+      }
+    }
+
+    if (!current.deliveries.empty()) {
+      auto deliveries = out.template field<"deliveries">();
+      auto mutation = deliveries.begin_mutation(deliveries.evaluation_time());
+      auto &emitted = current.emitted_keys;
+      emitted.clear();
+      std::deque<Value> remaining;
+      while (!current.deliveries.empty()) {
+        Value event = std::move(current.deliveries.front());
+        current.deliveries.pop_front();
+        const auto fields = event.view().as_bundle();
+        const auto key = fields.at("request_id");
+        if (!emitted.emplace(key).second) {
+          remaining.push_back(std::move(event));
+          continue;
+        }
+        mutation.set(key, event.view());
+      }
+      current.deliveries.swap(remaining);
+    }
+
+    if (!current.events.empty()) {
+      Value event = std::move(current.events.front());
+      current.events.pop_front();
+      out.template field<"events">().apply(event.view());
+    }
+
+    bool schedule_immediately =
+        !current.deliveries.empty() || !current.events.empty();
+    std::optional<DateTime> subscription_time;
+    if (!current.subscriptions.empty() && !subscription_is_blocked()) {
+      subscription_time = evaluation_time(current.subscriptions.front().view());
+      schedule_immediately = schedule_immediately ||
+                             !subscription_time.has_value() ||
+                             *subscription_time <= scheduler.now();
+    }
+    if (schedule_immediately) {
+      scheduler.schedule(MIN_TD);
+    } else if (subscription_time.has_value()) {
+      scheduler.schedule(*subscription_time);
+    }
   }
 };
 
-/** Groups delivery events by request id with O(B) work and O(B) transient
- * memory. Standard collect retains the per-key batches; map_ gives every id an
- * independent standard emit node for FIFO delivery. */
-struct GroupDeliveryBatchNode {
-  static constexpr auto name = "kafka_group_delivery_batch";
+/** Projects one subscription event. The custom emit and map_ own sequencing
+ * and keyed lifetime; this node retains no private state and costs O(1). */
+struct SubscriptionProjectionNode {
+  static constexpr auto name = "kafka_subscription_projection";
 
-  static void start(State<KafkaKeyedBatchBindings> bindings) {
-    const auto key = value_type_for_active_realization(
-        scalar_descriptor<Int>::value_meta());
-    const auto event = value_type_for_active_realization(
-        scalar_descriptor<KafkaTransportEvent>::value_meta());
-    const auto *event_batch_meta =
-        scalar_descriptor<KafkaTransportEventBatch>::value_meta();
-    const auto event_batch = compact_list_type(event, *event_batch_meta);
-    const auto sequenced_batch = value_type_for_active_realization(
-        scalar_descriptor<SequencedKafkaTransportBatch>::value_meta());
-    bindings.set(KafkaKeyedBatchBindings{
-        .key = key,
-        .event = event,
-        .event_batch = event_batch,
-        .sequenced_batch = sequenced_batch,
-        .batch_map = compact_map_type(key, sequenced_batch),
-    });
-  }
-
-  static void eval(In<"transport", TS<KafkaTransportEventBatch>> transport,
-                   State<KafkaKeyedBatchBindings> bindings,
-                   Out<TS<KafkaDeliveryTransportBatches>> out) {
-    std::unordered_map<Int, std::vector<std::size_t>> grouped;
-    const auto events = transport.base().value().as_list();
-    for (std::size_t index = 0; index != events.size(); ++index) {
-      const auto fields = events.at(index).as_bundle();
-      if (fields.at("kind").checked_as<KafkaTransportEventKind>() !=
-          KafkaTransportEventKind::Delivery) {
-        continue;
-      }
-      grouped[fields.at("request_id").checked_as<Int>()].push_back(index);
+  static void eval(In<"event", TS<KafkaTransportEvent>> event,
+                   Out<KafkaSubscriptionOutput> out) {
+    const auto fields = event.base().value().as_bundle();
+    const auto record = fields.at("record");
+    if (record.data() != nullptr) {
+      out.template field<"record">().apply(record);
     }
-    if (grouped.empty()) {
-      return;
+    const auto cursor = fields.at("cursor");
+    if (cursor.data() != nullptr) {
+      out.template field<"cursor">().apply(cursor);
     }
-
-    const auto &resolved = bindings.ref();
-    const auto *event_batch_meta =
-        scalar_descriptor<KafkaTransportEventBatch>::value_meta();
-    MapBuilder batches{resolved.key, resolved.sequenced_batch};
-    for (const auto &[request_id, indices] : grouped) {
-      ListBuilder event_batch{resolved.event, *event_batch_meta};
-      for (const auto index : indices) {
-        event_batch.push_back(events.at(index));
-      }
-      ListStorage event_storage = event_batch.build_storage();
-      Value event_value{resolved.event_batch, &event_storage};
-      BundleBuilder batch{resolved.sequenced_batch};
-      batch.set("sequence", Value{out.evaluation_time()});
-      batch.set("events", std::move(event_value));
-      const Value key{request_id};
-      batches.set_item(key.view(), batch.build().view());
+    const auto state = fields.at("state");
+    if (state.data() != nullptr) {
+      out.template field<"state">().apply(state);
     }
-    MapStorage batch_storage = batches.build_storage();
-    out.apply(ValueView{resolved.batch_map, &batch_storage});
   }
 };
 
-/** Projects one delivery report; buffering and scheduling are graph-owned. */
+struct SubscriptionProjectionGraph {
+  static constexpr auto name = "kafka_subscription_projection_graph";
+
+  static Port<KafkaSubscriptionOutput>
+  compose(Wiring &w, NamedPort<"key", TS<KafkaSubscriptionKey>>,
+          Port<TS<KafkaTransportEvent>> event) {
+    return wire<SubscriptionProjectionNode>(w, event)
+        .template as<KafkaSubscriptionOutput>();
+  }
+};
+
+/** Projects one delivery report; the custom emit and map_ own sequencing. */
 struct DeliveryProjectionNode {
   static constexpr auto name = "kafka_delivery_projection";
 
@@ -585,60 +504,9 @@ struct DeliveryProjectionGraph {
 
   static Port<TS<KafkaDeliveryReport>>
   compose(Wiring &w, NamedPort<"key", TS<Int>>,
-          Port<TS<SequencedKafkaTransportBatch>> batch) {
-    auto events = wire<stdlib::getattr_, TS<KafkaTransportEventBatch>>(
-        w, batch, Str{"events"});
-    auto event = wire<stdlib::emit>(w, events)
-                     .template as<TS<KafkaTransportEvent>>();
+          Port<TS<KafkaTransportEvent>> event) {
     return wire<DeliveryProjectionNode>(w, event)
         .template as<TS<KafkaDeliveryReport>>();
-  }
-};
-
-[[nodiscard]] inline Port<TSD<Int, TS<KafkaDeliveryReport>>>
-wire_delivery_output(Wiring &w,
-                     Port<TS<KafkaTransportEventBatch>> transport) {
-  auto grouped = wire<GroupDeliveryBatchNode>(w, transport)
-                     .template as<TS<KafkaDeliveryTransportBatches>>();
-  auto batches =
-      wire<stdlib::collect, TSD<Int, TS<SequencedKafkaTransportBatch>>>(
-          w, grouped);
-  return wire<stdlib::map_, TSD<Int, TS<KafkaDeliveryReport>>>(
-      w, fn<DeliveryProjectionGraph>(), batches);
-}
-
-/** Selects scalar service events from a mixed transport burst. It performs
- * O(B) work and transient memory; standard emit owns the FIFO thereafter. */
-struct SelectEventBatchNode {
-  static constexpr auto name = "kafka_select_event_batch";
-
-  static void start(State<stdlib::ResolvedBindings> bindings) {
-    const auto *batch_meta =
-        scalar_descriptor<KafkaTransportEventBatch>::value_meta();
-    bindings.set(stdlib::resolve_list_bindings(batch_meta));
-  }
-
-  static void eval(In<"transport", TS<KafkaTransportEventBatch>> transport,
-                   State<stdlib::ResolvedBindings> bindings,
-                   Out<TS<KafkaTransportEventBatch>> out) {
-    const auto &resolved = bindings.ref();
-    ListBuilder selected{resolved.primary,
-                         *scalar_descriptor<
-                             KafkaTransportEventBatch>::value_meta()};
-    const auto events = transport.base().value().as_list();
-    for (std::size_t index = 0; index != events.size(); ++index) {
-      const auto event = events.at(index);
-      const auto fields = event.as_bundle();
-      if (fields.at("kind").checked_as<KafkaTransportEventKind>() ==
-          KafkaTransportEventKind::Event) {
-        selected.push_back(event);
-      }
-    }
-    if (selected.empty()) {
-      return;
-    }
-    ListStorage storage = selected.build_storage();
-    out.apply(ValueView{resolved.result, &storage});
   }
 };
 
@@ -657,135 +525,6 @@ struct EventProjectionNode {
   }
 };
 
-[[nodiscard]] inline Port<TS<KafkaEvent>>
-wire_event_output(Wiring &w, Port<TS<KafkaTransportEventBatch>> transport) {
-  auto selected = wire<SelectEventBatchNode>(w, transport)
-                      .template as<TS<KafkaTransportEventBatch>>();
-  auto event = wire<stdlib::emit>(w, selected)
-                   .template as<TS<KafkaTransportEvent>>();
-  return wire<EventProjectionNode>(w, event).template as<TS<KafkaEvent>>();
-}
-
-/** Simulation projection applies a same-time batch as one keyed mutation so
- *  the graph observes an atomic replay cohort. It retains no replay history;
- *  cost is O(B) per tick for batch size B. */
-struct SimulationSubscriptionProjectionNode {
-  static constexpr auto name = "kafka_simulation_subscription_projection";
-
-  static void start(Scalar<"bindings", KafkaTransportBindingsHandle> bindings,
-                    State<SubscriptionEventScheduleHandle> state) {
-    state.set(SubscriptionEventScheduleHandle{
-        std::make_shared<SubscriptionEventSchedule>(*bindings.value().value)});
-  }
-
-  static void
-  eval(In<"transport", TS<KafkaTransportEventBatch>> transport,
-       Scalar<"bindings", KafkaTransportBindingsHandle>,
-       State<SubscriptionEventScheduleHandle> state,
-       Out<TSD<KafkaSubscriptionKey, KafkaSubscriptionOutput>> out) {
-    const auto values = transport.base().value().as_list();
-    bool has_subscription = false;
-    for (std::size_t index = 0; index != values.size(); ++index) {
-      if (values.at(index)
-              .as_bundle()
-              .at("kind")
-              .checked_as<KafkaTransportEventKind>() ==
-          KafkaTransportEventKind::Subscription) {
-        has_subscription = true;
-        break;
-      }
-    }
-    if (!has_subscription) {
-      return;
-    }
-    auto mutation = out.begin_mutation(out.evaluation_time());
-    for (std::size_t index = 0; index != values.size(); ++index) {
-      const auto value = values.at(index);
-      const auto fields = value.as_bundle();
-      if (fields.at("kind").checked_as<KafkaTransportEventKind>() !=
-          KafkaTransportEventKind::Subscription) {
-        continue;
-      }
-      const auto removed = fields.at("removed");
-      if (removed.data() != nullptr && removed.checked_as<Bool>()) {
-        static_cast<void>(mutation.erase(fields.at("subscription_key")));
-        continue;
-      }
-      BundleBuilder update{state.get().value->subscription_output_binding()};
-      for (const auto name :
-           {std::string_view{"record"}, std::string_view{"cursor"},
-            std::string_view{"state"}}) {
-        const auto field = fields.at(name);
-        if (field.data() != nullptr) {
-          update.set(name, field.clone());
-        }
-      }
-      const Value projected = update.build();
-      mutation.set(fields.at("subscription_key"), projected.view());
-    }
-  }
-};
-
-/** Stateless simulation delivery projection. It scans one replay batch and
- *  emits its delivery reports in one keyed mutation: O(B) per batch. */
-struct SimulationDeliveryProjectionNode {
-  static constexpr auto name = "kafka_simulation_delivery_projection";
-
-  static void eval(In<"transport", TS<KafkaTransportEventBatch>> transport,
-                   Out<TSD<Int, TS<KafkaDeliveryReport>>> out) {
-    const auto values = transport.base().value().as_list();
-    bool has_delivery = false;
-    for (std::size_t index = 0; index != values.size(); ++index) {
-      if (values.at(index)
-              .as_bundle()
-              .at("kind")
-              .checked_as<KafkaTransportEventKind>() ==
-          KafkaTransportEventKind::Delivery) {
-        has_delivery = true;
-        break;
-      }
-    }
-    if (!has_delivery) {
-      return;
-    }
-    auto mutation = out.begin_mutation(out.evaluation_time());
-    for (std::size_t index = 0; index != values.size(); ++index) {
-      const auto value = values.at(index);
-      const auto fields = value.as_bundle();
-      if (fields.at("kind").checked_as<KafkaTransportEventKind>() ==
-          KafkaTransportEventKind::Delivery) {
-        mutation.set(fields.at("request_id"), fields.at("report"));
-      }
-    }
-  }
-};
-
-/** Stateless simulation service-event projection. It scans at most one replay
- *  batch, emits the first event, and applies stop policy on the graph thread:
- *  O(B) worst-case per batch. */
-struct SimulationEventProjectionNode {
-  static constexpr auto name = "kafka_simulation_event_projection";
-
-  static void eval(In<"transport", TS<KafkaTransportEventBatch>> transport,
-                   EngineControlView engine, Out<TS<KafkaEvent>> out) {
-    const auto values = transport.base().value().as_list();
-    for (std::size_t index = 0; index != values.size(); ++index) {
-      const auto value = values.at(index);
-      const auto fields = value.as_bundle();
-      if (fields.at("kind").checked_as<KafkaTransportEventKind>() !=
-          KafkaTransportEventKind::Event) {
-        continue;
-      }
-      out.apply(fields.at("event"));
-      const auto stop_graph = fields.at("stop_graph");
-      if (stop_graph.data() != nullptr && stop_graph.checked_as<Bool>()) {
-        engine.request_stop();
-      }
-      return;
-    }
-  }
-};
-
 struct ServiceOutputs {
   Port<TSD<KafkaSubscriptionKey, KafkaSubscriptionOutput>> subscriptions;
   Port<TSD<Int, TS<KafkaDeliveryReport>>> deliveries;
@@ -795,25 +534,23 @@ struct ServiceOutputs {
 [[nodiscard]] inline ServiceOutputs
 wire_service_outputs(Wiring &w, Port<TS<KafkaTransportEventBatch>> transport,
                      KafkaTransportBindingsHandle bindings) {
+  auto streams = wire<KafkaTransportEmitNode>(w, transport, bindings)
+                     .template as<KafkaTransportStreams>();
+  auto subscriptions = wire<stdlib::getattr_,
+                            TSD<KafkaSubscriptionKey, TS<KafkaTransportEvent>>>(
+      w, streams, Str{"subscriptions"});
+  auto deliveries = wire<stdlib::getattr_, TSD<Int, TS<KafkaTransportEvent>>>(
+      w, streams, Str{"deliveries"});
+  auto events = wire<stdlib::getattr_, TS<KafkaTransportEvent>>(w, streams,
+                                                                Str{"events"});
   return ServiceOutputs{
-      wire<SubscriptionProjectionNode>(w, transport, bindings)
+      wire<stdlib::map_, TSD<KafkaSubscriptionKey, KafkaSubscriptionOutput>>(
+          w, fn<SubscriptionProjectionGraph>(), subscriptions)
           .template as<TSD<KafkaSubscriptionKey, KafkaSubscriptionOutput>>(),
-      wire_delivery_output(w, transport),
-      wire_event_output(w, transport),
-  };
-}
-
-[[nodiscard]] inline ServiceOutputs
-wire_simulation_service_outputs(Wiring &w,
-                                Port<TS<KafkaTransportEventBatch>> transport,
-                                KafkaTransportBindingsHandle bindings) {
-  return ServiceOutputs{
-      wire<SimulationSubscriptionProjectionNode>(w, transport, bindings)
-          .template as<TSD<KafkaSubscriptionKey, KafkaSubscriptionOutput>>(),
-      wire<SimulationDeliveryProjectionNode>(w, transport)
+      wire<stdlib::map_, TSD<Int, TS<KafkaDeliveryReport>>>(
+          w, fn<DeliveryProjectionGraph>(), deliveries)
           .template as<TSD<Int, TS<KafkaDeliveryReport>>>(),
-      wire<SimulationEventProjectionNode>(w, transport)
-          .template as<TS<KafkaEvent>>(),
+      wire<EventProjectionNode>(w, events).template as<TS<KafkaEvent>>(),
   };
 }
 

--- a/extensions/kafka/src/detail/service_transport.h
+++ b/extensions/kafka/src/detail/service_transport.h
@@ -3,7 +3,12 @@
 
 #include <hgraph/kafka/service.h>
 
+#include <hgraph/lib/std/operators/container.h>
+#include <hgraph/lib/std/operators/conversion.h>
+#include <hgraph/lib/std/operators/higher_order.h>
+#include <hgraph/lib/std/value_util.h>
 #include <hgraph/runtime/push_source_node.h>
+#include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/static_node.h>
 #include <hgraph/types/value/value_builder.h>
@@ -59,6 +64,23 @@ using KafkaTransportEvent =
            Field<"report", KafkaDeliveryReport>, Field<"event", KafkaEvent>,
            Field<"stop_graph", Bool>>;
 using KafkaTransportEventBatch = HomogeneousTuple<KafkaTransportEvent>;
+using SequencedKafkaTransportBatch =
+    Bundle<"hgraph.kafka.internal::SequencedKafkaTransportBatch",
+           Field<"sequence", DateTime>,
+           Field<"events", KafkaTransportEventBatch>>;
+using KafkaDeliveryTransportBatches =
+    Map<Int, SequencedKafkaTransportBatch>;
+
+struct KafkaKeyedBatchBindings {
+  ValueTypeRef key{};
+  ValueTypeRef event{};
+  ValueTypeRef event_batch{};
+  ValueTypeRef sequenced_batch{};
+  ValueTypeRef batch_map{};
+
+  friend bool operator==(const KafkaKeyedBatchBindings &,
+                         const KafkaKeyedBatchBindings &) noexcept = default;
+};
 
 struct KafkaTransportBindings {
   ValueTypeRef event{};
@@ -260,86 +282,6 @@ struct SubscriptionEventScheduleHandle {
   }
 };
 
-/** Graph-thread spill used when one burst contains several delivery reports
- * for the same service request id. Distinct ids never enter this state. Drain
- * cost is O(P) for P pending ids; retained memory is O(C) for collisions. */
-class DeliveryEventSchedule {
-public:
-  template <typename Apply>
-  void drain(std::unordered_set<Int> &emitted, Apply &&apply) {
-    for (auto entry = values_.begin(); entry != values_.end();) {
-      auto &queue = entry->second;
-      Value event = std::move(queue.front());
-      queue.pop_front();
-      apply(event.view());
-      emitted.emplace(entry->first);
-      if (queue.empty()) {
-        entry = values_.erase(entry);
-      } else {
-        ++entry;
-      }
-    }
-  }
-
-  void defer(Int request_id, const ValueView &event) {
-    values_[request_id].emplace_back(event);
-  }
-
-  [[nodiscard]] bool empty() const noexcept { return values_.empty(); }
-
-private:
-  std::unordered_map<Int, std::deque<Value>> values_{};
-};
-
-struct DeliveryEventScheduleHandle {
-  std::shared_ptr<DeliveryEventSchedule> value{};
-
-  friend bool
-  operator==(const DeliveryEventScheduleHandle &,
-             const DeliveryEventScheduleHandle &) noexcept = default;
-  friend std::strong_ordering
-  operator<=>(const DeliveryEventScheduleHandle &lhs,
-              const DeliveryEventScheduleHandle &rhs) noexcept {
-    return reinterpret_cast<std::uintptr_t>(lhs.value.get()) <=>
-           reinterpret_cast<std::uintptr_t>(rhs.value.get());
-  }
-};
-
-/** Graph-thread FIFO used only when a burst contains several scalar service
- * events. Cost is O(1) to emit and retain each event; memory is O(E) for E
- * events awaiting their own ticks. */
-class KafkaEventSchedule {
-public:
-  void defer(const ValueView &event) { values_.emplace_back(event); }
-
-  [[nodiscard]] std::optional<Value> pop() {
-    if (values_.empty()) {
-      return std::nullopt;
-    }
-    Value value = std::move(values_.front());
-    values_.pop_front();
-    return value;
-  }
-
-  [[nodiscard]] bool empty() const noexcept { return values_.empty(); }
-
-private:
-  std::deque<Value> values_{};
-};
-
-struct KafkaEventScheduleHandle {
-  std::shared_ptr<KafkaEventSchedule> value{};
-
-  friend bool operator==(const KafkaEventScheduleHandle &,
-                         const KafkaEventScheduleHandle &) noexcept = default;
-  friend std::strong_ordering
-  operator<=>(const KafkaEventScheduleHandle &lhs,
-              const KafkaEventScheduleHandle &rhs) noexcept {
-    return reinterpret_cast<std::uintptr_t>(lhs.value.get()) <=>
-           reinterpret_cast<std::uintptr_t>(rhs.value.get());
-  }
-};
-
 inline std::ostream &operator<<(std::ostream &stream,
                                 const SubscriptionEventScheduleHandle &value) {
   return stream << "SubscriptionEventScheduleHandle(" << value.value.get()
@@ -347,13 +289,9 @@ inline std::ostream &operator<<(std::ostream &stream,
 }
 
 inline std::ostream &operator<<(std::ostream &stream,
-                                const DeliveryEventScheduleHandle &value) {
-  return stream << "DeliveryEventScheduleHandle(" << value.value.get() << ')';
-}
-
-inline std::ostream &operator<<(std::ostream &stream,
-                                const KafkaEventScheduleHandle &value) {
-  return stream << "KafkaEventScheduleHandle(" << value.value.get() << ')';
+                                const KafkaKeyedBatchBindings &value) {
+  return stream << "KafkaKeyedBatchBindings(" << value.batch_map.schema()
+                << ')';
 }
 
 } // namespace hgraph::kafka::detail
@@ -374,17 +312,15 @@ struct hash<hgraph::kafka::detail::SubscriptionEventScheduleHandle> {
   }
 };
 
-template <> struct hash<hgraph::kafka::detail::DeliveryEventScheduleHandle> {
-  size_t operator()(const hgraph::kafka::detail::DeliveryEventScheduleHandle
+template <> struct hash<hgraph::kafka::detail::KafkaKeyedBatchBindings> {
+  size_t operator()(const hgraph::kafka::detail::KafkaKeyedBatchBindings
                         &value) const noexcept {
-    return hash<const void *>{}(value.value.get());
-  }
-};
-
-template <> struct hash<hgraph::kafka::detail::KafkaEventScheduleHandle> {
-  size_t operator()(const hgraph::kafka::detail::KafkaEventScheduleHandle
-                        &value) const noexcept {
-    return hash<const void *>{}(value.value.get());
+    size_t result = hash<hgraph::ValueTypeRef>{}(value.key);
+    result ^= hash<hgraph::ValueTypeRef>{}(value.event) + 0x9e3779b9U +
+              (result << 6U) + (result >> 2U);
+    result ^= hash<hgraph::ValueTypeRef>{}(value.batch_map) + 0x9e3779b9U +
+              (result << 6U) + (result >> 2U);
+    return result;
   }
 };
 } // namespace std
@@ -400,14 +336,9 @@ template <> struct scalar_name<kafka::detail::SubscriptionEventScheduleHandle> {
       "hgraph.kafka.internal::SubscriptionEventScheduleHandle"};
 };
 
-template <> struct scalar_name<kafka::detail::DeliveryEventScheduleHandle> {
+template <> struct scalar_name<kafka::detail::KafkaKeyedBatchBindings> {
   static constexpr std::string_view value{
-      "hgraph.kafka.internal::DeliveryEventScheduleHandle"};
-};
-
-template <> struct scalar_name<kafka::detail::KafkaEventScheduleHandle> {
-  static constexpr std::string_view value{
-      "hgraph.kafka.internal::KafkaEventScheduleHandle"};
+      "hgraph.kafka.internal::KafkaKeyedBatchBindings"};
 };
 } // namespace hgraph::static_schema_detail
 
@@ -574,98 +505,163 @@ struct SubscriptionProjectionNode {
   }
 };
 
-/** Runtime projection for delivery envelopes. Distinct request ids tick
- * together; same-id collisions retain FIFO order. Cost is O(B + P) per tick
- * for burst size B and P pending ids; retained memory is O(C) for collisions.
- * State is ephemeral ingress state and is discarded at stop. */
+/** Groups delivery events by request id with O(B) work and O(B) transient
+ * memory. Standard collect retains the per-key batches; map_ gives every id an
+ * independent standard emit node for FIFO delivery. */
+struct GroupDeliveryBatchNode {
+  static constexpr auto name = "kafka_group_delivery_batch";
+
+  static void start(State<KafkaKeyedBatchBindings> bindings) {
+    const auto key = value_type_for_active_realization(
+        scalar_descriptor<Int>::value_meta());
+    const auto event = value_type_for_active_realization(
+        scalar_descriptor<KafkaTransportEvent>::value_meta());
+    const auto *event_batch_meta =
+        scalar_descriptor<KafkaTransportEventBatch>::value_meta();
+    const auto event_batch = compact_list_type(event, *event_batch_meta);
+    const auto sequenced_batch = value_type_for_active_realization(
+        scalar_descriptor<SequencedKafkaTransportBatch>::value_meta());
+    bindings.set(KafkaKeyedBatchBindings{
+        .key = key,
+        .event = event,
+        .event_batch = event_batch,
+        .sequenced_batch = sequenced_batch,
+        .batch_map = compact_map_type(key, sequenced_batch),
+    });
+  }
+
+  static void eval(In<"transport", TS<KafkaTransportEventBatch>> transport,
+                   State<KafkaKeyedBatchBindings> bindings,
+                   Out<TS<KafkaDeliveryTransportBatches>> out) {
+    std::unordered_map<Int, std::vector<std::size_t>> grouped;
+    const auto events = transport.base().value().as_list();
+    for (std::size_t index = 0; index != events.size(); ++index) {
+      const auto fields = events.at(index).as_bundle();
+      if (fields.at("kind").checked_as<KafkaTransportEventKind>() !=
+          KafkaTransportEventKind::Delivery) {
+        continue;
+      }
+      grouped[fields.at("request_id").checked_as<Int>()].push_back(index);
+    }
+    if (grouped.empty()) {
+      return;
+    }
+
+    const auto &resolved = bindings.ref();
+    const auto *event_batch_meta =
+        scalar_descriptor<KafkaTransportEventBatch>::value_meta();
+    MapBuilder batches{resolved.key, resolved.sequenced_batch};
+    for (const auto &[request_id, indices] : grouped) {
+      ListBuilder event_batch{resolved.event, *event_batch_meta};
+      for (const auto index : indices) {
+        event_batch.push_back(events.at(index));
+      }
+      ListStorage event_storage = event_batch.build_storage();
+      Value event_value{resolved.event_batch, &event_storage};
+      BundleBuilder batch{resolved.sequenced_batch};
+      batch.set("sequence", Value{out.evaluation_time()});
+      batch.set("events", std::move(event_value));
+      const Value key{request_id};
+      batches.set_item(key.view(), batch.build().view());
+    }
+    MapStorage batch_storage = batches.build_storage();
+    out.apply(ValueView{resolved.batch_map, &batch_storage});
+  }
+};
+
+/** Projects one delivery report; buffering and scheduling are graph-owned. */
 struct DeliveryProjectionNode {
   static constexpr auto name = "kafka_delivery_projection";
 
-  static void start(State<DeliveryEventScheduleHandle> state) {
-    state.set(
-        DeliveryEventScheduleHandle{std::make_shared<DeliveryEventSchedule>()});
-  }
-
-  static void eval(In<"transport", TS<KafkaTransportEventBatch>> transport,
-                   State<DeliveryEventScheduleHandle> state,
-                   SingleShotScheduler scheduler,
-                   Out<TSD<Int, TS<KafkaDeliveryReport>>> out) {
-    auto schedule = state.get().value;
-    auto mutation = out.begin_mutation(out.evaluation_time());
-    std::unordered_set<Int> emitted;
-    const auto apply_event = [&](const ValueView &event) {
-      const auto fields = event.as_bundle();
-      mutation.set(fields.at("request_id"), fields.at("report"));
-    };
-    schedule->drain(emitted, apply_event);
-    if (transport.modified()) {
-      for (const auto event : transport.base().value().as_list()) {
-        const auto fields = event.as_bundle();
-        if (fields.at("kind").checked_as<KafkaTransportEventKind>() !=
-            KafkaTransportEventKind::Delivery) {
-          continue;
-        }
-        const Int request_id = fields.at("request_id").checked_as<Int>();
-        if (emitted.emplace(request_id).second) {
-          apply_event(event);
-        } else {
-          schedule->defer(request_id, event);
-        }
-      }
-    }
-    if (!schedule->empty()) {
-      scheduler.schedule(MIN_TD);
-    }
+  static void eval(In<"event", TS<KafkaTransportEvent>> event,
+                   Out<TS<KafkaDeliveryReport>> out) {
+    out.apply(event.base().value().as_bundle().at("report"));
   }
 };
 
-/** Runtime projection for scalar service-event output. A burst is scanned in
- * O(B), the first event is emitted, and remaining events are retained in FIFO
- * order using O(E) memory until their individual ticks. */
+struct DeliveryProjectionGraph {
+  static constexpr auto name = "kafka_delivery_projection_graph";
+
+  static Port<TS<KafkaDeliveryReport>>
+  compose(Wiring &w, NamedPort<"key", TS<Int>>,
+          Port<TS<SequencedKafkaTransportBatch>> batch) {
+    auto events = wire<stdlib::getattr_, TS<KafkaTransportEventBatch>>(
+        w, batch, Str{"events"});
+    auto event = wire<stdlib::emit>(w, events)
+                     .template as<TS<KafkaTransportEvent>>();
+    return wire<DeliveryProjectionNode>(w, event)
+        .template as<TS<KafkaDeliveryReport>>();
+  }
+};
+
+[[nodiscard]] inline Port<TSD<Int, TS<KafkaDeliveryReport>>>
+wire_delivery_output(Wiring &w,
+                     Port<TS<KafkaTransportEventBatch>> transport) {
+  auto grouped = wire<GroupDeliveryBatchNode>(w, transport)
+                     .template as<TS<KafkaDeliveryTransportBatches>>();
+  auto batches =
+      wire<stdlib::collect, TSD<Int, TS<SequencedKafkaTransportBatch>>>(
+          w, grouped);
+  return wire<stdlib::map_, TSD<Int, TS<KafkaDeliveryReport>>>(
+      w, fn<DeliveryProjectionGraph>(), batches);
+}
+
+/** Selects scalar service events from a mixed transport burst. It performs
+ * O(B) work and transient memory; standard emit owns the FIFO thereafter. */
+struct SelectEventBatchNode {
+  static constexpr auto name = "kafka_select_event_batch";
+
+  static void start(State<stdlib::ResolvedBindings> bindings) {
+    const auto *batch_meta =
+        scalar_descriptor<KafkaTransportEventBatch>::value_meta();
+    bindings.set(stdlib::resolve_list_bindings(batch_meta));
+  }
+
+  static void eval(In<"transport", TS<KafkaTransportEventBatch>> transport,
+                   State<stdlib::ResolvedBindings> bindings,
+                   Out<TS<KafkaTransportEventBatch>> out) {
+    const auto &resolved = bindings.ref();
+    ListBuilder selected{resolved.primary,
+                         *scalar_descriptor<
+                             KafkaTransportEventBatch>::value_meta()};
+    for (const auto event : transport.base().value().as_list()) {
+      const auto fields = event.as_bundle();
+      if (fields.at("kind").checked_as<KafkaTransportEventKind>() ==
+          KafkaTransportEventKind::Event) {
+        selected.push_back(event);
+      }
+    }
+    if (selected.empty()) {
+      return;
+    }
+    ListStorage storage = selected.build_storage();
+    out.apply(ValueView{resolved.result, &storage});
+  }
+};
+
+/** Projects one scalar service event and applies stop policy on graph. */
 struct EventProjectionNode {
   static constexpr auto name = "kafka_event_projection";
 
-  static void start(State<KafkaEventScheduleHandle> state) {
-    state.set(KafkaEventScheduleHandle{std::make_shared<KafkaEventSchedule>()});
-  }
-
-  static void eval(In<"transport", TS<KafkaTransportEventBatch>> transport,
-                   State<KafkaEventScheduleHandle> state,
-                   SingleShotScheduler scheduler, EngineControlView engine,
-                   Out<TS<KafkaEvent>> out) {
-    auto schedule = state.get().value;
-    bool emitted = false;
-    const auto apply_event = [&](const ValueView &event) {
-      const auto fields = event.as_bundle();
-      out.apply(fields.at("event"));
-      const auto stop_graph = fields.at("stop_graph");
-      if (stop_graph.data() != nullptr && stop_graph.checked_as<Bool>()) {
-        engine.request_stop();
-      }
-      emitted = true;
-    };
-    if (auto pending = schedule->pop()) {
-      apply_event(pending->view());
-    }
-    if (transport.modified()) {
-      for (const auto event : transport.base().value().as_list()) {
-        const auto fields = event.as_bundle();
-        if (fields.at("kind").checked_as<KafkaTransportEventKind>() !=
-            KafkaTransportEventKind::Event) {
-          continue;
-        }
-        if (emitted) {
-          schedule->defer(event);
-        } else {
-          apply_event(event);
-        }
-      }
-    }
-    if (!schedule->empty()) {
-      scheduler.schedule(MIN_TD);
+  static void eval(In<"event", TS<KafkaTransportEvent>> event,
+                   EngineControlView engine, Out<TS<KafkaEvent>> out) {
+    const auto fields = event.base().value().as_bundle();
+    out.apply(fields.at("event"));
+    const auto stop_graph = fields.at("stop_graph");
+    if (stop_graph.data() != nullptr && stop_graph.checked_as<Bool>()) {
+      engine.request_stop();
     }
   }
 };
+
+[[nodiscard]] inline Port<TS<KafkaEvent>>
+wire_event_output(Wiring &w, Port<TS<KafkaTransportEventBatch>> transport) {
+  auto selected = wire<SelectEventBatchNode>(w, transport)
+                      .template as<TS<KafkaTransportEventBatch>>();
+  auto event = wire<stdlib::emit>(w, selected)
+                   .template as<TS<KafkaTransportEvent>>();
+  return wire<EventProjectionNode>(w, event).template as<TS<KafkaEvent>>();
+}
 
 /** Simulation projection applies a same-time batch as one keyed mutation so
  *  the graph observes an atomic replay cohort. It retains no replay history;
@@ -787,9 +783,8 @@ wire_service_outputs(Wiring &w, Port<TS<KafkaTransportEventBatch>> transport,
   return ServiceOutputs{
       wire<SubscriptionProjectionNode>(w, transport, bindings)
           .template as<TSD<KafkaSubscriptionKey, KafkaSubscriptionOutput>>(),
-      wire<DeliveryProjectionNode>(w, transport)
-          .template as<TSD<Int, TS<KafkaDeliveryReport>>>(),
-      wire<EventProjectionNode>(w, transport).template as<TS<KafkaEvent>>(),
+      wire_delivery_output(w, transport),
+      wire_event_output(w, transport),
   };
 }
 

--- a/extensions/kafka/src/detail/service_transport.h
+++ b/extensions/kafka/src/detail/service_transport.h
@@ -130,10 +130,11 @@ struct OwnedValueEqual {
 
 struct KafkaTransportEmitState {
   ValueTypeRef event_binding{};
-  std::deque<Value> subscriptions{};
-  std::deque<Value> deliveries{};
-  std::deque<Value> events{};
-  std::unordered_set<Value, OwnedValueHash, OwnedValueEqual> emitted_keys{};
+  std::deque<Value> pending{};
+  // Per-evaluation output-occupancy scratch. It is cleared before dequeueing
+  // and never retains transport work; keeping its allocation avoids rebuilding
+  // the hash table on every engine cycle until outputs expose this directly.
+  std::unordered_set<Value, OwnedValueHash, OwnedValueEqual> occupied_keys{};
   bool recovery_blocked{};
 };
 
@@ -237,19 +238,19 @@ service_transport_event(const KafkaTransportBindings &bindings, Value event,
                           {"stop_graph", transport_atomic(stop_graph)}});
 }
 
-/** Splits one Kafka burst into graph-visible service lanes. Runtime envelope
- * kinds cannot be selected at wiring time, so this is the one Kafka-specific
- * emit primitive. Independent subscription keys and delivery request ids are
- * emitted together as keyed deltas; a repeated key is retained for the next
- * engine cycle so its event order remains observable. Scalar service events
- * remain FIFO and release one per cycle. Timestamped recovery events release
- * when due and remain blocked until their recovery barrier arrives.
+/** Splits one ordered Kafka burst into graph-visible service lanes. Runtime
+ * envelope kinds cannot be selected at wiring time, so this is the one
+ * Kafka-specific emit primitive. It walks one pending queue in order and
+ * delegates events until the next event would write a second value to an
+ * already occupied output in the same engine cycle. That event remains at the
+ * queue front and resumes on the next cycle. Timestamped recovery events
+ * release when due and remain blocked until their recovery barrier arrives.
  *
- * Normal live classification and draining are O(B + Q), where B is the
- * incoming burst and Q is retained work examined for the current lanes.
- * Sorted timestamp recovery insertion is O(Bs * Qs) worst-case for Bs new and
- * Qs retained subscription events. Retained memory is O(Q). State is
- * ephemeral ingress sequencing state and is discarded at stop. */
+ * Normal live append and draining are O(B + D), where B is the incoming burst
+ * and D is the prefix delegated this cycle. Sorted timestamp insertion and a
+ * live subscription's recovery-tail lookup are O(Bt * Q) worst-case for Bt
+ * timestamp-related events and Q retained events. Retained memory is O(Q).
+ * State is ephemeral ingress sequencing state and is discarded at stop. */
 struct KafkaTransportEmitNode {
   static constexpr auto name = "kafka_transport_emit";
 
@@ -297,31 +298,38 @@ struct KafkaTransportEmitNode {
       for (std::size_t index = 0; index != incoming.size(); ++index) {
         const auto value = incoming.at(index);
         const auto fields = value.as_bundle();
-        switch (fields.at("kind").checked_as<KafkaTransportEventKind>()) {
-        case KafkaTransportEventKind::Subscription: {
-          Value event = value.clone();
-          auto event_time = evaluation_time(value);
+        const auto kind =
+            fields.at("kind").checked_as<KafkaTransportEventKind>();
+        if (kind == KafkaTransportEventKind::RecoveryBarrier) {
+          current.recovery_blocked = false;
+          continue;
+        }
+
+        Value event = value.clone();
+        auto event_time = evaluation_time(value);
+        if (kind == KafkaTransportEventKind::Subscription) {
           const auto recovery = fields.at("recovery");
           if (recovery.data() != nullptr && recovery.checked_as<Bool>()) {
             current.recovery_blocked = true;
           }
-          // The ordered queue stores all live values before timestamped
-          // recovery. Avoid a predecessor scan on the normal live hot path
-          // when its tail proves that no timestamped value is retained.
+          // Untimed live values normally append in O(1). If timestamped work
+          // remains, a live value for the same subscription follows its
+          // recovery tail on the next engine time.
           const bool has_timestamped_tail =
-              !current.subscriptions.empty() &&
-              evaluation_time(current.subscriptions.back().view()).has_value();
+              !current.pending.empty() &&
+              evaluation_time(current.pending.back().view()).has_value();
           if (!event_time.has_value() && has_timestamped_tail) {
             const auto key = fields.at("subscription_key");
             const auto predecessor = std::find_if(
-                current.subscriptions.rbegin(), current.subscriptions.rend(),
+                current.pending.rbegin(), current.pending.rend(),
                 [&](const Value &candidate) {
-                  return candidate.view()
-                      .as_bundle()
-                      .at("subscription_key")
-                      .equals(key);
+                  const auto candidate_fields = candidate.view().as_bundle();
+                  return candidate_fields.at("kind")
+                                 .checked_as<KafkaTransportEventKind>() ==
+                             KafkaTransportEventKind::Subscription &&
+                         candidate_fields.at("subscription_key").equals(key);
                 });
-            if (predecessor != current.subscriptions.rend()) {
+            if (predecessor != current.pending.rend()) {
               const auto predecessor_time =
                   evaluation_time(predecessor->view());
               if (predecessor_time.has_value()) {
@@ -331,126 +339,89 @@ struct KafkaTransportEmitNode {
               }
             }
           }
-          if (!event_time.has_value() && !has_timestamped_tail) {
-            current.subscriptions.push_back(std::move(event));
-            break;
-          }
-          const auto position = std::upper_bound(
-              current.subscriptions.begin(), current.subscriptions.end(), event,
-              [&](const Value &lhs, const Value &rhs) {
-                const auto lhs_time = evaluation_time(lhs.view());
-                const auto rhs_time = evaluation_time(rhs.view());
-                if (!lhs_time.has_value()) {
-                  return rhs_time.has_value();
-                }
-                return rhs_time.has_value() && *lhs_time < *rhs_time;
-              });
-          current.subscriptions.insert(position, std::move(event));
-          break;
         }
-        case KafkaTransportEventKind::Delivery:
-          current.deliveries.emplace_back(value);
-          break;
-        case KafkaTransportEventKind::Event:
-          current.events.emplace_back(value);
-          break;
-        case KafkaTransportEventKind::RecoveryBarrier:
-          current.recovery_blocked = false;
-          break;
-        }
-      }
-    }
 
-    const auto subscription_is_blocked = [&] {
-      if (!current.recovery_blocked || current.subscriptions.empty()) {
-        return false;
-      }
-      const auto recovery =
-          current.subscriptions.front().view().as_bundle().at("recovery");
-      return recovery.data() != nullptr && recovery.checked_as<Bool>();
-    };
-
-    if (!current.subscriptions.empty() && !subscription_is_blocked()) {
-      const auto cohort_time =
-          evaluation_time(current.subscriptions.front().view());
-      if (!cohort_time.has_value() || *cohort_time <= scheduler.now()) {
-        auto subscriptions = out.template field<"subscriptions">();
-        auto mutation =
-            subscriptions.begin_mutation(subscriptions.evaluation_time());
-        auto &emitted = current.emitted_keys;
-        emitted.clear();
-        std::deque<Value> remaining;
-        while (!current.subscriptions.empty()) {
-          Value event = std::move(current.subscriptions.front());
-          current.subscriptions.pop_front();
-          const auto event_time = evaluation_time(event.view());
-          const bool outside_cohort = cohort_time.has_value()
-                                          ? event_time != cohort_time
-                                          : event_time.has_value();
-          if (outside_cohort) {
-            remaining.push_back(std::move(event));
-            while (!current.subscriptions.empty()) {
-              remaining.push_back(std::move(current.subscriptions.front()));
-              current.subscriptions.pop_front();
-            }
-            break;
-          }
-          const auto fields = event.view().as_bundle();
-          const auto key = fields.at("subscription_key");
-          if (!emitted.emplace(key).second) {
-            remaining.push_back(std::move(event));
-            continue;
-          }
-          const auto removed = fields.at("removed");
-          if (removed.data() != nullptr && removed.checked_as<Bool>()) {
-            static_cast<void>(mutation.erase(key));
-          } else {
-            mutation.set(key, event.view());
-          }
-        }
-        current.subscriptions.swap(remaining);
-      }
-    }
-
-    if (!current.deliveries.empty()) {
-      auto deliveries = out.template field<"deliveries">();
-      auto mutation = deliveries.begin_mutation(deliveries.evaluation_time());
-      auto &emitted = current.emitted_keys;
-      emitted.clear();
-      std::deque<Value> remaining;
-      while (!current.deliveries.empty()) {
-        Value event = std::move(current.deliveries.front());
-        current.deliveries.pop_front();
-        const auto fields = event.view().as_bundle();
-        const auto key = fields.at("request_id");
-        if (!emitted.emplace(key).second) {
-          remaining.push_back(std::move(event));
+        const bool has_timestamped_tail =
+            !current.pending.empty() &&
+            evaluation_time(current.pending.back().view()).has_value();
+        if (!event_time.has_value() && !has_timestamped_tail) {
+          current.pending.push_back(std::move(event));
           continue;
         }
-        mutation.set(key, event.view());
+        const auto position = std::upper_bound(
+            current.pending.begin(), current.pending.end(), event,
+            [&](const Value &lhs, const Value &rhs) {
+              const auto lhs_time = evaluation_time(lhs.view());
+              const auto rhs_time = evaluation_time(rhs.view());
+              if (!lhs_time.has_value()) {
+                return rhs_time.has_value();
+              }
+              return rhs_time.has_value() && *lhs_time < *rhs_time;
+            });
+        current.pending.insert(position, std::move(event));
       }
-      current.deliveries.swap(remaining);
     }
 
-    if (!current.events.empty()) {
-      Value event = std::move(current.events.front());
-      current.events.pop_front();
-      out.template field<"events">().apply(event.view());
-    }
+    auto subscriptions = out.template field<"subscriptions">();
+    std::optional<TSDDataMutationView> subscription_mutation;
+    auto deliveries = out.template field<"deliveries">();
+    std::optional<TSDDataMutationView> delivery_mutation;
+    auto events = out.template field<"events">();
+    auto &occupied = current.occupied_keys;
+    occupied.clear();
+    bool event_emitted{};
 
-    bool schedule_immediately =
-        !current.deliveries.empty() || !current.events.empty();
-    std::optional<DateTime> subscription_time;
-    if (!current.subscriptions.empty() && !subscription_is_blocked()) {
-      subscription_time = evaluation_time(current.subscriptions.front().view());
-      schedule_immediately = schedule_immediately ||
-                             !subscription_time.has_value() ||
-                             *subscription_time <= scheduler.now();
-    }
-    if (schedule_immediately) {
-      scheduler.schedule(MIN_TD);
-    } else if (subscription_time.has_value()) {
-      scheduler.schedule(*subscription_time);
+    while (!current.pending.empty()) {
+      const auto event = current.pending.front().view();
+      const auto fields = event.as_bundle();
+      const auto kind = fields.at("kind").checked_as<KafkaTransportEventKind>();
+
+      if (kind == KafkaTransportEventKind::Subscription) {
+        const auto recovery = fields.at("recovery");
+        if (current.recovery_blocked && recovery.data() != nullptr &&
+            recovery.checked_as<Bool>()) {
+          break;
+        }
+        const auto event_time = evaluation_time(event);
+        if (event_time.has_value() && *event_time > scheduler.now()) {
+          scheduler.schedule(*event_time);
+          break;
+        }
+        const auto key = fields.at("subscription_key");
+        if (!occupied.emplace(key).second) {
+          scheduler.schedule(MIN_TD);
+          break;
+        }
+        const auto removed = fields.at("removed");
+        if (!subscription_mutation.has_value()) {
+          subscription_mutation.emplace(
+              subscriptions.begin_mutation(subscriptions.evaluation_time()));
+        }
+        if (removed.data() != nullptr && removed.checked_as<Bool>()) {
+          static_cast<void>(subscription_mutation->erase(key));
+        } else {
+          subscription_mutation->set(key, event);
+        }
+      } else if (kind == KafkaTransportEventKind::Delivery) {
+        const auto key = fields.at("request_id");
+        if (!occupied.emplace(key).second) {
+          scheduler.schedule(MIN_TD);
+          break;
+        }
+        if (!delivery_mutation.has_value()) {
+          delivery_mutation.emplace(
+              deliveries.begin_mutation(deliveries.evaluation_time()));
+        }
+        delivery_mutation->set(key, event);
+      } else if (kind == KafkaTransportEventKind::Event) {
+        if (event_emitted) {
+          scheduler.schedule(MIN_TD);
+          break;
+        }
+        events.apply(event);
+        event_emitted = true;
+      }
+      current.pending.pop_front();
     }
   }
 };

--- a/extensions/kafka/src/detail/service_transport.h
+++ b/extensions/kafka/src/detail/service_transport.h
@@ -22,7 +22,6 @@
 #include <memory>
 #include <optional>
 #include <ostream>
-#include <ranges>
 #include <span>
 #include <string_view>
 #include <typeindex>
@@ -443,7 +442,9 @@ struct SubscriptionProjectionNode {
        Out<TSD<KafkaSubscriptionKey, KafkaSubscriptionOutput>> out) {
     auto schedule = state.get().value;
     if (transport.modified()) {
-      for (const auto event : transport.base().value().as_list()) {
+      const auto events = transport.base().value().as_list();
+      for (std::size_t index = 0; index != events.size(); ++index) {
+        const auto event = events.at(index);
         const auto fields = event.as_bundle();
         const auto kind =
             fields.at("kind").checked_as<KafkaTransportEventKind>();
@@ -624,7 +625,9 @@ struct SelectEventBatchNode {
     ListBuilder selected{resolved.primary,
                          *scalar_descriptor<
                              KafkaTransportEventBatch>::value_meta()};
-    for (const auto event : transport.base().value().as_list()) {
+    const auto events = transport.base().value().as_list();
+    for (std::size_t index = 0; index != events.size(); ++index) {
+      const auto event = events.at(index);
       const auto fields = event.as_bundle();
       if (fields.at("kind").checked_as<KafkaTransportEventKind>() ==
           KafkaTransportEventKind::Event) {
@@ -681,18 +684,23 @@ struct SimulationSubscriptionProjectionNode {
        State<SubscriptionEventScheduleHandle> state,
        Out<TSD<KafkaSubscriptionKey, KafkaSubscriptionOutput>> out) {
     const auto values = transport.base().value().as_list();
-    const bool has_subscription =
-        std::ranges::any_of(values, [](const ValueView &value) {
-          return value.as_bundle()
-                     .at("kind")
-                     .checked_as<KafkaTransportEventKind>() ==
-                 KafkaTransportEventKind::Subscription;
-        });
+    bool has_subscription = false;
+    for (std::size_t index = 0; index != values.size(); ++index) {
+      if (values.at(index)
+              .as_bundle()
+              .at("kind")
+              .checked_as<KafkaTransportEventKind>() ==
+          KafkaTransportEventKind::Subscription) {
+        has_subscription = true;
+        break;
+      }
+    }
     if (!has_subscription) {
       return;
     }
     auto mutation = out.begin_mutation(out.evaluation_time());
-    for (const auto value : values) {
+    for (std::size_t index = 0; index != values.size(); ++index) {
+      const auto value = values.at(index);
       const auto fields = value.as_bundle();
       if (fields.at("kind").checked_as<KafkaTransportEventKind>() !=
           KafkaTransportEventKind::Subscription) {
@@ -726,18 +734,23 @@ struct SimulationDeliveryProjectionNode {
   static void eval(In<"transport", TS<KafkaTransportEventBatch>> transport,
                    Out<TSD<Int, TS<KafkaDeliveryReport>>> out) {
     const auto values = transport.base().value().as_list();
-    const bool has_delivery =
-        std::ranges::any_of(values, [](const ValueView &value) {
-          return value.as_bundle()
-                     .at("kind")
-                     .checked_as<KafkaTransportEventKind>() ==
-                 KafkaTransportEventKind::Delivery;
-        });
+    bool has_delivery = false;
+    for (std::size_t index = 0; index != values.size(); ++index) {
+      if (values.at(index)
+              .as_bundle()
+              .at("kind")
+              .checked_as<KafkaTransportEventKind>() ==
+          KafkaTransportEventKind::Delivery) {
+        has_delivery = true;
+        break;
+      }
+    }
     if (!has_delivery) {
       return;
     }
     auto mutation = out.begin_mutation(out.evaluation_time());
-    for (const auto value : values) {
+    for (std::size_t index = 0; index != values.size(); ++index) {
+      const auto value = values.at(index);
       const auto fields = value.as_bundle();
       if (fields.at("kind").checked_as<KafkaTransportEventKind>() ==
           KafkaTransportEventKind::Delivery) {
@@ -755,7 +768,9 @@ struct SimulationEventProjectionNode {
 
   static void eval(In<"transport", TS<KafkaTransportEventBatch>> transport,
                    EngineControlView engine, Out<TS<KafkaEvent>> out) {
-    for (const auto value : transport.base().value().as_list()) {
+    const auto values = transport.base().value().as_list();
+    for (std::size_t index = 0; index != values.size(); ++index) {
+      const auto value = values.at(index);
       const auto fields = value.as_bundle();
       if (fields.at("kind").checked_as<KafkaTransportEventKind>() !=
           KafkaTransportEventKind::Event) {

--- a/extensions/kafka/src/librdkafka_service.cpp
+++ b/extensions/kafka/src/librdkafka_service.cpp
@@ -47,13 +47,13 @@ namespace hgraph::kafka::detail {
 namespace {
 [[nodiscard]] Value
 subscription_envelope(const KafkaTransportBindings &bindings, Value key,
-                      std::optional<Value> record,
-                      std::optional<Value> cursor, KafkaSubscriptionState state,
+                      std::optional<Value> record, std::optional<Value> cursor,
+                      KafkaSubscriptionState state,
                       std::optional<DateTime> evaluation_time,
                       Bool recovery = false) {
   return subscription_transport_event(bindings, std::move(key),
-                                      std::move(record), std::move(cursor), state,
-                                      evaluation_time, recovery);
+                                      std::move(record), std::move(cursor),
+                                      state, evaluation_time, recovery);
 }
 
 [[nodiscard]] Value delivery_envelope(const KafkaTransportBindings &bindings,
@@ -669,12 +669,10 @@ class KafkaRuntime : public std::enable_shared_from_this<KafkaRuntime> {
 public:
   using Output = std::function<bool(Value)>;
 
-  KafkaRuntime(RuntimeConfig config, Str path,
-               KafkaTransportBindings bindings, Output output,
-               DateTime graph_start_time, bool simulation)
+  KafkaRuntime(RuntimeConfig config, Str path, KafkaTransportBindings bindings,
+               Output output, DateTime graph_start_time, bool simulation)
       : config_{std::move(config)}, path_{std::move(path)},
-        bindings_{std::move(bindings)},
-        output_{std::move(output)},
+        bindings_{std::move(bindings)}, output_{std::move(output)},
         graph_start_ms_{std::chrono::duration_cast<std::chrono::milliseconds>(
                             graph_start_time.time_since_epoch())
                             .count()},
@@ -867,18 +865,18 @@ public:
   emit_subscription(Value key, std::optional<Value> record,
                     std::optional<Value> cursor, KafkaSubscriptionState state,
                     std::optional<DateTime> evaluation_time = std::nullopt) {
-    return output_(subscription_envelope(
-        bindings_, std::move(key), std::move(record), std::move(cursor), state,
-        evaluation_time));
+    return output_(subscription_envelope(bindings_, std::move(key),
+                                         std::move(record), std::move(cursor),
+                                         state, evaluation_time));
   }
 
   bool emit_recovery_subscription(Value key, std::optional<Value> record,
                                   std::optional<Value> cursor,
                                   KafkaSubscriptionState state,
                                   std::optional<DateTime> evaluation_time) {
-    return output_(subscription_envelope(
-        bindings_, std::move(key), std::move(record), std::move(cursor), state,
-        evaluation_time, !simulation_));
+    return output_(subscription_envelope(bindings_, std::move(key),
+                                         std::move(record), std::move(cursor),
+                                         state, evaluation_time, !simulation_));
   }
 
   void begin_record_time_recovery(std::size_t participants) {
@@ -954,17 +952,17 @@ public:
       Value key, KafkaSubscriptionState state,
       std::optional<DateTime> evaluation_time = std::nullopt) noexcept {
     try {
-      static_cast<void>(output_(subscription_envelope(
-          bindings_, std::move(key), std::nullopt, std::nullopt, state,
-          evaluation_time)));
+      static_cast<void>(
+          output_(subscription_envelope(bindings_, std::move(key), std::nullopt,
+                                        std::nullopt, state, evaluation_time)));
     } catch (...) {
     }
   }
 
   bool emit_delivery(Int request_id, Value report) noexcept {
     try {
-      return output_(delivery_envelope(bindings_, request_id,
-                                       std::move(report)));
+      return output_(
+          delivery_envelope(bindings_, request_id, std::move(report)));
     } catch (...) {
       return false;
     }
@@ -2774,7 +2772,7 @@ struct KafkaGraphDeliveryCommitSink {
 
 struct KafkaRealtimeTransportTag {};
 
-[[nodiscard]] Port<TS<detail::KafkaTransportEvent>>
+[[nodiscard]] Port<TS<detail::KafkaTransportEventBatch>>
 wire_realtime_transport(Wiring &w, detail::RuntimeConfigHandle config, Str path,
                         detail::KafkaRuntimeHandle runtime,
                         detail::KafkaTransportBindingsHandle bindings) {
@@ -2914,8 +2912,8 @@ struct KafkaServiceImpl {
             wire<KafkaSimulationReplayNode>(w, ready, runtime_config,
                                             path.value(), runtime, queue)
                 .template as<TS<detail::KafkaTransportEventBatch>>();
-        return detail::wire_simulation_service_outputs(
-            w, replay, transport_bindings);
+        return detail::wire_simulation_service_outputs(w, replay,
+                                                       transport_bindings);
       }
       auto source = wire_realtime_transport(w, runtime_config, path.value(),
                                             runtime, transport_bindings);

--- a/extensions/kafka/src/librdkafka_service.cpp
+++ b/extensions/kafka/src/librdkafka_service.cpp
@@ -2912,8 +2912,7 @@ struct KafkaServiceImpl {
             wire<KafkaSimulationReplayNode>(w, ready, runtime_config,
                                             path.value(), runtime, queue)
                 .template as<TS<detail::KafkaTransportEventBatch>>();
-        return detail::wire_simulation_service_outputs(w, replay,
-                                                       transport_bindings);
+        return detail::wire_service_outputs(w, replay, transport_bindings);
       }
       auto source = wire_realtime_transport(w, runtime_config, path.value(),
                                             runtime, transport_bindings);

--- a/extensions/kafka/src/testing/fake_broker.cpp
+++ b/extensions/kafka/src/testing/fake_broker.cpp
@@ -140,10 +140,9 @@ namespace {
   return field.data() != nullptr ? field.checked_as<Str>() : Str{};
 }
 
-[[nodiscard]] Value subscription_envelope(Value key, Value record, Value cursor,
-                                          KafkaSubscriptionState state,
-                                          const ::hgraph::kafka::detail::
-                                              KafkaTransportBindings &bindings) {
+[[nodiscard]] Value subscription_envelope(
+    Value key, Value record, Value cursor, KafkaSubscriptionState state,
+    const ::hgraph::kafka::detail::KafkaTransportBindings &bindings) {
   return ::hgraph::kafka::detail::subscription_transport_event(
       bindings, std::move(key), std::move(record), std::move(cursor), state);
 }
@@ -151,8 +150,8 @@ namespace {
 [[nodiscard]] Value delivery_envelope(
     Int request_id, Value report,
     const ::hgraph::kafka::detail::KafkaTransportBindings &bindings) {
-  return ::hgraph::kafka::detail::delivery_transport_event(
-      bindings, request_id, std::move(report));
+  return ::hgraph::kafka::detail::delivery_transport_event(bindings, request_id,
+                                                           std::move(report));
 }
 
 [[nodiscard]] Value event_envelope(
@@ -176,9 +175,9 @@ struct FakeBroker::Impl {
 };
 
 struct detail::FakeRuntimeAccess {
-  static void attach(
-      FakeBroker &broker, PushSourceSender sender,
-      ::hgraph::kafka::detail::KafkaTransportBindingsHandle bindings) {
+  static void
+  attach(FakeBroker &broker, PushSourceSender sender,
+         ::hgraph::kafka::detail::KafkaTransportBindingsHandle bindings) {
     {
       std::lock_guard lock{broker.impl_->mutex};
       broker.impl_->sender = std::move(sender);
@@ -228,9 +227,8 @@ struct detail::FakeRuntimeAccess {
     Value report =
         make_delivery_report(std::move(user_token), sequence, std::move(topic),
                              KafkaDeliveryStatus::Delivered, Int{0}, sequence);
-    if (!sender.send_blocking(
-            delivery_envelope(request_id, std::move(report),
-                              *bindings.value))) {
+    if (!sender.send_blocking(delivery_envelope(request_id, std::move(report),
+                                                *bindings.value))) {
       throw std::runtime_error("Kafka fake graph stopped before delivery");
     }
   }
@@ -322,10 +320,9 @@ void FakeBroker::emit_subscription(Value subscription_key, Value record,
     sender = impl_->sender;
     bindings = impl_->bindings;
   }
-  if (!sender.send_blocking(subscription_envelope(std::move(subscription_key),
-                                                  std::move(record),
-                                                  std::move(cursor), state,
-                                                  *bindings.value))) {
+  if (!sender.send_blocking(
+          subscription_envelope(std::move(subscription_key), std::move(record),
+                                std::move(cursor), state, *bindings.value))) {
     throw std::runtime_error("Kafka fake graph stopped before subscription");
   }
 }
@@ -395,11 +392,11 @@ fake_runtime(Scalar<"runtime", detail::FakeRuntimeHandle> runtime) {
 
 struct FakeTransportTag {};
 
-[[nodiscard]] Port<TS<::hgraph::kafka::detail::KafkaTransportEvent>>
-wire_fake_transport(Wiring &w, detail::FakeBrokerHandle broker,
-                    detail::FakeRuntimeHandle runtime,
-                    ::hgraph::kafka::detail::KafkaTransportBindingsHandle
-                        bindings) {
+[[nodiscard]] Port<TS<::hgraph::kafka::detail::KafkaTransportEventBatch>>
+wire_fake_transport(
+    Wiring &w, detail::FakeBrokerHandle broker,
+    detail::FakeRuntimeHandle runtime,
+    ::hgraph::kafka::detail::KafkaTransportBindingsHandle bindings) {
   return ::hgraph::kafka::detail::wire_transport_source<FakeTransportTag>(
       w,
       [broker = std::move(broker), runtime,

--- a/extensions/kafka/tests/test_service.cpp
+++ b/extensions/kafka/tests/test_service.cpp
@@ -136,7 +136,7 @@ void test_delivery_burst_unrolls_repeated_request_ids() {
           "same-id delivery reports were conflated or reordered");
 }
 
-void test_mixed_burst_only_defers_colliding_service_keys() {
+void test_mixed_burst_stops_at_first_output_collision() {
   const auto bindings = kafka::detail::make_transport_bindings();
   Value first_key = make_subscription_key(
       {Str{"orders-a"}}, Str{"mixed-a"}, Str{"earliest"}, Str{"unbounded"},
@@ -183,24 +183,25 @@ void test_mixed_burst_only_defers_colliding_service_keys() {
   std::vector<std::optional<Value>> input;
   input.emplace_back(burst.build());
   const auto output = eval_node<MixedTransportEmitGraph>(input);
-  require(output.size() >= 2 && output[0].has_value() && output[1].has_value(),
-          "mixed Kafka burst did not drain its collisions over two cycles");
+  require(output.size() >= 4 && output[0].has_value() &&
+              output[1].has_value() && output[2].has_value() &&
+              output[3].has_value(),
+          "mixed Kafka burst did not resume after each output collision");
+  const auto tsd_delta_empty = [](const ValueView &value) {
+    const auto delta = value.as_bundle();
+    return delta.at("removed").as_set().empty() &&
+           delta.at("modified").as_map().empty();
+  };
 
   const auto first = output[0]->view().as_bundle();
   const auto first_subscriptions =
       first.at("subscriptions").as_bundle().at("modified").as_map();
-  const auto first_deliveries =
-      first.at("deliveries").as_bundle().at("modified").as_map();
-  const Value first_delivery_key{Int{17}};
-  const Value independent_delivery_key{Int{23}};
   require(first_subscriptions.contains(first_key.view()) &&
               first_subscriptions.contains(second_key.view()),
-          "a subscription collision blocked an independent subscription");
-  require(first_deliveries.contains(first_delivery_key.view()) &&
-              first_deliveries.contains(independent_delivery_key.view()),
-          "a delivery collision blocked an independent delivery");
-  require(first.at("events").data() != nullptr,
-          "keyed collisions blocked the scalar service-event lane");
+          "the emitter did not delegate the collision-free queue prefix");
+  require(tsd_delta_empty(first.at("deliveries")) &&
+              !first.at("events").has_value(),
+          "an event overtook the first subscription-key collision");
 
   const auto second = output[1]->view().as_bundle();
   const auto second_subscriptions =
@@ -209,13 +210,30 @@ void test_mixed_burst_only_defers_colliding_service_keys() {
       second.at("deliveries").as_bundle().at("modified").as_map();
   require(second_subscriptions.size() == 1 &&
               second_subscriptions.contains(first_key.view()),
-          "the colliding subscription was not deferred exactly one cycle");
-  const Value delivery_key{Int{17}};
-  require(second_deliveries.size() == 1 &&
-              second_deliveries.contains(delivery_key.view()),
-          "the colliding delivery was not deferred exactly one cycle");
-  require(second.at("events").data() != nullptr,
-          "the second scalar service event was not drained in FIFO order");
+          "the emitter did not resume from the blocked subscription event");
+  const Value first_delivery_key{Int{17}};
+  const Value independent_delivery_key{Int{23}};
+  require(second_deliveries.contains(first_delivery_key.view()) &&
+              second_deliveries.contains(independent_delivery_key.view()),
+          "the emitter did not continue to the delivery-key collision");
+  require(!second.at("events").has_value(),
+          "a service event overtook the delivery-key collision");
+
+  const auto third = output[2]->view().as_bundle();
+  const auto third_deliveries =
+      third.at("deliveries").as_bundle().at("modified").as_map();
+  require(tsd_delta_empty(third.at("subscriptions")) &&
+              third_deliveries.size() == 1 &&
+              third_deliveries.contains(first_delivery_key.view()),
+          "the emitter did not resume from the blocked delivery event");
+  require(third.at("events").has_value(),
+          "the emitter did not continue to the first scalar service event");
+
+  const auto fourth = output[3]->view().as_bundle();
+  require(tsd_delta_empty(fourth.at("subscriptions")) &&
+              tsd_delta_empty(fourth.at("deliveries")) &&
+              fourth.at("events").has_value(),
+          "the emitter did not resume from the scalar output collision");
 }
 
 template <typename Fn> void require_invalid(Fn &&fn, std::string message) {
@@ -2916,7 +2934,7 @@ int main() {
     test_delivery_burst_unrolls_repeated_request_ids();
     const auto release_state = hgraph::make_scope_exit(release_test_state);
     initialize_values();
-    test_mixed_burst_only_defers_colliding_service_keys();
+    test_mixed_burst_stops_at_first_output_collision();
     test_runtime_specific_wiring_shapes();
     test_public_value_validation_and_producer_configuration();
     test_simulation_rejects_publish_and_commit_work();

--- a/extensions/kafka/tests/test_service.cpp
+++ b/extensions/kafka/tests/test_service.cpp
@@ -6,9 +6,12 @@
 #include <hgraph/lib/std/operators/container.h>
 #include <hgraph/lib/std/operators/conversion.h>
 #include <hgraph/lib/std/operators/registration.h>
+#include <hgraph/lib/testing/eval_node.h>
 #include <hgraph/lib/testing/runtime_support.h>
 #include <hgraph/runtime/runtime.h>
 #include <hgraph/util/scope.h>
+
+#include "../src/detail/service_transport.h"
 
 #include <algorithm>
 #include <array>
@@ -16,6 +19,7 @@
 #include <condition_variable>
 #include <cstddef>
 #include <cstdlib>
+#include <initializer_list>
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -66,6 +70,50 @@ void test_transport_sender_handles_graph_teardown() {
           "a Kafka transport sender accepted work after graph teardown");
 }
 
+Value delivery_burst(
+    const kafka::detail::KafkaTransportBindingsHandle &bindings, Int request_id,
+    std::initializer_list<Value> reports) {
+  ListBuilder builder{
+      bindings.value->event,
+      *scalar_descriptor<
+          kafka::detail::KafkaTransportEventBatch>::value_meta()};
+  for (const auto &report : reports) {
+    builder.push_back(kafka::detail::delivery_transport_event(
+        *bindings.value, request_id, report.clone()));
+  }
+  return builder.build();
+}
+
+void test_delivery_burst_unrolls_repeated_request_ids() {
+  const auto bindings = kafka::detail::make_transport_bindings();
+  const Int request_id{17};
+  Value first = make_delivery_report(Str{"first"}, Int{1}, Str{"orders"},
+                                     KafkaDeliveryStatus::Delivered);
+  Value second = make_delivery_report(Str{"second"}, Int{2}, Str{"orders"},
+                                      KafkaDeliveryStatus::Delivered);
+  std::vector<std::optional<Value>> input;
+  input.emplace_back(
+      delivery_burst(bindings, request_id, {first.clone(), second.clone()}));
+
+  const auto output = eval_node<kafka::detail::DeliveryProjectionNode>(input);
+  require(output.size() >= 2 && output[0].has_value() && output[1].has_value(),
+          "same-id delivery reports did not unroll over two ticks");
+  const Value key{request_id};
+  const auto sequence_at = [&](std::size_t index) {
+    return output[index]
+        ->view()
+        .as_bundle()
+        .at("modified")
+        .as_map()
+        .at(key.view())
+        .as_bundle()
+        .at("sequence")
+        .checked_as<Int>();
+  };
+  require(sequence_at(0) == Int{1} && sequence_at(1) == Int{2},
+          "same-id delivery reports were conflated or reordered");
+}
+
 template <typename Fn> void require_invalid(Fn &&fn, std::string message) {
   bool rejected = false;
   try {
@@ -98,8 +146,7 @@ void capture_value(Wiring &w, Port<Schema> port, Value &observed,
       std::span<const WiringPortRef>{inputs}, Value{});
 }
 
-template <typename G>
-[[nodiscard]] GraphBuilder build_realtime_graph() {
+template <typename G> [[nodiscard]] GraphBuilder build_realtime_graph() {
   return build_graph<G>(WiringOptions{.is_realtime = true});
 }
 
@@ -210,12 +257,48 @@ private:
   std::size_t count_{};
 };
 
+class EvaluationGate {
+public:
+  void reset() {
+    std::lock_guard lock{mutex_};
+    blocked_ = false;
+    released_ = false;
+  }
+
+  void block() {
+    std::unique_lock lock{mutex_};
+    blocked_ = true;
+    changed_.notify_all();
+    changed_.wait(lock, [&] { return released_; });
+  }
+
+  [[nodiscard]] bool await_blocked(std::chrono::milliseconds timeout) {
+    std::unique_lock lock{mutex_};
+    return changed_.wait_for(lock, timeout, [&] { return blocked_; });
+  }
+
+  void release() {
+    {
+      std::lock_guard lock{mutex_};
+      released_ = true;
+    }
+    changed_.notify_all();
+  }
+
+private:
+  std::mutex mutex_{};
+  std::condition_variable changed_{};
+  bool blocked_{};
+  bool released_{};
+};
+
 inline SenderLatch subscription_key_sender{};
 inline SenderLatch subscription_commit_sender{};
 inline GenerationLatch subscription_generations{};
 inline CountLatch stale_commit_events{};
 inline CountLatch graph_lifetime_live{};
 inline CountLatch record_time_recovery_started{};
+inline EvaluationGate burst_subscription_gate{};
 
 inline Value service_config{};
 inline Value subscription_key{};
@@ -259,6 +342,7 @@ inline std::size_t multi_bounded_complete_count{};
 inline std::size_t multi_bounded_failed_count{};
 inline std::vector<Int> backlog_offsets{};
 inline std::vector<Str> backlog_events{};
+inline std::vector<std::pair<Int, DateTime>> burst_subscription_records{};
 inline bool ordered_ingress_complete{};
 inline Value bounded_event{};
 inline std::size_t bounded_event_count{};
@@ -305,6 +389,31 @@ struct EventBacklogCapture {
     backlog_events.push_back(
         event.base().value().as_bundle().at("category").checked_as<Str>());
     if (backlog_events.size() == 3) {
+      node.graph().executor().request_stop();
+    }
+  }
+};
+
+struct BurstSubscriptionCapture {
+  static constexpr auto name = "kafka_burst_subscription_capture";
+
+  static void
+  eval(NodeView node,
+       In<"subscription", KafkaSubscriptionOutput, InputValidity::Unchecked>
+           subscription) {
+    auto record = subscription.template field<"record">();
+    if (!record.valid() || !record.modified()) {
+      return;
+    }
+    const Int offset =
+        record.base().value().as_bundle().at("offset").checked_as<Int>();
+    if (offset == Int{99}) {
+      burst_subscription_gate.block();
+      return;
+    }
+    burst_subscription_records.emplace_back(offset,
+                                            node.graph().evaluation_time());
+    if (burst_subscription_records.size() == 3) {
       node.graph().executor().request_stop();
     }
   }
@@ -506,8 +615,8 @@ struct GraphLifetimeSubscriptionGraph {
     register_service(w, path, production_config.clone());
     auto key = wire<stdlib::const_, TS<KafkaSubscriptionKey>>(
         w, subscription_key.clone());
-    static_cast<void>(wire<GraphLifetimeSubscriptionCapture>(
-        w, subscribe(w, path, key)));
+    static_cast<void>(
+        wire<GraphLifetimeSubscriptionCapture>(w, subscribe(w, path, key)));
   }
 };
 
@@ -645,8 +754,8 @@ struct MultiBoundedSubscriptionGraph {
 
 [[nodiscard]] std::size_t count_nodes(const GraphBuilder &graph,
                                       NodeKind kind) {
-  return static_cast<std::size_t>(std::ranges::count_if(
-      graph.nodes(), [kind](const NodeBuilder &node) {
+  return static_cast<std::size_t>(
+      std::ranges::count_if(graph.nodes(), [kind](const NodeBuilder &node) {
         const auto *schema = node.type().schema();
         return schema != nullptr && schema->node_kind == kind;
       }));
@@ -654,8 +763,8 @@ struct MultiBoundedSubscriptionGraph {
 
 [[nodiscard]] const NodeTypeMetaData *
 find_node_schema(const GraphBuilder &graph, std::string_view name) {
-  const auto found = std::ranges::find_if(
-      graph.nodes(), [name](const NodeBuilder &node) {
+  const auto found =
+      std::ranges::find_if(graph.nodes(), [name](const NodeBuilder &node) {
         const auto *schema = node.type().schema();
         return schema != nullptr && schema->display_name != nullptr &&
                std::string_view{schema->display_name} == name;
@@ -666,19 +775,16 @@ find_node_schema(const GraphBuilder &graph, std::string_view name) {
 void test_runtime_specific_wiring_shapes() {
   Value saved_config = std::move(production_config);
   production_config = service_config.clone();
-  const auto restore_config = make_scope_exit([&] {
-    production_config = std::move(saved_config);
-  });
-  const auto realtime =
-      build_realtime_graph<BoundedSubscriptionGraph>();
+  const auto restore_config =
+      make_scope_exit([&] { production_config = std::move(saved_config); });
+  const auto realtime = build_realtime_graph<BoundedSubscriptionGraph>();
   require(count_nodes(realtime, NodeKind::PushSource) == 1,
           "real-time Kafka did not wire exactly one standard push source");
-  for (const auto name :
-       {std::string_view{"kafka_subscription_commands"},
-        std::string_view{"kafka_publish_commands"},
-        std::string_view{"kafka_commit_commands"},
-        std::string_view{"kafka_graph_delivery_commit"},
-        std::string_view{"kafka_subscription_projection"}}) {
+  for (const auto name : {std::string_view{"kafka_subscription_commands"},
+                          std::string_view{"kafka_publish_commands"},
+                          std::string_view{"kafka_commit_commands"},
+                          std::string_view{"kafka_graph_delivery_commit"},
+                          std::string_view{"kafka_subscription_projection"}}) {
     require(find_node_schema(realtime, name) != nullptr,
             "real-time Kafka wiring is missing " + Str{name});
   }
@@ -692,8 +798,7 @@ void test_runtime_specific_wiring_shapes() {
   require(replay != nullptr,
           "simulation Kafka did not wire graph-owned replay");
   require(find_node_schema(simulation,
-                           "kafka_simulation_subscription_commands") !=
-              nullptr,
+                           "kafka_simulation_subscription_commands") != nullptr,
           "simulation Kafka did not wire graph-side subscription commands");
   require(find_node_schema(simulation,
                            "kafka_simulation_subscription_projection") !=
@@ -730,8 +835,7 @@ struct OrderedIngressSubscriptionGraph {
     register_service(w, path, production_config.clone());
     auto key = wire<stdlib::const_, TS<KafkaSubscriptionKey>>(
         w, subscription_key.clone());
-    static_cast<void>(
-        wire<OrderedIngressCapture>(w, subscribe(w, path, key)));
+    static_cast<void>(wire<OrderedIngressCapture>(w, subscribe(w, path, key)));
   }
 };
 
@@ -923,6 +1027,23 @@ struct EventBacklogGraph {
   }
 };
 
+struct BurstSubscriptionGraph {
+  static constexpr auto name = "kafka_burst_subscription_test_graph";
+
+  static void compose(Wiring &w) {
+    const auto path = service::path("burst-subscription");
+    register_fake_service(w, path, service_config.clone(), backlog_broker);
+    auto first = wire<stdlib::const_, TS<KafkaSubscriptionKey>>(
+        w, subscription_key.clone());
+    auto second = wire<stdlib::const_, TS<KafkaSubscriptionKey>>(
+        w, independent_subscription_key.clone());
+    static_cast<void>(
+        wire<BurstSubscriptionCapture>(w, subscribe(w, path, first)));
+    static_cast<void>(
+        wire<BurstSubscriptionCapture>(w, subscribe(w, path, second)));
+  }
+};
+
 void initialize_values() {
   register_kafka_types();
   service_config =
@@ -958,19 +1079,30 @@ void release_test_state() noexcept {
   multi_publish_broker.reset();
   sharing_broker.reset();
   backlog_broker.reset();
+  burst_subscription_gate.release();
 
   for (Value *value : std::array{
-           &service_config,        &subscription_key,
-           &consumed_record,       &cursor,
-           &produced_record,       &event_value,
-           &production_config,     &independent_subscription_key,
+           &service_config,
+           &subscription_key,
+           &consumed_record,
+           &cursor,
+           &produced_record,
+           &event_value,
+           &production_config,
+           &independent_subscription_key,
            &secondary_subscription_key,
-           &subscription_observed, &delivery_observed,
-           &event_observed,        &engine_a_event,
-           &engine_b_event,        &production_delivery,
-           &multi_delivery_a,      &multi_delivery_b,
-           &production_record,     &production_cursor,
-           &first_commit_cursor,   &first_readded_cursor,
+           &subscription_observed,
+           &delivery_observed,
+           &event_observed,
+           &engine_a_event,
+           &engine_b_event,
+           &production_delivery,
+           &multi_delivery_a,
+           &multi_delivery_b,
+           &production_record,
+           &production_cursor,
+           &first_commit_cursor,
+           &first_readded_cursor,
            &bounded_event,
        }) {
     *value = Value{};
@@ -1262,7 +1394,8 @@ void test_multiple_publishers_and_dynamic_topics() {
 
 void test_subscription_sharing_is_explicit_and_duplicate_registration_fails() {
   sharing_broker = std::make_shared<FakeBroker>();
-  auto executor = start_realtime(build_realtime_graph<SubscriptionSharingGraph>());
+  auto executor =
+      start_realtime(build_realtime_graph<SubscriptionSharingGraph>());
   auto view = executor.view();
   AsyncGraphExecutorRun runner{view};
 
@@ -1314,7 +1447,8 @@ void test_push_backlogs_drain_one_value_per_graph_cycle() {
 
   backlog_broker = std::make_shared<FakeBroker>();
   backlog_events.clear();
-  auto event_executor = start_realtime(build_realtime_graph<EventBacklogGraph>());
+  auto event_executor =
+      start_realtime(build_realtime_graph<EventBacklogGraph>());
   auto event_view = event_executor.view();
   AsyncGraphExecutorRun event_runner{event_view};
   require(backlog_broker->wait_until_attached(2s),
@@ -1328,6 +1462,67 @@ void test_push_backlogs_drain_one_value_per_graph_cycle() {
   require(backlog_events ==
               std::vector<Str>{Str{"event-0"}, Str{"event-1"}, Str{"event-2"}},
           "event backlog was conflated, reordered, or lost");
+}
+
+void test_burst_distributes_subscriptions_and_unrolls_key_collisions() {
+  backlog_broker = std::make_shared<FakeBroker>();
+  burst_subscription_records.clear();
+  burst_subscription_gate.reset();
+
+  auto executor =
+      start_realtime(build_realtime_graph<BurstSubscriptionGraph>());
+  auto view = executor.view();
+  AsyncGraphExecutorRun runner{view};
+  const auto release_gate =
+      hgraph::make_scope_exit([] { burst_subscription_gate.release(); });
+
+  require(backlog_broker->wait_for_subscription_updates(1, 2s),
+          "burst subscriptions did not reach the transport sink");
+  backlog_broker->emit_subscription(
+      subscription_key.clone(),
+      make_record(Str{"orders-a"}, Int{0}, Int{99}, Bytes{"gate"}),
+      make_cursor(Str{"orders-risk"}, Int{1}, Str{"orders-a"}, Int{0}, Int{0}));
+  require(burst_subscription_gate.await_blocked(2s),
+          "burst subscription capture did not block");
+  backlog_broker->emit_subscription(
+      subscription_key.clone(),
+      make_record(Str{"orders-a"}, Int{0}, Int{10}, Bytes{"first"}),
+      make_cursor(Str{"orders-risk"}, Int{1}, Str{"orders-a"}, Int{0},
+                  Int{11}));
+  backlog_broker->emit_subscription(
+      independent_subscription_key.clone(),
+      make_record(Str{"orders-b"}, Int{0}, Int{20}, Bytes{"second"}),
+      make_cursor(Str{"orders-risk-independent"}, Int{1}, Str{"orders-b"},
+                  Int{0}, Int{21}));
+  backlog_broker->emit_subscription(
+      subscription_key.clone(),
+      make_record(Str{"orders-a"}, Int{0}, Int{11}, Bytes{"collision"}),
+      make_cursor(Str{"orders-risk"}, Int{1}, Str{"orders-a"}, Int{0},
+                  Int{12}));
+  burst_subscription_gate.release();
+  runner.join();
+
+  require(burst_subscription_records.size() == 3,
+          "burst subscription records were lost or conflated");
+  std::optional<DateTime> first_time;
+  std::optional<DateTime> independent_time;
+  std::optional<DateTime> collision_time;
+  for (const auto &[offset, evaluation_time] : burst_subscription_records) {
+    if (offset == Int{10}) {
+      first_time = evaluation_time;
+    } else if (offset == Int{20}) {
+      independent_time = evaluation_time;
+    } else if (offset == Int{11}) {
+      collision_time = evaluation_time;
+    }
+  }
+  require(first_time.has_value() && independent_time.has_value() &&
+              collision_time.has_value(),
+          "burst subscription records used unexpected offsets");
+  require(*first_time == *independent_time,
+          "distinct Kafka subscription keys did not tick together");
+  require(*collision_time == *first_time + MIN_TD,
+          "same Kafka subscription key was not unrolled next cycle");
 }
 
 void test_service_can_start_and_stop_repeatedly() {
@@ -1348,9 +1543,8 @@ void test_service_can_start_and_stop_repeatedly() {
 }
 
 void test_standard_ingress_accepts_before_the_graph_drains() {
-  service_config =
-      make_service_config({Str{"localhost:9092"}}, Str{"bounded-test"}, true,
-                          Int{1}, Int{1});
+  service_config = make_service_config(
+      {Str{"localhost:9092"}}, Str{"bounded-test"}, true, Int{1}, Int{1});
   subscription_broker = std::make_shared<FakeBroker>();
   subscription_observed = Value{};
   subscription_count = 0;
@@ -1394,8 +1588,9 @@ void test_librdkafka_standard_ingress_preserves_order() {
   bounded_offsets.clear();
   ordered_ingress_complete = false;
 
-  auto executor = start_realtime(build_realtime_graph<OrderedIngressSubscriptionGraph>(),
-                                 TimeDelta{20'000'000});
+  auto executor =
+      start_realtime(build_realtime_graph<OrderedIngressSubscriptionGraph>(),
+                     TimeDelta{20'000'000});
   auto view = executor.view();
   AsyncGraphExecutorRun runner{view};
   runner.join();
@@ -1486,7 +1681,8 @@ void test_librdkafka_publish_path() {
   production_delivery = Value{};
   production_delivery_count = 0;
 
-  auto executor = start_realtime(build_realtime_graph<ProductionPublishGraph>());
+  auto executor =
+      start_realtime(build_realtime_graph<ProductionPublishGraph>());
   auto view = executor.view();
   AsyncGraphExecutorRun runner{view};
   runner.join();
@@ -1530,7 +1726,8 @@ void test_librdkafka_delivery_failures_are_typed() {
     production_delivery = Value{};
     production_delivery_count = 0;
 
-    auto executor = start_realtime(build_realtime_graph<ProductionPublishGraph>());
+    auto executor =
+        start_realtime(build_realtime_graph<ProductionPublishGraph>());
     auto view = executor.view();
     AsyncGraphExecutorRun runner{view};
     runner.join();
@@ -1570,7 +1767,8 @@ void test_librdkafka_subscription_path() {
   production_record = Value{};
   production_cursor = Value{};
 
-  auto executor = start_realtime(build_realtime_graph<ProductionSubscriptionGraph>());
+  auto executor =
+      start_realtime(build_realtime_graph<ProductionSubscriptionGraph>());
   auto view = executor.view();
   AsyncGraphExecutorRun runner{view};
   runner.join();
@@ -1631,10 +1829,10 @@ void test_graph_lifetime_stop_remains_live_in_real_time() {
   runner.join();
 
   require(production_record.view()
-              .as_bundle()
-              .at("value")
-              .checked_as<Bytes>()
-              .data == "live",
+                  .as_bundle()
+                  .at("value")
+                  .checked_as<Bytes>()
+                  .data == "live",
           "graph-lifetime subscription stopped at the real-time snapshot");
   initialize_values();
 }
@@ -1658,7 +1856,8 @@ void test_permanent_consumer_failure_stops_the_graph() {
   bounded_event_count = 0;
 
   const auto started = std::chrono::steady_clock::now();
-  auto executor = start_realtime(build_realtime_graph<BoundedSubscriptionGraph>());
+  auto executor =
+      start_realtime(build_realtime_graph<BoundedSubscriptionGraph>());
   auto view = executor.view();
   AsyncGraphExecutorRun runner{view};
   runner.join();
@@ -1669,10 +1868,7 @@ void test_permanent_consumer_failure_stops_the_graph() {
           "permanent Kafka consumer failure did not publish an event");
   require(bundle_string(bounded_event, "category") == Str{"poll"},
           "permanent Kafka consumer failure used the wrong event category");
-  require(bounded_event.view()
-              .as_bundle()
-              .at("fatal")
-              .checked_as<Bool>(),
+  require(bounded_event.view().as_bundle().at("fatal").checked_as<Bool>(),
           "permanent Kafka consumer failure was not marked fatal");
 }
 
@@ -1700,7 +1896,8 @@ void test_typed_explicit_partition_boundaries() {
   bounded_event = Value{};
   bounded_event_count = 0;
 
-  auto executor = start_realtime(build_realtime_graph<BoundedSubscriptionGraph>());
+  auto executor =
+      start_realtime(build_realtime_graph<BoundedSubscriptionGraph>());
   auto view = executor.view();
   AsyncGraphExecutorRun runner{view};
   runner.join();
@@ -1729,7 +1926,8 @@ void test_latest_snapshot_is_empty() {
   bounded_offsets.clear();
   bounded_states.clear();
 
-  auto executor = start_realtime(build_realtime_graph<BoundedSubscriptionGraph>());
+  auto executor =
+      start_realtime(build_realtime_graph<BoundedSubscriptionGraph>());
   auto view = executor.view();
   AsyncGraphExecutorRun runner{view};
   runner.join();
@@ -1751,7 +1949,8 @@ void run_bounded_subscription(std::string_view context = {}) {
   bounded_evaluation_times.clear();
   bounded_event = Value{};
   bounded_event_count = 0;
-  auto executor = start_realtime(build_realtime_graph<BoundedSubscriptionGraph>());
+  auto executor =
+      start_realtime(build_realtime_graph<BoundedSubscriptionGraph>());
   auto view = executor.view();
   AsyncGraphExecutorRun runner{view};
   runner.join();
@@ -1843,8 +2042,8 @@ void test_subscription_removal_and_readd_uses_a_fresh_assignment_generation() {
   subscription_generations.reset();
   stale_commit_events.reset();
   first_readded_cursor = Value{};
-  auto executor = start_realtime(build_realtime_graph<ReaddedSubscriptionGraph>(),
-                                 TimeDelta{20'000'000});
+  auto executor = start_realtime(
+      build_realtime_graph<ReaddedSubscriptionGraph>(), TimeDelta{20'000'000});
   auto view = executor.view();
   AsyncGraphExecutorRun runner{view};
   auto sender = subscription_key_sender.await();
@@ -1952,10 +2151,11 @@ void test_committed_start_retries_coordinator_initialization() {
   cluster.create_topic(Str{"typed-coordinator-startup"});
   cluster.seed_record(Str{"typed-coordinator-startup"}, Bytes{"available"});
   cluster.fail_next_committed_offset_fetch(2);
-  production_config = hgraph::kafka::service_config()
-                          .bootstrap_servers({cluster.bootstrap_servers()})
-                          .client_id(Str{"typed-coordinator-startup-subscriber"})
-                          .build();
+  production_config =
+      hgraph::kafka::service_config()
+          .bootstrap_servers({cluster.bootstrap_servers()})
+          .client_id(Str{"typed-coordinator-startup-subscriber"})
+          .build();
   subscription_key =
       hgraph::kafka::subscription_key()
           .topics({Str{"typed-coordinator-startup"}})
@@ -2142,8 +2342,9 @@ void test_record_time_recovery_hands_off_before_live_records() {
   record_time_recovery_started.reset();
   recovery_live_records.clear();
 
-  auto executor = start_realtime(build_realtime_graph<RecordTimeRecoveryLiveGraph>(),
-                                 TimeDelta{8'000'000});
+  auto executor =
+      start_realtime(build_realtime_graph<RecordTimeRecoveryLiveGraph>(),
+                     TimeDelta{8'000'000});
   auto view = executor.view();
   AsyncGraphExecutorRun runner{view};
   require(record_time_recovery_started.await(1),
@@ -2216,8 +2417,9 @@ void test_record_time_recovery_waits_for_independent_subscriptions() {
   multi_bounded_complete_count = 0;
   multi_bounded_failed_count = 0;
 
-  auto executor = start_realtime(build_realtime_graph<MultiBoundedSubscriptionGraph>(),
-                                 TimeDelta{5'000'000});
+  auto executor =
+      start_realtime(build_realtime_graph<MultiBoundedSubscriptionGraph>(),
+                     TimeDelta{5'000'000});
   auto view = executor.view();
   AsyncGraphExecutorRun runner{view};
   runner.join();
@@ -2351,8 +2553,9 @@ void test_record_time_recovery_releases_a_failed_participant() {
   multi_bounded_complete_count = 0;
   multi_bounded_failed_count = 0;
 
-  auto executor = start_realtime(build_realtime_graph<MultiBoundedSubscriptionGraph>(),
-                                 TimeDelta{5'000'000});
+  auto executor =
+      start_realtime(build_realtime_graph<MultiBoundedSubscriptionGraph>(),
+                     TimeDelta{5'000'000});
   auto view = executor.view();
   AsyncGraphExecutorRun runner{view};
   runner.join();
@@ -2403,12 +2606,12 @@ void test_graph_lifetime_stop_is_bounded_in_simulation() {
                               graph_start, record_time + TimeDelta{1'000'000},
                               GraphExecutorMode::Simulation));
 
-  require(
-      bounded_payloads == std::vector<Str>{Str{"simulation-history"}},
-      "graph-lifetime simulation completed before record-time history became available");
-  require(
-      bounded_evaluation_times == std::vector<DateTime>{record_time},
-      "graph-lifetime simulation did not use Kafka record time as the historical graph time");
+  require(bounded_payloads == std::vector<Str>{Str{"simulation-history"}},
+          "graph-lifetime simulation completed before record-time history "
+          "became available");
+  require(bounded_evaluation_times == std::vector<DateTime>{record_time},
+          "graph-lifetime simulation did not use Kafka record time as the "
+          "historical graph time");
 }
 
 void test_multiple_simulation_subscriptions_replay_at_record_time() {
@@ -2481,14 +2684,13 @@ void test_multiple_simulation_subscriptions_replay_at_record_time() {
             "timestamp replay test produced an unexpected payload");
     const auto offset =
         static_cast<Int>(std::stoll(payload.substr(separator + 1)));
-    require(evaluation_time == record_time + offset * MIN_TD,
-            "multiple simulation subscriptions replayed '" + payload +
-                "' at " +
-                std::to_string(evaluation_time.time_since_epoch().count()) +
-                " instead of Kafka record timestamp " +
-                std::to_string((record_time + offset * MIN_TD)
-                                   .time_since_epoch()
-                                   .count()));
+    require(
+        evaluation_time == record_time + offset * MIN_TD,
+        "multiple simulation subscriptions replayed '" + payload + "' at " +
+            std::to_string(evaluation_time.time_since_epoch().count()) +
+            " instead of Kafka record timestamp " +
+            std::to_string(
+                (record_time + offset * MIN_TD).time_since_epoch().count()));
   }
   require(multi_bounded_complete_count == 2,
           "simulation did not complete both bounded subscriptions");
@@ -2521,7 +2723,8 @@ void test_real_broker_publish_subscribe_and_commit_round_trip() {
   production_delivery = Value{};
   production_delivery_count = 0;
 
-  auto publish_executor = start_realtime(build_realtime_graph<ProductionPublishGraph>());
+  auto publish_executor =
+      start_realtime(build_realtime_graph<ProductionPublishGraph>());
   auto publish_view = publish_executor.view();
   AsyncGraphExecutorRun publish_runner{publish_view};
   publish_runner.join();
@@ -2549,9 +2752,9 @@ void test_real_broker_publish_subscribe_and_commit_round_trip() {
   bounded_evaluation_times.clear();
   bounded_event = Value{};
   bounded_event_count = 0;
-  auto commit_executor = start_realtime(
-      build_realtime_graph<BoundedSubscriptionCommitGraph>(),
-      TimeDelta{20'000'000});
+  auto commit_executor =
+      start_realtime(build_realtime_graph<BoundedSubscriptionCommitGraph>(),
+                     TimeDelta{20'000'000});
   auto commit_view = commit_executor.view();
   AsyncGraphExecutorRun commit_runner{commit_view};
   commit_runner.join();
@@ -2580,8 +2783,8 @@ void test_real_broker_publish_subscribe_and_commit_round_trip() {
   bounded_evaluation_times.clear();
   bounded_event = Value{};
   bounded_event_count = 0;
-  auto verify_executor = start_realtime(build_realtime_graph<BoundedSubscriptionGraph>(),
-                                        TimeDelta{20'000'000});
+  auto verify_executor = start_realtime(
+      build_realtime_graph<BoundedSubscriptionGraph>(), TimeDelta{20'000'000});
   auto verify_view = verify_executor.view();
   AsyncGraphExecutorRun verify_runner{verify_view};
   verify_runner.join();
@@ -2602,6 +2805,7 @@ int main() {
   try {
     hgraph::stdlib::register_standard_operators();
     test_transport_sender_handles_graph_teardown();
+    test_delivery_burst_unrolls_repeated_request_ids();
     const auto release_state = hgraph::make_scope_exit(release_test_state);
     initialize_values();
     test_runtime_specific_wiring_shapes();
@@ -2612,6 +2816,7 @@ int main() {
     test_multiple_publishers_and_dynamic_topics();
     test_subscription_sharing_is_explicit_and_duplicate_registration_fails();
     test_push_backlogs_drain_one_value_per_graph_cycle();
+    test_burst_distributes_subscriptions_and_unrolls_key_collisions();
     test_service_can_start_and_stop_repeatedly();
     test_subscription_removal_and_readd_uses_a_fresh_assignment_generation();
     test_standard_ingress_accepts_before_the_graph_drains();

--- a/extensions/kafka/tests/test_service.cpp
+++ b/extensions/kafka/tests/test_service.cpp
@@ -89,7 +89,20 @@ struct DeliveryBurstProjectionGraph {
 
   static Port<TSD<Int, TS<KafkaDeliveryReport>>>
   compose(Wiring &w, Port<TS<kafka::detail::KafkaTransportEventBatch>> batch) {
-    return kafka::detail::wire_delivery_output(w, batch);
+    return kafka::detail::wire_service_outputs(
+               w, batch, kafka::detail::make_transport_bindings())
+        .deliveries;
+  }
+};
+
+struct MixedTransportEmitGraph {
+  static constexpr auto name = "kafka_mixed_transport_emit_test_graph";
+
+  static Port<kafka::detail::KafkaTransportStreams>
+  compose(Wiring &w, Port<TS<kafka::detail::KafkaTransportEventBatch>> batch) {
+    return wire<kafka::detail::KafkaTransportEmitNode>(
+               w, batch, kafka::detail::make_transport_bindings())
+        .template as<kafka::detail::KafkaTransportStreams>();
   }
 };
 
@@ -121,6 +134,88 @@ void test_delivery_burst_unrolls_repeated_request_ids() {
   };
   require(sequence_at(0) == Int{1} && sequence_at(1) == Int{2},
           "same-id delivery reports were conflated or reordered");
+}
+
+void test_mixed_burst_only_defers_colliding_service_keys() {
+  const auto bindings = kafka::detail::make_transport_bindings();
+  Value first_key = make_subscription_key(
+      {Str{"orders-a"}}, Str{"mixed-a"}, Str{"earliest"}, Str{"unbounded"},
+      KafkaCommitMode::Explicit, Str{"mixed-a"});
+  Value second_key = make_subscription_key(
+      {Str{"orders-b"}}, Str{"mixed-b"}, Str{"earliest"}, Str{"unbounded"},
+      KafkaCommitMode::Explicit, Str{"mixed-b"});
+  Value first_report = make_delivery_report(Str{"first"}, Int{1}, Str{"orders"},
+                                            KafkaDeliveryStatus::Delivered);
+  Value second_report = make_delivery_report(
+      Str{"second"}, Int{2}, Str{"orders"}, KafkaDeliveryStatus::Delivered);
+  Value independent_report =
+      make_delivery_report(Str{"independent"}, Int{3}, Str{"orders"},
+                           KafkaDeliveryStatus::Delivered);
+
+  ListBuilder burst{bindings.value->event,
+                    *scalar_descriptor<
+                        kafka::detail::KafkaTransportEventBatch>::value_meta()};
+  burst.push_back(kafka::detail::subscription_transport_event(
+      *bindings.value, first_key.clone(),
+      make_record(Str{"orders-a"}, Int{0}, Int{1}, Bytes{"first"}),
+      std::nullopt, KafkaSubscriptionState::Live));
+  burst.push_back(kafka::detail::subscription_transport_event(
+      *bindings.value, second_key.clone(),
+      make_record(Str{"orders-b"}, Int{0}, Int{2}, Bytes{"independent"}),
+      std::nullopt, KafkaSubscriptionState::Live));
+  burst.push_back(kafka::detail::subscription_transport_event(
+      *bindings.value, first_key.clone(),
+      make_record(Str{"orders-a"}, Int{0}, Int{3}, Bytes{"collision"}),
+      std::nullopt, KafkaSubscriptionState::Live));
+  burst.push_back(kafka::detail::delivery_transport_event(
+      *bindings.value, Int{17}, std::move(first_report)));
+  burst.push_back(kafka::detail::delivery_transport_event(
+      *bindings.value, Int{23}, std::move(independent_report)));
+  burst.push_back(kafka::detail::delivery_transport_event(
+      *bindings.value, Int{17}, std::move(second_report)));
+  burst.push_back(kafka::detail::service_transport_event(
+      *bindings.value, make_event(KafkaSeverity::Info, Str{"consumer"},
+                                  Str{"first"}, Str{"mixed"}, Str{"first"})));
+  burst.push_back(kafka::detail::service_transport_event(
+      *bindings.value, make_event(KafkaSeverity::Info, Str{"consumer"},
+                                  Str{"second"}, Str{"mixed"}, Str{"second"})));
+
+  std::vector<std::optional<Value>> input;
+  input.emplace_back(burst.build());
+  const auto output = eval_node<MixedTransportEmitGraph>(input);
+  require(output.size() >= 2 && output[0].has_value() && output[1].has_value(),
+          "mixed Kafka burst did not drain its collisions over two cycles");
+
+  const auto first = output[0]->view().as_bundle();
+  const auto first_subscriptions =
+      first.at("subscriptions").as_bundle().at("modified").as_map();
+  const auto first_deliveries =
+      first.at("deliveries").as_bundle().at("modified").as_map();
+  const Value first_delivery_key{Int{17}};
+  const Value independent_delivery_key{Int{23}};
+  require(first_subscriptions.contains(first_key.view()) &&
+              first_subscriptions.contains(second_key.view()),
+          "a subscription collision blocked an independent subscription");
+  require(first_deliveries.contains(first_delivery_key.view()) &&
+              first_deliveries.contains(independent_delivery_key.view()),
+          "a delivery collision blocked an independent delivery");
+  require(first.at("events").data() != nullptr,
+          "keyed collisions blocked the scalar service-event lane");
+
+  const auto second = output[1]->view().as_bundle();
+  const auto second_subscriptions =
+      second.at("subscriptions").as_bundle().at("modified").as_map();
+  const auto second_deliveries =
+      second.at("deliveries").as_bundle().at("modified").as_map();
+  require(second_subscriptions.size() == 1 &&
+              second_subscriptions.contains(first_key.view()),
+          "the colliding subscription was not deferred exactly one cycle");
+  const Value delivery_key{Int{17}};
+  require(second_deliveries.size() == 1 &&
+              second_deliveries.contains(delivery_key.view()),
+          "the colliding delivery was not deferred exactly one cycle");
+  require(second.at("events").data() != nullptr,
+          "the second scalar service event was not drained in FIFO order");
 }
 
 template <typename Fn> void require_invalid(Fn &&fn, std::string message) {
@@ -793,15 +888,18 @@ void test_runtime_specific_wiring_shapes() {
                           std::string_view{"kafka_publish_commands"},
                           std::string_view{"kafka_commit_commands"},
                           std::string_view{"kafka_graph_delivery_commit"},
-                          std::string_view{"kafka_subscription_projection"},
-                          std::string_view{"kafka_group_delivery_batch"},
-                          std::string_view{"collect_tsd_from_map"},
-                          std::string_view{"kafka_select_event_batch"}}) {
+                          std::string_view{"kafka_transport_emit"},
+                          std::string_view{"kafka_event_projection"}}) {
     require(find_node_schema(realtime, name) != nullptr,
             "real-time Kafka wiring is missing " + Str{name});
   }
   require(find_node_schema(realtime, "kafka_simulation_replay") == nullptr,
           "real-time Kafka unexpectedly wired simulation replay");
+  for (const auto legacy : {std::string_view{"kafka_group_delivery_batch"},
+                            std::string_view{"kafka_select_event_batch"}}) {
+    require(find_node_schema(realtime, legacy) == nullptr,
+            "real-time Kafka retained the private drain node " + Str{legacy});
+  }
 
   const auto simulation = build_graph<BoundedSubscriptionGraph>();
   require(count_nodes(simulation, NodeKind::PushSource) == 0,
@@ -812,10 +910,8 @@ void test_runtime_specific_wiring_shapes() {
   require(find_node_schema(simulation,
                            "kafka_simulation_subscription_commands") != nullptr,
           "simulation Kafka did not wire graph-side subscription commands");
-  require(find_node_schema(simulation,
-                           "kafka_simulation_subscription_projection") !=
-              nullptr,
-          "simulation Kafka did not wire graph-side subscription projection");
+  require(find_node_schema(simulation, "kafka_transport_emit") != nullptr,
+          "simulation Kafka did not wire the shared transport emit");
 }
 
 struct OrderedIngressCapture {
@@ -2820,6 +2916,7 @@ int main() {
     test_delivery_burst_unrolls_repeated_request_ids();
     const auto release_state = hgraph::make_scope_exit(release_test_state);
     initialize_values();
+    test_mixed_burst_only_defers_colliding_service_keys();
     test_runtime_specific_wiring_shapes();
     test_public_value_validation_and_producer_configuration();
     test_simulation_rejects_publish_and_commit_work();

--- a/extensions/kafka/tests/test_service.cpp
+++ b/extensions/kafka/tests/test_service.cpp
@@ -84,6 +84,15 @@ Value delivery_burst(
   return builder.build();
 }
 
+struct DeliveryBurstProjectionGraph {
+  static constexpr auto name = "kafka_delivery_burst_projection_test_graph";
+
+  static Port<TSD<Int, TS<KafkaDeliveryReport>>>
+  compose(Wiring &w, Port<TS<kafka::detail::KafkaTransportEventBatch>> batch) {
+    return kafka::detail::wire_delivery_output(w, batch);
+  }
+};
+
 void test_delivery_burst_unrolls_repeated_request_ids() {
   const auto bindings = kafka::detail::make_transport_bindings();
   const Int request_id{17};
@@ -95,7 +104,7 @@ void test_delivery_burst_unrolls_repeated_request_ids() {
   input.emplace_back(
       delivery_burst(bindings, request_id, {first.clone(), second.clone()}));
 
-  const auto output = eval_node<kafka::detail::DeliveryProjectionNode>(input);
+  const auto output = eval_node<DeliveryBurstProjectionGraph>(input);
   require(output.size() >= 2 && output[0].has_value() && output[1].has_value(),
           "same-id delivery reports did not unroll over two ticks");
   const Value key{request_id};
@@ -784,7 +793,10 @@ void test_runtime_specific_wiring_shapes() {
                           std::string_view{"kafka_publish_commands"},
                           std::string_view{"kafka_commit_commands"},
                           std::string_view{"kafka_graph_delivery_commit"},
-                          std::string_view{"kafka_subscription_projection"}}) {
+                          std::string_view{"kafka_subscription_projection"},
+                          std::string_view{"kafka_group_delivery_batch"},
+                          std::string_view{"collect_tsd_from_map"},
+                          std::string_view{"kafka_select_event_batch"}}) {
     require(find_node_schema(realtime, name) != nullptr,
             "real-time Kafka wiring is missing " + Str{name});
   }

--- a/extensions/web/CHANGELOG.md
+++ b/extensions/web/CHANGELOG.md
@@ -6,8 +6,9 @@
 - Service tier: one standard bounded burst push source per independently
   ordered logical channel, avoiding cross-channel head-of-line blocking while
   distributing distinct TSD keys together and preserving same-key/scalar FIFO;
-  graph-side projections and command
-  sinks; domain byte/reservation watermarks without a second value queue; the
+  graph-side stateless grouping followed by standard `collect`/mapped `emit`,
+  standard scalar `emit`, and command sinks; domain byte/reservation watermarks
+  released at graph handoff without a second value queue; the
   eleven service interfaces wired through
   `impl_input`/`impl_output`, wiring sugar, and the socketless
   `FakeWebServer`/`FakeWebClient` transports. Graph-owned subscription
@@ -18,6 +19,8 @@
   and route/server authenticators, and `hgraph_web.compat` — the released
   tornado adaptor API re-implemented on the native transports with its
   legacy behaviors reproduced only there (parity notes in the module).
+  Compatibility requests are keyed before route streams merge, preserving
+  concurrent requests matched by distinct routes in one burst cycle.
 - Live transports: the Asio/Beast server (h1.1 + WebSocket, TLS with the
   HTTP/2 ALPN seam, route trie, port-sharing listener registry, request
   timeouts, watermark read-pausing, strict stop ordering) and the libcurl

--- a/extensions/web/CHANGELOG.md
+++ b/extensions/web/CHANGELOG.md
@@ -3,9 +3,10 @@
 ## Unreleased
 
 - Initial extension skeleton (RFC 0024).
-- Service tier: one standard bounded push source per independently ordered
-  logical channel, avoiding cross-channel head-of-line blocking while
-  preserving FIFO within each channel; graph-side projections and command
+- Service tier: one standard bounded burst push source per independently
+  ordered logical channel, avoiding cross-channel head-of-line blocking while
+  distributing distinct TSD keys together and preserving same-key/scalar FIFO;
+  graph-side projections and command
   sinks; domain byte/reservation watermarks without a second value queue; the
   eleven service interfaces wired through
   `impl_input`/`impl_output`, wiring sugar, and the socketless

--- a/extensions/web/python/hgraph_web/compat.py
+++ b/extensions/web/python/hgraph_web/compat.py
@@ -134,6 +134,7 @@ from hgraph import (
     from_graph,
     graph,
     map_,
+    make_tsd,
     merge,
     register_adaptor,
     to_graph,
@@ -580,23 +581,19 @@ def _native_response(response: HttpResponse) -> WebHttpResponse:
     )
 
 
-# One node, not one per method plus a merge: the released request union is a
-# polymorphic bundle, and merging is expressed as a fixed list of its inputs,
-# which that union cannot be an element of.
+# Convert after route and method streams have been keyed. The released request
+# union is a polymorphic bundle, while its request id is the stable scalar key
+# that lets independent burst arrivals coexist in one graph cycle.
 @compute_node(valid=())
 def _to_compat_requests(
-    get: TS[WebHttpServerRequest],
-    post: TS[WebHttpServerRequest],
-    put: TS[WebHttpServerRequest],
-    delete: TS[WebHttpServerRequest],
+    served: TSD[int, TS[WebHttpServerRequest]],
     url: str,
     captures: int,
 ) -> TSD[int, TS[HttpRequest]]:
-    requests = {}
-    for served in (get, post, put, delete):
-        if served.modified:
-            value = served.value
-            requests[value.request_id] = _compat_request(value, url, captures)
+    requests = {
+        request_id: _compat_request(request.value, url, captures)
+        for request_id, request in served.modified_items()
+    }
     return requests or None
 
 
@@ -799,19 +796,27 @@ def _keyed_bundle_field_types(annotation) -> dict[str, _TsExpr] | None:
     }
 
 
-def _serve(route: _CompatRoute, method: HttpMethod, path: str, upgrade: bool = False):
-    """One request stream for a method across every pattern of ``route``.
-
-    The transport delivers one request per engine cycle across all routes, and
-    a path matches at most one of a route's patterns, so merging their streams
-    cannot lose a request.
-    """
-
-    served = [
+def _serve_streams(
+    route: _CompatRoute, method: HttpMethod, path: str, upgrade: bool = False
+):
+    del upgrade
+    return [
         web_serve(WebRoute(method, pattern), path=path)["request"]
         for pattern in route.patterns
     ]
-    return served[0] if len(served) == 1 else merge(*served)
+
+
+def _serve(route: _CompatRoute, method: HttpMethod, path: str, upgrade: bool = False):
+    """One keyed request stream for a method across every route pattern.
+
+    Burst ingress may deliver several distinct routes in one engine cycle.
+    Keying each route stream by the transport request id before merging keeps
+    those independent requests visible to the compatibility graph.
+    """
+
+    served = _serve_streams(route, method, path, upgrade)
+    keyed = [make_tsd(_server_request_id(request), request) for request in served]
+    return keyed[0] if len(keyed) == 1 else merge(*keyed, disjoint=True)
 
 
 def _serve_requests(url: str, route: _CompatRoute, path: str):
@@ -819,11 +824,13 @@ def _serve_requests(url: str, route: _CompatRoute, path: str):
 
     streams = [_serve(route, method, path) for method in _HANDLED_METHODS]
     for method in _REJECTED_METHODS:
-        request = _serve(route, method, path)
-        web_respond(
-            _server_request_id(request), _method_not_allowed(request), path=path
-        )
-    return _to_compat_requests(*streams, url=url, captures=route.captures)
+        for request in _serve_streams(route, method, path):
+            web_respond(
+                _server_request_id(request), _method_not_allowed(request), path=path
+            )
+    return _to_compat_requests(
+        merge(*streams, disjoint=True), url=url, captures=route.captures
+    )
 
 
 def _wire_responses(responses, path: str) -> None:

--- a/extensions/web/python/tests/test_compat.py
+++ b/extensions/web/python/tests/test_compat.py
@@ -245,6 +245,40 @@ def test_a_keyed_batch_handler_receives_and_answers_by_request_id(free_tcp_port)
     assert received[0].body == "payload"
 
 
+def test_distinct_route_requests_in_one_cycle_remain_keyed():
+    """Burst delivery must not collapse requests matched by separate patterns."""
+
+    bare = web.HttpServerRequest(
+        request_id=101,
+        connection_id=1,
+        stream_id=1,
+        request=web.HttpRequest(web.HttpMethod.GET, path="/rest"),
+        peer=web.WebPeer(),
+    )
+    captured = web.HttpServerRequest(
+        request_id=202,
+        connection_id=2,
+        stream_id=3,
+        request=web.HttpRequest(
+            web.HttpMethod.GET,
+            path="/rest/item",
+            path_params=(web.WebParam("arg0", "item"),),
+        ),
+        peer=web.WebPeer(),
+    )
+
+    [requests] = hg.eval_node(
+        compat._to_compat_requests,
+        [{101: bare, 202: captured}],
+        url="/rest/?(.*)",
+        captures=1,
+    )
+
+    assert set(requests) == {101, 202}
+    assert requests[101].url_parsed_args == ("",)
+    assert requests[202].url_parsed_args == ("item",)
+
+
 def test_a_keyed_auxiliary_output_stays_observable(free_tcp_port):
     audits = []
 

--- a/extensions/web/src/detail/service_transport.h
+++ b/extensions/web/src/detail/service_transport.h
@@ -17,16 +17,20 @@
 #include <compare>
 #include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <functional>
 #include <limits>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <ostream>
 #include <span>
 #include <stdexcept>
 #include <string_view>
-#include <typeindex>
 #include <type_traits>
+#include <typeindex>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 namespace hgraph::web::detail {
@@ -80,13 +84,13 @@ struct WatermarkConfig {
 };
 
 /**
- * Domain byte and reservation accounting for standard channel push sources.
+ * Domain byte and reservation accounting for bounded burst push sources.
  *
  * This object owns no Values and is not a second transport queue. Each core
- * push source owns its channel's record storage, admission and wake-up. The
- * web runtime uses this graph-scoped budget only to reserve payload bytes
- * before socket reads, retain per-channel watermarks, and guarantee control
- * headroom.
+ * push source owns its channel's cross-thread record storage, queue admission,
+ * and wake-up. The web runtime uses this graph-scoped budget only to reserve
+ * payload bytes before socket reads, account for graph-side same-key spill,
+ * retain per-channel watermarks, and guarantee control headroom.
  */
 template <std::size_t ChannelCount> class AdmissionBudget {
 public:
@@ -151,7 +155,8 @@ public:
     std::lock_guard lock{mutex_};
     auto &state = at(channel);
     if (!accepting_ ||
-        state.payload_records + state.reserved_records >= state.limits.records ||
+        state.payload_records + state.reserved_records >=
+            state.limits.records ||
         bytes > state.limits.bytes -
                     std::min(state.payload_bytes + state.reserved_bytes,
                              state.limits.bytes)) {
@@ -341,9 +346,8 @@ template <typename Budget> struct AdmissionHandle {
 
   friend bool operator==(const AdmissionHandle &,
                          const AdmissionHandle &) noexcept = default;
-  friend std::strong_ordering
-  operator<=>(const AdmissionHandle &lhs,
-              const AdmissionHandle &rhs) noexcept {
+  friend std::strong_ordering operator<=>(const AdmissionHandle &lhs,
+                                          const AdmissionHandle &rhs) noexcept {
     return reinterpret_cast<std::uintptr_t>(lhs.value.get()) <=>
            reinterpret_cast<std::uintptr_t>(rhs.value.get());
   }
@@ -377,10 +381,10 @@ make_server_admission(const Value &config) {
   const auto view = config.view();
   const auto ingress =
       limits_from(view, "ingress_record_limit", "ingress_byte_limit");
-  const auto ws_ingress = limits_from(
-      view, "ws_ingress_record_limit", "ws_ingress_byte_limit");
-  const auto outbound = limits_from(
-      view, "outbound_message_limit", "outbound_byte_limit");
+  const auto ws_ingress =
+      limits_from(view, "ws_ingress_record_limit", "ws_ingress_byte_limit");
+  const auto outbound =
+      limits_from(view, "outbound_message_limit", "outbound_byte_limit");
   const OutputLimits control{1024, kControlLaneBytes};
   return ServerAdmissionHandle{std::make_shared<ServerAdmission>(
       std::array<OutputLimits, index(ServerChannel::Count)>{
@@ -396,10 +400,10 @@ make_client_admission(const Value &config) {
   const auto view = config.view();
   const auto ingress =
       limits_from(view, "ingress_record_limit", "ingress_byte_limit");
-  const auto ws_ingress = limits_from(
-      view, "ws_ingress_record_limit", "ws_ingress_byte_limit");
-  const auto outbound = limits_from(
-      view, "outbound_record_limit", "outbound_byte_limit");
+  const auto ws_ingress =
+      limits_from(view, "ws_ingress_record_limit", "ws_ingress_byte_limit");
+  const auto outbound =
+      limits_from(view, "outbound_record_limit", "outbound_byte_limit");
   const OutputLimits control{1024, kControlLaneBytes};
   return ClientAdmissionHandle{std::make_shared<ClientAdmission>(
       std::array<OutputLimits, index(ClientChannel::Count)>{
@@ -435,9 +439,125 @@ struct WebTransportBindingsHandle {
   }
 };
 
+struct OwnedValueHash {
+  using is_transparent = void;
+
+  [[nodiscard]] std::size_t operator()(const Value &value) const {
+    return value.hash();
+  }
+
+  [[nodiscard]] std::size_t operator()(const ValueView &value) const {
+    return value.hash();
+  }
+};
+
+struct OwnedValueEqual {
+  using is_transparent = void;
+
+  [[nodiscard]] bool operator()(const Value &lhs, const Value &rhs) const {
+    return lhs.equals(rhs.view());
+  }
+
+  [[nodiscard]] bool operator()(const Value &lhs, const ValueView &rhs) const {
+    return lhs.equals(rhs);
+  }
+
+  [[nodiscard]] bool operator()(const ValueView &lhs, const Value &rhs) const {
+    return rhs.equals(lhs);
+  }
+};
+
+/** Graph-thread-only overflow retained after a burst contains more than one
+ * event for the same public TSD key, plus scalar events awaiting their own
+ * ticks. Distinct keys never enter this state. Keyed drain is O(P) per tick
+ * for P pending keys; scalar drain is O(1). Retained memory is O(C + S) for C
+ * same-key collisions and S scalar events. */
+class WebProjectionSchedule {
+public:
+  using EmittedKeys =
+      std::unordered_set<Value, OwnedValueHash, OwnedValueEqual>;
+
+  template <typename Apply>
+  void drain_keyed(EmittedKeys &emitted, Apply &&apply) {
+    for (auto entry = keyed_.begin(); entry != keyed_.end();) {
+      auto &queue = entry->second;
+      bool did_emit = false;
+      while (!queue.empty() && !did_emit) {
+        Value event = std::move(queue.front());
+        queue.pop_front();
+        did_emit = apply(event.view());
+      }
+      if (did_emit) {
+        emitted.emplace(entry->first.clone());
+      }
+      if (queue.empty()) {
+        entry = keyed_.erase(entry);
+      } else {
+        ++entry;
+      }
+    }
+  }
+
+  [[nodiscard]] static bool contains(const EmittedKeys &emitted,
+                                     const ValueView &key) {
+    return emitted.contains(key);
+  }
+
+  static void mark(EmittedKeys &emitted, const ValueView &key) {
+    emitted.emplace(key);
+  }
+
+  void defer(const ValueView &key, const ValueView &event) {
+    auto entry = keyed_.find(key);
+    if (entry == keyed_.end()) {
+      entry = keyed_.try_emplace(Value{key}).first;
+    }
+    entry->second.emplace_back(event);
+  }
+
+  [[nodiscard]] bool keyed_empty() const noexcept { return keyed_.empty(); }
+
+  void defer_scalar(const ValueView &event) { scalar_.emplace_back(event); }
+
+  [[nodiscard]] std::optional<Value> pop_scalar() {
+    if (scalar_.empty()) {
+      return std::nullopt;
+    }
+    Value event = std::move(scalar_.front());
+    scalar_.pop_front();
+    return event;
+  }
+
+  [[nodiscard]] bool scalar_empty() const noexcept { return scalar_.empty(); }
+
+private:
+  std::unordered_map<Value, std::deque<Value>, OwnedValueHash, OwnedValueEqual>
+      keyed_{};
+  std::deque<Value> scalar_{};
+};
+
+struct WebProjectionScheduleHandle {
+  std::shared_ptr<WebProjectionSchedule> value{};
+
+  friend bool
+  operator==(const WebProjectionScheduleHandle &,
+             const WebProjectionScheduleHandle &) noexcept = default;
+  friend std::strong_ordering
+  operator<=>(const WebProjectionScheduleHandle &lhs,
+              const WebProjectionScheduleHandle &rhs) noexcept {
+    return reinterpret_cast<std::uintptr_t>(lhs.value.get()) <=>
+           reinterpret_cast<std::uintptr_t>(rhs.value.get());
+  }
+};
+
 inline std::ostream &operator<<(std::ostream &stream,
                                 const WebTransportBindingsHandle &value) {
   return stream << "WebTransportBindingsHandle(" << value.value.get() << ')';
+}
+
+inline std::ostream &operator<<(std::ostream &stream,
+                                const WebProjectionScheduleHandle &value) {
+  return stream << "WebProjectionScheduleHandle(" << value.value.get() << ')';
 }
 
 [[nodiscard]] inline WebTransportBindingsHandle make_transport_bindings() {
@@ -466,10 +586,12 @@ inline std::ostream &operator<<(std::ostream &stream,
   return Value{binding, source};
 }
 
-[[nodiscard]] inline Value transport_event(
-    const WebTransportBindings &bindings, WebTransportEventKind kind,
-    std::string_view payload_name, Value payload, std::size_t channel,
-    std::size_t retained_bytes, bool control) {
+[[nodiscard]] inline Value transport_event(const WebTransportBindings &bindings,
+                                           WebTransportEventKind kind,
+                                           std::string_view payload_name,
+                                           Value payload, std::size_t channel,
+                                           std::size_t retained_bytes,
+                                           bool control) {
   BundleBuilder builder{bindings.event};
   builder.set("kind", transport_scalar(bindings.event_kind, &kind));
   builder.set(payload_name, std::move(payload));
@@ -499,12 +621,11 @@ public:
     if (!admission_.value->admit(channel, retained_bytes, control)) {
       return false;
     }
-    auto rollback = make_scope_exit<true>([&] {
-      admission_.value->release(channel, retained_bytes, control);
-    });
-    Value event = transport_event(*bindings_.value, kind, payload_name,
-                                  std::move(payload), channel, retained_bytes,
-                                  control);
+    auto rollback = make_scope_exit<true>(
+        [&] { admission_.value->release(channel, retained_bytes, control); });
+    Value event =
+        transport_event(*bindings_.value, kind, payload_name,
+                        std::move(payload), channel, retained_bytes, control);
     if (!senders_.at(channel).try_send(std::move(event))) {
       return false;
     }
@@ -512,20 +633,20 @@ public:
     return true;
   }
 
-  [[nodiscard]] bool send_reserved(
-      WebTransportEventKind kind, std::string_view payload_name, Value payload,
-      std::size_t channel, std::size_t retained_bytes,
-      std::size_t reserved_bytes) const {
+  [[nodiscard]] bool send_reserved(WebTransportEventKind kind,
+                                   std::string_view payload_name, Value payload,
+                                   std::size_t channel,
+                                   std::size_t retained_bytes,
+                                   std::size_t reserved_bytes) const {
     if (!admission_.value->admit_reserved(channel, retained_bytes,
                                           reserved_bytes)) {
       return false;
     }
-    auto rollback = make_scope_exit<true>([&] {
-      admission_.value->release(channel, retained_bytes, false);
-    });
-    Value event = transport_event(*bindings_.value, kind, payload_name,
-                                  std::move(payload), channel, retained_bytes,
-                                  false);
+    auto rollback = make_scope_exit<true>(
+        [&] { admission_.value->release(channel, retained_bytes, false); });
+    Value event =
+        transport_event(*bindings_.value, kind, payload_name,
+                        std::move(payload), channel, retained_bytes, false);
     if (!senders_.at(channel).try_send(std::move(event))) {
       return false;
     }
@@ -541,10 +662,10 @@ private:
 
 using ServerTransportOutput = TransportOutput<ServerAdmission>;
 using ClientTransportOutput = TransportOutput<ClientAdmission>;
-using ServerTransportPorts =
-    std::array<Port<TS<WebTransportEvent>>, ServerAdmission::channel_count>;
-using ClientTransportPorts =
-    std::array<Port<TS<WebTransportEvent>>, ClientAdmission::channel_count>;
+using ServerTransportPorts = std::array<Port<TS<WebTransportEventBatch>>,
+                                        ServerAdmission::channel_count>;
+using ClientTransportPorts = std::array<Port<TS<WebTransportEventBatch>>,
+                                        ClientAdmission::channel_count>;
 
 /** Materialises a generation for each active subscription lifetime. The
  * generation is graph data derived from the key-set delta and retained in the
@@ -571,66 +692,67 @@ template <typename Key> struct SubscriptionGenerationNode {
   }
 };
 
-[[nodiscard]] inline bool generation_matches(
-    const TSDInputView &generations, const ValueView &key,
-    const ValueView &generation) {
+[[nodiscard]] inline bool generation_matches(const TSDInputView &generations,
+                                             const ValueView &key,
+                                             const ValueView &generation) {
   if (generation.data() == nullptr) {
     return false;
   }
   const auto current = generations.at(key);
-  return current.valid() &&
-         current.value().checked_as<DateTime>() ==
-             generation.checked_as<DateTime>();
+  return current.valid() && current.value().checked_as<DateTime>() ==
+                                generation.checked_as<DateTime>();
 }
 
-/** Releases domain record/byte accounting once the graph dequeues an event.
- * Cost is O(1) per transport tick. */
-template <typename Handle> struct AdmissionReleaseSink {
-  static constexpr auto name = "web_transport_admission_release";
+/** Releases one transport event after its public output has been applied or
+ * the event has been discarded. Deferred same-key collisions remain admitted,
+ * so the configured web record/byte limits also bound graph-side spill.
+ * Cost is O(1) per consumed event. */
+template <typename Handle>
+void release_transport_event(const Handle &admission, const ValueView &event) {
+  const auto fields = event.as_bundle();
+  admission.value->release(
+      static_cast<std::size_t>(fields.at("channel").checked_as<Int>()),
+      static_cast<std::size_t>(fields.at("retained_bytes").checked_as<Int>()),
+      fields.at("control").checked_as<Bool>());
+}
 
-  static void eval(In<"transport", TS<WebTransportEvent>> transport,
-                   Scalar<"admission", Handle> admission) {
-    const auto fields = transport.base().value().as_bundle();
-    admission.value().value->release(
-        static_cast<std::size_t>(fields.at("channel").checked_as<Int>()),
-        static_cast<std::size_t>(
-            fields.at("retained_bytes").checked_as<Int>()),
-        fields.at("control").checked_as<Bool>());
-  }
-};
-
-/** Projects HTTP route lifecycle and request events. Cost is O(A + R) for
- * route additions/removals plus O(1) for one transport event. */
+/** Projects HTTP route lifecycle and request bursts. Distinct routes tick
+ * together; same-route collisions retain FIFO order over following cycles.
+ * Cost is O(A + R + B + P) per tick for route delta sizes A/R, burst size B,
+ * and P pending route keys. Retained memory is O(C) for deferred collisions. */
 struct ServerRequestProjectionNode {
   static constexpr auto name = "web_server_request_projection";
 
-  static void eval(
-      In<"transport", TS<WebTransportEvent>, InputValidity::Unchecked>
-          transport,
-      In<"routes", TSS<WebRoute>, InputValidity::Unchecked> routes,
-      In<"generations", TSD<WebRoute, TS<DateTime>>,
-         InputValidity::Unchecked> generations,
-      Scalar<"bindings", WebTransportBindingsHandle> bindings,
-      Out<TSD<WebRoute, WebRouteOutput>> out) {
-    const bool has_event = transport.modified();
+  static void start(State<WebProjectionScheduleHandle> state) {
+    state.set(
+        WebProjectionScheduleHandle{std::make_shared<WebProjectionSchedule>()});
+  }
+
+  static void
+  eval(In<"transport", TS<WebTransportEventBatch>, InputValidity::Unchecked>
+           transport,
+       In<"routes", TSS<WebRoute>, InputValidity::Unchecked> routes,
+       In<"generations", TSD<WebRoute, TS<DateTime>>, InputValidity::Unchecked>
+           generations,
+       Scalar<"admission", ServerAdmissionHandle> admission,
+       Scalar<"bindings", WebTransportBindingsHandle> bindings,
+       State<WebProjectionScheduleHandle> state, SingleShotScheduler scheduler,
+       Out<TSD<WebRoute, WebRouteOutput>> out) {
+    const bool has_batch = transport.modified();
+    auto schedule = state.get().value;
     const auto &route_delta = static_cast<const TSSInputView &>(routes);
     const auto removed = route_delta.removed();
-    if (!has_event && !routes.modified()) {
+    if (!has_batch && !routes.modified() && schedule->keyed_empty()) {
       return;
     }
     auto mutation = out.begin_mutation(out.evaluation_time());
-    if (has_event) {
-      const auto envelope = transport.base()
-                                .value()
-                                .as_bundle()
-                                .at("request")
-                                .as_bundle();
+    WebProjectionSchedule::EmittedKeys emitted;
+    const auto apply_envelope = [&](const auto &envelope) {
       if (generation_matches(static_cast<const TSDInputView &>(generations),
-                             envelope.at("route"),
-                             envelope.at("generation"))) {
+                             envelope.at("route"), envelope.at("generation"))) {
         BundleBuilder value{bindings.value().value->server_route_output};
-        for (const auto name : {std::string_view{"request"},
-                                std::string_view{"state"}}) {
+        for (const auto name :
+             {std::string_view{"request"}, std::string_view{"state"}}) {
           const auto field = envelope.at(name);
           if (field.data() != nullptr) {
             value.set(name, field.clone());
@@ -638,14 +760,39 @@ struct ServerRequestProjectionNode {
         }
         const Value update = value.build();
         mutation.set(envelope.at("route"), update.view());
+        return true;
       }
+      return false;
+    };
+    schedule->drain_keyed(emitted, [&](const ValueView &event) {
+      const bool applied =
+          apply_envelope(event.as_bundle().at("request").as_bundle());
+      release_transport_event(admission.value(), event);
+      return applied;
+    });
+    if (has_batch) {
+      for (const auto event : transport.base().value().as_list()) {
+        const auto envelope = event.as_bundle().at("request").as_bundle();
+        const auto key = envelope.at("route");
+        if (WebProjectionSchedule::contains(emitted, key)) {
+          schedule->defer(key, event);
+        } else {
+          if (apply_envelope(envelope)) {
+            WebProjectionSchedule::mark(emitted, key);
+          }
+          release_transport_event(admission.value(), event);
+        }
+      }
+    }
+    if (!schedule->keyed_empty()) {
+      scheduler.schedule(MIN_TD);
     }
     if (routes.modified()) {
       for (const auto route : route_delta.added()) {
         const WebRouteState state = WebRouteState::Serving;
         BundleBuilder value{bindings.value().value->server_route_output};
-        value.set("state", transport_scalar(
-                               bindings.value().value->route_state, &state));
+        value.set("state", transport_scalar(bindings.value().value->route_state,
+                                            &state));
         const Value update = value.build();
         mutation.set(route, update.view());
       }
@@ -658,35 +805,41 @@ struct ServerRequestProjectionNode {
   }
 };
 
-/** Projects WebSocket ingress and route removal. Cost is O(R) for removed
- * routes plus O(1) for one transport event. */
+/** Projects WebSocket ingress and route removal. Distinct routes tick
+ * together; same-route collisions retain FIFO order. Cost is O(R + B + P)
+ * per tick for R removals, burst size B, and P pending route keys. Retained
+ * memory is O(C) for deferred collisions. */
 struct ServerWsProjectionNode {
   static constexpr auto name = "web_server_ws_projection";
 
-  static void eval(
-      In<"transport", TS<WebTransportEvent>, InputValidity::Unchecked>
-          transport,
-      In<"routes", TSS<WebRoute>, InputValidity::Unchecked> routes,
-      In<"generations", TSD<WebRoute, TS<DateTime>>,
-         InputValidity::Unchecked> generations,
-      Scalar<"bindings", WebTransportBindingsHandle> bindings,
-      Out<TSD<WebRoute, WsRouteOutput>> out) {
-    const bool has_event = transport.modified();
+  static void start(State<WebProjectionScheduleHandle> state) {
+    state.set(
+        WebProjectionScheduleHandle{std::make_shared<WebProjectionSchedule>()});
+  }
+
+  static void
+  eval(In<"transport", TS<WebTransportEventBatch>, InputValidity::Unchecked>
+           transport,
+       In<"routes", TSS<WebRoute>, InputValidity::Unchecked> routes,
+       In<"generations", TSD<WebRoute, TS<DateTime>>, InputValidity::Unchecked>
+           generations,
+       Scalar<"admission", ServerAdmissionHandle> admission,
+       Scalar<"bindings", WebTransportBindingsHandle> bindings,
+       State<WebProjectionScheduleHandle> state, SingleShotScheduler scheduler,
+       Out<TSD<WebRoute, WsRouteOutput>> out) {
+    const bool has_batch = transport.modified();
+    auto schedule = state.get().value;
     const auto &route_delta = static_cast<const TSSInputView &>(routes);
     const auto removed = route_delta.removed();
-    if (!has_event && (!routes.modified() || removed.begin() == removed.end())) {
+    if (!has_batch && schedule->keyed_empty() &&
+        (!routes.modified() || removed.begin() == removed.end())) {
       return;
     }
     auto mutation = out.begin_mutation(out.evaluation_time());
-    if (has_event) {
-      const auto envelope = transport.base()
-                                .value()
-                                .as_bundle()
-                                .at("server_ws")
-                                .as_bundle();
+    WebProjectionSchedule::EmittedKeys emitted;
+    const auto apply_envelope = [&](const auto &envelope) {
       if (generation_matches(static_cast<const TSDInputView &>(generations),
-                             envelope.at("route"),
-                             envelope.at("generation"))) {
+                             envelope.at("route"), envelope.at("generation"))) {
         BundleBuilder value{bindings.value().value->server_ws_output};
         for (const auto name :
              {std::string_view{"event"}, std::string_view{"frame"}}) {
@@ -697,7 +850,32 @@ struct ServerWsProjectionNode {
         }
         const Value update = value.build();
         mutation.set(envelope.at("route"), update.view());
+        return true;
       }
+      return false;
+    };
+    schedule->drain_keyed(emitted, [&](const ValueView &event) {
+      const bool applied =
+          apply_envelope(event.as_bundle().at("server_ws").as_bundle());
+      release_transport_event(admission.value(), event);
+      return applied;
+    });
+    if (has_batch) {
+      for (const auto event : transport.base().value().as_list()) {
+        const auto envelope = event.as_bundle().at("server_ws").as_bundle();
+        const auto key = envelope.at("route");
+        if (WebProjectionSchedule::contains(emitted, key)) {
+          schedule->defer(key, event);
+        } else {
+          if (apply_envelope(envelope)) {
+            WebProjectionSchedule::mark(emitted, key);
+          }
+          release_transport_event(admission.value(), event);
+        }
+      }
+    }
+    if (!schedule->keyed_empty()) {
+      scheduler.schedule(MIN_TD);
     }
     if (routes.modified()) {
       for (const auto route : removed) {
@@ -707,102 +885,216 @@ struct ServerWsProjectionNode {
   }
 };
 
-/** Projects one delivery-report event. Cost is O(1) per transport tick. */
-struct DeliveryProjectionNode {
+/** Projects delivery-report bursts. Distinct request ids tick together;
+ * duplicate ids retain FIFO order. Cost is O(B + P) per tick for burst size B
+ * and P pending ids. Retained memory is O(C) for duplicate-id collisions. */
+template <typename Admission> struct DeliveryProjectionNode {
   static constexpr auto name = "web_delivery_projection";
 
-  static void eval(In<"transport", TS<WebTransportEvent>> transport,
-                   Out<TSD<Int, TS<WebDeliveryReport>>> out) {
-    const auto fields = transport.base().value().as_bundle();
-    const auto envelope = fields.at("delivery").as_bundle();
-    auto mutation = out.begin_mutation(out.evaluation_time());
-    mutation.set(envelope.at("request_id"), envelope.at("report"));
+  static void start(State<WebProjectionScheduleHandle> state) {
+    state.set(
+        WebProjectionScheduleHandle{std::make_shared<WebProjectionSchedule>()});
   }
-};
 
-/** Projects one service event and applies its stop policy on graph. Cost is
- * O(1) per transport tick. */
-struct EventProjectionNode {
-  static constexpr auto name = "web_event_projection";
-
-  static void eval(In<"transport", TS<WebTransportEvent>> transport,
-                   EngineControlView engine, Out<TS<WebEvent>> out) {
-    const auto fields = transport.base().value().as_bundle();
-    const auto envelope = fields.at("event").as_bundle();
-    out.apply(envelope.at("event"));
-    if (envelope.at("stop_graph").checked_as<Bool>()) {
-      engine.request_stop();
+  static void eval(In<"transport", TS<WebTransportEventBatch>> transport,
+                   Scalar<"admission", Admission> admission,
+                   State<WebProjectionScheduleHandle> state,
+                   SingleShotScheduler scheduler,
+                   Out<TSD<Int, TS<WebDeliveryReport>>> out) {
+    auto schedule = state.get().value;
+    auto mutation = out.begin_mutation(out.evaluation_time());
+    WebProjectionSchedule::EmittedKeys emitted;
+    const auto apply_event = [&](const ValueView &event) {
+      const auto envelope = event.as_bundle().at("delivery").as_bundle();
+      mutation.set(envelope.at("request_id"), envelope.at("report"));
+      return true;
+    };
+    schedule->drain_keyed(emitted, [&](const ValueView &event) {
+      const bool applied = apply_event(event);
+      release_transport_event(admission.value(), event);
+      return applied;
+    });
+    if (transport.modified()) {
+      for (const auto event : transport.base().value().as_list()) {
+        const auto key =
+            event.as_bundle().at("delivery").as_bundle().at("request_id");
+        if (WebProjectionSchedule::contains(emitted, key)) {
+          schedule->defer(key, event);
+        } else {
+          static_cast<void>(apply_event(event));
+          WebProjectionSchedule::mark(emitted, key);
+          release_transport_event(admission.value(), event);
+        }
+      }
+    }
+    if (!schedule->keyed_empty()) {
+      scheduler.schedule(MIN_TD);
     }
   }
 };
 
-/** Projects one statistics sample. Cost is O(1) per transport tick. */
-template <typename Stats> struct StatsProjectionNode {
+/** Projects service-event bursts and applies stop policy on graph. Scalar
+ * output requires FIFO unrolling: O(B) to admit a burst, O(1) to emit, and
+ * O(S) retained memory for S pending events. */
+template <typename Admission> struct EventProjectionNode {
+  static constexpr auto name = "web_event_projection";
+
+  static void start(State<WebProjectionScheduleHandle> state) {
+    state.set(
+        WebProjectionScheduleHandle{std::make_shared<WebProjectionSchedule>()});
+  }
+
+  static void eval(In<"transport", TS<WebTransportEventBatch>> transport,
+                   Scalar<"admission", Admission> admission,
+                   State<WebProjectionScheduleHandle> state,
+                   SingleShotScheduler scheduler, EngineControlView engine,
+                   Out<TS<WebEvent>> out) {
+    auto schedule = state.get().value;
+    bool emitted = false;
+    const auto apply_event = [&](const ValueView &event) {
+      const auto envelope = event.as_bundle().at("event").as_bundle();
+      out.apply(envelope.at("event"));
+      if (envelope.at("stop_graph").checked_as<Bool>()) {
+        engine.request_stop();
+      }
+      emitted = true;
+    };
+    if (auto pending = schedule->pop_scalar()) {
+      apply_event(pending->view());
+      release_transport_event(admission.value(), pending->view());
+    }
+    if (transport.modified()) {
+      for (const auto event : transport.base().value().as_list()) {
+        if (emitted) {
+          schedule->defer_scalar(event);
+        } else {
+          apply_event(event);
+          release_transport_event(admission.value(), event);
+        }
+      }
+    }
+    if (!schedule->scalar_empty()) {
+      scheduler.schedule(MIN_TD);
+    }
+  }
+};
+
+/** Projects the latest statistics sample in a burst. Statistics describe
+ * current state rather than an event-accurate stream, so older samples are
+ * superseded. Cost is O(1) per tick and retained memory is O(1). */
+template <typename Stats, typename Admission> struct StatsProjectionNode {
   static constexpr auto name = "web_stats_projection";
 
-  static void eval(In<"transport", TS<WebTransportEvent>> transport,
+  static void eval(In<"transport", TS<WebTransportEventBatch>> transport,
+                   Scalar<"admission", Admission> admission,
                    Out<TS<Stats>> out) {
-    const auto fields = transport.base().value().as_bundle();
+    const auto events = transport.base().value().as_list();
+    const auto fields = events.at(events.size() - 1).as_bundle();
     if constexpr (std::is_same_v<Stats, WebServerStats>) {
       out.apply(fields.at("server_stats"));
     } else {
       out.apply(fields.at("client_stats"));
     }
+    for (const auto event : events) {
+      release_transport_event(admission.value(), event);
+    }
   }
 };
 
-/** Projects one HTTP client result. Cost is O(1) per transport tick. */
+/** Projects HTTP client result bursts. Distinct request ids tick together;
+ * duplicate ids retain FIFO order. Cost is O(B + P) per tick for burst size B
+ * and P pending ids. Retained memory is O(C) for duplicate-id collisions. */
 struct ClientResponseProjectionNode {
   static constexpr auto name = "web_client_response_projection";
 
-  static void eval(In<"transport", TS<WebTransportEvent>> transport,
+  static void start(State<WebProjectionScheduleHandle> state) {
+    state.set(
+        WebProjectionScheduleHandle{std::make_shared<WebProjectionSchedule>()});
+  }
+
+  static void eval(In<"transport", TS<WebTransportEventBatch>> transport,
+                   Scalar<"admission", ClientAdmissionHandle> admission,
                    Scalar<"bindings", WebTransportBindingsHandle> bindings,
+                   State<WebProjectionScheduleHandle> state,
+                   SingleShotScheduler scheduler,
                    Out<TSD<Int, HttpCallResult>> out) {
-    const auto fields = transport.base().value().as_bundle();
-    const auto envelope = fields.at("response").as_bundle();
-    BundleBuilder value{bindings.value().value->client_call_result};
-    for (const auto name :
-         {std::string_view{"response"}, std::string_view{"failure"}}) {
-      const auto field = envelope.at(name);
-      if (field.data() != nullptr) {
-        value.set(name, field.clone());
+    auto schedule = state.get().value;
+    auto mutation = out.begin_mutation(out.evaluation_time());
+    WebProjectionSchedule::EmittedKeys emitted;
+    const auto apply_event = [&](const ValueView &event) {
+      const auto envelope = event.as_bundle().at("response").as_bundle();
+      BundleBuilder value{bindings.value().value->client_call_result};
+      for (const auto name :
+           {std::string_view{"response"}, std::string_view{"failure"}}) {
+        const auto field = envelope.at(name);
+        if (field.data() != nullptr) {
+          value.set(name, field.clone());
+        }
+      }
+      const Value update = value.build();
+      mutation.set(envelope.at("request_id"), update.view());
+      return true;
+    };
+    schedule->drain_keyed(emitted, [&](const ValueView &event) {
+      const bool applied = apply_event(event);
+      release_transport_event(admission.value(), event);
+      return applied;
+    });
+    if (transport.modified()) {
+      for (const auto event : transport.base().value().as_list()) {
+        const auto key =
+            event.as_bundle().at("response").as_bundle().at("request_id");
+        if (WebProjectionSchedule::contains(emitted, key)) {
+          schedule->defer(key, event);
+        } else {
+          static_cast<void>(apply_event(event));
+          WebProjectionSchedule::mark(emitted, key);
+          release_transport_event(admission.value(), event);
+        }
       }
     }
-    const Value update = value.build();
-    auto mutation = out.begin_mutation(out.evaluation_time());
-    mutation.set(envelope.at("request_id"), update.view());
+    if (!schedule->keyed_empty()) {
+      scheduler.schedule(MIN_TD);
+    }
   }
 };
 
-/** Projects WebSocket client ingress and key removal. Cost is O(R) for
- * removed keys plus O(1) for one transport event. */
+/** Projects WebSocket client ingress and key removal. Distinct subscription
+ * keys tick together; same-key collisions retain FIFO order. Cost is
+ * O(R + B + P) per tick for R removals, burst size B, and P pending keys.
+ * Retained memory is O(C) for deferred collisions. */
 struct ClientWsProjectionNode {
   static constexpr auto name = "web_client_ws_projection";
 
-  static void eval(
-      In<"transport", TS<WebTransportEvent>, InputValidity::Unchecked>
-          transport,
-      In<"keys", TSS<WsClientKey>, InputValidity::Unchecked> keys,
-      In<"generations", TSD<WsClientKey, TS<DateTime>>,
-         InputValidity::Unchecked> generations,
-      Scalar<"bindings", WebTransportBindingsHandle> bindings,
-      Out<TSD<WsClientKey, WsClientOutput>> out) {
-    const bool has_event = transport.modified();
+  static void start(State<WebProjectionScheduleHandle> state) {
+    state.set(
+        WebProjectionScheduleHandle{std::make_shared<WebProjectionSchedule>()});
+  }
+
+  static void
+  eval(In<"transport", TS<WebTransportEventBatch>, InputValidity::Unchecked>
+           transport,
+       In<"keys", TSS<WsClientKey>, InputValidity::Unchecked> keys,
+       In<"generations", TSD<WsClientKey, TS<DateTime>>,
+          InputValidity::Unchecked>
+           generations,
+       Scalar<"admission", ClientAdmissionHandle> admission,
+       Scalar<"bindings", WebTransportBindingsHandle> bindings,
+       State<WebProjectionScheduleHandle> state, SingleShotScheduler scheduler,
+       Out<TSD<WsClientKey, WsClientOutput>> out) {
+    const bool has_batch = transport.modified();
+    auto schedule = state.get().value;
     const auto &key_delta = static_cast<const TSSInputView &>(keys);
     const auto removed = key_delta.removed();
-    if (!has_event && (!keys.modified() || removed.begin() == removed.end())) {
+    if (!has_batch && schedule->keyed_empty() &&
+        (!keys.modified() || removed.begin() == removed.end())) {
       return;
     }
     auto mutation = out.begin_mutation(out.evaluation_time());
-    if (has_event) {
-      const auto envelope = transport.base()
-                                .value()
-                                .as_bundle()
-                                .at("client_ws")
-                                .as_bundle();
+    WebProjectionSchedule::EmittedKeys emitted;
+    const auto apply_envelope = [&](const auto &envelope) {
       if (generation_matches(static_cast<const TSDInputView &>(generations),
-                             envelope.at("key"),
-                             envelope.at("generation"))) {
+                             envelope.at("key"), envelope.at("generation"))) {
         BundleBuilder value{bindings.value().value->client_ws_output};
         for (const auto name :
              {std::string_view{"event"}, std::string_view{"frame"}}) {
@@ -813,7 +1105,32 @@ struct ClientWsProjectionNode {
         }
         const Value update = value.build();
         mutation.set(envelope.at("key"), update.view());
+        return true;
       }
+      return false;
+    };
+    schedule->drain_keyed(emitted, [&](const ValueView &event) {
+      const bool applied =
+          apply_envelope(event.as_bundle().at("client_ws").as_bundle());
+      release_transport_event(admission.value(), event);
+      return applied;
+    });
+    if (has_batch) {
+      for (const auto event : transport.base().value().as_list()) {
+        const auto envelope = event.as_bundle().at("client_ws").as_bundle();
+        const auto key = envelope.at("key");
+        if (WebProjectionSchedule::contains(emitted, key)) {
+          schedule->defer(key, event);
+        } else {
+          if (apply_envelope(envelope)) {
+            WebProjectionSchedule::mark(emitted, key);
+          }
+          release_transport_event(admission.value(), event);
+        }
+      }
+    }
+    if (!schedule->keyed_empty()) {
+      scheduler.schedule(MIN_TD);
     }
     if (keys.modified()) {
       for (const auto key : removed) {
@@ -838,29 +1155,26 @@ struct ServerOutputs {
     Port<TSD<WebRoute, TS<DateTime>>> http_generations,
     Port<TSD<WebRoute, TS<DateTime>>> ws_generations,
     ServerAdmissionHandle admission, WebTransportBindingsHandle bindings) {
-  for (const auto &channel : transport) {
-    static_cast<void>(wire<AdmissionReleaseSink<ServerAdmissionHandle>>(
-        w, channel, admission));
-  }
   return ServerOutputs{
       wire<ServerRequestProjectionNode>(
           w, transport[index(ServerChannel::Request)], http_routes,
-          http_generations, bindings)
+          http_generations, admission, bindings)
           .template as<TSD<WebRoute, WebRouteOutput>>(),
       wire<ServerWsProjectionNode>(
           w, transport[index(ServerChannel::WsIngress)], ws_routes,
-          ws_generations, bindings)
+          ws_generations, admission, bindings)
           .template as<TSD<WebRoute, WsRouteOutput>>(),
-      wire<DeliveryProjectionNode>(
-          w, transport[index(ServerChannel::RespondDelivery)])
+      wire<DeliveryProjectionNode<ServerAdmissionHandle>>(
+          w, transport[index(ServerChannel::RespondDelivery)], admission)
           .template as<TSD<Int, TS<WebDeliveryReport>>>(),
-      wire<DeliveryProjectionNode>(
-          w, transport[index(ServerChannel::WsSendDelivery)])
+      wire<DeliveryProjectionNode<ServerAdmissionHandle>>(
+          w, transport[index(ServerChannel::WsSendDelivery)], admission)
           .template as<TSD<Int, TS<WebDeliveryReport>>>(),
-      wire<EventProjectionNode>(w, transport[index(ServerChannel::Event)])
+      wire<EventProjectionNode<ServerAdmissionHandle>>(
+          w, transport[index(ServerChannel::Event)], admission)
           .template as<TS<WebEvent>>(),
-      wire<StatsProjectionNode<WebServerStats>>(
-          w, transport[index(ServerChannel::Stats)])
+      wire<StatsProjectionNode<WebServerStats, ServerAdmissionHandle>>(
+          w, transport[index(ServerChannel::Stats)], admission)
           .template as<TS<WebServerStats>>(),
   };
 }
@@ -873,36 +1187,34 @@ struct ClientOutputs {
   Port<TS<WebClientStats>> stats;
 };
 
-[[nodiscard]] inline ClientOutputs wire_client_outputs(
-    Wiring &w, const ClientTransportPorts &transport,
-    Port<TSS<WsClientKey>> ws_keys,
-    Port<TSD<WsClientKey, TS<DateTime>>> ws_generations,
-    ClientAdmissionHandle admission,
-    WebTransportBindingsHandle bindings) {
-  for (const auto &channel : transport) {
-    static_cast<void>(wire<AdmissionReleaseSink<ClientAdmissionHandle>>(
-        w, channel, admission));
-  }
+[[nodiscard]] inline ClientOutputs
+wire_client_outputs(Wiring &w, const ClientTransportPorts &transport,
+                    Port<TSS<WsClientKey>> ws_keys,
+                    Port<TSD<WsClientKey, TS<DateTime>>> ws_generations,
+                    ClientAdmissionHandle admission,
+                    WebTransportBindingsHandle bindings) {
   return ClientOutputs{
       wire<ClientResponseProjectionNode>(
-          w, transport[index(ClientChannel::Response)], bindings)
+          w, transport[index(ClientChannel::Response)], admission, bindings)
           .template as<TSD<Int, HttpCallResult>>(),
-      wire<ClientWsProjectionNode>(
-          w, transport[index(ClientChannel::WsIngress)], ws_keys,
-          ws_generations, bindings)
+      wire<ClientWsProjectionNode>(w,
+                                   transport[index(ClientChannel::WsIngress)],
+                                   ws_keys, ws_generations, admission, bindings)
           .template as<TSD<WsClientKey, WsClientOutput>>(),
-      wire<DeliveryProjectionNode>(
-          w, transport[index(ClientChannel::SendDelivery)])
+      wire<DeliveryProjectionNode<ClientAdmissionHandle>>(
+          w, transport[index(ClientChannel::SendDelivery)], admission)
           .template as<TSD<Int, TS<WebDeliveryReport>>>(),
-      wire<EventProjectionNode>(w, transport[index(ClientChannel::Event)])
+      wire<EventProjectionNode<ClientAdmissionHandle>>(
+          w, transport[index(ClientChannel::Event)], admission)
           .template as<TS<WebEvent>>(),
-      wire<StatsProjectionNode<WebClientStats>>(
-          w, transport[index(ClientChannel::Stats)])
+      wire<StatsProjectionNode<WebClientStats, ClientAdmissionHandle>>(
+          w, transport[index(ClientChannel::Stats)], admission)
           .template as<TS<WebClientStats>>(),
   };
 }
 
-template <typename Tag, std::size_t Channel> struct TransportSourceChannelTag {};
+template <typename Tag, std::size_t Channel>
+struct TransportSourceChannelTag {};
 
 template <typename Budget> class TransportSourceGroup {
 public:
@@ -913,8 +1225,8 @@ public:
                        std::function<void(const NodeView &)> on_stop)
       : on_start_{std::move(on_start)}, on_stop_{std::move(on_stop)} {}
 
-  void start(std::size_t channel, PushSourceSender sender,
-             const NodeView &node, DateTime evaluation_time) {
+  void start(std::size_t channel, PushSourceSender sender, const NodeView &node,
+             DateTime evaluation_time) {
     senders_.at(channel) = std::move(sender);
     if (channel + 1 != Budget::channel_count) {
       return;
@@ -942,69 +1254,73 @@ private:
 };
 
 template <typename Tag, typename Budget, std::size_t... Channel>
-[[nodiscard]] std::array<Port<TS<WebTransportEvent>>, Budget::channel_count>
+[[nodiscard]]
+std::array<Port<TS<WebTransportEventBatch>>, Budget::channel_count>
 wire_transport_sources_impl(
     Wiring &w, const AdmissionHandle<Budget> &admission,
     const std::shared_ptr<TransportSourceGroup<Budget>> &group,
     std::index_sequence<Channel...>) {
-  const auto *schema = ts_type<TS<WebTransportEvent>>();
-  return {Port<TS<WebTransportEvent>>{
-      w,
-      w.add_unique_node(
-          std::type_index(typeid(TransportSourceChannelTag<Tag, Channel>)),
-          make_push_source_node_with_view(
-              *schema,
-              make_push_source_queue_policy(
-                  *schema, admission.value->max_pending(Channel)),
-              PushSourceNodeExtension{
-                  .on_start = [group](PushSourceSender sender,
-                                      const NodeView &node,
-                                      DateTime evaluation_time) {
-                    group->start(Channel, std::move(sender), node,
-                                 evaluation_time);
-                  },
-                  .on_stop = [group](const NodeView &node) {
-                    group->stop(Channel, node);
-                  },
-              }),
-          std::span<const WiringPortRef>{}, Value{})}...};
+  const auto *schema = ts_type<TS<WebTransportEventBatch>>();
+  return {Port<TS<WebTransportEventBatch>>{
+      w, w.add_unique_node(
+             std::type_index(typeid(TransportSourceChannelTag<Tag, Channel>)),
+             make_push_source_node_with_view(
+                 *schema,
+                 make_push_source_burst_policy(
+                     *schema, admission.value->max_pending(Channel)),
+                 PushSourceNodeExtension{
+                     .on_start =
+                         [group](PushSourceSender sender, const NodeView &node,
+                                 DateTime evaluation_time) {
+                           group->start(Channel, std::move(sender), node,
+                                        evaluation_time);
+                         },
+                     .on_stop =
+                         [group](const NodeView &node) {
+                           group->stop(Channel, node);
+                         },
+                 }),
+             std::span<const WiringPortRef>{}, Value{})}...};
 }
 
 template <typename Tag, typename Budget>
-[[nodiscard]] std::array<Port<TS<WebTransportEvent>>, Budget::channel_count>
-wire_transport_sources(
-    Wiring &w, AdmissionHandle<Budget> admission,
-    typename TransportSourceGroup<Budget>::Start on_start,
-    std::function<void(const NodeView &)> on_stop) {
+[[nodiscard]]
+std::array<Port<TS<WebTransportEventBatch>>, Budget::channel_count>
+wire_transport_sources(Wiring &w, AdmissionHandle<Budget> admission,
+                       typename TransportSourceGroup<Budget>::Start on_start,
+                       std::function<void(const NodeView &)> on_stop) {
   auto group = std::make_shared<TransportSourceGroup<Budget>>(
       std::move(on_start), std::move(on_stop));
   return wire_transport_sources_impl<Tag>(
-      w, admission, group,
-      std::make_index_sequence<Budget::channel_count>{});
+      w, admission, group, std::make_index_sequence<Budget::channel_count>{});
 }
 
 } // namespace hgraph::web::detail
 
 namespace std {
-template <>
-struct hash<hgraph::web::detail::ServerAdmissionHandle> {
+template <> struct hash<hgraph::web::detail::ServerAdmissionHandle> {
   size_t operator()(
       const hgraph::web::detail::ServerAdmissionHandle &value) const noexcept {
     return hash<const void *>{}(value.value.get());
   }
 };
 
-template <>
-struct hash<hgraph::web::detail::ClientAdmissionHandle> {
+template <> struct hash<hgraph::web::detail::ClientAdmissionHandle> {
   size_t operator()(
       const hgraph::web::detail::ClientAdmissionHandle &value) const noexcept {
     return hash<const void *>{}(value.value.get());
   }
 };
 
-template <>
-struct hash<hgraph::web::detail::WebTransportBindingsHandle> {
+template <> struct hash<hgraph::web::detail::WebTransportBindingsHandle> {
   size_t operator()(const hgraph::web::detail::WebTransportBindingsHandle
+                        &value) const noexcept {
+    return hash<const void *>{}(value.value.get());
+  }
+};
+
+template <> struct hash<hgraph::web::detail::WebProjectionScheduleHandle> {
+  size_t operator()(const hgraph::web::detail::WebProjectionScheduleHandle
                         &value) const noexcept {
     return hash<const void *>{}(value.value.get());
   }
@@ -1025,6 +1341,11 @@ template <> struct scalar_name<web::detail::ClientAdmissionHandle> {
 template <> struct scalar_name<web::detail::WebTransportBindingsHandle> {
   static constexpr std::string_view value{
       "hgraph.web.internal::WebTransportBindingsHandle"};
+};
+
+template <> struct scalar_name<web::detail::WebProjectionScheduleHandle> {
+  static constexpr std::string_view value{
+      "hgraph.web.internal::WebProjectionScheduleHandle"};
 };
 } // namespace hgraph::static_schema_detail
 

--- a/extensions/web/src/detail/service_transport.h
+++ b/extensions/web/src/detail/service_transport.h
@@ -5,8 +5,12 @@
 
 #include "stream_model.h"
 
+#include <hgraph/lib/std/operators/container.h>
+#include <hgraph/lib/std/operators/conversion.h>
+#include <hgraph/lib/std/operators/higher_order.h>
 #include <hgraph/runtime/executor.h>
 #include <hgraph/runtime/push_source_node.h>
+#include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/static_node.h>
 #include <hgraph/types/value/value_builder.h>
@@ -17,12 +21,10 @@
 #include <compare>
 #include <cstddef>
 #include <cstdint>
-#include <deque>
 #include <functional>
 #include <limits>
 #include <memory>
 #include <mutex>
-#include <optional>
 #include <ostream>
 #include <span>
 #include <stdexcept>
@@ -30,8 +32,8 @@
 #include <type_traits>
 #include <typeindex>
 #include <unordered_map>
-#include <unordered_set>
 #include <utility>
+#include <vector>
 
 namespace hgraph::web::detail {
 
@@ -89,8 +91,8 @@ struct WatermarkConfig {
  * This object owns no Values and is not a second transport queue. Each core
  * push source owns its channel's cross-thread record storage, queue admission,
  * and wake-up. The web runtime uses this graph-scoped budget only to reserve
- * payload bytes before socket reads, account for graph-side same-key spill,
- * retain per-channel watermarks, and guarantee control headroom.
+ * payload bytes before socket reads, retain per-channel watermarks, and
+ * guarantee control headroom until the admitted burst enters graph processing.
  */
 template <std::size_t ChannelCount> class AdmissionBudget {
 public:
@@ -419,11 +421,6 @@ struct WebTransportBindings {
   ValueTypeRef event_kind{};
   ValueTypeRef integer{};
   ValueTypeRef boolean{};
-  ValueTypeRef route_state{};
-  ValueTypeRef server_route_output{};
-  ValueTypeRef server_ws_output{};
-  ValueTypeRef client_call_result{};
-  ValueTypeRef client_ws_output{};
 };
 
 struct WebTransportBindingsHandle {
@@ -467,87 +464,18 @@ struct OwnedValueEqual {
   }
 };
 
-/** Graph-thread-only overflow retained after a burst contains more than one
- * event for the same public TSD key, plus scalar events awaiting their own
- * ticks. Distinct keys never enter this state. Keyed drain is O(P) per tick
- * for P pending keys; scalar drain is O(1). Retained memory is O(C + S) for C
- * same-key collisions and S scalar events. */
-class WebProjectionSchedule {
-public:
-  using EmittedKeys =
-      std::unordered_set<Value, OwnedValueHash, OwnedValueEqual>;
+/** Wiring-fixed value bindings used by the one graph-side grouping primitive.
+ * The node performs only O(B) transient classification. Standard collect,
+ * map_, and emit nodes own all state used to unroll same-key collisions. */
+struct WebKeyedBatchBindings {
+  ValueTypeRef key{};
+  ValueTypeRef event{};
+  ValueTypeRef event_batch{};
+  ValueTypeRef sequenced_batch{};
+  ValueTypeRef batch_map{};
 
-  template <typename Apply>
-  void drain_keyed(EmittedKeys &emitted, Apply &&apply) {
-    for (auto entry = keyed_.begin(); entry != keyed_.end();) {
-      auto &queue = entry->second;
-      bool did_emit = false;
-      while (!queue.empty() && !did_emit) {
-        Value event = std::move(queue.front());
-        queue.pop_front();
-        did_emit = apply(event.view());
-      }
-      if (did_emit) {
-        emitted.emplace(entry->first.clone());
-      }
-      if (queue.empty()) {
-        entry = keyed_.erase(entry);
-      } else {
-        ++entry;
-      }
-    }
-  }
-
-  [[nodiscard]] static bool contains(const EmittedKeys &emitted,
-                                     const ValueView &key) {
-    return emitted.contains(key);
-  }
-
-  static void mark(EmittedKeys &emitted, const ValueView &key) {
-    emitted.emplace(key);
-  }
-
-  void defer(const ValueView &key, const ValueView &event) {
-    auto entry = keyed_.find(key);
-    if (entry == keyed_.end()) {
-      entry = keyed_.try_emplace(Value{key}).first;
-    }
-    entry->second.emplace_back(event);
-  }
-
-  [[nodiscard]] bool keyed_empty() const noexcept { return keyed_.empty(); }
-
-  void defer_scalar(const ValueView &event) { scalar_.emplace_back(event); }
-
-  [[nodiscard]] std::optional<Value> pop_scalar() {
-    if (scalar_.empty()) {
-      return std::nullopt;
-    }
-    Value event = std::move(scalar_.front());
-    scalar_.pop_front();
-    return event;
-  }
-
-  [[nodiscard]] bool scalar_empty() const noexcept { return scalar_.empty(); }
-
-private:
-  std::unordered_map<Value, std::deque<Value>, OwnedValueHash, OwnedValueEqual>
-      keyed_{};
-  std::deque<Value> scalar_{};
-};
-
-struct WebProjectionScheduleHandle {
-  std::shared_ptr<WebProjectionSchedule> value{};
-
-  friend bool
-  operator==(const WebProjectionScheduleHandle &,
-             const WebProjectionScheduleHandle &) noexcept = default;
-  friend std::strong_ordering
-  operator<=>(const WebProjectionScheduleHandle &lhs,
-              const WebProjectionScheduleHandle &rhs) noexcept {
-    return reinterpret_cast<std::uintptr_t>(lhs.value.get()) <=>
-           reinterpret_cast<std::uintptr_t>(rhs.value.get());
-  }
+  friend bool operator==(const WebKeyedBatchBindings &,
+                         const WebKeyedBatchBindings &) noexcept = default;
 };
 
 inline std::ostream &operator<<(std::ostream &stream,
@@ -556,8 +484,8 @@ inline std::ostream &operator<<(std::ostream &stream,
 }
 
 inline std::ostream &operator<<(std::ostream &stream,
-                                const WebProjectionScheduleHandle &value) {
-  return stream << "WebProjectionScheduleHandle(" << value.value.get() << ')';
+                                const WebKeyedBatchBindings &value) {
+  return stream << "WebKeyedBatchBindings(" << value.batch_map.schema() << ')';
 }
 
 [[nodiscard]] inline WebTransportBindingsHandle make_transport_bindings() {
@@ -569,15 +497,6 @@ inline std::ostream &operator<<(std::ostream &stream,
               scalar_descriptor<WebTransportEventKind>::value_meta()),
           factory.type_for(scalar_descriptor<Int>::value_meta()),
           factory.type_for(scalar_descriptor<Bool>::value_meta()),
-          factory.type_for(scalar_descriptor<WebRouteState>::value_meta()),
-          factory.type_for(
-              schema_descriptor<WebRouteOutput>::ts_meta()->value_schema),
-          factory.type_for(
-              schema_descriptor<WsRouteOutput>::ts_meta()->value_schema),
-          factory.type_for(
-              schema_descriptor<HttpCallResult>::ts_meta()->value_schema),
-          factory.type_for(
-              schema_descriptor<WsClientOutput>::ts_meta()->value_schema),
       })};
 }
 
@@ -692,451 +611,335 @@ template <typename Key> struct SubscriptionGenerationNode {
   }
 };
 
-[[nodiscard]] inline bool generation_matches(const TSDInputView &generations,
-                                             const ValueView &key,
-                                             const ValueView &generation) {
-  if (generation.data() == nullptr) {
-    return false;
-  }
-  const auto current = generations.at(key);
-  return current.valid() && current.value().checked_as<DateTime>() ==
-                                generation.checked_as<DateTime>();
-}
+/** Releases the domain admission for a burst once the standard push source has
+ * handed it to graph processing. Protocol completion remains a later sink-node
+ * concern. Cost is O(B) per burst and retained memory is O(1). */
+template <typename Handle> struct ReleaseTransportBatchSink {
+  static constexpr auto name = "web_release_transport_batch";
 
-/** Releases one transport event after its public output has been applied or
- * the event has been discarded. Deferred same-key collisions remain admitted,
- * so the configured web record/byte limits also bound graph-side spill.
- * Cost is O(1) per consumed event. */
-template <typename Handle>
-void release_transport_event(const Handle &admission, const ValueView &event) {
-  const auto fields = event.as_bundle();
-  admission.value->release(
-      static_cast<std::size_t>(fields.at("channel").checked_as<Int>()),
-      static_cast<std::size_t>(fields.at("retained_bytes").checked_as<Int>()),
-      fields.at("control").checked_as<Bool>());
-}
-
-/** Projects HTTP route lifecycle and request bursts. Distinct routes tick
- * together; same-route collisions retain FIFO order over following cycles.
- * Cost is O(A + R + B + P) per tick for route delta sizes A/R, burst size B,
- * and P pending route keys. Retained memory is O(C) for deferred collisions. */
-struct ServerRequestProjectionNode {
-  static constexpr auto name = "web_server_request_projection";
-
-  static void start(State<WebProjectionScheduleHandle> state) {
-    state.set(
-        WebProjectionScheduleHandle{std::make_shared<WebProjectionSchedule>()});
-  }
-
-  static void
-  eval(In<"transport", TS<WebTransportEventBatch>, InputValidity::Unchecked>
-           transport,
-       In<"routes", TSS<WebRoute>, InputValidity::Unchecked> routes,
-       In<"generations", TSD<WebRoute, TS<DateTime>>, InputValidity::Unchecked>
-           generations,
-       Scalar<"admission", ServerAdmissionHandle> admission,
-       Scalar<"bindings", WebTransportBindingsHandle> bindings,
-       State<WebProjectionScheduleHandle> state, SingleShotScheduler scheduler,
-       Out<TSD<WebRoute, WebRouteOutput>> out) {
-    const bool has_batch = transport.modified();
-    auto schedule = state.get().value;
-    const auto &route_delta = static_cast<const TSSInputView &>(routes);
-    const auto removed = route_delta.removed();
-    if (!has_batch && !routes.modified() && schedule->keyed_empty()) {
-      return;
-    }
-    auto mutation = out.begin_mutation(out.evaluation_time());
-    WebProjectionSchedule::EmittedKeys emitted;
-    const auto apply_envelope = [&](const auto &envelope) {
-      if (generation_matches(static_cast<const TSDInputView &>(generations),
-                             envelope.at("route"), envelope.at("generation"))) {
-        BundleBuilder value{bindings.value().value->server_route_output};
-        for (const auto name :
-             {std::string_view{"request"}, std::string_view{"state"}}) {
-          const auto field = envelope.at(name);
-          if (field.data() != nullptr) {
-            value.set(name, field.clone());
-          }
-        }
-        const Value update = value.build();
-        mutation.set(envelope.at("route"), update.view());
-        return true;
-      }
-      return false;
-    };
-    schedule->drain_keyed(emitted, [&](const ValueView &event) {
-      const bool applied =
-          apply_envelope(event.as_bundle().at("request").as_bundle());
-      release_transport_event(admission.value(), event);
-      return applied;
-    });
-    if (has_batch) {
-      for (const auto event : transport.base().value().as_list()) {
-        const auto envelope = event.as_bundle().at("request").as_bundle();
-        const auto key = envelope.at("route");
-        if (WebProjectionSchedule::contains(emitted, key)) {
-          schedule->defer(key, event);
-        } else {
-          if (apply_envelope(envelope)) {
-            WebProjectionSchedule::mark(emitted, key);
-          }
-          release_transport_event(admission.value(), event);
-        }
-      }
-    }
-    if (!schedule->keyed_empty()) {
-      scheduler.schedule(MIN_TD);
-    }
-    if (routes.modified()) {
-      for (const auto route : route_delta.added()) {
-        const WebRouteState state = WebRouteState::Serving;
-        BundleBuilder value{bindings.value().value->server_route_output};
-        value.set("state", transport_scalar(bindings.value().value->route_state,
-                                            &state));
-        const Value update = value.build();
-        mutation.set(route, update.view());
-      }
-      // Push sources run before ordinary nodes. If the last admitted event and
-      // a graph-side route removal meet in one cycle, the later removal wins.
-      for (const auto route : removed) {
-        static_cast<void>(mutation.erase(route));
-      }
+  static void eval(In<"transport", TS<WebTransportEventBatch>> transport,
+                   Scalar<"admission", Handle> admission) {
+    for (const auto event : transport.base().value().as_list()) {
+      const auto fields = event.as_bundle();
+      admission.value().value->release(
+          static_cast<std::size_t>(fields.at("channel").checked_as<Int>()),
+          static_cast<std::size_t>(
+              fields.at("retained_bytes").checked_as<Int>()),
+          fields.at("control").checked_as<Bool>());
     }
   }
 };
 
-/** Projects WebSocket ingress and route removal. Distinct routes tick
- * together; same-route collisions retain FIFO order. Cost is O(R + B + P)
- * per tick for R removals, burst size B, and P pending route keys. Retained
- * memory is O(C) for deferred collisions. */
+/** Groups one burst by its public TSD key. This is the only web-specific
+ * collection primitive: it performs O(B) average work and O(B) transient
+ * memory per burst. Standard collect retains the latest per-key batch and a
+ * mapped standard emit supplies FIFO unrolling independently for every key. */
+template <typename Key, fixed_string PayloadField, fixed_string KeyField>
+struct GroupTransportBatchNode {
+  static constexpr auto name = "web_group_transport_batch";
+
+  static void start(State<WebKeyedBatchBindings> bindings) {
+    const auto key = value_type_for_active_realization(
+        scalar_descriptor<Key>::value_meta());
+    const auto event = value_type_for_active_realization(
+        scalar_descriptor<WebTransportEvent>::value_meta());
+    const auto *event_batch_meta =
+        scalar_descriptor<WebTransportEventBatch>::value_meta();
+    const auto event_batch = compact_list_type(event, *event_batch_meta);
+    const auto sequenced_batch = value_type_for_active_realization(
+        scalar_descriptor<SequencedWebTransportBatch>::value_meta());
+    bindings.set(WebKeyedBatchBindings{
+        .key = key,
+        .event = event,
+        .event_batch = event_batch,
+        .sequenced_batch = sequenced_batch,
+        .batch_map = compact_map_type(key, sequenced_batch),
+    });
+  }
+
+  static void eval(In<"transport", TS<WebTransportEventBatch>> transport,
+                   State<WebKeyedBatchBindings> bindings,
+                   Out<TS<KeyedWebTransportBatches<Key>>> out) {
+    using EventsByKey = std::unordered_map<Value, std::vector<std::size_t>,
+                                           OwnedValueHash, OwnedValueEqual>;
+    EventsByKey grouped;
+    const auto events = transport.base().value().as_list();
+    grouped.reserve(events.size());
+    for (std::size_t index = 0; index != events.size(); ++index) {
+      const auto event = events.at(index);
+      const auto envelope =
+          event.as_bundle().at(PayloadField.sv()).as_bundle();
+      const auto key = envelope.at(KeyField.sv());
+      auto entry = grouped.find(key);
+      if (entry == grouped.end()) {
+        entry = grouped.try_emplace(Value{key}).first;
+      }
+      entry->second.push_back(index);
+    }
+
+    const auto &resolved = bindings.ref();
+    const auto *event_batch_meta =
+        scalar_descriptor<WebTransportEventBatch>::value_meta();
+    MapBuilder batches{resolved.key, resolved.sequenced_batch};
+    for (const auto &[key, grouped_events] : grouped) {
+      ListBuilder event_batch{resolved.event, *event_batch_meta};
+      for (const auto index : grouped_events) {
+        event_batch.push_back(events.at(index));
+      }
+      ListStorage event_storage = event_batch.build_storage();
+      Value event_value{resolved.event_batch, &event_storage};
+      BundleBuilder batch{resolved.sequenced_batch};
+      batch.set("sequence", Value{out.evaluation_time()});
+      batch.set("events", std::move(event_value));
+      batches.set_item(key.view(), batch.build().view());
+    }
+    MapStorage batch_storage = batches.build_storage();
+    out.apply(ValueView{resolved.batch_map, &batch_storage});
+  }
+};
+
+template <typename Key, typename GroupNode>
+[[nodiscard]] Port<TSD<Key, TS<SequencedWebTransportBatch>>>
+wire_keyed_transport_batches(Wiring &w,
+                             Port<TS<WebTransportEventBatch>> transport) {
+  auto grouped = wire<GroupNode>(w, transport)
+                     .template as<TS<KeyedWebTransportBatches<Key>>>();
+  return wire<stdlib::collect,
+              TSD<Key, TS<SequencedWebTransportBatch>>>(w, grouped);
+}
+
+[[nodiscard]] inline Port<TS<WebTransportEvent>>
+wire_unrolled_transport_event(Wiring &w,
+                              Port<TS<SequencedWebTransportBatch>> batch) {
+  auto events = wire<stdlib::getattr_, TS<WebTransportEventBatch>>(
+      w, batch, Str{"events"});
+  return wire<stdlib::emit>(w, events).template as<TS<WebTransportEvent>>();
+}
+
+using ServerRequestBatchNode =
+    GroupTransportBatchNode<WebRoute, "request", "route">;
+using ServerWsBatchNode =
+    GroupTransportBatchNode<WebRoute, "server_ws", "route">;
+using DeliveryBatchNode =
+    GroupTransportBatchNode<Int, "delivery", "request_id">;
+using ClientResponseBatchNode =
+    GroupTransportBatchNode<Int, "response", "request_id">;
+using ClientWsBatchNode =
+    GroupTransportBatchNode<WsClientKey, "client_ws", "key">;
+
+/** Projects one request event. Route lifetime and same-route FIFO ownership
+ * are supplied by map_ and emit respectively, so this node retains no state. */
+struct ServerRequestProjectionNode {
+  static constexpr auto name = "web_server_request_projection";
+  static constexpr bool schedule_on_start = true;
+
+  static void eval(
+      In<"event", TS<WebTransportEvent>, InputValidity::Unchecked> event,
+      In<"generation", TS<DateTime>, InputValidity::Unchecked> generation,
+      Out<WebRouteOutput> out) {
+    auto state = out.template field<"state">();
+    if (!state.valid()) {
+      state.set(WebRouteState::Serving);
+    }
+    if (!event.modified() || !event.valid() || !generation.valid()) {
+      return;
+    }
+    const auto envelope =
+        event.base().value().as_bundle().at("request").as_bundle();
+    const auto event_generation = envelope.at("generation");
+    if (event_generation.data() == nullptr ||
+        event_generation.checked_as<DateTime>() != generation.value()) {
+      return;
+    }
+    const auto request = envelope.at("request");
+    if (request.data() != nullptr) {
+      out.template field<"request">().apply(request);
+    }
+  }
+};
+
+struct ServerRequestProjectionGraph {
+  static constexpr auto name = "web_server_request_projection_graph";
+
+  static Port<WebRouteOutput>
+  compose(Wiring &w, NamedPort<"key", TS<WebRoute>>,
+          Port<TS<SequencedWebTransportBatch>> batch,
+          Port<TS<DateTime>> generation) {
+    return wire<ServerRequestProjectionNode>(
+               w, wire_unrolled_transport_event(w, batch), generation)
+        .template as<WebRouteOutput>();
+  }
+};
+
+/** Projects one server WebSocket event. Cost is O(1) per event. */
 struct ServerWsProjectionNode {
   static constexpr auto name = "web_server_ws_projection";
 
-  static void start(State<WebProjectionScheduleHandle> state) {
-    state.set(
-        WebProjectionScheduleHandle{std::make_shared<WebProjectionSchedule>()});
-  }
-
-  static void
-  eval(In<"transport", TS<WebTransportEventBatch>, InputValidity::Unchecked>
-           transport,
-       In<"routes", TSS<WebRoute>, InputValidity::Unchecked> routes,
-       In<"generations", TSD<WebRoute, TS<DateTime>>, InputValidity::Unchecked>
-           generations,
-       Scalar<"admission", ServerAdmissionHandle> admission,
-       Scalar<"bindings", WebTransportBindingsHandle> bindings,
-       State<WebProjectionScheduleHandle> state, SingleShotScheduler scheduler,
-       Out<TSD<WebRoute, WsRouteOutput>> out) {
-    const bool has_batch = transport.modified();
-    auto schedule = state.get().value;
-    const auto &route_delta = static_cast<const TSSInputView &>(routes);
-    const auto removed = route_delta.removed();
-    if (!has_batch && schedule->keyed_empty() &&
-        (!routes.modified() || removed.begin() == removed.end())) {
+  static void eval(In<"event", TS<WebTransportEvent>> event,
+                   In<"generation", TS<DateTime>, InputValidity::Unchecked>
+                       generation,
+                   Out<WsRouteOutput> out) {
+    if (!generation.valid()) {
       return;
     }
-    auto mutation = out.begin_mutation(out.evaluation_time());
-    WebProjectionSchedule::EmittedKeys emitted;
-    const auto apply_envelope = [&](const auto &envelope) {
-      if (generation_matches(static_cast<const TSDInputView &>(generations),
-                             envelope.at("route"), envelope.at("generation"))) {
-        BundleBuilder value{bindings.value().value->server_ws_output};
-        for (const auto name :
-             {std::string_view{"event"}, std::string_view{"frame"}}) {
-          const auto field = envelope.at(name);
-          if (field.data() != nullptr) {
-            value.set(name, field.clone());
-          }
-        }
-        const Value update = value.build();
-        mutation.set(envelope.at("route"), update.view());
-        return true;
-      }
-      return false;
-    };
-    schedule->drain_keyed(emitted, [&](const ValueView &event) {
-      const bool applied =
-          apply_envelope(event.as_bundle().at("server_ws").as_bundle());
-      release_transport_event(admission.value(), event);
-      return applied;
-    });
-    if (has_batch) {
-      for (const auto event : transport.base().value().as_list()) {
-        const auto envelope = event.as_bundle().at("server_ws").as_bundle();
-        const auto key = envelope.at("route");
-        if (WebProjectionSchedule::contains(emitted, key)) {
-          schedule->defer(key, event);
-        } else {
-          if (apply_envelope(envelope)) {
-            WebProjectionSchedule::mark(emitted, key);
-          }
-          release_transport_event(admission.value(), event);
-        }
-      }
+    const auto envelope =
+        event.base().value().as_bundle().at("server_ws").as_bundle();
+    const auto event_generation = envelope.at("generation");
+    if (event_generation.data() == nullptr ||
+        event_generation.checked_as<DateTime>() != generation.value()) {
+      return;
     }
-    if (!schedule->keyed_empty()) {
-      scheduler.schedule(MIN_TD);
+    const auto event_value = envelope.at("event");
+    if (event_value.data() != nullptr) {
+      out.template field<"event">().apply(event_value);
     }
-    if (routes.modified()) {
-      for (const auto route : removed) {
-        static_cast<void>(mutation.erase(route));
-      }
+    const auto frame = envelope.at("frame");
+    if (frame.data() != nullptr) {
+      out.template field<"frame">().apply(frame);
     }
   }
 };
 
-/** Projects delivery-report bursts. Distinct request ids tick together;
- * duplicate ids retain FIFO order. Cost is O(B + P) per tick for burst size B
- * and P pending ids. Retained memory is O(C) for duplicate-id collisions. */
-template <typename Admission> struct DeliveryProjectionNode {
+struct ServerWsProjectionGraph {
+  static constexpr auto name = "web_server_ws_projection_graph";
+
+  static Port<WsRouteOutput>
+  compose(Wiring &w, NamedPort<"key", TS<WebRoute>>,
+          Port<TS<SequencedWebTransportBatch>> batch,
+          Port<TS<DateTime>> generation) {
+    return wire<ServerWsProjectionNode>(
+               w, wire_unrolled_transport_event(w, batch), generation)
+        .template as<WsRouteOutput>();
+  }
+};
+
+/** Projects one delivery report. Cost and retained memory are O(1). */
+struct DeliveryProjectionNode {
   static constexpr auto name = "web_delivery_projection";
 
-  static void start(State<WebProjectionScheduleHandle> state) {
-    state.set(
-        WebProjectionScheduleHandle{std::make_shared<WebProjectionSchedule>()});
-  }
-
-  static void eval(In<"transport", TS<WebTransportEventBatch>> transport,
-                   Scalar<"admission", Admission> admission,
-                   State<WebProjectionScheduleHandle> state,
-                   SingleShotScheduler scheduler,
-                   Out<TSD<Int, TS<WebDeliveryReport>>> out) {
-    auto schedule = state.get().value;
-    auto mutation = out.begin_mutation(out.evaluation_time());
-    WebProjectionSchedule::EmittedKeys emitted;
-    const auto apply_event = [&](const ValueView &event) {
-      const auto envelope = event.as_bundle().at("delivery").as_bundle();
-      mutation.set(envelope.at("request_id"), envelope.at("report"));
-      return true;
-    };
-    schedule->drain_keyed(emitted, [&](const ValueView &event) {
-      const bool applied = apply_event(event);
-      release_transport_event(admission.value(), event);
-      return applied;
-    });
-    if (transport.modified()) {
-      for (const auto event : transport.base().value().as_list()) {
-        const auto key =
-            event.as_bundle().at("delivery").as_bundle().at("request_id");
-        if (WebProjectionSchedule::contains(emitted, key)) {
-          schedule->defer(key, event);
-        } else {
-          static_cast<void>(apply_event(event));
-          WebProjectionSchedule::mark(emitted, key);
-          release_transport_event(admission.value(), event);
-        }
-      }
-    }
-    if (!schedule->keyed_empty()) {
-      scheduler.schedule(MIN_TD);
-    }
+  static void eval(In<"event", TS<WebTransportEvent>> event,
+                   Out<TS<WebDeliveryReport>> out) {
+    out.apply(event.base()
+                  .value()
+                  .as_bundle()
+                  .at("delivery")
+                  .as_bundle()
+                  .at("report"));
   }
 };
 
-/** Projects service-event bursts and applies stop policy on graph. Scalar
- * output requires FIFO unrolling: O(B) to admit a burst, O(1) to emit, and
- * O(S) retained memory for S pending events. */
-template <typename Admission> struct EventProjectionNode {
+struct DeliveryProjectionGraph {
+  static constexpr auto name = "web_delivery_projection_graph";
+
+  static Port<TS<WebDeliveryReport>>
+  compose(Wiring &w, NamedPort<"key", TS<Int>>,
+          Port<TS<SequencedWebTransportBatch>> batch) {
+    return wire<DeliveryProjectionNode>(
+               w, wire_unrolled_transport_event(w, batch))
+        .template as<TS<WebDeliveryReport>>();
+  }
+};
+
+/** Projects one graph service event and applies stop policy on graph. */
+struct EventProjectionNode {
   static constexpr auto name = "web_event_projection";
 
-  static void start(State<WebProjectionScheduleHandle> state) {
-    state.set(
-        WebProjectionScheduleHandle{std::make_shared<WebProjectionSchedule>()});
-  }
-
-  static void eval(In<"transport", TS<WebTransportEventBatch>> transport,
-                   Scalar<"admission", Admission> admission,
-                   State<WebProjectionScheduleHandle> state,
-                   SingleShotScheduler scheduler, EngineControlView engine,
-                   Out<TS<WebEvent>> out) {
-    auto schedule = state.get().value;
-    bool emitted = false;
-    const auto apply_event = [&](const ValueView &event) {
-      const auto envelope = event.as_bundle().at("event").as_bundle();
-      out.apply(envelope.at("event"));
-      if (envelope.at("stop_graph").checked_as<Bool>()) {
-        engine.request_stop();
-      }
-      emitted = true;
-    };
-    if (auto pending = schedule->pop_scalar()) {
-      apply_event(pending->view());
-      release_transport_event(admission.value(), pending->view());
-    }
-    if (transport.modified()) {
-      for (const auto event : transport.base().value().as_list()) {
-        if (emitted) {
-          schedule->defer_scalar(event);
-        } else {
-          apply_event(event);
-          release_transport_event(admission.value(), event);
-        }
-      }
-    }
-    if (!schedule->scalar_empty()) {
-      scheduler.schedule(MIN_TD);
+  static void eval(In<"event", TS<WebTransportEvent>> event,
+                   EngineControlView engine, Out<TS<WebEvent>> out) {
+    const auto envelope =
+        event.base().value().as_bundle().at("event").as_bundle();
+    out.apply(envelope.at("event"));
+    if (envelope.at("stop_graph").checked_as<Bool>()) {
+      engine.request_stop();
     }
   }
 };
 
-/** Projects the latest statistics sample in a burst. Statistics describe
- * current state rather than an event-accurate stream, so older samples are
- * superseded. Cost is O(1) per tick and retained memory is O(1). */
-template <typename Stats, typename Admission> struct StatsProjectionNode {
+/** Projects the selected latest statistics event. */
+template <typename Stats> struct StatsProjectionNode {
   static constexpr auto name = "web_stats_projection";
 
-  static void eval(In<"transport", TS<WebTransportEventBatch>> transport,
-                   Scalar<"admission", Admission> admission,
+  static void eval(In<"event", TS<WebTransportEvent>> event,
                    Out<TS<Stats>> out) {
-    const auto events = transport.base().value().as_list();
-    const auto fields = events.at(events.size() - 1).as_bundle();
+    const auto fields = event.base().value().as_bundle();
     if constexpr (std::is_same_v<Stats, WebServerStats>) {
       out.apply(fields.at("server_stats"));
     } else {
       out.apply(fields.at("client_stats"));
     }
-    for (const auto event : events) {
-      release_transport_event(admission.value(), event);
-    }
   }
 };
 
-/** Projects HTTP client result bursts. Distinct request ids tick together;
- * duplicate ids retain FIFO order. Cost is O(B + P) per tick for burst size B
- * and P pending ids. Retained memory is O(C) for duplicate-id collisions. */
+/** Projects one HTTP client result. Cost and retained memory are O(1). */
 struct ClientResponseProjectionNode {
   static constexpr auto name = "web_client_response_projection";
 
-  static void start(State<WebProjectionScheduleHandle> state) {
-    state.set(
-        WebProjectionScheduleHandle{std::make_shared<WebProjectionSchedule>()});
-  }
-
-  static void eval(In<"transport", TS<WebTransportEventBatch>> transport,
-                   Scalar<"admission", ClientAdmissionHandle> admission,
-                   Scalar<"bindings", WebTransportBindingsHandle> bindings,
-                   State<WebProjectionScheduleHandle> state,
-                   SingleShotScheduler scheduler,
-                   Out<TSD<Int, HttpCallResult>> out) {
-    auto schedule = state.get().value;
-    auto mutation = out.begin_mutation(out.evaluation_time());
-    WebProjectionSchedule::EmittedKeys emitted;
-    const auto apply_event = [&](const ValueView &event) {
-      const auto envelope = event.as_bundle().at("response").as_bundle();
-      BundleBuilder value{bindings.value().value->client_call_result};
-      for (const auto name :
-           {std::string_view{"response"}, std::string_view{"failure"}}) {
-        const auto field = envelope.at(name);
-        if (field.data() != nullptr) {
-          value.set(name, field.clone());
-        }
-      }
-      const Value update = value.build();
-      mutation.set(envelope.at("request_id"), update.view());
-      return true;
-    };
-    schedule->drain_keyed(emitted, [&](const ValueView &event) {
-      const bool applied = apply_event(event);
-      release_transport_event(admission.value(), event);
-      return applied;
-    });
-    if (transport.modified()) {
-      for (const auto event : transport.base().value().as_list()) {
-        const auto key =
-            event.as_bundle().at("response").as_bundle().at("request_id");
-        if (WebProjectionSchedule::contains(emitted, key)) {
-          schedule->defer(key, event);
-        } else {
-          static_cast<void>(apply_event(event));
-          WebProjectionSchedule::mark(emitted, key);
-          release_transport_event(admission.value(), event);
-        }
-      }
+  static void eval(In<"event", TS<WebTransportEvent>> event,
+                   Out<HttpCallResult> out) {
+    const auto envelope =
+        event.base().value().as_bundle().at("response").as_bundle();
+    const auto response = envelope.at("response");
+    if (response.data() != nullptr) {
+      out.template field<"response">().apply(response);
     }
-    if (!schedule->keyed_empty()) {
-      scheduler.schedule(MIN_TD);
+    const auto failure = envelope.at("failure");
+    if (failure.data() != nullptr) {
+      out.template field<"failure">().apply(failure);
     }
   }
 };
 
-/** Projects WebSocket client ingress and key removal. Distinct subscription
- * keys tick together; same-key collisions retain FIFO order. Cost is
- * O(R + B + P) per tick for R removals, burst size B, and P pending keys.
- * Retained memory is O(C) for deferred collisions. */
+struct ClientResponseProjectionGraph {
+  static constexpr auto name = "web_client_response_projection_graph";
+
+  static Port<HttpCallResult>
+  compose(Wiring &w, NamedPort<"key", TS<Int>>,
+          Port<TS<SequencedWebTransportBatch>> batch) {
+    return wire<ClientResponseProjectionNode>(
+               w, wire_unrolled_transport_event(w, batch))
+        .template as<HttpCallResult>();
+  }
+};
+
+/** Projects one WebSocket client event. Cost is O(1) per event. */
 struct ClientWsProjectionNode {
   static constexpr auto name = "web_client_ws_projection";
 
-  static void start(State<WebProjectionScheduleHandle> state) {
-    state.set(
-        WebProjectionScheduleHandle{std::make_shared<WebProjectionSchedule>()});
-  }
-
-  static void
-  eval(In<"transport", TS<WebTransportEventBatch>, InputValidity::Unchecked>
-           transport,
-       In<"keys", TSS<WsClientKey>, InputValidity::Unchecked> keys,
-       In<"generations", TSD<WsClientKey, TS<DateTime>>,
-          InputValidity::Unchecked>
-           generations,
-       Scalar<"admission", ClientAdmissionHandle> admission,
-       Scalar<"bindings", WebTransportBindingsHandle> bindings,
-       State<WebProjectionScheduleHandle> state, SingleShotScheduler scheduler,
-       Out<TSD<WsClientKey, WsClientOutput>> out) {
-    const bool has_batch = transport.modified();
-    auto schedule = state.get().value;
-    const auto &key_delta = static_cast<const TSSInputView &>(keys);
-    const auto removed = key_delta.removed();
-    if (!has_batch && schedule->keyed_empty() &&
-        (!keys.modified() || removed.begin() == removed.end())) {
+  static void eval(In<"event", TS<WebTransportEvent>> event,
+                   In<"generation", TS<DateTime>, InputValidity::Unchecked>
+                       generation,
+                   Out<WsClientOutput> out) {
+    if (!generation.valid()) {
       return;
     }
-    auto mutation = out.begin_mutation(out.evaluation_time());
-    WebProjectionSchedule::EmittedKeys emitted;
-    const auto apply_envelope = [&](const auto &envelope) {
-      if (generation_matches(static_cast<const TSDInputView &>(generations),
-                             envelope.at("key"), envelope.at("generation"))) {
-        BundleBuilder value{bindings.value().value->client_ws_output};
-        for (const auto name :
-             {std::string_view{"event"}, std::string_view{"frame"}}) {
-          const auto field = envelope.at(name);
-          if (field.data() != nullptr) {
-            value.set(name, field.clone());
-          }
-        }
-        const Value update = value.build();
-        mutation.set(envelope.at("key"), update.view());
-        return true;
-      }
-      return false;
-    };
-    schedule->drain_keyed(emitted, [&](const ValueView &event) {
-      const bool applied =
-          apply_envelope(event.as_bundle().at("client_ws").as_bundle());
-      release_transport_event(admission.value(), event);
-      return applied;
-    });
-    if (has_batch) {
-      for (const auto event : transport.base().value().as_list()) {
-        const auto envelope = event.as_bundle().at("client_ws").as_bundle();
-        const auto key = envelope.at("key");
-        if (WebProjectionSchedule::contains(emitted, key)) {
-          schedule->defer(key, event);
-        } else {
-          if (apply_envelope(envelope)) {
-            WebProjectionSchedule::mark(emitted, key);
-          }
-          release_transport_event(admission.value(), event);
-        }
-      }
+    const auto envelope =
+        event.base().value().as_bundle().at("client_ws").as_bundle();
+    const auto event_generation = envelope.at("generation");
+    if (event_generation.data() == nullptr ||
+        event_generation.checked_as<DateTime>() != generation.value()) {
+      return;
     }
-    if (!schedule->keyed_empty()) {
-      scheduler.schedule(MIN_TD);
+    const auto event_value = envelope.at("event");
+    if (event_value.data() != nullptr) {
+      out.template field<"event">().apply(event_value);
     }
-    if (keys.modified()) {
-      for (const auto key : removed) {
-        static_cast<void>(mutation.erase(key));
-      }
+    const auto frame = envelope.at("frame");
+    if (frame.data() != nullptr) {
+      out.template field<"frame">().apply(frame);
     }
+  }
+};
+
+struct ClientWsProjectionGraph {
+  static constexpr auto name = "web_client_ws_projection_graph";
+
+  static Port<WsClientOutput>
+  compose(Wiring &w, NamedPort<"key", TS<WsClientKey>>,
+          Port<TS<SequencedWebTransportBatch>> batch,
+          Port<TS<DateTime>> generation) {
+    return wire<ClientWsProjectionNode>(
+               w, wire_unrolled_transport_event(w, batch), generation)
+        .template as<WsClientOutput>();
   }
 };
 
@@ -1155,26 +958,49 @@ struct ServerOutputs {
     Port<TSD<WebRoute, TS<DateTime>>> http_generations,
     Port<TSD<WebRoute, TS<DateTime>>> ws_generations,
     ServerAdmissionHandle admission, WebTransportBindingsHandle bindings) {
+  static_cast<void>(bindings);
+  for (const auto &channel : transport) {
+    static_cast<void>(
+        wire<ReleaseTransportBatchSink<ServerAdmissionHandle>>(w, channel,
+                                                               admission));
+  }
+
+  auto requests = wire_keyed_transport_batches<WebRoute,
+                                                ServerRequestBatchNode>(
+      w, transport[index(ServerChannel::Request)]);
+  auto ws = wire_keyed_transport_batches<WebRoute, ServerWsBatchNode>(
+      w, transport[index(ServerChannel::WsIngress)]);
+  auto respond_deliveries =
+      wire_keyed_transport_batches<Int, DeliveryBatchNode>(
+          w, transport[index(ServerChannel::RespondDelivery)]);
+  auto ws_send_deliveries =
+      wire_keyed_transport_batches<Int, DeliveryBatchNode>(
+          w, transport[index(ServerChannel::WsSendDelivery)]);
+
+  auto event = wire<stdlib::emit>(w, transport[index(ServerChannel::Event)])
+                   .template as<TS<WebTransportEvent>>();
+  auto latest_stats = wire<stdlib::getitem_>(
+                          w, transport[index(ServerChannel::Stats)],
+                          wire<stdlib::const_, TS<Int>>(w, Int{-1}))
+          .template as<TS<WebTransportEvent>>();
+
   return ServerOutputs{
-      wire<ServerRequestProjectionNode>(
-          w, transport[index(ServerChannel::Request)], http_routes,
-          http_generations, admission, bindings)
+      wire<stdlib::map_, TSD<WebRoute, WebRouteOutput>>(
+          w, fn<ServerRequestProjectionGraph>(), requests, http_generations,
+          arg<"__keys__">(http_routes))
           .template as<TSD<WebRoute, WebRouteOutput>>(),
-      wire<ServerWsProjectionNode>(
-          w, transport[index(ServerChannel::WsIngress)], ws_routes,
-          ws_generations, admission, bindings)
+      wire<stdlib::map_, TSD<WebRoute, WsRouteOutput>>(
+          w, fn<ServerWsProjectionGraph>(), ws, ws_generations,
+          arg<"__keys__">(ws_routes))
           .template as<TSD<WebRoute, WsRouteOutput>>(),
-      wire<DeliveryProjectionNode<ServerAdmissionHandle>>(
-          w, transport[index(ServerChannel::RespondDelivery)], admission)
+      wire<stdlib::map_, TSD<Int, TS<WebDeliveryReport>>>(
+          w, fn<DeliveryProjectionGraph>(), respond_deliveries)
           .template as<TSD<Int, TS<WebDeliveryReport>>>(),
-      wire<DeliveryProjectionNode<ServerAdmissionHandle>>(
-          w, transport[index(ServerChannel::WsSendDelivery)], admission)
+      wire<stdlib::map_, TSD<Int, TS<WebDeliveryReport>>>(
+          w, fn<DeliveryProjectionGraph>(), ws_send_deliveries)
           .template as<TSD<Int, TS<WebDeliveryReport>>>(),
-      wire<EventProjectionNode<ServerAdmissionHandle>>(
-          w, transport[index(ServerChannel::Event)], admission)
-          .template as<TS<WebEvent>>(),
-      wire<StatsProjectionNode<WebServerStats, ServerAdmissionHandle>>(
-          w, transport[index(ServerChannel::Stats)], admission)
+      wire<EventProjectionNode>(w, event).template as<TS<WebEvent>>(),
+      wire<StatsProjectionNode<WebServerStats>>(w, latest_stats)
           .template as<TS<WebServerStats>>(),
   };
 }
@@ -1193,22 +1019,39 @@ wire_client_outputs(Wiring &w, const ClientTransportPorts &transport,
                     Port<TSD<WsClientKey, TS<DateTime>>> ws_generations,
                     ClientAdmissionHandle admission,
                     WebTransportBindingsHandle bindings) {
+  static_cast<void>(bindings);
+  for (const auto &channel : transport) {
+    static_cast<void>(
+        wire<ReleaseTransportBatchSink<ClientAdmissionHandle>>(w, channel,
+                                                               admission));
+  }
+
+  auto responses = wire_keyed_transport_batches<Int, ClientResponseBatchNode>(
+      w, transport[index(ClientChannel::Response)]);
+  auto ws = wire_keyed_transport_batches<WsClientKey, ClientWsBatchNode>(
+      w, transport[index(ClientChannel::WsIngress)]);
+  auto send_deliveries = wire_keyed_transport_batches<Int, DeliveryBatchNode>(
+      w, transport[index(ClientChannel::SendDelivery)]);
+  auto event = wire<stdlib::emit>(w, transport[index(ClientChannel::Event)])
+                   .template as<TS<WebTransportEvent>>();
+  auto latest_stats = wire<stdlib::getitem_>(
+                          w, transport[index(ClientChannel::Stats)],
+                          wire<stdlib::const_, TS<Int>>(w, Int{-1}))
+          .template as<TS<WebTransportEvent>>();
+
   return ClientOutputs{
-      wire<ClientResponseProjectionNode>(
-          w, transport[index(ClientChannel::Response)], admission, bindings)
+      wire<stdlib::map_, TSD<Int, HttpCallResult>>(
+          w, fn<ClientResponseProjectionGraph>(), responses)
           .template as<TSD<Int, HttpCallResult>>(),
-      wire<ClientWsProjectionNode>(w,
-                                   transport[index(ClientChannel::WsIngress)],
-                                   ws_keys, ws_generations, admission, bindings)
+      wire<stdlib::map_, TSD<WsClientKey, WsClientOutput>>(
+          w, fn<ClientWsProjectionGraph>(), ws, ws_generations,
+          arg<"__keys__">(ws_keys))
           .template as<TSD<WsClientKey, WsClientOutput>>(),
-      wire<DeliveryProjectionNode<ClientAdmissionHandle>>(
-          w, transport[index(ClientChannel::SendDelivery)], admission)
+      wire<stdlib::map_, TSD<Int, TS<WebDeliveryReport>>>(
+          w, fn<DeliveryProjectionGraph>(), send_deliveries)
           .template as<TSD<Int, TS<WebDeliveryReport>>>(),
-      wire<EventProjectionNode<ClientAdmissionHandle>>(
-          w, transport[index(ClientChannel::Event)], admission)
-          .template as<TS<WebEvent>>(),
-      wire<StatsProjectionNode<WebClientStats, ClientAdmissionHandle>>(
-          w, transport[index(ClientChannel::Stats)], admission)
+      wire<EventProjectionNode>(w, event).template as<TS<WebEvent>>(),
+      wire<StatsProjectionNode<WebClientStats>>(w, latest_stats)
           .template as<TS<WebClientStats>>(),
   };
 }
@@ -1319,10 +1162,15 @@ template <> struct hash<hgraph::web::detail::WebTransportBindingsHandle> {
   }
 };
 
-template <> struct hash<hgraph::web::detail::WebProjectionScheduleHandle> {
-  size_t operator()(const hgraph::web::detail::WebProjectionScheduleHandle
+template <> struct hash<hgraph::web::detail::WebKeyedBatchBindings> {
+  size_t operator()(const hgraph::web::detail::WebKeyedBatchBindings
                         &value) const noexcept {
-    return hash<const void *>{}(value.value.get());
+    size_t result = hash<hgraph::ValueTypeRef>{}(value.key);
+    result ^= hash<hgraph::ValueTypeRef>{}(value.event) + 0x9e3779b9U +
+              (result << 6U) + (result >> 2U);
+    result ^= hash<hgraph::ValueTypeRef>{}(value.batch_map) + 0x9e3779b9U +
+              (result << 6U) + (result >> 2U);
+    return result;
   }
 };
 } // namespace std
@@ -1343,9 +1191,9 @@ template <> struct scalar_name<web::detail::WebTransportBindingsHandle> {
       "hgraph.web.internal::WebTransportBindingsHandle"};
 };
 
-template <> struct scalar_name<web::detail::WebProjectionScheduleHandle> {
+template <> struct scalar_name<web::detail::WebKeyedBatchBindings> {
   static constexpr std::string_view value{
-      "hgraph.web.internal::WebProjectionScheduleHandle"};
+      "hgraph.web.internal::WebKeyedBatchBindings"};
 };
 } // namespace hgraph::static_schema_detail
 

--- a/extensions/web/src/detail/stream_model.h
+++ b/extensions/web/src/detail/stream_model.h
@@ -6,85 +6,93 @@
 #include <cstdint>
 #include <string_view>
 
-namespace hgraph::web::detail
-{
-    // Internal transport payloads. External tasks wrap these fully owned
-    // values in one WebTransportEvent stream; graph nodes project the public
-    // service outputs. A set `removed` field is retained for compatibility
-    // with persisted/test payloads, although graph-side key deltas now own
-    // route and connection removal.
+namespace hgraph::web::detail {
+// Internal transport payloads. External tasks wrap these fully owned
+// values in WebTransportEvent streams; burst push sources deliver the
+// pending events to graph nodes for projection onto the public service
+// outputs. A set `removed` field is retained for compatibility
+// with persisted/test payloads, although graph-side key deltas now own
+// route and connection removal.
 
-    using WebRequestEnvelope =
-        Bundle<"hgraph.web.internal::WebRequestEnvelope", Field<"route", WebRoute>, Field<"request", HttpServerRequest>,
-               Field<"state", WebRouteState>, Field<"generation", DateTime>, Field<"removed", Bool>>;
+using WebRequestEnvelope =
+    Bundle<"hgraph.web.internal::WebRequestEnvelope", Field<"route", WebRoute>,
+           Field<"request", HttpServerRequest>, Field<"state", WebRouteState>,
+           Field<"generation", DateTime>, Field<"removed", Bool>>;
 
-    using WsIngressEnvelope =
-        Bundle<"hgraph.web.internal::WsIngressEnvelope", Field<"route", WebRoute>, Field<"event", WsEvent>,
-               Field<"frame", WsInboundFrame>, Field<"generation", DateTime>, Field<"removed", Bool>>;
+using WsIngressEnvelope =
+    Bundle<"hgraph.web.internal::WsIngressEnvelope", Field<"route", WebRoute>,
+           Field<"event", WsEvent>, Field<"frame", WsInboundFrame>,
+           Field<"generation", DateTime>, Field<"removed", Bool>>;
 
-    using WsClientEnvelope =
-        Bundle<"hgraph.web.internal::WsClientEnvelope", Field<"key", WsClientKey>, Field<"event", WsEvent>,
-               Field<"frame", WsFrame>, Field<"generation", DateTime>, Field<"removed", Bool>>;
+using WsClientEnvelope =
+    Bundle<"hgraph.web.internal::WsClientEnvelope", Field<"key", WsClientKey>,
+           Field<"event", WsEvent>, Field<"frame", WsFrame>,
+           Field<"generation", DateTime>, Field<"removed", Bool>>;
 
-    // Exactly one of response/failure is set: transport failure is never
-    // disguised as an HTTP status (RFC 0024).
-    using WebResponseEnvelope =
-        Bundle<"hgraph.web.internal::WebResponseEnvelope", Field<"request_id", Int>, Field<"response", HttpResponse>,
-               Field<"failure", WebTransportError>>;
+// Exactly one of response/failure is set: transport failure is never
+// disguised as an HTTP status (RFC 0024).
+using WebResponseEnvelope =
+    Bundle<"hgraph.web.internal::WebResponseEnvelope", Field<"request_id", Int>,
+           Field<"response", HttpResponse>,
+           Field<"failure", WebTransportError>>;
 
-    using WebDeliveryEnvelope =
-        Bundle<"hgraph.web.internal::WebDeliveryEnvelope", Field<"request_id", Int>, Field<"report", WebDeliveryReport>>;
+using WebDeliveryEnvelope =
+    Bundle<"hgraph.web.internal::WebDeliveryEnvelope", Field<"request_id", Int>,
+           Field<"report", WebDeliveryReport>>;
 
-    using WebEventEnvelope =
-        Bundle<"hgraph.web.internal::WebEventEnvelope", Field<"event", WebEvent>, Field<"stop_graph", Bool>>;
+using WebEventEnvelope =
+    Bundle<"hgraph.web.internal::WebEventEnvelope", Field<"event", WebEvent>,
+           Field<"stop_graph", Bool>>;
 
-    /** The one ordered event stream crossing from a web runtime into its
-     *  graph. Server and client implementations each own one queue of this
-     *  schema; the kind selects the populated payload field. */
-    enum class WebTransportEventKind : std::int64_t
-    {
-        ServerRequest,
-        ServerWsIngress,
-        ServerRespondDelivery,
-        ServerWsSendDelivery,
-        ServerEvent,
-        ServerStats,
-        ClientResponse,
-        ClientWsIngress,
-        ClientSendDelivery,
-        ClientEvent,
-        ClientStats,
-    };
+/** The scalar event admitted to one independently ordered web channel.
+ *  Each channel owns a burst queue of this schema; the kind selects the
+ *  populated payload field. */
+enum class WebTransportEventKind : std::int64_t {
+  ServerRequest,
+  ServerWsIngress,
+  ServerRespondDelivery,
+  ServerWsSendDelivery,
+  ServerEvent,
+  ServerStats,
+  ClientResponse,
+  ClientWsIngress,
+  ClientSendDelivery,
+  ClientEvent,
+  ClientStats,
+};
 
-}  // namespace hgraph::web::detail
+} // namespace hgraph::web::detail
 
-namespace hgraph::static_schema_detail
-{
-    template <> struct scalar_name<web::detail::WebTransportEventKind>
-    {
-        static constexpr std::string_view value{"hgraph.web.internal::WebTransportEventKind"};
-    };
-}  // namespace hgraph::static_schema_detail
+namespace hgraph::static_schema_detail {
+template <> struct scalar_name<web::detail::WebTransportEventKind> {
+  static constexpr std::string_view value{
+      "hgraph.web.internal::WebTransportEventKind"};
+};
+} // namespace hgraph::static_schema_detail
 
-namespace hgraph::web::detail
-{
-    using WebTransportEvent = Bundle<
-        "hgraph.web.internal::WebTransportEvent", Field<"kind", WebTransportEventKind>,
-        Field<"request", WebRequestEnvelope>, Field<"server_ws", WsIngressEnvelope>,
-        Field<"client_ws", WsClientEnvelope>, Field<"response", WebResponseEnvelope>,
-        Field<"delivery", WebDeliveryEnvelope>, Field<"event", WebEventEnvelope>,
-        Field<"server_stats", WebServerStats>, Field<"client_stats", WebClientStats>, Field<"channel", Int>,
-        Field<"retained_bytes", Int>, Field<"control", Bool>>;
+namespace hgraph::web::detail {
+using WebTransportEvent = Bundle<
+    "hgraph.web.internal::WebTransportEvent",
+    Field<"kind", WebTransportEventKind>, Field<"request", WebRequestEnvelope>,
+    Field<"server_ws", WsIngressEnvelope>, Field<"client_ws", WsClientEnvelope>,
+    Field<"response", WebResponseEnvelope>,
+    Field<"delivery", WebDeliveryEnvelope>, Field<"event", WebEventEnvelope>,
+    Field<"server_stats", WebServerStats>,
+    Field<"client_stats", WebClientStats>, Field<"channel", Int>,
+    Field<"retained_bytes", Int>, Field<"control", Bool>>;
 
-    inline void register_internal_types() {
-        static_cast<void>(scalar_descriptor<WebRequestEnvelope>::value_meta());
-        static_cast<void>(scalar_descriptor<WsIngressEnvelope>::value_meta());
-        static_cast<void>(scalar_descriptor<WsClientEnvelope>::value_meta());
-        static_cast<void>(scalar_descriptor<WebResponseEnvelope>::value_meta());
-        static_cast<void>(scalar_descriptor<WebDeliveryEnvelope>::value_meta());
-        static_cast<void>(scalar_descriptor<WebEventEnvelope>::value_meta());
-        static_cast<void>(scalar_descriptor<WebTransportEvent>::value_meta());
-    }
-}  // namespace hgraph::web::detail
+using WebTransportEventBatch = HomogeneousTuple<WebTransportEvent>;
 
-#endif  // HGRAPH_WEB_DETAIL_STREAM_MODEL_H
+inline void register_internal_types() {
+  static_cast<void>(scalar_descriptor<WebRequestEnvelope>::value_meta());
+  static_cast<void>(scalar_descriptor<WsIngressEnvelope>::value_meta());
+  static_cast<void>(scalar_descriptor<WsClientEnvelope>::value_meta());
+  static_cast<void>(scalar_descriptor<WebResponseEnvelope>::value_meta());
+  static_cast<void>(scalar_descriptor<WebDeliveryEnvelope>::value_meta());
+  static_cast<void>(scalar_descriptor<WebEventEnvelope>::value_meta());
+  static_cast<void>(scalar_descriptor<WebTransportEvent>::value_meta());
+  static_cast<void>(scalar_descriptor<WebTransportEventBatch>::value_meta());
+}
+} // namespace hgraph::web::detail
+
+#endif // HGRAPH_WEB_DETAIL_STREAM_MODEL_H

--- a/extensions/web/src/detail/stream_model.h
+++ b/extensions/web/src/detail/stream_model.h
@@ -83,6 +83,17 @@ using WebTransportEvent = Bundle<
 
 using WebTransportEventBatch = HomogeneousTuple<WebTransportEvent>;
 
+/** One per-key slice of a transport burst. The evaluation-time sequence keeps
+ * repeated, value-equal event batches observable when they pass through the
+ * standard collect operator. */
+using SequencedWebTransportBatch =
+    Bundle<"hgraph.web.internal::SequencedWebTransportBatch",
+           Field<"sequence", DateTime>,
+           Field<"events", WebTransportEventBatch>>;
+
+template <typename Key>
+using KeyedWebTransportBatches = Map<Key, SequencedWebTransportBatch>;
+
 inline void register_internal_types() {
   static_cast<void>(scalar_descriptor<WebRequestEnvelope>::value_meta());
   static_cast<void>(scalar_descriptor<WsIngressEnvelope>::value_meta());
@@ -92,6 +103,14 @@ inline void register_internal_types() {
   static_cast<void>(scalar_descriptor<WebEventEnvelope>::value_meta());
   static_cast<void>(scalar_descriptor<WebTransportEvent>::value_meta());
   static_cast<void>(scalar_descriptor<WebTransportEventBatch>::value_meta());
+  static_cast<void>(
+      scalar_descriptor<SequencedWebTransportBatch>::value_meta());
+  static_cast<void>(
+      scalar_descriptor<KeyedWebTransportBatches<WebRoute>>::value_meta());
+  static_cast<void>(
+      scalar_descriptor<KeyedWebTransportBatches<Int>>::value_meta());
+  static_cast<void>(
+      scalar_descriptor<KeyedWebTransportBatches<WsClientKey>>::value_meta());
 }
 } // namespace hgraph::web::detail
 

--- a/extensions/web/tests/test_service.cpp
+++ b/extensions/web/tests/test_service.cpp
@@ -815,7 +815,9 @@ void test_runtime_specific_wiring_shapes() {
           "web server did not wire one burst push source per channel");
   for (const auto name : {std::string_view{"web_fake_server_http_routes"},
                           std::string_view{"web_fake_server_respond"},
-                          std::string_view{"web_server_request_projection"}}) {
+                          std::string_view{"web_group_transport_batch"},
+                          std::string_view{"collect_tsd_from_map"},
+                          std::string_view{"web_release_transport_batch"}}) {
     require(has_node(server, name),
             "web server wiring is missing graph node " + Str{name});
   }
@@ -826,7 +828,9 @@ void test_runtime_specific_wiring_shapes() {
           "web client did not wire one burst push source per channel");
   for (const auto name : {std::string_view{"web_fake_client_ws_keys"},
                           std::string_view{"web_fake_client_ws_send"},
-                          std::string_view{"web_client_ws_projection"}}) {
+                          std::string_view{"web_group_transport_batch"},
+                          std::string_view{"collect_tsd_from_map"},
+                          std::string_view{"web_release_transport_batch"}}) {
     require(has_node(client, name),
             "web client wiring is missing graph node " + Str{name});
   }

--- a/extensions/web/tests/test_service.cpp
+++ b/extensions/web/tests/test_service.cpp
@@ -1,5 +1,5 @@
 // Service-boundary tests over the socketless fake transport. The fake uses
-// the same standard channel push sources, graph projections, and graph sinks
+// the same burst channel push sources, graph projections, and graph sinks
 // as the live adaptors; only the external task is replaced (RFC 0024/0027).
 
 #include <hgraph/web/service.h>
@@ -104,6 +104,7 @@ inline Value observed_client_ws_report{};
 inline std::size_t backlog_request_count{};
 inline std::vector<Int> backlog_request_ids{};
 inline std::vector<std::pair<Str, DateTime>> observed_transport_progress{};
+inline std::vector<std::pair<Int, DateTime>> observed_burst_requests{};
 inline std::vector<Int> post_readd_request_ids{};
 inline std::vector<Str> post_readd_ws_frames{};
 inline std::vector<Str> post_readd_client_ws_frames{};
@@ -177,6 +178,7 @@ private:
 inline SenderLatch route_sender{};
 inline EvaluationGate route_generation_gate{};
 inline EvaluationGate transport_channel_gate{};
+inline EvaluationGate burst_route_gate{};
 inline std::size_t route_value_count{};
 
 void release_test_state() {
@@ -209,6 +211,7 @@ void release_test_state() {
   observed_client_ws_frame = Value{};
   observed_client_ws_report = Value{};
   observed_transport_progress.clear();
+  observed_burst_requests.clear();
   backlog_request_ids.clear();
   post_readd_request_ids.clear();
   post_readd_ws_frames.clear();
@@ -216,6 +219,7 @@ void release_test_state() {
   route_sender.reset();
   route_generation_gate.release();
   transport_channel_gate.release();
+  burst_route_gate.release();
 }
 
 [[nodiscard]] Value make_server_request(Int request_id) {
@@ -252,20 +256,19 @@ void initialize_values() {
   client_ws_key = make_ws_client_key("wss://feed/live");
   alternate_client_ws_key = make_ws_client_key("wss://feed/alternate");
   emitted_request = make_server_request(Int{41});
-  respond_response =
-      make_response(Int{201}, {{"Content-Type", "application/json"}},
-                    Bytes{"{\"ok\":true}"});
-  client_request = make_client_request(HttpMethod::Post, "https://api/orders",
-                                       {{"Content-Type", "application/json"}},
-                                       Bytes{"{}"});
+  respond_response = make_response(
+      Int{201}, {{"Content-Type", "application/json"}}, Bytes{"{\"ok\":true}"});
+  client_request =
+      make_client_request(HttpMethod::Post, "https://api/orders",
+                          {{"Content-Type", "application/json"}}, Bytes{"{}"});
 }
 
 struct ServeCapture {
   static constexpr auto name = "web_serve_capture";
 
-  static void eval(NodeView node,
-                   In<"routed", WebRouteOutput, InputValidity::Unchecked>
-                       routed) {
+  static void
+  eval(NodeView node,
+       In<"routed", WebRouteOutput, InputValidity::Unchecked> routed) {
     auto state = routed.template field<"state">();
     if (state.valid() && state.modified() &&
         state.value() == WebRouteState::Serving) {
@@ -287,8 +290,7 @@ struct ServeGraph {
   static void compose(Wiring &w) {
     const auto path = service::path("web-serve");
     register_fake_server(w, path, server_configuration.clone(), serve_server);
-    auto route =
-        wire<stdlib::const_, TS<WebRoute>>(w, serve_route.clone());
+    auto route = wire<stdlib::const_, TS<WebRoute>>(w, serve_route.clone());
     static_cast<void>(wire<ServeCapture>(w, serve(w, path, route)));
   }
 };
@@ -296,10 +298,9 @@ struct ServeGraph {
 struct ReportCapture {
   static constexpr auto name = "web_report_capture";
 
-  static void eval(NodeView node,
-                   In<"report", TS<WebDeliveryReport>,
-                      InputValidity::Unchecked>
-                       report) {
+  static void
+  eval(NodeView node,
+       In<"report", TS<WebDeliveryReport>, InputValidity::Unchecked> report) {
     if (!report.valid() || !report.modified()) {
       return;
     }
@@ -314,13 +315,11 @@ struct RespondGraph {
 
   static void compose(Wiring &w) {
     const auto path = service::path("web-respond");
-    register_fake_server(w, path, server_configuration.clone(),
-                         respond_server);
+    register_fake_server(w, path, server_configuration.clone(), respond_server);
     auto request_id = wire<stdlib::const_, TS<Int>>(w, Int{41});
     auto response =
         wire<stdlib::const_, TS<HttpResponse>>(w, respond_response.clone());
-    auto reports =
-        respond(w, path, respond_request(w, request_id, response));
+    auto reports = respond(w, path, respond_request(w, request_id, response));
     static_cast<void>(wire<ReportCapture>(w, reports));
   }
 };
@@ -328,9 +327,9 @@ struct RespondGraph {
 struct CallCapture {
   static constexpr auto name = "web_call_capture";
 
-  static void eval(NodeView node,
-                   In<"result", HttpCallResult, InputValidity::Unchecked>
-                       result) {
+  static void
+  eval(NodeView node,
+       In<"result", HttpCallResult, InputValidity::Unchecked> result) {
     auto response = result.template field<"response">();
     if (response.valid() && response.modified()) {
       observed_response = response.base().value().clone();
@@ -354,8 +353,8 @@ struct CallGraph {
     register_fake_client(w, path, client_configuration.clone(), call_client);
     auto request =
         wire<stdlib::const_, TS<HttpClientRequest>>(w, client_request.clone());
-    static_cast<void>(
-        wire<CallCapture>(w, http_request(w, path, http_client_call(w, request))));
+    static_cast<void>(wire<CallCapture>(
+        w, http_request(w, path, http_client_call(w, request))));
   }
 };
 
@@ -364,21 +363,20 @@ struct FailureGraph {
 
   static void compose(Wiring &w) {
     const auto path = service::path("web-failure");
-    register_fake_client(w, path, client_configuration.clone(),
-                         failure_client);
+    register_fake_client(w, path, client_configuration.clone(), failure_client);
     auto request =
         wire<stdlib::const_, TS<HttpClientRequest>>(w, client_request.clone());
-    static_cast<void>(
-        wire<CallCapture>(w, http_request(w, path, http_client_call(w, request))));
+    static_cast<void>(wire<CallCapture>(
+        w, http_request(w, path, http_client_call(w, request))));
   }
 };
 
 struct WsCapture {
   static constexpr auto name = "web_ws_capture";
 
-  static void eval(NodeView node,
-                   In<"routed", WsRouteOutput, InputValidity::Unchecked>
-                       routed) {
+  static void
+  eval(NodeView node,
+       In<"routed", WsRouteOutput, InputValidity::Unchecked> routed) {
     auto event = routed.template field<"event">();
     if (event.valid() && event.modified()) {
       observed_ws_event = event.base().value().clone();
@@ -394,9 +392,8 @@ struct WsCapture {
 struct WsReportCapture {
   static constexpr auto name = "web_ws_report_capture";
 
-  static void eval(In<"report", TS<WebDeliveryReport>,
-                      InputValidity::Unchecked>
-                       report) {
+  static void
+  eval(In<"report", TS<WebDeliveryReport>, InputValidity::Unchecked> report) {
     if (report.valid() && report.modified()) {
       observed_ws_report = report.base().value().clone();
     }
@@ -412,10 +409,8 @@ struct WsGraph {
     auto route = wire<stdlib::const_, TS<WebRoute>>(w, ws_route.clone());
     static_cast<void>(wire<WsCapture>(w, ws_serve(w, path, route)));
     auto connection_id = wire<stdlib::const_, TS<Int>>(w, Int{5});
-    auto frame =
-        wire<stdlib::const_, TS<WsFrame>>(w, make_text_frame("hello"));
-    auto reports =
-        ws_send(w, path, ws_send_request(w, connection_id, frame));
+    auto frame = wire<stdlib::const_, TS<WsFrame>>(w, make_text_frame("hello"));
+    auto reports = ws_send(w, path, ws_send_request(w, connection_id, frame));
     static_cast<void>(wire<WsReportCapture>(w, reports));
   }
 };
@@ -423,9 +418,9 @@ struct WsGraph {
 struct ClientWsCapture {
   static constexpr auto name = "web_client_ws_capture";
 
-  static void eval(NodeView node,
-                   In<"output", WsClientOutput, InputValidity::Unchecked>
-                       output) {
+  static void
+  eval(NodeView node,
+       In<"output", WsClientOutput, InputValidity::Unchecked> output) {
     auto frame = output.template field<"frame">();
     if (frame.valid() && frame.modified()) {
       observed_client_ws_frame = frame.base().value().clone();
@@ -437,9 +432,8 @@ struct ClientWsCapture {
 struct ClientWsReportCapture {
   static constexpr auto name = "web_client_ws_report_capture";
 
-  static void eval(In<"report", TS<WebDeliveryReport>,
-                      InputValidity::Unchecked>
-                       report) {
+  static void
+  eval(In<"report", TS<WebDeliveryReport>, InputValidity::Unchecked> report) {
     if (report.valid() && report.modified()) {
       observed_client_ws_report = report.base().value().clone();
     }
@@ -457,7 +451,8 @@ struct ClientWsGraph {
     static_cast<void>(wire<ClientWsCapture>(w, ws_connect(w, path, key)));
     auto frame =
         wire<stdlib::const_, TS<WsFrame>>(w, make_text_frame("subscribe"));
-    auto reports = ws_client_send(w, path, ws_client_send_request(w, key, frame));
+    auto reports =
+        ws_client_send(w, path, ws_client_send_request(w, key, frame));
     static_cast<void>(wire<ClientWsReportCapture>(w, reports));
   }
 };
@@ -465,9 +460,9 @@ struct ClientWsGraph {
 struct BacklogCapture {
   static constexpr auto name = "web_backlog_capture";
 
-  static void eval(NodeView node,
-                   In<"routed", WebRouteOutput, InputValidity::Unchecked>
-                       routed) {
+  static void
+  eval(NodeView node,
+       In<"routed", WebRouteOutput, InputValidity::Unchecked> routed) {
     auto request = routed.template field<"request">();
     if (!request.valid() || !request.modified()) {
       return;
@@ -486,11 +481,46 @@ struct BacklogGraph {
 
   static void compose(Wiring &w) {
     const auto path = service::path("web-backlog");
-    register_fake_server(w, path, server_configuration.clone(),
-                         backlog_server);
-    auto route =
-        wire<stdlib::const_, TS<WebRoute>>(w, serve_route.clone());
+    register_fake_server(w, path, server_configuration.clone(), backlog_server);
+    auto route = wire<stdlib::const_, TS<WebRoute>>(w, serve_route.clone());
     static_cast<void>(wire<BacklogCapture>(w, serve(w, path, route)));
+  }
+};
+
+struct BurstRouteCapture {
+  static constexpr auto name = "web_burst_route_capture";
+
+  static void
+  eval(NodeView node, DateTime evaluation_time,
+       In<"routed", WebRouteOutput, InputValidity::Unchecked> routed) {
+    auto request = routed.template field<"request">();
+    if (!request.valid() || !request.modified()) {
+      return;
+    }
+    const Int request_id =
+        request.base().value().as_bundle().at("request_id").checked_as<Int>();
+    if (request_id == Int{80}) {
+      burst_route_gate.block();
+      return;
+    }
+    observed_burst_requests.emplace_back(request_id, evaluation_time);
+    if (observed_burst_requests.size() == 3) {
+      node.graph().executor().request_stop();
+    }
+  }
+};
+
+struct BurstRouteGraph {
+  static constexpr auto name = "web_burst_route_test_graph";
+
+  static void compose(Wiring &w) {
+    const auto path = service::path("web-burst-routes");
+    register_fake_server(w, path, server_configuration.clone(), backlog_server);
+    auto first = wire<stdlib::const_, TS<WebRoute>>(w, serve_route.clone());
+    auto second =
+        wire<stdlib::const_, TS<WebRoute>>(w, alternate_route.clone());
+    static_cast<void>(wire<BurstRouteCapture>(w, serve(w, path, first)));
+    static_cast<void>(wire<BurstRouteCapture>(w, serve(w, path, second)));
   }
 };
 
@@ -499,8 +529,7 @@ struct RouteGenerationSourceTag {};
 struct RouteGenerationForward {
   static constexpr auto name = "web_route_generation_forward";
 
-  static void eval(In<"route", TS<WebRoute>> route,
-                   Out<TS<WebRoute>> out) {
+  static void eval(In<"route", TS<WebRoute>> route, Out<TS<WebRoute>> out) {
     ++route_value_count;
     out.apply(route.base().value());
   }
@@ -509,9 +538,9 @@ struct RouteGenerationForward {
 struct RouteGenerationCapture {
   static constexpr auto name = "web_route_generation_capture";
 
-  static void eval(
-      NodeView node,
-      In<"routed", WebRouteOutput, InputValidity::Unchecked> routed) {
+  static void
+  eval(NodeView node,
+       In<"routed", WebRouteOutput, InputValidity::Unchecked> routed) {
     auto request = routed.template field<"request">();
     if (!request.valid() || !request.modified()) {
       return;
@@ -540,15 +569,15 @@ struct RouteGenerationGraph {
                          lifecycle_server);
     const auto *route_schema = ts_type<TS<WebRoute>>();
     auto route = Port<TS<WebRoute>>{
-        w, w.add_unique_node(
-               std::type_index(typeid(RouteGenerationSourceTag)),
-               make_push_source_node(
-                   *route_schema,
-                   make_push_source_queue_policy(*route_schema, 8),
-                   [](PushSourceSender sender) {
-                     route_sender.publish(std::move(sender));
-                   }),
-               std::span<const WiringPortRef>{}, Value{})};
+        w,
+        w.add_unique_node(std::type_index(typeid(RouteGenerationSourceTag)),
+                          make_push_source_node(
+                              *route_schema,
+                              make_push_source_queue_policy(*route_schema, 8),
+                              [](PushSourceSender sender) {
+                                route_sender.publish(std::move(sender));
+                              }),
+                          std::span<const WiringPortRef>{}, Value{})};
     auto forwarded = wire<RouteGenerationForward>(w, route);
     static_cast<void>(wire<RouteGenerationCapture>(
         w, serve(w, path, forwarded.template as<TS<WebRoute>>())));
@@ -560,9 +589,9 @@ struct WsRouteGenerationSourceTag {};
 struct WsRouteGenerationCapture {
   static constexpr auto name = "web_ws_route_generation_capture";
 
-  static void eval(
-      NodeView node,
-      In<"routed", WsRouteOutput, InputValidity::Unchecked> routed) {
+  static void
+  eval(NodeView node,
+       In<"routed", WsRouteOutput, InputValidity::Unchecked> routed) {
     auto inbound = routed.template field<"frame">();
     if (!inbound.valid() || !inbound.modified()) {
       return;
@@ -596,15 +625,15 @@ struct WsRouteGenerationGraph {
                          lifecycle_server);
     const auto *route_schema = ts_type<TS<WebRoute>>();
     auto route = Port<TS<WebRoute>>{
-        w, w.add_unique_node(
-               std::type_index(typeid(WsRouteGenerationSourceTag)),
-               make_push_source_node(
-                   *route_schema,
-                   make_push_source_queue_policy(*route_schema, 8),
-                   [](PushSourceSender sender) {
-                     route_sender.publish(std::move(sender));
-                   }),
-               std::span<const WiringPortRef>{}, Value{})};
+        w,
+        w.add_unique_node(std::type_index(typeid(WsRouteGenerationSourceTag)),
+                          make_push_source_node(
+                              *route_schema,
+                              make_push_source_queue_policy(*route_schema, 8),
+                              [](PushSourceSender sender) {
+                                route_sender.publish(std::move(sender));
+                              }),
+                          std::span<const WiringPortRef>{}, Value{})};
     auto forwarded = wire<RouteGenerationForward>(w, route);
     static_cast<void>(wire<WsRouteGenerationCapture>(
         w, ws_serve(w, path, forwarded.template as<TS<WebRoute>>())));
@@ -616,8 +645,7 @@ struct ClientKeyGenerationSourceTag {};
 struct ClientKeyGenerationForward {
   static constexpr auto name = "web_client_key_generation_forward";
 
-  static void eval(In<"key", TS<WsClientKey>> key,
-                   Out<TS<WsClientKey>> out) {
+  static void eval(In<"key", TS<WsClientKey>> key, Out<TS<WsClientKey>> out) {
     ++route_value_count;
     out.apply(key.base().value());
   }
@@ -626,18 +654,15 @@ struct ClientKeyGenerationForward {
 struct ClientKeyGenerationCapture {
   static constexpr auto name = "web_client_key_generation_capture";
 
-  static void eval(
-      NodeView node,
-      In<"output", WsClientOutput, InputValidity::Unchecked> output) {
+  static void
+  eval(NodeView node,
+       In<"output", WsClientOutput, InputValidity::Unchecked> output) {
     auto frame = output.template field<"frame">();
     if (!frame.valid() || !frame.modified()) {
       return;
     }
-    const Str text = frame.base()
-                         .value()
-                         .as_bundle()
-                         .at("text")
-                         .checked_as<Str>();
+    const Str text =
+        frame.base().value().as_bundle().at("text").checked_as<Str>();
     if (text == Str{"block"}) {
       route_generation_gate.block();
       return;
@@ -695,9 +720,9 @@ struct IndependentEventCapture {
 struct IndependentRequestCapture {
   static constexpr auto name = "web_independent_request_capture";
 
-  static void eval(
-      NodeView node, DateTime evaluation_time,
-      In<"routed", WebRouteOutput, InputValidity::Unchecked> routed) {
+  static void
+  eval(NodeView node, DateTime evaluation_time,
+       In<"routed", WebRouteOutput, InputValidity::Unchecked> routed) {
     auto request = routed.template field<"request">();
     if (!request.valid() || !request.modified()) {
       return;
@@ -715,9 +740,9 @@ struct IndependentRequestCapture {
 struct IndependentWsCapture {
   static constexpr auto name = "web_independent_ws_capture";
 
-  static void eval(NodeView node, DateTime evaluation_time,
-                   In<"routed", WsRouteOutput, InputValidity::Unchecked>
-                       routed) {
+  static void
+  eval(NodeView node, DateTime evaluation_time,
+       In<"routed", WsRouteOutput, InputValidity::Unchecked> routed) {
     auto event = routed.template field<"event">();
     if (event.valid() && event.modified()) {
       capture_transport_progress(node, Str{"ws"}, evaluation_time);
@@ -740,8 +765,7 @@ struct IndependentTransportGraph {
         wire<IndependentRequestCapture>(w, serve(w, path, http_route)));
     static_cast<void>(
         wire<IndependentWsCapture>(w, ws_serve(w, path, websocket_route)));
-    static_cast<void>(
-        wire<IndependentEventCapture>(w, server_events(w, path)));
+    static_cast<void>(wire<IndependentEventCapture>(w, server_events(w, path)));
   }
 };
 
@@ -752,8 +776,7 @@ struct DuplicateRegistrationGraph {
     const auto path = service::path("web-duplicate");
     register_fake_server(w, path, server_configuration.clone(), serve_server);
     register_fake_server(w, path, server_configuration.clone(), serve_server);
-    auto route =
-        wire<stdlib::const_, TS<WebRoute>>(w, serve_route.clone());
+    auto route = wire<stdlib::const_, TS<WebRoute>>(w, serve_route.clone());
     static_cast<void>(wire<ServeCapture>(w, serve(w, path, route)));
   }
 };
@@ -774,8 +797,7 @@ template <typename G> GraphBuilder build_realtime() {
   return count;
 }
 
-[[nodiscard]] bool has_node(const GraphBuilder &graph,
-                            std::string_view name) {
+[[nodiscard]] bool has_node(const GraphBuilder &graph, std::string_view name) {
   for (const auto &node : graph.nodes()) {
     const auto *schema = node.type().schema();
     if (schema != nullptr && schema->display_name != nullptr &&
@@ -790,12 +812,10 @@ void test_runtime_specific_wiring_shapes() {
   serve_server = std::make_shared<FakeWebServer>();
   const auto server = build_realtime<ServeGraph>();
   require(count_nodes(server, NodeKind::PushSource) == 6,
-          "web server did not wire one standard push source per channel");
-  for (const auto name :
-       {std::string_view{"web_fake_server_http_routes"},
-        std::string_view{"web_fake_server_respond"},
-        std::string_view{"web_server_request_projection"},
-        std::string_view{"web_transport_admission_release"}}) {
+          "web server did not wire one burst push source per channel");
+  for (const auto name : {std::string_view{"web_fake_server_http_routes"},
+                          std::string_view{"web_fake_server_respond"},
+                          std::string_view{"web_server_request_projection"}}) {
     require(has_node(server, name),
             "web server wiring is missing graph node " + Str{name});
   }
@@ -803,12 +823,10 @@ void test_runtime_specific_wiring_shapes() {
   ws_client = std::make_shared<FakeWebClient>();
   const auto client = build_realtime<ClientWsGraph>();
   require(count_nodes(client, NodeKind::PushSource) == 5,
-          "web client did not wire one standard push source per channel");
-  for (const auto name :
-       {std::string_view{"web_fake_client_ws_keys"},
-        std::string_view{"web_fake_client_ws_send"},
-        std::string_view{"web_client_ws_projection"},
-        std::string_view{"web_transport_admission_release"}}) {
+          "web client did not wire one burst push source per channel");
+  for (const auto name : {std::string_view{"web_fake_client_ws_keys"},
+                          std::string_view{"web_fake_client_ws_send"},
+                          std::string_view{"web_client_ws_projection"}}) {
     require(has_node(client, name),
             "web client wiring is missing graph node " + Str{name});
   }
@@ -817,7 +835,8 @@ void test_runtime_specific_wiring_shapes() {
        {std::string_view{"web_request_drain"},
         std::string_view{"web_ws_ingress_drain"},
         std::string_view{"web_response_drain"},
-        std::string_view{"web_client_ws_drain"}}) {
+        std::string_view{"web_client_ws_drain"},
+        std::string_view{"web_transport_admission_release"}}) {
     require(!has_node(server, retired) && !has_node(client, retired),
             "web wiring retained private bridge drain " + Str{retired});
   }
@@ -825,14 +844,12 @@ void test_runtime_specific_wiring_shapes() {
 
 void test_simulation_rejects_live_push_adaptors() {
   serve_server = std::make_shared<FakeWebServer>();
-  require_failure(
-      [] { static_cast<void>(build_graph<ServeGraph>()); },
-      "simulation wiring accepted a push-based web server");
+  require_failure([] { static_cast<void>(build_graph<ServeGraph>()); },
+                  "simulation wiring accepted a push-based web server");
 
   ws_client = std::make_shared<FakeWebClient>();
-  require_failure(
-      [] { static_cast<void>(build_graph<ClientWsGraph>()); },
-      "simulation wiring accepted a push-based web client");
+  require_failure([] { static_cast<void>(build_graph<ClientWsGraph>()); },
+                  "simulation wiring accepted a push-based web client");
 }
 
 void test_serve_boundary() {
@@ -851,11 +868,8 @@ void test_serve_boundary() {
           "route did not reach the transport sink");
   const auto routes = serve_server->http_routes();
   require(routes.size() == 1, "unexpected route count");
-  require(routes.front()
-                  .view()
-                  .as_bundle()
-                  .at("pattern")
-                  .checked_as<Str>() == Str{"/orders/{id}"},
+  require(routes.front().view().as_bundle().at("pattern").checked_as<Str>() ==
+              Str{"/orders/{id}"},
           "route pattern was not preserved");
   serve_server->emit_request(serve_route.clone(), emitted_request.clone());
   runner.join();
@@ -923,9 +937,10 @@ void test_client_call_response_arm() {
           "client call did not reach the transport sink");
   const auto calls = call_client->calls();
   require(calls.size() == 1, "unexpected call count");
-  require(calls.front().request.view().as_bundle().at("url").checked_as<Str>() ==
-              Str{"https://api/orders"},
-          "client request url was not preserved");
+  require(
+      calls.front().request.view().as_bundle().at("url").checked_as<Str>() ==
+          Str{"https://api/orders"},
+      "client request url was not preserved");
   require(calls.front().options.has_value(),
           "client call options were not delivered");
   call_client->respond(calls.front().client_id,
@@ -1069,6 +1084,55 @@ void test_push_backlogs_deliver_one_request_per_cycle() {
           "backlogged requests were reordered");
 }
 
+void test_burst_distributes_distinct_routes_and_unrolls_collisions() {
+  backlog_server = std::make_shared<FakeWebServer>();
+  observed_burst_requests.clear();
+  burst_route_gate.reset();
+
+  auto executor = start_realtime(build_realtime<BurstRouteGraph>());
+  auto view = executor.view();
+  AsyncGraphExecutorRun runner{view};
+  const auto release_gate =
+      hgraph::make_scope_exit([] { burst_route_gate.release(); });
+
+  require(backlog_server->wait_for_http_routes(2, 2s),
+          "burst routes did not reach the transport sink");
+  backlog_server->emit_request(serve_route.clone(),
+                               make_server_request(Int{80}));
+  require(burst_route_gate.await_blocked(2s),
+          "burst route capture did not block");
+  backlog_server->emit_request(serve_route.clone(),
+                               make_server_request(Int{81}));
+  backlog_server->emit_request(alternate_route.clone(),
+                               make_server_request(Int{91}));
+  backlog_server->emit_request(serve_route.clone(),
+                               make_server_request(Int{82}));
+  burst_route_gate.release();
+  runner.join();
+
+  require(observed_burst_requests.size() == 3,
+          "burst requests were lost or conflated");
+  std::optional<DateTime> first_route_time;
+  std::optional<DateTime> second_route_time;
+  std::optional<DateTime> collision_time;
+  for (const auto &[request_id, evaluation_time] : observed_burst_requests) {
+    if (request_id == Int{81}) {
+      first_route_time = evaluation_time;
+    } else if (request_id == Int{91}) {
+      second_route_time = evaluation_time;
+    } else if (request_id == Int{82}) {
+      collision_time = evaluation_time;
+    }
+  }
+  require(first_route_time.has_value() && second_route_time.has_value() &&
+              collision_time.has_value(),
+          "burst requests were delivered under unexpected ids");
+  require(*first_route_time == *second_route_time,
+          "distinct routes from one burst did not tick together");
+  require(*collision_time == *first_route_time + MIN_TD,
+          "same-route collision was not unrolled on the next cycle");
+}
+
 void test_transport_channels_progress_independently() {
   lifecycle_server = std::make_shared<FakeWebServer>();
   observed_transport_progress.clear();
@@ -1189,8 +1253,7 @@ void test_removed_ws_route_drops_queued_frames_after_readd() {
   require(route_generation_gate.await_blocked(2s),
           "WebSocket route-generation capture did not block");
   for (const auto &text : {Str{"old-1"}, Str{"old-2"}, Str{"old-3"}}) {
-    lifecycle_server->emit_ws_frame(ws_route.clone(),
-                                    make_inbound_frame(text));
+    lifecycle_server->emit_ws_frame(ws_route.clone(), make_inbound_frame(text));
   }
   require(sender->send_blocking(alternate_ws_route.clone()),
           "WebSocket route removal was refused");
@@ -1257,9 +1320,7 @@ void test_removed_client_key_drops_queued_frames_after_readd() {
 void test_duplicate_registration_fails_and_service_restarts() {
   serve_server = std::make_shared<FakeWebServer>();
   require_failure(
-      [] {
-        static_cast<void>(build_realtime<DuplicateRegistrationGraph>());
-      },
+      [] { static_cast<void>(build_realtime<DuplicateRegistrationGraph>()); },
       "duplicate web service registration was accepted");
 
   for (int run = 0; run != 2; ++run) {
@@ -1274,8 +1335,7 @@ void test_duplicate_registration_fails_and_service_restarts() {
             "route did not reach the transport sink on restart");
     serve_server->emit_request(serve_route.clone(), emitted_request.clone());
     runner.join();
-    require(observed_request_count == 1,
-            "request did not tick after restart");
+    require(observed_request_count == 1, "request did not tick after restart");
   }
   require(serve_server->attach_count() == 2,
           "restarted service did not attach once per run");
@@ -1296,6 +1356,7 @@ int main() {
     test_ws_server_boundary();
     test_ws_client_boundary();
     test_push_backlogs_deliver_one_request_per_cycle();
+    test_burst_distributes_distinct_routes_and_unrolls_collisions();
     test_transport_channels_progress_independently();
     test_removed_route_drops_queued_events_after_readd();
     test_removed_ws_route_drops_queued_frames_after_readd();

--- a/extensions/web/tests/test_service_transport.cpp
+++ b/extensions/web/tests/test_service_transport.cpp
@@ -115,8 +115,13 @@ void test_watermarks_follow_graph_dequeue_accounting() {
   // standard push-source output. Capacity therefore means queued work, not
   // protocol completion or acknowledgement.
   budget->release(0, 400, false);
+  require(budget->payload_pending(0) == 1,
+          "one graph dequeue released more than one admitted record");
   require(transitions == std::vector<bool>{true, false},
           "low watermark did not resume after graph dequeue");
+  budget->release(0, 400, false);
+  require(budget->payload_pending(0) == 0,
+          "graph dequeue accounting did not return to zero");
   budget->stop();
 }
 

--- a/src/hgraph/runtime/push_source_node.cpp
+++ b/src/hgraph/runtime/push_source_node.cpp
@@ -1,6 +1,7 @@
 #include <hgraph/runtime/push_source_node.h>
 
 #include <hgraph/runtime/executor.h>
+#include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/time_series/ts_delta.h>
 #include <hgraph/types/time_series/ts_output.h>
 #include <hgraph/types/value/value_builder.h>
@@ -107,7 +108,7 @@ namespace hgraph
                 if (burst_output_schema != nullptr)
                 {
                     burst_element_binding =
-                        ValuePlanFactory::instance().type_for(context.sender_schema);
+                        value_type_for_active_realization(context.sender_schema);
                     burst_value_binding = compact_list_type(
                         burst_element_binding, *burst_output_schema->value_schema);
                 }

--- a/tests/cpp/test_realtime_execution.cpp
+++ b/tests/cpp/test_realtime_execution.cpp
@@ -1238,6 +1238,77 @@ TEST_CASE("real-time push source moves external polymorphic keys into graph pool
     CHECK_FALSE(second.contains(large_key.view()));
 }
 
+TEST_CASE("burst push source realizes polymorphic elements with the graph strategy")
+{
+    using namespace hgraph;
+
+    const auto schemas = push_polymorphic_schemas();
+    auto      &registry = TypeRegistry::instance();
+    const auto *tuple = registry.list(schemas.base, 0, true);
+    const auto *ts_tuple = registry.ts(tuple);
+    const auto *input_schema = hgraph::testing::single_input_schema(*ts_tuple);
+    const Value small = make_push_union(
+        schemas, make_push_leaf(schemas.small, Int{1}));
+    const Value large = make_push_union(
+        schemas, make_push_leaf(schemas.large, Int{2}, "large"));
+    std::vector<Int> observed;
+
+    PushSourceNodeExtension extension;
+    extension.on_start = [small, large](PushSourceSender sender,
+                                         const NodeView &, DateTime)
+    {
+        REQUIRE(sender.send_blocking(small));
+        REQUIRE(sender.send_blocking(large));
+    };
+
+    GraphBuilder graph_builder;
+    set_pooled_compound_scalar_storage(graph_builder.global_state());
+    graph_builder.type_realization(schemas.realization);
+    TypeRealizationScope realization_scope{schemas.realization.get()};
+    graph_builder.add_node(make_push_source_node_with_view(
+        *ts_tuple, make_push_source_burst_policy(*ts_tuple),
+        std::move(extension)));
+
+    NodeTypeMetaData sink_schema;
+    sink_schema.display_name = "testing_collecting_polymorphic_burst_sink";
+    sink_schema.input_schema = input_schema;
+    sink_schema.node_kind = NodeKind::Sink;
+    NodeCallbacks sink_callbacks;
+    sink_callbacks.evaluate = [&observed](const NodeView &view,
+                                           DateTime evaluation_time)
+    {
+        auto root = view.input(evaluation_time);
+        auto bundle = root.as_bundle();
+        const auto values = bundle[0].value().as_list();
+        for (std::size_t index = 0; index < values.size(); ++index)
+        {
+            observed.push_back(values[index].as_bundle()[0].checked_as<Int>());
+        }
+        view.graph().executor().request_stop();
+    };
+    graph_builder.add_node(NodeBuilder::native(
+        std::move(sink_schema), std::move(sink_callbacks),
+        hgraph::testing::single_input_endpoint(*input_schema, *ts_tuple)));
+    graph_builder.add_edge(GraphEdge{
+        .source_node = make_graph_edge_source(0),
+        .source_path = {},
+        .target_node = 1,
+        .target_path = {0},
+    });
+
+    const DateTime start_time = hgraph::testing::wall_now();
+    GraphExecutorBuilder executor_builder;
+    executor_builder.graph_builder(std::move(graph_builder))
+        .mode(GraphExecutorMode::RealTime)
+        .start_time(start_time)
+        .end_time(start_time + TimeDelta{1'000'000});
+    auto executor = executor_builder.make_executor();
+    executor.view().run();
+
+    const std::vector<Int> expected{Int{1}, Int{2}};
+    CHECK(observed == expected);
+}
+
 TEST_CASE("real-time conflating push source emits only the latest pending value")
 {
     using namespace hgraph;


### PR DESCRIPTION
## Summary

- use standard burst push sources for Kafka and each independently ordered web channel
- route each Kafka transport burst through one Kafka-specific graph emit whose structural bundle exposes keyed subscription and delivery lanes plus the scalar service-event lane
- retain Kafka transport work in one ordered queue and emit only its collision-free front prefix; the first repeated keyed output, second scalar event, or timestamp/recovery constraint stops dequeueing until the applicable next engine cycle, so no later event overtakes it
- project the Kafka lanes with standard `getattr_` and `map_` composition plus narrow stateless decode nodes; deterministic simulation replay feeds the same emit and projections without introducing a push source
- release web transport admission when a burst enters graph processing; later graph backlog is ordinary graph state, not transport capacity or protocol acknowledgement
- realize burst elements through the active graph value strategy and preserve concurrent compatibility requests by keying before route merges
- update RFCs, user guides, changelogs, topology assertions, and burst/compatibility regressions

## Validation

- macOS fresh native acceptance: 1620/1620 passed
- macOS Python 3.14 stable-ABI wheel compatibility suite: 2128 passed, 10 skipped
- Linux GCC 14 fresh native acceptance: 1620/1620 passed
- Linux GCC 14 Python 3.14 stable-ABI wheel compatibility suite: 2128 passed, 10 skipped
- Windows Visual Studio 2026 / MSVC 19.51 Kafka native target built and service tests passed
- Sphinx HTML build with warnings as errors passed
- `git diff --check` passed
