### PR TITLE
Fix benchmark probe and cache path validation

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -90,7 +90,8 @@ installed hgraph versions, Python/platform/architecture, CPU model, benchmark
 scenario-pack fingerprint, scale factors, and sample count. A changed hgraph
 version or scenario pack therefore reruns the baseline automatically; normal
 candidate iterations reuse the 0.8.1 cells. Use `--refresh-baseline` for a deliberate rerun, or
-`--baseline-cache PATH` to keep a separate controlled baseline. Cache files are
+`--baseline-cache benchmarks/results/NAME.json` to keep a separate controlled
+baseline. Cache paths are restricted to `benchmarks/results/`. Cache files are
 local measurement artifacts and are ignored by Git.
 
 Each timing sample runs in a fresh subprocess. The orchestrator rotates mode

--- a/benchmarks/memory_orchestrate.py
+++ b/benchmarks/memory_orchestrate.py
@@ -477,7 +477,8 @@ def main() -> int:
     parser.add_argument("--samples", type=int, default=3)
     parser.add_argument("--sampling-interval-ms", type=float, default=5.0)
     parser.add_argument("--timeout", type=int, default=600)
-    parser.add_argument("--baseline-cache", type=Path, default=BASELINE_CACHE)
+    parser.add_argument("--baseline-cache", type=performance.result_path_argument,
+                        default=BASELINE_CACHE)
     parser.add_argument("--refresh-baseline", action="store_true")
     parser.add_argument("--skip-validation", action="store_true")
     parser.add_argument("--skip-inspector", action="store_true")

--- a/benchmarks/orchestrate.py
+++ b/benchmarks/orchestrate.py
@@ -204,18 +204,31 @@ def benchmark_pack_fingerprint() -> str:
     return digest.hexdigest()
 
 
-def _first_line(command: list[str]) -> str:
+def _first_line(
+    command: list[str], *, accept_nonzero_stderr: bool = False
+) -> str:
     try:
         completed = subprocess.run(
             command, check=False, capture_output=True, text=True, cwd=REPO_ROOT,
         )
     except OSError:
         return "unknown"
-    # MSVC prints its banner to stderr and returns an error for ``cl
-    # --version`` after identifying itself. Preserve that useful first line
-    # while still treating a command with no diagnostic output as unknown.
-    output = completed.stdout.strip() or completed.stderr.strip()
+    if completed.returncode != 0:
+        if not accept_nonzero_stderr:
+            return "unknown"
+        output = completed.stderr.strip()
+    else:
+        output = completed.stdout.strip() or completed.stderr.strip()
     return output.splitlines()[0] if output else "unknown"
+
+
+def _compiler_version(command: list[str]) -> str:
+    # MSVC identifies itself on stderr and returns 2 for ``cl --version``.
+    is_msvc = any(
+        PureWindowsPath(part).name.lower() in {"cl", "cl.exe"}
+        for part in command[:-1]
+    )
+    return _first_line(command, accept_nonzero_stderr=is_msvc)
 
 
 def _cpu_model() -> str:
@@ -250,7 +263,7 @@ def benchmark_metadata() -> dict[str, str]:
         "revision": revision,
         "source_fingerprint": hg_cpp_source_fingerprint(),
         "build_type": "Release",
-        "compiler": _first_line([*compiler, "--version"]),
+        "compiler": _compiler_version([*compiler, "--version"]),
         "python": platform.python_version(),
         "cpu": _cpu_model(),
     }
@@ -399,7 +412,28 @@ def baseline_identity(
     }
 
 
+def _validated_result_path(path: Path) -> Path:
+    """Resolve a benchmark artifact path confined beneath ``RESULTS_DIR``."""
+    resolved = path.expanduser().resolve()
+    results_root = RESULTS_DIR.resolve()
+    try:
+        resolved.relative_to(results_root)
+    except ValueError as exc:
+        raise ValueError(
+            f"benchmark result path must be inside {results_root}: {path}"
+        ) from exc
+    return resolved
+
+
+def result_path_argument(value: str) -> Path:
+    try:
+        return _validated_result_path(Path(value))
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
 def load_baseline_cache(path: Path, identity: dict) -> dict:
+    path = _validated_result_path(path)
     try:
         payload = json.loads(path.read_text())
     except (OSError, json.JSONDecodeError):
@@ -411,6 +445,7 @@ def load_baseline_cache(path: Path, identity: dict) -> dict:
 
 
 def save_baseline_cache(path: Path, identity: dict, results: dict) -> None:
+    path = _validated_result_path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         "identity": identity,
@@ -734,7 +769,8 @@ def main() -> int:
                         help="restrict to mode(s); default fixed 0.8.1 and current source")
     parser.add_argument("--timeout", type=int, default=300,
                         help="per-scenario timeout, seconds")
-    parser.add_argument("--baseline-cache", type=Path, default=BASELINE_CACHE,
+    parser.add_argument("--baseline-cache", type=result_path_argument,
+                        default=BASELINE_CACHE,
                         help="fixed-release timing cache (default: platform-specific)")
     parser.add_argument("--refresh-baseline", action="store_true",
                         help="rerun selected fixed-release modes and refresh their cache")

--- a/benchmarks/orchestrate.py
+++ b/benchmarks/orchestrate.py
@@ -28,6 +28,7 @@ import hashlib
 import json
 import os
 import platform
+import re
 import shlex
 import statistics
 import subprocess
@@ -205,7 +206,7 @@ def benchmark_pack_fingerprint() -> str:
 
 
 def _first_line(
-    command: list[str], *, accept_nonzero_stderr: bool = False
+    command: list[str], *, nonzero_stderr_pattern: re.Pattern[str] | None = None
 ) -> str:
     try:
         completed = subprocess.run(
@@ -214,12 +215,16 @@ def _first_line(
     except OSError:
         return "unknown"
     if completed.returncode != 0:
-        if not accept_nonzero_stderr:
-            return "unknown"
         output = completed.stderr.strip()
     else:
         output = completed.stdout.strip() or completed.stderr.strip()
-    return output.splitlines()[0] if output else "unknown"
+    first_line = output.splitlines()[0] if output else "unknown"
+    if completed.returncode != 0 and (
+        nonzero_stderr_pattern is None
+        or nonzero_stderr_pattern.fullmatch(first_line) is None
+    ):
+        return "unknown"
+    return first_line
 
 
 def _compiler_version(command: list[str]) -> str:
@@ -228,7 +233,13 @@ def _compiler_version(command: list[str]) -> str:
         PureWindowsPath(part).name.lower() in {"cl", "cl.exe"}
         for part in command[:-1]
     )
-    return _first_line(command, accept_nonzero_stderr=is_msvc)
+    msvc_banner = re.compile(
+        r"Microsoft \(R\) C/C\+\+ Optimizing Compiler Version "
+        r"\d+(?:\.\d+)+(?: for .+)?"
+    )
+    return _first_line(
+        command, nonzero_stderr_pattern=msvc_banner if is_msvc else None
+    )
 
 
 def _cpu_model() -> str:

--- a/python/tests/test_benchmark_harness.py
+++ b/python/tests/test_benchmark_harness.py
@@ -44,6 +44,20 @@ def test_first_line_accepts_compiler_banner_from_failed_stderr(monkeypatch):
     assert orchestrate._compiler_version(["cl", "--version"]) == banner
 
 
+def test_compiler_version_rejects_launcher_failure_before_msvc(monkeypatch):
+    monkeypatch.setattr(
+        orchestrate.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args[0], returncode=1, stdout="", stderr="sccache: server unavailable\n"
+        ),
+    )
+
+    assert orchestrate._compiler_version(
+        ["sccache", "cl", "--version"]
+    ) == "unknown"
+
+
 def test_first_line_rejects_diagnostics_from_failed_commands(monkeypatch):
     monkeypatch.setattr(
         orchestrate.subprocess,

--- a/python/tests/test_benchmark_harness.py
+++ b/python/tests/test_benchmark_harness.py
@@ -4,6 +4,8 @@ import importlib.util
 from pathlib import Path
 import subprocess
 
+import pytest
+
 
 _ORCHESTRATE_PATH = (
     Path(__file__).parents[2] / "benchmarks" / "orchestrate.py"
@@ -39,7 +41,20 @@ def test_first_line_accepts_compiler_banner_from_failed_stderr(monkeypatch):
         ),
     )
 
-    assert orchestrate._first_line(["cl", "--version"]) == banner
+    assert orchestrate._compiler_version(["cl", "--version"]) == banner
+
+
+def test_first_line_rejects_diagnostics_from_failed_commands(monkeypatch):
+    monkeypatch.setattr(
+        orchestrate.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args[0], returncode=1, stdout="", stderr="fatal: not a repository\n"
+        ),
+    )
+
+    assert orchestrate._first_line(["git", "rev-parse", "HEAD"]) == "unknown"
+    assert orchestrate._compiler_version(["c++", "--version"]) == "unknown"
 
 
 def test_first_line_reports_unknown_when_command_has_no_output(monkeypatch):
@@ -140,7 +155,10 @@ def test_default_benchmark_report_compares_fixed_release_with_current_source():
     assert "`upstream-py`" not in report
 
 
-def test_upstream_baseline_cache_reuses_only_matching_successes(tmp_path):
+def test_upstream_baseline_cache_reuses_only_matching_successes(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(orchestrate, "RESULTS_DIR", tmp_path)
     cache_path = tmp_path / "nested" / "baseline.json"
     identity = {"schema": 1, "upstream_hgraph": "1.2.3"}
     measured = orchestrate.aggregate_samples(
@@ -165,6 +183,22 @@ def test_upstream_baseline_cache_reuses_only_matching_successes(tmp_path):
     assert orchestrate.cached_baseline_result(
         loaded, "missing", "upstream-cpp"
     ) is None
+
+
+def test_baseline_cache_path_cannot_escape_results_directory(
+    monkeypatch, tmp_path
+):
+    results_dir = tmp_path / "results"
+    monkeypatch.setattr(orchestrate, "RESULTS_DIR", results_dir)
+
+    inside = results_dir / "controlled" / "baseline.json"
+    orchestrate.save_baseline_cache(inside, {"schema": 1}, {})
+    assert inside.exists()
+
+    with pytest.raises(ValueError, match="must be inside"):
+        orchestrate.save_baseline_cache(
+            tmp_path / "outside.json", {"schema": 1}, {}
+        )
 
 
 def test_baseline_identity_is_fixed_to_both_released_lines():

--- a/python/tests/test_memory_benchmark_harness.py
+++ b/python/tests/test_memory_benchmark_harness.py
@@ -182,7 +182,8 @@ def test_current_source_registry_growth_is_reported_separately_from_live_memory(
     assert "42.0 +/- 0.0 | 10.0 +/- 0.0 | 10.0 +/- 0.0" in report
 
 
-def test_memory_baseline_cache_requires_exact_identity(tmp_path):
+def test_memory_baseline_cache_requires_exact_identity(monkeypatch, tmp_path):
+    monkeypatch.setattr(memory.performance, "RESULTS_DIR", tmp_path)
     path = tmp_path / "baseline.json"
     identity = {"schema": 1, "memory_pack": "abc"}
     measured = memory.aggregate_samples([_sample(10.0, 2.0)] * 3)


### PR DESCRIPTION
## Summary

- reject stderr diagnostics from failed metadata probes by default, while retaining the explicit MSVC cl.exe version-banner exception
- confine timing and memory baseline-cache reads and writes to benchmarks/results
- document the cache-path restriction and cover both behaviors with regression tests

Follow-up to #607 and its post-merge review/Sonar findings.

## Validation

- focused benchmark harness tests: 26 passed
- native C++ suite: 1,639 passed
- stable-ABI wheel built with Python 3.12 and full non-WIP compatibility suite run with Python 3.14: 2,187 passed, 10 skipped