### PR TITLE
Reject non-regular files in the local object store read path

### DIFF
--- a/extensions/persistence/src/impl/object_store_local.cpp
+++ b/extensions/persistence/src/impl/object_store_local.cpp
@@ -350,6 +350,12 @@ namespace hgraph::persistence::store::impl
                 (void)::close(descriptor);
                 throw system_failure("size object", path, failure);
             }
+            if (!S_ISREG(info.st_mode))
+            {
+                (void)::close(descriptor);
+                throw ObjectStoreError("not a stored object: '" + path.string() +
+                                       "' is not a regular file");
+            }
             if (info.st_size < 0 ||
                 static_cast<std::uintmax_t>(info.st_size) > std::numeric_limits<std::size_t>::max())
             {


### PR DESCRIPTION
## Problem

The POSIX branch of `read_object` in `extensions/persistence/src/impl/object_store_local.cpp` detected a directory at an object path only as a side effect of `::read` failing with `EISDIR`. That depends on the filesystem reporting a non-zero `st_size` for directories:

| Filesystem | dir `st_size` | Behaviour |
|---|---|---|
| APFS | 64 | read loop runs, `EISDIR`, raises |
| ext4 | 4096 | read loop runs, `EISDIR`, raises |
| btrfs | **0** | loop skipped, **returns an empty `StoredObject`** |

On btrfs `get()` silently returns an empty object instead of raising `ObjectStoreError`. It fails quietly, which is the damaging case: a caller cannot distinguish a corrupt store entry from a genuinely empty object.

RFC 0016 (`docs/source/rfc/rfc_0016_object_store_frame_persistence.rst`) specifies that reads report absence while failures are explicit "rather than silently losing data". The POSIX path was diverging from that record on btrfs, so this restores the documented contract rather than changing it — no doc update is needed.

## Fix

Check `S_ISREG` after the `fstat`, so a directory is rejected on every filesystem rather than incidentally. `S_ISREG` rather than `S_ISDIR` because a socket, FIFO or device node at an object path is equally not an object, at no extra cost.

The Windows branch is already correct and is untouched: `CreateFileW` without `FILE_FLAG_BACKUP_SEMANTICS` fails on a directory with `ERROR_ACCESS_DENIED`, which is neither `ERROR_FILE_NOT_FOUND` nor `ERROR_PATH_NOT_FOUND` and so falls through to `system_failure`.

## Testing

Covered by the existing case at `extensions/persistence/tests/test_object_store.cpp:254`, which was passing by accident on APFS/ext4 and failing on btrfs. No new test file, so no `tests/cpp/CMakeLists.txt` change.

Both acceptance gates run on Linux (Ubuntu 24.04, GCC 14, btrfs — the filesystem that exposes the bug):

- `ctest --preset cpp` — **1647/1647 passed** (`hgraph_persistence.tests` failed before this change, passes after)
- Wheel built with Python 3.12, installed into a fresh 3.14 environment, `pytest python/tests -m "not wip"` — **2216 passed, 10 skipped, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AV8Bb6Tk8iY1BbLSmPJYW