### PR TITLE
Add provider-scoped operator registrations

### DIFF
--- a/docs/source/developer_guide/operators.rst
+++ b/docs/source/developer_guide/operators.rst
@@ -300,6 +300,8 @@ A process-wide singleton maps an operator name to its candidates:
      public:
        static OperatorRegistry &instance();                    // plain static; single-threaded, no locks
        void register_overload(OperatorImpl);
+       OperatorProviderHandle register_installer(key, fn);
+       bool remove_provider(const OperatorProviderHandle&);    // rejects live graph/plan leases
        // Pick the unique best candidate and the ResolutionMap it produced.
        std::pair<const OperatorImpl*, ResolutionMap>
             resolve(std::string_view name,
@@ -327,6 +329,23 @@ vector preserves registration order, and no decision is ever made from
 hash-map iteration order. Rich rejected-candidate messages are produced from
 Phase 1 — operator misuse is the most common wiring error, and a bare "no
 overload" message is hostile.
+
+Installer callbacks also establish candidate provenance. Every overload
+registered while a keyed installer runs belongs to that provider generation.
+The opaque handle returned by ``register_installer`` can remove that exact
+generation without affecting direct registrations, another provider, or a
+later provider which reuses the same key. Removal erases both active candidates
+and installer intent, so reset cannot replay a removed provider. A throwing
+installer rolls back candidates contributed by its failed attempt before the
+next retry.
+
+Selecting a provider-owned overload retains one lease on the wiring result.
+That lease is carried from ``Wiring`` into the reusable ``GraphBuilder`` and
+then into every ``GraphValue`` made from it. ``remove_provider`` throws
+``OperatorProviderInUseError`` while any such plan or graph is live; a failed
+removal leaves the provider fully active. The registry performs logical
+operator removal only. A native module manager must separately coordinate
+other registries and may keep the image mapped after removal.
 
 
 Ranking (specificity)
@@ -538,6 +557,9 @@ schema pointers inside its candidates' patterns. The Catch2 reset listener
 It does **not** re-seed standard operators (that would collide with a test's own
 ad-hoc operators); a test that needs the ``lib/std`` family calls
 ``register_standard_operators()`` itself, after the reset, before wiring.
+Installer intent and provider identity survive reset, but a provider removed by
+its handle does not. Tests which install a temporary provider remove it before
+captured callbacks or native code can leave scope.
 
 
 The Python implementation path (Phase 4)
@@ -667,7 +689,9 @@ which since RFC 0025 checkpoint 3 records the whole list as the keyed
 installer ``"hgraph.stdlib"`` on ``OperatorRegistry`` and then runs every
 registered installer: a registry reset keeps installer intent, so one
 rebuild call replays core and every extension alike, idempotently
-between resets. The
+between resets. Keyed installers now also own the provenance and graph-plan
+leases needed for provider-scoped removal; process-lifetime callers may ignore
+the returned handle, while unloadable module managers retain it. The
 implemented subset currently covers scalar arithmetic (``impl/arithmetic_impl.h``),
 scalar comparison (``impl/comparison_impl.h``), scalar logical / bitwise operators
 (``impl/logical_impl.h``), string operators (``match_`` / ``replace`` /

--- a/docs/source/developer_guide/operators.rst
+++ b/docs/source/developer_guide/operators.rst
@@ -347,6 +347,12 @@ removal leaves the provider fully active. The registry performs logical
 operator removal only. A native module manager must separately coordinate
 other registries and may keep the image mapped after removal.
 
+An indirect wiring helper must therefore resolve through ``wire_operator`` or
+pass its active ``Wiring`` to ``OperatorRegistry::resolve``. This includes a
+helper which retains only a selected ``LiftedKernel`` pointer in a node plan;
+the pointer still names provider code. A schema-only probe may omit the wiring
+only when no candidate callback or metadata pointer escapes the probe.
+
 
 Ranking (specificity)
 ----------------------

--- a/include/hgraph/lib/std/operators/impl/higher_order_impl.h
+++ b/include/hgraph/lib/std/operators/impl/higher_order_impl.h
@@ -210,7 +210,8 @@ namespace hgraph::stdlib
         [[nodiscard]] inline const LiftedKernel *resolve_lifted_kernel_for_schemas(
             const WiredFn &func,
             std::span<const TSValueTypeMetaData *const> input_schemas,
-            const TSValueTypeMetaData *expected_output = nullptr)
+            const TSValueTypeMetaData *expected_output = nullptr,
+            Wiring *wiring = nullptr)
         {
             if (func.lifted != nullptr) { return func.lifted->valid() ? func.lifted : nullptr; }
             if (func.operator_name.empty()) { return nullptr; }
@@ -235,7 +236,10 @@ namespace hgraph::stdlib
                     OperatorRegistry::instance().resolve(func.operator_name,
                                                          std::span<const WiringArg>{args.data(), args.size()},
                                                          func.has_output,
-                                                         expected_output);
+                                                         expected_output,
+                                                         {},
+                                                         wiring != nullptr ? wiring->operator_state() : GlobalStateView{},
+                                                         wiring);
                 const LiftedKernel *kernel = resolved.impl != nullptr ? resolved.impl->lifted_kernel : nullptr;
                 return kernel != nullptr && kernel->valid() ? kernel : nullptr;
             });
@@ -407,7 +411,8 @@ namespace hgraph::stdlib
                     resolve_lifted_kernel_for_schemas(func.value(),
                                                       std::span<const TSValueTypeMetaData *const>{
                                                           input_schemas.data(), input_schemas.size()},
-                                                      element);
+                                                      element,
+                                                      &w);
                 return wire_lifted_reduce_tsl(w, func.value(), kernel, ts_ref);
             }
         };
@@ -657,7 +662,7 @@ namespace hgraph::stdlib
             spec.child.input_bindings = std::move(combiner_graph.input_bindings);
             spec.child.output_binding = combiner_graph.output_binding;
             spec.lifted_kernel = resolve_lifted_kernel_for_schemas(
-                combiner, std::span<const TSValueTypeMetaData *const>{schemas.data(), schemas.size()}, element);
+                combiner, std::span<const TSValueTypeMetaData *const>{schemas.data(), schemas.size()}, element, &w);
             if (spec.lifted_kernel != nullptr &&
                 (spec.lifted_kernel->arity != 2 || !spec.lifted_kernel->associative))
             {
@@ -2239,11 +2244,8 @@ namespace hgraph::stdlib
             arg.kind = WiringArg::Kind::TimeSeries;
             arg.port = source;
             std::array<WiringArg, 1> args{std::move(arg)};
-            ResolvedOperatorCall resolved = OperatorRegistry::instance().resolve(
-                "downcast_",
-                std::span<const WiringArg>{args.data(), args.size()}, true, target);
-            OperatorWireResult result = resolved.impl->wire(
-                w, resolved.map, resolved.args, resolved.kwargs);
+            OperatorWireResult result = wire_operator(
+                w, "downcast_", std::span<const WiringArg>{args.data(), args.size()}, true, target);
             if (!result.has_output)
             {
                 throw std::logic_error("dispatch_: checked downcast produced no output");
@@ -4020,7 +4022,8 @@ namespace hgraph::stdlib
             const WiredFn &func,
             std::span<const TSValueTypeMetaData *const> schemas,
             std::span<const std::uint8_t> arg_tags,
-            bool takes_key)
+            bool takes_key,
+            Wiring *wiring = nullptr)
         {
             if (takes_key || !func.has_output ||
                 (func.variadic ? schemas.size() < func.arity : func.arity != schemas.size()))
@@ -4069,7 +4072,9 @@ namespace hgraph::stdlib
             const LiftedKernel *kernel =
                 resolve_lifted_kernel_for_schemas(func,
                                                   std::span<const TSValueTypeMetaData *const>{expected_schemas.data(),
-                                                                                              expected_schemas.size()});
+                                                                                              expected_schemas.size()},
+                                                  nullptr,
+                                                  wiring);
             if (kernel == nullptr || kernel->arity != schemas.size()) { return std::nullopt; }
 
             for (std::size_t i = 0; i < expected_schemas.size(); ++i)
@@ -4117,7 +4122,8 @@ namespace hgraph::stdlib
                 lifted_map_tsl_plan(func,
                                     {schemas.data(), schemas.size()},
                                     {arg_tags.data(), arg_tags.size()},
-                                    /*takes_key=*/false);
+                                    /*takes_key=*/false,
+                                    &w);
             if (!plan.has_value())
             {
                 throw std::invalid_argument("map_: lifted TSL fast path requires a compatible lifted scalar function");

--- a/include/hgraph/runtime/graph.h
+++ b/include/hgraph/runtime/graph.h
@@ -391,6 +391,10 @@ struct HGRAPH_CLASS_EXPORT GraphEdge
         GraphBuilder &type_realization(std::shared_ptr<const TypeRealizationSnapshot> snapshot);
         [[nodiscard]] std::shared_ptr<const TypeRealizationSnapshot> type_realization() const;
 
+        /** Retain opaque extension/module state with this reusable plan and
+            every graph instance constructed from it. */
+        GraphBuilder &retain_extension_state(std::shared_ptr<void> state);
+
         /**
          * Set a graph trait (parent-chained key-value metadata; see
          * ``GraphView::trait_or``). Copied onto every graph instance the
@@ -435,6 +439,7 @@ struct HGRAPH_CLASS_EXPORT GraphEdge
         mutable GraphTypeRef          nested_type_{};
         mutable bool                  types_compiled_{false};
         mutable std::shared_ptr<const TypeRealizationSnapshot> type_realization_{};
+        std::vector<std::shared_ptr<void>> retained_state_{};
     };
 
     HGRAPH_EXPORT void clear_graph_runtime_types() noexcept;

--- a/include/hgraph/types/graph_wiring.h
+++ b/include/hgraph/types/graph_wiring.h
@@ -879,6 +879,14 @@ namespace hgraph
         void retain_extension_state(std::shared_ptr<void> state);
 
         /**
+         * Retain opaque state through the produced ``GraphBuilder`` and every
+         * graph instance built from it. Operator-provider leases use this to
+         * keep module code logically active for as long as a selected plan can
+         * call it. The runtime never inspects the retained value.
+         */
+        void retain_graph_state(std::shared_ptr<void> state);
+
+        /**
          * Return wiring-lifetime state for ``key``, creating it once on first
          * use. Native wiring extensions use this to share planning state
          * without process globals; the state is owned by this Wiring.

--- a/include/hgraph/types/operator_dispatch.h
+++ b/include/hgraph/types/operator_dispatch.h
@@ -18,6 +18,7 @@
 #include <concepts>
 #include <cstddef>
 #include <functional>
+#include <memory>
 #include <optional>
 #include <span>
 #include <stdexcept>
@@ -249,6 +250,45 @@ namespace hgraph
         }
     };
 
+    namespace operator_dispatch_detail
+    {
+        struct OperatorProviderState;
+    }
+
+    /**
+     * Opaque identity for one keyed operator-registration provider.
+     *
+     * ``register_installer`` returns this handle. Keeping it does not keep the
+     * provider active; it identifies the exact registration generation so a
+     * stale handle can never remove a later provider which reused the same
+     * key. Removal is explicit through ``OperatorRegistry::remove_provider``.
+     */
+    class HGRAPH_CLASS_EXPORT OperatorProviderHandle
+    {
+      public:
+        OperatorProviderHandle() noexcept = default;
+
+        [[nodiscard]] bool valid() const noexcept;
+        [[nodiscard]] bool active() const noexcept;
+        [[nodiscard]] std::string_view key() const noexcept;
+        [[nodiscard]] std::size_t live_leases() const noexcept;
+
+      private:
+        explicit OperatorProviderHandle(
+            std::shared_ptr<operator_dispatch_detail::OperatorProviderState> state) noexcept;
+
+        std::shared_ptr<operator_dispatch_detail::OperatorProviderState> state_{};
+
+        friend class OperatorRegistry;
+    };
+
+    /** Provider removal was requested while a graph or cached plan still uses it. */
+    class HGRAPH_CLASS_EXPORT OperatorProviderInUseError : public std::runtime_error
+    {
+      public:
+        using std::runtime_error::runtime_error;
+    };
+
     /** A type-erased operator candidate (a C++ or, later, a Python implementation). */
     struct OperatorImpl
     {
@@ -297,6 +337,10 @@ namespace hgraph
         std::function<OperatorWireResult(Wiring &, const ResolutionMap &, std::span<const WiringArg>,
                                          std::span<const std::pair<std::string, WiringPortRef>>)>
             wire{};
+        /** Internal provenance installed by ``OperatorRegistry`` while a keyed
+            provider callback is running. Directly registered candidates have
+            no provider and retain the historical process-lifetime behavior. */
+        std::shared_ptr<operator_dispatch_detail::OperatorProviderState> provider{};
     };
 
     struct OperatorCallableShape
@@ -430,20 +474,37 @@ namespace hgraph
          * module-lifetime ``nb`` class handles. Build-time machinery only;
          * nothing here touches the per-tick path.
          *
+         * The returned ``OperatorProviderHandle`` identifies that exact keyed
+         * provider generation. Candidates registered while its callback runs
+         * inherit its provenance; successful operator resolution retains a
+         * provider lease through the resulting graph plan and runtime graph.
+         * ``remove_provider`` rejects a live lease, then removes both the
+         * active candidates and installer intent so reset cannot resurrect it.
+         * Native image unloading remains the module manager's responsibility.
+         *
          * Keys are unique: re-registering a key replaces the callback
          * without re-applying an already-applied entry (registration entry
          * points stay idempotent between resets). Installers run in
          * first-registration order. An installer is marked applied only
          * AFTER it returns: a throwing installer stays unapplied so a retry
-         * (or the next rebuild) runs it again — but the registry has no
-         * unregister, so whatever it registered before throwing remains;
-         * the safe recovery from a partial installation is
-         * reset-and-rebuild, which this mechanism makes cheap.
+         * (or the next rebuild) runs it again. Candidates contributed by a
+         * throwing provider are rolled back before that retry. Side effects
+         * in registries outside ``OperatorRegistry`` remain the provider's
+         * transaction/module-manager responsibility.
          */
-        void register_installer(std::string_view key, std::function<void()> installer);
+        OperatorProviderHandle register_installer(std::string_view key, std::function<void()> installer);
 
         /** Apply every installer not applied since the last reset. */
         void run_installers();
+
+        /**
+         * Remove one exact provider generation: first reject the operation
+         * while any wired graph/plan lease is live, then erase the provider's
+         * active candidates and installer intent. Returns false when the
+         * handle is empty, stale, or already removed. A later registry reset
+         * cannot resurrect a successfully removed provider.
+         */
+        bool remove_provider(const OperatorProviderHandle &provider);
 
         /** Select the unique best candidate, with the normalised call it accepted. */
         [[nodiscard]] ResolvedOperatorCall resolve(
@@ -540,6 +601,9 @@ namespace hgraph
         // reset point for all wiring-time global state.
 
       private:
+        void erase_provider_candidates(
+            const std::shared_ptr<operator_dispatch_detail::OperatorProviderState> &provider) noexcept;
+
         struct MeshScope
         {
             const TSValueTypeMetaData *element_schema{nullptr};
@@ -551,6 +615,7 @@ namespace hgraph
         {
             std::string           key{};
             std::function<void()> fn{};
+            std::shared_ptr<operator_dispatch_detail::OperatorProviderState> provider{};
             bool                  applied{false};
             bool                  running{false};
         };
@@ -560,6 +625,7 @@ namespace hgraph
         std::vector<MeshScope>                                     mesh_scopes_{};
         std::vector<ContextScopeEntry>                             context_scopes_{};
         std::vector<Installer>                                     installers_{};
+        std::shared_ptr<operator_dispatch_detail::OperatorProviderState> active_provider_{};
     };
 
     namespace operator_dispatch_detail

--- a/language/docs/design/modules.md
+++ b/language/docs/design/modules.md
@@ -257,10 +257,12 @@ permitted only after all code and metadata references are gone. The initial
 implementation may perform logical registration removal while retaining the
 library image for process lifetime.
 
-The current hgraph registry supports keyed replayable installers but not
-provider-scoped candidate removal or installer unregistration. The language
-therefore requires a first-class public module-registration handle and lease
-contract in hgraph; it must not erase registry internals itself.
+The hgraph operator registry now supports keyed replayable installers,
+provider-scoped candidate and installer removal, failed-installer rollback, and
+leases retained by graph plans and instances. The language still requires a
+first-class module-registration transaction spanning the other owned surfaces
+(types, exact functions, associations, and native resources); it must not erase
+registry internals or privately compose several unrelated handles itself.
 
 ## Native adaptor boundary
 

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -138,8 +138,10 @@ Deliverables:
 - generated module descriptors, initialization/bootstrap entry points,
   replayable installers, registration handles, and reverse-order
   deinitialization;
-- public hgraph provider-scoped candidate provenance, installer removal,
-  registration removal, and live-plan lease support;
+- public hgraph provider-scoped operator candidate provenance, installer and
+  candidate removal, failed-install rollback, and live-plan lease support
+  (implemented); registration ownership for the remaining module surfaces is
+  still required;
 - public hgraph TSW patterns that match a concrete duration window and bind
   named maximum and minimum size generics of either kind, and a compile-time
   duration `TSW` marker (the parity matrix records the gap);
@@ -195,7 +197,9 @@ build or reuse a complete content-addressed native image, load it into the
 command process's registry, and run through the ordinary wiring backend. Cache
 publication is atomic, damaged entries are quarantined, and compile failures
 retain and report their artifacts. Windows support, child orchestration, cache
-pruning, and replaceable REPL images remain.
+pruning, and replaceable REPL images remain. The underlying hgraph registry now
+has removable provider handles and graph-plan leases; generated HGL lifecycle
+and transactional replacement do not yet consume them.
 
 Deliverables:
 

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -849,11 +849,15 @@ allowed only when no installer callback, generated function, or type metadata
 points into that image. Logical removal may retain the image for process
 lifetime in the initial implementation.
 
-The current public hgraph `OperatorRegistry` provides keyed installers and
-reset replay but no provider-scoped removal or installer unregistration. Hgraph
-must gain a first-class module registration transaction/handle, candidate
-provenance, removal, and lease contract. Generated language code must not reach
-into registry storage or attempt to coordinate several registries privately.
+The public hgraph `OperatorRegistry` now returns an opaque provider handle from
+keyed installer registration, records candidate provenance while the installer
+runs, removes that provider's candidates and installer intent, rolls back a
+throwing installer's candidates, and carries provider leases through wired graph
+plans and runtime graphs. This is the operator-registry foundation, not yet the
+complete HGL module ABI: hgraph still needs one transaction/handle coordinating
+type associations, exact-function metadata, native resources, and operator
+registration. Generated language code must not reach into registry storage or
+coordinate those registries privately.
 
 ## Direct-wiring backend
 
@@ -1200,9 +1204,10 @@ Loaded images remain resident for the short-lived command because registry
 callbacks point into them. Successful transient build directories are removed;
 a compile failure retains its complete directory and reports the path.
 
-The REPL still uses only direct wiring. Loading its runtime declarations safely
-requires provider-scoped installer/candidate removal before a replacement image
-can become active. The parity suite runs every composition test accepted by
+The REPL still uses only direct wiring. Hgraph now provides provider-scoped
+operator installer/candidate removal and graph-plan leases; the HGL loader must
+retain those handles and add transactional replacement before a replacement
+image can become active. The parity suite runs every composition test accepted by
 both backends and compares the recorded ticks; the runtime fixture executes
 both as an ahead-of-time module and through the scripted loader.
 

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -859,6 +859,12 @@ type associations, exact-function metadata, native resources, and operator
 registration. Generated language code must not reach into registry storage or
 coordinate those registries privately.
 
+Indirect resolution follows the same rule as direct operator wiring. In
+particular, selecting a lifted kernel for a reduce or map node passes the active
+`Wiring` to the registry before the kernel pointer is stored in the node plan.
+A schema-only resolution probe may omit the wiring only when no provider-owned
+callback or metadata pointer escapes the probe.
+
 ## Direct-wiring backend
 
 Status: executable prototype (2026-09-03) with the test harness and run model in

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -323,6 +323,12 @@ complete new universe active, never a mixture. Module removal runs only at a
 quiescent wiring boundary; tests must not rely on concurrent mutation of the
 process-wide operator registry.
 
+The hgraph core suite now covers the operator-owned subset of this matrix:
+provider-specific candidate and installer removal, stale-handle isolation,
+failed-installer rollback and retry, reset non-resurrection, and leases retained
+by both reusable graph plans and runtime graph instances. The generated-module,
+multi-registry transaction and REPL replacement cases remain HGL work.
+
 ## Direct-wiring backend and the harness
 
 The first pass is covered by `tests/wiring/backend_tests.cpp`

--- a/language/docs/user-guide/testing-and-running.md
+++ b/language/docs/user-guide/testing-and-running.md
@@ -208,7 +208,8 @@ content-addressed native image or reuse a complete cached image, load its
 candidates into the same hgraph registry, and then use the ordinary harness.
 A failed native build reports and retains its artifact directory; incomplete or
 digest-mismatched cache entries are never loaded. The REPL
-does not yet load runtime images because safe replacement requires candidate
-and installer removal. The
+does not yet load runtime images: hgraph now supplies removable provider-owned
+operator candidates, but generated HGL module handles and transactional session
+replacement are not yet wired into the driver. The
 [Architecture](../design/architecture.md#two-backends-one-wiring) record
 describes the split; both backends must produce the same ticks.

--- a/src/hgraph/runtime/graph.cpp
+++ b/src/hgraph/runtime/graph.cpp
@@ -194,6 +194,9 @@ struct GraphRuntimeBaseStorage {
   /** Selected with ``logger`` and cached through nested graphs in O(1). */
   const LoggerOps *logger_ops{nullptr};
   const TypeRealizationSnapshot *type_realization{nullptr};
+  /** Opaque extension/module state. The graph header is destroyed after node
+      storage, so code-bearing leases outlive every callback which can use it. */
+  std::vector<std::shared_ptr<void>> retained_extension_state{};
 };
 
 struct RootGraphRuntimeStorage : GraphRuntimeBaseStorage {
@@ -1729,6 +1732,7 @@ GraphValue::GraphValue(const GraphBuilder &builder, ExecutorPtr root_executor) {
           state.logger = GraphExecutorView{root_executor}.logger();
           state.logger_ops = GraphExecutorView{root_executor}.logger_ops();
           state.type_realization = snapshot.get();
+          state.retained_extension_state = builder.retained_state_;
         });
   });
   pointer_ = type.writable(storage_.data());
@@ -1762,6 +1766,7 @@ GraphValue::GraphValue(const GraphBuilder &builder, NodePtr parent_node) {
           state.logger = NodeView{parent_node}.graph().logger();
           state.logger_ops = NodeView{parent_node}.graph().logger_ops();
           state.type_realization = effective_snapshot;
+          state.retained_extension_state = builder.retained_state_;
         });
   });
   pointer_ = type.writable(storage_.data());
@@ -1807,6 +1812,7 @@ GraphValue::GraphValue(const GraphBuilder &builder, NodePtr parent_node,
         state.logger = NodeView{parent_node}.graph().logger();
         state.logger_ops = NodeView{parent_node}.graph().logger_ops();
         state.type_realization = effective_snapshot;
+        state.retained_extension_state = builder.retained_state_;
       });
   auto rollback =
       make_scope_exit([&]() noexcept { type.destroy_at(external_memory); });
@@ -1963,6 +1969,16 @@ GraphBuilder &GraphBuilder::type_realization(
         "graph type realization snapshot must not be null");
   }
   type_realization_ = std::move(snapshot);
+  return *this;
+}
+
+GraphBuilder &
+GraphBuilder::retain_extension_state(std::shared_ptr<void> state) {
+  if (state == nullptr) {
+    throw std::invalid_argument(
+        "graph builder extension state must not be null");
+  }
+  retained_state_.push_back(std::move(state));
   return *this;
 }
 

--- a/src/hgraph/types/graph_wiring.cpp
+++ b/src/hgraph/types/graph_wiring.cpp
@@ -1192,6 +1192,7 @@ struct Wiring::Impl {
   bool live_seeded{false};
   std::vector<std::shared_ptr<void>> extension_state{};
   std::unordered_map<std::type_index, std::shared_ptr<void>> keyed_extension_state{};
+  std::vector<std::shared_ptr<void>> graph_state{};
   std::vector<std::function<void(Wiring &)>> pre_rank_finalizers{};
   std::shared_ptr<WiringObserverRegistry> observers{};
   std::vector<std::string> wiring_path{};
@@ -1374,6 +1375,13 @@ void Wiring::retain_extension_state(std::shared_ptr<void> state) {
     throw std::invalid_argument("Wiring extension state must not be null");
   }
   impl_->extension_state.push_back(std::move(state));
+}
+
+void Wiring::retain_graph_state(std::shared_ptr<void> state) {
+  if (state == nullptr) {
+    throw std::invalid_argument("Wiring graph state must not be null");
+  }
+  impl_->graph_state.push_back(std::move(state));
 }
 
 std::shared_ptr<void> Wiring::acquire_extension_state(
@@ -2560,6 +2568,9 @@ GraphBuilder Wiring::finish_top_level(bool consume_state) {
   for (const auto [key, boxed] : traits_map) {
     build.graph_builder.trait(key.checked_as<Str>(), boxed.as_any().get());
   }
+  for (const auto &state : impl_->graph_state) {
+    build.graph_builder.retain_extension_state(state);
+  }
   return std::move(build.graph_builder);
 }
 
@@ -2763,6 +2774,9 @@ CompiledSubGraph Wiring::finish_subgraph(
   const auto traits_map = traits_value.as_map();
   for (const auto [key, boxed] : traits_map) {
     build.graph_builder.trait(key.checked_as<Str>(), boxed.as_any().get());
+  }
+  for (const auto &state : impl_->graph_state) {
+    build.graph_builder.retain_extension_state(state);
   }
   compiled.graph_builder = std::move(build.graph_builder);
   const auto &index_of = build.index_of;

--- a/src/hgraph/types/operator_dispatch.cpp
+++ b/src/hgraph/types/operator_dispatch.cpp
@@ -6,13 +6,41 @@
 #include <fmt/ranges.h>
 
 #include <algorithm>
+#include <atomic>
 #include <exception>
 #include <limits>
 
 namespace hgraph
 {
+    namespace operator_dispatch_detail
+    {
+        struct OperatorProviderState
+        {
+            std::string              key{};
+            std::atomic<std::size_t> live_leases{0};
+            std::atomic<bool>        active{true};
+        };
+    }  // namespace operator_dispatch_detail
+
     namespace
     {
+        struct OperatorProviderLease
+        {
+            explicit OperatorProviderLease(
+                std::shared_ptr<operator_dispatch_detail::OperatorProviderState> provider)
+                : provider(std::move(provider))
+            {
+                this->provider->live_leases.fetch_add(1, std::memory_order_relaxed);
+            }
+
+            ~OperatorProviderLease()
+            {
+                provider->live_leases.fetch_sub(1, std::memory_order_release);
+            }
+
+            std::shared_ptr<operator_dispatch_detail::OperatorProviderState> provider;
+        };
+
         /** Render a constrained scalar variable as its actual accepted public
             type when it has exactly one constraint. The variable name is an
             implementation detail in that case; exposing ``PN`` instead of
@@ -667,8 +695,32 @@ namespace hgraph
         return *registry;
     }
 
+    OperatorProviderHandle::OperatorProviderHandle(
+        std::shared_ptr<operator_dispatch_detail::OperatorProviderState> state) noexcept
+        : state_(std::move(state))
+    {
+    }
+
+    bool OperatorProviderHandle::valid() const noexcept { return state_ != nullptr; }
+
+    bool OperatorProviderHandle::active() const noexcept
+    {
+        return state_ != nullptr && state_->active.load(std::memory_order_acquire);
+    }
+
+    std::string_view OperatorProviderHandle::key() const noexcept
+    {
+        return state_ != nullptr ? std::string_view{state_->key} : std::string_view{};
+    }
+
+    std::size_t OperatorProviderHandle::live_leases() const noexcept
+    {
+        return state_ != nullptr ? state_->live_leases.load(std::memory_order_acquire) : 0;
+    }
+
     void OperatorRegistry::register_overload(OperatorImpl impl)
     {
+        impl.provider = active_provider_;
         const std::string name = impl.name;
         auto &overloads = overloads_[name];
         overloads.push_back(std::move(impl));
@@ -683,8 +735,11 @@ namespace hgraph
         }
     }
 
-    void OperatorRegistry::register_installer(std::string_view key, std::function<void()> installer)
+    OperatorProviderHandle OperatorRegistry::register_installer(
+        std::string_view key, std::function<void()> installer)
     {
+        if (key.empty()) { throw std::invalid_argument("operator installer key must not be empty"); }
+        if (!installer) { throw std::invalid_argument("operator installer callback must not be empty"); }
         for (Installer &entry : installers_)
         {
             if (entry.key == key)
@@ -694,10 +749,17 @@ namespace hgraph
                 // attempt left applied=false, so a replaced callback runs on
                 // the next rebuild.
                 entry.fn = std::move(installer);
-                return;
+                return OperatorProviderHandle{entry.provider};
             }
         }
-        installers_.push_back(Installer{.key = std::string{key}, .fn = std::move(installer)});
+        auto provider = std::make_shared<operator_dispatch_detail::OperatorProviderState>();
+        provider->key = key;
+        installers_.push_back(Installer{
+            .key = std::string{key},
+            .fn = std::move(installer),
+            .provider = provider,
+        });
+        return OperatorProviderHandle{std::move(provider)};
     }
 
     void OperatorRegistry::run_installers()
@@ -716,6 +778,8 @@ namespace hgraph
             // set only AFTER success so a throwing installer is retried by
             // the next rebuild rather than silently stranded.
             installers_[i].running = true;
+            const auto provider = installers_[i].provider;
+            const auto previous_provider = std::exchange(active_provider_, provider);
             try
             {
                 // Copy: the stored entry may move if the callback appends.
@@ -724,12 +788,74 @@ namespace hgraph
             }
             catch (...)
             {
+                active_provider_ = previous_provider;
                 installers_[i].running = false;
+                erase_provider_candidates(provider);
                 throw;
             }
+            active_provider_ = previous_provider;
             installers_[i].running = false;
             installers_[i].applied = true;
         }
+    }
+
+    void OperatorRegistry::erase_provider_candidates(
+        const std::shared_ptr<operator_dispatch_detail::OperatorProviderState> &provider) noexcept
+    {
+        for (auto entry = overloads_.begin(); entry != overloads_.end();)
+        {
+            auto &overloads = entry->second;
+            std::erase_if(overloads, [&](const OperatorImpl &impl) { return impl.provider == provider; });
+            if (overloads.empty())
+            {
+                suffix_min_ranks_.erase(entry->first);
+                entry = overloads_.erase(entry);
+                continue;
+            }
+
+            auto suffix = suffix_min_ranks_.find(entry->first);
+            if (suffix != suffix_min_ranks_.end())
+            {
+                suffix->second.resize(overloads.size());
+                int minimum = std::numeric_limits<int>::max();
+                for (std::size_t i = overloads.size(); i-- > 0;)
+                {
+                    minimum = std::min(minimum, overloads[i].rank);
+                    suffix->second[i] = minimum;
+                }
+            }
+            ++entry;
+        }
+    }
+
+    bool OperatorRegistry::remove_provider(const OperatorProviderHandle &handle)
+    {
+        const auto provider = handle.state_;
+        if (provider == nullptr || !provider->active.load(std::memory_order_acquire)) { return false; }
+        if (active_provider_ != nullptr)
+        {
+            throw std::logic_error("cannot remove an operator provider while installers are running");
+        }
+
+        const auto installer = std::find_if(installers_.begin(), installers_.end(),
+                                            [&](const Installer &entry) { return entry.provider == provider; });
+        if (installer == installers_.end()) { return false; }
+        if (installer->running)
+        {
+            throw std::logic_error("cannot remove an operator provider while its installer is running");
+        }
+
+        const std::size_t leases = provider->live_leases.load(std::memory_order_acquire);
+        if (leases != 0)
+        {
+            throw OperatorProviderInUseError(fmt::format(
+                "cannot remove operator provider '{}' while {} live lease(s) retain it", provider->key, leases));
+        }
+
+        erase_provider_candidates(provider);
+        installers_.erase(installer);
+        provider->active.store(false, std::memory_order_release);
+        return true;
     }
 
     Value OperatorRegistry::evaluate_const(std::string_view name, std::span<const WiringArg> args,
@@ -1282,11 +1408,16 @@ namespace hgraph
             WiringArg positional = kw_arg;
             positional.name.clear();   // const takes the value positionally
             ResolvedOperatorCall lifted =
-                resolve("const", std::span<const WiringArg>{&positional, 1}, true, nullptr, {}, global_state);
+                resolve("const", std::span<const WiringArg>{&positional, 1}, true, nullptr, {}, global_state,
+                        wiring);
             OperatorWireResult source = lifted.impl->wire(*wiring, lifted.map, lifted.args, lifted.kwargs);
             kwargs.emplace_back(kw_name, source.output.erased());
         }
 
+        if (wiring != nullptr && winner.impl->provider != nullptr)
+        {
+            wiring->retain_graph_state(std::make_shared<OperatorProviderLease>(winner.impl->provider));
+        }
         return ResolvedOperatorCall{winner.impl, std::move(winner.map), std::move(winner.call.args),
                                     std::move(kwargs)};
     }

--- a/src/hgraph/types/service_runtime.cpp
+++ b/src/hgraph/types/service_runtime.cpp
@@ -384,10 +384,8 @@ namespace hgraph
         key_arg.kind = WiringArg::Kind::TimeSeries;
         key_arg.port = adapted_key;
         std::array<WiringArg, 2> item_args{dict_arg, key_arg};
-        ResolvedOperatorCall resolved = OperatorRegistry::instance().resolve(
-            "getitem_", std::span<const WiringArg>{item_args.data(), item_args.size()});
-        WiringPortRef output =
-            resolved.impl->wire(w, resolved.map, resolved.args, resolved.kwargs).output;
+        WiringPortRef output = wire_operator(
+            w, "getitem_", std::span<const WiringArg>{item_args.data(), item_args.size()}).output;
         output.schema = descriptor.value_schema;
         WiringPortRef gated = keyed_service_transport::defer_subscription_client(
             w,
@@ -596,10 +594,8 @@ namespace hgraph
         id_arg.kind = WiringArg::Kind::TimeSeries;
         id_arg.port = request_id;
         std::array<WiringArg, 2> item_args{dict_arg, id_arg};
-        ResolvedOperatorCall resolved = OperatorRegistry::instance().resolve(
-            "getitem_", std::span<const WiringArg>{item_args.data(), item_args.size()});
-        WiringPortRef output =
-            resolved.impl->wire(w, resolved.map, resolved.args, resolved.kwargs).output;
+        WiringPortRef output = wire_operator(
+            w, "getitem_", std::span<const WiringArg>{item_args.data(), item_args.size()}).output;
         output.schema = descriptor.response_schema;
         return output;
     }
@@ -1306,10 +1302,8 @@ namespace hgraph
         id_arg.kind = WiringArg::Kind::TimeSeries;
         id_arg.port = request_id;
         std::array<WiringArg, 2> item_args{dict_arg, id_arg};
-        ResolvedOperatorCall resolved = OperatorRegistry::instance().resolve(
-            "getitem_", std::span<const WiringArg>{item_args.data(), item_args.size()});
-        WiringPortRef output =
-            resolved.impl->wire(w, resolved.map, resolved.args, resolved.kwargs).output;
+        WiringPortRef output = wire_operator(
+            w, "getitem_", std::span<const WiringArg>{item_args.data(), item_args.size()}).output;
         output.schema = descriptor.output_schema;
         return output;
     }

--- a/tests/cpp/test_operator_installers.cpp
+++ b/tests/cpp/test_operator_installers.cpp
@@ -10,6 +10,7 @@
 #include <hgraph/types/time_series/ts_delta.h>
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include <stdexcept>
 
@@ -96,6 +97,37 @@ namespace
             wire<stdlib::record>(w, source, Str{"out"});
         }
     };
+
+    struct provider_probe : Operator<"provider_lifecycle_probe", Out<TS<Int>>>
+    {
+    };
+
+    struct leased_provider_probe : Operator<"leased_provider_probe", Out<TS<Int>>>
+    {
+    };
+
+    struct provider_probe_impl
+    {
+        static constexpr auto name              = "provider_probe_impl";
+        static constexpr bool schedule_on_start = true;
+
+        static void eval(Out<TS<Int>> out) { out.set(1); }
+    };
+
+    void install_provider_probe()
+    {
+        register_overload<provider_probe, provider_probe_impl>();
+    }
+
+    void install_leased_provider_probe()
+    {
+        register_overload<leased_provider_probe, provider_probe_impl>();
+    }
+
+    [[nodiscard]] std::size_t provider_probe_count()
+    {
+        return OperatorRegistry::instance().overload_signatures("provider_lifecycle_probe").size();
+    }
 }  // namespace
 
 TEST_CASE("installers: a reset-and-rebuild replays extensions exactly as core")
@@ -183,4 +215,103 @@ TEST_CASE("installers: an external backend records and replays through the core 
     const auto state = view.graph().global_state();
     REQUIRE(state.get(":probe:out").valid());
     CHECK(state.get(":probe:out").checked_as<Int>() == 42);
+}
+
+TEST_CASE("installers: provider removal erases only its candidates and reset intent")
+{
+    auto &registry = OperatorRegistry::instance();
+
+    // A directly registered candidate has no provider and must survive
+    // removal of a provider contributing to the same overload set.
+    register_overload<provider_probe, provider_probe_impl>();
+    OperatorProviderHandle provider =
+        registry.register_installer("test.removable-provider", &install_provider_probe);
+    CHECK(provider.valid());
+    CHECK(provider.active());
+    CHECK(provider.key() == "test.removable-provider");
+    CHECK(provider.live_leases() == 0);
+
+    registry.run_installers();
+    CHECK(provider_probe_count() == 2);
+
+    CHECK(registry.remove_provider(provider));
+    CHECK_FALSE(provider.active());
+    CHECK(provider_probe_count() == 1);
+    CHECK_FALSE(registry.remove_provider(provider));
+
+    // The direct candidate is reset, while removed installer intent is not
+    // replayed. Reusing the key creates a new generation which the stale
+    // handle cannot remove.
+    reset_all_registries();
+    registry.run_installers();
+    CHECK(provider_probe_count() == 0);
+
+    OperatorProviderHandle replacement =
+        registry.register_installer("test.removable-provider", &install_provider_probe);
+    registry.run_installers();
+    CHECK(replacement.active());
+    CHECK(provider_probe_count() == 1);
+    CHECK_FALSE(registry.remove_provider(provider));
+    CHECK(provider_probe_count() == 1);
+    CHECK(registry.remove_provider(replacement));
+}
+
+TEST_CASE("installers: a throwing provider rolls back candidates before retry")
+{
+    auto &registry = OperatorRegistry::instance();
+    int   attempts = 0;
+    OperatorProviderHandle provider = registry.register_installer(
+        "test.transactional-provider", [&] {
+            register_overload<provider_probe, provider_probe_impl>();
+            ++attempts;
+            if (attempts == 1) { throw std::runtime_error("provider install failed"); }
+        });
+
+    CHECK_THROWS_AS(registry.run_installers(), std::runtime_error);
+    CHECK(attempts == 1);
+    CHECK(provider_probe_count() == 0);
+
+    registry.run_installers();
+    CHECK(attempts == 2);
+    CHECK(provider_probe_count() == 1);
+    CHECK(registry.remove_provider(provider));
+}
+
+TEST_CASE("installers: provider leases follow graph plan and runtime lifetimes")
+{
+    auto &registry = OperatorRegistry::instance();
+    OperatorProviderHandle provider =
+        registry.register_installer("test.leased-provider", &install_leased_provider_probe);
+    registry.run_installers();
+
+    GraphBuilder graph_builder;
+    {
+        Wiring wiring;
+        static_cast<void>(wire<leased_provider_probe, TS<Int>>(wiring));
+        CHECK(provider.live_leases() == 1);
+        CHECK_THROWS_AS(registry.remove_provider(provider), OperatorProviderInUseError);
+        graph_builder = std::move(wiring).finish();
+    }
+    CHECK(provider.live_leases() == 1);
+    CHECK_THROWS_AS(registry.remove_provider(provider), OperatorProviderInUseError);
+    CHECK(provider.active());
+
+    GraphExecutorValue executor;
+    {
+        GraphExecutorBuilder executor_builder;
+        executor_builder.graph_builder(std::move(graph_builder));
+        executor = executor_builder.make_executor();
+        CHECK(provider.live_leases() == 1);
+        CHECK_THROWS_AS(registry.remove_provider(provider), OperatorProviderInUseError);
+    }
+
+    // The reusable builder is gone, but the runtime graph independently
+    // retains the same lease until its executor is destroyed.
+    CHECK(provider.live_leases() == 1);
+    CHECK_THROWS_WITH(registry.remove_provider(provider),
+                      Catch::Matchers::ContainsSubstring("test.leased-provider") &&
+                          Catch::Matchers::ContainsSubstring("live lease"));
+    executor = GraphExecutorValue{};
+    CHECK(provider.live_leases() == 0);
+    CHECK(registry.remove_provider(provider));
 }

--- a/tests/cpp/test_operator_installers.cpp
+++ b/tests/cpp/test_operator_installers.cpp
@@ -1,5 +1,6 @@
 #include <hgraph/lib/std/operators/io.h>
 #include <hgraph/lib/std/std_operators.h>
+#include <hgraph/lib/std/value_util.h>
 #include <hgraph/runtime/node_scheduler.h>
 #include <hgraph/runtime/runtime.h>
 #include <hgraph/types/graph_wiring.h>
@@ -106,6 +107,13 @@ namespace
     {
     };
 
+    struct provider_lifted_add : Operator<"provider_lifted_add",
+                                          In<"lhs", TS<Int>>,
+                                          In<"rhs", TS<Int>>,
+                                          Out<TS<Int>>>
+    {
+    };
+
     struct provider_probe_impl
     {
         static constexpr auto name              = "provider_probe_impl";
@@ -122,6 +130,11 @@ namespace
     void install_leased_provider_probe()
     {
         register_overload<leased_provider_probe, provider_probe_impl>();
+    }
+
+    void install_provider_lifted_add()
+    {
+        register_overload<provider_lifted_add, lift<stdlib::scalar_add<Int>>>();
     }
 
     [[nodiscard]] std::size_t provider_probe_count()
@@ -312,6 +325,34 @@ TEST_CASE("installers: provider leases follow graph plan and runtime lifetimes")
                       Catch::Matchers::ContainsSubstring("test.leased-provider") &&
                           Catch::Matchers::ContainsSubstring("live lease"));
     executor = GraphExecutorValue{};
+    CHECK(provider.live_leases() == 0);
+    CHECK(registry.remove_provider(provider));
+}
+
+TEST_CASE("installers: lifted-kernel plans retain their operator provider")
+{
+    stdlib::register_standard_operators();
+    auto &registry = OperatorRegistry::instance();
+    OperatorProviderHandle provider =
+        registry.register_installer("test.lifted-provider", &install_provider_lifted_add);
+    registry.run_installers();
+
+    {
+        GraphBuilder graph_builder;
+        {
+            Wiring wiring;
+            auto values = wire<stdlib::const_, TSL<TS<Int>, 3>>(
+                wiring, stdlib::make_list<Int>({Int{1}, Int{2}, Int{3}}));
+            static_cast<void>(wire<stdlib::reduce_>(
+                wiring, fn<provider_lifted_add>(), values));
+            CHECK(provider.live_leases() > 0);
+            CHECK_THROWS_AS(registry.remove_provider(provider), OperatorProviderInUseError);
+            graph_builder = std::move(wiring).finish();
+        }
+        CHECK(provider.live_leases() > 0);
+        CHECK_THROWS_AS(registry.remove_provider(provider), OperatorProviderInUseError);
+    }
+
     CHECK(provider.live_leases() == 0);
     CHECK(registry.remove_provider(provider));
 }

--- a/tests/install_consumer/main.cpp
+++ b/tests/install_consumer/main.cpp
@@ -262,9 +262,10 @@ namespace
 
         // Registration intent recorded once; the rebuild call replays it —
         // including after a full registry reset (the extension contract).
-        OperatorRegistry::instance().register_installer("hgraph.test.probe",
-                                                        &install_probe_backend);
-        OperatorRegistry::instance().run_installers();
+        auto &operator_registry = OperatorRegistry::instance();
+        OperatorProviderHandle provider = operator_registry.register_installer(
+            "hgraph.test.probe", &install_probe_backend);
+        operator_registry.run_installers();
 
         const auto run_round_trip = [] {
             Wiring wiring;
@@ -299,6 +300,12 @@ namespace
         };
 
         run_round_trip();
+
+        if (provider.live_leases() != 0 || !operator_registry.remove_provider(provider) || provider.active())
+        {
+            throw std::runtime_error(
+                "installed operator provider did not release after its graph lifetime");
+        }
 
         // The reset-and-rebuild replay of this installer is covered by the
         // in-tree installer tests and the Python extension consumer:


### PR DESCRIPTION
## Summary

- return generation-stable provider handles from keyed `OperatorRegistry` installers and record candidate provenance
- roll back candidates from failed installer attempts, support provider-specific removal, and prevent reset from resurrecting removed providers
- retain provider leases through `Wiring`, reusable `GraphBuilder` plans, and runtime graph storage so removal is rejected while executable code is live
- document this core foundation and the remaining multi-registry HGL module transaction work
- exercise the public API through the installed-SDK consumer

## Validation

- macOS language-enabled fresh all-target build and CTest: 1,707/1,707 passed
- macOS Python 3.14 suite from a Python 3.12 ABI3 wheel: 2,287 passed, 10 skipped
- macOS installed-SDK consumer: passed
- private Linux language-enabled fresh all-target build and CTest: 1,707/1,707 passed
- private Linux Python 3.14 suite from a Python 3.12 ABI3 wheel: 2,287 passed, 10 skipped
- private Linux installed-SDK consumer: passed

## Stack

Depends on #641 and should be merged after it.