### PR TITLE
Add runnable examples for every extension

### DIFF
--- a/extensions/analytics/README.md
+++ b/extensions/analytics/README.md
@@ -9,6 +9,8 @@ analytical family migrated from core—`diff`, `count`, `clip`, `ewma`, and
 
 For installation, semantics, and Python/C++ usage patterns, see the
 [analytics user guide](https://github.com/hhenson/hgraph/blob/main/docs/source/user_guide/analytics.rst).
+Runnable examples covering scalar pipelines, rolling windows, and shaped-array
+analytics are in [`python/examples`](python/examples/README.md).
 
 ```python
 import hgraph as hg

--- a/extensions/analytics/python/examples/README.md
+++ b/extensions/analytics/python/examples/README.md
@@ -1,0 +1,22 @@
+# Python analytics examples
+
+These examples build from a scalar price pipeline to windowed and shaped-array
+analytics:
+
+- [`price_pipeline.py`](price_pipeline.py) composes percentage change,
+  clipping, EWMA smoothing, and a moving average.
+- [`window_statistics.py`](window_statistics.py) computes mean, sample standard
+  deviation, and median from one trailing tick window.
+- [`array_statistics.py`](array_statistics.py) demonstrates fixed-shape array
+  typing, cumulative sums, quantiles, and correlation.
+
+Each file is directly runnable after installing `hgraph` and
+`hgraph-analytics`:
+
+```sh
+python extensions/analytics/python/examples/price_pipeline.py
+```
+
+The graph functions are the reusable part. Their `run_example()` helpers only
+supply deterministic input ticks with `eval_node`, which makes the same files
+useful as small experiments and as application starting points.

--- a/extensions/analytics/python/examples/array_statistics.py
+++ b/extensions/analytics/python/examples/array_statistics.py
@@ -1,0 +1,33 @@
+"""Apply analytics to a fixed-shape numeric array time series."""
+
+import hgraph_analytics as analytics
+import numpy as np
+
+import hgraph as hg
+
+Vector4 = hg.Array[float, hg.Size[4]]
+
+
+class ArrayMetrics(hg.TimeSeriesSchema):
+    cumulative: hg.TS[Vector4]
+    median: hg.TS[float]
+    correlation: hg.TS[float]
+
+
+@hg.graph
+def array_metrics(values: hg.TS[Vector4]) -> hg.TSB[ArrayMetrics]:
+    """Produce array and scalar reductions from every valid array tick."""
+
+    return hg.TSB[ArrayMetrics].from_ts(
+        cumulative=analytics.cumulative_sum(values),
+        median=analytics.quantile(values, 0.5),
+        correlation=analytics.correlation(values),
+    )
+
+
+def run_example():
+    return hg.eval_node(array_metrics, [np.array([1.0, 2.0, 3.0, 4.0])])
+
+
+if __name__ == "__main__":
+    print(run_example()[0])

--- a/extensions/analytics/python/examples/price_pipeline.py
+++ b/extensions/analytics/python/examples/price_pipeline.py
@@ -1,0 +1,35 @@
+"""Compose a small streaming price-analysis pipeline."""
+
+import hgraph_analytics as analytics
+
+import hgraph as hg
+
+
+class PriceMetrics(hg.TimeSeriesSchema):
+    change: hg.TS[float]
+    smoothed_change: hg.TS[float]
+    moving_average: hg.TS[float]
+
+
+@hg.graph
+def price_metrics(price: hg.TS[float]) -> hg.TSB[PriceMetrics]:
+    """Return fractional returns and two differently smoothed views."""
+
+    change = analytics.pct_change(price)
+    bounded = analytics.clip(change, -0.25, 0.25)
+    return hg.TSB[PriceMetrics].from_ts(
+        change=change,
+        smoothed_change=analytics.ewma(bounded, alpha=0.5),
+        moving_average=analytics.rolling_mean(price, period=3, min_window_period=2),
+    )
+
+
+def run_example():
+    """Evaluate four price ticks and return the emitted metric bundles."""
+
+    return hg.eval_node(price_metrics, [100.0, 102.0, 101.0, 105.0])
+
+
+if __name__ == "__main__":
+    for tick in run_example():
+        print(tick)

--- a/extensions/analytics/python/examples/window_statistics.py
+++ b/extensions/analytics/python/examples/window_statistics.py
@@ -1,0 +1,32 @@
+"""Compute several statistics from one trailing tick window."""
+
+import hgraph_analytics as analytics
+
+import hgraph as hg
+
+
+class WindowMetrics(hg.TimeSeriesSchema):
+    mean: hg.TS[float]
+    sample_std: hg.TS[float]
+    median: hg.TS[float]
+
+
+@hg.graph
+def window_metrics(value: hg.TS[float]) -> hg.TSB[WindowMetrics]:
+    """Emit after two observations and retain at most three observations."""
+
+    window = hg.to_window(value, period=3, min_window_period=2)
+    return hg.TSB[WindowMetrics].from_ts(
+        mean=analytics.rolling_mean(value, period=3, min_window_period=2),
+        sample_std=analytics.std(window, ddof=1),
+        median=analytics.quantile(window, 0.5),
+    )
+
+
+def run_example():
+    return hg.eval_node(window_metrics, [1.0, 2.0, 5.0, 8.0])
+
+
+if __name__ == "__main__":
+    for tick in run_example():
+        print(tick)

--- a/extensions/analytics/python/tests/test_examples.py
+++ b/extensions/analytics/python/tests/test_examples.py
@@ -1,0 +1,34 @@
+import runpy
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+EXAMPLES = Path(__file__).parents[1] / "examples"
+
+
+def _example(name):
+    return runpy.run_path(EXAMPLES / name)
+
+
+def test_price_pipeline_example():
+    result = _example("price_pipeline.py")["run_example"]()
+
+    assert result[0] is None
+    assert result[-1]["change"] == pytest.approx(4.0 / 101.0)
+    assert result[-1]["moving_average"] == pytest.approx(308.0 / 3.0)
+
+
+def test_window_statistics_example():
+    result = _example("window_statistics.py")["run_example"]()
+
+    assert result[0] is None
+    assert result[-1] == pytest.approx({"mean": 5.0, "sample_std": 3.0, "median": 5.0})
+
+
+def test_array_statistics_example():
+    [result] = _example("array_statistics.py")["run_example"]()
+
+    np.testing.assert_array_equal(result["cumulative"], [1.0, 3.0, 6.0, 10.0])
+    assert result["median"] == 2.5
+    assert result["correlation"] == 1.0

--- a/extensions/kafka/README.md
+++ b/extensions/kafka/README.md
@@ -7,6 +7,8 @@ to native C++ and Python graphs.
 For installation, concepts, recovery and commit semantics, operational
 configuration, and Python/C++ usage patterns, see the
 [Kafka user guide](https://github.com/hhenson/hgraph/blob/main/docs/source/user_guide/adaptors/kafka.rst).
+Runnable Python worker, publisher, and bounded-replay examples are in
+[`python/examples`](python/examples/README.md).
 
 One path-bound, multi-interface `service_impl` owns the Kafka clients for a
 configuration. Subscriptions, publish requests, explicit commits, and events

--- a/extensions/kafka/python/examples/README.md
+++ b/extensions/kafka/python/examples/README.md
@@ -1,0 +1,27 @@
+# Python Kafka examples
+
+These examples cover the three normal Kafka graph shapes:
+
+- [`consume_and_commit.py`](consume_and_commit.py) decodes a record and only
+  exposes its paired cursor to the commit service after processing succeeds.
+- [`publish_with_delivery.py`](publish_with_delivery.py) publishes one record
+  with ordered headers and observes its asynchronous broker delivery report.
+- [`bounded_replay.py`](bounded_replay.py) runs a deterministic, timestamp-
+  ordered recovery over the graph's simulation interval.
+
+They use a Kafka broker at `localhost:9092` by default. Each script accepts
+`--bootstrap-servers`; the consumer and replay examples also accept topic and
+group arguments. For example:
+
+```sh
+python extensions/kafka/python/examples/consume_and_commit.py \
+  --bootstrap-servers localhost:9092 --topic orders
+```
+
+The outer `app` graph registers the service configuration. Reusable graph
+components only use the path-bound subscribe, publish, commit, event, and
+delivery-report edges.
+
+The bounded replay deliberately uses `EvaluationMode.SIMULATION`, a record-
+timestamp recovery clock, and a finite stop position. Publishing and commits
+are real-time operations and are rejected in simulation.

--- a/extensions/kafka/python/examples/bounded_replay.py
+++ b/extensions/kafka/python/examples/bounded_replay.py
@@ -1,0 +1,90 @@
+"""Replay finite Kafka history on deterministic graph timestamps."""
+
+import argparse
+from datetime import datetime
+
+import hgraph_kafka as kafka
+
+import hgraph as hg
+
+
+@hg.sink_node
+def show_record(record: hg.TS[kafka.KafkaRecord], _clock: hg.CLOCK = None) -> None:
+    print(_clock.evaluation_time, record.value)
+
+
+@hg.sink_node
+def stop_when_complete(
+    state: hg.TS[kafka.KafkaSubscriptionState],
+    _api: hg.EvaluationEngineApi = None,
+) -> None:
+    if state.value == kafka.KafkaSubscriptionState.BOUNDED_COMPLETE:
+        _api.request_engine_stop()
+
+
+@hg.graph
+def replay_topic(topic: str, group_id: str, path: str = "broker") -> None:
+    key = kafka.KafkaSubscriptionKey(
+        topics=(topic,),
+        group_id=group_id,
+        assignment_mode=kafka.KafkaAssignmentMode.INDEPENDENT,
+        start_position=kafka.KafkaStartPosition.graph_start_time(),
+        stop_position=kafka.KafkaStopPosition.graph_lifetime(),
+        commit_mode=kafka.KafkaCommitMode.NONE,
+        recovery_clock=kafka.KafkaRecoveryClock.RECORD_TIMESTAMP,
+        merge_policy=kafka.KafkaMergePolicy.TIMESTAMP_TOPIC_PARTITION_OFFSET,
+        sharing_identity=f"{group_id}-replay",
+    )
+    subscription = kafka.kafka_subscribe(
+        hg.const(key, tp=hg.TS[kafka.KafkaSubscriptionKey]), path=path
+    )
+    show_record(subscription["record"])
+    stop_when_complete(subscription["state"])
+
+
+@hg.graph
+def app(
+    config: kafka.KafkaServiceConfig,
+    topic: str = "orders",
+    group_id: str = "hgraph-example-replay",
+) -> None:
+    kafka.register_kafka_service(config, path="broker")
+    replay_topic(topic, group_id, path="broker")
+
+
+def run_example(
+    bootstrap_servers: str,
+    topic: str,
+    group_id: str,
+    start_time: datetime,
+    end_time: datetime,
+):
+    config = kafka.KafkaServiceConfig.from_bootstrap_servers(
+        [bootstrap_servers], client_id=group_id
+    )
+    hg.run_graph(
+        app,
+        config,
+        topic,
+        group_id,
+        run_mode=hg.EvaluationMode.SIMULATION,
+        start_time=start_time,
+        end_time=end_time,
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bootstrap-servers", default="localhost:9092")
+    parser.add_argument("--topic", default="orders")
+    parser.add_argument("--group-id", default="hgraph-example-replay")
+    parser.add_argument("--start", type=datetime.fromisoformat, required=True)
+    parser.add_argument("--end", type=datetime.fromisoformat, required=True)
+    args = parser.parse_args()
+    run_example(
+        args.bootstrap_servers,
+        args.topic,
+        args.group_id,
+        args.start,
+        args.end,
+    )

--- a/extensions/kafka/python/examples/consume_and_commit.py
+++ b/extensions/kafka/python/examples/consume_and_commit.py
@@ -1,0 +1,79 @@
+"""Consume Kafka records and acknowledge only successfully decoded records."""
+
+import argparse
+from datetime import timedelta
+
+import hgraph_kafka as kafka
+
+import hgraph as hg
+
+
+class ProcessedRecord(hg.TimeSeriesSchema):
+    payload: hg.TS[str]
+    cursor: hg.TS[kafka.KafkaCursor]
+
+
+@hg.compute_node
+def decode_then_ack(
+    record: hg.TS[kafka.KafkaRecord],
+    cursor: hg.TS[kafka.KafkaCursor],
+) -> hg.TSB[ProcessedRecord]:
+    """Decode first; a decoding failure therefore produces no commit cursor."""
+
+    value = record.value.value
+    if value is None:
+        raise ValueError("the application must handle Kafka tombstones explicitly")
+    payload = value.decode("utf-8")
+    return {"payload": payload, "cursor": cursor.value}
+
+
+@hg.graph
+def consume_topic(topic: str, group_id: str, path: str = "broker") -> None:
+    key = kafka.KafkaSubscriptionKey(
+        topics=(topic,),
+        group_id=group_id,
+        start_position=kafka.KafkaStartPosition.committed(),
+        commit_mode=kafka.KafkaCommitMode.EXPLICIT,
+    )
+    subscription = kafka.kafka_subscribe(
+        hg.const(key, tp=hg.TS[kafka.KafkaSubscriptionKey]), path=path
+    )
+
+    processed = decode_then_ack(subscription["record"], subscription["cursor"])
+    hg.debug_print("processed payload", processed["payload"])
+    kafka.kafka_commit(processed["cursor"], path=path)
+    hg.debug_print("Kafka event", kafka.kafka_events(path=path))
+
+
+@hg.graph
+def app(
+    config: kafka.KafkaServiceConfig,
+    topic: str = "orders",
+    group_id: str = "hgraph-example-worker",
+) -> None:
+    kafka.register_kafka_service(config, path="broker")
+    consume_topic(topic, group_id, path="broker")
+
+
+def run_example(bootstrap_servers: str, topic: str, group_id: str, seconds: int):
+    config = kafka.KafkaServiceConfig.from_bootstrap_servers(
+        [bootstrap_servers], client_id=group_id
+    )
+    hg.run_graph(
+        app,
+        config,
+        topic,
+        group_id,
+        run_mode=hg.EvaluationMode.REAL_TIME,
+        end_time=hg.utc_now() + timedelta(seconds=seconds),
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bootstrap-servers", default="localhost:9092")
+    parser.add_argument("--topic", default="orders")
+    parser.add_argument("--group-id", default="hgraph-example-worker")
+    parser.add_argument("--seconds", type=int, default=60)
+    args = parser.parse_args()
+    run_example(args.bootstrap_servers, args.topic, args.group_id, args.seconds)

--- a/extensions/kafka/python/examples/publish_with_delivery.py
+++ b/extensions/kafka/python/examples/publish_with_delivery.py
@@ -1,0 +1,71 @@
+"""Publish one Kafka record and wait for its delivery report."""
+
+import argparse
+from datetime import timedelta
+
+import hgraph_kafka as kafka
+
+import hgraph as hg
+
+
+@hg.compute_node
+def encode(value: hg.TS[str]) -> hg.TS[kafka.KafkaProduceRecord]:
+    return kafka.KafkaProduceRecord(
+        value=value.value.encode("utf-8"),
+        headers=(
+            kafka.KafkaHeader("content-type", b"text/plain"),
+            kafka.KafkaHeader("source", b"hgraph-example"),
+        ),
+        user_token="example-message",
+    )
+
+
+@hg.graph
+def publish_value(
+    value: hg.TS[str], topic: str, path: str = "broker"
+) -> hg.TS[kafka.KafkaDeliveryReport]:
+    return kafka.kafka_publish(topic, encode(value), path=path)
+
+
+@hg.sink_node
+def report_and_stop(
+    report: hg.TS[kafka.KafkaDeliveryReport],
+    _api: hg.EvaluationEngineApi = None,
+) -> None:
+    print(report.value)
+    _api.request_engine_stop()
+
+
+@hg.graph
+def app(
+    config: kafka.KafkaServiceConfig,
+    topic: str = "events",
+    value: str = "hello from hgraph",
+) -> None:
+    kafka.register_kafka_service(config, path="broker")
+    report_and_stop(publish_value(hg.const(value, tp=hg.TS[str]), topic, path="broker"))
+    hg.debug_print("Kafka event", kafka.kafka_events(path="broker"))
+
+
+def run_example(bootstrap_servers: str, topic: str, value: str, seconds: int):
+    config = kafka.KafkaServiceConfig.from_bootstrap_servers(
+        [bootstrap_servers], client_id="hgraph-example-publisher"
+    )
+    hg.run_graph(
+        app,
+        config,
+        topic,
+        value,
+        run_mode=hg.EvaluationMode.REAL_TIME,
+        end_time=hg.utc_now() + timedelta(seconds=seconds),
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bootstrap-servers", default="localhost:9092")
+    parser.add_argument("--topic", default="events")
+    parser.add_argument("--value", default="hello from hgraph")
+    parser.add_argument("--seconds", type=int, default=30)
+    args = parser.parse_args()
+    run_example(args.bootstrap_servers, args.topic, args.value, args.seconds)

--- a/extensions/kafka/python/tests/test_examples.py
+++ b/extensions/kafka/python/tests/test_examples.py
@@ -1,0 +1,40 @@
+import runpy
+from pathlib import Path
+
+import _hgraph
+import hgraph_kafka as kafka
+from hgraph.test import use_wiring
+
+EXAMPLES = Path(__file__).parents[1] / "examples"
+
+
+def _example(name):
+    return runpy.run_path(EXAMPLES / name)
+
+
+def _config(client_id):
+    return kafka.KafkaServiceConfig.from_bootstrap_servers(
+        ["localhost:9092"], client_id=client_id
+    )
+
+
+def _build(graph, *args, realtime):
+    wiring = _hgraph.Wiring(is_realtime=realtime)
+    with use_wiring(wiring):
+        graph(*args)
+    wiring.build_services()
+
+
+def test_consume_and_commit_example_wires_without_contacting_a_broker():
+    app = _example("consume_and_commit.py")["app"]
+    _build(app, _config("consumer-example"), "orders", "example", realtime=True)
+
+
+def test_publish_with_delivery_example_wires_without_contacting_a_broker():
+    app = _example("publish_with_delivery.py")["app"]
+    _build(app, _config("publisher-example"), "events", "payload", realtime=True)
+
+
+def test_bounded_replay_example_wires_as_simulation():
+    app = _example("bounded_replay.py")["app"]
+    _build(app, _config("replay-example"), "orders", "replay", realtime=False)

--- a/extensions/persistence/README.md
+++ b/extensions/persistence/README.md
@@ -32,5 +32,9 @@ newer at the final link.
 
 Installing and importing `hgraph_persistence` registers the
 `"hgraph.persistence.frame"` backend with the shared hgraph runtime;
-selecting that backend (`set_record_replay_model`) activates it from
+selecting that backend (`set_record_replay_config`) activates it from
 unchanged `hgraph` imports.
+
+Runnable Python examples for direct record/replay, transparent component
+modes, and keyed time-series storage are in
+[`python/examples`](python/examples/README.md).

--- a/extensions/persistence/python/examples/README.md
+++ b/extensions/persistence/python/examples/README.md
@@ -1,0 +1,21 @@
+# Python persistence examples
+
+These examples progress from explicit recording to component-level recovery:
+
+- [`record_and_replay.py`](record_and_replay.py) records a scalar time series,
+  inspects its Arrow frame, and replays it.
+- [`keyed_recording.py`](keyed_recording.py) records and replays a keyed `TSD`
+  stream while showing its partition column.
+- [`component_modes.py`](component_modes.py) applies record, replay, compare,
+  and recover modes to a reusable component without changing the component.
+
+Run any example after installing `hgraph` and `hgraph-persistence`:
+
+```sh
+python extensions/persistence/python/examples/record_and_replay.py
+```
+
+One `GlobalState` encloses the related recording and replay runs because the
+selected frame store is run configuration shared by those runs. The examples
+select `hgraph_persistence.FRAME_BACKEND`, rather than the deprecated
+`DataFrame` compatibility name.

--- a/extensions/persistence/python/examples/component_modes.py
+++ b/extensions/persistence/python/examples/component_modes.py
@@ -1,0 +1,57 @@
+"""Apply durable record/replay modes around an unchanged component."""
+
+import hgraph_persistence as persistence
+
+import hgraph as hg
+
+
+@hg.component
+def calculate_total(lhs: hg.TS[int], rhs: hg.TS[int]) -> hg.TS[int]:
+    return lhs + rhs
+
+
+@hg.graph
+def recording(lhs: hg.TS[int], rhs: hg.TS[int]) -> hg.TS[int]:
+    with hg.record_replay_scope(hg.RecordReplayEnum.RECORD):
+        return calculate_total(lhs, rhs)
+
+
+@hg.graph
+def replaying(lhs: hg.TS[int], rhs: hg.TS[int]) -> hg.TS[int]:
+    with hg.record_replay_scope(hg.RecordReplayEnum.REPLAY):
+        return calculate_total(lhs, rhs)
+
+
+@hg.graph
+def comparing(lhs: hg.TS[int], rhs: hg.TS[int]) -> hg.TS[int]:
+    with hg.record_replay_scope(hg.RecordReplayEnum.COMPARE):
+        return calculate_total(lhs, rhs)
+
+
+@hg.graph
+def recovering(lhs: hg.TS[int], rhs: hg.TS[int]) -> hg.TS[int]:
+    with hg.record_replay_scope(hg.RecordReplayEnum.RECOVER):
+        return calculate_total(lhs, rhs)
+
+
+def run_example():
+    with hg.GlobalState():
+        hg.set_record_replay_config(persistence.FRAME_BACKEND)
+
+        recorded = hg.eval_node(recording, [1, None, 3], [10, 20, None])
+        replayed = hg.eval_node(replaying, [100, 100, 100], [100, 100, 100])
+        hg.eval_node(comparing, [100, 100, 100], [100, 100, 100])
+        comparison = hg.comparison_summary("calculate_total.__compare__")
+        recovered = hg.eval_node(recovering, [None, 100], [None, None])
+
+        return {
+            "recorded": recorded,
+            "replayed": replayed,
+            "comparison": comparison,
+            "recovered": recovered,
+        }
+
+
+if __name__ == "__main__":
+    for name, result in run_example().items():
+        print(f"{name}: {result}")

--- a/extensions/persistence/python/examples/keyed_recording.py
+++ b/extensions/persistence/python/examples/keyed_recording.py
@@ -1,0 +1,34 @@
+"""Persist and replay updates to a keyed time series."""
+
+import hgraph_persistence as persistence
+
+import hgraph as hg
+
+Positions = hg.TSD[str, hg.TS[float]]
+
+
+@hg.graph
+def record_positions(positions: Positions) -> None:
+    hg.record(positions, key="positions", recordable_id="risk")
+
+
+@hg.graph
+def replay_positions() -> Positions:
+    return hg.replay[Positions](key="positions", recordable_id="risk")
+
+
+def run_example():
+    updates = [{"AAPL": 10.0}, {"MSFT": 5.0}, {"AAPL": 12.0}]
+    with hg.GlobalState():
+        hg.set_record_replay_config(persistence.FRAME_BACKEND)
+        hg.eval_node(record_positions, updates)
+
+        frame = persistence.frame_store_read("risk.positions")
+        replayed = hg.eval_node(replay_positions)
+        return frame, replayed
+
+
+if __name__ == "__main__":
+    stored, updates = run_example()
+    print(stored)
+    print("replayed:", updates)

--- a/extensions/persistence/python/examples/record_and_replay.py
+++ b/extensions/persistence/python/examples/record_and_replay.py
@@ -1,0 +1,31 @@
+"""Record a scalar stream, inspect its Arrow frame, and replay it."""
+
+import hgraph_persistence as persistence
+
+import hgraph as hg
+
+
+@hg.graph
+def record_values(value: hg.TS[int]) -> None:
+    hg.record(value, key="values", recordable_id="example")
+
+
+@hg.graph
+def replay_values() -> hg.TS[int]:
+    return hg.replay[hg.TS[int]](key="values", recordable_id="example")
+
+
+def run_example():
+    with hg.GlobalState():
+        hg.set_record_replay_config(persistence.FRAME_BACKEND)
+        hg.eval_node(record_values, [10, 20, 30])
+
+        frame = persistence.frame_store_read("example.values")
+        replayed = hg.eval_node(replay_values)
+        return frame, replayed
+
+
+if __name__ == "__main__":
+    stored, values = run_example()
+    print(stored)
+    print("replayed:", values)

--- a/extensions/persistence/python/tests/test_examples.py
+++ b/extensions/persistence/python/tests/test_examples.py
@@ -1,0 +1,33 @@
+import runpy
+from pathlib import Path
+
+EXAMPLES = Path(__file__).parents[1] / "examples"
+
+
+def _example(name):
+    return runpy.run_path(EXAMPLES / name)
+
+
+def test_record_and_replay_example():
+    frame, replayed = _example("record_and_replay.py")["run_example"]()
+
+    assert frame.column("value").to_pylist() == [10, 20, 30]
+    assert replayed == [10, 20, 30]
+
+
+def test_keyed_recording_example():
+    frame, replayed = _example("keyed_recording.py")["run_example"]()
+
+    assert frame.column("__key_1__").to_pylist() == ["AAPL", "MSFT", "AAPL"]
+    assert replayed == [{"AAPL": 10.0}, {"MSFT": 5.0}, {"AAPL": 12.0}]
+
+
+def test_component_modes_example():
+    result = _example("component_modes.py")["run_example"]()
+
+    assert result == {
+        "recorded": [11, 21, 23],
+        "replayed": [11, 21, 23],
+        "comparison": (3, 0),
+        "recovered": [11, 110],
+    }

--- a/extensions/web/README.md
+++ b/extensions/web/README.md
@@ -36,9 +36,10 @@ wheel installs only `hgraph_web`; it never contributes files to the core
 
 ## Status
 
-This is the packaging and public-header skeleton. The authoring surface —
-schemas, service interfaces, decorators, and codec helpers — lands with the
-service implementation; see the implementation plan in RFC 0024.
+The HTTP/1.1, HTTP/2 client, and WebSocket service implementations, schemas,
+service interfaces, endpoint decorators, and codec helpers are available.
+Runnable HTTP server/client and WebSocket loopback examples are in
+[`python/examples`](python/examples/README.md).
 
 ## Build and test
 

--- a/extensions/web/python/examples/README.md
+++ b/extensions/web/python/examples/README.md
@@ -1,0 +1,27 @@
+# Python Web examples
+
+These examples cover the Web extension's graph-owned transports:
+
+- [`hello_server.py`](hello_server.py) serves a small HTTP endpoint and keeps
+  server registration in the outer host graph.
+- [`http_client.py`](http_client.py) performs one HTTP request and handles the
+  response and transport-failure arms separately.
+- [`websocket_loopback.py`](websocket_loopback.py) runs an ephemeral WebSocket
+  server and client in one graph, sends a frame, echoes it, and stops.
+
+Run the server and request it from another terminal:
+
+```sh
+python extensions/web/python/examples/hello_server.py --port 8080
+curl http://127.0.0.1:8080/hello
+```
+
+The loopback example is self-contained:
+
+```sh
+python extensions/web/python/examples/websocket_loopback.py
+```
+
+Registration declares lazy, path-bound services. Sockets and worker threads
+are created when the graph starts and are stopped with it; there is no server
+or client object for application code to poll or close.

--- a/extensions/web/python/examples/hello_server.py
+++ b/extensions/web/python/examples/hello_server.py
@@ -1,0 +1,45 @@
+"""Serve a simple HTTP endpoint from a graph-owned Web service."""
+
+import argparse
+from datetime import timedelta
+
+import hgraph_web as web
+
+import hgraph as hg
+
+
+@web.http_endpoint("/hello", path="site")
+@hg.compute_node
+def hello(request: hg.TS[web.HttpServerRequest]) -> hg.TS[web.HttpResponse]:
+    del request
+    return web.HttpResponse(
+        200,
+        headers=(web.WebHeader("content-type", "text/plain; charset=utf-8"),),
+        body=b"hello from hgraph\n",
+    )
+
+
+@hg.graph
+def app(port: int = 8080) -> None:
+    web.register_web_server(
+        web.WebServerConfig(bind_address="127.0.0.1", port=port), path="site"
+    )
+    hello()
+    hg.debug_print("Web event", web.web_server_events(path="site"))
+
+
+def run_example(port: int, seconds: int):
+    hg.run_graph(
+        app,
+        port,
+        run_mode=hg.EvaluationMode.REAL_TIME,
+        end_time=hg.utc_now() + timedelta(seconds=seconds),
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, default=8080)
+    parser.add_argument("--seconds", type=int, default=300)
+    args = parser.parse_args()
+    run_example(args.port, args.seconds)

--- a/extensions/web/python/examples/http_client.py
+++ b/extensions/web/python/examples/http_client.py
@@ -1,0 +1,64 @@
+"""Make one HTTP request and keep HTTP and transport failures distinct."""
+
+import argparse
+from datetime import timedelta
+
+import hgraph_web as web
+
+import hgraph as hg
+
+
+@hg.sink_node
+def show_response(
+    response: hg.TS[web.HttpResponse],
+    _api: hg.EvaluationEngineApi = None,
+) -> None:
+    print(response.value.status, response.value.body.decode(errors="replace"))
+    _api.request_engine_stop()
+
+
+@hg.sink_node
+def show_failure(
+    failure: hg.TS[web.WebTransportError],
+    _api: hg.EvaluationEngineApi = None,
+) -> None:
+    print("transport failure:", failure.value.message)
+    _api.request_engine_stop()
+
+
+@hg.graph
+def fetch(url: str, path: str = "client") -> None:
+    result = web.web_http_request(
+        web.HttpClientRequest(
+            web.HttpMethod.GET,
+            url,
+            headers=(web.WebHeader("accept", "text/plain"),),
+        ),
+        path=path,
+    )
+    show_response(result["response"])
+    show_failure(result["failure"])
+
+
+@hg.graph
+def app(config: web.WebClientConfig, url: str) -> None:
+    web.register_web_client(config, path="client")
+    fetch(url, path="client")
+
+
+def run_example(url: str, seconds: int):
+    hg.run_graph(
+        app,
+        web.WebClientConfig(),
+        url,
+        run_mode=hg.EvaluationMode.REAL_TIME,
+        end_time=hg.utc_now() + timedelta(seconds=seconds),
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("url", nargs="?", default="http://127.0.0.1:8080/hello")
+    parser.add_argument("--seconds", type=int, default=30)
+    args = parser.parse_args()
+    run_example(args.url, args.seconds)

--- a/extensions/web/python/examples/websocket_loopback.py
+++ b/extensions/web/python/examples/websocket_loopback.py
@@ -1,0 +1,90 @@
+"""Run a WebSocket echo server and client together on an ephemeral port."""
+
+from datetime import timedelta
+
+import hgraph_web as web
+
+import hgraph as hg
+
+_received = []
+
+
+@hg.compute_node
+def text_connection_id(frame: hg.TS[web.WsInboundFrame]) -> hg.TS[int]:
+    inbound = frame.value.frame
+    if inbound is None or inbound.kind != web.WsFrameKind.TEXT:
+        return None
+    return frame.value.connection_id
+
+
+@web.ws_endpoint("/echo", path="site")
+@hg.graph
+def echo(
+    event: hg.TS[web.WsEvent], frame: hg.TS[web.WsInboundFrame]
+) -> hg.TSB[web.WsSendRequest]:
+    del event
+    return hg.TSB[web.WsSendRequest].from_ts(
+        connection_id=text_connection_id(frame),
+        frame=web.text_frame(web.ws_text(frame)),
+    )
+
+
+@hg.compute_node
+def client_key(
+    stats: hg.TS[web.WebServerStats], _state: hg.STATE = None
+) -> hg.TS[web.WsClientKey]:
+    port = stats.value.listening_port
+    if port == 0 or getattr(_state, "emitted", False):
+        return None
+    _state.emitted = True
+    return web.WsClientKey(f"ws://127.0.0.1:{port}/echo")
+
+
+@hg.compute_node
+def send_once(event: hg.TS[web.WsEvent], _state: hg.STATE = None) -> hg.TS[web.WsFrame]:
+    if getattr(_state, "emitted", False) or (
+        event.value.state != web.WsConnectionState.OPEN
+    ):
+        return None
+    _state.emitted = True
+    return web.WsFrame.text_frame("ping")
+
+
+@hg.sink_node
+def capture(
+    frame: hg.TS[web.WsFrame],
+    _api: hg.EvaluationEngineApi = None,
+) -> None:
+    _received.append(frame.value)
+    _api.request_engine_stop()
+
+
+@hg.graph
+def app() -> None:
+    web.register_web_server(
+        web.WebServerConfig(bind_address="127.0.0.1", port=0, stats_interval_ms=50),
+        path="site",
+    )
+    web.register_web_client(web.WebClientConfig(), path="client")
+
+    echo()
+
+    key = client_key(web.web_server_stats(path="site"))
+    connected = web.web_ws_connect(key, path="client")
+    web.web_ws_client_send(key, send_once(connected["event"]), path="client")
+    capture(connected["frame"])
+
+
+def run_example(seconds: int = 10):
+    _received.clear()
+    hg.run_graph(
+        app,
+        run_mode=hg.EvaluationMode.REAL_TIME,
+        end_time=hg.utc_now() + timedelta(seconds=seconds),
+    )
+    return list(_received)
+
+
+if __name__ == "__main__":
+    for frame in run_example():
+        print(frame)

--- a/extensions/web/python/tests/test_examples.py
+++ b/extensions/web/python/tests/test_examples.py
@@ -1,0 +1,38 @@
+import runpy
+from pathlib import Path
+
+import _hgraph
+import hgraph_web as web
+from hgraph.test import use_wiring
+
+EXAMPLES = Path(__file__).parents[1] / "examples"
+
+
+def _example(name):
+    return runpy.run_path(EXAMPLES / name)
+
+
+def _build(graph, *args):
+    wiring = _hgraph.Wiring(is_realtime=True)
+    with use_wiring(wiring):
+        graph(*args)
+    wiring.build_services()
+
+
+def test_hello_server_example_wires_without_binding_a_socket():
+    _build(_example("hello_server.py")["app"], 0)
+
+
+def test_http_client_example_wires_without_making_a_request():
+    _build(
+        _example("http_client.py")["app"],
+        web.WebClientConfig(),
+        "http://127.0.0.1:8080/hello",
+    )
+
+
+def test_websocket_loopback_example_runs_to_completion():
+    [frame] = _example("websocket_loopback.py")["run_example"]()
+
+    assert frame.kind == web.WsFrameKind.TEXT
+    assert frame.text == "ping"


### PR DESCRIPTION
## Summary

- add indexed Python example suites for Analytics, Persistence, Kafka, and Web
- retain and validate the existing Fabric examples so every extension now has an examples folder
- demonstrate graph-owned service lifecycle, downstream Kafka acknowledgement, deterministic recovery, durable record/replay, array/window analytics, and HTTP/WebSocket usage
- add executable example tests and link each extension README to its examples
- update the obsolete Web implementation status

## Validation

- focused example tests: 18 passed
- combined extension Python suites: 313 passed, 1 skipped
- complete native C++ suite: 1,655 passed
- fresh ABI3 wheel under Python 3.14: 2,223 passed, 10 skipped
- Ruff and diff checks passed
- all five extension source distributions include their example folders

Kafka examples were service-wiring tested without an external broker; the existing mock and fake transport suites passed. The WebSocket loopback example was executed over real sockets.