### PR TITLE
Extract the one GlobalState publishing protocol

### DIFF
--- a/python/hgraph/_wiring/_state.py
+++ b/python/hgraph/_wiring/_state.py
@@ -281,6 +281,56 @@ class _global_state_scope:
         return False
 
 
+class _published_in_global_state:
+    """Mixin for a ``with`` block that publishes itself into the GlobalState.
+
+    Four adaptor stores share one protocol, and it is fiddly enough in the
+    corners -- restoring a shadowed entry, closing only a scope this block
+    opened, holding both on the error path -- that four copies of it is four
+    places for those corners to drift apart.
+
+    A subclass supplies ``_STATE_KEY`` and may override ``_publish`` /
+    ``_unpublish`` when it has more to do than store itself under that key.
+    """
+
+    _MISSING = object()
+
+    def _publish(self, state):
+        state[self._STATE_KEY] = self
+
+    def _unpublish(self, state):
+        if self._previous is self._MISSING:
+            state.pop(self._STATE_KEY, None)
+        else:
+            state[self._STATE_KEY] = self._previous
+
+    def __enter__(self):
+        # The block publishes into the GlobalState for the wiring inside it to
+        # find, so it needs a state to publish into: open one when the caller
+        # has not, and close it in __exit__ -- the state must not outlive the
+        # `with` that needed it.
+        self._state_scope = _global_state_scope()
+        state = self._state_scope.__enter__()
+        try:
+            self._previous = state.get(self._STATE_KEY, self._MISSING)
+            self._publish(state)
+        except BaseException:
+            self._state_scope.__exit__(None, None, None)
+            self._state_scope = None
+            raise
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        try:
+            self._unpublish(_active_global_state())
+            self._previous = self._MISSING
+        finally:
+            scope, self._state_scope = getattr(self, "_state_scope", None), None
+            if scope is not None:
+                scope.__exit__(exc_type, exc_value, traceback)
+        return False
+
+
 def _enter_runtime():
     if getattr(_global_state_local, "runtime_active", False):
         raise RuntimeError("a runtime GlobalState is already active on this thread")

--- a/python/hgraph/adaptors/data_catalogue/catalogue.py
+++ b/python/hgraph/adaptors/data_catalogue/catalogue.py
@@ -7,7 +7,8 @@ from frozendict import frozendict
 from hgraph import CompoundScalar, GlobalState
 
 from .data_scopes import Scope
-from hgraph._wiring._state import _active_global_state, _global_state_scope
+from hgraph._wiring._state import (_active_global_state, _global_state_scope,
+                                   _published_in_global_state)
 
 __all__ = (
     "DataSource",
@@ -46,7 +47,7 @@ class DataCatalogueEntry(CompoundScalar, Generic[DATA_STORE]):
             DataCatalogue.instance().add_entry(self)
 
 
-class DataCatalogue:
+class DataCatalogue(_published_in_global_state):
     _STATE_KEY = ":adaptors:data_catalogue:catalogue"
     _MISSING = object()
 
@@ -63,28 +64,6 @@ class DataCatalogue:
             catalogue = cls()
             state[cls._STATE_KEY] = catalogue
         return catalogue
-
-    def __enter__(self):
-        # Publishes itself into the GlobalState for the wiring inside the block
-        # to find, so it opens a state when the caller has not and closes it in
-        # __exit__ -- the state must not outlive the `with` that needed it.
-        self._state_scope = _global_state_scope()
-        state = self._state_scope.__enter__()
-        self._previous = state.get(self._STATE_KEY, self._MISSING)
-        state[self._STATE_KEY] = self
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        state = _active_global_state()
-        if self._previous is self._MISSING:
-            state.pop(self._STATE_KEY, None)
-        else:
-            state[self._STATE_KEY] = self._previous
-        self._previous = self._MISSING
-        scope, self._state_scope = getattr(self, "_state_scope", None), None
-        if scope is not None:
-            scope.__exit__(exc_type, exc_value, traceback)
-        return False
 
     def add_entry(self, entry: DataCatalogueEntry):
         dataset_key = (entry.dataset, type(entry.store))
@@ -157,7 +136,7 @@ class DataEnvironmentEntry:
     environment_path: str
 
 
-class DataEnvironment:
+class DataEnvironment(_published_in_global_state):
     _STATE_KEY = ":adaptors:data_catalogue:environment"
     _MISSING = object()
 
@@ -179,28 +158,6 @@ class DataEnvironment:
     @classmethod
     def clear_current(cls):
         _active_global_state().pop(cls._STATE_KEY, None)
-
-    def __enter__(self):
-        # Publishes itself into the GlobalState for the wiring inside the block
-        # to find, so it opens a state when the caller has not and closes it in
-        # __exit__ -- the state must not outlive the `with` that needed it.
-        self._state_scope = _global_state_scope()
-        state = self._state_scope.__enter__()
-        self._previous = state.get(self._STATE_KEY, self._MISSING)
-        state[self._STATE_KEY] = self
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        state = _active_global_state()
-        if self._previous is self._MISSING:
-            state.pop(self._STATE_KEY, None)
-        else:
-            state[self._STATE_KEY] = self._previous
-        self._previous = self._MISSING
-        scope, self._state_scope = getattr(self, "_state_scope", None), None
-        if scope is not None:
-            scope.__exit__(exc_type, exc_value, traceback)
-        return False
 
     def add_entry(self, entry: DataEnvironmentEntry):
         self.environment[entry.source_path] = entry

--- a/python/hgraph/adaptors/data_frame/_data_frame_source.py
+++ b/python/hgraph/adaptors/data_frame/_data_frame_source.py
@@ -6,7 +6,8 @@ from typing import Iterator, TypeVar
 import pyarrow as pa
 
 from hgraph import GlobalState
-from hgraph._wiring._state import _active_global_state, _global_state_scope
+from hgraph._wiring._state import (_active_global_state, _global_state_scope,
+                                   _published_in_global_state)
 
 __all__ = (
     "DataFrameSource",
@@ -54,7 +55,7 @@ class DataFrameSource(ABC):
 DATA_FRAME_SOURCE = TypeVar("DATA_FRAME_SOURCE", bound=DataFrameSource)
 
 
-class DataStore:
+class DataStore(_published_in_global_state):
     """Data-source instances held in the Python seed/result GlobalState."""
 
     _STATE_KEY = ":adaptors:data_frame:sources"
@@ -88,29 +89,6 @@ class DataStore:
             self._data_frame_sources[dfs] = source
         return source
 
-    def __enter__(self):
-        # This block publishes the store into the GlobalState for the wiring
-        # inside it to find, so it needs a state to publish into.  Open one for
-        # the block when the caller has not, and close it in __exit__ -- the
-        # state must not outlive the `with` that needed it.
-        self._state_scope = _global_state_scope()
-        state = self._state_scope.__enter__()
-        self._previous = state.get(self._STATE_KEY, self._MISSING)
-        state[self._STATE_KEY] = self
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        state = _active_global_state()
-        if self._previous is self._MISSING:
-            state.pop(self._STATE_KEY, None)
-        else:
-            state[self._STATE_KEY] = self._previous
-        self._previous = self._MISSING
-        scope, self._state_scope = self._state_scope, None
-        if scope is not None:
-            scope.__exit__(exc_type, exc_value, traceback)
-        return False
-
 
 class ArrowDataFrameSource(DataFrameSource):
     def __init__(self, frame):
@@ -129,7 +107,7 @@ class PolarsDataFrameSource(ArrowDataFrameSource):
         super().__init__(df)
 
 
-class DataConnectionStore:
+class DataConnectionStore(_published_in_global_state):
     _STATE_KEY = ":adaptors:data_frame:connections"
     _MISSING = object()
 
@@ -157,29 +135,6 @@ class DataConnectionStore:
 
     def set_connection(self, name: str, connection):
         self._connections[name] = connection
-
-    def __enter__(self):
-        # This block publishes the store into the GlobalState for the wiring
-        # inside it to find, so it needs a state to publish into.  Open one for
-        # the block when the caller has not, and close it in __exit__ -- the
-        # state must not outlive the `with` that needed it.
-        self._state_scope = _global_state_scope()
-        state = self._state_scope.__enter__()
-        self._previous = state.get(self._STATE_KEY, self._MISSING)
-        state[self._STATE_KEY] = self
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        state = _active_global_state()
-        if self._previous is self._MISSING:
-            state.pop(self._STATE_KEY, None)
-        else:
-            state[self._STATE_KEY] = self._previous
-        self._previous = self._MISSING
-        scope, self._state_scope = self._state_scope, None
-        if scope is not None:
-            scope.__exit__(exc_type, exc_value, traceback)
-        return False
 
 
 class SqlDataFrameSource(DataFrameSource):


### PR DESCRIPTION
SonarCloud flagged duplication on #569 and it was right — the duplication was mine, and it is still on `main`.

## What it measured

`new_duplicated_lines_density` on #569: **9.11%**, against a **0.4%** project baseline. I queried its duplications API for the specific blocks rather than guessing:

| file | blocks |
|---|---|
| `adaptors/data_catalogue/catalogue.py` | lines 67 and 183 (17–21 lines) |
| `adaptors/data_frame/_data_frame_source.py` | lines 91 and 161 (18–22 lines) |

...plus the cross-file pairs between them. Four copies of the `__enter__`/`__exit__` state-publishing protocol, **character-for-character identical apart from one comment**. I wrote it for `DataStore` and pasted it into `DataConnectionStore`, `DataCatalogue` and `DataEnvironment`. Neither the persistence variant nor the runner was flagged.

## The change

`_published_in_global_state` in `_state.py`, beside the scope guard it uses. A subclass supplies `_STATE_KEY`, and may override `_publish` / `_unpublish` when it does more than store itself there — the hook that would let the persistence storage adopt it later rather than becoming a fifth copy.

**+58 / −96 lines.**

## Why extract rather than tolerate

The protocol is fiddly in exactly the places copies drift: restoring a *shadowed* entry rather than deleting, closing only a scope **this** block opened, and holding both on the error path. Four copies is four places for those to diverge silently.

Concretely, the extracted version already fixes something **none of the four copies did**: it closes the scope if publishing raises. That bug existed four times and would have had to be found and fixed four times.

## Verification

- Every adaptor suite that exercises these classes: **96 passed, 1 skipped**.
- Full core suite: the same 10 pre-existing subprocess-harness failures as before the change, **nothing new**.
- Checked the importers: `hgraph_persistence` uses `_active_global_state` and `_global_state_scope`, neither of which moved or changed signature.

**Not yet run:** the six-suite reproduction on `hg-linux` — the box went unreachable partway through (`Connection refused`). This is a Python-only refactor whose own tests run locally, so the local signal is meaningful here in a way it was not for the persistence failures; but I would rather say that plainly than imply full coverage. I will run it when the box is back and report on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)