### PR TITLE
Clear Python-side native caches before a registry reset

### DIFF
--- a/python/hgraph/_wiring/_state.py
+++ b/python/hgraph/_wiring/_state.py
@@ -6,6 +6,26 @@ import _hgraph
 from ._sentinels import REMOVE, Removed, _SetDelta
 
 _global_state_local = threading.local()
+
+
+def _clear_thread_local_state():
+    """Drop this thread's cached GlobalState before a registry reset.
+
+    ``GlobalState.instance()`` caches a native-backed store on the
+    thread-local. A reset frees the plans that store's destructor dispatches
+    through, so the wrapper has to die while they are still alive -- otherwise
+    it is collected at interpreter exit and calls through freed memory, which
+    is a segfault on Linux and silent UB on macOS (issue #505).
+
+    Registered as a reset hook rather than left to self-invalidate on next
+    access: a script that resets and exits never makes that access, and the
+    stale wrapper is exactly what teardown then collects.
+    """
+    for attribute in list(vars(_global_state_local)):
+        delattr(_global_state_local, attribute)
+
+
+_hgraph.register_reset_hook(_clear_thread_local_state)
 _GLOBAL_MISSING = object()
 _GRAPH_LOGGER_KEY = "__hgraph_graph_logger__"
 _GRAPH_LOGGER_FORMATTER_KEY = "__hgraph_graph_logger_formatter__"

--- a/python/module.cpp
+++ b/python/module.cpp
@@ -166,7 +166,20 @@ NB_MODULE(_hgraph, m)
     // stdout sinks cache the raw OS handle at construction, so tests that
     // redirect fds per-test (pytest capfd) must reset before logging.
     m.def("reset_logger", [] { hgraph::log::reset_logger(); });
-    m.def("reset_registries", [] {
+    // Python-side caches that hold nanobind-wrapped natives must be dropped
+    // BEFORE the native teardown below, for the same reason the C++ teardown
+    // is ordered: a wrapper outliving the plan its destructor dispatches
+    // through is a dangling call, and the final GC at interpreter exit is
+    // where it lands (issue #505).  A cache that cannot be reached from here
+    // registers a hook instead of growing a second teardown sequence.
+    m.attr("_reset_hooks") = nb::list();
+    m.def("register_reset_hook", [m](nb::callable hook) {
+        nb::cast<nb::list>(m.attr("_reset_hooks")).append(hook);
+    });
+    m.def("reset_registries", [m] {
+        for (auto hook : nb::cast<nb::list>(m.attr("_reset_hooks"))) {
+            nb::cast<nb::callable>(hook)();
+        }
         python_bridge::enum_class_registry().clear();   // meta pointers are re-interned
         python_bridge::enum_type_registry().clear();
         python_bridge::enum_to_python_registry().clear();

--- a/python/tests/test_registry_reset_teardown.py
+++ b/python/tests/test_registry_reset_teardown.py
@@ -6,6 +6,7 @@ through a plan the reset freed. Linux segfaults; macOS's allocator keeps the
 pages mapped and the same UB passes silently, so this test is only meaningful
 as a subprocess exit-code assertion -- an in-process check cannot observe it.
 """
+import os
 import subprocess
 import sys
 import textwrap
@@ -26,7 +27,14 @@ RESET_THEN_EXIT = textwrap.dedent(
 
 
 def _run(source):
-    return subprocess.run([sys.executable, "-c", source], capture_output=True, text=True)
+    # Hand the child this process's sys.path so it exercises the hgraph under
+    # test rather than whatever happens to be installed in the interpreter's
+    # site-packages -- otherwise a stale installed extension turns a crash
+    # assertion into an unrelated ImportError.
+    env = dict(os.environ, PYTHONPATH=os.pathsep.join(p for p in sys.path if p))
+    return subprocess.run(
+        [sys.executable, "-c", source], capture_output=True, text=True, env=env
+    )
 
 
 def test_reset_then_ordinary_exit_does_not_crash():

--- a/python/tests/test_registry_reset_teardown.py
+++ b/python/tests/test_registry_reset_teardown.py
@@ -1,0 +1,62 @@
+"""A reset followed by ordinary interpreter exit must not crash (issue #505).
+
+The failure is a dangling call during the final GC: a nanobind-wrapped native
+held by a Python-side cache outlives the reset, and its destructor dispatches
+through a plan the reset freed. Linux segfaults; macOS's allocator keeps the
+pages mapped and the same UB passes silently, so this test is only meaningful
+as a subprocess exit-code assertion -- an in-process check cannot observe it.
+"""
+import subprocess
+import sys
+import textwrap
+
+RESET_THEN_EXIT = textwrap.dedent(
+    """
+    import faulthandler; faulthandler.enable()
+    import _hgraph
+    from hgraph import TS, pass_through
+    from hgraph.test import eval_node
+
+    assert eval_node(pass_through, [1], resolution_dict={"ts": TS[int]}) == [1]
+    _hgraph.reset_registries()
+    print("ok")
+    # NB: no os._exit() -- ordinary interpreter teardown is the thing under test.
+    """
+)
+
+
+def _run(source):
+    return subprocess.run([sys.executable, "-c", source], capture_output=True, text=True)
+
+
+def test_reset_then_ordinary_exit_does_not_crash():
+    result = _run(RESET_THEN_EXIT)
+    assert result.returncode == 0, (
+        f"reset + exit returned {result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "ok" in result.stdout
+
+
+def test_reset_twice_then_exit_does_not_crash():
+    """A second reset must not resurrect the hazard through a re-cached state."""
+    source = RESET_THEN_EXIT.replace(
+        '_hgraph.reset_registries()\n    print("ok")',
+        '_hgraph.reset_registries()\n'
+        '    assert eval_node(pass_through, [2], resolution_dict={"ts": TS[int]}) == [2]\n'
+        '    _hgraph.reset_registries()\n'
+        '    print("ok")',
+    )
+    result = _run(source)
+    assert result.returncode == 0, (
+        f"double reset + exit returned {result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_reset_hook_is_registered_for_the_thread_local_state():
+    """The cache is cleared by a registered hook, not by luck of access order."""
+    import _hgraph
+    from hgraph._wiring import _state
+
+    assert _state._clear_thread_local_state in list(_hgraph._reset_hooks)


### PR DESCRIPTION
Fixes #505. **Still reproduced on current `main`** (`bd9f7f1e1`) before this change — I checked rather than assumed, since the issue is ten days old.

## Diagnosis

The stack named it precisely:

```
#0  0x00007fff0000007f in ?? ()      <- call through a freed function pointer
#1  _hgraph.abi3.so                   <- our destructor
#2  libnanobind-abi3.so
#3  subtype_dealloc
#6  local_clear                       <- a threading.local dict
#7  local_dealloc
#10 gc_collect_main / finalize_modules
```

`GlobalState.instance()` caches a native-backed store on a `threading.local` (`_state.py:176-179`). It outlives the reset; the final GC at interpreter exit collects it, and its destructor dispatches through a plan the reset freed. Linux has returned the pages and faults; macOS keeps them mapped and the same UB passes silently.

Deleting that one cached object before the reset makes the crash disappear — that was the confirmation before writing any fix.

## The fix

This is the reset contract's own rule reaching the Python layer. `registry_reset.h` already requires that any cache holding pointers into another registry's artifacts be cleared *before* its lender frees them — that is why the native teardown is ordered. The Python caches were simply outside that sequence.

`reset_registries()` now runs registered hooks first, and `_state.py` registers one for its thread-local.

**A hook, not self-invalidation.** `registry_reset.h` blesses caches that compare `reset_generation()` and drop themselves on next access, and that is the wrong shape here: a script that resets and exits never makes that access, and the stale wrapper is exactly what exit-time GC then collects.

## Evidence

Rebuilt the wheel-configured shared build on `hg-linux` — the configuration that originally reproduced it — before and after:

| | before | after |
|---|---|---|
| repro (reset + ordinary exit) | **SIGSEGV, exit 139** | **exit 0** |
| control (no reset) | exit 0 | exit 0 |
| new regression tests | — | 3 passed |

The tests assert a **subprocess exit code**, as the issue requested, and carry no `os._exit`. That shape is not incidental: an in-process assertion cannot observe this, and macOS cannot observe it at all — which is why it went unnoticed originally.

## Two things I did not do

- **`tests/python_extension_consumer/check.py` still ends in `os._exit(0)`.** That mitigation is probably now unnecessary, but its comment cites hazards beyond the thread-local (decoration-time `@graph` handles), and verifying removal needs the installed-SDK consumer fixture built on Linux — a separate exercise. Worth a follow-up; I would rather leave a working mitigation than remove it on inference.
- **`_published_contexts` in `_core.py`** also holds natives (ports and type handles). It is a balanced push/pop stack, so it should be empty outside a wiring context, and I did not add a speculative hook for it. The mechanism is there if a case turns up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)