### PR TITLE
Make extension test suites safe to run together

### DIFF
--- a/.github/workflows/test-platform-wheel.yml
+++ b/.github/workflows/test-platform-wheel.yml
@@ -121,16 +121,15 @@ jobs:
         run: uv run --no-sync --no-build python -c "import importlib.metadata as m; import _hgraph; print(m.version('hgraph'), _hgraph.__file__)"
       - name: Run Python compatibility suite
         run: uv run --no-sync --no-build python -m pytest python/tests -q -m "not wip"
-      - name: Run Kafka extension suite
-        run: uv run --no-sync --no-build python -m pytest extensions/kafka/python/tests -q
-      - name: Run analytics extension suite
-        run: uv run --no-sync --no-build python -m pytest extensions/analytics/python/tests -q
-      - name: Run persistence extension suite
-        run: uv run --no-sync --no-build python -m pytest extensions/persistence/python/tests -q
-      - name: Run Fabric extension suite
-        run: uv run --no-sync --no-build python -m pytest extensions/fabric/python/tests -q
-      - name: Run web extension suite
-        run: uv run --no-sync --no-build python -m pytest extensions/web/python/tests -q
+      - name: Run extension suites together
+        run: >-
+          uv run --no-sync --no-build python -m pytest
+          extensions/persistence/python/tests
+          extensions/fabric/python/tests
+          extensions/analytics/python/tests
+          extensions/kafka/python/tests
+          extensions/web/python/tests
+          -q
       - name: Build installed Python extension consumer
         if: matrix.python-version == '3.12'
         run: uv run --no-sync --no-build python tests/python_extension_consumer/check.py

--- a/extensions/fabric/python/tests/test_public_contracts.py
+++ b/extensions/fabric/python/tests/test_public_contracts.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
+import os
+import subprocess
 import sys
+import textwrap
 
 import _hgraph
 import pyarrow as pa
@@ -337,10 +339,42 @@ def test_python_explicit_dependencies_reject_arbitrary_and_duplicate_sources():
 
 
 def test_python_operator_registration_survives_registry_reset():
-    _hgraph.reset_registries()
-    wiring = _hgraph.Wiring()
-    with use_wiring(wiring):
-        hgf.register_memory_fabric_service()
-        value = hgf.subscribe_data("python/reset-input")
-        hgf.publish_data("python/reset-output", value)
-    wiring.run()
+    """Exercise installer replay without invalidating the parent test process.
+
+    ``reset_registries`` is a process-wide, test-only teardown.  Existing
+    Python annotations retain handles from the generation it destroys, so an
+    in-process reset would poison subsequently collected extension suites.
+    """
+    source = textwrap.dedent(
+        """
+        import faulthandler
+
+        faulthandler.enable()
+
+        import _hgraph
+        import hgraph_fabric as hgf
+        from hgraph.test import use_wiring
+
+        _hgraph.reset_registries()
+        wiring = _hgraph.Wiring()
+        with use_wiring(wiring):
+            hgf.register_memory_fabric_service()
+            value = hgf.subscribe_data("python/reset-input")
+            hgf.publish_data("python/reset-output", value)
+        wiring.run()
+        print("ok")
+        """
+    )
+    env = dict(os.environ, PYTHONPATH=os.pathsep.join(p for p in sys.path if p))
+    result = subprocess.run(
+        [sys.executable, "-c", source],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, (
+        f"registry reset child returned {result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "ok" in result.stdout

--- a/extensions/kafka/python/tests/test_packaging.py
+++ b/extensions/kafka/python/tests/test_packaging.py
@@ -127,7 +127,11 @@ def test_ci_builds_and_tests_separate_kafka_artifacts():
         "kafka-distribution-wheel-windows-latest",
     ):
         assert artifact in wheel_workflows
-    assert "python -m pytest extensions/kafka/python/tests -q" in wheel_workflows
+    test_workflow = (
+        REPOSITORY_ROOT / ".github/workflows/test-platform-wheel.yml"
+    ).read_text()
+    assert "Run extension suites together" in test_workflow
+    assert "extensions/kafka/python/tests" in test_workflow
     assert "-DHGRAPH_BUILD_KAFKA_EXTENSION=ON" in native_workflow
     assert "Build and test installed Kafka consumer" in native_workflow
     assert "run_kafka_broker_conformance.py" in native_workflow

--- a/extensions/persistence/python/tests/test_packaging.py
+++ b/extensions/persistence/python/tests/test_packaging.py
@@ -116,7 +116,14 @@ def test_ci_builds_and_tests_separate_persistence_artifacts():
         "persistence-distribution-wheel-windows-latest",
     ):
         assert artifact in wheel_workflows
-    assert "python -m pytest extensions/persistence/python/tests -q" in wheel_workflows
+    test_workflow = (
+        REPOSITORY_ROOT / ".github/workflows/test-platform-wheel.yml"
+    ).read_text()
+    assert "Run extension suites together" in test_workflow
+    assert "extensions/persistence/python/tests" in test_workflow
+    assert "--import-mode=importlib" in tomllib.loads(
+        (REPOSITORY_ROOT / "pyproject.toml").read_text()
+    )["tool"]["pytest"]["ini_options"]["addopts"]
     assert "-DHGRAPH_BUILD_PERSISTENCE_EXTENSION=ON" in native_workflow
     assert "Build and test installed persistence consumer" in native_workflow
     assert "hgraph-persistence-v_" not in release_workflow

--- a/extensions/web/python/tests/__init__.py
+++ b/extensions/web/python/tests/__init__.py
@@ -1,0 +1,1 @@
+"""hgraph-web Python test package."""

--- a/extensions/web/python/tests/test_endpoints.py
+++ b/extensions/web/python/tests/test_endpoints.py
@@ -27,7 +27,7 @@ except ImportError as error:  # pragma: no cover - exercised without the wheel
         allow_module_level=True,
     )
 
-import _loopback_harness as harness
+from extensions.web.python.tests import _loopback_harness as harness
 
 
 # Annotations are resolved against this module's globals, so any type named in

--- a/extensions/web/python/tests/test_endpoints.py
+++ b/extensions/web/python/tests/test_endpoints.py
@@ -27,7 +27,7 @@ except ImportError as error:  # pragma: no cover - exercised without the wheel
         allow_module_level=True,
     )
 
-from extensions.web.python.tests import _loopback_harness as harness
+from . import _loopback_harness as harness
 
 
 # Annotations are resolved against this module's globals, so any type named in

--- a/extensions/web/python/tests/test_packaging.py
+++ b/extensions/web/python/tests/test_packaging.py
@@ -159,7 +159,11 @@ def test_ci_builds_and_tests_separate_web_artifacts():
         "web-distribution-wheel-windows-latest",
     ):
         assert artifact in wheel_workflows
-    assert "python -m pytest extensions/web/python/tests -q" in wheel_workflows
+    test_workflow = (
+        REPOSITORY_ROOT / ".github/workflows/test-platform-wheel.yml"
+    ).read_text()
+    assert "Run extension suites together" in test_workflow
+    assert "extensions/web/python/tests" in test_workflow
     assert "-DHGRAPH_BUILD_WEB_EXTENSION=ON" in native_workflow
     assert "Build and test installed web consumer" in native_workflow
     assert '      - "*.*.*"' in release_workflow

--- a/extensions/web/python/tests/test_runtime.py
+++ b/extensions/web/python/tests/test_runtime.py
@@ -17,7 +17,7 @@ except ImportError as error:  # pragma: no cover - exercised without the wheel
         allow_module_level=True,
     )
 
-from extensions.web.python.tests import _loopback_harness as harness
+from . import _loopback_harness as harness
 
 
 def _header(response, name):

--- a/extensions/web/python/tests/test_runtime.py
+++ b/extensions/web/python/tests/test_runtime.py
@@ -17,7 +17,7 @@ except ImportError as error:  # pragma: no cover - exercised without the wheel
         allow_module_level=True,
     )
 
-import _loopback_harness as harness
+from extensions.web.python.tests import _loopback_harness as harness
 
 
 def _header(response, name):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,9 @@ BUILD_TESTING = "OFF"
 
 [tool.pytest.ini_options]
 minversion = "8.0"
+# Extension suites intentionally reuse descriptive test-module basenames.
+# Import modules by path so every extension can be collected in one process.
+addopts = ["--import-mode=importlib"]
 # The repo root, so `tools.api_inventory` imports in test_api_inventory.py.
 # Without it the suite only COLLECTS under `python -m pytest` run from the
 # root, which puts the cwd on sys.path as a side effect - a plain `pytest`

--- a/python/tests/test_packaging.py
+++ b/python/tests/test_packaging.py
@@ -315,7 +315,9 @@ def test_release_workflow_targets_supported_platforms():
     assert '- "3.12"' in test_workflow
     assert '- "3.13"' in test_workflow
     assert '- "3.14"' in test_workflow
-    assert test_workflow.count("uv run --no-sync --no-build") == 10
+    # All extension suites share one interpreter so duplicate test basenames
+    # and cross-extension lifecycle contamination are exercised in CI.
+    assert test_workflow.count("uv run --no-sync --no-build") == 6
 
 
 def test_platform_wheel_builds_use_stable_cacheable_paths():


### PR DESCRIPTION
## Summary

- use pytest importlib mode so extension suites with repeated test-module basenames collect together
- isolate Fabric's registry-installer reset test in a subprocess, preserving the test without invalidating type handles owned by other collected extensions
- run all five installed extension suites in one pytest process, keeping persistence -> Fabric -> Analytics as the lifecycle regression order
- make the Web loopback helper imports compatible with importlib collection and update the packaging workflow contracts

## Root cause

This was not a normal multi-extension runtime crash. Pytest imports every test module during collection, so Analytics had already created Python annotations backed by native type handles before any tests ran. The Fabric suite then called `reset_registries()` in the parent pytest process. That function is explicitly a process-wide, test-only teardown and invalidates those handles. When Analytics ran later, it reused the invalid annotations; Linux dereferenced one and segfaulted, while the current macOS build reported a schema-resolution failure.

The Fabric test still proves that its operator installer survives a registry rebuild, but now does so in an isolated child process, matching the existing core reset tests and the reset contract.

## Validation

- combined persistence, Fabric, Analytics, Kafka, and Web suites: 301 passed, 1 skipped locally
- same combined order on a private Linux validation host: 302 passed
- fresh native configure, clean build, and complete C++ suite: 1,655 passed
- Python 3.12-built stable-ABI wheel installed into a fresh Python 3.14 environment: 2,223 passed, 10 skipped

Closes #626
Closes #627
