### PR TITLE
Bind Fabric metadata codecs and value plans per graph run

### DIFF
--- a/docs/source/rfc/rfc_0030_typed_value_persistence.rst
+++ b/docs/source/rfc/rfc_0030_typed_value_persistence.rst
@@ -71,13 +71,22 @@ context. It is registered under a stable name.
 
 .. code-block:: cpp
 
+    struct ValueCodecBinding
+    {
+        std::shared_ptr<const void> owner;
+        const void *handle;
+    };
+
     struct ValueCodecOps
     {
-        /** Encode ``value`` onto ``out``. */
-        void (*encode)(void *context, const ValueView &value, ObjectBytes &out);
+        /** Resolve all schema-dependent state before evaluation. */
+        ValueCodecBinding (*bind)(void *context,
+                                  const ValueTypeMetaData *schema);
 
-        /** Decode ``encoded`` as ``schema``. */
-        Value (*decode)(void *context, const ValueTypeMetaData *schema,
+        /** Encode and decode through the bound schema handle. */
+        void (*encode)(void *context, const void *bound,
+                       const ValueView &value, ObjectBytes &out);
+        Value (*decode)(void *context, const void *bound,
                         std::span<const std::byte> encoded);
     };
 
@@ -92,29 +101,53 @@ registry, and only an explicit per-call override looks one up by name.
 
 **Binding: everything schema-dependent is resolved once.** ``ValueCodecOps``
 has three entry points, not two. ``bind`` takes a schema and returns an opaque
-handle the codec owns; ``encode`` and ``decode`` take that handle and must do no
-lookup, take no lock, and touch no registry. The json codec resolves the
-interned ``JsonConverter`` in ``bind`` — ``json_converter()`` locks, and its own
-documentation states the contract this follows: "nodes resolve their converter
-in ``start`` and carry it in node State".
+owner/handle pair; ``encode`` and ``decode`` take that handle and must do no
+schema-plan lookup and touch no type or realisation registry. The JSON codec
+builds an owned ``BoundJsonConverter`` in ``bind``.  That plan captures the
+active run's value
+bindings, hierarchy alternatives, and immutable parser configuration, so its
+read and write operations do not fall back to the interned-converter or graph
+realisation registries.
 
-A caller on the evaluation path binds at **wiring time** and carries the
-resulting ``BoundValueCodec``, which holds no ``shared_ptr`` and performs no
-lookup. Fabric binds in its configuration path (``bind_metadata_codecs``), which
-is where a run's resources are already assembled; its Kafka nodes bind in
-``start`` and hold the handle in node State. The unbound convenience calls on
-``ValueCodec`` and ``ValueStore`` bind per call and are for build-time and
-ad-hoc use only.
+A caller on the evaluation path binds while constructing **run-local
+node/service state**, before evaluation, and carries the resulting
+``BoundValueCodec``.  The binding retains the codec's erased
+``shared_ptr<void>`` implementation context, its schema, and the explicit
+erased owner/handle pair returned by ``bind``.  Retaining both owners is
+required: a custom codec may return a context-owned handle, while the built-in
+JSON codec returns an owned run-bound plan.  Encode and decode perform no
+schema or realisation lookup, validate the schema in both directions, and
+default or moved-from handles dispatch through a canonical throwing ops table
+rather than a nullable one.
+
+Reusable ``FabricConfig`` deliberately carries no bound handles.  It contains
+one authoritative ``ObjectStore`` and the metadata codec name; a Fabric node
+assembles a run-local ``ValueStore`` and private bounded revision/reference
+handles in ``start``.  The concrete Fabric value-plan binding stays behind the
+extension's ``impl`` boundary.  Keyed publisher and consistency state created
+later during evaluation copy that run binding instead of resolving another
+one.  Kafka nodes have no Fabric configuration, so they bind the transport codec in
+``start`` and retain it in node ``State``.  The notifier remains an opaque
+bounded transport and performs no semantic decode outside the graph.  The
+unbound convenience calls on ``ValueCodec`` and ``ValueStore`` bind per call
+and are for build-time and ad-hoc use only.
 
 This is enforced rather than asserted: every type-system mutex is a counted
-``TypeSystemMutex``, so a test drives 64 encodes through a wired fabric's codec
-and requires ``type_system_lock_count()`` to be unchanged.
+``TypeSystemMutex``.  Tests drive 64 complete Fabric metadata build, extract,
+encode and decode cycles, including structural list materialisation, and
+require ``type_system_lock_count()`` to be unchanged.  Separate regressions
+cover a whole steady-state publication and creation of new keyed publisher and
+consistency state after node start.  The core JSON binding participates in the
+same contract: it owns a converter tree with pre-resolved ``ValueTypeRef``
+bindings, parser configuration, and polymorphic discriminator alternatives.
+The bound reader and writer therefore do not consult the type registry,
+converter registry, or graph realisation snapshot during evaluation.
 
-A binding is invalidated by a registry reset, which frees the interned state it
-points at — exactly as it invalidates a node's captured converter. That is why
-binding belongs with graph construction and never in a process-lifetime static.
-The constraint is real: caching a bound codec in a function-local static crashed
-the Fabric suite with a bus error the first time it was written.
+A binding is invalidated by a registry reset, which frees canonical metadata it
+retains — exactly as it invalidates the bindings captured by ordinary nodes.
+That is why binding belongs with one graph run and never in reusable
+configuration or a process-lifetime static.  Ownership regressions explicitly
+exercise binding teardown rather than relying on this lifetime rule as prose.
 
 Selection
 ---------
@@ -126,6 +159,13 @@ The codec is **configuration**, at two levels:
   ``try_read``, ``try_read_versioned`` and ``compare_exchange``, which is what
   makes a mixed store possible -- small metadata as JSON beside a large record
   in a binary format -- without splitting the store.
+
+Fabric exposes only the store-level choice as ``FabricConfig::metadata_codec``.
+Its ``ObjectStore`` remains the sole metadata backend; the typed run binding is
+derived from those two reusable configuration fields.  A separately supplied
+``ValueStore`` would carry its own ``ObjectStore`` and permit revisions and
+indexes to be written to a different backend from the one used for listings,
+so that ambiguous configuration is intentionally not representable.
 
 It is never inferred. A read decodes with the codec the caller configured or
 named, so reading an object with a codec it was not written with is a
@@ -187,13 +227,22 @@ Store contract
         try_read_versioned(std::string_view key, const ValueTypeMetaData *schema,
                            std::optional<std::string_view> codec = {}) const;
 
-        [[nodiscard]] CompareExchangeResult
+        [[nodiscard]] ValueCompareExchangeResult
         compare_exchange(std::string_view key, const ValueView &value,
                          std::optional<std::string_view> expected_version,
                          std::optional<std::string_view> codec = {}) const;
+
+        [[nodiscard]] BoundValueStore
+        bind_schema(const ValueTypeMetaData *schema,
+                    std::optional<std::string_view> codec = {}) const;
     };
 
-``compare_exchange`` forwards the object store's version token unchanged.
+``BoundValueStore`` fixes the backend, codec and schema together for one run.
+Its reads, writes and compare/exchange results are typed; even a losing
+compare/exchange decodes the winning ``StoredValue`` through the same binding,
+so graph code never drops to ``ObjectStore`` bytes.  The unbound convenience
+form derives the binding from the candidate value's schema and returns the same
+typed result.  Both forms forward the object store's version token unchanged.
 Concurrency control stays a storage property; this store adds none.
 
 Non-goals
@@ -273,8 +322,12 @@ Each step is independently reviewable and leaves the tree green.
    ``compare_exchange``, and keys passed through verbatim. Tests covering a
    mixed-codec store, an unknown codec name failing closed, and a local-backend
    object read back off disk as a json file.
-3. Fabric writes and reads through ``ValueStore``; ``metadata_codec.{h,cpp}``
-   deleted outright.
+3. Fabric writes and reads through private run-bound typed-store handles.  Their
+   wrapper preserves Fabric's 16 MiB aggregate limit on every durable read,
+   write and compare/exchange result without putting a domain policy into
+   generic ``BoundValueStore``.  The former hand-written binary serializer is
+   deleted; ``metadata_codec`` remains only as the declared-schema validation
+   and transport-codec surface.
 4. Generic key primitives moved beside ``require_valid_key()``; Fabric keeps its
    key layout.
 

--- a/extensions/fabric/include/hgraph/fabric/config.h
+++ b/extensions/fabric/include/hgraph/fabric/config.h
@@ -6,42 +6,32 @@
 #include <hgraph/fabric/types.h>
 
 #include <hgraph/persistence/frame_store.h>
-#include <hgraph/persistence/value_store.h>
 #include <hgraph/persistence/object_store.h>
 #include <hgraph/runtime/global_state.h>
 
 #include <cstddef>
 #include <optional>
+#include <string>
 #include <string_view>
 
 namespace hgraph::fabric
 {
     inline constexpr std::size_t DEFAULT_NOTIFICATION_REQUEST_LIMIT{1024U};
 
-    /** Run-scoped fabric resources. Handles are owning and copyable so normal
-        GlobalState copy-in/copy-out preserves one configured fabric. */
+    /** Reusable Fabric resource configuration. Handles are owning and copyable
+        so normal GlobalState copy-in/copy-out preserves one configured
+        Fabric. Schema-dependent bindings are assembled separately for each
+        graph run and never retained here. */
     struct FabricConfig
     {
         Str                              prefix{};
         persistence::store::ObjectStore objects{};
         persistence::store::FrameStore  frames{};
-        /** Declared metadata schemas. Structured data goes here as ordinary
-            json documents; tabular data goes to `frames` as Arrow. Fabric owns
-            no serialization code of its own (RFC 0030). */
-        persistence::store::ValueStore  values{};
-        /** Codecs bound at wiring time, one per schema Fabric persists.
-            Publication and resolution run during evaluation, where resolving a
-            codec or a json converter would take a TypeSystemMutex per value --
-            the single-threaded evaluation ruling forbids it. Binding here, with
-            the rest of the run-scoped configuration, is the "compose once"
-            contract the runtime already applies to nodes. */
-        persistence::store::BoundValueCodec revision_codec{};
-        persistence::store::BoundValueCodec reference_codec{};
-        /** Transport payloads (Kafka records, notifier blobs) are messages
-            rather than stored objects and always use the json baseline, so a
-            topic stays readable by an ordinary consumer. Bound for the same
-            reason as the two above. */
-        persistence::store::BoundValueCodec notification_revision_codec{};
+        /** Named ValueStore codec for declared metadata. Empty selects JSON.
+            The run-local typed store is assembled from this policy and
+            `objects`, so configuration cannot accidentally supply two
+            different metadata backends. */
+        std::string                     metadata_codec{};
         Notifier                         notifications{};
         std::size_t                     notification_request_limit{
             DEFAULT_NOTIFICATION_REQUEST_LIMIT};

--- a/extensions/fabric/include/hgraph/fabric/metadata_codec.h
+++ b/extensions/fabric/include/hgraph/fabric/metadata_codec.h
@@ -4,7 +4,7 @@
 #include <hgraph/fabric/export.h>
 #include <hgraph/fabric/types.h>
 
-#include <hgraph/persistence/value_store.h>
+#include <hgraph/persistence/value_codec.h>
 #include <hgraph/types/value/value.h>
 
 #include <cstdint>
@@ -12,8 +12,6 @@
 
 namespace hgraph::fabric
 {
-    struct FabricConfig;
-
     /** Which index an object belongs to. Carried in the stored document so a
         latest entry read as an as-of entry is rejected rather than silently
         accepted; the check survived the move off the hand-written envelope
@@ -28,32 +26,28 @@ namespace hgraph::fabric
     /** The DataRevision schema, for reads that name their type. */
     [[nodiscard]] HGRAPH_FABRIC_EXPORT const ValueTypeMetaData *data_revision_meta();
 
-    /** Bind every codec Fabric persists or transmits with, once, at wiring
-        time. Called from the configuration path so nothing on the evaluation
-        path has to resolve a codec or a json converter. */
-    HGRAPH_FABRIC_EXPORT void bind_metadata_codecs(FabricConfig &config);
-
     /** The codec for transport payloads -- Kafka records and notifier blobs.
         Those are messages rather than stored objects, so they carry no key to
         name a format; they use the baseline json codec directly, which keeps a
         topic readable by an ordinary consumer. */
-    [[nodiscard]] HGRAPH_FABRIC_EXPORT const persistence::store::ValueCodec &
+    [[nodiscard]] HGRAPH_FABRIC_EXPORT persistence::store::ValueCodec
     notification_codec();
 
     /** The RevisionReference schema, for reads that name their type. */
     [[nodiscard]] HGRAPH_FABRIC_EXPORT const ValueTypeMetaData *revision_reference_meta();
 
-    /** Build an as-of or latest index entry. Fabric builds values; the store
-        decides how they are encoded. */
+    /** Ad-hoc as-of/latest index builder. Run-local code uses its private
+        retained binding; the store decides how values are encoded. */
     [[nodiscard]] HGRAPH_FABRIC_EXPORT Value
     make_revision_reference(MetadataObjectKind kind, RevisionId revision);
 
-    /** Read an index entry, requiring its kind to match the object being read.
-        Throws std::invalid_argument on a mismatch or a malformed entry. */
+    /** Ad-hoc index reader, requiring its kind to match the object being read.
+        Run-local code uses the retained binding. Throws std::invalid_argument
+        on a mismatch or malformed entry. */
     [[nodiscard]] HGRAPH_FABRIC_EXPORT RevisionId
     revision_reference_id(const ValueView &reference, MetadataObjectKind expected_kind);
 
-    /** Encode a DataRevision through `values`, enforcing Fabric's aggregate
+    /** Encode a DataRevision through `codec`, enforcing Fabric's aggregate
         metadata limit (MAX_METADATA_BYTES). The store owns the format; the
         limit is Fabric's own invariant and survived the move off the
         hand-written codec. */
@@ -61,11 +55,9 @@ namespace hgraph::fabric
     encode_data_revision(const persistence::store::BoundValueCodec &codec,
                          const ValueView                           &revision);
 
-    /** Decode a DataRevision through `values` and validate it. The documents
-        are externally readable and therefore externally editable, so every
-        field is checked here rather than trusted: ordinals must be positive
-        and in range, dependencies must be within the count limit and in
-        canonical order. Throws std::invalid_argument otherwise. */
+    /** Ad-hoc decode through `codec`, including Fabric validation. Graph code
+        uses its private run-local value binding instead. The documents are
+        externally editable, so every field is checked rather than trusted. */
     [[nodiscard]] HGRAPH_FABRIC_EXPORT Value
     decode_data_revision(const persistence::store::BoundValueCodec &codec,
                          std::span<const std::byte>                 encoded);
@@ -79,13 +71,12 @@ namespace hgraph::fabric
         too large to put on a topic. */
     HGRAPH_FABRIC_EXPORT void require_metadata_within_limit(std::size_t size);
 
-    /** Encode an index entry through `values`. The store decides the format;
-        this only spares every call site the schema and the view. */
+    /** Ad-hoc index-entry encode through `codec`. */
     [[nodiscard]] HGRAPH_FABRIC_EXPORT persistence::store::ObjectBytes
     encode_reference(const persistence::store::BoundValueCodec &codec,
                      MetadataObjectKind kind, RevisionId revision);
 
-    /** Decode an index entry through `values` and check its kind. */
+    /** Ad-hoc index-entry decode through `codec`, checking its kind. */
     [[nodiscard]] HGRAPH_FABRIC_EXPORT RevisionId
     revision_reference_value(const persistence::store::BoundValueCodec &codec,
                              MetadataObjectKind         expected_kind,

--- a/extensions/fabric/include/hgraph/fabric/notifier.h
+++ b/extensions/fabric/include/hgraph/fabric/notifier.h
@@ -3,8 +3,6 @@
 
 #include <hgraph/fabric/export.h>
 
-#include <hgraph/persistence/value_codec.h>
-
 #include <hgraph/persistence/object_store.h>
 #include <hgraph/types/primitive_types.h>
 
@@ -114,9 +112,13 @@ namespace hgraph::fabric
                                         RevisionNotification notification);
     };
 
-    /** Owning type-erased fabric notification contract. The contract validates
-        complete encoded accepted-revision notices and matching data ids before
-        dispatch; persistence remains authoritative. */
+    /** Owning type-erased fabric notification transport.
+
+        The graph constructs and validates accepted-revision messages before
+        publishing them, and ingress graph nodes validate broker payloads before
+        exposing them. This contract only admits a bounded, non-empty opaque
+        message and dispatches it; it does not duplicate Fabric semantics off
+        graph. */
     class HGRAPH_FABRIC_CLASS_EXPORT Notifier final
     {
       public:
@@ -135,20 +137,11 @@ namespace hgraph::fabric
         [[nodiscard]] explicit operator bool() const noexcept;
         void reset() noexcept;
 
-        /** Pre-bind the codec publish() validates with. Called at wiring time
-            from the fabric configuration path so publish(), which runs during
-            evaluation, resolves nothing. */
-        void bind_revision_codec(persistence::store::BoundValueCodec codec) noexcept;
-
       private:
         [[nodiscard]] static const NotifierOps &empty_ops() noexcept;
 
         std::shared_ptr<void> context_{};
         NotifierOps           ops_{empty_ops()};
-        /** Bound at wiring time. Mutable so a Notifier used outside the fabric
-            configuration path still works, binding once on first publish
-            rather than per call. */
-        mutable persistence::store::BoundValueCodec revision_codec_{};
     };
 
     /** Construct the broker-free, process-local conflating notifier used by

--- a/extensions/fabric/include/hgraph/fabric/publication.h
+++ b/extensions/fabric/include/hgraph/fabric/publication.h
@@ -13,6 +13,11 @@
 
 namespace hgraph::fabric
 {
+    namespace detail
+    {
+        struct BoundPublisherFactory;
+    }
+
     /** Externally visible progress through one RFC 0026 publication attempt.
         Each steady-state call to advance performs at most one durable or
         notification boundary. Initial recovery may scan and repair a
@@ -93,6 +98,10 @@ namespace hgraph::fabric
 
       private:
         struct Impl;
+        friend struct detail::BoundPublisherFactory;
+
+        explicit PublisherStateMachine(std::unique_ptr<Impl> impl) noexcept;
+
         std::unique_ptr<Impl> impl_;
     };
 }  // namespace hgraph::fabric

--- a/extensions/fabric/include/hgraph/fabric/resolution.h
+++ b/extensions/fabric/include/hgraph/fabric/resolution.h
@@ -16,6 +16,10 @@
 #include <vector>
 
 namespace hgraph::fabric {
+namespace detail {
+struct BoundConsistencyFactory;
+}  // namespace detail
+
 /** Outcome of resolving one independent RFC 0026 consistency forest. */
 enum class ResolutionStatus : std::uint8_t {
   Ready,
@@ -171,6 +175,10 @@ public:
 
 private:
   struct Impl;
+  friend struct detail::BoundConsistencyFactory;
+
+  explicit ConsistencyResolver(std::unique_ptr<Impl> impl) noexcept;
+
   std::unique_ptr<Impl> impl_;
 };
 
@@ -222,6 +230,10 @@ public:
 
 private:
   struct Impl;
+  friend struct detail::BoundConsistencyFactory;
+
+  explicit ConsistencyCoordinator(std::unique_ptr<Impl> impl) noexcept;
+
   std::unique_ptr<Impl> impl_;
 };
 } // namespace hgraph::fabric

--- a/extensions/fabric/include/hgraph/fabric/value_builders.h
+++ b/extensions/fabric/include/hgraph/fabric/value_builders.h
@@ -8,17 +8,19 @@
 
 namespace hgraph::fabric
 {
-    /** Build and validate a structural data dependency value. */
+    /** Ad-hoc convenience which resolves Fabric value plans for this call.
+        Evaluation code retains the private run-local binding instead. */
     [[nodiscard]] HGRAPH_FABRIC_EXPORT Value
     make_data_dependency(DataDependencyInput dependency);
 
-    /** Build a canonical structural revision value. Dependencies are sorted by
-        data id; duplicate ids and all invalid identifiers/ordinals fail. */
+    /** Ad-hoc canonical revision builder. Dependencies are sorted by data id;
+        duplicate ids and all invalid identifiers/ordinals fail. Evaluation
+        code uses the private run-local binding. */
     [[nodiscard]] HGRAPH_FABRIC_EXPORT Value
     make_data_revision(DataRevisionInput revision);
 
-    /** Extract and validate the native revision record represented by a
-        structural value. */
+    /** Ad-hoc extraction and validation convenience. Evaluation code uses its
+        private retained run binding. */
     [[nodiscard]] HGRAPH_FABRIC_EXPORT DataRevisionInput
     data_revision_input(ValueView revision);
 }  // namespace hgraph::fabric

--- a/extensions/fabric/src/config.cpp
+++ b/extensions/fabric/src/config.cpp
@@ -1,8 +1,7 @@
 #include <hgraph/fabric/config.h>
 
-#include <hgraph/fabric/metadata_codec.h>
-
 #include <hgraph/persistence/store_location.h>
+#include <hgraph/persistence/value_codec.h>
 #include <hgraph/types/metadata/type_registry.h>
 
 #include <stdexcept>
@@ -38,21 +37,6 @@ namespace hgraph::fabric
         }
     }  // namespace
 
-    void ensure_value_store(FabricConfig &config)
-    {
-        // Derived from the object store rather than configured separately:
-        // one backend, two typed views over it, so a caller cannot point
-        // metadata and frames at different places by accident.
-        if (config.values)
-        {
-            return;
-        }
-        persistence::store::register_builtin_value_codecs();
-        config.values = persistence::store::make_value_store(
-            persistence::store::ValueStoreConfig{.objects = config.objects});
-        bind_metadata_codecs(config);
-    }
-
     FabricConfig make_memory_fabric_config(Str prefix,
                                            std::size_t notification_request_limit)
     {
@@ -65,7 +49,6 @@ namespace hgraph::fabric
             .notifications = make_memory_notifier(),
             .notification_request_limit = notification_request_limit,
         };
-        ensure_value_store(config);
         require_valid_config(config);
         return config;
     }
@@ -81,6 +64,10 @@ namespace hgraph::fabric
         {
             throw std::invalid_argument("fabric configuration requires a frame store");
         }
+        static_cast<void>(persistence::store::value_codec(
+            config.metadata_codec.empty()
+                ? persistence::store::JSON_VALUE_CODEC
+                : std::string_view{config.metadata_codec}));
         if (!config.notifications)
         {
             throw std::invalid_argument("fabric configuration requires a notifier");
@@ -99,9 +86,6 @@ namespace hgraph::fabric
         {
             throw std::logic_error("fabric configuration requires GlobalState");
         }
-        // Every config reaches the runtime through here, so a hand-built one
-        // gets its value store without the caller knowing to ask.
-        ensure_value_store(config);
         require_valid_config(config);
         ensure_holder_type();
         state.set(config_key(path), Value{FabricConfigHolder{std::move(config)}});

--- a/extensions/fabric/src/history.cpp
+++ b/extensions/fabric/src/history.cpp
@@ -4,6 +4,8 @@
 #include <hgraph/fabric/metadata_codec.h>
 #include <hgraph/fabric/value_builders.h>
 
+#include "impl/metadata_binding.h"
+
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -24,6 +26,10 @@ namespace hgraph::fabric
         {
             return std::nullopt;
         }
+
+        // This is the deliberately synchronous non-graph API. Its binding is
+        // local to the call, rather than retained in reusable FabricConfig.
+        const detail::FabricMetadataBinding metadata{config};
 
         const std::string category = as_of_key_prefix(config.prefix, data_id);
         const std::string prefix = category + "/";
@@ -66,21 +72,22 @@ namespace hgraph::fabric
         {
             return std::nullopt;
         }
-        const auto reference = config.objects.get(*selected);
+        const auto reference = metadata.references().try_read(*selected);
         if (!reference.has_value())
         {
             throw std::runtime_error("fabric as-of index disappeared during load");
         }
-        const RevisionId revision_id = revision_reference_value(config.reference_codec, MetadataObjectKind::AsOf, reference->data);
-        const auto stored_revision = config.objects.get(
+        const RevisionId revision_id =
+            metadata.values().revision_reference_id(reference->view(),
+                                                    MetadataObjectKind::AsOf);
+        const auto stored_revision = metadata.revisions().try_read(
             revision_key(config.prefix, data_id, revision_id));
         if (!stored_revision.has_value())
         {
             throw std::runtime_error("fabric as-of index references a missing revision");
         }
-        const DataRevisionInput revision = data_revision_input(
-            decode_data_revision(config.revision_codec, stored_revision->data)
-                .view());
+        const DataRevisionInput revision =
+            metadata.values().data_revision_input(stored_revision->view());
         if (revision.data_id != data_id || revision.revision != revision_id ||
             revision.as_of != *selected_as_of)
         {

--- a/extensions/fabric/src/impl/metadata_binding.h
+++ b/extensions/fabric/src/impl/metadata_binding.h
@@ -1,0 +1,179 @@
+#ifndef HGRAPH_FABRIC_IMPL_METADATA_BINDING_H
+#define HGRAPH_FABRIC_IMPL_METADATA_BINDING_H
+
+#include <hgraph/fabric/config.h>
+#include <hgraph/fabric/metadata_codec.h>
+#include <hgraph/fabric/publication.h>
+#include <hgraph/fabric/resolution.h>
+
+#include <hgraph/persistence/value_store.h>
+
+#include "metadata_value_binding.h"
+
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+
+namespace hgraph::fabric::detail
+{
+    /** One Fabric metadata schema bound to its backend and codec.
+
+        The generic BoundValueStore deliberately has no domain-specific size
+        policy. Fabric's historical 16 MiB limit is therefore enforced here on
+        every durable read, write and compare/exchange winner before decoding.
+        Keeping this wrapper private prevents graph algorithms from bypassing
+        that semantic boundary by reaching directly for ObjectStore bytes. */
+    class BoundMetadataStore final
+    {
+      public:
+        BoundMetadataStore() noexcept = default;
+
+        BoundMetadataStore(persistence::store::ObjectStore objects,
+                           persistence::store::BoundValueCodec codec)
+            : objects_{std::move(objects)}, codec_{std::move(codec)}
+        {
+            if (!objects_ || !codec_)
+            {
+                throw std::invalid_argument(
+                    "fabric metadata store requires a backend and bound codec");
+            }
+        }
+
+        [[nodiscard]] persistence::store::ImmutableWriteResult
+        write(std::string_view key, const ValueView &value) const
+        {
+            return objects_.put_immutable(key, encode(value));
+        }
+
+        [[nodiscard]] std::optional<Value>
+        try_read(std::string_view key) const
+        {
+            auto stored = try_read_versioned(key);
+            if (!stored.has_value()) { return std::nullopt; }
+            return std::move(stored->value);
+        }
+
+        [[nodiscard]] std::optional<persistence::store::StoredValue>
+        try_read_versioned(std::string_view key) const
+        {
+            auto stored = objects_.get(key);
+            if (!stored.has_value()) { return std::nullopt; }
+            return persistence::store::StoredValue{
+                decode(stored->data), std::move(stored->version_token)};
+        }
+
+        [[nodiscard]] persistence::store::ValueCompareExchangeResult
+        compare_exchange(
+            std::string_view key, const ValueView &value,
+            std::optional<std::string_view> expected_version) const
+        {
+            auto result = objects_.compare_exchange_ref(
+                key, expected_version, encode(value));
+            persistence::store::ValueCompareExchangeResult typed{
+                .exchanged = result.exchanged};
+            if (result.current.has_value())
+            {
+                typed.current = persistence::store::StoredValue{
+                    decode(result.current->data),
+                    std::move(result.current->version_token)};
+            }
+            return typed;
+        }
+
+        [[nodiscard]] persistence::store::ObjectBytes
+        encode(const ValueView &value) const
+        {
+            auto encoded = codec_.encode(value);
+            require_metadata_within_limit(encoded.size());
+            return encoded;
+        }
+
+        [[nodiscard]] Value
+        decode(std::span<const std::byte> encoded) const
+        {
+            require_metadata_within_limit(encoded.size());
+            return codec_.decode(encoded);
+        }
+
+      private:
+        persistence::store::ObjectStore objects_{};
+        persistence::store::BoundValueCodec codec_{};
+    };
+
+    /** Schema and codec state owned by one running Fabric algorithm.
+
+        FabricConfig deliberately contains only reusable resources. This object
+        is constructed from that configuration when a node/service algorithm
+        starts and is destroyed with it, before any test registry reset can
+        invalidate its interned value plans and converter handles. */
+    class FabricMetadataBinding final
+    {
+      public:
+        explicit FabricMetadataBinding(const FabricConfig &config)
+            : store_{persistence::store::ValueStoreConfig{
+                  .objects = config.objects,
+                  .codec = config.metadata_codec}},
+              revisions_{config.objects,
+                         store_.bind(values_.data_revision_schema())},
+              references_{config.objects,
+                          store_.bind(values_.revision_reference_schema())},
+              transport_{notification_codec().bind(
+                  values_.data_revision_schema())}
+        {
+        }
+
+        [[nodiscard]] const FabricMetadataValueBinding &values() const noexcept
+        {
+            return values_;
+        }
+
+        [[nodiscard]] const BoundMetadataStore &
+        revisions() const noexcept
+        {
+            return revisions_;
+        }
+
+        [[nodiscard]] const BoundMetadataStore &
+        references() const noexcept
+        {
+            return references_;
+        }
+
+        [[nodiscard]] persistence::store::ObjectBytes
+        encode_transport(const ValueView &revision) const
+        {
+            auto encoded = transport_.encode(revision);
+            require_metadata_within_limit(encoded.size());
+            return encoded;
+        }
+
+      private:
+        FabricMetadataValueBinding             values_{};
+        persistence::store::ValueStore         store_{};
+        BoundMetadataStore                    revisions_{};
+        BoundMetadataStore                    references_{};
+        persistence::store::BoundValueCodec   transport_{};
+    };
+
+    /** Internal construction path for coordinators created after node start.
+        It copies a node's already-bound metadata state and performs no
+        registry or converter lookup. */
+    struct BoundConsistencyFactory
+    {
+        [[nodiscard]] static ConsistencyCoordinator coordinator(
+            FabricConfig config, std::vector<Str> roots,
+            FabricMetadataBinding metadata_binding);
+    };
+
+    /** Internal construction path for keyed publishers created after start. */
+    struct BoundPublisherFactory
+    {
+        [[nodiscard]] static std::unique_ptr<PublisherStateMachine> publisher(
+            FabricConfig config, Str data_id,
+            FabricMetadataBinding metadata_binding);
+    };
+}  // namespace hgraph::fabric::detail
+
+#endif  // HGRAPH_FABRIC_IMPL_METADATA_BINDING_H

--- a/extensions/fabric/src/impl/metadata_value_binding.h
+++ b/extensions/fabric/src/impl/metadata_value_binding.h
@@ -1,0 +1,49 @@
+#ifndef HGRAPH_FABRIC_IMPL_METADATA_VALUE_BINDING_H
+#define HGRAPH_FABRIC_IMPL_METADATA_VALUE_BINDING_H
+
+#include <hgraph/fabric/metadata_codec.h>
+
+#include <hgraph/types/value/value.h>
+#include <hgraph/types/value/value_type_ref.h>
+
+namespace hgraph::fabric::detail
+{
+    /** Run-local physical plans for Fabric's declared metadata values.
+
+        This is a concrete representation strategy, not part of Fabric's
+        public semantic contract. Construct it in node/service start state and
+        destroy it with that run; registry reset invalidates its interned plan
+        records. */
+    class FabricMetadataValueBinding final
+    {
+      public:
+        FabricMetadataValueBinding();
+
+        [[nodiscard]] Value make_data_dependency(
+            DataDependencyInput dependency) const;
+        [[nodiscard]] Value make_data_revision(
+            DataRevisionInput revision) const;
+        [[nodiscard]] DataRevisionInput data_revision_input(
+            ValueView revision) const;
+        [[nodiscard]] Value make_revision_reference(
+            MetadataObjectKind kind, RevisionId revision) const;
+        [[nodiscard]] RevisionId revision_reference_id(
+            ValueView reference, MetadataObjectKind expected_kind) const;
+
+        [[nodiscard]] const ValueTypeMetaData *
+        data_revision_schema() const noexcept;
+        [[nodiscard]] const ValueTypeMetaData *
+        revision_reference_schema() const noexcept;
+
+      private:
+        ValueTypeRef int_type_{};
+        ValueTypeRef str_type_{};
+        ValueTypeRef datetime_type_{};
+        ValueTypeRef dependency_type_{};
+        ValueTypeRef dependencies_type_{};
+        ValueTypeRef revision_type_{};
+        ValueTypeRef reference_type_{};
+    };
+}  // namespace hgraph::fabric::detail
+
+#endif  // HGRAPH_FABRIC_IMPL_METADATA_VALUE_BINDING_H

--- a/extensions/fabric/src/impl/service_state.h
+++ b/extensions/fabric/src/impl/service_state.h
@@ -2,11 +2,14 @@
 #define HGRAPH_FABRIC_IMPL_SERVICE_STATE_H
 
 #include <hgraph/fabric/publication.h>
+#include <hgraph/fabric/metadata_codec.h>
 #include <hgraph/fabric/resolution.h>
 #include <hgraph/fabric/service.h>
 
 #include <hgraph/runtime/node_scheduler.h>
 #include <hgraph/types/static_node.h>
+
+#include "metadata_value_binding.h"
 
 #include <compare>
 #include <cstdint>
@@ -14,6 +17,7 @@
 #include <memory>
 #include <optional>
 #include <ostream>
+#include <stdexcept>
 #include <string_view>
 #include <vector>
 
@@ -67,6 +71,53 @@ namespace hgraph::fabric::detail
 
         friend bool operator==(const TransportControlInput &,
                                const TransportControlInput &) = default;
+    };
+
+    /** Metadata schema plans retained by graph nodes which directly inspect or
+        construct Shared<DataRevision> values. */
+    struct RevisionValueState
+    {
+        std::optional<FabricMetadataValueBinding> binding{};
+
+        void bind() { binding.emplace(); }
+        void reset() noexcept { binding.reset(); }
+
+        [[nodiscard]] const FabricMetadataValueBinding &values() const
+        {
+            if (!binding.has_value())
+            {
+                throw std::logic_error(
+                    "fabric revision value state is not bound");
+            }
+            return *binding;
+        }
+    };
+
+    /** Scalar value plans used to publish diagnostic events. Bound in node
+        start, reset in stop, and never resolved during evaluation. */
+    class DiagnosticValueState final
+    {
+      public:
+        DiagnosticValueState() = default;
+
+        void bind();
+        void reset() noexcept;
+
+        [[nodiscard]] Value make_event(
+            const FabricDiagnosticEventInput &event) const;
+
+      private:
+        ValueTypeRef str_type_{};
+        ValueTypeRef bool_type_{};
+        ValueTypeRef int_type_{};
+        ValueTypeRef event_type_{};
+    };
+
+    /** Run-local resources for the synchronous graph load node. */
+    struct LoadNodeState
+    {
+        std::optional<FabricConfig> config{};
+        DiagnosticValueState diagnostic_values{};
     };
 
     struct FabricWiringPlan
@@ -139,8 +190,13 @@ namespace hgraph::fabric::detail
         [[nodiscard]] std::optional<DeliveryBatch> evaluate_planned(DateTime now,
                                                                     NodeScheduler scheduler);
         [[nodiscard]] FabricNodeDiagnostics diagnostics() const;
+        [[nodiscard]] const DiagnosticValueState &diagnostic_values() const noexcept
+        {
+            return diagnostic_values_;
+        }
 
       private:
+        DiagnosticValueState diagnostic_values_{};
         struct Impl;
         std::unique_ptr<Impl> impl_{};
     };
@@ -165,9 +221,15 @@ namespace hgraph::fabric::detail
         [[nodiscard]] std::optional<DeliveryBatch>
         evaluate_planned(std::vector<DataRevisionInput> revisions, DateTime now,
                          bool reconcile = false);
+        [[nodiscard]] DataRevisionInput decode_revision(ValueView revision) const;
         [[nodiscard]] FabricNodeDiagnostics diagnostics() const;
+        [[nodiscard]] const DiagnosticValueState &diagnostic_values() const noexcept
+        {
+            return diagnostic_values_;
+        }
 
       private:
+        DiagnosticValueState diagnostic_values_{};
         struct Impl;
         std::unique_ptr<Impl> impl_{};
     };
@@ -191,12 +253,18 @@ namespace hgraph::fabric::detail
         [[nodiscard]] std::vector<DataRevisionInput>
         advance(std::size_t notification_capacity =
                     std::numeric_limits<std::size_t>::max());
+        [[nodiscard]] Value make_revision(DataRevisionInput revision) const;
         void complete(NotificationDeliveryInput delivery);
         [[nodiscard]] bool work_pending() const noexcept;
         [[nodiscard]] std::size_t notification_request_limit() const;
         [[nodiscard]] FabricNodeDiagnostics diagnostics() const;
+        [[nodiscard]] const DiagnosticValueState &diagnostic_values() const noexcept
+        {
+            return diagnostic_values_;
+        }
 
       private:
+        DiagnosticValueState diagnostic_values_{};
         struct Impl;
         std::unique_ptr<Impl> impl_{};
     };
@@ -239,6 +307,24 @@ namespace hgraph::static_schema_detail
     template <> struct scalar_name<fabric::detail::FabricWiringPlanHandle>
     {
         static constexpr std::string_view value{"hgraph.fabric.internal::WiringPlanHandle"};
+    };
+
+    template <> struct scalar_name<fabric::detail::RevisionValueState>
+    {
+        static constexpr std::string_view value{
+            "hgraph.fabric.internal::RevisionValueState"};
+    };
+
+    template <> struct scalar_name<fabric::detail::DiagnosticValueState>
+    {
+        static constexpr std::string_view value{
+            "hgraph.fabric.internal::DiagnosticValueState"};
+    };
+
+    template <> struct scalar_name<fabric::detail::LoadNodeState>
+    {
+        static constexpr std::string_view value{
+            "hgraph.fabric.internal::LoadNodeState"};
     };
 
 } // namespace hgraph::static_schema_detail

--- a/extensions/fabric/src/kafka.cpp
+++ b/extensions/fabric/src/kafka.cpp
@@ -3,6 +3,8 @@
 #include <hgraph/fabric/metadata_codec.h>
 #include <hgraph/fabric/value_builders.h>
 
+#include "impl/metadata_value_binding.h"
+
 #include <hgraph/kafka/service.h>
 #include <hgraph/kafka/value_builders.h>
 
@@ -37,13 +39,29 @@ bytes_view(const Bytes &value) noexcept {
 namespace detail {
 /** The codec a Kafka node uses, bound once in start. A node must not resolve
     a codec or a json converter in eval: that takes a TypeSystemMutex on the
-    per-tick path. A function-local static would not do either -- a registry
-    reset clears the interned converters a binding points at, and node state is
-    torn down with the graph that owns it. */
+    per-tick path. A function-local static has the wrong lifetime: a registry
+    reset invalidates its value plans, whereas this state is torn down with the
+    graph run that owns it. */
 struct RevisionCodecState {
+  std::optional<FabricMetadataValueBinding> values{};
   persistence::store::BoundValueCodec codec{};
 
-  void bind() { codec = notification_codec().bind(data_revision_meta()); }
+  void bind() {
+    values.emplace();
+    codec = notification_codec().bind(values->data_revision_schema());
+  }
+
+  void reset() noexcept {
+    codec = {};
+    values.reset();
+  }
+
+  [[nodiscard]] const FabricMetadataValueBinding &bound_values() const {
+    if (!values.has_value()) {
+      throw std::logic_error("fabric Kafka revision codec is not bound");
+    }
+    return *values;
+  }
 };
 }  // namespace detail
 
@@ -96,7 +114,8 @@ struct FabricKafkaDecodeNode {
     const Bytes &payload_bytes = payload.checked_as<Bytes>();
     require_metadata_within_limit(payload_bytes.data.size());
     Value revision = state.ref().codec.decode(bytes_view(payload_bytes));
-    const DataRevisionInput decoded = data_revision_input(revision.view());
+    const DataRevisionInput decoded =
+        state.ref().bound_values().data_revision_input(revision.view());
     // A broker record is as untrusted as a stored document.
     validate_data_revision(decoded);
     if (key_bytes.data != decoded.data_id) {
@@ -104,6 +123,10 @@ struct FabricKafkaDecodeNode {
           "fabric Kafka record key does not match its revision data id");
     }
     out.apply(revision.view());
+  }
+
+  static void stop(State<detail::RevisionCodecState> state) {
+    state.modify().reset();
   }
 };
 
@@ -129,13 +152,18 @@ struct FabricKafkaProduceRecordNode {
                    State<detail::RevisionCodecState> state,
                    Out<TS<kafka::KafkaProduceRecord>> out) {
     const DataRevisionInput decoded =
-        data_revision_input(revision.base().value().concrete());
+        state.ref().bound_values().data_revision_input(
+            revision.base().value().concrete());
     persistence::store::ObjectBytes payload;
     state.ref().codec.encode(revision.base().value().concrete(), payload);
     Value record = kafka::make_produce_record(
         kafka_bytes(payload), Bytes{decoded.data_id}, {}, std::nullopt,
         std::nullopt, delivery_token(decoded.data_id, decoded.revision));
     out.apply(record.view());
+  }
+
+  static void stop(State<detail::RevisionCodecState> state) {
+    state.modify().reset();
   }
 };
 

--- a/extensions/fabric/src/metadata_codec.cpp
+++ b/extensions/fabric/src/metadata_codec.cpp
@@ -1,11 +1,10 @@
 #include <hgraph/fabric/metadata_codec.h>
 
-#include <hgraph/fabric/config.h>
 #include <hgraph/fabric/value_builders.h>
 
-#include <hgraph/types/metadata/type_registry.h>
+#include "impl/metadata_value_binding.h"
+
 #include <hgraph/types/static_schema.h>
-#include <hgraph/types/value/value_builder.h>
 
 #include <limits>
 #include <stdexcept>
@@ -16,20 +15,6 @@ namespace hgraph::fabric
 {
     namespace
     {
-        [[nodiscard]] std::string_view kind_name(MetadataObjectKind kind)
-        {
-            switch (kind)
-            {
-                case MetadataObjectKind::Revision:
-                    return "revision";
-                case MetadataObjectKind::AsOf:
-                    return "as_of";
-                case MetadataObjectKind::Latest:
-                    return "latest";
-            }
-            throw std::invalid_argument("unknown fabric metadata object kind");
-        }
-
         /** The hand-written codec rejected zero, negative and out-of-range
             ordinals at the decode boundary. A json document is easier to hand
             edit than a binary blob, not harder, so the check belongs here
@@ -82,21 +67,6 @@ namespace hgraph::fabric
         }
     }
 
-    void bind_metadata_codecs(FabricConfig &config)
-    {
-        // Wiring time: every schema-dependent resolution happens here, so the
-        // evaluation path carries handles rather than looking anything up.
-        config.revision_codec = config.values.bind(data_revision_meta());
-        config.reference_codec = config.values.bind(revision_reference_meta());
-        config.notification_revision_codec =
-            notification_codec().bind(data_revision_meta());
-        if (config.notifications)
-        {
-            config.notifications.bind_revision_codec(
-                config.notification_revision_codec);
-        }
-    }
-
     persistence::store::ObjectBytes
     encode_data_revision(const persistence::store::BoundValueCodec &codec,
                          const ValueView                           &revision)
@@ -111,17 +81,15 @@ namespace hgraph::fabric
     {
         require_metadata_within_limit(encoded.size());
         Value decoded = codec.decode(encoded);
-        validate_data_revision(data_revision_input(decoded.view()));
+        const detail::FabricMetadataValueBinding values;
+        validate_data_revision(values.data_revision_input(decoded.view()));
         return decoded;
     }
 
-    const persistence::store::ValueCodec &notification_codec()
+    persistence::store::ValueCodec notification_codec()
     {
-        static const persistence::store::ValueCodec codec = [] {
-            persistence::store::register_builtin_value_codecs();
-            return persistence::store::value_codec(persistence::store::JSON_VALUE_CODEC);
-        }();
-        return codec;
+        return persistence::store::value_codec(
+            persistence::store::JSON_VALUE_CODEC);
     }
 
     const ValueTypeMetaData *data_revision_meta()
@@ -136,56 +104,36 @@ namespace hgraph::fabric
 
     Value make_revision_reference(MetadataObjectKind kind, RevisionId revision)
     {
-        BundleBuilder builder{
-            ValuePlanFactory::instance().type_for(revision_reference_meta())};
-        if (kind != MetadataObjectKind::AsOf && kind != MetadataObjectKind::Latest)
-        {
-            throw std::invalid_argument(
-                "fabric revision reference kind must be as-of or latest");
-        }
-        require_positive_ordinal(revision, "revision reference");
-        builder.set("kind", Value{Str{kind_name(kind)}}.view());
-        builder.set("revision", Value{revision}.view());
-        return builder.build();
+        return detail::FabricMetadataValueBinding{}.make_revision_reference(
+            kind, revision);
     }
 
     RevisionId revision_reference_id(const ValueView   &reference,
                                      MetadataObjectKind expected_kind)
     {
-        const auto fields = reference.as_bundle();
-        const auto kind   = fields.at("kind");
-        const auto revision = fields.at("revision");
-        if (kind.data() == nullptr || revision.data() == nullptr)
-        {
-            throw std::invalid_argument("fabric revision reference is incomplete");
-        }
-        const auto stored_kind = kind.checked_as<Str>();
-        if (stored_kind != kind_name(expected_kind))
-        {
-            // The index a document belongs to is part of its meaning: a latest
-            // entry read as an as-of entry would silently answer the wrong
-            // question.
-            throw std::invalid_argument("fabric revision reference is a '" +
-                                        std::string{stored_kind} + "' entry, expected '" +
-                                        std::string{kind_name(expected_kind)} + "'");
-        }
-        const auto stored_revision = revision.checked_as<Int>();
-        require_positive_ordinal(stored_revision, "revision reference");
-        return stored_revision;
+        return detail::FabricMetadataValueBinding{}.revision_reference_id(
+            ValueView{reference.binding(), reference.data()}, expected_kind);
     }
 
     persistence::store::ObjectBytes encode_reference(
-        const persistence::store::BoundValueCodec &codec, MetadataObjectKind kind,
-        RevisionId revision)
+        const persistence::store::BoundValueCodec &codec,
+        MetadataObjectKind kind, RevisionId revision)
     {
-        return codec.encode(make_revision_reference(kind, revision).view());
+        const detail::FabricMetadataValueBinding values;
+        auto encoded =
+            codec.encode(values.make_revision_reference(kind, revision).view());
+        require_metadata_within_limit(encoded.size());
+        return encoded;
     }
 
     RevisionId revision_reference_value(const persistence::store::BoundValueCodec &codec,
                                         MetadataObjectKind         expected_kind,
                                         std::span<const std::byte> encoded)
     {
-        return revision_reference_id(codec.decode(encoded).view(), expected_kind);
+        require_metadata_within_limit(encoded.size());
+        const detail::FabricMetadataValueBinding values;
+        return values.revision_reference_id(codec.decode(encoded).view(),
+                                            expected_kind);
     }
 
 }  // namespace hgraph::fabric

--- a/extensions/fabric/src/notifier.cpp
+++ b/extensions/fabric/src/notifier.cpp
@@ -1,7 +1,5 @@
 #include <hgraph/fabric/notifier.h>
 
-#include <hgraph/fabric/metadata_codec.h>
-#include <hgraph/fabric/value_builders.h>
 #include <hgraph/fabric/types.h>
 
 #include <stdexcept>
@@ -193,12 +191,6 @@ namespace hgraph::fabric
         return *this;
     }
 
-    void Notifier::bind_revision_codec(
-        persistence::store::BoundValueCodec codec) noexcept
-    {
-        revision_codec_ = std::move(codec);
-    }
-
     NotificationSubscription Notifier::subscribe() const
     {
         return ops_.subscribe(context_.get());
@@ -213,20 +205,9 @@ namespace hgraph::fabric
             throw std::invalid_argument(
                 "fabric revision notification payload must not be empty");
         }
-        require_metadata_within_limit(notification.revision.size());
-        if (!revision_codec_)
+        if (notification.revision.size() > MAX_METADATA_BYTES)
         {
-            // Only for a notifier built outside the fabric configuration path;
-            // a configured one is bound at wiring time.
-            revision_codec_ = notification_codec().bind(data_revision_meta());
-        }
-        const Value decoded = revision_codec_.decode(notification.revision);
-        validate_data_revision(data_revision_input(decoded.view()));
-        if (decoded.view().as_bundle().at("data_id").checked_as<Str>() !=
-            notification.data_id)
-        {
-            throw std::invalid_argument(
-                "fabric revision notification data id does not match its payload");
+            throw std::invalid_argument("fabric metadata exceeds 16 MiB");
         }
         NotificationDelivery delivery =
             ops_.publish(context_.get(), std::move(notification));

--- a/extensions/fabric/src/planning.cpp
+++ b/extensions/fabric/src/planning.cpp
@@ -46,20 +46,19 @@ namespace hgraph::fabric
         {
             const auto element = ValuePlanFactory::instance().type_for(
                 scalar_descriptor<Element>::value_meta());
-            const auto tuple = ValuePlanFactory::instance().type_for(
-                scalar_descriptor<HomogeneousTuple<Element>>::value_meta());
-            if (!element || !tuple)
+            const auto *tuple =
+                scalar_descriptor<HomogeneousTuple<Element>>::value_meta();
+            if (!element || tuple == nullptr)
             {
                 throw std::logic_error(
                     "fabric dependency-plan tuple schema did not resolve");
             }
-            ListBuilder builder{element};
+            ListBuilder builder{element, *tuple};
             for (auto &value : values)
             {
-                builder.push_back_copy(value.view().data());
+                builder.push_back(value.view());
             }
-            ListStorage storage = builder.build_storage();
-            return Value{tuple, &storage};
+            return builder.build();
         }
 
         [[nodiscard]] Value strings(const std::vector<Str> &values)

--- a/extensions/fabric/src/publication.cpp
+++ b/extensions/fabric/src/publication.cpp
@@ -4,6 +4,8 @@
 #include <hgraph/fabric/metadata_codec.h>
 #include <hgraph/fabric/value_builders.h>
 
+#include "impl/metadata_binding.h"
+
 #include <arrow/table.h>
 
 #include <algorithm>
@@ -18,8 +20,6 @@ namespace hgraph::fabric
     namespace
     {
         using persistence::store::ImmutableWriteStatus;
-        using persistence::store::ObjectBytes;
-        using persistence::store::StoredObject;
 
         [[nodiscard]] bool same_schema(const Frame &frame,
                                        const std::shared_ptr<arrow::Schema> &schema)
@@ -89,44 +89,41 @@ namespace hgraph::fabric
     struct PublisherStateMachine::Impl
     {
         FabricConfig config;
+        detail::FabricMetadataBinding metadata_binding;
         Str          data_id;
         PublicationState state{PublicationState::Idle};
         PublicationInput input{};
         std::optional<DataRevisionInput> accepted{};
         std::optional<DataRevisionInput> candidate{};
-        ObjectBytes candidate_bytes{};
+        Value candidate_value{};
         /** The notification is a message, not a stored object, so it is
             encoded with the transport codec rather than the store's. Sharing
             one buffer would break any store configured with a non-json codec:
             the revision commits and the indexes advance, then the notifier
             fails decoding its own payload. */
-        ObjectBytes notification_bytes{};
+        persistence::store::ObjectBytes notification_bytes{};
         NotificationDelivery delivery{};
         std::shared_ptr<arrow::Schema> fixed_schema{};
 
-        Impl(FabricConfig configured, Str id)
-            : config(std::move(configured)), data_id(std::move(id))
+        Impl(FabricConfig configured, Str id,
+             detail::FabricMetadataBinding binding)
+            : config(std::move(configured)),
+              metadata_binding(std::move(binding)), data_id(std::move(id))
         {
-            require_valid_config(config);
             require_data_id(data_id);
-        }
-
-        [[nodiscard]] std::optional<StoredObject> metadata(std::string_view key) const
-        {
-            return config.objects.get(key);
         }
 
         [[nodiscard]] DataRevisionInput decode_slot(RevisionId revision) const
         {
-            const auto object = metadata(revision_key(config.prefix, data_id, revision));
-            if (!object.has_value())
+            const auto value = metadata_binding.revisions().try_read(
+                revision_key(config.prefix, data_id, revision));
+            if (!value.has_value())
             {
                 throw std::runtime_error("fabric accepted revision slot is missing: " +
                                          data_id + ":" + std::to_string(revision));
             }
             DataRevisionInput decoded =
-                data_revision_input(
-                    decode_data_revision(config.revision_codec, object->data).view());
+                metadata_binding.values().data_revision_input(value->view());
             if (decoded.data_id != data_id || decoded.revision != revision)
             {
                 throw std::runtime_error(
@@ -191,9 +188,10 @@ namespace hgraph::fabric
 
         void repair_as_of(const DataRevisionInput &revision) const
         {
-            const ObjectBytes desired = encode_reference(config.reference_codec, MetadataObjectKind::AsOf, revision.revision);
-            const auto result = config.objects.put_immutable(
-                as_of_key(config.prefix, data_id, revision.as_of), desired);
+            Value desired = metadata_binding.values().make_revision_reference(
+                MetadataObjectKind::AsOf, revision.revision);
+            const auto result = metadata_binding.references().write(
+                as_of_key(config.prefix, data_id, revision.as_of), desired.view());
             if (result.status == ImmutableWriteStatus::Conflict)
             {
                 throw std::runtime_error(
@@ -203,32 +201,40 @@ namespace hgraph::fabric
 
         [[nodiscard]] std::optional<RevisionId> latest_revision() const
         {
-            const auto current = metadata(latest_key(config.prefix, data_id));
+            const auto current = metadata_binding.references().try_read(
+                latest_key(config.prefix, data_id));
             if (!current.has_value()) { return std::nullopt; }
-            return revision_reference_value(config.reference_codec, MetadataObjectKind::Latest, current->data);
+            return metadata_binding.values().revision_reference_id(
+                current->view(), MetadataObjectKind::Latest);
         }
 
         void advance_latest(RevisionId target) const
         {
             const std::string key = latest_key(config.prefix, data_id);
-            const ObjectBytes desired = encode_reference(config.reference_codec, MetadataObjectKind::Latest, target);
+            Value desired = metadata_binding.values().make_revision_reference(
+                MetadataObjectKind::Latest, target);
             for (;;)
             {
-                const auto current = metadata(key);
+                const auto current =
+                    metadata_binding.references().try_read_versioned(key);
                 if (current.has_value())
                 {
-                    const RevisionId current_revision = revision_reference_value(config.reference_codec, MetadataObjectKind::Latest, current->data);
+                    const RevisionId current_revision =
+                        metadata_binding.values().revision_reference_id(
+                            current->value.view(), MetadataObjectKind::Latest);
                     if (current_revision >= target) { return; }
                 }
-                const auto result = config.objects.compare_exchange_ref(
+                const auto result = metadata_binding.references().compare_exchange(
                     key,
+                    desired.view(),
                     current.has_value()
                         ? std::optional<std::string_view>{current->version_token}
-                        : std::nullopt,
-                    desired);
+                        : std::nullopt);
                 if (result.exchanged) { return; }
                 if (!result.current.has_value()) { continue; }
-                const RevisionId winner = revision_reference_value(config.reference_codec, MetadataObjectKind::Latest, result.current->data);
+                const RevisionId winner =
+                    metadata_binding.values().revision_reference_id(
+                        result.current->value.view(), MetadataObjectKind::Latest);
                 if (winner >= target) { return; }
             }
         }
@@ -277,12 +283,11 @@ namespace hgraph::fabric
 
             for (;;)
             {
-                const auto object =
-                    metadata(revision_key(config.prefix, data_id, next));
-                if (!object.has_value()) { break; }
+                const auto value = metadata_binding.revisions().try_read(
+                    revision_key(config.prefix, data_id, next));
+                if (!value.has_value()) { break; }
                 DataRevisionInput revision =
-                    data_revision_input(
-                    decode_data_revision(config.revision_codec, object->data).view());
+                    metadata_binding.values().data_revision_input(value->view());
                 if (revision.data_id != data_id || revision.revision != next)
                 {
                     throw std::runtime_error(
@@ -376,17 +381,17 @@ namespace hgraph::fabric
                         ? std::optional<DateTime>{accepted->as_of}
                         : std::nullopt),
             };
-            Value canonical = make_data_revision(std::move(proposed));
-            candidate = data_revision_input(canonical.view());
-            candidate_bytes = encode_data_revision(config.revision_codec, canonical.view());
-            notification_bytes.clear();
-            config.notification_revision_codec.encode(canonical.view(), notification_bytes);
-            require_metadata_within_limit(notification_bytes.size());
+            candidate_value =
+                metadata_binding.values().make_data_revision(std::move(proposed));
+            candidate = metadata_binding.values().data_revision_input(
+                candidate_value.view());
+            notification_bytes =
+                metadata_binding.encode_transport(candidate_value.view());
 
             if (!input.output.has_value() && same_tuple(*candidate, *accepted))
             {
                 candidate.reset();
-                candidate_bytes.clear();
+                candidate_value = {};
                 notification_bytes.clear();
                 state = PublicationState::Unchanged;
                 return;
@@ -425,9 +430,9 @@ namespace hgraph::fabric
 
         void commit_revision()
         {
-            const auto result = config.objects.put_immutable(
+            const auto result = metadata_binding.revisions().write(
                 revision_key(config.prefix, data_id, candidate->revision),
-                candidate_bytes);
+                candidate_value.view());
             if (result.status == ImmutableWriteStatus::Conflict)
             {
                 DataRevisionInput winner = decode_slot(candidate->revision);
@@ -480,8 +485,29 @@ namespace hgraph::fabric
     };
 
     PublisherStateMachine::PublisherStateMachine(FabricConfig config, Str data_id)
-        : impl_(std::make_unique<Impl>(std::move(config), std::move(data_id)))
     {
+        require_valid_config(config);
+        detail::FabricMetadataBinding metadata_binding{config};
+        impl_ = std::make_unique<Impl>(std::move(config), std::move(data_id),
+                                      std::move(metadata_binding));
+    }
+
+    PublisherStateMachine::PublisherStateMachine(
+        std::unique_ptr<Impl> impl) noexcept
+        : impl_(std::move(impl))
+    {
+    }
+
+    std::unique_ptr<PublisherStateMachine>
+    detail::BoundPublisherFactory::publisher(
+        FabricConfig config, Str data_id,
+        FabricMetadataBinding metadata_binding)
+    {
+        auto impl = std::make_unique<PublisherStateMachine::Impl>(
+            std::move(config), std::move(data_id),
+            std::move(metadata_binding));
+        return std::unique_ptr<PublisherStateMachine>{
+            new PublisherStateMachine{std::move(impl)}};
     }
 
     PublisherStateMachine::~PublisherStateMachine() = default;
@@ -499,7 +525,7 @@ namespace hgraph::fabric
         }
         impl_->input = std::move(input);
         impl_->candidate.reset();
-        impl_->candidate_bytes.clear();
+        impl_->candidate_value = {};
         impl_->notification_bytes.clear();
         impl_->delivery.reset();
         impl_->state = PublicationState::Preparing;

--- a/extensions/fabric/src/python_module.cpp
+++ b/extensions/fabric/src/python_module.cpp
@@ -7,6 +7,8 @@
 #include <hgraph/fabric/service.h>
 #include <hgraph/fabric/value_builders.h>
 
+#include <hgraph/persistence/value_store.h>
+
 #include <hgraph/python/chrono.h>
 #include <hgraph/python/native_scalar_registration.h>
 #include <hgraph/types/operator_dispatch.h>
@@ -285,6 +287,10 @@ NB_MODULE(_hgraph_fabric, module)
 
             FabricConfig config =
                 make_memory_fabric_config("python/resolution-fixture");
+            const auto metadata = persistence::store::make_value_store(
+                {.objects = config.objects, .codec = config.metadata_codec});
+            const auto revision_store =
+                metadata.bind_schema(data_revision_meta());
             for (const auto &revision : revisions)
             {
                 const std::string frame_key = data_version_key(
@@ -295,10 +301,10 @@ NB_MODULE(_hgraph_fabric, module)
                         frame_key, fixture_frame(revision.output_version));
                 }
                 Value value = make_data_revision(revision);
-                const auto stored = config.objects.put_immutable(
+                const auto stored = revision_store.write(
                     revision_key(config.prefix, revision.data_id,
                                  revision.revision),
-                    config.values.encode(value.view()));
+                    value.view());
                 if (stored.status !=
                     persistence::store::ImmutableWriteStatus::Created)
                 {

--- a/extensions/fabric/src/resolution.cpp
+++ b/extensions/fabric/src/resolution.cpp
@@ -4,6 +4,8 @@
 #include <hgraph/fabric/metadata_codec.h>
 #include <hgraph/fabric/value_builders.h>
 
+#include "impl/metadata_binding.h"
+
 #include <arrow/table.h>
 
 #include <algorithm>
@@ -18,8 +20,6 @@
 namespace hgraph::fabric {
 namespace {
 using persistence::store::ImmutableWriteStatus;
-using persistence::store::ObjectBytes;
-using persistence::store::StoredObject;
 
 struct IdLess {
   using is_transparent = void;
@@ -116,6 +116,7 @@ struct ConsistencyResolver::Impl {
   };
 
   FabricConfig config;
+  detail::FabricMetadataBinding metadata_binding;
   std::map<Str, CachedData, IdLess> cache{};
   std::set<Str, IdLess> refreshed_this_call{};
   ResolverMetrics metrics{};
@@ -125,18 +126,15 @@ struct ConsistencyResolver::Impl {
   bool cache_only{};
   bool saw_cycle{};
 
-  explicit Impl(FabricConfig configured) : config(std::move(configured)) {
-    require_valid_config(config);
-  }
+  Impl(FabricConfig configured, detail::FabricMetadataBinding binding)
+      : config(std::move(configured)), metadata_binding(std::move(binding)) {}
 
   [[nodiscard]] DataRevisionInput
-  decode_slot(std::string_view data_id, RevisionId revision,
-              const StoredObject &object) const {
+  decode_value(std::string_view data_id, RevisionId revision,
+               ValueView value) const {
     try {
       DataRevisionInput decoded =
-          data_revision_input(decode_data_revision(config.revision_codec,
-                                                   object.data)
-                                  .view());
+          metadata_binding.values().data_revision_input(std::move(value));
       if (decoded.data_id != data_id || decoded.revision != revision) {
         throw CorruptHistory(
             "fabric revision payload does not match its durable key");
@@ -150,14 +148,28 @@ struct ConsistencyResolver::Impl {
     }
   }
 
+  [[nodiscard]] DataRevisionInput
+  decode_slot(std::string_view data_id, RevisionId revision) const {
+    const auto value = metadata_binding.revisions().try_read(
+        revision_key(config.prefix, data_id, revision));
+    if (!value.has_value()) {
+      throw CorruptHistory("fabric accepted revision slot is missing: " +
+                           std::string{data_id} + ":" +
+                           std::to_string(revision));
+    }
+    return decode_value(data_id, revision, value->view());
+  }
+
   [[nodiscard]] std::optional<RevisionId>
   indexed_latest(std::string_view data_id) const {
-    const auto object = config.objects.get(latest_key(config.prefix, data_id));
-    if (!object.has_value()) {
+    const auto value = metadata_binding.references().try_read(
+        latest_key(config.prefix, data_id));
+    if (!value.has_value()) {
       return std::nullopt;
     }
     try {
-      return revision_reference_value(config.reference_codec, MetadataObjectKind::Latest, object->data);
+      return metadata_binding.values().revision_reference_id(
+          value->view(), MetadataObjectKind::Latest);
     } catch (const std::exception &error) {
       throw CorruptHistory("fabric latest index is malformed for '" +
                            std::string{data_id} + "': " + error.what());
@@ -165,9 +177,11 @@ struct ConsistencyResolver::Impl {
   }
 
   void repair_as_of(const DataRevisionInput &revision) const {
-    const ObjectBytes desired = encode_reference(config.reference_codec, MetadataObjectKind::AsOf, revision.revision);
-    const auto result = config.objects.put_immutable(
-        as_of_key(config.prefix, revision.data_id, revision.as_of), desired);
+    Value desired = metadata_binding.values().make_revision_reference(
+        MetadataObjectKind::AsOf, revision.revision);
+    const auto result = metadata_binding.references().write(
+        as_of_key(config.prefix, revision.data_id, revision.as_of),
+        desired.view());
     if (result.status == ImmutableWriteStatus::Conflict) {
       throw CorruptHistory(
           "fabric as-of entry conflicts with accepted revision '" +
@@ -177,13 +191,16 @@ struct ConsistencyResolver::Impl {
 
   void advance_latest(std::string_view data_id, RevisionId target) const {
     const std::string key = latest_key(config.prefix, data_id);
-    const ObjectBytes desired = encode_reference(config.reference_codec, MetadataObjectKind::Latest, target);
+    Value desired = metadata_binding.values().make_revision_reference(
+        MetadataObjectKind::Latest, target);
     for (;;) {
-      const auto current = config.objects.get(key);
+      const auto current =
+          metadata_binding.references().try_read_versioned(key);
       if (current.has_value()) {
         RevisionId current_revision{};
         try {
-          current_revision = revision_reference_value(config.reference_codec, MetadataObjectKind::Latest, current->data);
+          current_revision = metadata_binding.values().revision_reference_id(
+              current->value.view(), MetadataObjectKind::Latest);
         } catch (const std::exception &error) {
           throw CorruptHistory("fabric latest index is malformed for '" +
                                std::string{data_id} + "': " + error.what());
@@ -192,12 +209,12 @@ struct ConsistencyResolver::Impl {
           return;
         }
       }
-      const auto result = config.objects.compare_exchange_ref(
+      const auto result = metadata_binding.references().compare_exchange(
           key,
+          desired.view(),
           current.has_value()
               ? std::optional<std::string_view>{current->version_token}
-              : std::nullopt,
-          desired);
+              : std::nullopt);
       if (result.exchanged) {
         return;
       }
@@ -205,7 +222,9 @@ struct ConsistencyResolver::Impl {
         continue;
       }
       try {
-        if (revision_reference_value(config.reference_codec, MetadataObjectKind::Latest, result.current->data) >= target) {
+        if (metadata_binding.values().revision_reference_id(
+                result.current->value.view(), MetadataObjectKind::Latest) >=
+            target) {
           return;
         }
       } catch (const std::exception &error) {
@@ -322,23 +341,17 @@ struct ConsistencyResolver::Impl {
       throw CorruptHistory("fabric latest index must be positive");
     }
     while (latest.has_value() && next <= *latest) {
-      const auto object =
-          config.objects.get(revision_key(config.prefix, data_id, next));
-      if (!object.has_value()) {
-        throw CorruptHistory("fabric accepted revision slot is missing: " +
-                             std::string{data_id} + ":" + std::to_string(next));
-      }
-      append(data, decode_slot(data_id, next, *object));
+      append(data, decode_slot(data_id, next));
       next = checked_increment(next, "revision id");
     }
 
     for (;;) {
-      const auto object =
-          config.objects.get(revision_key(config.prefix, data_id, next));
-      if (!object.has_value()) {
+      const auto value = metadata_binding.revisions().try_read(
+          revision_key(config.prefix, data_id, next));
+      if (!value.has_value()) {
         break;
       }
-      append(data, decode_slot(data_id, next, *object));
+      append(data, decode_value(data_id, next, value->view()));
       next = checked_increment(next, "revision id");
     }
     require_no_gap(data_id, next);
@@ -610,8 +623,9 @@ struct ConsistencyResolver::Impl {
   }
 
   void observe_revision(DataRevisionInput revision) {
-    Value canonical = make_data_revision(std::move(revision));
-    revision = data_revision_input(canonical.view());
+    Value canonical =
+        metadata_binding.values().make_data_revision(std::move(revision));
+    revision = metadata_binding.values().data_revision_input(canonical.view());
     auto [entry, inserted] = cache.try_emplace(revision.data_id);
     static_cast<void>(inserted);
     auto &data = entry->second;
@@ -627,14 +641,7 @@ struct ConsistencyResolver::Impl {
 
     RevisionId next = static_cast<RevisionId>(data.revisions.size() + 1);
     while (next < revision.revision) {
-      const auto object = config.objects.get(
-          revision_key(config.prefix, revision.data_id, next));
-      if (!object.has_value()) {
-        throw CorruptHistory(
-            "fabric accepted notice has a missing revision gap: " +
-            revision.data_id + ":" + std::to_string(next));
-      }
-      append(data, decode_slot(revision.data_id, next, *object), false);
+      append(data, decode_slot(revision.data_id, next), false);
       next = checked_increment(next, "revision id");
     }
     append(data, std::move(revision), false);
@@ -731,7 +738,16 @@ struct ConsistencyResolver::Impl {
 };
 
 ConsistencyResolver::ConsistencyResolver(FabricConfig config)
-    : impl_(std::make_unique<Impl>(std::move(config))) {}
+{
+  require_valid_config(config);
+  detail::FabricMetadataBinding metadata_binding{config};
+  impl_ = std::make_unique<Impl>(std::move(config),
+                                 std::move(metadata_binding));
+}
+
+ConsistencyResolver::ConsistencyResolver(
+    std::unique_ptr<Impl> impl) noexcept
+    : impl_(std::move(impl)) {}
 
 ConsistencyResolver::~ConsistencyResolver() = default;
 ConsistencyResolver::ConsistencyResolver(ConsistencyResolver &&) noexcept =
@@ -767,8 +783,10 @@ struct ConsistencyCoordinator::Impl {
   std::map<Str, ResolvedCut, IdLess> root_cuts{};
   std::map<Str, DateTime, IdLess> pending_notices{};
 
-  Impl(FabricConfig config, std::vector<Str> configured_roots)
-      : resolver(std::move(config)), roots(std::move(configured_roots)) {
+  Impl(ConsistencyResolver configured_resolver,
+       std::vector<Str> configured_roots)
+      : resolver(std::move(configured_resolver)),
+        roots(std::move(configured_roots)) {
     canonicalise_ids(roots, "coordinator roots");
   }
 
@@ -954,7 +972,12 @@ struct ConsistencyCoordinator::Impl {
 
 ConsistencyCoordinator::ConsistencyCoordinator(FabricConfig config,
                                                std::vector<Str> roots)
-    : impl_(std::make_unique<Impl>(std::move(config), std::move(roots))) {}
+    : impl_(std::make_unique<Impl>(ConsistencyResolver{std::move(config)},
+                                  std::move(roots))) {}
+
+ConsistencyCoordinator::ConsistencyCoordinator(
+    std::unique_ptr<Impl> impl) noexcept
+    : impl_(std::move(impl)) {}
 
 ConsistencyCoordinator::~ConsistencyCoordinator() = default;
 ConsistencyCoordinator::ConsistencyCoordinator(
@@ -982,5 +1005,16 @@ CoordinationResult ConsistencyCoordinator::resolve_cached(DateTime ready_at) {
 CoordinationResult ConsistencyCoordinator::resolve_at(DateTime maximum_as_of,
                                                       DateTime ready_at) {
   return impl_->resolve_all(ready_at, maximum_as_of, false);
+}
+
+ConsistencyCoordinator detail::BoundConsistencyFactory::coordinator(
+    FabricConfig config, std::vector<Str> roots,
+    FabricMetadataBinding metadata_binding) {
+  auto resolver_impl = std::make_unique<ConsistencyResolver::Impl>(
+      std::move(config), std::move(metadata_binding));
+  ConsistencyResolver resolver{std::move(resolver_impl)};
+  auto coordinator_impl = std::make_unique<ConsistencyCoordinator::Impl>(
+      std::move(resolver), std::move(roots));
+  return ConsistencyCoordinator{std::move(coordinator_impl)};
 }
 } // namespace hgraph::fabric

--- a/extensions/fabric/src/service.cpp
+++ b/extensions/fabric/src/service.cpp
@@ -31,6 +31,47 @@
 
 namespace hgraph::fabric
 {
+    void detail::DiagnosticValueState::bind()
+    {
+        auto &factory = ValuePlanFactory::instance();
+        str_type_ = factory.type_for(scalar_descriptor<Str>::value_meta());
+        bool_type_ = factory.type_for(scalar_descriptor<Bool>::value_meta());
+        int_type_ = factory.type_for(scalar_descriptor<Int>::value_meta());
+        event_type_ =
+            factory.type_for(scalar_descriptor<FabricDiagnosticEvent>::value_meta());
+        if (!str_type_ || !bool_type_ || !int_type_ || !event_type_)
+        {
+            throw std::logic_error(
+                "fabric diagnostic value bindings did not resolve");
+        }
+    }
+
+    void detail::DiagnosticValueState::reset() noexcept
+    {
+        str_type_ = {};
+        bool_type_ = {};
+        int_type_ = {};
+        event_type_ = {};
+    }
+
+    Value detail::DiagnosticValueState::make_event(
+        const FabricDiagnosticEventInput &event) const
+    {
+        if (!event_type_)
+        {
+            throw std::logic_error(
+                "fabric diagnostic value state is not bound");
+        }
+        BundleBuilder builder{event_type_};
+        builder.set(0U, Value{str_type_, &event.component});
+        builder.set(1U, Value{str_type_, &event.category});
+        builder.set(2U, Value{str_type_, &event.message});
+        builder.set(3U, Value{bool_type_, &event.retriable});
+        builder.set(4U, Value{bool_type_, &event.fatal});
+        builder.set(5U, Value{int_type_, &event.occurrences});
+        return builder.build();
+    }
+
     namespace
     {
         using detail::DeliveryBatch;
@@ -95,20 +136,8 @@ namespace hgraph::fabric
             return std::move(*config);
         }
 
-        [[nodiscard]] Value diagnostic_event_value(const FabricDiagnosticEventInput &event)
-        {
-            BundleBuilder builder{ValuePlanFactory::instance().type_for(
-                scalar_descriptor<FabricDiagnosticEvent>::value_meta())};
-            builder.set("component", Value{event.component});
-            builder.set("category", Value{event.category});
-            builder.set("message", Value{event.message});
-            builder.set("retriable", Value{event.retriable});
-            builder.set("fatal", Value{event.fatal});
-            builder.set("occurrences", Value{event.occurrences});
-            return builder.build();
-        }
-
         void record_diagnostic_event(const Out<TSD<Str, TS<FabricDiagnosticEvent>>> &events,
+                                     const detail::DiagnosticValueState &values,
                                      Str component, Str category, Str message, Bool retriable,
                                      Bool fatal)
         {
@@ -144,56 +173,40 @@ namespace hgraph::fabric
                 .fatal = fatal,
                 .occurrences = occurrences,
             };
-            auto mutation = events.begin_mutation(events.evaluation_time());
-            Value key{std::move(path)};
-            Value item = diagnostic_event_value(event);
-            mutation.set(key.view(), item.view());
+            Value item = values.make_event(event);
+            events.apply(path, item.view());
         }
 
         template <typename ValueSchema>
         void emit_node_diagnostics(FabricNodeDiagnostics diagnostics,
+                                   const detail::DiagnosticValueState &values,
                                    const Out<FabricServiceNodeResult<ValueSchema>> &result)
         {
             auto metrics = result.template field<"metrics">();
-            auto metric_mutation = metrics.begin_mutation(metrics.evaluation_time());
             for (auto &[name, value] : diagnostics.metrics)
             {
-                Value key{std::move(name)};
-                Value item{std::move(value)};
-                metric_mutation.set(key.view(), item.view());
+                metrics.set(name, std::move(value));
             }
 
             auto events = result.template field<"events">();
-            auto event_mutation = events.begin_mutation(events.evaluation_time());
             for (auto &[path, event] : diagnostics.events)
             {
-                Value key{std::move(path)};
-                Value item = diagnostic_event_value(event);
-                event_mutation.set(key.view(), item.view());
+                Value item = values.make_event(event);
+                events.apply(path, item.view());
             }
-        }
-
-        [[nodiscard]] Value ingress_value(const detail::DeliveredRoot &root)
-        {
-            BundleBuilder builder{ValuePlanFactory::instance().type_for(
-                schema_descriptor<FabricIngressSignal>::ts_meta()->value_schema)};
-            if (root.frame.has_value())
-            {
-                builder.set("frame", Value{*root.frame});
-            }
-            builder.set("version", Value{root.output_version});
-            builder.set("revision", Value{root.revision});
-            return builder.build();
         }
 
         void apply_delivery(DeliveryBatch delivery, Out<TSD<Str, FabricIngressSignal>> &out)
         {
-            auto mutation = out.begin_mutation(out.evaluation_time());
             for (const auto &root : delivery.roots)
             {
-                Value key{root.key};
-                Value update = ingress_value(root);
-                mutation.set(key.view(), update.view());
+                auto update = out.at(root.key);
+                if (root.frame.has_value())
+                {
+                    update.template field<"frame">().set(*root.frame);
+                }
+                update.template field<"version">().set(root.output_version);
+                update.template field<"revision">().set(root.revision);
             }
         }
 
@@ -213,7 +226,9 @@ namespace hgraph::fabric
         }
 
         template <typename Requests>
-        void collect_revisions(const Requests &requests, std::vector<DataRevisionInput> &revisions)
+        void collect_revisions(const Requests &requests,
+                               const detail::LiveNodeState &binding,
+                               std::vector<DataRevisionInput> &revisions)
         {
             if (!requests.modified())
             {
@@ -226,7 +241,8 @@ namespace hgraph::fabric
                 {
                     continue;
                 }
-                revisions.push_back(data_revision_input(revision.base().value().concrete()));
+                revisions.push_back(binding.decode_revision(
+                    revision.base().value().concrete()));
             }
         }
 
@@ -300,7 +316,8 @@ namespace hgraph::fabric
             {
                 auto out = result.template field<"value">();
                 UnwindCleanupGuard diagnostic_change{
-                    [&] { emit_node_diagnostics(state.ref().diagnostics(), result); }};
+                    [&] { emit_node_diagnostics(state.ref().diagnostics(),
+                                                state.ref().diagnostic_values(), result); }};
                 const auto &erased = static_cast<const TSSInputView &>(keys);
                 if (auto delivery = state.modify().evaluate(subscriptions(erased), now, scheduler);
                     delivery.has_value())
@@ -344,7 +361,8 @@ namespace hgraph::fabric
             {
                 auto out = result.template field<"value">();
                 UnwindCleanupGuard diagnostic_change{
-                    [&] { emit_node_diagnostics(state.ref().diagnostics(), result); }};
+                    [&] { emit_node_diagnostics(state.ref().diagnostics(),
+                                                state.ref().diagnostic_values(), result); }};
                 if (auto delivery = state.modify().evaluate_planned(now, scheduler);
                     delivery.has_value())
                 {
@@ -379,7 +397,8 @@ namespace hgraph::fabric
             {
                 auto out = result.template field<"value">();
                 UnwindCleanupGuard diagnostic_change{
-                    [&] { emit_node_diagnostics(state.ref().diagnostics(), result); }};
+                    [&] { emit_node_diagnostics(state.ref().diagnostics(),
+                                                state.ref().diagnostic_values(), result); }};
                 const auto control = transport_control(controls);
                 if (notification_mode.value() == FabricNotificationMode::GraphTransport)
                 {
@@ -396,7 +415,7 @@ namespace hgraph::fabric
                     }
                 }
                 std::vector<DataRevisionInput> revisions;
-                collect_revisions(notices, revisions);
+                collect_revisions(notices, state.ref(), revisions);
                 const auto &erased = static_cast<const TSSInputView &>(keys);
                 if (auto delivery =
                         state.modify().evaluate(subscriptions(erased), std::move(revisions), now,
@@ -444,7 +463,8 @@ namespace hgraph::fabric
             {
                 auto out = result.template field<"value">();
                 UnwindCleanupGuard diagnostic_change{
-                    [&] { emit_node_diagnostics(state.ref().diagnostics(), result); }};
+                    [&] { emit_node_diagnostics(state.ref().diagnostics(),
+                                                state.ref().diagnostic_values(), result); }};
                 const auto control = transport_control(controls);
                 if (notification_mode.value() == FabricNotificationMode::GraphTransport)
                 {
@@ -461,7 +481,7 @@ namespace hgraph::fabric
                     }
                 }
                 std::vector<DataRevisionInput> revisions;
-                collect_revisions(notices, revisions);
+                collect_revisions(notices, state.ref(), revisions);
                 if (auto delivery = state.modify().evaluate_planned(
                         std::move(revisions), now, control.has_value() && control->reconcile);
                     delivery.has_value())
@@ -552,7 +572,8 @@ namespace hgraph::fabric
                  Out<FabricServiceNodeResult<TSD<Str, TS<Shared<DataRevision>>>>> result)
             {
                 UnwindCleanupGuard diagnostic_change{
-                    [&] { emit_node_diagnostics(state.ref().diagnostics(), result); }};
+                    [&] { emit_node_diagnostics(state.ref().diagnostics(),
+                                                state.ref().diagnostic_values(), result); }};
                 auto &publication = state.modify();
                 enqueue_publications(requests, publication);
                 static_cast<void>(publication.advance());
@@ -590,7 +611,8 @@ namespace hgraph::fabric
             {
                 auto candidates = result.template field<"value">();
                 UnwindCleanupGuard diagnostic_change{
-                    [&] { emit_node_diagnostics(state.ref().diagnostics(), result); }};
+                    [&] { emit_node_diagnostics(state.ref().diagnostics(),
+                                                state.ref().diagnostic_values(), result); }};
                 auto &publication = state.modify();
                 enqueue_publications(requests, publication);
 
@@ -651,7 +673,7 @@ namespace hgraph::fabric
                         continue;
                     }
                     const Str data_id = revision.data_id;
-                    Value value = make_data_revision(std::move(revision));
+                    Value value = publication.make_revision(std::move(revision));
                     candidates.apply(data_id, value.view());
                 }
                 if (publication.work_pending() && candidates.size() < request_limit)
@@ -721,12 +743,18 @@ namespace hgraph::fabric
             static constexpr auto name = "hgraph.fabric.service.notification_flow";
             static constexpr bool schedule_on_start = true;
 
+            static void start(State<detail::RevisionValueState> value_state)
+            {
+                value_state.modify().bind();
+            }
+
             static void
             eval(In<"candidates", TSD<Str, TS<Shared<DataRevision>>>, InputValidity::Unchecked>
                      candidates,
                  In<"deliveries", TSD<Int, FabricNotificationDelivery>, InputValidity::Unchecked>
                      deliveries,
-                 NodeScheduler scheduler, Out<FabricNotificationFlowResult> result)
+                 NodeScheduler scheduler, State<detail::RevisionValueState> value_state,
+                 Out<FabricNotificationFlowResult> result)
             {
                 auto request = result.template field<"request">();
                 auto active_data_id = result.template field<"active_data_id">();
@@ -842,7 +870,8 @@ namespace hgraph::fabric
                         }
                         const Str data_id = key.checked_as<Str>();
                         const DataRevisionInput revision =
-                            data_revision_input(candidate.base().value().concrete());
+                            value_state.ref().values().data_revision_input(
+                                candidate.base().value().concrete());
                         if (revision.data_id != data_id)
                         {
                             throw std::invalid_argument("fabric notification request key does "
@@ -867,7 +896,8 @@ namespace hgraph::fabric
                         continue;
                     }
                     const DataRevisionInput revision =
-                        data_revision_input(candidate.base().value().concrete());
+                        value_state.ref().values().data_revision_input(
+                            candidate.base().value().concrete());
                     request.set(candidate.base().reference());
                     active_data_id.set(data_id);
                     active_revision.set(revision.revision);
@@ -876,6 +906,11 @@ namespace hgraph::fabric
                     retry_pending.set(false);
                     break;
                 }
+            }
+
+            static void stop(State<detail::RevisionValueState> value_state)
+            {
+                value_state.modify().reset();
             }
         };
 
@@ -903,23 +938,23 @@ namespace hgraph::fabric
             }
         };
 
-        [[nodiscard]] Value load_response_value(Str data_id, DataVersion version, Frame frame)
-        {
-            BundleBuilder builder{ValuePlanFactory::instance().type_for(
-                schema_descriptor<FabricLoadResponse>::ts_meta()->value_schema)};
-            builder.set("data_id", Value{std::move(data_id)});
-            builder.set("version", Value{version});
-            builder.set("frame", Value{std::move(frame)});
-            return builder.build();
-        }
-
         struct FabricLoadNode
         {
             static constexpr auto name = "hgraph.fabric.service.load";
 
+            static void start(Scalar<"path", Str> path,
+                              GlobalStateView global_state,
+                              State<detail::LoadNodeState> state)
+            {
+                FabricConfig config = service_config(global_state, path.value());
+                state.modify().diagnostic_values.bind();
+                state.modify().config = std::move(config);
+            }
+
             static void
             eval(In<"requests", TSD<Int, FabricLoadRequest>, InputValidity::Unchecked> requests,
-                 Scalar<"path", Str> path, GlobalStateView global_state,
+                 Scalar<"path", Str>,
+                 State<detail::LoadNodeState> state,
                  Out<FabricServiceNodeResult<TSD<Int, FabricLoadResponse>>> result)
             {
                 auto responses = result.template field<"value">();
@@ -927,9 +962,12 @@ namespace hgraph::fabric
                 {
                     return;
                 }
-                const FabricConfig config = service_config(global_state, path.value());
+                if (!state.ref().config.has_value())
+                {
+                    throw std::logic_error("fabric load node is not started");
+                }
+                const FabricConfig &config = *state.ref().config;
                 auto diagnostic_events = result.template field<"events">();
-                auto mutation = responses.begin_mutation(responses.evaluation_time());
                 for (const auto &[request_id, request] : requests.modified_items())
                 {
                     if (!request.valid())
@@ -957,22 +995,32 @@ namespace hgraph::fabric
                     }
                     catch (const std::exception &error)
                     {
-                        record_diagnostic_event(diagnostic_events, "store", "frame.read",
-                                                error.what(), false, true);
+                        record_diagnostic_event(
+                            diagnostic_events, state.ref().diagnostic_values, "store",
+                            "frame.read", error.what(), false, true);
                         throw;
                     }
                     if (!frame.has_value())
                     {
-                        record_diagnostic_event(diagnostic_events, "store", "frame.missing",
-                                                "requested Fabric Frame is not present: " +
-                                                    data_id + ":" + std::to_string(version),
-                                                false, false);
+                        record_diagnostic_event(
+                            diagnostic_events, state.ref().diagnostic_values, "store",
+                            "frame.missing",
+                            "requested Fabric Frame is not present: " + data_id +
+                                ":" + std::to_string(version),
+                            false, false);
                         continue;
                     }
-                    Value response =
-                        load_response_value(std::move(data_id), version, std::move(frame));
-                    mutation.set(request_id, response.view());
+                    auto response = responses.at(request_id.checked_as<Int>());
+                    response.template field<"data_id">().set(std::move(data_id));
+                    response.template field<"version">().set(version);
+                    response.template field<"frame">().set(std::move(frame));
                 }
+            }
+
+            static void stop(State<detail::LoadNodeState> state)
+            {
+                state.modify().config.reset();
+                state.modify().diagnostic_values.reset();
             }
         };
 
@@ -980,8 +1028,15 @@ namespace hgraph::fabric
         {
             static constexpr auto name = "hgraph.fabric.service.transport_events";
 
+            static void start(
+                State<detail::DiagnosticValueState> diagnostic_values)
+            {
+                diagnostic_values.modify().bind();
+            }
+
             static void
             eval(In<"events", TSD<Int, FabricTransportEvent>, InputValidity::Unchecked> events,
+                 State<detail::DiagnosticValueState> diagnostic_values,
                  Out<TSD<Str, TS<FabricDiagnosticEvent>>> diagnostics)
             {
                 if (!events.modified())
@@ -1005,16 +1060,30 @@ namespace hgraph::fabric
                     {
                         throw std::invalid_argument("fabric transport event is incomplete");
                     }
-                    record_diagnostic_event(diagnostics, component.value(), category.value(),
-                                            message.valid() ? message.value() : Str{},
-                                            retriable.value(), fatal.value());
+                    record_diagnostic_event(
+                        diagnostics, diagnostic_values.ref(), component.value(),
+                        category.value(),
+                        message.valid() ? message.value() : Str{},
+                        retriable.value(), fatal.value());
                 }
+            }
+
+            static void stop(
+                State<detail::DiagnosticValueState> diagnostic_values)
+            {
+                diagnostic_values.modify().reset();
             }
         };
 
         struct FabricDiagnosticsNode
         {
             static constexpr auto name = "hgraph.fabric.service.diagnostics";
+
+            static void start(
+                State<detail::DiagnosticValueState> diagnostic_values)
+            {
+                diagnostic_values.modify().bind();
+            }
 
             /** Aggregate node-owned diagnostic edges. Additive resolver and live
                 counters are reduced here; no mutable service facade is consulted. */
@@ -1042,6 +1111,7 @@ namespace hgraph::fabric
                  In<"transport_events", TSD<Str, TS<FabricDiagnosticEvent>>,
                     InputValidity::Unchecked>
                      transport_events,
+                 State<detail::DiagnosticValueState> diagnostic_values,
                  Out<FabricDiagnostics> diagnostics)
             {
                 auto metrics = diagnostics.template field<"metrics">();
@@ -1107,18 +1177,13 @@ namespace hgraph::fabric
                 direct.insert_or_assign("resolution.backtracking_depth.maximum",
                                         std::to_string(maximum_backtracking_depth));
 
-                auto mutation = metrics.begin_mutation(metrics.evaluation_time());
                 for (auto &[metric_name, value] : direct)
                 {
-                    Value key{metric_name};
-                    Value item{std::move(value)};
-                    mutation.set(key.view(), item.view());
+                    metrics.set(metric_name, std::move(value));
                 }
                 for (auto &[metric_name, value] : sums)
                 {
-                    Value key{metric_name};
-                    Value item{std::to_string(value)};
-                    mutation.set(key.view(), item.view());
+                    metrics.set(metric_name, std::to_string(value));
                 }
 
                 auto diagnostic_events = diagnostics.template field<"events">();
@@ -1181,14 +1246,17 @@ namespace hgraph::fabric
                 collect_event_input(static_cast<const TSDInputView &>(load_events));
                 collect_event_input(static_cast<const TSDInputView &>(transport_events));
 
-                auto event_mutation =
-                    diagnostic_events.begin_mutation(diagnostic_events.evaluation_time());
                 for (auto &[path, event] : combined_events)
                 {
-                    Value key{path};
-                    Value item = diagnostic_event_value(event);
-                    event_mutation.set(key.view(), item.view());
+                    Value item = diagnostic_values.ref().make_event(event);
+                    diagnostic_events.apply(path, item.view());
                 }
+            }
+
+            static void stop(
+                State<detail::DiagnosticValueState> diagnostic_values)
+            {
+                diagnostic_values.modify().reset();
             }
         };
 

--- a/extensions/fabric/src/subscription.cpp
+++ b/extensions/fabric/src/subscription.cpp
@@ -1,4 +1,5 @@
 #include "impl/service_state.h"
+#include "impl/metadata_binding.h"
 
 #include <hgraph/fabric/config.h>
 #include <hgraph/fabric/keys.h>
@@ -164,9 +165,13 @@ namespace hgraph::fabric::detail
             std::set<Str, IdLess> observed{};
             ResolutionMetrics metrics{};
 
-            ResolutionCore(FabricConfig configured, std::vector<Str> configured_roots)
+            ResolutionCore(FabricConfig configured,
+                           std::vector<Str> configured_roots,
+                           FabricMetadataBinding metadata_binding)
                 : config(std::move(configured)), roots(std::move(configured_roots)),
-                  coordinator(config, roots), observed(roots.begin(), roots.end())
+                  coordinator(BoundConsistencyFactory::coordinator(
+                      config, roots, std::move(metadata_binding))),
+                  observed(roots.begin(), roots.end())
             {
             }
 
@@ -279,7 +284,9 @@ namespace hgraph::fabric::detail
             std::optional<DateTime> cursor{};
             std::map<Str, std::vector<DateTime>, IdLess> histories{};
 
-            void configure(const FabricConfig &configured, std::vector<SubscriptionSpec> requested)
+            void configure(const FabricConfig &configured,
+                           const FabricMetadataBinding &metadata_binding,
+                           std::vector<SubscriptionSpec> requested)
             {
                 requested = canonical_subscriptions(std::move(requested));
                 if (requested == subscriptions && core)
@@ -291,7 +298,9 @@ namespace hgraph::fabric::detail
                 histories.clear();
                 core = subscriptions.empty()
                            ? nullptr
-                           : std::make_unique<ResolutionCore>(config, roots_of(subscriptions));
+                           : std::make_unique<ResolutionCore>(
+                                 config, roots_of(subscriptions),
+                                 metadata_binding);
                 cursor = core ? std::optional<DateTime>{start_time} : std::nullopt;
             }
 
@@ -404,7 +413,9 @@ namespace hgraph::fabric::detail
             std::map<Str, RevisionId, IdLess> admitted{};
             bool startup{true};
 
-            void configure(const FabricConfig &configured, std::vector<SubscriptionSpec> requested)
+            void configure(const FabricConfig &configured,
+                           const FabricMetadataBinding &metadata_binding,
+                           std::vector<SubscriptionSpec> requested)
             {
                 requested = canonical_subscriptions(std::move(requested));
                 if (requested == subscriptions && core)
@@ -415,7 +426,9 @@ namespace hgraph::fabric::detail
                 subscriptions = std::move(requested);
                 core = subscriptions.empty()
                            ? nullptr
-                           : std::make_unique<ResolutionCore>(config, roots_of(subscriptions));
+                           : std::make_unique<ResolutionCore>(
+                                 config, roots_of(subscriptions),
+                                 metadata_binding);
                 notice_cache.clear();
                 admitted.clear();
                 startup = true;
@@ -666,6 +679,7 @@ namespace hgraph::fabric::detail
     struct ReplayNodeState::Impl
     {
         std::optional<FabricConfig> config{};
+        std::optional<FabricMetadataBinding> metadata_binding{};
         std::vector<SubscriptionSpec> planned{};
         ReplaySession session{};
         DiagnosticState diagnostics{};
@@ -683,7 +697,11 @@ namespace hgraph::fabric::detail
         {
             throw std::logic_error("fabric replay node started twice");
         }
-        impl_->config = checked_config(std::move(config));
+        FabricConfig checked = checked_config(std::move(config));
+        FabricMetadataBinding metadata_binding{checked};
+        diagnostic_values_.bind();
+        impl_->config = std::move(checked);
+        impl_->metadata_binding.emplace(std::move(metadata_binding));
         impl_->planned = std::move(planned);
         impl_->session.start_time = start_time;
         impl_->session.end_time = end_time;
@@ -694,7 +712,9 @@ namespace hgraph::fabric::detail
         impl_->session = {};
         impl_->diagnostics = {};
         impl_->planned.clear();
+        impl_->metadata_binding.reset();
         impl_->config.reset();
+        diagnostic_values_.reset();
     }
 
     std::optional<DeliveryBatch> ReplayNodeState::evaluate_planned(DateTime now,
@@ -714,8 +734,10 @@ namespace hgraph::fabric::detail
         return with_failure_diagnostic(impl_->diagnostics, "store", "replay",
                                        [&]
                                        {
-                                           impl_->session.configure(*impl_->config,
-                                                                    std::move(subscriptions));
+                                           impl_->session.configure(
+                                               *impl_->config,
+                                               *impl_->metadata_binding,
+                                               std::move(subscriptions));
                                            return impl_->session.evaluate(now, scheduler);
                                        });
     }
@@ -730,6 +752,7 @@ namespace hgraph::fabric::detail
     struct LiveNodeState::Impl
     {
         std::optional<FabricConfig> config{};
+        std::optional<FabricMetadataBinding> metadata_binding{};
         std::vector<SubscriptionSpec> planned{};
         LiveSession session{};
         DiagnosticState diagnostics{};
@@ -746,7 +769,11 @@ namespace hgraph::fabric::detail
         {
             throw std::logic_error("fabric live node started twice");
         }
-        impl_->config = checked_config(std::move(config));
+        FabricConfig checked = checked_config(std::move(config));
+        FabricMetadataBinding metadata_binding{checked};
+        diagnostic_values_.bind();
+        impl_->config = std::move(checked);
+        impl_->metadata_binding.emplace(std::move(metadata_binding));
         impl_->planned = std::move(planned);
     }
 
@@ -755,7 +782,9 @@ namespace hgraph::fabric::detail
         impl_->session = {};
         impl_->diagnostics = {};
         impl_->planned.clear();
+        impl_->metadata_binding.reset();
         impl_->config.reset();
+        diagnostic_values_.reset();
     }
 
     std::optional<DeliveryBatch>
@@ -777,9 +806,21 @@ namespace hgraph::fabric::detail
             impl_->diagnostics, "fabric", "live",
             [&]
             {
-                impl_->session.configure(*impl_->config, std::move(subscriptions));
+                impl_->session.configure(*impl_->config,
+                                         *impl_->metadata_binding,
+                                         std::move(subscriptions));
                 return impl_->session.evaluate(std::move(revisions), now, reconcile);
             });
+    }
+
+    DataRevisionInput LiveNodeState::decode_revision(ValueView revision) const
+    {
+        if (!impl_->metadata_binding.has_value())
+        {
+            throw std::logic_error("fabric live node is not started");
+        }
+        return impl_->metadata_binding->values().data_revision_input(
+            std::move(revision));
     }
 
     FabricNodeDiagnostics LiveNodeState::diagnostics() const
@@ -797,6 +838,7 @@ namespace hgraph::fabric::detail
     struct PublicationNodeState::Impl
     {
         std::optional<FabricConfig> config{};
+        std::optional<FabricMetadataBinding> metadata_binding{};
         std::map<Str, std::unique_ptr<PublisherStateMachine>, IdLess> publishers{};
         std::map<Str, std::deque<PublicationRequestInput>, IdLess> queues{};
         std::map<Str, RevisionId, IdLess> advertised{};
@@ -822,9 +864,17 @@ namespace hgraph::fabric::detail
             auto machine = publishers.find(data_id);
             if (machine == publishers.end())
             {
+                if (!metadata_binding.has_value())
+                {
+                    throw std::logic_error(
+                        "fabric publication metadata is not bound");
+                }
                 machine = publishers
-                              .emplace(Str{data_id}, std::make_unique<PublisherStateMachine>(
-                                                         configured(), Str{data_id}))
+                              .emplace(
+                                  Str{data_id},
+                                  BoundPublisherFactory::publisher(
+                                      configured(), Str{data_id},
+                                      *metadata_binding))
                               .first;
             }
             if (!publication_terminal(machine->second->state()) &&
@@ -855,7 +905,11 @@ namespace hgraph::fabric::detail
         {
             throw std::logic_error("fabric publication node started twice");
         }
-        impl_->config = checked_config(std::move(config));
+        FabricConfig checked = checked_config(std::move(config));
+        FabricMetadataBinding metadata_binding{checked};
+        diagnostic_values_.bind();
+        impl_->config = std::move(checked);
+        impl_->metadata_binding.emplace(std::move(metadata_binding));
         impl_->graph_notifications = graph_notifications;
     }
 
@@ -865,8 +919,10 @@ namespace hgraph::fabric::detail
         impl_->queues.clear();
         impl_->advertised.clear();
         impl_->diagnostics = {};
+        impl_->metadata_binding.reset();
         impl_->config.reset();
         impl_->graph_notifications = false;
+        diagnostic_values_.reset();
     }
 
     void PublicationNodeState::enqueue(PublicationRequestInput request)
@@ -939,6 +995,16 @@ namespace hgraph::fabric::detail
             impl_->begin_next(data_id);
         }
         return accepted;
+    }
+
+    Value PublicationNodeState::make_revision(DataRevisionInput revision) const
+    {
+        if (!impl_->metadata_binding.has_value())
+        {
+            throw std::logic_error("fabric publication node is not started");
+        }
+        return impl_->metadata_binding->values().make_data_revision(
+            std::move(revision));
     }
 
     void PublicationNodeState::complete(NotificationDeliveryInput delivery)

--- a/extensions/fabric/src/value_builders.cpp
+++ b/extensions/fabric/src/value_builders.cpp
@@ -1,6 +1,11 @@
 #include <hgraph/fabric/value_builders.h>
 
+#include <hgraph/fabric/metadata_codec.h>
+
+#include "impl/metadata_value_binding.h"
+
 #include <hgraph/types/metadata/value_plan_factory.h>
+#include <hgraph/types/static_schema.h>
 #include <hgraph/types/value/value_builder.h>
 
 #include <algorithm>
@@ -12,48 +17,24 @@ namespace hgraph::fabric
     namespace
     {
         template <typename T>
-        [[nodiscard]] Value atomic(T value)
+        [[nodiscard]] Value atomic(const ValueTypeRef &binding, const T &value)
         {
-            // No value_meta() call: these are standard scalars, which
-            // TypeRegistry seeds (and re-seeds after a reset), so forcing
-            // registration here only added registry traffic per field on a
-            // path that runs during evaluation.
-            return Value{std::move(value)};
+            return Value{binding, std::addressof(value)};
         }
 
-        template <typename Schema>
-        [[nodiscard]] Value bundle(
-            std::vector<std::pair<std::string_view, Value>> fields)
+        [[nodiscard]] std::string_view reference_kind_name(MetadataObjectKind kind)
         {
-            BundleBuilder builder{ValuePlanFactory::instance().type_for(
-                scalar_descriptor<Schema>::value_meta())};
-            for (auto &[name, field] : fields)
+            switch (kind)
             {
-                if (field.has_value()) { builder.set(name, std::move(field)); }
+                case MetadataObjectKind::AsOf:
+                    return "as_of";
+                case MetadataObjectKind::Latest:
+                    return "latest";
+                case MetadataObjectKind::Revision:
+                    break;
             }
-            return builder.build();
-        }
-
-        [[nodiscard]] Value dependencies_value(
-            std::vector<DataDependencyInput> dependencies)
-        {
-            const auto element = ValuePlanFactory::instance().type_for(
-                scalar_descriptor<DataDependency>::value_meta());
-            const auto tuple = ValuePlanFactory::instance().type_for(
-                scalar_descriptor<HomogeneousTuple<DataDependency>>::value_meta());
-            if (!element || !tuple)
-            {
-                throw std::logic_error("fabric dependency tuple schema did not resolve");
-            }
-
-            ListBuilder builder{element};
-            for (auto &dependency : dependencies)
-            {
-                Value value = make_data_dependency(std::move(dependency));
-                builder.push_back_copy(value.view().data());
-            }
-            ListStorage storage = builder.build_storage();
-            return Value{tuple, &storage};
+            throw std::invalid_argument(
+                "fabric revision reference kind must be as-of or latest");
         }
 
         void require_positive(Int value, std::string_view field)
@@ -113,22 +94,42 @@ namespace hgraph::fabric
         }
     }  // namespace
 
-    Value make_data_dependency(DataDependencyInput dependency)
+    detail::FabricMetadataValueBinding::FabricMetadataValueBinding()
+    {
+        auto &factory = ValuePlanFactory::instance();
+        int_type_ = factory.type_for(scalar_descriptor<Int>::value_meta());
+        str_type_ = factory.type_for(scalar_descriptor<Str>::value_meta());
+        datetime_type_ = factory.type_for(scalar_descriptor<DateTime>::value_meta());
+        dependency_type_ =
+            factory.type_for(scalar_descriptor<DataDependency>::value_meta());
+        const auto *dependencies_meta =
+            scalar_descriptor<HomogeneousTuple<DataDependency>>::value_meta();
+        dependencies_type_ =
+            compact_list_type(dependency_type_, *dependencies_meta);
+        revision_type_ = factory.type_for(scalar_descriptor<DataRevision>::value_meta());
+        reference_type_ =
+            factory.type_for(scalar_descriptor<RevisionReference>::value_meta());
+        if (!int_type_ || !str_type_ || !datetime_type_ || !dependency_type_ ||
+            !dependencies_type_ || !revision_type_ || !reference_type_)
+        {
+            throw std::logic_error("fabric metadata value bindings did not resolve");
+        }
+    }
+
+    Value detail::FabricMetadataValueBinding::make_data_dependency(
+        DataDependencyInput dependency) const
     {
         require_data_id(dependency.data_id);
         require_positive(dependency.version, "dependency version");
-        return bundle<DataDependency>({
-            {"data_id", atomic(std::move(dependency.data_id))},
-            {"version", atomic(dependency.version)},
-        });
+        BundleBuilder builder{dependency_type_};
+        builder.set(0U, atomic(str_type_, dependency.data_id));
+        builder.set(1U, atomic(int_type_, dependency.version));
+        return builder.build();
     }
 
-    Value make_data_revision(DataRevisionInput revision)
+    Value detail::FabricMetadataValueBinding::make_data_revision(
+        DataRevisionInput revision) const
     {
-        // No register_fabric_types() here: bundle<DataRevision> resolves the
-        // schema it builds, which registers it, and this function runs during
-        // evaluation where a blanket six-schema registration is per-tick
-        // registry traffic for nothing.
         validate_revision_header(revision);
 
         std::ranges::sort(revision.dependencies,
@@ -139,59 +140,59 @@ namespace hgraph::fabric
                           });
         validate_revision_dependencies(revision);
 
-        std::vector<std::pair<std::string_view, Value>> fields{
-            {"format_version", atomic(revision.format_version)},
-            {"data_id", atomic(std::move(revision.data_id))},
-            {"revision", atomic(revision.revision)},
-            {"output_version", atomic(revision.output_version)},
-            {"dependencies", dependencies_value(std::move(revision.dependencies))},
-            {"as_of", atomic(revision.as_of)},
-        };
+        ListBuilder dependencies{dependency_type_};
+        for (auto &dependency : revision.dependencies)
+        {
+            dependencies.push_back(make_data_dependency(std::move(dependency)));
+        }
+        ListStorage dependency_storage = dependencies.build_storage();
+        Value dependency_value{dependencies_type_, &dependency_storage};
+
+        BundleBuilder builder{revision_type_};
+        builder.set(0U, atomic(int_type_, revision.format_version));
+        builder.set(1U, atomic(str_type_, revision.data_id));
+        builder.set(2U, atomic(int_type_, revision.revision));
+        builder.set(3U, atomic(int_type_, revision.output_version));
+        builder.set(4U, std::move(dependency_value));
         if (revision.self_predecessor.has_value())
         {
-            fields.emplace_back("self_predecessor",
-                                atomic(*revision.self_predecessor));
+            builder.set(5U, atomic(int_type_, *revision.self_predecessor));
         }
-        return bundle<DataRevision>(std::move(fields));
+        builder.set(6U, atomic(datetime_type_, revision.as_of));
+        return builder.build();
     }
 
-    DataRevisionInput data_revision_input(ValueView revision)
+    DataRevisionInput detail::FabricMetadataValueBinding::data_revision_input(
+        ValueView revision) const
     {
-        // The schema comparison below resolves DataRevision, which registers
-        // it; the blanket registration was per-call registry traffic on a path
-        // that runs during evaluation.
-        if (!revision.valid() ||
-            revision.schema() != scalar_descriptor<DataRevision>::value_meta())
+        if (!revision.valid() || revision.schema() != revision_type_.schema())
         {
             throw std::invalid_argument("expected a fabric DataRevision value");
         }
         const auto fields = revision.as_bundle();
         DataRevisionInput result{
-            .format_version = fields.at("format_version").checked_as<Int>(),
-            .data_id = fields.at("data_id").checked_as<Str>(),
-            .revision = fields.at("revision").checked_as<Int>(),
-            .output_version = fields.at("output_version").checked_as<Int>(),
+            .format_version = fields.at(0U).checked_as<Int>(),
+            .data_id = fields.at(1U).checked_as<Str>(),
+            .revision = fields.at(2U).checked_as<Int>(),
+            .output_version = fields.at(3U).checked_as<Int>(),
             .dependencies = {},
             .self_predecessor = {},
-            .as_of = fields.at("as_of").checked_as<DateTime>(),
+            .as_of = fields.at(6U).checked_as<DateTime>(),
         };
-        const ValueView predecessor = fields.at("self_predecessor");
+        const ValueView predecessor = fields.at(5U);
         if (predecessor.valid())
         {
             result.self_predecessor = predecessor.checked_as<Int>();
         }
-        for (const auto dependency : fields.at("dependencies").as_list())
+        for (const auto dependency : fields.at(4U).as_list())
         {
             const auto dependency_fields = dependency.as_bundle();
             result.dependencies.push_back(DataDependencyInput{
-                .data_id = dependency_fields.at("data_id").checked_as<Str>(),
-                .version = dependency_fields.at("version").checked_as<Int>(),
+                .data_id = dependency_fields.at(0U).checked_as<Str>(),
+                .version = dependency_fields.at(1U).checked_as<Int>(),
             });
         }
 
-        // Reject rather than silently canonicalise an already materialized
-        // non-canonical value. That keeps the codec single-valued without
-        // rebuilding the potentially large immutable revision.
         if (!std::ranges::is_sorted(
                 result.dependencies,
                 [](const DataDependencyInput &lhs,
@@ -205,5 +206,74 @@ namespace hgraph::fabric
         validate_revision_header(result);
         validate_revision_dependencies(result);
         return result;
+    }
+
+    Value detail::FabricMetadataValueBinding::make_revision_reference(
+        MetadataObjectKind kind, RevisionId revision) const
+    {
+        require_positive(revision, "revision reference");
+        const Str kind_value{reference_kind_name(kind)};
+        BundleBuilder builder{reference_type_};
+        builder.set(0U, atomic(str_type_, kind_value));
+        builder.set(1U, atomic(int_type_, revision));
+        return builder.build();
+    }
+
+    RevisionId detail::FabricMetadataValueBinding::revision_reference_id(
+        ValueView reference, MetadataObjectKind expected_kind) const
+    {
+        if (!reference.valid() || reference.schema() != reference_type_.schema())
+        {
+            throw std::invalid_argument(
+                "expected a fabric RevisionReference value");
+        }
+        const auto fields = reference.as_bundle();
+        const auto kind = fields.at(0U);
+        const auto revision = fields.at(1U);
+        if (!kind.valid() || !revision.valid())
+        {
+            throw std::invalid_argument("fabric revision reference is incomplete");
+        }
+        const auto expected_name = reference_kind_name(expected_kind);
+        const auto stored_kind = kind.checked_as<Str>();
+        if (stored_kind != expected_name)
+        {
+            throw std::invalid_argument("fabric revision reference is a '" +
+                                        std::string{stored_kind} + "' entry, expected '" +
+                                        std::string{expected_name} + "'");
+        }
+        const auto stored_revision = revision.checked_as<Int>();
+        require_positive(stored_revision, "revision reference");
+        return stored_revision;
+    }
+
+    const ValueTypeMetaData *
+    detail::FabricMetadataValueBinding::data_revision_schema() const noexcept
+    {
+        return revision_type_.schema();
+    }
+
+    const ValueTypeMetaData *
+    detail::FabricMetadataValueBinding::revision_reference_schema() const noexcept
+    {
+        return reference_type_.schema();
+    }
+
+    Value make_data_dependency(DataDependencyInput dependency)
+    {
+        return detail::FabricMetadataValueBinding{}.make_data_dependency(
+            std::move(dependency));
+    }
+
+    Value make_data_revision(DataRevisionInput revision)
+    {
+        return detail::FabricMetadataValueBinding{}.make_data_revision(
+            std::move(revision));
+    }
+
+    DataRevisionInput data_revision_input(ValueView revision)
+    {
+        return detail::FabricMetadataValueBinding{}.data_revision_input(
+            std::move(revision));
     }
 }  // namespace hgraph::fabric

--- a/extensions/fabric/test_package/main.cpp
+++ b/extensions/fabric/test_package/main.cpp
@@ -1,4 +1,6 @@
 #include <hgraph/fabric/fabric.h>
+
+#include <hgraph/persistence/value_store.h>
 #if defined(HGRAPH_FABRIC_CONSUMER_HAS_KAFKA)
 #include <hgraph/fabric/kafka.h>
 #include <hgraph/kafka/value_builders.h>
@@ -58,13 +60,16 @@ int main()
         .dependencies = {{"installed/input", 3}},
         .as_of = hg::MIN_ST,
     });
-    // Metadata is a declared value schema through the configured store, and
-    // the codecs are bound with that configuration at wiring time, so nothing
-    // on an evaluation path resolves a codec per value (RFC 0030). An
-    // installed consumer gets both without writing a codec.
+    // Metadata is a declared value schema through a store assembled from the
+    // Fabric object resource and codec policy. Run-local code binds this store
+    // once; an installed consumer gets the same contract without a codec of
+    // its own.
+    const auto values = hg::persistence::store::make_value_store(
+        {.objects = config->objects, .codec = config->metadata_codec});
+    const auto revision_codec = values.bind(hgf::data_revision_meta());
     const auto encoded =
-        hgf::encode_data_revision(config->revision_codec, revision.view());
-    const auto decoded = hgf::decode_data_revision(config->revision_codec, encoded);
+        hgf::encode_data_revision(revision_codec, revision.view());
+    const auto decoded = hgf::decode_data_revision(revision_codec, encoded);
     if (hgf::data_revision_input(decoded.view()) !=
         hgf::data_revision_input(revision.view()))
     {

--- a/extensions/fabric/tests/resolution_perf.cpp
+++ b/extensions/fabric/tests/resolution_perf.cpp
@@ -1,5 +1,7 @@
 #include <hgraph/fabric/fabric.h>
 
+#include <hgraph/persistence/value_store.h>
+
 #include <arrow/builder.h>
 #include <arrow/io/api.h>
 #include <arrow/ipc/api.h>
@@ -91,9 +93,11 @@ void seed(const hgf::FabricConfig &config,
     config.frames.write(frame_key, scalar_frame(input.output_version));
   }
   auto value = hgf::make_data_revision(input);
+  const auto metadata = hgps::make_value_store(
+      {.objects = config.objects, .codec = config.metadata_codec});
   const auto result = config.objects.put_immutable(
       hgf::revision_key(config.prefix, input.data_id, input.revision),
-      config.values.encode(value.view()));
+      metadata.encode(value.view()));
   if (result.status != hgps::ImmutableWriteStatus::Created) {
     throw std::runtime_error("failed to seed resolver benchmark");
   }

--- a/extensions/fabric/tests/test_backends.cpp
+++ b/extensions/fabric/tests/test_backends.cpp
@@ -1,5 +1,7 @@
 #include <hgraph/fabric/fabric.h>
 
+#include <hgraph/persistence/value_store.h>
+
 #include <hgraph/persistence/frame_store.h>
 #include <hgraph/persistence/object_store.h>
 #include <hgraph/persistence/store_location.h>
@@ -95,6 +97,12 @@ class TempFabricStore
     const auto values = std::static_pointer_cast<arrow::Int64Array>(
         value.table->column(0)->chunk(0));
     return values->Value(0);
+}
+
+[[nodiscard]] hgps::ValueStore metadata_store(const hgf::FabricConfig &config)
+{
+    return hgps::make_value_store({.objects = config.objects,
+                                   .codec = config.metadata_codec});
 }
 
 [[nodiscard]] hgf::FabricConfig config_for(
@@ -328,12 +336,14 @@ TEST_CASE("local Fabric publication has one accepted winner across processes")
     auto config = local_config(store, hgps::Format::ArrowIpc);
     const auto latest = config.objects.get(hgf::latest_key(config.prefix, "race"));
     REQUIRE(latest.has_value());
-    CHECK(hgf::revision_reference_value(config.reference_codec, hgf::MetadataObjectKind::Latest, latest->data) == 1);
+    CHECK(hgf::revision_reference_value(
+              metadata_store(config).bind(hgf::revision_reference_meta()),
+              hgf::MetadataObjectKind::Latest, latest->data) == 1);
     const auto stored = config.objects.get(
         hgf::revision_key(config.prefix, "race", 1));
     REQUIRE(stored.has_value());
     const auto winner = hgf::data_revision_input(
-        config.values.decode(hgf::data_revision_meta(), stored->data).view());
+        metadata_store(config).decode(hgf::data_revision_meta(), stored->data).view());
     CHECK(config.frames.contains(hgf::data_version_key(
         config.prefix, "race", winner.output_version)));
 }

--- a/extensions/fabric/tests/test_history.cpp
+++ b/extensions/fabric/tests/test_history.cpp
@@ -1,5 +1,7 @@
 #include <hgraph/fabric/fabric.h>
 
+#include <hgraph/persistence/value_store.h>
+
 #include <arrow/array.h>
 #include <arrow/builder.h>
 #include <arrow/table.h>
@@ -17,6 +19,12 @@ namespace
     namespace hgps = hgraph::persistence::store;
 
     constexpr hg::DateTime BASE_TIME{hg::TimeDelta{1'800'000'000'000'000}};
+
+    [[nodiscard]] hgps::ValueStore metadata_store(const hgf::FabricConfig &config)
+    {
+        return hgps::make_value_store({.objects = config.objects,
+                                       .codec = config.metadata_codec});
+    }
 
     [[nodiscard]] hg::Frame frame(std::int64_t value)
     {
@@ -52,12 +60,14 @@ namespace
         });
         REQUIRE(config.objects
                     .put_immutable(hgf::revision_key(config.prefix, "prices", revision),
-                                   config.values.encode(value.view()))
+                                   metadata_store(config).encode(value.view()))
                     .status == hgps::ImmutableWriteStatus::Created);
         REQUIRE(config.objects
                     .put_immutable(
                         hgf::as_of_key(config.prefix, "prices", as_of),
-                        hgf::encode_reference(config.reference_codec, hgf::MetadataObjectKind::AsOf, revision))
+                        hgf::encode_reference(
+                            metadata_store(config).bind(hgf::revision_reference_meta()),
+                            hgf::MetadataObjectKind::AsOf, revision))
                     .status == hgps::ImmutableWriteStatus::Created);
     }
 }  // namespace
@@ -85,7 +95,9 @@ TEST_CASE("load_data rejects an as-of index entry for another instant")
     REQUIRE(config.objects
                 .put_immutable(
                     hgf::as_of_key(config.prefix, "prices", BASE_TIME + hg::TimeDelta{20}),
-                    hgf::encode_reference(config.reference_codec, hgf::MetadataObjectKind::AsOf, 1))
+                    hgf::encode_reference(
+                        metadata_store(config).bind(hgf::revision_reference_meta()),
+                        hgf::MetadataObjectKind::AsOf, 1))
                 .status == hgps::ImmutableWriteStatus::Created);
 
     CHECK_THROWS_WITH(hgf::load_data(config, "prices", BASE_TIME + hg::TimeDelta{20}),
@@ -103,12 +115,14 @@ TEST_CASE("load_data fails on a missing referenced frame")
     });
     REQUIRE(config.objects
                 .put_immutable(hgf::revision_key(config.prefix, "prices", 1),
-                               config.values.encode(value.view()))
+                               metadata_store(config).encode(value.view()))
                 .status == hgps::ImmutableWriteStatus::Created);
     REQUIRE(config.objects
                 .put_immutable(
                     hgf::as_of_key(config.prefix, "prices", BASE_TIME),
-                    hgf::encode_reference(config.reference_codec, hgf::MetadataObjectKind::AsOf, 1))
+                    hgf::encode_reference(
+                        metadata_store(config).bind(hgf::revision_reference_meta()),
+                        hgf::MetadataObjectKind::AsOf, 1))
                 .status == hgps::ImmutableWriteStatus::Created);
 
     CHECK_THROWS_WITH(hgf::load_data(config, "prices", BASE_TIME),

--- a/extensions/fabric/tests/test_kafka.cpp
+++ b/extensions/fabric/tests/test_kafka.cpp
@@ -56,6 +56,11 @@ namespace hgps = hgraph::persistence::store;
   return store;
 }
 
+[[nodiscard]] hgps::ValueStore metadata_store(const hgf::FabricConfig &config) {
+  return hgps::make_value_store(
+      {.objects = config.objects, .codec = config.metadata_codec});
+}
+
 using namespace std::chrono_literals;
 
 constexpr std::string_view TOPIC{"hgraph-fabric-transport-test"};
@@ -148,14 +153,16 @@ template <typename Predicate>
   const auto decoded = hgf::data_revision_input(value.view());
   const auto revision_write = config.objects.put_immutable(
       hgf::revision_key(config.prefix, "prices", revision),
-      config.values.encode(value.view()));
+      metadata_store(config).encode(value.view()));
   if (revision_write.status ==
       hg::persistence::store::ImmutableWriteStatus::Conflict) {
     throw std::runtime_error("Fabric Kafka test revision conflicted");
   }
   const auto as_of_write = config.objects.put_immutable(
       hgf::as_of_key(config.prefix, "prices", decoded.as_of),
-      hgf::encode_reference(config.reference_codec, hgf::MetadataObjectKind::AsOf, revision));
+      hgf::encode_reference(metadata_store(config).bind(
+                                hgf::revision_reference_meta()),
+                            hgf::MetadataObjectKind::AsOf, revision));
   if (as_of_write.status ==
       hg::persistence::store::ImmutableWriteStatus::Conflict) {
     throw std::runtime_error("Fabric Kafka test as-of entry conflicted");
@@ -167,7 +174,9 @@ template <typename Predicate>
       current.has_value()
           ? std::optional<std::string_view>{current->version_token}
           : std::nullopt,
-      hgf::encode_reference(config.reference_codec, hgf::MetadataObjectKind::Latest, revision));
+      hgf::encode_reference(metadata_store(config).bind(
+                                hgf::revision_reference_meta()),
+                            hgf::MetadataObjectKind::Latest, revision));
   if (!latest.exchanged) {
     throw std::runtime_error("Fabric Kafka test latest update lost a race");
   }
@@ -496,7 +505,9 @@ TEST_CASE("Kafka queue wakes live Fabric through the Kafka root push source") {
   const auto latest =
       config.objects.get(hgf::latest_key(config.prefix, "prices"));
   REQUIRE(latest.has_value());
-  CHECK(hgf::revision_reference_value(config.reference_codec, hgf::MetadataObjectKind::Latest, latest->data) == 1);
+  CHECK(hgf::revision_reference_value(
+            metadata_store(config).bind(hgf::revision_reference_meta()),
+            hgf::MetadataObjectKind::Latest, latest->data) == 1);
   kafka_config = {};
 }
 
@@ -627,7 +638,9 @@ TEST_CASE("manual Kafka assignment recovers after every broker disconnects") {
         const auto latest =
             config.objects.get(hgf::latest_key(config.prefix, "prices"));
         return latest.has_value() &&
-               hgf::revision_reference_value(config.reference_codec, hgf::MetadataObjectKind::Latest, latest->data) == 2;
+               hgf::revision_reference_value(
+                   metadata_store(config).bind(hgf::revision_reference_meta()),
+                   hgf::MetadataObjectKind::Latest, latest->data) == 2;
       },
       5s);
   if (!second_is_durable ||
@@ -744,7 +757,9 @@ TEST_CASE("actual broker preserves Fabric recovery, retry, and ordering",
         const auto latest =
             config.objects.get(hgf::latest_key(config.prefix, "prices"));
         return latest.has_value() &&
-               hgf::revision_reference_value(config.reference_codec, hgf::MetadataObjectKind::Latest, latest->data) == 2;
+               hgf::revision_reference_value(
+                   metadata_store(config).bind(hgf::revision_reference_meta()),
+                   hgf::MetadataObjectKind::Latest, latest->data) == 2;
       },
       20s);
   if (!second_is_durable) {

--- a/extensions/fabric/tests/test_public_contracts.cpp
+++ b/extensions/fabric/tests/test_public_contracts.cpp
@@ -25,26 +25,21 @@ namespace
     namespace hgps = hgraph::persistence::store;
 
     /** A store for encoding fixtures, independent of any fabric config. */
-    [[nodiscard]] const hgps::ValueStore &contract_values()
+    [[nodiscard]] hgps::ValueStore contract_values()
     {
-        static const hgps::ValueStore store = [] {
-            hgps::register_builtin_value_codecs();
-            return hgps::make_value_store(
-                hgps::ValueStoreConfig{.objects = hgps::make_object_store(
-                                           hgps::ObjectStoreConfig{})});
-        }();
-        return store;
+        hgps::register_builtin_value_codecs();
+        return hgps::make_value_store(
+            hgps::ValueStoreConfig{.objects = hgps::make_object_store(
+                                       hgps::ObjectStoreConfig{})});
     }
 
 
-    /** The bound codecs a configured fabric would carry.
+    /** The bound codecs a running Fabric algorithm would carry.
 
-        Deliberately NOT cached in a static: this suite resets the registries
-        between cases, and a reset frees the interned converters a binding
-        points at. Caching one across a reset dangles -- it crashed this suite
-        with a bus error when first written, which is the hazard the
-        BoundValueCodec docs describe, reproduced. Real callers bind with the
-        config at wiring time and are torn down with the graph. */
+        Deliberately not cached in a static: this suite resets the registries
+        between cases, which invalidates registry-scoped metadata retained by
+        a binding. Real callers bind while constructing run-local node/service
+        state and tear the binding down with the graph. */
     [[nodiscard]] hgps::BoundValueCodec contract_revision_codec()
     {
         return contract_values().bind(hgf::data_revision_meta());
@@ -65,6 +60,17 @@ namespace
             .as_of = hg::DateTime{hg::TimeDelta{1'767'323'045'000'000 + revision}},
         });
         return contract_values().encode(value.view());
+    }
+
+    [[nodiscard]] hgps::ObjectBytes json_bytes(std::string_view text)
+    {
+        hgps::ObjectBytes result;
+        result.reserve(text.size());
+        for (const char character : text)
+        {
+            result.push_back(static_cast<std::byte>(character));
+        }
+        return result;
     }
 
     [[nodiscard]] hg::Value canonical_revision()
@@ -337,7 +343,6 @@ TEST_CASE("fabric metadata is a json document with the properties that matter")
     // the byte layout is now the library's business, covered by the value
     // store's own tests. What still belongs to fabric is behaviour.
     const auto &values = contract_values();
-
     hg::Value  revision = canonical_revision();
     const auto encoded  = values.encode(revision.view());
 
@@ -354,10 +359,14 @@ TEST_CASE("fabric metadata is a json document with the properties that matter")
     // An index entry names the index it belongs to, so reading a latest entry
     // as an as-of entry is refused rather than silently answered.
     const auto as_of =
-        hgf::encode_reference(contract_reference_codec(), hgf::MetadataObjectKind::AsOf, 3);
-    CHECK(hgf::revision_reference_value(contract_reference_codec(), hgf::MetadataObjectKind::AsOf, as_of) == 3);
+        hgf::encode_reference(contract_reference_codec(),
+                              hgf::MetadataObjectKind::AsOf, 3);
+    CHECK(hgf::revision_reference_value(
+              contract_reference_codec(), hgf::MetadataObjectKind::AsOf,
+              as_of) == 3);
     CHECK_THROWS_AS(
-        hgf::revision_reference_value(contract_reference_codec(), hgf::MetadataObjectKind::Latest, as_of),
+        hgf::revision_reference_value(contract_reference_codec(),
+                                      hgf::MetadataObjectKind::Latest, as_of),
         std::invalid_argument);
 
     // Malformed input still fails closed.
@@ -379,9 +388,6 @@ TEST_CASE("memory notifier fans out and conflates each data id")
           hgf::NotificationDeliveryStatus::Delivered);
     CHECK(notifier.publish({"a", notice("a", 2)}).poll().status ==
           hgf::NotificationDeliveryStatus::Delivered);
-    CHECK_THROWS_AS(notifier.publish({"a", notice("different", 1)}),
-                    std::invalid_argument);
-
     REQUIRE(first.pending() == 2);
     REQUIRE(second.pending() == 2);
     CHECK(first.try_pop() == hgf::RevisionNotification{"a", notice("a", 2)});
@@ -393,6 +399,19 @@ TEST_CASE("memory notifier fans out and conflates each data id")
           hgf::NotificationDeliveryStatus::Delivered);
     CHECK(second.pending() == 0);
     CHECK(first.try_pop() == hgf::RevisionNotification{"c", notice("c", 1)});
+}
+
+TEST_CASE("notifier transports opaque revision bytes without off-graph decoding")
+{
+    auto notifier = hgf::make_memory_notifier();
+    auto subscription = notifier.subscribe();
+    const hgraph::persistence::store::ObjectBytes opaque{
+        std::byte{'n'}, std::byte{'o'}, std::byte{'t'}, std::byte{'-'},
+        std::byte{'j'}, std::byte{'s'}, std::byte{'o'}, std::byte{'n'}};
+
+    CHECK(notifier.publish({"data", opaque}).poll().status ==
+          hgf::NotificationDeliveryStatus::Delivered);
+    CHECK(subscription.try_pop() == hgf::RevisionNotification{"data", opaque});
 }
 
 TEST_CASE("fabric configuration is run scoped and validates resources")
@@ -421,6 +440,27 @@ TEST_CASE("fabric configuration is run scoped and validates resources")
     hgf::clear_fabric_config(state, "left-fabric");
     CHECK_FALSE(hgf::fabric_config(state, "left-fabric").has_value());
     CHECK(hgf::fabric_config(state, "right-fabric").has_value());
+}
+
+TEST_CASE("reusable Fabric configuration contains no registry-bound state")
+{
+    auto config = hgf::make_memory_fabric_config("test/fabric/reusable");
+
+    // Configuration may be assembled before a run and copied into a later
+    // one. The reset destroys interned value plans and JSON converters; only
+    // run-local bindings created afterwards may point at their replacements.
+    hg::reset_all_registries();
+
+    const auto store = hgps::make_value_store(
+        {.objects = config.objects, .codec = config.metadata_codec});
+    const auto revisions = store.bind_schema(hgf::data_revision_meta());
+    hg::Value revision = hgf::make_data_revision(hgf::DataRevisionInput{
+        .data_id = "prices", .revision = 1, .output_version = 1,
+        .as_of = hg::MIN_ST});
+    REQUIRE(revisions.write("revision", revision.view()).status ==
+            hgps::ImmutableWriteStatus::Created);
+    CHECK(hgf::data_revision_input(revisions.read("revision").view()).data_id ==
+          "prices");
 }
 
 TEST_CASE("fabric operator installer survives a registry rebuild")
@@ -595,7 +635,6 @@ TEST_CASE("fabric rejects malformed metadata at the decode boundary")
     // checks existed in the hand-written codec and are not the store's job,
     // so they live with the schema that owns their meaning.
     const auto &values = contract_values();
-
     SECTION("a non-positive revision reference is malformed")
     {
         CHECK_THROWS_AS(hgf::make_revision_reference(hgf::MetadataObjectKind::Latest, 0),
@@ -624,30 +663,30 @@ TEST_CASE("fabric rejects malformed metadata at the decode boundary")
 
     SECTION("non-positive ordinals in a revision are malformed")
     {
-        auto encoded_with = [&](hgf::DataRevisionInput input) {
-            return values.encode(hgf::make_data_revision(std::move(input)).view());
-        };
-        const hgf::DataRevisionInput valid{
-            .data_id = "alpha", .revision = 1, .output_version = 1,
-            .as_of = hg::MIN_ST};
-
-        auto zero_revision = valid;
-        zero_revision.revision = 0;
-        CHECK_THROWS_AS(hgf::decode_data_revision(contract_revision_codec(), encoded_with(zero_revision)),
+        // These are externally edited documents. Going through
+        // make_data_revision would only prove that the builder rejects bad
+        // input before the decode boundary is reached.
+        CHECK_THROWS_AS(hgf::decode_data_revision(
+                            contract_revision_codec(),
+                            json_bytes(
+                                R"({"format_version":1,"data_id":"alpha","revision":0,"output_version":1,"dependencies":[],"as_of":"2024-06-13T10:15:30+00:00"})")),
                         std::invalid_argument);
-
-        auto zero_output = valid;
-        zero_output.output_version = 0;
-        CHECK_THROWS_AS(hgf::decode_data_revision(contract_revision_codec(), encoded_with(zero_output)),
+        CHECK_THROWS_AS(hgf::decode_data_revision(
+                            contract_revision_codec(),
+                            json_bytes(
+                                R"({"format_version":1,"data_id":"alpha","revision":1,"output_version":0,"dependencies":[],"as_of":"2024-06-13T10:15:30+00:00"})")),
                         std::invalid_argument);
-
-        auto bad_dependency = valid;
-        bad_dependency.dependencies = {{"input", 0}};
-        CHECK_THROWS_AS(hgf::decode_data_revision(contract_revision_codec(), encoded_with(bad_dependency)),
+        CHECK_THROWS_AS(hgf::decode_data_revision(
+                            contract_revision_codec(),
+                            json_bytes(
+                                R"({"format_version":1,"data_id":"alpha","revision":1,"output_version":1,"dependencies":[{"data_id":"input","version":0}],"as_of":"2024-06-13T10:15:30+00:00"})")),
                         std::invalid_argument);
 
         // A valid one still round trips, so the checks are not simply refusing.
-        CHECK_NOTHROW(hgf::decode_data_revision(contract_revision_codec(), encoded_with(valid)));
+        CHECK_NOTHROW(hgf::decode_data_revision(
+            contract_revision_codec(),
+            json_bytes(
+                R"({"format_version":1,"data_id":"alpha","revision":1,"output_version":1,"dependencies":[],"as_of":"2024-06-13T10:15:30+00:00"})")));
     }
 
     SECTION("dependencies out of canonical order are malformed")
@@ -672,7 +711,8 @@ TEST_CASE("fabric rejects malformed metadata at the decode boundary")
     {
         const std::vector<std::byte> oversized(hgf::MAX_METADATA_BYTES + 1,
                                                std::byte{'{'});
-        CHECK_THROWS_AS(hgf::decode_data_revision(contract_revision_codec(), oversized),
+        CHECK_THROWS_AS(hgf::decode_data_revision(contract_revision_codec(),
+                                                  oversized),
                         std::invalid_argument);
     }
 }

--- a/extensions/fabric/tests/test_publication.cpp
+++ b/extensions/fabric/tests/test_publication.cpp
@@ -1,6 +1,11 @@
 #include <hgraph/fabric/fabric.h>
 
+#include "../src/impl/metadata_binding.h"
+
+#include <hgraph/persistence/value_store.h>
+
 #include <hgraph/types/utils/counted_mutex.h>
+#include <hgraph/types/value/json_codec.h>
 
 #include <hgraph/persistence/frame_store.h>
 
@@ -14,6 +19,7 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -28,6 +34,12 @@ namespace
     constexpr hg::DateTime TIME_1{hg::TimeDelta{1'767'323'045'006'007}};
     constexpr hg::DateTime TIME_2{hg::TimeDelta{1'767'323'045'006'007}};
     constexpr hg::DateTime TIME_3{hg::TimeDelta{1'767'323'045'006'008}};
+
+    [[nodiscard]] hgps::ValueStore metadata_store(const hgf::FabricConfig &config)
+    {
+        return hgps::make_value_store({.objects = config.objects,
+                                       .codec = config.metadata_codec});
+    }
 
     [[nodiscard]] hg::Frame frame(std::int64_t value,
                                   std::string field_name = "value")
@@ -81,7 +93,8 @@ namespace
         const auto stored = config.objects.get(
             hgf::revision_key(config.prefix, data_id, revision));
         REQUIRE(stored.has_value());
-        return hgf::data_revision_input(config.values.decode(hgf::data_revision_meta(), stored->data).view());
+        return hgf::data_revision_input(
+            metadata_store(config).decode(hgf::data_revision_meta(), stored->data).view());
     }
 
     [[nodiscard]] hgf::RevisionId stored_latest(
@@ -90,7 +103,9 @@ namespace
         const auto stored =
             config.objects.get(hgf::latest_key(config.prefix, data_id));
         REQUIRE(stored.has_value());
-        return hgf::revision_reference_value(config.reference_codec, hgf::MetadataObjectKind::Latest, stored->data);
+        return hgf::revision_reference_value(
+            metadata_store(config).bind(hgf::revision_reference_meta()),
+            hgf::MetadataObjectKind::Latest, stored->data);
     }
 
     struct ControlledDelivery
@@ -154,6 +169,46 @@ namespace
             [](void *) {},
         };
         return ops;
+    }
+
+    hgps::ValueCodecBinding oversized_metadata_bind(
+        void *, const hg::ValueTypeMetaData *schema)
+    {
+        auto binding = std::make_shared<hg::BoundJsonConverter>(
+            hg::bind_json_converter(schema));
+        return hgps::ValueCodecBinding{binding, binding.get()};
+    }
+
+    void oversized_metadata_encode(
+        void *, const void *bound, const hg::ValueView &value,
+        hgps::ObjectBytes &out)
+    {
+        std::string text;
+        static_cast<const hg::BoundJsonConverter *>(bound)->write(value, text);
+        const auto bytes =
+            std::as_bytes(std::span{text.data(), text.size()});
+        out.insert(out.end(), bytes.begin(), bytes.end());
+        out.resize(hgf::MAX_METADATA_BYTES + 1U);
+    }
+
+    hg::Value oversized_metadata_decode(
+        void *, const void *bound, std::span<const std::byte> encoded)
+    {
+        return hg::from_json_string(
+            *static_cast<const hg::BoundJsonConverter *>(bound),
+            std::string_view{
+                reinterpret_cast<const char *>(encoded.data()),
+                encoded.size()});
+    }
+
+    void register_oversized_metadata_codec()
+    {
+        hgps::register_value_codec(
+            "test-fabric-oversized", nullptr,
+            hgps::ValueCodecOps{
+                .bind = &oversized_metadata_bind,
+                .encode = &oversized_metadata_encode,
+                .decode = &oversized_metadata_decode});
     }
 }  // namespace
 
@@ -231,7 +286,8 @@ TEST_CASE("publication makes the accepted revision durable before advertising it
     const auto notice = notices.try_pop();
     REQUIRE(notice.has_value());
     CHECK(notice->data_id == "result");
-    CHECK(hgf::data_revision_input(config.values.decode(hgf::data_revision_meta(), notice->revision).view()) ==
+    CHECK(hgf::data_revision_input(metadata_store(config).decode(
+                                      hgf::data_revision_meta(), notice->revision).view()) ==
           *candidate);
     CHECK(machine.advance() ==
           hgf::PublicationState::NotificationAcknowledged);
@@ -379,7 +435,8 @@ TEST_CASE("publication races are first-writer-wins and losers never become the n
         const auto notice = notices.try_pop();
         REQUIRE(notice);
         CHECK(hgf::data_revision_input(
-                  config.values.decode(hgf::data_revision_meta(), notice->revision).view()) ==
+                  metadata_store(config).decode(
+                      hgf::data_revision_meta(), notice->revision).view()) ==
               *first.candidate_revision());
     }
 
@@ -453,7 +510,9 @@ TEST_CASE("startup repairs contiguous revision slots and stale derived indexes")
         REQUIRE(current);
         const auto stale = config.objects.compare_exchange_ref(
             key, current->version_token,
-            hgf::encode_reference(config.reference_codec, hgf::MetadataObjectKind::Latest, 1));
+            hgf::encode_reference(metadata_store(config).bind(
+                                      hgf::revision_reference_meta()),
+                                  hgf::MetadataObjectKind::Latest, 1));
         REQUIRE(stale.exchanged);
 
         hgf::PublisherStateMachine recovered{config, "result"};
@@ -529,7 +588,7 @@ TEST_CASE("Frame failure and corrupt or non-contiguous histories never expose a 
         });
         REQUIRE(config.objects.put_immutable(
                     hgf::revision_key(config.prefix, "result", 1),
-                    config.values.encode(value.view()))
+                    metadata_store(config).encode(value.view()))
                     .status == hgps::ImmutableWriteStatus::Created);
         hgf::PublisherStateMachine machine{config, "result"};
         machine.begin(inputs_only({}));
@@ -553,7 +612,7 @@ TEST_CASE("Frame failure and corrupt or non-contiguous histories never expose a 
         });
         REQUIRE(config.objects.put_immutable(
                     hgf::revision_key(config.prefix, "result", 2),
-                    config.values.encode(value.view()))
+                    metadata_store(config).encode(value.view()))
                     .status == hgps::ImmutableWriteStatus::Created);
         hgf::PublisherStateMachine machine{config, "result"};
         machine.begin(inputs_only({}));
@@ -565,73 +624,97 @@ TEST_CASE("Frame failure and corrupt or non-contiguous histories never expose a 
     }
 }
 
-TEST_CASE("the codec a wired fabric carries resolves nothing per value")
+TEST_CASE("run-bound Fabric metadata performs no type-system lookup per value")
 {
-    // The enforceable form of the single-threaded evaluation ruling: every
-    // type-system mutex is counted, so a codec bound at wiring time must leave
-    // the counter untouched no matter how many values go through it.
-    // bind_metadata_codecs resolves the json converter once, in the
-    // configuration path; before that, to_json_string resolved it per value and
-    // locked to do it.
-    //
-    // This asserts the codec's contribution only. A whole publication still
-    // takes locks -- roughly 300 at the time of writing, down from 910 -- and
-    // those come from value construction and field reads (bundle plan lookup,
-    // checked_as per field) rather than from serialization. Removing them needs
-    // the same bind-at-wiring-time treatment applied to value plans, which is
-    // core-level and tracked separately; pinning a whole-publication number
-    // here would be a brittle proxy for a property this test can state exactly.
     auto config = hgf::make_memory_fabric_config("tests/fabric");
-    const hg::Value revision = hgf::make_data_revision(hgf::DataRevisionInput{
+    const hgf::detail::FabricMetadataBinding metadata{config};
+    const auto &values = metadata.values();
+    const auto &revisions = metadata.revisions();
+    const auto &references = metadata.references();
+    const hg::Value revision = values.make_data_revision(hgf::DataRevisionInput{
         .data_id = "result", .revision = 1, .output_version = 1,
         .as_of = hg::MIN_ST});
-
-    // Warm once: the converter is composed on first sight of the schema.
-    static_cast<void>(config.revision_codec.encode(revision.view()));
+    const auto encoded = revisions.encode(revision.view());
 
     const auto before = hgraph::type_system_lock_count();
     for (int index = 0; index < 64; ++index)
     {
-        static_cast<void>(config.revision_codec.encode(revision.view()));
+        const auto build_before = hgraph::type_system_lock_count();
+        hg::Value built = values.make_data_revision(hgf::DataRevisionInput{
+            .data_id = "result", .revision = index + 1,
+            .output_version = index + 1, .as_of = hg::MIN_ST});
+        CHECK(hgraph::type_system_lock_count() == build_before);
+        const auto input_before = hgraph::type_system_lock_count();
+        static_cast<void>(values.data_revision_input(built.view()));
+        CHECK(hgraph::type_system_lock_count() == input_before);
+        const auto encode_before = hgraph::type_system_lock_count();
+        static_cast<void>(revisions.encode(built.view()));
+        CHECK(hgraph::type_system_lock_count() == encode_before);
+        const auto decode_before = hgraph::type_system_lock_count();
+        static_cast<void>(revisions.decode(encoded));
+        CHECK(hgraph::type_system_lock_count() == decode_before);
+        const auto reference_before = hgraph::type_system_lock_count();
+        hg::Value reference = values.make_revision_reference(
+            hgf::MetadataObjectKind::Latest, index + 1);
+        const auto reference_bytes = references.encode(reference.view());
+        static_cast<void>(values.revision_reference_id(
+            references.decode(reference_bytes).view(),
+            hgf::MetadataObjectKind::Latest));
+        CHECK(hgraph::type_system_lock_count() == reference_before);
     }
     CHECK(hgraph::type_system_lock_count() == before);
 }
 
-TEST_CASE("diagnostic: where publication still locks", "[.diagnostic]")
+TEST_CASE("steady-state publication performs no type-system lookup")
 {
     auto config = hgf::make_memory_fabric_config("tests/fabric");
+    hgf::PublisherStateMachine publisher{config, "result"};
+    publisher.begin(output(7));
+    REQUIRE(drive(publisher) == hgf::PublicationState::Published);
+
+    auto next = output(8, TIME_3 + hg::TimeDelta{10});
+    const auto before = hgraph::type_system_lock_count();
+    publisher.begin(std::move(next));
+    REQUIRE(drive(publisher) == hgf::PublicationState::Published);
+    CHECK(hgraph::type_system_lock_count() == before);
+}
+
+TEST_CASE("run-bound Fabric stores enforce the metadata byte limit")
+{
+    SECTION("durable writes reject an oversized codec result")
     {
-        hgf::PublisherStateMachine warmup{config, "warm"};
-        warmup.begin(output(7));
-        while (warmup.advance() != hgf::PublicationState::Published) {}
+        register_oversized_metadata_codec();
+        auto config = hgf::make_memory_fabric_config(
+            "tests/fabric/metadata-limit/write");
+        config.metadata_codec = "test-fabric-oversized";
+        hgf::PublisherStateMachine publisher{config, "result"};
+        publisher.begin(output(7));
+
+        CHECK_THROWS_WITH(
+            [&] {
+                for (int step = 0; step < 16; ++step)
+                {
+                    publisher.advance();
+                }
+            }(),
+            "fabric metadata exceeds 16 MiB");
+        CHECK_FALSE(config.objects.get(
+            hgf::revision_key(config.prefix, "result", 1)));
     }
-    const hgf::DataRevisionInput input{
-        .data_id = "probe", .revision = 1, .output_version = 1,
-        .as_of = hg::MIN_ST};
 
-    auto measure = [](auto &&fn) {
-        const auto before = hgraph::type_system_lock_count();
-        fn();
-        return hgraph::type_system_lock_count() - before;
-    };
+    SECTION("durable reads reject oversized objects before decoding")
+    {
+        auto config = hgf::make_memory_fabric_config(
+            "tests/fabric/metadata-limit/read");
+        hgps::ObjectBytes oversized(hgf::MAX_METADATA_BYTES + 1U);
+        REQUIRE(config.objects.put_immutable(
+                    hgf::revision_key(config.prefix, "result", 1),
+                    oversized)
+                    .status == hgps::ImmutableWriteStatus::Created);
+        hgf::PublisherStateMachine publisher{config, "result"};
+        publisher.begin(inputs_only({}));
 
-    hg::Value revision = hgf::make_data_revision(input);
-    const auto build = measure([&] { static_cast<void>(hgf::make_data_revision(input)); });
-    const auto encode = measure([&] {
-        static_cast<void>(config.revision_codec.encode(revision.view()));
-    });
-    const auto encoded = config.revision_codec.encode(revision.view());
-    const auto decode = measure([&] {
-        static_cast<void>(config.revision_codec.decode(encoded));
-    });
-    const auto to_input = measure([&] {
-        static_cast<void>(hgf::data_revision_input(revision.view()));
-    });
-    const auto reference = measure([&] {
-        static_cast<void>(hgf::encode_reference(config.reference_codec,
-                                                hgf::MetadataObjectKind::Latest, 1));
-    });
-    WARN("make_data_revision=" << build << " encode=" << encode
-         << " decode=" << decode << " data_revision_input=" << to_input
-         << " encode_reference=" << reference);
+        CHECK_THROWS_WITH(publisher.advance(),
+                          "fabric metadata exceeds 16 MiB");
+    }
 }

--- a/extensions/fabric/tests/test_resolution.cpp
+++ b/extensions/fabric/tests/test_resolution.cpp
@@ -1,5 +1,11 @@
 #include <hgraph/fabric/fabric.h>
 
+#include <hgraph/persistence/value_store.h>
+
+#include "../src/impl/metadata_binding.h"
+
+#include <hgraph/types/utils/counted_mutex.h>
+
 #include <arrow/array.h>
 #include <arrow/builder.h>
 #include <arrow/table.h>
@@ -20,6 +26,11 @@ namespace hgf = hgraph::fabric;
 namespace hgps = hgraph::persistence::store;
 
 constexpr hg::DateTime BASE_TIME{hg::TimeDelta{1'800'000'000'000'000}};
+
+[[nodiscard]] hgps::ValueStore metadata_store(const hgf::FabricConfig &config) {
+  return hgps::make_value_store(
+      {.objects = config.objects, .codec = config.metadata_codec});
+}
 
 [[nodiscard]] hg::Frame frame(std::int64_t value, std::string field = "value") {
   arrow::Int64Builder builder;
@@ -53,7 +64,7 @@ void seed(const hgf::FabricConfig &config, std::string data_id,
   REQUIRE(config.objects
               .put_immutable(hgf::revision_key(config.prefix, decoded.data_id,
                                                decoded.revision),
-                             config.values.encode(value.view()))
+                             metadata_store(config).encode(value.view()))
               .status == hgps::ImmutableWriteStatus::Created);
 }
 
@@ -104,11 +115,15 @@ TEST_CASE("resolver reproduces the RFC D1 D2 D3 bootstrap cut") {
 
   const auto latest = config.objects.get(hgf::latest_key(config.prefix, "D1"));
   REQUIRE(latest.has_value());
-  CHECK(hgf::revision_reference_value(config.reference_codec, hgf::MetadataObjectKind::Latest, latest->data) == 3);
+  CHECK(hgf::revision_reference_value(
+            metadata_store(config).bind(hgf::revision_reference_meta()),
+            hgf::MetadataObjectKind::Latest, latest->data) == 3);
   const auto as_of = config.objects.get(
       hgf::as_of_key(config.prefix, "D1", BASE_TIME + hg::TimeDelta{3}));
   REQUIRE(as_of.has_value());
-  CHECK(hgf::revision_reference_value(config.reference_codec, hgf::MetadataObjectKind::AsOf, as_of->data) == 3);
+  CHECK(hgf::revision_reference_value(
+            metadata_store(config).bind(hgf::revision_reference_meta()),
+            hgf::MetadataObjectKind::AsOf, as_of->data) == 3);
 }
 
 TEST_CASE(
@@ -331,4 +346,17 @@ TEST_CASE(
   CHECK(warm.metrics.output_index_hits >= static_cast<std::uint64_t>(count));
   CHECK(warm.metrics.maximum_backtracking_depth >= 3);
   CHECK(warm.metrics.average_backtracking_depth() > 0.0);
+}
+
+TEST_CASE("dynamic coordinator state copies the node's run binding") {
+  auto config =
+      hgf::make_memory_fabric_config("tests/resolution/run-binding");
+  hgf::detail::FabricMetadataBinding binding{config};
+
+  const auto before = hg::type_system_lock_count();
+  auto coordinator = hgf::detail::BoundConsistencyFactory::coordinator(
+      config, {"A"}, binding);
+  CHECK(hg::type_system_lock_count() == before);
+  CHECK(coordinator.resolve().forests.front().status ==
+        hgf::ResolutionStatus::Pending);
 }

--- a/extensions/fabric/tests/test_subscription.cpp
+++ b/extensions/fabric/tests/test_subscription.cpp
@@ -2,6 +2,8 @@
 
 #include "../src/impl/service_state.h"
 
+#include <hgraph/persistence/value_store.h>
+
 #include <hgraph/lib/std/operators/control.h>
 #include <hgraph/lib/std/operators/conversion.h>
 #include <hgraph/lib/std/operators/registration.h>
@@ -9,6 +11,8 @@
 #include <hgraph/runtime/logger.h>
 #include <hgraph/runtime/runtime.h>
 #include <hgraph/types/static_node.h>
+#include <hgraph/types/utils/counted_mutex.h>
+#include <hgraph/types/registry_reset.h>
 
 #include <arrow/array.h>
 #include <arrow/builder.h>
@@ -36,6 +40,12 @@ namespace
     namespace hgps = hgraph::persistence::store;
 
     constexpr hg::DateTime BASE_TIME{hg::TimeDelta{1'800'000'000'000'000}};
+
+    [[nodiscard]] hgps::ValueStore metadata_store(const hgf::FabricConfig &config)
+    {
+        return hgps::make_value_store({.objects = config.objects,
+                                       .codec = config.metadata_codec});
+    }
 
     std::vector<std::pair<hg::DateTime, std::int64_t>> observed_frames{};
     std::vector<std::tuple<hg::DateTime, hg::Str, std::int64_t>> observed_tagged_frames{};
@@ -214,24 +224,28 @@ namespace
         {
             config.frames.write(data_key, frame(output_version));
         }
-        hg::Value value = hgf::make_data_revision(hgf::DataRevisionInput{
+        const hgf::detail::FabricMetadataValueBinding metadata_values;
+        hg::Value value = metadata_values.make_data_revision(hgf::DataRevisionInput{
             .data_id = std::move(data_id),
             .revision = revision,
             .output_version = output_version,
             .dependencies = std::move(dependencies),
             .as_of = as_of,
         });
-        const hgf::DataRevisionInput decoded = hgf::data_revision_input(value.view());
+        const hgf::DataRevisionInput decoded =
+            metadata_values.data_revision_input(value.view());
         const auto revision_result = config.objects.put_immutable(
             hgf::revision_key(config.prefix, decoded.data_id, revision),
-            config.values.encode(value.view()));
+            metadata_store(config).encode(value.view()));
         if (revision_result.status == hgps::ImmutableWriteStatus::Conflict)
         {
             throw std::runtime_error("test revision conflicted");
         }
         const auto as_of_result = config.objects.put_immutable(
             hgf::as_of_key(config.prefix, decoded.data_id, as_of),
-            hgf::encode_reference(config.reference_codec, hgf::MetadataObjectKind::AsOf, revision));
+            hgf::encode_reference(metadata_store(config).bind(
+                                      hgf::revision_reference_meta()),
+                                  hgf::MetadataObjectKind::AsOf, revision));
         if (as_of_result.status == hgps::ImmutableWriteStatus::Conflict)
         {
             throw std::runtime_error("test as-of index conflicted");
@@ -242,7 +256,9 @@ namespace
             latest_key,
             current.has_value() ? std::optional<std::string_view>{current->version_token}
                                 : std::nullopt,
-            hgf::encode_reference(config.reference_codec, hgf::MetadataObjectKind::Latest, revision));
+            hgf::encode_reference(metadata_store(config).bind(
+                                      hgf::revision_reference_meta()),
+                                  hgf::MetadataObjectKind::Latest, revision));
         if (!latest.exchanged)
         {
             throw std::runtime_error("test latest index update lost a race");
@@ -1056,12 +1072,15 @@ TEST_CASE("publish_data routes through the singleton service publication state")
 
     const auto latest = config.objects.get(hgf::latest_key(config.prefix, "published"));
     REQUIRE(latest.has_value());
-    CHECK(hgf::revision_reference_value(config.reference_codec, hgf::MetadataObjectKind::Latest, latest->data) == 1);
+    CHECK(hgf::revision_reference_value(
+              metadata_store(config).bind(hgf::revision_reference_meta()),
+              hgf::MetadataObjectKind::Latest, latest->data) == 1);
     const auto revision_object =
         config.objects.get(hgf::revision_key(config.prefix, "published", 1));
     REQUIRE(revision_object.has_value());
     const auto revision =
-        hgf::data_revision_input(config.values.decode(hgf::data_revision_meta(), revision_object->data).view());
+        hgf::data_revision_input(metadata_store(config).decode(
+            hgf::data_revision_meta(), revision_object->data).view());
     const auto stored = config.frames.read(
         hgf::data_version_key(config.prefix, "published", revision.output_version));
     REQUIRE(stored.has_value());
@@ -1279,6 +1298,51 @@ TEST_CASE("stalled service queues apply backpressure or enforce hard bounds")
     }
 }
 
+TEST_CASE("publication node creates keyed publisher state from its run binding")
+{
+    auto config =
+        hgf::make_memory_fabric_config("tests/subscription/run-binding");
+    hgf::detail::PublicationNodeState state;
+    state.start(config, false);
+
+    const auto before = hg::type_system_lock_count();
+    state.enqueue(hgf::detail::PublicationRequestInput{
+        .data_id = "first-key", .output = frame(1)});
+    CHECK(hg::type_system_lock_count() == before);
+    state.stop();
+
+    hg::reset_all_registries();
+    hg::stdlib::register_standard_operators();
+    hgf::register_fabric_operators();
+    state.start(config, false);
+    const auto after_restart = hg::type_system_lock_count();
+    state.enqueue(hgf::detail::PublicationRequestInput{
+        .data_id = "after-reset", .output = frame(2)});
+    CHECK(hg::type_system_lock_count() == after_restart);
+    state.stop();
+}
+
+TEST_CASE("fabric service diagnostic values use node-owned bindings")
+{
+    hgf::detail::DiagnosticValueState values;
+    values.bind();
+    const auto before = hg::type_system_lock_count();
+    for (hg::Int occurrence = 1; occurrence <= 64; ++occurrence)
+    {
+        const hg::Value event = values.make_event(
+            {.component = "fabric",
+             .category = "test",
+             .message = "bound",
+             .retriable = false,
+             .fatal = false,
+             .occurrences = occurrence});
+        CHECK(event.view().as_bundle().at("occurrences").checked_as<hg::Int>() ==
+              occurrence);
+    }
+    CHECK(hg::type_system_lock_count() == before);
+    values.reset();
+}
+
 TEST_CASE("graph notification flow retries the retained shared revision on "
           "explicit edges")
 {
@@ -1298,7 +1362,9 @@ TEST_CASE("graph notification flow retries the retained shared revision on "
     CHECK(observed_notification_metrics.at("transport.notification.delivered") == "1");
     const auto latest = config.objects.get(hgf::latest_key(config.prefix, "published"));
     REQUIRE(latest.has_value());
-    CHECK(hgf::revision_reference_value(config.reference_codec, hgf::MetadataObjectKind::Latest, latest->data) == 1);
+    CHECK(hgf::revision_reference_value(
+              metadata_store(config).bind(hgf::revision_reference_meta()),
+              hgf::MetadataObjectKind::Latest, latest->data) == 1);
 }
 
 TEST_CASE("a success clears retry state when duplicate reports arrive first")

--- a/extensions/fabric/tools/audit_distribution.py
+++ b/extensions/fabric/tools/audit_distribution.py
@@ -58,6 +58,8 @@ SDIST_REQUIRED = (
     "src/config.cpp",
     "src/history.cpp",
     "src/impl/memory_notifier.cpp",
+    "src/impl/metadata_binding.h",
+    "src/impl/metadata_value_binding.h",
     "src/impl/service_state.h",
     "src/kafka.cpp",
     "src/keys.cpp",

--- a/extensions/persistence/include/hgraph/persistence/value_codec.h
+++ b/extensions/persistence/include/hgraph/persistence/value_codec.h
@@ -21,6 +21,13 @@ namespace hgraph::persistence::store
         names none. RFC 0030. */
     inline constexpr std::string_view JSON_VALUE_CODEC{"json"};
 
+    /** Explicit erased ownership for schema-dependent codec state. */
+    struct ValueCodecBinding
+    {
+        std::shared_ptr<const void> owner{};
+        const void                 *handle{nullptr};
+    };
+
     /** Encode and decode one declared value schema.
 
         An ops table in the runtime's convention: function pointers whose first
@@ -30,21 +37,25 @@ namespace hgraph::persistence::store
         needs per-schema machinery -- json's interned converter, a protobuf
         descriptor, an avro schema -- synthesizes it once in `bind` and returns
         an opaque handle; `encode` and `decode` then take that handle and must
-        do no lookup, take no lock, and touch no registry. This is the same
+        do no schema-plan lookup and touch no type or realisation registry.
+        This is the same
         "compose once" contract the runtime already applies to nodes, which
         resolve their converter in `start` and carry it in node State.
 
-        A caller on the evaluation path binds at wiring time and carries the
-        BoundValueCodec. The unbound convenience calls on ValueCodec bind per
-        call and are for build-time and ad-hoc use only. */
+        A caller on the evaluation path binds while constructing run-local
+        node/service state and carries the BoundValueCodec. The unbound
+        convenience calls on ValueCodec bind per call and are for build-time
+        and ad-hoc use only. */
     struct ValueCodecOps
     {
-        /** Resolve the schema-dependent state once. The returned handle is
-            owned by the codec and must outlive every use; codecs are never
-            unregistered, so an interned or context-owned pointer is correct. */
-        const void *(*bind)(void *context, const ValueTypeMetaData *schema);
+        /** Resolve the schema-dependent state once. The returned erased owner
+            explicitly retains any run-local plan; a context-owned or interned
+            handle may leave owner empty because BoundValueCodec also retains
+            the registered implementation context. */
+        ValueCodecBinding (*bind)(void *context,
+                                  const ValueTypeMetaData *schema);
 
-        /** Encode with a handle from `bind`. Must not lock or allocate
+        /** Encode with a handle from `bind`. Must not look up or allocate
             schema state -- this is the per-tick path. */
         void (*encode)(void *context, const void *bound, const ValueView &value,
                        ObjectBytes &out);
@@ -54,37 +65,47 @@ namespace hgraph::persistence::store
                         std::span<const std::byte> encoded);
     };
 
-    /** A codec bound to one schema: the per-tick handle.
+    /** A codec bound to one schema: the run-local per-tick handle.
 
-        Bind at wiring time and carry this. It holds no shared_ptr and performs
-        no lookup, so encoding during evaluation acquires no TypeSystemMutex --
-        the single-threaded evaluation ruling. The bound handle and the codec
-        context are owned by the registry, which never removes a registration,
-        so the raw pointers stay valid; a registry reset that clears interned
-        state invalidates bindings exactly as it invalidates a node's captured
-        converter, which is why binding belongs with graph construction. */
+        Bind while constructing node/service state and carry this only for that
+        run. It retains the codec implementation context, but the schema-bound
+        handle may refer to interned type/converter state. Test-only registry
+        reset invalidates that state just as it invalidates bindings captured by
+        ordinary nodes, so a bound codec must never be stored in reusable graph
+        configuration or a process-lifetime static. */
     class HGRAPH_PERSISTENCE_CLASS_EXPORT BoundValueCodec final
     {
       public:
-        BoundValueCodec() noexcept = default;
-        BoundValueCodec(ValueCodecOps ops, void *context, const void *bound) noexcept
-            : ops_{ops}, context_{context}, bound_{bound}
-        {
-        }
+        BoundValueCodec() noexcept;
+        BoundValueCodec(ValueCodecOps ops, std::shared_ptr<void> context,
+                        const ValueTypeMetaData *schema,
+                        ValueCodecBinding binding);
+
+        BoundValueCodec(const BoundValueCodec &) = default;
+        BoundValueCodec &operator=(const BoundValueCodec &) = default;
+        BoundValueCodec(BoundValueCodec &&other) noexcept;
+        BoundValueCodec &operator=(BoundValueCodec &&other) noexcept;
+        ~BoundValueCodec() = default;
 
         [[nodiscard]] explicit operator bool() const noexcept
         {
-            return ops_.encode != nullptr;
+            return schema_ != nullptr;
         }
+
+        [[nodiscard]] const ValueTypeMetaData *schema() const noexcept { return schema_; }
 
         void encode(const ValueView &value, ObjectBytes &out) const;
         [[nodiscard]] ObjectBytes encode(const ValueView &value) const;
         [[nodiscard]] Value decode(std::span<const std::byte> encoded) const;
 
       private:
-        ValueCodecOps ops_{};
-        void         *context_{nullptr};
-        const void   *bound_{nullptr};
+        [[nodiscard]] static const ValueCodecOps &empty_ops() noexcept;
+
+        ValueCodecOps            ops_{};
+        std::shared_ptr<void>     context_{};
+        std::shared_ptr<const void> binding_owner_{};
+        const ValueTypeMetaData  *schema_{nullptr};
+        const void               *bound_{nullptr};
     };
 
     /** Register a codec under a stable name. Idempotent for an identical
@@ -101,15 +122,26 @@ namespace hgraph::persistence::store
     class HGRAPH_PERSISTENCE_CLASS_EXPORT ValueCodec final
     {
       public:
-        ValueCodec() noexcept = default;
+        ValueCodec() noexcept;
         ValueCodec(std::string name, std::shared_ptr<void> context,
                    ValueCodecOps ops) noexcept;
 
-        [[nodiscard]] bool valid() const noexcept { return ops_.encode != nullptr; }
+        ValueCodec(const ValueCodec &) = default;
+        ValueCodec &operator=(const ValueCodec &) = default;
+        ValueCodec(ValueCodec &&other) noexcept;
+        ValueCodec &operator=(ValueCodec &&other) noexcept;
+        ~ValueCodec() = default;
+
+        [[nodiscard]] bool valid() const noexcept
+        {
+            return !name_.empty() && ops_.bind != nullptr &&
+                   ops_.encode != nullptr && ops_.decode != nullptr;
+        }
         [[nodiscard]] const std::string &name() const noexcept { return name_; }
 
-        /** Resolve this codec's schema-dependent state once. Do this at wiring
-            time and keep the result for anything on the evaluation path. */
+        /** Resolve this codec's schema-dependent state once. Do this while
+            constructing run-local node/service state and keep the result for
+            anything on the evaluation path. */
         [[nodiscard]] BoundValueCodec bind(const ValueTypeMetaData *schema) const;
 
         /** Convenience: binds per call. Build-time and ad-hoc use only -- on
@@ -119,6 +151,8 @@ namespace hgraph::persistence::store
                                    std::span<const std::byte> encoded) const;
 
       private:
+        [[nodiscard]] static const ValueCodecOps &empty_ops() noexcept;
+
         std::string             name_{};
         std::shared_ptr<void>   context_{};
         ValueCodecOps           ops_{};

--- a/extensions/persistence/include/hgraph/persistence/value_store.h
+++ b/extensions/persistence/include/hgraph/persistence/value_store.h
@@ -50,6 +50,47 @@ namespace hgraph::persistence::store
         std::string version_token{};
     };
 
+    /** Typed compare/exchange result. The winner is decoded through the same
+        schema-bound codec, so callers of the typed store never have to reach
+        through it to the byte layer. */
+    struct ValueCompareExchangeResult
+    {
+        bool exchanged{false};
+        std::optional<StoredValue> current{};
+    };
+
+    /** One ValueStore bound to one schema for a graph run.
+
+        This is the evaluation-path contract: the object backend and codec
+        context remain owned, schema resolution has already happened, and all
+        reads (including compare/exchange conflicts) return typed values. */
+    class HGRAPH_PERSISTENCE_CLASS_EXPORT BoundValueStore final
+    {
+      public:
+        BoundValueStore() noexcept = default;
+        BoundValueStore(ObjectStore objects, BoundValueCodec codec);
+
+        [[nodiscard]] explicit operator bool() const noexcept;
+        [[nodiscard]] const ValueTypeMetaData *schema() const noexcept;
+
+        [[nodiscard]] ImmutableWriteResult
+        write(std::string_view key, const ValueView &value) const;
+        [[nodiscard]] Value read(std::string_view key) const;
+        [[nodiscard]] std::optional<Value> try_read(std::string_view key) const;
+        [[nodiscard]] std::optional<StoredValue>
+        try_read_versioned(std::string_view key) const;
+        [[nodiscard]] ValueCompareExchangeResult
+        compare_exchange(std::string_view key, const ValueView &value,
+                         std::optional<std::string_view> expected_version) const;
+
+        [[nodiscard]] ObjectBytes encode(const ValueView &value) const;
+        [[nodiscard]] Value decode(std::span<const std::byte> encoded) const;
+
+      private:
+        ObjectStore      objects_{};
+        BoundValueCodec codec_{};
+    };
+
     class HGRAPH_PERSISTENCE_CLASS_EXPORT ValueStore final
     {
       public:
@@ -82,20 +123,29 @@ namespace hgraph::persistence::store
         try_read_versioned(std::string_view key, const ValueTypeMetaData *schema,
                            std::optional<std::string_view> codec = {}) const;
 
-        /** Forwards the object store's version token unchanged; this store adds
-            no concurrency control of its own. */
-        [[nodiscard]] CompareExchangeResult
+        /** Forwards the object store's version token unchanged and decodes the
+            winning value through the candidate's schema. This store adds no
+            concurrency control of its own. */
+        [[nodiscard]] ValueCompareExchangeResult
         compare_exchange(std::string_view key, const ValueView &value,
                          std::optional<std::string_view> expected_version,
                          std::optional<std::string_view> codec = {}) const;
 
         /** Bind this store's codec to one schema, once. Callers on the
             evaluation path -- anything encoding or decoding during a graph
-            run -- must do this at wiring time and keep the result: the bound
-            handle performs no registry lookup and takes no lock, which the
-            unbound calls below cannot promise. */
+            run -- must do this while constructing run-local node/service state
+            and keep the result: the bound handle performs no schema-plan or
+            type-registry lookup, which the unbound calls below cannot
+            promise. */
         [[nodiscard]] BoundValueCodec bind(const ValueTypeMetaData        *schema,
                                            std::optional<std::string_view> codec = {}) const;
+
+        /** Bind both the backend and codec to one schema. Graph/runtime code
+            should keep this run-local handle rather than pairing a bound codec
+            with direct ObjectStore byte operations. */
+        [[nodiscard]] BoundValueStore
+        bind_schema(const ValueTypeMetaData        *schema,
+                    std::optional<std::string_view> codec = {}) const;
 
         /** The bytes a write would store: the codec's output verbatim. */
         [[nodiscard]] ObjectBytes encode(const ValueView                &value,
@@ -112,12 +162,11 @@ namespace hgraph::persistence::store
         ObjectStore objects_{};
         std::string default_codec_{JSON_VALUE_CODEC};
 
-        /** Resolved once at construction. Fabric encodes revisions during
-            evaluation, so the default path must not reach the registry: that
-            would take a TypeSystemMutex on the per-tick path, which the
-            single-threaded evaluation ruling forbids. An explicit per-call
-            override still resolves by name -- it is asked for by a caller that
-            is not on that path. */
+        /** Resolved once at construction. Evaluation-path users of the default
+            must not reach the registry per value: that would take a
+            TypeSystemMutex on the single-threaded graph path. An explicit
+            per-call override still resolves by name and is therefore an
+            ad-hoc, non-evaluation operation. */
         ValueCodec default_resolved_{};
     };
 

--- a/extensions/persistence/src/value_codec.cpp
+++ b/extensions/persistence/src/value_codec.cpp
@@ -21,7 +21,8 @@ namespace hgraph::persistence::store
             ValueCodecOps         ops{};
         };
 
-        const void *json_bind(void *context, const ValueTypeMetaData *schema);
+        ValueCodecBinding json_bind(void *context,
+                                    const ValueTypeMetaData *schema);
         void json_encode(void *context, const void *bound, const ValueView &value,
                          ObjectBytes &out);
         Value json_decode(void *context, const void *bound,
@@ -60,25 +61,28 @@ namespace hgraph::persistence::store
                    lhs.decode == rhs.decode;
         }
 
-        /** The baseline codec. Binding resolves the core's interned
-            JsonConverter, which is synthesized once per schema and locks to do
-            it -- so it happens here, in bind, and never again. to_json_string
-            and from_json_string(meta, ...) would repeat that lookup per value,
-            which is why neither is used below. */
-        const void *json_bind(void * /*context*/, const ValueTypeMetaData *schema)
+        /** The baseline codec. Binding owns a complete converter plan for the
+            active run, including realised value bindings and polymorphic
+            alternatives. Synthesis may lock, so it happens here and never in
+            encode/decode. The ad-hoc JSON helpers are not used below because
+            they resolve schema state per call. */
+        ValueCodecBinding json_bind(void * /*context*/,
+                                    const ValueTypeMetaData *schema)
         {
             if (schema == nullptr)
             {
                 throw std::invalid_argument("value codec bind requires a schema");
             }
-            return &json_converter(schema);
+            auto binding = std::make_shared<BoundJsonConverter>(
+                bind_json_converter(schema));
+            return ValueCodecBinding{binding, binding.get()};
         }
 
         void json_encode(void * /*context*/, const void *bound, const ValueView &value,
                          ObjectBytes &out)
         {
             std::string text;
-            static_cast<const JsonConverter *>(bound)->write(value, text);
+            static_cast<const BoundJsonConverter *>(bound)->write(value, text);
             const auto bytes = std::as_bytes(std::span{text.data(), text.size()});
             out.insert(out.end(), bytes.begin(), bytes.end());
         }
@@ -88,14 +92,110 @@ namespace hgraph::persistence::store
         {
             const std::string_view text{reinterpret_cast<const char *>(encoded.data()),
                                         encoded.size()};
-            return from_json_string(*static_cast<const JsonConverter *>(bound), text);
+            return from_json_string(
+                *static_cast<const BoundJsonConverter *>(bound), text);
+        }
+
+        ValueCodecBinding empty_bind(void *,
+                                     const ValueTypeMetaData *) noexcept
+        {
+            return {};
+        }
+
+        void empty_encode(void *, const void *, const ValueView &, ObjectBytes &)
+        {
+            throw std::logic_error("value codec is not bound to a schema");
+        }
+
+        Value empty_decode(void *, const void *, std::span<const std::byte>)
+        {
+            throw std::logic_error("value codec is not bound to a schema");
         }
     }  // namespace
+
+    const ValueCodecOps &BoundValueCodec::empty_ops() noexcept
+    {
+        static const ValueCodecOps ops{&empty_bind, &empty_encode, &empty_decode};
+        return ops;
+    }
+
+    BoundValueCodec::BoundValueCodec() noexcept : ops_{empty_ops()} {}
+
+    BoundValueCodec::BoundValueCodec(ValueCodecOps ops,
+                                     std::shared_ptr<void> context,
+                                     const ValueTypeMetaData *schema,
+                                     ValueCodecBinding binding)
+        : ops_{ops}, context_{std::move(context)},
+          binding_owner_{std::move(binding.owner)}, schema_{schema},
+          bound_{binding.handle}
+    {
+        if (schema_ == nullptr || bound_ == nullptr || ops_.bind == nullptr ||
+            ops_.encode == nullptr || ops_.decode == nullptr)
+        {
+            throw std::invalid_argument(
+                "bound value codec requires a schema, handle and complete operations");
+        }
+    }
+
+    BoundValueCodec::BoundValueCodec(BoundValueCodec &&other) noexcept
+        : ops_{other.ops_}, context_{std::move(other.context_)},
+          binding_owner_{std::move(other.binding_owner_)},
+          schema_{other.schema_}, bound_{other.bound_}
+    {
+        other.ops_ = empty_ops();
+        other.schema_ = nullptr;
+        other.bound_ = nullptr;
+    }
+
+    BoundValueCodec &BoundValueCodec::operator=(BoundValueCodec &&other) noexcept
+    {
+        if (this != &other)
+        {
+            ops_ = other.ops_;
+            context_ = std::move(other.context_);
+            binding_owner_ = std::move(other.binding_owner_);
+            schema_ = other.schema_;
+            bound_ = other.bound_;
+            other.ops_ = empty_ops();
+            other.schema_ = nullptr;
+            other.bound_ = nullptr;
+        }
+        return *this;
+    }
+
+    const ValueCodecOps &ValueCodec::empty_ops() noexcept
+    {
+        static const ValueCodecOps ops{&empty_bind, &empty_encode, &empty_decode};
+        return ops;
+    }
+
+    ValueCodec::ValueCodec() noexcept : ops_{empty_ops()} {}
 
     ValueCodec::ValueCodec(std::string name, std::shared_ptr<void> context,
                            ValueCodecOps ops) noexcept
         : name_{std::move(name)}, context_{std::move(context)}, ops_{ops}
     {
+    }
+
+    ValueCodec::ValueCodec(ValueCodec &&other) noexcept
+        : name_{std::move(other.name_)}, context_{std::move(other.context_)},
+          ops_{other.ops_}
+    {
+        other.name_.clear();
+        other.ops_ = empty_ops();
+    }
+
+    ValueCodec &ValueCodec::operator=(ValueCodec &&other) noexcept
+    {
+        if (this != &other)
+        {
+            name_ = std::move(other.name_);
+            context_ = std::move(other.context_);
+            ops_ = other.ops_;
+            other.name_.clear();
+            other.ops_ = empty_ops();
+        }
+        return *this;
     }
 
     void BoundValueCodec::encode(const ValueView &value, ObjectBytes &out) const
@@ -104,7 +204,12 @@ namespace hgraph::persistence::store
         {
             throw std::logic_error("value codec is not bound to a schema");
         }
-        ops_.encode(context_, bound_, value, out);
+        if (!value.valid() || value.schema() != schema_)
+        {
+            throw std::invalid_argument(
+                "value codec received a value with a different schema");
+        }
+        ops_.encode(context_.get(), bound_, value, out);
     }
 
     ObjectBytes BoundValueCodec::encode(const ValueView &value) const
@@ -120,7 +225,13 @@ namespace hgraph::persistence::store
         {
             throw std::logic_error("value codec is not bound to a schema");
         }
-        return ops_.decode(context_, bound_, encoded);
+        Value decoded = ops_.decode(context_.get(), bound_, encoded);
+        if (decoded.schema() != schema_)
+        {
+            throw std::invalid_argument(
+                "value codec returned a value with a different schema");
+        }
+        return decoded;
     }
 
     BoundValueCodec ValueCodec::bind(const ValueTypeMetaData *schema) const
@@ -129,7 +240,12 @@ namespace hgraph::persistence::store
         {
             throw std::logic_error("value codec is not bound to an implementation");
         }
-        return BoundValueCodec{ops_, context_.get(), ops_.bind(context_.get(), schema)};
+        if (schema == nullptr)
+        {
+            throw std::invalid_argument("value codec bind requires a schema");
+        }
+        return BoundValueCodec{ops_, context_, schema,
+                               ops_.bind(context_.get(), schema)};
     }
 
     void ValueCodec::encode(const ValueView &value, ObjectBytes &out) const

--- a/extensions/persistence/src/value_store.cpp
+++ b/extensions/persistence/src/value_store.cpp
@@ -5,6 +5,82 @@
 
 namespace hgraph::persistence::store
 {
+    BoundValueStore::BoundValueStore(ObjectStore objects, BoundValueCodec codec)
+        : objects_{std::move(objects)}, codec_{std::move(codec)}
+    {
+        if (!objects_ || !codec_)
+        {
+            throw std::invalid_argument(
+                "bound value store requires an object store and bound codec");
+        }
+    }
+
+    BoundValueStore::operator bool() const noexcept
+    {
+        return bool(objects_) && bool(codec_);
+    }
+
+    const ValueTypeMetaData *BoundValueStore::schema() const noexcept
+    {
+        return codec_.schema();
+    }
+
+    ObjectBytes BoundValueStore::encode(const ValueView &value) const
+    {
+        return codec_.encode(value);
+    }
+
+    Value BoundValueStore::decode(std::span<const std::byte> encoded) const
+    {
+        return codec_.decode(encoded);
+    }
+
+    ImmutableWriteResult BoundValueStore::write(std::string_view key,
+                                                const ValueView &value) const
+    {
+        return objects_.put_immutable(key, encode(value));
+    }
+
+    std::optional<StoredValue>
+    BoundValueStore::try_read_versioned(std::string_view key) const
+    {
+        const auto stored = objects_.get(key);
+        if (!stored.has_value()) { return std::nullopt; }
+        return StoredValue{decode(stored->data), stored->version_token};
+    }
+
+    std::optional<Value> BoundValueStore::try_read(std::string_view key) const
+    {
+        auto stored = try_read_versioned(key);
+        if (!stored.has_value()) { return std::nullopt; }
+        return std::move(stored->value);
+    }
+
+    Value BoundValueStore::read(std::string_view key) const
+    {
+        auto value = try_read(key);
+        if (!value.has_value())
+        {
+            throw ObjectStoreError{"value store key not found: " + std::string{key}};
+        }
+        return std::move(*value);
+    }
+
+    ValueCompareExchangeResult BoundValueStore::compare_exchange(
+        std::string_view key, const ValueView &value,
+        std::optional<std::string_view> expected_version) const
+    {
+        auto result = objects_.compare_exchange_ref(key, expected_version,
+                                                    encode(value));
+        ValueCompareExchangeResult typed{.exchanged = result.exchanged};
+        if (result.current.has_value())
+        {
+            typed.current = StoredValue{decode(result.current->data),
+                                        std::move(result.current->version_token)};
+        }
+        return typed;
+    }
+
     ValueStore::ValueStore(ValueStoreConfig config)
         : objects_{std::move(config.objects)},
           default_codec_{config.codec.empty() ? std::string{JSON_VALUE_CODEC}
@@ -26,6 +102,13 @@ namespace hgraph::persistence::store
     {
         if (uses_default(codec)) { return default_resolved_.bind(schema); }
         return value_codec(*codec).bind(schema);
+    }
+
+    BoundValueStore ValueStore::bind_schema(
+        const ValueTypeMetaData *schema,
+        std::optional<std::string_view> codec) const
+    {
+        return BoundValueStore{objects_, bind(schema, codec)};
     }
 
     ObjectBytes ValueStore::encode(const ValueView                &value,
@@ -88,12 +171,13 @@ namespace hgraph::persistence::store
         return std::move(*value);
     }
 
-    CompareExchangeResult
+    ValueCompareExchangeResult
     ValueStore::compare_exchange(std::string_view key, const ValueView &value,
                                  std::optional<std::string_view> expected_version,
                                  std::optional<std::string_view> codec) const
     {
-        return objects_.compare_exchange_ref(key, expected_version, encode(value, codec));
+        return bind_schema(value.schema(), codec)
+            .compare_exchange(key, value, expected_version);
     }
 
     ValueStore make_value_store(ValueStoreConfig config)

--- a/extensions/persistence/tests/test_value_store.cpp
+++ b/extensions/persistence/tests/test_value_store.cpp
@@ -3,6 +3,7 @@
 #include <hgraph/persistence/value_codec.h>
 #include <hgraph/persistence/value_store.h>
 
+#include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/utils/counted_mutex.h>
 #include <hgraph/types/static_schema.h>
@@ -356,6 +357,37 @@ TEST_CASE("bound codecs reject schema confusion in both directions")
                       .decode = &wrong_schema_decode}};
     const auto bound = wrong.bind(record_meta());
     CHECK_THROWS_AS(bound.decode({}), std::invalid_argument);
+}
+
+TEST_CASE("value codec ad-hoc calls preserve escaped polymorphic values")
+{
+    auto &registry = TypeRegistry::instance();
+    const auto *integer = registry.register_scalar<Int>("int");
+    const auto *base = registry.bundle(
+        "tests.value_codec_polymorphic", "Base", {{"id", integer}}, {}, true);
+    const auto *child = registry.bundle(
+        "tests.value_codec_polymorphic", "Child",
+        {{"id", integer}, {"quantity", integer}}, {base});
+    const auto realization = TypeRealizationSnapshot::capture(registry);
+
+    Value escaped;
+    {
+        TypeRealizationScope scope{realization.get()};
+        escaped = from_json_string(
+            bind_json_converter(base),
+            R"({"__type__": "tests.value_codec_polymorphic::Child", "id": 1, "quantity": 2})");
+    }
+    REQUIRE(escaped.view().concrete().schema() == child);
+
+    ObjectBytes encoded;
+    const auto codec = value_codec(JSON_VALUE_CODEC);
+    codec.encode(escaped.view(), encoded);
+    const auto text = as_text(encoded);
+    CHECK(text.find(
+              R"("__type__": "tests.value_codec_polymorphic::Child")") !=
+          std::string::npos);
+    CHECK(text.find(R"("quantity": 2)") != std::string::npos);
+    CHECK(codec.decode(base, encoded).view().concrete().schema() == child);
 }
 
 TEST_CASE("value codec registry: names are listed and re-registration is idempotent")

--- a/extensions/persistence/tests/test_value_store.cpp
+++ b/extensions/persistence/tests/test_value_store.cpp
@@ -61,18 +61,18 @@ namespace
     /** A second codec, so "pluggable" is exercised rather than asserted. It
         stores the JSON form reversed, which is enough to prove the store
         dispatches on the recorded name rather than assuming a format. */
-    const void *reversing_bind(void *, const ValueTypeMetaData *schema)
+    ValueCodecBinding reversing_bind(void *, const ValueTypeMetaData *schema)
     {
-        // Same binding the json codec performs: resolve the interned converter
-        // once so encode/decode take no lock.
-        return &json_converter(schema);
+        auto binding = std::make_shared<BoundJsonConverter>(
+            bind_json_converter(schema));
+        return ValueCodecBinding{binding, binding.get()};
     }
 
     void reversing_encode(void *, const void *bound, const ValueView &value,
                           ObjectBytes &out)
     {
         std::string text;
-        static_cast<const JsonConverter *>(bound)->write(value, text);
+        static_cast<const BoundJsonConverter *>(bound)->write(value, text);
         for (auto character = text.rbegin(); character != text.rend(); ++character)
         {
             out.push_back(static_cast<std::byte>(*character));
@@ -88,7 +88,34 @@ namespace
         {
             text.push_back(std::to_integer<char>(*byte));
         }
-        return from_json_string(*static_cast<const JsonConverter *>(bound), text);
+        return from_json_string(
+            *static_cast<const BoundJsonConverter *>(bound), text);
+    }
+
+    Value wrong_schema_decode(void *, const void *, std::span<const std::byte>)
+    {
+        return Value{Str{"wrong schema"}};
+    }
+
+    struct OwnedBindingPlan
+    {
+        BoundJsonConverter converter{};
+        std::shared_ptr<int> lifetime{};
+    };
+
+    struct OwnedBindingContext
+    {
+        std::weak_ptr<int> last_binding{};
+    };
+
+    ValueCodecBinding owned_binding_bind(void *raw_context,
+                                         const ValueTypeMetaData *schema)
+    {
+        auto token = std::make_shared<int>(1);
+        static_cast<OwnedBindingContext *>(raw_context)->last_binding = token;
+        auto plan = std::make_shared<OwnedBindingPlan>(
+            OwnedBindingPlan{bind_json_converter(schema), std::move(token)});
+        return ValueCodecBinding{plan, &plan->converter};
     }
 
     void register_reversing_codec()
@@ -237,11 +264,98 @@ TEST_CASE("value store: compare_exchange forwards the store's version token")
 
     const auto created = store.compare_exchange("records/cas", first.view(), std::nullopt);
     REQUIRE(created.exchanged);
+    REQUIRE(created.current.has_value());
+    CHECK(created.current->value.view().equals(first.view()));
 
     // A stale expectation loses, and the winner's value is unchanged.
     const auto stale = store.compare_exchange("records/cas", second.view(), "not-the-token");
     CHECK_FALSE(stale.exchanged);
-    CHECK(store.read("records/cas", record_meta()).view().equals(first.view()));
+    REQUIRE(stale.current.has_value());
+    CHECK(stale.current->value.view().equals(first.view()));
+}
+
+TEST_CASE("bound value store keeps byte storage behind its typed contract")
+{
+    const auto store = memory_store();
+    const auto bound = store.bind_schema(record_meta());
+    const Value first = record_value("alpha", 1, "BOM");
+    const Value second = record_value("alpha", 2, "BOM");
+
+    const auto created = bound.compare_exchange("records/typed-cas", first.view(),
+                                                std::nullopt);
+    REQUIRE(created.exchanged);
+    REQUIRE(created.current.has_value());
+    CHECK(created.current->value.view().equals(first.view()));
+
+    const auto stale = bound.compare_exchange("records/typed-cas", second.view(),
+                                              "not-the-token");
+    REQUIRE_FALSE(stale.exchanged);
+    REQUIRE(stale.current.has_value());
+    CHECK(stale.current->value.view().equals(first.view()));
+    CHECK(bound.read("records/typed-cas").view().equals(first.view()));
+}
+
+TEST_CASE("bound codecs retain implementation context and reset moved-from handles")
+{
+    auto context = std::make_shared<int>(7);
+    std::weak_ptr<int> lifetime = context;
+    ValueCodec codec{
+        "owned-test", context,
+        ValueCodecOps{.bind = &reversing_bind,
+                      .encode = &reversing_encode,
+                      .decode = &reversing_decode}};
+    context.reset();
+
+    auto bound = codec.bind(record_meta());
+    codec = {};
+    REQUIRE_FALSE(lifetime.expired());
+
+    auto moved = std::move(bound);
+    CHECK_FALSE(bound);
+    CHECK_THROWS_AS(bound.encode(record_value("x", 1, "Y").view()),
+                    std::logic_error);
+    CHECK(moved.decode(moved.encode(record_value("x", 1, "Y").view()))
+              .view()
+              .equals(record_value("x", 1, "Y").view()));
+
+    moved = {};
+    CHECK(lifetime.expired());
+}
+
+TEST_CASE("bound codecs retain schema-binding ownership")
+{
+    auto context = std::make_shared<OwnedBindingContext>();
+    ValueCodec codec{
+        "owned-binding", context,
+        ValueCodecOps{.bind = &owned_binding_bind,
+                      .encode = &reversing_encode,
+                      .decode = &reversing_decode}};
+
+    auto bound = codec.bind(record_meta());
+    REQUIRE_FALSE(context->last_binding.expired());
+    codec = {};
+    REQUIRE_FALSE(context->last_binding.expired());
+    CHECK(bound.decode(bound.encode(record_value("x", 1, "Y").view()))
+              .view()
+              .equals(record_value("x", 1, "Y").view()));
+
+    bound = {};
+    CHECK(context->last_binding.expired());
+}
+
+TEST_CASE("bound codecs reject schema confusion in both directions")
+{
+    const auto json = value_codec(JSON_VALUE_CODEC).bind(record_meta());
+    CHECK_THROWS_AS(json.encode(Value{Str{"not a record"}}.view()),
+                    std::invalid_argument);
+
+    ValueCodec wrong{
+        "wrong-schema", nullptr,
+        ValueCodecOps{.bind = &reversing_bind,
+                      .encode = &reversing_encode,
+                      .decode = &wrong_schema_decode}};
+    const auto bound = wrong.bind(record_meta());
+    CHECK_THROWS_AS(bound.decode({}), std::invalid_argument);
 }
 
 TEST_CASE("value codec registry: names are listed and re-registration is idempotent")
@@ -332,11 +446,11 @@ TEST_CASE("value store: the default codec is not looked up per call")
     // exactly the registry traffic this store avoids -- the difference, not an
     // absolute count, is the honest assertion.
     //
-    // Both codecs are warmed first: the interned JsonConverter is composed on
+    // Both codecs are warmed first: their run-bound JSON plans are composed on
     // first sight of a schema, and that one-off cost would otherwise swamp the
-    // measurement. Neither count is zero afterwards, because
-    // to_json_string/from_json_string resolve the converter per value and lock
-    // to do it -- the json codec's cost, not the store's, noted in RFC 0030.
+    // measurement. Neither count is zero afterwards because these unbound
+    // convenience calls deliberately bind a fresh schema plan per value; that
+    // is why evaluation code retains BoundValueStore instead.
     register_reversing_codec();
     const auto  store = memory_store();
     const Value written = record_value("alpha", 7, "BOM");

--- a/include/hgraph/lib/std/operators/impl/json_impl.h
+++ b/include/hgraph/lib/std/operators/impl/json_impl.h
@@ -48,8 +48,8 @@ namespace hgraph::stdlib
     using namespace hgraph::operator_type_resolution;
 
     /**
-     * ``to_json`` — erased implementations over any time-series. The composed
-     * ``JsonConverter`` is resolved ONCE in ``start`` and carried in node
+     * ``to_json`` — erased implementations over any time-series. A complete
+     * ``BoundJsonConverter`` is resolved ONCE in ``start`` and carried in node
      * State (the lifecycle form of the builder pattern); ``eval`` is a plain
      * converter invocation. The ``delta`` flag is a wiring-time constant, so
      * value vs delta is resolved by OVERLOAD SELECTION (``requires_`` on the
@@ -57,12 +57,12 @@ namespace hgraph::stdlib
      */
     namespace json_ts_detail
     {
-        /** Start-resolved converter plan mirroring the TS shape. Converter
-            lookup takes the (counted) converter-interning mutex, so nodes
-            resolve every converter their shape needs ONCE in ``start`` and
-            the per-tick walkers read plan pointers (lock-free per-tick
-            ruling). Owned via the pointer-in-State lifecycle: built in
-            ``start``, freed in ``stop``. */
+        /** Start-resolved converter plan mirroring the TS shape. Binding may
+            consult converter and graph-realisation registries, so nodes
+            resolve every converter their shape needs ONCE in ``start``. The
+            per-tick walkers use owned bound plans and perform no lookup.
+            Owned via the pointer-in-State lifecycle: built in ``start``,
+            freed in ``stop``. */
         struct TsJsonPlan;
 
         struct TsJsonPlanState
@@ -102,7 +102,13 @@ namespace hgraph::stdlib
 
         static void start(In<"ts", TsVar<"S">> ts, State<JsonCodecState> codec)
         {
-            codec.set(JsonCodecState{&json_converter(ts.base().schema()->value_schema)});
+            codec.set(JsonCodecState{
+                bind_json_converter(ts.base().schema()->value_schema)});
+        }
+
+        static void stop(State<JsonCodecState> codec)
+        {
+            codec.set(JsonCodecState{});
         }
 
         static void eval(In<"ts", TsVar<"S">> ts, Scalar<"delta", Bool> delta, State<JsonCodecState> codec,
@@ -110,7 +116,7 @@ namespace hgraph::stdlib
         {
             static_cast<void>(delta);   // resolved at wiring; always false here
             std::string text;
-            codec.get().converter->write(ts.value(), text);
+            codec.get().converter.write(ts.value(), text);
             out.set(std::move(text));
         }
     };

--- a/include/hgraph/types/metadata/type_realization.h
+++ b/include/hgraph/types/metadata/type_realization.h
@@ -67,6 +67,7 @@ namespace hgraph
      * Later registrations cannot change its alternatives or storage size.
      */
     class HGRAPH_CLASS_EXPORT TypeRealizationSnapshot
+        : public std::enable_shared_from_this<TypeRealizationSnapshot>
     {
       public:
         [[nodiscard]] static std::shared_ptr<const TypeRealizationSnapshot>

--- a/include/hgraph/types/value/json_codec.h
+++ b/include/hgraph/types/value/json_codec.h
@@ -8,6 +8,7 @@
 
 #include <string>
 #include <string_view>
+#include <memory>
 #include <vector>
 
 namespace hgraph
@@ -70,15 +71,59 @@ namespace hgraph
         AtomicTag                          atomic_tag{AtomicTag::None};
         std::vector<const JsonConverter *> children{};         ///< element / (key, value) / fields
         std::vector<std::string_view>      names{};            ///< bundle field names
+        /** Pre-resolved concrete alternatives in a run-bound converter. */
+        std::vector<const JsonConverter *> alternatives{};
+        /** Opaque immutable parser configuration captured by a bound plan. */
+        std::shared_ptr<const void> read_context{};
+        bool realization_bound{false};
+        bool polymorphic{false};
     };
 
     /**
      * The interned converter for ``meta``. Synthesizes (and caches) on first
      * use; throws ``std::logic_error`` for schemas with no JSON form.
-     * Build-time machinery: may lock; never called on the per-tick path
-     * directly (operators capture the converter at start/first use).
+     * Build-time/ad-hoc machinery: may lock. Evaluation paths use
+     * ``bind_json_converter`` and retain the resulting owned plan.
      */
     [[nodiscard]] HGRAPH_EXPORT const JsonConverter &json_converter(const ValueTypeMetaData *meta);
+
+    /**
+     * A JSON conversion plan bound to the active graph type-realisation
+     * snapshot. Construction may consult type registries and the snapshot;
+     * read/write perform no schema lookup and take no type-system or
+     * realisation lock. The plan owns its converter tree and retains the
+     * realisation snapshot backing graph-local bindings; canonical metadata
+     * remains registry-scoped. The plan is intended to live in run-local
+     * node/service state.
+     */
+    class HGRAPH_CLASS_EXPORT BoundJsonConverter final
+    {
+      public:
+        BoundJsonConverter() noexcept = default;
+        BoundJsonConverter(const BoundJsonConverter &) noexcept = default;
+        BoundJsonConverter &operator=(const BoundJsonConverter &) noexcept = default;
+        BoundJsonConverter(BoundJsonConverter &&) noexcept = default;
+        BoundJsonConverter &operator=(BoundJsonConverter &&) noexcept = default;
+        ~BoundJsonConverter() = default;
+
+        [[nodiscard]] explicit operator bool() const noexcept;
+        [[nodiscard]] const ValueTypeMetaData *schema() const noexcept;
+        void write(const ValueView &view, std::string &out) const;
+        [[nodiscard]] Value read(json_detail::Reader &reader) const;
+
+      private:
+        struct Impl;
+        explicit BoundJsonConverter(std::shared_ptr<const Impl> impl) noexcept;
+        [[nodiscard]] const JsonConverter &converter() const;
+
+        std::shared_ptr<const Impl> impl_{};
+
+        friend BoundJsonConverter bind_json_converter(const ValueTypeMetaData *meta);
+    };
+
+    /** Resolve and own a complete run-local conversion plan for ``meta``. */
+    [[nodiscard]] HGRAPH_EXPORT BoundJsonConverter
+    bind_json_converter(const ValueTypeMetaData *meta);
 
     /** Clear the interned converters (registry reset — see registry_reset.h). */
     HGRAPH_EXPORT void clear_json_converters() noexcept;
@@ -90,7 +135,10 @@ namespace hgraph
      *
      * Registration is process-wide, idempotent, and safe to perform while
      * other threads are reading JSON. ISO 8601 and the built-in compatibility
-     * formats are always tried before registered extensions.
+     * formats are always tried before registered extensions. A run-bound
+     * converter snapshots the registered formats when it is bound, so a new
+     * registration affects subsequently bound plans rather than changing an
+     * active graph run.
      */
     HGRAPH_EXPORT void register_json_datetime_format(
         std::string format, bool time_only = false);
@@ -101,8 +149,12 @@ namespace hgraph
     /** Parse ``text`` into an owned value of schema ``meta``. */
     [[nodiscard]] HGRAPH_EXPORT Value from_json_string(const ValueTypeMetaData *meta, std::string_view text);
 
-    /** Parse with a pre-resolved converter (the node-State fast path). */
+    /** Parse with an interned converter. Ad-hoc use; realisation may lock. */
     [[nodiscard]] HGRAPH_EXPORT Value from_json_string(const JsonConverter &converter, std::string_view text);
+
+    /** Parse with a run-bound converter (the lock-free evaluation path). */
+    [[nodiscard]] HGRAPH_EXPORT Value from_json_string(
+        const BoundJsonConverter &converter, std::string_view text);
 
     /**
      * Fragment cursor: lets TS-aware operators (the friendly JSON delta
@@ -127,6 +179,9 @@ namespace hgraph
         HGRAPH_EXPORT std::string parse_string(Cursor &cursor);
         /** Parse one meta-directed value at the cursor. */
         HGRAPH_EXPORT Value parse_value(const JsonConverter &converter, Cursor &cursor);
+        /** Parse one value through a run-bound conversion plan. */
+        HGRAPH_EXPORT Value parse_value(const BoundJsonConverter &converter,
+                                        Cursor &cursor);
         /** Throw a parse error at the cursor position. */
         [[noreturn]] HGRAPH_EXPORT void fail(Cursor &cursor, std::string_view message);
     }  // namespace json_fragment
@@ -137,7 +192,7 @@ namespace hgraph
      */
     struct JsonCodecState
     {
-        const JsonConverter *converter{nullptr};
+        BoundJsonConverter converter{};
     };
 }  // namespace hgraph
 

--- a/include/hgraph/types/value/json_codec.h
+++ b/include/hgraph/types/value/json_codec.h
@@ -6,9 +6,9 @@
 #include <hgraph/types/value/value.h>
 #include <hgraph/types/value/value_view.h>
 
+#include <memory>
 #include <string>
 #include <string_view>
-#include <memory>
 #include <vector>
 
 namespace hgraph
@@ -88,13 +88,12 @@ namespace hgraph
     [[nodiscard]] HGRAPH_EXPORT const JsonConverter &json_converter(const ValueTypeMetaData *meta);
 
     /**
-     * A JSON conversion plan bound to the active graph type-realisation
-     * snapshot. Construction may consult type registries and the snapshot;
-     * read/write perform no schema lookup and take no type-system or
-     * realisation lock. The plan owns its converter tree and retains the
-     * realisation snapshot backing graph-local bindings; canonical metadata
-     * remains registry-scoped. The plan is intended to live in run-local
-     * node/service state.
+     * A JSON conversion plan bound to a type-realisation snapshot.
+     * Construction may consult type registries and the snapshot; read/write
+     * perform no schema lookup and take no type-system or realisation lock.
+     * The plan owns its converter tree and retains the snapshot backing its
+     * bindings; canonical metadata remains registry-scoped. Evaluation code
+     * keeps it in run-local node/service state.
      */
     class HGRAPH_CLASS_EXPORT BoundJsonConverter final
     {
@@ -118,12 +117,14 @@ namespace hgraph
 
         std::shared_ptr<const Impl> impl_{};
 
-        friend BoundJsonConverter bind_json_converter(const ValueTypeMetaData *meta);
+        friend HGRAPH_EXPORT BoundJsonConverter bind_json_converter(const ValueTypeMetaData *meta);
     };
 
-    /** Resolve and own a complete run-local conversion plan for ``meta``. */
-    [[nodiscard]] HGRAPH_EXPORT BoundJsonConverter
-    bind_json_converter(const ValueTypeMetaData *meta);
+    /** Resolve and own a complete conversion plan for ``meta``. The active
+        graph realisation is retained when present; ad-hoc callers outside a
+        graph capture the current hierarchy so polymorphic dispatch remains
+        complete. */
+    [[nodiscard]] HGRAPH_EXPORT BoundJsonConverter bind_json_converter(const ValueTypeMetaData *meta);
 
     /** Clear the interned converters (registry reset — see registry_reset.h). */
     HGRAPH_EXPORT void clear_json_converters() noexcept;

--- a/src/hgraph/lib/std/operators/json_impl.cpp
+++ b/src/hgraph/lib/std/operators/json_impl.cpp
@@ -720,10 +720,10 @@ namespace hgraph::stdlib
             (uniform) element plan; TSB holds one per field. */
         struct TsJsonPlan
         {
-            const JsonConverter      *value{nullptr};    // leaf / whole-value
-            const JsonConverter      *element{nullptr};  // TSS element
-            const JsonConverter      *delta{nullptr};    // TSL index-map delta
-            const JsonConverter      *key{nullptr};      // TSD key
+            BoundJsonConverter        value{};    // leaf / whole-value
+            BoundJsonConverter        element{};  // TSS element
+            BoundJsonConverter        delta{};    // TSL index-map delta
+            BoundJsonConverter        key{};      // TSD key
             const ValueTypeMetaData  *key_meta{nullptr};
             std::vector<std::unique_ptr<TsJsonPlan>> children{};
         };
@@ -736,19 +736,21 @@ namespace hgraph::stdlib
                 case TSTypeKind::TSD: {
                     const auto *dict = time_series_schema_as<AnyTSD>(schema);
                     plan->key_meta   = dict->key_type();
-                    plan->key        = &json_converter(plan->key_meta);
+                    plan->key        = bind_json_converter(plan->key_meta);
                     plan->children.emplace_back(build_ts_json_plan(dict->element_ts()));
                     break;
                 }
                 case TSTypeKind::TSS: {
-                    plan->value   = &json_converter(schema->value_schema);
-                    plan->element = &json_converter(schema->value_schema->element_type);
+                    plan->value   = bind_json_converter(schema->value_schema);
+                    plan->element = bind_json_converter(
+                        schema->value_schema->element_type);
                     break;
                 }
                 case TSTypeKind::TSL: {
                     const auto *list = time_series_schema_as<AnyTSL>(schema);
-                    plan->value      = &json_converter(schema->value_schema);
-                    plan->delta      = &json_converter(schema->delta_value_schema);
+                    plan->value      = bind_json_converter(schema->value_schema);
+                    plan->delta      = bind_json_converter(
+                        schema->delta_value_schema);
                     plan->children.emplace_back(build_ts_json_plan(list->element_ts()));
                     break;
                 }
@@ -756,7 +758,7 @@ namespace hgraph::stdlib
                     // write_ts_delta recurses the fields; apply_ts_json
                     // treats a TSB as a whole-value leaf — carry both.
                     const auto *bundle = time_series_schema_as<AnyTSB>(schema);
-                    plan->value        = &json_converter(schema->value_schema);
+                    plan->value = bind_json_converter(schema->value_schema);
                     for (std::size_t index = 0; index < bundle->field_count(); ++index)
                     {
                         plan->children.emplace_back(
@@ -765,7 +767,7 @@ namespace hgraph::stdlib
                     break;
                 }
                 default: {
-                    plan->value = &json_converter(schema->value_schema);
+                    plan->value = bind_json_converter(schema->value_schema);
                     break;
                 }
             }
@@ -776,7 +778,8 @@ namespace hgraph::stdlib
 
         namespace
         {
-            void write_json_key(const JsonConverter &converter, const ValueView &key,
+            void write_json_key(const BoundJsonConverter &converter,
+                                const ValueView &key,
                                 std::string &out)
             {
                 // Keys are STRINGIFIED (python json.dumps): a Str renders as
@@ -809,20 +812,20 @@ namespace hgraph::stdlib
                     for (const ValueView key : dict.removed_keys())
                     {
                         write_separator(first, out);
-                        write_json_key(*plan.key, key, out);
+                        write_json_key(plan.key, key, out);
                         out += ": null";
                     }
                     for (auto &&[key, child] : dict.modified_items())
                     {
                         write_separator(first, out);
-                        write_json_key(*plan.key, key, out);
+                        write_json_key(plan.key, key, out);
                         out += ": ";
                         write_ts_delta(child, *plan.children[0], out);
                     }
                     out.push_back('}');
                 },
                 [&](TSSInputView set) {
-                    const auto &element = *plan.element;
+                    const auto &element = plan.element;
                     std::string added;
                     std::string removed;
                     bool        any_added   = false;
@@ -883,7 +886,7 @@ namespace hgraph::stdlib
                     }
                     out.push_back('}');
                 },
-                [&](TSInputView leaf) { plan.value->write(leaf.value(), out); });
+                [&](TSInputView leaf) { plan.value.write(leaf.value(), out); });
         }
 
         void apply_ts_json(const TSOutputView &out, const TsJsonPlan &plan,
@@ -905,7 +908,7 @@ namespace hgraph::stdlib
                         const std::string key_text = json_fragment::parse_string(cursor);
                         const Value       key =
                             string_key ? Value{Str{key_text}}
-                                       : from_json_string(*plan.key, key_text);
+                                       : from_json_string(plan.key, key_text);
                         if (!json_fragment::consume(cursor, ':'))
                         {
                             json_fragment::fail(cursor, "expected ':' after a TSD key");
@@ -927,7 +930,8 @@ namespace hgraph::stdlib
                     if (json_fragment::peek(cursor) == '[')
                     {
                         // A bare array replaces the whole membership.
-                        const Value parsed = json_fragment::parse_value(*plan.value, cursor);
+                        const Value parsed = json_fragment::parse_value(
+                            plan.value, cursor);
                         apply_current_value(set.base(), parsed.view());
                         return;
                     }
@@ -936,7 +940,7 @@ namespace hgraph::stdlib
                         json_fragment::fail(cursor, "expected '{' or '[' for a TSS");
                     }
                     auto        mutation = set.begin_mutation(set.evaluation_time());
-                    const auto &element  = *plan.element;
+                    const auto &element  = plan.element;
                     if (json_fragment::consume(cursor, '}')) { return; }
                     while (true)
                     {
@@ -965,17 +969,20 @@ namespace hgraph::stdlib
                 [&](TSLOutputView list) {
                     if (json_fragment::peek(cursor) == '[')
                     {
-                        const Value parsed = json_fragment::parse_value(*plan.value, cursor);
+                        const Value parsed = json_fragment::parse_value(
+                            plan.value, cursor);
                         apply_current_value(list.base(), parsed.view());
                         return;
                     }
                     // The index-object form IS the canonical TSL delta (an
                     // index map); its converter reads quoted keys.
-                    const Value parsed = json_fragment::parse_value(*plan.delta, cursor);
+                    const Value parsed = json_fragment::parse_value(
+                        plan.delta, cursor);
                     apply_delta(list.base(), parsed.view());
                 },
                 [&](TSOutputView leaf) {
-                    const Value parsed = json_fragment::parse_value(*plan.value, cursor);
+                    const Value parsed = json_fragment::parse_value(
+                        plan.value, cursor);
                     apply_current_value(leaf, parsed.view());
                 });
         }

--- a/src/hgraph/types/value/json_codec.cpp
+++ b/src/hgraph/types/value/json_codec.cpp
@@ -45,6 +45,12 @@ namespace hgraph
         using JsonDateTimeFormatSnapshot =
             std::shared_ptr<const RegisteredJsonDateTimeFormats>;
 
+        struct JsonReadContext
+        {
+            JsonDateTimeFormatSnapshot formats{};
+            std::shared_ptr<const TimeZoneProvider> time_zone_provider{};
+        };
+
         struct JsonDateTimeFormatRegistry
         {
             std::mutex mutex{};
@@ -568,7 +574,8 @@ namespace hgraph
 
         template <typename TimePoint>
         [[nodiscard]] std::optional<TimePoint> parse_json_datetime_value(
-            std::string_view text)
+            std::string_view text,
+            const RegisteredJsonDateTimeFormats &registered)
         {
             static constexpr std::array<std::string_view, 3> compact_formats{
                 "%Y%m%d", "%Y%m%d%H%M%S", "%Y%m%d%H%M%S"};
@@ -667,8 +674,7 @@ namespace hgraph
             {
                 return value;
             }
-            const auto registered = registered_datetime_format_snapshot();
-            for (const std::string &format : registered->datetime)
+            for (const std::string &format : registered.datetime)
             {
                 if (auto value =
                         parse_datetime_format<TimePoint>(text, format))
@@ -680,7 +686,8 @@ namespace hgraph
         }
 
         [[nodiscard]] std::optional<CivilTime> parse_json_time_value(
-            std::string_view text)
+            std::string_view text,
+            const RegisteredJsonDateTimeFormats &registered)
         {
             static constexpr std::array<std::string_view, 3> iso_formats{
                 "%H:%M:%S", "%H:%M", "%H"};
@@ -758,8 +765,7 @@ namespace hgraph
             {
                 if (auto value = parse(text, format)) { return value; }
             }
-            const auto registered = registered_datetime_format_snapshot();
-            for (const std::string &format : registered->time)
+            for (const std::string &format : registered.time)
             {
                 if (auto value = parse(text, format)) { return value; }
             }
@@ -767,11 +773,13 @@ namespace hgraph
         }
 
         [[nodiscard]] CivilDate json_date(
-            std::string_view text, Reader &reader)
+            std::string_view text, Reader &reader,
+            const RegisteredJsonDateTimeFormats &registered)
         {
             using LocalMicros =
                 JsonLocalTime<std::chrono::microseconds>;
-            auto value = parse_json_datetime_value<LocalMicros>(text);
+            auto value = parse_json_datetime_value<LocalMicros>(
+                text, registered);
             if (!value)
             {
                 reader.fail(fmt::format(
@@ -783,9 +791,10 @@ namespace hgraph
         }
 
         [[nodiscard]] CivilTime json_time(
-            std::string_view text, Reader &reader)
+            std::string_view text, Reader &reader,
+            const RegisteredJsonDateTimeFormats &registered)
         {
-            auto value = parse_json_time_value(text);
+            auto value = parse_json_time_value(text, registered);
             if (!value)
             {
                 reader.fail(fmt::format(
@@ -796,10 +805,12 @@ namespace hgraph
         }
 
         [[nodiscard]] Instant json_instant(
-            std::string_view text, Reader &reader)
+            std::string_view text, Reader &reader,
+            const RegisteredJsonDateTimeFormats &registered)
         {
             using SysMicros = JsonSysTime<std::chrono::microseconds>;
-            auto value = parse_json_datetime_value<SysMicros>(text);
+            auto value = parse_json_datetime_value<SysMicros>(
+                text, registered);
             if (!value)
             {
                 reader.fail(fmt::format(
@@ -1315,16 +1326,38 @@ namespace hgraph
             bool polymorphic = false;
             if (self.meta->is_named_bundle())
             {
-                const auto *snapshot = active_type_realization();
-                polymorphic = view.binding() != self.binding ||
-                              (snapshot != nullptr && snapshot->is_polymorphic(self.meta));
-                if (polymorphic)
+                if (self.realization_bound)
                 {
-                    if (!TypeRegistry::instance().bundle_is_a(concrete.schema(), self.meta))
+                    polymorphic = self.polymorphic;
+                    if (polymorphic)
                     {
-                        throw std::logic_error("json: polymorphic Bundle contains an invalid concrete type");
+                        const auto alternative = std::ranges::find_if(
+                            self.alternatives,
+                            [&](const JsonConverter *candidate) {
+                                return candidate->meta == concrete.schema();
+                            });
+                        if (alternative == self.alternatives.end())
+                        {
+                            throw std::logic_error(
+                                "json: polymorphic Bundle contains an invalid concrete type");
+                        }
+                        selected = *alternative;
                     }
-                    selected = &json_converter(concrete.schema());
+                }
+                else
+                {
+                    const auto *snapshot = active_type_realization();
+                    polymorphic = view.binding() != self.binding ||
+                                  (snapshot != nullptr && snapshot->is_polymorphic(self.meta));
+                    if (polymorphic)
+                    {
+                        if (!TypeRegistry::instance().bundle_is_a(concrete.schema(), self.meta))
+                        {
+                            throw std::logic_error(
+                                "json: polymorphic Bundle contains an invalid concrete type");
+                        }
+                        selected = &json_converter(concrete.schema());
+                    }
                 }
             }
 
@@ -1423,39 +1456,78 @@ namespace hgraph
         // Read thunks
         // ---------------------------------------------------------------
 
+        template <typename T>
+        [[nodiscard]] Value read_bound_atomic(const JsonConverter &self,
+                                              T value)
+        {
+            return Value{self.binding, std::addressof(value)};
+        }
+
         Value read_atomic(const JsonConverter &self, Reader &reader)
         {
+            JsonDateTimeFormatSnapshot dynamic_formats{};
+            const auto *bound_read_context =
+                static_cast<const JsonReadContext *>(
+                    self.read_context.get());
+            const auto registered_formats = [&]()
+                -> const RegisteredJsonDateTimeFormats & {
+                if (bound_read_context != nullptr)
+                {
+                    return *bound_read_context->formats;
+                }
+                dynamic_formats = registered_datetime_format_snapshot();
+                return *dynamic_formats;
+            };
             switch (self.atomic_tag)
             {
                 case AtomicTag::Bool: {
-                    if (reader.consume_keyword("true")) { return Value{Bool{true}}; }
-                    if (reader.consume_keyword("false")) { return Value{Bool{false}}; }
+                    if (reader.consume_keyword("true"))
+                    {
+                        return read_bound_atomic(self, Bool{true});
+                    }
+                    if (reader.consume_keyword("false"))
+                    {
+                        return read_bound_atomic(self, Bool{false});
+                    }
                     reader.fail("expected a boolean");
                 }
-                case AtomicTag::Int: return Value{json_detail::parse_int_token(reader.parse_number_token(), reader)};
+                case AtomicTag::Int:
+                    return read_bound_atomic(
+                        self, json_detail::parse_int_token(
+                                  reader.parse_number_token(), reader));
                 case AtomicTag::Float:
-                    return Value{json_detail::parse_float_token(reader.parse_number_token(), reader)};
-                case AtomicTag::Str: return Value{Str{reader.parse_string()}};
+                    return read_bound_atomic(
+                        self, json_detail::parse_float_token(
+                                  reader.parse_number_token(), reader));
+                case AtomicTag::Str:
+                    return read_bound_atomic(self, Str{reader.parse_string()});
                 case AtomicTag::Date: {
-                    return Value{json_detail::json_date(
-                        reader.parse_string(), reader)};
+                    return read_bound_atomic(
+                        self, json_detail::json_date(
+                                  reader.parse_string(), reader,
+                                  registered_formats()));
                 }
                 case AtomicTag::DateTime: {
-                    return Value{json_detail::json_instant(
-                        reader.parse_string(), reader)};
+                    return read_bound_atomic(
+                        self, json_detail::json_instant(
+                                  reader.parse_string(), reader,
+                                  registered_formats()));
                 }
                 case AtomicTag::TimeDelta: {
-                    return Value{
-                        json_detail::parse_json_duration(
-                            reader.parse_string(), reader)};
+                    return read_bound_atomic(
+                        self, json_detail::parse_json_duration(
+                                  reader.parse_string(), reader));
                 }
                 case AtomicTag::Time: {
-                    return Value{json_detail::json_time(
-                        reader.parse_string(), reader)};
+                    return read_bound_atomic(
+                        self, json_detail::json_time(
+                                  reader.parse_string(), reader,
+                                  registered_formats()));
                 }
                 case AtomicTag::CivilDateTime:
-                    return Value{json_detail::parse_civil_datetime(
-                        reader.parse_string(), reader, false)};
+                    return read_bound_atomic(
+                        self, json_detail::parse_civil_datetime(
+                                  reader.parse_string(), reader, false));
                 case AtomicTag::Period: {
                     reader.expect('{');
                     if (reader.parse_string() != "months")
@@ -1474,10 +1546,12 @@ namespace hgraph
                     const auto days = json_detail::parse_int_token(
                         reader.parse_number_token(), reader);
                     reader.expect('}');
-                    return Value{Period{0, months, days}};
+                    return read_bound_atomic(
+                        self, Period{0, months, days});
                 }
                 case AtomicTag::ZoneId:
-                    return Value{ZoneId{reader.parse_string()}};
+                    return read_bound_atomic(
+                        self, ZoneId{reader.parse_string()});
                 case AtomicTag::ZonedDateTime: {
                     const std::string text = reader.parse_string();
                     const auto bracket = text.find('[');
@@ -1522,38 +1596,43 @@ namespace hgraph
                                  1'000'000});
                     const ZonedDateTime verified =
                         at_zone(instant, zone,
-                                codec_time_zone_provider());
+                                bound_read_context != nullptr
+                                    ? *bound_read_context->time_zone_provider
+                                    : codec_time_zone_provider());
                     if (verified.offset_seconds() != offset)
                     {
                         reader.fail(
                             "zoned datetime offset disagrees with provider");
                     }
-                    return Value{verified};
+                    return read_bound_atomic(self, verified);
                 }
                 case AtomicTag::InstantRange:
-                    return Value{json_detail::read_range<InstantRange>(
-                        reader,
-                        [](std::string_view value, Reader &nested) {
-                            const CivilDateTime parsed =
-                                json_detail::parse_civil_datetime(
-                                    value, nested, true);
-                            return Instant{
-                                Duration{parsed.epoch_microseconds()}};
-                        })};
+                    return read_bound_atomic(
+                        self, json_detail::read_range<InstantRange>(
+                                  reader,
+                                  [](std::string_view value, Reader &nested) {
+                                      const CivilDateTime parsed =
+                                          json_detail::parse_civil_datetime(
+                                              value, nested, true);
+                                      return Instant{Duration{
+                                          parsed.epoch_microseconds()}};
+                                  }));
                 case AtomicTag::CivilDateRange:
-                    return Value{json_detail::read_range<CivilDateRange>(
-                        reader,
-                        [](std::string_view value, Reader &nested) {
-                            std::size_t position = 0;
-                            const CivilDate parsed =
-                                json_detail::parse_date_body(
-                                    value, position, nested);
-                            if (position != value.size())
-                            {
-                                nested.fail("trailing date content");
-                            }
-                            return parsed;
-                        })};
+                    return read_bound_atomic(
+                        self, json_detail::read_range<CivilDateRange>(
+                                  reader,
+                                  [](std::string_view value, Reader &nested) {
+                                      std::size_t position = 0;
+                                      const CivilDate parsed =
+                                          json_detail::parse_date_body(
+                                              value, position, nested);
+                                      if (position != value.size())
+                                      {
+                                          nested.fail(
+                                              "trailing date content");
+                                      }
+                                      return parsed;
+                                  }));
                 case AtomicTag::InstantRangeSet: {
                     std::array<InstantRange, 2> ranges{};
                     std::size_t size = 0;
@@ -1582,8 +1661,9 @@ namespace hgraph
                         }
                         reader.expect(']');
                     }
-                    return Value{InstantRangeSet{
-                        std::span<const InstantRange>{ranges.data(), size}}};
+                    return read_bound_atomic(
+                        self, InstantRangeSet{std::span<const InstantRange>{
+                                  ranges.data(), size}});
                 }
                 case AtomicTag::CivilDateRangeSet: {
                     std::array<CivilDateRange, 2> ranges{};
@@ -1618,8 +1698,10 @@ namespace hgraph
                         }
                         reader.expect(']');
                     }
-                    return Value{CivilDateRangeSet{
-                        std::span<const CivilDateRange>{ranges.data(), size}}};
+                    return read_bound_atomic(
+                        self,
+                        CivilDateRangeSet{std::span<const CivilDateRange>{
+                            ranges.data(), size}});
                 }
                 case AtomicTag::None: break;
             }
@@ -1628,8 +1710,15 @@ namespace hgraph
 
         Value read_realized(const JsonConverter &converter, Reader &reader)
         {
-            const auto *snapshot = active_type_realization();
-            if (snapshot == nullptr || !snapshot->is_polymorphic(converter.meta))
+            const auto *snapshot = converter.realization_bound
+                                       ? nullptr
+                                       : active_type_realization();
+            const bool polymorphic = converter.realization_bound
+                                         ? converter.polymorphic
+                                         : snapshot != nullptr &&
+                                               snapshot->is_polymorphic(
+                                                   converter.meta);
+            if (!polymorphic)
             {
                 return converter.read_(converter, reader);
             }
@@ -1656,15 +1745,44 @@ namespace hgraph
             }
 
             const ValueTypeMetaData *selected = nullptr;
-            for (const auto *alternative : snapshot->alternatives(converter.meta))
+            const JsonConverter *selected_converter = nullptr;
+            if (converter.realization_bound)
             {
-                if (alternative->matches_bundle_discriminator(requested))
+                for (const auto *alternative : converter.alternatives)
                 {
-                    if (selected != nullptr) { probe.fail("polymorphic Bundle discriminator is ambiguous"); }
-                    selected = alternative;
+                    if (alternative->meta->matches_bundle_discriminator(
+                            requested))
+                    {
+                        if (selected_converter != nullptr)
+                        {
+                            probe.fail(
+                                "polymorphic Bundle discriminator is ambiguous");
+                        }
+                        selected_converter = alternative;
+                    }
                 }
             }
-            if (selected == nullptr)
+            else
+            {
+                for (const auto *alternative :
+                     snapshot->alternatives(converter.meta))
+                {
+                    if (alternative->matches_bundle_discriminator(requested))
+                    {
+                        if (selected != nullptr)
+                        {
+                            probe.fail(
+                                "polymorphic Bundle discriminator is ambiguous");
+                        }
+                        selected = alternative;
+                    }
+                }
+            }
+            if (converter.realization_bound && selected_converter == nullptr)
+            {
+                probe.fail("polymorphic Bundle discriminator names no valid alternative");
+            }
+            if (!converter.realization_bound && selected == nullptr)
             {
                 probe.fail("polymorphic Bundle discriminator names no valid alternative");
             }
@@ -1672,9 +1790,15 @@ namespace hgraph
             // Read the selected alternative exactly. Its own children still
             // use read_realized, but an instantiable parent remains a valid
             // concrete alternative even when it also has descendants.
-            const auto &selected_converter = json_converter(selected);
-            Value       concrete            = selected_converter.read_(selected_converter, reader);
-            const auto  realized            = snapshot->type_for(converter.meta);
+            if (!converter.realization_bound)
+            {
+                selected_converter = &json_converter(selected);
+            }
+            Value concrete = selected_converter->read_(*selected_converter,
+                                                       reader);
+            const auto realized = converter.realization_bound
+                                      ? converter.binding
+                                      : snapshot->type_for(converter.meta);
             Value       result{realized};
             auto        destination = result.begin_mutation();
             realized.ops_ref().copy_assign_from(
@@ -1685,10 +1809,14 @@ namespace hgraph
         Value read_composite(const JsonConverter &self, Reader &reader)
         {
             auto binding = self.binding;
-            if (const auto *snapshot = active_type_realization();
-                snapshot != nullptr && !snapshot->is_polymorphic(self.meta))
+            if (!self.realization_bound)
             {
-                binding = snapshot->type_for(self.meta);
+                if (const auto *snapshot = active_type_realization();
+                    snapshot != nullptr &&
+                    !snapshot->is_polymorphic(self.meta))
+                {
+                    binding = snapshot->type_for(self.meta);
+                }
             }
             BundleBuilder builder{binding};
             if (self.names.empty())
@@ -1749,6 +1877,7 @@ namespace hgraph
 
         [[nodiscard]] ValueTypeRef realized_read_binding(const JsonConverter &converter)
         {
+            if (converter.realization_bound) { return converter.binding; }
             if (const auto *snapshot = active_type_realization(); snapshot != nullptr)
             {
                 return snapshot->type_for(converter.meta);
@@ -1758,8 +1887,9 @@ namespace hgraph
 
         Value read_list(const JsonConverter &self, Reader &reader)
         {
-            ListBuilder builder{
-                realized_read_binding(*self.children[0]), *self.meta};
+            const auto element_binding =
+                realized_read_binding(*self.children[0]);
+            ListBuilder builder{element_binding, *self.meta};
             reader.expect('[');
             if (!reader.consume_if(']'))
             {
@@ -1771,12 +1901,19 @@ namespace hgraph
                 }
                 reader.expect(']');
             }
-            return builder.build();
+            ListStorage storage = builder.build_storage();
+            const auto result_binding = self.realization_bound
+                                            ? self.binding
+                                            : compact_list_type(
+                                                  element_binding, *self.meta);
+            return Value{result_binding, &storage};
         }
 
         Value read_set(const JsonConverter &self, Reader &reader)
         {
-            SetBuilder builder{realized_read_binding(*self.children[0])};
+            const auto element_binding =
+                realized_read_binding(*self.children[0]);
+            SetBuilder builder{element_binding};
             reader.expect('[');
             if (!reader.consume_if(']'))
             {
@@ -1788,14 +1925,20 @@ namespace hgraph
                 }
                 reader.expect(']');
             }
-            return builder.build();
+            SetStorage storage = builder.build_storage();
+            const auto result_binding = self.realization_bound
+                                            ? self.binding
+                                            : compact_set_type(element_binding);
+            return Value{result_binding, &storage};
         }
 
         Value read_map(const JsonConverter &self, Reader &reader)
         {
-            MapBuilder builder{
-                realized_read_binding(*self.children[0]),
-                realized_read_binding(*self.children[1])};
+            const auto key_binding =
+                realized_read_binding(*self.children[0]);
+            const auto value_binding =
+                realized_read_binding(*self.children[1]);
+            MapBuilder builder{key_binding, value_binding};
             reader.expect('{');
             if (!reader.consume_if('}'))
             {
@@ -1805,7 +1948,11 @@ namespace hgraph
                     // its content, other keys parse the content as their token.
                     const std::string key_text = reader.parse_string();
                     Value             key;
-                    if (self.children[0]->atomic_tag == AtomicTag::Str) { key = Value{Str{key_text}}; }
+                    if (self.children[0]->atomic_tag == AtomicTag::Str)
+                    {
+                        key = read_bound_atomic(
+                            *self.children[0], Str{key_text});
+                    }
                     else
                     {
                         Reader key_reader{std::string_view{key_text}};
@@ -1840,7 +1987,12 @@ namespace hgraph
                 }
                 reader.expect('}');
             }
-            return builder.build();
+            MapStorage storage = builder.build_storage();
+            const auto result_binding = self.realization_bound
+                                            ? self.binding
+                                            : compact_map_type(
+                                                  key_binding, value_binding);
+            return Value{result_binding, &storage};
         }
 
         // ---------------------------------------------------------------
@@ -1994,7 +2146,149 @@ namespace hgraph
         }
     }  // namespace
 
+    struct BoundJsonConverter::Impl
+    {
+        explicit Impl(
+            std::shared_ptr<const TypeRealizationSnapshot> realization)
+            : realization_owner{std::move(realization)},
+              realization{realization_owner.get()},
+              read_context{std::make_shared<JsonReadContext>(
+                  JsonReadContext{
+                      registered_datetime_format_snapshot(),
+                      make_time_zone_provider()})}
+        {
+        }
+
+        [[nodiscard]] JsonConverter *build(const ValueTypeMetaData *meta,
+                                           bool exact_root)
+        {
+            auto &plans = exact_root ? exact_plans : plans_by_schema;
+            if (const auto found = plans.find(meta); found != plans.end())
+            {
+                return found->second.get();
+            }
+
+            const auto &prototype = json_converter(meta);
+            auto plan = std::make_unique<JsonConverter>();
+            auto *result = plan.get();
+            plans.emplace(meta, std::move(plan));
+
+            result->write_ = prototype.write_;
+            result->read_ = prototype.read_;
+            result->meta = prototype.meta;
+            result->atomic_tag = prototype.atomic_tag;
+            result->names = prototype.names;
+            result->read_context = read_context;
+            result->realization_bound = true;
+            result->binding = realization == nullptr
+                                  ? prototype.binding
+                                  : exact_root
+                                        ? realization->exact_type_for(meta)
+                                        : realization->type_for(meta);
+
+            result->children.reserve(prototype.children.size());
+            for (const auto *child : prototype.children)
+            {
+                result->children.push_back(build(child->meta, false));
+            }
+
+            // Container readers construct compact owning storage. A declared
+            // fixed List may have an inline canonical binding, so pairing its
+            // plan with a ListStorage address would be a representation lie.
+            // Resolve the matching owning representation once here; composite
+            // consumers convert it into their declared field binding through
+            // the normal erased assignment contract.
+            switch (meta->value_kind())
+            {
+                case ValueTypeKind::List:
+                    result->binding = compact_list_type(
+                        result->children[0]->binding, *meta);
+                    break;
+                case ValueTypeKind::Set:
+                    result->binding = compact_set_type(
+                        result->children[0]->binding);
+                    break;
+                case ValueTypeKind::Map:
+                    result->binding = compact_map_type(
+                        result->children[0]->binding,
+                        result->children[1]->binding);
+                    break;
+                default: break;
+            }
+
+            result->polymorphic = !exact_root && realization != nullptr &&
+                                  realization->is_polymorphic(meta);
+            if (result->polymorphic)
+            {
+                for (const auto *alternative : realization->alternatives(meta))
+                {
+                    result->alternatives.push_back(build(alternative, true));
+                }
+            }
+            return result;
+        }
+
+        std::shared_ptr<const TypeRealizationSnapshot> realization_owner{};
+        const TypeRealizationSnapshot *realization{nullptr};
+        std::shared_ptr<const JsonReadContext> read_context{};
+        std::unordered_map<const ValueTypeMetaData *,
+                           std::unique_ptr<JsonConverter>> plans_by_schema{};
+        std::unordered_map<const ValueTypeMetaData *,
+                           std::unique_ptr<JsonConverter>> exact_plans{};
+        const JsonConverter *root{nullptr};
+    };
+
     Value JsonConverter::read(json_detail::Reader &reader) const { return read_realized(*this, reader); }
+
+    BoundJsonConverter::BoundJsonConverter(
+        std::shared_ptr<const Impl> impl) noexcept
+        : impl_{std::move(impl)}
+    {
+    }
+
+    BoundJsonConverter::operator bool() const noexcept
+    {
+        return impl_ != nullptr && impl_->root != nullptr;
+    }
+
+    const ValueTypeMetaData *BoundJsonConverter::schema() const noexcept
+    {
+        return *this ? impl_->root->meta : nullptr;
+    }
+
+    const JsonConverter &BoundJsonConverter::converter() const
+    {
+        if (!*this)
+        {
+            throw std::logic_error("json: converter is not bound to a schema");
+        }
+        return *impl_->root;
+    }
+
+    void BoundJsonConverter::write(const ValueView &view,
+                                   std::string &out) const
+    {
+        converter().write(view, out);
+    }
+
+    Value BoundJsonConverter::read(json_detail::Reader &reader) const
+    {
+        return converter().read(reader);
+    }
+
+    BoundJsonConverter bind_json_converter(const ValueTypeMetaData *meta)
+    {
+        if (meta == nullptr)
+        {
+            throw std::invalid_argument(
+                "json: cannot bind a null value schema");
+        }
+        const auto *active = active_type_realization();
+        auto impl = std::make_shared<BoundJsonConverter::Impl>(
+            active != nullptr ? active->shared_from_this() : nullptr);
+        impl->root = impl->build(meta, false);
+        return BoundJsonConverter{std::move(impl)};
+    }
 
     const JsonConverter &json_converter(const ValueTypeMetaData *meta)
     {
@@ -2021,6 +2315,16 @@ namespace hgraph
     }
 
     Value from_json_string(const JsonConverter &converter, std::string_view text)
+    {
+        json_detail::Reader reader{text};
+        Value               result = converter.read(reader);
+        reader.skip_ws();
+        if (reader.pos != text.size()) { reader.fail("trailing content"); }
+        return result;
+    }
+
+    Value from_json_string(const BoundJsonConverter &converter,
+                           std::string_view text)
     {
         json_detail::Reader reader{text};
         Value               result = converter.read(reader);
@@ -2079,6 +2383,14 @@ namespace hgraph
         }
 
         Value parse_value(const JsonConverter &converter, Cursor &cursor)
+        {
+            json_detail::Reader reader{cursor.text, cursor.offset};
+            Value               result = converter.read(reader);
+            cursor.offset              = reader.pos;
+            return result;
+        }
+
+        Value parse_value(const BoundJsonConverter &converter, Cursor &cursor)
         {
             json_detail::Reader reader{cursor.text, cursor.offset};
             Value               result = converter.read(reader);

--- a/src/hgraph/types/value/json_codec.cpp
+++ b/src/hgraph/types/value/json_codec.cpp
@@ -2284,8 +2284,12 @@ namespace hgraph
                 "json: cannot bind a null value schema");
         }
         const auto *active = active_type_realization();
+        auto realization =
+            active != nullptr
+                ? active->shared_from_this()
+                : TypeRealizationSnapshot::capture(TypeRegistry::instance());
         auto impl = std::make_shared<BoundJsonConverter::Impl>(
-            active != nullptr ? active->shared_from_this() : nullptr);
+            std::move(realization));
         impl->root = impl->build(meta, false);
         return BoundJsonConverter{std::move(impl)};
     }

--- a/tests/cpp/test_json.cpp
+++ b/tests/cpp/test_json.cpp
@@ -4,7 +4,9 @@
 #include <hgraph/lib/testing/check_output.h>
 #include <hgraph/lib/testing/eval_node.h>
 #include <hgraph/types/graph_wiring.h>
+#include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/type_registry.h>
+#include <hgraph/types/utils/counted_mutex.h>
 #include <hgraph/types/value/json_codec.h>
 #include <hgraph/types/value/value_builder.h>
 #include <hgraph/types/temporal.h>
@@ -298,6 +300,81 @@ TEST_CASE("json: bundles serialize as objects; unknown fields are skipped on rea
     CHECK(back.view().as_bundle().at(1).checked_as<Str>() == Str{"here"});
 }
 
+TEST_CASE("json: a bound structural converter decodes without type-system locks")
+{
+    auto &registry = TypeRegistry::instance();
+    const auto *int_meta = registry.register_scalar<Int>("int");
+    const auto *str_meta = registry.register_scalar<Str>("str");
+    const auto *datetime_meta =
+        registry.register_scalar<DateTime>("datetime");
+    const auto *items_meta = registry.list(int_meta);
+    const auto *tags_meta = registry.set(int_meta);
+    const auto *counts_meta = registry.map(str_meta, int_meta);
+    const auto *bundle_meta = registry.un_named_bundle(
+        {{"count", int_meta},
+         {"label", str_meta},
+         {"as_of", datetime_meta},
+         {"items", items_meta},
+         {"tags", tags_meta},
+         {"counts", counts_meta}});
+    const auto converter = bind_json_converter(bundle_meta);
+
+    const auto before = type_system_lock_count();
+    for (int i = 0; i < 64; ++i)
+    {
+        const Value decoded = from_json_string(
+            converter,
+            R"({"count": 5, "label": "ready", "as_of": "2024-06-13T10:15:30.123456+00:00", "items": [1, 2, 3], "tags": [2, 4], "counts": {"left": 7}})");
+        const auto bundle = decoded.view().as_bundle();
+        CHECK(bundle.at("count").checked_as<Int>() == Int{5});
+        CHECK(bundle.at("label").checked_as<Str>() == Str{"ready"});
+        CHECK(bundle.at("as_of").checked_as<DateTime>() ==
+              utc_instant(2024, 6, 13, 10, 15, 30, 123'456));
+        const auto items = bundle.at("items").as_list();
+        REQUIRE(items.size() == 3);
+        CHECK(items.at(2).checked_as<Int>() == Int{3});
+        CHECK(bundle.at("tags").as_set().size() == 2);
+        CHECK(bundle.at("counts").as_map().size() == 1);
+    }
+    CHECK(type_system_lock_count() == before);
+}
+
+TEST_CASE("json: a run-bound polymorphic converter owns its complete plan")
+{
+    auto &registry = TypeRegistry::instance();
+    const auto *integer = registry.register_scalar<Int>("int");
+    const auto *base = registry.bundle(
+        "tests.bound_json", "Base", {{"id", integer}}, {}, true);
+    const auto *child = registry.bundle(
+        "tests.bound_json", "Child",
+        {{"id", integer}, {"quantity", integer}}, {base});
+    const auto realization = TypeRealizationSnapshot::capture(registry);
+
+    BoundJsonConverter converter;
+    {
+        TypeRealizationScope scope{realization.get()};
+        converter = bind_json_converter(base);
+    }
+    const ValueTypeRef expected_binding = realization->type_for(base);
+
+    const auto before = type_system_lock_count();
+    for (int i = 0; i < 64; ++i)
+    {
+        const Value decoded = from_json_string(
+            converter,
+            R"({"__type__": "tests.bound_json::Child", "id": 1, "quantity": 2})");
+        REQUIRE(decoded.binding() == expected_binding);
+        REQUIRE(decoded.view().concrete().schema() == child);
+
+        std::string encoded;
+        converter.write(decoded.view(), encoded);
+        CHECK(encoded.find(
+                  R"("__type__": "tests.bound_json::Child")") !=
+              std::string::npos);
+    }
+    CHECK(type_system_lock_count() == before);
+}
+
 TEST_CASE("json: unset bundle fields are omitted on write and null on read")
 {
     auto &registry = TypeRegistry::instance();
@@ -339,6 +416,19 @@ namespace
         {
             return wire<stdlib::from_json, TS<DateTime>>(w, ts)
                 .as<TS<DateTime>>();
+        }
+    };
+
+    struct FromJsonFixedListGraph
+    {
+        [[maybe_unused]] static constexpr auto name =
+            "from_json_fixed_list_graph";
+
+        static Port<TSL<TS<Int>, 2>> compose(Wiring &w,
+                                              Port<TS<Str>> ts)
+        {
+            return wire<stdlib::from_json, TSL<TS<Int>, 2>>(w, ts)
+                .as<TSL<TS<Int>, 2>>();
         }
     };
 
@@ -532,6 +622,15 @@ TEST_CASE("json operators: from_json parses into the resolved output type")
     stdlib::register_standard_operators();
     CHECK_OUTPUT(eval_node<FromJsonGraph>(values<Str>(Str{"3"}, none, Str{"-9"})),
                  values<Int>(3, none, -9));
+}
+
+TEST_CASE("json operators: from_json converts compact JSON arrays into fixed TSL storage")
+{
+    stdlib::register_standard_operators();
+    CHECK_OUTPUT(
+        eval_node<FromJsonFixedListGraph>(
+            values<Str>(Str{"[1, 2]"})),
+        values<Value>(list_delta<TS<Int>>({{0, 1}, {1, 2}})));
 }
 
 TEST_CASE("json operators: temporal parsing uses the shared native format registry")

--- a/tests/cpp/test_json.cpp
+++ b/tests/cpp/test_json.cpp
@@ -375,6 +375,42 @@ TEST_CASE("json: a run-bound polymorphic converter owns its complete plan")
     CHECK(type_system_lock_count() == before);
 }
 
+TEST_CASE("json: ad-hoc binding captures polymorphism outside a graph scope")
+{
+    auto &registry = TypeRegistry::instance();
+    const auto *integer = registry.register_scalar<Int>("int");
+    const auto *base = registry.bundle(
+        "tests.adhoc_bound_json", "Base", {{"id", integer}}, {}, true);
+    const auto *child = registry.bundle(
+        "tests.adhoc_bound_json", "Child",
+        {{"id", integer}, {"quantity", integer}}, {base});
+    const auto realization = TypeRealizationSnapshot::capture(registry);
+
+    Value escaped;
+    {
+        TypeRealizationScope scope{realization.get()};
+        const auto graph_converter = bind_json_converter(base);
+        escaped = from_json_string(
+            graph_converter,
+            R"({"__type__": "tests.adhoc_bound_json::Child", "id": 1, "quantity": 2})");
+    }
+    REQUIRE(active_type_realization() == nullptr);
+    REQUIRE(escaped.view().concrete().schema() == child);
+
+    const auto ad_hoc_converter = bind_json_converter(base);
+    const auto before = type_system_lock_count();
+    std::string encoded;
+    ad_hoc_converter.write(escaped.view(), encoded);
+    CHECK(encoded.find(
+              R"("__type__": "tests.adhoc_bound_json::Child")") !=
+          std::string::npos);
+    CHECK(encoded.find(R"("quantity": 2)") != std::string::npos);
+
+    const Value decoded = from_json_string(ad_hoc_converter, encoded);
+    CHECK(decoded.view().concrete().schema() == child);
+    CHECK(type_system_lock_count() == before);
+}
+
 TEST_CASE("json: unset bundle fields are omitted on write and null on read")
 {
     auto &registry = TypeRegistry::instance();


### PR DESCRIPTION
## Summary

- move schema-dependent Fabric codec and value-plan binding out of reusable configuration and into graph-run/node lifecycle state
- make `BoundValueCodec` retain explicit erased ownership and add complete run-bound JSON converter trees, including polymorphic alternatives and parser configuration
- keep Fabric and Kafka evaluation paths on retained bindings, leave the notifier transport-only, and copy those bindings into dynamically created publishers/coordinators
- remove evaluation-time Fabric type registration and plan lookup; steady-state build/extract/encode/decode and whole-publication tests require zero `TypeSystemMutex` acquisitions
- fix JSON and Fabric collection construction so dynamic compact storage is always paired with the matching physical binding
- add lifecycle, registry-reset, malformed metadata, nested structural/polymorphic, keyed-state, diagnostic, and lock-count regression coverage

## Validation

- macOS native: 1,650/1,650 passed from a fresh clean build
- macOS Python 3.14 compatibility: 2,216 passed, 10 skipped
- independent Linux native: 1,650/1,650 passed from a fresh clean build
- independent Linux Python 3.14 compatibility: 2,216 passed, 10 skipped
- Windows MSVC 19.51 warnings-as-errors build: all 810 targets built; 1,650/1,650 native tests passed
- stable-ABI wheel/distribution audits and installed Fabric C++ SDK consumer test passed