### PR TITLE
Restore one-size TSW shorthand semantics

### DIFF
--- a/docs/source/developer_guide/data_structures/schemas/static_schema.rst
+++ b/docs/source/developer_guide/data_structures/schemas/static_schema.rst
@@ -80,8 +80,9 @@ runtime — they exist purely to drive the descriptor traits.
     Time-series list of ``T`` (a static-schema time-series type).
     ``N == 0`` is the dynamic form; ``N > 0`` is fixed-size.
 
-``TSW<T, period, min_period = 0>``
-    Tick-based sliding window. (Duration-based windows are not yet
+``TSW<T, period, min_period = period>``
+    Tick-based sliding window. In the one-size shorthand the minimum
+    period equals the maximum period. (Duration-based windows are not yet
     expressible as a compile-time type; use the runtime registry for
     that case.)
 

--- a/docs/source/reference/types.rst
+++ b/docs/source/reference/types.rst
@@ -44,6 +44,11 @@ cannot express directly. ``Frame`` and ``Array`` are native scalar schemas for
 Arrow tables and shaped numeric arrays. See :doc:`../user_guide/data_and_analytics`
 for their storage and conversion rules.
 
+For ``TSW``, one size supplies both the maximum and minimum window period:
+``TSW[int, WindowSize[3]]`` is the same type as
+``TSW[int, WindowSize[3], WindowSize[3]]``. Supply the third parameter only
+when the window should become valid before it reaches its maximum size.
+
 Named scalar and bundle schemas
 -------------------------------
 

--- a/include/hgraph/types/static_schema.h
+++ b/include/hgraph/types/static_schema.h
@@ -131,9 +131,10 @@ namespace hgraph
      * Tick-based sliding window; equivalent to runtime ``TSW`` constructed
      * via ``tsw(value_type, period, min_period)``. Duration-based windows
      * are not yet expressible as a compile-time type — use the runtime
-     * registry for that case.
+     * registry for that case. Omitting ``MinPeriod`` makes it equal to
+     * ``Period``.
      */
-    template <typename TValue, std::size_t Period, std::size_t MinPeriod = 0>
+    template <typename TValue, std::size_t Period, std::size_t MinPeriod = Period>
     struct TSW
     {
         using value_type                      = TValue;

--- a/python/hgraph/_types.py
+++ b/python/hgraph/_types.py
@@ -2395,16 +2395,28 @@ class _TSWMeta(type):
                 pattern=_hgraph.type_pattern_tsw(element),
                 variables=_type_variables_of(items),
             )
+        resolved_sizes = (sizes[0], sizes[0]) if len(sizes) == 1 else sizes
         try:
             value_type = _value_type(value)
         except _GenericType as e:
-            period = int(sizes[0]) if sizes and isinstance(sizes[0], int) else 0
-            pattern = (_hgraph.type_pattern_tsw(e.pattern, period, period)
-                       if period > 0 else _hgraph.type_pattern_tsw(e.pattern))
+            period = (
+                int(resolved_sizes[0])
+                if resolved_sizes and isinstance(resolved_sizes[0], int)
+                else 0
+            )
+            min_period = (
+                int(resolved_sizes[1])
+                if len(resolved_sizes) > 1 and isinstance(resolved_sizes[1], int)
+                else 0
+            )
+            pattern = (
+                _hgraph.type_pattern_tsw(e.pattern, period, min_period)
+                if period > 0
+                else _hgraph.type_pattern_tsw(e.pattern)
+            )
             return _GenericTsExpr(
                 label, pattern=pattern, variables=_type_variables_of(items)
             )
-        resolved_sizes = (sizes[0], sizes[0]) if len(sizes) == 1 else sizes
         if any(isinstance(size, datetime.timedelta) for size in resolved_sizes):
             return _TsExpr(_hgraph.tsw_duration(value_type, *resolved_sizes), label)
         return _TsExpr(_hgraph.tsw(value_type, *(resolved_sizes or (0,))), label)

--- a/python/hgraph/_types.py
+++ b/python/hgraph/_types.py
@@ -2379,7 +2379,9 @@ class _TSWMeta(type):
         # int sizes -> a tick window, timedelta sizes -> a duration window,
         # a WINDOW_SIZE / WINDOW_SIZE_MIN sentinel anywhere -> the generic
         # window pattern (sizes resolve from the wired port). The bare form
-        # carries period 0 (supplied at to_window time).
+        # carries period 0 (supplied at to_window time). A single concrete
+        # size means both the maximum and minimum, matching hgraph's TSW
+        # shorthand and to_window(ts, period) default.
         items = item if isinstance(item, tuple) else (item,)
         value, sizes = items[0], items[1:]
         label = f"TSW[{item!r}]"
@@ -2397,14 +2399,15 @@ class _TSWMeta(type):
             value_type = _value_type(value)
         except _GenericType as e:
             period = int(sizes[0]) if sizes and isinstance(sizes[0], int) else 0
-            pattern = (_hgraph.type_pattern_tsw(e.pattern, period)
+            pattern = (_hgraph.type_pattern_tsw(e.pattern, period, period)
                        if period > 0 else _hgraph.type_pattern_tsw(e.pattern))
             return _GenericTsExpr(
                 label, pattern=pattern, variables=_type_variables_of(items)
             )
-        if any(isinstance(size, datetime.timedelta) for size in sizes):
-            return _TsExpr(_hgraph.tsw_duration(value_type, *sizes), label)
-        return _TsExpr(_hgraph.tsw(value_type, *(sizes or (0,))), label)
+        resolved_sizes = (sizes[0], sizes[0]) if len(sizes) == 1 else sizes
+        if any(isinstance(size, datetime.timedelta) for size in resolved_sizes):
+            return _TsExpr(_hgraph.tsw_duration(value_type, *resolved_sizes), label)
+        return _TsExpr(_hgraph.tsw(value_type, *(resolved_sizes or (0,))), label)
 
 
 class TSW(metaclass=_TSWMeta):

--- a/python/tests/test_compat_exports.py
+++ b/python/tests/test_compat_exports.py
@@ -135,10 +135,19 @@ def test_get_context_missing():
         eval_node(g2, [1])
 
 
-def test_tsw_out_maps_to_tsw():
+def test_tsw_out_and_single_size_shorthand_map_to_tsw():
+    from datetime import timedelta
+
     from hgraph import TSW, WindowSize
 
     assert hg.TSW_OUT[int, WindowSize[3]] == TSW[int, WindowSize[3]]
+    assert TSW[int, WindowSize[3]] == TSW[int, WindowSize[3], WindowSize[3]]
+    assert TSW[int, WindowSize[3]] != TSW[int, WindowSize[3], WindowSize[2]]
+    assert TSW[int, WindowSize[timedelta(seconds=3)]] == TSW[
+        int,
+        WindowSize[timedelta(seconds=3)],
+        WindowSize[timedelta(seconds=3)],
+    ]
 
 
 def test_collection_output_annotations_map_to_input_shapes():

--- a/python/tests/test_compat_exports.py
+++ b/python/tests/test_compat_exports.py
@@ -150,6 +150,20 @@ def test_tsw_out_and_single_size_shorthand_map_to_tsw():
     ]
 
 
+def test_generic_tsw_preserves_an_explicit_minimum():
+    from hgraph import SCALAR, TSW, WindowSize
+
+    single_size = TSW[SCALAR, WindowSize[3]]
+    explicit_minimum = TSW[SCALAR, WindowSize[3], WindowSize[0]]
+    exact_window = TSW[int, WindowSize[3], WindowSize[3]]
+    optional_window = TSW[int, WindowSize[3], WindowSize[0]]
+
+    assert _hgraph.ResolutionScope().match(single_size.pattern, exact_window.handle)
+    assert not _hgraph.ResolutionScope().match(single_size.pattern, optional_window.handle)
+    assert _hgraph.ResolutionScope().match(explicit_minimum.pattern, optional_window.handle)
+    assert not _hgraph.ResolutionScope().match(explicit_minimum.pattern, exact_window.handle)
+
+
 def test_collection_output_annotations_map_to_input_shapes():
     assert hg.TSD_OUT[str, TS[int]] == hg.TSD[str, TS[int]]
     assert hg.TSS_OUT[str] == hg.TSS[str]

--- a/tests/cpp/test_static_schema.cpp
+++ b/tests/cpp/test_static_schema.cpp
@@ -126,7 +126,8 @@ TEST_CASE("static_schema: TSW<T, period, min_period> descriptor matches registry
 
     const auto *float_meta = registry.value_type("float");
     REQUIRE(schema_descriptor<TSW<Float, 10, 3>>::ts_meta() == registry.tsw(float_meta, 10, 3));
-    REQUIRE(schema_descriptor<TSW<Float, 5>>::ts_meta() == registry.tsw(float_meta, 5, 0));
+    STATIC_REQUIRE(std::same_as<TSW<Float, 5>, TSW<Float, 5, 5>>);
+    REQUIRE(schema_descriptor<TSW<Float, 5>>::ts_meta() == registry.tsw(float_meta, 5, 5));
     REQUIRE_FALSE(schema_descriptor<TSWAny<ScalarVar<"T">>>::is_concrete());
     REQUIRE(schema_descriptor<TSWAny<ScalarVar<"T">>>::ts_meta() == nullptr);
 }


### PR DESCRIPTION
## Summary

- restore released-hgraph semantics where `TSW[T, size]` means `TSW[T, size, size]`
- apply the shorthand consistently to native C++ schemas and Python tick/duration type expressions
- add native and Python regression coverage and document when an explicit minimum is needed

`to_window(ts, period)` already defaulted its output minimum to the period; this fixes the shorthand type expression so callers no longer need to repeat that size to name the exact output type.

## Validation

- fresh native configure, clean build, and `ctest --preset cpp --parallel 2`: 1,655 passed
- stable-ABI wheel installed into fresh Python 3.14 environment: 2,229 passed, 10 skipped
- installed wheel C++ SDK consumer: passed
- parity corpus validation: 93 recipes
- differential PR campaign: 189 attempted, 0 new mismatches