### PR TITLE
Close the campaign feedback loop: origin dedup, PR checklist, skill rules

### DIFF
--- a/.agents/skills/hgraph-compute-sink-node/SKILL.md
+++ b/.agents/skills/hgraph-compute-sink-node/SKILL.md
@@ -101,6 +101,10 @@ lightweight C++ structures.
 - Use `REF` when dynamic source identity is part of the operator contract.
 - Before adding `REF`, state which copy or dynamic binding it avoids and verify
   that plain input binding cannot express the behavior.
+- Never dereference a `REF` by hand inside a node or its wiring: a non-`REF`
+  input already observes the referenced value (binding installs the from-REF
+  link), and `python/tests/test_architecture_ratchets.py` counts operator-side
+  `dereference(` calls so the copy count only falls.
 
 Do not reject `REF` merely because it is expensive. Use it whenever the
 indirection is required, and pay its overhead intentionally.

--- a/.agents/skills/hgraph-write-graphs/SKILL.md
+++ b/.agents/skills/hgraph-write-graphs/SKILL.md
@@ -125,7 +125,10 @@ wiring choice can change later in the run.
 - Keep generic variables linked consistently across inputs, outputs and scalar
   resolution parameters.
 - Return the declared time-series shape and preserve the established `REF`,
-  dereference and structural binding rules.
+  dereference and structural binding rules. When a graph consumes a `REF`
+  through a new operator or projection, add that product to
+  `python/tests/test_ref_consumer_sweep.py` rather than dereferencing in the
+  graph: the sweep's plain-versus-REF oracle is the contract.
 - Keep scalar policies at wiring time and use enums where several named
   trade-offs are supported.
 - Document public behavior, wiring-time choices, supported types, error cases

--- a/.agents/skills/hgraph-write-operators/SKILL.md
+++ b/.agents/skills/hgraph-write-operators/SKILL.md
@@ -81,6 +81,23 @@ knows these facts and should select the implementation once.
 - Keep representation-only dispatch inside an established erased ops-table;
   do not use erasure to conceal semantic implementation selection.
 
+Three rules that were each re-implemented per operator in the August 2026 fix
+series, and are now owned by one layer and pinned by
+`python/tests/test_architecture_ratchets.py`:
+
+- An operator never dereferences a `REF` input itself. A non-`REF` parameter
+  receives the referenced value because binding installs the from-REF
+  adaptation (`writing_nodes.rst`, "Where the rule is applied"). If a consumer
+  seems to receive a `REF` it did not declare, the defect is at the binding
+  site, not in the consumer.
+- Which argument is a type carrier (`type[...]`, `DEFAULT[X]`, `AUTO_RESOLVE`)
+  is a property of the signature, matched by the resolver. Never decide it by
+  operator name in Python wiring.
+- Nominal ancestry is `TypeRegistry::value_is_a` (lock-free); do not write
+  another walker, and do not probe `TSTypeKind::REF` on a per-tick path: REF
+  handling modes are decided when a node is built (`nested_graphs.rst`,
+  "switch_ output modes").
+
 ## Refine the contract in implementations
 
 Make every candidate more precise than, or otherwise compatible with, the

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+<!-- Keep what applies; delete the rest. CLAUDE.md sections 2 and 3 are the contract. -->
+
+## What and why
+
+## Design record
+- [ ] The developer-guide page this implements or changes is updated in this PR (`docs/source/developer_guide/...`), or this is explicitly a no-design-change fix.
+
+## Guardrails
+- [ ] `python/tests/test_architecture_ratchets.py` passes; any baseline change is a lowering, or a raise with its design record cited here.
+- [ ] No per-tick registry lock, `thread_local`, or `TSTypeKind::REF` probe was added to a runtime path.
+
+## If this fixes a behaviour found in the field
+- [ ] The minimised shape is covered by an authoring-shape sweep axis (`python/tests/test_*_sweep.py`) or a parity recipe/template (`tools/parity`), per `parity_testing.rst`.

--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -419,13 +419,17 @@ For the same reason the generator does not explore ruled parameter spaces which
 carry no independent signal (for example non-identity reduce zeros or
 undeduplicated key-set size); the corpus keeps explicit deviation recipes as
 permanently known mismatches.  The publisher additionally files at most one
-issue per fingerprint per run and at most one per generated **origin**
-(template plus seed): eight shards reducing one seeded failure each minimise
-it to a slightly different shape, and every shape mints a fresh fingerprint,
-which on 2026-08-27 filed 35 issues for one defect.  Every issue body carries
+issue per fingerprint per run and at most one per generated **origin**, the
+id of the original (pre-reduction) generated case: eight shards reducing one
+generated failure each minimise it to a slightly different shape, and every
+shape mints a fresh fingerprint, which on 2026-08-27 filed 35 issues for one
+defect.  The id hashes the case's own payload rather than the campaign seed,
+which one nightly shares across thousands of cases, so two defects surfaced
+by different cases of one template stay two issues.  Every issue body carries
 an origin marker beside its fingerprint marker, so a later run that reduces
-the same seed to yet another shape finds the open issue instead of filing a
-new one.  A corpus recipe has no seed and keeps fingerprint identity only.
+the same case to yet another shape finds the open issue instead of filing a
+new one.  A corpus recipe is not generated and keeps fingerprint identity
+only.
 
 A fix for Python-visible behavior must promote the minimized case to ordinary
 public Python wiring coverage and add equivalent native C++ ``eval_node``

--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -419,7 +419,13 @@ For the same reason the generator does not explore ruled parameter spaces which
 carry no independent signal (for example non-identity reduce zeros or
 undeduplicated key-set size); the corpus keeps explicit deviation recipes as
 permanently known mismatches.  The publisher additionally files at most one
-issue per fingerprint per run.
+issue per fingerprint per run and at most one per generated **origin**
+(template plus seed): eight shards reducing one seeded failure each minimise
+it to a slightly different shape, and every shape mints a fresh fingerprint,
+which on 2026-08-27 filed 35 issues for one defect.  Every issue body carries
+an origin marker beside its fingerprint marker, so a later run that reduces
+the same seed to yet another shape finds the open issue instead of filing a
+new one.  A corpus recipe has no seed and keeps fingerprint identity only.
 
 A fix for Python-visible behavior must promote the minimized case to ordinary
 public Python wiring coverage and add equivalent native C++ ``eval_node``

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -1383,6 +1383,107 @@ def test_issue_publisher_deduplicates_same_fingerprint_within_one_run(
     )
 
 
+def test_issue_publisher_folds_minimized_variants_of_one_seed_into_one_issue(
+    monkeypatch,
+):
+    # 2026-08-27: eight shards reduced one seeded failure to eight shapes and
+    # filed 35 issues (#570-#604). The origin (template + seed) is what stays
+    # stable across variants, so it is the second dedup key.
+    def variant(fingerprint, path, seed):
+        recipe = _scalar_recipe().to_dict()
+        recipe["seed"] = seed
+        return {
+            "failure_fingerprint": fingerprint,
+            "minimized_recipe": recipe,
+            "difference": {
+                "classification": "value",
+                "path": path,
+                "reference": 1,
+                "candidate": 2,
+            },
+            "reference": {"status": "ok", "trace": [1]},
+            "candidate": {"status": "ok", "trace": [2]},
+            "reduction": {"attempts": 3, "accepted": 1},
+        }
+
+    calls = []
+    monkeypatch.setattr(
+        "tools.parity.issues._existing_issues", lambda _repo: []
+    )
+
+    def fake_gh(arguments, *, repo, capture=False):
+        calls.append((arguments, repo, capture))
+        number = 45 + sum(1 for a, _, _ in calls if a[:2] == ["issue", "create"])
+        return SimpleNamespace(stdout=f"https://github.com/hhenson/hgraph/issues/{number}\n")
+
+    monkeypatch.setattr("tools.parity.issues._gh", fake_gh)
+
+    actions = publish_failures(
+        [
+            variant("shape-a", "$.trace[0]", 18),
+            variant("shape-b", "$.trace[1]", 18),
+            variant("shape-c", "$.trace[2]", 18),
+            variant("other-seed", "$.trace[0]", 19),
+        ],
+        repo="hhenson/hgraph",
+        publish=True,
+    )
+    assert [a["action"] for a in actions] == [
+        "created", "deduplicated", "deduplicated", "created"
+    ]
+    assert actions[1]["url"] == actions[0]["url"] == actions[2]["url"]
+    assert actions[3]["url"] != actions[0]["url"]
+    assert (
+        sum(1 for arguments, _, _ in calls if arguments[:2] == ["issue", "create"])
+        == 2
+    )
+
+
+def test_issue_publisher_matches_an_existing_issue_by_origin(monkeypatch):
+    # A later nightly reduces the same seed to yet another shape: the open
+    # issue for that origin is found by its origin marker, not refiled.
+    recipe = _scalar_recipe().to_dict()
+    recipe["seed"] = 18
+    failure = {
+        "failure_fingerprint": "yet-another-shape",
+        "minimized_recipe": recipe,
+        "difference": {
+            "classification": "value",
+            "path": "$.trace[3]",
+            "reference": 1,
+            "candidate": 2,
+        },
+        "reference": {"status": "ok", "trace": [1]},
+        "candidate": {"status": "ok", "trace": [2]},
+        "reduction": {"attempts": 0, "accepted": 0},
+    }
+    existing = {
+        "number": 570,
+        "state": "OPEN",
+        "title": "[parity] scalar_expression differs from released hgraph",
+        "body": "<!-- hgraph-parity:first-shape -->\n<!-- hgraph-parity-origin:scalar_expression:18 -->",
+        "url": "https://github.com/hhenson/hgraph/issues/570",
+    }
+    calls = []
+    monkeypatch.setattr(
+        "tools.parity.issues._existing_issues", lambda _repo: [existing]
+    )
+    monkeypatch.setattr(
+        "tools.parity.issues._gh",
+        lambda arguments, *, repo, capture=False: calls.append(arguments) or SimpleNamespace(stdout=""),
+    )
+
+    assert publish_failures([failure], repo="hhenson/hgraph", publish=True) == [
+        {
+            "action": "deduplicated",
+            "number": 570,
+            "url": "https://github.com/hhenson/hgraph/issues/570",
+            "fingerprint": "yet-another-shape",
+        }
+    ]
+    assert not any(a[:2] == ["issue", "create"] for a in calls)
+
+
 def test_publisher_consults_known_divergences_and_never_reopens(
     monkeypatch, tmp_path
 ):

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -17,7 +17,12 @@ from tools.parity.cli import CAMPAIGN_PROFILES, _path
 from tools.parity.compare import compare_outcomes
 from tools.parity.coverage import coverage_report, recipe_features
 from tools.parity.environments import ParityEnvironments, prepare_environments
-from tools.parity.issues import failure_fingerprint, issue_body, publish_failures
+from tools.parity.issues import (
+    failure_fingerprint,
+    failure_origin,
+    issue_body,
+    publish_failures,
+)
 from tools.parity.known import is_known_family_failure
 from tools.parity.model import Recipe, RecipeError, load_corpus
 from tools.parity.reduce import reduce_recipe
@@ -1383,18 +1388,23 @@ def test_issue_publisher_deduplicates_same_fingerprint_within_one_run(
     )
 
 
-def test_issue_publisher_folds_minimized_variants_of_one_seed_into_one_issue(
+def test_issue_publisher_folds_minimized_variants_of_one_case_into_one_issue(
     monkeypatch,
 ):
     # 2026-08-27: eight shards reduced one seeded failure to eight shapes and
-    # filed 35 issues (#570-#604). The origin (template + seed) is what stays
-    # stable across variants, so it is the second dedup key.
-    def variant(fingerprint, path, seed):
-        recipe = _scalar_recipe().to_dict()
-        recipe["seed"] = seed
+    # filed 35 issues (#570-#604). The origin (the original generated case's
+    # id) is what stays stable across variants, so it is the second dedup key.
+    # The campaign seed is NOT the key: one nightly generates thousands of
+    # cases from one seed, so two cases of one template must stay two issues.
+    def variant(fingerprint, path, case_id, seed=18):
+        original = _scalar_recipe().to_dict()
+        original["id"] = case_id
+        original["seed"] = seed
+        minimized = dict(original, inputs={"x": (1,)})
         return {
             "failure_fingerprint": fingerprint,
-            "minimized_recipe": recipe,
+            "original_recipe": original,
+            "minimized_recipe": minimized,
             "difference": {
                 "classification": "value",
                 "path": path,
@@ -1420,10 +1430,10 @@ def test_issue_publisher_folds_minimized_variants_of_one_seed_into_one_issue(
 
     actions = publish_failures(
         [
-            variant("shape-a", "$.trace[0]", 18),
-            variant("shape-b", "$.trace[1]", 18),
-            variant("shape-c", "$.trace[2]", 18),
-            variant("other-seed", "$.trace[0]", 19),
+            variant("shape-a", "$.trace[0]", "generated-scalar-expression-aaa111"),
+            variant("shape-b", "$.trace[1]", "generated-scalar-expression-aaa111"),
+            variant("shape-c", "$.trace[2]", "generated-scalar-expression-aaa111"),
+            variant("other-case", "$.trace[0]", "generated-scalar-expression-bbb222"),
         ],
         repo="hhenson/hgraph",
         publish=True,
@@ -1439,14 +1449,32 @@ def test_issue_publisher_folds_minimized_variants_of_one_seed_into_one_issue(
     )
 
 
+def test_failure_origin_is_the_original_case_not_the_seed():
+    original = _scalar_recipe().to_dict()
+    original["id"] = "generated-scalar-expression-aaa111"
+    original["seed"] = 18
+    minimized = dict(original, id="generated-scalar-expression-min000")
+    failure = {"original_recipe": original, "minimized_recipe": minimized}
+    assert failure_origin(failure) == "generated-scalar-expression-aaa111"
+    # A corpus recipe is not generated: no origin, fingerprint identity only.
+    corpus = _scalar_recipe().to_dict()
+    assert failure_origin({"minimized_recipe": corpus}) is None
+    # A record without the original (older campaign output) falls back to
+    # the minimized recipe, which still carries the seed and the template.
+    assert failure_origin({"minimized_recipe": minimized}) == "generated-scalar-expression-min000"
+
+
 def test_issue_publisher_matches_an_existing_issue_by_origin(monkeypatch):
-    # A later nightly reduces the same seed to yet another shape: the open
-    # issue for that origin is found by its origin marker, not refiled.
-    recipe = _scalar_recipe().to_dict()
-    recipe["seed"] = 18
+    # A later nightly reduces the same generated case to yet another shape:
+    # the open issue for that origin is found by its origin marker, not
+    # refiled.
+    original = _scalar_recipe().to_dict()
+    original["id"] = "generated-scalar-expression-aaa111"
+    original["seed"] = 18
     failure = {
         "failure_fingerprint": "yet-another-shape",
-        "minimized_recipe": recipe,
+        "original_recipe": original,
+        "minimized_recipe": dict(original, inputs={"x": (1,)}),
         "difference": {
             "classification": "value",
             "path": "$.trace[3]",
@@ -1461,7 +1489,7 @@ def test_issue_publisher_matches_an_existing_issue_by_origin(monkeypatch):
         "number": 570,
         "state": "OPEN",
         "title": "[parity] scalar_expression differs from released hgraph",
-        "body": "<!-- hgraph-parity:first-shape -->\n<!-- hgraph-parity-origin:scalar_expression:18 -->",
+        "body": "<!-- hgraph-parity:first-shape -->\n<!-- hgraph-parity-origin:generated-scalar-expression-aaa111 -->",
         "url": "https://github.com/hhenson/hgraph/issues/570",
     }
     calls = []

--- a/tools/parity/issues.py
+++ b/tools/parity/issues.py
@@ -72,21 +72,23 @@ def failure_fingerprint(failure: dict[str, Any]) -> str:
 
 
 def failure_origin(failure: dict[str, Any]) -> str | None:
-    """The generated case a failure was reduced from: ``template:seed``.
+    """The generated case a failure was reduced from: its recipe ``id``.
 
     Eight shards reducing one seeded failure each minimise it to a slightly
     different shape, and every shape mints a fresh fingerprint; on 2026-08-27
     that filed 35 issues (#570-#604) for one defect. The origin is stable
     across those variants, so the publisher files one issue per origin and
-    folds the variants into it. A corpus recipe has no seed and keeps
-    fingerprint identity only.
+    folds the variants into it. The key is the *original* (pre-reduction)
+    recipe's id, which hashes that case's payload: one campaign seed
+    produces thousands of cases, so the seed alone would fold unrelated
+    failures of one template into the first issue filed. A corpus recipe is
+    not generated and keeps fingerprint identity only.
     """
-    recipe = failure.get("minimized_recipe") or {}
-    seed = recipe.get("seed")
-    template = recipe.get("template")
-    if seed is None or template is None:
+    original = failure.get("original_recipe") or failure.get("minimized_recipe") or {}
+    if original.get("seed") is None:
         return None
-    return f"{template}:{seed}"
+    case_id = original.get("id")
+    return case_id if isinstance(case_id, str) and case_id else None
 
 
 def issue_title(failure: dict[str, Any]) -> str:
@@ -117,6 +119,7 @@ and was reduced before this issue was created.
 - Reference: `{reference.get('implementation', {})}`
 - Candidate: `{candidate.get('implementation', {})}`
 - Original seed: `{recipe.get('seed')}`
+- Origin case: `{origin or recipe.get('id')}`
 - Reduction: {reduction.get('accepted', 0)} accepted changes from {reduction.get('attempts', 0)} attempts
 - Failure fingerprint: `{fingerprint}`
 
@@ -251,8 +254,8 @@ def publish_failures(
             actions.append(known)
             continue
         # One issue per fingerprint per publish, and one per generated origin
-        # (template + seed): every minimized variant of one seeded failure
-        # folds into the first issue filed for it.
+        # (the original case's recipe id): every minimized variant of one
+        # generated failure folds into the first issue filed for it.
         folded = handled_this_run.get(fingerprint) or (
             handled_origins.get(origin) if origin else None
         )

--- a/tools/parity/issues.py
+++ b/tools/parity/issues.py
@@ -12,6 +12,7 @@ from typing import Any, Iterable
 
 
 FINGERPRINT_PREFIX = "hgraph-parity:"
+ORIGIN_PREFIX = "hgraph-parity-origin:"
 
 
 def _value_shape(value: Any, *, data_mapping: bool = False) -> Any:
@@ -70,6 +71,24 @@ def failure_fingerprint(failure: dict[str, Any]) -> str:
     return hashlib.sha256(encoded.encode()).hexdigest()
 
 
+def failure_origin(failure: dict[str, Any]) -> str | None:
+    """The generated case a failure was reduced from: ``template:seed``.
+
+    Eight shards reducing one seeded failure each minimise it to a slightly
+    different shape, and every shape mints a fresh fingerprint; on 2026-08-27
+    that filed 35 issues (#570-#604) for one defect. The origin is stable
+    across those variants, so the publisher files one issue per origin and
+    folds the variants into it. A corpus recipe has no seed and keeps
+    fingerprint identity only.
+    """
+    recipe = failure.get("minimized_recipe") or {}
+    seed = recipe.get("seed")
+    template = recipe.get("template")
+    if seed is None or template is None:
+        return None
+    return f"{template}:{seed}"
+
+
 def issue_title(failure: dict[str, Any]) -> str:
     recipe = failure["minimized_recipe"]
     return f"[parity] {recipe['template']} differs from released hgraph"
@@ -85,7 +104,9 @@ def issue_body(failure: dict[str, Any]) -> str:
     provenance = (
         f"\nRelated seed: {source_issue}\n" if source_issue else ""
     )
-    return f"""<!-- {FINGERPRINT_PREFIX}{fingerprint} -->
+    origin = failure_origin(failure)
+    origin_marker = f"\n<!-- {ORIGIN_PREFIX}{origin} -->" if origin else ""
+    return f"""<!-- {FINGERPRINT_PREFIX}{fingerprint} -->{origin_marker}
 ## Differential result
 
 A deterministic graph recipe passes with the maintained Python-first hgraph
@@ -216,23 +237,30 @@ def publish_failures(
     existing = _existing_issues(repo)
     actions: list[dict[str, Any]] = []
     handled_this_run: dict[str, str] = {}
+    handled_origins: dict[str, str] = {}
     for failure in failures:
         fingerprint = failure.get("failure_fingerprint") or failure_fingerprint(
             failure
         )
         marker = f"<!-- {FINGERPRINT_PREFIX}{fingerprint} -->"
+        origin = failure_origin(failure)
+        origin_marker = f"<!-- {ORIGIN_PREFIX}{origin} -->" if origin else None
         title = issue_title(failure)
         known = known_action(failure)
         if known is not None:
             actions.append(known)
             continue
-        if fingerprint in handled_this_run:
-            # One issue per fingerprint per publish: later failures in the
-            # same run (e.g. from other shards) fold into the first.
+        # One issue per fingerprint per publish, and one per generated origin
+        # (template + seed): every minimized variant of one seeded failure
+        # folds into the first issue filed for it.
+        folded = handled_this_run.get(fingerprint) or (
+            handled_origins.get(origin) if origin else None
+        )
+        if folded is not None:
             actions.append(
                 {
                     "action": "deduplicated",
-                    "url": handled_this_run[fingerprint],
+                    "url": folded,
                     "fingerprint": fingerprint,
                 }
             )
@@ -242,6 +270,7 @@ def publish_failures(
                 issue
                 for issue in existing
                 if marker in (issue.get("body") or "")
+                or (origin_marker is not None and origin_marker in (issue.get("body") or ""))
             ),
             None,
         )
@@ -263,6 +292,8 @@ def publish_failures(
                 }
             )
             handled_this_run[fingerprint] = match["url"]
+            if origin:
+                handled_origins[origin] = match["url"]
             continue
 
         with tempfile.NamedTemporaryFile(
@@ -298,4 +329,6 @@ def publish_failures(
             }
         )
         handled_this_run[fingerprint] = url
+        if origin:
+            handled_origins[origin] = url
     return actions


### PR DESCRIPTION
**Stack 2, PR 2 of N**, based on #658. Retarget to `main` when #658 merges.

Process half of the retrospective, three small pieces:

- **Publisher dedup by origin.** The nightly deduplicated by fingerprint only, but eight shards reducing one seeded failure each minimise it to a different shape and every shape mints a fresh fingerprint: on 2026-08-27 that filed 35 issues (#570–#604) for one defect. Every failure now carries an origin (`template:seed`); the publisher files one issue per origin per run, folds the other variants into it, and stamps an origin marker beside the fingerprint marker so a later nightly that reduces the same seed to yet another shape finds the open issue. Corpus recipes have no seed and keep fingerprint identity. Two tests pin both behaviours; the existing "distinct same-template failures still file" test still passes because distinct seeds are distinct origins.
- **PR template** asking for the design-record update in the same change (CLAUDE.md §2), the ratchet outcome, and sweep or parity coverage when a fix comes from the field (the `parity_testing.rst` rule none of the four fix PRs followed).
- **Skill checklists** gain the three rules the fix series re-implemented per operator: an operator never dereferences a REF input itself; type carriers are matched by the resolver, never by operator name; ancestry is `value_is_a` and REF handling modes are decided at build, never probed per tick.

Design record: `parity_testing.rst`, "Mismatch Lifecycle".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
