### PR TITLE
Use shared values for web ingress

### DIFF
--- a/docs/source/rfc/rfc_0024_web_extension_api.rst
+++ b/docs/source/rfc/rfc_0024_web_extension_api.rst
@@ -528,6 +528,11 @@ registry, and that holds no graph state.
   channels may advance in the same engine cycle and cannot head-of-line block
   one another. No public contract requires a total order across those service
   outputs.
+  The private request, response, WebSocket, delivery, and event payload
+  envelopes use ``Shared<T>`` so burst delivery and graph-side buffering retain
+  one immutable allocation.  Projection nodes checked-downcast the envelope
+  and copy once into the unchanged public service value.  Fixed-size,
+  self-superseding statistics remain inline.
   The graph-to-runtime direction consists of purpose-specific sink nodes for
   route/key deltas, responses, calls, and WebSocket sends. A graph-scoped
   admission budget retains the web-specific per-channel byte limits,

--- a/docs/source/rfc/rfc_0028_shared_value_representation.rst
+++ b/docs/source/rfc/rfc_0028_shared_value_representation.rst
@@ -1,7 +1,7 @@
 RFC 0028: Shared Value Representation
 =====================================
 
-:Status: Accepted (core and Kafka migration complete; web migration pending)
+:Status: Accepted (core, Kafka, and web migrations complete)
 :Author: Howard Henson
 :Created: 2026-08-24
 :Updated: 2026-08-27
@@ -293,10 +293,17 @@ The core implementation includes:
 Kafka subscription ingress now retains its record field as
 ``Shared<KafkaRecord>`` in the private cross-thread transport envelope.  The
 public service remains ``TS<KafkaRecord>`` and materialises one concrete copy
-at graph publication, so native and Python clients see no schema change.  Web
-transport remains a separately measurable follow-up.  The representation
-contract does not require every struct to become shared; sites opt in where
-retention data justifies it.
+at graph publication, so native and Python clients see no schema change.
+
+Web ingress retains the six private request, response, WebSocket, delivery,
+and event envelopes as ``Shared<T>`` values.  One envelope allocation now
+survives burst delivery, keyed grouping, standard ``collect``/``emit`` state,
+and graph publication.  Projection nodes checked-downcast the immutable
+envelope and keep the public HTTP, WebSocket, delivery, and event time-series
+schemas unchanged.  Small, self-superseding statistics remain inline because
+they do not have the same retained-copy fan-out.  The representation contract
+does not require every struct to become shared; sites opt in where retention
+data justifies it.
 
 Kafka transport evidence
 ------------------------
@@ -350,6 +357,93 @@ records with a 64 KiB payload was:
 This is the deterministic native retention segment, not broker/network
 latency.  Full Kafka service tests continue to cover real and mock broker
 ordering, recovery, lifecycle, and public C++/Python value behavior.
+
+Web transport evidence
+----------------------
+
+``hgraph_web_transport_perf`` retains the former plain transport schema as an
+A/B control and exercises server-request event construction, burst storage,
+graph-side retained copies, and the public ``HttpServerRequest`` projection.
+Latency and allocation measurements cover 20,000 requests.  Retained memory
+holds 64 requests concurrently so the process-wide arena reservation is
+reported at a representative bounded-ingress occupancy instead of being
+attributed entirely to one handle.
+
+Run from a Release ``cpp`` preset build with:
+
+.. code-block:: console
+
+   ./cmake-build-cpp/extensions/web/tests/hgraph_web_transport_perf
+   HGRAPH_WEB_TRANSPORT_PERF_PAYLOAD_BYTES=256 \
+     ./cmake-build-cpp/extensions/web/tests/hgraph_web_transport_perf
+
+On the same Apple M4 Max host, the median of three runs with a 256-byte body
+was:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 14 14 14 20 20
+
+   * - Envelope
+     - p50 ns
+     - p99 ns
+     - allocations / request
+     - allocated bytes / request
+     - tracked retained bytes
+   * - Plain control
+     - 4,166
+     - 5,334
+     - 18
+     - 38,640
+     - 214,016
+   * - Shared envelope
+     - 1,458
+     - 1,917
+     - 14
+     - 4,880
+     - 177,424
+   * - Change
+     - -65.0%
+     - -64.1%
+     - -22.2%
+     - -87.4%
+     - -17.1%
+
+With a 64 KiB body the median was:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 14 14 14 20 20
+
+   * - Envelope
+     - p50 ns
+     - p99 ns
+     - allocations / request
+     - allocated bytes / request
+     - tracked retained bytes
+   * - Plain control
+     - 10,583
+     - 13,625
+     - 18
+     - 430,320
+     - 12,747,776
+   * - Shared envelope
+     - 3,542
+     - 4,833
+     - 14
+     - 135,440
+     - 8,533,264
+   * - Change
+     - -66.5%
+     - -64.5%
+     - -22.2%
+     - -68.5%
+     - -33.1%
+
+These results isolate the deterministic value-retention segment rather than
+socket or protocol latency.  The web service, live HTTP/WebSocket loopback,
+and Python suites continue to cover ordering, backpressure, lifecycle, and
+the unchanged public value shapes.
 
 Acceptance criteria
 -------------------

--- a/extensions/web/CHANGELOG.md
+++ b/extensions/web/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Retain the private request, response, WebSocket, delivery, and event
+  transport envelopes as immutable `Shared<T>` allocations across the
+  push-source and graph-buffering path. Public web service schemas remain
+  unchanged and receive one concrete projection at publication.
+- Keep server timer handles immutable during shutdown so graph teardown cannot
+  race an Asio timer callback copying the same handle.
 - Initial extension skeleton (RFC 0024).
 - Service tier: one standard bounded burst push source per independently
   ordered logical channel, avoiding cross-channel head-of-line blocking while

--- a/extensions/web/CMakeLists.txt
+++ b/extensions/web/CMakeLists.txt
@@ -275,6 +275,13 @@ if(MSVC)
 else()
     target_compile_options(hgraph_web PRIVATE -Wall -Wextra -Wpedantic)
 endif()
+
+if(HGRAPH_ENABLE_TSAN AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # Boost.Asio uses atomic_thread_fence for its fenced block. GCC warns that
+    # TSan cannot model that standalone fence; keep the diagnostic visible but
+    # do not let warnings-as-errors prevent the sanitizer runtime from running.
+    target_compile_options(hgraph_web PRIVATE -Wno-error=tsan)
+endif()
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # GCC's -Wmaybe-uninitialized fires falsely on the std::optional-held
     # scalar tuple the static-node machinery instantiates for the server

--- a/extensions/web/src/asio_server.cpp
+++ b/extensions/web/src/asio_server.cpp
@@ -1978,8 +1978,13 @@ void WebServerRuntime::stop() noexcept {
       // still running.  Their wait handlers capture this runtime; stopping
       // the io_context first would strand those handlers and form the cycle
       // runtime -> listener -> io_context -> handler -> runtime.
-      auto sweep_timer = std::exchange(sweep_timer_, {});
-      auto stats_timer = std::exchange(stats_timer_, {});
+      // Keep the member handles immutable after start. Timer callbacks run
+      // on the Asio strand and may copy these handles while graph teardown is
+      // cancelling them; exchanging the members here would race those reads.
+      // The callbacks release their runtime captures after cancellation, so
+      // retaining the member handles until destruction does not form a cycle.
+      auto sweep_timer = sweep_timer_;
+      auto stats_timer = stats_timer_;
       const auto cancel_timer = [](const auto &timer) {
         if (timer) {
           asio::post(timer->get_executor(), [timer] {
@@ -2037,8 +2042,12 @@ void WebServerRuntime::stop() noexcept {
                               config_->shutdown_drain_timeout;
         while (std::chrono::steady_clock::now() < deadline &&
                (listener_->open_connections() != 0 ||
-                (sweep_timer && sweep_timer.use_count() > 1) ||
-                (stats_timer && stats_timer.use_count() > 1))) {
+                // One reference is retained by the runtime and one by this
+                // stop frame. Any additional reference belongs to a posted
+                // cancellation or wait handler that must drain before the IO
+                // pool is stopped.
+                (sweep_timer && sweep_timer.use_count() > 2) ||
+                (stats_timer && stats_timer.use_count() > 2))) {
           std::this_thread::sleep_for(std::chrono::milliseconds{10});
         }
         listener_->stop_io();

--- a/extensions/web/src/detail/service_transport.h
+++ b/extensions/web/src/detail/service_transport.h
@@ -641,7 +641,7 @@ struct GroupTransportBatchNode {
     for (std::size_t index = 0; index != events.size(); ++index) {
       const auto event = events.at(index);
       const auto envelope =
-          event.as_bundle().at(PayloadField.sv()).as_bundle();
+          event.as_bundle().at(PayloadField.sv()).concrete().as_bundle();
       const auto key = envelope.at(KeyField.sv());
       auto entry = grouped.find(key);
       if (entry == grouped.end()) {
@@ -718,7 +718,7 @@ struct ServerRequestProjectionNode {
       return;
     }
     const auto envelope =
-        event.base().value().as_bundle().at("request").as_bundle();
+        event.base().value().as_bundle().at("request").concrete().as_bundle();
     const auto event_generation = envelope.at("generation");
     if (event_generation.data() == nullptr ||
         event_generation.checked_as<DateTime>() != generation.value()) {
@@ -756,7 +756,12 @@ struct ServerWsProjectionNode {
       return;
     }
     const auto envelope =
-        event.base().value().as_bundle().at("server_ws").as_bundle();
+        event.base()
+            .value()
+            .as_bundle()
+            .at("server_ws")
+            .concrete()
+            .as_bundle();
     const auto event_generation = envelope.at("generation");
     if (event_generation.data() == nullptr ||
         event_generation.checked_as<DateTime>() != generation.value()) {
@@ -796,6 +801,7 @@ struct DeliveryProjectionNode {
                   .value()
                   .as_bundle()
                   .at("delivery")
+                  .concrete()
                   .as_bundle()
                   .at("report"));
   }
@@ -820,7 +826,7 @@ struct EventProjectionNode {
   static void eval(In<"event", TS<WebTransportEvent>> event,
                    EngineControlView engine, Out<TS<WebEvent>> out) {
     const auto envelope =
-        event.base().value().as_bundle().at("event").as_bundle();
+        event.base().value().as_bundle().at("event").concrete().as_bundle();
     out.apply(envelope.at("event"));
     if (envelope.at("stop_graph").checked_as<Bool>()) {
       engine.request_stop();
@@ -850,7 +856,12 @@ struct ClientResponseProjectionNode {
   static void eval(In<"event", TS<WebTransportEvent>> event,
                    Out<HttpCallResult> out) {
     const auto envelope =
-        event.base().value().as_bundle().at("response").as_bundle();
+        event.base()
+            .value()
+            .as_bundle()
+            .at("response")
+            .concrete()
+            .as_bundle();
     const auto response = envelope.at("response");
     if (response.data() != nullptr) {
       out.template field<"response">().apply(response);
@@ -886,7 +897,12 @@ struct ClientWsProjectionNode {
       return;
     }
     const auto envelope =
-        event.base().value().as_bundle().at("client_ws").as_bundle();
+        event.base()
+            .value()
+            .as_bundle()
+            .at("client_ws")
+            .concrete()
+            .as_bundle();
     const auto event_generation = envelope.at("generation");
     if (event_generation.data() == nullptr ||
         event_generation.checked_as<DateTime>() != generation.value()) {

--- a/extensions/web/src/detail/stream_model.h
+++ b/extensions/web/src/detail/stream_model.h
@@ -7,12 +7,13 @@
 #include <string_view>
 
 namespace hgraph::web::detail {
-// Internal transport payloads. External tasks wrap these fully owned
-// values in WebTransportEvent streams; burst push sources deliver the
-// pending events to graph nodes for projection onto the public service
-// outputs. A set `removed` field is retained for compatibility
-// with persisted/test payloads, although graph-side key deltas now own
-// route and connection removal.
+// Internal transport payloads. External tasks wrap these fully owned values
+// in WebTransportEvent streams. Large immutable envelopes use Shared<T>, so
+// batching and retained graph copies share one stable allocation. Burst push
+// sources deliver the pending events to graph nodes for projection onto the
+// public service outputs. A set `removed` field is retained for compatibility
+// with persisted/test payloads, although graph-side key deltas now own route
+// and connection removal.
 
 using WebRequestEnvelope =
     Bundle<"hgraph.web.internal::WebRequestEnvelope", Field<"route", WebRoute>,
@@ -73,10 +74,13 @@ template <> struct scalar_name<web::detail::WebTransportEventKind> {
 namespace hgraph::web::detail {
 using WebTransportEvent = Bundle<
     "hgraph.web.internal::WebTransportEvent",
-    Field<"kind", WebTransportEventKind>, Field<"request", WebRequestEnvelope>,
-    Field<"server_ws", WsIngressEnvelope>, Field<"client_ws", WsClientEnvelope>,
-    Field<"response", WebResponseEnvelope>,
-    Field<"delivery", WebDeliveryEnvelope>, Field<"event", WebEventEnvelope>,
+    Field<"kind", WebTransportEventKind>,
+    Field<"request", Shared<WebRequestEnvelope>>,
+    Field<"server_ws", Shared<WsIngressEnvelope>>,
+    Field<"client_ws", Shared<WsClientEnvelope>>,
+    Field<"response", Shared<WebResponseEnvelope>>,
+    Field<"delivery", Shared<WebDeliveryEnvelope>>,
+    Field<"event", Shared<WebEventEnvelope>>,
     Field<"server_stats", WebServerStats>,
     Field<"client_stats", WebClientStats>, Field<"channel", Int>,
     Field<"retained_bytes", Int>, Field<"control", Bool>>;

--- a/extensions/web/tests/CMakeLists.txt
+++ b/extensions/web/tests/CMakeLists.txt
@@ -27,6 +27,28 @@ add_executable(hgraph_web_h2_loopback_tests
 add_executable(hgraph_web_h2spec_server
     h2spec_server.cpp
 )
+add_executable(hgraph_web_transport_perf
+    transport_perf.cpp
+)
+target_compile_features(hgraph_web_transport_perf PRIVATE cxx_std_23)
+target_link_libraries(hgraph_web_transport_perf PRIVATE hgraph::web)
+target_include_directories(hgraph_web_transport_perf
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+if(MSVC)
+    target_compile_options(hgraph_web_transport_perf PRIVATE /W4 /permissive-)
+else()
+    target_compile_options(hgraph_web_transport_perf PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # This benchmark replaces global new/delete to count allocations. GCC can
+    # pair an inlined replacement new with the replacement delete and report
+    # a spurious mismatched-new-delete warning.
+    target_compile_options(hgraph_web_transport_perf PRIVATE -Wno-mismatched-new-delete)
+endif()
+if(HGRAPH_ENABLE_TSAN AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(hgraph_web_h2spec_server PRIVATE -Wno-error=tsan)
+    target_compile_options(hgraph_web_transport_perf PRIVATE -Wno-error=tsan)
+endif()
 target_compile_features(hgraph_web_h2spec_server PRIVATE cxx_std_23)
 target_link_libraries(hgraph_web_h2spec_server PRIVATE hgraph::web)
 # The loopback oracle is an independent Beast synchronous client, so this
@@ -62,6 +84,10 @@ foreach(target hgraph_web_tests hgraph_web_service_tests hgraph_web_route_table_
         target_compile_options(${target} PRIVATE /W4 /permissive-)
     else()
         target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic)
+    endif()
+
+    if(HGRAPH_ENABLE_TSAN AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        target_compile_options(${target} PRIVATE -Wno-error=tsan)
     endif()
 
     add_test(NAME ${target} COMMAND ${target})

--- a/extensions/web/tests/test_service_transport.cpp
+++ b/extensions/web/tests/test_service_transport.cpp
@@ -9,6 +9,7 @@
 #include <hgraph/lib/std/standard_types.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/static_schema.h>
+#include <hgraph/types/value/shared_value_pool.h>
 #include <hgraph/types/value/value_builder.h>
 
 #include <array>
@@ -47,6 +48,70 @@ using TestBudget = AdmissionBudget<1>;
   return BundleBuilder{ValuePlanFactory::instance().type_for(
                            scalar_descriptor<WebEventEnvelope>::value_meta())}
       .build();
+}
+
+template <typename Envelope> [[nodiscard]] Value empty_envelope() {
+  return BundleBuilder{ValuePlanFactory::instance().type_for(
+                           scalar_descriptor<Envelope>::value_meta())}
+      .build();
+}
+
+void test_transport_payloads_retain_one_shared_envelope() {
+  const auto bindings = hgraph::web::detail::make_transport_bindings();
+  const auto live_before = shared_value_pool_metrics().live_values;
+
+  const auto check = [&](WebTransportEventKind kind, std::string_view field,
+                         Value payload, const ValueTypeMetaData *schema) {
+    Value event = hgraph::web::detail::transport_event(
+        *bindings.value, kind, field, std::move(payload), 0, 128, false);
+    const auto retained = event.view().as_bundle().at(field);
+    require(retained.schema()->is_shared(),
+            "a web transport payload envelope was not shared");
+    require(retained.concrete().schema() == schema,
+            "a web transport shared envelope changed its concrete schema");
+    const void *stable = retained.concrete().data();
+    require(stable != nullptr, "a web transport shared envelope was empty");
+    require(shared_value_pool_metrics().live_values == live_before + 1,
+            "web transport materialised more than one shared envelope");
+
+    Value copied_event = event.clone();
+    const auto copied = copied_event.view().as_bundle().at(field);
+    require(copied.concrete().data() == stable,
+            "a web transport copy did not retain the shared envelope slot");
+    require(shared_value_pool_metrics().live_values == live_before + 1,
+            "a web transport copy duplicated the shared envelope payload");
+  };
+
+  check(WebTransportEventKind::ServerRequest, "request",
+        empty_envelope<hgraph::web::detail::WebRequestEnvelope>(),
+        scalar_descriptor<hgraph::web::detail::WebRequestEnvelope>::value_meta());
+  require(shared_value_pool_metrics().live_values == live_before,
+          "the shared request envelope outlived its transport values");
+  check(WebTransportEventKind::ServerWsIngress, "server_ws",
+        empty_envelope<hgraph::web::detail::WsIngressEnvelope>(),
+        scalar_descriptor<hgraph::web::detail::WsIngressEnvelope>::value_meta());
+  require(shared_value_pool_metrics().live_values == live_before,
+          "the shared server WS envelope outlived its transport values");
+  check(WebTransportEventKind::ClientWsIngress, "client_ws",
+        empty_envelope<hgraph::web::detail::WsClientEnvelope>(),
+        scalar_descriptor<hgraph::web::detail::WsClientEnvelope>::value_meta());
+  require(shared_value_pool_metrics().live_values == live_before,
+          "the shared client WS envelope outlived its transport values");
+  check(WebTransportEventKind::ClientResponse, "response",
+        empty_envelope<hgraph::web::detail::WebResponseEnvelope>(),
+        scalar_descriptor<hgraph::web::detail::WebResponseEnvelope>::value_meta());
+  require(shared_value_pool_metrics().live_values == live_before,
+          "the shared response envelope outlived its transport values");
+  check(WebTransportEventKind::ClientSendDelivery, "delivery",
+        empty_envelope<hgraph::web::detail::WebDeliveryEnvelope>(),
+        scalar_descriptor<hgraph::web::detail::WebDeliveryEnvelope>::value_meta());
+  require(shared_value_pool_metrics().live_values == live_before,
+          "the shared delivery envelope outlived its transport values");
+  check(WebTransportEventKind::ClientEvent, "event",
+        empty_envelope<hgraph::web::detail::WebEventEnvelope>(),
+        scalar_descriptor<hgraph::web::detail::WebEventEnvelope>::value_meta());
+  require(shared_value_pool_metrics().live_values == live_before,
+          "the shared event envelope outlived its transport values");
 }
 
 void test_late_reserved_completion_is_rejected_not_thrown() {
@@ -131,6 +196,7 @@ int main() {
   try {
     register_web_types();
     hgraph::web::detail::register_internal_types();
+    test_transport_payloads_retain_one_shared_envelope();
     test_late_reserved_completion_is_rejected_not_thrown();
     test_reservation_calls_after_stop_are_inert();
     test_stopped_sender_refusal_rolls_back_admission();

--- a/extensions/web/tests/transport_perf.cpp
+++ b/extensions/web/tests/transport_perf.cpp
@@ -1,0 +1,410 @@
+#include <hgraph/web/value_builders.h>
+
+#include "detail/service_transport.h"
+
+#include <hgraph/types/value/shared_value_pool.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <new>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#if defined(_MSC_VER)
+#include <malloc.h>
+#endif
+
+namespace {
+std::atomic<bool> g_count_allocations{false};
+std::atomic<std::size_t> g_allocations{0};
+std::atomic<std::size_t> g_allocated_bytes{0};
+volatile std::uint64_t g_retained_checksum{0};
+
+void record_allocation(std::size_t size) noexcept {
+  if (g_count_allocations.load(std::memory_order_relaxed)) {
+    g_allocations.fetch_add(1, std::memory_order_relaxed);
+    g_allocated_bytes.fetch_add(size, std::memory_order_relaxed);
+  }
+}
+
+[[nodiscard]] void *allocate_unaligned(std::size_t size) {
+  if (void *memory = std::malloc(std::max<std::size_t>(size, 1))) {
+    return memory;
+  }
+  throw std::bad_alloc{};
+}
+
+[[nodiscard]] void *allocate_aligned(std::size_t size, std::size_t alignment) {
+  const auto actual_size = std::max<std::size_t>(size, 1);
+#if defined(_MSC_VER)
+  if (void *memory = _aligned_malloc(actual_size, alignment)) {
+    return memory;
+  }
+#else
+  void *memory{};
+  if (posix_memalign(&memory, alignment, actual_size) == 0) {
+    return memory;
+  }
+#endif
+  throw std::bad_alloc{};
+}
+
+void free_aligned(void *memory) noexcept {
+#if defined(_MSC_VER)
+  _aligned_free(memory);
+#else
+  std::free(memory);
+#endif
+}
+
+struct AllocationScope {
+  AllocationScope() {
+    g_allocations.store(0, std::memory_order_relaxed);
+    g_allocated_bytes.store(0, std::memory_order_relaxed);
+    g_count_allocations.store(true, std::memory_order_relaxed);
+  }
+
+  ~AllocationScope() {
+    g_count_allocations.store(false, std::memory_order_relaxed);
+  }
+};
+} // namespace
+
+void *operator new(std::size_t size) {
+  record_allocation(size);
+  return allocate_unaligned(size);
+}
+
+void *operator new[](std::size_t size) {
+  record_allocation(size);
+  return allocate_unaligned(size);
+}
+
+void *operator new(std::size_t size, std::align_val_t alignment) {
+  record_allocation(size);
+  return allocate_aligned(size, static_cast<std::size_t>(alignment));
+}
+
+void *operator new[](std::size_t size, std::align_val_t alignment) {
+  record_allocation(size);
+  return allocate_aligned(size, static_cast<std::size_t>(alignment));
+}
+
+void *operator new(std::size_t size, const std::nothrow_t &) noexcept {
+  try {
+    return ::operator new(size);
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+void *operator new[](std::size_t size, const std::nothrow_t &) noexcept {
+  try {
+    return ::operator new[](size);
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+void *operator new(std::size_t size, std::align_val_t alignment,
+                   const std::nothrow_t &) noexcept {
+  try {
+    return ::operator new(size, alignment);
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+void *operator new[](std::size_t size, std::align_val_t alignment,
+                     const std::nothrow_t &) noexcept {
+  try {
+    return ::operator new[](size, alignment);
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+void operator delete(void *memory) noexcept { std::free(memory); }
+void operator delete[](void *memory) noexcept { std::free(memory); }
+void operator delete(void *memory, std::size_t) noexcept { std::free(memory); }
+void operator delete[](void *memory, std::size_t) noexcept {
+  std::free(memory);
+}
+void operator delete(void *memory, const std::nothrow_t &) noexcept {
+  std::free(memory);
+}
+void operator delete[](void *memory, const std::nothrow_t &) noexcept {
+  std::free(memory);
+}
+void operator delete(void *memory, std::align_val_t) noexcept {
+  free_aligned(memory);
+}
+void operator delete[](void *memory, std::align_val_t) noexcept {
+  free_aligned(memory);
+}
+void operator delete(void *memory, std::size_t, std::align_val_t) noexcept {
+  free_aligned(memory);
+}
+void operator delete[](void *memory, std::size_t, std::align_val_t) noexcept {
+  free_aligned(memory);
+}
+void operator delete(void *memory, std::align_val_t,
+                     const std::nothrow_t &) noexcept {
+  free_aligned(memory);
+}
+void operator delete[](void *memory, std::align_val_t,
+                       const std::nothrow_t &) noexcept {
+  free_aligned(memory);
+}
+
+namespace {
+using namespace hgraph;
+using namespace hgraph::web;
+namespace wd = hgraph::web::detail;
+
+// RFC 0028's before case, retained in this benchmark only. Keep every field
+// identical to WebTransportEvent except the six payload envelopes.
+using PlainWebTransportEvent =
+    Bundle<"hgraph.web.benchmark::PlainWebTransportEvent",
+           Field<"kind", wd::WebTransportEventKind>,
+           Field<"request", wd::WebRequestEnvelope>,
+           Field<"server_ws", wd::WsIngressEnvelope>,
+           Field<"client_ws", wd::WsClientEnvelope>,
+           Field<"response", wd::WebResponseEnvelope>,
+           Field<"delivery", wd::WebDeliveryEnvelope>,
+           Field<"event", wd::WebEventEnvelope>,
+           Field<"server_stats", WebServerStats>,
+           Field<"client_stats", WebClientStats>, Field<"channel", Int>,
+           Field<"retained_bytes", Int>, Field<"control", Bool>>;
+using PlainWebTransportEventBatch = HomogeneousTuple<PlainWebTransportEvent>;
+
+struct Variant {
+  std::string_view name;
+  ValueTypeRef event;
+  ValueTypeRef batch;
+  const ValueTypeMetaData *batch_schema;
+  bool shared_envelope;
+};
+
+struct RetainedMeasurement {
+  DynamicStorageMetrics values{};
+  std::size_t shared_pool_reserved_bytes{};
+};
+
+struct Fixture {
+  Variant plain;
+  Variant shared;
+  ValueTypeRef public_request;
+  Value request_envelope;
+
+  explicit Fixture(std::size_t payload_bytes) {
+    register_web_types();
+    wd::register_internal_types();
+    auto &factory = ValuePlanFactory::instance();
+    plain = Variant{
+        .name = "plain",
+        .event = factory.type_for(
+            scalar_descriptor<PlainWebTransportEvent>::value_meta()),
+        .batch = factory.type_for(
+            scalar_descriptor<PlainWebTransportEventBatch>::value_meta()),
+        .batch_schema =
+            scalar_descriptor<PlainWebTransportEventBatch>::value_meta(),
+        .shared_envelope = false,
+    };
+    shared = Variant{
+        .name = "shared",
+        .event = factory.type_for(
+            scalar_descriptor<wd::WebTransportEvent>::value_meta()),
+        .batch = factory.type_for(
+            scalar_descriptor<wd::WebTransportEventBatch>::value_meta()),
+        .batch_schema =
+            scalar_descriptor<wd::WebTransportEventBatch>::value_meta(),
+        .shared_envelope = true,
+    };
+    public_request =
+        factory.type_for(scalar_descriptor<HttpServerRequest>::value_meta());
+
+    Value route = make_route(HttpMethod::Post, Str{"/benchmark"});
+    Value request =
+        make_request(HttpMethod::Post, Str{"/benchmark"}, Str{"/benchmark"}, {},
+                     {}, {}, Bytes{std::string(payload_bytes, 'x')});
+    BundleBuilder server_request{public_request};
+    server_request.set("request_id", Value{Int{1}});
+    server_request.set("connection_id", Value{Int{2}});
+    server_request.set("stream_id", Value{Int{3}});
+    server_request.set("request", std::move(request));
+
+    BundleBuilder envelope{factory.type_for(
+        scalar_descriptor<wd::WebRequestEnvelope>::value_meta())};
+    envelope.set("route", std::move(route));
+    envelope.set("request", server_request.build());
+    envelope.set("generation", Value{DateTime{std::chrono::seconds{1}}});
+    request_envelope = envelope.build();
+  }
+
+  [[nodiscard]] Value event(const Variant &variant) const {
+    BundleBuilder builder{variant.event};
+    builder.set("kind", Value{wd::WebTransportEventKind::ServerRequest});
+    builder.set("request", request_envelope.clone());
+    builder.set("channel", Value{Int{0}});
+    builder.set("retained_bytes", Value{Int{65'536}});
+    builder.set("control", Value{Bool{false}});
+    return builder.build();
+  }
+
+  [[nodiscard]] std::uint64_t pipeline(const Variant &variant) const {
+    ListBuilder burst{variant.event, *variant.batch_schema};
+    burst.push_back(event(variant));
+    Value sender_batch = burst.build();
+
+    Value observed_batch{variant.batch, sender_batch.view()};
+    Value pending = observed_batch.view().as_list().at(0).clone();
+    Value keyed_child = pending.clone();
+    const auto envelope =
+        keyed_child.view().as_bundle().at("request").concrete().as_bundle();
+    Value public_output{public_request, envelope.at("request")};
+    const auto request =
+        public_output.view().as_bundle().at("request").as_bundle();
+    return static_cast<std::uint64_t>(
+               request.at("body").checked_as<Bytes>().data.size()) +
+           static_cast<std::uint64_t>(public_output.view()
+                                          .as_bundle()
+                                          .at("request_id")
+                                          .checked_as<Int>());
+  }
+
+  [[nodiscard]] RetainedMeasurement
+  retained_metrics(const Variant &variant, std::size_t records) const {
+    const DynamicStorageMetrics envelope_payload =
+        request_envelope.view().dynamic_storage_metrics();
+    std::vector<Value> retained;
+    retained.reserve(records * 3);
+    RetainedMeasurement result{};
+    for (std::size_t index = 0; index != records; ++index) {
+      ListBuilder burst{variant.event, *variant.batch_schema};
+      burst.push_back(event(variant));
+      Value sender_batch = burst.build();
+      retained.emplace_back(variant.batch, sender_batch.view());
+      Value pending = retained.back().view().as_list().at(0).clone();
+      retained.push_back(pending.clone());
+      const auto envelope = retained.back()
+                                .view()
+                                .as_bundle()
+                                .at("request")
+                                .concrete()
+                                .as_bundle();
+      retained.emplace_back(public_request, envelope.at("request"));
+
+      for (auto holder = retained.end() - 3; holder != retained.end();
+           ++holder) {
+        result.values += holder->view().dynamic_storage_metrics();
+      }
+      // Shared handles report zero for their payload. Attribute its one
+      // logical owner per admitted request so the comparison does not hide
+      // the immutable envelopes behind per-handle zero accounting.
+      if (variant.shared_envelope) {
+        result.values += envelope_payload;
+      }
+    }
+    result.shared_pool_reserved_bytes =
+        variant.shared_envelope ? shared_value_pool_metrics().reserved_bytes
+                                : 0;
+    return result;
+  }
+};
+
+[[nodiscard]] std::size_t env_size(const char *name, std::size_t fallback) {
+  const char *value = std::getenv(name);
+  if (value == nullptr || *value == '\0') {
+    return fallback;
+  }
+  char *end{};
+  const auto parsed = std::strtoull(value, &end, 10);
+  if (end == value || *end != '\0' || parsed == 0 ||
+      parsed > std::numeric_limits<std::size_t>::max()) {
+    throw std::invalid_argument(std::string{name} +
+                                " must be a positive integer");
+  }
+  return static_cast<std::size_t>(parsed);
+}
+
+[[nodiscard]] double percentile(std::vector<double> values, double quantile) {
+  std::ranges::sort(values);
+  const double position = quantile * static_cast<double>(values.size() - 1);
+  const auto lower = static_cast<std::size_t>(position);
+  const auto upper = std::min(lower + 1, values.size() - 1);
+  const double fraction = position - static_cast<double>(lower);
+  return values[lower] + (values[upper] - values[lower]) * fraction;
+}
+
+void run(const Fixture &fixture, const Variant &variant, std::size_t iterations,
+         std::size_t payload_bytes, std::size_t retained_records) {
+  for (std::size_t warmup = 0; warmup < 1'000; ++warmup) {
+    g_retained_checksum = fixture.pipeline(variant);
+  }
+
+  std::vector<double> latencies;
+  latencies.reserve(iterations);
+  std::uint64_t checksum{};
+  std::size_t allocations{};
+  std::size_t allocated_bytes{};
+  {
+    AllocationScope scope;
+    for (std::size_t index = 0; index < iterations; ++index) {
+      const auto start = std::chrono::steady_clock::now();
+      checksum += fixture.pipeline(variant);
+      latencies.push_back(std::chrono::duration<double, std::nano>(
+                              std::chrono::steady_clock::now() - start)
+                              .count());
+    }
+    allocations = g_allocations.load(std::memory_order_relaxed);
+    allocated_bytes = g_allocated_bytes.load(std::memory_order_relaxed);
+  }
+  g_retained_checksum = checksum;
+
+  const auto retained = fixture.retained_metrics(variant, retained_records);
+  std::cout
+      << "benchmark"
+      << " name=web_server_request_transport_" << variant.name
+      << " iterations=" << iterations << " payload_bytes=" << payload_bytes
+      << " retained_records=" << retained_records
+      << " p50_ns_per_request=" << percentile(latencies, 0.50)
+      << " p99_ns_per_request=" << percentile(latencies, 0.99)
+      << " allocations_per_request="
+      << static_cast<double>(allocations) / static_cast<double>(iterations)
+      << " allocated_bytes_per_request="
+      << static_cast<double>(allocated_bytes) / static_cast<double>(iterations)
+      << " retained_live_bytes=" << retained.values.live_bytes
+      << " retained_reserved_bytes=" << retained.values.reserved_bytes
+      << " shared_pool_reserved_bytes=" << retained.shared_pool_reserved_bytes
+      << " tracked_retained_bytes="
+      << retained.values.reserved_bytes + retained.shared_pool_reserved_bytes
+      << " checksum=" << checksum << '\n';
+}
+} // namespace
+
+int main() {
+  try {
+    const std::size_t iterations =
+        env_size("HGRAPH_WEB_TRANSPORT_PERF_ITERATIONS", 20'000);
+    const std::size_t payload_bytes =
+        env_size("HGRAPH_WEB_TRANSPORT_PERF_PAYLOAD_BYTES", 65'536);
+    const std::size_t retained_records =
+        env_size("HGRAPH_WEB_TRANSPORT_PERF_RETAINED_RECORDS", 64);
+    const Fixture fixture{payload_bytes};
+    run(fixture, fixture.plain, iterations, payload_bytes, retained_records);
+    run(fixture, fixture.shared, iterations, payload_bytes, retained_records);
+    return 0;
+  } catch (const std::exception &error) {
+    std::cerr << "Web transport benchmark failed: " << error.what() << '\n';
+    return 1;
+  }
+}


### PR DESCRIPTION
## Summary

- Retain the six private HTTP, WebSocket, response, delivery, and event transport envelopes as immutable Shared values across burst delivery and graph-side buffering.
- Checked-downcast each envelope at the projection boundary, preserving every public web service schema.
- Fix the reproducible shutdown crash by keeping Asio timer handles immutable while callbacks can still copy them.
- Add native lifetime coverage, an A/B transport benchmark, changelog notes, and RFC 0024/0028 implementation evidence.

## Performance

Apple M4 Max, 20,000 requests, median of three runs:

- 256-byte body: p50 latency -65.0%, p99 -64.1%, allocations/request -22.2%, allocated bytes/request -87.4%, tracked retained memory -17.1%.
- 64 KiB body: p50 latency -66.5%, p99 -64.5%, allocations/request -22.2%, allocated bytes/request -68.5%, tracked retained memory -33.1%.

The benchmark isolates deterministic value retention rather than socket or protocol latency.

## Validation

- Fresh native configure, clean build, and complete CTest suite: 1,639/1,639 passed.
- Stable-ABI wheel built with Python 3.12, installed into a fresh Python 3.14.7 environment: 2,184 passed, 10 skipped.
- Sphinx HTML build with warnings treated as errors passed.
- Web transport benchmark completed for both 256-byte and 64 KiB payloads with matching checksums.

## Related

Completes the initial Shared rollout after the process-wide pool in #561 and Kafka ingress migration in #566.