### PR TITLE
Harden Fabric notification retry and candidate capacity

### DIFF
--- a/docs/source/rfc/rfc_0026_versioned_dataflow_fabric.rst
+++ b/docs/source/rfc/rfc_0026_versioned_dataflow_fabric.rst
@@ -599,6 +599,7 @@ of execution with the normal graph state.  The semantic configuration includes:
        persistence::store::ObjectStore objects;
        persistence::store::FrameStore  frames;
        Notifier                         notifications;
+       std::size_t                      notification_candidate_limit;
    };
 
 The concrete persistence spelling is resolved with the prerequisite store
@@ -975,6 +976,15 @@ time-series state.  A retriable report temporarily unbinds and then rebinds the
 same reference on the next graph cycle, so retry neither copies the revision
 nor creates a new shared allocation.  Completion feedback removes the
 candidate and advances the publication state machine.
+
+``FabricConfig::notification_candidate_limit`` is the explicit resource bound
+on durable candidates awaiting the graph-native transport (1024 by default).
+Saturation is fatal rather than implicit backpressure: publication requests
+have already entered the graph and candidates may already be durable, so merely
+stopping candidate extraction would transfer an unbounded broker stall into
+the per-data-id publication queues without applying admission at the sender.
+Hosts size the bound for the maximum notification lag they are prepared to
+retain.
 
 The Kafka service task is deliberately narrower: a publish sink submits the
 request to the broker and the service's FIFO root push source returns delivery

--- a/extensions/fabric/README.md
+++ b/extensions/fabric/README.md
@@ -212,6 +212,7 @@ namespace hgf = hgraph::fabric;
 namespace hgps = hgraph::persistence::store;
 
 auto config = hgf::make_memory_fabric_config("production/blue");
+config.notification_candidate_limit = 4096;
 config.objects = hgps::make_object_store(
     hgps::ObjectStoreConfig{hgps::LocalLocation{"/srv/fabric/metadata"}});
 config.frames = hgps::make_frame_store(hgps::FrameStoreConfig{
@@ -222,6 +223,12 @@ config.frames = hgps::make_frame_store(hgps::FrameStoreConfig{
 hgf::set_fabric_config(wiring.global_state(), std::move(config));
 hgf::register_service(wiring);
 ```
+
+`notification_candidate_limit` bounds durable revisions waiting for the
+graph-native notification transport. Reaching the configured bound fails the
+run explicitly; it does not silently shift an unbounded broker backlog into
+the per-data-id publication queues. Size it for the maximum notification lag
+the host is prepared to retain. The default is 1024 candidates.
 
 For S3, replace both `LocalLocation` values with independently prefixed
 `S3Location` values. Credentials use the persistence extension's ambient,

--- a/extensions/fabric/include/hgraph/fabric/config.h
+++ b/extensions/fabric/include/hgraph/fabric/config.h
@@ -9,10 +9,13 @@
 #include <hgraph/persistence/object_store.h>
 #include <hgraph/runtime/global_state.h>
 
+#include <cstddef>
 #include <optional>
 
 namespace hgraph::fabric
 {
+    inline constexpr std::size_t FABRIC_NOTIFICATION_CANDIDATE_LIMIT{1024U};
+
     /** Run-scoped fabric resources. Handles are owning and copyable so normal
         GlobalState copy-in/copy-out preserves one configured fabric. */
     struct FabricConfig
@@ -21,6 +24,9 @@ namespace hgraph::fabric
         persistence::store::ObjectStore objects{};
         persistence::store::FrameStore  frames{};
         Notifier                         notifications{};
+        /** Maximum durable revisions retained while graph-native notification
+            delivery is outstanding. Must be greater than zero. */
+        std::size_t notification_candidate_limit{FABRIC_NOTIFICATION_CANDIDATE_LIMIT};
     };
 
     /** Construct an isolated in-process fabric for tests and local execution. */

--- a/extensions/fabric/include/hgraph/fabric/service.h
+++ b/extensions/fabric/include/hgraph/fabric/service.h
@@ -16,7 +16,6 @@ namespace hgraph::fabric
 inline constexpr std::string_view DEFAULT_SERVICE_PATH{"fabric"};
 inline constexpr std::size_t FABRIC_PUBLICATION_QUEUE_LIMIT_PER_DATA_ID{1024U};
 inline constexpr std::size_t FABRIC_LIVE_NOTICE_LIMIT_PER_SESSION{4096U};
-inline constexpr std::size_t FABRIC_NOTIFICATION_REQUEST_LIMIT{1024U};
 inline constexpr std::size_t FABRIC_NOTIFICATION_RETRY_LIMIT{8U};
 inline constexpr std::size_t FABRIC_DIAGNOSTIC_EVENT_LIMIT{256U};
 

--- a/extensions/fabric/src/config.cpp
+++ b/extensions/fabric/src/config.cpp
@@ -53,6 +53,11 @@ namespace hgraph::fabric
         {
             throw std::invalid_argument("fabric configuration requires a notifier");
         }
+        if (config.notification_candidate_limit == 0U)
+        {
+            throw std::invalid_argument(
+                "fabric notification candidate limit must be greater than zero");
+        }
     }
 
     void set_fabric_config(GlobalStateView state, FabricConfig config)

--- a/extensions/fabric/src/impl/service_state.h
+++ b/extensions/fabric/src/impl/service_state.h
@@ -82,7 +82,11 @@ namespace hgraph::fabric::detail
 
     /** Immutable wiring metadata shared by declarations and lazy service
         materialisation. Planned nodes copy their subscription vectors into
-        node State during start; execution cannot mutate this plan. */
+        node State during start; execution cannot mutate this plan.
+
+        Identity is the scalar contract. The address-derived ordering and hash
+        exist only so wiring containers can store the handle; addresses are not
+        stable across runs and must never determine plan iteration or output. */
     struct FabricWiringPlanHandle
     {
         std::shared_ptr<const FabricWiringPlan> value{};
@@ -227,6 +231,7 @@ namespace hgraph::fabric::detail
         [[nodiscard]] std::vector<DataRevisionInput> advance();
         void complete(NotificationDeliveryInput delivery);
         [[nodiscard]] bool work_pending() const noexcept;
+        [[nodiscard]] std::size_t notification_candidate_limit() const;
         [[nodiscard]] FabricNodeDiagnostics diagnostics() const;
 
       private:

--- a/extensions/fabric/src/service.cpp
+++ b/extensions/fabric/src/service.cpp
@@ -700,16 +700,22 @@ namespace hgraph::fabric
                     return;
                 }
 
+                const std::size_t candidate_limit = publication.notification_candidate_limit();
                 for (auto revision : publication.advance())
                 {
                     if (candidates.contains(revision.data_id))
                     {
                         continue;
                     }
-                    if (candidates.size() >= FABRIC_NOTIFICATION_REQUEST_LIMIT)
+                    if (candidates.size() >= candidate_limit)
                     {
-                        throw std::overflow_error(
-                            "fabric graph notification candidate set is full");
+                        // This configured cap is a fatal resource bound rather than
+                        // transport backpressure. Requests have already entered the
+                        // graph and candidates may already be durable; pausing here
+                        // would only move an unbounded broker stall into publication
+                        // queues without applying sender admission.
+                        throw std::overflow_error("fabric graph notification candidate set "
+                                                  "reached its configured limit");
                     }
                     const Str data_id = revision.data_id;
                     Value value = make_data_revision(std::move(revision));

--- a/extensions/fabric/src/service.cpp
+++ b/extensions/fabric/src/service.cpp
@@ -855,6 +855,7 @@ namespace hgraph::fabric
                         if (delivery.delivered)
                         {
                             active.set(false);
+                            retry_pending.set(false);
                             is_active = false;
                             completed_data_ids.push_back(delivery.data_id);
                             increment_counter(delivered_count);
@@ -881,6 +882,7 @@ namespace hgraph::fabric
                             delivery.message = "fabric notification delivery failed";
                         }
                         active.set(false);
+                        retry_pending.set(false);
                         is_active = false;
                         completed_data_ids.push_back(delivery.data_id);
                         increment_counter(failed_count);

--- a/extensions/fabric/src/subscription.cpp
+++ b/extensions/fabric/src/subscription.cpp
@@ -1156,6 +1156,15 @@ namespace hgraph::fabric::detail
                                    });
     }
 
+    std::size_t PublicationNodeState::notification_candidate_limit() const
+    {
+        if (!impl_->config.has_value())
+        {
+            throw std::logic_error("fabric publication node is not started");
+        }
+        return impl_->config->notification_candidate_limit;
+    }
+
     FabricNodeDiagnostics PublicationNodeState::diagnostics() const
     {
         std::size_t queued{};

--- a/extensions/fabric/tests/test_public_contracts.cpp
+++ b/extensions/fabric/tests/test_public_contracts.cpp
@@ -380,8 +380,15 @@ TEST_CASE("fabric configuration is run scoped and validates resources")
     CHECK(configured->objects);
     CHECK(configured->frames);
     CHECK(configured->notifications);
+    CHECK(configured->notification_candidate_limit ==
+          hgf::FABRIC_NOTIFICATION_CANDIDATE_LIMIT);
     hgf::clear_fabric_config(state);
     CHECK_FALSE(hgf::fabric_config(state).has_value());
+
+    auto invalid = hgf::make_memory_fabric_config("test/invalid-fabric");
+    invalid.notification_candidate_limit = 0U;
+    CHECK_THROWS_WITH(hgf::set_fabric_config(state, std::move(invalid)),
+                      "fabric notification candidate limit must be greater than zero");
 }
 
 TEST_CASE("fabric operator installer survives a registry rebuild")

--- a/extensions/fabric/tests/test_subscription.cpp
+++ b/extensions/fabric/tests/test_subscription.cpp
@@ -619,6 +619,21 @@ namespace
         }
     };
 
+    struct SaturatedGraphNotificationPublicationGraph
+    {
+        static constexpr auto name = "hgraph.fabric.test.saturated_graph_notification";
+
+        static void compose(hg::Wiring &wiring)
+        {
+            const auto path = hg::service::path(hgf::DEFAULT_SERVICE_PATH);
+            hgf::register_service(wiring, path, hgf::FabricNotificationMode::GraphTransport);
+            auto published = hg::wire<PublishedFrameSource>(wiring);
+            hgf::publish_data(wiring, "first", published);
+            hgf::publish_data(wiring, "second", published);
+            static_cast<void>(hgf::notification_requests(wiring, path));
+        }
+    };
+
     struct RetryAndCompletionNotificationGraph
     {
         static constexpr auto name = "hgraph.fabric.test.retry_and_delivery_notification";
@@ -1359,4 +1374,16 @@ TEST_CASE("graph notification completion cancels an earlier retry in the same ba
     CHECK(observed_notification_metrics.at("transport.notification.retried") == "1");
     CHECK(observed_notification_metrics.at("transport.notification.delivered") == "1");
     CHECK(observed_notification_metrics.at("transport.notification.stale_reports") == "0");
+}
+
+TEST_CASE("graph notification candidate saturation uses the Fabric configuration")
+{
+    hg::stdlib::register_standard_operators();
+    hgf::register_fabric_operators();
+    auto config =
+        hgf::make_memory_fabric_config("tests/subscription/graph-notification-capacity");
+    config.notification_candidate_limit = 1U;
+
+    CHECK_THROWS(run(hg::build_graph<SaturatedGraphNotificationPublicationGraph>(), config,
+                     BASE_TIME, BASE_TIME + hg::TimeDelta{5}));
 }

--- a/extensions/fabric/tests/test_subscription.cpp
+++ b/extensions/fabric/tests/test_subscription.cpp
@@ -525,6 +525,46 @@ namespace
         }
     };
 
+    struct RetriableNotificationDelivery
+    {
+        static constexpr auto name = "hgraph.fabric.test.retriable_notification";
+
+        static void eval(hg::In<"revision", hg::TS<hg::Shared<hgf::DataRevision>>> revision,
+                         hg::Out<hgf::FabricNotificationDelivery> delivery)
+        {
+            const hgf::DataRevisionInput decoded =
+                hgf::data_revision_input(revision.base().value().concrete());
+            delivery.template field<"data_id">().set(decoded.data_id);
+            delivery.template field<"revision">().set(decoded.revision);
+            delivery.template field<"delivered">().set(false);
+            delivery.template field<"retriable">().set(true);
+            delivery.template field<"message">().set(hg::Str{"retry once"});
+        }
+    };
+
+    struct CompleteNotificationAfterRetry
+    {
+        static constexpr auto name = "hgraph.fabric.test.deliver_notification_after_retry";
+
+        static void eval(hg::In<"revision", hg::TS<hg::Shared<hgf::DataRevision>>> revision,
+                         hg::State<hg::Bool> observed_initial_request,
+                         hg::Out<hgf::FabricNotificationDelivery> delivery)
+        {
+            if (!observed_initial_request.get())
+            {
+                observed_initial_request.set(true);
+                return;
+            }
+            const hgf::DataRevisionInput decoded =
+                hgf::data_revision_input(revision.base().value().concrete());
+            delivery.template field<"data_id">().set(decoded.data_id);
+            delivery.template field<"revision">().set(decoded.revision);
+            delivery.template field<"delivered">().set(true);
+            delivery.template field<"retriable">().set(false);
+            delivery.template field<"message">().set(hg::Str{});
+        }
+    };
+
     struct CaptureNotificationMetrics
     {
         static constexpr auto name = "hgraph.fabric.test.capture_notification_metrics";
@@ -574,6 +614,31 @@ namespace
             auto delivery = hg::wire<RetryThenDeliverNotification>(
                 wiring, hgf::notification_requests(wiring, path));
             delivery_feedback(delivery);
+            static_cast<void>(
+                hg::wire<CaptureNotificationMetrics>(wiring, hgf::diagnostics(wiring, path)));
+        }
+    };
+
+    struct RetryAndCompletionNotificationGraph
+    {
+        static constexpr auto name = "hgraph.fabric.test.retry_and_delivery_notification";
+
+        static void compose(hg::Wiring &wiring)
+        {
+            const auto path = hg::service::path(hgf::DEFAULT_SERVICE_PATH);
+            hgf::register_service(wiring, path, hgf::FabricNotificationMode::GraphTransport);
+            hgf::publish_data(wiring, "published", hg::wire<PublishedFrameSource>(wiring));
+            auto request = hgf::notification_requests(wiring, path);
+
+            // The first report requests a retry. On the retried request, the
+            // duplicate retriable report sorts before the terminal report.
+            auto retry_feedback = hg::stdlib::feedback<hgf::FabricNotificationDelivery>(wiring);
+            hgf::submit_notification_delivery(wiring, retry_feedback(), path);
+            retry_feedback(hg::wire<RetriableNotificationDelivery>(wiring, request));
+            auto completion_feedback =
+                hg::stdlib::feedback<hgf::FabricNotificationDelivery>(wiring);
+            hgf::submit_notification_delivery(wiring, completion_feedback(), path);
+            completion_feedback(hg::wire<CompleteNotificationAfterRetry>(wiring, request));
             static_cast<void>(
                 hg::wire<CaptureNotificationMetrics>(wiring, hgf::diagnostics(wiring, path)));
         }
@@ -1277,4 +1342,21 @@ TEST_CASE("graph notification flow retries the retained shared revision on "
     const auto latest = config.objects.get(hgf::latest_key(config.prefix, "published"));
     REQUIRE(latest.has_value());
     CHECK(hgf::decode_revision_reference(hgf::MetadataObjectKind::Latest, latest->data) == 1);
+}
+
+TEST_CASE("graph notification completion cancels an earlier retry in the same batch")
+{
+    hg::stdlib::register_standard_operators();
+    hgf::register_fabric_operators();
+    auto config = hgf::make_memory_fabric_config(
+        "tests/subscription/graph-notification-retry-completion");
+    observed_notification_metrics.clear();
+
+    static_cast<void>(run(hg::build_graph<RetryAndCompletionNotificationGraph>(), config,
+                          BASE_TIME, BASE_TIME + hg::TimeDelta{20}));
+
+    CHECK(observed_notification_metrics.at("transport.notification.pending") == "0");
+    CHECK(observed_notification_metrics.at("transport.notification.retried") == "1");
+    CHECK(observed_notification_metrics.at("transport.notification.delivered") == "1");
+    CHECK(observed_notification_metrics.at("transport.notification.stale_reports") == "0");
 }


### PR DESCRIPTION
## Summary

- cancel a pending notification retry when an ordered delivery batch reaches a terminal outcome
- expose the durable notification candidate limit through run-scoped `FabricConfig`, reject zero, and document its fatal resource-bound semantics
- document that wiring-plan pointer identity, ordering, and hashing are container mechanics only and must not influence observable output
- cover the at-least-once retry/success interleaving and configured candidate saturation

## Validation

- macOS fresh warnings-as-errors build: 1,647 native tests passed
- complete Python 3.14 non-WIP suite: 2,216 passed, 10 skipped
- Fabric native suite: 1,723 assertions across 54 cases passed
- Fabric Python suite: 25 tests passed against locally built stable-ABI wheels
- installed Fabric SDK consumer: configure, build, and test passed
- private Linux validation: focused Fabric build and notification-flow tests passed for the retry change
- private Windows validation: MSVC warnings-as-errors Fabric build and notification-flow tests passed for the retry change
