### PR TITLE
Ignore the storage category in type resolution

### DIFF
--- a/include/hgraph/types/graph_wiring.h
+++ b/include/hgraph/types/graph_wiring.h
@@ -1745,11 +1745,19 @@ namespace hgraph
             const auto *input = registry.dereference(input_schema);
             const auto *output = registry.dereference(output_schema);
             if (time_series_schema_equivalent(input, output)) { return true; }
-            return input != nullptr && output != nullptr && input->kind == TSTypeKind::TS &&
-                   output->kind == TSTypeKind::TS && input->value_schema != nullptr &&
-                   output->value_schema != nullptr && input->value_schema->is_named_bundle() &&
-                   output->value_schema->is_named_bundle() &&
-                   registry.bundle_is_a(output->value_schema, input->value_schema);
+            if (input == nullptr || output == nullptr || input->kind != TSTypeKind::TS ||
+                output->kind != TSTypeKind::TS)
+            {
+                return false;
+            }
+            // The subtype question is asked of the types, not of the storage
+            // categories they are held behind: a field declared as a
+            // polymorphic descendant arrives behind an owner pointer, and that
+            // says nothing about whether it derives from the declared input.
+            const auto *produced = value_schema_without_storage(output->value_schema);
+            const auto *expected = value_schema_without_storage(input->value_schema);
+            return produced != nullptr && expected != nullptr && expected->is_named_bundle() &&
+                   produced->is_named_bundle() && registry.bundle_is_a(produced, expected);
         }
 
         template <typename OutSchema>

--- a/include/hgraph/types/time_series/endpoint_schema.h
+++ b/include/hgraph/types/time_series/endpoint_schema.h
@@ -103,6 +103,28 @@ namespace hgraph
     /** Structural equality for canonical or equivalent time-series schemas. */
     [[nodiscard]] HGRAPH_EXPORT bool time_series_schema_equivalent(
         const TSValueTypeMetaData *lhs, const TSValueTypeMetaData *rhs) noexcept;
+
+    /**
+     * A value schema with its STORAGE CATEGORY removed, for type comparison.
+     *
+     * ``Owned<>`` and ``Shared<>`` are hints to the layout factory and to
+     * memory management: the first says a field is held behind one owner
+     * pointer (its declared type's closed union contains the leaf that embeds
+     * it, so a flat layout would recurse), the second that an allocation is
+     * reference counted. Neither says anything about type identity, so **type
+     * resolution ignores them everywhere** — the same transparency REF already
+     * has when schemas are compared.
+     *
+     * They differ from REF in one way that matters: a storage category is not
+     * an *alternative*. There is nothing to bind, present, or choose between,
+     * because the two schemas are the same type. Comparison normalises through
+     * the category and the question never arises.
+     *
+     * Stripping loops, so a category stacked over another reduces to the type
+     * underneath. Returns ``schema`` unchanged when it carries no category.
+     */
+    [[nodiscard]] HGRAPH_EXPORT const ValueTypeMetaData *value_schema_without_storage(
+        const ValueTypeMetaData *schema) noexcept;
 }  // namespace hgraph
 
 #endif  // HGRAPH_CPP_TIME_SERIES_ENDPOINT_SCHEMA_H

--- a/python/tests/test_compound_scalar_hierarchy.py
+++ b/python/tests/test_compound_scalar_hierarchy.py
@@ -162,6 +162,169 @@ def test_tsd_base_key_accepts_a_derived_key_port():
     assert eval_node(lookup, [{key: 7}], [key]) == [7]
 
 
+def test_base_declared_field_binds_to_a_node_declared_on_that_base():
+    """A field whose declared type is itself a polymorphic base (issue #556).
+
+    ``Derived.underlying`` is declared as ``Base``, and ``Base`` has a
+    descendant, so the field carries the one-pointer ``Owned<>`` representation
+    rather than a flat ``Base``.  Projecting it must still satisfy a parameter
+    declared on ``Base`` -- the carrier presents its target's read contract.
+    """
+
+    @dataclass(frozen=True)
+    class Base(CompoundScalar):
+        symbol: str
+
+    @dataclass(frozen=True)
+    class Derived(Base):
+        underlying: Base
+
+    @compute_node
+    def read_symbol(series: TS[Base]) -> TS[str]:
+        return series.value.symbol
+
+    @graph
+    def app(series: TS[Derived]) -> TS[str]:
+        return read_symbol(series.underlying)
+
+    assert eval_node(app, [Derived("BOM", Base("MONTHLY"))]) == ["MONTHLY"]
+
+
+def test_base_declared_field_binds_from_every_position():
+    """The same value reaching the same parameter by the other routes.
+
+    These bound before issue #556 was fixed, and they are what made the
+    failure attributable to the field projection rather than to the hierarchy.
+    """
+
+    @dataclass(frozen=True)
+    class Base(CompoundScalar):
+        symbol: str
+
+    @dataclass(frozen=True)
+    class Derived(Base):
+        underlying: Base
+
+    @compute_node
+    def read_symbol(series: TS[Base]) -> TS[str]:
+        return series.value.symbol
+
+    @graph
+    def top_level(series: TS[Derived]) -> TS[str]:
+        return read_symbol(series)
+
+    @graph
+    def from_tsd(series: TSD[str, TS[Base]]) -> TS[str]:
+        return read_symbol(series["only"])
+
+    class Leg(TimeSeriesSchema):
+        leg: TS[Base]
+
+    @graph
+    def from_tsb(series: TSB[Leg]) -> TS[str]:
+        return read_symbol(series.leg)
+
+    value = Derived("BOM", Base("MONTHLY"))
+    assert eval_node(top_level, [value]) == ["BOM"]
+    assert eval_node(from_tsd, [{"only": value}]) == ["BOM"]
+    assert eval_node(from_tsb, [{"leg": value}]) == ["BOM"]
+
+
+def test_base_declared_field_of_a_polymorphic_descendant_binds():
+    """The carrier of a DESCENDANT also satisfies a base-declared parameter.
+
+    ``Holder.leg`` is declared as ``Middle``, which is itself polymorphic, so
+    the projection carries ``Owned<Middle>`` while the reader is declared on
+    ``Base``.
+    """
+
+    @dataclass(frozen=True)
+    class Base(CompoundScalar):
+        symbol: str
+
+    @dataclass(frozen=True)
+    class Middle(Base):
+        tenor: str
+
+    @dataclass(frozen=True)
+    class Leaf(Middle):
+        depth: int
+
+    @dataclass(frozen=True)
+    class Holder(CompoundScalar):
+        leg: Middle
+
+    @compute_node
+    def read_symbol(series: TS[Base]) -> TS[str]:
+        return series.value.symbol
+
+    @graph
+    def app(holder: TS[Holder]) -> TS[str]:
+        return read_symbol(holder.leg)
+
+    assert eval_node(app, [Holder(Leaf("BOM", "M1", 2))]) == ["BOM"]
+
+
+def test_recursive_descendant_field_binds_to_a_base_parameter():
+    """A field whose declared type is its own ancestor.
+
+    ``Leaf.leg`` is declared as ``Middle``, which is itself polymorphic, so the
+    projection carries ``Owned[Middle]`` while the reader is declared on
+    ``Base``.  Accepting it needs the carrier to be unwrapped and then measured
+    against the hierarchy, not compared with the annotation alone.
+    """
+
+    @dataclass(frozen=True)
+    class Base(CompoundScalar):
+        symbol: str
+
+    @dataclass(frozen=True)
+    class Middle(Base):
+        tenor: str
+
+    @dataclass(frozen=True)
+    class Leaf(Middle):
+        leg: Middle
+
+    @compute_node
+    def read_symbol(series: TS[Base]) -> TS[str]:
+        return series.value.symbol
+
+    @graph
+    def app(leaf: TS[Leaf]) -> TS[str]:
+        return read_symbol(leaf.leg)
+
+    value = Leaf("BOM", "M1", Middle("MONTHLY", "M2"))
+    assert eval_node(app, [value]) == ["MONTHLY"]
+
+
+def test_unrelated_compound_scalar_field_is_still_refused():
+    """The widening is to the annotation's own carrier, not to any carrier."""
+
+    @dataclass(frozen=True)
+    class Base(CompoundScalar):
+        symbol: str
+
+    @dataclass(frozen=True)
+    class Derived(Base):
+        underlying: Base
+
+    @dataclass(frozen=True)
+    class Unrelated(CompoundScalar):
+        symbol: str
+
+    @compute_node
+    def read_unrelated(series: TS[Unrelated]) -> TS[str]:
+        return series.value.symbol
+
+    @graph
+    def app(series: TS[Derived]) -> TS[str]:
+        return read_unrelated(series.underlying)
+
+    with pytest.raises(Exception):
+        eval_node(app, [Derived("BOM", Base("MONTHLY"))])
+
+
 def test_frozen_generic_compound_scalar_plain_argument_preserves_specialization():
     value_type = TypeVar("value_type")
 

--- a/src/hgraph/types/time_series/endpoint_schema.cpp
+++ b/src/hgraph/types/time_series/endpoint_schema.cpp
@@ -95,6 +95,17 @@ namespace hgraph
         }
     }  // namespace
 
+    const ValueTypeMetaData *value_schema_without_storage(const ValueTypeMetaData *schema) noexcept
+    {
+        // A loop, not one unwrap: a storage category may sit over another, and
+        // every layer is invisible to the type system.
+        while (schema != nullptr && schema->is_indirect() && schema->element_type != nullptr)
+        {
+            schema = schema->element_type;
+        }
+        return schema;
+    }
+
     bool time_series_schema_equivalent(const TSValueTypeMetaData *lhs,
                                        const TSValueTypeMetaData *rhs) noexcept
     {
@@ -107,7 +118,9 @@ namespace hgraph
             case TSTypeKind::TSS:
             case TSTypeKind::TSW:
             case TSTypeKind::SIGNAL:
-                return lhs->value_type == rhs->value_type && lhs->period() == rhs->period() &&
+                return value_schema_without_storage(lhs->value_type) ==
+                           value_schema_without_storage(rhs->value_type) &&
+                       lhs->period() == rhs->period() &&
                        lhs->min_period() == rhs->min_period() &&
                        lhs->time_range() == rhs->time_range() &&
                        lhs->min_time_range() == rhs->min_time_range();

--- a/src/hgraph/types/type_pattern.cpp
+++ b/src/hgraph/types/type_pattern.cpp
@@ -1,5 +1,7 @@
 #include <hgraph/types/type_pattern.h>
 
+#include <hgraph/types/time_series/endpoint_schema.h>
+
 #include <hgraph/types/graph_wiring.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/time_series/endpoint_schema.h>  // time_series_schema_equivalent
@@ -98,6 +100,10 @@ namespace hgraph
 
     bool scalar_pattern_match(const ScalarPattern &pattern, const ValueTypeMetaData *concrete, ResolutionMap &map)
     {
+        // The storage category takes no part in type resolution, so it is
+        // stripped before anything is compared or bound: a variable binds the
+        // type, never the category it happens to be stored behind.
+        concrete = value_schema_without_storage(concrete);
         if (concrete == nullptr) { return false; }
         switch (pattern.kind)
         {

--- a/tests/cpp/test_type_registry.cpp
+++ b/tests/cpp/test_type_registry.cpp
@@ -1,6 +1,8 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <hgraph/types/metadata/type_realization.h>
+#include <hgraph/types/graph_wiring.h>
+#include <hgraph/types/time_series/endpoint_schema.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/utils/key_slot_store.h>
@@ -236,6 +238,64 @@ TEST_CASE("TypeRegistry records invariant Bundle specializations") {
                                     {{"value", integer}}, {}, false, "__type__",
                                     {text}),
                     std::invalid_argument);
+}
+
+TEST_CASE("a storage category takes no part in type resolution") {
+  using namespace hgraph;
+  auto &registry = TypeRegistry::instance();
+  const auto *text = registry.value_type("str");
+  REQUIRE(text != nullptr);
+
+  // Base has a descendant, so a field declared as Base is held behind an owner
+  // pointer: its closed union contains the leaf that embeds it and a flat
+  // layout would recurse (issue #556).
+  const auto *base = registry.bundle("tests.storage_category", "StorageBase",
+                                     {{"symbol", text}}, {}, true);
+  const auto *middle =
+      registry.bundle("tests.storage_category", "StorageMiddle",
+                      {{"symbol", text}, {"tenor", text}}, {base});
+  const auto *unrelated = registry.bundle(
+      "tests.storage_category", "StorageUnrelated", {{"symbol", text}}, {});
+
+  const auto *owned_base = registry.owned(base);
+  const auto *owned_middle = registry.owned(middle);
+  const auto *shared_base = registry.shared(base);
+  REQUIRE(owned_base != nullptr);
+  REQUIRE(shared_base != nullptr);
+  REQUIRE(owned_base->is_indirect());
+  REQUIRE(shared_base->is_indirect());
+
+  // Both categories are stripped, and stripping is idempotent on a plain type.
+  CHECK(value_schema_without_storage(owned_base) == base);
+  CHECK(value_schema_without_storage(shared_base) == base);
+  CHECK(value_schema_without_storage(base) == base);
+  CHECK(value_schema_without_storage(nullptr) == nullptr);
+
+  const auto *ts_base = registry.ts(base);
+  const auto *ts_middle = registry.ts(middle);
+  const auto *ts_unrelated = registry.ts(unrelated);
+  const auto *ts_owned_base = registry.ts(owned_base);
+  const auto *ts_owned_middle = registry.ts(owned_middle);
+  const auto *ts_shared_base = registry.ts(shared_base);
+
+  // Comparison is blind to the category: these ARE the same type, so there is
+  // nothing for an alternative to bind or present.
+  CHECK(time_series_schema_equivalent(ts_base, ts_owned_base));
+  CHECK(time_series_schema_equivalent(ts_owned_base, ts_base));
+  CHECK(time_series_schema_equivalent(ts_base, ts_shared_base));
+  CHECK(time_series_schema_equivalent(ts_owned_base, ts_shared_base));
+  // ... and still tells genuinely different types apart.
+  CHECK_FALSE(time_series_schema_equivalent(ts_base, ts_unrelated));
+  CHECK_FALSE(time_series_schema_equivalent(ts_base, ts_middle));
+
+  using hgraph::graph_wiring_detail::input_accepts_output_schema;
+
+  // The subtype question is asked of the types, not of the categories.
+  CHECK(input_accepts_output_schema(ts_base, ts_owned_middle));
+  CHECK(input_accepts_output_schema(ts_base, ts_middle));
+  CHECK(input_accepts_output_schema(ts_base, ts_shared_base));
+  CHECK_FALSE(input_accepts_output_schema(ts_middle, ts_owned_base));
+  CHECK_FALSE(input_accepts_output_schema(ts_unrelated, ts_owned_base));
 }
 
 TEST_CASE(


### PR DESCRIPTION
Fixes #556, and closes #564 with it.

Rebased onto current `main` (which now has `Shared<>`), and the approach changed completely after review — see *History* at the end.

## The rule

`Owned<>` and `Shared<>` are hints to the layout factory and to memory management. `Owned` says a field is held behind one owner pointer, because its declared type's closed union contains the very leaf that embeds it and a flat layout would recurse. `Shared` says an allocation is reference counted. **Neither says anything about type identity** — and the type system was treating both as part of it, so a projected field arrived as `TS[Owned[Base]]` and every consumer refused it.

Type resolution now ignores the category everywhere, the same transparency REF already has when schemas are compared.

It differs from REF in the way that matters: **a storage category is not an alternative.** There is nothing to bind, present, or choose between, because the two schemas are the same type. Comparison normalises through it and the question never arises.

## Why that is the whole fix

Patching consumer-facing gates one at a time hit four in a row — wiring, overload variable binding, runtime alternative binding, and then `RuntimeError: TSOutput structural reference alternatives are not implemented yet`. Treating the category as invisible to typing dissolves the sequence: `TSOutput::binding_for` now matches on its *first* equivalence check and returns the source handle, so no alternative is ever requested and gate 4 is never reached.

Three normalisation points, one rule (`value_schema_without_storage`): equivalence, scalar pattern resolution, and the bundle subtype question. Stripping loops, so a category over a category reduces to the type underneath, and it keys off `is_indirect()` — so `Shared` needed no site of its own.

## No Python change at all

The first draft widened the binding check in `_wiring/_node.py`. That gave one graph two authoring semantics — Python accepted a port that C++ dispatch refused — which is what the review caught. With the rule in the type system, Python's ordinary pattern match passes and the special case is gone.

## 0.5 parity

Measured against `.parity/envs/reference-3.12-darwin-arm64`:

| case | 0.5 | before | after |
|---|---|---|---|
| field → node on base | OK | fails | **OK** |
| field → `eq_` (generic `~T`) | OK | fails | **OK** |
| flat → `eq_` (control) | OK | OK | OK |

The generic-operator case is the one that needed unimplemented runtime machinery under the old approach.

## Coverage

- **Native**: both categories — stripping (including idempotence and null), equivalence in both directions, the subtype question, and the cases that must still be refused (unrelated schema, ancestor carrier, reverse direction). 20 assertions.
- **Python**: every position a base-declared value can reach a parameter from — nested field, top-level auto-cast, TSD value, TSB field, recursive descendant (`class Leaf(Middle): leg: Middle`), a non-polymorphic control, and an unrelated field that must still be refused.

## Validation

- Native: **1620 cases, 256,182 assertions, all pass**.
- Python: 8 failures before, 7 after, **none introduced**; the 7 are pre-existing artifacts of running a worktree against the main checkout's rootdir (a normal checkout passes 2166/10 skipped).

## History

The branch was rewritten. It previously carried a Python-side widening, then a move into `graph_wiring.h`, then a consolidation — all superseded by the rule above, which is smaller and covers strictly more. The review threads that drove it are still on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)