### PR TITLE
Stop the persistence API tests disabling their own extension loader

### DIFF
--- a/extensions/persistence/python/tests/test_api_persistence.py
+++ b/extensions/persistence/python/tests/test_api_persistence.py
@@ -16,18 +16,19 @@ def test_per_call_model_selection_loads_the_extension():
     # A per-call ``model=`` is an extension load point exactly like the
     # graph-level setter (RFC 0025): in a fresh process that never imports
     # hgraph_persistence, the documented ``hg.record(..., model=hg.DATA_FRAME)``
-    # flow must register the durable overloads itself. Run in a clean
-    # interpreter so this suite's own imports cannot mask the load.
-    import os
+    # flow must register the durable overloads itself. A fresh interpreter is
+    # the whole requirement, so the subprocess inherits this process's
+    # environment and resolves packages exactly as a user's would. Do not
+    # force resolution away from the installed package (an explicit
+    # PYTHONPATH, or dropping meta_path finders): under an editable install
+    # the scikit-build-core finder IS what serves the compiled
+    # _hgraph_persistence module, and the in-tree package directory has no
+    # .so for it to fall back to.
     import subprocess
     import sys
 
     script = (
         "import sys\n"
-        # Editable-install finders would shadow PYTHONPATH with a different
-        # checkout's package; drop them first (a no-op in CI).
-        "sys.meta_path = [finder for finder in sys.meta_path"
-        " if 'ScikitBuild' not in type(finder).__name__]\n"
         "import hgraph as hg\n"
         "from hgraph import TS, GlobalState, MIN_ST, MIN_TD, set_as_of\n"
         "from hgraph.test import eval_node\n"
@@ -44,7 +45,6 @@ def test_per_call_model_selection_loads_the_extension():
         [sys.executable, "-c", script],
         capture_output=True,
         text=True,
-        env={**os.environ, "PYTHONPATH": os.pathsep.join(sys.path)},
     )
     assert result.returncode == 0, result.stdout + result.stderr
 
@@ -53,14 +53,11 @@ def test_per_call_model_on_replay_const_loads_the_extension():
     # replay_const's durable overload accepts a per-call ``model=`` (the
     # operator has no in-memory implementation), so that call shape is a load
     # point exactly like record/replay/compare's (PR #507 review finding).
-    import os
     import subprocess
     import sys
 
     script = (
         "import sys\n"
-        "sys.meta_path = [finder for finder in sys.meta_path"
-        " if 'ScikitBuild' not in type(finder).__name__]\n"
         "import hgraph as hg\n"
         "from hgraph import TS\n"
         "assert 'hgraph_persistence' not in sys.modules\n"
@@ -74,7 +71,6 @@ def test_per_call_model_on_replay_const_loads_the_extension():
         [sys.executable, "-c", script],
         capture_output=True,
         text=True,
-        env={**os.environ, "PYTHONPATH": os.pathsep.join(sys.path)},
     )
     assert result.returncode == 0, result.stdout + result.stderr
 
@@ -85,14 +81,11 @@ def test_unloaded_extension_wiring_failure_names_the_activation_paths():
     # (RFC 0025's "wiring diagnoses the missing backend") rather than leaving
     # an unexplained resolution failure. Clean interpreter: this suite's own
     # imports must not mask the unloaded state.
-    import os
     import subprocess
     import sys
 
     script = (
         "import sys\n"
-        "sys.meta_path = [finder for finder in sys.meta_path"
-        " if 'ScikitBuild' not in type(finder).__name__]\n"
         "import hgraph as hg\n"
         "from hgraph import TS, GlobalState\n"
         "from hgraph.test import eval_node\n"
@@ -113,7 +106,6 @@ def test_unloaded_extension_wiring_failure_names_the_activation_paths():
         [sys.executable, "-c", script],
         capture_output=True,
         text=True,
-        env={**os.environ, "PYTHONPATH": os.pathsep.join(sys.path)},
     )
     assert result.returncode == 0, result.stdout + result.stderr
 


### PR DESCRIPTION
## The failure

Two tests in `extensions/persistence/python/tests/test_api_persistence.py` fail on any editable (dev) install, and have done since before any current feature branch — they reproduce on `main` at 947e24a1a:

- `test_per_call_model_selection_loads_the_extension`
- `test_per_call_model_on_replay_const_loads_the_extension`

The spawned subprocess dies with:

```
ImportError: cannot import name '_hgraph_persistence' from partially initialized module
'hgraph_persistence' (most likely due to a circular import)
```

The "circular import" wording is CPython's generic hint and a red herring. The module genuinely is not there.

## Cause

Each test builds a script and runs it in a fresh interpreter, prefixed with:

```python
sys.meta_path = [finder for finder in sys.meta_path
                 if 'ScikitBuild' not in type(finder).__name__]
```

and passes `env={**os.environ, "PYTHONPATH": os.pathsep.join(sys.path)}`.

Under a scikit-build-core editable install, that `ScikitBuild` meta_path finder is **precisely what serves the compiled `_hgraph_persistence` extension module**. The in-tree package directory `extensions/persistence/python/hgraph_persistence/` contains only `__init__.py` and `compat.py` — no `.so`. So the test strips the finder that provides its own extension, resolution falls through to the source directory via `PYTHONPATH`, and `from . import _hgraph_persistence` (`__init__.py:40`) has nothing to import.

The load point itself is fine: `_ensure_backend_extension` (`python/hgraph/_wiring/_state.py:391`) does a bare `import hgraph_persistence`, exactly as designed.

## Why CI never caught it

`.github/workflows/test-platform-wheel.yml` syncs with `--no-install-workspace` and then `uv pip install`s the built wheels into `.venv`. No editable finder exists there, so the strip is a genuine no-op and everything resolves from `site-packages` — which is what the now-removed `# (a no-op in CI)` comment recorded. The bug is invisible to a wheel install by construction.

## The change

Drop the meta_path stripping and the `PYTHONPATH` override, so each subprocess inherits the environment and resolves packages exactly as a user's would — consistent with the parent pytest process. The stale comment is replaced with one explaining why the environment is inherited.

What these tests actually require is only a fresh interpreter that has never imported `hgraph_persistence` — which the scripts assert up front, and which a plain subprocess already provides. The finder surgery was aimed at a *different checkout* shadowing the package; that concern does not arise here, as the repo root holds no `hgraph/` or `hgraph_persistence/` directory (they live under `python/` and `extensions/persistence/python/`).

**Applied to all three** subprocess tests in the file, not just the two failing ones. The third, `test_unloaded_extension_wiring_failure_names_the_activation_paths`, passes today only incidentally: with the finder stripped, `find_spec` still finds the *source* directory, so `_core.py:127` returns the "installed but not loaded" string it asserts on. Leaving one copy of a hack that breaks the import system would just be a trap for the next reader. It stays green.

No assertions were weakened. The `assert 'hgraph_persistence' not in sys.modules` before, and the `in sys.modules` plus `frame_store_contains` checks after, all survive unchanged.

## Verification

Locally, editable install, `CC=gcc-14 CXX=g++-14`:

| Suite | Before | After |
|---|---|---|
| `extensions/persistence/python/tests` | 2 failed, 80 passed | **82 passed** |
| `extensions/fabric/python/tests` | 30 passed | **30 passed** |

**Not a false green.** Temporarily breaking the per-call load path (`_state.py:391`) sends both tests red with `AssertionError: 'selection did not load'` — the intended assertion, not an import error — confirming they still gate the behaviour they exist to protect.

**Safe in CI as well as locally.** CI installs wheels into `.venv` with no editable finder present, and `sys.executable` is that venv's python, so an inherited environment resolves from `site-packages`; removing an additional `PYTHONPATH` cannot break that. `python -c` does put the cwd on `sys.path`, but the repo root shadows neither package.

Tests-only change; no developer-guide structure or invariant is altered.