### PR TITLE
Use hgraph datetime handling in Fabric metadata bridge

### DIFF
--- a/extensions/fabric/python/hgraph_fabric/__init__.py
+++ b/extensions/fabric/python/hgraph_fabric/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 from typing import Final
 
 from hgraph import (
@@ -156,22 +156,6 @@ def publish_data(
     )
 
 
-def _to_epoch_microseconds(value: datetime) -> int:
-    if value.tzinfo is None:
-        value = value.replace(tzinfo=timezone.utc)
-    value = value.astimezone(timezone.utc)
-    delta = value - datetime(1970, 1, 1, tzinfo=timezone.utc)
-    return (
-        delta.days * 86_400_000_000
-        + delta.seconds * 1_000_000
-        + delta.microseconds
-    )
-
-
-def _from_epoch_microseconds(value: int) -> datetime:
-    return (datetime(1970, 1, 1) + timedelta(microseconds=value))
-
-
 def encode_revision(revision: DataRevision) -> bytes:
     """Encode a semantic revision with the canonical native v1 codec."""
 
@@ -182,7 +166,7 @@ def encode_revision(revision: DataRevision) -> bytes:
         revision.output_version,
         [(item.data_id, item.version) for item in revision.dependencies],
         revision.self_predecessor,
-        _to_epoch_microseconds(revision.as_of),
+        revision.as_of,
     )
 
 
@@ -197,7 +181,7 @@ def decode_revision(encoded: bytes) -> DataRevision:
         output_version=value["output_version"],
         dependencies=tuple(DataDependency(*item) for item in value["dependencies"]),
         self_predecessor=value["self_predecessor"],
-        as_of=_from_epoch_microseconds(value["as_of_microseconds"]),
+        as_of=value["as_of"],
     )
 
 

--- a/extensions/fabric/python/tests/test_public_contracts.py
+++ b/extensions/fabric/python/tests/test_public_contracts.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import sys
 
@@ -74,6 +74,33 @@ def test_python_codec_does_not_replace_an_unsupported_format_version():
     )
     with pytest.raises(ValueError, match="unsupported fabric revision format"):
         hgf.encode_revision(invalid)
+
+
+def test_python_codec_uses_hgraph_datetime_timezone_semantics():
+    revision = _revision()
+    aware = hgf.DataRevision(
+        format_version=revision.format_version,
+        data_id=revision.data_id,
+        revision=revision.revision,
+        output_version=revision.output_version,
+        dependencies=revision.dependencies,
+        self_predecessor=revision.self_predecessor,
+        as_of=datetime(
+            2026,
+            1,
+            2,
+            7,
+            4,
+            5,
+            6007,
+            tzinfo=timezone(timedelta(hours=4)),
+        ),
+    )
+
+    decoded = hgf.decode_revision(hgf.encode_revision(aware))
+
+    assert decoded.as_of == datetime(2026, 1, 2, 3, 4, 5, 6007)
+    assert decoded.as_of.tzinfo is None
 
 
 def test_python_public_operators_wire_through_native_registry():

--- a/extensions/fabric/python/tests/test_public_contracts.py
+++ b/extensions/fabric/python/tests/test_public_contracts.py
@@ -103,6 +103,33 @@ def test_python_codec_uses_hgraph_datetime_timezone_semantics():
     assert decoded.as_of.tzinfo is None
 
 
+@pytest.mark.parametrize(
+    "as_of",
+    (
+        datetime.max.replace(
+            tzinfo=timezone(-timedelta(hours=23, minutes=59))
+        ),
+        datetime.min.replace(
+            tzinfo=timezone(timedelta(hours=23, minutes=59))
+        ),
+    ),
+)
+def test_python_codec_rejects_datetime_normalization_outside_python_range(as_of):
+    revision = _revision()
+    invalid = hgf.DataRevision(
+        format_version=revision.format_version,
+        data_id=revision.data_id,
+        revision=revision.revision,
+        output_version=revision.output_version,
+        dependencies=revision.dependencies,
+        self_predecessor=revision.self_predecessor,
+        as_of=as_of,
+    )
+
+    with pytest.raises(TypeError):
+        hgf.encode_revision(invalid)
+
+
 def test_python_public_operators_wire_through_native_registry():
     wiring = _hgraph.Wiring()
     with use_wiring(wiring):

--- a/extensions/fabric/src/python_module.cpp
+++ b/extensions/fabric/src/python_module.cpp
@@ -6,6 +6,7 @@
 #include <hgraph/fabric/service.h>
 #include <hgraph/fabric/value_builders.h>
 
+#include <hgraph/python/chrono.h>
 #include <hgraph/python/native_scalar_registration.h>
 #include <hgraph/types/operator_dispatch.h>
 
@@ -125,7 +126,7 @@ NB_MODULE(_hgraph_fabric, module)
            DataVersion output_version,
            std::vector<std::pair<Str, DataVersion>> dependencies,
            std::optional<DataVersion> self_predecessor,
-           std::int64_t as_of_microseconds) {
+           DateTime as_of) {
             std::vector<DataDependencyInput> native_dependencies;
             native_dependencies.reserve(dependencies.size());
             for (auto &[dependency_id, version] : dependencies)
@@ -142,13 +143,13 @@ NB_MODULE(_hgraph_fabric, module)
                 .output_version = output_version,
                 .dependencies = std::move(native_dependencies),
                 .self_predecessor = self_predecessor,
-                .as_of = DateTime{TimeDelta{as_of_microseconds}},
+                .as_of = as_of,
             });
             return to_python_bytes(encode_revision(value.view()));
         },
         nb::arg("format_version"), nb::arg("data_id"), nb::arg("revision"),
         nb::arg("output_version"), nb::arg("dependencies"),
-        nb::arg("self_predecessor"), nb::arg("as_of_microseconds"));
+        nb::arg("self_predecessor"), nb::arg("as_of"));
 
     module.def(
         "_decode_revision",
@@ -170,8 +171,7 @@ NB_MODULE(_hgraph_fabric, module)
             result["self_predecessor"] = revision.self_predecessor.has_value()
                                                ? nb::cast(*revision.self_predecessor)
                                                : nb::none();
-            result["as_of_microseconds"] =
-                revision.as_of.time_since_epoch().count();
+            result["as_of"] = nb::cast(revision.as_of);
             return result;
         },
         nb::arg("encoded"));

--- a/include/hgraph/python/chrono.h
+++ b/include/hgraph/python/chrono.h
@@ -24,6 +24,17 @@
 
 #include <nanobind/stl/detail/chrono.h>
 
+[[nodiscard]] constexpr bool python_datetime_representable(
+    std::chrono::microseconds value) noexcept {
+    namespace ch = std::chrono;
+
+    constexpr auto min_value = ch::duration_cast<ch::microseconds>(
+        ch::sys_days{ch::year{1} / ch::January / ch::day{1}}.time_since_epoch());
+    constexpr auto max_value = ch::duration_cast<ch::microseconds>(
+        ch::sys_days{ch::year{10000} / ch::January / ch::day{1}}.time_since_epoch());
+    return value >= min_value && value < max_value;
+}
+
 // Casts a std::chrono type (either a duration or a time_point) to/from
 // Python timedelta objects, or from a Python float representing seconds.
 template<typename type>
@@ -176,6 +187,13 @@ public:
             }
         } catch (python_error &e) {
             e.discard_as_unraisable(src.ptr());
+            return false;
+        }
+
+        // An aware datetime can itself be valid while its normalized UTC
+        // instant lies outside Python's year 1..9999 range. Reject it here so
+        // every accepted Python datetime can also be converted back to one.
+        if (!python_datetime_representable(total_us)) {
             return false;
         }
 

--- a/python/tests/test_bridge.py
+++ b/python/tests/test_bridge.py
@@ -110,6 +110,26 @@ def test_aware_datetime_is_normalized_to_naive_utc():
     check(result.tzinfo is None, f"native datetime must be timezone-free: {result!r}")
 
 
+def test_aware_datetime_normalization_rejects_python_range_overflow():
+    import datetime
+
+    sources = (
+        datetime.datetime.max.replace(
+            tzinfo=datetime.timezone(-datetime.timedelta(hours=23, minutes=59))
+        ),
+        datetime.datetime.min.replace(
+            tzinfo=datetime.timezone(datetime.timedelta(hours=23, minutes=59))
+        ),
+    )
+    for source in sources:
+        try:
+            hg._roundtrip_value(source)
+        except TypeError as error:
+            check("invalid Python datetime value" in str(error), f"unexpected error: {error}")
+        else:
+            raise AssertionError(f"out-of-range UTC normalization was accepted: {source!r}")
+
+
 def test_aware_time_is_rejected_without_a_zoned_time_scalar():
     import datetime
     from zoneinfo import ZoneInfo


### PR DESCRIPTION
## Summary

- pass Python `datetime` values directly through hgraph’s native `DateTime` caster at the Fabric binding boundary
- return decoded `DateTime` values directly instead of exposing epoch-microsecond storage details
- retain integer microseconds only inside the canonical binary metadata codec
- cover timezone-aware inputs using hgraph’s established naive-UTC normalization
- reject normalized instants outside Python datetime year 1..9999 in the shared caster before Fabric emits bytes

## Validation

- complete native suite: 1,647 passed
- stable-ABI wheel built with Python 3.12; complete Python 3.14 non-WIP suite: 2,216 passed, 10 skipped
- installed macOS Fabric wheel suite on Python 3.14: 19 passed
- independent Linux stable-ABI installed-wheel checks: core bridge 12 passed; Fabric 19 passed