### PR TITLE
Add scalar runtime node lowering to HGL

### DIFF
--- a/language/CHANGELOG.md
+++ b/language/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Lower the first scalar runtime-function slice through `hgl emit-cpp` as
+  native static nodes: activation from `modified`, variadic `valid` checks,
+  ordered `when` handlers, replay-aware aggregate scalar state, `return`,
+  `inject out`, state-and-configuration lifecycle blocks, passive sampled
+  inputs, and ordinary policy for functions without `when`. Runtime exports and
+  `impl fn`
+  candidates register as node overloads; generated execution tests exercise
+  their tick behavior through hgraph's public APIs.
 - Add `hgl emit-cpp`: a composition-only module becomes a `<name>.h` /
   `<name>.cpp` pair of public hgraph authoring code in the module's namespace,
   with `--out-dir` or `--include-dir`/`--src-dir` placement, `--print`, and

--- a/language/README.md
+++ b/language/README.md
@@ -8,9 +8,10 @@ native extensions.
 
 Two backends share one frontend: the direct-wiring backend wires composition
 programs onto the hgraph runtime in process (`hgl test`, `hgl run`, `hgl repl`),
-and the C++ backend (`hgl emit-cpp`) writes the same programs as public hgraph
-C++ authoring code that a package builds with the `hgl_add_module()` CMake
-function. Both build the same graph; the parity tests hold them to it.
+and the C++ backend (`hgl emit-cpp`) writes composition functions and the first
+scalar runtime-node slice as public hgraph C++ authoring code that a package
+builds with the `hgl_add_module()` CMake function. The shared subset builds the
+same graph; the parity tests hold the two paths to it.
 
 The project is an intentionally changeable prototype in its first executable
 slice. `hgl check` lexes, parses, and resolves a module and reports diagnostics
@@ -22,17 +23,22 @@ onto the hgraph runtime through the direct-wiring backend, including scalar
 struct construction, type-generic Bundle specializations, `atomic<S>` values,
 and field-wise temporal struct composition. On a terminal the REPL has line
 editing, history (`~/.hgl_history`) and tab completion. `hgl emit-cpp` writes a
-composition-only module as `<name>.h` / `<name>.cpp` in the module's namespace,
-registering its exported functions as hgraph operators, and `hgl_add_module()`
+module as `<name>.h` / `<name>.cpp` in the module's namespace, registering
+composition functions as graph overloads and scalar runtime functions as node
+overloads. Runtime functions currently cover scalar temporal inputs and output,
+`modified`/`valid` guards, ordered `when` handlers, scalar recordable `state`,
+`return`, `inject out`, and lifecycle blocks over state and `const`
+configuration. `hgl_add_module()`
 builds such modules — together with hand-written C++ — into a library and,
 optionally, a Python extension module with generated wrappers. Every file under
-`examples/` is a CTest check case, `midpoint.hgl` runs its test, and the
-`tests/codegen/parity.hgl` module is built through both backends.
+`examples/` is a CTest check case, `midpoint.hgl` runs its test, and the codegen
+fixtures compile and execute generated graph and runtime-node modules.
 
 Constructor inference, typed `const` arguments in native generic Bundle
 identity, multiple-parent field order, explicit optional-field clearing,
-runtime-function lowering (in both backends), structs and generics in generated
-C++, timed harness sequences, and TOML run configuration remain staged work
+runtime functions in the direct/scripted backend, runtime collection and
+callable lowering, structs and generics in generated C++, timed harness
+sequences, and TOML run configuration remain staged work
 ([roadmap](docs/design/roadmap.md)).
 
 ## Build

--- a/language/docs/README.md
+++ b/language/docs/README.md
@@ -10,11 +10,11 @@ The documentation is split by audience:
   the delivery roadmap.
 
 The language is still a design preview. Examples describe the target first
-vertical slice; the current `hgl` checks them (`hgl check`), and runs the
-composition-only ones through `hgl test`, `hgl run`, and `hgl repl` within
-the first-pass limits listed in the user guide. Provisional syntax is called
-out in the guides so that examples do not imply an implemented compatibility
-promise.
+vertical slice; the current `hgl` checks them (`hgl check`), runs the
+composition-only ones through `hgl test`, `hgl run`, and `hgl repl`, and
+emits the documented scalar runtime-node subset through `hgl emit-cpp`.
+First-pass limits are listed in the user guide. Provisional syntax is called
+out so examples do not imply an implemented compatibility promise.
 
 ## Design records
 

--- a/language/docs/design/architecture.md
+++ b/language/docs/design/architecture.md
@@ -209,10 +209,11 @@ stands: the backend interprets wiring-time code only, and it interprets it
 by calling hgraph.
 
 Runtime functions are node bodies. They have no wiring-time form and need the
-C++ backend. Until that backend lands, a program whose evaluated closure
-contains a runtime function fails in the direct-wiring backend with a
-diagnostic that names the function and says it needs the native backend;
-it does not degrade to a slower path.
+C++ backend. The first scalar subset is emitted as native static nodes. A
+program whose evaluated closure contains a runtime function still fails in the
+direct-wiring backend with a diagnostic that names the function and says it
+needs the native backend; it does not degrade to a slower path. Scripted
+commands will compile and load the emitted artifact in the next slice.
 
 The commands map onto the backends as follows:
 
@@ -224,15 +225,16 @@ The commands map onto the backends as follows:
   consumer's CMake build, through the `hgl_add_module()` function the language
   installs (there is no `hgl build`: a second build tool would duplicate what
   CMake and the hgraph SDK already provide). `hgl run` for a program that
-  contains a runtime function will use the same emitted C++ once the runtime
-  backend lands.
+  contains a runtime function will use the same emitted C++ once the scripted
+  compile/load driver lands.
 - Both backends must build the same graph for every program both accept. The
   parity suite evaluates the test corpus through each backend and compares
   the recorded ticks; a divergence is a compiler defect, and the C++ backend
   is the reference. Today `tests/codegen/parity.hgl` is that corpus: `hgl test`
   runs its tests, and the same module, emitted and compiled through
   `hgl_add_module()`, is driven through hgraph's `eval_node` to the same
-  ticks.
+  ticks. `tests/codegen/runtime.hgl` separately exercises supported runtime
+  functions through the generated and compiled path.
 
 ## Scripted and compiled execution
 

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -2,7 +2,7 @@
 
 Status: initial design
 
-## Prototype checkpoint (2026-09-03)
+## Prototype checkpoint (2026-09-04)
 
 The prototype deliberately permits incompatible AST and implementation
 changes while these slices are being exercised. The current tree implements
@@ -11,23 +11,28 @@ abstract-only single inheritance, effective fields, constructor completeness,
 generic argument roles, and statically decidable closed requirements; and
 directly wires scalar Bundle values, `atomic<S>` values, type-only generic
 specializations, sparse scalar deltas, and simple field-wise temporal structs.
+The generated C++ backend also lowers the first scalar runtime-node subset:
+ordered activation, aggregate recordable state, direct and terminating output,
+and lifecycle hooks over state and `const` configuration.
 
 The implementation fails closed where the public or language contract is not
 settled: multiple-parent field order, constructor inference, typed `const`
 generic Bundle metadata, explicit optional-field clearing, temporal deltas,
 callable generic substitution, source-defined operator candidates in the
-direct-wiring backend, and runtime function lowering. Slice numbering below
-still describes the intended end-to-end acceptance rather than a claim that
-all earlier deliverables are complete.
+direct-wiring backend, scripted runtime compilation/loading, and runtime
+collection or generic lowering. Slice numbering below still describes the
+intended end-to-end acceptance rather than a claim that all earlier
+deliverables are complete.
 
 The C++ backend exists as a first pass: `hgl emit-cpp` lowers the same
-composition-only subset the direct-wiring backend accepts (plus non-generic
-source `operator` / `impl fn` declarations) to a header/source pair, and
-`hgl_add_module()` builds it into a package with an optional Python module.
+composition subset the direct-wiring backend accepts, the first scalar runtime
+node subset, and non-generic source `operator` / `impl fn` declarations to a
+header/source pair, and `hgl_add_module()` builds it into a package with an
+optional Python module.
 Structs, generics, duration rolling windows (no compile-time hgraph marker
-yet), compound constant literals, `if` as a value, and runtime functions fail
-closed with a diagnostic that names the construct. The REPL edits lines with
-history and completion on a terminal.
+yet), compound constant literals, `if` as a value, and runtime constructs
+outside the scalar subset fail closed with a diagnostic that names the
+construct. The REPL edits lines with history and completion on a terminal.
 
 Development proceeds through executable vertical slices. Parser-only progress
 is not a usable milestone: each language slice must reach hgraph wiring,
@@ -147,7 +152,8 @@ Deliverables:
   generics, plus open structural patterns for required-field matching;
 - source mapping (`#line` or a sidecar map; the first pass writes source
   comments) and the module descriptor for generated packages;
-- `hgl emit-cpp` (done for the composition-only subset) and the
+- `hgl emit-cpp` (done for the composition subset and first scalar runtime-node
+  subset) and the
   `hgl_add_module()` CMake function that builds packages, including the Python
   extension module and wrappers (done); there is no `hgl build`;
 - the backend parity suite: every `hgl test` the direct-wiring backend

--- a/language/docs/developer-guide/README.md
+++ b/language/docs/developer-guide/README.md
@@ -13,10 +13,14 @@ for hgraph, not a second runtime.
 > rejects decidably false closed requirements, and classifies functions.
 > `src/wiring/` executes the composition-only subset for `test`, `run`, and the
 > REPL, including scalar and atomic struct values, type-only generic
-> specializations, and field-wise temporal struct composition. Typed HIR,
+> specializations, and field-wise temporal struct composition. `src/codegen/`
+> emits that composition subset and the first scalar runtime-node subset as
+> public hgraph C++, including activation, aggregate recordable state, output,
+> and lifecycle hooks over state and `const` configuration. Typed HIR,
 > constructor inference, `const` generic metadata, multiple-parent
-> linearization, explicit optional-field clearing, runtime-function lowering,
-> and generated C++ remain to be implemented.
+> linearization, explicit optional-field
+> clearing, scripted runtime compilation/loading, and broader runtime and
+> generated-C++ type support remain to be implemented.
 
 ## Guide map
 

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -653,10 +653,13 @@ that every payload read is dominated by a static or flow-sensitive validity
 check.
 
 State initializers become `start` work that only seeds invalid fields, so
-record/replay restoration is preserved. Explicit source `start` and `stop`
-blocks become the corresponding static hooks. All state variables share one
-typed state schema. A future ephemeral-cache form must lower separately and
-must not cause one node to mix incompatible state selectors.
+record/replay restoration is preserved. They may read scalar `const`
+parameters, which are included in the generated lifecycle signature. Explicit
+source `start` and `stop` blocks become the corresponding static hooks and may
+likewise read state and `const` parameters, but not temporal inputs or output.
+All state variables share one typed state schema. A future ephemeral-cache form
+must lower separately and must not cause one node to mix incompatible state
+selectors.
 
 An inject declaration maps each approved source capability to its public
 hgraph selector. The canonical signature includes lifecycle-only selectors
@@ -1022,8 +1025,9 @@ device. The TOML run configuration is not in the first pass.
 
 ## C++ backend, first pass
 
-Status: implemented (2026-09-03) for the composition-only subset; the
-runtime backend is staged.
+Status: implemented for the composition subset and, as of 2026-09-04, the
+first scalar runtime-node subset. Broader runtime lowering and the scripted
+compile/load driver remain staged.
 
 `hgl emit-cpp <file.hgl>` writes one header/source pair named after the
 source — `prices.hgl` becomes `prices.h` and `prices.cpp` — beside the
@@ -1048,6 +1052,13 @@ What is emitted, in this order:
   namespace of the source, in dependency order (a recursive helper is a
   diagnostic). `const` parameter defaults become `static auto defaults()`
   so the registry applies them when the function is called by name.
+- **Runtime-node structs.** A runtime function in the supported scalar subset
+  is an empty static node struct in the generated header. Its `eval` signature
+  carries typed `In`, `Scalar`, `RecordableState`, and `Out` selectors. The
+  union of `modified(...)` parameters selects active inputs; other temporal
+  inputs are passive. A function with `when` conservatively admits unchecked
+  inputs and retains its complete ordered predicates in `eval`. A function
+  without `when` uses ordinary active/valid input policy.
 - **Bodies.** The same lowering the direct-wiring backend performs, printed:
   a constant expression folds into a C++ expression with the same rules
   (`/` on integers is a `Float` division, `Int` and `Float` mix to `Float`,
@@ -1068,10 +1079,21 @@ What is emitted, in this order:
   `var` keeps the static type fixed by its annotation or initializer and every
   rebind is converted or checked at that boundary. `if` over a constant is a
   C++ `if`; `return` and the tail expression return the result port.
+- **Runtime bodies.** Scalar payload expressions use the same checked type and
+  widening rules, while `modified`, `valid`, and `all_valid` call selector
+  metadata directly. `valid(a, b)` is an `&&` fold and `modified(a, b)` is
+  an `||` fold. Ordered `when` blocks become independent `if` statements.
+  `return value` sets the output and returns; assignment through `inject out`
+  sets it and continues, so the final whole-output write wins. Scalar state
+  fields form one named `TSB` behind `RecordableState`; `start` seeds only
+  invalid fields before running an explicit state-and-configuration start
+  block.
 - **Registration.** `void register_operators()` registers each export and
-  each `impl fn` with `hgraph::register_graph_overload<ops::x, x>()` through
-  a keyed `OperatorRegistry` installer named after the module, then runs the
-  installers, so a registry reset replays it and repeated calls are no-ops.
+  each `impl fn` with `hgraph::register_graph_overload<ops::x, x>()` for a
+  composition or `hgraph::register_overload<ops::x, x>()` for a runtime node,
+  through a keyed `OperatorRegistry` installer named after the module. It then
+  runs the installers, so a registry reset replays them and repeated calls are
+  no-ops.
 - **Python.** With `--python <file> --python-native <module>` the wrapper
   module imports the native module (which registers) and binds each export
   to `hgraph.operator_function("module.name")`. Python keywords gain a
@@ -1084,9 +1106,11 @@ headers; the source includes only the header. Every emitted function is
 preceded by a `// file:line` comment; output is deterministic (basenames,
 no timestamps).
 
-The first pass fails closed, before writing either file, on: a runtime
-function anywhere in the module (`state`, `inject`, lifecycle, `when`,
-runtime traversal), generics, struct declarations, duration rolling windows
+The first pass fails closed, before writing either file, on: runtime sources
+and sinks, non-scalar runtime parameters, output, or state, runtime calls and
+collection traversal, injectables other than `out`, lifecycle access to
+temporal inputs or output, generics, struct declarations, duration rolling
+windows
 (hgraph has registry and runtime duration windows but no compile-time
 `TSW` marker for them — the parity matrix records the gap), tuple and list
 literals and other compound constants, `if` or a block used as a value,
@@ -1123,12 +1147,13 @@ them.
 ## Scripted, REPL, and AOT drivers
 
 `hgl test`, `hgl run`, `hgl repl`, and `hgl emit-cpp` use the same type
-expansion, function classifier, and typed IR. `emit-cpp` always uses the
-C++ backend; the other three use the direct-wiring backend when the evaluated
-closure is composition-only and the C++ backend otherwise. There is no
-`hgl build`: a package builds emitted C++ with `hgl_add_module()`. The parity
-suite runs every test the direct-wiring backend accepts through both
-backends and compares the recorded ticks.
+expansion, function classifier, and typed IR. `emit-cpp` always uses the C++
+backend. The other three currently use the direct-wiring backend and therefore
+still reject a runtime function in the evaluated closure. The next scripted
+slice will invoke the C++ backend, build or reuse a native artifact, load it,
+and run the same hgraph graph. There is no `hgl build`: a package builds emitted
+C++ with `hgl_add_module()`. The parity suite runs every test the direct-wiring
+backend accepts through both backends and compares the recorded ticks.
 
 The initial REPL may materialize a synthetic module and rebuild the full
 session. A failed declaration must not replace the last valid session.

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -883,7 +883,9 @@ assignment_operator
 
 State and inject declarations precede executable blocks. The first slice
 requires a state initializer and permits at most one `start` and one `stop`
-block. It permits multiple `when` blocks and preserves their source order.
+block. It permits multiple function-level `when` blocks and preserves their
+source order; a `when` nested in another block is rejected because it cannot
+contribute safely to the node's activation policy.
 These are semantic restrictions rather than parser shortcuts so diagnostics
 can identify the misplaced or duplicate construct precisely.
 
@@ -1256,9 +1258,11 @@ body. In a runtime expression it denotes the current admitted payload, while
 `modified(parameter)`, `valid(parameter)`, `last_modified(parameter)`, and
 `delta(parameter)` retain access to its endpoint metadata.
 
-Runtime validity checking is flow-sensitive. A payload read is valid when the
-input is statically admitted by the outer `when` predicate or the read is
-dominated by a successful `valid(input)` check. Otherwise it is a diagnostic.
+Runtime validity checking is flow-sensitive and follows Boolean short-circuit
+order. A payload read is valid when the node's ordinary no-`when` policy admits
+the input, or the read is dominated by a successful `valid(input)` check in an
+enclosing `when` or `if`. Otherwise it is a diagnostic; in particular,
+`value > 0.0 && valid(value)` is not safe, while the reversed order is.
 
 Multiple `when` blocks execute as independent ordered conditions. Classification
 and phase checking derive one safe node policy across the complete body:

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -377,8 +377,12 @@ and every fail-closed diagnostic.
 through `hgl_add_module()` under the repository's warnings and evaluates the
 generated graphs with `eval_node` — directly by struct and by registry name,
 where the `const` defaults apply — asserting the ticks the module's own
-`test` blocks assert. The command itself is checked on the examples: the
-composition-only ones emit, a runtime function is rejected by name.
+`test` blocks assert. `tests/codegen/runtime.hgl` and
+`generated_runtime_tests.cpp` exercise the compiled node path: modified-or and
+valid-and predicates, passive sampling, ordered state mutation and final-write
+behavior, selector metadata, prior-output access, lifecycle configuration, and
+ordinary no-`when` policy. The command itself is checked on both a composition
+and a runtime fixture.
 The CMake package test configures the installed-helper path without an `hgl`
 target, proves that touching the compiler regenerates outputs, checks keyword
 module namespace escaping, and asserts multi-config-safe native-module output.

--- a/language/docs/user-guide/README.md
+++ b/language/docs/user-guide/README.md
@@ -7,8 +7,9 @@ source calls reach hgraph.
 > **Design preview:** the current `hgl` command checks these examples and
 > runs the composition-only ones (`hgl test`, `hgl run`, `hgl repl`) within
 > the limits listed in [Testing and running](testing-and-running.md#first-pass-limits).
-> The documents record syntax agreed during design discussion, not a source
-> compatibility promise.
+> `hgl emit-cpp` additionally compiles the documented scalar runtime-node
+> subset. The documents record syntax agreed during design discussion, not a
+> source compatibility promise.
 
 ## Read in this order
 

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -342,6 +342,11 @@ read permits `b` to be invalid. In a runtime function, `return value` writes
 one output tick and terminates the current evaluation. Reaching the end without
 writing or returning produces no output tick.
 
+`when` is a function-level handler rather than a nested control-flow form.
+Use `if valid(value) { ... }` inside a handler when only part of that handler
+needs a value. Validity guards follow normal left-to-right short-circuit order,
+so place `valid(value)` before reading `value` in the same `&&` condition.
+
 This can deliberately fuse work that would otherwise become several
 primitive nodes and intermediate endpoints. Graph composition still flattens;
 the possible saving comes from eliminating intermediate nodes, bindings,

--- a/language/docs/user-guide/modules-and-tools.md
+++ b/language/docs/user-guide/modules-and-tools.md
@@ -274,27 +274,33 @@ a trailing underscore in this wrapper (`class` becomes `class_`) while their
 operator registry name remains unchanged; aliases that would collide are a
 generation error.
 
-What `emit-cpp` lowers today is the composition-only subset `hgl test` runs,
-plus non-generic `operator` / `impl fn` declarations. It reports, by name,
-and writes nothing for: runtime functions (`state`, `inject`, `when`,
-lifecycle blocks, runtime traversal), generics, structs, duration rolling
-windows, tuple and list literals, `if` used as a value, and zoned or civil
-literals.
+What `emit-cpp` lowers today is the composition subset `hgl test` runs, the
+first scalar runtime-node subset, and non-generic `operator` / `impl fn`
+declarations. The runtime subset supports scalar temporal inputs and output,
+`modified`/`valid` guards, ordered `when` handlers, scalar recordable `state`,
+`return`, `inject out`, and lifecycle blocks over state and `const`
+configuration. It reports, by name,
+and writes nothing for runtime sources or sinks, non-scalar runtime signatures
+or state, runtime calls or collection traversal, other injectables, lifecycle
+temporal-input/output access, generics, structs, duration rolling windows,
+tuple and list literals, `if` used as a value, and zoned or civil literals.
 
 ## One execution model
 
-`test`, `run`, `emit-cpp`, and the REPL share one checked semantic IR and
-one hgraph runtime. A program made only of composition functions is wired
-onto the runtime directly, in process; a program with runtime functions goes
-through generated C++:
+`test`, `run`, `emit-cpp`, and the REPL share one checked semantic IR and one
+hgraph runtime. A program made only of composition functions is wired onto the
+runtime directly, in process. An ahead-of-time package containing supported
+runtime functions goes through generated C++; using that same route from
+`test`, `run`, and the REPL is the next scripted-driver slice:
 
 ```text
 source -> checked semantic IR -> direct wiring          -> hgraph runtime
                               -> generated C++ -> native -> hgraph runtime
 ```
 
-Both paths build the same graph, and the compiler's parity suite holds them
-to the same ticks.
+Both paths build the same graph. The compiler's parity suite holds the shared
+composition subset to the same ticks and executes the runtime subset through
+the compiled path.
 
 The initial REPL may rebuild the whole session after each accepted declaration.
 That is slower than a JIT but guarantees that exploration sees the same

--- a/language/docs/user-guide/testing-and-running.md
+++ b/language/docs/user-guide/testing-and-running.md
@@ -202,6 +202,8 @@ Programs made only of composition functions, which includes every example
 on this page, are wired straight onto the hgraph runtime in process by
 `hgl test`, `hgl run`, and the REPL; no native toolchain is involved. A
 program that contains a runtime function (`state`, `inject`, `when`, ...)
-needs generated C++, which the C++ backend supplies once it lands. The
+needs generated C++. `hgl emit-cpp` supplies the supported scalar runtime-node
+subset for ahead-of-time packages; teaching these three scripted commands to
+build and load that artifact is the next implementation slice. The
 [Architecture](../design/architecture.md#two-backends-one-wiring) record
 describes the split; both backends must produce the same ticks.

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -386,6 +386,13 @@ namespace hgl::codegen
             void emit_if(const ast::If &branch, Frame &frame, Writer &out);
             [[nodiscard]] RuntimeInfo runtime_info(ast::DeclId decl);
             void collect_runtime_activation(ast::ExprId id, ast::DeclId decl, RuntimeInfo &info);
+            using RuntimeValidSet = std::unordered_set<std::size_t>;
+            void check_runtime_expr(ast::ExprId id, ast::DeclId decl, const RuntimeValidSet &valid);
+            [[nodiscard]] RuntimeValidSet runtime_true_valid(ast::ExprId id, ast::DeclId decl,
+                                                             const RuntimeValidSet &valid);
+            void check_runtime_block(ast::BlockId id, ast::DeclId decl, const RuntimeValidSet &valid,
+                                     bool allow_when = false);
+            void check_runtime_stmt(ast::StmtId id, ast::DeclId decl, const RuntimeValidSet &valid, bool allow_when);
             [[nodiscard]] std::string runtime_signature(ast::DeclId decl, const RuntimeInfo &info, Frame &frame, bool with_names,
                                                         bool include_inputs, bool include_output);
             void prepare_runtime_frame(ast::DeclId decl, const RuntimeInfo &info, Frame &frame, Writer &out, bool include_inputs,
@@ -1763,6 +1770,209 @@ namespace hgl::codegen
                 expr.node);
         }
 
+        void Emitter::check_runtime_expr(ast::ExprId id, ast::DeclId decl, const RuntimeValidSet &valid)
+        {
+            const ast::Expr &expr = module_.expr(id);
+            std::visit(
+                [&](const auto &node) {
+                    using T = std::decay_t<decltype(node)>;
+                    if constexpr (std::is_same_v<T, ast::NameRef> || std::is_same_v<T, ast::QualifiedRef>)
+                    {
+                        const semantics::Binding &binding = resolved_.binding(id);
+                        if (binding.kind == BindingKind::Parameter && binding.decl == decl &&
+                            binding.index < function(decl).signature.parameters.size() &&
+                            !function(decl).signature.parameters[binding.index].is_const && !valid.contains(binding.index))
+                        {
+                            fail(Category::Type, expr.range, "temporal input '" + slice(expr.range) +
+                                                                 "' may be invalid here; guard the read with valid(" +
+                                                                 slice(expr.range) + ")");
+                        }
+                    }
+                    else if constexpr (std::is_same_v<T, ast::Unary>)
+                    {
+                        check_runtime_expr(node.operand, decl, valid);
+                    }
+                    else if constexpr (std::is_same_v<T, ast::Binary>)
+                    {
+                        check_runtime_expr(node.lhs, decl, valid);
+                        const RuntimeValidSet rhs_valid =
+                            node.op == ast::BinaryOp::And ? runtime_true_valid(node.lhs, decl, valid) : valid;
+                        check_runtime_expr(node.rhs, decl, rhs_valid);
+                    }
+                    else if constexpr (std::is_same_v<T, ast::Call>)
+                    {
+                        const semantics::Binding &callee = resolved_.binding(node.callee);
+                        if (callee.kind == BindingKind::Intrinsic &&
+                            (callee.registry_name == "valid" || callee.registry_name == "all_valid" ||
+                             callee.registry_name == "modified" || callee.registry_name == "last_modified"))
+                        {
+                            // Metadata intrinsics inspect endpoint selectors; they do not read payloads.
+                            return;
+                        }
+                        check_runtime_expr(node.callee, decl, valid);
+                        for (const ast::Argument &argument : node.arguments)
+                        {
+                            check_runtime_expr(argument.value, decl, valid);
+                        }
+                    }
+                    else if constexpr (std::is_same_v<T, ast::Index>)
+                    {
+                        check_runtime_expr(node.target, decl, valid);
+                        check_runtime_expr(node.index, decl, valid);
+                    }
+                    else if constexpr (std::is_same_v<T, ast::Field>)
+                    {
+                        check_runtime_expr(node.target, decl, valid);
+                    }
+                    else if constexpr (std::is_same_v<T, ast::SequenceLiteral>)
+                    {
+                        for (const ast::SequenceElement &element : node.elements)
+                        {
+                            if (element.key != ast::no_node) { check_runtime_expr(element.key, decl, valid); }
+                            check_runtime_expr(element.value, decl, valid);
+                        }
+                    }
+                    else if constexpr (std::is_same_v<T, ast::TupleLiteral>)
+                    {
+                        for (const ast::ExprId element : node.elements)
+                        {
+                            check_runtime_expr(element, decl, valid);
+                        }
+                    }
+                    else if constexpr (std::is_same_v<T, ast::AnonymousFn>)
+                    {
+                        check_runtime_expr(node.body, decl, valid);
+                    }
+                    else if constexpr (std::is_same_v<T, ast::If>)
+                    {
+                        const RuntimeValidSet then_valid = runtime_true_valid(node.condition, decl, valid);
+                        check_runtime_block(node.then_block, decl, then_valid);
+                        if (node.otherwise != ast::no_node)
+                        {
+                            check_runtime_expr(node.otherwise, decl, valid);
+                        }
+                    }
+                    else if constexpr (std::is_same_v<T, ast::BlockExpr>)
+                    {
+                        check_runtime_block(node.block, decl, valid);
+                    }
+                    else if constexpr (std::is_same_v<T, ast::Eval>)
+                    {
+                        check_runtime_expr(node.callee, decl, valid);
+                        for (const ast::Argument &argument : node.arguments)
+                        {
+                            check_runtime_expr(argument.value, decl, valid);
+                        }
+                    }
+                    else if constexpr (std::is_same_v<T, ast::Construct>)
+                    {
+                        for (const ast::Argument &argument : node.arguments)
+                        {
+                            check_runtime_expr(argument.value, decl, valid);
+                        }
+                    }
+                },
+                expr.node);
+        }
+
+        Emitter::RuntimeValidSet Emitter::runtime_true_valid(ast::ExprId id, ast::DeclId decl,
+                                                              const RuntimeValidSet &valid)
+        {
+            check_runtime_expr(id, decl, valid);
+            RuntimeValidSet result = valid;
+            const ast::Expr &expr  = module_.expr(id);
+            if (const auto *call = std::get_if<ast::Call>(&expr.node))
+            {
+                const semantics::Binding &callee = resolved_.binding(call->callee);
+                if (callee.kind == BindingKind::Intrinsic &&
+                    (callee.registry_name == "valid" || callee.registry_name == "all_valid"))
+                {
+                    for (const ast::Argument &argument : call->arguments)
+                    {
+                        const semantics::Binding &binding = resolved_.binding(argument.value);
+                        if (binding.kind == BindingKind::Parameter && binding.decl == decl &&
+                            binding.index < function(decl).signature.parameters.size() &&
+                            !function(decl).signature.parameters[binding.index].is_const)
+                        {
+                            result.insert(binding.index);
+                        }
+                    }
+                }
+                return result;
+            }
+            const auto *binary = std::get_if<ast::Binary>(&expr.node);
+            if (binary == nullptr) { return result; }
+            if (binary->op == ast::BinaryOp::And)
+            {
+                result = runtime_true_valid(binary->lhs, decl, valid);
+                return runtime_true_valid(binary->rhs, decl, result);
+            }
+            if (binary->op == ast::BinaryOp::Or)
+            {
+                const RuntimeValidSet lhs = runtime_true_valid(binary->lhs, decl, valid);
+                const RuntimeValidSet rhs = runtime_true_valid(binary->rhs, decl, valid);
+                RuntimeValidSet       intersection;
+                for (const std::size_t index : lhs)
+                {
+                    if (rhs.contains(index)) { intersection.insert(index); }
+                }
+                return intersection;
+            }
+            return result;
+        }
+
+        void Emitter::check_runtime_stmt(ast::StmtId id, ast::DeclId decl, const RuntimeValidSet &valid, bool allow_when)
+        {
+            const ast::Stmt &stmt = module_.stmt(id);
+            std::visit(
+                [&](const auto &node) {
+                    using T = std::decay_t<decltype(node)>;
+                    if constexpr (std::is_same_v<T, ast::LocalDecl>)
+                    {
+                        check_runtime_expr(node.init, decl, valid);
+                    }
+                    else if constexpr (std::is_same_v<T, ast::WhenStmt>)
+                    {
+                        if (!allow_when)
+                        {
+                            backend(stmt.range, "a 'when' block must be at function top level");
+                        }
+                        const RuntimeValidSet body_valid = runtime_true_valid(node.condition, decl, valid);
+                        check_runtime_block(node.block, decl, body_valid);
+                    }
+                    else if constexpr (std::is_same_v<T, ast::ForStmt>)
+                    {
+                        check_runtime_expr(node.iterable, decl, valid);
+                        check_runtime_block(node.block, decl, valid);
+                    }
+                    else if constexpr (std::is_same_v<T, ast::AssignStmt>)
+                    {
+                        check_runtime_expr(node.value, decl, valid);
+                    }
+                    else if constexpr (std::is_same_v<T, ast::ReturnStmt>)
+                    {
+                        if (node.value != ast::no_node) { check_runtime_expr(node.value, decl, valid); }
+                    }
+                    else if constexpr (std::is_same_v<T, ast::AssertStmt>)
+                    {
+                        check_runtime_expr(node.condition, decl, valid);
+                    }
+                    else if constexpr (std::is_same_v<T, ast::ExprStmt>)
+                    {
+                        check_runtime_expr(node.expr, decl, valid);
+                    }
+                },
+                stmt.node);
+        }
+
+        void Emitter::check_runtime_block(ast::BlockId id, ast::DeclId decl, const RuntimeValidSet &valid, bool allow_when)
+        {
+            for (const ast::StmtId stmt : module_.block(id).statements)
+            {
+                check_runtime_stmt(stmt, decl, valid, allow_when);
+            }
+        }
+
         RuntimeInfo Emitter::runtime_info(ast::DeclId decl)
         {
             const ast::FunctionDecl &fn = function(decl);
@@ -1873,6 +2083,19 @@ namespace hgl::codegen
                         info.active_parameters.insert(i);
                     }
                 }
+            }
+            RuntimeValidSet valid;
+            if (!info.has_when) { valid = info.active_parameters; }
+            for (const ast::StmtId id : module_.block(fn.block_body).statements)
+            {
+                const ast::Stmt &stmt = module_.stmt(id);
+                if (std::holds_alternative<ast::StateDecl>(stmt.node) ||
+                    std::holds_alternative<ast::InjectDecl>(stmt.node) ||
+                    std::holds_alternative<ast::LifecycleBlock>(stmt.node))
+                {
+                    continue;
+                }
+                check_runtime_stmt(id, decl, valid, true);
             }
             return info;
         }

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -17,12 +17,11 @@
 #include <variant>
 #include <vector>
 
-// The C++ backend of the first pass. It mirrors the direct-wiring backend
-// construct by construct (the same operator names, the same folding rules,
-// the same fail-closed list) so that a program both backends accept builds
-// the same graph; where the direct backend consults the live registry, this
-// backend prints the public marker and lets the native compiler and the
-// registry check it when the package is built and wired.
+// The C++ backend of the first pass. Its composition subset mirrors the
+// direct-wiring backend construct by construct so that programs both accept
+// build the same graph. It additionally lowers the first scalar runtime
+// subset to public static-node selectors; the native compiler and hgraph
+// registry check the emitted implementation when its package is built.
 namespace hgl::codegen
 {
     namespace
@@ -96,6 +95,7 @@ namespace hgl::codegen
                 Void,
                 Const,
                 Port,
+                Runtime,  ///< an evaluation-time scalar, optionally backed by a selector
                 Function,
                 Operator,       ///< an imported kernel operator: `name` is the C++ marker
                 LocalOperator,  ///< a module `operator`: `name` is the C++ marker
@@ -104,6 +104,9 @@ namespace hgl::codegen
 
             Kind        kind{Kind::Void};
             std::string code{};
+            /// Runtime values backed by an endpoint keep its selector spelling
+            /// so metadata intrinsics and assignments do not read the payload.
+            std::string selector{};
             /// Const: the value type. Port: the temporal type, Unknown when the
             /// registry decides it (an operator result).
             HType       type{};
@@ -119,6 +122,7 @@ namespace hgl::codegen
 
             [[nodiscard]] bool is_const() const noexcept { return kind == Kind::Const; }
             [[nodiscard]] bool is_port() const noexcept { return kind == Kind::Port; }
+            [[nodiscard]] bool is_runtime() const noexcept { return kind == Kind::Runtime; }
         };
 
         struct Frame
@@ -126,6 +130,29 @@ namespace hgl::codegen
             ast::DeclId                           fn{ast::no_node};
             std::vector<Value>                    params{};
             std::unordered_map<ast::StmtId, Value> locals{};
+            std::unordered_map<std::string, Value> injects{};
+            bool                                   runtime{false};
+            bool                                   runtime_inputs_available{true};
+            bool                                   output_available{false};
+        };
+
+        struct RuntimeState
+        {
+            ast::StmtId id{ast::no_node};
+            std::string name{};
+            HType       type{};
+            ast::ExprId init{ast::no_node};
+            SourceRange range{};
+        };
+
+        struct RuntimeInfo
+        {
+            std::vector<RuntimeState>       states{};
+            std::vector<ast::StmtId>        start_blocks{};
+            std::vector<ast::StmtId>        stop_blocks{};
+            std::unordered_set<std::size_t> active_parameters{};
+            bool                            inject_out{false};
+            bool                            has_when{false};
         };
 
         std::optional<double>       numeric_value(const Value &value);
@@ -145,7 +172,8 @@ namespace hgl::codegen
             "try", "typedef", "typeid", "typename", "union", "unsigned", "using", "virtual", "void", "volatile",
             "wchar_t", "while", "xor", "xor_eq",
             // names the generated code uses itself
-            "w", "hgraph", "std", "ops", "register_operators", "compose", "name", "defaults",
+            "w", "hgraph", "std", "ops", "register_operators", "compose", "name", "defaults", "recordable_state",
+            "hgl_state", "hgl_output",
         };
 
         constexpr std::string_view python_keywords[] = {
@@ -333,6 +361,10 @@ namespace hgl::codegen
             void emit_block(ast::BlockId id, Frame &frame, Writer &out, bool function_body);
             void emit_stmt(ast::StmtId id, Frame &frame, Writer &out);
             void emit_return(const Value &value, Frame &frame, Writer &out, SourceRange range);
+            void emit_runtime_stmt(ast::StmtId id, Frame &frame, Writer &out);
+            void emit_runtime_block(ast::BlockId id, Frame &frame, Writer &out);
+            void emit_runtime_if(const ast::If &branch, Frame &frame, Writer &out);
+            [[nodiscard]] std::string as_runtime(const Value &value, const HType &target, SourceRange range, const std::string &what);
 
             // -- declarations
             void check_supported(ast::DeclId decl);
@@ -350,7 +382,15 @@ namespace hgl::codegen
                 OutOfLine,
             };
             void emit_function(ast::DeclId decl, Writer &out, Form form);
+            void emit_runtime_function(ast::DeclId decl, Writer &out);
             void emit_if(const ast::If &branch, Frame &frame, Writer &out);
+            [[nodiscard]] RuntimeInfo runtime_info(ast::DeclId decl);
+            void collect_runtime_activation(ast::ExprId id, ast::DeclId decl, RuntimeInfo &info);
+            [[nodiscard]] std::string runtime_signature(ast::DeclId decl, const RuntimeInfo &info, Frame &frame, bool with_names,
+                                                        bool include_inputs, bool include_output);
+            void prepare_runtime_frame(ast::DeclId decl, const RuntimeInfo &info, Frame &frame, Writer &out, bool include_inputs,
+                                       bool include_output);
+            void emit_runtime_defaults(ast::DeclId decl, Writer &out);
             [[nodiscard]] std::vector<ast::DeclId> ordered_internal_functions();
             void collect_calls(ast::ExprId id, std::set<ast::DeclId> &calls);
             void collect_calls_block(ast::BlockId id, std::set<ast::DeclId> &calls);
@@ -627,12 +667,26 @@ namespace hgl::codegen
             return value;
         }
 
+        Value make_runtime(std::string code, HType type, SourceRange range, std::string selector = {})
+        {
+            Value value;
+            value.kind     = Value::Kind::Runtime;
+            value.code     = std::move(code);
+            value.selector = std::move(selector);
+            value.type     = std::move(type);
+            value.range    = range;
+            return value;
+        }
+
         std::string Emitter::argument_code(const Value &value)
         {
             switch (value.kind)
             {
                 case Value::Kind::Const:
-                case Value::Kind::Port: return value.code;
+                case Value::Kind::Port:
+                    return value.code;
+                case Value::Kind::Runtime:
+                    backend(value.range, "an evaluation-time value cannot be passed while wiring");
                 case Value::Kind::Function:
                 case Value::Kind::Operator:
                 case Value::Kind::LocalOperator:
@@ -641,6 +695,23 @@ namespace hgl::codegen
                 case Value::Kind::Void: break;
             }
             backend(value.range, "this expression produces no value");
+        }
+
+        std::string Emitter::as_runtime(const Value &value, const HType &target, SourceRange range, const std::string &what)
+        {
+            if (!value.is_const() && !value.is_runtime())
+            {
+                fail(Category::Type, range, what + " needs an evaluation-time scalar value");
+            }
+            if (same_type(value.type, target))
+            {
+                return value.code;
+            }
+            if (value.type.is(ast::ScalarType::I64) && target.is(ast::ScalarType::F64))
+            {
+                return "static_cast<hgraph::Float>(" + value.code + ")";
+            }
+            fail(Category::Type, range, what + " expects " + value_type(target, range) + ", got " + value_type(value.type, range));
         }
 
         /// The value as a constant of `target` (a `const` parameter): the
@@ -687,6 +758,15 @@ namespace hgl::codegen
 
         Value Emitter::fold_unary(ast::UnaryOp op, const Value &operand, SourceRange range)
         {
+            const bool runtime = operand.is_runtime();
+            const auto result  = [&](Value value) {
+                if (runtime)
+                {
+                    value.kind   = Value::Kind::Runtime;
+                    value.number = {};
+                }
+                return value;
+            };
             switch (op)
             {
                 case ast::UnaryOp::Negate:
@@ -699,11 +779,14 @@ namespace hgl::codegen
                             number = -*integer;
                         }
                         else if (const auto *floating = std::get_if<double>(&operand.number)) { number = -*floating; }
-                        return make_const("(-" + operand.code + ")", operand.type, range, std::move(number));
+                        return result(make_const("(-" + operand.code + ")", operand.type, range, std::move(number)));
                     }
                     fail(Category::Type, range, "unary '-' needs a number, got " + value_type(operand.type, range));
                 case ast::UnaryOp::Not:
-                    if (operand.type.is(ast::ScalarType::Bool)) { return make_const("(!" + operand.code + ")", operand.type, range); }
+                    if (operand.type.is(ast::ScalarType::Bool))
+                    {
+                        return result(make_const("(!" + operand.code + ")", operand.type, range));
+                    }
                     fail(Category::Type, range, "'!' needs a bool, got " + value_type(operand.type, range));
             }
             backend(range, "unsupported unary operator");
@@ -715,14 +798,20 @@ namespace hgl::codegen
             using ast::ScalarType;
             const bool numeric = lhs.type.numeric() && rhs.type.numeric();
             const bool ints    = lhs.type.is(ScalarType::I64) && rhs.type.is(ScalarType::I64);
+            const bool runtime = lhs.is_runtime() || rhs.is_runtime();
             const auto type_error = [&]() -> Value {
                 fail(Category::Type, range,
                      std::string{"'"} + std::string{ast::binary_op_spelling(op)} + "' is not defined for " +
                          value_type(lhs.type, range) + " and " + value_type(rhs.type, range));
             };
             const auto binary = [&](std::string_view spelling, HType type) {
-                return make_const("(" + lhs.code + " " + std::string{spelling} + " " + rhs.code + ")", std::move(type), range,
-                                  folded_number(op, lhs, rhs));
+                Value value = make_const("(" + lhs.code + " " + std::string{spelling} + " " + rhs.code + ")", std::move(type), range,
+                                         runtime ? std::variant<std::monostate, std::int64_t, double>{} : folded_number(op, lhs, rhs));
+                if (runtime)
+                {
+                    value.kind = Value::Kind::Runtime;
+                }
+                return value;
             };
             const HType float_t = scalar_type(ScalarType::F64);
             const HType bool_t  = scalar_type(ScalarType::Bool);
@@ -758,9 +847,16 @@ namespace hgl::codegen
                         {
                             fail(Category::Type, range, "division by zero");
                         }
-                        return make_const("(static_cast<hgraph::Float>(" + lhs.code + ") / static_cast<hgraph::Float>(" +
-                                              rhs.code + "))",
-                                          float_t, range, folded_number(op, lhs, rhs));
+                        Value value = make_const("(static_cast<hgraph::Float>(" + lhs.code + ") / static_cast<hgraph::Float>(" +
+                                                     rhs.code + "))",
+                                                 float_t, range,
+                                                 runtime ? std::variant<std::monostate, std::int64_t, double>{}
+                                                         : folded_number(op, lhs, rhs));
+                        if (runtime)
+                        {
+                            value.kind = Value::Kind::Runtime;
+                        }
+                        return value;
                     }
                     return type_error();
                 case BinaryOp::Rem:
@@ -837,7 +933,17 @@ namespace hgl::codegen
             {
                 case BindingKind::Local: {
                     const auto found = frame.locals.find(binding.stmt);
-                    if (found == frame.locals.end()) { backend(range, "'" + slice(range) + "' is not bound in this function"); }
+                    if (found == frame.locals.end())
+                    {
+                        const auto injected = frame.injects.find(slice(range));
+                        if (injected == frame.injects.end())
+                        {
+                            backend(range, "'" + slice(range) + "' is not bound in this function");
+                        }
+                        Value value = injected->second;
+                        value.range = range;
+                        return value;
+                    }
                     Value value = found->second;
                     value.range = range;
                     return value;
@@ -846,6 +952,12 @@ namespace hgl::codegen
                     if (binding.decl != frame.fn || binding.index >= frame.params.size())
                     {
                         backend(range, "'" + slice(range) + "' is not a parameter of this function");
+                    }
+                    if (frame.runtime && !frame.runtime_inputs_available &&
+                        !function(frame.fn).signature.parameters[binding.index].is_const)
+                    {
+                        fail(Category::Phase, range,
+                             "temporal parameters are not available in runtime lifecycle blocks");
                     }
                     Value value = frame.params[binding.index];
                     value.range = range;
@@ -958,8 +1070,14 @@ namespace hgl::codegen
                     else if constexpr (std::is_same_v<T, ast::Unary>)
                     {
                         const Value operand = eval_expr(node.operand, frame);
-                        if (operand.is_const()) { return fold_unary(node.op, operand, expr.range); }
-                        if (!operand.is_port()) { backend(expr.range, "this operand has no value"); }
+                        if (operand.is_const() || operand.is_runtime())
+                        {
+                            return fold_unary(node.op, operand, expr.range);
+                        }
+                        if (!operand.is_port())
+                        {
+                            backend(expr.range, "this operand has no value");
+                        }
                         return wire(node.op == ast::UnaryOp::Negate ? "hgraph::stdlib::neg_" : "hgraph::stdlib::not_",
                                     {operand.code}, expr.range);
                     }
@@ -967,7 +1085,10 @@ namespace hgl::codegen
                     {
                         const Value lhs = eval_expr(node.lhs, frame);
                         const Value rhs = eval_expr(node.rhs, frame);
-                        if (lhs.is_const() && rhs.is_const()) { return fold_binary(node.op, lhs, rhs, expr.range); }
+                        if ((lhs.is_const() || lhs.is_runtime()) && (rhs.is_const() || rhs.is_runtime()))
+                        {
+                            return fold_binary(node.op, lhs, rhs, expr.range);
+                        }
                         return wire_binary(node.op, lhs, rhs, expr.range);
                     }
                     else if constexpr (std::is_same_v<T, ast::Call>) { return eval_call(node, expr.range, frame); }
@@ -1017,6 +1138,10 @@ namespace hgl::codegen
         Value Emitter::eval_call(const ast::Call &call, SourceRange range, Frame &frame)
         {
             const Value callee = eval_expr(call.callee, frame);
+            if (frame.runtime && callee.kind != Value::Kind::Intrinsic)
+            {
+                backend(range, "calls in a runtime function are not supported by emit-cpp yet");
+            }
             switch (callee.kind)
             {
                 case Value::Kind::Operator:
@@ -1038,7 +1163,9 @@ namespace hgl::codegen
                 case Value::Kind::Intrinsic: return eval_intrinsic(callee, call, range, frame);
                 case Value::Kind::Const:
                 case Value::Kind::Port:
-                case Value::Kind::Void: break;
+                case Value::Kind::Runtime:
+                case Value::Kind::Void:
+                    break;
             }
             fail(Category::Type, module_.expr(call.callee).range,
                  "'" + slice(module_.expr(call.callee).range) + "' is not callable");
@@ -1049,7 +1176,29 @@ namespace hgl::codegen
             const std::string &name = callee.name;
             if (name == "valid" || name == "modified" || name == "all_valid")
             {
-                if (call.arguments.empty()) { fail(Category::Type, range, "'" + name + "' takes at least one time-series argument"); }
+                if (call.arguments.empty())
+                {
+                    fail(Category::Type, range, "'" + name + "' takes at least one time-series argument");
+                }
+                if (frame.runtime)
+                {
+                    std::vector<std::string> tests;
+                    tests.reserve(call.arguments.size());
+                    for (const ast::Argument &argument : call.arguments)
+                    {
+                        const Value value = eval_expr(argument.value, frame);
+                        if (!value.is_runtime() || value.selector.empty())
+                        {
+                            fail(Category::Type, module_.expr(argument.value).range,
+                                 "'" + name + "' takes time-series selectors in a runtime function");
+                        }
+                        const std::string method =
+                            name == "modified" ? "modified()" : name == "all_valid" ? "all_valid()" : "valid()";
+                        tests.push_back(value.selector + "." + method);
+                    }
+                    return make_runtime("(" + join(tests, name == "modified" ? " || " : " && ") + ")", scalar_type(ast::ScalarType::Bool),
+                                        range);
+                }
                 const std::string op   = name == "modified" ? "hgraph::stdlib::modified" : "hgraph::stdlib::valid";
                 const std::string fold = name == "modified" ? "hgraph::stdlib::or_" : "hgraph::stdlib::and_";
                 std::optional<Value> result;
@@ -1069,6 +1218,19 @@ namespace hgl::codegen
             {
                 if (call.arguments.size() != 1) { fail(Category::Type, range, "'" + name + "' takes one time-series argument"); }
                 const Value value = eval_expr(call.arguments[0].value, frame);
+                if (frame.runtime)
+                {
+                    if (name == "key_set")
+                    {
+                        backend(range, "runtime collection traversal is not supported by emit-cpp yet");
+                    }
+                    if (!value.is_runtime() || value.selector.empty())
+                    {
+                        fail(Category::Type, module_.expr(call.arguments[0].value).range,
+                             "'last_modified' takes a time-series selector in a runtime function");
+                    }
+                    return make_runtime(value.selector + ".last_modified_time()", scalar_type(ast::ScalarType::DateTime), range);
+                }
                 if (!value.is_port())
                 {
                     fail(Category::Type, module_.expr(call.arguments[0].value).range, "'" + name + "' takes a time-series argument");
@@ -1076,7 +1238,8 @@ namespace hgl::codegen
                 return wire(name == "last_modified" ? "hgraph::stdlib::last_modified_time" : "hgraph::stdlib::keys_", {value.code},
                             range);
             }
-            backend(range, "'" + name + "' is a runtime traversal; it is not available in a composition body of the first pass");
+            backend(range, "'" + name +
+                               "' is a runtime traversal; it is not available in a composition body of the first pass");
         }
 
         std::vector<ast::ExprId> Emitter::bind_arguments(const ast::FunctionDecl &fn, const std::vector<ast::Argument> &arguments,
@@ -1340,19 +1503,575 @@ namespace hgl::codegen
             }
         }
 
+        void Emitter::emit_runtime_if(const ast::If &branch, Frame &frame, Writer &out)
+        {
+            const Value condition = eval_expr(branch.condition, frame);
+            if ((!condition.is_const() && !condition.is_runtime()) || !condition.type.is(ast::ScalarType::Bool))
+            {
+                fail(Category::Type, module_.expr(branch.condition).range, "an 'if' condition is a bool scalar");
+            }
+            out.open("if (" + condition.code + ")");
+            emit_runtime_block(branch.then_block, frame, out);
+            out.close();
+            if (branch.otherwise == ast::no_node)
+            {
+                return;
+            }
+            const ast::Expr &otherwise = module_.expr(branch.otherwise);
+            if (const auto *block = std::get_if<ast::BlockExpr>(&otherwise.node))
+            {
+                out.open("else");
+                emit_runtime_block(block->block, frame, out);
+                out.close();
+            }
+            else if (const auto *chained = std::get_if<ast::If>(&otherwise.node))
+            {
+                out.open("else");
+                emit_runtime_if(*chained, frame, out);
+                out.close();
+            }
+            else
+            {
+                unsupported(otherwise.range, "this runtime 'else' form");
+            }
+        }
+
+        void Emitter::emit_runtime_stmt(ast::StmtId id, Frame &frame, Writer &out)
+        {
+            const ast::Stmt &stmt = module_.stmt(id);
+            std::visit(
+                [&](const auto &node) {
+                    using T = std::decay_t<decltype(node)>;
+                    if constexpr (std::is_same_v<T, ast::LocalDecl>)
+                    {
+                        Value value = eval_expr(node.init, frame);
+                        if (!value.is_const() && !value.is_runtime())
+                        {
+                            fail(Category::Type, stmt.range, "a runtime local needs a scalar value");
+                        }
+                        if (node.type != ast::no_node)
+                        {
+                            const HType declared = type_of(node.type, frame);
+                            value.code           = as_runtime(value, declared, value.range, "'" + std::string{node.name.text} + "'");
+                            value.type           = declared;
+                        }
+                        const std::string base   = cpp_name(node.name.text);
+                        std::string       local  = base;
+                        int              &suffix = local_counts_[base];
+                        while (local_names_.contains(local))
+                        {
+                            local = base + "_" + std::to_string(++suffix);
+                        }
+                        local_names_.insert(local);
+                        out.line((node.mutable_ ? "auto " : "const auto ") + local + " = " + value.code + ";");
+                        value.code = local;
+                        value.selector.clear();
+                        value.kind       = Value::Kind::Runtime;
+                        value.number     = {};
+                        frame.locals[id] = std::move(value);
+                    }
+                    else if constexpr (std::is_same_v<T, ast::AssignStmt>)
+                    {
+                        const ast::Expr &place = module_.expr(node.place);
+                        if (!std::holds_alternative<ast::NameRef>(place.node) || resolved_.binding(node.place).kind != BindingKind::Local)
+                        {
+                            backend(place.range, "runtime assignment currently targets a "
+                                                 "local, state value, or 'out'");
+                        }
+                        const semantics::Binding &binding = resolved_.binding(node.place);
+                        const ast::StmtId         target  = binding.stmt;
+                        const auto                local   = frame.locals.find(target);
+                        Value                     current;
+                        bool                      selector_assignment = false;
+                        if (local != frame.locals.end())
+                        {
+                            current = local->second;
+                            if (const auto *decl = std::get_if<ast::LocalDecl>(&module_.stmt(target).node);
+                                decl != nullptr && !decl->mutable_)
+                            {
+                                fail(Category::Type, place.range, "'" + slice(place.range) + "' is not a 'var'");
+                            }
+                            selector_assignment = std::holds_alternative<ast::StateDecl>(module_.stmt(target).node);
+                        }
+                        else
+                        {
+                            const auto injected = frame.injects.find(slice(place.range));
+                            if (injected == frame.injects.end())
+                            {
+                                backend(place.range, "'" + slice(place.range) + "' is not writable in this hook");
+                            }
+                            current             = injected->second;
+                            selector_assignment = true;
+                        }
+                        Value value = eval_expr(node.value, frame);
+                        if (node.op != ast::AssignOp::Assign)
+                        {
+                            const ast::BinaryOp op = node.op == ast::AssignOp::Add   ? ast::BinaryOp::Add
+                                                     : node.op == ast::AssignOp::Sub ? ast::BinaryOp::Sub
+                                                     : node.op == ast::AssignOp::Mul ? ast::BinaryOp::Mul
+                                                                                     : ast::BinaryOp::Div;
+                            value                  = fold_binary(op, current, value, stmt.range);
+                        }
+                        const std::string converted =
+                            as_runtime(value, current.type, value.range, "assignment to '" + slice(place.range) + "'");
+                        if (selector_assignment)
+                        {
+                            if (current.selector.empty())
+                            {
+                                backend(place.range, "this runtime value is not writable");
+                            }
+                            out.line(current.selector + ".set(" + converted + ");");
+                        }
+                        else
+                        {
+                            out.line(current.code + " = " + converted + ";");
+                            Value updated        = current;
+                            updated.kind         = Value::Kind::Runtime;
+                            updated.number       = {};
+                            frame.locals[target] = std::move(updated);
+                        }
+                    }
+                    else if constexpr (std::is_same_v<T, ast::ReturnStmt>)
+                    {
+                        if (!frame.output_available)
+                        {
+                            fail(Category::Phase, stmt.range, "'return' is not available in a lifecycle block");
+                        }
+                        if (node.value != ast::no_node)
+                        {
+                            const ast::FunctionDecl &fn = function(frame.fn);
+                            if (fn.signature.result == ast::no_node)
+                            {
+                                fail(Category::Type, stmt.range, "'" + std::string{fn.name.text} + "' has no result");
+                            }
+                            const HType result = type_of(fn.signature.result, frame);
+                            const Value value  = eval_expr(node.value, frame);
+                            out.line("hgl_output.set(" + as_runtime(value, result, value.range, "return value") + ");");
+                        }
+                        out.line("return;");
+                    }
+                    else if constexpr (std::is_same_v<T, ast::WhenStmt>)
+                    {
+                        const Value condition = eval_expr(node.condition, frame);
+                        if ((!condition.is_const() && !condition.is_runtime()) || !condition.type.is(ast::ScalarType::Bool))
+                        {
+                            fail(Category::Type, module_.expr(node.condition).range, "a 'when' condition is a bool scalar");
+                        }
+                        out.open("if (" + condition.code + ")");
+                        emit_runtime_block(node.block, frame, out);
+                        out.close();
+                    }
+                    else if constexpr (std::is_same_v<T, ast::ExprStmt>)
+                    {
+                        const ast::Expr &expr = module_.expr(node.expr);
+                        if (const auto *branch = std::get_if<ast::If>(&expr.node))
+                        {
+                            emit_runtime_if(*branch, frame, out);
+                            return;
+                        }
+                        const Value value = eval_expr(node.expr, frame);
+                        if (value.kind == Value::Kind::Void)
+                        {
+                            out.line(value.code + ";");
+                        }
+                        else
+                        {
+                            out.line("(void)" + value.code + ";");
+                        }
+                    }
+                    else if constexpr (std::is_same_v<T, ast::AssertStmt>)
+                    {
+                        fail(Category::Type, stmt.range, "'assert' is only valid in a test");
+                    }
+                    else if constexpr (std::is_same_v<T, ast::ForStmt>)
+                    {
+                        backend(stmt.range, "runtime collection traversal is not supported by emit-cpp yet");
+                    }
+                    else
+                    {
+                        backend(stmt.range, "state, inject, start, and stop are "
+                                            "function-level runtime declarations");
+                    }
+                },
+                stmt.node);
+        }
+
+        void Emitter::emit_runtime_block(ast::BlockId id, Frame &frame, Writer &out)
+        {
+            for (const ast::StmtId stmt : module_.block(id).statements)
+            {
+                emit_runtime_stmt(stmt, frame, out);
+            }
+        }
+
         // ------------------------------------------------------ declarations
+
+        void Emitter::collect_runtime_activation(ast::ExprId id, ast::DeclId decl, RuntimeInfo &info)
+        {
+            const ast::Expr &expr = module_.expr(id);
+            std::visit(
+                [&](const auto &node) {
+                    using T = std::decay_t<decltype(node)>;
+                    if constexpr (std::is_same_v<T, ast::Call>)
+                    {
+                        const semantics::Binding &callee = resolved_.binding(node.callee);
+                        if (callee.kind == BindingKind::Intrinsic && callee.registry_name == "modified")
+                        {
+                            for (const ast::Argument &argument : node.arguments)
+                            {
+                                const semantics::Binding &binding = resolved_.binding(argument.value);
+                                if (binding.kind != BindingKind::Parameter || binding.decl != decl ||
+                                    binding.index >= function(decl).signature.parameters.size() ||
+                                    function(decl).signature.parameters[binding.index].is_const)
+                                {
+                                    backend(module_.expr(argument.value).range, "the first runtime-node slice requires 'modified' "
+                                                                                "arguments to be temporal parameters");
+                                }
+                                info.active_parameters.insert(binding.index);
+                            }
+                            return;
+                        }
+                        collect_runtime_activation(node.callee, decl, info);
+                        for (const ast::Argument &argument : node.arguments)
+                        {
+                            collect_runtime_activation(argument.value, decl, info);
+                        }
+                    }
+                    else if constexpr (std::is_same_v<T, ast::Unary>)
+                    {
+                        collect_runtime_activation(node.operand, decl, info);
+                    }
+                    else if constexpr (std::is_same_v<T, ast::Binary>)
+                    {
+                        collect_runtime_activation(node.lhs, decl, info);
+                        collect_runtime_activation(node.rhs, decl, info);
+                    }
+                    else if constexpr (std::is_same_v<T, ast::Index>)
+                    {
+                        collect_runtime_activation(node.target, decl, info);
+                        collect_runtime_activation(node.index, decl, info);
+                    }
+                    else if constexpr (std::is_same_v<T, ast::Field>)
+                    {
+                        collect_runtime_activation(node.target, decl, info);
+                    }
+                    else if constexpr (std::is_same_v<T, ast::If>)
+                    {
+                        collect_runtime_activation(node.condition, decl, info);
+                    }
+                },
+                expr.node);
+        }
+
+        RuntimeInfo Emitter::runtime_info(ast::DeclId decl)
+        {
+            const ast::FunctionDecl &fn = function(decl);
+            RuntimeInfo              info;
+            Frame                    frame;
+            frame.fn      = decl;
+            frame.runtime = true;
+
+            if (fn.concise_body != ast::no_node || fn.block_body == ast::no_node)
+            {
+                backend(module_.decl(decl).range, "a runtime function needs a block body");
+            }
+            if (fn.signature.result == ast::no_node)
+            {
+                backend(fn.name.range, "generated runtime sinks are not supported by emit-cpp yet");
+            }
+            const HType result = type_of(fn.signature.result, frame);
+            if (result.kind != HType::Kind::Scalar)
+            {
+                backend(module_.type(fn.signature.result).range, "the first runtime-node slice supports scalar time-series outputs");
+            }
+
+            std::size_t temporal_count = 0;
+            for (const ast::Parameter &param : fn.signature.parameters)
+            {
+                const HType type = type_of(param.type, frame);
+                if (type.kind != HType::Kind::Scalar)
+                {
+                    backend(module_.type(param.type).range, "the first runtime-node slice supports scalar parameters");
+                }
+                if (!param.is_const)
+                {
+                    ++temporal_count;
+                }
+            }
+            if (temporal_count == 0)
+            {
+                backend(fn.name.range, "generated runtime sources are not supported by emit-cpp yet");
+            }
+
+            for (const ast::StmtId id : module_.block(fn.block_body).statements)
+            {
+                const ast::Stmt &stmt = module_.stmt(id);
+                std::visit(
+                    [&](const auto &node) {
+                        using T = std::decay_t<decltype(node)>;
+                        if constexpr (std::is_same_v<T, ast::StateDecl>)
+                        {
+                            if (node.type == ast::no_node)
+                            {
+                                backend(node.name.range, "a generated runtime state declaration "
+                                                         "needs an explicit scalar type");
+                            }
+                            const HType type = type_of(node.type, frame);
+                            if (type.kind != HType::Kind::Scalar)
+                            {
+                                backend(module_.type(node.type).range, "the first runtime-node slice supports scalar state fields");
+                            }
+                            if (node.init == ast::no_node)
+                            {
+                                backend(node.name.range, "a generated runtime state field needs an initializer");
+                            }
+                            info.states.push_back(RuntimeState{
+                                .id = id, .name = std::string{node.name.text}, .type = type, .init = node.init, .range = node.name.range});
+                        }
+                        else if constexpr (std::is_same_v<T, ast::InjectDecl>)
+                        {
+                            for (const ast::Name &name : node.names)
+                            {
+                                if (name.text != "out")
+                                {
+                                    backend(name.range, "injectable '" + std::string{name.text} + "' is not supported by emit-cpp yet");
+                                }
+                                info.inject_out = true;
+                            }
+                        }
+                        else if constexpr (std::is_same_v<T, ast::LifecycleBlock>)
+                        {
+                            (node.is_stop ? info.stop_blocks : info.start_blocks).push_back(id);
+                        }
+                        else if constexpr (std::is_same_v<T, ast::WhenStmt>)
+                        {
+                            info.has_when = true;
+                            collect_runtime_activation(node.condition, decl, info);
+                        }
+                    },
+                    stmt.node);
+            }
+            if (info.start_blocks.size() > 1)
+            {
+                backend(module_.stmt(info.start_blocks[1]).range, "a runtime function has at most one 'start' block");
+            }
+            if (info.stop_blocks.size() > 1)
+            {
+                backend(module_.stmt(info.stop_blocks[1]).range, "a runtime function has at most one 'stop' block");
+            }
+            if (info.has_when && info.active_parameters.empty())
+            {
+                backend(fn.name.range, "a generated runtime function with 'when' needs a "
+                                       "temporal parameter in 'modified(...)'");
+            }
+            if (!info.has_when)
+            {
+                for (std::size_t i = 0; i < fn.signature.parameters.size(); ++i)
+                {
+                    if (!fn.signature.parameters[i].is_const)
+                    {
+                        info.active_parameters.insert(i);
+                    }
+                }
+            }
+            return info;
+        }
 
         void Emitter::check_supported(ast::DeclId decl)
         {
             const ast::FunctionDecl &fn    = function(decl);
             const SourceRange        range = module_.decl(decl).range;
+            if (!fn.generics.empty())
+            {
+                unsupported(range, "a generic function");
+            }
             if (resolved_.kind(decl) == semantics::FunctionKind::Runtime)
             {
-                backend(range, "'" + std::string{fn.name.text} +
-                                   "' is a runtime function; emit-cpp lowers compositions in the first pass (the runtime "
-                                   "backend is staged)");
+                static_cast<void>(runtime_info(decl));
             }
-            if (!fn.generics.empty()) { unsupported(range, "a generic function"); }
+        }
+
+        std::string Emitter::runtime_signature(ast::DeclId decl, const RuntimeInfo &info, Frame &frame, bool with_names,
+                                               bool include_inputs, bool include_output)
+        {
+            const ast::FunctionDecl &fn = function(decl);
+            std::vector<std::string> params;
+            for (std::size_t i = 0; i < fn.signature.parameters.size(); ++i)
+            {
+                const ast::Parameter &param  = fn.signature.parameters[i];
+                const HType           type   = type_of(param.type, frame);
+                const std::string     name   = with_names ? " " + cpp_name(param.name.text) : "";
+                const std::string     unused = with_names ? "[[maybe_unused]] " : "";
+                if (param.is_const)
+                {
+                    params.push_back(unused + "hgraph::Scalar<" + quote(param.name.text) + ", " +
+                                     value_type(type, module_.type(param.type).range) + ">" + name);
+                    continue;
+                }
+                if (!include_inputs) { continue; }
+                std::string selector =
+                    unused + "hgraph::In<" + quote(param.name.text) + ", " + schema(type, module_.type(param.type).range);
+                if (!info.active_parameters.contains(i))
+                {
+                    selector += ", hgraph::InputActivity::Passive";
+                }
+                if (info.has_when)
+                {
+                    selector += ", hgraph::InputValidity::Unchecked";
+                }
+                selector += ">" + name;
+                params.push_back(std::move(selector));
+            }
+            if (!info.states.empty())
+            {
+                params.push_back(std::string{with_names ? "[[maybe_unused]] " : ""} + "hgraph::RecordableState<recordable_state>" +
+                                 std::string{with_names ? " hgl_state" : ""});
+            }
+            if (include_output)
+            {
+                params.push_back(std::string{with_names ? "[[maybe_unused]] " : ""} + "hgraph::Out<" +
+                                 schema(type_of(fn.signature.result, frame), module_.type(fn.signature.result).range) + ">" +
+                                 std::string{with_names ? " hgl_output" : ""});
+            }
+            return join(params, ", ");
+        }
+
+        void Emitter::prepare_runtime_frame(ast::DeclId decl, const RuntimeInfo &info, Frame &frame, Writer &out, bool include_inputs,
+                                            bool include_output)
+        {
+            const ast::FunctionDecl &fn    = function(decl);
+            frame.fn                       = decl;
+            frame.runtime                  = true;
+            frame.runtime_inputs_available = include_inputs;
+            frame.output_available         = include_output;
+            frame.params.resize(fn.signature.parameters.size());
+            frame.locals.clear();
+            frame.injects.clear();
+            local_counts_.clear();
+            local_names_.clear();
+            local_names_.insert("hgl_state");
+            local_names_.insert("hgl_output");
+            for (std::size_t i = 0; i < fn.signature.parameters.size(); ++i)
+            {
+                const ast::Parameter &param = fn.signature.parameters[i];
+                const HType           type  = type_of(param.type, frame);
+                const std::string     name  = cpp_name(param.name.text);
+                local_names_.insert(name);
+                frame.params[i] = param.is_const ? make_const(name + ".value()", type, param.name.range)
+                                                 : make_runtime(name + ".value()", type, param.name.range, name);
+            }
+            for (const RuntimeState &state : info.states)
+            {
+                const std::string base   = cpp_name(state.name);
+                std::string       local  = base;
+                int              &suffix = local_counts_[base];
+                while (local_names_.contains(local))
+                {
+                    local = base + "_" + std::to_string(++suffix);
+                }
+                local_names_.insert(local);
+                out.line("auto " + local + " = hgl_state.field<" + quote(state.name) + ">();");
+                frame.locals[state.id] = make_runtime(local + ".value().checked_as<" + value_type(state.type, state.range) + ">()",
+                                                      state.type, state.range, local);
+            }
+            if (include_output && info.inject_out)
+            {
+                const HType result = type_of(fn.signature.result, frame);
+                frame.injects.emplace("out", make_runtime("hgl_output.value().checked_as<" +
+                                                              value_type(result, module_.type(fn.signature.result).range) + ">()",
+                                                          result, fn.name.range, "hgl_output"));
+            }
+        }
+
+        void Emitter::emit_runtime_defaults(ast::DeclId decl, Writer &out)
+        {
+            const ast::FunctionDecl &fn = function(decl);
+            std::vector<std::string> defaults;
+            for (const ast::Parameter &param : fn.signature.parameters)
+            {
+                if (!param.is_const || param.default_value == ast::no_node)
+                {
+                    continue;
+                }
+                Frame scratch;
+                scratch.fn        = decl;
+                const Value value = eval_expr(param.default_value, scratch);
+                const HType type  = type_of(param.type, scratch);
+                defaults.push_back("hgraph::arg<" + quote(param.name.text) + ">(" +
+                                   as_const(value, type, value.range, "default of '" + std::string{param.name.text} + "'") + ")");
+            }
+            if (!defaults.empty())
+            {
+                out.line("static auto defaults() { return std::tuple{" + join(defaults, ", ") + "}; }");
+            }
+        }
+
+        void Emitter::emit_runtime_function(ast::DeclId decl, Writer &out)
+        {
+            const ast::FunctionDecl &fn   = function(decl);
+            const RuntimeInfo        info = runtime_info(decl);
+            Frame                    frame;
+            frame.fn      = decl;
+            frame.runtime = true;
+            out.line("// " + where(module_.decl(decl).range));
+            out.open("struct " + cpp_name(fn.name.text));
+            out.line("static constexpr auto name = " + quote(module_name_ + "." + std::string{fn.name.text}) + ";");
+            emit_runtime_defaults(decl, out);
+            if (!info.states.empty())
+            {
+                std::vector<std::string> fields;
+                for (const RuntimeState &state : info.states)
+                {
+                    fields.push_back("hgraph::Field<" + quote(state.name) + ", " + schema(state.type, state.range) + ">");
+                }
+                out.line("using recordable_state = hgraph::TSB<" + quote(module_name_ + "." + std::string{fn.name.text} + ".state") + ", " +
+                         join(fields, ", ") + ">;");
+            }
+
+            if (!info.states.empty() || !info.start_blocks.empty())
+            {
+                out.line("static void start(" + runtime_signature(decl, info, frame, true, false, false) + ")");
+                out.open("");
+                prepare_runtime_frame(decl, info, frame, out, false, false);
+                for (const RuntimeState &state : info.states)
+                {
+                    const Value &target = frame.locals.at(state.id);
+                    const Value  init   = eval_expr(state.init, frame);
+                    out.line("if (!" + target.selector + ".valid()) { " + target.selector + ".set(" +
+                             as_runtime(init, state.type, init.range, "initializer of '" + state.name + "'") + "); }");
+                }
+                for (const ast::StmtId id : info.start_blocks)
+                {
+                    emit_runtime_block(std::get<ast::LifecycleBlock>(module_.stmt(id).node).block, frame, out);
+                }
+                out.close();
+            }
+
+            out.line("static void eval(" + runtime_signature(decl, info, frame, true, true, true) + ")");
+            out.open("");
+            prepare_runtime_frame(decl, info, frame, out, true, true);
+            for (const ast::StmtId id : module_.block(fn.block_body).statements)
+            {
+                const ast::StmtNode &node = module_.stmt(id).node;
+                if (std::holds_alternative<ast::StateDecl>(node) || std::holds_alternative<ast::InjectDecl>(node) ||
+                    std::holds_alternative<ast::LifecycleBlock>(node))
+                {
+                    continue;
+                }
+                emit_runtime_stmt(id, frame, out);
+            }
+            out.close();
+
+            if (!info.stop_blocks.empty())
+            {
+                out.line("static void stop(" + runtime_signature(decl, info, frame, true, false, false) + ")");
+                out.open("");
+                prepare_runtime_frame(decl, info, frame, out, false, false);
+                emit_runtime_block(std::get<ast::LifecycleBlock>(module_.stmt(info.stop_blocks.front()).node).block, frame, out);
+                out.close();
+            }
+            out.close(";");
+            out.line();
         }
 
         std::string Emitter::signature(ast::DeclId decl, Frame &frame, bool with_names)
@@ -1420,6 +2139,16 @@ namespace hgl::codegen
         void Emitter::emit_function(ast::DeclId decl, Writer &out, Form form)
         {
             check_supported(decl);
+            if (resolved_.kind(decl) == semantics::FunctionKind::Runtime)
+            {
+                if (form != Form::InlineStruct)
+                {
+                    backend(module_.decl(decl).range, "a generated runtime node must be "
+                                                      "emitted as a complete static struct");
+                }
+                emit_runtime_function(decl, out);
+                return;
+            }
             const ast::FunctionDecl &fn = function(decl);
             Frame                    frame;
             frame.fn = decl;
@@ -1706,7 +2435,13 @@ namespace hgl::codegen
                 body.dedent();
             }
             body.indent();
-            for (const ast::DeclId id : exports) { emit_function(id, body, Form::OutOfLine); }
+            for (const ast::DeclId id : exports)
+            {
+                if (resolved_.kind(id) == semantics::FunctionKind::Composition)
+                {
+                    emit_function(id, body, Form::OutOfLine);
+                }
+            }
 
             // Registration: exported functions and operator implementations
             // become registry candidates under module-qualified names, and
@@ -1717,7 +2452,10 @@ namespace hgl::codegen
             for (const ast::DeclId id : exports)
             {
                 const std::string name = cpp_name(function(id).name.text);
-                body.line("hgraph::register_graph_overload<ops::" + name + ", " + name + ">();");
+                const std::string registration = resolved_.kind(id) == semantics::FunctionKind::Runtime
+                                                     ? "hgraph::register_overload"
+                                                     : "hgraph::register_graph_overload";
+                body.line(registration + "<ops::" + name + ", " + name + ">();");
             }
             for (const ast::DeclId id : impls)
             {
@@ -1731,8 +2469,14 @@ namespace hgl::codegen
                         break;
                     }
                 }
-                if (!bound) { unsupported(module_.decl(id).range, "an impl fn of an imported operator"); }
-                body.line("hgraph::register_graph_overload<ops::" + cpp_name(fn.name.text) + ", " + cpp_name(fn.name.text) + ">();");
+                if (!bound)
+                {
+                    unsupported(module_.decl(id).range, "an impl fn of an imported operator");
+                }
+                const std::string registration = resolved_.kind(id) == semantics::FunctionKind::Runtime
+                                                     ? "hgraph::register_overload"
+                                                     : "hgraph::register_graph_overload";
+                body.line(registration + "<ops::" + cpp_name(fn.name.text) + ", " + cpp_name(fn.name.text) + ">();");
             }
             body.close(");");
             body.line("hgraph::OperatorRegistry::instance().run_installers();");
@@ -1786,7 +2530,8 @@ namespace hgl::codegen
             header.line();
             for (const ast::DeclId id : exports)
             {
-                emit_function(id, header, Form::Declaration);
+                emit_function(id, header,
+                              resolved_.kind(id) == semantics::FunctionKind::Runtime ? Form::InlineStruct : Form::Declaration);
                 result.exports.push_back(std::string{function(id).name.text});
             }
             header.line("/// Register the module's operators and implementations with the hgraph");

--- a/language/src/codegen/cpp_emitter.h
+++ b/language/src/codegen/cpp_emitter.h
@@ -13,8 +13,9 @@
 /// The C++ backend, first pass (developer guide, "C++ backend, first pass"):
 /// one header/source pair of public hgraph authoring code per module. It is
 /// hgraph-free like the resolver — it prints names and types — so what it
-/// emits is checked by the native compiler that builds the package, and by
-/// the parity tests that run the generated graphs beside `hgl test`.
+/// emits is checked by the native compiler that builds the package. Tests run
+/// generated graphs beside `hgl test` and exercise generated runtime nodes
+/// directly through hgraph's public harness.
 namespace hgl::codegen
 {
     namespace ast = syntax::ast;

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -84,14 +84,14 @@ hgl_apply_warnings(hgl_codegen_tests)
 
 add_test(NAME hgraph_language_codegen COMMAND hgl_codegen_tests)
 
-# ... and what that C++ does once built: the parity fixture emitted and compiled
-# through the same `hgl_add_module()` a package uses, under the repository's
-# warnings, then evaluated with hgraph's harness beside `hgl test` on the same
-# module (developer guide, "Backend parity").
-hgl_add_module(hgl_codegen_fixture STATIC HGL codegen/parity.hgl)
+# ... and what that C++ does once built: the parity and scalar runtime fixtures
+# emitted and compiled through the same `hgl_add_module()` a package uses,
+# under the repository's warnings. hgraph's harness evaluates graph parity
+# beside `hgl test` and the native-only runtime-node behavior.
+hgl_add_module(hgl_codegen_fixture STATIC HGL codegen/parity.hgl codegen/runtime.hgl)
 hgl_apply_warnings(hgl_codegen_fixture)
 
-add_executable(hgl_generated_tests codegen/generated_tests.cpp)
+add_executable(hgl_generated_tests codegen/generated_tests.cpp codegen/generated_runtime_tests.cpp)
 target_compile_features(hgl_generated_tests PRIVATE cxx_std_23)
 target_link_libraries(hgl_generated_tests PRIVATE hgl_codegen_fixture hgl::wiring Catch2::Catch2WithMain)
 hgl_link_runtime_executable(hgl_generated_tests)
@@ -107,8 +107,7 @@ set_tests_properties(hgraph_language_test_parity PROPERTIES
     PASS_REGULAR_EXPRESSION "6 tests, 0 failed"
 )
 
-# The command itself: a composition-only example emits; a runtime function
-# fails closed with a diagnostic that names it.
+# The command itself: composition and the first scalar runtime-node slice emit.
 add_test(
     NAME hgraph_language_emit_midpoint
     COMMAND $<TARGET_FILE:hgl> emit-cpp ${CMAKE_CURRENT_SOURCE_DIR}/../examples/midpoint.hgl --print
@@ -117,11 +116,11 @@ set_tests_properties(hgraph_language_emit_midpoint PROPERTIES
     PASS_REGULAR_EXPRESSION "namespace examples::prices"
 )
 add_test(
-    NAME hgraph_language_emit_rejects_runtime
-    COMMAND $<TARGET_FILE:hgl> emit-cpp ${CMAKE_CURRENT_SOURCE_DIR}/../examples/stateful-node.hgl --print
+    NAME hgraph_language_emit_runtime
+    COMMAND $<TARGET_FILE:hgl> emit-cpp ${CMAKE_CURRENT_SOURCE_DIR}/codegen/runtime.hgl --print
 )
-set_tests_properties(hgraph_language_emit_rejects_runtime PROPERTIES
-    PASS_REGULAR_EXPRESSION "is a runtime function"
+set_tests_properties(hgraph_language_emit_runtime PROPERTIES
+    PASS_REGULAR_EXPRESSION "struct combined_total"
 )
 
 # The REPL over a pipe: the plain-line path of the line reader.

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -325,6 +325,63 @@ export fn total(a: f64, b: f64) -> f64 {
     CHECK_FALSE(contains(emitted->source, "register_graph_overload<ops::total"));
 }
 
+TEST_CASE("emit-cpp requires validity to dominate runtime payload reads", "[codegen][runtime]")
+{
+    SECTION("a when and nested if establish validity for their bodies")
+    {
+        Unit unit{R"(
+module t
+export fn sampled(trigger: f64, sample: f64) -> f64 {
+    when modified(trigger) && valid(trigger) {
+        if valid(sample) && sample > 0.0 {
+            return trigger + sample
+        }
+    }
+}
+)"};
+        REQUIRE(unit.emit());
+    }
+    SECTION("an unchecked temporal payload read fails closed")
+    {
+        Unit unit{R"(
+module t
+export fn sampled(trigger: f64, sample: f64) -> f64 {
+    when modified(trigger) {
+        return sample
+    }
+}
+)"};
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Type, "temporal input 'sample' may be invalid here; guard the read with valid(sample)"));
+    }
+    SECTION("validity must precede a payload read in a short-circuit condition")
+    {
+        Unit unit{R"(
+module t
+export fn positive(value: f64) -> f64 {
+    when modified(value) && value > 0.0 && valid(value) {
+        return value
+    }
+}
+)"};
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Type, "temporal input 'value' may be invalid here; guard the read with valid(value)"));
+    }
+    SECTION("when blocks are function-level handlers")
+    {
+        Unit unit{R"(
+module t
+export fn sampled(value: f64) -> f64 {
+    if valid(value) {
+        when modified(value) { return value }
+    }
+}
+)"};
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Backend, "a 'when' block must be at function top level"));
+    }
+}
+
 TEST_CASE("emit-cpp fails closed on what the first pass does not lower", "[codegen]")
 {
     SECTION("a runtime call")
@@ -333,7 +390,7 @@ TEST_CASE("emit-cpp fails closed on what the first pass does not lower", "[codeg
 module t
 fn twice(x: f64) -> f64 => x * 2.0
 export fn sampled(x: f64) -> f64 {
-    when modified(x) { return twice(x) }
+    when modified(x) && valid(x) { return twice(x) }
 }
 )"};
         CHECK_FALSE(unit.emit());
@@ -370,7 +427,7 @@ module t
 export fn seeded(x: f64) -> f64 {
     state seed: f64 = 0.0
     start { seed = x }
-    when modified(x) { return x }
+    when modified(x) && valid(x) { return x }
 }
 )"};
         CHECK_FALSE(unit.emit());

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -296,23 +296,85 @@ fn plus_one(y: f64) -> f64 => y + 1.0
     CHECK(emitted->source.find("struct plus_one") < emitted->source.find("fixed::compose"));
 }
 
+TEST_CASE("emit-cpp lowers scalar runtime functions to static nodes", "[codegen][runtime]")
+{
+    Unit unit{R"(
+module t
+export fn total(a: f64, b: f64) -> f64 {
+    state sum: f64 = 0.0
+    inject out
+    when modified(a, b) && valid(a) {
+        if valid(b) {
+            sum += a + b
+            out = sum
+        }
+    }
+}
+)"};
+    const auto emitted = unit.emit();
+    REQUIRE(emitted);
+
+    CHECK(contains(emitted->header, "using recordable_state = hgraph::TSB<\"t.total.state\", "
+                                    "hgraph::Field<\"sum\", hgraph::TS<hgraph::Float>>>;"));
+    CHECK(contains(emitted->header, "hgraph::InputValidity::Unchecked"));
+    CHECK(contains(emitted->header, "if (((a.modified() || b.modified()) && (a.valid())))"));
+    CHECK(contains(emitted->header, "if (!sum.valid())"));
+    CHECK(contains(emitted->header, "sum.set((sum.value().checked_as<hgraph::Float>() + (a.value() + b.value())));"));
+    CHECK(contains(emitted->header, "hgl_output.set(sum.value().checked_as<hgraph::Float>());"));
+    CHECK(contains(emitted->source, "hgraph::register_overload<ops::total, total>();"));
+    CHECK_FALSE(contains(emitted->source, "register_graph_overload<ops::total"));
+}
+
 TEST_CASE("emit-cpp fails closed on what the first pass does not lower", "[codegen]")
 {
-    SECTION("a runtime function")
+    SECTION("a runtime call")
     {
         Unit unit{R"(
 module t
-fn total(a: f64) -> f64 {
-    state sum: f64 = 0.0
-    when modified(a) {
-        sum += a
-        return sum
-    }
+fn twice(x: f64) -> f64 => x * 2.0
+export fn sampled(x: f64) -> f64 {
+    when modified(x) { return twice(x) }
 }
-export fn twice(x: f64) -> f64 => x * 2.0
 )"};
         CHECK_FALSE(unit.emit());
-        CHECK(unit.has(Category::Backend, "'total' is a runtime function"));
+        CHECK(unit.has(Category::Backend, "calls in a runtime function are not supported by emit-cpp yet"));
+    }
+    SECTION("an unsupported runtime injectable")
+    {
+        Unit unit{R"(
+module t
+export fn logged(x: f64) -> f64 {
+    inject logger
+    when modified(x) { return x }
+}
+)"};
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Backend, "injectable 'logger' is not supported by emit-cpp yet"));
+    }
+    SECTION("runtime state without an explicit type")
+    {
+        Unit unit{R"(
+module t
+export fn total(x: f64) -> f64 {
+    state sum = 0.0
+    when modified(x) { return x }
+}
+)"};
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Backend, "runtime state declaration needs an explicit scalar type"));
+    }
+    SECTION("a temporal input in a lifecycle block")
+    {
+        Unit unit{R"(
+module t
+export fn seeded(x: f64) -> f64 {
+    state seed: f64 = 0.0
+    start { seed = x }
+    when modified(x) { return x }
+}
+)"};
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Phase, "temporal parameters are not available in runtime lifecycle blocks"));
     }
     SECTION("a struct declaration")
     {

--- a/language/tests/codegen/generated_runtime_tests.cpp
+++ b/language/tests/codegen/generated_runtime_tests.cpp
@@ -1,0 +1,95 @@
+#include <runtime.h>
+
+#include "wiring/backend.h"
+
+#include <hgraph/lib/testing/check_output.h>
+#include <hgraph/lib/testing/eval_node.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace hgraph;
+using namespace hgraph::testing;
+namespace runtime = hgl::codegen::runtime;
+
+namespace
+{
+    void session()
+    {
+        hgl::wiring::ensure_session();
+        runtime::register_operators();
+    }
+}  // namespace
+
+TEST_CASE("generated runtime impl functions register as node overloads", "[codegen][runtime]")
+{
+    session();
+    CHECK_OUTPUT(eval_node<runtime::ops::absolute>(values<Float>(-2.0, 3.0)),
+                 values<Float>(2.0, 3.0));
+}
+
+TEST_CASE("generated runtime predicates use modified-or and valid-and semantics", "[codegen][runtime]")
+{
+    session();
+    CHECK_OUTPUT(eval_node<runtime::ops::add_when_ready>(values<Float>(1.0, none, 3.0),
+                                                        values<Float>(none, 10.0, 20.0)),
+                 values<Float>(none, 11.0, 23.0));
+}
+
+TEST_CASE("generated activation analysis leaves sampled inputs passive", "[codegen][runtime]")
+{
+    session();
+    CHECK_OUTPUT(eval_node<runtime::ops::sample_on_trigger>(values<Float>(1.0, none, 2.0),
+                                                           values<Float>(10.0, 20.0, none)),
+                 values<Float>(10.0, none, 20.0));
+}
+
+TEST_CASE("generated runtime metadata reads the input selector", "[codegen][runtime]")
+{
+    session();
+    CHECK_OUTPUT(eval_node<runtime::ops::updated_at>(values<Float>(1.0, none, 2.0)),
+                 values<DateTime>(MIN_ST, none, MIN_ST + 2 * MIN_TD));
+}
+
+TEST_CASE("generated runtime handlers share recordable state and run in source order", "[codegen][runtime]")
+{
+    session();
+    CHECK_OUTPUT(eval_node<runtime::ops::combined_total>(values<Float>(10.0, none, 2.0),
+                                                        values<Float>(3.0, 1.0, none)),
+                 values<Float>(7.0, 6.0, 8.0));
+}
+
+TEST_CASE("a generated composition can wire a generated runtime node", "[codegen][runtime]")
+{
+    session();
+    CHECK_OUTPUT(eval_node<runtime::ops::combined_total_graph>(values<Float>(10.0, none, 2.0),
+                                                              values<Float>(3.0, 1.0, none)),
+                 values<Float>(7.0, 6.0, 8.0));
+}
+
+TEST_CASE("generated inject out exposes the previous value and writes non-terminally", "[codegen][runtime]")
+{
+    session();
+    CHECK_OUTPUT(eval_node<runtime::ops::running_total>(values<Float>(1.0, 2.0, 3.0)),
+                 values<Float>(1.0, 3.0, 6.0));
+}
+
+TEST_CASE("generated runtime lifecycle hooks run around evaluation", "[codegen][runtime]")
+{
+    session();
+    CHECK_OUTPUT(eval_node<runtime::ops::lifecycle_value>(values<Float>(4.0, 5.0)),
+                 values<Float>(4.0, 5.0));
+}
+
+TEST_CASE("generated state initializers can use const parameters", "[codegen][runtime]")
+{
+    session();
+    CHECK_OUTPUT(eval_node<runtime::ops::configured_total>(values<Float>(1.0, 2.0), arg<"initial">(Float{5.0})),
+                 values<Float>(6.0, 8.0));
+}
+
+TEST_CASE("generated runtime functions without when use ordinary input policy", "[codegen][runtime]")
+{
+    session();
+    CHECK_OUTPUT(eval_node<runtime::ops::unconditional_total>(values<Float>(1.0, 2.0, 3.0)),
+                 values<Float>(1.0, 3.0, 6.0));
+}

--- a/language/tests/codegen/runtime.hgl
+++ b/language/tests/codegen/runtime.hgl
@@ -1,0 +1,97 @@
+// The first runtime-node backend fixture. Unlike parity.hgl this cannot yet
+// run through the direct-wiring `hgl test` path: it is emitted, compiled, and
+// evaluated through hgraph's public C++ authoring surface.
+
+module hgl.codegen.runtime
+
+operator absolute(value: f64) -> f64
+
+impl fn absolute(value: f64) -> f64 {
+    when modified(value) && valid(value) {
+        if value < 0.0 {
+            return -value
+        }
+        return value
+    }
+}
+
+export fn add_when_ready(a: f64, b: f64) -> f64 {
+    when modified(a, b) && valid(a, b) {
+        return a + b
+    }
+}
+
+export fn sample_on_trigger(trigger: f64, sample: f64) -> f64 {
+    when modified(trigger) && valid(trigger, sample) {
+        return sample
+    }
+}
+
+export fn updated_at(value: f64) -> datetime {
+    when modified(value) {
+        return last_modified(value)
+    }
+}
+
+export fn combined_total(a: f64, b: f64) -> f64 {
+    state total: f64 = 0.0
+    inject out
+
+    when modified(a) && valid(a) {
+        total += a
+        out = total
+    }
+
+    when modified(b) && valid(b) {
+        total -= b
+        out = total
+    }
+}
+
+export fn combined_total_graph(a: f64, b: f64) -> f64 =>
+    combined_total(a, b)
+
+export fn running_total(value: f64) -> f64 {
+    inject out
+
+    when modified(value) && valid(value) {
+        if valid(out) {
+            out += value
+        } else {
+            out = value
+        }
+    }
+}
+
+export fn lifecycle_value(value: f64) -> f64 {
+    state ready: bool = false
+
+    start {
+        ready = true
+    }
+
+    when modified(value) && valid(value) {
+        if ready {
+            return value
+        }
+    }
+
+    stop {
+        ready = false
+    }
+}
+
+export fn configured_total(value: f64, const initial: f64 = 10.0) -> f64 {
+    state total: f64 = initial
+
+    when modified(value) && valid(value) {
+        total += value
+        return total
+    }
+}
+
+export fn unconditional_total(value: f64) -> f64 {
+    state total: f64 = 0.0
+    total += value
+    return total
+}


### PR DESCRIPTION
## Summary

- lower the first scalar HGL runtime-function subset to public hgraph static nodes, including selector-derived activation, passive sampled inputs, ordered handlers, scalar recordable state, output access, and lifecycle hooks over state and const configuration
- register runtime exports and local `impl fn` candidates as node overloads while keeping composition functions as graph overloads
- compile and execute a generated runtime fixture covering predicates, metadata, state/order, prior output, lifecycle, const initialization, no-`when` policy, operator dispatch, and composition-to-node wiring
- update the language user/developer guides, architecture, roadmap, and changelog to distinguish implemented AOT behavior from staged work

## Validation

- macOS Release all-target build with `HGRAPH_BUILD_LANGUAGE=ON`
- macOS CTest: 1,700/1,700 passed
- macOS stable-ABI wheel installed into fresh Python 3.14 environment: 2,287 passed, 10 skipped
- installed SDK consumer: installed `hgl` generated, compiled, linked, and registered a scalar runtime module
- private Linux GCC 14 Release all-target build with `HGRAPH_BUILD_LANGUAGE=ON`
- private Linux CTest: 1,700/1,700 passed
- private Linux stable-ABI wheel installed into fresh Python 3.14 environment: 2,287 passed, 10 skipped

## Deferred prototype scope

- scripted compile/load support for runtime functions in `hgl test`, `hgl run`, and the REPL
- collection, struct, generic, and callable lowering inside runtime functions
- injectables other than `out`, plus runtime sources and sinks
- lifecycle access to temporal inputs or output
