### PR TITLE
Use shared values for Kafka ingress

### DIFF
--- a/docs/source/rfc/rfc_0015_kafka_extension_api.rst
+++ b/docs/source/rfc/rfc_0015_kafka_extension_api.rst
@@ -977,7 +977,9 @@ The native hot path must avoid Python and minimise copies:
 * librdkafka payloads are copied or retained exactly once into an owned
   cross-thread record according to the chosen safe lifetime strategy;
 * the standard burst push-source queue retains transport envelopes by move;
-* graph-thread publication moves into the native time-series value;
+* the private transport envelope retains ``Shared<KafkaRecord>`` handles
+  across graph-thread hand-offs, then copies the concrete record once into the
+  public ``TS<KafkaRecord>`` value;
 * codecs run after transport unless a native codec explicitly opts into safe
   off-thread decoding; and
 * delivery callbacks use their opaque token to avoid record lookup by content.

--- a/docs/source/rfc/rfc_0028_shared_value_representation.rst
+++ b/docs/source/rfc/rfc_0028_shared_value_representation.rst
@@ -1,10 +1,10 @@
 RFC 0028: Shared Value Representation
 =====================================
 
-:Status: Accepted (core implementation complete; adaptor migration pending)
+:Status: Accepted (core and Kafka migration complete; web migration pending)
 :Author: Howard Henson
 :Created: 2026-08-24
-:Updated: 2026-08-26
+:Updated: 2026-08-27
 :Target: C++ value storage, cross-thread retention, adaptor ingress paths
 
 Summary
@@ -290,10 +290,66 @@ The core implementation includes:
 * native tests for immutability, stable reuse, cross-schema class reuse,
   concurrent retain/release, allocator contention, JSON, and Python exposure.
 
-Migration of Kafka/web transport fields and before/after adaptor benchmarks is
-deliberately a subsequent, separately measurable change.  The representation
+Kafka subscription ingress now retains its record field as
+``Shared<KafkaRecord>`` in the private cross-thread transport envelope.  The
+public service remains ``TS<KafkaRecord>`` and materialises one concrete copy
+at graph publication, so native and Python clients see no schema change.  Web
+transport remains a separately measurable follow-up.  The representation
 contract does not require every struct to become shared; sites opt in where
 retention data justifies it.
+
+Kafka transport evidence
+------------------------
+
+``hgraph_kafka_transport_perf`` preserves the former plain-record envelope as
+an A/B control and exercises the production retention segment: envelope
+construction, burst push output, emit pending state, keyed transport child,
+and the public record projection.  It reports allocation count and bytes for
+the complete segment, p50/p99 segment latency, and the peak tracked retained
+state.  The retained figure includes the shared arena slab reservation rather
+than hiding it behind per-handle zero accounting.
+
+Run from a Release ``cpp`` preset build with:
+
+.. code-block:: console
+
+   ./cmake-build-cpp/extensions/kafka/tests/hgraph_kafka_transport_perf
+
+On an Apple M4 Max running macOS 26.6.2, the median of three runs of 20,000
+records with a 64 KiB payload was:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 14 14 14 20 20
+
+   * - Envelope
+     - p50 ns
+     - p99 ns
+     - allocations / record
+     - allocated bytes / record
+     - tracked retained bytes
+   * - Plain control
+     - 9,041
+     - 11,583
+     - 31
+     - 409,224
+     - 197,912
+   * - Shared record
+     - 4,708
+     - 6,084
+     - 23
+     - 144,632
+     - 151,088
+   * - Change
+     - -47.9%
+     - -47.5%
+     - -25.8%
+     - -64.7%
+     - -23.7%
+
+This is the deterministic native retention segment, not broker/network
+latency.  Full Kafka service tests continue to cover real and mock broker
+ordering, recovery, lifecycle, and public C++/Python value behavior.
 
 Acceptance criteria
 -------------------

--- a/extensions/kafka/CHANGELOG.md
+++ b/extensions/kafka/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Retain consumed records as one immutable `Shared<KafkaRecord>` allocation
+  through the private cross-thread transport pipeline. The public
+  `TS<KafkaRecord>` service and Python value remain unchanged and receive one
+  concrete projection at graph publication.
 - Rebuild manual/independent assignments as a new recovery generation after a
   broker disconnect, allowing live consumers to resume from committed offsets
   and exposing `Retrying` -> `Recovering` -> `Live` lifecycle transitions.

--- a/extensions/kafka/CMakeLists.txt
+++ b/extensions/kafka/CMakeLists.txt
@@ -82,6 +82,49 @@ if(NOT TARGET RdKafka::rdkafka AND NOT TARGET rdkafka)
     )
     FetchContent_MakeAvailable(librdkafka)
 
+    if(HGRAPH_ENABLE_TSAN)
+        if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+            # glibc's C11 thrd_create/mtx_* entry points are not intercepted by
+            # ThreadSanitizer.  librdkafka worker threads created through that
+            # backend therefore enter instrumented code without TSan thread
+            # state and crash inside the sanitizer allocator.  Select its
+            # pthread-backed implementation after feature detection has
+            # generated config.h; pthread lifecycle and synchronization are
+            # visible to TSan.
+            set(_hgraph_kafka_rdkafka_config
+                "${librdkafka_BINARY_DIR}/generated/config.h")
+            file(READ "${_hgraph_kafka_rdkafka_config}"
+                _hgraph_kafka_rdkafka_config_contents)
+            if(_hgraph_kafka_rdkafka_config_contents MATCHES
+                    "#define WITH_C11THREADS 1")
+                string(REPLACE
+                    "#define WITH_C11THREADS 1"
+                    "#define WITH_C11THREADS 0"
+                    _hgraph_kafka_rdkafka_config_contents
+                    "${_hgraph_kafka_rdkafka_config_contents}")
+                file(WRITE "${_hgraph_kafka_rdkafka_config}"
+                    "${_hgraph_kafka_rdkafka_config_contents}")
+            elseif(NOT _hgraph_kafka_rdkafka_config_contents MATCHES
+                    "#define WITH_C11THREADS 0")
+                message(FATAL_ERROR
+                    "The pinned librdkafka config no longer declares "
+                    "WITH_C11THREADS; update the TSan compatibility setup")
+            endif()
+            set(WITH_C11THREADS OFF CACHE INTERNAL
+                "Use librdkafka's pthread-backed thread primitives under TSan"
+                FORCE)
+        endif()
+
+        # Instrument the fetched dependency as well as hgraph.  In addition to
+        # checking its accesses, this prevents interceptor-only reports from
+        # librdkafka allocation helpers whose surrounding atomic operations
+        # would otherwise be invisible to TSan.
+        target_compile_options(rdkafka PRIVATE
+            -fsanitize=thread
+            -fno-omit-frame-pointer
+        )
+    endif()
+
     if(MSVC AND OPENSSL_USE_STATIC_LIBS)
         # librdkafka's Windows TLS source embeds default-library directives for
         # the OpenSSL import libraries.  Ignore those names when CMake selected

--- a/extensions/kafka/src/detail/service_transport.h
+++ b/extensions/kafka/src/detail/service_transport.h
@@ -53,7 +53,7 @@ using KafkaTransportEvent =
     Bundle<"hgraph.kafka.internal::KafkaTransportEvent",
            Field<"kind", KafkaTransportEventKind>,
            Field<"subscription_key", KafkaSubscriptionKey>,
-           Field<"record", KafkaRecord>, Field<"cursor", KafkaCursor>,
+           Field<"record", Shared<KafkaRecord>>, Field<"cursor", KafkaCursor>,
            Field<"state", KafkaSubscriptionState>,
            Field<"evaluation_time", DateTime>, Field<"removed", Bool>,
            Field<"recovery", Bool>, Field<"request_id", Int>,
@@ -409,7 +409,10 @@ struct SubscriptionProjectionNode {
     const auto fields = event.base().value().as_bundle();
     const auto record = fields.at("record");
     if (record.data() != nullptr) {
-      out.template field<"record">().apply(record);
+      // The transport retains the immutable record through Shared<T>, while
+      // the public Kafka service deliberately remains TS<KafkaRecord>. Project
+      // the read-only concrete payload for the one public-output copy.
+      out.template field<"record">().apply(record.concrete());
     }
     const auto cursor = fields.at("cursor");
     if (cursor.data() != nullptr) {

--- a/extensions/kafka/tests/CMakeLists.txt
+++ b/extensions/kafka/tests/CMakeLists.txt
@@ -17,3 +17,25 @@ add_test(NAME hgraph_kafka_tests COMMAND hgraph_kafka_tests)
 if(COMMAND hgraph_configure_test_runtime_paths)
     hgraph_configure_test_runtime_paths(hgraph_kafka_tests)
 endif()
+
+add_executable(hgraph_kafka_transport_perf
+    transport_perf.cpp
+)
+
+target_compile_features(hgraph_kafka_transport_perf PRIVATE cxx_std_23)
+target_link_libraries(hgraph_kafka_transport_perf PRIVATE hgraph::kafka)
+target_include_directories(hgraph_kafka_transport_perf
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+
+if(MSVC)
+    target_compile_options(hgraph_kafka_transport_perf PRIVATE /W4 /permissive-)
+else()
+    target_compile_options(hgraph_kafka_transport_perf PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # This benchmark replaces global new/delete to count allocations. GCC can
+    # pair an inlined replacement new with the replacement delete and report
+    # a spurious mismatched-new-delete warning.
+    target_compile_options(hgraph_kafka_transport_perf PRIVATE -Wno-mismatched-new-delete)
+endif()

--- a/extensions/kafka/tests/test_service.cpp
+++ b/extensions/kafka/tests/test_service.cpp
@@ -9,6 +9,7 @@
 #include <hgraph/lib/testing/eval_node.h>
 #include <hgraph/lib/testing/runtime_support.h>
 #include <hgraph/runtime/runtime.h>
+#include <hgraph/types/value/shared_value_pool.h>
 #include <hgraph/util/scope.h>
 
 #include "../src/detail/service_transport.h"
@@ -68,6 +69,44 @@ void test_transport_sender_handles_graph_teardown() {
   // inert as soon as the graph closes the push source.
   require(!sender.send_blocking(Value{Int{1}}),
           "a Kafka transport sender accepted work after graph teardown");
+}
+
+void test_subscription_transport_retains_one_shared_record() {
+  const auto bindings = kafka::detail::make_transport_bindings();
+  const auto live_before = shared_value_pool_metrics().live_values;
+  Value key = make_subscription_key(
+      {Str{"shared-records"}}, Str{"shared-records"}, Str{"earliest"},
+      Str{"unbounded"}, KafkaCommitMode::Explicit, Str{"shared-records"});
+  Value record = make_record(Str{"shared-records"}, Int{1}, Int{42},
+                             Bytes{std::string(8'192, 'x')});
+  Value event = kafka::detail::subscription_transport_event(
+      *bindings.value, std::move(key), std::move(record), std::nullopt,
+      KafkaSubscriptionState::Live);
+
+  const auto retained_record = event.view().as_bundle().at("record");
+  require(retained_record.schema()->is_shared(),
+          "Kafka transport record did not use Shared<KafkaRecord>");
+  const void *stable = retained_record.concrete().data();
+  require(stable != nullptr, "Kafka transport record has no shared payload");
+  require(shared_value_pool_metrics().live_values == live_before + 1,
+          "Kafka transport materialised more than one shared record");
+
+  Value copied_event = event.clone();
+  const auto copied_record = copied_event.view().as_bundle().at("record");
+  require(copied_record.concrete().data() == stable,
+          "Kafka transport copy did not retain the shared record slot");
+  require(shared_value_pool_metrics().live_values == live_before + 1,
+          "Kafka transport copy duplicated the shared record payload");
+
+  const auto plain_record_binding = ValuePlanFactory::instance().type_for(
+      scalar_descriptor<KafkaRecord>::value_meta());
+  Value public_record{plain_record_binding, copied_record.concrete()};
+  require(public_record.view().as_bundle().at("offset").checked_as<Int>() ==
+              Int{42},
+          "Kafka public record projection changed its value semantics");
+  require(public_record.schema() ==
+              scalar_descriptor<KafkaRecord>::value_meta(),
+          "Kafka shared transport representation escaped the public schema");
 }
 
 Value delivery_burst(
@@ -2931,6 +2970,7 @@ int main() {
   try {
     hgraph::stdlib::register_standard_operators();
     test_transport_sender_handles_graph_teardown();
+    test_subscription_transport_retains_one_shared_record();
     test_delivery_burst_unrolls_repeated_request_ids();
     const auto release_state = hgraph::make_scope_exit(release_test_state);
     initialize_values();

--- a/extensions/kafka/tests/transport_perf.cpp
+++ b/extensions/kafka/tests/transport_perf.cpp
@@ -1,0 +1,391 @@
+#include <hgraph/kafka/value_builders.h>
+
+#include "detail/service_transport.h"
+
+#include <hgraph/types/value/shared_value_pool.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <new>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#if defined(_MSC_VER)
+#include <malloc.h>
+#endif
+
+namespace {
+std::atomic<bool> g_count_allocations{false};
+std::atomic<std::size_t> g_allocations{0};
+std::atomic<std::size_t> g_allocated_bytes{0};
+volatile std::uint64_t g_retained_checksum{0};
+
+void record_allocation(std::size_t size) noexcept {
+  if (g_count_allocations.load(std::memory_order_relaxed)) {
+    g_allocations.fetch_add(1, std::memory_order_relaxed);
+    g_allocated_bytes.fetch_add(size, std::memory_order_relaxed);
+  }
+}
+
+[[nodiscard]] void *allocate_unaligned(std::size_t size) {
+  if (void *memory = std::malloc(std::max<std::size_t>(size, 1))) {
+    return memory;
+  }
+  throw std::bad_alloc{};
+}
+
+[[nodiscard]] void *allocate_aligned(std::size_t size, std::size_t alignment) {
+  const auto actual_size = std::max<std::size_t>(size, 1);
+#if defined(_MSC_VER)
+  if (void *memory = _aligned_malloc(actual_size, alignment)) {
+    return memory;
+  }
+#else
+  void *memory{};
+  if (posix_memalign(&memory, alignment, actual_size) == 0) {
+    return memory;
+  }
+#endif
+  throw std::bad_alloc{};
+}
+
+void free_aligned(void *memory) noexcept {
+#if defined(_MSC_VER)
+  _aligned_free(memory);
+#else
+  std::free(memory);
+#endif
+}
+
+struct AllocationScope {
+  AllocationScope() {
+    g_allocations.store(0, std::memory_order_relaxed);
+    g_allocated_bytes.store(0, std::memory_order_relaxed);
+    g_count_allocations.store(true, std::memory_order_relaxed);
+  }
+
+  ~AllocationScope() {
+    g_count_allocations.store(false, std::memory_order_relaxed);
+  }
+};
+} // namespace
+
+void *operator new(std::size_t size) {
+  record_allocation(size);
+  return allocate_unaligned(size);
+}
+
+void *operator new[](std::size_t size) {
+  record_allocation(size);
+  return allocate_unaligned(size);
+}
+
+void *operator new(std::size_t size, std::align_val_t alignment) {
+  record_allocation(size);
+  return allocate_aligned(size, static_cast<std::size_t>(alignment));
+}
+
+void *operator new[](std::size_t size, std::align_val_t alignment) {
+  record_allocation(size);
+  return allocate_aligned(size, static_cast<std::size_t>(alignment));
+}
+
+void *operator new(std::size_t size, const std::nothrow_t &) noexcept {
+  try {
+    return ::operator new(size);
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+void *operator new[](std::size_t size, const std::nothrow_t &) noexcept {
+  try {
+    return ::operator new[](size);
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+void *operator new(std::size_t size, std::align_val_t alignment,
+                   const std::nothrow_t &) noexcept {
+  try {
+    return ::operator new(size, alignment);
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+void *operator new[](std::size_t size, std::align_val_t alignment,
+                     const std::nothrow_t &) noexcept {
+  try {
+    return ::operator new[](size, alignment);
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+void operator delete(void *memory) noexcept { std::free(memory); }
+void operator delete[](void *memory) noexcept { std::free(memory); }
+void operator delete(void *memory, std::size_t) noexcept { std::free(memory); }
+void operator delete[](void *memory, std::size_t) noexcept {
+  std::free(memory);
+}
+void operator delete(void *memory, const std::nothrow_t &) noexcept {
+  std::free(memory);
+}
+void operator delete[](void *memory, const std::nothrow_t &) noexcept {
+  std::free(memory);
+}
+void operator delete(void *memory, std::align_val_t) noexcept {
+  free_aligned(memory);
+}
+void operator delete[](void *memory, std::align_val_t) noexcept {
+  free_aligned(memory);
+}
+void operator delete(void *memory, std::size_t, std::align_val_t) noexcept {
+  free_aligned(memory);
+}
+void operator delete[](void *memory, std::size_t, std::align_val_t) noexcept {
+  free_aligned(memory);
+}
+void operator delete(void *memory, std::align_val_t,
+                     const std::nothrow_t &) noexcept {
+  free_aligned(memory);
+}
+void operator delete[](void *memory, std::align_val_t,
+                       const std::nothrow_t &) noexcept {
+  free_aligned(memory);
+}
+
+namespace {
+using namespace hgraph;
+using namespace hgraph::kafka;
+
+// RFC 0028's before case, retained in this benchmark only. Keep every field
+// identical to KafkaTransportEvent except the record representation.
+using PlainKafkaTransportEvent =
+    Bundle<"hgraph.kafka.benchmark::PlainKafkaTransportEvent",
+           Field<"kind", kafka::detail::KafkaTransportEventKind>,
+           Field<"subscription_key", KafkaSubscriptionKey>,
+           Field<"record", KafkaRecord>, Field<"cursor", KafkaCursor>,
+           Field<"state", KafkaSubscriptionState>,
+           Field<"evaluation_time", DateTime>, Field<"removed", Bool>,
+           Field<"recovery", Bool>, Field<"request_id", Int>,
+           Field<"report", KafkaDeliveryReport>, Field<"event", KafkaEvent>,
+           Field<"stop_graph", Bool>>;
+using PlainKafkaTransportEventBatch =
+    HomogeneousTuple<PlainKafkaTransportEvent>;
+
+struct Variant {
+  std::string_view name;
+  ValueTypeRef event;
+  ValueTypeRef batch;
+  const ValueTypeMetaData *batch_schema;
+  bool shared_record;
+};
+
+struct Fixture {
+  Variant plain;
+  Variant shared;
+  ValueTypeRef public_record;
+  Value subscription_key;
+  Value cursor;
+  Value record;
+
+  explicit Fixture(std::size_t payload_bytes) {
+    register_kafka_types();
+    auto &factory = ValuePlanFactory::instance();
+    const auto bindings = kafka::detail::make_transport_bindings();
+    plain = Variant{
+        .name = "plain",
+        .event = factory.type_for(
+            scalar_descriptor<PlainKafkaTransportEvent>::value_meta()),
+        .batch = factory.type_for(
+            scalar_descriptor<PlainKafkaTransportEventBatch>::value_meta()),
+        .batch_schema =
+            scalar_descriptor<PlainKafkaTransportEventBatch>::value_meta(),
+        .shared_record = false,
+    };
+    shared = Variant{
+        .name = "shared",
+        .event = bindings.value->event,
+        .batch = bindings.value->batch,
+        .batch_schema = scalar_descriptor<
+            kafka::detail::KafkaTransportEventBatch>::value_meta(),
+        .shared_record = true,
+    };
+    public_record =
+        factory.type_for(scalar_descriptor<KafkaRecord>::value_meta());
+    subscription_key = make_subscription_key(
+        {Str{"benchmark-records"}}, Str{"benchmark-records"}, Str{"earliest"},
+        Str{"unbounded"}, KafkaCommitMode::Explicit, Str{"benchmark-records"});
+    cursor = make_cursor(Str{"benchmark-records"}, Int{1},
+                         Str{"benchmark-records"}, Int{0}, Int{2});
+    record = make_record(Str{"benchmark-records"}, Int{0}, Int{1},
+                         Bytes{std::string(payload_bytes, 'x')},
+                         Bytes{std::string(64, 'k')});
+  }
+
+  [[nodiscard]] Value event(const Variant &variant) const {
+    BundleBuilder builder{variant.event};
+    builder.set("kind",
+                Value{kafka::detail::KafkaTransportEventKind::Subscription});
+    builder.set("subscription_key", subscription_key.clone());
+    builder.set("record", record.clone());
+    builder.set("cursor", cursor.clone());
+    builder.set("state", Value{KafkaSubscriptionState::Live});
+    return builder.build();
+  }
+
+  [[nodiscard]] std::uint64_t pipeline(const Variant &variant) const {
+    ListBuilder burst{variant.event, *variant.batch_schema};
+    burst.push_back(event(variant));
+    Value sender_batch = burst.build();
+
+    // These are the retained representations on the production path: push
+    // output, emitter pending queue, keyed transport child, and public output.
+    Value observed_batch{variant.batch, sender_batch.view()};
+    Value pending = observed_batch.view().as_list().at(0).clone();
+    Value keyed_child = pending.clone();
+    const auto retained_record =
+        keyed_child.view().as_bundle().at("record").concrete();
+    Value public_output{public_record, retained_record};
+    const auto fields = public_output.view().as_bundle();
+    return static_cast<std::uint64_t>(
+               fields.at("value").checked_as<Bytes>().data.size()) +
+           static_cast<std::uint64_t>(fields.at("offset").checked_as<Int>());
+  }
+
+  [[nodiscard]] DynamicStorageMetrics
+  retained_metrics(const Variant &variant) const {
+    const DynamicStorageMetrics record_payload =
+        record.view().dynamic_storage_metrics();
+    Value initial_event = event(variant);
+    ListBuilder burst{variant.event, *variant.batch_schema};
+    burst.push_back(std::move(initial_event));
+    Value sender_batch = burst.build();
+    Value observed_batch{variant.batch, sender_batch.view()};
+    sender_batch.reset();
+    Value pending = observed_batch.view().as_list().at(0).clone();
+    Value keyed_child = pending.clone();
+    pending.reset();
+    Value public_output{public_record,
+                        keyed_child.view().as_bundle().at("record").concrete()};
+
+    // At projection time the push output and keyed child remain live while
+    // the public TS<KafkaRecord> output is populated. This is the path's peak
+    // retained-record state: three payload copies before, one shared payload
+    // plus one public copy after.
+    DynamicStorageMetrics result{};
+    for (const Value *holder :
+         {&observed_batch, &keyed_child, &public_output}) {
+      result += holder->view().dynamic_storage_metrics();
+    }
+    // Shared handles intentionally report zero for their payload. Add its one
+    // logical owner here so retained bytes compare like-for-like without
+    // multiplying the shared allocation by the number of handles.
+    if (variant.shared_record) {
+      result += record_payload;
+    }
+    return result;
+  }
+};
+
+[[nodiscard]] std::size_t env_size(const char *name, std::size_t fallback) {
+  const char *value = std::getenv(name);
+  if (value == nullptr || *value == '\0') {
+    return fallback;
+  }
+  char *end{};
+  const auto parsed = std::strtoull(value, &end, 10);
+  if (end == value || *end != '\0' || parsed == 0 ||
+      parsed > std::numeric_limits<std::size_t>::max()) {
+    throw std::invalid_argument(std::string{name} +
+                                " must be a positive integer");
+  }
+  return static_cast<std::size_t>(parsed);
+}
+
+[[nodiscard]] double percentile(std::vector<double> values, double quantile) {
+  std::ranges::sort(values);
+  const double position = quantile * static_cast<double>(values.size() - 1);
+  const auto lower = static_cast<std::size_t>(position);
+  const auto upper = std::min(lower + 1, values.size() - 1);
+  const double fraction = position - static_cast<double>(lower);
+  return values[lower] + (values[upper] - values[lower]) * fraction;
+}
+
+void run(const Fixture &fixture, const Variant &variant, std::size_t iterations,
+         std::size_t payload_bytes) {
+  for (std::size_t warmup = 0; warmup < 1'000; ++warmup) {
+    g_retained_checksum = fixture.pipeline(variant);
+  }
+
+  std::vector<double> latencies;
+  latencies.reserve(iterations);
+  std::uint64_t checksum{};
+  std::size_t allocations{};
+  std::size_t allocated_bytes{};
+  {
+    AllocationScope scope;
+    for (std::size_t index = 0; index < iterations; ++index) {
+      const auto start = std::chrono::steady_clock::now();
+      checksum += fixture.pipeline(variant);
+      latencies.push_back(std::chrono::duration<double, std::nano>(
+                              std::chrono::steady_clock::now() - start)
+                              .count());
+    }
+    allocations = g_allocations.load(std::memory_order_relaxed);
+    allocated_bytes = g_allocated_bytes.load(std::memory_order_relaxed);
+  }
+  g_retained_checksum = checksum;
+
+  const auto retained = fixture.retained_metrics(variant);
+  const auto pool = shared_value_pool_metrics();
+  const auto shared_pool_reserved =
+      variant.shared_record ? pool.reserved_bytes : 0;
+  std::cout << "benchmark"
+            << " name=kafka_subscription_transport_" << variant.name
+            << " iterations=" << iterations
+            << " payload_bytes=" << payload_bytes
+            << " p50_ns_per_record=" << percentile(latencies, 0.50)
+            << " p99_ns_per_record=" << percentile(latencies, 0.99)
+            << " allocations_per_record="
+            << static_cast<double>(allocations) /
+                   static_cast<double>(iterations)
+            << " allocated_bytes_per_record="
+            << static_cast<double>(allocated_bytes) /
+                   static_cast<double>(iterations)
+            << " retained_live_bytes=" << retained.live_bytes
+            << " retained_reserved_bytes=" << retained.reserved_bytes
+            << " shared_pool_reserved_bytes=" << shared_pool_reserved
+            << " tracked_retained_bytes="
+            << retained.reserved_bytes + shared_pool_reserved
+            << " checksum=" << checksum << '\n';
+}
+} // namespace
+
+int main() {
+  try {
+    const std::size_t iterations =
+        env_size("HGRAPH_KAFKA_TRANSPORT_PERF_ITERATIONS", 20'000);
+    const std::size_t payload_bytes =
+        env_size("HGRAPH_KAFKA_TRANSPORT_PERF_PAYLOAD_BYTES", 65'536);
+    const Fixture fixture{payload_bytes};
+    run(fixture, fixture.plain, iterations, payload_bytes);
+    run(fixture, fixture.shared, iterations, payload_bytes);
+    return 0;
+  } catch (const std::exception &error) {
+    std::cerr << "Kafka transport benchmark failed: " << error.what() << '\n';
+    return 1;
+  }
+}


### PR DESCRIPTION
## Summary

- retain Kafka subscription records as immutable `Shared<KafkaRecord>` values through the private cross-thread transport path
- preserve the public `TS<KafkaRecord>` contract by projecting one concrete copy at graph publication
- add a regression test and A/B transport benchmark, and record the measured RFC 0028 evidence
- make fetched librdkafka safe under Linux ThreadSanitizer by selecting its pthread-backed thread primitives and instrumenting the dependency

## Performance

For 20,000 records with 64 KiB payloads on Apple M4 Max, the shared transport reduced p50 latency by 47.9%, p99 by 47.5%, allocations per record by 25.8%, allocated bytes per record by 64.7%, and tracked retained bytes by 23.7%.

## Validation

- macOS native suite: 1,638 passed
- macOS Python 3.14 compatibility suite: 2,168 passed, 10 skipped
- Linux native suite: 1,638 passed
- Linux Python 3.14 compatibility suite: 2,168 passed, 10 skipped
- Linux full Kafka service suite under ThreadSanitizer: passed with no sanitizer report
- focused ASan/UBSan and contention checks: passed
- rebased Kafka service integration test: passed
- strict Sphinx build: passed
- installed core SDK consumer: passed