### PR TITLE
Add differential JSON API parity coverage

### DIFF
--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -50,6 +50,22 @@ Useful focused commands are:
    python -m tools.parity reduce path/to/failing-recipe.json
    python -m tools.parity coverage --inventory
    python -m tools.parity catalogue
+   python -m tools.parity surface --exit-zero
+
+The ``surface`` campaign compares exported names and user-callable parameter
+names, kinds, and defaults.  A lazy export which cannot resolve because an
+optional distribution is absent is recorded against that name; it does not
+abort the rest of the audit.  ``--exit-zero`` is appropriate while reviewing
+the broad discovery report.  Remove it when the actionable set is expected to
+be empty.
+
+Call shapes which are inseparable from runtime semantics should also appear in
+the fixed differential corpus.  For example, ``json_operator_contract``
+compares the public ``to_json`` and ``from_json`` signatures and their
+multi-tick TS, TSS, TSL, and TSD behaviour in the same recipe family.  This
+prevents an internal implementation signature from being mistaken for a
+supported public call merely because candidate-only generated documentation
+is internally consistent.
 
 Upstream conformance suite
 --------------------------

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -228,13 +228,15 @@ def test_json_operator_contract_rejects_non_public_and_malformed_cases():
         },
         "features": ["conversion:json"],
     }
+    recipe = Recipe.from_dict(raw)
     with pytest.raises(RecipeError, match="non-public delta argument"):
-        validate_recipe(Recipe.from_dict(raw))
+        validate_recipe(recipe)
 
     raw["parameters"]["delta"] = False
     raw["inputs"]["value"] = ["not-json"]
+    recipe = Recipe.from_dict(raw)
     with pytest.raises(RecipeError, match="must contain valid JSON"):
-        validate_recipe(Recipe.from_dict(raw))
+        validate_recipe(recipe)
 
     raw["parameters"] = {
         "operation": "to_json",
@@ -244,8 +246,9 @@ def test_json_operator_contract_rejects_non_public_and_malformed_cases():
     raw["inputs"]["value"] = [
         {"$set_delta": {"added": [1], "removed": [1]}}
     ]
+    recipe = Recipe.from_dict(raw)
     with pytest.raises(RecipeError, match="invalid input for tss"):
-        validate_recipe(Recipe.from_dict(raw))
+        validate_recipe(recipe)
 
 
 def test_realtime_default_start_recipe_requires_one_boolean_probe():

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -215,6 +215,39 @@ def test_legacy_compound_scalar_json_recipe_rejects_malformed_values():
         validate_recipe(recipe)
 
 
+def test_json_operator_contract_rejects_non_public_and_malformed_cases():
+    raw = {
+        "schema_version": 1,
+        "id": "test-invalid-json-operator-contract",
+        "template": "json_operator_contract",
+        "inputs": {"value": ["[1, 2]"]},
+        "parameters": {
+            "operation": "from_json",
+            "shape": "tss",
+            "delta": True,
+        },
+        "features": ["conversion:json"],
+    }
+    with pytest.raises(RecipeError, match="non-public delta argument"):
+        validate_recipe(Recipe.from_dict(raw))
+
+    raw["parameters"]["delta"] = False
+    raw["inputs"]["value"] = ["not-json"]
+    with pytest.raises(RecipeError, match="must contain valid JSON"):
+        validate_recipe(Recipe.from_dict(raw))
+
+    raw["parameters"] = {
+        "operation": "to_json",
+        "shape": "tss",
+        "delta": True,
+    }
+    raw["inputs"]["value"] = [
+        {"$set_delta": {"added": [1], "removed": [1]}}
+    ]
+    with pytest.raises(RecipeError, match="invalid input for tss"):
+        validate_recipe(Recipe.from_dict(raw))
+
+
 def test_realtime_default_start_recipe_requires_one_boolean_probe():
     raw = {
         "schema_version": 1,

--- a/python/tests/test_surface_parity.py
+++ b/python/tests/test_surface_parity.py
@@ -32,6 +32,35 @@ def test_surface_probe_records_a_failing_lazy_export(monkeypatch):
     }
 
 
+def test_surface_probe_compares_lazy_export_failure_details():
+    def module(error):
+        return {
+            "hgraph": {
+                "surface": {
+                    "optional": {
+                        "kind": "attribute-error",
+                        "error": error,
+                    }
+                },
+                "has_all": True,
+            }
+        }
+
+    missing = module("ModuleNotFoundError: optional package is not installed")
+    broken = module("RuntimeError: lazy resolver failed")
+
+    assert compare_surfaces(missing, missing)["findings"] == []
+    assert compare_surfaces(missing, broken)["findings"] == [
+        {
+            "module": "hgraph",
+            "name": "optional",
+            "kind": "attribute-error-mismatch",
+            "reference_error": "ModuleNotFoundError: optional package is not installed",
+            "candidate_error": "RuntimeError: lazy resolver failed",
+        }
+    ]
+
+
 def test_surface_probe_reports_json_public_signature_drift():
     def module(to_json, from_json):
         return {

--- a/python/tests/test_surface_parity.py
+++ b/python/tests/test_surface_parity.py
@@ -1,6 +1,69 @@
 """Focused contracts for the public API surface classifier."""
 
-from tools.parity.surface import classify_findings
+import sys
+from types import ModuleType
+
+from tools.parity.surface import (
+    _describe_module,
+    classify_findings,
+    compare_surfaces,
+)
+
+
+def test_surface_probe_records_a_failing_lazy_export(monkeypatch):
+    module = ModuleType("surface_probe_lazy_export")
+    module.__all__ = ["available", "optional"]
+    module.available = lambda: None
+
+    def resolve(name):
+        if name == "optional":
+            raise ModuleNotFoundError("optional distribution is not installed")
+        raise AttributeError(name)
+
+    module.__getattr__ = resolve
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+
+    surface = _describe_module(module.__name__)["surface"]
+
+    assert surface["available"]["kind"] == "callable"
+    assert surface["optional"] == {
+        "kind": "attribute-error",
+        "error": "ModuleNotFoundError: optional distribution is not installed",
+    }
+
+
+def test_surface_probe_reports_json_public_signature_drift():
+    def module(to_json, from_json):
+        return {
+            "hgraph": {
+                "surface": {
+                    "to_json": {"kind": "callable", "signature": to_json},
+                    "from_json": {"kind": "callable", "signature": from_json},
+                },
+                "has_all": True,
+            }
+        }
+
+    ts = {"name": "ts", "kind": "POSITIONAL_OR_KEYWORD", "default": None}
+    delta = {
+        "name": "delta",
+        "kind": "POSITIONAL_OR_KEYWORD",
+        "default": "False",
+    }
+    internal_type = {
+        "name": "_tp",
+        "kind": "POSITIONAL_OR_KEYWORD",
+        "default": "AUTO_RESOLVE",
+    }
+    reference = module([ts, delta], [ts])
+    candidate = module([ts, internal_type, delta], [ts, internal_type, delta])
+
+    findings = compare_surfaces(reference, candidate)["findings"]
+
+    assert [(finding["name"], finding["kind"]) for finding in findings] == [
+        ("from_json", "signature-mismatch"),
+        ("to_json", "signature-mismatch"),
+    ]
 
 
 def test_surface_rule_with_exact_signatures_does_not_mask_later_drift():

--- a/tools/parity/catalog.py
+++ b/tools/parity/catalog.py
@@ -44,6 +44,7 @@ _SCALAR_ARGUMENT_OPERATIONS = {
 _COMPARISON_OPERATIONS = {"eq", "ne", "lt", "le", "gt", "ge"}
 _DIVIDE_POLICY_OPERATIONS = {"div", "floordiv", "mod", "pow"}
 _DIVIDE_BY_ZERO_POLICIES = {"ERROR", "NAN", "INF", "NONE", "ZERO", "ONE"}
+_SET_DELTA = "$set_delta"
 
 
 @dataclass(frozen=True)
@@ -73,17 +74,19 @@ def _decode_value(hg, value):
         return hg.REMOVE
     if set(value) == {"$remove_if_exists"} and value["$remove_if_exists"] is True:
         return hg.REMOVE_IF_EXISTS
-    if set(value) == {"$set_delta"}:
-        delta = value["$set_delta"]
+    if set(value) == {_SET_DELTA}:
+        delta = value[_SET_DELTA]
         if not isinstance(delta, dict) or set(delta) != {"added", "removed"}:
-            raise RecipeError("$set_delta requires added and removed lists")
+            raise RecipeError(f"{_SET_DELTA} requires added and removed lists")
         added = [_decode_value(hg, item) for item in delta["added"]]
         removed = [_decode_value(hg, item) for item in delta["removed"]]
         overlap = set(added) & set(removed)
         if overlap:
             # Ruling 2026-07-28: added/removed must be disjoint — an element
             # in both is incorrect data, not a recipe to explore.
-            raise RecipeError(f"$set_delta added/removed overlap: {sorted(overlap)!r}")
+            raise RecipeError(
+                f"{_SET_DELTA} added/removed overlap: {sorted(overlap)!r}"
+            )
         return hg.set_delta(added=added, removed=removed)
     if set(value) == {"$frozendict"}:
         from frozendict import frozendict
@@ -2736,7 +2739,7 @@ def _legacy_compound_scalar_json(hg, recipe):
     return {"encoded": encoded, "decoded": decoded}
 
 
-def _validate_json_operator_contract(recipe):
+def _json_operator_parameters(recipe):
     if set(recipe.parameters) != {"operation", "shape", "delta"}:
         raise RecipeError(
             "json_operator_contract requires operation, shape, and delta parameters"
@@ -2758,77 +2761,102 @@ def _validate_json_operator_contract(recipe):
         raise RecipeError(
             "json_operator_contract cannot pass the non-public delta argument to from_json"
         )
-    def is_int(value):
-        return isinstance(value, int) and not isinstance(value, bool)
+    return operation, shape
 
-    def validate_value(value, *, encoded):
-        if shape == "ts":
-            valid = is_int(value)
-        elif shape == "tss":
-            if encoded:
-                valid = isinstance(value, list) and all(is_int(item) for item in value)
-                if isinstance(value, dict):
-                    valid = (
-                        set(value) == {"added", "removed"}
-                        and all(
-                            isinstance(value[name], list)
-                            and all(is_int(item) for item in value[name])
-                            for name in ("added", "removed")
-                        )
-                    )
-            else:
-                valid = (
-                    isinstance(value, dict)
-                    and set(value) == {"$set_delta"}
-                    and isinstance(value["$set_delta"], dict)
-                    and set(value["$set_delta"]) == {"added", "removed"}
-                    and all(
-                        isinstance(value["$set_delta"][name], list)
-                        and all(is_int(item) for item in value["$set_delta"][name])
-                        for name in ("added", "removed")
-                    )
-                )
-            if valid and isinstance(value, dict):
-                delta = value if encoded else value["$set_delta"]
-                valid = not set(delta["added"]) & set(delta["removed"])
-        elif shape == "tsd":
-            valid = isinstance(value, dict) and all(
-                isinstance(key, str)
-                and (
-                    is_int(item)
-                    or (item is None if encoded else item == {"$remove": True})
-                )
-                for key, item in value.items()
-            )
-        else:
-            valid = (
-                isinstance(value, list)
-                and len(value) <= 2
-                and all(item is None or is_int(item) for item in value)
-            )
-        if not valid:
-            representation = "decoded JSON" if encoded else "input"
-            raise RecipeError(
-                f"json_operator_contract invalid {representation} for {shape}: {value!r}"
-            )
+
+def _is_json_int(value):
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _is_json_int_list(value):
+    return isinstance(value, list) and all(_is_json_int(item) for item in value)
+
+
+def _is_json_set_delta(value):
+    return (
+        isinstance(value, dict)
+        and set(value) == {"added", "removed"}
+        and all(_is_json_int_list(value[name]) for name in ("added", "removed"))
+        and not set(value["added"]) & set(value["removed"])
+    )
+
+
+def _is_json_ts_value(value, _encoded):
+    return _is_json_int(value)
+
+
+def _is_json_tss_value(value, encoded):
+    if encoded and _is_json_int_list(value):
+        return True
+    if not isinstance(value, dict):
+        return False
+    if encoded:
+        delta = value
+    elif set(value) == {_SET_DELTA}:
+        delta = value[_SET_DELTA]
+    else:
+        return False
+    return _is_json_set_delta(delta)
+
+
+def _is_json_tsd_value(value, encoded):
+    def is_item(item):
+        removal = item is None if encoded else item == {"$remove": True}
+        return _is_json_int(item) or removal
+
+    return isinstance(value, dict) and all(
+        isinstance(key, str) and is_item(item)
+        for key, item in value.items()
+    )
+
+
+def _is_json_tsl_value(value, _encoded):
+    return (
+        isinstance(value, list)
+        and len(value) <= 2
+        and all(item is None or _is_json_int(item) for item in value)
+    )
+
+
+_JSON_OPERATOR_VALUE_VALIDATORS = {
+    "ts": _is_json_ts_value,
+    "tss": _is_json_tss_value,
+    "tsd": _is_json_tsd_value,
+    "tsl": _is_json_tsl_value,
+}
+
+
+def _parse_json_operator_tick(tick):
+    if not isinstance(tick, str):
+        raise RecipeError(
+            "json_operator_contract from_json values must be strings or null ticks"
+        )
+    try:
+        return json.loads(tick)
+    except json.JSONDecodeError as error:
+        raise RecipeError(
+            "json_operator_contract from_json values must contain valid JSON"
+        ) from error
+
+
+def _validate_json_operator_value(shape, value, *, encoded):
+    if _JSON_OPERATOR_VALUE_VALIDATORS[shape](value, encoded):
+        return
+    representation = "decoded JSON" if encoded else "input"
+    raise RecipeError(
+        f"json_operator_contract invalid {representation} for {shape}: {value!r}"
+    )
+
+
+def _validate_json_operator_contract(recipe):
+    operation, shape = _json_operator_parameters(recipe)
+    encoded = operation == "from_json"
 
     for tick in recipe.inputs["value"]:
         if tick is None:
             continue
-        if operation == "from_json":
-            if not isinstance(tick, str):
-                raise RecipeError(
-                    "json_operator_contract from_json values must be strings or null ticks"
-                )
-            try:
-                value = json.loads(tick)
-            except json.JSONDecodeError as error:
-                raise RecipeError(
-                    "json_operator_contract from_json values must contain valid JSON"
-                ) from error
-            validate_value(value, encoded=True)
-        else:
-            validate_value(tick, encoded=False)
+        value = _parse_json_operator_tick(tick) if encoded else tick
+        _validate_json_operator_value(shape, value, encoded=encoded)
 
 
 def _json_operator_contract(hg, recipe):

--- a/tools/parity/catalog.py
+++ b/tools/parity/catalog.py
@@ -2736,6 +2736,149 @@ def _legacy_compound_scalar_json(hg, recipe):
     return {"encoded": encoded, "decoded": decoded}
 
 
+def _validate_json_operator_contract(recipe):
+    if set(recipe.parameters) != {"operation", "shape", "delta"}:
+        raise RecipeError(
+            "json_operator_contract requires operation, shape, and delta parameters"
+        )
+    operation = recipe.parameters["operation"]
+    shape = recipe.parameters["shape"]
+    delta = recipe.parameters["delta"]
+    if operation not in {"from_json", "to_json"}:
+        raise RecipeError(
+            "json_operator_contract operation must be from_json or to_json"
+        )
+    if shape not in {"ts", "tss", "tsd", "tsl"}:
+        raise RecipeError(
+            "json_operator_contract shape must be ts, tss, tsd, or tsl"
+        )
+    if not isinstance(delta, bool):
+        raise RecipeError("json_operator_contract delta must be a boolean")
+    if operation == "from_json" and delta:
+        raise RecipeError(
+            "json_operator_contract cannot pass the non-public delta argument to from_json"
+        )
+    def is_int(value):
+        return isinstance(value, int) and not isinstance(value, bool)
+
+    def validate_value(value, *, encoded):
+        if shape == "ts":
+            valid = is_int(value)
+        elif shape == "tss":
+            if encoded:
+                valid = isinstance(value, list) and all(is_int(item) for item in value)
+                if isinstance(value, dict):
+                    valid = (
+                        set(value) == {"added", "removed"}
+                        and all(
+                            isinstance(value[name], list)
+                            and all(is_int(item) for item in value[name])
+                            for name in ("added", "removed")
+                        )
+                    )
+            else:
+                valid = (
+                    isinstance(value, dict)
+                    and set(value) == {"$set_delta"}
+                    and isinstance(value["$set_delta"], dict)
+                    and set(value["$set_delta"]) == {"added", "removed"}
+                    and all(
+                        isinstance(value["$set_delta"][name], list)
+                        and all(is_int(item) for item in value["$set_delta"][name])
+                        for name in ("added", "removed")
+                    )
+                )
+            if valid and isinstance(value, dict):
+                delta = value if encoded else value["$set_delta"]
+                valid = not set(delta["added"]) & set(delta["removed"])
+        elif shape == "tsd":
+            valid = isinstance(value, dict) and all(
+                isinstance(key, str)
+                and (
+                    is_int(item)
+                    or (item is None if encoded else item == {"$remove": True})
+                )
+                for key, item in value.items()
+            )
+        else:
+            valid = (
+                isinstance(value, list)
+                and len(value) <= 2
+                and all(item is None or is_int(item) for item in value)
+            )
+        if not valid:
+            representation = "decoded JSON" if encoded else "input"
+            raise RecipeError(
+                f"json_operator_contract invalid {representation} for {shape}: {value!r}"
+            )
+
+    for tick in recipe.inputs["value"]:
+        if tick is None:
+            continue
+        if operation == "from_json":
+            if not isinstance(tick, str):
+                raise RecipeError(
+                    "json_operator_contract from_json values must be strings or null ticks"
+                )
+            try:
+                value = json.loads(tick)
+            except json.JSONDecodeError as error:
+                raise RecipeError(
+                    "json_operator_contract from_json values must contain valid JSON"
+                ) from error
+            validate_value(value, encoded=True)
+        else:
+            validate_value(tick, encoded=False)
+
+
+def _json_operator_contract(hg, recipe):
+    import inspect
+
+    from hgraph.test import eval_node
+
+    shape = recipe.parameters["shape"]
+    ts_type = {
+        "ts": hg.TS[int],
+        "tss": hg.TSS[int],
+        "tsd": hg.TSD[str, hg.TS[int]],
+        "tsl": hg.TSL[hg.TS[int], hg.Size[2]],
+    }[shape]
+
+    def call_shape(operator):
+        return [
+            {
+                "name": parameter.name,
+                "kind": str(parameter.kind),
+                "default": (
+                    repr(parameter.default)
+                    if parameter.default is not inspect.Parameter.empty
+                    else None
+                ),
+            }
+            for parameter in inspect.signature(operator).parameters.values()
+        ]
+
+    if recipe.parameters["operation"] == "from_json":
+        values = eval_node(
+            hg.from_json[ts_type],
+            list(recipe.inputs["value"]),
+        )
+    else:
+        values = eval_node(
+            hg.to_json[ts_type],
+            decoded_inputs(hg, recipe)["value"],
+            recipe.parameters["delta"],
+        )
+
+    return {
+        "call_shapes": {
+            "to_json": call_shape(hg.to_json),
+            "from_json": call_shape(hg.from_json),
+        },
+        "values": values,
+    }
+
+
 CATALOG = {
     "scalar_expression": TemplateSpec(
         name="scalar_expression",
@@ -3239,6 +3382,18 @@ CATALOG = {
         operators=("to_json", "from_json"),
         execute=_legacy_compound_scalar_json,
     ),
+    "json_operator_contract": TemplateSpec(
+        name="json_operator_contract",
+        required_inputs=("value",),
+        features=(
+            "conversion:json",
+            "compatibility:release-0.5",
+            "api:public-signature",
+            "lifecycle:multi-cycle",
+        ),
+        operators=("to_json", "from_json"),
+        execute=_json_operator_contract,
+    ),
     "temporal_expression": TemplateSpec(
         name="temporal_expression",
         required_inputs=None,
@@ -3386,6 +3541,8 @@ def validate_recipe(recipe):
         _validate_enum_literal_selection(recipe)
     elif recipe.template == "legacy_compound_scalar_json":
         _validate_legacy_compound_scalar_json(recipe)
+    elif recipe.template == "json_operator_contract":
+        _validate_json_operator_contract(recipe)
     elif recipe.template == "polymorphic_event_flow":
         _validate_polymorphic_event_flow(recipe)
     elif recipe.template == "polymorphic_event_map":

--- a/tools/parity/corpus/json-operator-from-json-ts.json
+++ b/tools/parity/corpus/json-operator-from-json-ts.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "id": "json-operator-from-json-ts",
+  "description": "The public from_json call shape and atomic multi-tick decoding match release/0.5.",
+  "template": "json_operator_contract",
+  "inputs": {
+    "value": ["1", null, "-2", "3"]
+  },
+  "parameters": {
+    "operation": "from_json",
+    "shape": "ts",
+    "delta": false
+  },
+  "features": [
+    "shape:TS",
+    "type:int",
+    "direction:decode"
+  ]
+}

--- a/tools/parity/corpus/json-operator-from-json-tsd.json
+++ b/tools/parity/corpus/json-operator-from-json-tsd.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "id": "json-operator-from-json-tsd",
+  "description": "TSD JSON decoding preserves keyed updates and null removal semantics across ticks.",
+  "template": "json_operator_contract",
+  "inputs": {
+    "value": [
+      "{\"a\": 1, \"b\": 2}",
+      "{\"a\": null, \"c\": 3}",
+      "{\"b\": 5}"
+    ]
+  },
+  "parameters": {
+    "operation": "from_json",
+    "shape": "tsd",
+    "delta": false
+  },
+  "features": [
+    "shape:TSD",
+    "type:int",
+    "type:str-key",
+    "direction:decode",
+    "lifecycle:keyed",
+    "lifecycle:removal"
+  ]
+}

--- a/tools/parity/corpus/json-operator-from-json-tsl.json
+++ b/tools/parity/corpus/json-operator-from-json-tsl.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "id": "json-operator-from-json-tsl",
+  "description": "A null TSL array element leaves that child unticked while later elements update.",
+  "template": "json_operator_contract",
+  "inputs": {
+    "value": ["[1, 2]", "[null, 9]", "[7, null]"]
+  },
+  "parameters": {
+    "operation": "from_json",
+    "shape": "tsl",
+    "delta": false
+  },
+  "features": [
+    "shape:TSL",
+    "type:int",
+    "direction:decode",
+    "lifecycle:partial-update"
+  ]
+}

--- a/tools/parity/corpus/json-operator-from-json-tss.json
+++ b/tools/parity/corpus/json-operator-from-json-tss.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "id": "json-operator-from-json-tss",
+  "description": "Bare TSS arrays add without removing prior members, while the explicit delta form removes them.",
+  "template": "json_operator_contract",
+  "inputs": {
+    "value": [
+      "[1, 2]",
+      "[3]",
+      "{\"added\": [4], \"removed\": [2]}"
+    ]
+  },
+  "parameters": {
+    "operation": "from_json",
+    "shape": "tss",
+    "delta": false
+  },
+  "features": [
+    "shape:TSS",
+    "type:int",
+    "direction:decode",
+    "lifecycle:additive-delta",
+    "lifecycle:removal"
+  ]
+}

--- a/tools/parity/corpus/json-operator-to-json-ts.json
+++ b/tools/parity/corpus/json-operator-to-json-ts.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "id": "json-operator-to-json-ts",
+  "description": "The public to_json call shape and positional delta flag match release/0.5 for atomic ticks.",
+  "template": "json_operator_contract",
+  "inputs": {
+    "value": [1, null, -2, 3]
+  },
+  "parameters": {
+    "operation": "to_json",
+    "shape": "ts",
+    "delta": true
+  },
+  "features": [
+    "shape:TS",
+    "type:int",
+    "direction:encode",
+    "mode:delta"
+  ]
+}

--- a/tools/parity/corpus/json-operator-to-json-tss.json
+++ b/tools/parity/corpus/json-operator-to-json-tss.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "id": "json-operator-to-json-tss",
+  "description": "to_json emits release/0.5-compatible explicit set deltas over multiple membership changes.",
+  "template": "json_operator_contract",
+  "inputs": {
+    "value": [
+      {"$set_delta": {"added": [1, 2], "removed": []}},
+      {"$set_delta": {"added": [3], "removed": [1]}},
+      {"$set_delta": {"added": [4], "removed": [2]}}
+    ]
+  },
+  "parameters": {
+    "operation": "to_json",
+    "shape": "tss",
+    "delta": true
+  },
+  "features": [
+    "shape:TSS",
+    "type:int",
+    "direction:encode",
+    "mode:delta",
+    "lifecycle:removal"
+  ]
+}

--- a/tools/parity/surface.py
+++ b/tools/parity/surface.py
@@ -73,50 +73,65 @@ def _describe_callable(obj):
     return {"signature": params}
 
 
+def _error_description(error):
+    return f"{type(error).__name__}: {error}"
+
+
+def _safe_describe_callable(obj):
+    try:
+        return _describe_callable(obj)
+    except Exception:  # A broken signature is surface data, not a probe failure.
+        return {"signature": None}
+
+
+def _describe_class(obj):
+    methods = {}
+    for name in sorted(member for member in dir(obj) if not member.startswith("_")):
+        attr = inspect.getattr_static(obj, name, None)
+        if callable(attr) or isinstance(attr, (staticmethod, classmethod)):
+            try:
+                method = getattr(obj, name)
+            except Exception:  # A descriptor may fail while being resolved.
+                methods[name] = {"signature": None}
+            else:
+                methods[name] = _safe_describe_callable(method)
+    return {
+        "kind": "class",
+        "methods": methods,
+        "constructor": _safe_describe_callable(obj)["signature"],
+    }
+
+
+def _describe_export(module, name):
+    try:
+        obj = getattr(module, name)
+    except Exception as error:  # Lazy optional imports are recorded per export.
+        return {
+            "kind": "attribute-error",
+            "error": _error_description(error),
+        }
+    if inspect.isclass(obj):
+        return _describe_class(obj)
+    if callable(obj):
+        return {"kind": "callable", **_describe_callable(obj)}
+    return {"kind": type(obj).__name__}
+
+
 def _describe_module(name):
     try:
         module = importlib.import_module(name)
-    except BaseException as error:  # noqa: BLE001 - import asymmetry IS the finding
-        return {"import_error": f"{type(error).__name__}: {error}"}
+    except Exception as error:  # Import asymmetry is a finding.
+        return {"import_error": _error_description(error)}
     exported = getattr(module, "__all__", None)
-    names = exported if exported is not None else [
-        n for n in dir(module) if not n.startswith("_")
-    ]
-    surface = {}
-    for name_ in sorted(set(names)):
-        try:
-            obj = getattr(module, name_)
-        except BaseException as error:  # noqa: BLE001 - a lazy export may fail
-            surface[name_] = {
-                "kind": "attribute-error",
-                "error": f"{type(error).__name__}: {error}",
-            }
-            continue
-        if inspect.isclass(obj):
-            # The constructor IS public API: required-parameter changes must
-            # surface even when the method map is unchanged.
-            try:
-                constructor = _describe_callable(obj)
-            except BaseException:  # noqa: BLE001
-                constructor = {"signature": None}
-            methods = {}
-            for m in sorted(dir(obj)):
-                if m.startswith("_"):
-                    continue
-                attr = inspect.getattr_static(obj, m, None)
-                if callable(attr) or isinstance(attr, (staticmethod, classmethod)):
-                    try:
-                        methods[m] = _describe_callable(getattr(obj, m))
-                    except BaseException:  # noqa: BLE001
-                        methods[m] = {"signature": None}
-            surface[name_] = {"kind": "class", "methods": methods,
-                              "constructor": constructor.get("signature")}
-        elif callable(obj):
-            entry = _describe_callable(obj)
-            entry["kind"] = "callable"
-            surface[name_] = entry
-        else:
-            surface[name_] = {"kind": type(obj).__name__}
+    names = (
+        exported
+        if exported is not None
+        else [member for member in dir(module) if not member.startswith("_")]
+    )
+    surface = {
+        name: _describe_export(module, name)
+        for name in sorted(set(names))
+    }
     return {"surface": surface, "has_all": exported is not None}
 
 
@@ -126,7 +141,7 @@ def _collect_modules(package_name, modules):
     # probed via describe_module, which contains its own import guard.
     try:
         package = importlib.import_module(package_name)
-    except BaseException:  # noqa: BLE001
+    except Exception:
         return
     for info in pkgutil.iter_modules(getattr(package, "__path__", [])):
         qualified = f"{package_name}.{info.name}"
@@ -212,6 +227,18 @@ def compare_surfaces(
                     "kind": "kind-mismatch",
                     "reference": r.get("kind"),
                     "candidate": c.get("kind"),
+                })
+                continue
+            if (
+                r.get("kind") == "attribute-error"
+                and r.get("error") != c.get("error")
+            ):
+                findings.append({
+                    "module": module,
+                    "name": name,
+                    "kind": "attribute-error-mismatch",
+                    "reference_error": r.get("error"),
+                    "candidate_error": c.get("error"),
                 })
                 continue
             if r.get("kind") == "callable" and _signature_key(r) != _signature_key(c):

--- a/tools/parity/surface.py
+++ b/tools/parity/surface.py
@@ -15,8 +15,13 @@ import in the candidate.
 from __future__ import annotations
 
 import fnmatch
+import importlib
+import inspect
 import json
+import pkgutil
+import re
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -40,17 +45,16 @@ SURFACE_EXTRA_DEPENDENCIES: tuple[str, ...] = (
     "adbc-driver-snowflake>=1.8",
 )
 
-_PROBE = r"""
-import importlib, inspect, json, pkgutil, re, sys
-
 _ADDRESS = re.compile(r" at 0x[0-9a-fA-F]+")
+
 
 def _default_repr(value):
     # Identity sentinels (``object()`` defaults) repr with a process-local
     # address; normalize so two probes of the same implementation agree.
     return _ADDRESS.sub("", repr(value))
 
-def describe_callable(obj):
+
+def _describe_callable(obj):
     try:
         signature = inspect.signature(obj)
     except (ValueError, TypeError):
@@ -60,11 +64,16 @@ def describe_callable(obj):
         params.append({
             "name": p.name,
             "kind": str(p.kind),
-            "default": _default_repr(p.default) if p.default is not inspect.Parameter.empty else None,
+            "default": (
+                _default_repr(p.default)
+                if p.default is not inspect.Parameter.empty
+                else None
+            ),
         })
     return {"signature": params}
 
-def describe_module(name):
+
+def _describe_module(name):
     try:
         module = importlib.import_module(name)
     except BaseException as error:  # noqa: BLE001 - import asymmetry IS the finding
@@ -77,14 +86,17 @@ def describe_module(name):
     for name_ in sorted(set(names)):
         try:
             obj = getattr(module, name_)
-        except AttributeError:
-            surface[name_] = {"kind": "missing-attr"}
+        except BaseException as error:  # noqa: BLE001 - a lazy export may fail
+            surface[name_] = {
+                "kind": "attribute-error",
+                "error": f"{type(error).__name__}: {error}",
+            }
             continue
         if inspect.isclass(obj):
             # The constructor IS public API: required-parameter changes must
             # surface even when the method map is unchanged.
             try:
-                constructor = describe_callable(obj)
+                constructor = _describe_callable(obj)
             except BaseException:  # noqa: BLE001
                 constructor = {"signature": None}
             methods = {}
@@ -94,22 +106,21 @@ def describe_module(name):
                 attr = inspect.getattr_static(obj, m, None)
                 if callable(attr) or isinstance(attr, (staticmethod, classmethod)):
                     try:
-                        methods[m] = describe_callable(getattr(obj, m))
+                        methods[m] = _describe_callable(getattr(obj, m))
                     except BaseException:  # noqa: BLE001
                         methods[m] = {"signature": None}
             surface[name_] = {"kind": "class", "methods": methods,
                               "constructor": constructor.get("signature")}
         elif callable(obj):
-            entry = describe_callable(obj)
+            entry = _describe_callable(obj)
             entry["kind"] = "callable"
             surface[name_] = entry
         else:
             surface[name_] = {"kind": type(obj).__name__}
     return {"surface": surface, "has_all": exported is not None}
 
-modules = ["hgraph", "hgraph.test", "hgraph.adaptors"]
 
-def _collect(package_name):
+def _collect_modules(package_name, modules):
     # Recursive discovery: nested paths (hgraph.adaptors.sql.sql_connection)
     # break independently of their parent package. Each discovered module is
     # probed via describe_module, which contains its own import guard.
@@ -121,22 +132,38 @@ def _collect(package_name):
         qualified = f"{package_name}.{info.name}"
         modules.append(qualified)
         if info.ispkg:
-            _collect(qualified)
+            _collect_modules(qualified, modules)
 
-_collect("hgraph.adaptors")
 
-print(json.dumps({name: describe_module(name) for name in sorted(set(modules))}))
-"""
+def _probe_payload():
+    modules = ["hgraph", "hgraph.test", "hgraph.adaptors"]
+    _collect_modules("hgraph.adaptors", modules)
+    return {
+        name: _describe_module(name)
+        for name in sorted(set(modules))
+    }
+
+
+def _probe_main():
+    print(json.dumps(_probe_payload()))
 
 
 def probe_surface(python: Path | str) -> dict[str, Any]:
     result = subprocess.run(
-        [str(python), "-c", _PROBE],
+        [
+            str(python),
+            "-c",
+            "from tools.parity.surface import _probe_main; _probe_main()",
+        ],
         capture_output=True,
         text=True,
         timeout=300,
-        check=True,
+        cwd=Path(__file__).resolve().parents[2],
     )
+    if result.returncode:
+        raise RuntimeError(
+            f"surface probe failed under {python}:\n{result.stderr.strip()}"
+        )
     return json.loads(result.stdout)
 
 


### PR DESCRIPTION
## Summary

- add a bounded differential JSON operator family that compares the released public call shapes and multi-tick TS, TSS, TSL, and TSD behavior
- make the broad surface probe record failing lazy optional exports instead of aborting the complete audit
- compare lazy-export failure details so a candidate runtime defect cannot hide behind the same generic failure kind
- add regression tests and document how surface discovery complements behavioral corpus coverage

## Audit finding

The earlier API audit could give false confidence because the generated inventory described only the candidate registry. It could therefore document an internally consistent but incorrect public signature. The independent surface campaign was also absent from the PR smoke path and could abort on a single lazy export whose optional distribution was unavailable.

These recipes compare the candidate directly with the pinned release/0.5 package, including the exact public parameter names, kinds, and defaults. They therefore reject the `_tp` and `from_json(delta=...)` mistake corrected and merged through #625 while also checking the JSON behavior involved in that change.

The broad surface audit now completes in the current audit environment. It still reports existing actionable differences outside this focused JSON correction, so this PR does not claim that global API parity is complete.

## Validation

- clean native suite: 1655/1655 passed
- installed-wheel Python 3.14 non-WIP suite: 2223 passed, 10 skipped
- focused parity tests: 57 passed
- recipe validation: 93 recipes
- full PR differential campaign with the required persistence extension: 189 attempted; 167 matched, 22 already-known mismatches, 0 new mismatches, 0 quarantined
- all six JSON contract recipes replayed independently with no difference
- broad surface audit completed with unchanged classification totals
- Sphinx HTML build with warnings as errors
- `git diff --check`