### PR TITLE
Rename the Local endpoint role out of collision with Owned storage

### DIFF
--- a/include/hgraph/lib/std/operators/impl/higher_order_impl.h
+++ b/include/hgraph/lib/std/operators/impl/higher_order_impl.h
@@ -1101,7 +1101,7 @@ namespace hgraph::stdlib
             }
             if (depth == source_path.size())
             {
-                return peered_terminal ? TSEndpointSchema::peered(schema) : TSEndpointSchema::owned(schema);
+                return peered_terminal ? TSEndpointSchema::peered(schema) : TSEndpointSchema::local(schema);
             }
 
             const auto selected = source_path[depth];
@@ -1119,7 +1119,7 @@ namespace hgraph::stdlib
                 children.push_back(index == selected
                                        ? switch_branch_output_endpoint_schema_for(
                                              child_schema, source_path, peered_terminal, depth + 1)
-                                       : TSEndpointSchema::owned(child_schema));
+                                       : TSEndpointSchema::local(child_schema));
             }
             return TSEndpointSchema::non_peered(schema, std::move(children));
         }
@@ -2607,7 +2607,7 @@ namespace hgraph::stdlib
             element. A terminal with endpoint topology of its own, including
             the synthetic REF used for composed fixed structures, stays owned
             by the child and the element forwards to it. Only an ordinary
-            owned terminal with the exact public schema is re-homed so it can
+            local terminal with the exact public schema is re-homed so it can
             write directly into the container element. */
         [[nodiscard]] inline MapOutputBindingMode configure_mapped_child_terminal(
             NodeBuilder &terminal,

--- a/include/hgraph/runtime/tsl_map_node.h
+++ b/include/hgraph/runtime/tsl_map_node.h
@@ -23,7 +23,7 @@ namespace hgraph
         /** Entry-owned ``TS<int64>`` used when the child accepts ``ndx``. */
         const TSValueTypeMetaData *index_output_schema{nullptr};
         /** Whether the child terminal writes into the list element or the
-            element preserves and forwards to a child-owned terminal. */
+            element preserves and forwards to a child-local terminal. */
         MapOutputBindingMode output_binding_mode{
             MapOutputBindingMode::ChildTerminalWritesElement};
     };

--- a/include/hgraph/types/time_series/endpoint_schema.h
+++ b/include/hgraph/types/time_series/endpoint_schema.h
@@ -21,7 +21,7 @@ namespace hgraph
     {
         Peered,
         NonPeered,
-        Owned,
+        Local,
     };
 
     /**
@@ -31,8 +31,14 @@ namespace hgraph
      * endpoint annotation records how runtime endpoint state is constructed for
      * each level of that schema: a non-peered collection prefix or a peered
      * terminal. Once traversal reaches a peered node, that entire subtree is
-     * associated with one output peering. An owned terminal uses ordinary local
-     * TSData storage for the whole remaining subtree.
+     * associated with one output peering. A ``Local`` terminal instead holds
+     * its own TSData storage for the whole remaining subtree.
+     *
+     * ``Local`` answers "who owns the time-series STATE" — this endpoint, or
+     * the output it is peered with. It is unrelated to ``ValueTypeFlags::Owned``,
+     * which answers "how are a scalar's BYTES laid out"; the two are chosen by
+     * different factories from different inputs, and a peered endpoint over a
+     * carried value is an ordinary combination.
      */
     class HGRAPH_EXPORT TSEndpointSchema
     {
@@ -42,8 +48,8 @@ namespace hgraph
         /** Peered terminal for ``schema``; no child annotation is needed. */
         [[nodiscard]] static TSEndpointSchema peered(const TSValueTypeMetaData *schema);
 
-        /** Owned terminal for ``schema``; ordinary TSData storage is used. */
-        [[nodiscard]] static TSEndpointSchema owned(const TSValueTypeMetaData *schema);
+        /** Local terminal for ``schema``; it holds its own TSData storage. */
+        [[nodiscard]] static TSEndpointSchema local(const TSValueTypeMetaData *schema);
 
         /**
          * Non-peered TSB, fixed-size TSL, or dynamic TSD prefix with explicit child
@@ -84,7 +90,7 @@ namespace hgraph
         [[nodiscard]] const TSValueTypeMetaData *schema() const noexcept;
         [[nodiscard]] bool is_peered() const noexcept;
         [[nodiscard]] bool is_non_peered() const noexcept;
-        [[nodiscard]] bool is_owned() const noexcept;
+        [[nodiscard]] bool is_local() const noexcept;
 
         [[nodiscard]] std::size_t child_count() const noexcept;
         [[nodiscard]] const TSEndpointSchema &child(std::size_t index) const;

--- a/include/hgraph/types/time_series/ts_input/detail.h
+++ b/include/hgraph/types/time_series/ts_input/detail.h
@@ -33,7 +33,7 @@ namespace hgraph::detail
     {
         if (endpoint.empty()) { return false; }
         if (endpoint.is_peered()) { return true; }
-        if (endpoint.is_owned()) { return false; }
+        if (endpoint.is_local()) { return false; }
         for (const auto &child : endpoint.children())
         {
             if (!input_storage_type_is_realization_invariant(child)) { return false; }

--- a/src/hgraph/runtime/nested_graph_node.cpp
+++ b/src/hgraph/runtime/nested_graph_node.cpp
@@ -162,7 +162,7 @@ namespace hgraph
                 const auto *child_schema = nested_output_child_schema(*schema, index);
                 children.push_back(index == selected
                                        ? nested_output_endpoint_schema_for(child_schema, target_path, depth + 1)
-                                       : TSEndpointSchema::owned(child_schema));
+                                       : TSEndpointSchema::local(child_schema));
             }
             return TSEndpointSchema::non_peered(schema, std::move(children));
         }

--- a/src/hgraph/runtime/switch_node.cpp
+++ b/src/hgraph/runtime/switch_node.cpp
@@ -516,7 +516,7 @@ NodeBuilder switch_node(NodeTypeMetaData meta, SwitchNodeSpec spec) {
     meta.output_endpoint_schema = spec.output_forwards_to_child_terminal
                                       ? forwarding_output_endpoint_schema(
                                             meta.output_schema)
-                                      : TSEndpointSchema::owned(
+                                      : TSEndpointSchema::local(
                                             meta.output_schema);
   }
 

--- a/src/hgraph/types/time_series/endpoint_schema.cpp
+++ b/src/hgraph/types/time_series/endpoint_schema.cpp
@@ -155,10 +155,10 @@ namespace hgraph
         return TSEndpointSchema{TSEndpointRole::Peered, schema, {}};
     }
 
-    TSEndpointSchema TSEndpointSchema::owned(const TSValueTypeMetaData *schema)
+    TSEndpointSchema TSEndpointSchema::local(const TSValueTypeMetaData *schema)
     {
         validate_schema(schema, "TSEndpointSchema::owned requires a schema");
-        return TSEndpointSchema{TSEndpointRole::Owned, schema, {}};
+        return TSEndpointSchema{TSEndpointRole::Local, schema, {}};
     }
 
     TSEndpointSchema TSEndpointSchema::non_peered(
@@ -228,9 +228,9 @@ namespace hgraph
         return role_ == TSEndpointRole::NonPeered && schema_ != nullptr;
     }
 
-    bool TSEndpointSchema::is_owned() const noexcept
+    bool TSEndpointSchema::is_local() const noexcept
     {
-        return role_ == TSEndpointRole::Owned && schema_ != nullptr;
+        return role_ == TSEndpointRole::Local && schema_ != nullptr;
     }
 
     std::size_t TSEndpointSchema::child_count() const noexcept

--- a/src/hgraph/types/time_series/ts_input.cpp
+++ b/src/hgraph/types/time_series/ts_input.cpp
@@ -84,30 +84,30 @@ namespace hgraph
                 const bool scalar = schema->kind == TSTypeKind::TS || schema->kind == TSTypeKind::SIGNAL ||
                                     schema->kind == TSTypeKind::REF;
                 const bool direct_peered = endpoint_schema.is_peered();
-                const bool owned_scalar = scalar && endpoint_schema.is_owned();
-                const bool owned_fixed = (schema->kind == TSTypeKind::TSB ||
+                const bool local_scalar = scalar && endpoint_schema.is_local();
+                const bool local_fixed = (schema->kind == TSTypeKind::TSB ||
                                           (schema->kind == TSTypeKind::TSL && schema->fixed_size() != 0)) &&
-                                         endpoint_schema.is_owned();
-                const bool owned_keyed = (schema->kind == TSTypeKind::TSS || schema->kind == TSTypeKind::TSD) &&
-                                         endpoint_schema.is_owned();
-                const bool owned_dynamic = ((schema->kind == TSTypeKind::TSL && schema->fixed_size() == 0) ||
+                                         endpoint_schema.is_local();
+                const bool local_keyed = (schema->kind == TSTypeKind::TSS || schema->kind == TSTypeKind::TSD) &&
+                                         endpoint_schema.is_local();
+                const bool local_dynamic = ((schema->kind == TSTypeKind::TSL && schema->fixed_size() == 0) ||
                                             schema->kind == TSTypeKind::TSW) &&
-                                           endpoint_schema.is_owned();
+                                           endpoint_schema.is_local();
                 const bool structural_root =
                     (schema->kind == TSTypeKind::TSB ||
                      schema->kind == TSTypeKind::TSD ||
                      (schema->kind == TSTypeKind::TSL &&
                       schema->fixed_size() == 0)) &&
                     endpoint_schema.is_non_peered();
-                if (!direct_peered && !owned_scalar && !owned_fixed && !owned_keyed && !owned_dynamic &&
+                if (!direct_peered && !local_scalar && !local_fixed && !local_keyed && !local_dynamic &&
                     !structural_root)
                 {
                     throw std::invalid_argument(
-                        "TSInput root must be peered, owned, or a supported non-peered composite");
+                        "TSInput root must be peered, local, or a supported non-peered composite");
                 }
             }
 
-            if (endpoint_schema.is_owned()) { return; }
+            if (endpoint_schema.is_local()) { return; }
             if (endpoint_schema.is_peered()) { return; }
             if (schema->kind == TSTypeKind::TSD)
             {
@@ -524,7 +524,7 @@ namespace hgraph
             {
                 throw std::logic_error("TSInput owned dynamic element schema is not resolved");
             }
-            const auto endpoint = TSEndpointSchema::owned(element_schema);
+            const auto endpoint = TSEndpointSchema::local(element_schema);
             const auto &plan = input_storage_plan(endpoint);
             return input_storage_type_for(endpoint, plan, 0, true, storage_role);
         }
@@ -635,7 +635,7 @@ namespace hgraph
                 }
                 return detail::target_link_storage_plan_for(schema->kind);
             }
-            if (endpoint_schema.is_owned())
+            if (endpoint_schema.is_local())
             {
                 const auto *schema = endpoint_schema.schema();
                 if (schema == nullptr)
@@ -2040,7 +2040,7 @@ namespace hgraph
                                       target_link_ops_for(endpoint_schema, root_plan, storage_offset),
                                       implementation_label);
             }
-            if (endpoint_schema.is_owned())
+            if (endpoint_schema.is_local())
             {
                 const auto &local_plan = input_storage_plan(endpoint_schema);
                 const bool root_record = storage_offset == 0 && &root_plan == &local_plan;
@@ -2156,7 +2156,7 @@ namespace hgraph
                     .regular_value_binding = regular_value_binding_for(child_schema.schema()),
                     .data_offset = child_offset,
                     .target_link = child_schema.is_peered(),
-                    .direct_child_memory = child_schema.is_owned(),
+                    .direct_child_memory = child_schema.is_local(),
                     .local_storage = child_type.plan() != &root_plan,
                 });
                 if (context->schema->kind == TSTypeKind::TSB)
@@ -2358,7 +2358,7 @@ namespace hgraph
                 throw std::invalid_argument("scalar input type requires a peered or owned TS/SIGNAL endpoint");
             }
 
-            if (endpoint_schema.is_owned())
+            if (endpoint_schema.is_local())
             {
                 const auto &root_plan = input_storage_plan(endpoint_schema);
                 return TSInputTypeRef::checked(input_storage_type_for(
@@ -2464,7 +2464,7 @@ namespace hgraph
                 return intern_ts_type(*schema, role, root_plan, ops, label);
             }
 
-            if (endpoint_schema.is_owned())
+            if (endpoint_schema.is_local())
             {
                 const auto &local_plan = input_storage_plan(endpoint_schema);
                 if (dynamic_list)
@@ -2933,25 +2933,25 @@ namespace hgraph
         const bool scalar = schema != nullptr && (schema->kind == TSTypeKind::TS || schema->kind == TSTypeKind::SIGNAL ||
                                                   schema->kind == TSTypeKind::REF);
         const bool direct_peered = schema != nullptr && plan.endpoint_schema().is_peered();
-        const bool owned_scalar = scalar && plan.endpoint_schema().is_owned();
-        const bool owned_fixed = schema != nullptr &&
+        const bool local_scalar = scalar && plan.endpoint_schema().is_local();
+        const bool local_fixed = schema != nullptr &&
                                  (schema->kind == TSTypeKind::TSB ||
                                   (schema->kind == TSTypeKind::TSL && schema->fixed_size() != 0)) &&
-                                 plan.endpoint_schema().is_owned();
-        const bool owned_keyed = schema != nullptr &&
+                                 plan.endpoint_schema().is_local();
+        const bool local_keyed = schema != nullptr &&
                                  (schema->kind == TSTypeKind::TSS || schema->kind == TSTypeKind::TSD) &&
-                                 plan.endpoint_schema().is_owned();
-        const bool owned_dynamic = schema != nullptr &&
+                                 plan.endpoint_schema().is_local();
+        const bool local_dynamic = schema != nullptr &&
                                    ((schema->kind == TSTypeKind::TSL && schema->fixed_size() == 0) ||
                                     schema->kind == TSTypeKind::TSW) &&
-                                   plan.endpoint_schema().is_owned();
+                                   plan.endpoint_schema().is_local();
         const bool structural_root = schema != nullptr &&
                                      (schema->kind == TSTypeKind::TSB ||
                                       schema->kind == TSTypeKind::TSD ||
                                       (schema->kind == TSTypeKind::TSL &&
                                        schema->fixed_size() == 0)) &&
                                      plan.endpoint_schema().is_non_peered();
-        if (!direct_peered && !owned_scalar && !owned_fixed && !owned_keyed && !owned_dynamic && !structural_root)
+        if (!direct_peered && !local_scalar && !local_fixed && !local_keyed && !local_dynamic && !structural_root)
         {
             return nullptr;
         }
@@ -2971,7 +2971,7 @@ namespace hgraph
     {
         if (const auto *builder = builder_for(plan); builder != nullptr) { return *builder; }
         throw std::invalid_argument(
-            "TSInputBuilderFactory requires a peered, owned, or supported non-peered composite root");
+            "TSInputBuilderFactory requires a peered, local, or supported non-peered composite root");
     }
 
     void TSInputBuilderFactory::reset() noexcept

--- a/src/hgraph/types/time_series/ts_output.cpp
+++ b/src/hgraph/types/time_series/ts_output.cpp
@@ -256,7 +256,7 @@ TSData TSOutput::checked_data_for(const TSEndpointSchema &endpoint_schema) {
         "TSOutput requires a non-empty output endpoint schema");
   }
   if (const auto *schema = endpoint_schema.schema();
-      endpoint_schema.is_owned()) {
+      endpoint_schema.is_local()) {
     return checked_data_for(schema);
   }
   const auto type = detail::output_data_storage_type_for(endpoint_schema);

--- a/tests/cpp/test_ts_input.cpp
+++ b/tests/cpp/test_ts_input.cpp
@@ -168,15 +168,15 @@ TEST_CASE("TSInput storage caching excludes endpoint trees with owned payloads")
          TSEndpointSchema::non_peered(inner, {TSEndpointSchema::peered(polymorphic)})});
     const auto owned_leaf = TSEndpointSchema::non_peered(
         root,
-        {TSEndpointSchema::owned(ts),
+        {TSEndpointSchema::local(ts),
          TSEndpointSchema::non_peered(inner, {TSEndpointSchema::peered(polymorphic)})});
     const auto owned_subtree = TSEndpointSchema::non_peered(
         root,
-        {TSEndpointSchema::peered(ts), TSEndpointSchema::owned(inner)});
+        {TSEndpointSchema::peered(ts), TSEndpointSchema::local(inner)});
 
     REQUIRE(input_storage_type_is_realization_invariant(TSEndpointSchema::peered(root)));
     REQUIRE(input_storage_type_is_realization_invariant(all_peered));
-    REQUIRE_FALSE(input_storage_type_is_realization_invariant(TSEndpointSchema::owned(root)));
+    REQUIRE_FALSE(input_storage_type_is_realization_invariant(TSEndpointSchema::local(root)));
     REQUIRE_FALSE(input_storage_type_is_realization_invariant(owned_leaf));
     REQUIRE_FALSE(input_storage_type_is_realization_invariant(owned_subtree));
 }
@@ -297,7 +297,7 @@ TEST_CASE("cached TSInput builders resolve owned polymorphic storage in each gra
     registry.bundle(
         "tests.ts_input_cache.realization", "First", {{"id", integer}, {"value", integer}}, {base});
     const auto *polymorphic = registry.ts(base);
-    const auto endpoint = TSEndpointSchema::owned(polymorphic);
+    const auto endpoint = TSEndpointSchema::local(polymorphic);
 
     const auto first_snapshot = TypeRealizationSnapshot::capture(registry);
     const TSInputBuilder *builder = nullptr;
@@ -343,7 +343,7 @@ TEST_CASE("cached composite TSInput builders re-realize owned polymorphic leaves
     const auto *root = registry.tsb(
         "TSInputCacheCompositeRoot", {{"owned", polymorphic}, {"peered", scalar}});
     const auto endpoint = TSEndpointSchema::non_peered(
-        root, {TSEndpointSchema::owned(polymorphic), TSEndpointSchema::peered(scalar)});
+        root, {TSEndpointSchema::local(polymorphic), TSEndpointSchema::peered(scalar)});
     const auto owned_binding = [](TSInput &input) {
         auto root_view = input.view();
         auto bundle = root_view.as_bundle();
@@ -387,7 +387,7 @@ TEST_CASE("cached owned TSS inputs re-realize polymorphic keys")
     const auto *base = registry.bundle("tests.ts_input_cache.tss", "Base", {{"id", integer}}, {}, true);
     registry.bundle("tests.ts_input_cache.tss", "First", {{"id", integer}, {"value", integer}}, {base});
     const auto *schema = registry.tss(base);
-    const auto endpoint = TSEndpointSchema::owned(schema);
+    const auto endpoint = TSEndpointSchema::local(schema);
     const auto key_binding = [](TSInput &input)
     {
         auto root = input.view();
@@ -437,7 +437,7 @@ TEST_CASE("cached owned TSD inputs re-realize polymorphic keys and values")
     registry.bundle("tests.ts_input_cache.tsd_key", "First", {{"id", integer}, {"value", integer}}, {key_base});
     registry.bundle("tests.ts_input_cache.tsd_value", "First", {{"id", integer}, {"value", integer}}, {value_base});
     const auto *schema = registry.tsd(key_base, registry.ts(value_base));
-    const auto endpoint = TSEndpointSchema::owned(schema);
+    const auto endpoint = TSEndpointSchema::local(schema);
     const auto bindings = [](TSInput &input)
     {
         auto root = input.view();
@@ -501,7 +501,7 @@ TEST_CASE("cached composite TSD inputs re-realize polymorphic keys and owned "
                     {value_base});
     const auto *element = registry.ts(value_base);
     const auto *schema = registry.tsd(key_base, element);
-    const auto endpoint = TSEndpointSchema::non_peered_dict(schema, TSEndpointSchema::owned(element));
+    const auto endpoint = TSEndpointSchema::non_peered_dict(schema, TSEndpointSchema::local(element));
     const auto bindings = [](TSInput &input)
     {
         auto root = input.view();
@@ -557,7 +557,7 @@ TEST_CASE("cached owned dynamic TSL inputs re-realize polymorphic elements")
     const auto *base = registry.bundle("tests.ts_input_cache.dynamic_tsl", "Base", {{"id", integer}}, {}, true);
     registry.bundle("tests.ts_input_cache.dynamic_tsl", "First", {{"id", integer}, {"value", integer}}, {base});
     const auto *schema = registry.tsl(registry.ts(base));
-    const auto endpoint = TSEndpointSchema::owned(schema);
+    const auto endpoint = TSEndpointSchema::local(schema);
     const auto element_binding = [](TSInput &input)
     {
         auto root = input.view();
@@ -608,7 +608,7 @@ TEST_CASE("cached owned TSW inputs re-realize polymorphic elements")
     const auto *base = registry.bundle("tests.ts_input_cache.tsw", "Base", {{"id", integer}}, {}, true);
     registry.bundle("tests.ts_input_cache.tsw", "First", {{"id", integer}, {"value", integer}}, {base});
     const auto *schema = registry.tsw(base, 3, 1);
-    const auto endpoint = TSEndpointSchema::owned(schema);
+    const auto endpoint = TSEndpointSchema::local(schema);
     const auto element_binding = [](TSInput &input)
     {
         auto root = input.view();
@@ -668,7 +668,7 @@ TEST_CASE("cached wholly owned fixed inputs re-realize nested keyed and dynamic 
     const auto *dict = registry.tsd(key_base, registry.ts(dict_base));
     const auto *list = registry.tsl(registry.ts(list_base));
     const auto *root = registry.tsb("TSInputCacheNestedOwnedRoot", {{"dict", dict}, {"list", list}});
-    const auto endpoint = TSEndpointSchema::owned(root);
+    const auto endpoint = TSEndpointSchema::local(root);
     const auto bindings = [](TSInput &input)
     {
         auto root_view = input.view();
@@ -1332,7 +1332,7 @@ TEST_CASE("TSInput projected owned children use their nonzero child storage offs
         "TSInputOwnedChildOffsets", {{"first", ts_int}, {"second", ts_int}, {"third", ts_int}});
     const auto annotation = TSEndpointSchema::non_peered(
         root,
-        {TSEndpointSchema::owned(ts_int), TSEndpointSchema::owned(ts_int), TSEndpointSchema::owned(ts_int)});
+        {TSEndpointSchema::local(ts_int), TSEndpointSchema::local(ts_int), TSEndpointSchema::local(ts_int)});
 
     Value snapshot;
     Value clone;
@@ -2454,7 +2454,7 @@ TEST_CASE("TSW ranges use stable ops contexts across data and endpoint roles")
     REQUIRE(range_size(output_window.value_times()) == 3);
 
     TSInput owned{TSInputBuilderFactory::checked_builder_for(
-        *schema, TSEndpointSchema::owned(schema))};
+        *schema, TSEndpointSchema::local(schema))};
     auto owned_root = owned.view(nullptr, t3);
     auto owned_window = owned_root.as_window();
     auto owned_data = owned_window.data_view();

--- a/tests/cpp/test_ts_type_ref.cpp
+++ b/tests/cpp/test_ts_type_ref.cpp
@@ -149,7 +149,7 @@ TEST_CASE("scalar time-series role records are canonical, exact, and thread stab
 
     const auto data = factory.data_type_for(schema);
     const auto output = factory.output_type_for(schema);
-    const auto input_builder = TSInputBuilderFactory::checked_builder_for(*schema, TSEndpointSchema::owned(schema));
+    const auto input_builder = TSInputBuilderFactory::checked_builder_for(*schema, TSEndpointSchema::local(schema));
     TSInput input{input_builder};
     const auto input_type = input.type_ref();
 
@@ -215,7 +215,7 @@ TEST_CASE("scalar role references validate AnyPtr boundaries and enforce role mu
     }
     REQUIRE(data.view().value().checked_as<std::int32_t>() == 42);
 
-    TSInput owned{TSInputBuilderFactory::checked_builder_for(*schema, TSEndpointSchema::owned(schema))};
+    TSInput owned{TSInputBuilderFactory::checked_builder_for(*schema, TSEndpointSchema::local(schema))};
     REQUIRE(owned.type_ref().record() != nullptr);
     REQUIRE_THROWS_AS(owned.view(nullptr, MIN_ST).data_view().begin_mutation(MIN_ST), std::logic_error);
 }
@@ -353,8 +353,8 @@ TEST_CASE("mixed fixed output topology preserves Output roles through forwarding
     const auto endpoint = TSEndpointSchema::non_peered(
         root,
         {TSEndpointSchema::non_peered(
-             inner, {TSEndpointSchema::owned(ts), TSEndpointSchema::peered(ts)}),
-         TSEndpointSchema::owned(ts)});
+             inner, {TSEndpointSchema::local(ts), TSEndpointSchema::peered(ts)}),
+         TSEndpointSchema::local(ts)});
 
     TSOutput output{endpoint};
     auto root_view = output.view(MIN_ST);
@@ -413,7 +413,7 @@ TEST_CASE("composed fixed input ownership remains local across copy move rebind 
                 nested,
                 {
                     TSEndpointSchema::non_peered_list(list, TSEndpointSchema::peered(ts)),
-                    TSEndpointSchema::owned(ts),
+                    TSEndpointSchema::local(ts),
                 }),
         });
     const auto &builder = TSInputBuilderFactory::checked_builder_for(*root, endpoint);
@@ -644,7 +644,7 @@ TEST_CASE("fixed ownership traversal has the same local boundary for Data Input 
     verify(data.view(), TypeRole::Data);
 
     TSInput input{TSInputBuilderFactory::checked_builder_for(
-        *root_schema, TSEndpointSchema::owned(root_schema))};
+        *root_schema, TSEndpointSchema::local(root_schema))};
     verify(input.view().data_view().borrowed_ref(), TypeRole::Input);
 
     TSOutput output{root_schema};
@@ -702,7 +702,7 @@ TEST_CASE("fixed input records describe owned target composite and embedded topo
     const auto *list = registry.tsl(ts, 2);
     const auto *root = registry.tsb("FixedInputRoles", {{"owned", ts}, {"target", ts}, {"items", list}});
 
-    TSInput owned{TSInputBuilderFactory::checked_builder_for(*root, TSEndpointSchema::owned(root))};
+    TSInput owned{TSInputBuilderFactory::checked_builder_for(*root, TSEndpointSchema::local(root))};
     REQUIRE(owned.type_ref().schema() == root);
     REQUIRE(std::string{owned.type_ref().record()->implementation_name()} == "ts.fixed.input.owned");
 
@@ -712,8 +712,8 @@ TEST_CASE("fixed input records describe owned target composite and embedded topo
 
     const auto composite_schema = TSEndpointSchema::non_peered(
         root,
-        {TSEndpointSchema::owned(ts), TSEndpointSchema::peered(ts),
-         TSEndpointSchema::non_peered_list(list, TSEndpointSchema::owned(ts))});
+        {TSEndpointSchema::local(ts), TSEndpointSchema::peered(ts),
+         TSEndpointSchema::non_peered_list(list, TSEndpointSchema::local(ts))});
     TSInput composite{TSInputBuilderFactory::checked_builder_for(*root, composite_schema)};
     const auto root_type = composite.type_ref();
     REQUIRE(root_type.schema() == root);
@@ -781,7 +781,7 @@ TEST_CASE("keyed and reference role records preserve root input and projection t
              std::tuple{tsd, "ts.tsd.input.owned", "ts.tsd.input.target"},
              std::tuple{ref, "ts.ref.input.owned", "ts.ref.input.target"}})
     {
-        TSInput owned{TSInputBuilderFactory::checked_builder_for(*schema, TSEndpointSchema::owned(schema))};
+        TSInput owned{TSInputBuilderFactory::checked_builder_for(*schema, TSEndpointSchema::local(schema))};
         TSInput target{TSInputBuilderFactory::checked_builder_for(*schema, TSEndpointSchema::peered(schema))};
         REQUIRE(label(owned.type_ref()) == owned_label);
         REQUIRE(label(target.type_ref()) == target_label);
@@ -817,7 +817,7 @@ TEST_CASE("TSB strategies publish debugger fields through inspection operations"
         "InspectionOpsBundle", {{"left", ts}, {"right", ts}});
 
     TSInput owned{TSInputBuilderFactory::checked_builder_for(
-        *bundle, TSEndpointSchema::owned(bundle))};
+        *bundle, TSEndpointSchema::local(bundle))};
     TSInput composite{TSInputBuilderFactory::checked_builder_for(
         *bundle,
         TSEndpointSchema::non_peered(
@@ -994,7 +994,7 @@ TEST_CASE("dynamic TSL and TSW role records are canonical distinct and exactly l
         const auto data = factory.data_type_for(item.schema);
         const auto output = factory.output_type_for(item.schema);
         TSInput owned{TSInputBuilderFactory::checked_builder_for(
-            *item.schema, TSEndpointSchema::owned(item.schema))};
+            *item.schema, TSEndpointSchema::local(item.schema))};
         TSInput target{TSInputBuilderFactory::checked_builder_for(
             *item.schema, TSEndpointSchema::peered(item.schema))};
 
@@ -1039,7 +1039,7 @@ TEST_CASE("dynamic TSL and TSW records preserve roles through fixed parents")
 
     TSData data{TSDataPlanFactory::instance().data_type_for(root)};
     TSOutput output{root};
-    TSInput input{TSInputBuilderFactory::checked_builder_for(*root, TSEndpointSchema::owned(root))};
+    TSInput input{TSInputBuilderFactory::checked_builder_for(*root, TSEndpointSchema::local(root))};
 
     struct ParentCase
     {
@@ -1623,7 +1623,7 @@ TEST_CASE("dynamic TSL and TSW role contexts reset and reseed without stale reco
             TSData data{factory.data_type_for(schema)};
             TSOutput output{schema};
             TSInput owned{TSInputBuilderFactory::checked_builder_for(
-                *schema, TSEndpointSchema::owned(schema))};
+                *schema, TSEndpointSchema::local(schema))};
             TSInput target{TSInputBuilderFactory::checked_builder_for(
                 *schema, TSEndpointSchema::peered(schema))};
             labels.emplace_back(data.type_ref().record()->implementation_name());
@@ -1661,7 +1661,7 @@ TEST_CASE("fixed role caches reset after owners are destroyed and reseed cleanly
         old_schema = registry.tsb("FixedResetBundle", {{"items", list}, {"target", ts}});
         const auto endpoint = TSEndpointSchema::non_peered(
             old_schema,
-            {TSEndpointSchema::non_peered_list(list, TSEndpointSchema::owned(ts)),
+            {TSEndpointSchema::non_peered_list(list, TSEndpointSchema::local(ts)),
              TSEndpointSchema::peered(ts)});
 
         TSData data{TSDataPlanFactory::instance().data_type_for(old_schema)};
@@ -1689,7 +1689,7 @@ TEST_CASE("fixed role caches reset after owners are destroyed and reseed cleanly
     const auto *schema = registry.tsb("FixedResetBundle", {{"items", list}, {"target", ts}});
     const auto endpoint = TSEndpointSchema::non_peered(
         schema,
-        {TSEndpointSchema::non_peered_list(list, TSEndpointSchema::owned(ts)),
+        {TSEndpointSchema::non_peered_list(list, TSEndpointSchema::local(ts)),
          TSEndpointSchema::peered(ts)});
     TSData data{TSDataPlanFactory::instance().data_type_for(schema)};
     TSInput input{TSInputBuilderFactory::checked_builder_for(*schema, endpoint)};

--- a/tests/cpp/test_type_erasure_layout.cpp
+++ b/tests/cpp/test_type_erasure_layout.cpp
@@ -236,7 +236,7 @@ TEST_CASE("dynamic TSL and TSW physical plans retain their baseline layouts")
         const auto data = factory.data_type_for(schema);
         const auto output = factory.output_type_for(schema);
         TSInput owned{TSInputBuilderFactory::checked_builder_for(
-            *schema, TSEndpointSchema::owned(schema))};
+            *schema, TSEndpointSchema::local(schema))};
         const auto input = owned.type_ref();
         const auto &plan = data.checked_plan();
 


### PR DESCRIPTION
Pure rename, no behaviour change. Follows from auditing RFC 0028's `Owned`-flag sites, where most of the noise turned out to be a different concept wearing the same name.

## The two concepts

| | `TSEndpointRole::Owned` → **`Local`** | `ValueTypeFlags::Owned` (unchanged) |
|---|---|---|
| layer | time-series endpoints | value layer |
| question | who owns the **state** — this endpoint, or the output it is peered with? | how are a scalar's **bytes** laid out — inline, or behind one pointer? |
| set by | endpoint plan factories, from wiring topology | the layout factory, from schema recursion |
| siblings | `Peered`, `NonPeered` | `Shared` |

They never interact: a peered endpoint over a carried value is an ordinary combination.

## Why it was worth doing

`git grep is_owned` returns both, and the endpoint role dominates — about 15 of ~22 hits. An audit of the storage flags (which RFC 0028 explicitly invites, and which I have just done) has to wade through hits that cannot possibly be relevant. That is a standing tax on exactly the reviews most likely to matter for `Shared`.

## Why `Local`

It is the word the code already used to explain the role — *"an owned terminal uses ordinary **local** TSData storage"* — so the doc comment now needs one fewer indirection.

`Direct` was the other candidate and is worse here: `ts_input.cpp` already has `direct_peered` for the *opposite* condition, so `Direct` would collide with an existing local meaning "peered without an intermediate".

## What changed

The enum value, the `TSEndpointSchema::owned` factory, the `is_owned` predicate, the four derived flags (`owned_scalar`/`owned_fixed`/`owned_keyed`/`owned_dynamic`), and the two diagnostics that named the role. The header doc now states the distinction outright so the next reader does not have to rediscover it.

The value-layer `is_owned()` is untouched, and the role is not exposed through the Python bridge, so there is no API or wire change.

## Validation

Native suite: **1619 cases, 256,162 assertions, all pass**.

## Note for merge order

Touches `endpoint_schema.h`/`.cpp`, as does #563 (which adds `value_schema_without_storage` to the same header). Different regions, so the conflict is textual at worst — whichever lands second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)