### PR TITLE
Add Python Fabric usage examples

### DIFF
--- a/extensions/fabric/README.md
+++ b/extensions/fabric/README.md
@@ -76,6 +76,130 @@ Python consumers import `hgraph_fabric` and call
 `register_memory_fabric_service()` for the deterministic local host; importing
 the package registers the same native operators and scalar enum.
 
+## Python examples
+
+Install the extension and import ordinary hgraph graph-building primitives:
+
+```sh
+python -m pip install hgraph-fabric
+```
+
+Fabric registration belongs in the outer host graph. Reusable components call
+only `subscribe_data()` and `publish_data()`, so the same component can run
+against the local memory host or a production host configured with persistent
+stores and Kafka.
+
+### Publish one Frame locally
+
+This complete example publishes one atomic Arrow table. The memory service is
+run-scoped and intended for local development and tests; a separate graph run
+gets a separate memory Fabric.
+
+```python
+from datetime import timedelta
+
+import pyarrow as pa
+import hgraph as hg
+import hgraph_fabric as fabric
+
+
+@hg.graph
+def publish_prices() -> None:
+    prices = hg.const(
+        pa.table({"symbol": ["AAPL", "MSFT"], "price": [201.5, 415.0]}),
+        tp=hg.TS[hg.Frame],
+    )
+    fabric.publish_data("prices/raw", prices)
+
+
+@hg.graph
+def local_app() -> None:
+    fabric.register_memory_fabric_service(prefix="examples/basic")
+    publish_prices()
+
+
+hg.run_graph(
+    local_app,
+    run_mode=hg.EvaluationMode.SIMULATION,
+    start_time=hg.MIN_ST,
+    end_time=hg.MIN_ST + timedelta(microseconds=20),
+)
+```
+
+The runnable version is
+[`python/examples/publish_once.py`](python/examples/publish_once.py).
+
+### Subscribe using Live, Replay, or Snapshot
+
+Choose exactly one policy for a data id in one root graph:
+
+```python
+from datetime import datetime
+
+live = fabric.subscribe_data(
+    "prices/enriched", mode=fabric.SubscriptionMode.LIVE
+)
+
+replay = fabric.subscribe_data(
+    "prices/enriched", mode=fabric.SubscriptionMode.REPLAY
+)
+
+snapshot = fabric.subscribe_data(
+    "prices/enriched",
+    mode=fabric.SubscriptionMode.SNAPSHOT,
+    as_of=datetime(2026, 1, 2, 12, 0),
+)
+```
+
+`LIVE` follows new accepted revisions and is normally run by a real-time host.
+`REPLAY` deterministically walks revisions in the graph executor's start/end
+interval. `SNAPSHOT` emits one consistent image at the required `as_of` cutoff.
+The alternatives are separate graphs in
+[`python/examples/subscription_modes.py`](python/examples/subscription_modes.py);
+wiring several policies for the same data id into one graph is rejected because
+it would make that graph's consistency contract ambiguous.
+
+### Build a derived dataset with automatic lineage
+
+Application code may give incoming Frames typed row views, compose ordinary
+hgraph operators, and publish the complete result. Fabric's durable boundary is
+`TS[Frame]`, so the typed result is converted back to that schema-free Frame
+view for publication; its Arrow schema remains part of the stored Frame.
+
+```python
+raw_prices = fabric.subscribe_data(
+    "prices/raw", mode=fabric.SubscriptionMode.LIVE
+)
+instrument_reference = fabric.subscribe_data(
+    "instruments/reference", mode=fabric.SubscriptionMode.LIVE
+)
+
+prices = hg.convert[hg.TS[hg.Frame[Price]]](raw_prices)
+instruments = hg.convert[hg.TS[hg.Frame[Instrument]]](instrument_reference)
+enriched: hg.TS[hg.Frame[EnrichedPrice]] = hg.join(
+    prices, instruments, on="symbol", how="left"
+)
+
+fabric.publish_data(
+    "prices/enriched", hg.convert[hg.TS[hg.Frame]](enriched)
+)
+```
+
+The wiring planner discovers both subscriptions upstream of the joined result,
+so every accepted `prices/enriched` revision records both immediate input
+versions. Reusing one subscription in several computations is safe: each
+publisher records the lineage reachable from its own value edge.
+
+[`python/examples/derived_dataset.py`](python/examples/derived_dataset.py)
+contains the complete graph, plus an explicit-lineage variant using
+`dependency_handle()` and `DependencySelection.explicit()`. Prefer automatic
+lineage; use explicit handles only when the semantic dependency is deliberately
+not reachable through the published value's graph ancestry.
+
+All example files keep service registration in small local host wrappers. A
+production native host installs `FabricConfig` and the Kafka transport instead;
+the reusable Python component graphs are unchanged.
+
 ## Production configuration
 
 `FabricConfig` is run-scoped state. A host constructs the persistence handles

--- a/extensions/fabric/python/examples/README.md
+++ b/extensions/fabric/python/examples/README.md
@@ -1,0 +1,35 @@
+# Python Fabric examples
+
+These examples progress from a one-frame local publisher to subscription
+policies and a typed multi-input derived dataset:
+
+- [`publish_once.py`](publish_once.py) is a complete runnable local example.
+- [`subscription_modes.py`](subscription_modes.py) shows separate Live, Replay,
+  and Snapshot consumers.
+- [`derived_dataset.py`](derived_dataset.py) joins two Fabric inputs and
+  publishes a derived dataset with automatic or explicit lineage.
+
+Run the basic publisher from the repository root after installing the hgraph,
+persistence, and Fabric wheels:
+
+```sh
+python extensions/fabric/python/examples/publish_once.py
+```
+
+The local memory service is scoped to one graph execution. It is useful for
+testing publication and wiring, but it does not provide data to a later process
+or graph run. Reusable component graphs therefore do not register a service;
+the outer host wrapper does that once. A production native host supplies
+persistent object/Frame stores and Kafka while reusing the same Python
+components.
+
+Subscription modes are alternatives for a given data id in one root graph:
+
+- `LIVE` follows new accepted revisions and normally runs in real time.
+- `REPLAY` walks durable revisions over the executor's start/end interval.
+- `SNAPSHOT` emits one consistent image at a required `as_of` cutoff.
+
+Fabric publishes complete atomic Frames. Typed `Frame[Row]` views are useful
+inside an application graph; convert the final value to `TS[Frame]` at the
+Fabric publication boundary. The Arrow schema is retained in the stored Frame.
+

--- a/extensions/fabric/python/examples/derived_dataset.py
+++ b/extensions/fabric/python/examples/derived_dataset.py
@@ -1,0 +1,94 @@
+"""Join two Fabric datasets and publish a lineage-aware derived Frame."""
+
+from dataclasses import dataclass
+
+import hgraph as hg
+import hgraph_fabric as fabric
+
+
+@dataclass(frozen=True)
+class Price(hg.CompoundScalar):
+    symbol: str
+    price: float
+
+
+@dataclass(frozen=True)
+class Instrument(hg.CompoundScalar):
+    symbol: str
+    currency: str
+
+
+@dataclass(frozen=True)
+class EnrichedPrice(hg.CompoundScalar):
+    symbol: str
+    price: float
+    currency: str
+
+
+@hg.graph
+def enrich_prices(
+    prices: hg.TS[hg.Frame[Price]],
+    instruments: hg.TS[hg.Frame[Instrument]],
+) -> hg.TS[hg.Frame]:
+    """Use typed views internally and return Fabric's complete Frame shape."""
+
+    enriched: hg.TS[hg.Frame[EnrichedPrice]] = hg.join(
+        prices, instruments, on="symbol", how="left"
+    )
+    return hg.convert[hg.TS[hg.Frame]](enriched)
+
+
+@hg.graph
+def build_enriched_prices() -> None:
+    """Publish with the preferred automatic upstream-lineage discovery."""
+
+    raw_prices = fabric.subscribe_data(
+        "prices/raw", mode=fabric.SubscriptionMode.LIVE
+    )
+    instrument_reference = fabric.subscribe_data(
+        "instruments/reference", mode=fabric.SubscriptionMode.LIVE
+    )
+
+    enriched = enrich_prices(
+        hg.convert[hg.TS[hg.Frame[Price]]](raw_prices),
+        hg.convert[hg.TS[hg.Frame[Instrument]]](instrument_reference),
+    )
+    fabric.publish_data("prices/enriched", enriched)
+
+
+@hg.graph
+def build_enriched_prices_with_explicit_lineage() -> None:
+    """Name dependencies explicitly when value ancestry cannot represent them."""
+
+    raw_prices = fabric.subscribe_data(
+        "prices/raw", mode=fabric.SubscriptionMode.LIVE
+    )
+    instrument_reference = fabric.subscribe_data(
+        "instruments/reference", mode=fabric.SubscriptionMode.LIVE
+    )
+
+    enriched = enrich_prices(
+        hg.convert[hg.TS[hg.Frame[Price]]](raw_prices),
+        hg.convert[hg.TS[hg.Frame[Instrument]]](instrument_reference),
+    )
+    fabric.publish_data(
+        "prices/enriched-explicit",
+        enriched,
+        dependencies=fabric.DependencySelection.explicit(
+            fabric.dependency_handle(raw_prices),
+            fabric.dependency_handle(instrument_reference),
+        ),
+    )
+
+
+@hg.graph
+def local_automatic_app() -> None:
+    fabric.register_memory_fabric_service(prefix="examples/derived-auto")
+    build_enriched_prices()
+
+
+@hg.graph
+def local_explicit_app() -> None:
+    fabric.register_memory_fabric_service(prefix="examples/derived-explicit")
+    build_enriched_prices_with_explicit_lineage()
+

--- a/extensions/fabric/python/examples/publish_once.py
+++ b/extensions/fabric/python/examples/publish_once.py
@@ -1,0 +1,38 @@
+"""Publish one complete Frame through the run-scoped memory Fabric."""
+
+from datetime import timedelta
+
+import pyarrow as pa
+
+import hgraph as hg
+import hgraph_fabric as fabric
+
+
+@hg.graph
+def publish_prices() -> None:
+    """Reusable producer component; the outer host owns Fabric registration."""
+
+    prices = hg.const(
+        pa.table({"symbol": ["AAPL", "MSFT"], "price": [201.5, 415.0]}),
+        tp=hg.TS[hg.Frame],
+    )
+    hg.debug_print("publishing prices/raw", prices)
+    fabric.publish_data("prices/raw", prices)
+
+
+@hg.graph
+def local_app() -> None:
+    """Deterministic local host for the producer component."""
+
+    fabric.register_memory_fabric_service(prefix="examples/basic")
+    publish_prices()
+
+
+if __name__ == "__main__":
+    hg.run_graph(
+        local_app,
+        run_mode=hg.EvaluationMode.SIMULATION,
+        start_time=hg.MIN_ST,
+        end_time=hg.MIN_ST + timedelta(microseconds=20),
+    )
+

--- a/extensions/fabric/python/examples/subscription_modes.py
+++ b/extensions/fabric/python/examples/subscription_modes.py
@@ -1,0 +1,62 @@
+"""Choose one Fabric subscription policy for each data id in a root graph."""
+
+from datetime import datetime
+
+import hgraph as hg
+import hgraph_fabric as fabric
+
+
+@hg.graph
+def consume_live_prices() -> None:
+    """Follow accepted revisions as the production transport announces them."""
+
+    prices = fabric.subscribe_data(
+        "prices/enriched", mode=fabric.SubscriptionMode.LIVE
+    )
+    hg.debug_print("live prices/enriched", prices)
+
+
+@hg.graph
+def consume_replayed_prices() -> None:
+    """Replay revisions over the enclosing executor's start/end interval."""
+
+    prices = fabric.subscribe_data(
+        "prices/enriched", mode=fabric.SubscriptionMode.REPLAY
+    )
+    hg.debug_print("replayed prices/enriched", prices)
+
+
+@hg.graph
+def consume_price_snapshot(as_of: datetime) -> None:
+    """Load one consistent image at a wiring-time cutoff."""
+
+    prices = fabric.subscribe_data(
+        "prices/enriched",
+        mode=fabric.SubscriptionMode.SNAPSHOT,
+        as_of=as_of,
+    )
+    hg.debug_print("snapshot prices/enriched", prices)
+
+
+# The wrappers below make each component independently wireable against the
+# deterministic local host. A production host registers its service once and
+# calls the corresponding consume_* component directly.
+
+
+@hg.graph
+def local_live_app() -> None:
+    fabric.register_memory_fabric_service(prefix="examples/live")
+    consume_live_prices()
+
+
+@hg.graph
+def local_replay_app() -> None:
+    fabric.register_memory_fabric_service(prefix="examples/replay")
+    consume_replayed_prices()
+
+
+@hg.graph
+def local_snapshot_app() -> None:
+    fabric.register_memory_fabric_service(prefix="examples/snapshot")
+    consume_price_snapshot(datetime(2026, 1, 2, 12, 0))
+

--- a/extensions/fabric/python/examples/subscription_modes.py
+++ b/extensions/fabric/python/examples/subscription_modes.py
@@ -6,12 +6,15 @@ import hgraph as hg
 import hgraph_fabric as fabric
 
 
+ENRICHED_PRICES_DATA_ID = "prices/enriched"
+
+
 @hg.graph
 def consume_live_prices() -> None:
     """Follow accepted revisions as the production transport announces them."""
 
     prices = fabric.subscribe_data(
-        "prices/enriched", mode=fabric.SubscriptionMode.LIVE
+        ENRICHED_PRICES_DATA_ID, mode=fabric.SubscriptionMode.LIVE
     )
     hg.debug_print("live prices/enriched", prices)
 
@@ -21,7 +24,7 @@ def consume_replayed_prices() -> None:
     """Replay revisions over the enclosing executor's start/end interval."""
 
     prices = fabric.subscribe_data(
-        "prices/enriched", mode=fabric.SubscriptionMode.REPLAY
+        ENRICHED_PRICES_DATA_ID, mode=fabric.SubscriptionMode.REPLAY
     )
     hg.debug_print("replayed prices/enriched", prices)
 
@@ -31,7 +34,7 @@ def consume_price_snapshot(as_of: datetime) -> None:
     """Load one consistent image at a wiring-time cutoff."""
 
     prices = fabric.subscribe_data(
-        "prices/enriched",
+        ENRICHED_PRICES_DATA_ID,
         mode=fabric.SubscriptionMode.SNAPSHOT,
         as_of=as_of,
     )
@@ -59,4 +62,3 @@ def local_replay_app() -> None:
 def local_snapshot_app() -> None:
     fabric.register_memory_fabric_service(prefix="examples/snapshot")
     consume_price_snapshot(datetime(2026, 1, 2, 12, 0))
-

--- a/extensions/fabric/python/tests/test_examples.py
+++ b/extensions/fabric/python/tests/test_examples.py
@@ -1,10 +1,9 @@
 import runpy
 from pathlib import Path
 
-import _hgraph
 import pytest
 
-from hgraph.test import use_wiring
+from hgraph.test import eval_node
 
 
 EXAMPLES = Path(__file__).resolve().parents[1] / "examples"
@@ -25,7 +24,4 @@ def test_python_fabric_example_wires_through_public_api(module, graph_name):
     namespace = runpy.run_path(EXAMPLES / module)
     example = namespace[graph_name]
 
-    wiring = _hgraph.Wiring()
-    with use_wiring(wiring):
-        example()
-    wiring.run()
+    assert eval_node(example) is None

--- a/extensions/fabric/python/tests/test_examples.py
+++ b/extensions/fabric/python/tests/test_examples.py
@@ -1,0 +1,31 @@
+import runpy
+from pathlib import Path
+
+import _hgraph
+import pytest
+
+from hgraph.test import use_wiring
+
+
+EXAMPLES = Path(__file__).resolve().parents[1] / "examples"
+
+
+@pytest.mark.parametrize(
+    ("module", "graph_name"),
+    (
+        ("publish_once.py", "local_app"),
+        ("subscription_modes.py", "local_live_app"),
+        ("subscription_modes.py", "local_replay_app"),
+        ("subscription_modes.py", "local_snapshot_app"),
+        ("derived_dataset.py", "local_automatic_app"),
+        ("derived_dataset.py", "local_explicit_app"),
+    ),
+)
+def test_python_fabric_example_wires_through_public_api(module, graph_name):
+    namespace = runpy.run_path(EXAMPLES / module)
+    example = namespace[graph_name]
+
+    wiring = _hgraph.Wiring()
+    with use_wiring(wiring):
+        example()
+    wiring.run()


### PR DESCRIPTION
## Summary

- add a runnable local Python publisher using the run-scoped memory Fabric
- document separate Live, Replay, and Snapshot consumer graphs
- add a typed two-input Frame join that publishes a derived dataset with automatic lineage
- show the explicit dependency-handle path for deliberately hidden ancestry
- keep Fabric registration in outer host wrappers and reusable processing in ordinary `@graph` components
- include the examples in the source distribution and evaluate every wrapper through the public `eval_node` API

## Validation

- fresh installed-wheel Fabric Python suite: 25 passed
- example public-evaluation cases: 6 passed
- runnable local publisher completed and emitted a two-row Frame
- Fabric source distribution built and passed the distribution audit with all example files included
- `git diff --check`