### PR TITLE
Apply the value-consumer REF rule where inputs are adapted

### DIFF
--- a/docs/source/developer_guide/writing_nodes.rst
+++ b/docs/source/developer_guide/writing_nodes.rst
@@ -111,7 +111,17 @@ where the value belonged. Nothing raises, and the output looks like data.
 **Where the rule is applied.** At the point arguments are BOUND, not in each
 consumer:
 
-* ordinary inputs — ``adapt_source_for_input`` installs the adaptation;
+* ordinary inputs — ``adapt_source_for_input`` installs the adaptation. A
+  peered source that carries a ``REF`` anywhere in its schema is described
+  by its value schema whenever the declared input contains no ``REF``, so a
+  hand-wired consumer that builds its node schema from the port (``reduce``,
+  ``mesh_``) sees the value it will observe; input binding installs the
+  from-REF link. The rule follows structural ``TSL``/``TSB`` sources down to
+  their leaves but stops at a declared ``REF``: the children of a source
+  adapted to ``REF[X]`` keep their reference identity, which is how ``race``
+  observes a candidate going invalid. Before this was made structural (#649,
+  2026-09-04) such consumers saw ``REF[TSD]`` and either rejected it at
+  wiring or failed at runtime on the ops kind;
 * variadic tails — ``operator_dispatch_detail::value_argument`` dereferences
   unless the declared schema is ``REF<...>``;
 * an UNTYPED ``VarKwIn<Name>`` — nothing in a bare collector could ask for a

--- a/docs/source/developer_guide/writing_nodes.rst
+++ b/docs/source/developer_guide/writing_nodes.rst
@@ -112,16 +112,22 @@ where the value belonged. Nothing raises, and the output looks like data.
 consumer:
 
 * ordinary inputs — ``adapt_source_for_input`` installs the adaptation. A
-  peered source that carries a ``REF`` anywhere in its schema is described
-  by its value schema whenever the declared input contains no ``REF``, so a
-  hand-wired consumer that builds its node schema from the port (``reduce``,
-  ``mesh_``) sees the value it will observe; input binding installs the
-  from-REF link. The rule follows structural ``TSL``/``TSB`` sources down to
-  their leaves but stops at a declared ``REF``: the children of a source
-  adapted to ``REF[X]`` keep their reference identity, which is how ``race``
-  observes a candidate going invalid. Before this was made structural (#649,
-  2026-09-04) such consumers saw ``REF[TSD]`` and either rejected it at
-  wiring or failed at runtime on the ops kind;
+  peered *reference* source (a top-level ``REF``) is described by its value
+  schema whenever the declared input contains no ``REF``, so a hand-wired
+  consumer that builds its node schema from the port (``reduce``, ``mesh_``)
+  sees the value it will observe; input binding installs the from-REF link.
+  Only the top-level reference is rewritten: a value collection whose
+  elements are references (a ``map_`` output) is left as supplied, because
+  its element links dereference on access and describing it by element
+  values would install a from-REF link per element for a consumer that may
+  only hold tokens (an interleaved A/B against ``main`` showed no runtime
+  difference either way; the narrower rewrite is the minimal adaptation).
+  The rule follows structural ``TSL``/``TSB``
+  sources down to their leaves but stops at a declared ``REF``: the children
+  of a source adapted to ``REF[X]`` keep their reference identity, which is
+  how ``race`` observes a candidate going invalid. Before this was made
+  structural (#649, 2026-09-04) such consumers saw ``REF[TSD]`` and either
+  rejected it at wiring or failed at runtime on the ops kind;
 * variadic tails — ``operator_dispatch_detail::value_argument`` dereferences
   unless the declared schema is ``REF<...>``;
 * an UNTYPED ``VarKwIn<Name>`` — nothing in a bare collector could ask for a

--- a/include/hgraph/lib/std/operators/impl/higher_order_impl.h
+++ b/include/hgraph/lib/std/operators/impl/higher_order_impl.h
@@ -3597,7 +3597,9 @@ namespace hgraph::stdlib
                 throw std::invalid_argument(
                     "mesh lookup key type does not match the enclosing mesh key type");
             }
-            WiringPortRef item = graph_wiring_detail::value_consumer_source(key);
+            // The key is a value input of the subscribe node: the from-REF rule is
+            // applied where every input gets it, not by hand here.
+            WiringPortRef item = graph_wiring_detail::adapt_source_for_input(w, key_schema, key);
 
             // {item, value}: ``item`` is the requested key (wired); ``value`` starts at a
             // never-ticking ``nothing<OUT>`` placeholder and is rebound at runtime to

--- a/python/tests/test_architecture_ratchets.py
+++ b/python/tests/test_architecture_ratchets.py
@@ -77,8 +77,9 @@ RATCHETS: tuple[Ratchet, ...] = (
         roots=("src/hgraph", "include/hgraph", "python"),
         suffixes=(".cpp", ".h"),
         pattern=r"\bvalue_consumer_source\(",
-        owner="value_argument is the sole caller; declaration + definition + "
-        "that caller is the floor",
+        owner="value_argument (variadic tails) and adapt_source_for_input "
+        "(ordinary inputs) are the two rule sites; declaration + those two "
+        "is the floor",
     ),
     # --- REF ownership at nested boundaries is a build-time property (family 2) ---
     Ratchet(

--- a/python/tests/test_ref_consumer_sweep.py
+++ b/python/tests/test_ref_consumer_sweep.py
@@ -372,15 +372,7 @@ _REF_COLLECTION_SOURCES = ("ref_node", "tsd_getitem", "map_element", "if_true", 
 
 KNOWN_GAPS: dict[str, str] = {
     **{
-        f"TSD[str, TS[int]]-{source}-reduce": "#649 reduce rejects a REF-valued TSD (family 1)"
-        for source in _REF_COLLECTION_SOURCES
-    },
-    **{
         f"TSD[str, TS[int]]-{source}-mesh_": "#649 mesh_ fails at runtime on a REF-valued TSD (family 1)"
-        for source in _REF_COLLECTION_SOURCES
-    },
-    **{
-        f"TSL[TS[int], Size[2]]-{source}-reduce": "#649 reduce rejects a REF-valued TSL (family 1)"
         for source in _REF_COLLECTION_SOURCES
     },
 }

--- a/src/hgraph/types/graph_wiring.cpp
+++ b/src/hgraph/types/graph_wiring.cpp
@@ -979,8 +979,31 @@ build_ranked_graph(std::deque<WiringInstance> &instances,
 }
 } // namespace
 
+namespace {
+// ``value_consumer`` is true while the declared input being adapted asks for
+// a value: it is cleared once adaptation descends inside a declared REF, so a
+// reference-constructing node keeps its children's reference identity.
+WiringPortRef adapt_source_for_input_impl(Wiring &w,
+                                          const TSValueTypeMetaData *input_schema,
+                                          WiringPortRef source,
+                                          bool value_consumer);
+} // namespace
+
 WiringPortRef graph_wiring_detail::adapt_source_for_input(
     Wiring &w, const TSValueTypeMetaData *input_schema, WiringPortRef source) {
+  const bool value_consumer =
+      input_schema != nullptr && !TypeRegistry::contains_ref(input_schema);
+  return adapt_source_for_input_impl(w, input_schema, std::move(source),
+                                     value_consumer);
+}
+
+namespace {
+WiringPortRef adapt_source_for_input_impl(Wiring &w,
+                                          const TSValueTypeMetaData *input_schema,
+                                          WiringPortRef source,
+                                          const bool value_consumer) {
+  using graph_wiring_detail::input_accepts_output_schema;
+  using graph_wiring_detail::value_consumer_source;
   if (input_schema == nullptr) {
     return source;
   }
@@ -1015,6 +1038,17 @@ WiringPortRef graph_wiring_detail::adapt_source_for_input(
   }
 
   if (!source.is_structural_source()) {
+    // A value consumer observes the referenced value, never the REF token
+    // used to reach it (writing_nodes.rst, "Where the rule is applied"). A
+    // peered source that carries a REF is therefore described by the value
+    // schema, so ordinary input binding installs the from-REF adaptation
+    // instead of every hand-wired consumer dereferencing for itself (#649).
+    // A REF declared anywhere in the input keeps the source as supplied: the
+    // declaration wins.
+    if (value_consumer && source.schema != nullptr &&
+        TypeRegistry::contains_ref(source.schema)) {
+      return value_consumer_source(std::move(source));
+    }
     return source;
   }
 
@@ -1025,7 +1059,9 @@ WiringPortRef graph_wiring_detail::adapt_source_for_input(
           "wire<T>: structural source schema does not match REF input target");
     }
 
-    source = adapt_source_for_input(w, target_schema, std::move(source));
+    // Inside a declared REF the children keep their reference identity.
+    source = adapt_source_for_input_impl(w, target_schema, std::move(source),
+                                         false);
     std::array<WiringPortRef, 1> inputs{std::move(source)};
     NodeBuilder builder = structural_ref_node_builder(target_schema, inputs[0]);
     return w.add_node(
@@ -1043,8 +1079,8 @@ WiringPortRef graph_wiring_detail::adapt_source_for_input(
     }
     adapted.reserve(source_children.size());
     for (const WiringPortRef &child : source_children) {
-      adapted.push_back(
-          adapt_source_for_input(w, input_schema->element_ts(), child));
+      adapted.push_back(adapt_source_for_input_impl(
+          w, input_schema->element_ts(), child, value_consumer));
     }
     return WiringPortRef::structural_source(input_schema, std::move(adapted));
 
@@ -1054,8 +1090,9 @@ WiringPortRef graph_wiring_detail::adapt_source_for_input(
     }
     adapted.reserve(source_children.size());
     for (std::size_t index = 0; index < source_children.size(); ++index) {
-      adapted.push_back(adapt_source_for_input(
-          w, input_schema->fields()[index].type, source_children[index]));
+      adapted.push_back(adapt_source_for_input_impl(
+          w, input_schema->fields()[index].type, source_children[index],
+          value_consumer));
     }
     return WiringPortRef::structural_source(input_schema, std::move(adapted));
 
@@ -1063,6 +1100,7 @@ WiringPortRef graph_wiring_detail::adapt_source_for_input(
     return source;
   }
 }
+} // namespace
 
 WiringPortRef
 graph_wiring_detail::resolve_context_source(Wiring &w, std::string_view name) {

--- a/src/hgraph/types/graph_wiring.cpp
+++ b/src/hgraph/types/graph_wiring.cpp
@@ -1040,13 +1040,17 @@ WiringPortRef adapt_source_for_input_impl(Wiring &w,
   if (!source.is_structural_source()) {
     // A value consumer observes the referenced value, never the REF token
     // used to reach it (writing_nodes.rst, "Where the rule is applied"). A
-    // peered source that carries a REF is therefore described by the value
-    // schema, so ordinary input binding installs the from-REF adaptation
-    // instead of every hand-wired consumer dereferencing for itself (#649).
-    // A REF declared anywhere in the input keeps the source as supplied: the
+    // peered REFERENCE source is therefore described by the value schema, so
+    // ordinary input binding installs the from-REF adaptation instead of
+    // every hand-wired consumer dereferencing for itself (#649). Only the
+    // top-level reference: a value collection whose elements are references
+    // (a map_ output) is left as supplied - its element links dereference on
+    // access, and describing it by element values would install a from-REF
+    // link per element for a consumer that may only hold tokens. A REF
+    // declared anywhere in the input keeps the source as supplied: the
     // declaration wins.
     if (value_consumer && source.schema != nullptr &&
-        TypeRegistry::contains_ref(source.schema)) {
+        source.schema->kind == TSTypeKind::REF) {
       return value_consumer_source(std::move(source));
     }
     return source;


### PR DESCRIPTION
**Stack 3 of N**, based on #651 (REF-by-consumer sweep) → #648 (ratchets). Retarget as parents merge.

Fixes #649 for `reduce`; `mesh_` remains a known gap here and is fixed in #655.

**The rule already in the design record.** `writing_nodes.rst` ("Where the rule is applied") says a consumer that does not declare `REF` observes the referenced value, applied *at the point arguments are bound*: ordinary inputs by `adapt_source_for_input`, variadic tails by `value_argument`. The code honoured only the second half: a peered REF port fed to a value-declared input passed through `adapt_source_for_input` untouched, so every hand-wired consumer that builds its node schema from the port had to dereference for itself. That is the mechanism behind the ten per-consumer REF fixes in #636.

**The change.** `adapt_source_for_input` now describes a peered *top-level reference* by its value schema whenever the declared input contains no REF, so ordinary input binding installs the from-REF link. Two clauses are load-bearing, both found by measurement rather than reasoning:

- it **stops at a declared REF**: the children of a structural source adapted to `REF[X]` keep their reference identity. The first cut applied the rule inside `race`'s structural REF node and broke `test_race_tsls`/`tsbs` plus two Catch2 race cases, because `race` watches candidates *going invalid* through their references;
- it rewrites the **top-level reference only**. A `map_` output is a TSD whose elements are references; rewriting any REF-carrying source described every generic consumer of one (a `null_sink` included) as a value consumer of each element, installing a from-REF link per element for a consumer that may only hold tokens. Element references inside a value collection are left as supplied; their links dereference on access as they always did. An interleaved A/B of `main` and stack wheels showed no runtime difference either way on the dense map workloads (a first cross-run comparison had suggested 17%, which turned out to be machine-state noise: `main`'s own samples are bimodal), so this is the minimal adaptation by design, not a measured saving.

`mesh_subscribe`'s key now goes through the same site instead of calling `value_consumer_source` by hand (the doc-comment relaxation from 44147ef14 is no longer needed), so the `value-consumer-source-callers` ratchet stays at its floor with the owner text naming both sanctioned sites.

**Evidence.** The sweep's `reduce` products pass for both collection kinds and all five REF sources; their strict gap entries are removed. `python/tests`: 3057 passed, 80 xfailed. `hgraph_unit_tests`: 1669 cases passed.

**Found on the way** (both filed): #653 two `TimeSeriesSchema` classes with the same bare name cannot coexist; and `ported/_wiring/test_higher_order_overloads.py` registers a `mesh_` overload whose `requires` captures the lambda `value + 1` for the rest of the process.

Design record: `docs/source/developer_guide/writing_nodes.rst`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga

