### PR TITLE
Make benchmark redaction test portable on Windows

### DIFF
--- a/python/tests/test_benchmark_harness.py
+++ b/python/tests/test_benchmark_harness.py
@@ -89,7 +89,9 @@ def test_public_benchmark_artifacts_redact_developer_local_paths(
     repo = tmp_path / "checkout"
     home = tmp_path / "developer"
     monkeypatch.setattr(orchestrate, "REPO_ROOT", repo)
-    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(
+        orchestrate.Path, "home", classmethod(lambda _cls: home)
+    )
 
     sanitized = orchestrate.sanitize_public_artifact({
         "native_module": str(repo / ".venv" / "_hgraph.so"),
@@ -98,7 +100,9 @@ def test_public_benchmark_artifacts_redact_developer_local_paths(
     })
 
     assert sanitized["native_module"] == "<repo>/.venv/_hgraph.so"
-    assert sanitized["error"] == "failed in <home>/private/source.cpp"
+    assert sanitized["error"].replace("\\", "/") == (
+        "failed in <home>/private/source.cpp"
+    )
     assert sanitized["samples"][0]["native_module"] == "_hgraph.so"
 
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

- mock Path.home directly in the benchmark redaction test instead of setting the POSIX-only HOME variable
- normalize path separators in the portable artifact assertion

All three Windows jobs on merged PR #608 failed only this test. The corrected test passes on the hg-windows128 host with Python 3.14.

## Validation

- hg-windows128 Python 3.14 focused harness: 17 passed
- macOS Python 3.14 focused harness: 17 passed
- full non-WIP Python 3.14 suite: 2,188 passed, 10 skipped
- native C++ suite: 1,639 passed