### PR TITLE
Kafka: report adaptor failures without stopping the graph

### DIFF
--- a/docs/source/rfc/rfc_0015_kafka_extension_api.rst
+++ b/docs/source/rfc/rfc_0015_kafka_extension_api.rst
@@ -680,8 +680,10 @@ reports/events through the standard transport sender.
 
 No worker thread calls ``EvaluationEngineApi``, requests graph stop, mutates a
 time-series value, or retains a borrowed graph value.  Fatal events cross the
-push boundary, and an ordinary graph-thread node applies the configured
-``Report`` or ``StopGraph`` policy.
+push boundary into the public ``KafkaEvent`` flow.  An always-active
+graph-thread diagnostic sink logs each event at its declared severity whether
+or not a client subscribes to that flow.  Kafka adaptor nodes do not request
+engine shutdown; applications decide how to react to the typed diagnostic.
 
 Queue ownership and capacity
 ----------------------------

--- a/docs/source/user_guide/adaptors/kafka.rst
+++ b/docs/source/user_guide/adaptors/kafka.rst
@@ -349,7 +349,7 @@ Configuration, flow control, and failures
 
 ``KafkaServiceConfig`` has separate connection, consumer-default, and
 producer sections.  The defaults are suitable for a local broker, but
-production applications should make their record limits, failure policy, and
+production applications should make their record limits and
 librdkafka options explicit.  Options are immutable ``KafkaOption`` pairs;
 keep secrets out of source control and supply the appropriate Kafka security
 options through deployment configuration.
@@ -368,7 +368,6 @@ options through deployment configuration.
        consumer_defaults=kafka.KafkaConsumerDefaults(
            ingress_record_limit=20_000,
            inbound_overflow=kafka.KafkaOverflowAction.FAIL,
-           failure_policy=kafka.KafkaFailurePolicy.STOP_GRAPH,
        ),
        producer=kafka.KafkaProducerOptions(
            idempotent=True,
@@ -377,7 +376,6 @@ options through deployment configuration.
            outbound_record_limit=20_000,
            overflow=kafka.KafkaOverflowAction.STAGE,
            stage_overflow=kafka.KafkaOverflowAction.FAIL,
-           failure_policy=kafka.KafkaFailurePolicy.STOP_GRAPH,
        ),
    )
 
@@ -386,10 +384,16 @@ real-time ingress uses the service's standard unbounded burst push source and
 has no byte-capacity setting.  Recovery overflow may ``FAIL`` or ``DROP``; it
 cannot stage.  Outbound overflow may ``FAIL``, ``DROP``, or ``STAGE`` in a
 record-counted queue, whose own overflow action must be ``FAIL`` or ``DROP``.
-A failure policy of ``REPORT``
-keeps the graph running and reports the problem as ``KafkaEvent`` or a delivery
-report; ``STOP_GRAPH`` requests an orderly graph stop.  Choose it according to
-whether your application can safely continue after that failure.
+Kafka operational failures never request an engine stop.  They flow through
+``kafka_events`` as ``KafkaEvent`` values and, for publication failures, the
+corresponding delivery reports.  Every ``KafkaEvent`` is also written to the
+run logger at its declared severity with the complete sanitized diagnostic,
+including the service path, component, category, error code, retry/fatal
+flags, subscription or publisher identity, and broker message.  Unknown
+topics, authorization failures, and broker failures are therefore visible in
+the engine log even when no client subscribes to ``kafka_events``.  The
+application remains responsible for deciding whether a particular diagnostic
+should stop its own graph.
 
 Idempotent production requires ``acknowledgements="all"`` (``"-1"`` is also
 accepted).  These are Kafka producer mechanisms, not an end-to-end processing
@@ -464,6 +468,8 @@ Existing imports from ``hgraph.adaptors.kafka`` continue to work when
 ``message_subscriber``, and ``register_kafka_adaptor`` are compatibility
 wrappers over this native service.  They retain historical constraints such as
 one publisher per topic and their reduced message/header shape.
+Consumer failures use the same ``KafkaEvent`` diagnostic flow, so a topic or
+broker problem is logged and the engine continues running.
 
 Prefer the new API for new work.  It makes topic selection, replay boundaries,
 commit timing, failure handling, and delivery reports explicit; it also keeps

--- a/extensions/kafka/include/hgraph/kafka/types.h
+++ b/extensions/kafka/include/hgraph/kafka/types.h
@@ -100,11 +100,6 @@ namespace hgraph::kafka
         Stage,
     };
 
-    enum class KafkaFailurePolicy : std::int64_t {
-        Report,
-        StopGraph,
-    };
-
     namespace detail
     {
         [[nodiscard]] constexpr std::string_view enum_name(KafkaTimestampType value) noexcept {
@@ -234,13 +229,6 @@ namespace hgraph::kafka
             return "Unknown";
         }
 
-        [[nodiscard]] constexpr std::string_view enum_name(KafkaFailurePolicy value) noexcept {
-            switch (value) {
-                case KafkaFailurePolicy::Report: return "Report";
-                case KafkaFailurePolicy::StopGraph: return "StopGraph";
-            }
-            return "Unknown";
-        }
     }  // namespace detail
 
     template <typename T>
@@ -317,10 +305,6 @@ namespace hgraph::static_schema_detail
         static constexpr std::string_view value{"hgraph.kafka::KafkaOverflowAction"};
     };
 
-    template <> struct scalar_name<kafka::KafkaFailurePolicy>
-    {
-        static constexpr std::string_view value{"hgraph.kafka::KafkaFailurePolicy"};
-    };
 }  // namespace hgraph::static_schema_detail
 
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
@@ -349,8 +333,6 @@ namespace hgraph
     HGRAPH_KAFKA_PYTHON_ENUM_CONVERSION(KafkaRecoveryClock);
     HGRAPH_KAFKA_PYTHON_ENUM_CONVERSION(KafkaMergePolicy);
     HGRAPH_KAFKA_PYTHON_ENUM_CONVERSION(KafkaOverflowAction);
-    HGRAPH_KAFKA_PYTHON_ENUM_CONVERSION(KafkaFailurePolicy);
-
     #undef HGRAPH_KAFKA_PYTHON_ENUM_CONVERSION
 }  // namespace hgraph
 #endif
@@ -378,15 +360,14 @@ namespace hgraph::kafka
 
     using KafkaConsumerDefaults =
         Bundle<"hgraph.kafka::KafkaConsumerDefaults", Field<"ingress_record_limit", Int>,
-               Field<"inbound_overflow", KafkaOverflowAction>, Field<"failure_policy", KafkaFailurePolicy>,
-               Field<"options", HomogeneousTuple<KafkaOption>>>;
+               Field<"inbound_overflow", KafkaOverflowAction>, Field<"options", HomogeneousTuple<KafkaOption>>>;
 
     using KafkaProducerOptions =
         Bundle<"hgraph.kafka::KafkaProducerOptions", Field<"idempotent", Bool>, Field<"acknowledgements", Str>,
                Field<"retries", Int>, Field<"linger_ms", Int>, Field<"batch_record_limit", Int>,
                Field<"outbound_record_limit", Int>, Field<"overflow", KafkaOverflowAction>,
                Field<"stage_overflow", KafkaOverflowAction>, Field<"shutdown_drain_timeout_ms", Int>,
-               Field<"failure_policy", KafkaFailurePolicy>, Field<"options", HomogeneousTuple<KafkaOption>>>;
+               Field<"options", HomogeneousTuple<KafkaOption>>>;
 
     using KafkaServiceConfig = Bundle<"hgraph.kafka::KafkaServiceConfig", Field<"connection", KafkaConnectionConfig>,
                                       Field<"consumer_defaults", KafkaConsumerDefaults>, Field<"producer", KafkaProducerOptions>>;

--- a/extensions/kafka/include/hgraph/kafka/value_builders.h
+++ b/extensions/kafka/include/hgraph/kafka/value_builders.h
@@ -42,11 +42,9 @@ namespace hgraph::kafka
         ServiceConfigBuilder &ingress_limit(Int records);
         ServiceConfigBuilder &outbound_limit(Int records);
         ServiceConfigBuilder &inbound_overflow(KafkaOverflowAction value);
-        ServiceConfigBuilder &consumer_failure_policy(KafkaFailurePolicy value);
         ServiceConfigBuilder &outbound_overflow(KafkaOverflowAction value,
                                                 KafkaOverflowAction stage_full = KafkaOverflowAction::Fail);
         ServiceConfigBuilder &shutdown_drain_timeout(std::chrono::milliseconds value);
-        ServiceConfigBuilder &producer_failure_policy(KafkaFailurePolicy value);
         ServiceConfigBuilder &common_option(Str name, Str value);
         ServiceConfigBuilder &consumer_option(Str name, Str value);
         ServiceConfigBuilder &producer_option(Str name, Str value);
@@ -67,11 +65,9 @@ namespace hgraph::kafka
         std::vector<KafkaOptionInput> consumer_options_{};
         std::vector<KafkaOptionInput> producer_options_{};
         KafkaOverflowAction           inbound_overflow_{KafkaOverflowAction::Fail};
-        KafkaFailurePolicy            consumer_failure_policy_{KafkaFailurePolicy::Report};
         KafkaOverflowAction           outbound_overflow_{KafkaOverflowAction::Stage};
         KafkaOverflowAction           stage_overflow_{KafkaOverflowAction::Fail};
         Int                           shutdown_drain_timeout_ms_{5'000};
-        KafkaFailurePolicy            producer_failure_policy_{KafkaFailurePolicy::Report};
     };
 
     [[nodiscard]] HGRAPH_KAFKA_EXPORT ServiceConfigBuilder service_config();
@@ -128,11 +124,10 @@ namespace hgraph::kafka
         Int outbound_record_limit = 10'000,
         std::vector<KafkaOptionInput> common_options = {}, std::vector<KafkaOptionInput> consumer_options = {},
         std::vector<KafkaOptionInput> producer_options = {}, KafkaOverflowAction inbound_overflow = KafkaOverflowAction::Fail,
-        KafkaFailurePolicy  consumer_failure_policy = KafkaFailurePolicy::Report,
-        KafkaOverflowAction outbound_overflow       = KafkaOverflowAction::Stage,
+        KafkaOverflowAction outbound_overflow = KafkaOverflowAction::Stage,
         KafkaOverflowAction stage_overflow = KafkaOverflowAction::Fail, Int shutdown_drain_timeout_ms = 5'000,
-        KafkaFailurePolicy producer_failure_policy = KafkaFailurePolicy::Report, Str producer_acknowledgements = "all",
-        Int producer_retries = 2'147'483'647, Int producer_linger_ms = 5, Int producer_batch_record_limit = 1'000);
+        Str producer_acknowledgements = "all", Int producer_retries = 2'147'483'647, Int producer_linger_ms = 5,
+        Int producer_batch_record_limit = 1'000);
 
     [[nodiscard]] HGRAPH_KAFKA_EXPORT Value make_subscription_key(
         std::vector<Str> topics, Str group_id, Str start_position = "committed:earliest", Str stop_position = "unbounded",

--- a/extensions/kafka/python/hgraph_kafka/__init__.py
+++ b/extensions/kafka/python/hgraph_kafka/__init__.py
@@ -25,7 +25,6 @@ from ._hgraph_kafka import (
     KafkaMergePolicy,
     KafkaOffsetFallback,
     KafkaOverflowAction,
-    KafkaFailurePolicy,
     KafkaRecoveryClock,
     KafkaSelectorKind,
     KafkaSeverity,
@@ -197,7 +196,6 @@ class KafkaConnectionConfig(CompoundScalar, namespace=_NAMESPACE):
 class KafkaConsumerDefaults(CompoundScalar, namespace=_NAMESPACE):
     ingress_record_limit: int = 10_000
     inbound_overflow: KafkaOverflowAction = KafkaOverflowAction.FAIL
-    failure_policy: KafkaFailurePolicy = KafkaFailurePolicy.REPORT
     options: tuple[KafkaOption, ...] = ()
 
     def __post_init__(self) -> None:
@@ -218,7 +216,6 @@ class KafkaProducerOptions(CompoundScalar, namespace=_NAMESPACE):
     overflow: KafkaOverflowAction = KafkaOverflowAction.STAGE
     stage_overflow: KafkaOverflowAction = KafkaOverflowAction.FAIL
     shutdown_drain_timeout_ms: int = 5_000
-    failure_policy: KafkaFailurePolicy = KafkaFailurePolicy.REPORT
     options: tuple[KafkaOption, ...] = ()
 
     def __post_init__(self) -> None:

--- a/extensions/kafka/python/hgraph_kafka/compat.py
+++ b/extensions/kafka/python/hgraph_kafka/compat.py
@@ -31,7 +31,6 @@ from . import (
     KafkaCommitMode,
     KafkaConnectionConfig,
     KafkaConsumerDefaults,
-    KafkaFailurePolicy,
     KafkaHeader,
     KafkaMergePolicy,
     KafkaOffsetFallback,
@@ -217,7 +216,6 @@ def _legacy_config(value: dict | KafkaServiceConfig) -> KafkaServiceConfig:
     return KafkaServiceConfig(
         KafkaConnectionConfig(servers, client_id, tuple(common)),
         KafkaConsumerDefaults(
-            failure_policy=KafkaFailurePolicy.STOP_GRAPH,
             options=tuple(consumer),
         ),
         KafkaProducerOptions(

--- a/extensions/kafka/python/tests/test_api.py
+++ b/extensions/kafka/python/tests/test_api.py
@@ -109,6 +109,12 @@ def test_graph_lifetime_stop_policy_is_exposed_to_python() -> None:
     assert stop.offsets == ()
 
 
+def test_kafka_diagnostics_expose_no_engine_stop_policy() -> None:
+    assert not hasattr(kafka, "KafkaFailurePolicy")
+    assert not hasattr(kafka.KafkaConsumerDefaults(), "failure_policy")
+    assert not hasattr(kafka.KafkaProducerOptions(), "failure_policy")
+
+
 def test_all_service_interfaces_and_topic_forms_share_one_binding() -> None:
     wiring = _hgraph.Wiring()
     config = kafka.KafkaServiceConfig.from_bootstrap_servers(

--- a/extensions/kafka/python/tests/test_compat.py
+++ b/extensions/kafka/python/tests/test_compat.py
@@ -188,7 +188,7 @@ def test_released_producer_batching_defaults_map_to_typed_native_options() -> No
     assert config.producer.retries == 7
     assert config.producer.linger_ms == 25
     assert config.producer.batch_record_limit == 1_000
-    assert config.consumer_defaults.failure_policy.name == "STOP_GRAPH"
+    assert not hasattr(config.consumer_defaults, "failure_policy")
 
 
 def _consume(headers, payload=b'{"a": 1}'):

--- a/extensions/kafka/python/tests/test_runtime.py
+++ b/extensions/kafka/python/tests/test_runtime.py
@@ -692,7 +692,9 @@ def test_legacy_live_only_subscriber_does_not_receive_history() -> None:
     assert observed == [b"live"]
 
 
-def test_legacy_permanent_consumer_failure_stops_the_graph() -> None:
+def test_legacy_permanent_consumer_failure_is_reported_without_stopping_graph(
+    caplog,
+) -> None:
     cluster = MockCluster()
     cluster.create_topic("legacy-consumer-failure")
     cluster.fail_next_fetch(MockConsumeError.PERMANENT, 10)
@@ -710,16 +712,21 @@ def test_legacy_permanent_consumer_failure_stops_the_graph() -> None:
             }
         )
         subscriber()
-        kafka.kafka_events(path="legacy")
 
     started = time.monotonic()
     hg.run_graph(
         app,
         run_mode=hg.EvaluationMode.REAL_TIME,
-        end_time=hg.utc_now() + timedelta(seconds=5),
+        end_time=hg.utc_now() + timedelta(seconds=3),
     )
+    logged = caplog.text
 
-    assert time.monotonic() - started < 2.0
+    assert time.monotonic() - started >= 2.5
+    assert "Kafka event: severity=Fatal" in logged
+    assert "service_path=legacy" in logged
+    assert "component=consumer" in logged
+    assert "category=poll" in logged
+    assert "topic authorization failed" in logged.lower()
 
 
 def test_legacy_replaying_publisher_is_bounded_to_its_start_snapshot(monkeypatch) -> None:

--- a/extensions/kafka/src/detail/service_transport.h
+++ b/extensions/kafka/src/detail/service_transport.h
@@ -5,6 +5,7 @@
 
 #include <hgraph/lib/std/operators/container.h>
 #include <hgraph/lib/std/operators/higher_order.h>
+#include <hgraph/runtime/logger.h>
 #include <hgraph/runtime/push_source_node.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/static_node.h>
@@ -57,8 +58,7 @@ using KafkaTransportEvent =
            Field<"state", KafkaSubscriptionState>,
            Field<"evaluation_time", DateTime>, Field<"removed", Bool>,
            Field<"recovery", Bool>, Field<"request_id", Int>,
-           Field<"report", KafkaDeliveryReport>, Field<"event", KafkaEvent>,
-           Field<"stop_graph", Bool>>;
+           Field<"report", KafkaDeliveryReport>, Field<"event", KafkaEvent>>;
 using KafkaTransportEventBatch = HomogeneousTuple<KafkaTransportEvent>;
 using KafkaTransportStreams = TSB<
     "hgraph.kafka.internal::KafkaTransportStreams",
@@ -204,11 +204,9 @@ delivery_transport_event(const KafkaTransportBindings &bindings, Int request_id,
 }
 
 [[nodiscard]] inline Value
-service_transport_event(const KafkaTransportBindings &bindings, Value event,
-                        Bool stop_graph = false) {
+service_transport_event(const KafkaTransportBindings &bindings, Value event) {
   return transport_event(bindings, KafkaTransportEventKind::Event,
-                         {{"event", std::move(event)},
-                          {"stop_graph", transport_atomic(stop_graph)}});
+                         {{"event", std::move(event)}});
 }
 
 /** Splits one ordered Kafka burst into graph-visible service lanes. Runtime
@@ -255,8 +253,7 @@ struct KafkaTransportEmitNode {
             std::string_view{"record"}, std::string_view{"cursor"},
             std::string_view{"state"}, std::string_view{"removed"},
             std::string_view{"recovery"}, std::string_view{"request_id"},
-            std::string_view{"report"}, std::string_view{"event"},
-            std::string_view{"stop_graph"}}) {
+            std::string_view{"report"}, std::string_view{"event"}}) {
         const auto field = fields.at(name);
         if (field.data() != nullptr) {
           builder.set(name, field.clone());
@@ -460,18 +457,56 @@ struct DeliveryProjectionGraph {
   }
 };
 
-/** Projects one scalar service event and applies stop policy on graph. */
+/** Projects one scalar service event. */
 struct EventProjectionNode {
   static constexpr auto name = "kafka_event_projection";
 
   static void eval(In<"event", TS<KafkaTransportEvent>> event,
-                   EngineControlView engine, Out<TS<KafkaEvent>> out) {
-    const auto fields = event.base().value().as_bundle();
-    out.apply(fields.at("event"));
-    const auto stop_graph = fields.at("stop_graph");
-    if (stop_graph.data() != nullptr && stop_graph.checked_as<Bool>()) {
-      engine.request_stop();
+                   Out<TS<KafkaEvent>> out) {
+    out.apply(event.base().value().as_bundle().at("event"));
+  }
+};
+
+/** Terminal diagnostic flow: every Kafka event is logged at its declared
+ *  severity whether or not a client subscribes to the public event output. */
+struct EventDiagnosticSink {
+  static constexpr auto name = "kafka_event_diagnostic_sink";
+
+  static void eval(In<"diagnostic", TS<KafkaEvent>> diagnostic,
+                   LoggerView log) {
+    const auto kafka_event = diagnostic.base().value().as_bundle();
+    const auto severity =
+        kafka_event.at("severity").checked_as<KafkaSeverity>();
+    const int log_level = static_cast<int>(severity) + 1;
+    if (log.should_log(log_level)) {
+      log.log(log_level,
+              fmt::format(
+                  "Kafka event: severity={} service_path={} "
+                  "component={} category={} error_code={} retriable={} "
+                  "fatal={} subscription_identity={} publisher_identity={} "
+                  "message={}",
+                  enum_name(severity),
+                  kafka_event.at("service_path").checked_as<Str>(),
+                  kafka_event.at("component").checked_as<Str>(),
+                  kafka_event.at("category").checked_as<Str>(),
+                  kafka_event.at("error_code").checked_as<Int>(),
+                  kafka_event.at("retriable").checked_as<Bool>(),
+                  kafka_event.at("fatal").checked_as<Bool>(),
+                  kafka_event.at("subscription_identity").checked_as<Str>(),
+                  kafka_event.at("publisher_identity").checked_as<Str>(),
+                  kafka_event.at("message").checked_as<Str>()));
     }
+  }
+};
+
+struct EventProjectionGraph {
+  static constexpr auto name = "kafka_event_projection_graph";
+
+  static Port<TS<KafkaEvent>>
+  compose(Wiring &w, Port<TS<KafkaTransportEvent>> event) {
+    auto diagnostic = wire<EventProjectionNode>(w, event).as<TS<KafkaEvent>>();
+    static_cast<void>(wire<EventDiagnosticSink>(w, diagnostic));
+    return diagnostic;
   }
 };
 
@@ -500,7 +535,7 @@ wire_service_outputs(Wiring &w, Port<TS<KafkaTransportEventBatch>> transport,
       wire<stdlib::map_, TSD<Int, TS<KafkaDeliveryReport>>>(
           w, fn<DeliveryProjectionGraph>(), deliveries)
           .template as<TSD<Int, TS<KafkaDeliveryReport>>>(),
-      wire<EventProjectionNode>(w, events).template as<TS<KafkaEvent>>(),
+      wire<EventProjectionGraph>(w, events).template as<TS<KafkaEvent>>(),
   };
 }
 

--- a/extensions/kafka/src/librdkafka_service.cpp
+++ b/extensions/kafka/src/librdkafka_service.cpp
@@ -62,8 +62,8 @@ subscription_envelope(const KafkaTransportBindings &bindings, Value key,
 }
 
 [[nodiscard]] Value event_envelope(const KafkaTransportBindings &bindings,
-                                   Value event, Bool stop_graph) {
-  return service_transport_event(bindings, std::move(event), stop_graph);
+                                   Value event) {
+  return service_transport_event(bindings, std::move(event));
 }
 
 [[nodiscard]] bool present(const ValueView &value) noexcept {
@@ -107,11 +107,9 @@ struct RuntimeConfig {
   std::size_t ingress_records{};
   std::size_t outbound_records{};
   KafkaOverflowAction inbound_overflow{KafkaOverflowAction::Fail};
-  KafkaFailurePolicy consumer_failure_policy{KafkaFailurePolicy::Report};
   KafkaOverflowAction outbound_overflow{KafkaOverflowAction::Stage};
   KafkaOverflowAction stage_overflow{KafkaOverflowAction::Fail};
   std::chrono::milliseconds shutdown_drain_timeout{5'000};
-  KafkaFailurePolicy producer_failure_policy{KafkaFailurePolicy::Report};
 };
 
 [[nodiscard]] std::size_t positive_limit(ValueView field,
@@ -151,8 +149,6 @@ struct RuntimeConfig {
                                            "outbound record limit");
   result.inbound_overflow =
       consumer.at("inbound_overflow").checked_as<KafkaOverflowAction>();
-  result.consumer_failure_policy =
-      consumer.at("failure_policy").checked_as<KafkaFailurePolicy>();
   result.outbound_overflow =
       producer.at("overflow").checked_as<KafkaOverflowAction>();
   result.stage_overflow =
@@ -165,8 +161,6 @@ struct RuntimeConfig {
   }
   result.shutdown_drain_timeout =
       std::chrono::milliseconds{shutdown_drain_timeout_ms};
-  result.producer_failure_policy =
-      producer.at("failure_policy").checked_as<KafkaFailurePolicy>();
   if (result.bootstrap_servers.empty()) {
     throw std::invalid_argument("Kafka service requires bootstrap servers");
   }
@@ -832,8 +826,6 @@ public:
                 ? config_.stage_overflow
                 : config_.outbound_overflow;
         const bool dropped = action == KafkaOverflowAction::Drop;
-        const bool stop_graph = !dropped && config_.producer_failure_policy ==
-                                                KafkaFailurePolicy::StopGraph;
         emit_delivery(
             request_id,
             make_delivery_report(parsed.user_token, sequence, parsed.topic,
@@ -848,7 +840,7 @@ public:
                    dropped ? Str{"outbound record was dropped because the "
                                  "staging queue is full"}
                            : Str{"outbound staging queue is full"},
-                   {}, parsed.user_token, stop_graph);
+                   {}, parsed.user_token);
         return;
       }
       producer_queue_.push_back(std::move(parsed));
@@ -985,15 +977,14 @@ public:
 
   void emit_event(KafkaSeverity severity, Str component, Str category,
                   Int error_code, Bool retriable, Bool fatal, Str message,
-                  Str subscription_identity = {}, Str publisher_identity = {},
-                  Bool stop_graph = false) noexcept {
+                  Str subscription_identity = {},
+                  Str publisher_identity = {}) noexcept {
     try {
       Value event = make_event(
           severity, std::move(component), std::move(category), path_,
           std::move(message), error_code, retriable, fatal,
           std::move(subscription_identity), std::move(publisher_identity));
-      static_cast<void>(
-          output_(event_envelope(bindings_, std::move(event), stop_graph)));
+      static_cast<void>(output_(event_envelope(bindings_, std::move(event))));
     } catch (...) {
     }
   }
@@ -1048,9 +1039,7 @@ private:
         opaque->runtime->emit_event(
             fatal ? KafkaSeverity::Fatal : KafkaSeverity::Error,
             Str{"producer"}, Str{"delivery"}, static_cast<Int>(message->err),
-            retriable, fatal, error_message, {}, opaque->user_token,
-            !retriable && opaque->runtime->config().producer_failure_policy ==
-                              KafkaFailurePolicy::StopGraph);
+            retriable, fatal, error_message, {}, opaque->user_token);
       }
     } catch (...) {
     }
@@ -1068,10 +1057,7 @@ private:
         Str{"producer"}, Str{"client_error"}, static_cast<Int>(error),
         retriable_error(static_cast<rd_kafka_resp_err_t>(error)),
         error == RD_KAFKA_RESP_ERR__FATAL,
-        Str{rd_kafka_err2str(static_cast<rd_kafka_resp_err_t>(error))}, {}, {},
-        error == RD_KAFKA_RESP_ERR__FATAL &&
-            runtime->config().producer_failure_policy ==
-                KafkaFailurePolicy::StopGraph);
+        Str{rd_kafka_err2str(static_cast<rd_kafka_resp_err_t>(error))});
   }
 
   void create_producer() {
@@ -1156,9 +1142,7 @@ private:
         }
         emit_event(KafkaSeverity::Fatal, Str{"producer"}, Str{"worker"}, 0,
                    false, true, exception.what(), {},
-                   record.has_value() ? record->user_token : Str{},
-                   config_.producer_failure_policy ==
-                       KafkaFailurePolicy::StopGraph);
+                   record.has_value() ? record->user_token : Str{});
         producer_stopping_ = true;
       }
     }
@@ -1170,8 +1154,7 @@ private:
       emit_event(
           KafkaSeverity::Error, Str{"producer"}, Str{"shutdown_timeout"},
           flush_error, true, false,
-          Str{"Kafka producer did not drain before the shutdown timeout"}, {},
-          {}, config_.producer_failure_policy == KafkaFailurePolicy::StopGraph);
+          Str{"Kafka producer did not drain before the shutdown timeout"});
     }
   }
 
@@ -1201,8 +1184,7 @@ private:
                           Str{rd_kafka_err2str(error)}));
         emit_event(
             KafkaSeverity::Error, Str{"producer"}, Str{"header"}, error, false,
-            false, Str{rd_kafka_err2str(error)}, {}, record.user_token,
-            config_.producer_failure_policy == KafkaFailurePolicy::StopGraph);
+            false, Str{rd_kafka_err2str(error)}, {}, record.user_token);
         return true;
       }
     }
@@ -1283,9 +1265,7 @@ private:
                error, retriable, fatal,
                dropped ? Str{"outbound record was dropped"}
                        : Str{rd_kafka_err2str(error)},
-               {}, record.user_token,
-               !dropped && config_.producer_failure_policy ==
-                               KafkaFailurePolicy::StopGraph);
+               {}, record.user_token);
     return true;
   }
 
@@ -1414,9 +1394,7 @@ void ConsumerSession::rebalance_callback(
     session->complete_preload(exception.what());
     session->owner_.emit_event(
         KafkaSeverity::Error, Str{"consumer"}, Str{"rebalance"}, error, true,
-        false, exception.what(), session->spec_.identity, {},
-        session->owner_.config().consumer_failure_policy ==
-            KafkaFailurePolicy::StopGraph);
+        false, exception.what(), session->spec_.identity);
   }
 }
 
@@ -1433,10 +1411,7 @@ void ConsumerSession::error_callback(rd_kafka_t *, int error, const char *,
                                         : KafkaSeverity::Error,
       Str{"consumer"}, Str{"client_error"}, error, retriable,
       error == RD_KAFKA_RESP_ERR__FATAL, Str{rd_kafka_err2str(kafka_error)},
-      session->spec_.identity, {},
-      error == RD_KAFKA_RESP_ERR__FATAL &&
-          session->owner_.config().consumer_failure_policy ==
-              KafkaFailurePolicy::StopGraph);
+      session->spec_.identity);
   if (retriable && session->uses_manual_assignment()) {
     session->reconnect_requested_.store(true, std::memory_order_release);
   }
@@ -1620,9 +1595,7 @@ void ConsumerSession::run() noexcept {
       rd_kafka_destroy(consumer);
     }
     owner_.emit_event(KafkaSeverity::Error, Str{"consumer"}, Str{"lifecycle"},
-                      0, false, false, exception.what(), spec_.identity, {},
-                      owner_.config().consumer_failure_policy ==
-                          KafkaFailurePolicy::StopGraph);
+                      0, false, false, exception.what(), spec_.identity);
     complete_preload(exception.what());
     emit_state(KafkaSubscriptionState::Failed);
   }
@@ -1634,9 +1607,7 @@ void ConsumerSession::handle_poll_error(rd_kafka_resp_err_t error,
   const bool fatal = !retriable;
   owner_.emit_event(fatal ? KafkaSeverity::Fatal : KafkaSeverity::Error,
                     Str{"consumer"}, Str{"poll"}, error, retriable, fatal,
-                    Str{message}, spec_.identity, {},
-                    fatal && owner_.config().consumer_failure_policy ==
-                                 KafkaFailurePolicy::StopGraph);
+                    Str{message}, spec_.identity);
   if (fatal) {
     failed_ = true;
     stopping_ = true;
@@ -2171,9 +2142,7 @@ void ConsumerSession::buffer_recovery_record(BufferedRecord record) {
                     dropped ? Str{"Kafka recovery record was dropped because "
                                   "the bounded replay buffer is full"}
                             : Str{"bounded Kafka recovery buffer is full"},
-                    spec_.identity, {},
-                    !dropped && owner_.config().consumer_failure_policy ==
-                                    KafkaFailurePolicy::StopGraph);
+                    spec_.identity);
   if (!dropped) {
     failed_ = true;
     stopping_ = true;

--- a/extensions/kafka/src/python_module.cpp
+++ b/extensions/kafka/src/python_module.cpp
@@ -129,11 +129,6 @@ NB_MODULE(_hgraph_kafka, module) {
           .value("DROP", KafkaOverflowAction::Drop)
           .value("STAGE", KafkaOverflowAction::Stage);
 
-  auto failure_policy =
-      nb::enum_<KafkaFailurePolicy>(module, "KafkaFailurePolicy")
-          .value("REPORT", KafkaFailurePolicy::Report)
-          .value("STOP_GRAPH", KafkaFailurePolicy::StopGraph);
-
   // Keyed installer (RFC 0025 checkpoint 3): the extension's ENTIRE
   // registration — native types, operator overloads, AND the python
   // scalar associations (the captured class handles) — so a registry
@@ -156,7 +151,6 @@ NB_MODULE(_hgraph_kafka, module) {
         python_bridge::register_native_scalar_type<KafkaRecoveryClock>(recovery_clock);
         python_bridge::register_native_scalar_type<KafkaMergePolicy>(merge_policy);
         python_bridge::register_native_scalar_type<KafkaOverflowAction>(overflow_action);
-        python_bridge::register_native_scalar_type<KafkaFailurePolicy>(failure_policy);
       });
   hgraph::OperatorRegistry::instance().run_installers();
 

--- a/extensions/kafka/src/value_builders.cpp
+++ b/extensions/kafka/src/value_builders.cpp
@@ -229,11 +229,6 @@ namespace hgraph::kafka
         return *this;
     }
 
-    ServiceConfigBuilder &ServiceConfigBuilder::consumer_failure_policy(KafkaFailurePolicy value) {
-        consumer_failure_policy_ = value;
-        return *this;
-    }
-
     ServiceConfigBuilder &ServiceConfigBuilder::outbound_overflow(KafkaOverflowAction value, KafkaOverflowAction stage_full) {
         outbound_overflow_ = value;
         stage_overflow_    = stage_full;
@@ -242,11 +237,6 @@ namespace hgraph::kafka
 
     ServiceConfigBuilder &ServiceConfigBuilder::shutdown_drain_timeout(std::chrono::milliseconds value) {
         shutdown_drain_timeout_ms_ = value.count();
-        return *this;
-    }
-
-    ServiceConfigBuilder &ServiceConfigBuilder::producer_failure_policy(KafkaFailurePolicy value) {
-        producer_failure_policy_ = value;
         return *this;
     }
 
@@ -268,8 +258,7 @@ namespace hgraph::kafka
     Value ServiceConfigBuilder::build() const {
         return make_service_config(
             bootstrap_servers_, client_id_, idempotent_producer_, ingress_record_limit_, outbound_record_limit_, common_options_,
-            consumer_options_, producer_options_, inbound_overflow_,
-            consumer_failure_policy_, outbound_overflow_, stage_overflow_, shutdown_drain_timeout_ms_, producer_failure_policy_,
+            consumer_options_, producer_options_, inbound_overflow_, outbound_overflow_, stage_overflow_, shutdown_drain_timeout_ms_,
             producer_acknowledgements_, producer_retries_, producer_linger_ms_, producer_batch_record_limit_);
     }
 
@@ -385,8 +374,6 @@ namespace hgraph::kafka
         static_cast<void>(scalar_descriptor<KafkaRecoveryClock>::value_meta());
         static_cast<void>(scalar_descriptor<KafkaMergePolicy>::value_meta());
         static_cast<void>(scalar_descriptor<KafkaOverflowAction>::value_meta());
-        static_cast<void>(scalar_descriptor<KafkaFailurePolicy>::value_meta());
-
         static_cast<void>(scalar_descriptor<KafkaHeader>::value_meta());
         static_cast<void>(scalar_descriptor<KafkaOption>::value_meta());
         static_cast<void>(scalar_descriptor<KafkaTopicPartition>::value_meta());
@@ -458,9 +445,8 @@ namespace hgraph::kafka
                               Int outbound_record_limit,
                               std::vector<KafkaOptionInput> common_options, std::vector<KafkaOptionInput> consumer_options,
                               std::vector<KafkaOptionInput> producer_options, KafkaOverflowAction inbound_overflow,
-                              KafkaFailurePolicy consumer_failure_policy, KafkaOverflowAction outbound_overflow,
-                              KafkaOverflowAction stage_overflow, Int shutdown_drain_timeout_ms,
-                              KafkaFailurePolicy producer_failure_policy, Str producer_acknowledgements, Int producer_retries,
+                              KafkaOverflowAction outbound_overflow, KafkaOverflowAction stage_overflow,
+                              Int shutdown_drain_timeout_ms, Str producer_acknowledgements, Int producer_retries,
                               Int producer_linger_ms, Int producer_batch_record_limit) {
         register_kafka_types();
         if (bootstrap_servers.empty()) {
@@ -498,7 +484,6 @@ namespace hgraph::kafka
         Value consumer   = bundle<KafkaConsumerDefaults>({
             {"ingress_record_limit", atomic(ingress_record_limit)},
             {"inbound_overflow", atomic(inbound_overflow)},
-            {"failure_policy", atomic(consumer_failure_policy)},
             {"options", options(std::move(consumer_options))},
         });
         Value producer   = bundle<KafkaProducerOptions>({
@@ -511,7 +496,6 @@ namespace hgraph::kafka
             {"overflow", atomic(outbound_overflow)},
             {"stage_overflow", atomic(stage_overflow)},
             {"shutdown_drain_timeout_ms", atomic(shutdown_drain_timeout_ms)},
-            {"failure_policy", atomic(producer_failure_policy)},
             {"options", options(std::move(producer_options))},
         });
         return bundle<KafkaServiceConfig>({

--- a/extensions/kafka/tests/test_service.cpp
+++ b/extensions/kafka/tests/test_service.cpp
@@ -8,10 +8,13 @@
 #include <hgraph/lib/std/operators/registration.h>
 #include <hgraph/lib/testing/eval_node.h>
 #include <hgraph/lib/testing/runtime_support.h>
+#include <hgraph/runtime/logger.h>
 #include <hgraph/runtime/runtime.h>
 #include <hgraph/types/value/shared_value_pool.h>
 #include <hgraph/util/environment.h>
 #include <hgraph/util/scope.h>
+
+#include <spdlog/sinks/ringbuffer_sink.h>
 
 #include "../src/detail/service_transport.h"
 
@@ -180,6 +183,49 @@ void test_delivery_burst_unrolls_repeated_request_ids() {
   };
   require(sequence_at(0) == Int{1} && sequence_at(1) == Int{2},
           "same-id delivery reports were conflated or reordered");
+}
+
+void test_reported_event_logs_complete_reason() {
+  auto previous_logger = log::shared_logger();
+  auto sink = std::make_shared<spdlog::sinks::ringbuffer_sink_mt>(8);
+  auto logger =
+      std::make_shared<spdlog::logger>("hgraph-kafka-diagnostic-test", sink);
+  logger->set_pattern("%v");
+  log::set_logger(std::move(logger));
+  const auto restore_logger =
+      make_scope_exit([previous_logger] { log::set_logger(previous_logger); });
+
+  const auto bindings = kafka::detail::make_transport_bindings();
+  Value diagnostic = make_event(
+      KafkaSeverity::Fatal, Str{"consumer"}, Str{"poll"}, Str{"legacy"},
+      Str{"Broker: Topic authorization failed"}, Int{29}, false, true,
+      Str{"legacy:live:orders"});
+  Value transport = kafka::detail::service_transport_event(
+      *bindings.value, std::move(diagnostic));
+
+  std::vector<std::optional<Value>> input;
+  input.emplace_back(std::move(transport));
+  const auto output =
+      eval_node<kafka::detail::EventProjectionGraph>(input);
+  require(output.size() == 1 && output[0].has_value(),
+          "reported Kafka event was not published");
+
+  std::string rendered;
+  for (const auto &line : sink->last_formatted()) {
+    rendered += line;
+  }
+  require(rendered.find("Kafka event: severity=Fatal") != std::string::npos &&
+              rendered.find("service_path=legacy") != std::string::npos &&
+              rendered.find("component=consumer") != std::string::npos &&
+              rendered.find("category=poll") != std::string::npos &&
+              rendered.find("error_code=29") != std::string::npos &&
+              rendered.find("retriable=false") != std::string::npos &&
+              rendered.find("fatal=true") != std::string::npos &&
+              rendered.find("subscription_identity=legacy:live:orders") !=
+                  std::string::npos &&
+              rendered.find("Broker: Topic authorization failed") !=
+                  std::string::npos,
+          "reported Kafka event log did not preserve the failure diagnostic");
 }
 
 void test_mixed_burst_stops_at_first_output_collision() {
@@ -363,13 +409,14 @@ template <typename Fn> void require_failure(Fn &&fn, std::string message) {
 
 template <typename Schema, typename Tag>
 void capture_value(Wiring &w, Port<Schema> port, Value &observed,
-                   std::size_t &count) {
+                   std::size_t &count, bool request_stop = true) {
   const auto *input_ts = ts_type<Schema>();
   const auto *input_schema = single_input_schema(*input_ts);
   const std::array inputs{port.erased()};
   w.add_unique_node(
       std::type_index(typeid(Tag)),
-      recording_value_sink(*input_schema, *input_ts, observed, count),
+      recording_value_sink(*input_schema, *input_ts, observed, count,
+                           request_stop),
       std::span<const WiringPortRef>{inputs}, Value{});
 }
 
@@ -925,6 +972,21 @@ struct BoundedSubscriptionGraph {
         wire<BoundedSubscriptionCapture>(w, subscribe(w, path, key)));
     capture_value<TS<KafkaEvent>, BoundedEventCaptureTag>(
         w, events(w, path), bounded_event, bounded_event_count);
+  }
+};
+
+struct NonStoppingFailureGraph {
+  static constexpr auto name = "kafka_non_stopping_failure_test_graph";
+
+  static void compose(Wiring &w) {
+    const auto path = service::path("production-non-stopping-failure");
+    register_service(w, path, production_config.clone());
+    auto key = wire<stdlib::const_, TS<KafkaSubscriptionKey>>(
+        w, subscription_key.clone());
+    static_cast<void>(
+        wire<BoundedSubscriptionCapture>(w, subscribe(w, path, key)));
+    capture_value<TS<KafkaEvent>, BoundedEventCaptureTag>(
+        w, events(w, path), bounded_event, bounded_event_count, false);
   }
 };
 
@@ -2092,7 +2154,7 @@ void test_graph_lifetime_stop_remains_live_in_real_time() {
   initialize_values();
 }
 
-void test_permanent_consumer_failure_stops_the_graph() {
+void test_permanent_consumer_failure_reports_without_stopping_graph() {
   MockCluster cluster;
   cluster.create_topic(Str{"native-consumer-failure"});
   cluster.fail_next_fetch(MockConsumeError::Permanent, 10);
@@ -2101,7 +2163,6 @@ void test_permanent_consumer_failure_stops_the_graph() {
       hgraph::kafka::service_config()
           .bootstrap_servers({cluster.bootstrap_servers()})
           .client_id(Str{"native-consumer-failure"})
-          .consumer_failure_policy(KafkaFailurePolicy::StopGraph)
           .build();
   subscription_key = make_subscription_key(
       {Str{"native-consumer-failure"}}, Str{"native-consumer-failure-group"},
@@ -2111,14 +2172,14 @@ void test_permanent_consumer_failure_stops_the_graph() {
   bounded_event_count = 0;
 
   const auto started = std::chrono::steady_clock::now();
-  auto executor =
-      start_realtime(build_realtime_graph<BoundedSubscriptionGraph>());
+  auto executor = start_realtime(
+      build_realtime_graph<NonStoppingFailureGraph>(), TimeDelta{3'000'000});
   auto view = executor.view();
   AsyncGraphExecutorRun runner{view};
   runner.join();
 
-  require(std::chrono::steady_clock::now() - started < 2s,
-          "permanent Kafka consumer failure did not stop the graph");
+  require(std::chrono::steady_clock::now() - started >= 2500ms,
+          "permanent Kafka consumer failure stopped the graph");
   require(bounded_event_count != 0,
           "permanent Kafka consumer failure did not publish an event");
   require(bundle_string(bounded_event, "category") == Str{"poll"},
@@ -3067,6 +3128,7 @@ int main() {
     test_transport_sender_handles_graph_teardown();
     test_subscription_transport_retains_one_shared_record();
     test_delivery_burst_unrolls_repeated_request_ids();
+    test_reported_event_logs_complete_reason();
     const auto release_state = hgraph::make_scope_exit(release_test_state);
     initialize_values();
     test_mixed_burst_stops_at_first_output_collision();
@@ -3090,7 +3152,7 @@ int main() {
     test_librdkafka_delivery_failures_are_typed();
     test_librdkafka_subscription_path();
     test_graph_lifetime_stop_remains_live_in_real_time();
-    test_permanent_consumer_failure_stops_the_graph();
+    test_permanent_consumer_failure_reports_without_stopping_graph();
     test_typed_explicit_partition_boundaries();
     test_latest_snapshot_is_empty();
     test_timestamp_and_graph_start_positions();

--- a/extensions/kafka/tests/transport_perf.cpp
+++ b/extensions/kafka/tests/transport_perf.cpp
@@ -181,8 +181,7 @@ using PlainKafkaTransportEvent =
            Field<"state", KafkaSubscriptionState>,
            Field<"evaluation_time", DateTime>, Field<"removed", Bool>,
            Field<"recovery", Bool>, Field<"request_id", Int>,
-           Field<"report", KafkaDeliveryReport>, Field<"event", KafkaEvent>,
-           Field<"stop_graph", Bool>>;
+           Field<"report", KafkaDeliveryReport>, Field<"event", KafkaEvent>>;
 using PlainKafkaTransportEventBatch =
     HomogeneousTuple<PlainKafkaTransportEvent>;
 


### PR DESCRIPTION
## Summary

- remove KafkaFailurePolicy and the STOP_GRAPH configuration from the public C++ and Python APIs
- remove stop flags and EngineControlView usage from the Kafka transport path
- route operational failures through KafkaEvent and log every diagnostic automatically at its declared severity
- preserve the full sanitized broker reason and service, component, category, error, retry, fatal, subscription, and publisher context
- document that applications, rather than the adaptor, decide whether a diagnostic should end a graph

## Regression coverage

- verifies a complete fatal KafkaEvent is logged
- verifies a permanent consumer failure is reported while the real-time graph continues to its configured end time
- verifies diagnostics are logged even when the application does not subscribe to kafka_events
- verifies the removed stop policy is absent from native and compatibility APIs

## Validation

macOS:
- native C++ suite: 1656 passed
- Python 3.14 non-WIP suite from the CPython 3.12 ABI3 wheel: 2232 passed, 10 skipped
- Kafka Python suite: 62 passed
- installed C++ SDK consumer: 1 passed

Private Linux validation host:
- clean GCC native C++ suite: 1656 passed
- Python 3.14 non-WIP suite from the CPython 3.12 ABI3 wheel: 2232 passed, 10 skipped
- Kafka ABI3 extension suite: 62 passed