### PR TITLE
Run HGL runtime modules from scripted commands

### DIFF
--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -129,11 +129,15 @@ hgl_apply_warnings(hgl_codegen)
 add_library(hgl_driver STATIC
     src/driver/driver.cpp
     src/driver/line_reader.cpp
+    src/driver/native_module.cpp
 )
 add_library(hgl::driver ALIAS hgl_driver)
 target_compile_features(hgl_driver PUBLIC cxx_std_23)
 target_include_directories(hgl_driver PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_link_libraries(hgl_driver PUBLIC hgl::wiring hgl::codegen hgraph::core)
+if(UNIX)
+    target_link_libraries(hgl_driver PRIVATE ${CMAKE_DL_LIBS})
+endif()
 if(HGL_ENABLE_LINE_EDITING)
     target_link_libraries(hgl_driver PRIVATE hgl_isocline)
     target_compile_definitions(hgl_driver PRIVATE HGL_HAVE_ISOCLINE=1)
@@ -146,6 +150,21 @@ target_compile_definitions(hgl PRIVATE
     HGRAPH_LANGUAGE_VERSION="${PROJECT_VERSION}"
 )
 target_link_libraries(hgl PRIVATE hgl::driver hgraph::core)
+# Scripted modules are loadable images which resolve the hgraph symbols from
+# this process. Export those symbols so every module shares this process's
+# operator registry rather than linking a second static runtime.
+set_target_properties(hgl PROPERTIES ENABLE_EXPORTS ON)
+
+# Capture the compiler context needed by the scripted module builder. The
+# executable-prefix include path is added at runtime for an installed SDK;
+# these evaluated paths also support the in-tree compiler and external/system
+# dependencies selected by this build.
+set(_hgl_native_config_dir "${CMAKE_CURRENT_BINARY_DIR}/generated/$<CONFIG>")
+file(GENERATE
+    OUTPUT "${_hgl_native_config_dir}/hgl_native_compile_config.h"
+    CONTENT "#pragma once\n\n#include <string_view>\n\nnamespace hgl::driver::native_config\n{\n    inline constexpr std::string_view compiler = R\"hgl(${CMAKE_CXX_COMPILER})hgl\";\n    inline constexpr std::string_view compiler_launcher = R\"hgl(${CMAKE_CXX_COMPILER_LAUNCHER})hgl\";\n    inline constexpr std::string_view definitions = R\"hgl($<JOIN:$<TARGET_PROPERTY:hgl,COMPILE_DEFINITIONS>,;>)hgl\";\n    inline constexpr std::string_view include_directories = R\"hgl($<JOIN:$<TARGET_PROPERTY:hgl,INCLUDE_DIRECTORIES>,;>)hgl\";\n    inline constexpr std::string_view compile_options = R\"hgl($<JOIN:$<TARGET_PROPERTY:hgl,COMPILE_OPTIONS>,;>)hgl\";\n    inline constexpr std::string_view link_options = R\"hgl($<JOIN:$<TARGET_PROPERTY:hgl,LINK_OPTIONS>,;>)hgl\";\n}\n"
+    TARGET hgl)
+target_include_directories(hgl_driver PRIVATE "${_hgl_native_config_dir}")
 # `hgl` is a build-time tool for installed consumers. Preserve runtime search
 # paths contributed by external shared dependencies when CMake installs the
 # executable; otherwise HglLanguage.cmake can find the compiler but a

--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -160,9 +160,12 @@ set_target_properties(hgl PROPERTIES ENABLE_EXPORTS ON)
 # these evaluated paths also support the in-tree compiler and external/system
 # dependencies selected by this build.
 set(_hgl_native_config_dir "${CMAKE_CURRENT_BINARY_DIR}/generated/$<CONFIG>")
+file(RELATIVE_PATH _hgl_install_include_from_bindir
+    "${CMAKE_INSTALL_FULL_BINDIR}/"
+    "${CMAKE_INSTALL_FULL_INCLUDEDIR}/")
 file(GENERATE
     OUTPUT "${_hgl_native_config_dir}/hgl_native_compile_config.h"
-    CONTENT "#pragma once\n\n#include <string_view>\n\nnamespace hgl::driver::native_config\n{\n    inline constexpr std::string_view compiler = R\"hgl(${CMAKE_CXX_COMPILER})hgl\";\n    inline constexpr std::string_view compiler_launcher = R\"hgl(${CMAKE_CXX_COMPILER_LAUNCHER})hgl\";\n    inline constexpr std::string_view definitions = R\"hgl($<JOIN:$<TARGET_PROPERTY:hgl,COMPILE_DEFINITIONS>,;>)hgl\";\n    inline constexpr std::string_view include_directories = R\"hgl($<JOIN:$<TARGET_PROPERTY:hgl,INCLUDE_DIRECTORIES>,;>)hgl\";\n    inline constexpr std::string_view compile_options = R\"hgl($<JOIN:$<TARGET_PROPERTY:hgl,COMPILE_OPTIONS>,;>)hgl\";\n    inline constexpr std::string_view link_options = R\"hgl($<JOIN:$<TARGET_PROPERTY:hgl,LINK_OPTIONS>,;>)hgl\";\n}\n"
+    CONTENT "#pragma once\n\n#include <string_view>\n\nnamespace hgl::driver::native_config\n{\n    inline constexpr std::string_view compiler = R\"hgl(${CMAKE_CXX_COMPILER})hgl\";\n    inline constexpr std::string_view install_include_from_bindir = R\"hgl(${_hgl_install_include_from_bindir})hgl\";\n    inline constexpr std::string_view definitions = R\"hgl($<JOIN:$<TARGET_PROPERTY:hgl,COMPILE_DEFINITIONS>,;>)hgl\";\n    inline constexpr std::string_view include_directories = R\"hgl($<JOIN:$<TARGET_PROPERTY:hgl,INCLUDE_DIRECTORIES>,;>)hgl\";\n    inline constexpr std::string_view compile_options = R\"hgl($<JOIN:$<TARGET_PROPERTY:hgl,COMPILE_OPTIONS>,;>)hgl\";\n    inline constexpr std::string_view link_options = R\"hgl($<JOIN:$<TARGET_PROPERTY:hgl,LINK_OPTIONS>,;>)hgl\";\n}\n"
     TARGET hgl)
 target_include_directories(hgl_driver PRIVATE "${_hgl_native_config_dir}")
 # `hgl` is a build-time tool for installed consumers. Preserve runtime search

--- a/language/README.md
+++ b/language/README.md
@@ -7,19 +7,22 @@ hgraph, not for implementing transports, threads, callbacks, or arbitrary
 native extensions.
 
 Two backends share one frontend: the direct-wiring backend wires composition
-programs onto the hgraph runtime in process (`hgl test`, `hgl run`, `hgl repl`),
-and the C++ backend (`hgl emit-cpp`) writes composition functions and the first
-scalar runtime-node slice as public hgraph C++ authoring code that a package
-builds with the `hgl_add_module()` CMake function. The shared subset builds the
-same graph; the parity tests hold the two paths to it.
+programs onto the hgraph runtime in process, and the C++ backend writes
+composition functions and the first scalar runtime-node slice as public hgraph
+C++. `hgl test` and `hgl run` compile and load that generated C++ when a file
+contains runtime functions or source-defined implementations; `hgl emit-cpp`
+and `hgl_add_module()` expose the same route to package builds. The shared
+subset builds the same graph; the parity tests hold the two paths to it.
 
 The project is an intentionally changeable prototype in its first executable
 slice. `hgl check` lexes, parses, and resolves a module and reports diagnostics
 (`--dump-tokens` and `--dump-ast` show the frontend's view). That frontend now
 models nominal and generic structs, abstract-only inheritance, defaults and
 optional fields, `requires` constraints, and sparse `delta<S>` construction.
-`hgl test`, `hgl run`, and `hgl repl` wire composition-only programs straight
-onto the hgraph runtime through the direct-wiring backend, including scalar
+`hgl test` and `hgl run` additionally execute the generated scalar
+runtime-node subset through a transient native image on Unix. `hgl repl` wires
+composition-only sessions straight onto the hgraph runtime through the
+direct-wiring backend. Both paths include scalar
 struct construction, type-generic Bundle specializations, `atomic<S>` values,
 and field-wise temporal struct composition. On a terminal the REPL has line
 editing, history (`~/.hgl_history`) and tab completion. `hgl emit-cpp` writes a
@@ -34,11 +37,11 @@ optionally, a Python extension module with generated wrappers. Every file under
 `examples/` is a CTest check case, `midpoint.hgl` runs its test, and the codegen
 fixtures compile and execute generated graph and runtime-node modules.
 
-Constructor inference, typed `const` arguments in native generic Bundle
+Native artifact caching and safe runtime-module replacement in the REPL,
+constructor inference, typed `const` arguments in native generic Bundle
 identity, multiple-parent field order, explicit optional-field clearing,
-runtime functions in the direct/scripted backend, runtime collection and
-callable lowering, structs and generics in generated C++, timed harness
-sequences, and TOML run configuration remain staged work
+runtime collection and callable lowering, structs and generics in generated
+C++, timed harness sequences, and TOML run configuration remain staged work
 ([roadmap](docs/design/roadmap.md)).
 
 ## Build

--- a/language/docs/README.md
+++ b/language/docs/README.md
@@ -10,9 +10,10 @@ The documentation is split by audience:
   the delivery roadmap.
 
 The language is still a design preview. Examples describe the target first
-vertical slice; the current `hgl` checks them (`hgl check`), runs the
-composition-only ones through `hgl test`, `hgl run`, and `hgl repl`, and
-emits the documented scalar runtime-node subset through `hgl emit-cpp`.
+vertical slice; the current `hgl` checks them (`hgl check`), runs composition
+functions directly, compiles and loads the documented scalar runtime-node
+subset for file-based `hgl test` and `hgl run`, and emits the same C++ through
+`hgl emit-cpp`. The REPL remains composition-only.
 First-pass limits are listed in the user guide. Provisional syntax is called
 out so examples do not imply an implemented compatibility promise.
 

--- a/language/docs/design/architecture.md
+++ b/language/docs/design/architecture.md
@@ -208,12 +208,11 @@ The non-goal "reimplementing hgraph behavior in an interpreter" therefore
 stands: the backend interprets wiring-time code only, and it interprets it
 by calling hgraph.
 
-Runtime functions are node bodies. They have no wiring-time form and need the
-C++ backend. The first scalar subset is emitted as native static nodes. A
-program whose evaluated closure contains a runtime function still fails in the
-direct-wiring backend with a diagnostic that names the function and says it
-needs the native backend; it does not degrade to a slower path. Scripted
-commands will compile and load the emitted artifact in the next slice.
+Runtime functions are node bodies. They have no interpreted tick-time form and
+need the C++ backend. The first scalar subset is emitted as native static nodes.
+For file-based `test` and `run` on Unix, the driver compiles and loads that
+emitted artifact before direct wiring reaches the function's module-qualified
+operator identity. The backend still never evaluates the body itself.
 
 The commands map onto the backends as follows:
 
@@ -224,9 +223,9 @@ The commands map onto the backends as follows:
   header/source pair; building, linking and packaging that output is the
   consumer's CMake build, through the `hgl_add_module()` function the language
   installs (there is no `hgl build`: a second build tool would duplicate what
-  CMake and the hgraph SDK already provide). `hgl run` for a program that
-  contains a runtime function will use the same emitted C++ once the scripted
-  compile/load driver lands.
+  CMake and the hgraph SDK already provide). File-based `hgl test` and
+  `hgl run` use the same emitted C++ for the supported runtime subset through
+  a transient Unix image; persistent caching and the REPL route remain staged.
 - Both backends must build the same graph for every program both accept. The
   parity suite evaluates the test corpus through each backend and compares
   the recorded ticks; a divergence is a compiler defect, and the C++ backend
@@ -234,16 +233,18 @@ The commands map onto the backends as follows:
   runs its tests, and the same module, emitted and compiled through
   `hgl_add_module()`, is driven through hgraph's `eval_node` to the same
   ticks. `tests/codegen/runtime.hgl` separately exercises supported runtime
-  functions through the generated and compiled path.
+  functions through both the generated package and scripted compiled paths.
 
 ## Scripted and compiled execution
 
 `hgl run` on a composition-only program wires and evaluates it in process.
-`hgl run` on a program with runtime functions compiles the source package into
-a content-addressed cache and executes it in a child process. `hgl repl`
-accumulates source declarations and evaluates the current session through the
-same two paths. The initial REPL may rebuild the complete session; correctness
-and diagnostic quality precede incremental compilation.
+The current Unix prototype also compiles a unit with runtime functions to a
+transient image and loads it into that command process; the image shares the
+process registry and remains resident until command exit. The production route
+will add a content-addressed cache and portable child-process orchestration.
+`hgl repl` currently remains composition-only; its compiled path must rebuild
+the complete session transactionally. Correctness and diagnostic quality
+precede incremental compilation.
 
 Every mode derives the same candidate universe from the target and lock file.
 When the REPL replaces a module, it removes the old registration handle before

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -18,17 +18,19 @@ and lifecycle hooks over state and `const` configuration.
 The implementation fails closed where the public or language contract is not
 settled: multiple-parent field order, constructor inference, typed `const`
 generic Bundle metadata, explicit optional-field clearing, temporal deltas,
-callable generic substitution, source-defined operator candidates in the
-direct-wiring backend, scripted runtime compilation/loading, and runtime
-collection or generic lowering. Slice numbering below still describes the
-intended end-to-end acceptance rather than a claim that all earlier
-deliverables are complete.
+callable generic substitution, cached and replaceable runtime images, portable
+scripted loading, and runtime collection or generic lowering. Slice numbering
+below still describes the intended end-to-end acceptance rather than a claim
+that all earlier deliverables are complete.
 
 The C++ backend exists as a first pass: `hgl emit-cpp` lowers the same
 composition subset the direct-wiring backend accepts, the first scalar runtime
 node subset, and non-generic source `operator` / `impl fn` declarations to a
 header/source pair, and `hgl_add_module()` builds it into a package with an
 optional Python module.
+On Unix, file-based `hgl test` and `hgl run` also compile a unit containing
+runtime functions or implementations to a transient image and load its
+candidates into the command process before wiring.
 Structs, generics, duration rolling windows (no compile-time hgraph marker
 yet), compound constant literals, `if` as a value, and runtime constructs
 outside the scalar subset fail closed with a diagnostic that names the
@@ -114,8 +116,8 @@ Acceptance:
 - malformed input recovers sufficiently to report multiple useful errors;
 - `eval` over a standard operator records the same ticks as the C++
   `eval_node` harness for the same call, dense and timed;
-- a program containing a runtime function is rejected by the direct-wiring
-  backend with a diagnostic that names the function;
+- a runtime function without a loaded candidate is rejected by the
+  direct-wiring backend with a diagnostic that names its operator identity;
 - `hgl run` of a composition-only entry produces the same ticks in
   simulation as the equivalent hgraph `run_graph` call.
 
@@ -187,10 +189,17 @@ Acceptance:
 
 ## Slice 3: scripted workflow
 
+Status: the first uncached Unix file-command layer is implemented. `hgl test`
+and `hgl run` emit a unit containing runtime functions or implementations,
+compile a transient native image, load it into the command process's registry,
+and run through the ordinary wiring backend. Compile failures retain and report
+their artifacts. Persistent caching, Windows support, child orchestration, and
+replaceable REPL images remain.
+
 Deliverables:
 
 - content-addressed native build cache;
-- `hgl run` and `hgl test` in an isolated child process for programs with
+- portable `hgl run` and `hgl test` child orchestration for programs with
   runtime functions;
 - REPL sessions that accumulate declarations and rebuild through either
   backend as the session's classification requires;

--- a/language/docs/developer-guide/README.md
+++ b/language/docs/developer-guide/README.md
@@ -11,15 +11,16 @@ for hgraph, not a second runtime.
 > structured `delta` forms. `src/semantics/` binds constraint names, resolves
 > struct families and effective fields, validates hierarchy and construction,
 > rejects decidably false closed requirements, and classifies functions.
-> `src/wiring/` executes the composition-only subset for `test`, `run`, and the
+> `src/wiring/` executes the composition subset for `test`, `run`, and the
 > REPL, including scalar and atomic struct values, type-only generic
 > specializations, and field-wise temporal struct composition. `src/codegen/`
 > emits that composition subset and the first scalar runtime-node subset as
 > public hgraph C++, including activation, aggregate recordable state, output,
-> and lifecycle hooks over state and `const` configuration. Typed HIR,
+> and lifecycle hooks over state and `const` configuration. The driver compiles
+> and loads that subset for file-based `test` and `run` on Unix. Typed HIR,
 > constructor inference, `const` generic metadata, multiple-parent
 > linearization, explicit optional-field
-> clearing, scripted runtime compilation/loading, and broader runtime and
+> clearing, cached/replaceable REPL runtime images, and broader runtime and
 > generated-C++ type support remain to be implemented.
 
 ## Guide map

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -1160,8 +1160,11 @@ wires tests or the entry through the same backend and hgraph registry. There
 is no `hgl build`: a package builds emitted C++ with `hgl_add_module()`.
 
 The scripted compiler configuration is generated from the `hgl` CMake target:
-compiler launcher, compiler, preprocessor definitions, and evaluated include
-paths. An installed executable also probes its prefix's `include` directory.
+compiler, preprocessor definitions, and evaluated include paths. It does not
+retain the build machine's compiler launcher. An installed executable also
+resolves the SDK include directory relative to its configured
+`CMAKE_INSTALL_BINDIR`/`CMAKE_INSTALL_INCLUDEDIR` layout rather than assuming
+the default `bin` and `include` names.
 `HGL_CXX` overrides the compiler for diagnostics/testing and
 `HGL_ARTIFACT_DIR` selects the temporary root. Successful images remain loaded
 for the short-lived command because registry callbacks point into them, while

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -906,11 +906,12 @@ constants as scalar arguments, applies the mode, start, and end to the
 executor builder, and prints each tick of the result port through a `record`
 sink read after the run (simulation) or a streaming sink (real time).
 
-The backend rejects, with a `backend` diagnostic that names the function, any
-evaluated closure that contains a runtime function, a source-defined operator
-whose selected candidate is a runtime function, or a `use` of a module whose
-descriptor has no loaded native image. Those programs need the C++ backend.
-It never emulates a node body.
+The backend never emulates a node body. A runtime function or source-defined
+operator is wired by its module-qualified registry name, so the driver must
+first load the generated native image which supplies that candidate. Calling
+the backend API directly without such an image produces an operator-resolution
+diagnostic. Imported modules whose descriptors have no loaded image remain an
+error.
 
 The backend depends only on public hgraph headers: `operator_dispatch.h`,
 `graph_wiring.h`, `executor.h`, `lib/testing/record_replay.h`, and the
@@ -1026,8 +1027,9 @@ device. The TOML run configuration is not in the first pass.
 ## C++ backend, first pass
 
 Status: implemented for the composition subset and, as of 2026-09-04, the
-first scalar runtime-node subset. Broader runtime lowering and the scripted
-compile/load driver remain staged.
+first scalar runtime-node subset. File-based `test` and `run` compile/load that
+subset on Unix; broader runtime lowering, caching, Windows loading, and REPL
+replacement remain staged.
 
 `hgl emit-cpp <file.hgl>` writes one header/source pair named after the
 source — `prices.hgl` becomes `prices.h` and `prices.cpp` — beside the
@@ -1090,10 +1092,12 @@ What is emitted, in this order:
   block.
 - **Registration.** `void register_operators()` registers each export and
   each `impl fn` with `hgraph::register_graph_overload<ops::x, x>()` for a
-  composition or `hgraph::register_overload<ops::x, x>()` for a runtime node,
-  through a keyed `OperatorRegistry` installer named after the module. It then
-  runs the installers, so a registry reset replays them and repeated calls are
-  no-ops.
+  composition or `hgraph::register_overload<ops::x, x>()` for a runtime node.
+  Private runtime helpers get translation-unit-local markers under the same
+  module-qualified identities so direct wiring can compose them without
+  exposing them in the module header. Registration uses a keyed
+  `OperatorRegistry` installer named after the module and then runs the
+  installers, so a registry reset replays them and repeated calls are no-ops.
 - **Python.** With `--python <file> --python-native <module>` the wrapper
   module imports the native module (which registers) and binds each export
   to `hgraph.operator_function("module.name")`. Python keywords gain a
@@ -1147,13 +1151,30 @@ them.
 ## Scripted, REPL, and AOT drivers
 
 `hgl test`, `hgl run`, `hgl repl`, and `hgl emit-cpp` use the same type
-expansion, function classifier, and typed IR. `emit-cpp` always uses the C++
-backend. The other three currently use the direct-wiring backend and therefore
-still reject a runtime function in the evaluated closure. The next scripted
-slice will invoke the C++ backend, build or reuse a native artifact, load it,
-and run the same hgraph graph. There is no `hgl build`: a package builds emitted
-C++ with `hgl_add_module()`. The parity suite runs every test the direct-wiring
-backend accepts through both backends and compares the recorded ticks.
+expansion, function classifier, and checked tree. `emit-cpp` always uses the
+C++ backend. File-based `test` and `run` keep the direct-wiring path for a
+composition-only unit; when a unit contains a runtime function or `impl fn`,
+the driver emits the whole unit, invokes the configured C++ compiler, loads
+the resulting image, invokes its fixed registration entry point, and then
+wires tests or the entry through the same backend and hgraph registry. There
+is no `hgl build`: a package builds emitted C++ with `hgl_add_module()`.
+
+The scripted compiler configuration is generated from the `hgl` CMake target:
+compiler launcher, compiler, preprocessor definitions, and evaluated include
+paths. An installed executable also probes its prefix's `include` directory.
+`HGL_CXX` overrides the compiler for diagnostics/testing and
+`HGL_ARTIFACT_DIR` selects the temporary root. Successful images remain loaded
+for the short-lived command because registry callbacks point into them, while
+their files are removed; a compile failure retains its complete directory and
+reports the path. The executable exports hgraph symbols and the transient image
+does not link a second static hgraph, so both use one registry. This path is
+currently Unix-only and has no persistent cache.
+
+The REPL still uses only direct wiring. Loading its runtime declarations safely
+requires provider-scoped installer/candidate removal before a replacement image
+can become active. The parity suite runs every composition test accepted by
+both backends and compares the recorded ticks; the runtime fixture executes
+both as an ahead-of-time module and through the scripted loader.
 
 The initial REPL may materialize a synthetic module and rebuild the full
 session. A failed declaration must not replace the last valid session.

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -331,7 +331,7 @@ backend against the live registry: constant folding of every folded
 operator, `eval` of a composition through the harness with `_`, defaults,
 and literal conversion, the failure detail of a wrong value and of a wrong
 length, selected tests and the REPL's described tail, the first-pass
-limits as diagnostics (timed sequences, runtime functions, element types),
+limits as diagnostics (timed sequences, an unloaded runtime function, element types),
 `run_program` into a stream with `--set`, `--start`, and a duration end,
 and `format_time`. `hgraph_language_test_midpoint` runs `hgl test` over
 the guide's `midpoint.hgl`.
@@ -348,9 +348,9 @@ it:
 - `const` folding produces the scalar arguments hgraph's resolver lifts,
   including temporal constants and `[run.params]` values of every mapped
   TOML type;
-- a runtime function anywhere in the evaluated closure is a `backend`
-  diagnostic naming the function, and a module without a loaded native
-  image is a `backend` diagnostic naming the module;
+- a runtime function without a loaded native image is an operator diagnostic
+  naming its module-qualified identity; the file driver loads the supported
+  runtime subset before invoking this backend;
 - `hgl test` reports each failing assertion with the cycle or time, the
   expected element, and the observed element, and exits non-zero;
 - `hgl run` in simulation over an entry with `[run.params]` prints the same
@@ -358,6 +358,14 @@ it:
   command-line overrides win over the file.
 
 Every `test` in the guide examples runs under `hgl test` in CI.
+
+`hgraph_language_test_runtime` and `hgraph_language_run_runtime` compile and
+load the runtime fixture through the actual CLI, covering an exported node, a
+private runtime helper, a source-defined operator implementation, lifecycle and
+state code in the compiled unit, and a const-only entry whose graph contains a
+runtime node. `hgraph_language_native_compile_failure` injects a missing
+compiler, checks the diagnostic and retained artifact directory, then removes
+the test artifact.
 
 ## Generated C++
 

--- a/language/docs/user-guide/README.md
+++ b/language/docs/user-guide/README.md
@@ -5,11 +5,12 @@ view: how functions and types look, which values change over time, and how
 source calls reach hgraph.
 
 > **Design preview:** the current `hgl` command checks these examples and
-> runs the composition-only ones (`hgl test`, `hgl run`, `hgl repl`) within
-> the limits listed in [Testing and running](testing-and-running.md#first-pass-limits).
-> `hgl emit-cpp` additionally compiles the documented scalar runtime-node
-> subset. The documents record syntax agreed during design discussion, not a
-> source compatibility promise.
+> runs composition functions directly and, for file-based `hgl test` and
+> `hgl run`, compiles and loads the documented scalar runtime-node subset.
+> The REPL remains composition-only within the limits listed in
+> [Testing and running](testing-and-running.md#first-pass-limits). The
+> documents record syntax agreed during design discussion, not a source
+> compatibility promise.
 
 ## Read in this order
 
@@ -30,8 +31,7 @@ source calls reach hgraph.
    line or a configuration file, and the REPL.
 
 Source files are collected under [`language/examples`](../../examples). The
-frontend checks every example; the direct-wiring backend runs the supported
-composition subset described in
+frontend checks every example; the scripted backends run the supported subset described in
 [Testing and running](testing-and-running.md#first-pass-limits).
 
 ## Current language shape

--- a/language/docs/user-guide/modules-and-tools.md
+++ b/language/docs/user-guide/modules-and-tools.md
@@ -204,9 +204,11 @@ hgl repl
 run configuration file from the author's side.
 
 The current `hgl` implements `--help`, `--version`, `check`, `test`, `run`
-(without `--config`), `emit-cpp`, and `repl` for composition-only programs
-over the `hgraph.std` and `hgraph.analytics` kernels. `test` accepts test
-names after the file to run a selection. The first-pass limits are listed in
+(without `--config`), `emit-cpp`, and `repl` over the `hgraph.std` and
+`hgraph.analytics` kernels. File-based `test` and `run` compile/load the
+supported scalar runtime-node subset on Unix; the REPL remains
+composition-only. `test` accepts test names after the file to run a selection.
+The first-pass limits are listed in
 [Testing and running](testing-and-running.md#first-pass-limits); the
 constructs `emit-cpp` does not yet lower are listed under
 [Building a package](#building-a-package).
@@ -289,18 +291,20 @@ tuple and list literals, `if` used as a value, and zoned or civil literals.
 
 `test`, `run`, `emit-cpp`, and the REPL share one checked semantic IR and one
 hgraph runtime. A program made only of composition functions is wired onto the
-runtime directly, in process. An ahead-of-time package containing supported
-runtime functions goes through generated C++; using that same route from
-`test`, `run`, and the REPL is the next scripted-driver slice:
+runtime directly, in process. A file-based `test` or `run` containing supported
+runtime functions goes through generated C++, as does an ahead-of-time package.
+The REPL's compiled route remains staged:
 
 ```text
 source -> checked semantic IR -> direct wiring          -> hgraph runtime
                               -> generated C++ -> native -> hgraph runtime
 ```
 
-Both paths build the same graph. The compiler's parity suite holds the shared
-composition subset to the same ticks and executes the runtime subset through
-the compiled path.
+Both paths build the same graph. The scripted image resolves hgraph symbols
+from the running `hgl` process, so it registers into that process's registry
+rather than linking a second static runtime. The compiler's parity suite holds
+the shared composition subset to the same ticks and executes the runtime
+subset through both the scripted and ahead-of-time compiled paths.
 
 The initial REPL may rebuild the whole session after each accepted declaration.
 That is slower than a JIT but guarantees that exploration sees the same

--- a/language/docs/user-guide/testing-and-running.md
+++ b/language/docs/user-guide/testing-and-running.md
@@ -186,8 +186,9 @@ The current `hgl` runs everything on this page that is written with
 - `eval` takes a module `fn`; wrap an operator in a `fn` to evaluate it;
 - `hgl run` takes its configuration from the command line only; the
   `--config` file is not read yet;
-- a program with a runtime function, an `impl fn`, or a generic function
-  checks, but running it is reported as unsupported;
+- file-based `test` and `run` compile supported runtime functions and
+  non-generic `impl fn` candidates on Unix; the REPL still reports them as
+  unsupported, and generic functions remain unsupported by every backend;
 - complete scalar struct values, type-only generic struct specializations,
   `atomic<S>` harness values, and simple field-wise temporal struct
   construction run; generic constructor inference, `const` generic struct
@@ -200,10 +201,13 @@ The current `hgl` runs everything on this page that is written with
 
 Programs made only of composition functions, which includes every example
 on this page, are wired straight onto the hgraph runtime in process by
-`hgl test`, `hgl run`, and the REPL; no native toolchain is involved. A
-program that contains a runtime function (`state`, `inject`, `when`, ...)
-needs generated C++. `hgl emit-cpp` supplies the supported scalar runtime-node
-subset for ahead-of-time packages; teaching these three scripted commands to
-build and load that artifact is the next implementation slice. The
+`hgl test`, `hgl run`, and the REPL; no native toolchain is involved. For a
+file containing a runtime function (`state`, `inject`, `when`, ...) or an
+`impl fn`, `hgl test` and `hgl run` emit the complete module, compile a
+transient native image, load its candidates into the same hgraph registry,
+and then use the ordinary harness. A successful transient artifact is removed;
+a failed native build reports and retains its artifact directory. The REPL
+does not yet load runtime images because safe replacement requires candidate
+and installer removal. The
 [Architecture](../design/architecture.md#two-backends-one-wiring) record
 describes the split; both backends must produce the same ticks.

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -2651,6 +2651,20 @@ namespace hgl::codegen
             {
                 body.indent();
                 body.open("namespace");
+                for (const ast::DeclId id : internal)
+                {
+                    if (resolved_.kind(id) != semantics::FunctionKind::Runtime) { continue; }
+                    Frame frame;
+                    frame.fn = id;
+                    body.line("struct hgl_internal_operator_" + std::to_string(id) + " : " +
+                              marker(id, result.module_name + "." + std::string{function(id).name.text}, frame) + " {};");
+                }
+                if (std::any_of(internal.begin(), internal.end(), [&](ast::DeclId id) {
+                        return resolved_.kind(id) == semantics::FunctionKind::Runtime;
+                    }))
+                {
+                    body.line();
+                }
                 for (const ast::DeclId id : internal) { emit_function(id, body, Form::InlineStruct); }
                 for (const ast::DeclId id : impls) { emit_function(id, body, Form::InlineStruct); }
                 body.close("  // namespace");
@@ -2679,6 +2693,12 @@ namespace hgl::codegen
                                                      ? "hgraph::register_overload"
                                                      : "hgraph::register_graph_overload";
                 body.line(registration + "<ops::" + name + ", " + name + ">();");
+            }
+            for (const ast::DeclId id : internal)
+            {
+                if (resolved_.kind(id) != semantics::FunctionKind::Runtime) { continue; }
+                body.line("hgraph::register_overload<hgl_internal_operator_" + std::to_string(id) + ", " +
+                          cpp_name(function(id).name.text) + ">();");
             }
             for (const ast::DeclId id : impls)
             {

--- a/language/src/driver/driver.cpp
+++ b/language/src/driver/driver.cpp
@@ -2,6 +2,7 @@
 
 #include "codegen/cpp_emitter.h"
 #include "driver/line_reader.h"
+#include "driver/native_module.h"
 #include "semantics/resolve.h"
 #include "syntax/ast_printer.h"
 #include "syntax/diagnostic.h"
@@ -125,6 +126,38 @@ namespace hgl::driver
             return unit;
         }
 
+        bool needs_native_module(const Unit &unit)
+        {
+            return std::any_of(unit.resolved.functions.begin(), unit.resolved.functions.end(), [&](syntax::ast::DeclId id) {
+                const auto &fn = std::get<syntax::ast::FunctionDecl>(unit.module.decl(id).node);
+                return unit.resolved.kind(id) == semantics::FunctionKind::Runtime ||
+                       fn.visibility == syntax::ast::FunctionVisibility::Impl;
+            });
+        }
+
+        /// The scripted path for runtime functions: lower the whole resolved
+        /// unit, compile a transient native image, load it into this process,
+        /// and register its overloads before the direct harness wires tests or
+        /// an entry point. Composition-only units retain the fast direct path.
+        bool load_native_module(Unit &unit, std::string_view language_version)
+        {
+            if (!needs_native_module(unit)) { return true; }
+            wiring::ensure_session();
+            codegen::EmitOptions options;
+            options.header_name  = "module.h";
+            options.tool_version = std::string{language_version};
+            const std::optional<codegen::EmittedModule> emitted =
+                codegen::emit_cpp(unit.file, unit.module, unit.resolved, options, unit.diagnostics);
+            if (!emitted) { return false; }
+            std::string error;
+            if (!compile_and_load_native_module(*emitted, "module", error))
+            {
+                unit.diagnostics.report(syntax::Category::Backend, syntax::SourceRange{0, 0}, std::move(error));
+                return false;
+            }
+            return true;
+        }
+
         int check(std::span<const std::string_view> arguments)
         {
             std::optional<std::string> path;
@@ -180,7 +213,7 @@ namespace hgl::driver
             out << results.size() << (results.size() == 1 ? " test" : " tests") << ", " << failed << " failed\n";
         }
 
-        int test(std::span<const std::string_view> arguments)
+        int test(std::span<const std::string_view> arguments, std::string_view language_version)
         {
             std::optional<std::string> path;
             wiring::TestOptions        options;
@@ -207,6 +240,11 @@ namespace hgl::driver
                                                });
                 if (!known) { return usage_error("no test named '" + name + "'"); }
             }
+            if (!load_native_module(*unit, language_version))
+            {
+                std::cerr << unit->diagnostics.render(unit->file);
+                return exit_diagnostics;
+            }
             const std::vector<wiring::TestResult> results =
                 wiring::run_tests(unit->file, unit->module, unit->resolved, options, unit->diagnostics);
             print_test_results(results, std::cout);
@@ -229,7 +267,7 @@ namespace hgl::driver
             return parsed.value;
         }
 
-        int run_command(std::span<const std::string_view> arguments)
+        int run_command(std::span<const std::string_view> arguments, std::string_view language_version)
         {
             std::optional<std::string> path;
             wiring::RunOptions         options;
@@ -295,7 +333,7 @@ namespace hgl::driver
             if (!path) { return usage_error("run needs a file"); }
             std::optional<Unit> unit = load(*path);
             if (!unit) { return exit_usage; }
-            if (unit->ok)
+            if (unit->ok && load_native_module(*unit, language_version))
             {
                 (void)wiring::run_program(unit->file, unit->module, unit->resolved, options, unit->diagnostics,
                                           std::cout);
@@ -675,8 +713,8 @@ namespace hgl::driver
             return exit_ok;
         }
         if (command == "check") { return check(rest); }
-        if (command == "test") { return test(rest); }
-        if (command == "run") { return run_command(rest); }
+        if (command == "test") { return test(rest, language_version); }
+        if (command == "run") { return run_command(rest, language_version); }
         if (command == "repl") { return repl(rest); }
         if (command == "emit-cpp") { return emit_cpp(rest, language_version); }
         if (command == "build")

--- a/language/src/driver/native_module.cpp
+++ b/language/src/driver/native_module.cpp
@@ -249,12 +249,13 @@ namespace hgl::driver
             return std::nullopt;
         }
 
-        std::vector<std::string> command = split(native_config::compiler_launcher, ';');
         const char *compiler_override = std::getenv("HGL_CXX");
         const std::string compiler = compiler_override != nullptr && *compiler_override != '\0'
                                          ? std::string{compiler_override}
                                          : std::string{native_config::compiler};
-        command.push_back(compiler);
+        // A compiler launcher belongs to the machine that built hgl and is
+        // deliberately not persisted into the installed scripted compiler.
+        std::vector<std::string> command{compiler};
         command.emplace_back("-std=c++23");
         command.emplace_back("-fPIC");
         command.emplace_back("-fvisibility=hidden");
@@ -267,7 +268,8 @@ namespace hgl::driver
         const std::filesystem::path executable = executable_path();
         if (!executable.empty())
         {
-            const std::filesystem::path installed_include = executable.parent_path().parent_path() / "include";
+            const std::filesystem::path installed_include =
+                (executable.parent_path() / native_config::install_include_from_bindir).lexically_normal();
             std::error_code            include_error;
             if (std::filesystem::is_directory(installed_include, include_error))
             {

--- a/language/src/driver/native_module.cpp
+++ b/language/src/driver/native_module.cpp
@@ -1,0 +1,356 @@
+#include "driver/native_module.h"
+
+#include "hgl_native_compile_config.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <cstdlib>
+#include <exception>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#if defined(__APPLE__)
+#include <mach-o/dyld.h>
+#endif
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+namespace hgl::driver
+{
+    namespace
+    {
+        constexpr std::string_view registration_symbol = "hgl_register_module_v1";
+
+        std::vector<std::string> split(std::string_view text, char separator)
+        {
+            std::vector<std::string> values;
+            std::size_t              begin = 0;
+            while (begin <= text.size())
+            {
+                const std::size_t end = text.find(separator, begin);
+                std::string value{
+                    text.substr(begin, end == std::string_view::npos ? text.size() - begin : end - begin)};
+                if (!value.empty() && std::find(values.begin(), values.end(), value) == values.end())
+                {
+                    values.push_back(std::move(value));
+                }
+                if (end == std::string_view::npos) { break; }
+                begin = end + 1;
+            }
+            return values;
+        }
+
+        bool write_file(const std::filesystem::path &path, std::string_view contents, std::string &error)
+        {
+            std::ofstream out{path, std::ios::binary | std::ios::trunc};
+            if (!out)
+            {
+                error = "cannot write native artifact '" + path.string() + "'";
+                return false;
+            }
+            out << contents;
+            if (!out)
+            {
+                error = "cannot finish native artifact '" + path.string() + "'";
+                return false;
+            }
+            return true;
+        }
+
+        std::optional<std::filesystem::path> make_artifact_directory(std::string &error)
+        {
+            std::error_code ec;
+            std::filesystem::path root;
+            if (const char *configured = std::getenv("HGL_ARTIFACT_DIR"); configured != nullptr && *configured != '\0')
+            {
+                root = configured;
+                std::filesystem::create_directories(root, ec);
+                if (ec)
+                {
+                    error = "cannot create HGL artifact root '" + root.string() + "': " + ec.message();
+                    return std::nullopt;
+                }
+            }
+            else
+            {
+                root = std::filesystem::temp_directory_path(ec);
+                if (ec)
+                {
+                    error = "cannot locate the temporary directory: " + ec.message();
+                    return std::nullopt;
+                }
+            }
+
+            static std::atomic<std::uint64_t> next{0};
+#if defined(_WIN32)
+            const auto process = static_cast<unsigned long>(GetCurrentProcessId());
+#else
+            const auto process = static_cast<unsigned long>(::getpid());
+#endif
+            for (unsigned attempt = 0; attempt != 1000; ++attempt)
+            {
+                const std::filesystem::path candidate =
+                    root / ("hgl-" + std::to_string(process) + "-" + std::to_string(next.fetch_add(1)));
+                ec.clear();
+                if (std::filesystem::create_directory(candidate, ec)) { return candidate; }
+                if (ec && ec != std::errc::file_exists)
+                {
+                    error = "cannot create HGL artifact directory '" + candidate.string() + "': " + ec.message();
+                    return std::nullopt;
+                }
+            }
+            error = "cannot allocate a unique HGL artifact directory under '" + root.string() + "'";
+            return std::nullopt;
+        }
+
+#if !defined(_WIN32)
+        struct ProcessResult
+        {
+            int         status{-1};
+            std::string output{};
+        };
+
+        ProcessResult run_process(const std::vector<std::string> &arguments)
+        {
+            int output_pipe[2];
+            if (::pipe(output_pipe) != 0)
+            {
+                return {-1, "cannot create compiler output pipe: " + std::string{std::strerror(errno)}};
+            }
+            const pid_t child = ::fork();
+            if (child < 0)
+            {
+                const std::string message = "cannot start the native compiler: " + std::string{std::strerror(errno)};
+                ::close(output_pipe[0]);
+                ::close(output_pipe[1]);
+                return {-1, message};
+            }
+            if (child == 0)
+            {
+                ::close(output_pipe[0]);
+                (void)::dup2(output_pipe[1], STDOUT_FILENO);
+                (void)::dup2(output_pipe[1], STDERR_FILENO);
+                ::close(output_pipe[1]);
+                std::vector<char *> argv;
+                argv.reserve(arguments.size() + 1);
+                for (const std::string &argument : arguments) { argv.push_back(const_cast<char *>(argument.c_str())); }
+                argv.push_back(nullptr);
+                ::execvp(argv.front(), argv.data());
+                const std::string message =
+                    "cannot execute '" + arguments.front() + "': " + std::string{std::strerror(errno)} + "\n";
+                (void)::write(STDERR_FILENO, message.data(), message.size());
+                _exit(127);
+            }
+
+            ::close(output_pipe[1]);
+            std::string output;
+            char        buffer[4096];
+            while (true)
+            {
+                const ssize_t count = ::read(output_pipe[0], buffer, sizeof(buffer));
+                if (count > 0) { output.append(buffer, static_cast<std::size_t>(count)); }
+                else if (count == 0) { break; }
+                else if (errno != EINTR)
+                {
+                    output += "cannot read compiler output: " + std::string{std::strerror(errno)};
+                    break;
+                }
+            }
+            ::close(output_pipe[0]);
+
+            int status = 0;
+            while (::waitpid(child, &status, 0) < 0)
+            {
+                if (errno != EINTR) { return {-1, output + "cannot wait for the native compiler"}; }
+            }
+            if (WIFEXITED(status)) { return {WEXITSTATUS(status), std::move(output)}; }
+            if (WIFSIGNALED(status))
+            {
+                return {128 + WTERMSIG(status), output + "native compiler terminated by signal " +
+                                                     std::to_string(WTERMSIG(status))};
+            }
+            return {-1, std::move(output)};
+        }
+
+        std::filesystem::path executable_path()
+        {
+#if defined(__APPLE__)
+            std::uint32_t size = 1024;
+            std::vector<char> buffer(size);
+            if (::_NSGetExecutablePath(buffer.data(), &size) != 0)
+            {
+                buffer.resize(size);
+                if (::_NSGetExecutablePath(buffer.data(), &size) != 0) { return {}; }
+            }
+            return std::filesystem::path{buffer.data()};
+#elif defined(__linux__)
+            std::vector<char> buffer(4096);
+            const ssize_t count = ::readlink("/proc/self/exe", buffer.data(), buffer.size());
+            return count > 0 ? std::filesystem::path{std::string{buffer.data(), static_cast<std::size_t>(count)}}
+                             : std::filesystem::path{};
+#else
+            return {};
+#endif
+        }
+
+        std::vector<void *> &resident_images()
+        {
+            // Deliberately process-lifetime: registry candidates hold code
+            // pointers into every image registered here.
+            static auto *images = new std::vector<void *>;
+            return *images;
+        }
+#endif
+    }  // namespace
+
+    std::optional<NativeModule> compile_and_load_native_module(const codegen::EmittedModule &module,
+                                                                std::string_view source_stem, std::string &error)
+    {
+#if defined(_WIN32)
+        (void)module;
+        (void)source_stem;
+        error = "scripted native HGL modules are not yet supported on Windows";
+        return std::nullopt;
+#else
+        const std::optional<std::filesystem::path> artifact_directory = make_artifact_directory(error);
+        if (!artifact_directory) { return std::nullopt; }
+
+        std::string stem{source_stem};
+        if (stem.empty()) { stem = "module"; }
+        const std::filesystem::path header_path = *artifact_directory / (stem + ".h");
+        const std::filesystem::path source_path = *artifact_directory / (stem + ".cpp");
+        const std::filesystem::path bootstrap_path = *artifact_directory / "hgl_module.cpp";
+#if defined(__APPLE__)
+        const std::filesystem::path image_path = *artifact_directory / (stem + ".bundle");
+#else
+        const std::filesystem::path image_path = *artifact_directory / (stem + ".so");
+#endif
+
+        std::ostringstream bootstrap;
+        bootstrap << "#include \"" << stem << ".h\"\n\n"
+                     "extern \"C\" __attribute__((visibility(\"default\"))) void "
+                  << registration_symbol << "()\n{\n    " << module.namespace_name << "::register_operators();\n}\n";
+        if (!write_file(header_path, module.header, error) || !write_file(source_path, module.source, error) ||
+            !write_file(bootstrap_path, bootstrap.str(), error))
+        {
+            error += "; artifacts retained in '" + artifact_directory->string() + "'";
+            return std::nullopt;
+        }
+
+        std::vector<std::string> command = split(native_config::compiler_launcher, ';');
+        const char *compiler_override = std::getenv("HGL_CXX");
+        const std::string compiler = compiler_override != nullptr && *compiler_override != '\0'
+                                         ? std::string{compiler_override}
+                                         : std::string{native_config::compiler};
+        command.push_back(compiler);
+        command.emplace_back("-std=c++23");
+        command.emplace_back("-fPIC");
+        command.emplace_back("-fvisibility=hidden");
+        for (const std::string &option : split(native_config::compile_options, ';')) { command.push_back(option); }
+        for (const std::string &option : split(native_config::link_options, ';')) { command.push_back(option); }
+        for (const std::string &definition : split(native_config::definitions, ';'))
+        {
+            command.push_back("-D" + definition);
+        }
+        const std::filesystem::path executable = executable_path();
+        if (!executable.empty())
+        {
+            const std::filesystem::path installed_include = executable.parent_path().parent_path() / "include";
+            std::error_code            include_error;
+            if (std::filesystem::is_directory(installed_include, include_error))
+            {
+                command.push_back("-I" + installed_include.string());
+            }
+        }
+        for (const std::string &include : split(native_config::include_directories, ';'))
+        {
+            command.push_back("-I" + include);
+        }
+        command.push_back("-I" + artifact_directory->string());
+#if defined(__APPLE__)
+        command.emplace_back("-bundle");
+        command.emplace_back("-undefined");
+        command.emplace_back("dynamic_lookup");
+        if (!executable.empty())
+        {
+            command.emplace_back("-bundle_loader");
+            command.push_back(executable.string());
+        }
+#else
+        command.emplace_back("-shared");
+#endif
+        command.push_back(source_path.string());
+        command.push_back(bootstrap_path.string());
+        command.emplace_back("-o");
+        command.push_back(image_path.string());
+
+        const ProcessResult compiled = run_process(command);
+        if (compiled.status != 0)
+        {
+            error = "native compilation failed with '" + compiler + "' (exit " + std::to_string(compiled.status) + ")";
+            if (!compiled.output.empty())
+            {
+                error += ":\n" + compiled.output;
+                if (error.back() != '\n') { error += '\n'; }
+            }
+            error += "artifacts retained in '" + artifact_directory->string() + "'";
+            return std::nullopt;
+        }
+
+        void *image = ::dlopen(image_path.c_str(), RTLD_NOW | RTLD_LOCAL);
+        if (image == nullptr)
+        {
+            const char *load_error = ::dlerror();
+            error = "cannot load native artifact '" + image_path.string() + "': " +
+                    (load_error != nullptr ? std::string{load_error} : std::string{"unknown loader error"}) +
+                    "; artifacts retained in '" + artifact_directory->string() + "'";
+            return std::nullopt;
+        }
+        ::dlerror();
+        void *symbol = ::dlsym(image, registration_symbol.data());
+        if (const char *load_error = ::dlerror(); load_error != nullptr)
+        {
+            error = "native artifact has no registration entry point: " + std::string{load_error} +
+                    "; artifacts retained in '" + artifact_directory->string() + "'";
+            ::dlclose(image);
+            return std::nullopt;
+        }
+        using Register = void (*)();
+        resident_images().push_back(image);
+        try
+        {
+            reinterpret_cast<Register>(symbol)();
+        }
+        catch (const std::exception &exception)
+        {
+            error = "native module registration failed: " + std::string{exception.what()} +
+                    "; artifacts retained in '" + artifact_directory->string() + "'";
+            return std::nullopt;
+        }
+        catch (...)
+        {
+            error = "native module registration failed with an unknown exception; artifacts retained in '" +
+                    artifact_directory->string() + "'";
+            return std::nullopt;
+        }
+        std::error_code cleanup_error;
+        std::filesystem::remove_all(*artifact_directory, cleanup_error);
+        return NativeModule{*artifact_directory};
+#endif
+    }
+}  // namespace hgl::driver

--- a/language/src/driver/native_module.cpp
+++ b/language/src/driver/native_module.cpp
@@ -151,9 +151,6 @@ namespace hgl::driver
                 for (const std::string &argument : arguments) { argv.push_back(const_cast<char *>(argument.c_str())); }
                 argv.push_back(nullptr);
                 ::execvp(argv.front(), argv.data());
-                const std::string message =
-                    "cannot execute '" + arguments.front() + "': " + std::string{std::strerror(errno)} + "\n";
-                (void)::write(STDERR_FILENO, message.data(), message.size());
                 _exit(127);
             }
 

--- a/language/src/driver/native_module.h
+++ b/language/src/driver/native_module.h
@@ -1,0 +1,29 @@
+#ifndef HGL_DRIVER_NATIVE_MODULE_H
+#define HGL_DRIVER_NATIVE_MODULE_H
+
+#include "codegen/cpp_emitter.h"
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace hgl::driver
+{
+    /// Result of compiling and loading one generated HGL module. Successful
+    /// images remain resident for the process lifetime because their overload
+    /// registrations contain code pointers into the image.
+    struct NativeModule
+    {
+        std::filesystem::path artifact_directory{};
+    };
+
+    /// Compile the emitted C++ as a loadable image, load it into this hgl
+    /// process, and invoke its registration entry point. The current compiler
+    /// is used with the same definitions and include paths as hgl itself.
+    /// Failed build artifacts are retained and named in `error`.
+    [[nodiscard]] std::optional<NativeModule> compile_and_load_native_module(
+        const codegen::EmittedModule &module, std::string_view source_stem, std::string &error);
+}  // namespace hgl::driver
+
+#endif  // HGL_DRIVER_NATIVE_MODULE_H

--- a/language/src/wiring/backend.cpp
+++ b/language/src/wiring/backend.cpp
@@ -357,6 +357,7 @@ namespace hgl::wiring
             [[nodiscard]] Slot eval_eval(const ast::Eval &eval, SourceRange range, Frame &frame);
             [[nodiscard]] Slot call_function(ast::DeclId decl, const std::vector<ast::Argument> &arguments, SourceRange range,
                                              Frame &frame);
+            [[nodiscard]] Slot wire_function(ast::DeclId decl, Frame &callee, SourceRange range);
             [[nodiscard]] Slot invoke(ast::DeclId decl, Frame &callee);
             [[nodiscard]] Slot exec_block(ast::BlockId id, Frame &frame);
             void               exec_stmt(ast::StmtId id, Frame &frame);
@@ -1425,7 +1426,14 @@ namespace hgl::wiring
                     return slot;
                 }
                 case BindingKind::LocalOperator:
-                    backend(range, "source-defined operators are not supported by the first pass");
+                {
+                    const auto &op = std::get<ast::OperatorDecl>(module_.decl(binding.decl).node);
+                    Slot        slot;
+                    slot.kind  = Slot::Kind::Operator;
+                    slot.name  = resolved_.module_path + "." + std::string{op.name.text};
+                    slot.range = range;
+                    return slot;
+                }
                 case BindingKind::Intrinsic:
                 {
                     Slot slot;
@@ -1752,14 +1760,9 @@ namespace hgl::wiring
                                      Frame &frame)
         {
             const ast::FunctionDecl &fn = function(decl);
-            if (resolved_.kind(decl) == semantics::FunctionKind::Runtime)
-            {
-                backend(range, "'" + std::string{fn.name.text} +
-                                   "' is a runtime function; the first pass composes graphs from kernel operators");
-            }
             if (fn.visibility == ast::FunctionVisibility::Impl)
             {
-                backend(range, "source-defined operators are not supported by the first pass");
+                backend(range, "an impl fn is reached through its operator, not called directly");
             }
             if (!fn.generics.empty()) { backend(range, "generic functions are not supported by the first pass"); }
             const std::vector<ast::ExprId> bound = bind_arguments(fn, arguments, range);
@@ -1778,9 +1781,22 @@ namespace hgl::wiring
                     callee.params[i] = bind_parameter(params[i], arg, callee, arg.range);
                 }
             }
-            Slot result  = invoke(decl, callee);
+            Slot result = resolved_.kind(decl) == semantics::FunctionKind::Runtime ? wire_function(decl, callee, range)
+                                                                                   : invoke(decl, callee);
             result.range = range;
             return result;
+        }
+
+        Slot Compiler::wire_function(ast::DeclId decl, Frame &callee, SourceRange range)
+        {
+            const ast::FunctionDecl       &fn = function(decl);
+            std::vector<hgraph::WiringArg> arguments;
+            arguments.reserve(fn.signature.parameters.size());
+            for (std::size_t i = 0; i < fn.signature.parameters.size(); ++i)
+            {
+                arguments.push_back(argument_of(callee.params[i], std::string{fn.signature.parameters[i].name.text}));
+            }
+            return wire(resolved_.module_path + "." + std::string{fn.name.text}, std::move(arguments), range);
         }
 
         Slot Compiler::invoke(ast::DeclId decl, Frame &callee)
@@ -1930,10 +1946,6 @@ namespace hgl::wiring
                 fail(Category::Type, module_.expr(eval.callee).range, "eval takes a function");
             }
             const ast::FunctionDecl &fn = function(callee.fn);
-            if (resolved_.kind(callee.fn) == semantics::FunctionKind::Runtime)
-            {
-                backend(range, "'" + std::string{fn.name.text} + "' is a runtime function; the first pass evaluates compositions");
-            }
             if (!fn.generics.empty()) { backend(range, "generic functions are not supported by the first pass"); }
             const std::vector<ast::ExprId> bound = bind_arguments(fn, eval.arguments, range);
             const auto                    &params = fn.signature.parameters;
@@ -2007,7 +2019,9 @@ namespace hgl::wiring
                 }
             }
 
-            Slot result = invoke(callee.fn, callee_frame);
+            Slot result = resolved_.kind(callee.fn) == semantics::FunctionKind::Runtime
+                              ? wire_function(callee.fn, callee_frame, range)
+                              : invoke(callee.fn, callee_frame);
             if (result.is_const()) { result = wire_constant(result, registry_.ts(result.meta())); }
             const hgraph::TSValueTypeMetaData *out_schema = nullptr;
             if (result.is_port())
@@ -2193,10 +2207,6 @@ namespace hgl::wiring
                 }
                 const ast::DeclId        entry = candidates.front();
                 const ast::FunctionDecl &fn    = function(entry);
-                if (resolved_.kind(entry) == semantics::FunctionKind::Runtime)
-                {
-                    backend(module_.decl(entry).range, "'" + std::string{fn.name.text} + "' is a runtime function");
-                }
                 for (const Setting &setting : options.settings)
                 {
                     const auto &params = fn.signature.parameters;
@@ -2238,7 +2248,9 @@ namespace hgl::wiring
                                                         std::string{param.name.text} + "=<value>");
                     }
                 }
-                Slot result = invoke(entry, frame);
+                Slot result = resolved_.kind(entry) == semantics::FunctionKind::Runtime
+                                  ? wire_function(entry, frame, module_.decl(entry).range)
+                                  : invoke(entry, frame);
                 if (result.is_const()) { result = wire_constant(result, registry_.ts(result.meta())); }
                 if (!result.is_port())
                 {

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -107,6 +107,37 @@ set_tests_properties(hgraph_language_test_parity PROPERTIES
     PASS_REGULAR_EXPRESSION "6 tests, 0 failed"
 )
 
+if(UNIX)
+    # Runtime-node modules take the scripted compile/load path, then use the
+    # same direct harness as composition-only tests to wire the registered
+    # candidates. The prototype loader is currently Unix-only.
+    add_test(
+        NAME hgraph_language_test_runtime
+        COMMAND $<TARGET_FILE:hgl> test ${CMAKE_CURRENT_SOURCE_DIR}/codegen/runtime.hgl
+    )
+    set_tests_properties(hgraph_language_test_runtime PROPERTIES
+        PASS_REGULAR_EXPRESSION "3 tests, 0 failed"
+    )
+
+    add_test(
+        NAME hgraph_language_run_runtime
+        COMMAND $<TARGET_FILE:hgl> run ${CMAKE_CURRENT_SOURCE_DIR}/codegen/runtime.hgl
+            --entry configured_app --set value=2.0 --set initial=5.0 --end 1us
+    )
+    set_tests_properties(hgraph_language_run_runtime PROPERTIES
+        PASS_REGULAR_EXPRESSION "1970-01-01T00:00:00.000001Z 7"
+    )
+
+    add_test(
+        NAME hgraph_language_native_compile_failure
+        COMMAND ${CMAKE_COMMAND}
+            -DHGL=$<TARGET_FILE:hgl>
+            -DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/codegen/runtime.hgl
+            -DOUT=${CMAKE_CURRENT_BINARY_DIR}/native-failure
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/driver/native_failure.cmake
+    )
+endif()
+
 # The command itself: composition and the first scalar runtime-node slice emit.
 add_test(
     NAME hgraph_language_emit_midpoint

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -313,7 +313,7 @@ export fn total(a: f64, b: f64) -> f64 {
 
 fn private_total(a: f64) -> f64 {
     state sum: f64 = 0.0
-    when modified(a) {
+    when modified(a) && valid(a) {
         sum += a
         return sum
     }

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -310,6 +310,16 @@ export fn total(a: f64, b: f64) -> f64 {
         }
     }
 }
+
+fn private_total(a: f64) -> f64 {
+    state sum: f64 = 0.0
+    when modified(a) {
+        sum += a
+        return sum
+    }
+}
+
+export fn through_private(a: f64) -> f64 => private_total(a)
 )"};
     const auto emitted = unit.emit();
     REQUIRE(emitted);
@@ -323,6 +333,10 @@ export fn total(a: f64, b: f64) -> f64 {
     CHECK(contains(emitted->header, "hgl_output.set(sum.value().checked_as<hgraph::Float>());"));
     CHECK(contains(emitted->source, "hgraph::register_overload<ops::total, total>();"));
     CHECK_FALSE(contains(emitted->source, "register_graph_overload<ops::total"));
+    CHECK_FALSE(contains(emitted->header, "private_total"));
+    CHECK(contains(emitted->source, "struct hgl_internal_operator_"));
+    CHECK(contains(emitted->source, "hgraph::register_overload<hgl_internal_operator_"));
+    CHECK(contains(emitted->source, "hgraph::wire<private_total>(w, a)"));
 }
 
 TEST_CASE("emit-cpp requires validity to dominate runtime payload reads", "[codegen][runtime]")

--- a/language/tests/codegen/generated_runtime_tests.cpp
+++ b/language/tests/codegen/generated_runtime_tests.cpp
@@ -27,6 +27,13 @@ TEST_CASE("generated runtime impl functions register as node overloads", "[codeg
                  values<Float>(2.0, 3.0));
 }
 
+TEST_CASE("a generated composition can wire a generated operator implementation", "[codegen][runtime]")
+{
+    session();
+    CHECK_OUTPUT(eval_node<runtime::ops::absolute_graph>(values<Float>(-2.0, 3.0)),
+                 values<Float>(2.0, 3.0));
+}
+
 TEST_CASE("generated runtime predicates use modified-or and valid-and semantics", "[codegen][runtime]")
 {
     session();
@@ -91,5 +98,12 @@ TEST_CASE("generated runtime functions without when use ordinary input policy", 
 {
     session();
     CHECK_OUTPUT(eval_node<runtime::ops::unconditional_total>(values<Float>(1.0, 2.0, 3.0)),
+                 values<Float>(1.0, 3.0, 6.0));
+}
+
+TEST_CASE("a generated composition can wire a private generated runtime node", "[codegen][runtime]")
+{
+    session();
+    CHECK_OUTPUT(eval_node<runtime::ops::private_total_graph>(values<Float>(1.0, 2.0, 3.0)),
                  values<Float>(1.0, 3.0, 6.0));
 }

--- a/language/tests/codegen/runtime.hgl
+++ b/language/tests/codegen/runtime.hgl
@@ -1,6 +1,6 @@
-// The first runtime-node backend fixture. Unlike parity.hgl this cannot yet
-// run through the direct-wiring `hgl test` path: it is emitted, compiled, and
-// evaluated through hgraph's public C++ authoring surface.
+// The first runtime-node backend fixture. It is emitted and compiled both as
+// a package through hgl_add_module() and as a transient scripted image through
+// `hgl test`, then evaluated through hgraph's public wiring/runtime surface.
 
 module hgl.codegen.runtime
 
@@ -14,6 +14,8 @@ impl fn absolute(value: f64) -> f64 {
         return value
     }
 }
+
+export fn absolute_graph(value: f64) -> f64 => absolute(value)
 
 export fn add_when_ready(a: f64, b: f64) -> f64 {
     when modified(a, b) && valid(a, b) {
@@ -90,8 +92,34 @@ export fn configured_total(value: f64, const initial: f64 = 10.0) -> f64 {
     }
 }
 
+export fn configured_app(const value: f64 = 2.0, const initial: f64 = 5.0) -> f64 =>
+    configured_total(value, initial)
+
 export fn unconditional_total(value: f64) -> f64 {
     state total: f64 = 0.0
     total += value
     return total
+}
+
+fn private_total(value: f64) -> f64 {
+    state total: f64 = 0.0
+
+    when modified(value) && valid(value) {
+        total += value
+        return total
+    }
+}
+
+export fn private_total_graph(value: f64) -> f64 => private_total(value)
+
+test scripted_runtime_node {
+    assert eval(add_when_ready, a: [1.0, _, 3.0], b: [_, 10.0, 20.0]) == [_, 11.0, 23.0]
+}
+
+test scripted_operator_impl {
+    assert eval(absolute_graph, value: [-2.0, 3.0]) == [2.0, 3.0]
+}
+
+test scripted_private_runtime_node {
+    assert eval(private_total_graph, value: [1.0, 2.0, 3.0]) == [1.0, 3.0, 6.0]
 }

--- a/language/tests/driver/native_failure.cmake
+++ b/language/tests/driver/native_failure.cmake
@@ -1,0 +1,29 @@
+if(NOT HGL OR NOT SOURCE OR NOT OUT)
+    message(FATAL_ERROR "HGL, SOURCE and OUT are required")
+endif()
+
+file(REMOVE_RECURSE "${OUT}")
+file(MAKE_DIRECTORY "${OUT}")
+execute_process(
+    COMMAND "${CMAKE_COMMAND}" -E env
+        "HGL_CXX=${OUT}/missing-cxx"
+        "HGL_ARTIFACT_DIR=${OUT}"
+        "${HGL}" test "${SOURCE}"
+    RESULT_VARIABLE _result
+    OUTPUT_VARIABLE _stdout
+    ERROR_VARIABLE _stderr)
+set(_output "${_stdout}\n${_stderr}")
+if(_result EQUAL 0)
+    message(FATAL_ERROR "a missing native compiler unexpectedly succeeded:\n${_output}")
+endif()
+if(NOT _output MATCHES "native compilation failed")
+    message(FATAL_ERROR "the compiler failure was not diagnosed:\n${_output}")
+endif()
+if(NOT _output MATCHES "artifacts retained in")
+    message(FATAL_ERROR "the retained artifact directory was not reported:\n${_output}")
+endif()
+file(GLOB _artifacts "${OUT}/hgl-*")
+if(NOT _artifacts)
+    message(FATAL_ERROR "the failed native build retained no artifact directory")
+endif()
+file(REMOVE_RECURSE "${OUT}")

--- a/language/tests/wiring/backend_tests.cpp
+++ b/language/tests/wiring/backend_tests.cpp
@@ -392,7 +392,7 @@ test wrong_type {
     REQUIRE(results.size() == 3);
     for (const TestResult &result : results) { CHECK_FALSE(result.passed); }
     CHECK(unit.has(Category::Test, "timed sequences are not supported by the first pass"));
-    CHECK(unit.has(Category::Backend, "'counter' is a runtime function"));
+    CHECK(unit.has(Category::Operator, "t.counter"));
     CHECK(unit.has(Category::Type, "the sequence element expects Tuple[float,float], got str"));
 }
 


### PR DESCRIPTION
## Summary

- compile and load generated HGL runtime modules for file-based `hgl test` and `hgl run` on Unix
- register source-defined operators and private runtime helpers into the running command's hgraph registry, then wire them through the existing direct backend
- derive the transient compiler context from the built `hgl` target, support installed SDK headers, and retain failed native artifacts with actionable diagnostics
- cover scripted runtime nodes, operator implementations, private helpers, installed-tool execution, and native compiler failures; update the user, developer, architecture, and roadmap docs

## Stack

- Depends on #639 (`codex/hgl-runtime-node-lowering`)
- Persistent native artifact caching, replaceable runtime modules in the REPL, and Windows loading remain follow-up slices

## Validation

- macOS: fresh configure and clean build with `HGRAPH_BUILD_LANGUAGE=ON`; 1,703/1,703 CTest cases passed
- private Linux host: fresh configure and clean build with `HGRAPH_BUILD_LANGUAGE=ON`; 1,703/1,703 CTest cases passed
- macOS and private Linux host: Python 3.12 stable-ABI wheel installed under Python 3.14; 2,287 passed, 10 skipped
- installed SDK prefix: `hgl test language/tests/codegen/runtime.hgl` and runtime-backed `hgl run` passed
