### PR TITLE
Reject time-series schemas used as scalar types

### DIFF
--- a/python/hgraph/_types.py
+++ b/python/hgraph/_types.py
@@ -1525,7 +1525,22 @@ def resolve_type_alias(annotation):
 
 
 def _value_type(scalar):
+    import typing
+
     scalar = resolve_type_alias(scalar)
+    time_series_schema = globals().get("TimeSeriesSchema")
+    scalar_origin = typing.get_origin(scalar) or scalar
+    if (
+        isinstance(time_series_schema, type)
+        and isinstance(scalar_origin, type)
+        and issubclass(scalar_origin, time_series_schema)
+    ):
+        schema_name = scalar_origin.__name__
+        raise TypeError(
+            f"TimeSeriesSchema {schema_name} describes a live TSB and cannot "
+            "be used as a scalar type; use TSB[Schema] for the live bundle "
+            "or Schema.to_scalar_schema() for its full-value scalar"
+        )
     if isinstance(scalar, _hgraph.ValueType):
         return scalar
     if isinstance(scalar, _SharedType):
@@ -1601,7 +1616,6 @@ def _value_type(scalar):
     # typing generics: tuple[X, ...] / tuple[A, B] / frozenset[X] / dict[K, V]
     import collections.abc as _abc
     import enum as _enum
-    import typing
 
     origin = typing.get_origin(scalar)
     if scalar in (typing.Callable, _abc.Callable) or origin is _abc.Callable:

--- a/python/tests/test_compound_scalar_hierarchy.py
+++ b/python/tests/test_compound_scalar_hierarchy.py
@@ -1513,6 +1513,46 @@ def test_time_series_schema_to_scalar_schema_supports_windows():
     assert scalar(tick=7, duration="seven").duration == "seven"
 
 
+@pytest.mark.parametrize(
+    "scalar_container",
+    (
+        lambda schema: schema,
+        lambda schema: tuple[schema],
+        lambda schema: tuple[schema, ...],
+        lambda schema: frozenset[schema],
+        lambda schema: dict[str, schema],
+    ),
+)
+def test_time_series_schema_is_not_a_scalar_type(scalar_container):
+    class Bundle(TimeSeriesSchema):
+        number: TS[int]
+
+    with pytest.raises(
+        TypeError,
+        match=(
+            r"TimeSeriesSchema Bundle describes a live TSB and cannot be used "
+            r"as a scalar type"
+        ),
+    ):
+        TS[scalar_container(Bundle)]
+
+
+def test_time_series_schema_explicit_live_and_full_value_forms_remain_supported():
+    class Bundle(TimeSeriesSchema):
+        number: TS[int]
+
+    class OuterBundle(TimeSeriesSchema):
+        nested: TSB[Bundle]
+
+    scalar = Bundle.to_scalar_schema()
+    outer_scalar = OuterBundle.to_scalar_schema()
+
+    assert TSB[Bundle].handle.is_tsb
+    assert TS[scalar].handle.is_ts
+    assert TS[tuple[scalar, ...]].handle.is_ts
+    assert outer_scalar.__annotations__ == {"nested": scalar}
+
+
 def test_recursive_base_reference_inside_container_uses_owned_storage():
     @dataclass(frozen=True)
     class Base(CompoundScalar, namespace="tests.container_recursion", abstract=True):


### PR DESCRIPTION
## Summary

- reject `TimeSeriesSchema` classes when scalar schema lowering encounters them directly or inside scalar containers
- preserve the explicit supported forms: `TSB[Schema]`, `TS[Schema.to_scalar_schema()]`, and nested TSB full-value conversion
- cover direct, fixed-tuple, variadic-tuple, set, and mapping misuse with regression tests

## Compatibility

Released hgraph 0.5.41 classified this invalid composition as a catch-all `HgObjectType`. That allowed opaque internal type names to surface at runtime. This change intentionally reports the schema error at annotation construction instead.

## Validation

- `ctest --preset cpp --parallel 2`: 1,655 passed
- fresh stable-ABI wheel installed under Python 3.14: 2,229 passed, 10 skipped
- `.venv/bin/python -m tools.parity validate`: 93 recipes valid
- focused `TimeSeriesSchema` regressions: 9 passed