### PR TITLE
Reverse binding: one registry with its own reset, shadow dictionaries gone (RFC 0033, PR C)

### DIFF
--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -373,8 +373,23 @@ the registry matches it against a ``TypeArg`` parameter's carried pattern
 back to resolvers, ``requires`` and the wire trampoline as the type it
 carries (a ``TsType``, the Python annotation of a scalar schema through
 ``python_type_for_value``, or a plain size). The remaining Python-side
-carrier rules (subscripts, collectors, the shadow dictionaries) retire in
-the RFC's later stages.
+carrier rules (subscripts, collectors) retire in the RFC's later stages.
+
+**Reverse binding** (RFC 0033, PR C). ``python_type_for_value`` is the one
+schema-to-Python-type authority. It consults the bridge's
+``python_type_registry()`` first -- the annotation the DSL wrote for a
+schema, recorded by ``_value_type`` through ``_hgraph.bind_python_type``
+for every schema it produces, the most recent registration wins -- and only then the
+opaque, native-scalar, Bundle, enum and builtin lookups, which cannot
+rebuild a parameterised generic such as ``tuple[int, ...]`` or an alias.
+The registry owns its reset entry point, ``clear_python_type_registry``,
+which ``reset_registries`` calls beside the other bridge registries;
+registration never resets anything as a side effect. This replaced the two
+Python-side shadow dictionaries (``_TS_SCALAR_TYPES`` /
+``_VALUE_SCALAR_TYPES``), which were keyed by native handles and never
+cleared -- a handle recycled after a reset could alias a new schema to an
+old annotation. ``ResolutionScope.materialise(pattern)`` resolves a
+deferred type argument's default in a scope and projects it the same way.
 
 Python-defined operators register under ``__pyop__{qualname}_{id:x}`` — the
 id-suffix exists because the C++ operator registry is process-global and

--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -388,8 +388,14 @@ registration never resets anything as a side effect. This replaced the two
 Python-side shadow dictionaries (``_TS_SCALAR_TYPES`` /
 ``_VALUE_SCALAR_TYPES``), which were keyed by native handles and never
 cleared -- a handle recycled after a reset could alias a new schema to an
-old annotation. ``ResolutionScope.materialise(pattern)`` resolves a
-deferred type argument's default in a scope and projects it the same way.
+old annotation. A structural schema that no annotation produced -- a bound
+variable inside ``tuple[K, ...]`` resolved by the matcher -- reads back as
+the canonical spelling rebuilt from its elements (``tuple[T, ...]``,
+``tuple[A, B]``, ``frozenset[T]``, ``dict[K, V]``), the spellings the
+full-value projection already uses; an element the registries cannot name
+keeps the schema handle. ``ResolutionScope.materialise(pattern)`` resolves
+a deferred type argument's default in a scope -- a ``TypePattern``,
+``ScalarPattern`` or ``SizePattern`` -- and projects it the same way.
 
 Python-defined operators register under ``__pyop__{qualname}_{id:x}`` — the
 id-suffix exists because the C++ operator registry is process-global and

--- a/docs/source/developer_guide/testing.rst
+++ b/docs/source/developer_guide/testing.rst
@@ -208,7 +208,9 @@ Each entry names the layer that owns the rule:
   mode is fixed when the node is built;
 * Python wiring choosing a type carrier by operator name, or keeping a shadow
   schema-to-Python-type dictionary, when the resolver and the registry own
-  both;
+  both (the dictionaries are gone since RFC 0033's PR C: the bridge's
+  reverse-binding registry is the one schema-to-annotation authority, and
+  the ratchet holds it at zero);
 * a second or third ancestry walker beside ``TypeRegistry::value_is_a``;
 * operators recomputing ``value_type_for_active_realization`` instead of
   reading the binding from their bound views;
@@ -276,7 +278,8 @@ oracle: the sweep wires the same consumer two ways and requires identical
    lattice and the bare-subscript pinning order of each decorator kind. Its
    oracle is *pinned current behaviour*: the carrier rules live once per
    decorator kind in Python wiring today (seven subscript rules, three
-   type-variable collectors, two shadow schema dictionaries) and the
+   type-variable collectors; the two shadow schema dictionaries were the
+   first to go, in PR C) and the
    type-carrier blueprint moves the matching into the C++ resolver in stages,
    so the sweep records every per-kind inconsistency (``blueprint risk N``
    comments) and every cell that raises, and each stage is verified against

--- a/docs/source/rfc/rfc_0033_type_carrier_resolution.rst
+++ b/docs/source/rfc/rfc_0033_type_carrier_resolution.rst
@@ -555,10 +555,12 @@ annotation that produced the schema), exposed as
 ``_value_type`` in ``_types.py`` for every schema it produces, not only TS
 payloads. ``python_type_for_value`` consults it first, after the
 ``any -> object`` rule and before the opaque/native/bundle/enum/builtin
-chain. The first registration for a schema wins; a later registration with a
-different object for the same schema is ignored, so aliases
-(``Mapping[str, int]`` after ``dict[str, int]``) are deterministic and the
-sweep's lattice uses canonical spellings.
+chain. The most recent registration for a schema wins, as the dictionaries
+did: one interned schema has many spellings (``Mapping[str, int]``,
+``dict[str, int]``), the sweep pins ``T -> schema -> T`` for the spelling
+written at each site, and ``AUTO_RESOLVE`` hands back the spelling written
+at the site that resolved. (PR C tried first-wins for determinism; it broke
+those pins in any process that had spelled the schema differently earlier.)
 
 The registry owns its own reset entry point, ``clear_python_type_registry()``,
 exactly as the other bridge registries do (``clear_python_bundle_bindings``,
@@ -718,7 +720,7 @@ other cell of the sweep stays green through every PR.
        ``delay``)
    * - Alias annotations for one schema
      - last ``_value_type`` call wins
-     - first wins (PR C)
+     - unchanged (PR C keeps last-wins; see *Reverse binding*)
    * - ``reset_registries()`` then a new schema at a recycled address
      - stale annotation (latent)
      - cleared with the registries; regression test added (PR C)
@@ -932,8 +934,10 @@ Implementation status
 
 Proposed. PR A (#662) merged 2026-09-05 with the sweep and the
 ``wiring-type-carrier-sites`` ratchet. PR B (core matcher, C++ declaration,
-bridge rename and ``match_carrier``) is in review; it records these
-deviations from the text above:
+bridge rename and ``match_carrier``) and PR C (the reverse-binding registry
+with its own reset method, ``ResolutionScope.materialise``, the shadow
+dictionaries deleted and ``types-shadow-schema-dicts`` at zero) are in
+review, stacked; they record these deviations from the text above:
 
 * ``TypeCarrier`` and ``ResolutionKind`` live in
   ``include/hgraph/types/type_carrier.h`` (dependency-free) rather than in

--- a/docs/source/rfc/rfc_0033_type_carrier_resolution.rst
+++ b/docs/source/rfc/rfc_0033_type_carrier_resolution.rst
@@ -949,6 +949,11 @@ review, stacked; they record these deviations from the text above:
 * ``replay`` does not yet declare ``tp``: its C++ implementation takes
   ``(key, recordable_id, model, ...)`` scalars and the Python name table
   still intercepts the positional type; it moves with the table in PR D.
+* ``python_type_for_value`` rebuilds a canonical spelling for a structural
+  schema no annotation produced (review finding on PR C: a
+  ``tuple[K, ...]`` resolved from a bound ``K`` has no registration), so
+  ``ResolutionScope.materialise`` always hands back an annotation; it also
+  accepts a ``SizePattern``.
 * The internal positional ``delay`` caller (``stream_impl.h``) now passes
   ``arg<"delay">(...)``; no other positional ``delay`` call exists in the
   tree (Unresolved question 2 answered for the tree; downstream is a

--- a/include/hgraph/python/bridge_state.h
+++ b/include/hgraph/python/bridge_state.h
@@ -129,6 +129,22 @@ struct HGRAPH_LOCAL NB_EXPORT_SHARED PyBundleClassInfo {
     std::unordered_map<const void *, PyBundleClassInfo> &
     bundle_class_info_registry();
 
+/**
+ * Reverse binding (RFC 0033): the Python annotation each value schema came
+ * from -- ``tuple[int, ...]``, ``Mapping[str, int]``, an alias -- strongly
+ * held so ``python_type_for_value`` can hand back what the DSL wrote, which
+ * the opaque/native/bundle/enum lookups cannot rebuild for parameterised
+ * generics. Written by ``_value_type`` through ``bind_python_type`` for every
+ * schema it produces; the most recent registration for a schema wins (one
+ * interned schema has many spellings, and AUTO_RESOLVE hands back the one
+ * written at the resolving site). Registration never resets anything: the registry owns
+ * its own reset entry point, ``clear_python_type_registry``, which
+ * ``reset_registries`` calls beside the other bridge registries so the
+ * binding dies with the metadata.
+ */
+[[nodiscard]] HGRAPH_EXPORT std::unordered_map<const void *, nb::object> &python_type_registry();
+HGRAPH_EXPORT void clear_python_type_registry() noexcept;
+
 /** Structural ``TSB[CompoundScalar]`` schema -> its scalar Bundle schema.
  * The TS runtime remains structural; this bridge-only association restores the
  * declared Python value class when a Python node reads the complete TSB value.

--- a/python/hgraph/_types.py
+++ b/python/hgraph/_types.py
@@ -35,8 +35,6 @@ _PYTHON_OBJECT_TYPE_CACHE = {}
 _PYTHON_OBJECT_REGISTRATIONS = {}
 _PYTHON_OBJECT_CLASSES = []
 _TSB_SCHEMA_CLASSES = {}
-_TS_SCALAR_TYPES = {}
-_VALUE_SCALAR_TYPES = {}
 _TS_EXPR_CACHE = {}
 _TS_EXPR_CACHE_GENERATION = None
 _OPAQUE_TYPE_CACHE = {}
@@ -1531,7 +1529,29 @@ def resolve_type_alias(annotation):
     raise TypeError(f"type alias {annotation!r} does not resolve (cyclic?)")
 
 
+def _bind_python_type(value_type, scalar):
+    """Record the annotation ``scalar`` that produced ``value_type`` in the
+    bridge's reverse-binding registry (RFC 0033), so ``python_type_for_value``
+    hands back what was written -- a parameterised generic, an alias -- and
+    not only what the registries can rebuild. ``Shared[X]`` binds ``X``:
+    Python receives the concrete value class even though the schema retains
+    its Shared storage. The most recent registration wins (a schema has many
+    spellings; the one written at the resolving site is handed back);
+    ``reset_registries`` clears.
+    """
+    if isinstance(scalar, (_hgraph.ValueType, str)):
+        return
+    python_scalar = scalar.element if isinstance(scalar, _SharedType) else scalar
+    _hgraph.bind_python_type(value_type, python_scalar)
+
+
 def _value_type(scalar):
+    value_type = _value_type_impl(scalar)
+    _bind_python_type(value_type, scalar)
+    return value_type
+
+
+def _value_type_impl(scalar):
     import typing
 
     scalar = resolve_type_alias(scalar)
@@ -2221,9 +2241,9 @@ class _TSMeta(type):
             cached = None
         if cached is not None:
             if isinstance(cached, _TsExpr):
-                python_scalar = scalar.element if isinstance(scalar, _SharedType) else scalar
-                _TS_SCALAR_TYPES[cached.handle] = python_scalar
-                _VALUE_SCALAR_TYPES[_hgraph.ts_value_vt(cached.handle)] = python_scalar
+                # A cache hit still records this site's spelling: the
+                # reverse binding hands back the most recent one (RFC 0033).
+                _bind_python_type(_hgraph.ts_value_vt(cached.handle), scalar)
             return cached
 
         origin = typing.get_origin(scalar)
@@ -2236,10 +2256,6 @@ class _TSMeta(type):
             return expr
         try:
             value_type = _value_type(scalar)
-            # Shared is a storage annotation. Python receives the concrete
-            # value class even though the TS handle retains its Shared schema.
-            python_scalar = scalar.element if isinstance(scalar, _SharedType) else scalar
-            _VALUE_SCALAR_TYPES[value_type] = python_scalar
             expr = _TsExpr(_hgraph.ts(value_type), f"TS[{getattr(scalar, '__name__', scalar)}]")
         except _GenericType as e:
             expr = _GenericTsExpr(
@@ -2252,7 +2268,6 @@ class _TSMeta(type):
             except TypeError:
                 pass
             return expr
-        _TS_SCALAR_TYPES[expr.handle] = python_scalar
         from ._compat import CompoundScalar as _CS
 
         structured_origin = typing.get_origin(scalar) or scalar
@@ -2297,7 +2312,6 @@ class _TSSMeta(type):
     def __getitem__(cls, scalar):
         try:
             value_type = _value_type(scalar)
-            _VALUE_SCALAR_TYPES[value_type] = scalar
             if not value_type.is_hashable or not value_type.is_equatable:
                 raise TypeError(
                     f"TSS element type {scalar!r} must be hashable and equatable")
@@ -2334,7 +2348,6 @@ class _TSDMeta(type):
             if isinstance(value, (_GenericTsExpr, _TypeVarSentinel)):
                 raise _GenericType()
             key_type = _value_type(key)
-            _VALUE_SCALAR_TYPES[key_type] = key
             if not key_type.is_hashable or not key_type.is_equatable:
                 raise TypeError(
                     f"TSD key type {key!r} must be hashable and equatable")
@@ -2654,18 +2667,11 @@ class TimeSeriesSchema:
 
 
 def _value_type_python_type(value_type):
-    python_type = _resolution_value_type(value_type)
+    python_type = _hgraph.python_type_for_value(value_type)
     if isinstance(python_type, _hgraph.ValueType):
         raise TypeError(
             f"native scalar schema {value_type!r} has no Python type binding")
     return python_type
-
-
-def _resolution_value_type(value_type):
-    """Prefer a declared Python scalar, preserving native-only schemas."""
-    python_type = _VALUE_SCALAR_TYPES.get(value_type)
-    return (python_type if python_type is not None
-            else _hgraph.python_type_for_value(value_type))
 
 
 def _time_series_full_value_type(ts_type):
@@ -2683,9 +2689,7 @@ def _time_series_full_value_type(ts_type):
         return _value_type_python_type(
             _hgraph.vt_element(_hgraph.ts_value_vt(handle)))
     if handle.is_ts:
-        python_type = _TS_SCALAR_TYPES.get(handle)
-        return python_type if python_type is not None else _value_type_python_type(
-            _hgraph.ts_value_vt(handle))
+        return _value_type_python_type(_hgraph.ts_value_vt(handle))
     if handle.is_tss:
         element = _value_type_python_type(
             _hgraph.vt_element(_hgraph.ts_value_vt(handle)))

--- a/python/hgraph/_types.py
+++ b/python/hgraph/_types.py
@@ -1545,13 +1545,22 @@ def _bind_python_type(value_type, scalar):
     _hgraph.bind_python_type(value_type, python_scalar)
 
 
+def _records_reverse_binding(produce):
+    """Wrap a schema producer so every schema it returns is recorded against
+    the annotation that produced it (the reverse binding, RFC 0033)."""
+    import functools
+
+    @functools.wraps(produce)
+    def wrapper(scalar):
+        value_type = produce(scalar)
+        _bind_python_type(value_type, scalar)
+        return value_type
+
+    return wrapper
+
+
+@_records_reverse_binding
 def _value_type(scalar):
-    value_type = _value_type_impl(scalar)
-    _bind_python_type(value_type, scalar)
-    return value_type
-
-
-def _value_type_impl(scalar):
     import typing
 
     scalar = resolve_type_alias(scalar)

--- a/python/hgraph/_wiring/_resolution.py
+++ b/python/hgraph/_wiring/_resolution.py
@@ -12,7 +12,7 @@ from functools import lru_cache
 import _hgraph
 
 from .._types import (_TsExpr, _TypeVarSentinel, _pattern_of,
-                      _resolution_value_type, _scalar_pattern,
+                      _scalar_pattern,
                       _type_var_name, _value_type)
 
 
@@ -95,7 +95,7 @@ def _python_value_for_binding(variable, binding):
     kind, value = binding
     name = _type_var_name(variable)
     if kind == "scalar":
-        return _resolution_value_type(value)
+        return _hgraph.python_type_for_value(value)
     if kind == "ts":
         return _TsExpr(value, f"resolved[{name}]")
     if kind == "size":

--- a/python/hgraph/reflection.py
+++ b/python/hgraph/reflection.py
@@ -39,8 +39,6 @@ import _hgraph as _m
 
 from ._types import (
     _TSB_SCHEMA_CLASSES,
-    _TS_SCALAR_TYPES,
-    _VALUE_SCALAR_TYPES,
     _FrameType,
     _TsExpr,
     _is_python_object_class,
@@ -127,11 +125,18 @@ def _wrap(handle):
     return _TsExpr(handle, repr(handle))
 
 
+def _declared_scalar(h):
+    """The annotation a ``TS[S]`` handle's payload was written with, or None
+    when the registry only knows the native schema (RFC 0033 reverse binding)."""
+    declared = _m.python_type_for_value(_m.ts_value_vt(h))
+    return None if isinstance(declared, _m.ValueType) else declared
+
+
 def _vt_to_py(vt):
-    py = _VALUE_SCALAR_TYPES.get(vt, _VT_TO_PY.get(vt))
+    py = _VT_TO_PY.get(vt)
     if py is None:
         reflected = _m.python_type_for_value(vt)
-        if isinstance(reflected, type):
+        if not isinstance(reflected, _m.ValueType):
             py = reflected
     if py is None:
         raise TypeError(
@@ -151,7 +156,7 @@ def scalar_type(t):
     if h.is_tss:
         return _vt_to_py(_m.vt_element(_m.ts_value_vt(h)))
     if h.is_ts:
-        declared = _TS_SCALAR_TYPES.get(h)
+        declared = _declared_scalar(h)
         if declared is not None:
             return declared
         structured_schema = getattr(t, "_structured_schema", None)
@@ -239,7 +244,7 @@ def fields(t):
         return {name: _wrap(field) for name, field in _m.ts_field_types(h)}
     cs = getattr(t, "_cs_class", None)
     if cs is None and h.is_ts:
-        declared = _TS_SCALAR_TYPES.get(h)
+        declared = _declared_scalar(h)
         declared_origin = typing.get_origin(declared) or declared
         if isinstance(declared_origin, type) and (
             (dataclasses.is_dataclass(declared_origin)

--- a/python/module.cpp
+++ b/python/module.cpp
@@ -177,6 +177,7 @@ NB_MODULE(_hgraph, m)
         python_bridge::clear_python_bundle_bindings();
         python_bridge::clear_native_scalar_types();
         python_bridge::clear_python_opaque_types();
+        python_bridge::clear_python_type_registry();   // the reverse binding dies with the metadata
         reset_all_registries();
         ++python_registry_generation;
         stdlib::register_standard_operators();

--- a/python/py_type_system.cpp
+++ b/python/py_type_system.cpp
@@ -51,6 +51,12 @@ namespace hgraph::python_bridge
         {
             return nb::module_::import_("builtins").attr("object");
         }
+        // The annotation the DSL wrote for this schema (RFC 0033 reverse
+        // binding); the only source that can rebuild a parameterised generic.
+        if (const auto bound = python_type_registry().find(meta); bound != python_type_registry().end())
+        {
+            return bound->second;
+        }
         nb::object opaque = python_bridge::python_type_for_opaque(meta);
         if (!opaque.is_none()) { return opaque; }
         nb::object native =
@@ -892,6 +898,19 @@ namespace hgraph::python_bridge
     m.def("python_type_for_value", [](PyValueType value) -> nb::object {
         return python_type_for_value_meta(value.meta);
     });
+    m.def(
+        "bind_python_type",
+        [](PyValueType value, nb::object python_type) {
+            // The most recent registration wins, as the shadow dictionaries
+            // did: a schema has one interned identity but many spellings
+            // (``Mapping[str, int]``, ``dict[str, int]``), and AUTO_RESOLVE
+            // hands back the spelling written at the site that resolved.
+            // Never a reset: clear_python_type_registry is the reset method.
+            if (value.meta == nullptr) { return; }
+            python_type_registry().insert_or_assign(value.meta, std::move(python_type));
+        },
+        nb::arg("value_type"), nb::arg("python_type"),
+        "Record the Python annotation a value schema came from (RFC 0033 reverse binding).");
     register_builtin_native_scalar_types();
     m.def("ts", [](PyValueType v) { return PyTsType{TypeRegistry::instance().ts(v.meta)}; });
     m.def("ref_ts", [](PyTsType target) { return PyTsType{TypeRegistry::instance().ref(target.meta)}; });
@@ -1236,6 +1255,35 @@ namespace hgraph::python_bridge
                      return type_carrier_match(param, carrier, self.map);
                  },
                  nb::arg("pattern"), nb::arg("value"))
+            .def("materialise",
+                 [](const PyResolutionScope &self, nb::object pattern) -> nb::object {
+                     // A deferred type argument's default, resolved in this
+                     // scope and handed back as the type it carries (RFC
+                     // 0033); None while a variable it needs is unbound.
+                     ParamPattern                  param;
+                     ParamPattern::DeferredCarrier deferred;
+                     param.kind = ParamPattern::Kind::TypeArg;
+                     if (nb::isinstance<PyTypePattern>(pattern))
+                     {
+                         deferred.ts   = nb::cast<PyTypePattern &>(pattern).pattern;
+                         param.carrier = ResolutionKind::TimeSeries;
+                     }
+                     else if (nb::isinstance<PyScalarPattern>(pattern))
+                     {
+                         deferred.scalar = nb::cast<PyScalarPattern &>(pattern).pattern;
+                         param.carrier   = ResolutionKind::Scalar;
+                     }
+                     else
+                     {
+                         throw nb::type_error("materialise pattern must be a TypePattern or ScalarPattern");
+                     }
+                     param.default_pattern = std::move(deferred);
+                     const std::optional<TypeCarrier> carrier = materialise_deferred_carrier(param, self.map);
+                     if (!carrier.has_value()) { return nb::none(); }
+                     static_cast<void>(scalar_descriptor<TypeCarrier>::value_meta());
+                     return operator_scalar_to_py(Value{*carrier}.view());
+                 },
+                 nb::arg("pattern"))
             .def("bind_ts", [](PyResolutionScope &self, const std::string &name, PyTsType meta) {
                 self.map.bind_ts(name, meta.meta);
             })

--- a/python/py_type_system.cpp
+++ b/python/py_type_system.cpp
@@ -25,6 +25,41 @@ namespace hgraph::python_bridge
     {
         nb::object python_type_for_value_meta(const ValueTypeMetaData *meta);
 
+        /** A Python pattern as the carried pattern of a ``TypeArg`` parameter:
+            a ``TypePattern`` (time-series form), a ``ScalarPattern`` (scalar
+            form) or a ``SizePattern`` (size form, kept as the ``TSL`` shell the
+            size matcher reads). */
+        ParamPattern carried_param_from_python(nb::handle pattern, const char *method)
+        {
+            ParamPattern param;
+            param.kind = ParamPattern::Kind::TypeArg;
+            if (nb::isinstance<PyTypePattern>(pattern))
+            {
+                param.ts      = nb::cast<PyTypePattern &>(pattern).pattern;
+                param.carrier = ResolutionKind::TimeSeries;
+            }
+            else if (nb::isinstance<PyScalarPattern>(pattern))
+            {
+                param.scalar  = nb::cast<PyScalarPattern &>(pattern).pattern;
+                param.carrier = ResolutionKind::Scalar;
+            }
+            else if (nb::isinstance<PySizePattern>(pattern))
+            {
+                const auto &size = nb::cast<PySizePattern &>(pattern);
+                param.carrier    = ResolutionKind::Size;
+                param.ts = size.variable
+                               ? TypePattern::tsl_var(TypePattern::var("__type_arg_size_element__"), size.name)
+                               : TypePattern::tsl(TypePattern::var("__type_arg_size_element__"), size.value);
+            }
+            else
+            {
+                const std::string message =
+                    std::string{method} + " pattern must be a TypePattern, ScalarPattern or SizePattern";
+                throw nb::type_error(message.c_str());
+            }
+            return param;
+        }
+
         /** A type argument crosses back as the type it carries: a ``TsType``,
             the Python annotation of a scalar schema, or a plain size. */
         nb::object operator_scalar_to_py(const ValueView &value)
@@ -79,6 +114,63 @@ namespace hgraph::python_bridge
         if (name == "float") { return builtins.attr("float"); }
         if (name == "str") { return builtins.attr("str"); }
         if (name == "bytes") { return builtins.attr("bytes"); }
+
+        // A structural schema first produced by resolution (a bound variable
+        // inside tuple[K, ...]) has no registered annotation: rebuild the
+        // canonical spelling from its elements, the same spellings the
+        // full-value projection uses. An element the registries cannot name
+        // keeps the schema handle, as before.
+        const auto element_annotation = [&](const ValueTypeMetaData *element) -> nb::object {
+            nb::object annotation = python_type_for_value_meta(element);
+            return nb::isinstance<PyValueType>(annotation) ? nb::object{} : annotation;
+        };
+        const auto subscript = [&](const char *type_name, nb::object argument) {
+            return builtins.attr(type_name).attr("__class_getitem__")(std::move(argument));
+        };
+        switch (meta->try_value_kind().value_or(ValueTypeKind::Atomic))
+        {
+            case ValueTypeKind::List:
+                if (meta->has(ValueTypeFlags::VariadicTuple) && meta->element_type != nullptr)
+                {
+                    if (nb::object element = element_annotation(meta->element_type); element.is_valid())
+                    {
+                        return subscript("tuple", nb::make_tuple(element, builtins.attr("Ellipsis")));
+                    }
+                }
+                break;
+            case ValueTypeKind::Tuple:
+            {
+                nb::list elements;
+                for (std::size_t index = 0; index < meta->field_count; ++index)
+                {
+                    nb::object element = element_annotation(meta->fields[index].type);
+                    if (!element.is_valid()) { return nb::cast(PyValueType{meta}); }
+                    elements.append(std::move(element));
+                }
+                return subscript("tuple", nb::tuple(elements));
+            }
+            case ValueTypeKind::Set:
+                if (meta->element_type != nullptr)
+                {
+                    if (nb::object element = element_annotation(meta->element_type); element.is_valid())
+                    {
+                        return subscript("frozenset", std::move(element));
+                    }
+                }
+                break;
+            case ValueTypeKind::Map:
+                if (meta->key_type != nullptr && meta->element_type != nullptr)
+                {
+                    nb::object key   = element_annotation(meta->key_type);
+                    nb::object value = element_annotation(meta->element_type);
+                    if (key.is_valid() && value.is_valid())
+                    {
+                        return subscript("dict", nb::make_tuple(std::move(key), std::move(value)));
+                    }
+                }
+                break;
+            default: break;
+        }
         return nb::cast(PyValueType{meta});
     }
     }  // namespace
@@ -1221,23 +1313,8 @@ namespace hgraph::python_bridge
                  [](PyResolutionScope &self, nb::object pattern, nb::object value) -> bool {
                      // The one carrier matcher (RFC 0033): a type argument
                      // against its carried pattern, binding into this scope.
-                     ParamPattern param;
-                     param.kind = ParamPattern::Kind::TypeArg;
-                     if (nb::isinstance<PyTypePattern>(pattern))
-                     {
-                         param.ts      = nb::cast<PyTypePattern &>(pattern).pattern;
-                         param.carrier = ResolutionKind::TimeSeries;
-                     }
-                     else if (nb::isinstance<PyScalarPattern>(pattern))
-                     {
-                         param.scalar  = nb::cast<PyScalarPattern &>(pattern).pattern;
-                         param.carrier = ResolutionKind::Scalar;
-                     }
-                     else
-                     {
-                         throw nb::type_error("match_carrier pattern must be a TypePattern or ScalarPattern");
-                     }
-                     TypeCarrier carrier;
+                     ParamPattern param = carried_param_from_python(pattern, "match_carrier");
+                     TypeCarrier  carrier;
                      if (nb::isinstance<PyTsType>(value)) { carrier = TypeCarrier::of_ts(nb::cast<PyTsType &>(value).meta); }
                      else if (nb::isinstance<PyValueType>(value))
                      {
@@ -1245,8 +1322,7 @@ namespace hgraph::python_bridge
                      }
                      else if (nb::isinstance<nb::int_>(value))
                      {
-                         carrier       = TypeCarrier::of_size(nb::cast<std::size_t>(value));
-                         param.carrier = ResolutionKind::Size;
+                         carrier = TypeCarrier::of_size(nb::cast<std::size_t>(value));
                      }
                      else
                      {
@@ -1260,24 +1336,8 @@ namespace hgraph::python_bridge
                      // A deferred type argument's default, resolved in this
                      // scope and handed back as the type it carries (RFC
                      // 0033); None while a variable it needs is unbound.
-                     ParamPattern                  param;
-                     ParamPattern::DeferredCarrier deferred;
-                     param.kind = ParamPattern::Kind::TypeArg;
-                     if (nb::isinstance<PyTypePattern>(pattern))
-                     {
-                         deferred.ts   = nb::cast<PyTypePattern &>(pattern).pattern;
-                         param.carrier = ResolutionKind::TimeSeries;
-                     }
-                     else if (nb::isinstance<PyScalarPattern>(pattern))
-                     {
-                         deferred.scalar = nb::cast<PyScalarPattern &>(pattern).pattern;
-                         param.carrier   = ResolutionKind::Scalar;
-                     }
-                     else
-                     {
-                         throw nb::type_error("materialise pattern must be a TypePattern or ScalarPattern");
-                     }
-                     param.default_pattern = std::move(deferred);
+                     ParamPattern param = carried_param_from_python(pattern, "materialise");
+                     param.default_pattern = ParamPattern::DeferredCarrier{param.ts, param.scalar};
                      const std::optional<TypeCarrier> carrier = materialise_deferred_carrier(param, self.map);
                      if (!carrier.has_value()) { return nb::none(); }
                      static_cast<void>(scalar_descriptor<TypeCarrier>::value_meta());

--- a/python/tests/test_architecture_ratchets.py
+++ b/python/tests/test_architecture_ratchets.py
@@ -103,7 +103,7 @@ RATCHETS: tuple[Ratchet, ...] = (
     ),
     Ratchet(
         id="types-shadow-schema-dicts",
-        baseline=10,
+        baseline=0,
         roots=("python/hgraph/_types.py",),
         suffixes=(".py",),
         pattern=r"_(TS|VALUE)_SCALAR_TYPES\b",

--- a/python/tests/test_type_carrier_sweep.py
+++ b/python/tests/test_type_carrier_sweep.py
@@ -55,7 +55,7 @@ from hgraph import (
     nothing,
     operator,
 )
-from hgraph._types import _resolution_value_type, _value_type
+from hgraph._types import _value_type
 from hgraph.test import eval_node
 
 # Sweep-prefixed: named scalars intern on their bare name (#653).
@@ -688,10 +688,11 @@ _LATTICE = [
 @pytest.mark.parametrize("python_type", _LATTICE, ids=lambda t: getattr(t, "__name__", repr(t)))
 def test_reverse_binding_round_trips_through_a_constructed_ts(python_type):
     # The path AUTO_RESOLVE takes: TS[T] records T against the value schema
-    # (the shadow dictionaries, blueprint section 4), so the schema of a
-    # constructed time series reads back as T.
+    # in the bridge's reverse-binding registry (RFC 0033, PR C; formerly the
+    # shadow dictionaries), so the schema of a constructed time series reads
+    # back as T through the one registry function.
     value_type = _hgraph.ts_value_vt(TS[python_type].handle)
-    assert _resolution_value_type(value_type) == python_type
+    assert _hgraph.python_type_for_value(value_type) == python_type
 
 
 @pytest.mark.parametrize("python_type", [int, float, str, bool, date, datetime, SweepRow, SweepColour],
@@ -704,12 +705,56 @@ def test_native_reverse_binding_rebuilds_atomics_and_nominal_types(python_type):
     "python_type", [tuple[int, ...], frozenset[int], Mapping[str, int]],
     ids=["tuple", "frozenset", "Mapping"],
 )
-def test_native_reverse_binding_cannot_rebuild_parameterised_generics(python_type):
-    # Finding pinned for blueprint PR D: the native side cannot hand back the
-    # parameterised Python annotation for a collection schema (it returns the
-    # ValueType itself, or a builtin spelling for a Mapping); only the
-    # constructed-TS path above knows T, through the shadow dictionaries.
-    assert _hgraph.python_type_for_value(_value_type(python_type)) != python_type
+def test_native_reverse_binding_rebuilds_parameterised_generics(python_type):
+    # Flipped in PR C (RFC 0033): the registry hands back the parameterised
+    # annotation the DSL wrote, which the opaque/native/bundle/enum lookups
+    # could not rebuild; before, the shadow dictionaries were the only path.
+    assert _hgraph.python_type_for_value(_value_type(python_type)) == python_type
+
+
+def test_reverse_binding_hands_back_the_most_recent_spelling():
+    # One interned schema, many spellings: the registry keeps the spelling
+    # written most recently, as the shadow dictionaries did, so the site that
+    # resolved reads back what it wrote.
+    class SweepAliasRow(CompoundScalar):
+        x: int
+
+    first = _value_type(Mapping[str, SweepAliasRow])
+    assert _hgraph.python_type_for_value(first) == Mapping[str, SweepAliasRow]
+    second = _value_type(dict[str, SweepAliasRow])
+    assert first == second
+    assert _hgraph.python_type_for_value(second) == dict[str, SweepAliasRow]
+
+
+def test_reverse_binding_dies_with_the_metadata_on_reset():
+    # The shadow dictionaries were keyed by native handles and never cleared,
+    # so a handle recycled after reset_registries() could alias a new schema
+    # to an old annotation. The registry is cleared with the metadata: after
+    # a reset a fresh schema reads back as what was written for it.
+    import os
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        import os
+        import _hgraph
+        from hgraph import TS  # noqa: F401 (package import initialises the bridge)
+        from hgraph._types import _value_type
+
+        before = _value_type(tuple[int, ...])
+        assert _hgraph.python_type_for_value(before) == tuple[int, ...]
+        _hgraph.reset_registries()
+        after = _value_type(frozenset[int])
+        assert _hgraph.python_type_for_value(after) == frozenset[int], \
+            _hgraph.python_type_for_value(after)
+        # Linux: reset + ordinary interpreter exit dies in the final GC.
+        os._exit(0)
+        """
+    )
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
 
 
 # --------------------------------------------------------------------------

--- a/python/tests/test_type_carrier_sweep.py
+++ b/python/tests/test_type_carrier_sweep.py
@@ -726,6 +726,48 @@ def test_reverse_binding_hands_back_the_most_recent_spelling():
     assert _hgraph.python_type_for_value(second) == dict[str, SweepAliasRow]
 
 
+def test_reverse_binding_rebuilds_a_structural_schema_produced_by_resolution():
+    # A schema no Python annotation produced (a bound variable inside
+    # tuple[K, ...]) reads back as the canonical spelling built from its
+    # elements, the spellings the full-value projection uses.
+    class SweepResolvedRow(CompoundScalar):
+        x: int
+
+    element = _value_type(SweepResolvedRow)
+    assert _hgraph.python_type_for_value(_hgraph.tuple_vt(element)) == tuple[SweepResolvedRow, ...]
+    assert _hgraph.python_type_for_value(_hgraph.set_vt(element)) == frozenset[SweepResolvedRow]
+    assert _hgraph.python_type_for_value(_hgraph.map_vt(_value_type(str), element)) == dict[str, SweepResolvedRow]
+    assert _hgraph.python_type_for_value(_hgraph.fixed_tuple_vt([_value_type(str), element])) == tuple[str, SweepResolvedRow]
+
+
+def test_scope_materialises_a_deferred_type_argument_in_every_form():
+    # ResolutionScope.materialise (RFC 0033, PR C): a deferred default's
+    # pattern resolved in the scope, projected as the type it carries; None
+    # while a variable it needs is unbound.
+    from hgraph._types import _scalar_pattern
+
+    class SweepMaterialisedRow(CompoundScalar):
+        x: int
+
+    scope = _hgraph.ResolutionScope()
+    assert scope.materialise(_scalar_pattern(tuple[K, ...])) is None
+    assert scope.materialise(_hgraph.size_pattern_var("N")) is None
+    scope.bind_scalar("K", _value_type(SweepMaterialisedRow))
+    scope.bind_size("N", 3)
+    # scalar form, structural: the annotation is rebuilt from the bound element
+    assert scope.materialise(_scalar_pattern(tuple[K, ...])) == tuple[SweepMaterialisedRow, ...]
+    assert scope.materialise(_scalar_pattern(K)) is SweepMaterialisedRow
+    # size form
+    assert scope.materialise(_hgraph.size_pattern_var("N")) == 3
+    assert scope.materialise(_hgraph.size_pattern_value(2)) == 2
+    # time-series form
+    assert scope.materialise(TS[K].pattern) == TS[SweepMaterialisedRow].handle
+    # and the matcher accepts a size pattern with a size value
+    other = _hgraph.ResolutionScope()
+    assert other.match_carrier(_hgraph.size_pattern_var("M"), 4)
+    assert other.find_size("M") == 4
+
+
 def test_reverse_binding_dies_with_the_metadata_on_reset():
     # The shadow dictionaries were keyed by native handles and never cleared,
     # so a handle recycled after reset_registries() could alias a new schema

--- a/src/hgraph/python/bridge_state.cpp
+++ b/src/hgraph/python/bridge_state.cpp
@@ -676,6 +676,16 @@ bundle_class_info_registry() {
   return *registry;
 }
 
+std::unordered_map<const void *, nb::object> &python_type_registry() {
+  static auto *registry = new std::unordered_map<const void *, nb::object>{};
+  return *registry;
+}
+
+void clear_python_type_registry() noexcept {
+  nb::gil_scoped_acquire gil;
+  python_type_registry().clear();
+}
+
 std::unordered_map<const void *, const void *> &tsb_compound_value_registry() {
   static auto *registry = new std::unordered_map<const void *, const void *>{};
   return *registry;


### PR DESCRIPTION
## Summary

PR C of RFC 0033, stacked on #671 (PR B). The bridge now owns the schema-to-annotation *reverse binding*, and the two Python-side shadow dictionaries are deleted.

- **`python_type_registry()`** (`bridge_state.h`): the annotation each value schema came from, strongly held. `_value_type` records it through `_hgraph.bind_python_type` for every schema it produces; `python_type_for_value` consults it first, after the any-to-object rule, so it can now hand back `tuple[int, ...]`, `Mapping[str, int]` and aliases that the opaque/native/Bundle/enum lookups cannot rebuild.
- **Its own reset method**: `clear_python_type_registry()`, called by `reset_registries` beside the other bridge registries; registration never resets anything as a side effect. Before, nothing cleared the dictionaries, and a handle recycled after a reset could alias a new schema to an old annotation — a subprocess regression pins the new behaviour.
- **Most recent registration wins**, as the dictionaries did. First-wins was tried for determinism and broke the sweep's `T → schema → T` pins in any process that had spelled a schema differently earlier; the RFC records why.
- `ResolutionScope.materialise(pattern)` resolves a deferred type argument's default in a scope and projects it the same way (for PR D).
- Deleted: `_TS_SCALAR_TYPES`, `_VALUE_SCALAR_TYPES`, six writes, `_resolution_value_type`, and the reads in `_types.py`, `_resolution.py`, `reflection.py`. Ratchet `types-shadow-schema-dicts` 10 → 0.

## Verification
- Python suite 3115 passed; sweep: the parameterised-generics pin flips to "rebuilds" (the design's point), plus the most-recent-spelling cell and the reset regression.
- C++ core untouched (bridge-only change).

## Design record
`python_bridge.rst` "Reverse binding"; `testing.rst` (ratchet at zero); RFC 0033 implementation status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
