### PR TITLE
Restore RFC 0029 pool binding onto main

### DIFF
--- a/docs/source/developer_guide/data_structures/unified_type_erasure.rst
+++ b/docs/source/developer_guide/data_structures/unified_type_erasure.rst
@@ -452,9 +452,11 @@ from a larger externally owned value without fabricating a non-owning
 Pooling is an explicit graph-level realisation policy.  An opted-in root
 graph's named storage plan contains a two-word compound-scalar owner, and its
 nested plan contains the two-word borrowed view.  Disabled plans contain
-neither field and select lifecycle/evaluation ops which do not establish a
-compound-storage scope.  The owner allocates its concrete per-leaf registry
-only when a pooled value is first constructed.  Ordinary root/nested graphs
+neither field.  The owner binds itself into its realisation's pool binding for
+its own lifetime (:doc:`RFC 0029 </rfc/rfc_0029_value_pool_ownership_and_binding>`),
+so lifecycle and evaluation ops are the same functions in both cases and no
+scope is established around them.  The owner allocates its concrete per-leaf
+registry only when a pooled value is first constructed.  Ordinary root/nested graphs
 point into their owner. Slot-placed nested graphs have no owner and point into
 graph/slot memory, whose stop/delete and destructor/erase protocol remains the
 lifetime authority.  ``GraphValue`` remains five words on 64-bit builds;
@@ -462,7 +464,9 @@ lifetime authority.  ``GraphValue`` remains five words on 64-bit builds;
 words.
 
 Representation selection is also type-erased. ``PolymorphicValueType`` is a
-two-word, move-only passive-ops owner held by the realisation snapshot.  Its
+two-word, move-only passive-ops owner held by the realisation snapshot; a
+pooled strategy also holds a pointer to that snapshot's pool binding, which is
+how an allocating op reaches the pool of the root graph it is running in.  Its
 default and moved-from states bind a canonical no-op table.  The concrete
 pooled-union strategy and its Python source resolver remain under the
 implementation boundary; semantic realisation code asks only for the facade's

--- a/docs/source/rfc/rfc_0013_pooled_polymorphic_compound_scalars.rst
+++ b/docs/source/rfc/rfc_0013_pooled_polymorphic_compound_scalars.rst
@@ -62,9 +62,9 @@ An opted-in root graph's erased storage plan contains one compound-scalar
 storage owner; its nested-graph plan contains a borrowed view of that owner.
 These are conditional named plan fields, not fixed runtime-header members.
 The concrete pool registry is allocated lazily on the first pooled value.  A
-graph which does not opt in has neither field, constructs no pool facade, and
-does not establish a compound-storage scope around graph lifecycle or
-evaluation.  A graph-local pooled handle never crosses to another root graph
+graph which does not opt in has neither field and constructs no pool facade.
+(The compound-storage scope this originally described is gone; see
+:doc:`RFC 0029 <rfc_0029_value_pool_ownership_and_binding>`.)  A graph-local pooled handle never crosses to another root graph
 without materialisation.  Consequently intrusive reference counts are
 non-atomic: allocation, retain, release, and mutation occur on the graph's own
 evaluation thread.
@@ -198,7 +198,9 @@ Acceptance criteria
 -------------------
 
 * Disabled graph plans contain no pool owner/view field and execute the
-  ordinary lifecycle/evaluation ops without a compound-storage scope.
+  ordinary lifecycle/evaluation ops.  (Originally: "without a compound-storage
+  scope" — under :doc:`RFC 0029 <rfc_0029_value_pool_ownership_and_binding>` no
+  graph establishes one.)
 * Eligible opted-in holders are one pointer and existing payload pointers
   remain stable across leaf-pool growth.
 * Separate leaf records never share a pool, and each slot uses only its exact

--- a/docs/source/rfc/rfc_0029_value_pool_ownership_and_binding.rst
+++ b/docs/source/rfc/rfc_0029_value_pool_ownership_and_binding.rst
@@ -227,10 +227,20 @@ Binding a second one is refused with a diagnostic rather than silently
 overwriting.  Admission is **claimed atomically**, because a cached realization
 can have two root graphs constructed against it concurrently: a check-then-set
 would let both through and tear the two-word view, so the refusal the design
-depends on would not hold exactly when it matters.  The claim is taken once per
-root graph construction and released once at teardown — never on the per-tick
-path, which reads the bound view plainly and only from the graph holding the
-claim.  Nothing in the tree violates it — a snapshot is captured per
+depends on would not hold exactly when it matters.
+
+Admission carries the view's publication protocol with it.  It has three
+states, and the middle one is the point: ``Claiming`` is the winner's window,
+where it holds admission but has not yet published its view, and throughout
+which the binding reads as **unbound**.  The winner writes the view and then
+releases ``Bound``; every read acquires it first, so a thread that observes
+``Bound`` observes the whole view and never a half-written one, and a binding
+mid-claim is never mistaken for a usable one.
+
+The claim is a read-modify-write exactly once per root graph construction and
+once at teardown.  The allocation path pays an acquire **load** of one byte,
+in place of the view test it would do anyway — no read-modify-write and no
+contention on the per-tick path.  Nothing in the tree violates it — a snapshot is captured per
 builder (``graph.cpp:2170``) and a nested graph deliberately reuses its root's
 (``graph_wiring.cpp:2539``, ``:2746``) — and it is strictly tighter than what
 the thread-local permitted, which was two root graphs sharing a snapshot on two

--- a/docs/source/rfc/rfc_0029_value_pool_ownership_and_binding.rst
+++ b/docs/source/rfc/rfc_0029_value_pool_ownership_and_binding.rst
@@ -224,7 +224,13 @@ The binding is exclusive, and this is the invariant the design rests on:
    A realization snapshot has at most one live root graph.
 
 Binding a second one is refused with a diagnostic rather than silently
-overwriting.  Nothing in the tree violates it — a snapshot is captured per
+overwriting.  Admission is **claimed atomically**, because a cached realization
+can have two root graphs constructed against it concurrently: a check-then-set
+would let both through and tear the two-word view, so the refusal the design
+depends on would not hold exactly when it matters.  The claim is taken once per
+root graph construction and released once at teardown — never on the per-tick
+path, which reads the bound view plainly and only from the graph holding the
+claim.  Nothing in the tree violates it — a snapshot is captured per
 builder (``graph.cpp:2170``) and a nested graph deliberately reuses its root's
 (``graph_wiring.cpp:2539``, ``:2746``) — and it is strictly tighter than what
 the thread-local permitted, which was two root graphs sharing a snapshot on two
@@ -453,6 +459,8 @@ Acceptance criteria
 * Binding a second live root graph to one realization is refused with a
   diagnostic; binding, unbinding, and rebinding in sequence works, including
   after a failed graph construction unwinds.
+* Concurrent admission of two root graphs to one realization admits exactly
+  one, under TSAN as well as ordinary builds.
 * A node-local pool and its graph's pool are live simultaneously, and values
   allocated from each release to the correct owner.
 * A ``Synchronised`` pool acquires off-thread, batches its returns through an

--- a/docs/source/rfc/rfc_0029_value_pool_ownership_and_binding.rst
+++ b/docs/source/rfc/rfc_0029_value_pool_ownership_and_binding.rst
@@ -324,10 +324,15 @@ What is removed
 * the ``thread_local`` at ``stable_leaf_compound_scalar_storage.cpp:417``;
 * ``active_compound_scalar_storage()`` and ``CompoundScalarStorageScope``,
   including their declarations in ``compound_scalar_storage.h``;
-* the eight scope installations in ``graph.cpp`` listed under `Motivation`_,
-  and the four in the native tests (``test_ts_input.cpp:2268``,
-  ``test_type_registry.cpp:572``/``:591``, ``test_value_builder.cpp:302``,
-  ``type_erasure_perf.cpp:661``), which become explicit pool arguments; and
+* the eight scope installations in ``graph.cpp`` listed under `Motivation`_ —
+  three of which were ``pooled_start_impl``, ``pooled_stop_impl``, and
+  ``pooled_evaluate_impl``, wrappers that existed only to install a scope and
+  so charged a thread-local write and restore to **every graph cycle**; pooled
+  graphs now run the same lifecycle functions as every other graph;
+* the five scope installations in the native tests
+  (``test_ts_input.cpp``, ``test_type_registry.cpp`` ×2,
+  ``test_value_builder.cpp``, ``type_erasure_perf.cpp``), which bind to a
+  realization instead; and
 * the ambient availability condition: an allocating op now fails against its
   own binding, with a diagnostic saying no root graph is bound, rather than
   reporting that some scope was never installed.
@@ -366,6 +371,12 @@ renames above.  No extension in this repository references either type, so the
 migration is internal; it is nevertheless an ABI change requiring a rebuild of
 downstream native extensions, and the installed-SDK consumer fixture must build
 against the renamed header.
+
+One exported function changes shape rather than name:
+``retain_or_copy_pooled_compound_scalar`` takes the pool it is retaining *into*
+as its first argument.  Its ambient form could only ask which thread was
+calling; a payload from another pool is materialised into the target it was
+given.
 
 Python exposure is one reserved ``GlobalState`` key holding an opaque handle.
 It is not part of the public Python surface and is erased before run-end copy

--- a/docs/source/rfc/rfc_0029_value_pool_ownership_and_binding.rst
+++ b/docs/source/rfc/rfc_0029_value_pool_ownership_and_binding.rst
@@ -256,6 +256,50 @@ Nested graphs inherit the root's binding by construction: they share its
 realization, so they share its cell and never bind one of their own.  A builder
 used to construct two root graphs in sequence binds, unbinds, and binds again.
 
+Concurrency limit: one live pooled root graph per realization
+-------------------------------------------------------------
+
+Exclusivity has a consequence that must be stated rather than discovered.
+``TypeRealizationSnapshot::capture`` **caches** by ``(registry generation,
+options)`` and returns the same snapshot to every caller
+(``type_realization.cpp:1350-1368``).  Two pooled root graphs built at the same
+registry generation with the same options therefore share one realization, and
+so one binding cell: the second to construct is **refused**, with a diagnostic
+naming the conflict.
+
+What still works is most of what is done:
+
+* **Sequential runs** — bind, unbind on teardown, bind again.  A graph run
+  repeatedly from one builder is unaffected.
+* **Nested graphs** — they share their root's realization deliberately and
+  never bind one of their own.
+* **Every graph that has not opted into pooling** — no pool, no cell, no
+  binding, and no behaviour change of any kind.
+* **Concurrent engines whose realizations differ** — a different registry
+  generation or different options gives a different snapshot and a different
+  pool.
+
+What is refused is two *concurrently live* pooled root graphs sharing a
+realization.  RFC 0013 lists "multiple pure-C++ engines execute concurrently on
+separate threads without sharing pool state" as an acceptance criterion, and
+under the thread-local that case worked by giving each thread its own ambient
+slot.  This RFC narrows it for pooled graphs: the case is refused loudly
+instead of served.  That is a deliberate trade — the alternative designs below
+cost considerably more — and it is reversible without changing the binding
+contract.
+
+Two follow-ups would restore it, neither needed until a real use appears:
+
+* **Lease a realization per live pooled graph.**  Capture would hand out a
+  realization whose cell is free rather than a shared one.  The cost is one
+  graph-type compilation per concurrent pooled graph, plus lifetime work that
+  is not incidental: value types interned from a snapshot outlive it today, and
+  the process-wide graph type registry holds them, so realizations are
+  effectively immortal by design.
+* **Thread the pool through the allocating ops.**  Correct for any number of
+  concurrent graphs, and disproportionate: it changes the signature of the ops
+  vocabulary to serve three allocating entries.
+
 Why not per-instance realized types
 -----------------------------------
 
@@ -284,7 +328,9 @@ What is removed
   and the four in the native tests (``test_ts_input.cpp:2268``,
   ``test_type_registry.cpp:572``/``:591``, ``test_value_builder.cpp:302``,
   ``type_erasure_perf.cpp:661``), which become explicit pool arguments; and
-* the allocating no-op entries and ``unavailable_storage()``.
+* the ambient availability condition: an allocating op now fails against its
+  own binding, with a diagnostic saying no root graph is bound, rather than
+  reporting that some scope was never installed.
 
 Explicitly **not** removed, and out of scope here: the type-realization
 thread-locals ``active_snapshot`` and ``graph_value_realization``
@@ -391,8 +437,8 @@ Acceptance criteria
   state is reachable other than through a running graph or a node — enforced by
   a source-level check alongside the existing lock-counting enforcement, so the
   channel cannot quietly return.
-* A test constructs two root graphs on two threads and proves each allocates
-  into its own pool, and the same test passes with both graphs on one thread.
+* Two root graphs whose realizations differ allocate into their own pools, on
+  one thread and on two.
 * Binding a second live root graph to one realization is refused with a
   diagnostic; binding, unbinding, and rebinding in sequence works, including
   after a failed graph construction unwinds.

--- a/include/hgraph/types/metadata/type_realization.h
+++ b/include/hgraph/types/metadata/type_realization.h
@@ -11,6 +11,7 @@
 
 namespace hgraph
 {
+    class CompoundScalarStorageBinding;
     class GlobalStateView;
     class TypeRegistry;
 
@@ -74,6 +75,13 @@ namespace hgraph
 
         [[nodiscard]] std::uint64_t generation() const noexcept;
         [[nodiscard]] TypeRealizationOptions options() const noexcept;
+        /**
+         * The cell through which this realization's pooled value types reach
+         * their pool.  A root graph's pool owner binds itself here for its
+         * lifetime; the binding is exclusive, so a realization serves at most
+         * one live root graph (RFC 0029).
+         */
+        [[nodiscard]] CompoundScalarStorageBinding &pool_binding() const noexcept;
         [[nodiscard]] bool pooled_compound_storage_enabled() const noexcept;
         [[nodiscard]] bool is_polymorphic(const ValueTypeMetaData *schema) const noexcept;
         [[nodiscard]] std::vector<const ValueTypeMetaData *>

--- a/include/hgraph/types/value/compound_scalar_storage.h
+++ b/include/hgraph/types/value/compound_scalar_storage.h
@@ -5,6 +5,7 @@
 #include <hgraph/types/storage_metrics.h>
 #include <hgraph/types/value/value_type_ref.h>
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
@@ -131,6 +132,15 @@ public:
   void unbind() noexcept;
 
 private:
+  /**
+   * Admission is claimed atomically: a realization cached by ``(generation,
+   * options)`` is shared, so two root graphs can be constructed against it
+   * concurrently and a check-then-set would let both through and tear the
+   * two-word view.  The claim is taken once per root graph construction and
+   * released once at its teardown — never on the per-tick path, which reads
+   * ``storage_`` plainly and only from the graph that won the claim.
+   */
+  std::atomic<bool> claimed_{false};
   CompoundScalarStorageView storage_{};
 };
 

--- a/include/hgraph/types/value/compound_scalar_storage.h
+++ b/include/hgraph/types/value/compound_scalar_storage.h
@@ -133,14 +133,24 @@ public:
 
 private:
   /**
-   * Admission is claimed atomically: a realization cached by ``(generation,
-   * options)`` is shared, so two root graphs can be constructed against it
-   * concurrently and a check-then-set would let both through and tear the
-   * two-word view.  The claim is taken once per root graph construction and
-   * released once at its teardown — never on the per-tick path, which reads
-   * ``storage_`` plainly and only from the graph that won the claim.
+   * Admission state, and the publication protocol for ``storage_``.
+   *
+   * A realization cached by ``(generation, options)`` is shared, so two root
+   * graphs can be constructed against it concurrently.  ``Claiming`` is the
+   * winner's exclusive window: it has admission but has not yet published its
+   * view, so no reader may treat the binding as usable.  ``bind`` writes
+   * ``storage_`` and then releases ``Bound``; every read acquires it first, so
+   * a thread that observes ``Bound`` also observes the whole two-word view and
+   * never a half-written one.
+   *
+   * The claim is an RMW exactly once per root graph construction and once at
+   * teardown.  Reads on the allocation path are an acquire **load** of one
+   * byte, which replaces the view test that was there before it — no
+   * read-modify-write and no contention on the per-tick path.
    */
-  std::atomic<bool> claimed_{false};
+  enum class Admission : std::uint8_t { Free, Claiming, Bound };
+
+  std::atomic<Admission> admission_{Admission::Free};
   CompoundScalarStorageView storage_{};
 };
 

--- a/include/hgraph/types/value/compound_scalar_storage.h
+++ b/include/hgraph/types/value/compound_scalar_storage.h
@@ -10,6 +10,8 @@
 #include <type_traits>
 
 namespace hgraph {
+class CompoundScalarStorageBinding;
+
 /** Cold-path, data-only summary of one root graph's polymorphic leaf pools. */
 struct CompoundScalarStorageInspection {
   std::size_t leaf_pool_count{0};
@@ -82,6 +84,14 @@ public:
   [[nodiscard]] CompoundScalarStorageView view() noexcept;
   [[nodiscard]] CompoundScalarStorageView view() const noexcept;
 
+  /**
+   * Bind this owner into ``binding`` for the rest of its life; the binding is
+   * released when this owner is destroyed, and follows it when it is moved.
+   * One object therefore owns both the pool and its binding, so an unwound
+   * graph construction cannot leave a binding behind.
+   */
+  void bind(CompoundScalarStorageBinding &binding);
+
 private:
   CompoundScalarStorage(void *context,
                         const CompoundScalarStorageOps *ops) noexcept;
@@ -89,24 +99,40 @@ private:
 
   void *context_{nullptr};
   const CompoundScalarStorageOps *ops_{nullptr};
+  CompoundScalarStorageBinding *binding_{nullptr};
 };
 
-/** Thread-local graph-lifetime selection used by pooled value plans. */
-class HGRAPH_EXPORT CompoundScalarStorageScope {
+/**
+ * Stable-address cell through which a realization's pooled value types reach
+ * the pool of the root graph bound to them (RFC 0029).
+ *
+ * One cell belongs to a ``TypeRealizationSnapshot``; every pooled value type it
+ * realizes holds a pointer to that cell.  A root graph's pool owner binds
+ * itself for its own lifetime, so an allocating op reads a pointer rather than
+ * asking which thread is asking.
+ *
+ * The binding is **exclusive**: a realization has at most one live root graph.
+ * Binding a second is refused rather than silently overwriting the first.
+ */
+class HGRAPH_EXPORT CompoundScalarStorageBinding {
 public:
-  explicit CompoundScalarStorageScope(
-      CompoundScalarStorageView storage) noexcept;
-  CompoundScalarStorageScope(const CompoundScalarStorageScope &) = delete;
-  CompoundScalarStorageScope &
-  operator=(const CompoundScalarStorageScope &) = delete;
-  ~CompoundScalarStorageScope() noexcept;
+  CompoundScalarStorageBinding() noexcept = default;
+  CompoundScalarStorageBinding(const CompoundScalarStorageBinding &) = delete;
+  CompoundScalarStorageBinding &
+  operator=(const CompoundScalarStorageBinding &) = delete;
+
+  [[nodiscard]] bool bound() const noexcept;
+  /** The bound storage; throws when no root graph is bound. */
+  [[nodiscard]] CompoundScalarStorageView storage() const;
+
+  void bind(CompoundScalarStorageView storage);
+  /** Re-point an existing binding after its owner moved. */
+  void rebind(CompoundScalarStorageView storage) noexcept;
+  void unbind() noexcept;
 
 private:
-  CompoundScalarStorageView previous_{};
+  CompoundScalarStorageView storage_{};
 };
-
-[[nodiscard]] HGRAPH_EXPORT CompoundScalarStorageView
-active_compound_scalar_storage() noexcept;
 
 /**
  * Operations on a one-word pooled holder.  ``payload`` is the stable
@@ -115,7 +141,8 @@ active_compound_scalar_storage() noexcept;
 [[nodiscard]] HGRAPH_EXPORT ValueTypeRef
 pooled_compound_scalar_leaf_type(const void *payload) noexcept;
 [[nodiscard]] HGRAPH_EXPORT void *
-retain_or_copy_pooled_compound_scalar(const void *payload);
+retain_or_copy_pooled_compound_scalar(CompoundScalarStorageView target,
+                                      const void *payload);
 HGRAPH_EXPORT void release_pooled_compound_scalar(void *payload) noexcept;
 [[nodiscard]] HGRAPH_EXPORT void *
 writable_pooled_compound_scalar(void *payload);

--- a/src/hgraph/runtime/graph.cpp
+++ b/src/hgraph/runtime/graph.cpp
@@ -563,13 +563,23 @@ void construct_graph_storage(GraphTypeRef type, const GraphBuilder &builder,
   header_constructed = true;
   std::forward<InitHeader>(init_header)(graph_header<Header>(context, memory));
 
-  CompoundScalarStorageView compound_storage{};
   if (graph_has_compound_scalar_storage(context)) {
     if constexpr (std::is_same_v<Header, RootGraphRuntimeStorage>) {
       auto &owner = graph_compound_scalar_storage<CompoundScalarStorage>(
           context, memory);
       std::construct_at(&owner, CompoundScalarStorage::make_default());
-      compound_storage = owner.view();
+      compound_storage_constructed = true;
+      // RFC 0029: the pool binds itself into this graph's realization for the
+      // owner's lifetime, so every pooled value type it realized allocates
+      // here without consulting anything ambient.  The owner releases the
+      // binding when it is destroyed, including on an unwound construction.
+      const auto *realization =
+          graph_header<Header>(context, memory).type_realization;
+      if (realization == nullptr) {
+        throw std::logic_error(
+            "Pooled root graph requires its type realization snapshot");
+      }
+      owner.bind(realization->pool_binding());
     } else {
       if (!inherited_storage.available()) {
         throw std::logic_error(
@@ -578,27 +588,18 @@ void construct_graph_storage(GraphTypeRef type, const GraphBuilder &builder,
       auto &view = graph_compound_scalar_storage<CompoundScalarStorageView>(
           context, memory);
       std::construct_at(&view, inherited_storage);
-      compound_storage = view;
+      compound_storage_constructed = true;
     }
-    compound_storage_constructed = true;
   }
 
-  const auto construct_nodes_and_schedule = [&] {
-    for (std::size_t index = 0; index < context.layout.node_count; ++index) {
-      builder.nodes()[index].construct_node_storage(
-          graph_node_memory(context, memory, index), index);
-      ++constructed_nodes;
-    }
-    for (std::size_t index = 0; index < context.layout.node_count; ++index) {
-      std::construct_at(&graph_schedule(context, memory, index), MIN_DT);
-      ++constructed_schedule;
-    }
-  };
-  if (compound_storage.available()) {
-    CompoundScalarStorageScope storage_scope{compound_storage};
-    construct_nodes_and_schedule();
-  } else {
-    construct_nodes_and_schedule();
+  for (std::size_t index = 0; index < context.layout.node_count; ++index) {
+    builder.nodes()[index].construct_node_storage(
+        graph_node_memory(context, memory, index), index);
+    ++constructed_nodes;
+  }
+  for (std::size_t index = 0; index < context.layout.node_count; ++index) {
+    std::construct_at(&graph_schedule(context, memory, index), MIN_DT);
+    ++constructed_schedule;
   }
   graph_complete = true;
   bind_edges(context, memory, builder.edges());
@@ -1201,30 +1202,6 @@ bool evaluate_impl(const void *context, const GraphView &graph,
   return true;
 }
 
-template <typename Storage>
-void pooled_start_impl(const void *context, const GraphView &graph,
-                       DateTime start_time) {
-  CompoundScalarStorageScope storage_scope{
-      compound_scalar_storage_impl<Storage>(context, graph.data())};
-  start_impl<Storage>(context, graph, start_time);
-}
-
-template <typename Storage>
-void pooled_stop_impl(const void *context, const GraphView &graph,
-                      DateTime stop_time) {
-  CompoundScalarStorageScope storage_scope{
-      compound_scalar_storage_impl<Storage>(context, graph.data())};
-  stop_impl<Storage>(context, graph, stop_time);
-}
-
-template <typename Storage>
-bool pooled_evaluate_impl(const void *context, const GraphView &graph,
-                          DateTime evaluation_time) {
-  CompoundScalarStorageScope storage_scope{
-      compound_scalar_storage_impl<Storage>(context, graph.data())};
-  return evaluate_impl<Storage>(context, graph, evaluation_time);
-}
-
 struct GraphRuntimeRegistry {
   struct Entry {
     GraphTypeMetaData schema{};
@@ -1373,15 +1350,9 @@ struct GraphRuntimeRegistry {
         .context = context,
         .parent_kind = GraphParentKind::Root,
         .attach_nodes_impl = &attach_nodes_impl<RootGraphRuntimeStorage>,
-        .start_impl =
-            pooled_storage ? &pooled_start_impl<RootGraphRuntimeStorage>
-                           : &start_impl<RootGraphRuntimeStorage>,
-        .stop_impl =
-            pooled_storage ? &pooled_stop_impl<RootGraphRuntimeStorage>
-                           : &stop_impl<RootGraphRuntimeStorage>,
-        .evaluate_impl =
-            pooled_storage ? &pooled_evaluate_impl<RootGraphRuntimeStorage>
-                           : &evaluate_impl<RootGraphRuntimeStorage>,
+        .start_impl = &start_impl<RootGraphRuntimeStorage>,
+        .stop_impl = &stop_impl<RootGraphRuntimeStorage>,
+        .evaluate_impl = &evaluate_impl<RootGraphRuntimeStorage>,
         .schedule_node_impl = &schedule_node_impl<RootGraphRuntimeStorage>,
         .started_impl = &started_impl<RootGraphRuntimeStorage>,
         .starting_impl = &starting_impl<RootGraphRuntimeStorage>,
@@ -1419,15 +1390,9 @@ struct GraphRuntimeRegistry {
         .context = context,
         .parent_kind = GraphParentKind::Nested,
         .attach_nodes_impl = &attach_nodes_impl<NestedGraphRuntimeStorage>,
-        .start_impl =
-            pooled_storage ? &pooled_start_impl<NestedGraphRuntimeStorage>
-                           : &start_impl<NestedGraphRuntimeStorage>,
-        .stop_impl =
-            pooled_storage ? &pooled_stop_impl<NestedGraphRuntimeStorage>
-                           : &stop_impl<NestedGraphRuntimeStorage>,
-        .evaluate_impl =
-            pooled_storage ? &pooled_evaluate_impl<NestedGraphRuntimeStorage>
-                           : &evaluate_impl<NestedGraphRuntimeStorage>,
+        .start_impl = &start_impl<NestedGraphRuntimeStorage>,
+        .stop_impl = &stop_impl<NestedGraphRuntimeStorage>,
+        .evaluate_impl = &evaluate_impl<NestedGraphRuntimeStorage>,
         .schedule_node_impl = &nested_schedule_node_impl,
         .started_impl = &started_impl<NestedGraphRuntimeStorage>,
         .starting_impl = &starting_impl<NestedGraphRuntimeStorage>,
@@ -1897,13 +1862,7 @@ GraphValue::GraphValue(const GraphBuilder &builder, ExecutorPtr root_executor) {
         });
   });
   pointer_ = type.writable(storage_.data());
-  const auto compound_storage = view().compound_scalar_storage();
-  if (compound_storage.available()) {
-    CompoundScalarStorageScope storage_scope{compound_storage};
-    attach_nodes();
-  } else {
-    attach_nodes();
-  }
+  attach_nodes();
 }
 
 GraphValue::GraphValue(const GraphBuilder &builder, NodePtr parent_node) {
@@ -1939,12 +1898,7 @@ GraphValue::GraphValue(const GraphBuilder &builder, NodePtr parent_node) {
         shared_storage);
   });
   pointer_ = type.writable(storage_.data());
-  if (shared_storage.available()) {
-    CompoundScalarStorageScope storage_scope{shared_storage};
-    attach_nodes();
-  } else {
-    attach_nodes();
-  }
+  attach_nodes();
 }
 
 GraphValue::GraphValue(const GraphBuilder &builder, NodePtr parent_node,
@@ -1993,12 +1947,7 @@ GraphValue::GraphValue(const GraphBuilder &builder, NodePtr parent_node,
   auto rollback =
       make_scope_exit([&]() noexcept { type.destroy_at(external_memory); });
   pointer_ = type.writable(external_memory);
-  if (shared_storage.available()) {
-    CompoundScalarStorageScope storage_scope{shared_storage};
-    attach_nodes();
-  } else {
-    attach_nodes();
-  }
+  attach_nodes();
   rollback.release();
 }
 
@@ -2018,21 +1967,10 @@ void GraphValue::reset() noexcept {
       }));
     }
   }
-  const auto pooled_storage = pointer_.has_value()
-                                  ? view().compound_scalar_storage()
-                                  : CompoundScalarStorageView{};
-  const auto destroy_storage = [&] {
-    if (uses_external_storage()) {
-      type().destroy_at(const_cast<void *>(pointer_.data()));
-    } else {
-      storage_.reset();
-    }
-  };
-  if (pooled_storage.available()) {
-    CompoundScalarStorageScope storage_scope{pooled_storage};
-    destroy_storage();
+  if (uses_external_storage()) {
+    type().destroy_at(const_cast<void *>(pointer_.data()));
   } else {
-    destroy_storage();
+    storage_.reset();
   }
   pointer_ = {};
 }

--- a/src/hgraph/types/metadata/type_realization.cpp
+++ b/src/hgraph/types/metadata/type_realization.cpp
@@ -28,6 +28,7 @@
 #include <mutex>
 
 #include <hgraph/types/utils/counted_mutex.h>
+#include <hgraph/types/value/compound_scalar_storage.h>
 #include <new>
 #include <stdexcept>
 #include <string>
@@ -778,6 +779,10 @@ struct TypeRealizationSnapshot::Impl {
       graph_inline_union_types{};
   mutable std::unordered_map<const ValueTypeMetaData *, PolymorphicValueType>
       graph_pooled_union_types{};
+  // Stable address handed to every pooled entry realized here; the root graph
+  // that runs this realization binds its pool into it.
+  std::unique_ptr<CompoundScalarStorageBinding> pool_binding{
+      std::make_unique<CompoundScalarStorageBinding>()};
   enum class RealizationKind : std::uint8_t {
     ExternalExact,
     ExternalUnion,
@@ -1191,7 +1196,7 @@ struct TypeRealizationSnapshot::Impl {
     ValueTypeRef result{};
     if (use_pool) {
       auto created = detail::make_pooled_polymorphic_value_type(
-          schema, std::move(alternatives)
+          schema, pool_binding.get(), std::move(alternatives)
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                       ,
           detail::PolymorphicPythonSourceResolver{
@@ -1368,6 +1373,11 @@ std::uint64_t TypeRealizationSnapshot::generation() const noexcept {
 
 TypeRealizationOptions TypeRealizationSnapshot::options() const noexcept {
   return impl_->options;
+}
+
+CompoundScalarStorageBinding &
+TypeRealizationSnapshot::pool_binding() const noexcept {
+  return *impl_->pool_binding;
 }
 
 bool TypeRealizationSnapshot::pooled_compound_storage_enabled() const noexcept {

--- a/src/hgraph/types/metadata/type_realization.cpp
+++ b/src/hgraph/types/metadata/type_realization.cpp
@@ -779,10 +779,11 @@ struct TypeRealizationSnapshot::Impl {
       graph_inline_union_types{};
   mutable std::unordered_map<const ValueTypeMetaData *, PolymorphicValueType>
       graph_pooled_union_types{};
-  // Stable address handed to every pooled entry realized here; the root graph
-  // that runs this realization binds its pool into it.
-  std::unique_ptr<CompoundScalarStorageBinding> pool_binding{
-      std::make_unique<CompoundScalarStorageBinding>()};
+  // Handed by address to every pooled entry realized here; the root graph that
+  // runs this realization binds its pool into it.  An Impl is made once with
+  // make_shared and is never copied or moved, so this member's address is
+  // stable for the realization's whole life without further indirection.
+  CompoundScalarStorageBinding pool_binding{};
   enum class RealizationKind : std::uint8_t {
     ExternalExact,
     ExternalUnion,
@@ -1196,7 +1197,7 @@ struct TypeRealizationSnapshot::Impl {
     ValueTypeRef result{};
     if (use_pool) {
       auto created = detail::make_pooled_polymorphic_value_type(
-          schema, pool_binding.get(), std::move(alternatives)
+          schema, &pool_binding, std::move(alternatives)
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                       ,
           detail::PolymorphicPythonSourceResolver{
@@ -1377,7 +1378,7 @@ TypeRealizationOptions TypeRealizationSnapshot::options() const noexcept {
 
 CompoundScalarStorageBinding &
 TypeRealizationSnapshot::pool_binding() const noexcept {
-  return *impl_->pool_binding;
+  return impl_->pool_binding;
 }
 
 bool TypeRealizationSnapshot::pooled_compound_storage_enabled() const noexcept {

--- a/src/hgraph/types/value/impl/pooled_polymorphic_value_type.cpp
+++ b/src/hgraph/types/value/impl/pooled_polymorphic_value_type.cpp
@@ -28,6 +28,7 @@ const PolymorphicValueTypeOps &nop_ops() noexcept {
 /** Pointer-sized graph-local closed union backed by root-graph pools. */
 struct PooledUnionEntry {
   const ValueTypeMetaData *declared{nullptr};
+  const CompoundScalarStorageBinding *pool_binding{nullptr};
   std::vector<ValueTypeRef> alternatives{};
   std::unordered_map<const TypeRecord *, ValueTypeRef> alternatives_by_record{};
   std::unordered_map<const ValueTypeMetaData *, ValueTypeRef>
@@ -41,13 +42,15 @@ struct PooledUnionEntry {
   ValueTypeRef binding{};
 
   PooledUnionEntry(const ValueTypeMetaData *schema,
+                   const CompoundScalarStorageBinding *pool,
                    std::vector<ValueTypeRef> realized_alternatives
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                    ,
                    detail::PolymorphicPythonSourceResolver source_resolver
 #endif
                    )
-      : declared(schema), alternatives(std::move(realized_alternatives))
+      : declared(schema), pool_binding(pool),
+        alternatives(std::move(realized_alternatives))
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
         ,
         python_source(source_resolver)
@@ -155,16 +158,23 @@ struct PooledUnionEntry {
                                                  : ValueTypeRef{};
   }
 
+  /** The pool of the root graph bound to this realization (RFC 0029). */
+  [[nodiscard]] CompoundScalarStorageView storage() const {
+    if (pool_binding == nullptr) {
+      throw std::logic_error(
+          "pooled closed Bundle was realized without a pool binding");
+    }
+    return pool_binding->storage();
+  }
+
   [[nodiscard]] void *make_copy(ValueTypeRef target, ValueTypeRef source,
                                 const void *source_memory) const {
-    return active_compound_scalar_storage().copy_value(target, source,
-                                                       source_memory);
+    return storage().copy_value(target, source, source_memory);
   }
 
   [[nodiscard]] void *make_move(ValueTypeRef target, ValueTypeRef source,
                                 void *source_memory) const {
-    return active_compound_scalar_storage().move_value(target, source,
-                                                       source_memory);
+    return storage().move_value(target, source, source_memory);
   }
 
   static void replace_payload(void *memory, void *replacement) noexcept {
@@ -176,8 +186,8 @@ struct PooledUnionEntry {
   static void default_construct(void *memory, const void *context) {
     const auto &self = entry(context);
     set_stored_payload(memory, nullptr);
-    set_stored_payload(memory, active_compound_scalar_storage().default_value(
-                                   self.default_type));
+    set_stored_payload(memory,
+                       self.storage().default_value(self.default_type));
   }
 
   static void destroy(void *memory, const void *) noexcept {
@@ -186,14 +196,15 @@ struct PooledUnionEntry {
     release_pooled_compound_scalar(payload);
   }
 
-  static void copy_construct(void *dst, const void *src, const void *) {
+  static void copy_construct(void *dst, const void *src, const void *context) {
     const auto payload = stored_payload(src);
     if (payload == nullptr) {
       throw std::logic_error(
           "pooled closed Bundle source has an invalid active type");
     }
     set_stored_payload(dst, nullptr);
-    set_stored_payload(dst, retain_or_copy_pooled_compound_scalar(payload));
+    set_stored_payload(dst, retain_or_copy_pooled_compound_scalar(
+                                entry(context).storage(), payload));
   }
 
   static void move_construct(void *dst, void *src, const void *context) {
@@ -202,13 +213,14 @@ struct PooledUnionEntry {
     copy_construct(dst, src, context);
   }
 
-  static void copy_assign(void *dst, const void *src, const void *) {
+  static void copy_assign(void *dst, const void *src, const void *context) {
     const auto payload = stored_payload(src);
     if (payload == nullptr) {
       throw std::logic_error(
           "pooled closed Bundle source has an invalid active type");
     }
-    replace_payload(dst, retain_or_copy_pooled_compound_scalar(payload));
+    replace_payload(dst, retain_or_copy_pooled_compound_scalar(
+                             entry(context).storage(), payload));
   }
 
   static void move_assign(void *dst, void *src, const void *context) {
@@ -466,7 +478,7 @@ struct PooledUnionEntry {
       throw std::invalid_argument(
           "Python value is outside this graph's pooled Bundle snapshot");
     }
-    void *replacement = active_compound_scalar_storage().default_value(target);
+    void *replacement = self.storage().default_value(target);
     auto release = make_scope_exit(
         [&]() noexcept { release_pooled_compound_scalar(replacement); });
     target.ops_ref().from_python(target, replacement, source);
@@ -529,13 +541,15 @@ void PolymorphicValueType::reset() noexcept {
 namespace detail {
 PolymorphicValueType
 make_pooled_polymorphic_value_type(const ValueTypeMetaData *schema,
+                                   const CompoundScalarStorageBinding *pool_binding,
                                    std::vector<ValueTypeRef> alternatives
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                                    ,
                                    PolymorphicPythonSourceResolver python_source
 #endif
 ) {
-  auto *entry = new PooledUnionEntry{schema, std::move(alternatives)
+  auto *entry = new PooledUnionEntry{schema, pool_binding,
+                                     std::move(alternatives)
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                                                  ,
                                      python_source

--- a/src/hgraph/types/value/impl/pooled_polymorphic_value_type.h
+++ b/src/hgraph/types/value/impl/pooled_polymorphic_value_type.h
@@ -3,6 +3,7 @@
 
 #include <hgraph/config.h>
 #include <hgraph/types/metadata/value_type_meta_data.h>
+#include <hgraph/types/value/compound_scalar_storage.h>
 #include <hgraph/types/value/polymorphic_value_type.h>
 
 #include <vector>
@@ -23,6 +24,7 @@ struct PolymorphicPythonSourceResolver {
 
 [[nodiscard]] PolymorphicValueType
 make_pooled_polymorphic_value_type(const ValueTypeMetaData *schema,
+                                   const CompoundScalarStorageBinding *pool_binding,
                                    std::vector<ValueTypeRef> alternatives
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                                    ,

--- a/src/hgraph/types/value/impl/stable_leaf_compound_scalar_storage.cpp
+++ b/src/hgraph/types/value/impl/stable_leaf_compound_scalar_storage.cpp
@@ -414,7 +414,6 @@ const CompoundScalarStorageOps &stable_ops() noexcept {
   return ops;
 }
 
-thread_local CompoundScalarStorageView active_storage{};
 } // namespace
 
 CompoundScalarStorageView::CompoundScalarStorageView() noexcept
@@ -470,10 +469,29 @@ CompoundScalarStorage::CompoundScalarStorage(
 
 CompoundScalarStorage::~CompoundScalarStorage() { reset(); }
 
+void CompoundScalarStorage::bind(CompoundScalarStorageBinding &binding) {
+  if (binding_ == &binding) {
+    return;
+  }
+  if (binding_ != nullptr) {
+    throw std::logic_error(
+        "compound scalar storage is already bound to a realization");
+  }
+  binding.bind(view());
+  binding_ = &binding;
+}
+
 CompoundScalarStorage::CompoundScalarStorage(
     CompoundScalarStorage &&other) noexcept
     : context_(std::exchange(other.context_, nullptr)),
-      ops_(std::exchange(other.ops_, &nop_ops())) {}
+      ops_(std::exchange(other.ops_, &nop_ops())),
+      binding_(std::exchange(other.binding_, nullptr)) {
+  // A view addresses this owner's context slot, so a move must re-point the
+  // binding at the new address rather than leave it addressing the corpse.
+  if (binding_ != nullptr) {
+    binding_->rebind(view());
+  }
+}
 
 CompoundScalarStorage &
 CompoundScalarStorage::operator=(CompoundScalarStorage &&other) noexcept {
@@ -481,6 +499,10 @@ CompoundScalarStorage::operator=(CompoundScalarStorage &&other) noexcept {
     reset();
     context_ = std::exchange(other.context_, nullptr);
     ops_ = std::exchange(other.ops_, &nop_ops());
+    binding_ = std::exchange(other.binding_, nullptr);
+    if (binding_ != nullptr) {
+      binding_->rebind(view());
+    }
   }
   return *this;
 }
@@ -500,37 +522,62 @@ CompoundScalarStorageView CompoundScalarStorage::view() const noexcept {
 }
 
 void CompoundScalarStorage::reset() noexcept {
+  if (auto *binding = std::exchange(binding_, nullptr); binding != nullptr) {
+    binding->unbind();
+  }
   ops_->destroy_impl(&context_);
   context_ = nullptr;
   ops_ = &nop_ops();
 }
 
-CompoundScalarStorageScope::CompoundScalarStorageScope(
-    CompoundScalarStorageView storage) noexcept
-    : previous_(active_storage) {
-  active_storage = storage;
+bool CompoundScalarStorageBinding::bound() const noexcept {
+  return storage_.available();
 }
 
-CompoundScalarStorageScope::~CompoundScalarStorageScope() noexcept {
-  active_storage = previous_;
+CompoundScalarStorageView CompoundScalarStorageBinding::storage() const {
+  if (!storage_.available()) {
+    throw std::logic_error(
+        "pooled value storage has no bound root graph; a pooled value cannot "
+        "be constructed outside the graph that owns its pool");
+  }
+  return storage_;
 }
 
-CompoundScalarStorageView active_compound_scalar_storage() noexcept {
-  return active_storage;
+void CompoundScalarStorageBinding::bind(CompoundScalarStorageView storage) {
+  if (!storage.available()) {
+    throw std::invalid_argument(
+        "cannot bind unavailable compound scalar storage");
+  }
+  if (storage_.available()) {
+    throw std::logic_error(
+        "a type realization already has a live root graph; its pooled value "
+        "types cannot serve a second one");
+  }
+  storage_ = storage;
 }
+
+void CompoundScalarStorageBinding::rebind(
+    CompoundScalarStorageView storage) noexcept {
+  storage_ = storage;
+}
+
+void CompoundScalarStorageBinding::unbind() noexcept { storage_ = {}; }
+
 
 ValueTypeRef pooled_compound_scalar_leaf_type(const void *payload) noexcept {
   return payload != nullptr ? header_for(payload).owner->leaf()
                             : ValueTypeRef{};
 }
 
-void *retain_or_copy_pooled_compound_scalar(const void *payload) {
+void *retain_or_copy_pooled_compound_scalar(CompoundScalarStorageView target,
+                                            const void *payload) {
   if (payload == nullptr)
     throw std::invalid_argument("cannot retain a null pooled compound scalar");
-  const auto active = active_compound_scalar_storage();
-  if (!active.owns(payload)) {
+  if (!target.owns(payload)) {
+    // A payload from another graph's pool is materialised into this one; a
+    // slot is only ever shared within the pool that owns it.
     const auto leaf = pooled_compound_scalar_leaf_type(payload);
-    return active.copy_value(leaf, leaf, payload);
+    return target.copy_value(leaf, leaf, payload);
   }
   return header_for(payload).owner->retain_or_copy(payload);
 }

--- a/src/hgraph/types/value/impl/stable_leaf_compound_scalar_storage.cpp
+++ b/src/hgraph/types/value/impl/stable_leaf_compound_scalar_storage.cpp
@@ -548,7 +548,13 @@ void CompoundScalarStorageBinding::bind(CompoundScalarStorageView storage) {
     throw std::invalid_argument(
         "cannot bind unavailable compound scalar storage");
   }
-  if (storage_.available()) {
+  // Claim before writing: the loser of a concurrent admission never reaches
+  // the view, so the winner is the only writer and the graph that owns it is
+  // the only reader.
+  bool unclaimed = false;
+  if (!claimed_.compare_exchange_strong(unclaimed, true,
+                                        std::memory_order_acq_rel,
+                                        std::memory_order_acquire)) {
     throw std::logic_error(
         "a type realization already has a live root graph; its pooled value "
         "types cannot serve a second one");
@@ -561,7 +567,12 @@ void CompoundScalarStorageBinding::rebind(
   storage_ = storage;
 }
 
-void CompoundScalarStorageBinding::unbind() noexcept { storage_ = {}; }
+void CompoundScalarStorageBinding::unbind() noexcept {
+  // Clear the view before releasing the claim so the next graph to win it
+  // cannot observe the departing graph's storage.
+  storage_ = {};
+  claimed_.store(false, std::memory_order_release);
+}
 
 
 ValueTypeRef pooled_compound_scalar_leaf_type(const void *payload) noexcept {

--- a/src/hgraph/types/value/impl/stable_leaf_compound_scalar_storage.cpp
+++ b/src/hgraph/types/value/impl/stable_leaf_compound_scalar_storage.cpp
@@ -531,11 +531,15 @@ void CompoundScalarStorage::reset() noexcept {
 }
 
 bool CompoundScalarStorageBinding::bound() const noexcept {
-  return storage_.available();
+  return admission_.load(std::memory_order_acquire) == Admission::Bound;
 }
 
 CompoundScalarStorageView CompoundScalarStorageBinding::storage() const {
-  if (!storage_.available()) {
+  // Acquiring here is what makes the view safe to read: it pairs with the
+  // release in bind(), so the published view is whole for any reader that
+  // gets this far.  A binding mid-claim reads as unbound rather than as a
+  // usable half-state.
+  if (admission_.load(std::memory_order_acquire) != Admission::Bound) {
     throw std::logic_error(
         "pooled value storage has no bound root graph; a pooled value cannot "
         "be constructed outside the graph that owns its pool");
@@ -549,17 +553,19 @@ void CompoundScalarStorageBinding::bind(CompoundScalarStorageView storage) {
         "cannot bind unavailable compound scalar storage");
   }
   // Claim before writing: the loser of a concurrent admission never reaches
-  // the view, so the winner is the only writer and the graph that owns it is
-  // the only reader.
-  bool unclaimed = false;
-  if (!claimed_.compare_exchange_strong(unclaimed, true,
-                                        std::memory_order_acq_rel,
-                                        std::memory_order_acquire)) {
+  // the view, so the winner is the only writer.  Between the claim and the
+  // release below the binding reads as unbound, which is what stops a reader
+  // seeing a view that is not there yet.
+  Admission expected = Admission::Free;
+  if (!admission_.compare_exchange_strong(expected, Admission::Claiming,
+                                          std::memory_order_acq_rel,
+                                          std::memory_order_acquire)) {
     throw std::logic_error(
         "a type realization already has a live root graph; its pooled value "
         "types cannot serve a second one");
   }
   storage_ = storage;
+  admission_.store(Admission::Bound, std::memory_order_release);
 }
 
 void CompoundScalarStorageBinding::rebind(
@@ -568,10 +574,11 @@ void CompoundScalarStorageBinding::rebind(
 }
 
 void CompoundScalarStorageBinding::unbind() noexcept {
-  // Clear the view before releasing the claim so the next graph to win it
-  // cannot observe the departing graph's storage.
+  // Withdraw first, so the view is cleared while the binding already reads as
+  // unbound, then free the claim for the next graph.
+  admission_.store(Admission::Claiming, std::memory_order_release);
   storage_ = {};
-  claimed_.store(false, std::memory_order_release);
+  admission_.store(Admission::Free, std::memory_order_release);
 }
 
 

--- a/tests/cpp/test_ts_input.cpp
+++ b/tests/cpp/test_ts_input.cpp
@@ -2265,7 +2265,7 @@ TEST_CASE("forwarding TSData projections preserve target bindings across realiza
 
     CompoundScalarStorage pools = CompoundScalarStorage::make_default();
     TypeRealizationScope pooled_scope{pooled_realization.get()};
-    CompoundScalarStorageScope pool_scope{pools.view()};
+    pools.bind(pooled_realization->pool_binding());
 
     Value concrete{ValuePlanFactory::instance().type_for(leaf)};
     auto concrete_fields = concrete.as_bundle().begin_mutation();

--- a/tests/cpp/test_type_registry.cpp
+++ b/tests/cpp/test_type_registry.cpp
@@ -10,6 +10,7 @@
 #include <hgraph/types/value/value.h>
 
 #include <array>
+#include <atomic>
 #include <cstdint>
 #include <string>
 #include <thread>
@@ -683,6 +684,125 @@ TEST_CASE("graph realization keeps narrow polymorphic Bundles inline") {
   REQUIRE(inspection.representation == GraphValueRepresentation::InlineUnion);
   REQUIRE(inspection.maximum_leaf_size - inspection.minimum_leaf_size <= 32);
   REQUIRE(inspection.graph_size > sizeof(void *));
+}
+
+namespace {
+struct AdmissionRace {
+  std::size_t admitted{0};
+  std::size_t refused{0};
+  std::size_t owners{0};
+};
+
+/** Race `contenders` pool owners into one binding; report who got in. */
+[[nodiscard]] AdmissionRace
+race_admission(hgraph::CompoundScalarStorageBinding &binding,
+               std::size_t contenders) {
+  using namespace hgraph;
+  std::vector<CompoundScalarStorage> pools;
+  pools.reserve(contenders);
+  for (std::size_t index = 0; index < contenders; ++index) {
+    pools.push_back(CompoundScalarStorage::make_default());
+  }
+
+  std::atomic<std::size_t> ready{0};
+  std::atomic<bool> go{false};
+  std::atomic<std::size_t> admitted{0};
+  std::atomic<std::size_t> refused{0};
+  std::vector<std::thread> threads;
+  threads.reserve(contenders);
+  for (std::size_t index = 0; index < contenders; ++index) {
+    threads.emplace_back([&, index] {
+      ready.fetch_add(1, std::memory_order_release);
+      while (!go.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+      }
+      try {
+        pools[index].bind(binding);
+        admitted.fetch_add(1, std::memory_order_relaxed);
+      } catch (const std::logic_error &) {
+        refused.fetch_add(1, std::memory_order_relaxed);
+      }
+    });
+  }
+  while (ready.load(std::memory_order_acquire) < contenders) {
+    std::this_thread::yield();
+  }
+  go.store(true, std::memory_order_release);
+  for (auto &thread : threads) {
+    thread.join();
+  }
+
+  AdmissionRace result{admitted.load(), refused.load(), 0};
+  if (binding.bound()) {
+    // A torn write matches no contender's storage entire.
+    const auto bound = binding.storage();
+    for (auto &pool : pools) {
+      if (pool.view().same_storage(bound)) {
+        ++result.owners;
+      }
+    }
+  }
+  return result;
+}
+} // namespace
+
+TEST_CASE("a realization admits exactly one root graph pool concurrently") {
+  using namespace hgraph;
+  auto &registry = TypeRegistry::instance();
+  const auto *integer = registry.value_type("int");
+  REQUIRE(integer != nullptr);
+
+  // Registering here moves the bundle-hierarchy generation on, so the cached
+  // snapshot this captures is this test's own and its binding starts free.
+  registry.bundle("tests.realization.admission", "Base", {{"id", integer}}, {},
+                  true);
+  const auto snapshot = TypeRealizationSnapshot::capture(
+      registry,
+      TypeRealizationOptions{
+          .polymorphic_compound_storage =
+              PolymorphicCompoundStoragePolicy::Pooled,
+      });
+  REQUIRE_FALSE(snapshot->pool_binding().bound());
+
+  // A cached realization is shared, so two root graphs can be constructed
+  // against it at once.  Exactly one may claim its pooled value types.
+  constexpr std::size_t contenders = 8;
+  {
+    const auto race = race_admission(snapshot->pool_binding(), contenders);
+    CHECK(race.admitted == 1);
+    CHECK(race.refused == contenders - 1);
+    CHECK(race.owners == 1);
+  }
+
+  // The claim is released with its owner, and the next graph may take it.
+  CHECK_FALSE(snapshot->pool_binding().bound());
+  CompoundScalarStorage successor = CompoundScalarStorage::make_default();
+  REQUIRE_NOTHROW(successor.bind(snapshot->pool_binding()));
+  CHECK(snapshot->pool_binding().storage().same_storage(successor.view()));
+}
+
+TEST_CASE("concurrent binding admission never admits twice") {
+  using namespace hgraph;
+  // One race is a weak probe: a check-then-set admission passes it most of the
+  // time.  Repeating over a fresh binding each round makes a non-atomic
+  // admission fail reliably rather than occasionally.
+  constexpr std::size_t rounds = 48;
+  constexpr std::size_t contenders = 8;
+  std::size_t double_admissions = 0;
+  std::size_t torn_views = 0;
+  for (std::size_t round = 0; round < rounds; ++round) {
+    CompoundScalarStorageBinding binding{};
+    const auto race = race_admission(binding, contenders);
+    if (race.admitted != 1) {
+      ++double_admissions;
+    }
+    if (race.owners != 1) {
+      ++torn_views;
+    }
+    CHECK(race.admitted + race.refused == contenders);
+  }
+  CHECK(double_admissions == 0);
+  CHECK(torn_views == 0);
 }
 
 TEST_CASE("abstract Bundle without a concrete alternative cannot be realized") {

--- a/tests/cpp/test_type_registry.cpp
+++ b/tests/cpp/test_type_registry.cpp
@@ -569,7 +569,7 @@ TEST_CASE("graph realization pools wide polymorphic Bundles without escaping "
 
   CompoundScalarStorage pools = CompoundScalarStorage::make_default();
   TypeRealizationScope realization_scope{snapshot.get()};
-  CompoundScalarStorageScope pool_scope{pools.view()};
+  pools.bind(snapshot->pool_binding());
 
   Value escaped;
   {
@@ -586,18 +586,13 @@ TEST_CASE("graph realization pools wide polymorphic Bundles without escaping "
     REQUIRE(graph.ops_ref().concrete_type(graph, first.data()).schema() ==
             large);
 
+    // RFC 0029: a realization's pooled types serve exactly one live root
+    // graph, so a second pool cannot claim them while this one is bound.
     CompoundScalarStorage other_root = CompoundScalarStorage::make_default();
-    {
-      CompoundScalarStorageScope other_scope{other_root.view()};
-      Value::storage_type cross_root{first};
-      const void *const cross_root_payload =
-          graph.ops_ref().concrete_memory(cross_root.data());
-      REQUIRE(cross_root_payload != first_payload);
-      REQUIRE(other_root.view().owns(cross_root_payload));
-      REQUIRE_FALSE(pools.view().owns(cross_root_payload));
-      REQUIRE(other_root.view().inspect().live_slot_count == 1);
-    }
+    REQUIRE_THROWS_AS(other_root.bind(snapshot->pool_binding()),
+                      std::logic_error);
     REQUIRE(other_root.view().inspect().live_slot_count == 0);
+    REQUIRE(pools.view().owns(first_payload));
 
     std::vector<Value::storage_type> replicated_keys;
     replicated_keys.reserve(1024);

--- a/tests/cpp/test_value_builder.cpp
+++ b/tests/cpp/test_value_builder.cpp
@@ -299,7 +299,7 @@ TEST_CASE("list builders dispatch target transfer through the external owning bi
         TypeRegistry::instance(), options);
     TypeRealizationScope realization_scope{realization.get()};
     CompoundScalarStorage pools = CompoundScalarStorage::make_default();
-    CompoundScalarStorageScope pool_scope{pools.view()};
+    pools.bind(realization->pool_binding());
 
     auto       &registry = TypeRegistry::instance();
     const auto *list_schema = registry.list(schemas.event);

--- a/tests/cpp/type_erasure_perf.cpp
+++ b/tests/cpp/type_erasure_perf.cpp
@@ -658,7 +658,7 @@ int main()
 
         CompoundScalarStorage pools = CompoundScalarStorage::make_default();
         TypeRealizationScope realization_scope{realization.get()};
-        CompoundScalarStorageScope storage_scope{pools.view()};
+        pools.bind(realization->pool_binding());
         Value::storage_type external_source{*external.record()};
         Value::storage_type pooled_source{*pooled.record()};
         external.ops_ref().copy_assign_from(external, external_source.data(), small_value.binding(),


### PR DESCRIPTION
Recovery PR. **#558 merged into `docs/rfc-0029-value-pool-ownership` rather than into `main`.** #557 had already merged that branch into `main` at 11:00; #558 landed in it at 15:10, so all six implementation commits ended up on a branch that is now 31 commits behind `main`. `main` currently has the RFC text and none of the code — `active_compound_scalar_storage()` and its `thread_local` are still there.

This merges the orphaned work onto current `main`. No conflicts; content is identical to what was reviewed on #558:

| Commit | |
|---|---|
| `0f347e538` | Bind pooled value storage to its root graph, not to a thread |
| `1ca789d69` | Reconcile RFC 0013 and the type-erasure guide with the implementation |
| `d75781134` | Drop the redundant allocation from the binding cell |
| `72f12be37` | Serialize binding admission |
| `9732f89eb` | Record in RFC 0029 that admission is atomic |
| `3b47253b9` | Cover concurrent binding admission |

Revalidated against current `main` (which has since taken `Add public Value hash and equality functors` and `Make dispatch selector memory linear`): build clean, full native suite re-run in this PR's branch.

Merge this with a **merge commit into `main`**, not into another topic branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)