### PR TITLE
Add architecture ratchets for wrong-layer patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,12 @@ Concretely, for any non-trivial change:
 - **(iii) Parallel abstractions.** v2 principle: **one runtime model, no generic
   fallback**. Subscription/notification, delta cleanup, and modified-time tracking
   already exist (§4). Two ways to do one thing is the smell to kill, not add to.
+  **Enforced** (2026-09-04): `python/tests/test_architecture_ratchets.py` pins the
+  occurrence counts of the known wrong-layer patterns (consumer-side REF
+  dereference, per-tick `TSTypeKind::REF` probes, operator-name type-carrier
+  branches, extra ancestry walkers, Python-object handling in the type layer,
+  runtime thread-locals). A count may only fall; raising one needs a design
+  record in the same change. See `testing.rst`, "Architecture ratchets".
 
 ---
 

--- a/docs/source/developer_guide/testing.rst
+++ b/docs/source/developer_guide/testing.rst
@@ -192,6 +192,39 @@ The continuously evolving released-hgraph comparison is documented in
 verified mismatch into the ordinary Python and native C++ regression layers;
 it does not replace either acceptance suite.
 
+Architecture ratchets
+---------------------
+
+``python/tests/test_architecture_ratchets.py`` pins the number of occurrences
+of a small set of source patterns that the 2026-09-04 fix-series retrospective
+(PRs #525, #555, #610, #636) identified as a rule applied at the wrong layer.
+Each entry names the layer that owns the rule:
+
+* a std operator dereferencing its own ``REF`` input, or Python wiring
+  handling ``is_ref``/``dereferenced`` by hand, when binding inserts the
+  from-REF adaptation and the type-pattern matcher binds the dereferenced
+  schema;
+* the runtime probing ``TSTypeKind::REF`` per tick, when a node's REF handling
+  mode is fixed when the node is built;
+* Python wiring choosing a type carrier by operator name, or keeping a shadow
+  schema-to-Python-type dictionary, when the resolver and the registry own
+  both;
+* a second or third ancestry walker beside ``TypeRegistry::value_is_a``;
+* operators recomputing ``value_type_for_active_realization`` instead of
+  reading the binding from their bound views;
+* Python-object hashing in more than one translation unit, and
+  ``HGRAPH_ENABLE_PYTHON_USER_NODES`` conditionals inside the type layer;
+* ``thread_local`` in the runtime.
+
+The test fails when a count moves in either direction. A rise is a new copy
+of a rule that already has an owner: fix it at the owning layer, or record the
+deliberate exception in the relevant developer-guide page and raise the
+baseline in the same change. A fall is the intended outcome of a
+consolidation: lower the baseline in the same change so the ratchet stays
+tight. ``HGRAPH_RATCHET_REPORT=1`` prints the current table with a per-file
+breakdown instead of asserting. The test reads the source tree and skips when
+run against an installed wheel outside the repository.
+
 Commands
 --------
 

--- a/python/tests/test_architecture_ratchets.py
+++ b/python/tests/test_architecture_ratchets.py
@@ -1,0 +1,242 @@
+"""Architecture ratchets: layering leaks that must only ever shrink.
+
+Design record: ``docs/source/developer_guide/testing.rst`` ("Architecture
+ratchets"). Each entry below pins the number of occurrences of a pattern that
+the 2026-09-04 fix-series retrospective identified as a rule applied at the
+wrong layer (a consumer dereferencing a REF that binding should have
+dereferenced, Python wiring matching type carriers by operator name, the
+runtime probing a schema kind per tick, Python-object handling inside the
+type layer, ...).
+
+The test fails when a count moves in *either* direction:
+
+* an increase means a new copy of a rule that already has an owner - fix it
+  at the owning layer instead, or record the deliberate exception in the
+  developer guide and raise the baseline in the same change;
+* a decrease is the intended outcome of a consolidation - lower the baseline
+  in the same change so the ratchet stays tight.
+
+Run with ``HGRAPH_RATCHET_REPORT=1`` to print the current table instead of
+asserting.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_EXCLUDED_PARTS = {"tests", "_deps", "build", ".venv", "__pycache__"}
+
+
+@dataclass(frozen=True)
+class Ratchet:
+    """One pinned occurrence count.
+
+    ``mode`` is ``"matches"`` (total regex matches) or ``"files"`` (number of
+    files containing at least one match).
+    """
+
+    id: str
+    baseline: int
+    roots: tuple[str, ...]
+    suffixes: tuple[str, ...]
+    pattern: str
+    owner: str
+    mode: str = "matches"
+
+
+RATCHETS: tuple[Ratchet, ...] = (
+    # --- REF transparency belongs to the binding (retrospective family 1) ---
+    Ratchet(
+        id="stdlib-ref-dereference",
+        baseline=64,
+        roots=("include/hgraph/lib/std/operators/impl",),
+        suffixes=(".h",),
+        pattern=r"\bdereference\(",
+        owner="type_pattern input matcher binds the recursively dereferenced "
+        "schema; an operator never dereferences its own input",
+    ),
+    Ratchet(
+        id="wiring-ref-handling",
+        baseline=22,
+        roots=("python/hgraph/_wiring",),
+        suffixes=(".py",),
+        pattern=r"\b(is_ref|dereferenced|ref_target)\b",
+        owner="binding inserts the from-REF adaptation "
+        "(python_bridge.rst, 'Value and reference crossings')",
+    ),
+    Ratchet(
+        id="value-consumer-source-callers",
+        baseline=3,
+        roots=("src/hgraph", "include/hgraph", "python"),
+        suffixes=(".cpp", ".h"),
+        pattern=r"\bvalue_consumer_source\(",
+        owner="value_argument is the sole caller; declaration + definition + "
+        "that caller is the floor",
+    ),
+    # --- REF ownership at nested boundaries is a build-time property (family 2) ---
+    Ratchet(
+        id="runtime-ref-kind-probes",
+        baseline=13,
+        roots=("src/hgraph/runtime", "include/hgraph/runtime"),
+        suffixes=(".cpp", ".h"),
+        pattern=r"TSTypeKind::REF",
+        owner="a node's REF handling mode is decided when the node is built "
+        "(nested_graphs.rst), not by probing the schema per tick",
+    ),
+    # --- Type carriers are resolved by the resolver (family 3) ---
+    Ratchet(
+        id="wiring-operator-name-branches",
+        baseline=8,
+        roots=("python/hgraph/_wiring",),
+        suffixes=(".py",),
+        pattern=r"self\.__name__\s*(==|in)\s",
+        owner="which argument is a type carrier is a property of the "
+        "signature (operators.rst), never of the operator name",
+    ),
+    Ratchet(
+        id="types-shadow-schema-dicts",
+        baseline=10,
+        roots=("python/hgraph/_types.py",),
+        suffixes=(".py",),
+        pattern=r"_(TS|VALUE)_SCALAR_TYPES\b",
+        owner="the registry is the single schema-to-Python-type authority",
+    ),
+    # --- One ancestry walker (family 4) ---
+    Ratchet(
+        id="bundle-only-ancestry",
+        baseline=23,
+        roots=("src/hgraph", "include/hgraph", "python"),
+        suffixes=(".cpp", ".h"),
+        pattern=r"\bbundle_is_a\(",
+        owner="TypeRegistry::value_is_a covers bundles and opaque Python "
+        "values; bundle_is_a is the un-migrated remainder",
+    ),
+    Ratchet(
+        id="stdlib-ancestry-walker",
+        baseline=4,
+        roots=("include/hgraph/lib/std", "src/hgraph/lib/std"),
+        suffixes=(".cpp", ".h"),
+        pattern=r"\bdispatch_bundle_is_a\b",
+        owner="the registry owns ancestry; a lock-free is_a on its immutable "
+        "parent links replaces the std-operator copy",
+    ),
+    # --- Operators read bindings from views (family 5) ---
+    Ratchet(
+        id="stdlib-active-realization",
+        baseline=34,
+        roots=("include/hgraph/lib/std/operators/impl",),
+        suffixes=(".h",),
+        pattern=r"\bvalue_type_for_active_realization\b",
+        owner="realized bindings travel with bound views; operators do not "
+        "recompute realization",
+    ),
+    # --- Python-object handling stays behind an ops table (family 6) ---
+    Ratchet(
+        id="python-object-hash-units",
+        baseline=3,
+        roots=("src/hgraph", "include/hgraph", "python"),
+        suffixes=(".cpp", ".h"),
+        pattern=r"\bPyObject_Hash\b",
+        owner="one PythonObjectOps table; translation units that hash a "
+        "Python object",
+        mode="files",
+    ),
+    Ratchet(
+        id="type-layer-python-conditionals",
+        baseline=165,
+        roots=("src/hgraph/types", "include/hgraph/types"),
+        suffixes=(".cpp", ".h"),
+        pattern=r"HGRAPH_ENABLE_PYTHON_USER_NODES",
+        owner="the type layer sees Python only through registered ops tables "
+        "(python_bridge.rst, 'No kind-switches in conversion')",
+    ),
+    # --- Rulings (family 8) ---
+    Ratchet(
+        id="runtime-thread-locals",
+        baseline=2,
+        roots=("src/hgraph/runtime", "include/hgraph/runtime"),
+        suffixes=(".cpp", ".h"),
+        pattern=r"\bthread_local\b",
+        owner="per-graph state binds to the running graph, never the thread "
+        "(CLAUDE.md conventions)",
+    ),
+)
+
+
+def _files(ratchet: Ratchet):
+    for root in ratchet.roots:
+        path = REPO_ROOT / root
+        if path.is_file():
+            if path.suffix in ratchet.suffixes:
+                yield path
+            continue
+        if not path.is_dir():
+            continue
+        for candidate in sorted(path.rglob("*")):
+            if not candidate.is_file() or candidate.suffix not in ratchet.suffixes:
+                continue
+            relative = candidate.relative_to(REPO_ROOT)
+            if _EXCLUDED_PARTS.intersection(relative.parts[:-1]):
+                continue
+            yield candidate
+
+
+def measure(ratchet: Ratchet) -> tuple[int, dict[str, int]]:
+    """Return the current count and a per-file breakdown."""
+    expression = re.compile(ratchet.pattern)
+    per_file: dict[str, int] = {}
+    for path in _files(ratchet):
+        hits = len(expression.findall(path.read_text(encoding="utf-8", errors="replace")))
+        if hits:
+            per_file[path.relative_to(REPO_ROOT).as_posix()] = hits
+    if ratchet.mode == "files":
+        return len(per_file), per_file
+    return sum(per_file.values()), per_file
+
+
+def _breakdown(per_file: dict[str, int]) -> str:
+    return "\n".join(f"    {count:4d}  {path}" for path, count in sorted(per_file.items()))
+
+
+_SOURCE_PRESENT = (REPO_ROOT / "src" / "hgraph").is_dir() and (
+    REPO_ROOT / "python" / "hgraph"
+).is_dir()
+
+
+@pytest.mark.skipif(not _SOURCE_PRESENT, reason="ratchets read the source tree")
+@pytest.mark.parametrize("ratchet", RATCHETS, ids=[r.id for r in RATCHETS])
+def test_architecture_ratchet(ratchet: Ratchet):
+    count, per_file = measure(ratchet)
+    if os.environ.get("HGRAPH_RATCHET_REPORT"):
+        print(f"{ratchet.id}: {count} (baseline {ratchet.baseline})\n{_breakdown(per_file)}")
+        return
+    if count > ratchet.baseline:
+        pytest.fail(
+            f"{ratchet.id}: {count} occurrences, baseline {ratchet.baseline}.\n"
+            f"  Owner of this rule: {ratchet.owner}.\n"
+            "  A new copy of a rule that already has an owner is the layering leak "
+            "this ratchet exists to catch. Fix it at the owning layer, or record the "
+            "exception in the developer guide and raise the baseline in the same "
+            "change.\n"
+            f"{_breakdown(per_file)}"
+        )
+    if count < ratchet.baseline:
+        pytest.fail(
+            f"{ratchet.id}: {count} occurrences, baseline {ratchet.baseline}.\n"
+            "  The count dropped - good. Lower the baseline in "
+            "python/tests/test_architecture_ratchets.py in this change so the "
+            "ratchet stays tight.\n"
+            f"{_breakdown(per_file)}"
+        )
+
+
+def test_ratchet_ids_are_unique():
+    ids = [ratchet.id for ratchet in RATCHETS]
+    assert len(ids) == len(set(ids))

--- a/python/tests/test_architecture_ratchets.py
+++ b/python/tests/test_architecture_ratchets.py
@@ -212,10 +212,13 @@ _SOURCE_PRESENT = (REPO_ROOT / "src" / "hgraph").is_dir() and (
 
 @pytest.mark.skipif(not _SOURCE_PRESENT, reason="ratchets read the source tree")
 @pytest.mark.parametrize("ratchet", RATCHETS, ids=[r.id for r in RATCHETS])
-def test_architecture_ratchet(ratchet: Ratchet):
+def test_architecture_ratchet(ratchet: Ratchet, pytestconfig: pytest.Config):
     count, per_file = measure(ratchet)
     if os.environ.get("HGRAPH_RATCHET_REPORT"):
-        print(f"{ratchet.id}: {count} (baseline {ratchet.baseline})\n{_breakdown(per_file)}")
+        reporter = pytestconfig.pluginmanager.get_plugin("terminalreporter")
+        reporter.write_line(
+            f"{ratchet.id}: {count} (baseline {ratchet.baseline})\n{_breakdown(per_file)}"
+        )
         return
     if count > ratchet.baseline:
         pytest.fail(


### PR DESCRIPTION
**Stack 1 of N** from the 2026-09-04 fix-series retrospective (review of #525, #555, #610, #636). Base: `main`.

The review found the same few rules re-implemented at the consumer that happened to fail rather than at the layer that owns them. This PR adds `python/tests/test_architecture_ratchets.py`, which pins the occurrence count of each known wrong-layer pattern:

| ratchet | baseline | owning layer |
|---|---:|---|
| `stdlib-ref-dereference` | 64 | type-pattern matcher binds the dereferenced schema |
| `wiring-ref-handling` | 22 | binding inserts the from-REF adaptation |
| `value-consumer-source-callers` | 3 | `value_argument` is the sole caller |
| `runtime-ref-kind-probes` | 13 | REF mode is fixed when the node is built |
| `wiring-operator-name-branches` | 8 | type carriers are a property of the signature |
| `types-shadow-schema-dicts` | 10 | the registry is the schema-to-Python-type authority |
| `bundle-only-ancestry` | 23 | `TypeRegistry::value_is_a` |
| `stdlib-ancestry-walker` | 4 | registry ancestry, lock-free |
| `stdlib-active-realization` | 34 | bindings travel with bound views |
| `python-object-hash-units` | 3 files | one Python-object ops table |
| `type-layer-python-conditionals` | 165 | type layer sees Python only via ops tables |
| `runtime-thread-locals` | 2 | per-graph state binds to the graph |

A count may only fall. A rise fails with the owning layer named; raising a baseline requires a design record in the same change. A fall also fails, asking for the baseline to be lowered in the same change so the ratchet stays tight. `HGRAPH_RATCHET_REPORT=1` prints the table with a per-file breakdown.

Design record: `docs/source/developer_guide/testing.rst`, "Architecture ratchets". CLAUDE.md guardrail (iii) now points at the test.

Following PRs in the stack lower these numbers: REF-by-consumer sweep, REF at the matcher, nested-boundary output mode, type carriers into the resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
