### PR TITLE
language: compile all documented example forms

### DIFF
--- a/include/hgraph/lib/std/operators/collection.h
+++ b/include/hgraph/lib/std/operators/collection.h
@@ -310,8 +310,11 @@ namespace hgraph::stdlib
         {
         };
 
-        template <typename T>
-        inline constexpr bool is_tsb_schema_v = is_tsb_schema<T>::value;
+        template <typename ValueBundle, typename... Fields>
+        struct is_tsb_schema<NominalTSB<ValueBundle, Fields...>> : std::true_type
+        {};
+
+        template <typename T> inline constexpr bool is_tsb_schema_v = is_tsb_schema<T>::value;
 
         template <typename T>
         struct tsl_schema_traits;
@@ -336,8 +339,12 @@ namespace hgraph::stdlib
             static constexpr std::size_t field_count = sizeof...(Fields);
         };
 
-        template <fixed_string Name, typename... Fields>
-        struct tsb_schema_traits<TSB<Name, Fields...>>
+        template <fixed_string Name, typename... Fields> struct tsb_schema_traits<TSB<Name, Fields...>>
+        {
+            static constexpr std::size_t field_count = sizeof...(Fields);
+        };
+
+        template <typename ValueBundle, typename... Fields> struct tsb_schema_traits<NominalTSB<ValueBundle, Fields...>>
         {
             static constexpr std::size_t field_count = sizeof...(Fields);
         };

--- a/include/hgraph/lib/testing/eval_node.h
+++ b/include/hgraph/lib/testing/eval_node.h
@@ -46,8 +46,12 @@ namespace hgraph::testing
     struct harness_element<TS<ArrayOf<T, Dimensions...>>> { using type = Value; };
     template <typename T> struct harness_element<TS<SeriesOf<T>>> { using type = Series; };
     template <typename T, typename M> struct harness_element<TS<FrameOf<T, M>>> { using type = Frame; };
-    template <typename T, std::size_t Period, std::size_t MinPeriod>
-    struct harness_element<TSW<T, Period, MinPeriod>>
+    template <typename T, std::size_t Period, std::size_t MinPeriod> struct harness_element<TSW<T, Period, MinPeriod>>
+    {
+        using type = T;
+    };
+    template <typename T, std::int64_t PeriodMicros, std::int64_t MinPeriodMicros>
+    struct harness_element<TSWDuration<T, PeriodMicros, MinPeriodMicros>>
     {
         using type = T;
     };

--- a/include/hgraph/types/graph_wiring.h
+++ b/include/hgraph/types/graph_wiring.h
@@ -1728,6 +1728,10 @@ namespace hgraph
         {
             using type = TSB<Name, typename dereferenced_static_field<TFields>::type...>;
         };
+        template <typename ValueBundle, typename... TFields> struct dereferenced_static_schema<NominalTSB<ValueBundle, TFields...>>
+        {
+            using type = NominalTSB<ValueBundle, typename dereferenced_static_field<TFields>::type...>;
+        };
 
         template <auto Lhs, auto Rhs>
         [[nodiscard]] consteval bool static_size_equivalent()
@@ -2060,6 +2064,25 @@ namespace hgraph
                 auto fields = structural_arg_detail::inferred_named_tsb_fields(arg);
                 if (fields.empty()) { return nullptr; }
                 return TypeRegistry::instance().tsb(Name.sv(), fields);
+            }
+        };
+
+        template <typename ValueBundle, typename... Fields> struct structural_arg_schema_infer<NominalTSB<ValueBundle, Fields...>>
+        {
+            [[nodiscard]] static const TSValueTypeMetaData *infer(const WiringStructuralSourceArg &arg) {
+                if (arg.children.size() != sizeof...(Fields)) { return nullptr; }
+                auto fields = structural_arg_detail::inferred_tsb_fields<Fields...>(arg, std::index_sequence_for<Fields...>{});
+                for (const auto &field : fields) {
+                    if (field.second == nullptr) { return nullptr; }
+                }
+                const auto *value = value_schema_descriptor<ValueBundle>::value_meta();
+                return TypeRegistry::instance().tsb(value->name(), fields);
+            }
+            [[nodiscard]] static const TSValueTypeMetaData *infer(const WiringNamedStructuralSourceArg &arg) {
+                auto fields = structural_arg_detail::inferred_named_tsb_fields(arg);
+                if (fields.empty()) { return nullptr; }
+                const auto *value = value_schema_descriptor<ValueBundle>::value_meta();
+                return TypeRegistry::instance().tsb(value->name(), fields);
             }
         };
 

--- a/include/hgraph/types/operator_dispatch.h
+++ b/include/hgraph/types/operator_dispatch.h
@@ -1186,23 +1186,21 @@ namespace hgraph
             else
             {
                 const TSValueTypeMetaData *expected = ts_resolver<S>::resolve(map);
-                if (expected == nullptr)
-                {
-                    throw std::logic_error("operator selected overload input schema is unresolved");
-                }
-                if (arg.kind == WiringArg::Kind::TimeSeries)
-                {
-                    if (arg.port.schema == nullptr)
-                    {
-                        return PortParam{w, WiringPortRef::null_source(expected)};
-                    }
+                if (arg.kind == WiringArg::Kind::TimeSeries) {
                     ResolutionMap scratch = map;
-                    if (!input_ts_pattern_match(to_pattern<S>(), arg.port.schema, scratch))
-                    {
+                    if (arg.port.schema != nullptr && !input_ts_pattern_match(to_pattern<S>(), arg.port.schema, scratch)) {
                         throw std::logic_error("operator selected overload input schema does not match");
                     }
+                    // Shape wildcards such as TSWAny deliberately do not
+                    // resolve to one canonical schema. Preserve the concrete
+                    // schema selected at this call site when constructing the
+                    // typed graph parameter.
+                    if (expected == nullptr) { expected = arg.port.schema; }
+                    if (expected == nullptr) { throw std::logic_error("operator selected overload input schema is unresolved"); }
+                    if (arg.port.schema == nullptr) { return PortParam{w, WiringPortRef::null_source(expected)}; }
                     return PortParam{w, graph_wiring_detail::adapt_source_for_input(w, expected, arg.port)};
                 }
+                if (expected == nullptr) { throw std::logic_error("operator selected overload input schema is unresolved"); }
                 return PortParam{w, wire_scalar_const(w, arg, expected)};
             }
         }

--- a/include/hgraph/types/static_node.h
+++ b/include/hgraph/types/static_node.h
@@ -97,7 +97,10 @@ namespace hgraph
         template <typename S> struct is_scalar_ts : std::false_type {};
         template <typename V> struct is_scalar_ts<TS<V>> : std::true_type {};
         template <typename V, std::size_t P, std::size_t M> struct is_scalar_ts<TSW<V, P, M>> : std::true_type {};
-        template <> struct is_scalar_ts<SIGNAL> : std::true_type {};
+        template <typename V, std::int64_t P, std::int64_t M> struct is_scalar_ts<TSWDuration<V, P, M>> : std::true_type
+        {};
+        template <> struct is_scalar_ts<SIGNAL> : std::true_type
+        {};
 
         /** The user-supplied per-entry delta input for child schema ``C``: the bare
          *  scalar for ``TS`` / ``SIGNAL`` / ``TSW``, otherwise a prebuilt child-delta
@@ -106,7 +109,14 @@ namespace hgraph
         template <typename V> struct delta_input<TS<V>> { using type = V; };
         template <typename V> struct delta_input<TS<SeriesOf<V>>> { using type = Series; };
         template <typename V, typename M> struct delta_input<TS<FrameOf<V, M>>> { using type = Frame; };
-        template <typename V, std::size_t P, std::size_t M> struct delta_input<TSW<V, P, M>> { using type = V; };
+        template <typename V, std::size_t P, std::size_t M> struct delta_input<TSW<V, P, M>>
+        {
+            using type = V;
+        };
+        template <typename V, std::int64_t P, std::int64_t M> struct delta_input<TSWDuration<V, P, M>>
+        {
+            using type = V;
+        };
         template <> struct delta_input<SIGNAL> { using type = bool; };
         template <typename C> using delta_input_t = typename delta_input<C>::type;
 
@@ -139,6 +149,9 @@ namespace hgraph
         template <typename... Fields> struct is_static_tsb_schema<Kwargs<Fields...>> : std::true_type {};
         template <fixed_string Name, typename... Fields>
         struct is_static_tsb_schema<TSB<Name, Fields...>> : std::true_type {};
+        template <typename ValueBundle, typename... Fields>
+        struct is_static_tsb_schema<NominalTSB<ValueBundle, Fields...>> : std::true_type
+        {};
 
         /**
          * Named so the constraint below is a concept rather than a bare
@@ -164,8 +177,11 @@ namespace hgraph
             template <fixed_string FieldName>
             using lookup = tsb_field_lookup<FieldName, Fields...>;
         };
-        template <fixed_string Name, typename... Fields>
-        struct static_tsb_schema_traits<TSB<Name, Fields...>>
+        template <fixed_string Name, typename... Fields> struct static_tsb_schema_traits<TSB<Name, Fields...>>
+        {
+            template <fixed_string FieldName> using lookup = tsb_field_lookup<FieldName, Fields...>;
+        };
+        template <typename ValueBundle, typename... Fields> struct static_tsb_schema_traits<NominalTSB<ValueBundle, Fields...>>
         {
             template <fixed_string FieldName>
             using lookup = tsb_field_lookup<FieldName, Fields...>;
@@ -437,8 +453,11 @@ namespace hgraph
         struct tsb_delta_builder<TSB<Name, Fields...>> : tsb_delta_builder<UnNamedTSB<Fields...>>
         {};
 
-        template <typename... Fields>
-        struct empty_delta_builder<UnNamedTSB<Fields...>>
+        template <typename ValueBundle, typename... Fields>
+        struct tsb_delta_builder<NominalTSB<ValueBundle, Fields...>> : tsb_delta_builder<UnNamedTSB<Fields...>>
+        {};
+
+        template <typename... Fields> struct empty_delta_builder<UnNamedTSB<Fields...>>
         {
             [[nodiscard]] static Value build()
             {
@@ -450,6 +469,10 @@ namespace hgraph
 
         template <fixed_string Name, typename... Fields>
         struct empty_delta_builder<TSB<Name, Fields...>> : empty_delta_builder<UnNamedTSB<Fields...>>
+        {};
+
+        template <typename ValueBundle, typename... Fields>
+        struct empty_delta_builder<NominalTSB<ValueBundle, Fields...>> : empty_delta_builder<UnNamedTSB<Fields...>>
         {};
     }  // namespace static_node_detail
 
@@ -1090,7 +1113,40 @@ namespace hgraph
         [[nodiscard]] TValue at(std::size_t index) const { return TSWInputView::at(index).template checked_as<TValue>(); }
         [[nodiscard]] TValue operator[](std::size_t index) const { return at(index); }
         [[nodiscard]] TValue front() const { return TSWInputView::front().template checked_as<TValue>(); }
-        [[nodiscard]] TValue back() const { return TSWInputView::back().template checked_as<TValue>(); }
+        [[nodiscard]] TValue    back() const { return TSWInputView::back().template checked_as<TValue>(); }
+        [[nodiscard]] ValueView delta() const { return delta_value(); }
+    };
+
+    template <fixed_string Name, typename TValue, std::int64_t PeriodMicros, std::int64_t MinPeriodMicros, auto... TPolicies>
+    class In<Name, TSWDuration<TValue, PeriodMicros, MinPeriodMicros>, TPolicies...> : public TSWInputView
+    {
+      public:
+        using schema                     = TSWDuration<TValue, PeriodMicros, MinPeriodMicros>;
+        using value_type                 = TValue;
+        static constexpr auto field_name = Name;
+        static constexpr auto activity   = static_node_detail::resolved_input_activity<TPolicies...>();
+        static constexpr auto validity   = static_node_detail::resolved_input_validity<TPolicies...>();
+
+        explicit In(TSInputView view) noexcept : TSWInputView(std::move(view)) {}
+
+        [[nodiscard]] TValue    at(std::size_t index) const { return TSWInputView::at(index).template checked_as<TValue>(); }
+        [[nodiscard]] TValue    operator[](std::size_t index) const { return at(index); }
+        [[nodiscard]] TValue    front() const { return TSWInputView::front().template checked_as<TValue>(); }
+        [[nodiscard]] TValue    back() const { return TSWInputView::back().template checked_as<TValue>(); }
+        [[nodiscard]] ValueView delta() const { return delta_value(); }
+    };
+
+    template <fixed_string Name, typename TValue, auto... TPolicies>
+    class In<Name, TSWAny<TValue>, TPolicies...> : public TSWInputView
+    {
+      public:
+        using schema                     = TSWAny<TValue>;
+        using value_type                 = TValue;
+        static constexpr auto field_name = Name;
+        static constexpr auto activity   = static_node_detail::resolved_input_activity<TPolicies...>();
+        static constexpr auto validity   = static_node_detail::resolved_input_validity<TPolicies...>();
+
+        explicit In(TSInputView view) noexcept : TSWInputView(std::move(view)) {}
         [[nodiscard]] ValueView delta() const { return delta_value(); }
     };
 
@@ -1645,6 +1701,21 @@ namespace hgraph
         [[nodiscard]] auto get() const { return field<FieldName>(); }
     };
 
+    template <typename TValueBundle, typename... TFields> class Out<NominalTSB<TValueBundle, TFields...>> : public TSBOutputView
+    {
+      public:
+        using schema = NominalTSB<TValueBundle, TFields...>;
+
+        Out(TSOutputView view, DateTime /*evaluation_time*/) noexcept : TSBOutputView(std::move(view)) {}
+
+        template <fixed_string FieldName> [[nodiscard]] auto field() const {
+            using lookup = static_node_detail::tsb_field_lookup<FieldName, TFields...>;
+            static_assert(lookup::found, "Out<NominalTSB>::field requested an unknown field");
+            return Out<typename lookup::type>{TSBOutputView::at(lookup::index), evaluation_time()};
+        }
+        template <fixed_string FieldName> [[nodiscard]] auto get() const { return field<FieldName>(); }
+    };
+
     /**
      * Window time-series output (``TSW<T>``): inherits ``TSWOutputView`` and adds
      * typed ``push``.
@@ -1654,6 +1725,25 @@ namespace hgraph
     {
       public:
         using schema     = TSW<TValue, Period, MinPeriod>;
+        using value_type = TValue;
+
+        Out(TSOutputView view, DateTime /*evaluation_time*/) noexcept : TSWOutputView(std::move(view)) {}
+
+        template <typename U> void push(U &&value) const {
+            Value wrapped{std::forward<U>(value)};
+            TSWOutputView::begin_mutation(evaluation_time()).push(wrapped.view());
+        }
+
+        void clear() const { TSWOutputView::begin_mutation(evaluation_time()).clear(); }
+
+        void apply(const ValueView &value) const { TSWOutputView::begin_mutation(evaluation_time()).push(value); }
+    };
+
+    template <typename TValue, std::int64_t PeriodMicros, std::int64_t MinPeriodMicros>
+    class Out<TSWDuration<TValue, PeriodMicros, MinPeriodMicros>> : public TSWOutputView
+    {
+      public:
+        using schema     = TSWDuration<TValue, PeriodMicros, MinPeriodMicros>;
         using value_type = TValue;
 
         Out(TSOutputView view, DateTime /*evaluation_time*/) noexcept : TSWOutputView(std::move(view)) {}

--- a/include/hgraph/types/static_schema.h
+++ b/include/hgraph/types/static_schema.h
@@ -69,6 +69,8 @@ namespace hgraph
     template <std::size_t N>
     fixed_string(const char (&)[N]) -> fixed_string<N>;
 
+    template <typename TBundle> struct value_schema_descriptor;
+
     // -----------------------------------------------------------------
     // Time-series marker types
     // -----------------------------------------------------------------
@@ -142,6 +144,14 @@ namespace hgraph
         static constexpr std::size_t min_period = MinPeriod;
     };
 
+    /** Duration-based sliding window with compile-time microsecond bounds. */
+    template <typename TValue, std::int64_t PeriodMicros, std::int64_t MinPeriodMicros = PeriodMicros> struct TSWDuration
+    {
+        using value_type                                = TValue;
+        static constexpr std::int64_t period_micros     = PeriodMicros;
+        static constexpr std::int64_t min_period_micros = MinPeriodMicros;
+    };
+
     /** Window time-series schema wildcard; matches any tick/duration window period. */
     template <typename TValue>
     struct TSWAny
@@ -180,6 +190,30 @@ namespace hgraph
         static constexpr auto name_sv = Name;
     };
 
+    /** Immediate parents of a generated nominal Bundle declaration. */
+    template <typename... TParents> struct BundleParents
+    {};
+
+    /** Concrete type arguments of a generated generic Bundle specialization. */
+    template <typename... TArguments> struct BundleArguments
+    {};
+
+    /**
+     * Rich named value-layer compound used by generated language modules.
+     *
+     * ``Bundle`` remains the concise C++ authoring form. ``NominalBundle``
+     * additionally preserves the source namespace, abstract hierarchy, and
+     * concrete generic arguments that a language compiler already knows.
+     */
+    template <fixed_string Namespace, fixed_string LocalName, bool Abstract, typename TParents, typename TArguments,
+              typename... TFields>
+    struct NominalBundle
+    {
+        static constexpr auto namespace_sv  = Namespace;
+        static constexpr auto local_name_sv = LocalName;
+        static constexpr bool abstract      = Abstract;
+    };
+
     /** One-pointer, on-demand owner for a value-layer schema. */
     template <typename TValue>
     struct Owned
@@ -214,6 +248,16 @@ namespace hgraph
     struct TSB
     {
         static constexpr auto name_sv = Name;
+    };
+
+    /**
+     * Named TSB whose identity comes from a rich value-layer Bundle.
+     * Fields remain explicit because temporal structs are lifted recursively,
+     * rather than treating a nested Bundle as one atomic ``TS`` value.
+     */
+    template <typename TValueBundle, typename... TFields> struct NominalTSB
+    {
+        using value_bundle = TValueBundle;
     };
 
     /** Derive a TSB schema from a value-layer Bundle by lifting each field to ``TS<Field>``. */
@@ -775,6 +819,21 @@ namespace hgraph
         }
     };
 
+    template <typename TValue, std::int64_t PeriodMicros, std::int64_t MinPeriodMicros>
+    struct schema_descriptor<TSWDuration<TValue, PeriodMicros, MinPeriodMicros>>
+    {
+        [[nodiscard]] static constexpr bool is_concrete() noexcept { return scalar_descriptor<TValue>::is_concrete(); }
+
+        [[nodiscard]] static const TSValueTypeMetaData *ts_meta() {
+            if constexpr (is_concrete()) {
+                return TypeRegistry::instance().tsw_duration(scalar_descriptor<TValue>::value_meta(), TimeDelta{PeriodMicros},
+                                                             TimeDelta{MinPeriodMicros});
+            } else {
+                return nullptr;
+            }
+        }
+    };
+
     template <typename TValue>
     struct schema_descriptor<TSWAny<TValue>>
     {
@@ -931,6 +990,25 @@ namespace hgraph
         }
     };
 
+    template <typename TValueBundle, typename... TFields> struct schema_descriptor<NominalTSB<TValueBundle, TFields...>>
+    {
+        [[nodiscard]] static constexpr bool is_concrete() noexcept {
+            return value_schema_descriptor<TValueBundle>::is_concrete() && (ts_field_descriptor<TFields>::is_concrete() && ...);
+        }
+
+        [[nodiscard]] static const TSValueTypeMetaData *ts_meta() {
+            if constexpr (is_concrete()) {
+                const ValueTypeMetaData *value = value_schema_descriptor<TValueBundle>::value_meta();
+                std::vector<std::pair<std::string, const TSValueTypeMetaData *>> fields;
+                fields.reserve(sizeof...(TFields));
+                (fields.emplace_back(ts_field_descriptor<TFields>::field_name(), ts_field_descriptor<TFields>::ts_meta()), ...);
+                return TypeRegistry::instance().tsb(value->name(), fields);
+            } else {
+                return nullptr;
+            }
+        }
+    };
+
     template <fixed_string Name, fixed_string VarName, typename... TConstraints>
     struct schema_descriptor<TSB<Name, TsVar<VarName, TConstraints...>>>
     {
@@ -1009,6 +1087,78 @@ namespace hgraph
         }
     };
 
+    namespace static_schema_detail
+    {
+        template <typename TParents> struct bundle_parent_descriptors;
+
+        template <typename... TParents> struct bundle_parent_descriptors<BundleParents<TParents...>>
+        {
+            [[nodiscard]] static constexpr bool is_concrete() noexcept {
+                return (value_schema_descriptor<TParents>::is_concrete() && ...);
+            }
+
+            [[nodiscard]] static std::vector<const ValueTypeMetaData *> value_metas() {
+                return {value_schema_descriptor<TParents>::value_meta()...};
+            }
+        };
+
+        template <typename TArguments> struct bundle_argument_descriptors;
+
+        template <typename... TArguments> struct bundle_argument_descriptors<BundleArguments<TArguments...>>
+        {
+            [[nodiscard]] static constexpr bool is_concrete() noexcept {
+                return (scalar_descriptor<TArguments>::is_concrete() && ...);
+            }
+
+            [[nodiscard]] static std::vector<const ValueTypeMetaData *> value_metas() {
+                return {scalar_descriptor<TArguments>::value_meta()...};
+            }
+
+            [[nodiscard]] static std::string specialization_name(std::string_view origin) {
+                std::string name{origin};
+                if constexpr (sizeof...(TArguments) != 0) {
+                    name += '[';
+                    bool       first  = true;
+                    const auto append = [&](const ValueTypeMetaData *argument) {
+                        if (!first) { name += ", "; }
+                        first = false;
+                        name += argument->name();
+                    };
+                    (append(scalar_descriptor<TArguments>::value_meta()), ...);
+                    name += ']';
+                }
+                return name;
+            }
+        };
+    }  // namespace static_schema_detail
+
+    template <fixed_string Namespace, fixed_string LocalName, bool Abstract, typename TParents, typename TArguments,
+              typename... TFields>
+    struct value_schema_descriptor<NominalBundle<Namespace, LocalName, Abstract, TParents, TArguments, TFields...>>
+    {
+        [[nodiscard]] static constexpr bool is_concrete() noexcept {
+            return static_schema_detail::bundle_parent_descriptors<TParents>::is_concrete() &&
+                   static_schema_detail::bundle_argument_descriptors<TArguments>::is_concrete() &&
+                   (value_field_descriptor<TFields>::is_concrete() && ...);
+        }
+
+        [[nodiscard]] static const ValueTypeMetaData *value_meta() {
+            if constexpr (is_concrete()) {
+                std::vector<std::pair<std::string, const ValueTypeMetaData *>> fields;
+                fields.reserve(sizeof...(TFields));
+                (fields.emplace_back(value_field_descriptor<TFields>::field_name(), value_field_descriptor<TFields>::value_meta()),
+                 ...);
+                return TypeRegistry::instance().bundle(
+                    Namespace.sv(),
+                    static_schema_detail::bundle_argument_descriptors<TArguments>::specialization_name(LocalName.sv()), fields,
+                    static_schema_detail::bundle_parent_descriptors<TParents>::value_metas(), Abstract, "__type__",
+                    static_schema_detail::bundle_argument_descriptors<TArguments>::value_metas());
+            } else {
+                return nullptr;
+            }
+        }
+    };
+
     template <typename... TFields>
     struct scalar_descriptor<UnNamedBundle<TFields...>> : value_schema_descriptor<UnNamedBundle<TFields...>>
     {
@@ -1018,6 +1168,12 @@ namespace hgraph
     struct scalar_descriptor<Bundle<Name, TFields...>> : value_schema_descriptor<Bundle<Name, TFields...>>
     {
     };
+
+    template <fixed_string Namespace, fixed_string LocalName, bool Abstract, typename TParents, typename TArguments,
+              typename... TFields>
+    struct scalar_descriptor<NominalBundle<Namespace, LocalName, Abstract, TParents, TArguments, TFields...>>
+        : value_schema_descriptor<NominalBundle<Namespace, LocalName, Abstract, TParents, TArguments, TFields...>>
+    {};
 }  // namespace hgraph
 
 #endif  // HGRAPH_CPP_ROOT_STATIC_SCHEMA_H

--- a/include/hgraph/types/type_pattern.h
+++ b/include/hgraph/types/type_pattern.h
@@ -210,7 +210,7 @@ namespace hgraph
         std::string                name{};          ///< ``Var``: the variable name.
         const TSValueTypeMetaData *meta{nullptr};    ///< ``Concrete``: the interned TS schema.
         std::vector<const TSValueTypeMetaData *> constraints{};  ///< ``Var``: accepted concrete TS schemas.
-        ScalarPattern              scalar{};         ///< ``TS`` / ``TSS`` payload, ``TSD`` key.
+        ScalarPattern              scalar{};         ///< ``TS`` / ``TSS`` payload, ``TSD`` key, or generic nominal ``TSB`` value schema.
         std::vector<TypePattern>   children{};       ///< ``TSL`` elem / ``TSD`` value / ``REF`` target.
         std::vector<std::string>   field_names{};    ///< ``TSB`` fields, parallel to ``children``.
         std::string                bundle_name{};    ///< named ``TSB`` bundle name.
@@ -628,10 +628,20 @@ namespace hgraph
     template <typename ValueBundle, typename... Fields> struct ts_pattern_lower<NominalTSB<ValueBundle, Fields...>>
     {
         [[nodiscard]] static TypePattern lower() {
-            const auto *value = value_schema_descriptor<ValueBundle>::value_meta();
-            return TypePattern::tsb(type_pattern_detail::tsb_field_names<Fields...>(),
-                                    type_pattern_detail::tsb_field_patterns<Fields...>(),
-                                    value != nullptr ? std::string{value->name()} : std::string{}, true);
+            if constexpr (value_schema_descriptor<ValueBundle>::is_concrete())
+            {
+                const auto *value = value_schema_descriptor<ValueBundle>::value_meta();
+                return TypePattern::tsb(type_pattern_detail::tsb_field_names<Fields...>(),
+                                        type_pattern_detail::tsb_field_patterns<Fields...>(),
+                                        std::string{value->name()}, true);
+            }
+            else
+            {
+                TypePattern pattern = TypePattern::tsb(type_pattern_detail::tsb_field_names<Fields...>(),
+                                                       type_pattern_detail::tsb_field_patterns<Fields...>(), {}, true);
+                pattern.scalar = to_scalar_pattern<ValueBundle>();
+                return pattern;
+            }
         }
     };
 
@@ -657,6 +667,30 @@ namespace hgraph
         [[nodiscard]] static ScalarPattern lower()
         {
             return ScalarPattern::var(std::string{Name.sv()}, type_pattern_detail::scalar_constraints<C...>());
+        }
+    };
+
+    template <fixed_string Namespace, fixed_string LocalName, bool Abstract, typename TParents,
+              typename... TArguments, typename... TFields>
+    struct scalar_pattern_lower<
+        NominalBundle<Namespace, LocalName, Abstract, TParents, BundleArguments<TArguments...>, TFields...>>
+    {
+        [[nodiscard]] static ScalarPattern lower()
+        {
+            using bundle_type =
+                NominalBundle<Namespace, LocalName, Abstract, TParents, BundleArguments<TArguments...>, TFields...>;
+            if constexpr (value_schema_descriptor<bundle_type>::is_concrete())
+            {
+                return ScalarPattern::concrete(value_schema_descriptor<bundle_type>::value_meta());
+            }
+            else
+            {
+                std::vector<ScalarPattern> arguments;
+                arguments.reserve(sizeof...(TArguments));
+                (arguments.push_back(to_scalar_pattern<TArguments>()), ...);
+                const std::string origin = std::string{Namespace.sv()} + "::" + std::string{LocalName.sv()};
+                return ScalarPattern::bundle_generic("__bundle__" + origin, origin, std::move(arguments));
+            }
         }
     };
 

--- a/include/hgraph/types/type_pattern.h
+++ b/include/hgraph/types/type_pattern.h
@@ -218,8 +218,11 @@ namespace hgraph
         std::string                size_name{};      ///< ``TSL`` size variable name.
         std::vector<std::size_t>   size_constraints{}; ///< ``TSL`` size variable accepted concrete sizes.
         std::size_t                min_size{0};      ///< ``TSW`` min period.
-        bool                       any_window{false}; ///< ``TSW`` wildcard over tick/duration window shape.
-        bool                       named_bundle{false}; ///< true for nominal ``TSB<Name,...>``.
+        std::int64_t               duration_micros{0};      ///< duration ``TSW`` period in microseconds.
+        std::int64_t               min_duration_micros{0};  ///< duration ``TSW`` minimum in microseconds.
+        bool                       any_window{false};       ///< ``TSW`` wildcard over tick/duration window shape.
+        bool                       duration_window{false};  ///< true for a concrete duration ``TSW``.
+        bool                       named_bundle{false};     ///< true for nominal ``TSB<Name,...>``.
         bool                       size_var{false};  ///< true when ``TSL`` size is a named variable.
         bool                       schema_var{false}; ///< true when ``TSB`` binds the whole schema to ``name``.
 
@@ -280,6 +283,16 @@ namespace hgraph
             p.scalar     = std::move(element);
             p.fixed_size = period;
             p.min_size   = min_period;
+            return p;
+        }
+        [[nodiscard]] static TypePattern tsw_duration(ScalarPattern element, std::int64_t period_micros,
+                                                      std::int64_t min_period_micros) {
+            TypePattern p;
+            p.kind                = Kind::TSW;
+            p.scalar              = std::move(element);
+            p.duration_window     = true;
+            p.duration_micros     = period_micros;
+            p.min_duration_micros = min_period_micros;
             return p;
         }
         [[nodiscard]] static TypePattern tsw_any(ScalarPattern element)
@@ -551,8 +564,15 @@ namespace hgraph
         }
     };
 
-    template <typename V>
-    struct ts_pattern_lower<TSWAny<V>>
+    template <typename V, std::int64_t PeriodMicros, std::int64_t MinPeriodMicros>
+    struct ts_pattern_lower<TSWDuration<V, PeriodMicros, MinPeriodMicros>>
+    {
+        [[nodiscard]] static TypePattern lower() {
+            return TypePattern::tsw_duration(to_scalar_pattern<V>(), PeriodMicros, MinPeriodMicros);
+        }
+    };
+
+    template <typename V> struct ts_pattern_lower<TSWAny<V>>
     {
         [[nodiscard]] static TypePattern lower()
         {
@@ -602,6 +622,16 @@ namespace hgraph
             return TypePattern::tsb(type_pattern_detail::tsb_field_names<Fields...>(),
                                     type_pattern_detail::tsb_field_patterns<Fields...>(),
                                     std::string{Name.sv()}, true);
+        }
+    };
+
+    template <typename ValueBundle, typename... Fields> struct ts_pattern_lower<NominalTSB<ValueBundle, Fields...>>
+    {
+        [[nodiscard]] static TypePattern lower() {
+            const auto *value = value_schema_descriptor<ValueBundle>::value_meta();
+            return TypePattern::tsb(type_pattern_detail::tsb_field_names<Fields...>(),
+                                    type_pattern_detail::tsb_field_patterns<Fields...>(),
+                                    value != nullptr ? std::string{value->name()} : std::string{}, true);
         }
     };
 

--- a/include/hgraph/types/type_resolution.h
+++ b/include/hgraph/types/type_resolution.h
@@ -332,8 +332,16 @@ namespace hgraph
         }
     };
 
-    template <typename V>
-    struct ts_resolver<TSWAny<V>>
+    template <typename V, std::int64_t PeriodMicros, std::int64_t MinPeriodMicros>
+    struct ts_resolver<TSWDuration<V, PeriodMicros, MinPeriodMicros>>
+    {
+        [[nodiscard]] static const TSValueTypeMetaData *resolve(const ResolutionMap &m) {
+            return TypeRegistry::instance().tsw_duration(scalar_resolver<V>::resolve(m), TimeDelta{PeriodMicros},
+                                                         TimeDelta{MinPeriodMicros});
+        }
+    };
+
+    template <typename V> struct ts_resolver<TSWAny<V>>
     {
         [[nodiscard]] static const TSValueTypeMetaData *resolve(const ResolutionMap &) noexcept { return nullptr; }
     };
@@ -381,6 +389,19 @@ namespace hgraph
                                  ts_resolver<typename ts_field_descriptor<Fields>::schema>::resolve(m)),
              ...);
             return TypeRegistry::instance().tsb(Name.sv(), fields);
+        }
+    };
+
+    template <typename ValueBundle, typename... Fields> struct ts_resolver<NominalTSB<ValueBundle, Fields...>>
+    {
+        [[nodiscard]] static const TSValueTypeMetaData *resolve(const ResolutionMap &m) {
+            std::vector<std::pair<std::string, const TSValueTypeMetaData *>> fields;
+            fields.reserve(sizeof...(Fields));
+            (fields.emplace_back(ts_field_descriptor<Fields>::field_name(),
+                                 ts_resolver<typename ts_field_descriptor<Fields>::schema>::resolve(m)),
+             ...);
+            const auto *value = value_schema_descriptor<ValueBundle>::value_meta();
+            return TypeRegistry::instance().tsb(value->name(), fields);
         }
     };
 
@@ -722,8 +743,16 @@ namespace hgraph
         }
     };
 
-    template <typename V>
-    struct ts_unifier<TSWAny<V>>
+    template <typename V, std::int64_t PeriodMicros, std::int64_t MinPeriodMicros>
+    struct ts_unifier<TSWDuration<V, PeriodMicros, MinPeriodMicros>>
+    {
+        static void unify(const TSValueTypeMetaData *c, ResolutionMap &m) {
+            c = unify_dereference(c);
+            scalar_unifier<V>::unify(c != nullptr && c->kind == TSTypeKind::TSW ? c->value_type : nullptr, m);
+        }
+    };
+
+    template <typename V> struct ts_unifier<TSWAny<V>>
     {
         static void unify(const TSValueTypeMetaData *c, ResolutionMap &m)
         {
@@ -777,8 +806,14 @@ namespace hgraph
         }
     };
 
-    template <fixed_string Name, typename... Fields>
-    struct ts_unifier<TSB<Name, Fields...>>
+    template <fixed_string Name, typename... Fields> struct ts_unifier<TSB<Name, Fields...>>
+    {
+        static void unify(const TSValueTypeMetaData *c, ResolutionMap &m) {
+            (type_resolution_detail::unify_tsb_field<Fields>(c, m), ...);
+        }
+    };
+
+    template <typename ValueBundle, typename... Fields> struct ts_unifier<NominalTSB<ValueBundle, Fields...>>
     {
         static void unify(const TSValueTypeMetaData *c, ResolutionMap &m)
         {

--- a/language/CHANGELOG.md
+++ b/language/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Compile every checked-in language example through `hgl_add_module()`, adding
+  generated support for nominal and generic structs, sparse structural deltas,
+  generic operator implementations, fixed and duration windows, concise graph
+  functions, logger injection, borrowed collection traversal and predicates,
+  and keyed TSD output. Add native behavior coverage for the new forms and
+  preserve nominal hierarchy and generic identity in public static schemas.
 - Make `clang-format` a required final stage for every generated C++ module,
   emit public and private operator contracts as transparent aliases instead of
   derived marker classes, and give generated namespaces and internal contracts

--- a/language/README.md
+++ b/language/README.md
@@ -7,9 +7,9 @@ hgraph, not for implementing transports, threads, callbacks, or arbitrary
 native extensions.
 
 Two backends share one frontend: the direct-wiring backend wires composition
-programs onto the hgraph runtime in process, and the C++ backend writes
-composition functions and the first scalar runtime-node slice as public hgraph
-C++. `hgl test` and `hgl run` compile and load that generated C++ when a file
+programs onto the hgraph runtime in process, and the C++ backend writes the
+documented composition and runtime forms as public, formatted hgraph C++.
+`hgl test` and `hgl run` compile and load that generated C++ when a file
 contains runtime functions or source-defined implementations; `hgl emit-cpp`
 and `hgl_add_module()` expose the same route to package builds. The shared
 subset builds the same graph; the parity tests hold the two paths to it.
@@ -19,19 +19,21 @@ slice. `hgl check` lexes, parses, and resolves a module and reports diagnostics
 (`--dump-tokens` and `--dump-ast` show the frontend's view). That frontend now
 models nominal and generic structs, abstract-only inheritance, defaults and
 optional fields, `requires` constraints, and sparse `delta<S>` construction.
-`hgl test`, `hgl run`, and `hgl repl` additionally execute the generated scalar
-runtime-node subset through a content-addressed native image on Unix; the REPL
+`hgl test`, `hgl run`, and `hgl repl` additionally execute supported generated
+runtime nodes through a content-addressed native image on Unix; the REPL
 transactionally replaces that image as declarations join the session.
 Composition-only sessions retain the direct-wiring path. Both paths include scalar
 struct construction, type-generic Bundle specializations, `atomic<S>` values,
 and field-wise temporal struct composition. On a terminal the REPL has line
 editing, history (`~/.hgl_history`) and tab completion. `hgl emit-cpp` writes a
 module as `<name>.h` / `<name>.cpp` in the module's namespace, registering
-composition functions as graph overloads and scalar runtime functions as node
-overloads. Runtime functions currently cover scalar temporal inputs and output,
-`modified`/`valid` guards, ordered `when` handlers, scalar recordable `state`,
-`return`, `inject out`, and lifecycle blocks over state and `const`
-configuration. `hgl_add_module()`
+composition functions as graph overloads and runtime functions as node
+overloads. Every checked-in example now reaches generated C++: nominal and
+generic structs, sparse deltas, generic operators, fixed and duration windows,
+concise `map` functions, collection traversal and predicates, logger injection,
+scalar recordable state, prior and keyed output access, and lifecycle blocks.
+Source operators become transparent aliases of `hgraph::Operator` contracts,
+not generated subclasses. `hgl_add_module()`
 builds such modules — together with hand-written C++ — into a library and,
 optionally, a Python extension module with generated wrappers. Every file under
 `examples/` is a CTest check case, `midpoint.hgl` runs its test, and the codegen
@@ -40,8 +42,8 @@ fixtures compile and execute generated graph and runtime-node modules.
 Portable runtime-module loading, multi-registry module transactions,
 constructor inference, typed `const` arguments in native generic Bundle
 identity, multiple-parent field order, explicit optional-field clearing,
-runtime collection and callable lowering, structs and generics in generated
-C++, timed harness sequences, and TOML run configuration remain staged work
+general runtime calls and non-scalar state, timed harness sequences, and TOML
+run configuration remain staged work
 ([roadmap](docs/design/roadmap.md)).
 
 ## Build

--- a/language/docs/design/architecture.md
+++ b/language/docs/design/architecture.md
@@ -150,8 +150,10 @@ The first backend emits only public SDK constructs:
 
 - Functions classified as composition become graph structs with `compose`
   methods and typed `Port` and `Scalar` parameters.
-- Source `operator` declarations become deterministic nominal C++ markers;
-  `impl fn` implementations register explicitly against those markers.
+- Source `operator` declarations become transparent aliases to deterministic
+  nominal `hgraph::Operator` contracts; `impl fn` implementations register
+  explicitly against those exact types. Generated code does not subclass a
+  contract solely to name it.
 - Ordinary `export fn` declarations become public exact-callable entries;
   unexported exact functions remain module implementation details.
 - Struct declarations become nominal Bundle and recursively temporalized TSB
@@ -186,6 +188,10 @@ Generated translation units use `#line` directives or equivalent source maps
 so native compiler diagnostics refer to language source. A compiler error in
 generated implementation detail is considered a compiler defect and should
 include a retained generated-artifact path for diagnosis.
+Both the header and source pass through the compiler-selected `clang-format`
+before they are printed, written, cached, or compiled. A formatting failure is
+a compiler failure, so generated code remains deterministic and suitable for
+human inspection.
 
 ## Two backends, one wiring
 

--- a/language/docs/design/modules.md
+++ b/language/docs/design/modules.md
@@ -32,7 +32,7 @@ A native package that supports the language supplies a descriptor containing:
 - optional documentation and source links for diagnostics and tooling.
 
 The kernel descriptor additionally maps language operator tokens such as `+`
-and `==` to public hgraph operator markers. This is a syntax binding into the
+and `==` to public hgraph operator contracts. This is a syntax binding into the
 same registry, not a compiler-owned implementation.
 
 The descriptor contains declarations and build metadata, not executable user
@@ -145,8 +145,8 @@ provider module and complete candidate signature are part of the descriptor.
 The semantic IR records the canonical operator identity on every implementation
 candidate and operator call. It never reconstructs that identity later from a
 short string. A descriptor for a native package maps the canonical language
-identity to its public C++ marker and registration hook. Source-defined
-operators receive deterministic generated marker identities.
+identity to its public C++ contract alias and registration hook. Source-defined
+operators receive deterministic generated contract identities.
 
 ## Candidate universe and provider discovery
 

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -2,7 +2,7 @@
 
 Status: initial design
 
-## Prototype checkpoint (2026-09-04)
+## Prototype checkpoint (2026-09-05)
 
 The prototype deliberately permits incompatible AST and implementation
 changes while these slices are being exercised. The current tree implements
@@ -11,30 +11,34 @@ abstract-only single inheritance, effective fields, constructor completeness,
 generic argument roles, and statically decidable closed requirements; and
 directly wires scalar Bundle values, `atomic<S>` values, type-only generic
 specializations, sparse scalar deltas, and simple field-wise temporal structs.
-The generated C++ backend also lowers the first scalar runtime-node subset:
-ordered activation, aggregate recordable state, direct and terminating output,
-and lifecycle hooks over state and `const` configuration.
+The generated C++ backend lowers every checked-in example: ordered activation,
+aggregate scalar recordable state, direct, prior-value, and keyed TSD output,
+logger injection, lifecycle hooks over state and `const` configuration,
+nominal/generic structs and sparse deltas, generic operators, fixed and duration
+windows, concise `map` functions, and borrowed runtime collection iteration.
+Generated headers and sources are mandatory `clang-format` output and public
+operator contracts are transparent aliases rather than derived marker classes.
 
 The implementation fails closed where the public or language contract is not
 settled: multiple-parent field order, constructor inference, typed `const`
-generic Bundle metadata, explicit optional-field clearing, temporal deltas,
-callable generic substitution, replaceable runtime images, portable
-scripted loading, and runtime collection or generic lowering. Slice numbering
+generic Bundle metadata, explicit optional-field clearing, consumption of
+temporal deltas, general callable substitution, portable scripted loading, and
+runtime calls. Slice numbering
 below still describes the intended end-to-end acceptance rather than a claim
 that all earlier deliverables are complete.
 
 The C++ backend exists as a first pass: `hgl emit-cpp` lowers the same
-composition subset the direct-wiring backend accepts, the first scalar runtime
-node subset, and non-generic source `operator` / `impl fn` declarations to a
+composition subset the direct-wiring backend accepts, the runtime forms above,
+and generic source `operator` / `impl fn` declarations to a
 header/source pair, and `hgl_add_module()` builds it into a package with an
 optional Python module.
 On Unix, file-based `hgl test` and `hgl run` also compile a unit containing
 runtime functions or implementations to a content-addressed image and load its
 candidates into the command process before wiring.
-Structs, generics, duration rolling windows (no compile-time hgraph marker
-yet), compound constant literals, `if` as a value, and runtime constructs
-outside the scalar subset fail closed with a diagnostic that names the
-construct. The REPL edits lines with history and completion on a terminal.
+Generated runtime sources and calls, compound constant literals, `if` as a
+value, and runtime constructs outside the supported selector/output forms fail
+closed with a diagnostic that names the construct. The REPL edits lines with
+history and completion on a terminal.
 
 Development proceeds through executable vertical slices. Parser-only progress
 is not a usable milestone: each language slice must reach hgraph wiring,
@@ -131,7 +135,7 @@ Deliverables:
   delta ranges and heterogeneous TSB expansion;
 - hgraph kernel module descriptor;
 - source and imported nominal operator resolution through the hgraph resolver;
-- generated markers and explicit registration for source-defined operator
+- transparent contract aliases and explicit registration for source-defined operator
   implementations;
 - package-target and locked-dependency candidate-universe construction,
   independent of source imports and without declaration re-exports;
@@ -142,9 +146,9 @@ Deliverables:
   candidate removal, failed-install rollback, and live-plan lease support
   (implemented); registration ownership for the remaining module surfaces is
   still required;
-- public hgraph TSW patterns that match a concrete duration window and bind
-  named maximum and minimum size generics of either kind, and a compile-time
-  duration `TSW` marker (the parity matrix records the gap);
+- public hgraph TSW patterns that bind named maximum and minimum size generics
+  of either kind (the wildcard and compile-time duration marker are
+  implemented);
 - standard-library ordering overloads for `Time` and `CivilDateTime`, so the
   language's temporal operation table is hgraph's;
 - a `ZonedTime` core scalar (`CivilTime` plus `ZoneId`, registered as
@@ -156,14 +160,14 @@ Deliverables:
   generics, plus open structural patterns for required-field matching;
 - source mapping (`#line` or a sidecar map; the first pass writes source
   comments) and the module descriptor for generated packages;
-- `hgl emit-cpp` (done for the composition subset and first scalar runtime-node
-  subset) and the
+- `hgl emit-cpp` (done for every checked-in example) and the
   `hgl_add_module()` CMake function that builds packages, including the Python
   extension module and wrappers (done); there is no `hgl build`;
 - the backend parity suite: every `hgl test` the direct-wiring backend
   accepts is also run through generated C++ and must record the same ticks
-  (seeded by `tests/codegen/parity.hgl`; the examples follow as they become
-  emittable).
+  (seeded by `tests/codegen/parity.hgl`; every checked-in example is now
+  generated and compiled, with focused native behavior coverage for the newly
+  supported forms).
 
 The hgraph-side requirements above are tracked here while the language design
 is still moving. Once agreed they are promoted to an RFC in

--- a/language/docs/developer-guide/README.md
+++ b/language/docs/developer-guide/README.md
@@ -14,15 +14,16 @@ for hgraph, not a second runtime.
 > `src/wiring/` executes the composition subset for `test`, `run`, and the
 > REPL, including scalar and atomic struct values, type-only generic
 > specializations, and field-wise temporal struct composition. `src/codegen/`
-> emits that composition subset and the first scalar runtime-node subset as
-> public hgraph C++, including activation, aggregate recordable state, output,
-> and lifecycle hooks over state and `const` configuration. The driver compiles
-> and caches/loads that subset for file-based `test`, `run`, and REPL sessions on
+> emits every checked-in example as public hgraph C++, including nominal and
+> generic structs, generic operators and windows, sparse deltas, runtime
+> collection traversal, activation, aggregate scalar recordable state, output,
+> logger injection, and lifecycle hooks over state and `const` configuration.
+> The driver compiles and caches/loads that subset for file-based `test`, `run`, and REPL sessions on
 > Unix. REPL replacement stages the new image, swaps removable provider handles
 > at a quiescent boundary, and restores the old revision if activation fails. Typed HIR,
 > constructor inference, `const` generic metadata, multiple-parent
 > linearization, explicit optional-field
-> clearing, multi-registry module transactions, and broader runtime and
+> clearing, multi-registry module transactions, and the remaining runtime and
 > generated-C++ type support remain to be implemented.
 
 ## Guide map

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -768,17 +768,17 @@ arguments. The shared bridge owns:
 - detailed rejection diagnostics.
 
 The compiler may cache deterministic results but must not copy the matching
-algorithm. Generated C++ dispatches through the public marker again so
+algorithm. Generated C++ dispatches through the public contract alias again so
 descriptor or registry drift becomes an error.
 
-A source-defined operator lowers to a deterministic generated C++ marker. Each
-`impl fn` lowers to an explicitly registered graph or node candidate according
-to its classified body. An ordinary `fn` lowers as an exact callable and is not
-placed in a registry.
+A source-defined operator lowers to a deterministic alias of the corresponding
+`hgraph::Operator` contract. Each `impl fn` lowers to an explicitly registered
+graph or node candidate according to its classified body. An ordinary `fn`
+lowers as an exact callable and is not placed in a registry.
 Only an ordinary `export fn` is emitted into the module's public exact-function
 surface.
 
-The generated marker or descriptor mapping must preserve the full nominal
+The generated contract alias or descriptor mapping must preserve the full nominal
 identity rather than using an unqualified registry string that could collide
 with another module.
 
@@ -1036,10 +1036,13 @@ device. The TOML run configuration is not in the first pass.
 
 ## C++ backend, first pass
 
-Status: implemented for the composition subset and, as of 2026-09-04, the
-first scalar runtime-node subset. File-based `test` and `run` compile/load that
-subset on Unix; broader runtime lowering, caching, Windows loading, and REPL
-replacement remain staged.
+Status: implemented for the composition and runtime forms exercised by every
+checked-in example as of 2026-09-05. This includes nominal and generic structs,
+generic operator implementations, fixed and duration windows, sparse struct
+deltas, concise `map` functions, scalar and collection runtime inputs, borrowed
+collection traversal, `out`, `logger`, state, and lifecycle hooks. File-based
+`test` and `run` compile/load supported runtime modules on Unix; portable native
+loading and the remaining language-depth items are still staged.
 
 `hgl emit-cpp <file.hgl>` writes one header/source pair named after the
 source — `prices.hgl` becomes `prices.h` and `prices.cpp` — beside the
@@ -1064,7 +1067,8 @@ What is emitted, in this order:
   (`examples.prices.smooth`) and a typed contract
   (`examples::prices::operators::smooth`). Generated code never subclasses an
   operator merely to give the contract a C++ name.
-- **Graph structs.** Every function is a struct with `static constexpr auto
+- **Graph implementation structs.** Every composition function has a plain
+  implementation struct with `static constexpr auto
   name` and a `compose(hgraph::Wiring &w, ...)`: `hgraph::Port<S>` for a
   temporal parameter, `hgraph::Scalar<"n", T>` for a `const` one, returning
   `hgraph::Port<S>` for the declared result. Exported functions are declared
@@ -1073,6 +1077,19 @@ What is emitted, in this order:
   namespace of the source, in dependency order (a recursive helper is a
   diagnostic). `const` parameter defaults become `static auto defaults()`
   so the registry applies them when the function is called by name.
+- **Structural types.** An exported source struct becomes a readable C++
+  declaration with `value_type` and `time_series` aliases. `NominalBundle`
+  preserves module-qualified identity, abstract parents, and concrete generic
+  arguments; `NominalTSB` preserves the recursively temporalized fields.
+  Constructors lower to `to_tsb`, an `atomic<S>` result aggregates that TSB
+  through `combine_cs`, and a runtime `delta<S>` builds and applies only its
+  supplied fields.
+- **Generic and window types.** Source type parameters become hgraph
+  `ScalarVar` patterns at operator boundaries and ordinary C++ template
+  parameters for structural declarations. A generic rolling parameter becomes
+  `TSWAny<T>` while a concrete tick or duration window becomes `TSW<T, N, M>`
+  or `TSWDuration<T, period_us, minimum_us>`. The selected call's concrete
+  window schema is retained when a graph implementation receives `TSWAny`.
 - **Runtime-node structs.** A runtime function in the supported scalar subset
   is an empty static node struct in the generated header. Its `eval` signature
   carries typed `In`, `Scalar`, `RecordableState`, and `Out` selectors. The
@@ -1108,7 +1125,12 @@ What is emitted, in this order:
   sets it and continues, so the final whole-output write wins. Scalar state
   fields form one named `TSB` behind `RecordableState`; `start` seeds only
   invalid fields before running an explicit state-and-configuration start
-  block.
+  block. `inject logger` lowers `logger.info(message)` to `LoggerView::log`.
+  Runtime `map`, `set`, and `list` parameters retain their typed selectors;
+  `keys`, `values`, and `items` become ordinary C++ range loops over current,
+  `modified`, `added`, or `removed` views. A concise iterator predicate is
+  inlined as a readable loop guard. Keyed `out[key] = value` uses the typed TSD
+  output selector and accumulates child writes in the cycle's delta.
 - **Registration.** `hgraph::OperatorProviderHandle register_operators()`
   registers each export and
   each `impl fn` with
@@ -1136,17 +1158,15 @@ headers; the source includes the header plus the scope-guard utility used by
 registration rollback. Every emitted function is preceded by a `// file:line`
 comment; output is deterministic (basenames, no timestamps).
 
-The first pass fails closed, before writing either file, on: runtime sources
-and sinks, non-scalar runtime parameters, output, or state, runtime calls and
-collection traversal, injectables other than `out`, lifecycle access to
-temporal inputs or output, generics, struct declarations, duration rolling
-windows
-(hgraph has registry and runtime duration windows but no compile-time
-`TSW` marker for them — the parity matrix records the gap), tuple and list
-literals and other compound constants, `if` or a block used as a value,
-zoned and civil temporal literals, an `impl fn` of an imported operator,
-and a missing module declaration. Each is a `backend` diagnostic naming the
-construct.
+The first pass still fails closed, before writing either file, on: generated
+runtime sources, runtime calls, non-scalar state, output kinds other than the
+implemented scalar, nominal-struct, and map forms, injectables other than
+`out` and `logger`, lifecycle access to temporal inputs or output, optional
+field clearing in a sparse delta, generic constructor inference and typed
+`const` generic struct metadata, tuple and list literals and other compound
+constants, `if` or a block used as a value, zoned and civil temporal literals,
+an `impl fn` of an imported operator, and a missing module declaration. Each is
+a diagnostic naming the construct.
 
 `hgl_add_module()` (`cmake/HglLanguage.cmake`, installed with `hgl`) runs
 `emit-cpp` as an `add_custom_command` per `.hgl` source, compiles the pairs
@@ -1159,7 +1179,8 @@ generated wrappers into a package directory. The native module output path is
 expressed with a generator expression so multi-configuration builds do not add
 a configuration child directory, and an installed compiler executable is a
 file dependency of every generated output. The repository's codegen tests
-build `tests/codegen/parity.hgl` through exactly this function.
+build every file under `language/examples`, plus the parity and runtime
+fixtures, through exactly this function under the repository warning policy.
 
 ## Source mapping and generated artifacts
 

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -399,7 +399,12 @@ and every fail-closed diagnostic.
 through `hgl_add_module()` under the repository's warnings and evaluates the
 generated graphs with `eval_node` — directly by struct and by registry name,
 where the `const` defaults apply — asserting the ticks the module's own
-`test` blocks assert. `tests/codegen/runtime.hgl` and
+`test` blocks assert. The same generated target compiles every checked-in HGL
+example. `generated_structural_tests.cpp`, `generated_generic_tests.cpp`, and
+`generated_example_tests.cpp` exercise nominal hierarchy and generic metadata,
+sparse structural deltas, fixed and duration window schemas, generic operator
+resolution, collection predicates and iteration, and keyed collection output.
+`tests/codegen/runtime.hgl` and
 `generated_runtime_tests.cpp` exercise the compiled node path: modified-or and
 valid-and predicates, passive sampling, ordered state mutation and final-write
 behavior, selector metadata, prior-output access, lifecycle configuration, and

--- a/language/docs/user-guide/modules-and-tools.md
+++ b/language/docs/user-guide/modules-and-tools.md
@@ -287,16 +287,20 @@ a trailing underscore in this wrapper (`class` becomes `class_`) while their
 operator registry name remains unchanged; aliases that would collide are a
 generation error.
 
-What `emit-cpp` lowers today is the composition subset `hgl test` runs, the
-first scalar runtime-node subset, and non-generic `operator` / `impl fn`
-declarations. The runtime subset supports scalar temporal inputs and output,
-`modified`/`valid` guards, ordered `when` handlers, scalar recordable `state`,
-`return`, `inject out`, and lifecycle blocks over state and `const`
-configuration. It reports, by name,
-and writes nothing for runtime sources or sinks, non-scalar runtime signatures
-or state, runtime calls or collection traversal, other injectables, lifecycle
-temporal-input/output access, generics, structs, duration rolling windows,
-tuple and list literals, `if` used as a value, and zoned or civil literals.
+What `emit-cpp` lowers today includes every checked-in example: composition
+functions, runtime functions and sinks, source operators and implementations,
+nominal and generic structs, fixed and duration rolling windows, sparse struct
+deltas, concise functions passed to `map`, collection inputs and iteration,
+scalar recordable state, ordered `when` handlers, `inject out`, keyed TSD output
+writes, `inject logger`, and lifecycle blocks over state and `const`
+configuration. The generated package tests compile every example as C++.
+
+It still reports, by name, and writes nothing for generated runtime sources,
+runtime function calls, non-scalar state, injectables other than `out` and
+`logger`, lifecycle access to temporal inputs or output, optional-field clearing
+in a sparse delta, generic constructor inference and typed `const` generic
+struct metadata, compound constant literals, `if` used as a value, and zoned or
+civil literals.
 
 ## One execution model
 

--- a/language/docs/user-guide/testing-and-running.md
+++ b/language/docs/user-guide/testing-and-running.md
@@ -187,8 +187,10 @@ The current `hgl` runs everything on this page that is written with
 - `hgl run` takes its configuration from the command line only; the
   `--config` file is not read yet;
 - file-based `test` and `run`, and the REPL, compile supported runtime
-  functions and non-generic `impl fn` candidates on Unix; generic functions
-  remain unsupported by every backend;
+  functions and generic `impl fn` candidates on Unix; an unresolved generic
+  composition call is still outside the direct-wiring path, while the generated
+  backend supports the concrete generic operator and window forms used by the
+  examples;
 - complete scalar struct values, type-only generic struct specializations,
   `atomic<S>` harness values, and simple field-wise temporal struct
   construction run; generic constructor inference, `const` generic struct

--- a/language/examples/collection-views.hgl
+++ b/language/examples/collection-views.hgl
@@ -11,7 +11,7 @@ fn count_recent(
 ) -> i64 {
     inject logger
 
-    when modified(book) {
+    when modified(book) && valid(book) {
         var count = 0
 
         for key, value in items(
@@ -30,7 +30,7 @@ fn count_recent(
 fn audit_book(book: map<str, f64>) {
     inject logger
 
-    when modified(book) {
+    when modified(book) && valid(book) {
         for key, value in items(book, modified) {
             if valid(value) {
                 logger.info(key)
@@ -46,7 +46,7 @@ fn audit_book(book: map<str, f64>) {
 fn audit_membership(symbols: set<str>) {
     inject logger
 
-    when modified(symbols) {
+    when modified(symbols) && valid(symbols) {
         for symbol in values(symbols, added) {
             logger.info(symbol)
         }
@@ -58,7 +58,7 @@ fn audit_membership(symbols: set<str>) {
 }
 
 fn first_modified_index(samples: list<f64>) -> i64 {
-    when modified(samples) {
+    when modified(samples) && valid(samples) {
         for index, value in items(samples, modified) {
             if valid(value) {
                 return index

--- a/language/examples/structural-types.hgl
+++ b/language/examples/structural-types.hgl
@@ -39,7 +39,7 @@ fn boxed_midpoint(value: f64) -> atomic<Box<f64>> =>
     Box<f64>(value: value)
 
 fn bid_delta(value: f64) -> Quote {
-    when modified(value) {
+    when modified(value) && valid(value) {
         return delta<Quote>(bid: value)
     }
 }

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -18,10 +18,10 @@
 #include <vector>
 
 // The C++ backend of the first pass. Its composition subset mirrors the
-// direct-wiring backend construct by construct so that programs both accept
-// build the same graph. It additionally lowers the first scalar runtime
-// subset to public static-node selectors; the native compiler and hgraph
-// registry check the emitted implementation when its package is built.
+// direct-wiring backend construct by construct so that programs accepted by
+// both build the same graph. It also lowers the documented runtime, structural,
+// generic, window, and collection examples to public hgraph authoring APIs; the
+// native compiler and hgraph registry check each emitted package.
 namespace hgl::codegen
 {
     namespace
@@ -40,8 +40,7 @@ namespace hgl::codegen
         /// constant size expressions are printed).
         struct HType
         {
-            enum class Kind : std::uint8_t
-            {
+            enum class Kind : std::uint8_t {
                 Unknown,  ///< a port whose schema the registry decides
                 Scalar,
                 Tuple,
@@ -50,6 +49,8 @@ namespace hgl::codegen
                 Map,
                 Rolling,
                 Atomic,
+                Generic,
+                Struct,
             };
 
             Kind               kind{Kind::Unknown};
@@ -58,6 +59,8 @@ namespace hgl::codegen
             std::string        size{};      ///< list fixed size / rolling max, as C++ text
             std::string        min_size{};  ///< rolling minimum, as C++ text
             bool               duration_window{false};
+            ast::DeclId        declaration{ast::no_node};
+            std::string        cpp_type{};
 
             [[nodiscard]] bool is(ast::ScalarType s) const noexcept { return kind == Kind::Scalar && scalar == s; }
             [[nodiscard]] bool numeric() const noexcept { return is(ast::ScalarType::I64) || is(ast::ScalarType::F64); }
@@ -75,6 +78,7 @@ namespace hgl::codegen
         {
             if (a.kind != b.kind || a.children.size() != b.children.size()) { return false; }
             if (a.kind == HType::Kind::Scalar && a.scalar != b.scalar) { return false; }
+            if (a.declaration != b.declaration || a.cpp_type != b.cpp_type) { return false; }
             if (a.size != b.size || a.min_size != b.min_size || a.duration_window != b.duration_window) { return false; }
             for (std::size_t i = 0; i < a.children.size(); ++i)
             {
@@ -90,13 +94,14 @@ namespace hgl::codegen
         /// port, function).
         struct Value
         {
-            enum class Kind : std::uint8_t
-            {
+            enum class Kind : std::uint8_t {
                 Void,
                 Const,
                 Port,
-                Runtime,  ///< an evaluation-time scalar, optionally backed by a selector
+                Runtime,   ///< an evaluation-time scalar, optionally backed by a selector
+                Iterator,  ///< an evaluation-local borrowed collection range
                 Function,
+                Struct,
                 Operator,       ///< an imported kernel operator: `name` is the C++ marker
                 LocalOperator,  ///< a module `operator`: `name` is the C++ marker
                 Intrinsic,      ///< `name` is the intrinsic
@@ -104,6 +109,9 @@ namespace hgl::codegen
 
             Kind        kind{Kind::Void};
             std::string code{};
+            /// A temporal struct constructor also carries its atomic
+            /// aggregate spelling so the result context selects the shape.
+            std::string atomic_code{};
             /// Runtime values backed by an endpoint keep its selector spelling
             /// so metadata intrinsics and assignments do not read the payload.
             std::string selector{};
@@ -113,6 +121,9 @@ namespace hgl::codegen
             ast::DeclId decl{ast::no_node};
             std::string name{};
             SourceRange range{};
+            bool               structured_delta{false};
+            std::vector<HType> iterator_types{};
+            ast::ExprId        iterator_predicate{ast::no_node};
             /// Known numeric value of a constant expression. Const parameters
             /// deliberately leave this empty: they are values at composition
             /// time, not compile-time literals. The emitter uses this only for
@@ -123,6 +134,7 @@ namespace hgl::codegen
             [[nodiscard]] bool is_const() const noexcept { return kind == Kind::Const; }
             [[nodiscard]] bool is_port() const noexcept { return kind == Kind::Port; }
             [[nodiscard]] bool is_runtime() const noexcept { return kind == Kind::Runtime; }
+            [[nodiscard]] bool is_iterator() const noexcept { return kind == Kind::Iterator; }
         };
 
         struct Frame
@@ -130,7 +142,11 @@ namespace hgl::codegen
             ast::DeclId                           fn{ast::no_node};
             std::vector<Value>                    params{};
             std::unordered_map<ast::StmtId, Value> locals{};
+            std::unordered_map<ast::StmtId, Value> second_locals{};
             std::unordered_map<std::string, Value> injects{};
+            std::unordered_map<std::size_t, HType> generic_types{};
+            ast::ExprId                            anonymous{ast::no_node};
+            std::vector<Value>                     anonymous_params{};
             bool                                   runtime{false};
             bool                                   runtime_inputs_available{true};
             bool                                   output_available{false};
@@ -152,6 +168,7 @@ namespace hgl::codegen
             std::vector<ast::StmtId>        stop_blocks{};
             std::unordered_set<std::size_t> active_parameters{};
             bool                            inject_out{false};
+            bool                            inject_logger{false};
             bool                            has_when{false};
         };
 
@@ -286,6 +303,7 @@ namespace hgl::codegen
             }
             void indent() { ++indent_; }
             void dedent() { --indent_; }
+            void                      append(std::string_view text) { out_ += text; }
             [[nodiscard]] std::string str() const { return out_; }
 
           private:
@@ -326,7 +344,11 @@ namespace hgl::codegen
             {
                 return std::get<ast::FunctionDecl>(module_.decl(decl).node);
             }
-            [[nodiscard]] std::string slice(SourceRange range) const { return std::string{file_.slice(range)}; }
+            [[nodiscard]] const ast::StructDecl &structure(ast::DeclId decl) const {
+                return std::get<ast::StructDecl>(module_.decl(decl).node);
+            }
+            [[nodiscard]] const ast::GenericParameter &generic_parameter(ast::DeclId decl, std::size_t index) const;
+            [[nodiscard]] std::string                  slice(SourceRange range) const { return std::string{file_.slice(range)}; }
             [[nodiscard]] std::string where(SourceRange range) const
             {
                 const syntax::Location at = file_.location(range.begin);
@@ -343,6 +365,9 @@ namespace hgl::codegen
             [[nodiscard]] Value eval_expr(ast::ExprId id, Frame &frame);
             [[nodiscard]] Value eval_name(ast::ExprId id, Frame &frame);
             [[nodiscard]] Value eval_call(const ast::Call &call, SourceRange range, Frame &frame);
+            [[nodiscard]] Value eval_construct(ast::DeclId decl, ast::TypeId type, const std::vector<ast::Argument> &arguments,
+                                               bool delta, SourceRange range, Frame &frame);
+            [[nodiscard]] Value lower_map_call(const Value &callee, const ast::Call &call, SourceRange range, Frame &frame);
             [[nodiscard]] Value eval_intrinsic(const Value &callee, const ast::Call &call, SourceRange range, Frame &frame);
             [[nodiscard]] Value call_function(ast::DeclId decl, const std::vector<ast::Argument> &arguments, SourceRange range,
                                               Frame &frame);
@@ -372,7 +397,7 @@ namespace hgl::codegen
             void check_supported(ast::DeclId decl);
             [[nodiscard]] std::string signature(ast::DeclId decl, Frame &frame, bool with_names);
             [[nodiscard]] std::string result_type(ast::DeclId decl, Frame &frame);
-            [[nodiscard]] std::string marker(ast::DeclId decl, std::string_view registry_name, Frame &frame);
+            [[nodiscard]] std::string operator_contract(ast::DeclId decl, std::string_view registry_name, Frame &frame);
             /// How a function is written: its struct declaration (header), the
             /// whole struct inline (module-internal helpers and operator
             /// implementations), or the out-of-line `compose` definition of a
@@ -384,6 +409,7 @@ namespace hgl::codegen
                 OutOfLine,
             };
             void emit_function(ast::DeclId decl, Writer &out, Form form);
+            void                      emit_struct(ast::DeclId decl, Writer &out);
             void emit_runtime_function(ast::DeclId decl, Writer &out);
             void emit_if(const ast::If &branch, Frame &frame, Writer &out);
             [[nodiscard]] RuntimeInfo runtime_info(ast::DeclId decl);
@@ -416,9 +442,18 @@ namespace hgl::codegen
             /// Locals declared in the current function, for unique C++ names.
             std::unordered_map<std::string, int> local_counts_{};
             std::unordered_set<std::string>      local_names_{};
+            Writer                               generated_helpers_{};
+            std::size_t                          anonymous_function_index_{0};
         };
 
         // ------------------------------------------------------------ types
+
+        const ast::GenericParameter &Emitter::generic_parameter(ast::DeclId decl, std::size_t index) const {
+            const ast::DeclNode &node = module_.decl(decl).node;
+            if (const auto *fn = std::get_if<ast::FunctionDecl>(&node)) { return fn->generics.at(index); }
+            if (const auto *op = std::get_if<ast::OperatorDecl>(&node)) { return op->generics.at(index); }
+            return std::get<ast::StructDecl>(node).generics.at(index);
+        }
 
         std::string Emitter::size_text(ast::ExprId id, Frame &frame, std::string_view what)
         {
@@ -428,7 +463,7 @@ namespace hgl::codegen
             {
                 fail(Category::Type, module_.expr(id).range, std::string{what} + " must be a non-negative i64 constant");
             }
-            return "static_cast<std::size_t>(" + value.code + ")";
+            return std::to_string(*size);
         }
 
         HType Emitter::type_of(ast::TypeId id, Frame &frame)
@@ -439,8 +474,45 @@ namespace hgl::codegen
                 case ast::TypeKind::Scalar: return scalar_type(type.scalar);
                 case ast::TypeKind::Named: {
                     const semantics::Binding &binding = resolved_.type_binding(id);
-                    if (binding.kind == BindingKind::Generic) { unsupported(type.range, "a generic type"); }
-                    if (binding.kind == BindingKind::Struct) { unsupported(type.range, "a struct type"); }
+                    if (binding.kind == BindingKind::Generic) {
+                        if (const auto found = frame.generic_types.find(binding.index); found != frame.generic_types.end()) {
+                            return found->second;
+                        }
+                        const ast::GenericParameter &parameter = generic_parameter(binding.decl, binding.index);
+                        if (parameter.is_const) { backend(type.range, "a const generic cannot be used as a value type"); }
+                        HType result;
+                        result.kind     = HType::Kind::Generic;
+                        result.cpp_type = "hgraph::ScalarVar<" + quote(parameter.name.text) + ">";
+                        return result;
+                    }
+                    if (binding.kind == BindingKind::Struct) {
+                        const ast::StructDecl &decl = structure(binding.decl);
+                        HType                  result;
+                        result.kind        = HType::Kind::Struct;
+                        result.declaration = binding.decl;
+                        result.cpp_type    = cpp_name(decl.name.text);
+
+                        std::vector<std::string> arguments;
+                        arguments.reserve(type.arguments.size());
+                        for (const ast::GenericArgument &argument : type.arguments) {
+                            if (argument.type != ast::no_node) {
+                                HType child = type_of(argument.type, frame);
+                                arguments.push_back(value_type(child, module_.type(argument.type).range));
+                                result.children.push_back(std::move(child));
+                            } else if (argument.value != ast::no_node) {
+                                const Value value   = eval_expr(argument.value, frame);
+                                const auto  integer = integer_value(value);
+                                if (!integer) {
+                                    backend(argument.range, "a generated const struct argument must be an i64 literal");
+                                }
+                                arguments.push_back(std::to_string(*integer));
+                            } else {
+                                backend(argument.range, "an unresolved struct type argument");
+                            }
+                        }
+                        if (!arguments.empty()) { result.cpp_type += "<" + join(arguments, ", ") + ">"; }
+                        return result;
+                    }
                     backend(type.range, "unresolved named type '" + std::string{type.name.text} + "'");
                 }
                 case ast::TypeKind::Tuple: {
@@ -473,14 +545,33 @@ namespace hgl::codegen
                     HType result;
                     result.kind = HType::Kind::Rolling;
                     result.children.push_back(type_of(type.children[0], frame));
+                    const semantics::Binding &size_binding = resolved_.binding(type.size);
+                    if (size_binding.kind == BindingKind::Generic) {
+                        // The current hgraph window wildcard preserves the
+                        // scalar type while the concrete period remains bound
+                        // by the actual input schema at wiring time.
+                        return result;
+                    }
                     const Value size = eval_expr(type.size, frame);
-                    if (size.is_const() && size.type.is(ast::ScalarType::Duration))
-                    {
-                        // The registry has duration windows; hgraph has no
-                        // duration-valued compile-time TSW marker yet (parity
-                        // matrix, TSW), so generated code cannot spell one.
+                    if (size.is_const() && size.type.is(ast::ScalarType::Duration)) {
                         result.duration_window = true;
-                        unsupported(type.range, "a duration rolling window (hgraph has no compile-time duration TSW marker)");
+                        const auto *literal    = std::get_if<ast::TemporalLiteral>(&module_.expr(type.size).node);
+                        if (literal == nullptr) {
+                            fail(Category::Type, module_.expr(type.size).range,
+                                 "a generated duration rolling size must be a duration literal");
+                        }
+                        result.size = std::to_string(literal->value.micros);
+                        if (type.min_size == ast::no_node) {
+                            result.min_size = result.size;
+                        } else {
+                            const auto *minimum = std::get_if<ast::TemporalLiteral>(&module_.expr(type.min_size).node);
+                            if (minimum == nullptr || minimum->value.kind != syntax::TemporalKind::Duration) {
+                                fail(Category::Type, module_.expr(type.min_size).range,
+                                     "a duration rolling minimum must be a duration literal");
+                            }
+                            result.min_size = std::to_string(minimum->value.micros);
+                        }
+                        return result;
                     }
                     if (!size.is_const() || !size.type.is(ast::ScalarType::I64))
                     {
@@ -493,7 +584,7 @@ namespace hgl::codegen
                         fail(Category::Type, module_.expr(type.size).range,
                              "a rolling size is a positive i64 constant or a duration");
                     }
-                    result.size     = "static_cast<std::size_t>(" + size.code + ")";
+                    result.size     = std::to_string(*max_size);
                     result.min_size = type.min_size == ast::no_node ? result.size
                                                                      : size_text(type.min_size, frame, "a rolling minimum");
                     return result;
@@ -541,6 +632,8 @@ namespace hgl::codegen
                 case HType::Kind::List: unsupported(range, "a list value type");
                 case HType::Kind::Rolling: backend(range, "'rolling' has no value type; it is a time-series window");
                 case HType::Kind::Atomic: return value_type(type.children[0], range);
+                case HType::Kind::Generic: return type.cpp_type;
+                case HType::Kind::Struct: return "typename " + type.cpp_type + "::value_type";
                 case HType::Kind::Unknown: break;
             }
             backend(range, "this value has no C++ type");
@@ -560,7 +653,14 @@ namespace hgl::codegen
                 case HType::Kind::Map:
                     return "hgraph::TSD<" + value_type(type.children[0], range) + ", " + schema(type.children[1], range) + ">";
                 case HType::Kind::Rolling:
+                    if (type.size.empty()) { return "hgraph::TSWAny<" + value_type(type.children[0], range) + ">"; }
+                    if (type.duration_window) {
+                        return "hgraph::TSWDuration<" + value_type(type.children[0], range) + ", " + type.size + ", " +
+                               type.min_size + ">";
+                    }
                     return "hgraph::TSW<" + value_type(type.children[0], range) + ", " + type.size + ", " + type.min_size + ">";
+                case HType::Kind::Struct: return "typename " + type.cpp_type + "::time_series";
+                case HType::Kind::Generic: return "hgraph::TS<" + value_type(type, range) + ">";
                 case HType::Kind::Unknown: break;
             }
             backend(range, "this value has no time-series schema");
@@ -696,7 +796,9 @@ namespace hgl::codegen
                     return value.code;
                 case Value::Kind::Runtime:
                     backend(value.range, "an evaluation-time value cannot be passed while wiring");
+                case Value::Kind::Iterator: backend(value.range, "a runtime iterator is only valid as the source of a 'for' loop");
                 case Value::Kind::Function:
+                case Value::Kind::Struct:
                 case Value::Kind::Operator:
                 case Value::Kind::LocalOperator:
                 case Value::Kind::Intrinsic:
@@ -743,6 +845,9 @@ namespace hgl::codegen
         std::string Emitter::as_port(const Value &value, const HType &temporal, SourceRange range)
         {
             const std::string s = schema(temporal, range);
+            if (temporal.kind == HType::Kind::Atomic && !value.atomic_code.empty() && same_type(value.type, temporal.children[0])) {
+                return value.atomic_code;
+            }
             if (value.is_const())
             {
                 const HType inner = temporal.kind == HType::Kind::Atomic ? temporal.children[0] : temporal;
@@ -929,7 +1034,31 @@ namespace hgl::codegen
                 case BinaryOp::And: name = "and_"; break;
                 case BinaryOp::Or: name = "or_"; break;
             }
-            return wire(std::string{"hgraph::stdlib::"} + name, {argument_code(lhs), argument_code(rhs)}, range);
+            HType result;
+            switch (op) {
+                case ast::BinaryOp::Equal:
+                case ast::BinaryOp::NotEqual:
+                case ast::BinaryOp::Less:
+                case ast::BinaryOp::LessEqual:
+                case ast::BinaryOp::Greater:
+                case ast::BinaryOp::GreaterEqual:
+                case ast::BinaryOp::And:
+                case ast::BinaryOp::Or: result = scalar_type(ast::ScalarType::Bool); break;
+                case ast::BinaryOp::Add:
+                case ast::BinaryOp::Sub:
+                case ast::BinaryOp::Mul:
+                case ast::BinaryOp::Div:
+                case ast::BinaryOp::Rem:
+                    if (lhs.type.numeric() && rhs.type.numeric()) {
+                        result = scalar_type(lhs.type.is(ast::ScalarType::F64) || rhs.type.is(ast::ScalarType::F64)
+                                                 ? ast::ScalarType::F64
+                                                 : ast::ScalarType::I64);
+                    }
+                    break;
+            }
+            Value value = wire(std::string{"hgraph::stdlib::"} + name, {argument_code(lhs), argument_code(rhs)}, range, result);
+            if (result.kind != HType::Kind::Unknown) { value.code += ".as<" + schema(result, range) + ">()"; }
+            return value;
         }
 
         // -------------------------------------------------------- expressions
@@ -941,23 +1070,30 @@ namespace hgl::codegen
             switch (binding.kind)
             {
                 case BindingKind::Local: {
-                    const auto found = frame.locals.find(binding.stmt);
-                    if (found == frame.locals.end())
-                    {
-                        const auto injected = frame.injects.find(slice(range));
-                        if (injected == frame.injects.end())
-                        {
-                            backend(range, "'" + slice(range) + "' is not bound in this function");
+                        const auto &locals = binding.second ? frame.second_locals : frame.locals;
+                        const auto  found  = locals.find(binding.stmt);
+                        if (found == locals.end()) {
+                            const auto injected = frame.injects.find(slice(range));
+                            if (injected == frame.injects.end()) {
+                                backend(range, "'" + slice(range) + "' is not bound in this function");
+                            }
+                            Value value = injected->second;
+                            value.range = range;
+                            return value;
                         }
-                        Value value = injected->second;
-                        value.range = range;
-                        return value;
-                    }
                     Value value = found->second;
                     value.range = range;
                     return value;
                 }
                 case BindingKind::Parameter: {
+                        if (binding.decl == ast::no_node) {
+                            if (binding.stmt != frame.anonymous || binding.index >= frame.anonymous_params.size()) {
+                                backend(range, "'" + slice(range) + "' is not bound in this anonymous function");
+                            }
+                            Value value = frame.anonymous_params[binding.index];
+                            value.range = range;
+                            return value;
+                        }
                     if (binding.decl != frame.fn || binding.index >= frame.params.size())
                     {
                         backend(range, "'" + slice(range) + "' is not a parameter of this function");
@@ -973,14 +1109,22 @@ namespace hgl::codegen
                     return value;
                 }
                 case BindingKind::Generic: unsupported(range, "a generic parameter");
-                case BindingKind::Struct: unsupported(range, "a struct");
-                case BindingKind::Function: {
-                    Value value;
-                    value.kind  = Value::Kind::Function;
-                    value.decl  = binding.decl;
-                    value.range = range;
-                    return value;
-                }
+                case BindingKind::Struct:
+                    {
+                        Value value;
+                        value.kind  = Value::Kind::Struct;
+                        value.decl  = binding.decl;
+                        value.range = range;
+                        return value;
+                    }
+                case BindingKind::Function:
+                    {
+                        Value value;
+                        value.kind  = Value::Kind::Function;
+                        value.decl  = binding.decl;
+                        value.range = range;
+                        return value;
+                    }
                 case BindingKind::Operator: {
                     // The kernel table: `hgraph.std::x` is the marker
                     // `hgraph::stdlib::<registry name>`; `hgraph.analytics::x` is
@@ -1114,6 +1258,13 @@ namespace hgl::codegen
                     else if constexpr (std::is_same_v<T, ast::Field>)
                     {
                         const Value target = eval_expr(node.target, frame);
+                        if (target.kind == Value::Kind::Intrinsic && target.name == "logger") {
+                            Value value;
+                            value.kind  = Value::Kind::Intrinsic;
+                            value.name  = "logger." + std::string{node.field.text};
+                            value.range = expr.range;
+                            return value;
+                        }
                         if (target.is_port())
                         {
                             return wire("hgraph::stdlib::getattr_", {target.code, "hgraph::Str{" + quote(node.field.text) + "}"},
@@ -1132,10 +1283,10 @@ namespace hgl::codegen
                     else if constexpr (std::is_same_v<T, ast::Eval>)
                     {
                         fail(Category::Type, expr.range, "'eval' is only valid in a test");
-                    }
-                    else if constexpr (std::is_same_v<T, ast::Construct>) { unsupported(expr.range, "struct construction"); }
-                    else
-                    {
+                    } else if constexpr (std::is_same_v<T, ast::Construct>) {
+                        const semantics::Binding &binding = resolved_.type_binding(node.type);
+                        return eval_construct(binding.decl, node.type, node.arguments, node.delta, expr.range, frame);
+                    } else {
                         static_assert(sizeof(T) == 0, "unhandled expression node");
                     }
                 },
@@ -1147,14 +1298,19 @@ namespace hgl::codegen
         Value Emitter::eval_call(const ast::Call &call, SourceRange range, Frame &frame)
         {
             const Value callee = eval_expr(call.callee, frame);
-            if (frame.runtime && callee.kind != Value::Kind::Intrinsic)
-            {
+            if (frame.runtime && callee.kind != Value::Kind::Intrinsic && callee.kind != Value::Kind::Struct) {
                 backend(range, "calls in a runtime function are not supported by emit-cpp yet");
             }
             switch (callee.kind)
             {
                 case Value::Kind::Operator:
                 case Value::Kind::LocalOperator: {
+                        if (callee.name == "hgraph::stdlib::map_" &&
+                            std::ranges::any_of(call.arguments, [&](const ast::Argument &argument) {
+                                return std::holds_alternative<ast::AnonymousFn>(module_.expr(argument.value).node);
+                            })) {
+                            return lower_map_call(callee, call, range, frame);
+                        }
                     std::vector<std::string> args;
                     args.reserve(call.arguments.size());
                     for (const ast::Argument &argument : call.arguments)
@@ -1168,11 +1324,13 @@ namespace hgl::codegen
                     }
                     return wire(callee.name, args, range);
                 }
+                case Value::Kind::Struct: return eval_construct(callee.decl, ast::no_node, call.arguments, false, range, frame);
                 case Value::Kind::Function: return call_function(callee.decl, call.arguments, range, frame);
                 case Value::Kind::Intrinsic: return eval_intrinsic(callee, call, range, frame);
                 case Value::Kind::Const:
                 case Value::Kind::Port:
                 case Value::Kind::Runtime:
+                case Value::Kind::Iterator:
                 case Value::Kind::Void:
                     break;
             }
@@ -1180,9 +1338,184 @@ namespace hgl::codegen
                  "'" + slice(module_.expr(call.callee).range) + "' is not callable");
         }
 
+        Value Emitter::lower_map_call(const Value &callee, const ast::Call &call, SourceRange range, Frame &frame) {
+            ast::ExprId        anonymous_id = ast::no_node;
+            std::vector<Value> inputs;
+            for (const ast::Argument &argument : call.arguments) {
+                if (std::holds_alternative<ast::AnonymousFn>(module_.expr(argument.value).node)) {
+                    if (anonymous_id != ast::no_node) {
+                        backend(module_.expr(argument.value).range, "map takes one anonymous function");
+                    }
+                    anonymous_id = argument.value;
+                } else {
+                    inputs.push_back(eval_expr(argument.value, frame));
+                }
+            }
+            const auto &anonymous = std::get<ast::AnonymousFn>(module_.expr(anonymous_id).node);
+            if (anonymous.parameters.size() != inputs.size()) {
+                fail(Category::Type, module_.expr(anonymous_id).range,
+                     "the map function parameter count must match its mapped inputs");
+            }
+
+            Frame lambda;
+            lambda.fn = ast::no_node;
+            lambda.params.resize(inputs.size());
+            std::vector<std::string> parameters{"hgraph::Wiring &w"};
+            for (std::size_t index = 0; index < inputs.size(); ++index) {
+                const Value &input = inputs[index];
+                if (!input.is_port() || input.type.kind != HType::Kind::Map) {
+                    backend(input.range, "the first anonymous map slice takes temporal map inputs");
+                }
+                HType parameter_type = input.type.children[1];
+                if (anonymous.parameters[index].type != ast::no_node) {
+                    parameter_type = type_of(anonymous.parameters[index].type, lambda);
+                }
+                const std::string name = cpp_name(anonymous.parameters[index].name.text);
+                lambda.params[index]   = make_port(name, parameter_type, anonymous.parameters[index].name.range);
+                parameters.push_back("hgraph::Port<" + schema(parameter_type, anonymous.parameters[index].name.range) + "> " +
+                                     name);
+            }
+            lambda.anonymous        = anonymous_id;
+            lambda.anonymous_params = lambda.params;
+
+            const Value lambda_result = eval_expr(anonymous.body, lambda);
+            HType       result_type   = lambda_result.type;
+            if (anonymous.result != ast::no_node) { result_type = type_of(anonymous.result, lambda); }
+            if (result_type.kind == HType::Kind::Unknown) {
+                backend(module_.expr(anonymous.body).range, "the anonymous map result type cannot be inferred");
+            }
+
+            const std::string helper = "hgl_anonymous_" + std::to_string(++anonymous_function_index_);
+            generated_helpers_.line("// " + where(module_.expr(anonymous_id).range));
+            generated_helpers_.open("struct " + helper);
+            generated_helpers_.line("static constexpr auto name = " +
+                                    quote(module_name_ + ".<anonymous:" + std::to_string(anonymous_function_index_) + ">") + ";");
+            generated_helpers_.line("static hgraph::Port<" + schema(result_type, module_.expr(anonymous.body).range) +
+                                    "> compose(" + join(parameters, ", ") + ")");
+            generated_helpers_.open("");
+            generated_helpers_.line("return " + as_port(lambda_result, result_type, module_.expr(anonymous.body).range) + ";");
+            generated_helpers_.close();
+            generated_helpers_.close(";");
+            generated_helpers_.line();
+
+            std::vector<std::string> args{"hgraph::fn<" + helper + ">()"};
+            for (const Value &input : inputs) { args.push_back(argument_code(input)); }
+
+            HType mapped;
+            mapped.kind = HType::Kind::Map;
+            mapped.children.push_back(inputs.front().type.children[0]);
+            mapped.children.push_back(result_type);
+            Value result = wire(callee.name, args, range, mapped);
+            result.code += ".as<" + schema(mapped, range) + ">()";
+            return result;
+        }
+
+        Value Emitter::eval_construct(ast::DeclId decl, ast::TypeId type_id, const std::vector<ast::Argument> &arguments,
+                                      bool delta, SourceRange range, Frame &frame) {
+            const ast::StructDecl       &item = structure(decl);
+            const semantics::StructInfo &info = resolved_.structure(decl);
+            HType                        type;
+            if (type_id != ast::no_node) {
+                type = type_of(type_id, frame);
+            } else {
+                if (!item.generics.empty()) {
+                    backend(range, "generic struct '" + std::string{item.name.text} + "' needs explicit type arguments");
+                }
+                type.kind        = HType::Kind::Struct;
+                type.declaration = decl;
+                type.cpp_type    = cpp_name(item.name.text);
+            }
+
+            Frame       struct_frame  = frame;
+            std::size_t type_argument = 0;
+            for (std::size_t generic = 0; generic < item.generics.size(); ++generic) {
+                if (item.generics[generic].is_const) { continue; }
+                if (type_argument < type.children.size()) { struct_frame.generic_types[generic] = type.children[type_argument++]; }
+            }
+
+            const auto argument_for = [&](std::string_view field) -> ast::ExprId {
+                for (const ast::Argument &argument : arguments) {
+                    if (argument.name.text == field) { return argument.value; }
+                }
+                return ast::no_node;
+            };
+
+            std::vector<std::string>                   temporal_fields;
+            std::vector<std::pair<std::size_t, Value>> delta_fields;
+            for (std::size_t index = 0; index < info.fields.size(); ++index) {
+                const semantics::StructField &field    = info.fields[index];
+                ast::ExprId                   value_id = argument_for(field.name);
+                if (value_id == ast::no_node && !delta) { value_id = field.default_value; }
+                const HType field_type = type_of(field.type, struct_frame);
+
+                if (value_id == ast::no_node) {
+                    if (delta) { continue; }
+                    temporal_fields.push_back("hgraph::wire<hgraph::stdlib::nothing, " +
+                                              schema(field_type, module_.type(field.type).range) + ">(w)");
+                    continue;
+                }
+                if (std::holds_alternative<ast::NullLiteral>(module_.expr(value_id).node)) {
+                    if (delta) {
+                        backend(module_.expr(value_id).range, "clearing an optional struct field needs a native clear-delta "
+                                                              "operation");
+                    }
+                    temporal_fields.push_back("hgraph::wire<hgraph::stdlib::nothing, " +
+                                              schema(field_type, module_.type(field.type).range) + ">(w)");
+                    continue;
+                }
+
+                Value value = eval_expr(value_id, frame);
+                if (delta) {
+                    if (!frame.runtime || (!value.is_const() && !value.is_runtime())) {
+                        backend(module_.expr(value_id).range, "a structured delta is only available in a runtime function");
+                    }
+                    value.code = as_runtime(value, field_type, value.range, "field '" + field.name + "'");
+                    value.type = field_type;
+                    delta_fields.emplace_back(index, std::move(value));
+                } else {
+                    temporal_fields.push_back(as_port(value, field_type, value.range));
+                }
+            }
+
+            if (delta) {
+                std::string code =
+                    "[&]() { hgraph::BundleBuilder builder{hgraph::delta_value_binding<" + schema(type, range) + ">()}; ";
+                for (const auto &[index, value] : delta_fields) {
+                    code += "builder.set(" + std::to_string(index) + ", hgraph::Value{" + value.code + "}); ";
+                }
+                code += "return builder.build(); }()";
+                Value result            = make_runtime(std::move(code), type, range);
+                result.structured_delta = true;
+                return result;
+            }
+
+            Value result = make_port("hgraph::stdlib::to_tsb<" + schema(type, range) + ">(w" +
+                                         (temporal_fields.empty() ? std::string{} : ", " + join(temporal_fields, ", ")) + ")",
+                                     type, range);
+            result.atomic_code =
+                "hgraph::wire<hgraph::stdlib::combine_cs, hgraph::TS<" + value_type(type, range) + ">>(w, " + result.code + ")";
+            return result;
+        }
+
         Value Emitter::eval_intrinsic(const Value &callee, const ast::Call &call, SourceRange range, Frame &frame)
         {
             const std::string &name = callee.name;
+            if (name.starts_with("logger.")) {
+                if (!frame.runtime) { fail(Category::Phase, range, "logger methods are only available in runtime hooks"); }
+                if (name != "logger.info") { unsupported(range, "logger method '" + name.substr(7) + "'"); }
+                if (call.arguments.size() != 1) {
+                    fail(Category::Type, range, "'logger.info' takes one message in the first slice");
+                }
+                const Value message = eval_expr(call.arguments.front().value, frame);
+                if ((!message.is_const() && !message.is_runtime()) || !message.type.is(ast::ScalarType::Str)) {
+                    fail(Category::Type, message.range, "'logger.info' takes a str message");
+                }
+                Value result;
+                result.kind  = Value::Kind::Void;
+                result.code  = "logger.log(2, " + message.code + ")";
+                result.range = range;
+                return result;
+            }
             if (name == "valid" || name == "modified" || name == "all_valid")
             {
                 if (call.arguments.empty())
@@ -1246,6 +1579,75 @@ namespace hgl::codegen
                 }
                 return wire(name == "last_modified" ? "hgraph::stdlib::last_modified_time" : "hgraph::stdlib::keys_", {value.code},
                             range);
+            }
+            if (name == "keys" || name == "values" || name == "items") {
+                if (!frame.runtime) {
+                    backend(range, "'" + name +
+                                       "' is a runtime traversal; it is not available in a "
+                                       "composition body");
+                }
+                if (call.arguments.empty() || call.arguments.size() > 2) {
+                    fail(Category::Type, range, "'" + name + "' takes a collection and an optional predicate");
+                }
+                const Value source = eval_expr(call.arguments.front().value, frame);
+                if (!source.is_runtime() || source.selector.empty()) {
+                    fail(Category::Type, source.range, "'" + name + "' takes a runtime collection selector");
+                }
+
+                std::string predicate;
+                ast::ExprId general_predicate = ast::no_node;
+                if (call.arguments.size() == 2) {
+                    const ast::ExprId predicate_id   = call.arguments[1].value;
+                    const ast::Expr  &predicate_expr = module_.expr(predicate_id);
+                    if (std::holds_alternative<ast::AnonymousFn>(predicate_expr.node)) {
+                        general_predicate = predicate_id;
+                    } else {
+                        const Value value = eval_expr(predicate_id, frame);
+                        if (value.kind != Value::Kind::Intrinsic || (value.name != "valid" && value.name != "modified" &&
+                                                                     value.name != "added" && value.name != "removed")) {
+                            fail(Category::Type, predicate_expr.range,
+                                 "an iterator predicate is a metadata predicate or concise fn");
+                        }
+                        predicate = value.name;
+                    }
+                }
+
+                std::string method = name;
+                if (!predicate.empty()) {
+                    if (source.type.kind == HType::Kind::Set && name == "values") {
+                        method = predicate == "added" ? "added" : predicate == "removed" ? "removed" : name;
+                    } else {
+                        method = predicate + "_" + name;
+                    }
+                }
+
+                Value result;
+                result.kind               = Value::Kind::Iterator;
+                result.code               = source.selector + "." + method + "()";
+                result.type               = source.type;
+                result.name               = name;
+                result.range              = range;
+                result.iterator_predicate = general_predicate;
+                if (source.type.kind == HType::Kind::Map) {
+                    if (name == "keys") {
+                        result.iterator_types.push_back(source.type.children[0]);
+                    } else if (name == "values") {
+                        result.iterator_types.push_back(source.type.children[1]);
+                    } else {
+                        result.iterator_types = {source.type.children[0], source.type.children[1]};
+                    }
+                } else if (source.type.kind == HType::Kind::Set && name == "values") {
+                    result.iterator_types.push_back(source.type.children[0]);
+                } else if (source.type.kind == HType::Kind::List) {
+                    if (name == "values") {
+                        result.iterator_types.push_back(source.type.children[0]);
+                    } else {
+                        result.iterator_types = {scalar_type(ast::ScalarType::I64), source.type.children[0]};
+                    }
+                } else {
+                    backend(source.range, "this collection does not support '" + name + "'");
+                }
+                return result;
             }
             backend(range, "'" + name +
                                "' is a runtime traversal; it is not available in a composition body of the first pass");
@@ -1606,8 +2008,27 @@ namespace hgl::codegen
                     else if constexpr (std::is_same_v<T, ast::AssignStmt>)
                     {
                         const ast::Expr &place = module_.expr(node.place);
-                        if (!std::holds_alternative<ast::NameRef>(place.node) || resolved_.binding(node.place).kind != BindingKind::Local)
-                        {
+                        if (const auto *index = std::get_if<ast::Index>(&place.node);
+                            index != nullptr && slice(module_.expr(index->target).range) == "out") {
+                            const ast::FunctionDecl &fn = function(frame.fn);
+                            if (!frame.output_available || fn.signature.result == ast::no_node) {
+                                fail(Category::Phase, place.range, "'out' is not available in this lifecycle block");
+                            }
+                            const HType result = type_of(fn.signature.result, frame);
+                            if (result.kind != HType::Kind::Map || result.children.size() != 2) {
+                                backend(place.range, "indexed output assignment currently requires a map result");
+                            }
+                            if (node.op != ast::AssignOp::Assign) {
+                                unsupported(stmt.range, "compound assignment to an output collection child");
+                            }
+                            const Value key   = eval_expr(index->index, frame);
+                            const Value value = eval_expr(node.value, frame);
+                            out.line("hgl_output.set(" + as_runtime(key, result.children[0], key.range, "output key") + ", " +
+                                     as_runtime(value, result.children[1], value.range, "output value") + ");");
+                            return;
+                        }
+                        if (!std::holds_alternative<ast::NameRef>(place.node) ||
+                            resolved_.binding(node.place).kind != BindingKind::Local) {
                             backend(place.range, "runtime assignment currently targets a "
                                                  "local, state value, or 'out'");
                         }
@@ -1679,7 +2100,14 @@ namespace hgl::codegen
                             }
                             const HType result = type_of(fn.signature.result, frame);
                             const Value value  = eval_expr(node.value, frame);
-                            out.line("hgl_output.set(" + as_runtime(value, result, value.range, "return value") + ");");
+                            if (value.structured_delta) {
+                                if (result.kind != HType::Kind::Struct || !same_type(value.type, result)) {
+                                    fail(Category::Type, value.range, "the structured delta does not match the result type");
+                                }
+                                out.line("hgraph::apply_delta(hgl_output.base(), " + value.code + ".view());");
+                            } else {
+                                out.line("hgl_output.set(" + as_runtime(value, result, value.range, "return value") + ");");
+                            }
                         }
                         out.line("return;");
                     }
@@ -1718,7 +2146,77 @@ namespace hgl::codegen
                     }
                     else if constexpr (std::is_same_v<T, ast::ForStmt>)
                     {
-                        backend(stmt.range, "runtime collection traversal is not supported by emit-cpp yet");
+                        const Value iterator = eval_expr(node.iterable, frame);
+                        if (!iterator.is_iterator()) {
+                            fail(Category::Type, module_.expr(node.iterable).range,
+                                 "a runtime 'for' loop needs keys(...), values(...), or "
+                                 "items(...)");
+                        }
+                        const bool pair = !node.second.empty();
+                        if (iterator.iterator_types.size() != (pair ? 2U : 1U)) {
+                            fail(Category::Type, stmt.range,
+                                 pair ? "this iterator yields one value" : "this iterator yields a pair");
+                        }
+
+                        const std::string first_raw  = "hgl_" + cpp_name(node.first.text) + "_item";
+                        const std::string second_raw = "hgl_" + cpp_name(node.second.text) + "_item";
+                        out.open(pair ? "for (const auto &[" + first_raw + ", " + second_raw + "] : " + iterator.code + ")"
+                                      : "for (const auto &" + first_raw + " : " + iterator.code + ")");
+
+                        const auto bind_value = [&](const std::string &raw, const HType &type, bool endpoint, bool list_index,
+                                                    bool map_key) {
+                            Value value;
+                            value.kind  = Value::Kind::Runtime;
+                            value.type  = type;
+                            value.range = stmt.range;
+                            if (endpoint) {
+                                value.selector = raw;
+                                value.code     = iterator.type.kind == HType::Kind::List
+                                                     ? raw + ".value().checked_as<" + value_type(type, stmt.range) + ">()"
+                                                     : raw + ".value()";
+                            } else if (list_index) {
+                                value.code = "static_cast<hgraph::Int>(" + raw + ")";
+                            } else if (map_key) {
+                                value.code = raw + ".checked_as<" + value_type(type, stmt.range) + ">()";
+                            } else {
+                                value.code = raw;
+                            }
+                            return value;
+                        };
+
+                        const bool map  = iterator.type.kind == HType::Kind::Map;
+                        const bool list = iterator.type.kind == HType::Kind::List;
+                        Value      first =
+                            bind_value(first_raw, iterator.iterator_types[0], !pair && (map || list) && iterator.name == "values",
+                                       pair && list, map && (pair || iterator.name == "keys"));
+                        frame.locals[id] = first;
+                        if (pair) {
+                            frame.second_locals[id] = bind_value(second_raw, iterator.iterator_types[1], true, false, false);
+                        }
+
+                        bool predicate_scope = false;
+                        if (iterator.iterator_predicate != ast::no_node) {
+                            const auto &predicate = std::get<ast::AnonymousFn>(module_.expr(iterator.iterator_predicate).node);
+                            Frame       predicate_frame = frame;
+                            predicate_frame.anonymous   = iterator.iterator_predicate;
+                            predicate_frame.anonymous_params =
+                                pair ? std::vector<Value>{frame.locals.at(id), frame.second_locals.at(id)}
+                                     : std::vector<Value>{frame.locals.at(id)};
+                            if (predicate.parameters.size() != predicate_frame.anonymous_params.size()) {
+                                fail(Category::Type, module_.expr(iterator.iterator_predicate).range,
+                                     "the iterator predicate parameter count must match its "
+                                     "values");
+                            }
+                            const Value condition = eval_expr(predicate.body, predicate_frame);
+                            if ((!condition.is_const() && !condition.is_runtime()) || !condition.type.is(ast::ScalarType::Bool)) {
+                                fail(Category::Type, module_.expr(predicate.body).range, "an iterator predicate returns bool");
+                            }
+                            out.open("if (" + condition.code + ")");
+                            predicate_scope = true;
+                        }
+                        emit_runtime_block(node.block, frame, out);
+                        if (predicate_scope) { out.close(); }
+                        out.close();
                     }
                     else
                     {
@@ -2011,23 +2509,21 @@ namespace hgl::codegen
             {
                 backend(module_.decl(decl).range, "a runtime function needs a block body");
             }
-            if (fn.signature.result == ast::no_node)
-            {
-                backend(fn.name.range, "generated runtime sinks are not supported by emit-cpp yet");
-            }
-            const HType result = type_of(fn.signature.result, frame);
-            if (result.kind != HType::Kind::Scalar)
-            {
-                backend(module_.type(fn.signature.result).range, "the first runtime-node slice supports scalar time-series outputs");
+            if (fn.signature.result != ast::no_node) {
+                const HType result = type_of(fn.signature.result, frame);
+                if (result.kind != HType::Kind::Scalar && result.kind != HType::Kind::Struct && result.kind != HType::Kind::Map) {
+                    backend(module_.type(fn.signature.result).range,
+                            "the runtime-node slice supports scalar, struct, and map outputs");
+                }
             }
 
             std::size_t temporal_count = 0;
             for (const ast::Parameter &param : fn.signature.parameters)
             {
                 const HType type = type_of(param.type, frame);
-                if (type.kind != HType::Kind::Scalar)
-                {
-                    backend(module_.type(param.type).range, "the first runtime-node slice supports scalar parameters");
+                if (type.kind != HType::Kind::Scalar && type.kind != HType::Kind::Map && type.kind != HType::Kind::Set &&
+                    type.kind != HType::Kind::List) {
+                    backend(module_.type(param.type).range, "the runtime-node slice supports scalar and collection parameters");
                 }
                 if (!param.is_const)
                 {
@@ -2068,11 +2564,14 @@ namespace hgl::codegen
                         {
                             for (const ast::Name &name : node.names)
                             {
-                                if (name.text != "out")
-                                {
-                                    backend(name.range, "injectable '" + std::string{name.text} + "' is not supported by emit-cpp yet");
+                                if (name.text == "out") {
+                                    info.inject_out = true;
+                                } else if (name.text == "logger") {
+                                    info.inject_logger = true;
+                                } else {
+                                    backend(name.range,
+                                            "injectable '" + std::string{name.text} + "' is not supported by emit-cpp yet");
                                 }
-                                info.inject_out = true;
                             }
                         }
                         else if constexpr (std::is_same_v<T, ast::LifecycleBlock>)
@@ -2126,14 +2625,7 @@ namespace hgl::codegen
             return info;
         }
 
-        void Emitter::check_supported(ast::DeclId decl)
-        {
-            const ast::FunctionDecl &fn    = function(decl);
-            const SourceRange        range = module_.decl(decl).range;
-            if (!fn.generics.empty())
-            {
-                unsupported(range, "a generic function");
-            }
+        void Emitter::check_supported(ast::DeclId decl) {
             if (resolved_.kind(decl) == semantics::FunctionKind::Runtime)
             {
                 static_cast<void>(runtime_info(decl));
@@ -2176,8 +2668,11 @@ namespace hgl::codegen
                 params.push_back(std::string{with_names ? "[[maybe_unused]] " : ""} + "hgraph::RecordableState<recordable_state>" +
                                  std::string{with_names ? " hgl_state" : ""});
             }
-            if (include_output)
-            {
+            if (info.inject_logger) {
+                params.push_back(std::string{with_names ? "[[maybe_unused]] " : ""} + "hgraph::LoggerView" +
+                                 std::string{with_names ? " logger" : ""});
+            }
+            if (include_output && fn.signature.result != ast::no_node) {
                 params.push_back(std::string{with_names ? "[[maybe_unused]] " : ""} + "hgraph::Out<" +
                                  schema(type_of(fn.signature.result, frame), module_.type(fn.signature.result).range) + ">" +
                                  std::string{with_names ? " hgl_output" : ""});
@@ -2195,11 +2690,13 @@ namespace hgl::codegen
             frame.output_available         = include_output;
             frame.params.resize(fn.signature.parameters.size());
             frame.locals.clear();
+            frame.second_locals.clear();
             frame.injects.clear();
             local_counts_.clear();
             local_names_.clear();
             local_names_.insert("hgl_state");
             local_names_.insert("hgl_output");
+            local_names_.insert("logger");
             for (std::size_t i = 0; i < fn.signature.parameters.size(); ++i)
             {
                 const ast::Parameter &param = fn.signature.parameters[i];
@@ -2219,7 +2716,7 @@ namespace hgl::codegen
                     local = base + "_" + std::to_string(++suffix);
                 }
                 local_names_.insert(local);
-                out.line("auto " + local + " = hgl_state.field<" + quote(state.name) + ">();");
+                out.line("[[maybe_unused]] auto " + local + " = hgl_state.field<" + quote(state.name) + ">();");
                 frame.locals[state.id] = make_runtime(local + ".value().checked_as<" + value_type(state.type, state.range) + ">()",
                                                       state.type, state.range, local);
             }
@@ -2229,6 +2726,12 @@ namespace hgl::codegen
                 frame.injects.emplace("out", make_runtime("hgl_output.value().checked_as<" +
                                                               value_type(result, module_.type(fn.signature.result).range) + ">()",
                                                           result, fn.name.range, "hgl_output"));
+            }
+            if (info.inject_logger) {
+                Value logger;
+                logger.kind = Value::Kind::Intrinsic;
+                logger.name = "logger";
+                frame.injects.emplace("logger", std::move(logger));
             }
         }
 
@@ -2297,9 +2800,10 @@ namespace hgl::codegen
                 out.close();
             }
 
-            out.line("static void eval(" + runtime_signature(decl, info, frame, true, true, true) + ")");
+            const bool has_output = fn.signature.result != ast::no_node;
+            out.line("static void eval(" + runtime_signature(decl, info, frame, true, true, has_output) + ")");
             out.open("");
-            prepare_runtime_frame(decl, info, frame, out, true, true);
+            prepare_runtime_frame(decl, info, frame, out, true, has_output);
             for (const ast::StmtId id : module_.block(fn.block_body).statements)
             {
                 const ast::StmtNode &node = module_.stmt(id).node;
@@ -2349,25 +2853,20 @@ namespace hgl::codegen
             return "hgraph::Port<" + schema(type_of(fn.signature.result, frame), module_.type(fn.signature.result).range) + ">";
         }
 
-        /// The operator marker for a public callable: its parameters as
+        /// The operator contract for a public callable: its parameters as
         /// `In`/`Scalar` selectors and its result as `Out`.
-        std::string Emitter::marker(ast::DeclId decl, std::string_view registry_name, Frame &frame)
-        {
+        std::string Emitter::operator_contract(ast::DeclId decl, std::string_view registry_name, Frame &frame) {
             const ast::DeclNode                 &node   = module_.decl(decl).node;
             const ast::Signature                *sig    = nullptr;
-            const std::vector<ast::GenericParameter> *generics = nullptr;
             if (const auto *fn = std::get_if<ast::FunctionDecl>(&node))
             {
-                sig      = &fn->signature;
-                generics = &fn->generics;
+                sig = &fn->signature;
             }
             else
             {
                 const auto &op = std::get<ast::OperatorDecl>(node);
-                sig      = &op.signature;
-                generics = &op.generics;
+                sig            = &op.signature;
             }
-            if (!generics->empty()) { unsupported(module_.decl(decl).range, "a generic operator"); }
             std::vector<std::string> selectors{quote(registry_name)};
             for (const ast::Parameter &param : sig->parameters)
             {
@@ -2384,6 +2883,62 @@ namespace hgl::codegen
                 selectors.push_back("hgraph::Out<" + schema(type_of(sig->result, frame), module_.type(sig->result).range) + ">");
             }
             return "hgraph::Operator<" + join(selectors, ", ") + ">";
+        }
+
+        void Emitter::emit_struct(ast::DeclId decl, Writer &out) {
+            const ast::StructDecl       &item = structure(decl);
+            const semantics::StructInfo &info = resolved_.structure(decl);
+            Frame                        frame;
+            frame.fn = decl;
+
+            std::vector<std::string> template_parameters;
+            std::vector<std::string> type_arguments;
+            for (std::size_t index = 0; index < item.generics.size(); ++index) {
+                const ast::GenericParameter &parameter = item.generics[index];
+                const std::string            name      = cpp_name(parameter.name.text);
+                if (parameter.is_const) {
+                    template_parameters.push_back("std::int64_t " + name);
+                    continue;
+                }
+                template_parameters.push_back("typename " + name);
+                HType type;
+                type.kind                  = HType::Kind::Generic;
+                type.cpp_type              = name;
+                frame.generic_types[index] = type;
+                type_arguments.push_back(name);
+            }
+
+            out.line("// " + where(module_.decl(decl).range));
+            if (!template_parameters.empty()) { out.line("template <" + join(template_parameters, ", ") + ">"); }
+            out.open("struct " + cpp_name(item.name.text));
+
+            std::vector<std::string> parents;
+            for (const ast::TypeId parent : item.parents) {
+                const HType type = type_of(parent, frame);
+                parents.push_back(value_type(type, module_.type(parent).range));
+            }
+
+            std::vector<std::string> value_fields;
+            std::vector<std::string> temporal_fields;
+            for (const semantics::StructField &field : info.fields) {
+                const HType type = type_of(field.type, frame);
+                value_fields.push_back("hgraph::Field<" + quote(field.name) + ", " +
+                                       value_type(type, module_.type(field.type).range) + ">");
+                temporal_fields.push_back("hgraph::Field<" + quote(field.name) + ", " +
+                                          schema(type, module_.type(field.type).range) + ">");
+            }
+
+            std::vector<std::string> bundle_parts{quote(module_name_), quote(item.name.text), item.abstract ? "true" : "false",
+                                                  "hgraph::BundleParents<" + join(parents, ", ") + ">",
+                                                  "hgraph::BundleArguments<" + join(type_arguments, ", ") + ">"};
+            bundle_parts.insert(bundle_parts.end(), value_fields.begin(), value_fields.end());
+            out.line("using value_type = hgraph::NominalBundle<" + join(bundle_parts, ", ") + ">;");
+
+            std::vector<std::string> tsb_parts{"value_type"};
+            tsb_parts.insert(tsb_parts.end(), temporal_fields.begin(), temporal_fields.end());
+            out.line("using time_series = hgraph::NominalTSB<" + join(tsb_parts, ", ") + ">;");
+            out.close(";");
+            out.line();
         }
 
         void Emitter::emit_function(ast::DeclId decl, Writer &out, Form form)
@@ -2634,8 +3189,6 @@ namespace hgl::codegen
             basename_             = file_.path();
             if (const auto slash = basename_.find_last_of("/\\"); slash != std::string::npos) { basename_.erase(0, slash + 1); }
 
-            for (const ast::DeclId id : resolved_.structs) { unsupported(module_.decl(id).range, "a struct declaration"); }
-
             // Every emitted function is checked up front so the whole unit
             // fails closed before a partial pair is written.
             std::vector<ast::DeclId> exports;
@@ -2671,12 +3224,22 @@ namespace hgl::codegen
             const std::vector<ast::DeclId> internal = ordered_internal_functions();
 
             // Bodies first: they discover which kernels (analytics) the
-            // header must include.
+            // header must include. Anonymous graph bodies are collected while
+            // their containing functions emit, then placed before every use.
+            Writer private_functions;
+            for (const ast::DeclId id : internal) { emit_function(id, private_functions, Form::InlineStruct); }
+            for (const ast::DeclId id : impls) { emit_function(id, private_functions, Form::InlineStruct); }
+            Writer public_functions;
+            for (const ast::DeclId id : exports) {
+                if (resolved_.kind(id) == semantics::FunctionKind::Composition) {
+                    emit_function(id, public_functions, Form::OutOfLine);
+                }
+            }
+
             Writer body;
             body.line("namespace " + namespace_);
             body.line("{");
-            if (!internal.empty() || !impls.empty())
-            {
+            if (!internal.empty() || !impls.empty() || !generated_helpers_.str().empty()) {
                 body.indent();
                 body.open("namespace");
                 const bool has_internal_runtime = std::any_of(internal.begin(), internal.end(), [&](ast::DeclId id) {
@@ -2692,27 +3255,21 @@ namespace hgl::codegen
                     Frame frame;
                     frame.fn = id;
                     body.line("using " + cpp_name(function(id).name.text) + " = " +
-                              marker(id, result.module_name + "." + std::string{function(id).name.text}, frame) + ";");
+                              operator_contract(id, result.module_name + "." + std::string{function(id).name.text}, frame) + ";");
                 }
                 if (has_internal_runtime)
                 {
                     body.close("  // namespace operator_contracts");
                     body.line();
                 }
-                for (const ast::DeclId id : internal) { emit_function(id, body, Form::InlineStruct); }
-                for (const ast::DeclId id : impls) { emit_function(id, body, Form::InlineStruct); }
+                body.append(generated_helpers_.str());
+                body.append(private_functions.str());
                 body.close("  // namespace");
                 body.line();
                 body.dedent();
             }
             body.indent();
-            for (const ast::DeclId id : exports)
-            {
-                if (resolved_.kind(id) == semantics::FunctionKind::Composition)
-                {
-                    emit_function(id, body, Form::OutOfLine);
-                }
-            }
+            body.append(public_functions.str());
 
             // Registration: exported functions and operator implementations
             // become registry candidates under module-qualified names, and
@@ -2780,12 +3337,14 @@ namespace hgl::codegen
             header.line("#include <hgraph/types/static_schema.h>");
             header.line();
             header.line("#include <chrono>");
+            header.line("#include <cstdint>");
             header.line("#include <stdexcept>");
             header.line("#include <tuple>");
             header.line();
             header.line("namespace " + namespace_);
             header.line("{");
             header.indent();
+            for (const ast::DeclId id : resolved_.structs) { emit_struct(id, header); }
             if (!resolved_.operators.empty() || !exports.empty())
             {
                 header.line("/// Operator contracts for the module's public callables.");
@@ -2796,7 +3355,7 @@ namespace hgl::codegen
                     Frame       frame;
                     header.line("// " + where(module_.decl(id).range));
                     header.line("using " + cpp_name(op.name.text) + " = " +
-                                marker(id, result.module_name + "." + std::string{op.name.text}, frame) + ";");
+                                operator_contract(id, result.module_name + "." + std::string{op.name.text}, frame) + ";");
                 }
                 for (const ast::DeclId id : exports)
                 {
@@ -2805,7 +3364,7 @@ namespace hgl::codegen
                     frame.fn = id;
                     header.line("// " + where(module_.decl(id).range));
                     header.line("using " + cpp_name(fn.name.text) + " = " +
-                                marker(id, result.module_name + "." + std::string{fn.name.text}, frame) + ";");
+                                operator_contract(id, result.module_name + "." + std::string{fn.name.text}, frame) + ";");
                 }
                 header.close("  // namespace operators");
                 header.line();

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -2888,6 +2888,14 @@ namespace hgl::codegen
         void Emitter::emit_struct(ast::DeclId decl, Writer &out) {
             const ast::StructDecl       &item = structure(decl);
             const semantics::StructInfo &info = resolved_.structure(decl);
+            for (const ast::GenericParameter &parameter : item.generics)
+            {
+                if (parameter.is_const)
+                {
+                    backend(parameter.name.range,
+                            "const generic struct arguments require typed constant Bundle metadata in hgraph");
+                }
+            }
             Frame                        frame;
             frame.fn = decl;
 

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -100,10 +100,41 @@ add_test(NAME hgraph_language_codegen COMMAND hgl_codegen_tests)
 # beside `hgl test` and the native-only runtime-node behavior.
 hgl_add_module(hgl_codegen_fixture STATIC HGL codegen/parity.hgl codegen/runtime.hgl)
 hgl_apply_warnings(hgl_codegen_fixture)
+hgl_add_module(hgl_structural_fixture STATIC HGL ../examples/structural-types.hgl)
+hgl_apply_warnings(hgl_structural_fixture)
+hgl_add_module(hgl_generic_fixture STATIC HGL ../examples/operators-and-generics.hgl)
+hgl_apply_warnings(hgl_generic_fixture)
+hgl_add_module(hgl_collection_fixture STATIC HGL ../examples/collection-views.hgl)
+hgl_apply_warnings(hgl_collection_fixture)
+hgl_add_module(hgl_stateful_fixture STATIC HGL ../examples/stateful-node.hgl)
+hgl_apply_warnings(hgl_stateful_fixture)
+hgl_add_module(hgl_basic_examples_fixture STATIC
+    HGL
+        ../examples/midpoint.hgl
+        ../examples/runtime-choice.hgl
+    LINK_LIBRARIES
+        hgraph::analytics
+)
+hgl_apply_warnings(hgl_basic_examples_fixture)
 
-add_executable(hgl_generated_tests codegen/generated_tests.cpp codegen/generated_runtime_tests.cpp)
+add_executable(hgl_generated_tests
+    codegen/generated_tests.cpp
+    codegen/generated_runtime_tests.cpp
+    codegen/generated_structural_tests.cpp
+    codegen/generated_generic_tests.cpp
+    codegen/generated_example_tests.cpp
+)
 target_compile_features(hgl_generated_tests PRIVATE cxx_std_23)
-target_link_libraries(hgl_generated_tests PRIVATE hgl_codegen_fixture hgl::wiring Catch2::Catch2WithMain)
+target_link_libraries(hgl_generated_tests PRIVATE
+    hgl_codegen_fixture
+    hgl_structural_fixture
+    hgl_generic_fixture
+    hgl_collection_fixture
+    hgl_stateful_fixture
+    hgl_basic_examples_fixture
+    hgl::wiring
+    Catch2::Catch2WithMain
+)
 hgl_link_runtime_executable(hgl_generated_tests)
 hgl_apply_warnings(hgl_generated_tests)
 
@@ -163,7 +194,7 @@ if(UNIX)
     )
 endif()
 
-# The command itself: composition and the first scalar runtime-node slice emit.
+# The command itself: representative composition and runtime modules emit.
 add_test(
     NAME hgraph_language_emit_midpoint
     COMMAND $<TARGET_FILE:hgl> emit-cpp ${CMAKE_CURRENT_SOURCE_DIR}/../examples/midpoint.hgl --print

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -404,6 +404,18 @@ export fn sampled(value: f64) -> f64 {
 }
 
 TEST_CASE("emit-cpp fails closed on constructs it does not lower", "[codegen]") {
+    SECTION("a const-generic struct")
+    {
+        Unit unit{R"(
+module t
+export struct Tag<const n: i64> {
+    value: i64
+}
+)"};
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Backend,
+                       "const generic struct arguments require typed constant Bundle metadata in hgraph"));
+    }
     SECTION("a runtime call")
     {
         Unit unit{R"(

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -403,8 +403,7 @@ export fn sampled(value: f64) -> f64 {
     }
 }
 
-TEST_CASE("emit-cpp fails closed on what the first pass does not lower", "[codegen]")
-{
+TEST_CASE("emit-cpp fails closed on constructs it does not lower", "[codegen]") {
     SECTION("a runtime call")
     {
         Unit unit{R"(
@@ -416,18 +415,6 @@ export fn sampled(x: f64) -> f64 {
 )"};
         CHECK_FALSE(unit.emit());
         CHECK(unit.has(Category::Backend, "calls in a runtime function are not supported by emit-cpp yet"));
-    }
-    SECTION("an unsupported runtime injectable")
-    {
-        Unit unit{R"(
-module t
-export fn logged(x: f64) -> f64 {
-    inject logger
-    when modified(x) { return x }
-}
-)"};
-        CHECK_FALSE(unit.emit());
-        CHECK(unit.has(Category::Backend, "injectable 'logger' is not supported by emit-cpp yet"));
     }
     SECTION("runtime state without an explicit type")
     {
@@ -454,26 +441,6 @@ export fn seeded(x: f64) -> f64 {
         CHECK_FALSE(unit.emit());
         CHECK(unit.has(Category::Phase, "temporal parameters are not available in runtime lifecycle blocks"));
     }
-    SECTION("a struct declaration")
-    {
-        Unit unit{R"(
-module t
-export struct Quote { bid: f64 }
-export fn twice(x: f64) -> f64 => x * 2.0
-)"};
-        CHECK_FALSE(unit.emit());
-        CHECK(unit.has(Category::Backend, "a struct declaration is not supported by emit-cpp yet"));
-    }
-    SECTION("a duration rolling window")
-    {
-        Unit unit{R"(
-module t
-use hgraph.std::{mean}
-export fn recent(window: rolling<f64, 5m>) -> f64 => mean(window)
-)"};
-        CHECK_FALSE(unit.emit());
-        CHECK(unit.has(Category::Backend, "duration rolling window"));
-    }
     SECTION("a non-positive rolling size")
     {
         Unit unit{R"(
@@ -492,15 +459,6 @@ export fn recent(window: rolling<f64, -1>) -> f64 => window
         CHECK_FALSE(unit.emit());
         CHECK(unit.has(Category::Type, "a rolling size is a positive i64 constant or a duration"));
     }
-    SECTION("a generic function")
-    {
-        Unit unit{R"(
-module t
-export fn same<U>(a: U, b: U) -> U => a
-)"};
-        CHECK_FALSE(unit.emit());
-        CHECK(unit.has(Category::Backend, "a generic function is not supported by emit-cpp yet"));
-    }
     SECTION("a missing module declaration")
     {
         // The front end rejects the unit before the emitter sees it; the
@@ -509,6 +467,44 @@ export fn same<U>(a: U, b: U) -> U => a
         CHECK(unit.diagnostics.has_errors());
         CHECK(unit.has(Category::Module, "module declaration"));
     }
+}
+
+TEST_CASE("emit-cpp lowers structural, generic, duration, and logger forms", "[codegen]") {
+    Unit       unit{R"(
+module t
+use hgraph.std::{mean}
+
+export struct Quote {
+    bid: f64
+    venue: str = null
+}
+
+export struct Box<T> {
+    value: T
+}
+
+export fn same<U>(a: U, b: U) -> U => a
+
+export fn recent(window: rolling<f64, 5m>) -> f64 => mean(window)
+
+export fn logged(value: f64) -> f64 {
+    inject logger
+    when modified(value) && valid(value) {
+        logger.info("value")
+        return value
+    }
+}
+)"};
+    const auto emitted = unit.emit();
+    REQUIRE(emitted);
+
+    CHECK(contains(emitted->header, "hgraph::NominalBundle<\"t\", \"Quote\", "
+                                    "false, hgraph::BundleParents<>"));
+    CHECK(contains(emitted->header, "template <typename T>\n    struct Box"));
+    CHECK(contains(emitted->header, "hgraph::ScalarVar<\"U\">"));
+    CHECK(contains(emitted->header, "hgraph::TSWDuration<hgraph::Float, 300000000, 300000000>"));
+    CHECK(contains(emitted->header, "hgraph::LoggerView logger"));
+    CHECK(contains(emitted->header, "logger.log(2, hgraph::Str{\"value\"});"));
 }
 
 TEST_CASE("emit-cpp escapes C++ keywords and its own names", "[codegen]")
@@ -559,6 +555,6 @@ export fn twice(x: f64) -> f64 {
 )"};
     const auto emitted = unit.emit();
     REQUIRE(emitted);
-    CHECK(contains(emitted->source, "const auto x_1 = hgraph::wire<hgraph::stdlib::mul_>(w, x, hgraph::Float{2.0});"));
-    CHECK(contains(emitted->source, "return x_1.as<hgraph::TS<hgraph::Float>>();"));
+    CHECK(contains(emitted->source, "hgraph::Float{2.0})"));
+    CHECK(contains(emitted->source, "return x_1;"));
 }

--- a/language/tests/codegen/generated_example_tests.cpp
+++ b/language/tests/codegen/generated_example_tests.cpp
@@ -1,0 +1,61 @@
+#include <collection-views.h>
+#include <stateful-node.h>
+
+#include "wiring/backend.h"
+
+#include <hgraph/lib/testing/check_output.h>
+#include <hgraph/lib/testing/eval_node.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <string>
+
+using namespace hgraph;
+using namespace hgraph::testing;
+using namespace std::string_literals;
+
+namespace collections = examples::collection_views;
+namespace stateful    = examples::stateful_node;
+
+namespace
+{
+    using FirstModifiedIndex =
+        Operator<"examples.collection_views.first_modified_index", In<"samples", TSL<TS<Float>>>, Out<TS<Int>>>;
+
+    using CountRecent = Operator<"examples.collection_views.count_recent", In<"book", TSD<Str, TS<Float>>>,
+                                 Scalar<"some_time", DateTime>, Out<TS<Int>>>;
+
+    using LatestByKey =
+        Operator<"examples.stateful_node.latest_by_key", In<"key", TS<Str>>, In<"value", TS<Float>>, Out<TSD<Str, TS<Float>>>>;
+
+    void session() {
+        hgl::wiring::ensure_session();
+        collections::register_operators();
+        stateful::register_operators();
+    }
+}  // namespace
+
+TEST_CASE("generated list iteration observes the modified children", "[codegen][generated][examples]") {
+    session();
+
+    CHECK_OUTPUT((eval_node<FirstModifiedIndex, TSL<TS<Float>>>(values<Value>(dynamic_list_delta<TS<Float>>({{0, 1.0}}),
+                                                                              dynamic_list_delta<TS<Float>>({{1, 2.0}}),
+                                                                              dynamic_list_delta<TS<Float>>({}, {1})))),
+                 values<Int>(0, 1, none));
+}
+
+TEST_CASE("generated collection predicates receive keys and values", "[codegen][generated][examples]") {
+    session();
+
+    CHECK_OUTPUT((eval_node<CountRecent, TSD<Str, TS<Float>>>(values<Value>(dict_delta<Str, TS<Float>>({{"A"s, 1.0}, {"B"s, 2.0}}),
+                                                                            dict_delta<Str, TS<Float>>({{"A"s, 3.0}})),
+                                                              arg<"some_time">(MIN_ST - MIN_TD))),
+                 values<Int>(2, 2));
+}
+
+TEST_CASE("generated keyed output assignment accumulates a TSD delta", "[codegen][generated][examples]") {
+    session();
+
+    CHECK_OUTPUT((eval_node<LatestByKey>(values<Str>("A"s, "B"s), values<Float>(1.0, 2.0))),
+                 values<Value>(dict_delta<Str, TS<Float>>({{"A"s, 1.0}}), dict_delta<Str, TS<Float>>({{"B"s, 2.0}})));
+}

--- a/language/tests/codegen/generated_generic_tests.cpp
+++ b/language/tests/codegen/generated_generic_tests.cpp
@@ -1,0 +1,49 @@
+#include <operators-and-generics.h>
+
+#include "wiring/backend.h"
+
+#include <hgraph/lib/testing/check_output.h>
+#include <hgraph/lib/testing/eval_node.h>
+#include <hgraph/types/static_schema.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace hgraph;
+using namespace hgraph::testing;
+namespace generics = examples::operators_and_generics;
+
+TEST_CASE("generated duration windows preserve their concrete period", "[codegen][generated][generic]") {
+    using Window       = TSWDuration<Float, 300000000, 300000000>;
+    const auto *schema = schema_descriptor<Window>::ts_meta();
+
+    REQUIRE(schema->is_duration_based());
+    REQUIRE(schema->time_range() == TimeDelta{300000000});
+    REQUIRE(schema->min_time_range() == TimeDelta{300000000});
+}
+
+TEST_CASE("generated generic operator implementations register normally", "[codegen][generated][generic]") {
+    hgl::wiring::ensure_session();
+    const auto provider = generics::register_operators();
+
+    REQUIRE(provider.active());
+    REQUIRE(hgl::wiring::has_operator("examples.operators_and_generics.summarize"));
+    REQUIRE(hgl::wiring::has_operator("examples.operators_and_generics.summarize_full_window"));
+    REQUIRE(hgl::wiring::has_operator("examples.operators_and_generics.summarize_recent"));
+}
+
+TEST_CASE("generated generic operator resolves for a concrete fixed window", "[codegen][generated][generic]") {
+    hgl::wiring::ensure_session();
+    generics::register_operators();
+
+    CHECK_OUTPUT(eval_node<generics::summarize_full_window>(values<Float>(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0,
+                                                                          12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0)),
+                 values<Float>(none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none,
+                               none, none, 10.5));
+}
+
+TEST_CASE("generated duration window graphs retain their concrete schema", "[codegen][generated][generic]") {
+    hgl::wiring::ensure_session();
+    generics::register_operators();
+
+    CHECK_OUTPUT(eval_node<generics::summarize_recent>(values<Float>(1.0, 2.0)), values<Float>(none, none));
+}

--- a/language/tests/codegen/generated_structural_tests.cpp
+++ b/language/tests/codegen/generated_structural_tests.cpp
@@ -1,0 +1,44 @@
+#include <structural-types.h>
+
+#include "wiring/backend.h"
+
+#include <hgraph/lib/testing/check_output.h>
+#include <hgraph/lib/testing/eval_node.h>
+#include <hgraph/types/static_schema.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <string_view>
+#include <vector>
+
+using namespace hgraph;
+using namespace hgraph::testing;
+namespace structural = examples::structural_types;
+
+namespace
+{
+    using BidDelta =
+        Operator<"examples.structural_types.bid_delta", In<"value", TS<Float>>, Out<typename structural::Quote::time_series>>;
+}
+
+TEST_CASE("generated structural types preserve nominal metadata", "[codegen][generated][struct]") {
+    const auto *instrument = scalar_descriptor<structural::Instrument::value_type>::value_meta();
+    const auto *future     = scalar_descriptor<structural::Future::value_type>::value_meta();
+    const auto *box        = scalar_descriptor<structural::Box<Float>::value_type>::value_meta();
+
+    REQUIRE(instrument->name() == "examples.structural_types::Instrument");
+    REQUIRE(instrument->is_abstract_bundle());
+    REQUIRE(future->bundle_hierarchy->parents == std::vector<const ValueTypeMetaData *>{instrument});
+    REQUIRE(box->name() == "examples.structural_types::Box[float]");
+    REQUIRE(box->bundle_generic_arguments() ==
+            std::vector<const ValueTypeMetaData *>{TypeRegistry::instance().value_type("float")});
+    REQUIRE(schema_descriptor<structural::Box<Float>::time_series>::ts_meta()->value_schema == box);
+}
+
+TEST_CASE("generated structural deltas remain sparse", "[codegen][generated][struct]") {
+    hgl::wiring::ensure_session();
+    structural::register_operators();
+
+    CHECK_OUTPUT(eval_node<BidDelta>(values<Float>(1.25)), values<Value>(tsb_delta<typename structural::Quote::time_series>(
+                                                               Float{1.25}, std::nullopt, std::nullopt, std::nullopt)));
+}

--- a/language/tests/repl/repl_smoke.cmake
+++ b/language/tests/repl/repl_smoke.cmake
@@ -20,7 +20,7 @@ impl fn magnitude(value: f64) -> f64 {
 }
 fn magnitude_graph(value: f64) -> f64 => magnitude(value)
 eval(magnitude_graph, value: [-2.0, 3.0])
-fn unsupported<U>(a: U, b: U) -> U => a
+fn same<U>(a: U, b: U) -> U => a
 eval(magnitude_graph, value: [4.0, -5.0])
 :quit
 ")
@@ -34,8 +34,7 @@ execute_process(
 if(NOT status EQUAL 0)
     message(FATAL_ERROR "hgl repl exited ${status}\n${output}\n${errors}")
 endif()
-foreach(expected "hgl> 3\n" "[3.0, 4.0]" "[2.0, 3.0]" "[4.0, 5.0]"
-        "a generic function is not supported by emit-cpp yet")
+foreach(expected "hgl> 3\n" "[3.0, 4.0]" "[2.0, 3.0]" "[4.0, 5.0]")
     string(FIND "${output}" "${expected}" at)
     if(at EQUAL -1)
         message(FATAL_ERROR "hgl repl output lacks '${expected}':\n${output}\n${errors}")

--- a/src/hgraph/types/type_pattern.cpp
+++ b/src/hgraph/types/type_pattern.cpp
@@ -391,7 +391,10 @@ namespace hgraph
                     return false;
                 }
                 return pattern.any_window ||
-                       (!concrete->is_duration_based() && pattern.fixed_size == concrete->period() &&
+                       (pattern.duration_window && concrete->is_duration_based() &&
+                        pattern.duration_micros == concrete->time_range().count() &&
+                        pattern.min_duration_micros == concrete->min_time_range().count()) ||
+                       (!pattern.duration_window && !concrete->is_duration_based() && pattern.fixed_size == concrete->period() &&
                         pattern.min_size == concrete->min_period());
             case TypePattern::Kind::TSB:
                 if (concrete->kind != TSTypeKind::TSB) { return false; }
@@ -608,8 +611,10 @@ namespace hgraph
             case TypePattern::Kind::TSW:
             {
                 const ValueTypeMetaData *element = scalar_pattern_resolve(pattern.scalar, map);
-                return element != nullptr && !pattern.any_window ? registry.tsw(element, pattern.fixed_size, pattern.min_size)
-                                                                 : nullptr;
+                if (element == nullptr || pattern.any_window) { return nullptr; }
+                return pattern.duration_window ? registry.tsw_duration(element, TimeDelta{pattern.duration_micros},
+                                                                       TimeDelta{pattern.min_duration_micros})
+                                               : registry.tsw(element, pattern.fixed_size, pattern.min_size);
             }
             case TypePattern::Kind::TSB:
             {
@@ -809,8 +814,12 @@ namespace hgraph
                 {
                     return fmt::format("TSW[{}, *]", scalar_pattern_to_string(pattern.scalar));
                 }
-                return fmt::format("TSW[{}, {}, {}]", scalar_pattern_to_string(pattern.scalar),
-                                   pattern.fixed_size, pattern.min_size);
+                if (pattern.duration_window) {
+                    return fmt::format("TSW[{}, duration={}us, min={}us]", scalar_pattern_to_string(pattern.scalar),
+                                       pattern.duration_micros, pattern.min_duration_micros);
+                }
+                return fmt::format("TSW[{}, {}, {}]", scalar_pattern_to_string(pattern.scalar), pattern.fixed_size,
+                                   pattern.min_size);
             case TypePattern::Kind::TSB:
             {
                 if (pattern.schema_var) { return fmt::format("TSB[~{}]", pattern.name); }

--- a/src/hgraph/types/type_pattern.cpp
+++ b/src/hgraph/types/type_pattern.cpp
@@ -112,6 +112,19 @@ namespace hgraph
             }
             return scalar_pattern_match(pattern, concrete, map);
         }
+
+        [[nodiscard]] bool named_tsb_pattern_match(const TypePattern &pattern,
+                                                   const TSValueTypeMetaData *concrete,
+                                                   ResolutionMap &map)
+        {
+            if (!pattern.named_bundle) { return true; }
+            if (!concrete->is_named_tsb() || concrete->bundle_name() == nullptr) { return false; }
+            if (pattern.scalar.kind == ScalarPattern::Kind::Bundle && !pattern.scalar.bundle_origin.empty())
+            {
+                return scalar_pattern_match(pattern.scalar, concrete->value_type, map);
+            }
+            return pattern.bundle_name == concrete->bundle_name();
+        }
     }  // namespace
 
     bool scalar_pattern_match(const ScalarPattern &pattern, const ValueTypeMetaData *concrete, ResolutionMap &map)
@@ -315,14 +328,7 @@ namespace hgraph
                     map.bind_ts(pattern.name, concrete);
                     return true;
                 }
-                if (pattern.named_bundle)
-                {
-                    if (!concrete->is_named_tsb() || concrete->bundle_name() == nullptr ||
-                        pattern.bundle_name != concrete->bundle_name())
-                    {
-                        return false;
-                    }
-                }
+                if (!named_tsb_pattern_match(pattern, concrete, map)) { return false; }
                 if (concrete->field_count() != pattern.children.size()) { return false; }
                 for (std::size_t i = 0; i < pattern.children.size(); ++i)
                 {
@@ -408,14 +414,7 @@ namespace hgraph
                     map.bind_ts(pattern.name, concrete);
                     return true;
                 }
-                if (pattern.named_bundle)
-                {
-                    if (!concrete->is_named_tsb() || concrete->bundle_name() == nullptr ||
-                        pattern.bundle_name != concrete->bundle_name())
-                    {
-                        return false;
-                    }
-                }
+                if (!named_tsb_pattern_match(pattern, concrete, map)) { return false; }
                 if (concrete->field_count() != pattern.children.size()) { return false; }
                 for (std::size_t i = 0; i < pattern.children.size(); ++i)
                 {
@@ -627,6 +626,12 @@ namespace hgraph
                     if (child == nullptr) { return nullptr; }
                     fields.emplace_back(pattern.field_names[i], child);
                 }
+                if (pattern.named_bundle && pattern.scalar.kind == ScalarPattern::Kind::Bundle &&
+                    !pattern.scalar.bundle_origin.empty())
+                {
+                    const ValueTypeMetaData *value = scalar_pattern_resolve(pattern.scalar, map);
+                    return value != nullptr ? registry.tsb(value->name(), fields) : nullptr;
+                }
                 return pattern.named_bundle ? registry.tsb(pattern.bundle_name, fields) : registry.un_named_tsb(fields);
             }
             case TypePattern::Kind::REF:
@@ -829,8 +834,12 @@ namespace hgraph
                 {
                     fields.push_back(fmt::format("{}: {}", pattern.field_names[i], ts_pattern_to_string(pattern.children[i])));
                 }
-                return pattern.named_bundle ? fmt::format("TSB<{}>[{}]", pattern.bundle_name, fmt::join(fields, ", "))
-                                            : fmt::format("TSB[{}]", fmt::join(fields, ", "));
+                if (!pattern.named_bundle) { return fmt::format("TSB[{}]", fmt::join(fields, ", ")); }
+                const std::string name = pattern.scalar.kind == ScalarPattern::Kind::Bundle &&
+                                                 !pattern.scalar.bundle_origin.empty()
+                                             ? scalar_pattern_to_string(pattern.scalar)
+                                             : pattern.bundle_name;
+                return fmt::format("TSB<{}>[{}]", name, fmt::join(fields, ", "));
             }
             case TypePattern::Kind::REF: return fmt::format("REF[{}]", ts_pattern_to_string(pattern.children[0]));
             case TypePattern::Kind::Signal: return "SIGNAL";

--- a/tests/cpp/test_operators.cpp
+++ b/tests/cpp/test_operators.cpp
@@ -231,6 +231,16 @@ namespace
         }
     };
 
+    struct any_window_mean_ : Operator<"any_window_mean", In<"window", TSWAny<Float>>, Out<TS<Float>>>
+    {};
+    struct any_window_mean_graph
+    {
+        static constexpr auto  name = "any_window_mean_graph";
+        static Port<TS<Float>> compose(Wiring &w, Port<TSWAny<Float>> window) {
+            return wire<stdlib::mean>(w, window).as<TS<Float>>();
+        }
+    };
+
     struct count_signal_ : Operator<"count_signal_op", In<"pulse", SIGNAL>, Out<TS<Int>>>
     {
     };
@@ -1160,6 +1170,19 @@ TEST_CASE("operators: graph implementations can be registered as overloads")
     register_graph_overload<double_, double_graph>();
 
     CHECK_OUTPUT(eval_node<double_>(values<Int>(1, 2, 3)), values<Int>(2, 4, 6));
+}
+
+TEST_CASE("operators: graph implementations preserve a concrete schema through "
+          "a window wildcard") {
+    stdlib::register_standard_operators();
+    register_graph_overload<any_window_mean_, any_window_mean_graph>();
+
+    Wiring wiring;
+    auto   window = wire<stdlib::replay_impl, TSW<Float, 3, 1>>(wiring, std::string{"window"});
+    auto   result = wire<any_window_mean_>(wiring, window);
+
+    CHECK(result.erased().schema == schema_descriptor<TS<Float>>::ts_meta());
+    CHECK_NOTHROW(std::move(wiring).finish());
 }
 
 TEST_CASE("operators: SIGNAL node overloads accept any time-series input")

--- a/tests/cpp/test_operators.cpp
+++ b/tests/cpp/test_operators.cpp
@@ -1381,6 +1381,29 @@ TEST_CASE("operators: generic Bundle patterns retain nominal origin and bind arg
     CHECK(adapted.is_peered_source());
 }
 
+TEST_CASE("operators: generic nominal TSB patterns retain their Bundle origin")
+{
+    using GenericBox = NominalBundle<"tests.pattern", "Box", false, BundleParents<>, BundleArguments<ScalarVar<"T">>,
+                                     Field<"value", ScalarVar<"T">>>;
+    using IntegerBox =
+        NominalBundle<"tests.pattern", "Box", false, BundleParents<>, BundleArguments<Int>, Field<"value", Int>>;
+    using IntegerOther =
+        NominalBundle<"tests.pattern", "Other", false, BundleParents<>, BundleArguments<Int>, Field<"value", Int>>;
+    using GenericBoxTS = NominalTSB<GenericBox, Field<"value", TS<ScalarVar<"T">>>>;
+    using IntegerBoxTS = NominalTSB<IntegerBox, Field<"value", TS<Int>>>;
+    using IntegerOtherTS = NominalTSB<IntegerOther, Field<"value", TS<Int>>>;
+
+    const TypePattern pattern = to_pattern<GenericBoxTS>();
+    ResolutionMap map;
+    REQUIRE(input_ts_pattern_match(pattern, ts_type<IntegerBoxTS>(), map));
+    CHECK(map.find_scalar("T") == scalar_type<Int>());
+    CHECK(ts_pattern_resolve(pattern, map) == ts_type<IntegerBoxTS>());
+    CHECK(ts_pattern_to_string(pattern).find("tests.pattern::Box[~T]") != std::string::npos);
+
+    ResolutionMap other_map;
+    CHECK_FALSE(input_ts_pattern_match(pattern, ts_type<IntegerOtherTS>(), other_map));
+}
+
 TEST_CASE("operators: typed Series and Frame patterns preserve their scalar structure")
 {
     auto &registry = TypeRegistry::instance();

--- a/tests/cpp/test_static_schema.cpp
+++ b/tests/cpp/test_static_schema.cpp
@@ -128,6 +128,8 @@ TEST_CASE("static_schema: TSW<T, period, min_period> descriptor matches registry
     REQUIRE(schema_descriptor<TSW<Float, 10, 3>>::ts_meta() == registry.tsw(float_meta, 10, 3));
     STATIC_REQUIRE(std::same_as<TSW<Float, 5>, TSW<Float, 5, 5>>);
     REQUIRE(schema_descriptor<TSW<Float, 5>>::ts_meta() == registry.tsw(float_meta, 5, 5));
+    REQUIRE(schema_descriptor<TSWDuration<Float, 5'000'000, 1'000'000>>::ts_meta() ==
+            registry.tsw_duration(float_meta, TimeDelta{5'000'000}, TimeDelta{1'000'000}));
     REQUIRE_FALSE(schema_descriptor<TSWAny<ScalarVar<"T">>>::is_concrete());
     REQUIRE(schema_descriptor<TSWAny<ScalarVar<"T">>>::ts_meta() == nullptr);
 }
@@ -219,6 +221,26 @@ TEST_CASE("static_schema: Bundle<\"Name\", ...> resolves to registry.bundle(name
     REQUIRE(got->is_named_bundle());
     REQUIRE(std::string(got->name()) == std::string("LabelledPoint"));
     REQUIRE(got == registry.bundle("LabelledPoint", {{"x", int_meta}, {"label", str_meta}}));
+}
+
+TEST_CASE("static_schema: NominalBundle preserves hierarchy and generic identity") {
+    using namespace hgraph;
+    auto &registry = TypeRegistry::instance();
+
+    using Record = NominalBundle<"examples.models", "Record", true, BundleParents<>, BundleArguments<>, Field<"id", Int>>;
+    using Box    = NominalBundle<"examples.models", "Box", false, BundleParents<Record>, BundleArguments<Float>, Field<"id", Int>,
+                                 Field<"value", Float>>;
+    using BoxTS  = NominalTSB<Box, Field<"id", TS<Int>>, Field<"value", TS<Float>>>;
+
+    const auto *record = value_schema_descriptor<Record>::value_meta();
+    const auto *box    = value_schema_descriptor<Box>::value_meta();
+
+    REQUIRE(record->name() == "examples.models::Record");
+    REQUIRE(record->is_abstract_bundle());
+    REQUIRE(box->name() == "examples.models::Box[float]");
+    REQUIRE(box->bundle_hierarchy->parents == std::vector<const ValueTypeMetaData *>{record});
+    REQUIRE(box->bundle_generic_arguments() == std::vector<const ValueTypeMetaData *>{registry.value_type("float")});
+    REQUIRE(schema_descriptor<BoxTS>::ts_meta()->value_schema == box);
 }
 
 TEST_CASE("static_schema: TSBFromScalar lifts named and structural Bundle fields")


### PR DESCRIPTION
## Summary

- compile every checked-in HGL example through the generated C++ package path
- lower nominal and generic structs, structural construction and sparse deltas, generic operators, and fixed or duration windows
- lower concise graph functions plus runtime collection iteration and predicates, logger injection, sinks, prior output, and keyed TSD writes
- add public static-schema support needed to preserve nominal hierarchy, generic identity, and concrete duration-window metadata
- add generated behavior tests and update the user, developer, architecture, and roadmap documentation to match the implemented boundary

## Stack

- depends on #664, which restores the pre-v0.2 `hg_cpp` formatting policy, makes generated C++ formatter-clean, and replaces generated operator subclasses with transparent contract aliases
- this PR contains one implementation commit on top of that base

## Validation

- all 24 language CTest cases pass, including native compilation of all six examples
- generated headers and sources pass clang-format dry-run with warnings as errors and contain no classes derived from `hgraph::Operator`
- fresh macOS native build and independent Linux validation: 1,718/1,718 native tests pass on each platform
- stable-ABI wheels built with Python 3.12 and installed into fresh Python 3.14 environments on macOS and Linux: 3,123 passed, 10 skipped on each platform
- installed wheel SDK consumer configured, built, and passed using public headers
