### PR TITLE
Define Python-object value semantics once in the bridge

### DIFF
--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -42,6 +42,12 @@ File                          Contents
 ``module_internal.h``         ``PyObj`` (the object-scalar carrier) + the
                               value-conversion API shared with
                               ``value_conversion.cpp``.
+``object_semantics.h``        The Python-object value contract
+                              (``object_hash`` / ``object_equals`` /
+                              ``object_compare`` / ``object_str``), the one
+                              definition every ops table that stores a
+                              ``PyObject`` delegates to; implemented behind
+                              ``src/hgraph/python/impl/``.
 ``py_carriers.h``             Small cross-TU carrier structs handed to/from
                               Python (``PyTsType``, ``PyValueType``, patterns,
                               ``PyPort``, ``PyNodeRef``/``PyNodeRecord``,
@@ -391,7 +397,9 @@ Value and reference crossings
   needs conversion, extend its ops, not ``value_conversion.cpp``.
 - **One set of Python-object value primitives** (2026-09-05):
   ``python_bridge::object_hash`` / ``object_equals`` / ``object_compare`` /
-  ``object_str`` in ``bridge_state.cpp`` define what hashing, equality,
+  ``object_str`` -- the contract in ``include/hgraph/python/object_semantics.h``,
+  implemented in ``src/hgraph/python/impl/object_semantics.cpp`` so semantic
+  owners depend on the contract and not on bridge state -- define what hashing, equality,
   ordering and rendering mean for a stored ``PyObject`` (address-hash
   fallback for unhashable objects, equality that keeps equal values on
   equal hashes, ordering that maps comparison errors to unordered). The

--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -389,6 +389,18 @@ Value and reference crossings
   per-type *ops tables* (``python_conversion_traits`` hooks), never a switch
   over value kinds in the bridge (ruling 2026-07-07). If a new value kind
   needs conversion, extend its ops, not ``value_conversion.cpp``.
+- **One set of Python-object value primitives** (2026-09-05):
+  ``python_bridge::object_hash`` / ``object_equals`` / ``object_compare`` /
+  ``object_str`` in ``bridge_state.cpp`` define what hashing, equality,
+  ordering and rendering mean for a stored ``PyObject`` (address-hash
+  fallback for unhashable objects, equality that keeps equal values on
+  equal hashes, ordering that maps comparison errors to unordered). The
+  Python-owned Bundle entry, the retained-value entry and the bridge's
+  ``PyObj`` hash all delegate to them; the ``python-object-hash-units``
+  ratchet pins ``PyObject_Hash`` to that one translation unit. The retained
+  entry itself still lives in ``types/metadata/value_plan_factory.cpp``;
+  moving it behind a bridge-registered provider is the remaining layering
+  step for that file.
 
 Per-tick application is registry-free (ruling 2026-08-15)
 ---------------------------------------------------------

--- a/include/hgraph/python/bridge_state.h
+++ b/include/hgraph/python/bridge_state.h
@@ -3,6 +3,7 @@
 
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
 
+#include <compare>
 #include <hgraph/hgraph_export.h>
 
 #include <nanobind/nanobind.h>
@@ -53,6 +54,23 @@ struct HGRAPH_LOCAL PythonValueHolder {
     std::swap(object, other.object);
   }
 };
+
+/**
+ * The one set of Python-object value primitives shared by every ops table
+ * that stores a PyObject (Python-owned Bundles, retained values, the
+ * bridge's PyObj hash). Hash falls back to the object's address when the
+ * object is unhashable; equality runs Python ``__eq__`` first so its
+ * exceptions stay observable, then refuses to call two unhashable objects
+ * equal so equal values keep equal hashes; ordering maps a Python comparison
+ * error to ``unordered`` and an empty side below a live one. Each acquires
+ * the GIL itself. ``object_hash`` requires a live object; callers decide
+ * what an empty holder means.
+ */
+[[nodiscard]] HGRAPH_EXPORT std::size_t object_hash(PyObject *object);
+[[nodiscard]] HGRAPH_EXPORT bool object_equals(PyObject *lhs, PyObject *rhs);
+[[nodiscard]] HGRAPH_EXPORT std::partial_ordering object_compare(PyObject *lhs,
+                                                                PyObject *rhs) noexcept;
+[[nodiscard]] HGRAPH_EXPORT std::string object_str(PyObject *object);
 
 [[nodiscard]] HGRAPH_EXPORT nb::object &cmp_result_enum_slot();
 [[nodiscard]] HGRAPH_EXPORT nb::object &divide_by_zero_enum_slot();

--- a/include/hgraph/python/bridge_state.h
+++ b/include/hgraph/python/bridge_state.h
@@ -55,23 +55,6 @@ struct HGRAPH_LOCAL PythonValueHolder {
   }
 };
 
-/**
- * The one set of Python-object value primitives shared by every ops table
- * that stores a PyObject (Python-owned Bundles, retained values, the
- * bridge's PyObj hash). Hash falls back to the object's address when the
- * object is unhashable; equality runs Python ``__eq__`` first so its
- * exceptions stay observable, then refuses to call two unhashable objects
- * equal so equal values keep equal hashes; ordering maps a Python comparison
- * error to ``unordered`` and an empty side below a live one. Each acquires
- * the GIL itself. ``object_hash`` requires a live object; callers decide
- * what an empty holder means.
- */
-[[nodiscard]] HGRAPH_EXPORT std::size_t object_hash(PyObject *object);
-[[nodiscard]] HGRAPH_EXPORT bool object_equals(PyObject *lhs, PyObject *rhs);
-[[nodiscard]] HGRAPH_EXPORT std::partial_ordering object_compare(PyObject *lhs,
-                                                                PyObject *rhs) noexcept;
-[[nodiscard]] HGRAPH_EXPORT std::string object_str(PyObject *object);
-
 [[nodiscard]] HGRAPH_EXPORT nb::object &cmp_result_enum_slot();
 [[nodiscard]] HGRAPH_EXPORT nb::object &divide_by_zero_enum_slot();
 /** The recording-shape policy enums (RFC 0019). Registered like the enums

--- a/include/hgraph/python/object_semantics.h
+++ b/include/hgraph/python/object_semantics.h
@@ -1,0 +1,40 @@
+#ifndef HGRAPH_PYTHON_OBJECT_SEMANTICS_H
+#define HGRAPH_PYTHON_OBJECT_SEMANTICS_H
+
+#if HGRAPH_ENABLE_PYTHON_USER_NODES
+
+#include <hgraph/hgraph_export.h>
+
+#include <Python.h>
+
+#include <compare>
+#include <cstddef>
+#include <string>
+
+/**
+ * The one set of Python-object value primitives: what hashing, equality,
+ * ordering and rendering mean for a stored ``PyObject``. Every ops table that
+ * stores one (Python-owned Bundles, retained values, the bridge's ``PyObj``
+ * hash) delegates here; none re-derives the rules. This header is the
+ * contract; the concrete CPython implementation lives behind the bridge's
+ * ``impl`` boundary (``src/hgraph/python/impl/object_semantics.cpp``), so a
+ * semantic owner depends on these four functions and never on bridge state.
+ *
+ * Rules: hash falls back to the object's address when the object is
+ * unhashable; equality runs Python ``__eq__`` first so its exceptions stay
+ * observable, then refuses to call two unhashable objects equal so equal
+ * values keep equal hashes; ordering maps a Python comparison error to
+ * ``unordered`` and an empty side below a live one. Each acquires the GIL
+ * itself. ``object_hash`` requires a live object; callers decide what an
+ * empty holder means.
+ */
+namespace hgraph::python_bridge {
+[[nodiscard]] HGRAPH_EXPORT std::size_t object_hash(PyObject *object);
+[[nodiscard]] HGRAPH_EXPORT bool object_equals(PyObject *lhs, PyObject *rhs);
+[[nodiscard]] HGRAPH_EXPORT std::partial_ordering object_compare(PyObject *lhs,
+                                                                PyObject *rhs) noexcept;
+[[nodiscard]] HGRAPH_EXPORT std::string object_str(PyObject *object);
+} // namespace hgraph::python_bridge
+
+#endif // HGRAPH_ENABLE_PYTHON_USER_NODES
+#endif // HGRAPH_PYTHON_OBJECT_SEMANTICS_H

--- a/python/tests/test_architecture_ratchets.py
+++ b/python/tests/test_architecture_ratchets.py
@@ -152,7 +152,7 @@ RATCHETS: tuple[Ratchet, ...] = (
     # --- Python-object handling stays behind an ops table (family 6) ---
     Ratchet(
         id="python-object-hash-units",
-        baseline=3,
+        baseline=1,
         roots=("src/hgraph", "include/hgraph", "python"),
         suffixes=(".cpp", ".h"),
         pattern=r"\bPyObject_Hash\b",

--- a/python/tests/test_architecture_ratchets.py
+++ b/python/tests/test_architecture_ratchets.py
@@ -156,8 +156,10 @@ RATCHETS: tuple[Ratchet, ...] = (
         roots=("src/hgraph", "include/hgraph", "python"),
         suffixes=(".cpp", ".h"),
         pattern=r"\bPyObject_Hash\b",
-        owner="one PythonObjectOps table; translation units that hash a "
-        "Python object",
+        owner="python_bridge::object_hash/equals/compare/str "
+        "(include/hgraph/python/object_semantics.h, implemented in "
+        "src/hgraph/python/impl/object_semantics.cpp) are the one set of "
+        "Python-object primitives; every ops table delegates to them",
         mode="files",
     ),
     Ratchet(

--- a/python/value_conversion.cpp
+++ b/python/value_conversion.cpp
@@ -1,6 +1,7 @@
 #include "module_internal.h"
 
 #include <hgraph/python/native_scalar_registration.h>
+#include <hgraph/python/object_semantics.h>
 #include <hgraph/python/ts_data_conversion.h>
 #include <hgraph/types/metadata/type_realization.h>
 

--- a/python/value_conversion.cpp
+++ b/python/value_conversion.cpp
@@ -989,12 +989,5 @@ std::size_t std::hash<hgraph::python_bridge::PyObj>::operator()(
     const hgraph::python_bridge::PyObj &value) const noexcept
 {
     if (value.object == nullptr) { return 0; }
-    nanobind::gil_scoped_acquire gil;
-    const Py_hash_t result = PyObject_Hash(value.object);
-    if (result == -1)
-    {
-        PyErr_Clear();
-        return std::hash<const void *>{}(value.object);
-    }
-    return static_cast<std::size_t>(result);
+    return hgraph::python_bridge::object_hash(value.object);
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,6 +96,7 @@ set(HGRAPH_RUNTIME_SOURCES
 if(HGRAPH_BUILD_PYTHON_BINDINGS OR HGRAPH_ENABLE_PYTHON_USER_NODES)
     list(APPEND HGRAPH_RUNTIME_SOURCES
         hgraph/python/bridge_state.cpp
+        hgraph/python/impl/object_semantics.cpp
         hgraph/python/impl/ts_data_conversion.cpp
     )
 endif()

--- a/src/hgraph/python/bridge_state.cpp
+++ b/src/hgraph/python/bridge_state.cpp
@@ -85,6 +85,83 @@ nb::object PythonValueHolder::get() const {
 }
 
 namespace {
+}  // namespace
+
+std::size_t object_hash(PyObject *object) {
+  if (object == nullptr) {
+    throw std::logic_error("cannot hash an empty Python object");
+  }
+  nb::gil_scoped_acquire gil;
+  const Py_hash_t result = PyObject_Hash(object);
+  if (result == -1) {
+    PyErr_Clear();
+    return std::hash<const void *>{}(object);
+  }
+  return static_cast<std::size_t>(result);
+}
+
+bool object_equals(PyObject *lhs, PyObject *rhs) {
+  if (lhs == rhs) {
+    return true;
+  }
+  if (lhs == nullptr || rhs == nullptr) {
+    return false;
+  }
+  nb::gil_scoped_acquire gil;
+  const int result = PyObject_RichCompareBool(lhs, rhs, Py_EQ);
+  if (result < 0) {
+    throw nb::python_error();
+  }
+  if (result == 0) {
+    return false;
+  }
+  // Semantic equality succeeded. If either side is unhashable its hash is
+  // its address, so two distinct objects must not compare equal or equal
+  // values would carry different hashes. Equality ran first so a Python
+  // __eq__ exception keeps its public behaviour.
+  if (PyObject_Hash(lhs) == -1) {
+    PyErr_Clear();
+    return false;
+  }
+  if (PyObject_Hash(rhs) == -1) {
+    PyErr_Clear();
+    return false;
+  }
+  return true;
+}
+
+std::partial_ordering object_compare(PyObject *lhs, PyObject *rhs) noexcept {
+  nb::gil_scoped_acquire gil;
+  try {
+    if (lhs == rhs) {
+      return std::partial_ordering::equivalent;
+    }
+    if (lhs == nullptr || rhs == nullptr) {
+      return lhs == nullptr ? std::partial_ordering::less
+                            : std::partial_ordering::greater;
+    }
+    const int less = PyObject_RichCompareBool(lhs, rhs, Py_LT);
+    if (less < 0) {
+      PyErr_Clear();
+      return std::partial_ordering::unordered;
+    }
+    if (less == 1) {
+      return std::partial_ordering::less;
+    }
+    const int greater = PyObject_RichCompareBool(lhs, rhs, Py_GT);
+    if (greater < 0) {
+      PyErr_Clear();
+      return std::partial_ordering::unordered;
+    }
+    return greater == 1 ? std::partial_ordering::greater
+                        : std::partial_ordering::equivalent;
+  } catch (...) {
+    PyErr_Clear();
+    return std::partial_ordering::unordered;
+  }
+}
+
+namespace {
 [[nodiscard]] std::string python_utf8(nb::handle value) {
   Py_ssize_t size{};
   const char *data = PyUnicode_AsUTF8AndSize(value.ptr(), &size);
@@ -93,6 +170,18 @@ namespace {
   }
   return {data, static_cast<std::size_t>(size)};
 }
+}  // namespace
+
+std::string object_str(PyObject *object) {
+  nb::gil_scoped_acquire gil;
+  nb::object text = nb::steal(PyObject_Str(object));
+  if (!text.is_valid()) {
+    throw nb::python_error();
+  }
+  return python_utf8(text);
+}
+
+namespace {
 
 struct NativeScalarRegistrations {
   std::unordered_map<PyObject *,
@@ -309,46 +398,12 @@ struct PythonBundleBindingEntry {
     if (stored.object == nullptr) {
       throw std::logic_error("cannot hash an empty Python-owned Bundle");
     }
-    nb::gil_scoped_acquire gil;
-    const Py_hash_t result = PyObject_Hash(stored.object);
-    if (result == -1) {
-      PyErr_Clear();
-      return std::hash<const void *>{}(stored.object);
-    }
-    return static_cast<std::size_t>(result);
+    return object_hash(stored.object);
   }
 
   static bool equals(const void *, const void *lhs, const void *rhs) {
-    const auto &left = *static_cast<const PythonBundleValue *>(lhs);
-    const auto &right = *static_cast<const PythonBundleValue *>(rhs);
-    if (left.object == right.object) {
-      return true;
-    }
-    if (left.object == nullptr || right.object == nullptr) {
-      return false;
-    }
-    nb::gil_scoped_acquire gil;
-    const int result =
-        PyObject_RichCompareBool(left.object, right.object, Py_EQ);
-    if (result < 0) {
-      throw nb::python_error();
-    }
-    if (result == 0) {
-      return false;
-    }
-    // If semantic equality succeeds but Python hashing fails, ``hash`` uses
-    // the object's address. Preserve equal-values-have-equal-hashes by using
-    // identity equality for those distinct objects. The equality call stays
-    // first so Python comparison errors retain their public behavior.
-    if (PyObject_Hash(left.object) == -1) {
-      PyErr_Clear();
-      return false;
-    }
-    if (PyObject_Hash(right.object) == -1) {
-      PyErr_Clear();
-      return false;
-    }
-    return true;
+    return object_equals(static_cast<const PythonBundleValue *>(lhs)->object,
+                         static_cast<const PythonBundleValue *>(rhs)->object);
   }
 
   static std::string to_string(const void *, const void *memory) {
@@ -356,12 +411,7 @@ struct PythonBundleBindingEntry {
     if (stored.object == nullptr) {
       return "<empty Python-owned Bundle>";
     }
-    nb::gil_scoped_acquire gil;
-    nb::object text = nb::steal(PyObject_Str(stored.object));
-    if (!text.is_valid()) {
-      throw nb::python_error();
-    }
-    return python_utf8(text);
+    return object_str(stored.object);
   }
 
   static nb::object to_python(const void *, const void *memory) {

--- a/src/hgraph/python/bridge_state.cpp
+++ b/src/hgraph/python/bridge_state.cpp
@@ -1,5 +1,6 @@
 #include <hgraph/python/bridge_state.h>
 #include <hgraph/python/native_scalar_registration.h>
+#include <hgraph/python/object_semantics.h>
 
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
 
@@ -82,103 +83,6 @@ void PythonValueHolder::set(nb::handle source) {
 
 nb::object PythonValueHolder::get() const {
   return object != nullptr ? nb::borrow<nb::object>(object) : nb::none();
-}
-
-namespace {
-}  // namespace
-
-std::size_t object_hash(PyObject *object) {
-  if (object == nullptr) {
-    throw std::logic_error("cannot hash an empty Python object");
-  }
-  nb::gil_scoped_acquire gil;
-  const Py_hash_t result = PyObject_Hash(object);
-  if (result == -1) {
-    PyErr_Clear();
-    return std::hash<const void *>{}(object);
-  }
-  return static_cast<std::size_t>(result);
-}
-
-bool object_equals(PyObject *lhs, PyObject *rhs) {
-  if (lhs == rhs) {
-    return true;
-  }
-  if (lhs == nullptr || rhs == nullptr) {
-    return false;
-  }
-  nb::gil_scoped_acquire gil;
-  const int result = PyObject_RichCompareBool(lhs, rhs, Py_EQ);
-  if (result < 0) {
-    throw nb::python_error();
-  }
-  if (result == 0) {
-    return false;
-  }
-  // Semantic equality succeeded. If either side is unhashable its hash is
-  // its address, so two distinct objects must not compare equal or equal
-  // values would carry different hashes. Equality ran first so a Python
-  // __eq__ exception keeps its public behaviour.
-  if (PyObject_Hash(lhs) == -1) {
-    PyErr_Clear();
-    return false;
-  }
-  if (PyObject_Hash(rhs) == -1) {
-    PyErr_Clear();
-    return false;
-  }
-  return true;
-}
-
-std::partial_ordering object_compare(PyObject *lhs, PyObject *rhs) noexcept {
-  nb::gil_scoped_acquire gil;
-  try {
-    if (lhs == rhs) {
-      return std::partial_ordering::equivalent;
-    }
-    if (lhs == nullptr || rhs == nullptr) {
-      return lhs == nullptr ? std::partial_ordering::less
-                            : std::partial_ordering::greater;
-    }
-    const int less = PyObject_RichCompareBool(lhs, rhs, Py_LT);
-    if (less < 0) {
-      PyErr_Clear();
-      return std::partial_ordering::unordered;
-    }
-    if (less == 1) {
-      return std::partial_ordering::less;
-    }
-    const int greater = PyObject_RichCompareBool(lhs, rhs, Py_GT);
-    if (greater < 0) {
-      PyErr_Clear();
-      return std::partial_ordering::unordered;
-    }
-    return greater == 1 ? std::partial_ordering::greater
-                        : std::partial_ordering::equivalent;
-  } catch (...) {
-    PyErr_Clear();
-    return std::partial_ordering::unordered;
-  }
-}
-
-namespace {
-[[nodiscard]] std::string python_utf8(nb::handle value) {
-  Py_ssize_t size{};
-  const char *data = PyUnicode_AsUTF8AndSize(value.ptr(), &size);
-  if (data == nullptr) {
-    throw nb::python_error();
-  }
-  return {data, static_cast<std::size_t>(size)};
-}
-}  // namespace
-
-std::string object_str(PyObject *object) {
-  nb::gil_scoped_acquire gil;
-  nb::object text = nb::steal(PyObject_Str(object));
-  if (!text.is_valid()) {
-    throw nb::python_error();
-  }
-  return python_utf8(text);
 }
 
 namespace {
@@ -650,8 +554,8 @@ struct PythonBundleBindingEntry {
       nb::object actual_type = nb::steal(PyObject_Type(attribute.ptr()));
       std::string actual =
           actual_type.is_valid()
-              ? python_utf8(
-                    nb::getattr(actual_type, "__name__", nb::str{"<unknown>"}))
+              ? object_str(
+                    nb::getattr(actual_type, "__name__", nb::str{"<unknown>"}).ptr())
               : std::string{"<unknown>"};
       const char *field_name = self.schema->fields[index].name;
       std::throw_with_nested(std::invalid_argument(

--- a/src/hgraph/python/impl/object_semantics.cpp
+++ b/src/hgraph/python/impl/object_semantics.cpp
@@ -1,0 +1,111 @@
+#include <hgraph/python/object_semantics.h>
+
+#if HGRAPH_ENABLE_PYTHON_USER_NODES
+
+#include <nanobind/nanobind.h>
+
+#include <compare>
+#include <cstddef>
+#include <functional>
+#include <stdexcept>
+#include <string>
+
+namespace nb = nanobind;
+
+namespace hgraph::python_bridge {
+std::size_t object_hash(PyObject *object) {
+  if (object == nullptr) {
+    throw std::logic_error("cannot hash an empty Python object");
+  }
+  nb::gil_scoped_acquire gil;
+  const Py_hash_t result = PyObject_Hash(object);
+  if (result == -1) {
+    PyErr_Clear();
+    return std::hash<const void *>{}(object);
+  }
+  return static_cast<std::size_t>(result);
+}
+
+bool object_equals(PyObject *lhs, PyObject *rhs) {
+  if (lhs == rhs) {
+    return true;
+  }
+  if (lhs == nullptr || rhs == nullptr) {
+    return false;
+  }
+  nb::gil_scoped_acquire gil;
+  const int result = PyObject_RichCompareBool(lhs, rhs, Py_EQ);
+  if (result < 0) {
+    throw nb::python_error();
+  }
+  if (result == 0) {
+    return false;
+  }
+  // Semantic equality succeeded. If either side is unhashable its hash is
+  // its address, so two distinct objects must not compare equal or equal
+  // values would carry different hashes. Equality ran first so a Python
+  // __eq__ exception keeps its public behaviour.
+  if (PyObject_Hash(lhs) == -1) {
+    PyErr_Clear();
+    return false;
+  }
+  if (PyObject_Hash(rhs) == -1) {
+    PyErr_Clear();
+    return false;
+  }
+  return true;
+}
+
+std::partial_ordering object_compare(PyObject *lhs, PyObject *rhs) noexcept {
+  nb::gil_scoped_acquire gil;
+  try {
+    if (lhs == rhs) {
+      return std::partial_ordering::equivalent;
+    }
+    if (lhs == nullptr || rhs == nullptr) {
+      return lhs == nullptr ? std::partial_ordering::less
+                            : std::partial_ordering::greater;
+    }
+    const int less = PyObject_RichCompareBool(lhs, rhs, Py_LT);
+    if (less < 0) {
+      PyErr_Clear();
+      return std::partial_ordering::unordered;
+    }
+    if (less == 1) {
+      return std::partial_ordering::less;
+    }
+    const int greater = PyObject_RichCompareBool(lhs, rhs, Py_GT);
+    if (greater < 0) {
+      PyErr_Clear();
+      return std::partial_ordering::unordered;
+    }
+    return greater == 1 ? std::partial_ordering::greater
+                        : std::partial_ordering::equivalent;
+  } catch (...) {
+    PyErr_Clear();
+    return std::partial_ordering::unordered;
+  }
+}
+
+namespace {
+[[nodiscard]] std::string python_utf8(nb::handle value) {
+  Py_ssize_t size{};
+  const char *data = PyUnicode_AsUTF8AndSize(value.ptr(), &size);
+  if (data == nullptr) {
+    throw nb::python_error();
+  }
+  return {data, static_cast<std::size_t>(size)};
+}
+}  // namespace
+
+std::string object_str(PyObject *object) {
+  nb::gil_scoped_acquire gil;
+  nb::object text = nb::steal(PyObject_Str(object));
+  if (!text.is_valid()) {
+    throw nb::python_error();
+  }
+  return python_utf8(text);
+}
+}  // namespace hgraph::python_bridge
+
+#endif  // HGRAPH_ENABLE_PYTHON_USER_NODES

--- a/src/hgraph/python/impl/object_semantics.cpp
+++ b/src/hgraph/python/impl/object_semantics.cpp
@@ -1,4 +1,5 @@
 #include <hgraph/python/object_semantics.h>
+#include <hgraph/util/scope.h>
 
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
 
@@ -58,33 +59,33 @@ bool object_equals(PyObject *lhs, PyObject *rhs) {
 
 std::partial_ordering object_compare(PyObject *lhs, PyObject *rhs) noexcept {
   nb::gil_scoped_acquire gil;
-  try {
-    if (lhs == rhs) {
-      return std::partial_ordering::equivalent;
-    }
-    if (lhs == nullptr || rhs == nullptr) {
-      return lhs == nullptr ? std::partial_ordering::less
-                            : std::partial_ordering::greater;
-    }
-    const int less = PyObject_RichCompareBool(lhs, rhs, Py_LT);
-    if (less < 0) {
-      PyErr_Clear();
-      return std::partial_ordering::unordered;
-    }
-    if (less == 1) {
-      return std::partial_ordering::less;
-    }
-    const int greater = PyObject_RichCompareBool(lhs, rhs, Py_GT);
-    if (greater < 0) {
-      PyErr_Clear();
-      return std::partial_ordering::unordered;
-    }
-    return greater == 1 ? std::partial_ordering::greater
-                        : std::partial_ordering::equivalent;
-  } catch (...) {
-    PyErr_Clear();
-    return std::partial_ordering::unordered;
-  }
+  return fallback_on_exception(
+      std::partial_ordering::unordered,
+      [&] {
+      if (lhs == rhs) {
+        return std::partial_ordering::equivalent;
+      }
+      if (lhs == nullptr || rhs == nullptr) {
+        return lhs == nullptr ? std::partial_ordering::less
+                              : std::partial_ordering::greater;
+      }
+      const int less = PyObject_RichCompareBool(lhs, rhs, Py_LT);
+      if (less < 0) {
+        PyErr_Clear();
+        return std::partial_ordering::unordered;
+      }
+      if (less == 1) {
+        return std::partial_ordering::less;
+      }
+      const int greater = PyObject_RichCompareBool(lhs, rhs, Py_GT);
+      if (greater < 0) {
+        PyErr_Clear();
+        return std::partial_ordering::unordered;
+      }
+      return greater == 1 ? std::partial_ordering::greater
+                          : std::partial_ordering::equivalent;
+      },
+      [](const char *) { PyErr_Clear(); });
 }
 
 namespace {

--- a/src/hgraph/types/metadata/value_plan_factory.cpp
+++ b/src/hgraph/types/metadata/value_plan_factory.cpp
@@ -2758,86 +2758,23 @@ struct PythonRetainedBindingEntry {
     return *static_cast<const python_bridge::PythonValueHolder *>(memory);
   }
 
+  // Value semantics come from the bridge's one set of Python-object
+  // primitives (python_bridge::object_*); this entry owns only the holder.
   static std::size_t hash(const void *, const void *memory) {
     const auto &stored = value(memory);
     if (stored.object == nullptr) {
       throw std::logic_error("cannot hash an empty Python-retained value");
     }
-    nb::gil_scoped_acquire gil;
-    const Py_hash_t result = PyObject_Hash(stored.object);
-    if (result == -1) {
-      PyErr_Clear();
-      return std::hash<const void *>{}(stored.object);
-    }
-    return static_cast<std::size_t>(result);
+    return python_bridge::object_hash(stored.object);
   }
 
   static bool equals(const void *, const void *lhs, const void *rhs) {
-    const auto &left = value(lhs);
-    const auto &right = value(rhs);
-    if (left.object == right.object) {
-      return true;
-    }
-    if (left.object == nullptr || right.object == nullptr) {
-      return false;
-    }
-    nb::gil_scoped_acquire gil;
-    const int result =
-        PyObject_RichCompareBool(left.object, right.object, Py_EQ);
-    if (result < 0) {
-      throw nb::python_error();
-    }
-    if (result == 0) {
-      return false;
-    }
-    // Only replace successful semantic equality after establishing that one
-    // side requires the address-hash fallback. Running equality first keeps
-    // Python ``__eq__`` exceptions observable at the bridge boundary.
-    if (PyObject_Hash(left.object) == -1) {
-      PyErr_Clear();
-      return false;
-    }
-    if (PyObject_Hash(right.object) == -1) {
-      PyErr_Clear();
-      return false;
-    }
-    return true;
+    return python_bridge::object_equals(value(lhs).object, value(rhs).object);
   }
 
   static std::partial_ordering compare(const void *, const void *lhs,
                                        const void *rhs) noexcept {
-    nb::gil_scoped_acquire gil;
-    try {
-      const auto &left = value(lhs);
-      const auto &right = value(rhs);
-      if (left.object == right.object) {
-        return std::partial_ordering::equivalent;
-      }
-      if (left.object == nullptr || right.object == nullptr) {
-        return left.object == nullptr ? std::partial_ordering::less
-                                      : std::partial_ordering::greater;
-      }
-      const int less =
-          PyObject_RichCompareBool(left.object, right.object, Py_LT);
-      if (less < 0) {
-        PyErr_Clear();
-        return std::partial_ordering::unordered;
-      }
-      if (less == 1) {
-        return std::partial_ordering::less;
-      }
-      const int greater =
-          PyObject_RichCompareBool(left.object, right.object, Py_GT);
-      if (greater < 0) {
-        PyErr_Clear();
-        return std::partial_ordering::unordered;
-      }
-      return greater == 1 ? std::partial_ordering::greater
-                          : std::partial_ordering::equivalent;
-    } catch (...) {
-      PyErr_Clear();
-      return std::partial_ordering::unordered;
-    }
+    return python_bridge::object_compare(value(lhs).object, value(rhs).object);
   }
 
   static std::string to_string(const void *, const void *memory) {
@@ -2845,12 +2782,7 @@ struct PythonRetainedBindingEntry {
     if (stored.object == nullptr) {
       return "<empty Python-retained value>";
     }
-    nb::gil_scoped_acquire gil;
-    nb::object text = nb::steal(PyObject_Str(stored.object));
-    if (!text.is_valid()) {
-      throw nb::python_error();
-    }
-    return nb::cast<std::string>(text);
+    return python_bridge::object_str(stored.object);
   }
 
   static nb::object to_python(const void *, const void *memory) {

--- a/src/hgraph/types/metadata/value_plan_factory.cpp
+++ b/src/hgraph/types/metadata/value_plan_factory.cpp
@@ -4,6 +4,7 @@
 
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
 #include <hgraph/python/bridge_state.h>
+#include <hgraph/python/object_semantics.h>
 #include <hgraph/types/primitive_types.h>
 #include <hgraph/types/static_schema.h>
 #endif


### PR DESCRIPTION
**Stack 2, PR 5 of N**, based on #662 → #660 → #659 → #658. Retarget as parents merge.

Family 6 of the retrospective (Python-object handling inside the type layer), first step. Three translation units each decided what hashing and equality mean for a stored `PyObject`: the Python-owned Bundle entry (`bridge_state.cpp`), the retained-value entry (`types/metadata/value_plan_factory.cpp`) and the bridge's `PyObj` hash (`value_conversion.cpp`). #555 added the address-hash fallback and the equal-values-keep-equal-hashes rule to two of them separately, and the retained entry rendered strings through a different path.

`python_bridge::object_hash` / `object_equals` / `object_compare` / `object_str` are now the one definition; all three sites delegate. Behaviour is unchanged except that the retained entry renders through the same UTF-8 path as the bundle entry. `PyObject_Hash` is in exactly one translation unit: ratchet `python-object-hash-units` 3 → 1. Verified: Python-enabled build links; `python/tests` 3251 passed.

Not in this PR, and recorded in the design record as the remaining layering step for that file: moving the retained entry itself out of `types/metadata` behind a bridge-registered provider (the type layer still carries 13 Python conditionals in that file).

Design record: `python_bridge.rst`, "Value and reference crossings".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
