### PR TITLE
Name every exception boundary: hand-rolled catch(...) blocks use the scope.h helpers

### DIFF
--- a/docs/source/developer_guide/architecture.rst
+++ b/docs/source/developer_guide/architecture.rst
@@ -449,6 +449,42 @@ unwinding calls ``std::terminate``). Observers should treat their own
 notification methods as diagnostic/logging code, not as a place to signal
 failure back into the runtime.
 
+Named exception boundaries
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Every place the runtime deliberately stops an exception is one of the
+``util/scope.h`` forms, each of which names what happens to the failure:
+
+* ``fallback_on_exception(fallback, f)`` -- a ``noexcept`` predicate or
+  query whose fallback is a valid domain result (``false``, ``unordered``,
+  empty metrics, ``std::nullopt``); the three-argument form additionally
+  hands the message to an ``on_error`` callback (diagnostics that record
+  ``error`` strings, Python boundaries that must ``PyErr_Clear``);
+* ``annotate_on_exception(f, annotate)`` -- rethrow enriched with context
+  (``std::throw_with_nested`` from inside ``annotate``);
+* ``UnwindCleanupGuard`` / ``make_scope_exit`` -- rollback that must run
+  when the protected step unwinds (deallocate what was allocated, clear a
+  path that was set), with ``release()``/``complete()`` on the success path;
+* ``scope_exit<F, true>`` -- best-effort cleanup during an already-failing
+  path, where a second failure must not mask the first;
+* ``FirstExceptionRecorder`` -- a sequence of best-effort steps that all run
+  and then surface the first failure.
+
+Outside that header a bare ``catch (...)`` appears only at the three
+translation boundaries that turn an unknown exception into a typed message:
+``py_error_on_exception`` (``python/module_internal.h``, the raw CPython slot
+boundary), ``retained_error_message`` (``python/py_wiring.cpp``, a retained
+run failure) and the node-phase error prefix in ``runtime/graph.cpp``. The
+``catch-all-sites`` architecture ratchet (``testing.rst``) pins that count. A
+new ``try``/``catch (...)`` is therefore a design question -- which of the
+forms above is it? -- rather than a local convenience; the 2026-09-05 sweep
+converted 24 hand-rolled blocks (JSON accessors, time-zone lookups, storage
+metrics, diagnostics rendering, slab and slot construction rollback, service
+materialisation, Python-owned Bundle field errors) to the helper that names
+their behaviour, and the only observable change is that a non-``std``
+exception in the diagnostics renderers now reports the helper's ``"unknown
+error"`` instead of a per-site wording.
+
 Executor Error Policy
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/developer_guide/testing.rst
+++ b/docs/source/developer_guide/testing.rst
@@ -214,7 +214,10 @@ Each entry names the layer that owns the rule:
   reading the binding from their bound views;
 * Python-object hashing in more than one translation unit, and
   ``HGRAPH_ENABLE_PYTHON_USER_NODES`` conditionals inside the type layer;
-* ``thread_local`` in the runtime.
+* ``thread_local`` in the runtime;
+* a bare ``catch (...)`` outside ``util/scope.h`` and the three documented
+  translation boundaries -- an exception boundary without a name (see
+  ``architecture.rst``, "Named exception boundaries").
 
 The test fails when a count moves in either direction. A rise is a new copy
 of a rule that already has an owner: fix it at the owning layer, or record the

--- a/include/hgraph/lib/std/operators/impl/higher_order_impl.h
+++ b/include/hgraph/lib/std/operators/impl/higher_order_impl.h
@@ -4501,49 +4501,49 @@ namespace hgraph::stdlib
             auto  ordered  = ordered_map_schemas(context, "ndx");
             if (!ordered.has_value()) { return; }
 
-            try {
+            // Leave the output unresolved on any failure; the real wiring path reports the error.
+            static_cast<void>(fallback_on_exception(false, [&] {
                 auto tag_at = [&](std::size_t index) {
-                    return index < ordered->arg_tags.size() ? static_cast<WiringPortRef::ArgTag>(ordered->arg_tags[index])
-                                                            : WiringPortRef::ArgTag::None;
-                };
+                        return index < ordered->arg_tags.size() ? static_cast<WiringPortRef::ArgTag>(ordered->arg_tags[index])
+                                                                : WiringPortRef::ArgTag::None;
+                    };
 
-                // A no_key TSL still anchors the size here so resolution
-                // succeeds and compose can reject it with the clear message.
-                bool        found_collection = false;
-                std::size_t size             = 0;
-                for (std::size_t i = 0; i < ordered->schemas.size(); ++i) {
-                    if (tag_at(i) == WiringPortRef::ArgTag::PassThrough) { continue; }
-                    const auto *tsl = time_series_schema_as<AnyTSL>(ordered->schemas[i]);
-                    if (tsl != nullptr) {
-                        found_collection = true;
-                        size             = tsl->fixed_size();
-                        break;
+                    // A no_key TSL still anchors the size here so resolution
+                    // succeeds and compose can reject it with the clear message.
+                    bool        found_collection = false;
+                    std::size_t size             = 0;
+                    for (std::size_t i = 0; i < ordered->schemas.size(); ++i) {
+                        if (tag_at(i) == WiringPortRef::ArgTag::PassThrough) { continue; }
+                        const auto *tsl = time_series_schema_as<AnyTSL>(ordered->schemas[i]);
+                        if (tsl != nullptr) {
+                            found_collection = true;
+                            size             = tsl->fixed_size();
+                            break;
+                        }
                     }
-                }
-                if (!found_collection) { return; }
+                    if (!found_collection) { return true; }
 
-                std::vector<const TSValueTypeMetaData *> schemas;
-                schemas.reserve(func->arity);
-                if (ordered->takes_key) { schemas.push_back(registry.ts(scalar_descriptor<Int>::value_meta())); }
-                for (std::size_t i = 0; i < ordered->schemas.size(); ++i) {
-                    if (tag_at(i) != WiringPortRef::ArgTag::PassThrough && tsl_arg_is_multiplexed(ordered->schemas[i], size)) {
-                        schemas.push_back(time_series_schema_as<AnyTSL>(ordered->schemas[i])->element_ts());
-                    } else {
-                        schemas.push_back(ordered->schemas[i]);
+                    std::vector<const TSValueTypeMetaData *> schemas;
+                    schemas.reserve(func->arity);
+                    if (ordered->takes_key) { schemas.push_back(registry.ts(scalar_descriptor<Int>::value_meta())); }
+                    for (std::size_t i = 0; i < ordered->schemas.size(); ++i) {
+                        if (tag_at(i) != WiringPortRef::ArgTag::PassThrough && tsl_arg_is_multiplexed(ordered->schemas[i], size)) {
+                            schemas.push_back(time_series_schema_as<AnyTSL>(ordered->schemas[i])->element_ts());
+                        } else {
+                            schemas.push_back(ordered->schemas[i]);
+                        }
                     }
-                }
 
-                const auto child_schemas =
-                    std::span<const TSValueTypeMetaData *const>{schemas.data(),
-                                                               schemas.size()};
-                Wiring probe = output_probe_parent(context.wiring);
-                CompiledSubGraph compiled = func->compile(probe, child_schemas);
-                if (compiled.output_schema != nullptr) {
-                    bind_graph_output(resolution, registry.tsl(compiled.output_schema, size), "O");
-                }
-            } catch (...) {
-                // Leave unresolved; the real wiring path reports the error.
-            }
+                    const auto child_schemas =
+                        std::span<const TSValueTypeMetaData *const>{schemas.data(),
+                                                                   schemas.size()};
+                    Wiring probe = output_probe_parent(context.wiring);
+                    CompiledSubGraph compiled = func->compile(probe, child_schemas);
+                    if (compiled.output_schema != nullptr) {
+                        bind_graph_output(resolution, registry.tsl(compiled.output_schema, size), "O");
+                    }
+                return true;
+            }));
         }
 
         inline void resolve_lifted_map_tsl_output(ResolutionMap &resolution, OperatorCallContext context) {

--- a/python/tests/test_architecture_ratchets.py
+++ b/python/tests/test_architecture_ratchets.py
@@ -149,6 +149,20 @@ RATCHETS: tuple[Ratchet, ...] = (
         owner="realized bindings travel with bound views; operators do not "
         "recompute realization",
     ),
+    # --- Exception boundaries are named (AGENTS.md: prefer the scope.h guards) ---
+    Ratchet(
+        id="catch-all-sites",
+        baseline=9,
+        roots=("src/hgraph", "include/hgraph", "python"),
+        suffixes=(".cpp", ".h"),
+        pattern=r"catch\s*\(\s*\.\.\.\s*\)",
+        owner="util/scope.h owns the catch-all forms (fallback_on_exception, "
+        "annotate_on_exception, scope_exit<HideExceptions>, UnwindCleanupGuard, "
+        "FirstExceptionRecorder); the only others are the documented "
+        "translation boundaries (py_error_on_exception, retained_error_message, "
+        "the node-phase error prefix). A new bare catch(...) is a boundary "
+        "without a name: use a helper or document the boundary",
+    ),
     # --- Python-object handling stays behind an ops table (family 6) ---
     Ratchet(
         id="python-object-hash-units",

--- a/src/hgraph/lib/std/operators/json_impl.cpp
+++ b/src/hgraph/lib/std/operators/json_impl.cpp
@@ -1,4 +1,5 @@
 #include <hgraph/lib/std/operators/impl/json_impl.h>
+#include <hgraph/util/scope.h>
 #include <hgraph/types/time_series/visitor.h>
 #include <hgraph/types/value/visitor.h>
 
@@ -577,8 +578,7 @@ namespace hgraph::stdlib::json_tree
     {
         auto current = Access::try_element(*this);
         if (!current.has_value()) { return std::nullopt; }
-        try
-        {
+        return fallback_on_exception(std::optional<Int>{}, [&]() -> std::optional<Int> {
             if (current->type() == simdjson::dom::element_type::INT64)
             {
                 return static_cast<Int>(static_cast<std::int64_t>(*current));
@@ -591,17 +591,15 @@ namespace hgraph::stdlib::json_tree
                     return static_cast<Int>(value);
                 }
             }
-        }
-        catch (...) { return std::nullopt; }
-        return std::nullopt;
+            return std::nullopt;
+        });
     }
 
     std::optional<Float> JsonValue::as_float() const
     {
         auto current = Access::try_element(*this);
         if (!current.has_value()) { return std::nullopt; }
-        try
-        {
+        return fallback_on_exception(std::optional<Float>{}, [&]() -> std::optional<Float> {
             if (current->type() == simdjson::dom::element_type::DOUBLE)
             {
                 return static_cast<Float>(static_cast<double>(*current));
@@ -614,69 +612,62 @@ namespace hgraph::stdlib::json_tree
             {
                 return static_cast<Float>(static_cast<std::uint64_t>(*current));
             }
-        }
-        catch (...) { return std::nullopt; }
-        return std::nullopt;
+            return std::nullopt;
+        });
     }
 
     std::optional<Str> JsonValue::as_str() const
     {
         auto current = Access::try_element(*this);
         if (!current.has_value()) { return std::nullopt; }
-        try
-        {
+        return fallback_on_exception(std::optional<Str>{}, [&]() -> std::optional<Str> {
             if (current->type() == simdjson::dom::element_type::STRING)
             {
                 return Str{std::string_view(*current)};
             }
-        }
-        catch (...) { return std::nullopt; }
-        return std::nullopt;
+            return std::nullopt;
+        });
     }
 
     std::optional<Bool> JsonValue::as_bool() const
     {
         auto current = Access::try_element(*this);
         if (!current.has_value()) { return std::nullopt; }
-        try
-        {
+        return fallback_on_exception(std::optional<Bool>{}, [&]() -> std::optional<Bool> {
             if (current->type() == simdjson::dom::element_type::BOOL)
             {
                 return Bool{static_cast<bool>(*current)};
             }
-        }
-        catch (...) { return std::nullopt; }
-        return std::nullopt;
+            return std::nullopt;
+        });
     }
 
     std::size_t JsonValue::hash() const noexcept
     {
-        try { return materialize().hash(); }
-        catch (...) { return 0; }
+        return fallback_on_exception(std::size_t{0}, [&] { return materialize().hash(); });
     }
 
     bool JsonValue::operator==(const JsonValue &other) const noexcept
     {
-        try
-        {
+        return fallback_on_exception(false, [&] {
             auto lhs = Access::try_element(*this);
             auto rhs = Access::try_element(other);
             if (lhs.has_value() && rhs.has_value()) { return simdjson_equal(*lhs, *rhs); }
             return materialize().equals(other.materialize());
-        }
-        catch (...) { return false; }
+        });
     }
 
     std::partial_ordering JsonValue::operator<=>(const JsonValue &other) const noexcept
     {
-        try { return materialize().compare(other.materialize()); }
-        catch (...) { return std::partial_ordering::unordered; }
+        return fallback_on_exception(std::partial_ordering::unordered,
+                                     [&] { return materialize().compare(other.materialize()); });
     }
 
     std::ostream &operator<<(std::ostream &out, const JsonValue &value)
     {
-        try { out << value.encode(); }
-        catch (...) { out << "<invalid JSON>"; }
+        static_cast<void>(fallback_on_exception(
+            false, [&] { out << value.encode(); return true; },
+            [&](const char *) { out << "<invalid JSON>"; }));
         return out;
     }
 

--- a/src/hgraph/python/bridge_state.cpp
+++ b/src/hgraph/python/bridge_state.cpp
@@ -1,4 +1,5 @@
 #include <hgraph/python/bridge_state.h>
+#include <hgraph/util/scope.h>
 #include <hgraph/python/native_scalar_registration.h>
 #include <hgraph/python/object_semantics.h>
 
@@ -524,16 +525,14 @@ struct PythonBundleBindingEntry {
         PyErr_Clear();
         return nullptr;
       }
-      try {
-        throw nb::python_error();
-      } catch (...) {
+      annotate_on_exception([] { throw nb::python_error(); }, [&] {
         const char *field_name = self.schema->fields[index].name;
         std::throw_with_nested(std::runtime_error(
             "Python-backed Bundle '" + std::string{self.schema->name()} +
             "' failed to read field '" +
             std::string{field_name != nullptr ? field_name : "<unnamed>"} +
             "'"));
-      }
+      });
     }
     nb::object attribute = nb::steal(raw);
     if (attribute.is_none()) {
@@ -547,9 +546,7 @@ struct PythonBundleBindingEntry {
     if (!fields[index].binding()) {
       fields[index] = Value{self.field_bindings[index]};
     }
-    try {
-      fields[index].view().assign_from_python(attribute);
-    } catch (...) {
+    annotate_on_exception([&] { fields[index].view().assign_from_python(attribute); }, [&] {
       const auto *declared = self.schema->fields[index].type;
       nb::object actual_type = nb::steal(PyObject_Type(attribute.ptr()));
       std::string actual =
@@ -565,7 +562,7 @@ struct PythonBundleBindingEntry {
           "' declared as '" +
           std::string{declared != nullptr ? declared->name() : "<unknown>"} +
           "' cannot convert value of type '" + actual + "'"));
-    }
+    });
     return fields[index].view().data();
   }
 

--- a/src/hgraph/runtime/graph_diagnostics.cpp
+++ b/src/hgraph/runtime/graph_diagnostics.cpp
@@ -1458,8 +1458,9 @@ namespace hgraph
                                 ? TypeRegistry::instance().ts(scalar_schema)
                                 : nullptr,
                             table_projections, resolver, resolver_context);
-                    return true;
-                }));
+                        return true;
+                    },
+                    [&](const char *message) { entry.scalars.error = message; }));
             }
         }
 

--- a/src/hgraph/runtime/graph_diagnostics.cpp
+++ b/src/hgraph/runtime/graph_diagnostics.cpp
@@ -1,4 +1,5 @@
 #include <hgraph/runtime/graph_diagnostics.h>
+#include <hgraph/util/scope.h>
 
 #include <hgraph/runtime/diagnostic_path.h>
 #include <hgraph/runtime/executor.h>
@@ -503,18 +504,13 @@ namespace hgraph
             }
 
             DiagnosticTableProjectionResult result;
-            try
-            {
-                result.projection = diagnostic_table_projection(schema);
-            }
-            catch (const std::exception &error)
-            {
-                result.error = error.what();
-            }
-            catch (...)
-            {
-                result.error = "unknown conversion-plan failure";
-            }
+            static_cast<void>(fallback_on_exception(
+                false,
+                [&] {
+                    result.projection = diagnostic_table_projection(schema);
+                    return true;
+                },
+                [&](const char *message) { result.error = message; }));
             return cache.emplace(schema, std::move(result)).first->second;
         }
 
@@ -1151,62 +1147,54 @@ namespace hgraph
             {
                 target.schema_label = label;
             }
-            try
-            {
-                ValueView concrete = value.concrete();
-                if (concrete.valid() && concrete.holds_alternative<Frame>())
-                {
-                    target.frame = concrete.checked_as<Frame>();
-                }
-                target.json = diagnostic_json(value, evaluation_time, &target,
-                                              resolver, resolver_context);
-                if (!target.frame.has_value() && ts_schema != nullptr)
-                {
-                    try
+            static_cast<void>(fallback_on_exception(
+                false,
+                [&] {
+                    ValueView concrete = value.concrete();
+                    if (concrete.valid() && concrete.holds_alternative<Frame>())
                     {
-                        const auto &projection_result =
-                            cached_diagnostic_table_projection(
-                                table_projections, ts_schema);
-                        if (projection_result.projection == nullptr)
-                        {
-                            throw std::logic_error(projection_result.error);
-                        }
-                        const auto &projection = *projection_result.projection;
-                        Value materialized;
-                        if (!target.json.empty() && target.json != "null")
-                        {
-                            materialized = from_json_string(
-                                *projection.json_converter, target.json);
-                        }
-                        target.frame = diagnostic_table_frame(
-                            projection, materialized.view());
+                        target.frame = concrete.checked_as<Frame>();
                     }
-                    catch (const std::exception &error)
+                    target.json = diagnostic_json(value, evaluation_time, &target,
+                                                  resolver, resolver_context);
+                    if (!target.frame.has_value() && ts_schema != nullptr)
                     {
                         // JSON remains the universally available owned view.
                         // A schema that has no released tabular form simply
                         // omits the optional Frame instead of making the row
                         // itself unavailable.
-                        target.frame = {};
-                        target.table_error = error.what();
+                        static_cast<void>(fallback_on_exception(
+                            false,
+                            [&] {
+                                const auto &projection_result =
+                                    cached_diagnostic_table_projection(
+                                        table_projections, ts_schema);
+                                if (projection_result.projection == nullptr)
+                                {
+                                    throw std::logic_error(projection_result.error);
+                                }
+                                const auto &projection = *projection_result.projection;
+                                Value materialized;
+                                if (!target.json.empty() && target.json != "null")
+                                {
+                                    materialized = from_json_string(
+                                        *projection.json_converter, target.json);
+                                }
+                                target.frame = diagnostic_table_frame(
+                                    projection, materialized.view());
+                                return true;
+                            },
+                            [&](const char *message) {
+                                target.frame = {};
+                                target.table_error = message;
+                            }));
                     }
-                    catch (...)
-                    {
-                        target.frame = {};
-                        target.table_error = "unknown conversion failure";
-                    }
-                }
-            }
-            catch (const std::exception &error)
-            {
-                target.json.clear();
-                target.error = error.what();
-            }
-            catch (...)
-            {
-                target.json.clear();
-                target.error = "value rendering failed";
-            }
+                    return true;
+                },
+                [&](const char *message) {
+                    target.json.clear();
+                    target.error = message;
+                }));
         }
 
         [[nodiscard]] std::vector<std::string> python_input_names(
@@ -1305,31 +1293,27 @@ namespace hgraph
             target.json.push_back('}');
             internal_json.push_back('}');
 
-            try
-            {
-                const auto &projection_result =
-                    cached_diagnostic_table_projection(
-                        table_projections, packed.schema());
-                if (projection_result.projection == nullptr)
-                {
-                    throw std::logic_error(projection_result.error);
-                }
-                const auto &projection = *projection_result.projection;
-                Value materialized = from_json_string(
-                    *projection.json_converter, internal_json);
-                target.frame = diagnostic_table_frame(
-                    projection, materialized.view());
-            }
-            catch (const std::exception &error)
-            {
-                target.frame = {};
-                target.table_error = error.what();
-            }
-            catch (...)
-            {
-                target.frame = {};
-                target.table_error = "unknown conversion failure";
-            }
+            static_cast<void>(fallback_on_exception(
+                false,
+                [&] {
+                    const auto &projection_result =
+                        cached_diagnostic_table_projection(
+                            table_projections, packed.schema());
+                    if (projection_result.projection == nullptr)
+                    {
+                        throw std::logic_error(projection_result.error);
+                    }
+                    const auto &projection = *projection_result.projection;
+                    Value materialized = from_json_string(
+                        *projection.json_converter, internal_json);
+                    target.frame = diagnostic_table_frame(
+                        projection, materialized.view());
+                    return true;
+                },
+                [&](const char *message) {
+                    target.frame = {};
+                    target.table_error = message;
+                }));
             if (!target.frame.has_value()) { return true; }
 
             std::vector<std::string> columns =
@@ -1374,124 +1358,108 @@ namespace hgraph
             const DateTime evaluation_time = node.graph().evaluation_time();
             if (entry.input.available)
             {
-                try
-                {
-                    TSInputView input = node.input(evaluation_time);
-                    entry.input.target_node_ids.clear();
-                    entry.input.targets.clear();
-                    entry.input.bound_targets.clear();
-                    const bool projected =
-                        entry.implementation_label.starts_with("hgraph.python.") &&
-                        capture_python_input(
-                            entry.input, input, python_input_names(node),
-                            evaluation_time, table_projections, resolver,
-                            resolver_context);
-                    if (!projected)
-                    {
-                        capture_bound_targets(
-                            entry.input.bound_targets, resolver,
-                            resolver_context, input);
-                        capture_reference_targets(
-                            entry.input, input.reference(), evaluation_time,
-                            resolver, resolver_context);
-                        capture_value(
-                            entry.input, input.value(), input.valid(),
-                            input.last_modified_time(), evaluation_time,
-                            input.schema(), table_projections, nullptr, nullptr);
-                    }
-                }
-                catch (const std::exception &error)
-                {
-                    entry.input.error = error.what();
-                }
-                catch (...)
-                {
-                    entry.input.error = "input rendering failed";
-                }
+                static_cast<void>(fallback_on_exception(
+                    false,
+                    [&] {
+                        TSInputView input = node.input(evaluation_time);
+                        entry.input.target_node_ids.clear();
+                        entry.input.targets.clear();
+                        entry.input.bound_targets.clear();
+                        const bool projected =
+                            entry.implementation_label.starts_with("hgraph.python.") &&
+                            capture_python_input(
+                                entry.input, input, python_input_names(node),
+                                evaluation_time, table_projections, resolver,
+                                resolver_context);
+                        if (!projected)
+                        {
+                            capture_bound_targets(
+                                entry.input.bound_targets, resolver,
+                                resolver_context, input);
+                            capture_reference_targets(
+                                entry.input, input.reference(), evaluation_time,
+                                resolver, resolver_context);
+                            capture_value(
+                                entry.input, input.value(), input.valid(),
+                                input.last_modified_time(), evaluation_time,
+                                input.schema(), table_projections, nullptr, nullptr);
+                        }
+                        return true;
+                    },
+                    [&](const char *message) { entry.input.error = message; }));
             }
             if (entry.output.available)
             {
-                try
-                {
-                    TSOutputView output = node.output(evaluation_time);
-                    entry.output.target_node_ids.clear();
-                    entry.output.targets.clear();
-                    entry.output.bound_targets.clear();
-                    capture_value(entry.output, output.value(), output.valid(),
-                                  output.last_modified_time(), evaluation_time,
-                                  output.schema(),
-                                  table_projections,
-                                  resolver, resolver_context);
-                }
-                catch (const std::exception &error)
-                {
-                    entry.output.error = error.what();
-                }
-                catch (...)
-                {
-                    entry.output.error = "output rendering failed";
-                }
+                static_cast<void>(fallback_on_exception(
+                    false,
+                    [&] {
+                        TSOutputView output = node.output(evaluation_time);
+                        entry.output.target_node_ids.clear();
+                        entry.output.targets.clear();
+                        entry.output.bound_targets.clear();
+                        capture_value(entry.output, output.value(), output.valid(),
+                                      output.last_modified_time(), evaluation_time,
+                                      output.schema(),
+                                      table_projections,
+                                      resolver, resolver_context);
+                        return true;
+                    },
+                    [&](const char *message) { entry.output.error = message; }));
             }
             if (entry.scalars.available)
             {
-                try
-                {
-                    ValueView scalars = node.scalars();
-                    entry.scalars.target_node_ids.clear();
-                    entry.scalars.targets.clear();
-                    entry.scalars.bound_targets.clear();
-                    // Python node representations carry bridge callables and
-                    // lifecycle configuration alongside the user-authored
-                    // scalar arguments.  Released inspector SCALARS exposes
-                    // only that nested user scalar bundle; bridge machinery
-                    // is neither user API nor JSON-renderable graph data.
-                    if (entry.implementation_label.starts_with("hgraph.python."))
-                    {
-                        auto bundle = scalars.try_as_bundle();
-                        if (bundle.has_value() && bundle->has_field("scalars"))
+                static_cast<void>(fallback_on_exception(
+                    false,
+                    [&] {
+                        ValueView scalars = node.scalars();
+                        entry.scalars.target_node_ids.clear();
+                        entry.scalars.targets.clear();
+                        entry.scalars.bound_targets.clear();
+                        // Python node representations carry bridge callables and
+                        // lifecycle configuration alongside the user-authored
+                        // scalar arguments.  Released inspector SCALARS exposes
+                        // only that nested user scalar bundle; bridge machinery
+                        // is neither user API nor JSON-renderable graph data.
+                        if (entry.implementation_label.starts_with("hgraph.python."))
                         {
-                            ValueView user_scalars = bundle->at("scalars");
-                            if (auto user_bundle = user_scalars.try_as_bundle();
-                                user_bundle.has_value() && user_bundle->size() == 0)
+                            auto bundle = scalars.try_as_bundle();
+                            if (bundle.has_value() && bundle->has_field("scalars"))
                             {
-                                entry.scalars.available = false;
-                                entry.scalars.valid = false;
-                                entry.scalars.json.clear();
-                                entry.scalars.error.clear();
-                                entry.scalars.table_error.clear();
-                                entry.scalars.frame = {};
-                                return;
+                                ValueView user_scalars = bundle->at("scalars");
+                                if (auto user_bundle = user_scalars.try_as_bundle();
+                                    user_bundle.has_value() && user_bundle->size() == 0)
+                                {
+                                    entry.scalars.available = false;
+                                    entry.scalars.valid = false;
+                                    entry.scalars.json.clear();
+                                    entry.scalars.error.clear();
+                                    entry.scalars.table_error.clear();
+                                    entry.scalars.frame = {};
+                                    return true;
+                                }
+                                const auto *scalar_schema = user_scalars.schema();
+                                capture_value(
+                                    entry.scalars, std::move(user_scalars),
+                                    scalar_schema != nullptr, MIN_DT, evaluation_time,
+                                    scalar_schema != nullptr
+                                        ? TypeRegistry::instance().ts(scalar_schema)
+                                        : nullptr,
+                                    table_projections, resolver, resolver_context);
+                                return true;
                             }
-                            const auto *scalar_schema = user_scalars.schema();
-                            capture_value(
-                                entry.scalars, std::move(user_scalars),
-                                scalar_schema != nullptr, MIN_DT, evaluation_time,
-                                scalar_schema != nullptr
-                                    ? TypeRegistry::instance().ts(scalar_schema)
-                                    : nullptr,
-                                table_projections, resolver, resolver_context);
-                            return;
                         }
-                    }
 
-                    const bool valid = scalars.valid();
-                    const auto *scalar_schema = scalars.schema();
-                    capture_value(
-                        entry.scalars, std::move(scalars), valid, MIN_DT,
-                        evaluation_time,
-                        scalar_schema != nullptr
-                            ? TypeRegistry::instance().ts(scalar_schema)
-                            : nullptr,
-                        table_projections, resolver, resolver_context);
-                }
-                catch (const std::exception &error)
-                {
-                    entry.scalars.error = error.what();
-                }
-                catch (...)
-                {
-                    entry.scalars.error = "scalar rendering failed";
-                }
+                        const bool valid = scalars.valid();
+                        const auto *scalar_schema = scalars.schema();
+                        capture_value(
+                            entry.scalars, std::move(scalars), valid, MIN_DT,
+                            evaluation_time,
+                            scalar_schema != nullptr
+                                ? TypeRegistry::instance().ts(scalar_schema)
+                                : nullptr,
+                            table_projections, resolver, resolver_context);
+                    return true;
+                }));
             }
         }
 

--- a/src/hgraph/runtime/node.cpp
+++ b/src/hgraph/runtime/node.cpp
@@ -1613,8 +1613,8 @@ namespace hgraph
             result.dynamic_live_bytes += metrics.live_bytes;
             result.dynamic_reserved_bytes += metrics.reserved_bytes;
         };
-        try
-        {
+        // Graph diagnostics are cold-path and must not affect graph execution.
+        static_cast<void>(fallback_on_exception(false, [&] {
             if (has_state()) { add_value_storage(state()); }
             if (has_scalars()) { add_value_storage(scalars()); }
             if (has_input())
@@ -1626,11 +1626,8 @@ namespace hgraph
             if (has_output()) { add_ts_output_storage(output(MIN_DT)); }
             if (has_error_output()) { add_ts_output_storage(error_output(MIN_DT)); }
             if (has_recordable_state()) { add_ts_output_storage(recordable_state(MIN_DT)); }
-        }
-        catch (...)
-        {
-            // Graph diagnostics are cold-path and must not affect graph execution.
-        }
+            return true;
+        }));
         return result;
     }
 

--- a/src/hgraph/types/frame.cpp
+++ b/src/hgraph/types/frame.cpp
@@ -1,4 +1,5 @@
 #include <hgraph/types/frame.h>
+#include <hgraph/util/scope.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/static_schema.h>
 #include <hgraph/types/value/json_codec.h>
@@ -315,8 +316,7 @@ namespace hgraph
 
     bool frame_metadata_equal(const Frame &lhs, const Frame &rhs) noexcept
     {
-        try
-        {
+        return fallback_on_exception(false, [&] {
             auto lhs_entries = hgraph_metadata_entries(lhs);
             auto rhs_entries = hgraph_metadata_entries(rhs);
             const auto lhs_schema = lhs_entries.find(std::string{frame_metadata_schema_key});
@@ -329,11 +329,7 @@ namespace hgraph
             lhs_entries.erase(std::string{frame_metadata_schema_key});
             rhs_entries.erase(std::string{frame_metadata_schema_key});
             return lhs_entries == rhs_entries;
-        }
-        catch (...)
-        {
-            return false;
-        }
+        });
     }
 
     Frame without_frame_metadata(Frame frame)

--- a/src/hgraph/types/graph_wiring.cpp
+++ b/src/hgraph/types/graph_wiring.cpp
@@ -2038,101 +2038,92 @@ void Wiring::build_services() {
   }
   impl_->building_services = true;
   const auto reset_building = [this] { impl_->building_services = false; };
-  try {
+  auto reset = make_scope_exit([&] { reset_building(); });
   bool progress = true;
   while (progress) {
-    progress = false;
+  progress = false;
 
-    // Ordinary exact-path candidates form the recursive fixed point. Mark a
-    // candidate before invoking it so a recursively requested sibling cannot
-    // materialize the same multi-interface implementation twice.
+  // Ordinary exact-path candidates form the recursive fixed point. Mark a
+  // candidate before invoking it so a recursively requested sibling cannot
+  // materialize the same multi-interface implementation twice.
+  for (std::size_t i = 0; i < impl_->service_candidates.size(); ++i) {
+    auto &candidate = impl_->service_candidates[i];
+    if (candidate.materialized || candidate.catch_all || candidate.default_fallback) {
+      continue;
+    }
+    const bool requested = std::ranges::any_of(
+        candidate.paths, [&](const std::string &path) {
+          return impl_->client_service_paths.contains(path) &&
+                 !impl_->built_service_paths.contains(path);
+        });
+    if (!requested) {
+      continue;
+    }
+    candidate.materialized = true;
+    auto materialize = candidate.materialize;
+    materialize(*this);
+    progress = true;
+  }
+
+  // Exact registrations take precedence. For every remaining concrete
+  // request, materialize the matching interface-default candidate at that
+  // requested path, once per path/specialization.
+  const auto clients = service_client_paths();
+  for (const auto &[path, _kind] : clients) {
+    if (impl_->built_service_paths.contains(path) ||
+        impl_->service_candidate_paths.contains(path)) {
+      continue;
+    }
     for (std::size_t i = 0; i < impl_->service_candidates.size(); ++i) {
       auto &candidate = impl_->service_candidates[i];
-      if (candidate.materialized || candidate.catch_all || candidate.default_fallback) {
+      if (!candidate.default_fallback) {
         continue;
       }
-      const bool requested = std::ranges::any_of(
-          candidate.paths, [&](const std::string &path) {
-            return impl_->client_service_paths.contains(path) &&
-                   !impl_->built_service_paths.contains(path);
+      const auto selector = std::ranges::find_if(
+          candidate.path_selectors, [&](const auto &value) {
+            return path.starts_with(value.first) && path.ends_with(value.second) &&
+                   path.size() >= value.first.size() + value.second.size();
           });
-      if (!requested) {
-        continue;
+      if (selector == candidate.path_selectors.end()) { continue; }
+      const std::string concrete_user_path = path.substr(
+          selector->first.size(),
+          path.size() - selector->first.size() - selector->second.size());
+      if (candidate.materialized_paths.contains(concrete_user_path)) { continue; }
+      for (const auto &[prefix, suffix] : candidate.path_selectors) {
+        const std::string sibling_path = prefix + concrete_user_path + suffix;
+        if (const auto exact = impl_->service_candidate_paths.find(sibling_path);
+            exact != impl_->service_candidate_paths.end()) {
+          throw std::invalid_argument(
+              "default multi-interface implementation '" + candidate.description +
+              "' overlaps exact implementation '" +
+              impl_->service_candidates[exact->second].description +
+              "' at '" + sibling_path + "'");
+        }
       }
-      candidate.materialized = true;
-      auto materialize = candidate.materialize;
-      materialize(*this);
+      candidate.materialized_paths.insert(concrete_user_path);
+      auto materialize = candidate.materialize_default;
+      impl_->service_materialization_path = path;
+      auto clear_path =
+          make_scope_exit([&] { impl_->service_materialization_path.clear(); });
+      materialize(*this, path);
       progress = true;
-    }
-
-    // Exact registrations take precedence. For every remaining concrete
-    // request, materialize the matching interface-default candidate at that
-    // requested path, once per path/specialization.
-    const auto clients = service_client_paths();
-    for (const auto &[path, _kind] : clients) {
-      if (impl_->built_service_paths.contains(path) ||
-          impl_->service_candidate_paths.contains(path)) {
-        continue;
-      }
-      for (std::size_t i = 0; i < impl_->service_candidates.size(); ++i) {
-        auto &candidate = impl_->service_candidates[i];
-        if (!candidate.default_fallback) {
-          continue;
-        }
-        const auto selector = std::ranges::find_if(
-            candidate.path_selectors, [&](const auto &value) {
-              return path.starts_with(value.first) && path.ends_with(value.second) &&
-                     path.size() >= value.first.size() + value.second.size();
-            });
-        if (selector == candidate.path_selectors.end()) { continue; }
-        const std::string concrete_user_path = path.substr(
-            selector->first.size(),
-            path.size() - selector->first.size() - selector->second.size());
-        if (candidate.materialized_paths.contains(concrete_user_path)) { continue; }
-        for (const auto &[prefix, suffix] : candidate.path_selectors) {
-          const std::string sibling_path = prefix + concrete_user_path + suffix;
-          if (const auto exact = impl_->service_candidate_paths.find(sibling_path);
-              exact != impl_->service_candidate_paths.end()) {
-            throw std::invalid_argument(
-                "default multi-interface implementation '" + candidate.description +
-                "' overlaps exact implementation '" +
-                impl_->service_candidates[exact->second].description +
-                "' at '" + sibling_path + "'");
-          }
-        }
-        candidate.materialized_paths.insert(concrete_user_path);
-        auto materialize = candidate.materialize_default;
-        impl_->service_materialization_path = path;
-        try {
-          materialize(*this, path);
-          impl_->service_materialization_path.clear();
-        } catch (...) {
-          impl_->service_materialization_path.clear();
-          throw;
-        }
-        progress = true;
-        break;
-      }
-    }
-
-    // Catch-all registrations are ordinary implementation graphs which inspect
-    // the complete demand ledger themselves. Compose each once, matching the
-    // reference engine; rewiring the same graph for later clients is invalid.
-    for (std::size_t i = 0; i < impl_->service_candidates.size(); ++i) {
-      auto &candidate = impl_->service_candidates[i];
-      if (!candidate.catch_all || candidate.materialized) {
-        continue;
-      }
-      candidate.materialized = true;
-      auto materialize = candidate.materialize;
-      materialize(*this);
-      progress = true;
+      break;
     }
   }
-  reset_building();
-  } catch (...) {
-    reset_building();
-    throw;
+
+  // Catch-all registrations are ordinary implementation graphs which inspect
+  // the complete demand ledger themselves. Compose each once, matching the
+  // reference engine; rewiring the same graph for later clients is invalid.
+  for (std::size_t i = 0; i < impl_->service_candidates.size(); ++i) {
+    auto &candidate = impl_->service_candidates[i];
+    if (!candidate.catch_all || candidate.materialized) {
+      continue;
+    }
+    candidate.materialized = true;
+    auto materialize = candidate.materialize;
+    materialize(*this);
+    progress = true;
+  }
   }
 }
 

--- a/src/hgraph/types/time_series/ts_data/base_view.cpp
+++ b/src/hgraph/types/time_series/ts_data/base_view.cpp
@@ -1,4 +1,5 @@
 #include <hgraph/types/time_series/ts_data.h>
+#include <hgraph/util/scope.h>
 
 #include <hgraph/runtime/graph.h>
 #include <hgraph/runtime/node.h>
@@ -18,7 +19,7 @@ DynamicStorageMetrics observer_storage_metrics(const TSDataView &view) noexcept 
   if (!view.valid()) {
     return {};
   }
-  try {
+  return fallback_on_exception(DynamicStorageMetrics{}, [&] {
     DynamicStorageMetrics result =
         view.tracking().observers.dynamic_storage_metrics();
     const auto &table = view.ops();
@@ -38,9 +39,7 @@ DynamicStorageMetrics observer_storage_metrics(const TSDataView &view) noexcept 
       result += observer_storage_metrics(TSDataView{child.type, child.data});
     }
     return result;
-  } catch (...) {
-    return {};
-  }
+  });
 }
 } // namespace
 
@@ -219,13 +218,11 @@ DynamicStorageMetrics TSDataView::dynamic_storage_metrics() const noexcept {
   if (!valid()) {
     return {};
   }
-  try {
+  return fallback_on_exception(DynamicStorageMetrics{}, [&] {
     const auto &table = ops();
     return table.dynamic_storage_metrics_impl(table.context, data()) +
            observer_storage_metrics(*this);
-  } catch (...) {
-    return {};
-  }
+  });
 }
 
 std::size_t TSDataView::indexed_child_count() const {

--- a/src/hgraph/types/time_zone_provider.cpp
+++ b/src/hgraph/types/time_zone_provider.cpp
@@ -1,4 +1,5 @@
 #include <hgraph/types/temporal.h>
+#include <hgraph/util/scope.h>
 
 #include <hgraph/runtime/global_state.h>
 #include <hgraph/types/metadata/type_registry.h>
@@ -286,8 +287,7 @@ namespace hgraph
 
             [[nodiscard]] bool contains(ZoneId zone) const noexcept override
             {
-                try { return locate(zone) != nullptr; }
-                catch (...) { return false; }
+                return fallback_on_exception(false, [&] { return locate(zone) != nullptr; });
             }
 
             [[nodiscard]] OffsetInfo at(
@@ -380,14 +380,7 @@ namespace hgraph
 
             [[nodiscard]] bool contains(ZoneId zone) const noexcept override
             {
-                try
-                {
-                    return locate(zone) != nullptr;
-                }
-                catch (...)
-                {
-                    return false;
-                }
+                return fallback_on_exception(false, [&] { return locate(zone) != nullptr; });
             }
 
             [[nodiscard]] OffsetInfo at(

--- a/src/hgraph/types/utils/stable_slot_store.cpp
+++ b/src/hgraph/types/utils/stable_slot_store.cpp
@@ -1,4 +1,5 @@
 #include <hgraph/types/utils/stable_slot_store.h>
+#include <hgraph/util/scope.h>
 
 #include <cassert>
 #include <memory>
@@ -17,12 +18,10 @@ namespace hgraph
             static_assert(alignof(Implementation) > detail::STABLE_SLOT_STORE_IMPLEMENTATION_TAG_MASK);
             const auto &plan = MemoryUtils::plan_for<Implementation>();
             void *storage = allocator.allocate_storage(plan.layout);
-            try {
-                std::construct_at(static_cast<Implementation *>(storage), layout, allocator);
-            } catch (...) {
-                allocator.deallocate_storage(storage, plan.layout);
-                throw;
-            }
+            auto release_storage =
+                UnwindCleanupGuard([&] { allocator.deallocate_storage(storage, plan.layout); });
+            std::construct_at(static_cast<Implementation *>(storage), layout, allocator);
+            release_storage.release();
 
             const auto address = reinterpret_cast<std::uintptr_t>(storage);
             assert((address & detail::STABLE_SLOT_STORE_IMPLEMENTATION_TAG_MASK) == 0);

--- a/src/hgraph/types/value/compact_container_ops.cpp
+++ b/src/hgraph/types/value/compact_container_ops.cpp
@@ -26,14 +26,7 @@ namespace hgraph
         {
             if (!binding || !source) { return false; }
             if (binding.schema() == source.schema() || binding.plan() == source.plan()) { return true; }
-            try
-            {
-                return TypeRegistry::instance().value_is_a(source.schema(), binding.schema());
-            }
-            catch (...)
-            {
-                return false;
-            }
+            return TypeRegistry::instance().value_is_a(source.schema(), binding.schema());
         }
 
         void compact_list_copy_assign_from(const void *, ValueTypeRef binding, void *dst, ValueTypeRef source,

--- a/src/hgraph/types/value/shared_value_pool.cpp
+++ b/src/hgraph/types/value/shared_value_pool.cpp
@@ -1,4 +1,5 @@
 #include <hgraph/types/value/shared_value_pool.h>
+#include <hgraph/util/scope.h>
 
 #include "impl/lock_free_freelist.h"
 
@@ -150,19 +151,18 @@ private:
     };
     void *memory = MemoryUtils::allocator().allocate_storage(layout);
     std::size_t constructed = 0;
-    try {
-      for (; constructed < slots_per_slab_; ++constructed) {
-        ::new (allocation_at(memory, constructed))
-            SharedValueAllocation{.owner = this};
-      }
-      slabs_.push_back(Slab{memory, layout, slots_per_slab_});
-    } catch (...) {
+    auto rollback = UnwindCleanupGuard([&] {
       for (std::size_t index = 0; index < constructed; ++index) {
         allocation_at(memory, index)->~SharedValueAllocation();
       }
       MemoryUtils::allocator().deallocate_storage(memory, layout);
-      throw;
+    });
+    for (; constructed < slots_per_slab_; ++constructed) {
+      ::new (allocation_at(memory, constructed))
+          SharedValueAllocation{.owner = this};
     }
+    slabs_.push_back(Slab{memory, layout, slots_per_slab_});
+    rollback.release();
 
     slabs_count_.fetch_add(1, std::memory_order_relaxed);
     capacity_.fetch_add(slots_per_slab_, std::memory_order_relaxed);


### PR DESCRIPTION
## Summary

Stacked on #663. Review item from the fix-series work: there were naked `try`/`catch (...)` blocks across the runtime that restated, by hand, one of the forms `util/scope.h` already names. AGENTS.md asks for the scope guards; this makes it so and pins it.

- **24 blocks converted** in 13 files, each to the helper that names its behaviour:
  - `fallback_on_exception(fallback, f)` — noexcept queries with a domain fallback: JSON `as_int/as_float/as_str/as_bool/hash/==/<=>`, time-zone `contains` (both providers), frame metadata equality, TSData storage metrics (two), node storage diagnostics, the lifted `map_` TSL output resolver.
  - `fallback_on_exception(fallback, f, on_error)` — the seven graph-diagnostics renderers that record an error string, JSON `operator<<`, and `object_compare` (the `PyErr_Clear` case).
  - `UnwindCleanupGuard` — construction rollback in `stable_slot_store` and the shared-value slab allocator.
  - `make_scope_exit` — clearing the service-materialisation path and `building_services` however `build_services` ends.
  - `annotate_on_exception` — the two Python-owned Bundle field errors that rethrow with `std::throw_with_nested`.
  - `compact_accepts_source` dropped its guard entirely: `value_is_a` is `noexcept` since #658.
- **What remains is intentional**: the six forms inside `scope.h` and three documented translation boundaries (`py_error_on_exception`, `retained_error_message`, the node-phase error prefix in `graph.cpp`). A new ratchet `catch-all-sites` pins the count at 9.
- **Design record**: `architecture.rst` gains "Named exception boundaries" (which form to reach for, and why a new bare `catch (...)` is a design question); `testing.rst` lists the ratchet.

## Behaviour

No functional change except one wording: a non-`std::exception` in the diagnostics renderers now reports the helper's `"unknown error"` rather than a per-site string. No test pinned those strings.

## Verification

- C++: 1675 cases / 257213 assertions green (`hgraph_unit_tests`).
- Python-enabled core compiles (`cmake-build-python-user-nodes`, `_hgraph`); Python suite run on the branch below.
- Ratchet report: `catch-all-sites: 9 (baseline 9)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
