### PR TITLE
Scope the GlobalState thread-local to its context

### DIFF
--- a/extensions/persistence/python/hgraph_persistence/__init__.py
+++ b/extensions/persistence/python/hgraph_persistence/__init__.py
@@ -38,6 +38,7 @@ if _sys.platform == "win32":
 from enum import Enum
 
 from . import _hgraph_persistence
+from hgraph._wiring._state import _active_global_state
 
 __all__ = (
     "FRAME_BACKEND",
@@ -94,7 +95,7 @@ _hgraph_persistence._register_recording_option_enums(RecordAsOf, RecordRemoves)
 def _state(global_state=None):
     from hgraph import GlobalState
 
-    state = global_state if global_state is not None else GlobalState.instance()
+    state = global_state if global_state is not None else _active_global_state()
     return state._impl
 
 

--- a/extensions/persistence/python/hgraph_persistence/compat.py
+++ b/extensions/persistence/python/hgraph_persistence/compat.py
@@ -18,7 +18,7 @@ from hgraph import (
 )
 
 from . import _hgraph_persistence
-from hgraph._wiring._state import _active_global_state
+from hgraph._wiring._state import _active_global_state, _global_state_scope
 
 __all__ = (
     "WriteMode",
@@ -117,6 +117,7 @@ class DataFrameStorage(ABC):
 
     def __init__(self):
         self._previous = self._MISSING
+        self._state_scope = None
 
     @classmethod
     def instance(cls, global_state=None):
@@ -169,11 +170,26 @@ class DataFrameStorage(ABC):
             return False
 
     def __enter__(self):
-        self.set_as_instance()
+        # This block publishes the storage into the GlobalState for the wiring
+        # inside it to find, so it needs a state to publish into: open one for
+        # the block when the caller has not, and close it in __exit__.
+        self._state_scope = _global_state_scope()
+        self._state_scope.__enter__()
+        try:
+            self.set_as_instance()
+        except BaseException:
+            self._state_scope.__exit__(None, None, None)
+            self._state_scope = None
+            raise
         return self
 
     def __exit__(self, *_):
-        self.release_as_instance()
+        try:
+            self.release_as_instance()
+        finally:
+            scope, self._state_scope = getattr(self, "_state_scope", None), None
+            if scope is not None:
+                scope.__exit__(None, None, None)
         return False
 
     @abstractmethod

--- a/extensions/persistence/python/hgraph_persistence/compat.py
+++ b/extensions/persistence/python/hgraph_persistence/compat.py
@@ -18,6 +18,7 @@ from hgraph import (
 )
 
 from . import _hgraph_persistence
+from hgraph._wiring._state import _active_global_state
 
 __all__ = (
     "WriteMode",
@@ -42,7 +43,7 @@ _STORAGE_KEY = ":data_frame:__storage__"
 
 
 def set_data_frame_record_path(path):
-    GlobalState.instance()[_PATH_KEY] = Path(path)
+    _active_global_state()[_PATH_KEY] = Path(path)
 
 
 class _OverrideState:
@@ -61,7 +62,7 @@ class _OverrideState:
 
 
 def _overrides(state=None):
-    state = state or GlobalState.instance()
+    state = state or _active_global_state()
     value = state.get(_OVERRIDES_KEY)
     if value is None:
         value = _OverrideState()
@@ -119,11 +120,11 @@ class DataFrameStorage(ABC):
 
     @classmethod
     def instance(cls, global_state=None):
-        state = global_state if global_state is not None else GlobalState.instance()
+        state = global_state if global_state is not None else _active_global_state()
         return state.get(_STORAGE_KEY)
 
     def set_as_instance(self):
-        state = GlobalState.instance()
+        state = _active_global_state()
         self._previous = state.get(_STORAGE_KEY, self._MISSING)
         self._date_key = get_table_schema_date_key(state._impl)
         self._as_of_key = get_table_schema_as_of_key(state._impl)
@@ -131,7 +132,7 @@ class DataFrameStorage(ABC):
         _hgraph_persistence._set_python_frame_store(state._impl, self)
 
     def release_as_instance(self):
-        state = GlobalState.instance()
+        state = _active_global_state()
         _hgraph_persistence._restore_python_frame_store(state._impl)
         if self._previous is self._MISSING:
             state.pop(_STORAGE_KEY, None)
@@ -347,7 +348,7 @@ def _legacy_record_replay_kwargs(name, args, kwargs):
 
     if not GlobalState.has_instance():
         return kwargs
-    state = GlobalState.instance()
+    state = _active_global_state()
     if state.get("__record_replay_model__") != DATA_FRAME:
         return kwargs
     if DataFrameStorage.instance(state) is None:

--- a/extensions/persistence/python/tests/conftest.py
+++ b/extensions/persistence/python/tests/conftest.py
@@ -10,3 +10,22 @@ import os
 
 
 os.environ["HGRAPH_POLARS_FRAMES"] = "false"
+
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _global_state_scope():
+    """Give every test one GlobalState spanning its configuration and its runs.
+
+    These tests configure record/replay with the compatibility setters and then
+    wire a graph, which only works if both see the same state. The state exists
+    only inside a scope, and it is the caller who owns that scope -- a runner
+    that opened its own would close it before the next call, and the
+    configuration would be lost between them.
+    """
+    import hgraph as hg
+
+    with hg.GlobalState():
+        yield

--- a/extensions/persistence/python/tests/conftest.py
+++ b/extensions/persistence/python/tests/conftest.py
@@ -11,21 +11,3 @@ import os
 
 os.environ["HGRAPH_POLARS_FRAMES"] = "false"
 
-
-import pytest
-
-
-@pytest.fixture(autouse=True)
-def _global_state_scope():
-    """Give every test one GlobalState spanning its configuration and its runs.
-
-    These tests configure record/replay with the compatibility setters and then
-    wire a graph, which only works if both see the same state. The state exists
-    only inside a scope, and it is the caller who owns that scope -- a runner
-    that opened its own would close it before the next call, and the
-    configuration would be lost between them.
-    """
-    import hgraph as hg
-
-    with hg.GlobalState():
-        yield

--- a/extensions/persistence/python/tests/test_api_persistence.py
+++ b/extensions/persistence/python/tests/test_api_persistence.py
@@ -134,76 +134,82 @@ def test_durable_replay_overload_registers_partition_signature():
 
 
 def test_component_record_replay_modes():
-    hg.set_record_replay_config(hg.DATA_FRAME)
-    M = hg.RecordReplayEnum
+    # One state spans the whole test: it configures record/replay and then
+    # reads recordings back between runs, so both must see the same state.
+    with hg.GlobalState():
+        hg.set_record_replay_config(hg.DATA_FRAME)
+        M = hg.RecordReplayEnum
 
-    @hg.component
-    def calc(lhs: TS[int], rhs: TS[int]) -> TS[int]:
-        return lhs + rhs
+        @hg.component
+        def calc(lhs: TS[int], rhs: TS[int]) -> TS[int]:
+            return lhs + rhs
 
-    @graph
-    def recording(a: TS[int], b: TS[int]) -> TS[int]:
-        with hg.record_replay_scope(M.RECORD):
-            return calc(a, b)
+        @graph
+        def recording(a: TS[int], b: TS[int]) -> TS[int]:
+            with hg.record_replay_scope(M.RECORD):
+                return calc(a, b)
 
-    out = eval_node(recording, [1, None, 3], [10, 20, None])
-    check(out == [11, 21, 23], f"record: {out}")
-    for key in ("calc.lhs", "calc.rhs", "calc.__out__"):
-        check(hg.frame_store_contains(key), f"missing frame {key}")
+        out = eval_node(recording, [1, None, 3], [10, 20, None])
+        check(out == [11, 21, 23], f"record: {out}")
+        for key in ("calc.lhs", "calc.rhs", "calc.__out__"):
+            check(hg.frame_store_contains(key), f"missing frame {key}")
 
-    @graph
-    def replaying(a: TS[int], b: TS[int]) -> TS[int]:
-        with hg.record_replay_scope(M.REPLAY):
-            return calc(a, b)
+        @graph
+        def replaying(a: TS[int], b: TS[int]) -> TS[int]:
+            with hg.record_replay_scope(M.REPLAY):
+                return calc(a, b)
 
-    # The recordings win over garbage live inputs.
-    out = eval_node(replaying, [100, 100, 100], [100, 100, 100])
-    check(out == [11, 21, 23], f"replay: {out}")
+        # The recordings win over garbage live inputs.
+        out = eval_node(replaying, [100, 100, 100], [100, 100, 100])
+        check(out == [11, 21, 23], f"replay: {out}")
 
-    @graph
-    def comparing(a: TS[int], b: TS[int]) -> TS[int]:
-        with hg.record_replay_scope(M.COMPARE):
-            return calc(a, b)
+        @graph
+        def comparing(a: TS[int], b: TS[int]) -> TS[int]:
+            with hg.record_replay_scope(M.COMPARE):
+                return calc(a, b)
 
-    eval_node(comparing, [100, 100, 100], [100, 100, 100])
-    check(hg.comparison_summary("calc.__compare__") == (3, 0), "compare clean")
+        eval_node(comparing, [100, 100, 100], [100, 100, 100])
+        check(hg.comparison_summary("calc.__compare__") == (3, 0), "compare clean")
 
-    @graph
-    def recovering(a: TS[int], b: TS[int]) -> TS[int]:
-        with hg.record_replay_scope(M.RECOVER):
-            return calc(a, b)
+        @graph
+        def recovering(a: TS[int], b: TS[int]) -> TS[int]:
+            with hg.record_replay_scope(M.RECOVER):
+                return calc(a, b)
 
-    # Seeded from the recordings at start (1+10), live overrides (100+10).
-    out = eval_node(recovering, [None, 100], [None, None])
-    check(out == [11, 110], f"recover: {out}")
+        # Seeded from the recordings at start (1+10), live overrides (100+10).
+        out = eval_node(recovering, [None, 100], [None, None])
+        check(out == [11, 110], f"recover: {out}")
 
-    hg.set_record_replay_config(hg.IN_MEMORY)
+        hg.set_record_replay_config(hg.IN_MEMORY)
 
 
 
 
 def test_frame_pyarrow_round_trip():
-    # Frames cross the boundary as pyarrow.Tables (the Arrow C stream
-    # protocol - zero copy): store reads return Tables, and Tables convert
-    # back to Frame values.
-    import pyarrow as pa
+    # One state spans the whole test: it configures record/replay and then
+    # reads recordings back between runs, so both must see the same state.
+    with hg.GlobalState():
+        # Frames cross the boundary as pyarrow.Tables (the Arrow C stream
+        # protocol - zero copy): store reads return Tables, and Tables convert
+        # back to Frame values.
+        import pyarrow as pa
 
-    hg.set_record_replay_config(hg.DATA_FRAME)
+        hg.set_record_replay_config(hg.DATA_FRAME)
 
-    @hg.component
-    def snap(x: TS[int]) -> TS[int]:
-        return x + x
+        @hg.component
+        def snap(x: TS[int]) -> TS[int]:
+            return x + x
 
-    @graph
-    def recording(x: TS[int]) -> TS[int]:
-        with hg.record_replay_scope(hg.RecordReplayEnum.RECORD):
-            return snap(x)
+        @graph
+        def recording(x: TS[int]) -> TS[int]:
+            with hg.record_replay_scope(hg.RecordReplayEnum.RECORD):
+                return snap(x)
 
-    eval_node(recording, [1, 2, 3])
-    table = hg.frame_store_read("snap.__out__")
-    check(isinstance(table, pa.Table), f"expected a pyarrow.Table, got {type(table)}")
-    check(table.column("value").to_pylist() == [2, 4, 6], f"values: {table.to_pydict()}")
-    check(table.num_columns == 3, "bitemporal columns present")
-    hg.set_record_replay_config(hg.IN_MEMORY)
+        eval_node(recording, [1, 2, 3])
+        table = hg.frame_store_read("snap.__out__")
+        check(isinstance(table, pa.Table), f"expected a pyarrow.Table, got {type(table)}")
+        check(table.column("value").to_pylist() == [2, 4, 6], f"values: {table.to_pydict()}")
+        check(table.num_columns == 3, "bitemporal columns present")
+        hg.set_record_replay_config(hg.IN_MEMORY)
 
 

--- a/extensions/persistence/python/tests/test_polars_persistence.py
+++ b/extensions/persistence/python/tests/test_polars_persistence.py
@@ -34,28 +34,31 @@ def test_frame_store_read_presents_naive_utc_timestamps():
     from hgraph import graph
     from hgraph.test import eval_node
 
-    hg.set_record_replay_config(hg.DATA_FRAME)
-    try:
-        @hg.component
-        def snap(x: TS[int]) -> TS[int]:
-            return x + x
+    # One state spans the whole test: it configures record/replay and then
+    # reads recordings back between runs, so both must see the same state.
+    with hg.GlobalState():
+        hg.set_record_replay_config(hg.DATA_FRAME)
+        try:
+            @hg.component
+            def snap(x: TS[int]) -> TS[int]:
+                return x + x
 
-        @graph
-        def recording(x: TS[int]) -> TS[int]:
-            with hg.record_replay_scope(hg.RecordReplayEnum.RECORD):
-                return snap(x)
+            @graph
+            def recording(x: TS[int]) -> TS[int]:
+                with hg.record_replay_scope(hg.RecordReplayEnum.RECORD):
+                    return snap(x)
 
-        eval_node(recording, [1, 2, 3])
-        table = hg.frame_store_read("snap.__out__")
-        assert isinstance(table, pa.Table)
-        for field in table.schema:
-            if pa.types.is_timestamp(field.type):
-                assert field.type.tz is None, field
-        first = table.to_pylist()[0]["__date_time__"]
-        assert isinstance(first, datetime) and first.tzinfo is None
-        assert b"hgraph.temporal.version" not in (table.schema.metadata or {})
-    finally:
-        hg.set_record_replay_config(hg.IN_MEMORY)
+            eval_node(recording, [1, 2, 3])
+            table = hg.frame_store_read("snap.__out__")
+            assert isinstance(table, pa.Table)
+            for field in table.schema:
+                if pa.types.is_timestamp(field.type):
+                    assert field.type.tz is None, field
+            first = table.to_pylist()[0]["__date_time__"]
+            assert isinstance(first, datetime) and first.tzinfo is None
+            assert b"hgraph.temporal.version" not in (table.schema.metadata or {})
+        finally:
+            hg.set_record_replay_config(hg.IN_MEMORY)
 
 
 

--- a/python/hgraph/_table.py
+++ b/python/hgraph/_table.py
@@ -13,6 +13,7 @@ from typing import get_args, get_origin
 import _hgraph
 
 from ._types import _resolve
+from hgraph._wiring._state import _active_global_state
 
 
 class ToTableMode(Enum):
@@ -66,7 +67,7 @@ def _config_keys(global_state=None):
     from ._wiring import GlobalState
 
     if GlobalState.has_instance():
-        return _hgraph._table_schema_keys(GlobalState.instance()._impl)
+        return _hgraph._table_schema_keys(_active_global_state()._impl)
     return "__date_time__", "__as_of__"
 
 

--- a/python/hgraph/_wiring/_core.py
+++ b/python/hgraph/_wiring/_core.py
@@ -13,6 +13,7 @@ import _hgraph
 from .._operator_signature import PublicTypePatternFormatter
 from .._types import _TsExpr
 from ._sentinels import _REDUCE_ZERO
+from ._state import _active_global_state
 
 _wiring_stack = []
 _wiring_lock = threading.RLock()
@@ -72,7 +73,7 @@ def _durable_backend_selected(kwargs):
         try:
             from ._state import GlobalState
 
-            model = GlobalState.instance().get("__record_replay_model__")
+            model = _active_global_state().get("__record_replay_model__")
         except Exception:  # no active global state — nothing was selected
             return False
     if model is None:

--- a/python/hgraph/_wiring/_graph.py
+++ b/python/hgraph/_wiring/_graph.py
@@ -17,7 +17,7 @@ from ._node import (_PyNode, _is_time_series_annotation,
 from ._operator import _register_overload, _run_requires
 from ._resolution import (_apply_resolvers, _python_value_for_binding,
                           _resolution_binding)
-from ._state import GlobalState, _GRAPH_LOGGER_KEY
+from ._state import GlobalState, _GRAPH_LOGGER_KEY, _active_global_state
 
 
 _GRAPH_INJECTABLES = frozenset((GlobalState, LOGGER))
@@ -537,9 +537,9 @@ class _GraphFn:
                     raise TypeError(
                         f"{self.__name__}: injectable '{param.name}' cannot be supplied")
                 if param.annotation is GlobalState:
-                    bound.arguments[param.name] = GlobalState.instance()
+                    bound.arguments[param.name] = _active_global_state()
                 else:
-                    logger = GlobalState.instance().get(_GRAPH_LOGGER_KEY)
+                    logger = _active_global_state().get(_GRAPH_LOGGER_KEY)
                     bound.arguments[param.name] = (
                         logger if logger is not None else logging.getLogger("hgraph"))
             value = bound.arguments.get(param.name)

--- a/python/hgraph/_wiring/_lower.py
+++ b/python/hgraph/_wiring/_lower.py
@@ -10,7 +10,7 @@ from ._graph import _GraphFn, _wrap_graph_fn
 from ._markers import _INJECTABLE_MARKERS
 from ._node import _PyNode, _is_time_series_annotation
 from ._runner import _make_evaluation_trace
-from ._state import GlobalState
+from ._state import GlobalState, _active_global_state
 
 
 def lower(fn, /, date_col="date", as_of_col="as_of", no_as_of_support=True):
@@ -75,7 +75,7 @@ def lower(fn, /, date_col="date", as_of_col="as_of", no_as_of_support=True):
         wired = _wrap_graph_fn(
             fn, input_names=input_names, scalar_bindings=scalar_bindings)
         result = _hgraph._lower(
-            GlobalState.instance()._impl,
+            _active_global_state()._impl,
             wired,
             input_frames,
             date_column=date_col,

--- a/python/hgraph/_wiring/_lower.py
+++ b/python/hgraph/_wiring/_lower.py
@@ -10,6 +10,7 @@ from ._graph import _GraphFn, _wrap_graph_fn
 from ._markers import _INJECTABLE_MARKERS
 from ._node import _PyNode, _is_time_series_annotation
 from ._runner import _make_evaluation_trace
+from ._state import _global_state_scope
 from ._state import GlobalState, _active_global_state
 
 
@@ -74,17 +75,20 @@ def lower(fn, /, date_col="date", as_of_col="as_of", no_as_of_support=True):
 
         wired = _wrap_graph_fn(
             fn, input_names=input_names, scalar_bindings=scalar_bindings)
-        result = _hgraph._lower(
-            _active_global_state()._impl,
-            wired,
-            input_frames,
-            date_column=date_col,
-            as_of_column=as_of_col,
-            no_as_of_support=no_as_of_support,
-            start_time=__start_time__,
-            end_time=__end_time__,
-            trace=_make_evaluation_trace(__trace__),
-        )
+        # lower() wires and runs a graph, so like the other runner entry points
+        # it opens a state for the run and closes it afterwards.
+        with _global_state_scope() as state:
+            result = _hgraph._lower(
+                state._impl,
+                wired,
+                input_frames,
+                date_column=date_col,
+                as_of_column=as_of_col,
+                no_as_of_support=no_as_of_support,
+                start_time=__start_time__,
+                end_time=__end_time__,
+                trace=_make_evaluation_trace(__trace__),
+            )
         if result is None or not return_polars:
             return result
         import polars as pl

--- a/python/hgraph/_wiring/_runner.py
+++ b/python/hgraph/_wiring/_runner.py
@@ -280,16 +280,23 @@ def _evaluate_graph(graph_fn, config, args, kwargs):
     # outlive the run that needed it (see _global_state_scope).
     _gs_scope = _global_state_scope()
     state = _gs_scope.__enter__()
-    missing = object()
-    previous_logger = state.get(_GRAPH_LOGGER_KEY, missing)
-    previous_formatter = state.get(_GRAPH_LOGGER_FORMATTER_KEY, missing)
-    previous_start_time = state.get("__start_time__", missing)
-    state[_GRAPH_LOGGER_KEY] = config.graph_logger
-    if config.logger_formatter is None:
-        state.pop(_GRAPH_LOGGER_FORMATTER_KEY, None)
-    else:
-        state[_GRAPH_LOGGER_FORMATTER_KEY] = config.logger_formatter
-    config.graph_logger.setLevel(config.default_log_level)
+    # Setup between here and the try below can raise -- config.graph_logger
+    # .setLevel() rejects a bad level, for one -- and the scope must not be
+    # left open when it does, or the next run inherits a contaminated state.
+    try:
+        missing = object()
+        previous_logger = state.get(_GRAPH_LOGGER_KEY, missing)
+        previous_formatter = state.get(_GRAPH_LOGGER_FORMATTER_KEY, missing)
+        previous_start_time = state.get("__start_time__", missing)
+        state[_GRAPH_LOGGER_KEY] = config.graph_logger
+        if config.logger_formatter is None:
+            state.pop(_GRAPH_LOGGER_FORMATTER_KEY, None)
+        else:
+            state[_GRAPH_LOGGER_FORMATTER_KEY] = config.logger_formatter
+        config.graph_logger.setLevel(config.default_log_level)
+    except BaseException:
+        _gs_scope.__exit__(None, None, None)
+        raise
     w = None
     wiring_pushed = False
     wiring_lock_held = False

--- a/python/hgraph/_wiring/_runner.py
+++ b/python/hgraph/_wiring/_runner.py
@@ -16,7 +16,8 @@ from ._core import (WiringError, WiringPort, _OperatorFunction, _unwrap,
 from ._graph import _GraphFn
 from ._node import _PyNode
 from ._sentinels import _simplify_delta
-from ._state import (GlobalState, _GRAPH_LOGGER_FORMATTER_KEY,
+from ._state import (GlobalState, _global_state_scope,
+                     _GRAPH_LOGGER_FORMATTER_KEY,
                      _GRAPH_LOGGER_KEY, utc_now)
 
 class EvaluationMode:
@@ -275,7 +276,10 @@ def _evaluate_graph(graph_fn, config, args, kwargs):
     profiler = _make_evaluation_profiler(config.profile)
     from .._types import _finalize_compound_scalar_types
     _finalize_compound_scalar_types()
-    state = GlobalState.instance()
+    # Opened before wiring, closed in the finally below: the state must not
+    # outlive the run that needed it (see _global_state_scope).
+    _gs_scope = _global_state_scope()
+    state = _gs_scope.__enter__()
     missing = object()
     previous_logger = state.get(_GRAPH_LOGGER_KEY, missing)
     previous_formatter = state.get(_GRAPH_LOGGER_FORMATTER_KEY, missing)
@@ -369,6 +373,7 @@ def _evaluate_graph(graph_fn, config, args, kwargs):
             state.pop("__start_time__", None)
         else:
             state["__start_time__"] = previous_start_time
+        _gs_scope.__exit__(None, None, None)
     if profiler is not None:
         _log_evaluation_profile(config.graph_logger, profiler.snapshot())
     if out is None:
@@ -664,7 +669,16 @@ def eval_node(node, *args, output_type=None, resolution_dict=None,
     trace = _make_evaluation_trace(__trace__)
     from .._types import _finalize_compound_scalar_types
     _finalize_compound_scalar_types()
-    w = _hgraph.Wiring(GlobalState.instance()._impl, realtime)
+    # The scope guard opens BEFORE wiring so the state cannot outlive it: it
+    # defers to a caller's `with GlobalState():` when one is active, and
+    # otherwise opens one for exactly this run and closes it in the finally.
+    _gs_scope = _global_state_scope()
+    _global_state = _gs_scope.__enter__()
+    try:
+        w = _hgraph.Wiring(_global_state._impl, realtime)
+    except BaseException:
+        _gs_scope.__exit__(None, None, None)
+        raise
     _wiring_stack.append(w)
     try:
         w.configure_wiring_observers(__trace_wiring__, ())
@@ -781,7 +795,7 @@ def eval_node(node, *args, output_type=None, resolution_dict=None,
         # Python-readable mirror of the run start (the C++ run bounds have no
         # wiring-time getter): start-time-aware wiring — the DATA_FRAME
         # replay overloads' upstream `_api.start_time` filter — reads this.
-        GlobalState.instance()["__start_time__"] = (
+        _global_state["__start_time__"] = (
             __start_time__ if __start_time__ is not None else _hgraph.MIN_ST)
         out = fn(*ports, **scalars)
         # Replay values convert AFTER wiring: hgraph surfaces wiring errors
@@ -823,6 +837,7 @@ def eval_node(node, *args, output_type=None, resolution_dict=None,
             print(line)
         w._release_seed_context()
         _wiring_stack.pop()
+        _gs_scope.__exit__(None, None, None)
     if __elide__:
         # hgraph parity: elide keeps only the ticked cycles, in order (the
         # recording was made SPARSE, so this is just the list).

--- a/python/hgraph/_wiring/_state.py
+++ b/python/hgraph/_wiring/_state.py
@@ -6,6 +6,32 @@ import _hgraph
 from ._sentinels import REMOVE, Removed, _SetDelta
 
 _global_state_local = threading.local()
+
+
+def _active_global_state():
+    """The GlobalState selected by the innermost active scope.
+
+    The thread-local exists ONLY between ``GlobalContext.__enter__`` and its
+    paired ``__exit__``.  Nothing else may create it: an accessor that
+    lazily installed one made its own side effect the lifecycle, so the state
+    outlived every wiring that used it and was still there at interpreter exit
+    (issue #505).
+    """
+    if getattr(_global_state_local, "runtime_active", False):
+        raise RuntimeError(
+            "the GlobalState is wiring-only during graph execution; "
+            "declare a GlobalState injectable on the graph or node instead"
+        )
+    state = getattr(_global_state_local, "state", None)
+    if state is None:
+        raise RuntimeError(
+            "no active GlobalState. Declare it as an injectable on the graph "
+            "or node that needs it -- `def my_graph(..., state: GlobalState = None)` "
+            "-- which binds the state the runtime is actually using. "
+            "`with GlobalState():` selects a seed around wiring and is a "
+            "compatibility surface that is removed in 1.0."
+        )
+    return state
 _GLOBAL_MISSING = object()
 _GRAPH_LOGGER_KEY = "__hgraph_graph_logger__"
 _GRAPH_LOGGER_FORMATTER_KEY = "__hgraph_graph_logger_formatter__"
@@ -32,7 +58,7 @@ def get_recorded_value(key="out", recordable_id=None):
     plain-key form is this runtime's cycle-aligned harness recording (bare
     values, no timestamps); record with ``recordable_id=`` for the
     timestamped shape."""
-    state = GlobalState.instance()
+    state = _active_global_state()
     if recordable_id is not None:
         return state[f":memory:{recordable_id}.{key}"]
     default_key = f":memory:nodes.record.{key}"
@@ -43,20 +69,20 @@ def get_recorded_value(key="out", recordable_id=None):
 
 def set_recorder_api(recorder):
     """Store the process-specific recorder API in the active graph state."""
-    GlobalState.instance()[_RECORDER_API_KEY] = recorder
+    _active_global_state()[_RECORDER_API_KEY] = recorder
 
 
 def get_recorder_api():
     """Return the recorder API selected for the active graph state."""
-    return GlobalState.instance()[_RECORDER_API_KEY]
+    return _active_global_state()[_RECORDER_API_KEY]
 
 
 def set_recording_label(label):
-    GlobalState.instance()[_RECORDER_LABEL_KEY] = label
+    _active_global_state()[_RECORDER_LABEL_KEY] = label
 
 
 def get_recording_label():
-    return GlobalState.instance()[_RECORDER_LABEL_KEY]
+    return _active_global_state()[_RECORDER_LABEL_KEY]
 
 
 def _friendly_recording_delta(delta):
@@ -99,7 +125,7 @@ class GlobalState:
 
     Use ``GlobalContext`` (or this object as a context manager) to select the
     state while wiring and running a graph. Inside a node callback, declare a
-    ``GlobalState`` injectable instead of calling ``GlobalState.instance()``.
+    ``GlobalState`` injectable instead of calling ``_active_global_state()``.
     """
 
     def __init__(self, **kwargs):
@@ -167,16 +193,12 @@ class GlobalState:
 
     @staticmethod
     def instance():
-        if getattr(_global_state_local, "runtime_active", False):
-            raise RuntimeError(
-                "GlobalState.instance() is wiring-only during graph execution; "
-                "declare a GlobalState injectable on the graph or node instead"
-            )
-        state = getattr(_global_state_local, "state", None)
-        if state is None:
-            state = GlobalState()
-            _global_state_local.state = state
-        return state
+        """The active GlobalState. **Compatibility surface, removed in 1.0.**
+
+        hgraph's own code must not call this -- it takes the state from the
+        active scope (``_active_global_state``) or from a declared injectable.
+        """
+        return _active_global_state()
 
     def __enter__(self):
         if self._compat_context is not None:
@@ -196,7 +218,12 @@ class GlobalContext:
     """
 
     def __init__(self, state=None):
-        self.state = state if state is not None else GlobalState.instance()
+        # NOT _active_global_state(): a context with no explicit state selects a
+        # NEW one.  Reading the ambient here would prime the thread-local before
+        # __enter__ samples _previous, so __exit__ would take the restore branch
+        # and leave the state behind -- the context could never clean up after
+        # itself, which is how the thread-local came to outlive wiring.
+        self.state = state if state is not None else GlobalState()
         if not isinstance(self.state, GlobalState):
             raise TypeError("GlobalContext state must be a GlobalState")
         self._previous = None
@@ -220,6 +247,37 @@ class GlobalContext:
                 _global_state_local.state = self._previous
             self._previous = None
             self._entered = False
+        return False
+
+
+class _global_state_scope:
+    """Scope guard: guarantee a GlobalState for the duration of a block.
+
+    Entering selects the caller's state when a scope is already active, and
+    otherwise opens one for exactly this block and closes it afterwards -- so
+    the thread-local never outlives what needed it.
+
+    A caller who wants the state to survive (to read recordings back, say)
+    holds the scope themselves with ``with GlobalState():``; this guard then
+    defers to it and leaves it alone.  Used by the runner around wiring, and
+    by the adaptor stores whose ``with`` blocks publish themselves into the
+    state for the wiring inside them to find.
+    """
+
+    __slots__ = ("_context",)
+
+    def __enter__(self):
+        if getattr(_global_state_local, "state", None) is not None:
+            self._context = None          # a caller's scope is already active
+        else:
+            self._context = GlobalContext()
+            self._context.__enter__()
+        return _active_global_state()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        context, self._context = self._context, None
+        if context is not None:
+            context.__exit__(exc_type, exc_value, traceback)
         return False
 
 
@@ -300,11 +358,11 @@ def set_record_replay_config(model):
         # native store unless a user-owned python compat store is active).
         import hgraph_persistence
 
-        hgraph_persistence.start_recording_session(GlobalState.instance())
-    _hgraph._set_record_replay_config(GlobalState.instance()._impl, backend)
+        hgraph_persistence.start_recording_session(_active_global_state())
+    _hgraph._set_record_replay_config(_active_global_state()._impl, backend)
     # python-readable mirror (backend-gated python overloads read it in their
     # requires= predicates; the C++ config has no python getter)
-    GlobalState.instance()["__record_replay_model__"] = backend
+    _active_global_state()["__record_replay_model__"] = backend
 
 
 def set_pooled_compound_scalar_storage(enabled=True):
@@ -314,32 +372,32 @@ def set_pooled_compound_scalar_storage(enabled=True):
     default and does not alter graphs wired from another ``GlobalState``.
     """
     _hgraph._set_pooled_compound_scalar_storage(
-        GlobalState.instance()._impl, bool(enabled))
+        _active_global_state()._impl, bool(enabled))
 
 
 def set_as_of(dt):
     value = dt
-    _hgraph._set_as_of(GlobalState.instance()._impl, value)
+    _hgraph._set_as_of(_active_global_state()._impl, value)
     # python-readable mirror (the data-frame record/replay model reads it
     # at wiring/replay time; the C++ config has no python getter)
-    GlobalState.instance()["__as_of__"] = value
+    _active_global_state()["__as_of__"] = value
 
 
 def set_time_zone_provider():
     """Install the configured immutable C++ TZDB provider for this graph seed."""
-    _hgraph._set_time_zone_provider(GlobalState.instance()._impl)
+    _hgraph._set_time_zone_provider(_active_global_state()._impl)
 
 
 def set_table_schema_date_key(key):
-    _hgraph._set_table_schema_date_key(GlobalState.instance()._impl, key)
+    _hgraph._set_table_schema_date_key(_active_global_state()._impl, key)
 
 
 def set_table_schema_as_of_key(key):
-    _hgraph._set_table_schema_as_of_key(GlobalState.instance()._impl, key)
+    _hgraph._set_table_schema_as_of_key(_active_global_state()._impl, key)
 
 
 def evaluate_const(name, args=(), kwargs=None, output_type=None):
-    return _hgraph._evaluate_const(GlobalState.instance()._impl, name, args, kwargs or {}, output_type)
+    return _hgraph._evaluate_const(_active_global_state()._impl, name, args, kwargs or {}, output_type)
 
 class _RecordReplayModes:
     NONE = _hgraph.MODE_NONE
@@ -390,4 +448,4 @@ def set_record_replay_model(model):
 
 def comparison_summary(fq_key):
     """(compared, mismatches) from a Compare run's ``fq.__compare__``."""
-    return _hgraph._comparison_summary(GlobalState.instance()._impl, fq_key)
+    return _hgraph._comparison_summary(_active_global_state()._impl, fq_key)

--- a/python/hgraph/adaptors/data_catalogue/catalogue.py
+++ b/python/hgraph/adaptors/data_catalogue/catalogue.py
@@ -7,7 +7,7 @@ from frozendict import frozendict
 from hgraph import CompoundScalar, GlobalState
 
 from .data_scopes import Scope
-from hgraph._wiring._state import _active_global_state
+from hgraph._wiring._state import _active_global_state, _global_state_scope
 
 __all__ = (
     "DataSource",
@@ -65,7 +65,11 @@ class DataCatalogue:
         return catalogue
 
     def __enter__(self):
-        state = _active_global_state()
+        # Publishes itself into the GlobalState for the wiring inside the block
+        # to find, so it opens a state when the caller has not and closes it in
+        # __exit__ -- the state must not outlive the `with` that needed it.
+        self._state_scope = _global_state_scope()
+        state = self._state_scope.__enter__()
         self._previous = state.get(self._STATE_KEY, self._MISSING)
         state[self._STATE_KEY] = self
         return self
@@ -77,6 +81,9 @@ class DataCatalogue:
         else:
             state[self._STATE_KEY] = self._previous
         self._previous = self._MISSING
+        scope, self._state_scope = getattr(self, "_state_scope", None), None
+        if scope is not None:
+            scope.__exit__(exc_type, exc_value, traceback)
         return False
 
     def add_entry(self, entry: DataCatalogueEntry):
@@ -174,7 +181,11 @@ class DataEnvironment:
         _active_global_state().pop(cls._STATE_KEY, None)
 
     def __enter__(self):
-        state = _active_global_state()
+        # Publishes itself into the GlobalState for the wiring inside the block
+        # to find, so it opens a state when the caller has not and closes it in
+        # __exit__ -- the state must not outlive the `with` that needed it.
+        self._state_scope = _global_state_scope()
+        state = self._state_scope.__enter__()
         self._previous = state.get(self._STATE_KEY, self._MISSING)
         state[self._STATE_KEY] = self
         return self
@@ -186,6 +197,9 @@ class DataEnvironment:
         else:
             state[self._STATE_KEY] = self._previous
         self._previous = self._MISSING
+        scope, self._state_scope = getattr(self, "_state_scope", None), None
+        if scope is not None:
+            scope.__exit__(exc_type, exc_value, traceback)
         return False
 
     def add_entry(self, entry: DataEnvironmentEntry):

--- a/python/hgraph/adaptors/data_catalogue/catalogue.py
+++ b/python/hgraph/adaptors/data_catalogue/catalogue.py
@@ -7,6 +7,7 @@ from frozendict import frozendict
 from hgraph import CompoundScalar, GlobalState
 
 from .data_scopes import Scope
+from hgraph._wiring._state import _active_global_state
 
 __all__ = (
     "DataSource",
@@ -56,7 +57,7 @@ class DataCatalogue:
 
     @classmethod
     def instance(cls, global_state=None):
-        state = global_state if global_state is not None else GlobalState.instance()
+        state = global_state if global_state is not None else _active_global_state()
         catalogue = state.get(cls._STATE_KEY)
         if catalogue is None:
             catalogue = cls()
@@ -64,13 +65,13 @@ class DataCatalogue:
         return catalogue
 
     def __enter__(self):
-        state = GlobalState.instance()
+        state = _active_global_state()
         self._previous = state.get(self._STATE_KEY, self._MISSING)
         state[self._STATE_KEY] = self
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        state = GlobalState.instance()
+        state = _active_global_state()
         if self._previous is self._MISSING:
             state.pop(self._STATE_KEY, None)
         else:
@@ -159,27 +160,27 @@ class DataEnvironment:
 
     @classmethod
     def current(cls):
-        return GlobalState.instance().get(cls._STATE_KEY)
+        return _active_global_state().get(cls._STATE_KEY)
 
     @classmethod
     def set_current(cls, environment):
-        state = GlobalState.instance()
+        state = _active_global_state()
         if cls._STATE_KEY in state:
             raise ValueError("current data environment is already set")
         state[cls._STATE_KEY] = environment
 
     @classmethod
     def clear_current(cls):
-        GlobalState.instance().pop(cls._STATE_KEY, None)
+        _active_global_state().pop(cls._STATE_KEY, None)
 
     def __enter__(self):
-        state = GlobalState.instance()
+        state = _active_global_state()
         self._previous = state.get(self._STATE_KEY, self._MISSING)
         state[self._STATE_KEY] = self
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        state = GlobalState.instance()
+        state = _active_global_state()
         if self._previous is self._MISSING:
             state.pop(self._STATE_KEY, None)
         else:

--- a/python/hgraph/adaptors/data_frame/_data_frame_source.py
+++ b/python/hgraph/adaptors/data_frame/_data_frame_source.py
@@ -6,6 +6,7 @@ from typing import Iterator, TypeVar
 import pyarrow as pa
 
 from hgraph import GlobalState
+from hgraph._wiring._state import _active_global_state, _global_state_scope
 
 __all__ = (
     "DataFrameSource",
@@ -62,10 +63,11 @@ class DataStore:
     def __init__(self):
         self._data_frame_sources = {}
         self._previous = self._MISSING
+        self._state_scope = None
 
     @classmethod
     def instance(cls) -> "DataStore":
-        state = GlobalState.instance()
+        state = _active_global_state()
         store = state.get(cls._STATE_KEY)
         if store is None:
             store = cls()
@@ -87,18 +89,26 @@ class DataStore:
         return source
 
     def __enter__(self):
-        state = GlobalState.instance()
+        # This block publishes the store into the GlobalState for the wiring
+        # inside it to find, so it needs a state to publish into.  Open one for
+        # the block when the caller has not, and close it in __exit__ -- the
+        # state must not outlive the `with` that needed it.
+        self._state_scope = _global_state_scope()
+        state = self._state_scope.__enter__()
         self._previous = state.get(self._STATE_KEY, self._MISSING)
         state[self._STATE_KEY] = self
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        state = GlobalState.instance()
+        state = _active_global_state()
         if self._previous is self._MISSING:
             state.pop(self._STATE_KEY, None)
         else:
             state[self._STATE_KEY] = self._previous
         self._previous = self._MISSING
+        scope, self._state_scope = self._state_scope, None
+        if scope is not None:
+            scope.__exit__(exc_type, exc_value, traceback)
         return False
 
 
@@ -129,7 +139,7 @@ class DataConnectionStore:
 
     @classmethod
     def instance(cls) -> "DataConnectionStore":
-        state = GlobalState.instance()
+        state = _active_global_state()
         store = state.get(cls._STATE_KEY)
         if store is None:
             store = cls()
@@ -149,18 +159,26 @@ class DataConnectionStore:
         self._connections[name] = connection
 
     def __enter__(self):
-        state = GlobalState.instance()
+        # This block publishes the store into the GlobalState for the wiring
+        # inside it to find, so it needs a state to publish into.  Open one for
+        # the block when the caller has not, and close it in __exit__ -- the
+        # state must not outlive the `with` that needed it.
+        self._state_scope = _global_state_scope()
+        state = self._state_scope.__enter__()
         self._previous = state.get(self._STATE_KEY, self._MISSING)
         state[self._STATE_KEY] = self
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        state = GlobalState.instance()
+        state = _active_global_state()
         if self._previous is self._MISSING:
             state.pop(self._STATE_KEY, None)
         else:
             state[self._STATE_KEY] = self._previous
         self._previous = self._MISSING
+        scope, self._state_scope = self._state_scope, None
+        if scope is not None:
+            scope.__exit__(exc_type, exc_value, traceback)
         return False
 
 

--- a/python/hgraph/adaptors/perspective/_perspective.py
+++ b/python/hgraph/adaptors/perspective/_perspective.py
@@ -27,6 +27,7 @@ import tornado.web
 
 from hgraph import GlobalState, STATE, TS, sink_node
 from hgraph.adaptors.tornado._tornado_web import BaseHandler, TornadoWeb
+from hgraph._wiring._state import _active_global_state
 
 __all__ = (
     "PerspectiveTablesManager",
@@ -166,14 +167,14 @@ class PerspectiveTablesManager:
 
     @classmethod
     def set_current(cls, self, global_state: GlobalState = None):
-        state = global_state if global_state is not None else GlobalState.instance()
+        state = global_state if global_state is not None else _active_global_state()
         if state.get(cls._STATE_KEY) is not None:
             raise ValueError("a PerspectiveTablesManager is already configured")
         state[cls._STATE_KEY] = self
 
     @classmethod
     def current(cls, global_state: GlobalState = None):
-        state = global_state if global_state is not None else GlobalState.instance()
+        state = global_state if global_state is not None else _active_global_state()
         manager = state.get(cls._STATE_KEY)
         if manager is None:
             manager = cls()

--- a/python/hgraph/temporal.py
+++ b/python/hgraph/temporal.py
@@ -13,11 +13,11 @@ from typing import Any
 
 import _hgraph
 
-from ._wiring._state import GlobalState
+from ._wiring._state import GlobalState, _active_global_state
 
 
 def _active_state_handle(global_state=None):
-    state = global_state if global_state is not None else GlobalState.instance()
+    state = global_state if global_state is not None else _active_global_state()
     return state._impl if isinstance(state, GlobalState) else state
 
 

--- a/python/tests/test_global_state_lifecycle.py
+++ b/python/tests/test_global_state_lifecycle.py
@@ -62,3 +62,24 @@ def test_a_failed_wiring_still_removes_the_scope():
     assert not _thread_local_has_state(), (
         "the guard must close on the error path too"
     )
+
+
+def test_a_failed_runner_setup_still_removes_the_scope():
+    """The guard opens before the run's own try, so setup must be guarded too.
+
+    ``graph_logger.setLevel`` rejects a bad level, and that happens after the
+    scope is entered. Leaking it there would hand the next run a contaminated
+    state -- the very thing this change removes.
+    """
+    from hgraph._wiring._runner import GraphConfiguration, evaluate_graph
+
+    @hg.graph
+    def g(ts: TS[int]) -> TS[int]:
+        return ts
+
+    assert not _thread_local_has_state()
+    with pytest.raises(Exception):
+        evaluate_graph(g, GraphConfiguration(default_log_level=object()), [1])
+    assert not _thread_local_has_state(), (
+        "a failure during runner setup must still close the scope"
+    )

--- a/python/tests/test_global_state_lifecycle.py
+++ b/python/tests/test_global_state_lifecycle.py
@@ -1,0 +1,64 @@
+"""The GlobalState thread-local lives only inside its scope.
+
+It is a compatibility surface. Nothing may install it lazily: an accessor that
+did made its own side effect the lifecycle, so the state outlived every wiring
+that used it and was still there at interpreter exit, where its native handles
+were destroyed against freed metadata (issue #505).
+"""
+import pytest
+
+import hgraph as hg
+from hgraph import TS, pass_through
+from hgraph._wiring import _state
+from hgraph.test import eval_node
+
+
+def _thread_local_has_state():
+    return getattr(_state._global_state_local, "state", None) is not None
+
+
+def test_instance_raises_without_a_scope():
+    assert not _thread_local_has_state()
+    with pytest.raises(RuntimeError, match="no active GlobalState"):
+        hg.GlobalState.instance()
+
+
+def test_the_error_points_at_the_injectable():
+    with pytest.raises(RuntimeError) as info:
+        hg.GlobalState.instance()
+    message = str(info.value)
+    assert "injectable" in message
+    assert "GlobalState = None" in message
+
+
+def test_wiring_does_not_leave_the_thread_local_behind():
+    assert not _thread_local_has_state()
+    assert eval_node(pass_through, [1], resolution_dict={"ts": TS[int]}) == [1]
+    assert not _thread_local_has_state(), (
+        "the runner's scope guard must remove the state it opened"
+    )
+
+
+def test_a_caller_scope_survives_the_run_and_is_removed_at_exit():
+    assert not _thread_local_has_state()
+    with hg.GlobalState() as state:
+        state["marker"] = 1
+        assert eval_node(pass_through, [1], resolution_dict={"ts": TS[int]}) == [1]
+        # The runner defers to the caller's scope rather than opening its own,
+        # so values written before the run are still readable after it.
+        assert hg.GlobalState.instance()["marker"] == 1
+    assert not _thread_local_has_state()
+
+
+def test_a_failed_wiring_still_removes_the_scope():
+    assert not _thread_local_has_state()
+
+    @hg.graph
+    def broken(ts: TS[int]) -> TS[int]:
+        raise ValueError("boom")
+
+    with pytest.raises(Exception):
+        eval_node(broken, [1])
+    assert not _thread_local_has_state(), (
+        "the guard must close on the error path too"
+    )

--- a/python/tests/test_persistence_deprecations.py
+++ b/python/tests/test_persistence_deprecations.py
@@ -37,12 +37,15 @@ def _uncached(module_name, *names):
 
 @pytest.mark.parametrize("name", ["frame_store_contains", "frame_store_read"])
 def test_core_frame_store_helpers_warn(name):
-    with pytest.warns(DeprecationWarning, match=rf"hgraph\.{name}.*removed in {REMOVAL}"):
-        try:
-            getattr(hg, name)("some/key")
-        except ModuleNotFoundError as error:
-            # Core-only install: the warning precedes the pointed install error.
-            assert error.name == "hgraph_persistence"
+    # These read "the active graph's frame store", so they need a state to read
+    # from; without a scope there is no active graph and asking is meaningless.
+    with hg.GlobalState():
+        with pytest.warns(DeprecationWarning, match=rf"hgraph\.{name}.*removed in {REMOVAL}"):
+            try:
+                getattr(hg, name)("some/key")
+            except ModuleNotFoundError as error:
+                # Core-only install: the warning precedes the pointed install error.
+                assert error.name == "hgraph_persistence"
 
 
 @pytest.mark.parametrize(

--- a/python/tests/test_registry_reset_teardown.py
+++ b/python/tests/test_registry_reset_teardown.py
@@ -1,0 +1,115 @@
+"""A reset followed by ordinary interpreter exit must not crash (issue #505).
+
+The failure is a dangling call during the final GC: a nanobind-wrapped native
+held by a Python-side cache outlives the reset, and its destructor dispatches
+through a plan the reset freed. Linux segfaults; macOS's allocator keeps the
+pages mapped and the same UB passes silently, so this test is only meaningful
+as a subprocess exit-code assertion -- an in-process check cannot observe it.
+"""
+import os
+import subprocess
+import sys
+import textwrap
+
+RESET_THEN_EXIT = textwrap.dedent(
+    """
+    import faulthandler; faulthandler.enable()
+    import _hgraph
+    from hgraph import TS, pass_through
+    from hgraph.test import eval_node
+
+    assert eval_node(pass_through, [1], resolution_dict={"ts": TS[int]}) == [1]
+    _hgraph.reset_registries()
+    print("ok")
+    # NB: no os._exit() -- ordinary interpreter teardown is the thing under test.
+    """
+)
+
+
+def _run(source):
+    # Hand the child this process's sys.path so it exercises the hgraph under
+    # test rather than whatever happens to be installed in the interpreter's
+    # site-packages -- otherwise a stale installed extension turns a crash
+    # assertion into an unrelated ImportError.
+    env = dict(os.environ, PYTHONPATH=os.pathsep.join(p for p in sys.path if p))
+    return subprocess.run(
+        [sys.executable, "-c", source], capture_output=True, text=True, env=env
+    )
+
+
+def test_reset_then_ordinary_exit_does_not_crash():
+    result = _run(RESET_THEN_EXIT)
+    assert result.returncode == 0, (
+        f"reset + exit returned {result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "ok" in result.stdout
+
+
+RESET_TWICE_THEN_EXIT = textwrap.dedent(
+    """
+    import faulthandler; faulthandler.enable()
+    import _hgraph
+    from hgraph import TS, pass_through
+    from hgraph.test import eval_node
+
+    assert eval_node(pass_through, [1], resolution_dict={"ts": TS[int]}) == [1]
+    _hgraph.reset_registries()
+    # Wire again so the second reset has a freshly cached generation to free.
+    assert eval_node(pass_through, [2], resolution_dict={"ts": TS[int]}) == [2]
+    _hgraph.reset_registries()
+    print("ok")
+    """
+)
+
+
+def test_reset_twice_then_exit_does_not_crash():
+    """A second reset must not resurrect the hazard through a re-cached state.
+
+    Written as its own script rather than patched into the first: RESET_THEN_EXIT
+    is already dedented, so a replacement keyed on indented source silently
+    matched nothing and this ran a single reset.
+    """
+    result = _run(RESET_TWICE_THEN_EXIT)
+    assert result.returncode == 0, (
+        f"double reset + exit returned {result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+NO_STRANDED_STATE = textwrap.dedent(
+    """
+    import _hgraph
+    from hgraph import TS, pass_through
+    from hgraph.test import eval_node
+    from hgraph._wiring import _state
+
+    def cached():
+        return getattr(_state._global_state_local, "state", None)
+
+    assert eval_node(pass_through, [1], resolution_dict={"ts": TS[int]}) == [1]
+    assert cached() is None, "wiring left a state on the thread-local"
+    _hgraph.reset_registries()
+    assert cached() is None, "the reset left a state on the thread-local"
+    print("ok")
+    """
+)
+
+
+def test_a_reset_after_wiring_has_no_cached_state_to_strand():
+    """The reason the crash cannot happen: there is nothing left to free.
+
+    The wrapper collected against freed metadata at exit was a GlobalState
+    cached on the thread-local by a lazy accessor. Wiring no longer leaves one
+    behind, so a reset has nothing of the previous generation to strand.
+
+    A subprocess, like its siblings: reset_registries() is a process-wide,
+    test-only teardown, and calling it in-process detonates every test that
+    runs after it in the same session.
+    """
+    result = _run(NO_STRANDED_STATE)
+    assert result.returncode == 0, (
+        f"returned {result.returncode}\nstdout: {result.stdout}\n"
+        f"stderr: {result.stderr}"
+    )
+    assert "ok" in result.stdout


### PR DESCRIPTION
Fixes #505 at the root, and **supersedes #568**, which treated the symptom.

## Why the thread-local outlived wiring

It is a compatibility surface and was meant to exist only between `GlobalContext.__enter__` and its paired `__exit__`. Two things defeated that, and neither was the context:

**1. `instance()` made its own side effect the lifecycle.** Its lazy branch *created and cached* a state whenever anyone asked, with nothing to remove it:

```python
state = getattr(_global_state_local, "state", None)
if state is None:
    state = GlobalState()
    _global_state_local.state = state      # nothing ever removes this
```

And hgraph's own code asked — **39 times across 10 files**, including the runner at `_runner.py:278`, `:667`, `:784`. The first call installed a state for the life of the thread.

**2. The context could never clean up after itself.** `GlobalContext.__init__` called `instance()` for its default (`:199`), priming the thread-local *before* `__enter__` sampled `_previous` (`:208`). So `_previous` was non-None and `__exit__` took the *restore* branch instead of the *delete* branch. The one mechanism designed to remove the thread-local was disarmed by the accessor it used to find a default.

## The change

- `instance()` **throws** when no scope is active, and names the injectable: `def my_graph(..., state: GlobalState = None)`.
- The thread-local is written **only** by `GlobalContext.__enter__`/`__exit__` — verified by grepping every write. `__init__` now takes a fresh `GlobalState()` instead of reading the ambient.
- A **scope guard opens before wiring** in every wire-and-run entry (`eval_node`, `_evaluate_graph`, `lower`) and closes after, deferring to a caller's `with GlobalState():` when one is active.
- The adaptor stores that publish themselves into the state for the wiring inside them (`DataStore`, `DataConnectionStore`, both catalogue managers) open a scope for their own `with` block, the same way.
- All 39 internal `.instance()` calls take the active state.

## Evidence

The #505 repro on a wheel built from this branch on `hg-linux`, with `register_reset_hook` confirmed absent from `module.cpp`:

| | before | after |
|---|---|---|
| repro (reset + ordinary exit) | SIGSEGV, exit 139 | **exit 0** |

Linux full suite: **2104 passed**; the 23 failures are absent optional extras in that bare venv (`tornado` ×10, `sql` ×7, `deltalake` ×4, `hypothesis` ×2), none related.

Eight regression tests, including that a **failed** wiring still removes the scope.

## It also answers the open review on #568

That PR carried two P2s. This supersedes both:

- **Cross-thread staleness** — the reviewer was right that `vars(_global_state_local)` sees only the calling thread. This removes the source instead of chasing it: with no lazy create, a thread can hold a state only *while inside a live scope*, so a stale cross-thread cache has nowhere to come from.
- **The double-reset test was a no-op** — also right, and worse than untested: it silently ran one reset and passed. Fixed and carried across here.

## One thing the suite caught in my own work

The replacement for #568's hook-registration test called `reset_registries()` **in-process**. That is a process-wide, test-only teardown: it wrecked the registries for every test after it, and the session segfaulted several files later in `test_registry_snapshot.py`. It presented as "0 failures" because the run died before printing any. It is a subprocess now, like its siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)