### PR TITLE
Escape JSON by runs and share one escaper between both encoders

### DIFF
--- a/include/hgraph/types/temporal.h
+++ b/include/hgraph/types/temporal.h
@@ -1028,6 +1028,7 @@ namespace hgraph
     [[nodiscard]] HGRAPH_EXPORT std::string format_civil_date(CivilDate value);
     [[nodiscard]] HGRAPH_EXPORT std::string format_civil_time(CivilTime value);
     [[nodiscard]] HGRAPH_EXPORT std::string format_civil_datetime(CivilDateTime value);
+    [[nodiscard]] HGRAPH_EXPORT std::string format_zoned_datetime(const ZonedDateTime &value);
 
     HGRAPH_EXPORT std::ostream &operator<<(std::ostream &out, const CivilDateTime &value);
     HGRAPH_EXPORT std::ostream &operator<<(std::ostream &out, const Period &value);

--- a/include/hgraph/types/value/json_codec.h
+++ b/include/hgraph/types/value/json_codec.h
@@ -17,6 +17,11 @@ namespace hgraph
     {
         /** Minimal recursive-descent JSON reader; parsing is meta-directed. */
         struct Reader;
+
+        /** Append ``text`` to ``out`` as a quoted, RFC 8259-escaped JSON
+         *  string. THE one escaper: the operator encoder shares it so the
+         *  two paths cannot drift on which characters need escaping. */
+        HGRAPH_EXPORT void append_escaped(std::string_view text, std::string &out);
     }  // namespace json_detail
 
     /**

--- a/src/hgraph/lib/std/operators/json_impl.cpp
+++ b/src/hgraph/lib/std/operators/json_impl.cpp
@@ -35,23 +35,6 @@ namespace hgraph::stdlib::json_tree
             return out;
         }
 
-        inline void escape_into(const Str &text, std::string &out)
-        {
-            out += '"';
-            for (const char c : text)
-            {
-                switch (c)
-                {
-                    case '"': out += "\\\""; break;
-                    case '\\': out += "\\\\"; break;
-                    case '\n': out += "\\n"; break;
-                    case '\t': out += "\\t"; break;
-                    case '\r': out += "\\r"; break;
-                    default: out += c;
-                }
-            }
-            out += '"';
-        }
     }  // namespace
 
     const ValueTypeMetaData *json_meta()
@@ -348,7 +331,7 @@ namespace hgraph::stdlib::json_tree
         }
         if (meta == scalar_descriptor<Str>::value_meta())
         {
-            escape_into(inner.checked_as<Str>(), out);
+            json_detail::append_escaped(inner.checked_as<Str>(), out);
             return;
         }
         if (meta->value_kind() == ValueTypeKind::List)
@@ -374,7 +357,7 @@ namespace hgraph::stdlib::json_tree
             {
                 if (!first) { out += ", "; }
                 first = false;
-                escape_into(key.checked_as<Str>(), out);
+                json_detail::append_escaped(key.checked_as<Str>(), out);
                 out += ": ";
                 encode(item, out);
             }
@@ -453,7 +436,7 @@ namespace hgraph::stdlib::json_tree
                 out += fmt::format("{}", static_cast<double>(element));
                 return;
             case simdjson::dom::element_type::STRING:
-                escape_into(Str{std::string_view(element)}, out);
+                json_detail::append_escaped(std::string_view(element), out);
                 return;
             case simdjson::dom::element_type::ARRAY: {
                 out += '[';
@@ -474,7 +457,7 @@ namespace hgraph::stdlib::json_tree
                 {
                     if (!first) { out += ", "; }
                     first = false;
-                    escape_into(Str{std::string_view(field.key)}, out);
+                    json_detail::append_escaped(std::string_view(field.key), out);
                     out += ": ";
                     encode_simdjson(field.value, out);
                 }

--- a/src/hgraph/types/temporal.cpp
+++ b/src/hgraph/types/temporal.cpp
@@ -1212,17 +1212,27 @@ namespace hgraph
         return out << value.name();
     }
 
+    std::string format_zoned_datetime(const ZonedDateTime &value)
+    {
+        const int  offset = value.offset_seconds();
+        const char sign = offset < 0 ? '-' : '+';
+        const int  magnitude = offset < 0 ? -offset : offset;
+        char       suffix[16];
+        std::snprintf(suffix, sizeof suffix, "%c%02d:%02d", sign,
+                      magnitude / 3600, (magnitude / 60) % 60);
+        std::string text = format_civil_datetime(value.civil());
+        text += suffix;
+        text += '[';
+        text += value.zone().name();
+        text += ']';
+        return text;
+    }
+
+    // Streaming delegates to the string form so the layout is stated once.
     std::ostream &operator<<(std::ostream &out,
                              const ZonedDateTime &value)
     {
-        const int offset = value.offset_seconds();
-        const char sign = offset < 0 ? '-' : '+';
-        const int magnitude = offset < 0 ? -offset : offset;
-        char suffix[16];
-        std::snprintf(suffix, sizeof suffix, "%c%02d:%02d", sign,
-                      magnitude / 3600, (magnitude / 60) % 60);
-        return out << format_civil_datetime(value.civil()) << suffix << '['
-                   << value.zone().name() << ']';
+        return out << format_zoned_datetime(value);
     }
 
     std::ostream &operator<<(std::ostream &out,

--- a/src/hgraph/types/value/json_codec.cpp
+++ b/src/hgraph/types/value/json_codec.cpp
@@ -22,6 +22,7 @@
 #include <charconv>
 #include <chrono>
 #include <cctype>
+#include <iterator>
 #include <locale>
 #include <memory>
 #include <mutex>
@@ -116,46 +117,59 @@ namespace hgraph
 
         void append_escaped(std::string_view text, std::string &out)
         {
+            // Escape by RUNS, not by character: JSON payloads are
+            // overwhelmingly clean text, so the common path is a bulk copy of
+            // the span between two escapes rather than a push_back per byte.
             out.push_back('"');
-            for (const char c : text)
+            std::size_t clean = 0;
+            for (std::size_t index = 0; index < text.size(); ++index)
             {
+                const auto       c = static_cast<unsigned char>(text[index]);
+                std::string_view escape;
+                // Only \u00XX reaches this buffer (c < 0x20), so two nibbles
+                // suffice; it stays alive until the append below consumes it.
+                char             control[6] = {'\\', 'u', '0', '0', '0', '0'};
                 switch (c)
                 {
-                    case '"': out += "\\\""; break;
-                    case '\\': out += "\\\\"; break;
-                    case '\b': out += "\\b"; break;
-                    case '\f': out += "\\f"; break;
-                    case '\n': out += "\\n"; break;
-                    case '\r': out += "\\r"; break;
-                    case '\t': out += "\\t"; break;
-                    default:
-                        if (static_cast<unsigned char>(c) < 0x20)
-                        {
-                            out += fmt::format("\\u{:04x}", static_cast<unsigned char>(c));
-                        }
-                        else
-                        {
-                            out.push_back(c);
-                        }
+                    case '"': escape = "\\\""; break;
+                    case '\\': escape = "\\\\"; break;
+                    case '\b': escape = "\\b"; break;
+                    case '\f': escape = "\\f"; break;
+                    case '\n': escape = "\\n"; break;
+                    case '\r': escape = "\\r"; break;
+                    case '\t': escape = "\\t"; break;
+                    default: {
+                        if (c >= 0x20) { continue; }
+                        constexpr char digits[] = "0123456789abcdef";
+                        control[4] = digits[(c >> 4) & 0xF];
+                        control[5] = digits[c & 0xF];
+                        escape     = std::string_view{control, sizeof control};
+                        break;
+                    }
                 }
+                out.append(text.substr(clean, index - clean));
+                out.append(escape);
+                clean = index + 1;
             }
+            out.append(text.substr(clean));
             out.push_back('"');
         }
 
         void append_date(Date value, std::string &out)
         {
-            out += fmt::format("{:04}-{:02}-{:02}", static_cast<int>(value.year()),
-                               static_cast<unsigned>(value.month()), static_cast<unsigned>(value.day()));
+            fmt::format_to(std::back_inserter(out), "{:04}-{:02}-{:02}",
+                           static_cast<int>(value.year()),
+                           static_cast<unsigned>(value.month()), static_cast<unsigned>(value.day()));
         }
 
         void append_time_of_day(std::int64_t micros_since_midnight, std::string &out)
         {
             const auto total_seconds = micros_since_midnight / 1'000'000;
             const auto micros = micros_since_midnight % 1'000'000;
-            out += fmt::format("{:02}:{:02}:{:02}", total_seconds / 3'600,
-                               (total_seconds / 60) % 60,
-                               total_seconds % 60);
-            if (micros != 0) { out += fmt::format(".{:06}", micros); }
+            fmt::format_to(std::back_inserter(out), "{:02}:{:02}:{:02}",
+                           total_seconds / 3'600, (total_seconds / 60) % 60,
+                           total_seconds % 60);
+            if (micros != 0) { fmt::format_to(std::back_inserter(out), ".{:06}", micros); }
         }
 
         // ---------------------------------------------------------------
@@ -1217,8 +1231,12 @@ namespace hgraph
             switch (self.atomic_tag)
             {
                 case AtomicTag::Bool: out += view.checked_as<Bool>() ? "true" : "false"; return;
-                case AtomicTag::Int: out += fmt::format("{}", view.checked_as<Int>()); return;
-                case AtomicTag::Float: out += fmt::format("{}", view.checked_as<Float>()); return;
+                case AtomicTag::Int:
+                    fmt::format_to(std::back_inserter(out), "{}", view.checked_as<Int>());
+                    return;
+                case AtomicTag::Float:
+                    fmt::format_to(std::back_inserter(out), "{}", view.checked_as<Float>());
+                    return;
                 case AtomicTag::Str: json_detail::append_escaped(view.checked_as<Str>(), out); return;
                 case AtomicTag::Date: {
                     out.push_back('"');
@@ -1250,21 +1268,20 @@ namespace hgraph
                     return;
                 case AtomicTag::Period: {
                     const Period value = view.checked_as<Period>();
-                    out += fmt::format(
-                        "{{\"months\": {}, \"days\": {}}}",
-                        value.total_months(), value.days());
+                    fmt::format_to(std::back_inserter(out),
+                                   "{{\"months\": {}, \"days\": {}}}",
+                                   value.total_months(), value.days());
                     return;
                 }
                 case AtomicTag::ZoneId:
                     json_detail::append_escaped(
                         view.checked_as<ZoneId>().name(), out);
                     return;
-                case AtomicTag::ZonedDateTime: {
-                    std::ostringstream text;
-                    text << view.checked_as<ZonedDateTime>();
-                    json_detail::append_escaped(text.str(), out);
+                case AtomicTag::ZonedDateTime:
+                    json_detail::append_escaped(
+                        format_zoned_datetime(view.checked_as<ZonedDateTime>()),
+                        out);
                     return;
-                }
                 case AtomicTag::InstantRange:
                     json_detail::write_range(
                         view.checked_as<InstantRange>(),

--- a/tests/cpp/test_json.cpp
+++ b/tests/cpp/test_json.cpp
@@ -80,6 +80,19 @@ TEST_CASE("json: atomic values round-trip in the Python wire format")
     CHECK(round_trip(time_of_day(9, 30, 5)) == "\"09:30:05\"");
 }
 
+TEST_CASE("json: control characters escape as RFC 8259 requires")
+{
+    // Every character below 0x20 MUST be escaped: \b and \f have short
+    // forms, anything else falls back to \u00XX. Escaping walks runs, so a
+    // clean span either side of an escape must survive the bulk copy.
+    CHECK(round_trip(Str{"back\bspace"}) == "\"back\\bspace\"");
+    CHECK(round_trip(Str{"form\ffeed"}) == "\"form\\ffeed\"");
+    CHECK(round_trip(Str{"unit\x1f" "sep"}) == "\"unit\\u001fsep\"");
+    CHECK(round_trip(Str{std::string("nul\0byte", 8)}) == "\"nul\\u0000byte\"");
+    CHECK(round_trip(Str{"lead\ttrail"}) == "\"lead\\ttrail\"");
+    CHECK(round_trip(Str{"\x01" "\x02"}) == "\"\\u0001\\u0002\"");
+}
+
 TEST_CASE("json: temporal version 2 scalar and range forms round-trip")
 {
     using namespace std::chrono;
@@ -704,6 +717,27 @@ TEST_CASE("dynamic json operators: decoded values encode canonically")
     CHECK_OUTPUT(eval_node<JsonDynamicEncodeGraph>(
                      values<Str>(Str{"{\"a\":1,\"b\":[true,null,\"x\"]}"})),
                  values<Str>(Str{"{\"a\": 1, \"b\": [true, null, \"x\"]}"}));
+}
+
+TEST_CASE("dynamic json operators: re-encoding escapes control characters")
+{
+    stdlib::register_standard_operators();
+    // Regression: the dynamic encoder kept its own escaper which handled only
+    // " \\ \n \t \r and emitted every other sub-0x20 byte RAW — invalid JSON
+    // per RFC 8259, and unparseable on the way back. Both encoders now share
+    // json_detail::append_escaped. Values AND keys go through it.
+    CHECK_OUTPUT(eval_node<JsonDynamicEncodeGraph>(
+                     values<Str>(Str{"{\"a\":\"x\\u0008y\"}"})),
+                 values<Str>(Str{"{\"a\": \"x\\by\"}"}));
+    CHECK_OUTPUT(eval_node<JsonDynamicEncodeGraph>(
+                     values<Str>(Str{"{\"a\":\"x\\u000cy\"}"})),
+                 values<Str>(Str{"{\"a\": \"x\\fy\"}"}));
+    CHECK_OUTPUT(eval_node<JsonDynamicEncodeGraph>(
+                     values<Str>(Str{"{\"a\":\"x\\u001fy\"}"})),
+                 values<Str>(Str{"{\"a\": \"x\\u001fy\"}"}));
+    CHECK_OUTPUT(eval_node<JsonDynamicEncodeGraph>(
+                     values<Str>(Str{"{\"k\\u0009k\":1}"})),
+                 values<Str>(Str{"{\"k\\tk\": 1}"}));
 }
 
 TEST_CASE("dynamic json operators: equality is semantic not raw string equality")


### PR DESCRIPTION
Started as a look at string building in the JSON codec and turned up a correctness bug next to it. Both are here.

## 1. Correctness: the two encoders had drifted

`json_impl.cpp` carried its own `escape_into` handling only `"`, `\`, `\n`, `\t`, `\r`, and emitting **every other sub-0x20 byte raw**. RFC 8259 requires all of them escaped, so `\b`, `\f` and the control range produced **invalid JSON that will not parse back** - a silent round-trip break on the dynamic `json` type.

`json_codec.cpp`'s `append_escaped` had always been correct. The two implementations had simply drifted apart - the "two ways to do one thing" smell `CLAUDE.md` section 3(iii) names. `append_escaped` is now declared in `json_codec.h` and both encoders share it, so they cannot diverge again.

Two call sites (`json_impl.cpp:456,477`) were constructing a throwaway `Str{std::string_view(...)}` purely to satisfy the old signature; they now pass the view straight through.

## 2. Performance: escape by runs, not by character

`append_escaped` walked the input one character at a time with a `push_back` per byte. It now bulk-copies the clean span between escapes.

Measured with both versions copied verbatim into a harness, output verified byte-identical on every case:

| case | old (ms) | new (ms) | speedup |
|---|---|---|---|
| clean, 64B x 2000 | 188.94 | 107.15 | 1.76x |
| clean, 1KB x 200 | 299.38 | 135.78 | 2.20x |
| clean, 64KB x 10 | 893.66 | 404.31 | 2.21x |
| 2% escapes, 1KB x 200 | 284.13 | 171.77 | 1.65x |
| 10% escapes, 1KB x 200 | 394.74 | 271.67 | 1.45x |
| short keys, 12B x 20000 | 214.35 | 121.06 | 1.77x |

Alongside that, six `fmt::format` temporaries became `fmt::format_to(std::back_inserter(out), ...)` so dates, times, `Int`, `Float` and `Period` format straight into the buffer instead of building a `std::string` to copy and discard.

The single `std::ostringstream` is gone - it built a stream and paid a full `.str()` copy for one atomic tag. Removing it needed a string form, so `format_zoned_datetime` joins its exported siblings `format_instant` / `format_civil_datetime`, with `operator<<` delegating to it so the layout is stated once rather than duplicated.

### What the end-to-end numbers actually say

`hgraph_json_perf` shows **no measurable end-to-end gain on its payload**. Baseline `decode+encode` across four runs: 584.0 / 554.7 / 575.4 / 570.2 ms; new code 574.0 ms - inside the noise - with allocation counts identical at 112047.

That is expected and worth stating plainly rather than quoting a flattering delta: that payload is short keys and integers where simdjson decode dominates, and the escaping win needs string-heavy input. The micro-benchmark above is the honest measure of what changed.

## Tests

Two regressions in `test_json.cpp`:

- **Codec path** - `\b`, `\f`, a unit-separator escaped as `\u001f`, an embedded NUL, and clean runs either side of an escape (12 assertions).
- **Dynamic-encode path** - the direct regression, **verified to fail on unmodified `json_impl.cpp`**: 3 of 4 assertions fail, with `actual: {"a": "xy"}` carrying a raw 0x08 byte.

Worth recording for whoever extends these: a `to_json`-on-scalar test does **not** witness this bug - that path runs through `json_codec` and was always correct. An earlier attempt of mine did exactly that, passed against the unfixed code, and was replaced once I checked it could actually fail.

Full suite **1653/1653** (was 1651), clean build under the project's picky warning set.

## Notes

- **No doc change.** RFC 0002 does not enumerate the temporal formatters and `python_api_inventory.rst` lists python-exposed names only, so the C++-only `format_zoned_datetime` completes an existing family rather than altering a documented surface.
- **Not validated against the Python extension locally** - the editable install predates these changes, so the Python suites here did not exercise them. No Python test asserts control-character escaping, so the behaviour change only affects output that was previously invalid; CI's wheel builds and Python suites are the real check.
- The new `HGRAPH_EXPORT format_zoned_datetime` declaration is the shape that tripped MSVC `/WX` on #623, so the Windows wheel job is the one to watch.
