### PR TITLE
Clean up Windows build warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,8 +137,13 @@ target_compile_features(hgraph_options INTERFACE cxx_std_23)
 target_include_directories(hgraph_options INTERFACE
     $<BUILD_INTERFACE:${HGRAPH_GENERATED_INCLUDE_DIR}>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/third_party>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+# Bundled headers are part of the SDK include path but are not hgraph warning
+# surfaces.  Mark just that subtree external so /W4 and -Wall remain strict for
+# every public hgraph header that includes it.
+target_include_directories(hgraph_options SYSTEM INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/third_party>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/third_party>
 )
 
@@ -281,7 +286,43 @@ if(_hgraph_selected_time_zone_backend STREQUAL "date")
             set(ENABLE_DATE_INSTALL ON CACHE BOOL
                 "Install date/tz with static hgraph SDKs" FORCE)
         endif()
-        FetchContent_MakeAvailable(date)
+        # The pinned release still declares compatibility with obsolete CMake
+        # versions. Suppress that dependency-owned deprecation only while its
+        # project is configured; hgraph deprecations remain visible.
+        if(CMAKE_VERSION VERSION_GREATER_EQUAL 4.0)
+            set(_hgraph_had_policy_version_minimum FALSE)
+            if(DEFINED CMAKE_POLICY_VERSION_MINIMUM)
+                set(_hgraph_had_policy_version_minimum TRUE)
+                set(_hgraph_saved_policy_version_minimum "${CMAKE_POLICY_VERSION_MINIMUM}")
+            endif()
+            if(NOT DEFINED CMAKE_POLICY_VERSION_MINIMUM OR
+               CMAKE_POLICY_VERSION_MINIMUM VERSION_LESS 3.10)
+                set(CMAKE_POLICY_VERSION_MINIMUM 3.10)
+            endif()
+            FetchContent_MakeAvailable(date)
+            if(_hgraph_had_policy_version_minimum)
+                set(CMAKE_POLICY_VERSION_MINIMUM "${_hgraph_saved_policy_version_minimum}")
+            else()
+                unset(CMAKE_POLICY_VERSION_MINIMUM)
+            endif()
+            unset(_hgraph_saved_policy_version_minimum)
+            unset(_hgraph_had_policy_version_minimum)
+        else()
+            set(_hgraph_had_cmake_warn_deprecated FALSE)
+            if(DEFINED CMAKE_WARN_DEPRECATED)
+                set(_hgraph_had_cmake_warn_deprecated TRUE)
+                set(_hgraph_saved_cmake_warn_deprecated "${CMAKE_WARN_DEPRECATED}")
+            endif()
+            set(CMAKE_WARN_DEPRECATED OFF)
+            FetchContent_MakeAvailable(date)
+            if(_hgraph_had_cmake_warn_deprecated)
+                set(CMAKE_WARN_DEPRECATED "${_hgraph_saved_cmake_warn_deprecated}")
+            else()
+                unset(CMAKE_WARN_DEPRECATED)
+            endif()
+            unset(_hgraph_saved_cmake_warn_deprecated)
+            unset(_hgraph_had_cmake_warn_deprecated)
+        endif()
         set(_hgraph_date_fetched ON)
     endif()
     if(HGRAPH_BUILD_SHARED)
@@ -847,15 +888,15 @@ set(_hgraph_config_dependencies "find_dependency(Threads)\n")
 if(NOT HGRAPH_BUILD_SHARED OR NOT HGRAPH_BUILD_PYTHON_BINDINGS)
     list(APPEND _hgraph_config_dependencies
         "find_dependency(fmt 11 CONFIG)\n"
-        "find_dependency(Arrow CONFIG)\n"
+        "find_dependency(Arrow CONFIG QUIET)\n"
         # Some packagers (Conan's Arrow) define the compute/acero targets
         # from the single Arrow config; only find the split packages when
         # the targets are still missing, mirroring the build-side guard.
         "if(NOT TARGET ArrowCompute::arrow_compute_shared AND NOT TARGET ArrowCompute::arrow_compute_static)\n"
-        "  find_dependency(ArrowCompute CONFIG)\n"
+        "  find_dependency(ArrowCompute CONFIG QUIET)\n"
         "endif()\n"
         "if(NOT TARGET ArrowAcero::arrow_acero_shared AND NOT TARGET ArrowAcero::arrow_acero_static)\n"
-        "  find_dependency(ArrowAcero CONFIG)\n"
+        "  find_dependency(ArrowAcero CONFIG QUIET)\n"
         "endif()\n"
         "find_dependency(spdlog 1.15 CONFIG)\n"
         # Static consumers link these implementation dependencies. The

--- a/extensions/fabric/src/service.cpp
+++ b/extensions/fabric/src/service.cpp
@@ -590,17 +590,17 @@ struct FabricDiagnosticsNode
         }
         auto metrics = diagnostics.template field<"metrics">();
         auto mutation = metrics.begin_mutation(metrics.evaluation_time());
-        for (auto &[name, value] : runtime.value().value->diagnostics())
+        for (auto &[metric_name, value] : runtime.value().value->diagnostics())
         {
-            Value key{std::move(name)};
+            Value key{std::move(metric_name)};
             Value item{std::move(value)};
             mutation.set(key.view(), item.view());
         }
         if (bridge.value().value)
         {
-            for (auto &[name, value] : bridge.value().value->diagnostics())
+            for (auto &[metric_name, value] : bridge.value().value->diagnostics())
             {
-                Value key{std::move(name)};
+                Value key{std::move(metric_name)};
                 Value item{std::move(value)};
                 mutation.set(key.view(), item.view());
             }

--- a/extensions/fabric/src/subscription.cpp
+++ b/extensions/fabric/src/subscription.cpp
@@ -403,11 +403,11 @@ struct ReplaySession
 
         const std::string category = as_of_key_prefix(config.prefix, data_id);
         const std::string prefix = category + "/";
-        std::optional<std::string> cursor;
+        std::optional<std::string> page_cursor;
         for (;;)
         {
             const auto page = config.objects.list(
-                prefix, cursor.has_value() ? std::optional<std::string_view>{*cursor} : std::nullopt, 1000);
+                prefix, page_cursor.has_value() ? std::optional<std::string_view>{*page_cursor} : std::nullopt, 1000);
             for (const auto &object : page.objects)
             {
                 if (!object.key.starts_with(prefix))
@@ -421,7 +421,7 @@ struct ReplaySession
             {
                 break;
             }
-            cursor = page.next_start_after;
+            page_cursor = page.next_start_after;
         }
         return entry->second;
     }

--- a/extensions/fabric/test_package/CMakeLists.txt
+++ b/extensions/fabric/test_package/CMakeLists.txt
@@ -8,10 +8,11 @@ find_package(hgraph-fabric CONFIG REQUIRED)
 
 add_executable(hgraph_fabric_consumer main.cpp)
 target_compile_features(hgraph_fabric_consumer PRIVATE cxx_std_23)
-target_link_libraries(hgraph_fabric_consumer PRIVATE hgraph::fabric)
 if(TARGET hgraph::fabric_kafka)
     target_link_libraries(hgraph_fabric_consumer PRIVATE hgraph::fabric_kafka)
     target_compile_definitions(hgraph_fabric_consumer PRIVATE HGRAPH_FABRIC_CONSUMER_HAS_KAFKA=1)
+else()
+    target_link_libraries(hgraph_fabric_consumer PRIVATE hgraph::fabric)
 endif()
 
 if(TARGET hgraph::nanobind AND NOT TARGET Python::Python)

--- a/extensions/fabric/tests/CMakeLists.txt
+++ b/extensions/fabric/tests/CMakeLists.txt
@@ -27,7 +27,7 @@ target_compile_definitions(hgraph_fabric_tests PRIVATE
 
 add_test(NAME hgraph_fabric.tests COMMAND hgraph_fabric_tests)
 if(COMMAND hgraph_configure_test_runtime_paths)
-    hgraph_configure_test_runtime_paths(hgraph_fabric_tests)
+    hgraph_configure_test_runtime_paths(hgraph_fabric.tests)
 endif()
 
 if(TARGET hgraph::fabric_kafka)
@@ -37,7 +37,7 @@ if(TARGET hgraph::fabric_kafka)
     target_compile_features(hgraph_fabric_kafka_tests PRIVATE cxx_std_23)
     add_test(NAME hgraph_fabric.kafka_tests COMMAND hgraph_fabric_kafka_tests)
     if(COMMAND hgraph_configure_test_runtime_paths)
-        hgraph_configure_test_runtime_paths(hgraph_fabric_kafka_tests)
+        hgraph_configure_test_runtime_paths(hgraph_fabric.kafka_tests)
     endif()
 endif()
 

--- a/extensions/fabric/tests/test_backends.cpp
+++ b/extensions/fabric/tests/test_backends.cpp
@@ -3,6 +3,7 @@
 #include <hgraph/persistence/frame_store.h>
 #include <hgraph/persistence/object_store.h>
 #include <hgraph/persistence/store_location.h>
+#include <hgraph/util/environment.h>
 
 #include <arrow/array.h>
 #include <arrow/builder.h>
@@ -169,27 +170,26 @@ void check_backend_round_trip(const hgf::FabricConfig &writer,
 
 [[nodiscard]] hgps::S3Location s3_location(std::string prefix)
 {
-    const char *endpoint = std::getenv("HGRAPH_S3_TEST_ENDPOINT");
-    if (endpoint == nullptr)
+    const auto endpoint = hg::environment_variable("HGRAPH_S3_TEST_ENDPOINT");
+    if (!endpoint)
     {
         throw std::logic_error("missing HGRAPH_S3_TEST_ENDPOINT");
     }
     hgps::S3Location location;
-    location.bucket = std::getenv("HGRAPH_S3_TEST_BUCKET") != nullptr
-                          ? std::getenv("HGRAPH_S3_TEST_BUCKET")
-                          : "hgraph-test";
+    location.bucket =
+        hg::environment_variable("HGRAPH_S3_TEST_BUCKET").value_or("hgraph-test");
     location.prefix = std::move(prefix);
     location.region = "us-east-1";
-    location.endpoint_override = endpoint;
-    if (const char *key = std::getenv("AWS_ACCESS_KEY_ID"); key != nullptr)
+    location.endpoint_override = *endpoint;
+    if (const auto key = hg::environment_variable("AWS_ACCESS_KEY_ID"))
     {
-        const char *secret = std::getenv("AWS_SECRET_ACCESS_KEY");
-        if (secret == nullptr)
+        const auto secret = hg::environment_variable("AWS_SECRET_ACCESS_KEY");
+        if (!secret)
         {
             throw std::logic_error("missing AWS_SECRET_ACCESS_KEY");
         }
         location.credentials.source =
-            hgps::Credentials::Explicit{key, secret, {}};
+            hgps::Credentials::Explicit{*key, *secret, {}};
     }
     return location;
 }
@@ -212,7 +212,7 @@ TEST_CASE("Fabric behavior is identical over local Arrow IPC and Parquet")
 
 TEST_CASE("Fabric behavior is identical over S3 Arrow IPC and Parquet", "[.s3]")
 {
-    if (std::getenv("HGRAPH_S3_TEST_ENDPOINT") == nullptr)
+    if (!hg::environment_variable("HGRAPH_S3_TEST_ENDPOINT"))
     {
         SKIP("set HGRAPH_S3_TEST_ENDPOINT to run the Fabric S3 contract");
     }

--- a/extensions/fabric/tests/test_kafka.cpp
+++ b/extensions/fabric/tests/test_kafka.cpp
@@ -11,6 +11,7 @@
 #include <hgraph/lib/testing/runtime_support.h>
 #include <hgraph/runtime/runtime.h>
 #include <hgraph/types/static_node.h>
+#include <hgraph/util/environment.h>
 
 #include <arrow/array.h>
 #include <arrow/builder.h>
@@ -625,27 +626,28 @@ TEST_CASE("manual Kafka assignment recovers after every broker disconnects") {
 
 TEST_CASE("actual broker preserves Fabric recovery, retry, and ordering",
           "[.kafka-broker]") {
-  const char *bootstrap =
-      std::getenv("HGRAPH_FABRIC_KAFKA_INTEGRATION_BOOTSTRAP");
-  const char *topic = std::getenv("HGRAPH_FABRIC_KAFKA_INTEGRATION_TOPIC");
-  const char *control =
-      std::getenv("HGRAPH_FABRIC_KAFKA_INTEGRATION_CONTROL_DIR");
-  if (bootstrap == nullptr && topic == nullptr && control == nullptr) {
+  const auto bootstrap =
+      hg::environment_variable("HGRAPH_FABRIC_KAFKA_INTEGRATION_BOOTSTRAP");
+  const auto topic =
+      hg::environment_variable("HGRAPH_FABRIC_KAFKA_INTEGRATION_TOPIC");
+  const auto control =
+      hg::environment_variable("HGRAPH_FABRIC_KAFKA_INTEGRATION_CONTROL_DIR");
+  if (!bootstrap && !topic && !control) {
     SKIP("run through run_kafka_broker_conformance.py");
   }
-  REQUIRE(bootstrap != nullptr);
-  REQUIRE(topic != nullptr);
-  REQUIRE(control != nullptr);
+  REQUIRE(bootstrap.has_value());
+  REQUIRE(topic.has_value());
+  REQUIRE(control.has_value());
 
   hg::stdlib::register_standard_operators();
   hgf::register_fabric_operators();
   hgk::register_kafka_types();
 
-  actual_topic = topic;
-  actual_control_dir = control;
+  actual_topic = *topic;
+  actual_control_dir = *control;
   std::filesystem::create_directories(actual_control_dir);
   actual_kafka_config = hgk::service_config()
-                            .bootstrap_servers({bootstrap})
+                            .bootstrap_servers({*bootstrap})
                             .client_id("hgraph-fabric-broker-conformance")
                             .ingress_limit(8)
                             .outbound_limit(2)

--- a/extensions/kafka/CMakeLists.txt
+++ b/extensions/kafka/CMakeLists.txt
@@ -80,7 +80,68 @@ if(NOT TARGET RdKafka::rdkafka AND NOT TARGET rdkafka)
         GIT_TAG v2.15.0
         GIT_SHALLOW TRUE
     )
-    FetchContent_MakeAvailable(librdkafka)
+    # The pinned release still declares compatibility with obsolete CMake
+    # versions. Suppress that dependency-owned deprecation only while its
+    # project is configured; hgraph-kafka deprecations remain visible.
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 4.0)
+        set(_hgraph_kafka_had_policy_version_minimum FALSE)
+        if(DEFINED CMAKE_POLICY_VERSION_MINIMUM)
+            set(_hgraph_kafka_had_policy_version_minimum TRUE)
+            set(_hgraph_kafka_saved_policy_version_minimum "${CMAKE_POLICY_VERSION_MINIMUM}")
+        endif()
+        if(NOT DEFINED CMAKE_POLICY_VERSION_MINIMUM OR
+           CMAKE_POLICY_VERSION_MINIMUM VERSION_LESS 3.10)
+            set(CMAKE_POLICY_VERSION_MINIMUM 3.10)
+        endif()
+        FetchContent_MakeAvailable(librdkafka)
+        if(_hgraph_kafka_had_policy_version_minimum)
+            set(CMAKE_POLICY_VERSION_MINIMUM "${_hgraph_kafka_saved_policy_version_minimum}")
+        else()
+            unset(CMAKE_POLICY_VERSION_MINIMUM)
+        endif()
+        unset(_hgraph_kafka_saved_policy_version_minimum)
+        unset(_hgraph_kafka_had_policy_version_minimum)
+    else()
+        set(_hgraph_kafka_had_cmake_warn_deprecated FALSE)
+        if(DEFINED CMAKE_WARN_DEPRECATED)
+            set(_hgraph_kafka_had_cmake_warn_deprecated TRUE)
+            set(_hgraph_kafka_saved_cmake_warn_deprecated "${CMAKE_WARN_DEPRECATED}")
+        endif()
+        set(CMAKE_WARN_DEPRECATED OFF)
+        FetchContent_MakeAvailable(librdkafka)
+        if(_hgraph_kafka_had_cmake_warn_deprecated)
+            set(CMAKE_WARN_DEPRECATED "${_hgraph_kafka_saved_cmake_warn_deprecated}")
+        else()
+            unset(CMAKE_WARN_DEPRECATED)
+        endif()
+        unset(_hgraph_kafka_saved_cmake_warn_deprecated)
+        unset(_hgraph_kafka_had_cmake_warn_deprecated)
+    endif()
+
+    if(MSVC)
+        # Pinned librdkafka 2.15 has two MSVC-only C diagnostics in its own
+        # sources: a va_list flow false positive and a Windows SSPI typedef
+        # mismatch. Keep third-party warnings out of hgraph /WX builds without
+        # weakening warning policy on hgraph targets.
+        target_compile_options(rdkafka PRIVATE /wd4133 /wd4700)
+    elseif(CMAKE_C_COMPILER_ID MATCHES "Clang")
+        # Pinned librdkafka 2.15 triggers Clang diagnostics in its telemetry,
+        # legacy OpenSSL engine, and platform-format code. Scope these to the
+        # fetched third-party target so hgraph keeps its normal warning policy.
+        target_compile_options(rdkafka PRIVATE
+            -Wno-deprecated-declarations
+            -Wno-format
+            -Wno-implicit-enum-enum-cast
+        )
+    elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+        # GCC diagnoses the same legacy OpenSSL engine calls plus const
+        # conversions in librdkafka's C compatibility surface. Both belong to
+        # the pinned dependency rather than hgraph targets.
+        target_compile_options(rdkafka PRIVATE
+            -Wno-deprecated-declarations
+            -Wno-discarded-qualifiers
+        )
+    endif()
 
     if(HGRAPH_ENABLE_TSAN)
         if(CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/extensions/kafka/tests/test_service.cpp
+++ b/extensions/kafka/tests/test_service.cpp
@@ -10,6 +10,7 @@
 #include <hgraph/lib/testing/runtime_support.h>
 #include <hgraph/runtime/runtime.h>
 #include <hgraph/types/value/shared_value_pool.h>
+#include <hgraph/util/environment.h>
 #include <hgraph/util/scope.h>
 
 #include "../src/detail/service_transport.h"
@@ -1026,17 +1027,17 @@ struct ReverseCommitCursors {
   static constexpr auto name = "kafka_reverse_commit_cursors";
 
   static void
-  eval(In<"cursor", TS<KafkaCursor>, InputValidity::Unchecked> cursor,
+  eval(In<"cursor", TS<KafkaCursor>, InputValidity::Unchecked> input_cursor,
        NodeScheduler scheduler, State<Int> phase, EngineControlView engine,
        Out<TS<KafkaCursor>> out) {
-    if (cursor.valid() && cursor.modified()) {
+    if (input_cursor.valid() && input_cursor.modified()) {
       if (phase.get() == Int{0}) {
-        first_commit_cursor = cursor.base().value().clone();
+        first_commit_cursor = input_cursor.base().value().clone();
         phase.set(Int{1});
         return;
       }
       if (phase.get() == Int{1}) {
-        out.apply(cursor.base().value());
+        out.apply(input_cursor.base().value());
         phase.set(Int{2});
         scheduler.schedule(TimeDelta{100'000});
         return;
@@ -2862,19 +2863,20 @@ void test_multiple_simulation_subscriptions_replay_at_record_time() {
 }
 
 void test_real_broker_publish_subscribe_and_commit_round_trip() {
-  const char *bootstrap_value =
-      std::getenv("HGRAPH_KAFKA_INTEGRATION_BOOTSTRAP");
-  const char *topic_value = std::getenv("HGRAPH_KAFKA_INTEGRATION_TOPIC");
-  if (bootstrap_value == nullptr && topic_value == nullptr) {
+  const auto bootstrap_value =
+      hgraph::environment_variable("HGRAPH_KAFKA_INTEGRATION_BOOTSTRAP");
+  const auto topic_value =
+      hgraph::environment_variable("HGRAPH_KAFKA_INTEGRATION_TOPIC");
+  if (!bootstrap_value && !topic_value) {
     return;
   }
   require(
-      bootstrap_value != nullptr && topic_value != nullptr,
+      bootstrap_value.has_value() && topic_value.has_value(),
       "real Kafka integration requires both HGRAPH_KAFKA_INTEGRATION_BOOTSTRAP "
       "and HGRAPH_KAFKA_INTEGRATION_TOPIC");
 
-  const Str bootstrap{bootstrap_value};
-  const Str topic{topic_value};
+  const Str bootstrap{*bootstrap_value};
+  const Str topic{*topic_value};
   const Str group = Str{"hgraph-kafka-integration-"} + topic;
   production_topic = topic;
   produced_record = make_produce_record(

--- a/extensions/kafka/tests/transport_perf.cpp
+++ b/extensions/kafka/tests/transport_perf.cpp
@@ -3,6 +3,7 @@
 #include "detail/service_transport.h"
 
 #include <hgraph/types/value/shared_value_pool.h>
+#include <hgraph/util/environment.h>
 
 #include <algorithm>
 #include <atomic>
@@ -301,13 +302,14 @@ struct Fixture {
 };
 
 [[nodiscard]] std::size_t env_size(const char *name, std::size_t fallback) {
-  const char *value = std::getenv(name);
-  if (value == nullptr || *value == '\0') {
+  const auto value = hgraph::environment_variable(name);
+  if (!value || value->empty()) {
     return fallback;
   }
   char *end{};
-  const auto parsed = std::strtoull(value, &end, 10);
-  if (end == value || *end != '\0' || parsed == 0 ||
+  const char *begin = value->c_str();
+  const auto parsed = std::strtoull(begin, &end, 10);
+  if (end == begin || *end != '\0' || parsed == 0 ||
       parsed > std::numeric_limits<std::size_t>::max()) {
     throw std::invalid_argument(std::string{name} +
                                 " must be a positive integer");

--- a/extensions/persistence/tests/test_frame_store.cpp
+++ b/extensions/persistence/tests/test_frame_store.cpp
@@ -14,6 +14,7 @@
 #include <hgraph/types/record_replay.h>
 #include <hgraph/types/static_schema.h>
 #include <hgraph/types/value/value_builder.h>
+#include <hgraph/util/environment.h>
 
 #include <arrow/array.h>
 #include <arrow/builder.h>
@@ -506,25 +507,25 @@ TEST_CASE("frame store: an unbuildable configuration fails rather than degrading
 //     ./hgraph_persistence_tests "[s3]"
 TEST_CASE("frame store: an S3 store round-trips against a local endpoint", "[.s3]")
 {
-    const char *endpoint = std::getenv("HGRAPH_S3_TEST_ENDPOINT");
-    if (endpoint == nullptr)
+    const auto endpoint = hgraph::environment_variable("HGRAPH_S3_TEST_ENDPOINT");
+    if (!endpoint)
     {
         SKIP("set HGRAPH_S3_TEST_ENDPOINT to run the S3 backend against a local "
              "endpoint");
     }
 
-    const char *bucket_name = std::getenv("HGRAPH_S3_TEST_BUCKET");
-    const char *key_id = std::getenv("AWS_ACCESS_KEY_ID");
-    const char *secret = std::getenv("AWS_SECRET_ACCESS_KEY");
+    const auto bucket_name = hgraph::environment_variable("HGRAPH_S3_TEST_BUCKET");
+    const auto key_id = hgraph::environment_variable("AWS_ACCESS_KEY_ID");
+    const auto secret = hgraph::environment_variable("AWS_SECRET_ACCESS_KEY");
 
     S3Location location;
-    location.bucket = bucket_name != nullptr ? bucket_name : "hgraph-test";
+    location.bucket = bucket_name.value_or("hgraph-test");
     location.prefix = "/frame-store/";
     location.region = "us-east-1";
-    location.endpoint_override = endpoint;
-    if (key_id != nullptr && secret != nullptr)
+    location.endpoint_override = *endpoint;
+    if (key_id && secret)
     {
-        location.credentials.source = Credentials::Explicit{key_id, secret, {}};
+        location.credentials.source = Credentials::Explicit{*key_id, *secret, {}};
     }
 
     const Frame expected = make_metadata_frame();

--- a/extensions/persistence/tests/test_object_store.cpp
+++ b/extensions/persistence/tests/test_object_store.cpp
@@ -1,4 +1,5 @@
 #include <hgraph/persistence/object_store.h>
+#include <hgraph/util/environment.h>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -484,24 +485,23 @@ TEST_CASE("object store: a crashed local writer never exposes a partial object")
 
 TEST_CASE("object store: S3 uses conditional writes, ETags, and ordered discovery", "[.s3]")
 {
-    const char *endpoint = std::getenv("HGRAPH_S3_TEST_ENDPOINT");
-    if (endpoint == nullptr)
+    const auto endpoint = hgraph::environment_variable("HGRAPH_S3_TEST_ENDPOINT");
+    if (!endpoint)
     {
         SKIP("set HGRAPH_S3_TEST_ENDPOINT to run the object-store S3 contract");
     }
 
     S3Location location;
-    location.bucket = std::getenv("HGRAPH_S3_TEST_BUCKET") != nullptr
-                          ? std::getenv("HGRAPH_S3_TEST_BUCKET")
-                          : "hgraph-test";
+    location.bucket =
+        hgraph::environment_variable("HGRAPH_S3_TEST_BUCKET").value_or("hgraph-test");
     location.prefix = "/object-store/";
     location.region = "us-east-1";
-    location.endpoint_override = endpoint;
-    if (const char *key = std::getenv("AWS_ACCESS_KEY_ID"); key != nullptr)
+    location.endpoint_override = *endpoint;
+    if (const auto key = hgraph::environment_variable("AWS_ACCESS_KEY_ID"))
     {
-        const char *secret = std::getenv("AWS_SECRET_ACCESS_KEY");
-        REQUIRE(secret != nullptr);
-        location.credentials.source = Credentials::Explicit{key, secret, {}};
+        const auto secret = hgraph::environment_variable("AWS_SECRET_ACCESS_KEY");
+        REQUIRE(secret.has_value());
+        location.credentials.source = Credentials::Explicit{*key, *secret, {}};
     }
 
     auto store = make_object_store(ObjectStoreConfig{location});

--- a/extensions/web/CMakeLists.txt
+++ b/extensions/web/CMakeLists.txt
@@ -160,6 +160,19 @@ if(NOT HGRAPH_WEB_CURL_TARGET)
         GIT_SHALLOW TRUE
     )
     FetchContent_MakeAvailable(curl)
+    if(APPLE AND CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND
+       TARGET libcurl_static)
+        # curl 8.11.1 passes an intentionally zero-length transfer buffer that
+        # AppleClang 21 diagnoses as an uninitialized const pointer. Keep that
+        # dependency-owned warning out of otherwise clean hgraph builds.
+        target_compile_options(libcurl_static PRIVATE
+            -Wno-uninitialized-const-pointer)
+    elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND TARGET libcurl_static)
+        # GCC 14 diagnoses const conversions in curl 8.11.1's C compatibility
+        # surface. Keep that pinned-dependency warning off hgraph build logs.
+        target_compile_options(libcurl_static PRIVATE
+            -Wno-discarded-qualifiers)
+    endif()
     # Adopt the concrete static target: the CURL::libcurl alias name may
     # already be taken by a sibling's system-curl import.
     if(TARGET libcurl_static)
@@ -204,6 +217,12 @@ if(NOT HGRAPH_WEB_BOOST_TARGETS)
     FetchContent_MakeAvailable(boost)
     if(NOT TARGET Boost::beast)
         message(FATAL_ERROR "Boost did not provide its Beast target")
+    endif()
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND TARGET boost_container)
+        # GCC 14 reports an unreachable size_t wraparound iteration in the
+        # pinned Boost.Container dlmalloc implementation after inlining.
+        target_compile_options(boost_container PRIVATE
+            -Wno-aggressive-loop-optimizations)
     endif()
     set(HGRAPH_WEB_BOOST_TARGETS Boost::beast Boost::asio Boost::system)
 endif()
@@ -268,9 +287,13 @@ set_target_properties(hgraph_web PROPERTIES
 if(MSVC)
     # The transport implementation includes Windows headers.  Keep their
     # min/max macros from rewriting standard-library calls in this target.
+    # Its Asio transport requires Windows 10 APIs; publish that build-tree
+    # target to sibling tests so Boost does not silently assume Windows 7.
     # Beast's template instantiation count in the server TU exceeds the
     # default COFF section limit, hence /bigobj.
     target_compile_definitions(hgraph_web PRIVATE NOMINMAX WIN32_LEAN_AND_MEAN)
+    target_compile_definitions(hgraph_web PUBLIC
+        $<BUILD_INTERFACE:_WIN32_WINNT=0x0A00>)
     target_compile_options(hgraph_web PRIVATE /W4 /permissive- /bigobj)
 else()
     target_compile_options(hgraph_web PRIVATE -Wall -Wextra -Wpedantic)

--- a/extensions/web/src/asio_server.cpp
+++ b/extensions/web/src/asio_server.cpp
@@ -822,24 +822,40 @@ private:
 // ---------------------------------------------------------------------------
 // Runtime
 
-// Lock-free published-snapshot access for io threads.  Apple's libc++ does
-// not provide std::atomic<std::shared_ptr>, and GCC deprecates the free
-// functions; the deprecation is suppressed here and nowhere else.
+// Lock-free published-snapshot access for io threads. Prefer the C++20
+// specialization where the standard library provides it. Older Apple libc++
+// releases expose only the free shared_ptr atomics, which remain the fallback.
+#if defined(__cpp_lib_atomic_shared_ptr) && __cpp_lib_atomic_shared_ptr >= 201711L
+using PublishedRoutes = std::atomic<std::shared_ptr<const CompiledRoutes>>;
+
+[[nodiscard]] inline std::shared_ptr<const CompiledRoutes>
+atomic_load_routes(const PublishedRoutes *slot) {
+  return slot->load(std::memory_order_acquire);
+}
+
+inline void atomic_store_routes(PublishedRoutes *slot,
+                                std::shared_ptr<const CompiledRoutes> value) {
+  slot->store(std::move(value), std::memory_order_release);
+}
+#else
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
+using PublishedRoutes = std::shared_ptr<const CompiledRoutes>;
+
 [[nodiscard]] inline std::shared_ptr<const CompiledRoutes>
-atomic_load_routes(const std::shared_ptr<const CompiledRoutes> *slot) {
+atomic_load_routes(const PublishedRoutes *slot) {
   return std::atomic_load(slot);
 }
 
-inline void atomic_store_routes(std::shared_ptr<const CompiledRoutes> *slot,
+inline void atomic_store_routes(PublishedRoutes *slot,
                                 std::shared_ptr<const CompiledRoutes> value) {
   std::atomic_store(slot, std::move(value));
 }
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
+#endif
 #endif
 
 class ServerConnection;
@@ -991,7 +1007,7 @@ private:
   void arm_sweep_timer();
   void arm_stats_timer();
   void emit_stats_once();
-  void rebuild(std::shared_ptr<const CompiledRoutes> &slot,
+  void rebuild(PublishedRoutes &slot,
                std::vector<std::tuple<HttpMethod, std::string, Value, DateTime>>
                    &master,
                std::vector<SubscriptionBinding> added,
@@ -1010,9 +1026,9 @@ private:
   // The wire-format ALPN preference list the select callback reads; owned
   // here so its address outlives every TLS handshake on this context.
   std::vector<unsigned char> alpn_wire_{};
-  std::shared_ptr<const CompiledRoutes> http_routes_{
+  PublishedRoutes http_routes_{
       std::make_shared<CompiledRoutes>()};
-  std::shared_ptr<const CompiledRoutes> ws_routes_{
+  PublishedRoutes ws_routes_{
       std::make_shared<CompiledRoutes>()};
   std::mutex routes_mutex_{};
   std::vector<std::tuple<HttpMethod, std::string, Value, DateTime>>
@@ -2059,7 +2075,7 @@ void WebServerRuntime::stop() noexcept {
 }
 
 void WebServerRuntime::rebuild(
-    std::shared_ptr<const CompiledRoutes> &slot,
+    PublishedRoutes &slot,
     std::vector<std::tuple<HttpMethod, std::string, Value, DateTime>> &master,
     std::vector<SubscriptionBinding> added, std::vector<Value> removed) {
   std::lock_guard lock{routes_mutex_};

--- a/extensions/web/tests/CMakeLists.txt
+++ b/extensions/web/tests/CMakeLists.txt
@@ -67,14 +67,19 @@ target_include_directories(hgraph_web_transport_tests
 # client session, so it links the same nghttp2 the extension uses.
 target_include_directories(hgraph_web_h2_engine_tests
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
-target_link_libraries(hgraph_web_h2_engine_tests
-    PRIVATE ${HGRAPH_WEB_NGHTTP2_TARGET})
+target_include_directories(hgraph_web_h2_engine_tests SYSTEM PRIVATE
+    $<TARGET_PROPERTY:${HGRAPH_WEB_NGHTTP2_TARGET},INTERFACE_INCLUDE_DIRECTORIES>)
+target_compile_definitions(hgraph_web_h2_engine_tests PRIVATE
+    $<TARGET_PROPERTY:${HGRAPH_WEB_NGHTTP2_TARGET},INTERFACE_COMPILE_DEFINITIONS>)
 # The h2 loopback also carries a small independent nghttp2/TLS client for
 # rejection/window-restoration behavior that the public call shape cannot
 # express (an open stream plus DATA followed by request trailers).
+target_include_directories(hgraph_web_h2_loopback_tests SYSTEM PRIVATE
+    $<TARGET_PROPERTY:${HGRAPH_WEB_NGHTTP2_TARGET},INTERFACE_INCLUDE_DIRECTORIES>)
+target_compile_definitions(hgraph_web_h2_loopback_tests PRIVATE
+    $<TARGET_PROPERTY:${HGRAPH_WEB_NGHTTP2_TARGET},INTERFACE_COMPILE_DEFINITIONS>)
 target_link_libraries(hgraph_web_h2_loopback_tests
-    PRIVATE ${HGRAPH_WEB_NGHTTP2_TARGET} OpenSSL::SSL OpenSSL::Crypto
-            ${HGRAPH_WEB_BOOST_TARGETS})
+    PRIVATE OpenSSL::SSL OpenSSL::Crypto ${HGRAPH_WEB_BOOST_TARGETS})
 
 foreach(target hgraph_web_tests hgraph_web_service_tests hgraph_web_route_table_tests hgraph_web_transport_tests hgraph_web_h2_engine_tests hgraph_web_loopback_tests hgraph_web_client_loopback_tests hgraph_web_h2_loopback_tests)
     target_compile_features(${target} PRIVATE cxx_std_23)

--- a/extensions/web/tests/CMakeLists.txt
+++ b/extensions/web/tests/CMakeLists.txt
@@ -81,6 +81,16 @@ target_compile_definitions(hgraph_web_h2_loopback_tests PRIVATE
 target_link_libraries(hgraph_web_h2_loopback_tests
     PRIVATE OpenSSL::SSL OpenSSL::Crypto ${HGRAPH_WEB_BOOST_TARGETS})
 
+# A static hgraph_web propagates its private nghttp2 dependency as link-only;
+# a shared hgraph_web consumes it internally, so tests that call nghttp2
+# directly must add their own link-only dependency.
+if(HGRAPH_WEB_LIBRARY_TYPE STREQUAL "SHARED_LIBRARY")
+    target_link_libraries(hgraph_web_h2_engine_tests
+        PRIVATE $<LINK_ONLY:${HGRAPH_WEB_NGHTTP2_TARGET}>)
+    target_link_libraries(hgraph_web_h2_loopback_tests
+        PRIVATE $<LINK_ONLY:${HGRAPH_WEB_NGHTTP2_TARGET}>)
+endif()
+
 foreach(target hgraph_web_tests hgraph_web_service_tests hgraph_web_route_table_tests hgraph_web_transport_tests hgraph_web_h2_engine_tests hgraph_web_loopback_tests hgraph_web_client_loopback_tests hgraph_web_h2_loopback_tests)
     target_compile_features(${target} PRIVATE cxx_std_23)
     target_link_libraries(${target} PRIVATE hgraph::web)

--- a/extensions/web/tests/test_h2_loopback.cpp
+++ b/extensions/web/tests/test_h2_loopback.cpp
@@ -19,6 +19,11 @@
 #include <boost/asio/connect.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/ssl.hpp>
+#if defined(_WIN32)
+// Use nghttp2's portable signed-size alias instead of requiring the legacy
+// POSIX ssize_t name in the Windows SDK namespace.
+#define NGHTTP2_NO_SSIZE_T
+#endif
 #include <nghttp2/nghttp2.h>
 
 #include <array>

--- a/extensions/web/tests/transport_perf.cpp
+++ b/extensions/web/tests/transport_perf.cpp
@@ -3,6 +3,7 @@
 #include "detail/service_transport.h"
 
 #include <hgraph/types/value/shared_value_pool.h>
+#include <hgraph/util/environment.h>
 
 #include <algorithm>
 #include <atomic>
@@ -322,13 +323,14 @@ struct Fixture {
 };
 
 [[nodiscard]] std::size_t env_size(const char *name, std::size_t fallback) {
-  const char *value = std::getenv(name);
-  if (value == nullptr || *value == '\0') {
+  const auto value = hgraph::environment_variable(name);
+  if (!value || value->empty()) {
     return fallback;
   }
   char *end{};
-  const auto parsed = std::strtoull(value, &end, 10);
-  if (end == value || *end != '\0' || parsed == 0 ||
+  const char *begin = value->c_str();
+  const auto parsed = std::strtoull(begin, &end, 10);
+  if (end == begin || *end != '\0' || parsed == 0 ||
       parsed > std::numeric_limits<std::size_t>::max()) {
     throw std::invalid_argument(std::string{name} +
                                 " must be a positive integer");

--- a/include/hgraph/types/graph_wiring.h
+++ b/include/hgraph/types/graph_wiring.h
@@ -1153,37 +1153,64 @@ namespace hgraph
             return WiringObservationScope{*this, std::move(event)};
         }
 
+#if defined(_MSC_VER)
+        // Failure-observation tests instantiate this template with callbacks
+        // that deliberately never return. MSVC reports the ordinary success
+        // paths as C4702 during those specializations.
+#pragma warning(push)
+#pragma warning(disable: 4702)
+#endif
         template <typename Fn>
         decltype(auto) observe(WiringScopeEvent event, Fn &&fn)
         {
-            if (!has_wiring_observers())
-            {
-                return std::invoke(std::forward<Fn>(fn));
-            }
+            using result_type = decltype(std::invoke(std::forward<Fn>(fn)));
 
-            WiringObservationScope scope{*this, std::move(event)};
-            return annotate_on_exception<std::exception>(
-                [&]() -> decltype(auto) {
-                if constexpr (std::is_void_v<std::invoke_result_t<Fn>>)
+            if constexpr (std::is_void_v<result_type>)
+            {
+                if (!has_wiring_observers())
                 {
                     std::invoke(std::forward<Fn>(fn));
-                    scope.complete();
                     return;
                 }
-                else
+
+                WiringObservationScope scope{*this, std::move(event)};
+                annotate_on_exception<std::exception>(
+                    [&] {
+                        std::invoke(std::forward<Fn>(fn));
+                        scope.complete();
+                    },
+                    [&](const std::exception &error) {
+                        static_cast<void>(fallback_on_exception(false, [&] {
+                            scope.fail(error.what());
+                            return true;
+                        }));
+                    });
+            }
+            else
+            {
+                if (!has_wiring_observers())
                 {
-                    decltype(auto) result = std::invoke(std::forward<Fn>(fn));
-                    scope.complete();
-                    return result;
+                    return std::invoke(std::forward<Fn>(fn));
                 }
-                },
-                [&](const std::exception &error) {
-                    static_cast<void>(fallback_on_exception(false, [&] {
-                        scope.fail(error.what());
-                        return true;
-                    }));
-                });
+
+                WiringObservationScope scope{*this, std::move(event)};
+                return annotate_on_exception<std::exception>(
+                    [&]() -> result_type {
+                        result_type result = std::invoke(std::forward<Fn>(fn));
+                        scope.complete();
+                        return std::forward<result_type>(result);
+                    },
+                    [&](const std::exception &error) {
+                        static_cast<void>(fallback_on_exception(false, [&] {
+                            scope.fail(error.what());
+                            return true;
+                        }));
+                    });
+            }
         }
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
         /** Topologically sort + rank the wired nodes into a rank-ordered GraphBuilder. */
         [[nodiscard]] GraphBuilder finish() &&;
@@ -3494,6 +3521,13 @@ namespace hgraph
         auto   arg_tuple    = std::forward_as_tuple(std::forward<Args>(args)...);
         auto   default_args = call_args_detail::default_args_for<G>();
         call_args_detail::validate_call_args<params>("build_graph<G>", arg_tuple, default_args, "scalar parameter");
+#if defined(_MSC_VER)
+        // Graphs used to test wiring failures may have a compose body that
+        // unconditionally throws. The finish call remains the required success
+        // path for every normal graph specialization.
+#pragma warning(push)
+#pragma warning(disable: 4702)
+#endif
         auto build = [&] {
             [&]<std::size_t... I>(std::index_sequence<I...>) {
                 G::compose(
@@ -3503,6 +3537,9 @@ namespace hgraph
             }(std::make_index_sequence<sig::param_count()>{});
             return std::move(w).finish();
         };
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
         GraphBuilder graph_builder = [&] {
             if (!w.has_wiring_observers()) { return build(); }
             const std::string label = static_node_detail::diagnostic_name<G>();

--- a/include/hgraph/types/lift.h
+++ b/include/hgraph/types/lift.h
@@ -494,8 +494,8 @@ namespace hgraph
                 // acquire/clear lifecycle as static nodes.
                 if (input_schema != nullptr)
                 {
-                    const std::array fields{prepared_routes_storage_field<arity_v<F>>()};
-                    descriptor.storage_plan = &node_storage_plan_for(descriptor.schema, fields);
+                    const std::array storage_fields{prepared_routes_storage_field<arity_v<F>>()};
+                    descriptor.storage_plan = &node_storage_plan_for(descriptor.schema, storage_fields);
                     descriptor.callbacks.start = [](const NodeView &node, DateTime evaluation_time) {
                         acquire_prepared_input_routes<arity_v<F>>(node, evaluation_time);
                     };

--- a/include/hgraph/types/static_node.h
+++ b/include/hgraph/types/static_node.h
@@ -2275,10 +2275,12 @@ namespace hgraph
                            }
                            else
                            {
-                               constexpr std::size_t slot =
-                                   canonical_input_slot<selector, CanonicalArgs>();
-                               if constexpr (!slot_covered_by_eval<slot, EvalArgs, CanonicalArgs>())
+                               if constexpr (!slot_covered_by_eval<
+                                                 canonical_input_slot<selector, CanonicalArgs>(),
+                                                 EvalArgs, CanonicalArgs>())
                                {
+                                   constexpr std::size_t slot =
+                                       canonical_input_slot<selector, CanonicalArgs>();
                                    auto view = frame.input_at(slot);
                                    if constexpr (selector::validity == InputValidity::Valid)
                                    {
@@ -3174,6 +3176,12 @@ namespace hgraph
                         view, evaluation_time, prepared_input_routes_for(view));
                 };
                 callbacks.input_validity_in_evaluate = true;
+#if defined(_MSC_VER)
+                // A deliberately throwing start hook makes the route-acquire
+                // success path unreachable in that specialization.
+#pragma warning(push)
+#pragma warning(disable: 4702)
+#endif
                 callbacks.start = [](const NodeView &view, DateTime evaluation_time) {
                     // The user hook runs with the slow path (routes not yet
                     // acquired); a throwing start leaves nothing behind.
@@ -3183,7 +3191,11 @@ namespace hgraph
                     }
                     acquire_prepared_input_routes<slot_count>(view, evaluation_time);
                 };
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
                 callbacks.stop = [](const NodeView &view, DateTime evaluation_time) {
+                    static_cast<void>(evaluation_time);
                     auto clear_routes = UnwindCleanupGuard([&]() noexcept {
                         clear_prepared_input_routes<slot_count>(view);
                     });

--- a/include/hgraph/types/utils/stable_slot_store.h
+++ b/include/hgraph/types/utils/stable_slot_store.h
@@ -438,9 +438,9 @@ namespace hgraph
         [[nodiscard]] StableSlotDebugView implementation_debug_view(const Implementation *typed,
                                                                     bool tagged) const noexcept
         {
-            const auto *base = reinterpret_cast<const std::byte *>(typed);
-            const auto offset_of = [base](const void *address) {
-                return static_cast<std::size_t>(static_cast<const std::byte *>(address) - base);
+            const auto *implementation_base = reinterpret_cast<const std::byte *>(typed);
+            const auto offset_of = [implementation_base](const void *address) {
+                return static_cast<std::size_t>(static_cast<const std::byte *>(address) - implementation_base);
             };
             return {
                 .implementation_pointer = &implementation_,

--- a/include/hgraph/util/environment.h
+++ b/include/hgraph/util/environment.h
@@ -1,0 +1,38 @@
+#ifndef HGRAPH_UTIL_ENVIRONMENT_H
+#define HGRAPH_UTIL_ENVIRONMENT_H
+
+#include <cerrno>
+#include <cstdlib>
+#include <memory>
+#include <new>
+#include <optional>
+#include <string>
+
+namespace hgraph
+{
+    /**
+     * Return an owned snapshot of a process environment variable.
+     *
+     * MSVC deprecates ``getenv`` because its borrowed pointer can be invalidated
+     * by later environment mutation. ``_dupenv_s`` provides the same owned
+     * semantics used on every platform here.
+     */
+    [[nodiscard]] inline std::optional<std::string> environment_variable(const char *name)
+    {
+#if defined(_MSC_VER)
+        char       *buffer = nullptr;
+        std::size_t size = 0;
+        const errno_t error = ::_dupenv_s(&buffer, &size, name);
+        if (error == ENOMEM) { throw std::bad_alloc{}; }
+        if (error != 0 || buffer == nullptr) { return std::nullopt; }
+
+        const std::unique_ptr<char, decltype(&std::free)> owned{buffer, &std::free};
+        return std::string{owned.get()};
+#else
+        const char *value = std::getenv(name);
+        return value == nullptr ? std::nullopt : std::optional<std::string>{std::in_place, value};
+#endif
+    }
+}
+
+#endif  // HGRAPH_UTIL_ENVIRONMENT_H

--- a/include/hgraph/util/scope.h
+++ b/include/hgraph/util/scope.h
@@ -162,9 +162,7 @@ namespace hgraph {
         /** Run the cleanup now, allowing any failure to propagate. */
         void complete()
         {
-            if (!active_) { return; }
-            active_ = false;
-            fn_();
+            if (std::exchange(active_, false)) { fn_(); }
         }
 
         /** Disarm the guard; the cleanup will not run on destruction. */

--- a/include/third_party/sul/dynamic_bitset.hpp
+++ b/include/third_party/sul/dynamic_bitset.hpp
@@ -8,6 +8,15 @@
 #ifndef SUL_DYNAMIC_BITSET_HPP
 #define SUL_DYNAMIC_BITSET_HPP
 
+#if defined(_MSC_VER)
+// MSVC reports C4702 in the constexpr first-set-bit fallback after the
+// compiler-specific intrinsic branches have returned. The fallback remains
+// required for unsupported block types, so suppress that false positive only
+// while compiling this bundled third-party header.
+#pragma warning(push)
+#pragma warning(disable: 4702)
+#endif
+
 /**
  * @brief      @ref sul::dynamic_bitset version major.
  */
@@ -3355,6 +3364,10 @@ constexpr void swap(dynamic_bitset<Block, Allocator>& bitset1,
 
 #ifndef DYNAMIC_BITSET_NO_NAMESPACE
 } // namespace sul
+#endif
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
 #endif
 
 #endif //SUL_DYNAMIC_BITSET_HPP

--- a/src/hgraph/runtime/push_source_node.cpp
+++ b/src/hgraph/runtime/push_source_node.cpp
@@ -206,9 +206,9 @@ namespace hgraph
                 return result;
             }
 
-            [[nodiscard]] Value make_burst(std::deque<Value> values) const
+            [[nodiscard]] Value make_burst(std::deque<Value> burst_values) const
             {
-                if (values.empty())
+                if (burst_values.empty())
                 {
                     return {};
                 }
@@ -218,7 +218,7 @@ namespace hgraph
                 }
 
                 ListBuilder builder{burst_element_binding, *burst_value_binding.schema()};
-                for (Value &value : values)
+                for (Value &value : burst_values)
                 {
                     builder.push_back(std::move(value));
                 }

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -256,6 +256,7 @@ hgraph_add_test_objects(hgraph_value_test_objects
     test_any_value.cpp
     test_bundle_builder.cpp
     test_compact_storage.cpp
+    test_environment.cpp
     test_intern_table.cpp
     test_memory_utils.cpp
     test_mutable_list.cpp

--- a/tests/cpp/json_perf.cpp
+++ b/tests/cpp/json_perf.cpp
@@ -4,6 +4,7 @@
 #include <hgraph/runtime/runtime.h>
 #include <hgraph/types/graph_wiring.h>
 #include <hgraph/types/static_node.h>
+#include <hgraph/util/environment.h>
 
 #include <atomic>
 #include <chrono>
@@ -230,9 +231,9 @@ namespace
 
     int env_int(const char *name, int fallback)
     {
-        const char *value = std::getenv(name);
-        if (value == nullptr) { return fallback; }
-        return std::max(1, std::atoi(value));
+        const auto value = hgraph::environment_variable(name);
+        if (!value) { return fallback; }
+        return std::max(1, std::atoi(value->c_str()));
     }
 }  // namespace
 

--- a/tests/cpp/stable_slot_representation_perf.cpp
+++ b/tests/cpp/stable_slot_representation_perf.cpp
@@ -1,6 +1,7 @@
 #include "stable_slot_representation_prototype.h"
 
 #include <hgraph/types/utils/stable_slot_store.h>
+#include <hgraph/util/environment.h>
 
 #include <algorithm>
 #include <atomic>
@@ -67,14 +68,15 @@ static_assert(!std::is_trivially_destructible_v<PackedTracked9>);
 
 [[nodiscard]] std::size_t env_size(const char *name, std::size_t fallback,
                                    std::size_t minimum = 1) {
-  const char *value = std::getenv(name);
-  if (value == nullptr || *value == '\0') {
+  const auto value = hgraph::environment_variable(name);
+  if (!value || value->empty()) {
     return fallback;
   }
 
   char *end = nullptr;
-  const auto parsed = std::strtoull(value, &end, 10);
-  if (end == value || *end != '\0' ||
+  const char *begin = value->c_str();
+  const auto parsed = std::strtoull(begin, &end, 10);
+  if (end == begin || *end != '\0' ||
       parsed > std::numeric_limits<std::size_t>::max()) {
     throw std::invalid_argument(std::string{name} +
                                 " must be a non-negative integer");
@@ -82,9 +84,10 @@ static_assert(!std::is_trivially_destructible_v<PackedTracked9>);
   return std::max<std::size_t>(static_cast<std::size_t>(parsed), minimum);
 }
 
-[[nodiscard]] bool selected(std::string_view name) noexcept {
-  const char *filter = std::getenv("HGRAPH_STABLE_SLOT_PERF_FILTER");
-  return filter == nullptr || *filter == '\0' || name.contains(filter);
+[[nodiscard]] bool selected(std::string_view name) {
+  const auto filter =
+      hgraph::environment_variable("HGRAPH_STABLE_SLOT_PERF_FILTER");
+  return !filter || filter->empty() || name.contains(*filter);
 }
 
 template <typename T> [[nodiscard]] T median(std::vector<T> values) {

--- a/tests/cpp/test_environment.cpp
+++ b/tests/cpp/test_environment.cpp
@@ -1,0 +1,45 @@
+#include <hgraph/util/environment.h>
+#include <hgraph/util/scope.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdlib>
+#include <optional>
+#include <string>
+
+TEST_CASE("environment variables are returned as owned snapshots")
+{
+    constexpr const char *name = "HGRAPH_CPP_ENVIRONMENT_SNAPSHOT_TEST";
+    const auto original = hgraph::environment_variable(name);
+    auto restore = hgraph::make_scope_exit([&] {
+#if defined(_MSC_VER)
+        static_cast<void>(::_putenv_s(name, original ? original->c_str() : ""));
+#else
+        if (original)
+        {
+            static_cast<void>(::setenv(name, original->c_str(), 1));
+        }
+        else
+        {
+            static_cast<void>(::unsetenv(name));
+        }
+#endif
+    });
+
+#if defined(_MSC_VER)
+    REQUIRE(::_putenv_s(name, "first") == 0);
+#else
+    REQUIRE(::setenv(name, "first", 1) == 0);
+#endif
+    const auto snapshot = hgraph::environment_variable(name);
+    REQUIRE(snapshot == std::optional<std::string>{"first"});
+
+#if defined(_MSC_VER)
+    REQUIRE(::_putenv_s(name, "second") == 0);
+#else
+    REQUIRE(::setenv(name, "second", 1) == 0);
+#endif
+    CHECK(*snapshot == "first");
+    CHECK(hgraph::environment_variable(name) ==
+          std::optional<std::string>{"second"});
+}

--- a/tests/cpp/test_memory_utils.cpp
+++ b/tests/cpp/test_memory_utils.cpp
@@ -471,11 +471,20 @@ TEST_CASE("memory utils supports custom inline policies and aligned heap ownersh
     REQUIRE(over_aligned_handle.stores_heap());
     REQUIRE(reinterpret_cast<std::uintptr_t>(over_aligned_handle.data()) % alignof(OverAlignedValue) == 0u);
 
+#if defined(_MSC_VER)
+    // The test deliberately requests an over-aligned inline buffer. Padding
+    // in this one owner specialization is the contract under test.
+#pragma warning(push)
+#pragma warning(disable: 4324)
+#endif
     using OverAlignedInlinePolicy =
         MemoryUtils::InlineStoragePolicy<sizeof(OverAlignedValue), alignof(OverAlignedValue)>;
     REQUIRE(over_aligned_plan.template stores_inline<OverAlignedInlinePolicy>());
 
     MemoryUtils::ErasedOwner<OverAlignedInlinePolicy> over_aligned_inline(over_aligned_plan);
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
     REQUIRE(over_aligned_inline.stores_inline());
     REQUIRE(reinterpret_cast<std::uintptr_t>(over_aligned_inline.data()) % alignof(OverAlignedValue) == 0u);
 }

--- a/tests/cpp/test_wiring_observers.cpp
+++ b/tests/cpp/test_wiring_observers.cpp
@@ -196,6 +196,37 @@ namespace
     }
 }
 
+TEST_CASE("wiring observation preserves owned value and reference results")
+{
+    auto check_results = [](Wiring &wiring) {
+        std::string source{"owned"};
+        auto owned = wiring.observe(
+            WiringScopeEvent{.kind = WiringScopeKind::Node, .label = "owned"},
+            [&] { return source; });
+        source = "changed";
+        CHECK(owned == "owned");
+
+        Int referenced = 7;
+        Int &result = wiring.observe(
+            WiringScopeEvent{.kind = WiringScopeKind::Node, .label = "reference"},
+            [&]() -> Int & { return referenced; });
+        result = 11;
+        CHECK(referenced == 11);
+    };
+
+    Wiring plain;
+    check_results(plain);
+
+    RecordingWiringObserver observer;
+    Wiring                  observed;
+    observed.add_wiring_observer(&observer);
+    check_results(observed);
+    REQUIRE(observer.node_entries.size() == 2);
+    REQUIRE(observer.node_exits.size() == 2);
+    CHECK(observer.node_exits[0].error.empty());
+    CHECK(observer.node_exits[1].error.empty());
+}
+
 TEST_CASE("wiring observers expose stable graph, node, and overload records")
 {
     register_overload<observed_, ObservedString>();

--- a/tests/cpp/type_erasure_perf.cpp
+++ b/tests/cpp/type_erasure_perf.cpp
@@ -16,6 +16,7 @@
 #include <hgraph/types/value/compound_scalar_storage.h>
 #include <hgraph/types/value/value_builder.h>
 #include <hgraph/types/value/visitor.h>
+#include <hgraph/util/environment.h>
 
 #include <algorithm>
 #include <atomic>
@@ -120,15 +121,16 @@ namespace
 
     [[nodiscard]] std::size_t env_size(const char *name, std::size_t fallback, std::size_t minimum = 1)
     {
-        const char *value = std::getenv(name);
-        if (value == nullptr)
+        const auto value = hgraph::environment_variable(name);
+        if (!value)
         {
             return fallback;
         }
 
         char *end = nullptr;
-        const auto parsed = std::strtoull(value, &end, 10);
-        if (end == value || *end != '\0' || parsed > std::numeric_limits<std::size_t>::max())
+        const char *begin = value->c_str();
+        const auto parsed = std::strtoull(begin, &end, 10);
+        if (end == begin || *end != '\0' || parsed > std::numeric_limits<std::size_t>::max())
         {
             throw std::invalid_argument(std::string{name} + " must be a positive integer");
         }
@@ -163,22 +165,20 @@ namespace
         return median(std::move(deviations));
     }
 
-    [[nodiscard]] bool benchmark_selected(std::string_view name) noexcept
+    [[nodiscard]] bool benchmark_selected(std::string_view name)
     {
-        const char *filter = std::getenv("HGRAPH_TYPE_ERASURE_PERF_FILTER");
-        return filter == nullptr || *filter == '\0' || name.contains(filter);
+        const auto filter = hgraph::environment_variable("HGRAPH_TYPE_ERASURE_PERF_FILTER");
+        return !filter || filter->empty() || name.contains(*filter);
     }
 
     [[nodiscard]] bool env_enabled(const char *name)
     {
-        const char *value = std::getenv(name);
-        if (value == nullptr || *value == '\0' || std::string_view{value} == "0" ||
-            std::string_view{value} == "false" || std::string_view{value} == "off")
+        const auto value = hgraph::environment_variable(name);
+        if (!value || value->empty() || *value == "0" || *value == "false" || *value == "off")
         {
             return false;
         }
-        if (std::string_view{value} == "1" || std::string_view{value} == "true" ||
-            std::string_view{value} == "on")
+        if (*value == "1" || *value == "true" || *value == "on")
         {
             return true;
         }
@@ -584,8 +584,8 @@ int main()
     const std::size_t samples = env_size("HGRAPH_TYPE_ERASURE_PERF_SAMPLES", 7, 7);
     const std::size_t warmup = env_size("HGRAPH_TYPE_ERASURE_PERF_WARMUP", 64, 0);
 
-    const char *filter = std::getenv("HGRAPH_TYPE_ERASURE_PERF_FILTER");
-    const char *host_label = std::getenv("HGRAPH_TYPE_ERASURE_PERF_HOST");
+    const auto filter = hgraph::environment_variable("HGRAPH_TYPE_ERASURE_PERF_FILTER");
+    const auto host_label = hgraph::environment_variable("HGRAPH_TYPE_ERASURE_PERF_HOST");
 #if defined(__apple_build_version__)
     constexpr std::string_view compiler_family{"appleclang"};
 #elif defined(__clang__)
@@ -606,8 +606,8 @@ int main()
 #endif
     std::cout << std::fixed << std::setprecision(3) << "type_erasure_perf format=2 samples=" << samples
               << " warmup_iterations=" << warmup << " filter="
-              << (filter == nullptr || *filter == '\0' ? "all" : filter) << " host="
-              << (host_label == nullptr || *host_label == '\0' ? "unspecified" : host_label)
+              << (!filter || filter->empty() ? "all" : *filter) << " host="
+              << (!host_label || host_label->empty() ? "unspecified" : *host_label)
               << " pooled_compound_scalars=" << (pooled_compound_scalars ? "on" : "off")
               << " compiler=" << compiler_family
 #if defined(__clang__)
@@ -1276,21 +1276,21 @@ int main()
     std::uint64_t nested_checksum = 0;
     for (std::size_t index = 0; index < nested_graph.node_count(); ++index)
     {
-        auto node = nested_graph.node_at(index);
-        if (node.is<MapNodeView>())
+        auto nested_node = nested_graph.node_at(index);
+        if (nested_node.is<MapNodeView>())
         {
             nested_node_indices.push_back(index);
-            nested_checksum += node.as<MapNodeView>().active_count();
+            nested_checksum += nested_node.as<MapNodeView>().active_count();
         }
-        else if (node.is<MeshNodeView>())
+        else if (nested_node.is<MeshNodeView>())
         {
             nested_node_indices.push_back(index);
-            nested_checksum += node.as<MeshNodeView>().active_count();
+            nested_checksum += nested_node.as<MeshNodeView>().active_count();
         }
-        else if (node.is<ReduceNodeView>())
+        else if (nested_node.is<ReduceNodeView>())
         {
             nested_node_indices.push_back(index);
-            nested_checksum += node.as<ReduceNodeView>().combiner_count();
+            nested_checksum += nested_node.as<ReduceNodeView>().combiner_count();
         }
     }
     if (nested_node_indices.size() != 3 || nested_checksum == 0)


### PR DESCRIPTION
## Summary

- make the all-extension MSVC build clean under warnings-as-errors
- isolate pinned third-party warning policy and CMake deprecation noise
- add owned environment-variable access and fix warning-exposed portability issues
- preserve wiring observer value/reference results and modernize shared-route publication

## Validation

- private Windows validation host: all-extension MSVC 19.51 build with warnings-as-errors and no compiler, linker, MSBuild, or CMake warnings; full 1,648-test native pass plus final affected H2 tests (2/2)
- macOS: clean native preset build, 1,648 native tests passed, warning-free logs
- private Linux validation host: clean native preset build, 1,648 native tests passed, warning-free logs
- stable-ABI wheel built with Python 3.12 and tested under Python 3.14 on macOS and Linux: 2,214 passed, 10 skipped
- installed SDK consumers: core, Kafka, analytics, Web, persistence, and Fabric all passed
