### PR TITLE
Refuse an unhandled storage category instead of laying it out flat

### DIFF
--- a/src/hgraph/types/metadata/value_plan_factory.cpp
+++ b/src/hgraph/types/metadata/value_plan_factory.cpp
@@ -3063,6 +3063,18 @@ ValuePlanFactory::synthesise(const ValueTypeMetaData *schema) {
     return it->second;
   }
 
+  // Every storage category needs its own plan: the layout is one pointer and
+  // the lifecycle ops differ per category.  Falling through to the value_kind
+  // switch below would synthesise a FLAT plan for a one-pointer carrier -- a
+  // silently wrong layout rather than an error -- so an unhandled category
+  // stops here.  Unreachable while Owned and Shared are the only two.
+  if (schema->is_indirect()) {
+    throw std::logic_error(
+        "ValuePlanFactory: unhandled storage category for schema '" +
+        std::string{schema->name()} +
+        "'; a new storage category needs its own plan entry");
+  }
+
   const MemoryUtils::StoragePlan *plan = nullptr;
 
   switch (schema->value_kind()) {
@@ -3185,6 +3197,14 @@ ValuePlanFactory::synthesise_type(const ValueTypeMetaData *schema) {
     const auto [it, _] = type_cache_.emplace(schema, type);
     cache_.try_emplace(schema, type.plan());
     return it->second;
+  }
+  // See synthesise(): an unhandled storage category must not fall through to
+  // the value_kind switch and be given a flat binding.
+  if (schema->is_indirect()) {
+    throw std::logic_error(
+        "ValuePlanFactory: unhandled storage category for schema '" +
+        std::string{schema->name()} +
+        "'; a new storage category needs its own plan entry");
   }
 
   ValueTypeRef type{};


### PR DESCRIPTION
The actionable residue of auditing RFC 0028's `Owned`-flag sites. **The larger half of that audit was measured and rejected — see below.**

## The gap

`synthesise()` and `synthesise_type()` branch on `is_owned()`, then `is_shared()`, and anything else falls through to the `value_kind()` switch. A storage category's `value_kind()` is `Bundle`, so a third category would be handed a **flat bundle plan for a one-pointer carrier** — the wrong layout, silently, rather than an error.

Both now stop on `is_indirect()` after the two known branches, naming the schema. The condition is unreachable while `Owned` and `Shared` are the only categories; it exists so that adding a third fails at the place that needs editing, instead of corrupting layout somewhere downstream. I've marked it as unreachable-today in the comment rather than pretending it's live coverage.

## Why the entries were NOT merged

I suggested folding `OwnedValueEntry` and `SharedValueEntry` into one entry parameterised by allocation source and mutability — RFC 0028 anticipates exactly that ("the two markers share one plan entry, which selects different lifecycle function pointers at construction"). Measured against the shipped code, it does not hold:

- After normalising their names, **308 of 434 lines still differ**.
- The divergence is **semantic**, not shape. `Owned::from_python` *reuses* its allocation in place when the record matches — sound only because it is uniquely owned and mutable. `Shared::from_python` *always replaces* the handle, because writing through would be visible to every other holder. `equals` differs for the same reason: Shared has a pointer-identity fast path that is meaningful only under aliasing.

So a merged entry needs policy threaded through the function *bodies*, not chosen once in the constructor. That is a rewrite of hot value ops concentrated exactly where mutation semantics live — the opposite of the constraint RFC 0028 set ("no branch on the per-tick path"). The duplication here is shape-level; the behaviour genuinely differs.

## And why `Owned` cannot collapse into `Shared` either

Also checked, since it was the framing question:

| | `Owned` | `Shared` |
|---|---|---|
| copy | deep copy | retain (alias) |
| mutation | `allows_mutation = true`, four mutation ops | none published |
| chosen by | layout factory, automatically, to break a cycle | the author, explicitly |
| copy cost | O(payload), no atomics | O(1), **atomic CAS per copy** |

Aliasing is sound only because `Shared` is immutable, and `Owned` fields are mutable fields of ordinary user dataclasses. Collapsing without copy-on-write changes value semantics; with it, RFC 0013's sticky `unshareable` behaviour comes back. It would also swap a cheap memcpy for an atomic RMW on the single-threaded per-tick path for every auto-inserted cycle-breaker, and make an invisible layout decision into implicit reference counting — the visibility cliff RFC 0028 opens by rejecting.

Two constraints I expected did *not* apply, which is worth recording: the shipped arena is process-wide (`shared_value_arena()` is a function-local static), and `strong_refs` is a real `std::atomic` with a CAS loop, so `Shared` is neither graph-scoped nor thread-confined as RFC 0028 proposed.

## Validation

Native suite: **1620 cases, 256,182 assertions, all pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)