### PR TITLE
language: make generated C++ readable and formatted

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,48 @@
+---
+BasedOnStyle: LLVM
+Language: Cpp
+Standard: c++20
+
+IndentWidth: 4
+ContinuationIndentWidth: 4
+ColumnLimit: 132
+
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlines: Right
+AlignTrailingComments: true
+
+AllowShortBlocksOnASingleLine: Always
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Always
+AllowShortLoopsOnASingleLine: true
+AllowShortLambdasOnASingleLine: All
+
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterControlStatement: false
+  AfterClass: true
+  AfterFunction: false
+  AfterNamespace: true
+  AfterStruct: true
+  BeforeCatch: false
+  BeforeElse: false
+  SplitEmptyFunction: false
+  SplitEmptyNamespace: false
+  SplitEmptyRecord: false
+  IndentBraces: false
+
+BreakBeforeBinaryOperators: None
+IndentCaseBlocks: true
+IndentCaseLabels: true
+IndentExternBlock: Indent
+IndentPPDirectives: BeforeHash
+NamespaceIndentation: All
+SpaceBeforeAssignmentOperators: true
+SpacesBeforeTrailingComments: 2
+SpaceBeforeCpp11BracedList: false
+UseCRLF: false
+ReflowComments: true
+Cpp11BracedListStyle: true

--- a/.github/workflows/language.yml
+++ b/.github/workflows/language.yml
@@ -71,6 +71,12 @@ jobs:
         run: >-
           python -m pip install --upgrade --only-binary=:all:
           "cmake==4.4.2" "ninja==1.13.0" "pyarrow==25.0.0"
+      - name: Install clang-format on Linux
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y clang-format
+      - name: Install clang-format on macOS
+        if: runner.os == 'macOS'
+        run: brew install clang-format
       - name: Expose Arrow runtime libraries
         shell: python
         run: |

--- a/conanfile.py
+++ b/conanfile.py
@@ -25,6 +25,17 @@ import subprocess
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import get
+from conan.tools.system.package_manager import (
+    Apk,
+    Apt,
+    Brew,
+    Chocolatey,
+    Dnf,
+    PacMan,
+    Pkg,
+    Yum,
+    Zypper,
+)
 
 MINIMUM_RELEASE_VERSION = (0, 8, 0)
 
@@ -102,6 +113,28 @@ class HgraphConan(ConanFile):
         self.requires("date/3.0.4")
         self.requires("arrow/25.0.0",
                       transitive_headers=True, transitive_libs=True)
+
+    def system_requirements(self):
+        if not self.options.language:
+            return
+
+        # hgl formats every emitted C++ translation unit. Declare the tool as
+        # a system requirement so it is checked (or installed when Conan's
+        # package-manager mode is ``install``) both while creating this package
+        # and when a consumer installs the language-enabled binary package.
+        packages = (
+            (Apt, "clang-format"),
+            (Dnf, "clang-tools-extra"),
+            (Yum, "clang-tools-extra"),
+            (Apk, "clang-extra-tools"),
+            (PacMan, "clang"),
+            (Zypper, "clang-tools"),
+            (Pkg, "llvm"),
+            (Brew, "clang-format"),
+            (Chocolatey, "llvm"),
+        )
+        for manager, package in packages:
+            manager(self).install([package], update=True, host_package=False)
 
     def configure(self):
         # The SDK links Arrow's shared targets and needs compute + acero.

--- a/docs/source/developer_guide/build_system.rst
+++ b/docs/source/developer_guide/build_system.rst
@@ -247,7 +247,13 @@ The ``language`` option (default off) adds the ``hgl`` toolchain to the
 package (RFC 0032): the recipe exports ``language/``, configures with
 ``HGRAPH_BUILD_LANGUAGE=ON``, fetches the REPL's isocline source in
 ``source()`` so the configure needs no network, and publishes ``bin`` and
-``lib/cmake/hgl``. ``test_package`` then also runs ``hgl --version``::
+``lib/cmake/hgl``. Because ``hgl`` formats every emitted translation unit,
+the language-enabled package declares clang-format through Conan's system
+package-manager integration. Conan checks that requirement by default; on a
+clean machine, opt into installation with
+``-c tools.system.package_manager:mode=install`` (and configure Conan's
+``tools.system.package_manager:sudo`` setting when the host package manager
+requires elevation). ``test_package`` then also runs ``hgl --version``::
 
    conan create . --build=missing -o "hgraph/*:language=True" \
        -s "arrow/*:compiler.cppstd=gnu20" -s "&:compiler.cppstd=gnu23"

--- a/language/CHANGELOG.md
+++ b/language/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Make `clang-format` a required final stage for every generated C++ module,
+  emit public and private operator contracts as transparent aliases instead of
+  derived marker classes, and give generated namespaces and internal contracts
+  source-level names. Generated result functions also omit unreachable fallback
+  throws after an unconditional return.
 - Make generated operator registration return a provider handle, add targeted
   provider activation, and use those handles for transactional runtime-bearing
   REPL sessions. The native loader ABI and cache advance to v2; a replacement

--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -129,9 +129,11 @@ hgl_apply_warnings(hgl_codegen)
 
 # The command driver (src/driver): check, test, run, repl, emit-cpp and the dumps.
 add_library(hgl_driver STATIC
+    src/driver/cpp_formatter.cpp
     src/driver/driver.cpp
     src/driver/line_reader.cpp
     src/driver/native_module.cpp
+    src/driver/process.cpp
 )
 add_library(hgl::driver ALIAS hgl_driver)
 target_compile_features(hgl_driver PUBLIC cxx_std_23)
@@ -159,12 +161,15 @@ set_target_properties(hgl PROPERTIES ENABLE_EXPORTS ON)
 # these evaluated paths also support the in-tree compiler and external/system
 # dependencies selected by this build.
 set(_hgl_native_config_dir "${CMAKE_CURRENT_BINARY_DIR}/generated/$<CONFIG>")
+find_program(HGL_CLANG_FORMAT_EXECUTABLE
+    NAMES clang-format clang-format-23 clang-format-22 clang-format-21 clang-format-20 clang-format-19 clang-format-18
+    REQUIRED)
 file(RELATIVE_PATH _hgl_install_include_from_bindir
     "${CMAKE_INSTALL_FULL_BINDIR}/"
     "${CMAKE_INSTALL_FULL_INCLUDEDIR}/")
 file(GENERATE
     OUTPUT "${_hgl_native_config_dir}/hgl_native_compile_config.h"
-    CONTENT "#pragma once\n\n#include <string_view>\n\nnamespace hgl::driver::native_config\n{\n    inline constexpr std::string_view compiler = R\"hgl(${CMAKE_CXX_COMPILER})hgl\";\n    inline constexpr std::string_view install_include_from_bindir = R\"hgl(${_hgl_install_include_from_bindir})hgl\";\n    inline constexpr std::string_view definitions = R\"hgl($<JOIN:$<TARGET_PROPERTY:hgl,COMPILE_DEFINITIONS>,;>)hgl\";\n    inline constexpr std::string_view include_directories = R\"hgl($<JOIN:$<TARGET_PROPERTY:hgl,INCLUDE_DIRECTORIES>,;>)hgl\";\n    inline constexpr std::string_view compile_options = R\"hgl($<JOIN:$<TARGET_PROPERTY:hgl,COMPILE_OPTIONS>,;>)hgl\";\n    inline constexpr std::string_view link_options = R\"hgl($<JOIN:$<TARGET_PROPERTY:hgl,LINK_OPTIONS>,;>)hgl\";\n    inline constexpr std::string_view system_name = R\"hgl(${CMAKE_SYSTEM_NAME})hgl\";\n    inline constexpr std::string_view system_processor = R\"hgl(${CMAKE_SYSTEM_PROCESSOR})hgl\";\n    inline constexpr std::string_view configuration = R\"hgl($<CONFIG>)hgl\";\n}\n"
+    CONTENT "#pragma once\n\n#include <string_view>\n\nnamespace hgl::driver::native_config\n{\n    inline constexpr std::string_view compiler = R\"hgl(${CMAKE_CXX_COMPILER})hgl\";\n    inline constexpr std::string_view clang_format = R\"hgl(${HGL_CLANG_FORMAT_EXECUTABLE})hgl\";\n    inline constexpr std::string_view install_include_from_bindir = R\"hgl(${_hgl_install_include_from_bindir})hgl\";\n    inline constexpr std::string_view definitions = R\"hgl($<JOIN:$<TARGET_PROPERTY:hgl,COMPILE_DEFINITIONS>,;>)hgl\";\n    inline constexpr std::string_view include_directories = R\"hgl($<JOIN:$<TARGET_PROPERTY:hgl,INCLUDE_DIRECTORIES>,;>)hgl\";\n    inline constexpr std::string_view compile_options = R\"hgl($<JOIN:$<TARGET_PROPERTY:hgl,COMPILE_OPTIONS>,;>)hgl\";\n    inline constexpr std::string_view link_options = R\"hgl($<JOIN:$<TARGET_PROPERTY:hgl,LINK_OPTIONS>,;>)hgl\";\n    inline constexpr std::string_view system_name = R\"hgl(${CMAKE_SYSTEM_NAME})hgl\";\n    inline constexpr std::string_view system_processor = R\"hgl(${CMAKE_SYSTEM_PROCESSOR})hgl\";\n    inline constexpr std::string_view configuration = R\"hgl($<CONFIG>)hgl\";\n}\n"
     TARGET hgl)
 target_include_directories(hgl_driver PRIVATE "${_hgl_native_config_dir}")
 # `hgl` is a build-time tool for installed consumers. Preserve runtime search

--- a/language/README.md
+++ b/language/README.md
@@ -59,8 +59,10 @@ fetched at configure time) and its network fetch; the REPL then reads plain
 lines. `clang-format` is required because formatted C++ is part of every
 `emit-cpp`, scripted, and AOT generation path. Set
 `HGL_CLANG_FORMAT_EXECUTABLE` while configuring to select it and
-`HGL_CLANG_FORMAT` while running `hgl` to override it. A build with no network
-keeps the editor by handing CMake an
+`HGL_CLANG_FORMAT` while running `hgl` to override it. Generated code uses the
+repository's `.clang-format` policy, embedded in `hgl` so output does not vary
+with the caller's working directory. A build with no network keeps the editor
+by handing CMake an
 unpacked isocline v1.1.0 source tree:
 `-DFETCHCONTENT_SOURCE_DIR_ISOCLINE=/path/to/isocline
 -DFETCHCONTENT_FULLY_DISCONNECTED=ON` (this is what the Homebrew formula in

--- a/language/README.md
+++ b/language/README.md
@@ -56,7 +56,11 @@ ctest --preset cpp -R hgraph_language
 
 `HGL_ENABLE_LINE_EDITING=OFF` drops the REPL's line editor (isocline, MIT,
 fetched at configure time) and its network fetch; the REPL then reads plain
-lines. A build with no network keeps the editor by handing CMake an
+lines. `clang-format` is required because formatted C++ is part of every
+`emit-cpp`, scripted, and AOT generation path. Set
+`HGL_CLANG_FORMAT_EXECUTABLE` while configuring to select it and
+`HGL_CLANG_FORMAT` while running `hgl` to override it. A build with no network
+keeps the editor by handing CMake an
 unpacked isocline v1.1.0 source tree:
 `-DFETCHCONTENT_SOURCE_DIR_ISOCLINE=/path/to/isocline
 -DFETCHCONTENT_FULLY_DISCONNECTED=ON` (this is what the Homebrew formula in

--- a/language/cmake/HglLanguage.cmake
+++ b/language/cmake/HglLanguage.cmake
@@ -44,7 +44,7 @@ function(_hgl_cpp_name out_var name)
         namespace new noexcept not not_eq nullptr operator or or_eq private protected public register reinterpret_cast requires
         return short signed sizeof static static_assert static_cast struct switch template this thread_local throw true try
         typedef typeid typename union unsigned using virtual void volatile wchar_t while xor xor_eq
-        w hgraph std ops register_operators compose name defaults)
+        w hgraph std operators operator_contracts register_operators compose name defaults)
     list(FIND _reserved "${name}" _reserved_index)
     if(_reserved_index EQUAL -1)
         set(${out_var} "${name}" PARENT_SCOPE)

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -1047,14 +1047,21 @@ source by default, into one directory with `--out-dir`, or split with
 `--include-dir` and `--src-dir`; `--print` writes both to stdout for tooling
 and tests. The namespace is the module name: `module examples.prices` emits
 `namespace examples::prices`, and a C++ keyword or a name the generated code
-reserves (`w`, `ops`, `compose`, ...) gets a trailing underscore.
+reserves (`w`, `operators`, `compose`, ...) gets a trailing underscore. Before
+the driver exposes the pair, it runs both files through `clang-format` with the
+language's fixed generated-code style. Formatting failure is a compilation
+diagnostic, not a best-effort warning; `HGL_CLANG_FORMAT` overrides the
+executable selected when `hgl` was built.
 
 What is emitted, in this order:
 
-- **Markers.** `namespace ops` holds one `hgraph::Operator<"module.name",
+- **Operator contracts.** `namespace operators` holds one transparent alias to
+  `hgraph::Operator<"module.name",
   In<...>..., Scalar<...>..., Out<...>>` per source `operator` and per
   `export fn`, so every public callable has a registry identity
-  (`examples.prices.smooth`) and a typed marker (`examples::prices::ops::smooth`).
+  (`examples.prices.smooth`) and a typed contract
+  (`examples::prices::operators::smooth`). Generated code never subclasses an
+  operator merely to give the contract a C++ name.
 - **Graph structs.** Every function is a struct with `static constexpr auto
   name` and a `compose(hgraph::Wiring &w, ...)`: `hgraph::Port<S>` for a
   temporal parameter, `hgraph::Scalar<"n", T>` for a `const` one, returning
@@ -1102,11 +1109,13 @@ What is emitted, in this order:
   block.
 - **Registration.** `hgraph::OperatorProviderHandle register_operators()`
   registers each export and
-  each `impl fn` with `hgraph::register_graph_overload<ops::x, x>()` for a
-  composition or `hgraph::register_overload<ops::x, x>()` for a runtime node.
-  Private runtime helpers get translation-unit-local markers under the same
-  module-qualified identities so direct wiring can compose them without
-  exposing them in the module header. Registration creates a keyed provider
+  each `impl fn` with
+  `hgraph::register_graph_overload<operators::x, x>()` for a composition or
+  `hgraph::register_overload<operators::x, x>()` for a runtime node. Private
+  runtime helpers get readable aliases in a translation-unit-local
+  `operator_contracts` namespace under the same module-qualified identities,
+  so direct wiring can compose them without exposing them in the module
+  header. Registration creates a keyed provider
   installer named after the module, activates exactly that provider, and
   returns its opaque handle. Activation can nest under an aggregate library
   installer while preserving each provider's provenance. A scoped rollback
@@ -1180,7 +1189,8 @@ retain the build machine's compiler launcher. An installed executable also
 resolves the SDK include directory relative to its configured
 `CMAKE_INSTALL_BINDIR`/`CMAKE_INSTALL_INCLUDEDIR` layout rather than assuming
 the default `bin` and `include` names.
-`HGL_CXX` overrides the compiler for diagnostics/testing and
+`HGL_CXX` overrides the compiler for diagnostics/testing,
+`HGL_CLANG_FORMAT` overrides the required generated-code formatter, and
 `HGL_ARTIFACT_DIR` selects the transient and failed-build root. The executable
 exports hgraph symbols and the generated image does not link a second static
 hgraph, so both use one registry. This path is currently Unix-only.

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -1049,9 +1049,11 @@ and tests. The namespace is the module name: `module examples.prices` emits
 `namespace examples::prices`, and a C++ keyword or a name the generated code
 reserves (`w`, `operators`, `compose`, ...) gets a trailing underscore. Before
 the driver exposes the pair, it runs both files through `clang-format` with the
-language's fixed generated-code style. Formatting failure is a compilation
-diagnostic, not a best-effort warning; `HGL_CLANG_FORMAT` overrides the
-executable selected when `hgl` was built.
+repository's fixed generated-code style. That policy is embedded in the
+compiler, so invoking an installed `hgl` from a project with a different
+`.clang-format` file does not change its output. Formatting failure is a
+compilation diagnostic, not a best-effort warning; `HGL_CLANG_FORMAT`
+overrides the executable selected when `hgl` was built.
 
 What is emitted, in this order:
 

--- a/language/docs/user-guide/modules-and-tools.md
+++ b/language/docs/user-guide/modules-and-tools.md
@@ -247,9 +247,11 @@ Module-internal functions stay inside the `.cpp`.
 The compiler runs both generated C++ files through `clang-format` before it
 prints, writes, caches, or compiles them. `clang-format` is therefore a tool
 dependency of `hgl`; set `HGL_CLANG_FORMAT` to select a particular executable.
-The generated `operators` namespace contains transparent type aliases rather
-than derived marker classes, so the registry contract visible in the source is
-the exact hgraph `Operator` type.
+The repository's `.clang-format` policy is embedded in the compiler, so the
+result does not depend on a consuming project's local formatter settings. The
+generated `operators` namespace contains transparent type aliases rather than
+derived marker classes, so the registry contract visible in the source is the
+exact hgraph `Operator` type.
 
 A package is a CMake project. `hgl_add_module()`, installed with `hgl` in
 `lib/cmake/hgl/HglLanguage.cmake`, runs `emit-cpp` at build time and compiles

--- a/language/docs/user-guide/modules-and-tools.md
+++ b/language/docs/user-guide/modules-and-tools.md
@@ -222,9 +222,9 @@ constructs `emit-cpp` does not yet lower are listed under
 ```cpp
 namespace examples::prices
 {
-    namespace ops
+    namespace operators
     {
-        struct smooth : hgraph::Operator<"examples.prices.smooth", ...> {};
+        using smooth = hgraph::Operator<"examples.prices.smooth", ...>;
     }
     struct smooth
     {
@@ -243,6 +243,13 @@ Exported functions become graph structs a C++ author wires with
 `register_operators()` — operators any hgraph front end reaches by name,
 `examples.prices.smooth`. The returned provider handle owns that registration.
 Module-internal functions stay inside the `.cpp`.
+
+The compiler runs both generated C++ files through `clang-format` before it
+prints, writes, caches, or compiles them. `clang-format` is therefore a tool
+dependency of `hgl`; set `HGL_CLANG_FORMAT` to select a particular executable.
+The generated `operators` namespace contains transparent type aliases rather
+than derived marker classes, so the registry contract visible in the source is
+the exact hgraph `Operator` type.
 
 A package is a CMake project. `hgl_add_module()`, installed with `hgl` in
 `lib/cmake/hgl/HglLanguage.cmake`, runs `emit-cpp` at build time and compiles
@@ -317,8 +324,9 @@ identified or no per-user cache root is available, the command uses a transient
 image instead of a shared temporary cache.
 `HGL_DISABLE_CACHE=1` forces a transient compile, while `HGL_CACHE_TRACE=1`
 prints cache hits, misses, and publication fallbacks. `HGL_ARTIFACT_DIR`
-selects where transient and failed builds are written, and `HGL_CXX` overrides
-the compiler. Cache entries are immutable and safe for concurrent command
+selects where transient and failed builds are written, `HGL_CXX` overrides the
+compiler, and `HGL_CLANG_FORMAT` overrides the formatter used for generated
+C++. Cache entries are immutable and safe for concurrent command
 processes; this prototype does not yet prune them automatically.
 
 The initial REPL rebuilds the whole session after each accepted runtime

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -172,8 +172,8 @@ namespace hgl::codegen
             "try", "typedef", "typeid", "typename", "union", "unsigned", "using", "virtual", "void", "volatile",
             "wchar_t", "while", "xor", "xor_eq",
             // names the generated code uses itself
-            "w", "hgraph", "std", "ops", "register_operators", "compose", "name", "defaults", "recordable_state",
-            "hgl_state", "hgl_output",
+            "w", "hgraph", "std", "operators", "operator_contracts", "register_operators", "compose", "name",
+            "defaults", "recordable_state", "hgl_state", "hgl_output",
         };
 
         constexpr std::string_view python_keywords[] = {
@@ -364,6 +364,8 @@ namespace hgl::codegen
             void emit_runtime_stmt(ast::StmtId id, Frame &frame, Writer &out);
             void emit_runtime_block(ast::BlockId id, Frame &frame, Writer &out);
             void emit_runtime_if(const ast::If &branch, Frame &frame, Writer &out);
+            [[nodiscard]] bool expression_terminates(ast::ExprId id) const;
+            [[nodiscard]] bool block_terminates(ast::BlockId id) const;
             [[nodiscard]] std::string as_runtime(const Value &value, const HType &target, SourceRange range, const std::string &what);
 
             // -- declarations
@@ -1000,7 +1002,7 @@ namespace hgl::codegen
                     Value       value;
                     value.kind  = Value::Kind::LocalOperator;
                     value.decl  = binding.decl;
-                    value.name  = "ops::" + cpp_name(op.name.text);
+                    value.name  = "operators::" + cpp_name(op.name.text);
                     value.range = range;
                     return value;
                 }
@@ -1501,13 +1503,37 @@ namespace hgl::codegen
                 }
                 emit_stmt(block.statements[i], frame, out);
             }
-            if (function_body && function(frame.fn).signature.result != ast::no_node && block.tail == ast::no_node)
+            if (function_body && function(frame.fn).signature.result != ast::no_node && block.tail == ast::no_node &&
+                !block_terminates(id))
             {
                 // Every path must return: a body that ends after a `return`
                 // inside `if` still needs a terminating statement for C++.
                 out.line("throw std::logic_error(\"" + std::string{function(frame.fn).name.text} +
                          ": reached the end of the body without a result\");");
             }
+        }
+
+        bool Emitter::expression_terminates(ast::ExprId id) const
+        {
+            const ast::Expr &expr = module_.expr(id);
+            if (const auto *block = std::get_if<ast::BlockExpr>(&expr.node)) { return block_terminates(block->block); }
+            const auto *branch = std::get_if<ast::If>(&expr.node);
+            return branch != nullptr && block_terminates(branch->then_block) && branch->otherwise != ast::no_node &&
+                   expression_terminates(branch->otherwise);
+        }
+
+        bool Emitter::block_terminates(ast::BlockId id) const
+        {
+            const ast::Block &block = module_.block(id);
+            if (block.tail != ast::no_node) { return true; }
+            if (block.statements.empty()) { return false; }
+            const ast::StmtNode &last = module_.stmt(block.statements.back()).node;
+            if (std::holds_alternative<ast::ReturnStmt>(last)) { return true; }
+            if (const auto *expression = std::get_if<ast::ExprStmt>(&last))
+            {
+                return expression_terminates(expression->expr);
+            }
+            return false;
         }
 
         void Emitter::emit_runtime_if(const ast::If &branch, Frame &frame, Writer &out)
@@ -2653,18 +2679,24 @@ namespace hgl::codegen
             {
                 body.indent();
                 body.open("namespace");
+                const bool has_internal_runtime = std::any_of(internal.begin(), internal.end(), [&](ast::DeclId id) {
+                    return resolved_.kind(id) == semantics::FunctionKind::Runtime;
+                });
+                if (has_internal_runtime)
+                {
+                    body.open("namespace operator_contracts");
+                }
                 for (const ast::DeclId id : internal)
                 {
                     if (resolved_.kind(id) != semantics::FunctionKind::Runtime) { continue; }
                     Frame frame;
                     frame.fn = id;
-                    body.line("struct hgl_internal_operator_" + std::to_string(id) + " : " +
-                              marker(id, result.module_name + "." + std::string{function(id).name.text}, frame) + " {};");
+                    body.line("using " + cpp_name(function(id).name.text) + " = " +
+                              marker(id, result.module_name + "." + std::string{function(id).name.text}, frame) + ";");
                 }
-                if (std::any_of(internal.begin(), internal.end(), [&](ast::DeclId id) {
-                        return resolved_.kind(id) == semantics::FunctionKind::Runtime;
-                    }))
+                if (has_internal_runtime)
                 {
+                    body.close("  // namespace operator_contracts");
                     body.line();
                 }
                 for (const ast::DeclId id : internal) { emit_function(id, body, Form::InlineStruct); }
@@ -2694,13 +2726,13 @@ namespace hgl::codegen
                 const std::string registration = resolved_.kind(id) == semantics::FunctionKind::Runtime
                                                      ? "hgraph::register_overload"
                                                      : "hgraph::register_graph_overload";
-                body.line(registration + "<ops::" + name + ", " + name + ">();");
+                body.line(registration + "<operators::" + name + ", " + name + ">();");
             }
             for (const ast::DeclId id : internal)
             {
                 if (resolved_.kind(id) != semantics::FunctionKind::Runtime) { continue; }
-                body.line("hgraph::register_overload<hgl_internal_operator_" + std::to_string(id) + ", " +
-                          cpp_name(function(id).name.text) + ">();");
+                const std::string name = cpp_name(function(id).name.text);
+                body.line("hgraph::register_overload<operator_contracts::" + name + ", " + name + ">();");
             }
             for (const ast::DeclId id : impls)
             {
@@ -2721,7 +2753,7 @@ namespace hgl::codegen
                 const std::string registration = resolved_.kind(id) == semantics::FunctionKind::Runtime
                                                      ? "hgraph::register_overload"
                                                      : "hgraph::register_graph_overload";
-                body.line(registration + "<ops::" + cpp_name(fn.name.text) + ", " + cpp_name(fn.name.text) + ">();");
+                body.line(registration + "<operators::" + cpp_name(fn.name.text) + ", " + cpp_name(fn.name.text) + ">();");
             }
             body.close(");");
             body.open("auto rollback = hgraph::make_scope_exit<true>([&]");
@@ -2754,27 +2786,30 @@ namespace hgl::codegen
             header.line("namespace " + namespace_);
             header.line("{");
             header.indent();
-            header.line("/// Operator markers: the module's public callables by registry name.");
-            header.open("namespace ops");
-            for (const ast::DeclId id : resolved_.operators)
+            if (!resolved_.operators.empty() || !exports.empty())
             {
-                const auto &op = std::get<ast::OperatorDecl>(module_.decl(id).node);
-                Frame       frame;
-                header.line("// " + where(module_.decl(id).range));
-                header.line("struct " + cpp_name(op.name.text) + " : " +
-                            marker(id, result.module_name + "." + std::string{op.name.text}, frame) + " {};");
+                header.line("/// Operator contracts for the module's public callables.");
+                header.open("namespace operators");
+                for (const ast::DeclId id : resolved_.operators)
+                {
+                    const auto &op = std::get<ast::OperatorDecl>(module_.decl(id).node);
+                    Frame       frame;
+                    header.line("// " + where(module_.decl(id).range));
+                    header.line("using " + cpp_name(op.name.text) + " = " +
+                                marker(id, result.module_name + "." + std::string{op.name.text}, frame) + ";");
+                }
+                for (const ast::DeclId id : exports)
+                {
+                    const ast::FunctionDecl &fn = function(id);
+                    Frame                    frame;
+                    frame.fn = id;
+                    header.line("// " + where(module_.decl(id).range));
+                    header.line("using " + cpp_name(fn.name.text) + " = " +
+                                marker(id, result.module_name + "." + std::string{fn.name.text}, frame) + ";");
+                }
+                header.close("  // namespace operators");
+                header.line();
             }
-            for (const ast::DeclId id : exports)
-            {
-                const ast::FunctionDecl &fn = function(id);
-                Frame                    frame;
-                frame.fn = id;
-                header.line("// " + where(module_.decl(id).range));
-                header.line("struct " + cpp_name(fn.name.text) + " : " +
-                            marker(id, result.module_name + "." + std::string{fn.name.text}, frame) + " {};");
-            }
-            header.close("  // namespace ops");
-            header.line();
             for (const ast::DeclId id : exports)
             {
                 emit_function(id, header,

--- a/language/src/driver/cpp_formatter.cpp
+++ b/language/src/driver/cpp_formatter.cpp
@@ -107,6 +107,28 @@ namespace hgl::driver
             }
             return "clang-format";
         }
+
+        // Keep generated modules independent of the caller's working tree while
+        // following the repository's .clang-format policy. This is the compact
+        // style carried forward from hg_cpp before v0.2.0.
+        constexpr std::string_view generated_code_style =
+            "{BasedOnStyle: LLVM, Language: Cpp, Standard: c++20, "
+            "IndentWidth: 4, ContinuationIndentWidth: 4, ColumnLimit: 132, "
+            "AlignConsecutiveAssignments: true, AlignConsecutiveDeclarations: true, "
+            "AlignEscapedNewlines: Right, AlignTrailingComments: true, "
+            "AllowShortBlocksOnASingleLine: Always, AllowShortCaseLabelsOnASingleLine: true, "
+            "AllowShortFunctionsOnASingleLine: All, AllowShortIfStatementsOnASingleLine: Always, "
+            "AllowShortLoopsOnASingleLine: true, AllowShortLambdasOnASingleLine: All, "
+            "BreakBeforeBraces: Custom, "
+            "BraceWrapping: {AfterCaseLabel: false, AfterControlStatement: false, AfterClass: true, "
+            "AfterFunction: false, AfterNamespace: true, AfterStruct: true, BeforeCatch: false, "
+            "BeforeElse: false, SplitEmptyFunction: false, SplitEmptyNamespace: false, "
+            "SplitEmptyRecord: false, IndentBraces: false}, "
+            "BreakBeforeBinaryOperators: None, IndentCaseBlocks: true, IndentCaseLabels: true, "
+            "IndentExternBlock: Indent, IndentPPDirectives: BeforeHash, NamespaceIndentation: All, "
+            "SpaceBeforeAssignmentOperators: true, SpacesBeforeTrailingComments: 2, "
+            "SpaceBeforeCpp11BracedList: false, UseCRLF: false, ReflowComments: true, "
+            "Cpp11BracedListStyle: true}";
     }  // namespace
 
     bool format_cpp(codegen::EmittedModule &module, std::string &error)
@@ -131,18 +153,8 @@ namespace hgl::driver
         }
 
         const std::string executable = formatter();
-        const std::vector<std::string> command = {
-            executable,
-            "-i",
-            "--style={BasedOnStyle: LLVM, BreakBeforeBraces: Allman, ColumnLimit: "
-            "120, SortIncludes: Never, "
-            "IndentWidth: 4, ContinuationIndentWidth: 4, NamespaceIndentation: All, "
-            "AllowShortFunctionsOnASingleLine: Empty, "
-            "AllowShortLambdasOnASingleLine: None, "
-            "SpacesBeforeTrailingComments: 2, "
-            "PenaltyReturnTypeOnItsOwnLine: 1000000}",
-            header.string(),
-            source.string(),
+        const std::vector<std::string> command    = {
+            executable, "-i", "--style=" + std::string{generated_code_style}, header.string(), source.string(),
         };
         const ProcessResult result = run_process(command);
         if (result.status != 0)

--- a/language/src/driver/cpp_formatter.cpp
+++ b/language/src/driver/cpp_formatter.cpp
@@ -1,0 +1,169 @@
+#include "driver/cpp_formatter.h"
+
+#include "driver/process.h"
+#include "hgl_native_compile_config.h"
+
+#include <hgraph/util/scope.h>
+
+#include <atomic>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace hgl::driver
+{
+    namespace
+    {
+        std::atomic<std::uint64_t> next_format{0};
+
+        unsigned long process_id()
+        {
+#if defined(_WIN32)
+            return static_cast<unsigned long>(GetCurrentProcessId());
+#else
+            return static_cast<unsigned long>(::getpid());
+#endif
+        }
+
+        std::optional<std::filesystem::path> make_format_directory(std::string &error)
+        {
+            std::error_code ec;
+            const std::filesystem::path root = std::filesystem::temp_directory_path(ec);
+            if (ec)
+            {
+                error = "cannot locate the temporary directory for clang-format: " + ec.message();
+                return std::nullopt;
+            }
+            for (unsigned attempt = 0; attempt != 1000; ++attempt)
+            {
+                const std::filesystem::path candidate = root / ("hgl-format-" + std::to_string(process_id()) + "-" +
+                                                                std::to_string(next_format.fetch_add(1)));
+                ec.clear();
+                if (std::filesystem::create_directory(candidate, ec))
+                {
+                    return candidate;
+                }
+                if (ec && ec != std::errc::file_exists)
+                {
+                    error = "cannot create clang-format directory '" + candidate.string() + "': " + ec.message();
+                    return std::nullopt;
+                }
+            }
+            error = "cannot allocate a temporary clang-format directory";
+            return std::nullopt;
+        }
+
+        bool write(const std::filesystem::path &path, std::string_view text, std::string &error)
+        {
+            std::ofstream out{path, std::ios::binary | std::ios::trunc};
+            if (!out)
+            {
+                error = "cannot write temporary clang-format input '" + path.string() + "'";
+                return false;
+            }
+            out << text;
+            if (!out)
+            {
+                error = "cannot finish temporary clang-format input '" + path.string() + "'";
+                return false;
+            }
+            return true;
+        }
+
+        std::optional<std::string> read(const std::filesystem::path &path)
+        {
+            std::ifstream in{path, std::ios::binary};
+            if (!in)
+            {
+                return std::nullopt;
+            }
+            return std::string{std::istreambuf_iterator<char>{in}, std::istreambuf_iterator<char>{}};
+        }
+
+        std::string formatter()
+        {
+            if (const char *configured = std::getenv("HGL_CLANG_FORMAT"); configured != nullptr && *configured != '\0')
+            {
+                return configured;
+            }
+            const std::filesystem::path built_with{native_config::clang_format};
+            std::error_code ec;
+            if (!built_with.empty() && std::filesystem::is_regular_file(built_with, ec) && !ec)
+            {
+                return built_with.string();
+            }
+            return "clang-format";
+        }
+    }  // namespace
+
+    bool format_cpp(codegen::EmittedModule &module, std::string &error)
+    {
+        const std::optional<std::filesystem::path> directory = make_format_directory(error);
+        if (!directory)
+        {
+            return false;
+        }
+        auto cleanup = hgraph::make_scope_exit<true>(
+            [&]
+            {
+                std::error_code ignored;
+                std::filesystem::remove_all(*directory, ignored);
+            });
+
+        const std::filesystem::path header = *directory / "module.h";
+        const std::filesystem::path source = *directory / "module.cpp";
+        if (!write(header, module.header, error) || !write(source, module.source, error))
+        {
+            return false;
+        }
+
+        const std::string executable = formatter();
+        const std::vector<std::string> command = {
+            executable,
+            "-i",
+            "--style={BasedOnStyle: LLVM, BreakBeforeBraces: Allman, ColumnLimit: "
+            "120, SortIncludes: Never, "
+            "IndentWidth: 4, ContinuationIndentWidth: 4, NamespaceIndentation: All, "
+            "AllowShortFunctionsOnASingleLine: Empty, "
+            "AllowShortLambdasOnASingleLine: None, "
+            "SpacesBeforeTrailingComments: 2, "
+            "PenaltyReturnTypeOnItsOwnLine: 1000000}",
+            header.string(),
+            source.string(),
+        };
+        const ProcessResult result = run_process(command);
+        if (result.status != 0)
+        {
+            error = "clang-format failed with '" + executable + "' (exit " + std::to_string(result.status) + ")";
+            if (!result.output.empty())
+            {
+                error += ":\n" + result.output;
+            }
+            return false;
+        }
+
+        std::optional<std::string> formatted_header = read(header);
+        std::optional<std::string> formatted_source = read(source);
+        if (!formatted_header || !formatted_source)
+        {
+            error = "cannot read clang-format output";
+            return false;
+        }
+        module.header = std::move(*formatted_header);
+        module.source = std::move(*formatted_source);
+        return true;
+    }
+}  // namespace hgl::driver

--- a/language/src/driver/cpp_formatter.h
+++ b/language/src/driver/cpp_formatter.h
@@ -1,0 +1,15 @@
+#ifndef HGL_DRIVER_CPP_FORMATTER_H
+#define HGL_DRIVER_CPP_FORMATTER_H
+
+#include "codegen/cpp_emitter.h"
+
+#include <string>
+
+namespace hgl::driver
+{
+    /// Run clang-format over both generated C++ files. Formatting is a
+    /// required compiler stage: failure leaves the module untouched.
+    [[nodiscard]] bool format_cpp(codegen::EmittedModule &module, std::string &error);
+}  // namespace hgl::driver
+
+#endif  // HGL_DRIVER_CPP_FORMATTER_H

--- a/language/src/driver/driver.cpp
+++ b/language/src/driver/driver.cpp
@@ -1,6 +1,7 @@
 #include "driver/driver.h"
 
 #include "codegen/cpp_emitter.h"
+#include "driver/cpp_formatter.h"
 #include "driver/line_reader.h"
 #include "driver/native_module.h"
 #include "semantics/resolve.h"
@@ -61,6 +62,7 @@ namespace hgl::driver
                          "  HGL_DISABLE_CACHE   compile through a transient artifact when non-zero\n"
                          "  HGL_CACHE_TRACE     report cache hits, misses and publication fallbacks\n"
                          "  HGL_ARTIFACT_DIR    override the transient/failed artifact root\n"
+                         "  HGL_CLANG_FORMAT    override the clang-format executable\n"
                          "  HGL_CXX             override the scripted native C++ compiler\n";
         }
 
@@ -147,8 +149,17 @@ namespace hgl::driver
             codegen::EmitOptions options;
             options.header_name  = "module.h";
             options.tool_version = std::string{language_version};
-            const std::optional<codegen::EmittedModule> emitted =
+            std::optional<codegen::EmittedModule> emitted =
                 codegen::emit_cpp(unit.file, unit.module, unit.resolved, options, unit.diagnostics);
+            if (emitted)
+            {
+                std::string error;
+                if (!format_cpp(*emitted, error))
+                {
+                    unit.diagnostics.report(syntax::Category::Backend, syntax::SourceRange{0, 0}, std::move(error));
+                    return std::nullopt;
+                }
+            }
             return emitted;
         }
 
@@ -460,10 +471,17 @@ namespace hgl::driver
             options.header_name          = stem + ".h";
             options.tool_version         = std::string{tool_version};
             options.python_native_module = python_native;
-            const std::optional<codegen::EmittedModule> emitted =
+            std::optional<codegen::EmittedModule> emitted =
                 codegen::emit_cpp(unit->file, unit->module, unit->resolved, options, unit->diagnostics);
             if (!emitted)
             {
+                std::cerr << unit->diagnostics.render(unit->file);
+                return exit_diagnostics;
+            }
+            std::string format_error;
+            if (!format_cpp(*emitted, format_error))
+            {
+                unit->diagnostics.report(syntax::Category::Backend, syntax::SourceRange{0, 0}, std::move(format_error));
                 std::cerr << unit->diagnostics.render(unit->file);
                 return exit_diagnostics;
             }

--- a/language/src/driver/native_module.cpp
+++ b/language/src/driver/native_module.cpp
@@ -1,5 +1,6 @@
 #include "driver/native_module.h"
 
+#include "driver/process.h"
 #include "hgl_native_compile_config.h"
 
 #include <hgraph/util/scope.h>
@@ -9,9 +10,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
-#include <cerrno>
 #include <cstdint>
-#include <cstring>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
@@ -33,8 +32,6 @@
 #if defined(__APPLE__)
 #include <mach-o/dyld.h>
 #endif
-#include <sys/types.h>
-#include <sys/wait.h>
 #include <unistd.h>
 #endif
 
@@ -166,71 +163,6 @@ namespace hgl::driver
         }
 
 #if !defined(_WIN32)
-        struct ProcessResult
-        {
-            int         status{-1};
-            std::string output{};
-        };
-
-        ProcessResult run_process(const std::vector<std::string> &arguments)
-        {
-            int output_pipe[2];
-            if (::pipe(output_pipe) != 0)
-            {
-                return {-1, "cannot create compiler output pipe: " + std::string{std::strerror(errno)}};
-            }
-            const pid_t child = ::fork();
-            if (child < 0)
-            {
-                const std::string message = "cannot start the native compiler: " + std::string{std::strerror(errno)};
-                ::close(output_pipe[0]);
-                ::close(output_pipe[1]);
-                return {-1, message};
-            }
-            if (child == 0)
-            {
-                ::close(output_pipe[0]);
-                (void)::dup2(output_pipe[1], STDOUT_FILENO);
-                (void)::dup2(output_pipe[1], STDERR_FILENO);
-                ::close(output_pipe[1]);
-                std::vector<char *> argv;
-                argv.reserve(arguments.size() + 1);
-                for (const std::string &argument : arguments) { argv.push_back(const_cast<char *>(argument.c_str())); }
-                argv.push_back(nullptr);
-                ::execvp(argv.front(), argv.data());
-                _exit(127);
-            }
-
-            ::close(output_pipe[1]);
-            std::string output;
-            char        buffer[4096];
-            while (true)
-            {
-                const ssize_t count = ::read(output_pipe[0], buffer, sizeof(buffer));
-                if (count > 0) { output.append(buffer, static_cast<std::size_t>(count)); }
-                else if (count == 0) { break; }
-                else if (errno != EINTR)
-                {
-                    output += "cannot read compiler output: " + std::string{std::strerror(errno)};
-                    break;
-                }
-            }
-            ::close(output_pipe[0]);
-
-            int status = 0;
-            while (::waitpid(child, &status, 0) < 0)
-            {
-                if (errno != EINTR) { return {-1, output + "cannot wait for the native compiler"}; }
-            }
-            if (WIFEXITED(status)) { return {WEXITSTATUS(status), std::move(output)}; }
-            if (WIFSIGNALED(status))
-            {
-                return {128 + WTERMSIG(status), output + "native compiler terminated by signal " +
-                                                     std::to_string(WTERMSIG(status))};
-            }
-            return {-1, std::move(output)};
-        }
-
         std::filesystem::path executable_path()
         {
 #if defined(__APPLE__)

--- a/language/src/driver/process.cpp
+++ b/language/src/driver/process.cpp
@@ -1,0 +1,215 @@
+#include "driver/process.h"
+
+#include <cerrno>
+#include <cstring>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+namespace hgl::driver
+{
+#if defined(_WIN32)
+    namespace
+    {
+        std::string windows_argument(std::string_view argument)
+        {
+            if (argument.find_first_of(" \t\n\v\"") == std::string_view::npos)
+            {
+                return std::string{argument};
+            }
+
+            std::string quoted{"\""};
+            std::size_t backslashes = 0;
+            for (const char c : argument)
+            {
+                if (c == '\\')
+                {
+                    ++backslashes;
+                    continue;
+                }
+                if (c == '"')
+                {
+                    quoted.append(backslashes * 2 + 1, '\\');
+                    quoted += c;
+                    backslashes = 0;
+                    continue;
+                }
+                quoted.append(backslashes, '\\');
+                backslashes = 0;
+                quoted += c;
+            }
+            quoted.append(backslashes * 2, '\\');
+            quoted += '"';
+            return quoted;
+        }
+
+        std::string windows_error(std::string_view action)
+        {
+            return std::string{action} + " (Windows error " + std::to_string(GetLastError()) + ")";
+        }
+    }  // namespace
+
+    ProcessResult run_process(std::span<const std::string> arguments)
+    {
+        if (arguments.empty())
+        {
+            return {-1, "cannot start an empty process command"};
+        }
+
+        std::string command_line;
+        for (const std::string &argument : arguments)
+        {
+            if (!command_line.empty())
+            {
+                command_line += ' ';
+            }
+            command_line += windows_argument(argument);
+        }
+
+        SECURITY_ATTRIBUTES security{sizeof(SECURITY_ATTRIBUTES), nullptr, TRUE};
+        HANDLE output_read = nullptr;
+        HANDLE output_write = nullptr;
+        if (!CreatePipe(&output_read, &output_write, &security, 0))
+        {
+            return {-1, windows_error("cannot create process output pipe")};
+        }
+        if (!SetHandleInformation(output_read, HANDLE_FLAG_INHERIT, 0))
+        {
+            const std::string error = windows_error("cannot configure process output pipe");
+            CloseHandle(output_read);
+            CloseHandle(output_write);
+            return {-1, error};
+        }
+
+        STARTUPINFOA startup{};
+        startup.cb = sizeof(startup);
+        startup.dwFlags = STARTF_USESTDHANDLES;
+        startup.hStdOutput = output_write;
+        startup.hStdError = output_write;
+        startup.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
+        PROCESS_INFORMATION process{};
+        const BOOL started = CreateProcessA(nullptr, command_line.data(), nullptr, nullptr, TRUE, CREATE_NO_WINDOW,
+                                            nullptr, nullptr, &startup, &process);
+        CloseHandle(output_write);
+        if (!started)
+        {
+            const std::string error = windows_error("cannot start process");
+            CloseHandle(output_read);
+            return {-1, error};
+        }
+
+        CloseHandle(process.hThread);
+        std::string output;
+        char buffer[4096];
+        DWORD count = 0;
+        while (ReadFile(output_read, buffer, sizeof(buffer), &count, nullptr) && count != 0)
+        {
+            output.append(buffer, static_cast<std::size_t>(count));
+        }
+        CloseHandle(output_read);
+
+        if (WaitForSingleObject(process.hProcess, INFINITE) != WAIT_OBJECT_0)
+        {
+            const std::string error = windows_error("cannot wait for process");
+            CloseHandle(process.hProcess);
+            return {-1, output + error};
+        }
+        DWORD status = 0;
+        if (!GetExitCodeProcess(process.hProcess, &status))
+        {
+            const std::string error = windows_error("cannot read process status");
+            CloseHandle(process.hProcess);
+            return {-1, output + error};
+        }
+        CloseHandle(process.hProcess);
+        return {static_cast<int>(status), std::move(output)};
+    }
+#else
+    ProcessResult run_process(std::span<const std::string> arguments)
+    {
+        if (arguments.empty())
+        {
+            return {-1, "cannot start an empty process command"};
+        }
+
+        int output_pipe[2];
+        if (::pipe(output_pipe) != 0)
+        {
+            return {-1, "cannot create process output pipe: " + std::string{std::strerror(errno)}};
+        }
+        const pid_t child = ::fork();
+        if (child < 0)
+        {
+            const std::string message = "cannot start process: " + std::string{std::strerror(errno)};
+            ::close(output_pipe[0]);
+            ::close(output_pipe[1]);
+            return {-1, message};
+        }
+        if (child == 0)
+        {
+            ::close(output_pipe[0]);
+            (void)::dup2(output_pipe[1], STDOUT_FILENO);
+            (void)::dup2(output_pipe[1], STDERR_FILENO);
+            ::close(output_pipe[1]);
+            std::vector<char *> argv;
+            argv.reserve(arguments.size() + 1);
+            for (const std::string &argument : arguments)
+            {
+                argv.push_back(const_cast<char *>(argument.c_str()));
+            }
+            argv.push_back(nullptr);
+            ::execvp(argv.front(), argv.data());
+            _exit(127);
+        }
+
+        ::close(output_pipe[1]);
+        std::string output;
+        char buffer[4096];
+        while (true)
+        {
+            const ssize_t count = ::read(output_pipe[0], buffer, sizeof(buffer));
+            if (count > 0)
+            {
+                output.append(buffer, static_cast<std::size_t>(count));
+            }
+            else if (count == 0)
+            {
+                break;
+            }
+            else if (errno != EINTR)
+            {
+                output += "cannot read process output: " + std::string{std::strerror(errno)};
+                break;
+            }
+        }
+        ::close(output_pipe[0]);
+
+        int status = 0;
+        while (::waitpid(child, &status, 0) < 0)
+        {
+            if (errno != EINTR)
+            {
+                return {-1, output + "cannot wait for process"};
+            }
+        }
+        if (WIFEXITED(status))
+        {
+            return {WEXITSTATUS(status), std::move(output)};
+        }
+        if (WIFSIGNALED(status))
+        {
+            return {128 + WTERMSIG(status),
+                    output + "process terminated by signal " + std::to_string(WTERMSIG(status))};
+        }
+        return {-1, std::move(output)};
+    }
+#endif
+}  // namespace hgl::driver

--- a/language/src/driver/process.h
+++ b/language/src/driver/process.h
@@ -1,0 +1,20 @@
+#ifndef HGL_DRIVER_PROCESS_H
+#define HGL_DRIVER_PROCESS_H
+
+#include <span>
+#include <string>
+
+namespace hgl::driver
+{
+    struct ProcessResult
+    {
+        int status{-1};
+        std::string output{};
+    };
+
+    /// Run one process without a command shell and capture its standard output
+    /// and standard error together. Arguments are passed exactly as supplied.
+    [[nodiscard]] ProcessResult run_process(std::span<const std::string> arguments);
+}  // namespace hgl::driver
+
+#endif  // HGL_DRIVER_PROCESS_H

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -79,12 +79,12 @@ TEST_CASE("emit-cpp names the pair after the module and exports its functions", 
     CHECK(emitted->module_name == "hgl.codegen.parity");
     CHECK(emitted->exports == std::vector<std::string>{"plus", "scaled_sum", "above", "maybe_double", "offset_by"});
 
-    // The header declares the exported graphs and their operator markers.
+    // The header declares the exported graphs and transparent operator aliases.
     CHECK(contains(emitted->header, "#pragma once"));
     CHECK(contains(emitted->header, "namespace hgl::codegen::parity"));
-    CHECK(contains(emitted->header, "struct plus : hgraph::Operator<\"hgl.codegen.parity.plus\", "
+    CHECK(contains(emitted->header, "using plus = hgraph::Operator<\"hgl.codegen.parity.plus\", "
                                     "hgraph::In<\"a\", hgraph::TS<hgraph::Float>>, hgraph::In<\"b\", hgraph::TS<hgraph::Float>>, "
-                                    "hgraph::Out<hgraph::TS<hgraph::Float>>> {};"));
+                                    "hgraph::Out<hgraph::TS<hgraph::Float>>>;"));
     CHECK(contains(emitted->header, "[[maybe_unused]] static constexpr auto name = \"hgl.codegen.parity.plus\";"));
     CHECK(contains(emitted->header, "static hgraph::Port<hgraph::TS<hgraph::Float>> compose(hgraph::Wiring &, "
                                     "hgraph::Port<hgraph::TS<hgraph::Float>>, hgraph::Port<hgraph::TS<hgraph::Float>>);"));
@@ -112,7 +112,7 @@ TEST_CASE("emit-cpp names the pair after the module and exports its functions", 
     CHECK(contains(emitted->source, "(void)registry.remove_provider(provider);"));
     CHECK(contains(emitted->source, "rollback.release();"));
     CHECK(contains(emitted->source, "return provider;"));
-    CHECK(contains(emitted->source, "hgraph::register_graph_overload<ops::plus, plus>();"));
+    CHECK(contains(emitted->source, "hgraph::register_graph_overload<operators::plus, plus>();"));
     CHECK(contains(emitted->source, "// parity.hgl:"));
 
     // Deterministic: the same input prints the same pair.
@@ -337,11 +337,12 @@ export fn through_private(a: f64) -> f64 => private_total(a)
     CHECK(contains(emitted->header, "if (!sum.valid())"));
     CHECK(contains(emitted->header, "sum.set((sum.value().checked_as<hgraph::Float>() + (a.value() + b.value())));"));
     CHECK(contains(emitted->header, "hgl_output.set(sum.value().checked_as<hgraph::Float>());"));
-    CHECK(contains(emitted->source, "hgraph::register_overload<ops::total, total>();"));
-    CHECK_FALSE(contains(emitted->source, "register_graph_overload<ops::total"));
+    CHECK(contains(emitted->source, "hgraph::register_overload<operators::total, total>();"));
+    CHECK_FALSE(contains(emitted->source, "register_graph_overload<operators::total"));
     CHECK_FALSE(contains(emitted->header, "private_total"));
-    CHECK(contains(emitted->source, "struct hgl_internal_operator_"));
-    CHECK(contains(emitted->source, "hgraph::register_overload<hgl_internal_operator_"));
+    CHECK(contains(emitted->source, "namespace operator_contracts"));
+    CHECK(contains(emitted->source, "using private_total = hgraph::Operator<"));
+    CHECK(contains(emitted->source, "hgraph::register_overload<operator_contracts::private_total, private_total>()"));
     CHECK(contains(emitted->source, "hgraph::wire<private_total>(w, a)"));
 }
 
@@ -519,7 +520,7 @@ export fn w(delete: f64, const int: i64 = 1) -> f64 => delete * int
     const auto emitted = unit.emit();
     REQUIRE(emitted);
     CHECK(emitted->namespace_name == "t::new_");
-    CHECK(contains(emitted->header, "struct w_ : hgraph::Operator<\"t.new.w\""));
+    CHECK(contains(emitted->header, "using w_ = hgraph::Operator<\"t.new.w\""));
     CHECK(contains(emitted->source, "hgraph::Port<hgraph::TS<hgraph::Float>> w_::compose(hgraph::Wiring &w, "
                                     "hgraph::Port<hgraph::TS<hgraph::Float>> delete_, hgraph::Scalar<\"int\", hgraph::Int> int_)"));
 }

--- a/language/tests/codegen/generated_runtime_tests.cpp
+++ b/language/tests/codegen/generated_runtime_tests.cpp
@@ -42,21 +42,21 @@ TEST_CASE("generated module registration owns a removable provider generation", 
 TEST_CASE("generated runtime impl functions register as node overloads", "[codegen][runtime]")
 {
     session();
-    CHECK_OUTPUT(eval_node<runtime::ops::absolute>(values<Float>(-2.0, 3.0)),
+    CHECK_OUTPUT(eval_node<runtime::operators::absolute>(values<Float>(-2.0, 3.0)),
                  values<Float>(2.0, 3.0));
 }
 
 TEST_CASE("a generated composition can wire a generated operator implementation", "[codegen][runtime]")
 {
     session();
-    CHECK_OUTPUT(eval_node<runtime::ops::absolute_graph>(values<Float>(-2.0, 3.0)),
+    CHECK_OUTPUT(eval_node<runtime::operators::absolute_graph>(values<Float>(-2.0, 3.0)),
                  values<Float>(2.0, 3.0));
 }
 
 TEST_CASE("generated runtime predicates use modified-or and valid-and semantics", "[codegen][runtime]")
 {
     session();
-    CHECK_OUTPUT(eval_node<runtime::ops::add_when_ready>(values<Float>(1.0, none, 3.0),
+    CHECK_OUTPUT(eval_node<runtime::operators::add_when_ready>(values<Float>(1.0, none, 3.0),
                                                         values<Float>(none, 10.0, 20.0)),
                  values<Float>(none, 11.0, 23.0));
 }
@@ -64,7 +64,7 @@ TEST_CASE("generated runtime predicates use modified-or and valid-and semantics"
 TEST_CASE("generated activation analysis leaves sampled inputs passive", "[codegen][runtime]")
 {
     session();
-    CHECK_OUTPUT(eval_node<runtime::ops::sample_on_trigger>(values<Float>(1.0, none, 2.0),
+    CHECK_OUTPUT(eval_node<runtime::operators::sample_on_trigger>(values<Float>(1.0, none, 2.0),
                                                            values<Float>(10.0, 20.0, none)),
                  values<Float>(10.0, none, 20.0));
 }
@@ -72,14 +72,14 @@ TEST_CASE("generated activation analysis leaves sampled inputs passive", "[codeg
 TEST_CASE("generated runtime metadata reads the input selector", "[codegen][runtime]")
 {
     session();
-    CHECK_OUTPUT(eval_node<runtime::ops::updated_at>(values<Float>(1.0, none, 2.0)),
+    CHECK_OUTPUT(eval_node<runtime::operators::updated_at>(values<Float>(1.0, none, 2.0)),
                  values<DateTime>(MIN_ST, none, MIN_ST + 2 * MIN_TD));
 }
 
 TEST_CASE("generated runtime handlers share recordable state and run in source order", "[codegen][runtime]")
 {
     session();
-    CHECK_OUTPUT(eval_node<runtime::ops::combined_total>(values<Float>(10.0, none, 2.0),
+    CHECK_OUTPUT(eval_node<runtime::operators::combined_total>(values<Float>(10.0, none, 2.0),
                                                         values<Float>(3.0, 1.0, none)),
                  values<Float>(7.0, 6.0, 8.0));
 }
@@ -87,7 +87,7 @@ TEST_CASE("generated runtime handlers share recordable state and run in source o
 TEST_CASE("a generated composition can wire a generated runtime node", "[codegen][runtime]")
 {
     session();
-    CHECK_OUTPUT(eval_node<runtime::ops::combined_total_graph>(values<Float>(10.0, none, 2.0),
+    CHECK_OUTPUT(eval_node<runtime::operators::combined_total_graph>(values<Float>(10.0, none, 2.0),
                                                               values<Float>(3.0, 1.0, none)),
                  values<Float>(7.0, 6.0, 8.0));
 }
@@ -95,34 +95,34 @@ TEST_CASE("a generated composition can wire a generated runtime node", "[codegen
 TEST_CASE("generated inject out exposes the previous value and writes non-terminally", "[codegen][runtime]")
 {
     session();
-    CHECK_OUTPUT(eval_node<runtime::ops::running_total>(values<Float>(1.0, 2.0, 3.0)),
+    CHECK_OUTPUT(eval_node<runtime::operators::running_total>(values<Float>(1.0, 2.0, 3.0)),
                  values<Float>(1.0, 3.0, 6.0));
 }
 
 TEST_CASE("generated runtime lifecycle hooks run around evaluation", "[codegen][runtime]")
 {
     session();
-    CHECK_OUTPUT(eval_node<runtime::ops::lifecycle_value>(values<Float>(4.0, 5.0)),
+    CHECK_OUTPUT(eval_node<runtime::operators::lifecycle_value>(values<Float>(4.0, 5.0)),
                  values<Float>(4.0, 5.0));
 }
 
 TEST_CASE("generated state initializers can use const parameters", "[codegen][runtime]")
 {
     session();
-    CHECK_OUTPUT(eval_node<runtime::ops::configured_total>(values<Float>(1.0, 2.0), arg<"initial">(Float{5.0})),
+    CHECK_OUTPUT(eval_node<runtime::operators::configured_total>(values<Float>(1.0, 2.0), arg<"initial">(Float{5.0})),
                  values<Float>(6.0, 8.0));
 }
 
 TEST_CASE("generated runtime functions without when use ordinary input policy", "[codegen][runtime]")
 {
     session();
-    CHECK_OUTPUT(eval_node<runtime::ops::unconditional_total>(values<Float>(1.0, 2.0, 3.0)),
+    CHECK_OUTPUT(eval_node<runtime::operators::unconditional_total>(values<Float>(1.0, 2.0, 3.0)),
                  values<Float>(1.0, 3.0, 6.0));
 }
 
 TEST_CASE("a generated composition can wire a private generated runtime node", "[codegen][runtime]")
 {
     session();
-    CHECK_OUTPUT(eval_node<runtime::ops::private_total_graph>(values<Float>(1.0, 2.0, 3.0)),
+    CHECK_OUTPUT(eval_node<runtime::operators::private_total_graph>(values<Float>(1.0, 2.0, 3.0)),
                  values<Float>(1.0, 3.0, 6.0));
 }

--- a/language/tests/codegen/generated_tests.cpp
+++ b/language/tests/codegen/generated_tests.cpp
@@ -49,6 +49,6 @@ TEST_CASE("generated exports are registered by module-qualified name with their 
     CHECK(hgl::wiring::has_operator("hgl.codegen.parity.plus"));
     CHECK(hgl::wiring::has_operator("hgl.codegen.parity.scaled_sum"));
     // Through the registry the const default applies, as it would from Python.
-    CHECK_OUTPUT(eval_node<parity::ops::scaled_sum>(values<Float>(1.0), values<Float>(2.0)), values<Float>(6.0));
-    CHECK_OUTPUT(eval_node<parity::ops::maybe_double>(values<Float>(1.5)), values<Float>(3.0));
+    CHECK_OUTPUT(eval_node<parity::operators::scaled_sum>(values<Float>(1.0), values<Float>(2.0)), values<Float>(6.0));
+    CHECK_OUTPUT(eval_node<parity::operators::maybe_double>(values<Float>(1.5)), values<Float>(3.0));
 }

--- a/language/tests/driver/native_module_tests.cpp
+++ b/language/tests/driver/native_module_tests.cpp
@@ -1,3 +1,4 @@
+#include "driver/cpp_formatter.h"
 #include "driver/native_module.h"
 
 #include <catch2/catch_test_macros.hpp>
@@ -18,22 +19,54 @@ namespace
     }
 }  // namespace
 
-TEST_CASE("native module activation reports standard exceptions through the scope helper")
+TEST_CASE("native module activation reports standard exceptions through the "
+          "scope helper")
 {
     hgl::driver::NativeModule module{"retained", {}, false, throw_standard_exception};
-    std::string               error;
+    std::string error;
 
     CHECK_FALSE(module.activate(error));
-    CHECK(error == "native module registration failed: registration error; artifacts retained in 'retained'");
+    CHECK(error == "native module registration failed: registration error; "
+                   "artifacts retained in 'retained'");
     CHECK_FALSE(module.active());
 }
 
-TEST_CASE("native module activation reports unknown exceptions through the scope helper")
+TEST_CASE("native module activation reports unknown exceptions through the "
+          "scope helper")
 {
     hgl::driver::NativeModule module{"retained", {}, false, throw_unknown_exception};
-    std::string               error;
+    std::string error;
 
     CHECK_FALSE(module.activate(error));
-    CHECK(error == "native module registration failed: unknown error; artifacts retained in 'retained'");
+    CHECK(error == "native module registration failed: unknown error; artifacts "
+                   "retained in 'retained'");
     CHECK_FALSE(module.active());
+}
+
+TEST_CASE("generated C++ is passed through clang-format")
+{
+    hgl::codegen::EmittedModule module;
+    module.header = "#pragma once\nnamespace example{using value=int;}\n";
+    module.source = "#include \"module.h\"\nnamespace example{int twice(int "
+                    "x){return x*2;}}\n";
+    std::string error;
+
+    const bool formatted = hgl::driver::format_cpp(module, error);
+    INFO(error);
+    REQUIRE(formatted);
+    CHECK(module.header == R"(#pragma once
+namespace example
+{
+    using value = int;
+}
+)");
+    CHECK(module.source == R"(#include "module.h"
+namespace example
+{
+    int twice(int x)
+    {
+        return x * 2;
+    }
+}  // namespace example
+)");
 }

--- a/language/tests/driver/native_module_tests.cpp
+++ b/language/tests/driver/native_module_tests.cpp
@@ -63,10 +63,7 @@ namespace example
     CHECK(module.source == R"(#include "module.h"
 namespace example
 {
-    int twice(int x)
-    {
-        return x * 2;
-    }
+    int twice(int x) { return x * 2; }
 }  // namespace example
 )");
 }

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -13,10 +13,10 @@ out tree and publishes nothing.
 
 | Path | Purpose |
 |---|---|
-| `homebrew/Formula/hgraph.rb` | The formula: builds the SDK, `hgl` and the analytics extension from a release tarball, stages isocline as a resource so the build runs with FetchContent disconnected, and tests `hgl test` and `hgl --version`. |
+| `homebrew/Formula/hgraph.rb` | The formula: builds the SDK, `hgl` and the analytics extension from a release tarball, installs the `clang-format` used by every code-generation path, stages isocline as a resource so the build runs with FetchContent disconnected, and tests `hgl test` and `hgl --version`. |
 | `homebrew/Aliases/hgl` | `brew install hhenson/hgraph/hgl` resolves to the same formula. |
 | `homebrew/README.md`, `homebrew/.github/workflows/` | The tap repository's README and its `brew test-bot` / `brew pr-pull` workflows. Copied verbatim into `hhenson/homebrew-hgraph` at the release switch. |
-| `docker/Dockerfile` | Multi-stage Debian image with `hgl`, the SDK under `/usr/local` (with the fmt, spdlog, simdjson and date it was built against, so `find_package(hgraph)` resolves inside the image), CMake, Ninja and `g++` so runtime functions and downstream packages compile inside the container; runs as the unprivileged user `hgl`. `Dockerfile.dockerignore` trims the build context. |
+| `docker/Dockerfile` | Multi-stage Debian image with `hgl`, the SDK under `/usr/local` (with the fmt, spdlog, simdjson and date it was built against, so `find_package(hgraph)` resolves inside the image), `clang-format`, CMake, Ninja and `g++` so generated C++ is formatted and runtime functions and downstream packages compile inside the container; runs as the unprivileged user `hgl`. `Dockerfile.dockerignore` trims the build context. |
 | `smoke/smoke.hgl` | The one-module smoke every channel runs after installing: `hgl test smoke.hgl` must report `twice_ticks ... ok`. |
 | `smoke/consumer/` | The installed-SDK consumer every channel builds: `find_package(hgraph)`, `hgl_add_module()` on `smoke.hgl`, and a `main.cpp` that evaluates the generated operator through the public harness and prints `hgl smoke consumer ok`. Homebrew installs the directory as `share/hgraph/smoke` and builds it in `brew test`; the Conan test package carries a copy (`test_package/smoke.hgl`, `hgl_consumer.cpp`) because an exported recipe cannot reach this directory. |
 

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update \
  && rm "./apache-arrow-apt-source-latest-${DEBIAN_CODENAME}.deb" \
  && apt-get update \
  && apt-get install -y --no-install-recommends \
-      cmake g++ libarrow-acero-dev libarrow-compute-dev libarrow-dev ninja-build tzdata \
+      clang-format cmake g++ libarrow-acero-dev libarrow-compute-dev libarrow-dev ninja-build tzdata \
  && rm -rf /var/lib/apt/lists/*
 
 # ---------------------------------------------------------------------------

--- a/packaging/homebrew/Formula/hgraph.rb
+++ b/packaging/homebrew/Formula/hgraph.rb
@@ -21,9 +21,9 @@ class Hgraph < Formula
   depends_on "cmake" => [:build, :test]
   depends_on "ninja" => [:build, :test]
   depends_on "apache-arrow"
+  depends_on "clang-format" # runtime dependency of hgl code generation
   depends_on "fmt"
   depends_on "howard-hinnant-date"
-  depends_on "clang-format" # runtime dependency of hgl code generation
   depends_on "simdjson"
   depends_on "spdlog"
 

--- a/packaging/homebrew/Formula/hgraph.rb
+++ b/packaging/homebrew/Formula/hgraph.rb
@@ -23,6 +23,7 @@ class Hgraph < Formula
   depends_on "apache-arrow"
   depends_on "fmt"
   depends_on "howard-hinnant-date"
+  depends_on "clang-format" # runtime dependency of hgl code generation
   depends_on "simdjson"
   depends_on "spdlog"
 

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -11,7 +11,8 @@ hgl --version
 The formula installs `bin/hgl`, the SDK headers and shared libraries, and
 the CMake packages (`lib/cmake/hgraph`, `lib/cmake/hgl`) that
 `find_package(hgraph)` and `hgl_add_module()` consume. Arrow, fmt, spdlog,
-simdjson and date come from homebrew-core; runtime (`state`/`when`)
+simdjson, date, and the `clang-format` used by code generation come from
+homebrew-core; runtime (`state`/`when`)
 functions compile at run time with the Xcode command-line tools on macOS
 and the `gcc` formula on Linux.
 

--- a/packaging/smoke/consumer/main.cpp
+++ b/packaging/smoke/consumer/main.cpp
@@ -24,7 +24,7 @@ int main()
         throw std::logic_error("smoke.twice did not double its input");
     }
     // Dispatch through the registry marker: the erased harness yields Values.
-    const auto by_name = hgraph::testing::eval_node<smoke::ops::twice>(ticks{3.0});
+    const auto by_name = hgraph::testing::eval_node<smoke::operators::twice>(ticks{3.0});
     if (by_name.size() != 1 || !by_name[0] || by_name[0]->as<Float>() != 6.0)
     {
         throw std::logic_error("smoke.twice is not registered by name");

--- a/python/tests/test_packaging.py
+++ b/python/tests/test_packaging.py
@@ -59,6 +59,24 @@ def test_conan_sdk_propagates_public_native_dependency_usage_requirements():
         assert "transitive_libs=True" in call.group(0), requirement
 
 
+def test_conan_language_declares_its_formatter_and_current_generated_namespace():
+    conan = (ROOT / "conanfile.py").read_text()
+    consumer = (ROOT / "test_package/hgl_consumer.cpp").read_text()
+
+    assert "def system_requirements(self):" in conan
+    assert "if not self.options.language:" in conan
+    for manager, package in {
+        "Apt": "clang-format",
+        "Dnf": "clang-tools-extra",
+        "Brew": "clang-format",
+        "Chocolatey": "llvm",
+    }.items():
+        assert f'({manager}, "{package}")' in conan
+    assert "host_package=False" in conan
+    assert "smoke::operators::twice" in consumer
+    assert "smoke::ops::twice" not in consumer
+
+
 def test_nanobind_build_and_sdk_headers_use_one_exact_runtime_abi():
     project = load_project()
 

--- a/test_package/hgl_consumer.cpp
+++ b/test_package/hgl_consumer.cpp
@@ -12,22 +12,19 @@
 #include <stdexcept>
 #include <vector>
 
-int main()
-{
+int main() {
     using hgraph::Float;
     using ticks = std::vector<std::optional<Float>>;
 
     hgraph::stdlib::register_standard_operators();
     smoke::register_operators();
 
-    if (hgraph::testing::eval_node<smoke::twice>(ticks{1.0, 2.0}) != ticks{2.0, 4.0})
-    {
+    if (hgraph::testing::eval_node<smoke::twice>(ticks{1.0, 2.0}) != ticks{2.0, 4.0}) {
         throw std::logic_error("smoke.twice did not double its input");
     }
     // Dispatch through the registry marker: the erased harness yields Values.
-    const auto by_name = hgraph::testing::eval_node<smoke::ops::twice>(ticks{3.0});
-    if (by_name.size() != 1 || !by_name[0] || by_name[0]->as<Float>() != 6.0)
-    {
+    const auto by_name = hgraph::testing::eval_node<smoke::operators::twice>(ticks{3.0});
+    if (by_name.size() != 1 || !by_name[0] || by_name[0]->as<Float>() != 6.0) {
         throw std::logic_error("smoke.twice is not registered by name");
     }
 


### PR DESCRIPTION
## Summary

- restore the pre-v0.2 `hg_cpp` clang-format policy as the starting point for hgraph, retaining its `c++20` parser mode for clang-format 18+ compatibility
- make clang-format a required final stage for emitted, scripted, cached, and AOT-generated C++
- embed the same policy in `hgl`, so generated output does not depend on the caller's working directory or local `.clang-format`
- represent generated operator contracts with transparent `using` aliases instead of derived marker classes
- use readable `operators` and `operator_contracts` namespaces and source-level internal names
- omit unreachable result fallbacks after an unconditional return
- carry the formatter dependency through CI, Homebrew, and the container distribution

This is the base of the stack that will bring every checked-in language example through native code generation and execution. Keeping that semantic work above this PR makes its generated output reviewable. Existing C++ is not reformatted repo-wide by this change.

## Validation

- focused language codegen, generated-code, native-module, and midpoint/runtime CLI tests: 7 passed
- complete native suite: 1,692 passed
- stable-ABI wheel installed into Python 3.14; complete non-WIP compatibility suite: 3,123 passed, 10 skipped
- installed SDK smoke consumer: configured, generated, built, and passed
