### PR TITLE
Add public Value hash and equality functors

### DIFF
--- a/docs/source/developer_guide/data_structures/plans_and_ops/scalar.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/scalar.rst
@@ -113,6 +113,12 @@ Owning Value
   ``std::partial_ordering`` to match the type-erased ``<=>``-style
   contract. ``Value`` itself only carries the minimum behaviour needed
   to live in a container.
+- ``ValueHash`` / ``ValueEqual`` (``value_hash.h``) — the public transparent
+  container functors for owning ``Value`` keys and allocation-free borrowed
+  ``ValueView`` lookup. Payload-free values hash to zero; equality still uses
+  ``ValueView::equals`` so typed-null schema identity is preserved. Concrete
+  runtime, standard-library, and extension code should use this pair rather
+  than defining private value-key policies.
 - ``clone()`` and construction from ``ValueView`` — copy the represented
   type and payload, preserving typed-null state when the view carries
   a type record without a live payload.

--- a/extensions/kafka/src/detail/service_transport.h
+++ b/extensions/kafka/src/detail/service_transport.h
@@ -9,6 +9,7 @@
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/static_node.h>
 #include <hgraph/types/value/value_builder.h>
+#include <hgraph/types/value/value_hash.h>
 
 #include <algorithm>
 #include <compare>
@@ -100,41 +101,13 @@ inline std::ostream &operator<<(std::ostream &stream,
       })};
 }
 
-struct OwnedValueHash {
-  using is_transparent = void;
-
-  [[nodiscard]] std::size_t operator()(const Value &value) const {
-    return value.hash();
-  }
-
-  [[nodiscard]] std::size_t operator()(const ValueView &value) const {
-    return value.hash();
-  }
-};
-
-struct OwnedValueEqual {
-  using is_transparent = void;
-
-  [[nodiscard]] bool operator()(const Value &lhs, const Value &rhs) const {
-    return lhs.equals(rhs.view());
-  }
-
-  [[nodiscard]] bool operator()(const Value &lhs, const ValueView &rhs) const {
-    return lhs.equals(rhs);
-  }
-
-  [[nodiscard]] bool operator()(const ValueView &lhs, const Value &rhs) const {
-    return rhs.equals(lhs);
-  }
-};
-
 struct KafkaTransportEmitState {
   ValueTypeRef event_binding{};
   std::deque<Value> pending{};
   // Per-evaluation output-occupancy scratch. It is cleared before dequeueing
   // and never retains transport work; keeping its allocation avoids rebuilding
   // the hash table on every engine cycle until outputs expose this directly.
-  std::unordered_set<Value, OwnedValueHash, OwnedValueEqual> occupied_keys{};
+  std::unordered_set<Value, ValueHash, ValueEqual> occupied_keys{};
   bool recovery_blocked{};
 };
 

--- a/extensions/web/src/detail/service_transport.h
+++ b/extensions/web/src/detail/service_transport.h
@@ -14,6 +14,7 @@
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/static_node.h>
 #include <hgraph/types/value/value_builder.h>
+#include <hgraph/types/value/value_hash.h>
 #include <hgraph/util/scope.h>
 
 #include <algorithm>
@@ -436,34 +437,6 @@ struct WebTransportBindingsHandle {
   }
 };
 
-struct OwnedValueHash {
-  using is_transparent = void;
-
-  [[nodiscard]] std::size_t operator()(const Value &value) const {
-    return value.hash();
-  }
-
-  [[nodiscard]] std::size_t operator()(const ValueView &value) const {
-    return value.hash();
-  }
-};
-
-struct OwnedValueEqual {
-  using is_transparent = void;
-
-  [[nodiscard]] bool operator()(const Value &lhs, const Value &rhs) const {
-    return lhs.equals(rhs.view());
-  }
-
-  [[nodiscard]] bool operator()(const Value &lhs, const ValueView &rhs) const {
-    return lhs.equals(rhs);
-  }
-
-  [[nodiscard]] bool operator()(const ValueView &lhs, const Value &rhs) const {
-    return rhs.equals(lhs);
-  }
-};
-
 /** Wiring-fixed value bindings used by the one graph-side grouping primitive.
  * The node performs only O(B) transient classification. Standard collect,
  * map_, and emit nodes own all state used to unroll same-key collisions. */
@@ -661,7 +634,7 @@ struct GroupTransportBatchNode {
                    State<WebKeyedBatchBindings> bindings,
                    Out<TS<KeyedWebTransportBatches<Key>>> out) {
     using EventsByKey = std::unordered_map<Value, std::vector<std::size_t>,
-                                           OwnedValueHash, OwnedValueEqual>;
+                                           ValueHash, ValueEqual>;
     EventsByKey grouped;
     const auto events = transport.base().value().as_list();
     grouped.reserve(events.size());

--- a/include/hgraph/lib/std/operators/impl/collection_impl.h
+++ b/include/hgraph/lib/std/operators/impl/collection_impl.h
@@ -27,6 +27,7 @@
 #include <hgraph/types/lift.h>
 #include <hgraph/types/subgraph_wiring.h>
 #include <hgraph/types/static_node.h>
+#include <hgraph/types/value/value_hash.h>
 
 #include <ankerl/unordered_dense.h>
 
@@ -69,23 +70,6 @@ namespace hgraph::stdlib
 
     namespace collection_impl_detail
     {
-        struct ValueKeyHash
-        {
-            [[nodiscard]] std::size_t operator()(const Value &value) const
-            {
-                return value.has_value() ? value.hash() : 0;
-            }
-        };
-
-        struct ValueKeyEqual
-        {
-            [[nodiscard]] bool operator()(const Value &lhs, const Value &rhs) const
-            {
-                if (lhs.has_value() != rhs.has_value()) { return false; }
-                return !lhs.has_value() || lhs.equals(rhs);
-            }
-        };
-
         inline void apply_tss_delta(TSSOutputView &out, const std::vector<Value> &removed,
                                     const std::vector<Value> &added)
         {
@@ -1047,7 +1031,7 @@ namespace hgraph::stdlib
             return slot != TS_DATA_NO_CHILD_ID && tsd.slot_modified(slot) && tsd.at_slot(slot).valid();
         }
 
-        using FlippedPreviousIndex = ankerl::unordered_dense::map<Value, Value, ValueKeyHash, ValueKeyEqual>;
+        using FlippedPreviousIndex = ankerl::unordered_dense::map<Value, Value, ValueHash, ValueEqual>;
 
         inline FlippedPreviousIndex build_flipped_previous_index(const TSDOutputView &out)
         {
@@ -1451,7 +1435,7 @@ namespace hgraph::stdlib
 
                 // The desired pivot: inner key -> {outer key -> leaf ref}.
                 using Members = std::vector<std::pair<Value, Value>>;
-                ankerl::unordered_dense::map<Value, Members, ValueKeyHash, ValueKeyEqual> desired;
+                ankerl::unordered_dense::map<Value, Members, ValueHash, ValueEqual> desired;
                 const TSDInputView &source = ts;
                 for (auto &&[outer_key, child] : source.items())
                 {
@@ -1677,7 +1661,7 @@ namespace hgraph::stdlib
                 const auto     evaluation_time = out_dict.evaluation_time();
                 const TSDInputView &dict = ts;
 
-                ankerl::unordered_dense::map<Value, std::vector<Value>, ValueKeyHash, ValueKeyEqual> groups;
+                ankerl::unordered_dense::map<Value, std::vector<Value>, ValueHash, ValueEqual> groups;
                 for (auto &&[key, child] : dict.items())
                 {
                     if (child.valid()) { groups[Value{child.value()}].emplace_back(key); }

--- a/include/hgraph/types/value/value_hash.h
+++ b/include/hgraph/types/value/value_hash.h
@@ -1,0 +1,67 @@
+#ifndef HGRAPH_TYPES_VALUE_VALUE_HASH_H
+#define HGRAPH_TYPES_VALUE_VALUE_HASH_H
+
+#include <hgraph/types/value/value.h>
+
+#include <cstddef>
+
+namespace hgraph
+{
+    /**
+     * Transparent hash for owning ``Value`` keys and borrowed ``ValueView``
+     * lookups.
+     *
+     * Values without a payload hash to zero. Live values dispatch through
+     * their erased ``ValueOps`` hash implementation, so an unhashable live
+     * value retains the normal ``Value::hash`` failure behavior.
+     */
+    struct ValueHash
+    {
+        using is_transparent = void;
+
+        [[nodiscard]] std::size_t operator()(const Value &value) const
+        {
+            return value.has_value() ? value.hash() : std::size_t{0};
+        }
+
+        [[nodiscard]] std::size_t operator()(const ValueView &value) const
+        {
+            return value.has_value() ? value.hash() : std::size_t{0};
+        }
+    };
+
+    /**
+     * Transparent semantic equality for every owning and borrowed value-key
+     * combination.
+     *
+     * Equality delegates to ``ValueView::equals``. This preserves schema
+     * identity for typed-null values while allowing semantically equivalent
+     * live values with compatible erased representations to compare equal.
+     */
+    struct ValueEqual
+    {
+        using is_transparent = void;
+
+        [[nodiscard]] bool operator()(const Value &lhs, const Value &rhs) const
+        {
+            return lhs.equals(rhs);
+        }
+
+        [[nodiscard]] bool operator()(const Value &lhs, const ValueView &rhs) const
+        {
+            return lhs.equals(rhs);
+        }
+
+        [[nodiscard]] bool operator()(const ValueView &lhs, const Value &rhs) const
+        {
+            return lhs.equals(rhs.view());
+        }
+
+        [[nodiscard]] bool operator()(const ValueView &lhs, const ValueView &rhs) const
+        {
+            return lhs.equals(rhs);
+        }
+    };
+}  // namespace hgraph
+
+#endif  // HGRAPH_TYPES_VALUE_VALUE_HASH_H

--- a/src/hgraph/runtime/mesh_node.cpp
+++ b/src/hgraph/runtime/mesh_node.cpp
@@ -7,6 +7,7 @@
 #include <hgraph/types/utils/key_slot_store.h>
 #include <hgraph/types/utils/slot_bitmap.h>
 #include <hgraph/types/value/impl/graph_local_value.h>
+#include <hgraph/types/value/value_hash.h>
 #include <hgraph/util/date_time.h>
 #include <hgraph/util/scope.h>
 
@@ -34,33 +35,8 @@ constexpr std::string_view mesh_storage_field_name{"mesh"};
 constexpr std::string_view mesh_subscribe_storage_field_name{"mesh_subscribe"};
 constexpr std::string_view mesh_key_set_storage_field_name{"mesh_key_set"};
 
-struct ValueKeyHash {
-  using is_transparent = void;
-  [[nodiscard]] std::size_t operator()(const Value &v) const noexcept {
-    return v.hash();
-  }
-  [[nodiscard]] std::size_t operator()(const ValueView &v) const noexcept {
-    return v.hash();
-  }
-};
-
-struct ValueKeyEqual {
-  using is_transparent = void;
-  [[nodiscard]] bool operator()(const Value &a, const Value &b) const noexcept {
-    return a.equals(b);
-  }
-  [[nodiscard]] bool operator()(const Value &a,
-                                const ValueView &b) const noexcept {
-    return a.equals(b);
-  }
-  [[nodiscard]] bool operator()(const ValueView &a,
-                                const Value &b) const noexcept {
-    return b.equals(a);
-  }
-};
-
 using ValueSet =
-    ankerl::unordered_dense::set<Value, ValueKeyHash, ValueKeyEqual>;
+    ankerl::unordered_dense::set<Value, ValueHash, ValueEqual>;
 
 struct MeshNodeStorage;
 
@@ -154,7 +130,7 @@ struct MeshNodeStorage final : SlotObserver {
   std::vector<TSOutputHandle> outer_sources{};
   bool refresh_all_bindings{false};
   // depends_on -> set of keys that depend on it (reverse edges).
-  ankerl::unordered_dense::map<Value, ValueSet, ValueKeyHash, ValueKeyEqual>
+  ankerl::unordered_dense::map<Value, ValueSet, ValueHash, ValueEqual>
       dependents{};
 
   std::vector<Value>

--- a/src/hgraph/runtime/race_tsd_node.cpp
+++ b/src/hgraph/runtime/race_tsd_node.cpp
@@ -10,6 +10,7 @@
 #include <hgraph/types/time_series/ts_output/base_view.h>
 #include <hgraph/types/time_series_reference.h>
 #include <hgraph/types/value/value.h>
+#include <hgraph/types/value/value_hash.h>
 #include <hgraph/types/value/value_view.h>
 #include <hgraph/util/date_time.h>
 #include <hgraph/util/scope.h>
@@ -54,24 +55,11 @@ namespace hgraph
             bool                        seen{false};
         };
 
-        struct ValueKeyHash
-        {
-            [[nodiscard]] std::size_t operator()(const Value &value) const { return value.view().hash(); }
-        };
-
-        struct ValueKeyEq
-        {
-            [[nodiscard]] bool operator()(const Value &lhs, const Value &rhs) const
-            {
-                return lhs.view().equals(rhs.view());
-            }
-        };
-
         /** One race per FIELD (hgraph's reduce_tsd_of_bundles_with_race);
             a non-bundle OUT is the single-field degenerate case. */
         struct RaceFieldState
         {
-            ankerl::unordered_dense::map<Value, RaceTsdEntry, ValueKeyHash, ValueKeyEq> entries{};
+            ankerl::unordered_dense::map<Value, RaceTsdEntry, ValueHash, ValueEqual> entries{};
             Value winner{};
         };
 

--- a/src/hgraph/runtime/reduce_node.cpp
+++ b/src/hgraph/runtime/reduce_node.cpp
@@ -4,6 +4,7 @@
 #include <hgraph/types/wired_fn.h>
 #include <hgraph/types/utils/slot_bitmap.h>
 #include <hgraph/types/value/impl/graph_local_value.h>
+#include <hgraph/types/value/value_hash.h>
 #include <hgraph/util/scope.h>
 
 #include "reduce_output_binding.h"
@@ -35,37 +36,6 @@ namespace hgraph
         {
             GraphValue     graph{};
             TSOutputHandle output{};
-        };
-
-        struct ValueKeyHash
-        {
-            using is_transparent = void;
-            [[nodiscard]] std::size_t operator()(const Value &value) const
-            {
-                return value.has_value() ? value.hash() : 0;
-            }
-            [[nodiscard]] std::size_t operator()(const ValueView &value) const noexcept
-            {
-                return value.valid() ? value.hash() : 0;
-            }
-        };
-
-        struct ValueKeyEqual
-        {
-            using is_transparent = void;
-            [[nodiscard]] bool operator()(const Value &lhs, const Value &rhs) const
-            {
-                if (lhs.has_value() != rhs.has_value()) { return false; }
-                return !lhs.has_value() || lhs.equals(rhs);
-            }
-            [[nodiscard]] bool operator()(const Value &lhs, const ValueView &rhs) const noexcept
-            {
-                return lhs.has_value() == rhs.valid() && (!lhs.has_value() || lhs.equals(rhs));
-            }
-            [[nodiscard]] bool operator()(const ValueView &lhs, const Value &rhs) const noexcept
-            {
-                return (*this)(rhs, lhs);
-            }
         };
 
         struct ReduceNodeStorage
@@ -130,7 +100,7 @@ namespace hgraph
             std::vector<std::size_t> dense_to_source_slot{};
             /** TSL dense leaf -> effective child source, detecting same-slot re-points. */
             std::vector<TSOutputHandle> dense_to_source_handle{};
-            ankerl::unordered_dense::map<Value, std::size_t, ValueKeyHash, ValueKeyEqual> key_to_leaf{};
+            ankerl::unordered_dense::map<Value, std::size_t, ValueHash, ValueEqual> key_to_leaf{};
 
             /** Power-of-two tree width (monotonic; 0 until the first key). */
             std::size_t leaf_capacity{0};

--- a/src/hgraph/runtime/service_node.cpp
+++ b/src/hgraph/runtime/service_node.cpp
@@ -10,6 +10,7 @@
 #include <hgraph/types/time_series/ts_output/base_view.h>
 #include <hgraph/types/time_series/ts_output/dict_view.h>
 #include <hgraph/types/time_series/ts_output/set_view.h>
+#include <hgraph/types/value/value_hash.h>
 
 #include <ankerl/unordered_dense.h>
 
@@ -41,27 +42,6 @@ namespace hgraph
         constexpr std::string_view request_input_source_storage_field{"request_input_source"};
         constexpr std::string_view request_input_capture_storage_field{"request_input_capture"};
 
-        struct ValueKeyHash
-        {
-            using is_transparent = void;
-
-            [[nodiscard]] std::size_t operator()(const Value &value) const
-            {
-                return value.has_value() ? value.hash() : 0;
-            }
-        };
-
-        struct ValueKeyEqual
-        {
-            using is_transparent = void;
-
-            [[nodiscard]] bool operator()(const Value &lhs, const Value &rhs) const
-            {
-                if (lhs.has_value() != rhs.has_value()) { return false; }
-                return !lhs.has_value() || lhs.equals(rhs);
-            }
-        };
-
         struct SubscriptionKeyChange
         {
             Value    key{};
@@ -71,7 +51,7 @@ namespace hgraph
 
         struct SubscriptionKeySourceStorage
         {
-            ankerl::unordered_dense::map<Value, std::size_t, ValueKeyHash, ValueKeyEqual> counts{};
+            ankerl::unordered_dense::map<Value, std::size_t, ValueHash, ValueEqual> counts{};
             std::vector<SubscriptionKeyChange>                                            pending{};
         };
 

--- a/tests/cpp/header_compile_check.cpp
+++ b/tests/cpp/header_compile_check.cpp
@@ -38,6 +38,7 @@
 #include <hgraph/types/value/container_ops.h>
 #include <hgraph/types/value/specialized_views.h>
 #include <hgraph/types/value/value_builder.h>
+#include <hgraph/types/value/value_hash.h>
 #include <hgraph/types/value/value_range.h>
 #include <hgraph/lib/testing/runtime_support.h>
 #include <hgraph/util/date_time.h>

--- a/tests/cpp/test_value.cpp
+++ b/tests/cpp/test_value.cpp
@@ -16,6 +16,7 @@
 #include <hgraph/types/type_resolution.h>
 #include <hgraph/types/utils/memory_utils.h>
 #include <hgraph/types/value/value.h>
+#include <hgraph/types/value/value_hash.h>
 #include <hgraph/types/value/value_ops.h>
 #include <hgraph/types/value/value_view.h>
 
@@ -24,6 +25,7 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+#include <unordered_set>
 #include <utility>
 
 namespace
@@ -306,6 +308,59 @@ TEST_CASE("ValueOps: unsupported scalar operations do not use object bytes as fa
     Value value{NoValueOpsScalar{1}};
     REQUIRE_THROWS_AS(value.hash(), std::logic_error);
     REQUIRE_THROWS_AS(ValueView{}.hash(), std::logic_error);
+}
+
+TEST_CASE("ValueHash and ValueEqual support owning keys and borrowed lookups")
+{
+    using namespace hgraph;
+
+    Value stored{Int{42}};
+    Value equal_value{Int{42}};
+    Value different_value{Int{7}};
+    auto equal_view = equal_value.view();
+    auto different_view = different_value.view();
+
+    std::unordered_set<Value, ValueHash, ValueEqual> values;
+    values.insert(stored);
+
+    CHECK(values.contains(equal_value));
+    CHECK(values.contains(equal_view));
+    CHECK_FALSE(values.contains(different_value));
+    CHECK_FALSE(values.contains(different_view));
+    CHECK(ValueHash{}(stored) == ValueHash{}(equal_view));
+    CHECK(ValueEqual{}(stored, equal_view));
+    CHECK(ValueEqual{}(equal_view, stored));
+    CHECK(ValueEqual{}(stored.view(), equal_view));
+}
+
+TEST_CASE("ValueHash and ValueEqual preserve empty value schema identity")
+{
+    using namespace hgraph;
+
+    Value unbound_a{};
+    Value unbound_b{};
+    Value int_null{*scalar_descriptor<Int>::value_meta()};
+    Value another_int_null{*scalar_descriptor<Int>::value_meta()};
+    Value str_null{*scalar_descriptor<Str>::value_meta()};
+    auto int_null_view = another_int_null.view();
+
+    const ValueHash hash;
+    const ValueEqual equal;
+    CHECK(hash(unbound_a) == 0);
+    CHECK(hash(int_null) == 0);
+    CHECK(hash(int_null_view) == 0);
+    CHECK(equal(unbound_a, unbound_b));
+    CHECK(equal(int_null, another_int_null));
+    CHECK(equal(int_null, int_null_view));
+    CHECK_FALSE(equal(unbound_a, int_null));
+    CHECK_FALSE(equal(int_null, str_null));
+
+    std::unordered_set<Value, ValueHash, ValueEqual> values;
+    values.insert(unbound_a);
+    values.insert(int_null);
+    values.insert(str_null);
+    CHECK(values.size() == 3);
+    CHECK(values.contains(int_null_view));
 }
 
 TEST_CASE("TypeRegistry::register_scalar pairs the schema with a binding")

--- a/tests/install_consumer/main.cpp
+++ b/tests/install_consumer/main.cpp
@@ -34,6 +34,7 @@
 #include <hgraph/types/value/polymorphic_value_type.h>
 #include <hgraph/types/value/value.h>
 #include <hgraph/types/value/value_builder.h>
+#include <hgraph/types/value/value_hash.h>
 #include <hgraph/types/value/visitor.h>
 
 #include <arrow/api.h>
@@ -46,6 +47,7 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+#include <unordered_set>
 #include <vector>
 
 namespace
@@ -149,6 +151,22 @@ namespace
 
         check_capacity(*ts_int, make_push_source_queue_policy(*ts_int, 1));
         check_capacity(*ts_tuple, make_push_source_burst_policy(*ts_tuple, 1));
+    }
+
+    void check_value_hash_contract()
+    {
+        using namespace hgraph;
+
+        Value stored{Int{42}};
+        Value lookup{Int{42}};
+        auto lookup_view = lookup.view();
+        std::unordered_set<Value, ValueHash, ValueEqual> values;
+        values.insert(stored);
+        if (!values.contains(lookup_view))
+        {
+            throw std::runtime_error(
+                "installed ValueHash/ValueEqual cannot perform borrowed lookup");
+        }
     }
 
     // ------------------------------------------------------------------
@@ -562,6 +580,7 @@ int main()
 
     check_probe_backend_round_trip();
     check_push_source_queue_contract();
+    check_value_hash_contract();
     hgraph_install_consumer::check_fabric_core_extension_seam();
 
     return 0;


### PR DESCRIPTION
## Summary

- add public transparent ValueHash and ValueEqual functors for owning keys and borrowed ValueView lookup
- preserve typed-null schema identity while hashing payload-free values consistently
- replace private policies in runtime, stdlib, Kafka, and Web with the shared core contract
- cover native behavior, public-header compilation, installed-SDK consumption, and developer documentation

## Validation

- macOS native: 1622/1622 passed
- macOS Python 3.14 non-WIP: 2128 passed, 10 skipped
- Linux GCC 14 native: 1622/1622 passed
- Linux GCC 14 Python 3.14 non-WIP: 2128 passed, 10 skipped
- installed-package consumer: passed
- Sphinx warning-as-error build: passed