### PR TITLE
language: define compiler architecture and migration roadmap

### DIFF
--- a/language/docs/README.md
+++ b/language/docs/README.md
@@ -29,11 +29,22 @@ out so examples do not imply an implemented compatibility promise.
    generic construction, inherited defaults, optional fields, sparse deltas,
    runtime state, lifecycle, activation, output, tests and running, and syntax
    decisions.
-3. [Modules and native extensions](design/modules.md) — how C++ packages become
+3. [Compiler architecture](design/compiler-architecture.md) — source fidelity,
+   pass contracts, typed HIR, hgraph IR, backend boundaries, and the parser
+   migration.
+4. [Modules and native extensions](design/modules.md) — how C++ packages become
    importable, contribute overloads, and participate in generated module
    initialization and deinitialization without exposing a general FFI.
-4. [Roadmap](design/roadmap.md) — vertical slices and their acceptance gates.
-5. [Distribution and deployment](design/distribution.md) — release train,
+5. [Native interface](design/native-interface.md) — constrained scalar kernels,
+   opaque state, phase/effect/ownership metadata, and why ordinary HGL has no
+   inline C++ escape.
+6. [Documentation architecture](design/documentation.md) — audience boundaries,
+   feature status, executable examples, and code documentation.
+7. [Architecture decisions](design/decisions/README.md) — numbered decisions
+   that constrain several compiler passes or artifacts.
+8. [Roadmap](design/roadmap.md) — vertical slices, the compiler architecture
+   stack, core-library migration, and acceptance gates.
+9. [Distribution and deployment](design/distribution.md) — release train,
    package channels (Homebrew first), the relocatable native context, and
    what a host needs to run an HGL program.
 6. [Type extensions](design/type-extensions.md) — agreed atomic treatment of

--- a/language/docs/design/architecture.md
+++ b/language/docs/design/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Status: initial design
+Status: accepted direction; prototype migration is tracked in the roadmap
 
 ## Purpose
 
@@ -34,6 +34,10 @@ the directory into a separate repository without changing hgraph core.
   dependencies of the compiler or generated programs that do not use them.
 - Preserve the same graph, node, type, overload, lifecycle, and record/replay
   semantics as native C++ hgraph authoring.
+- Make the HGL standard library expressive enough to replace the algorithmic
+  graph and node implementations currently hand-authored in hgraph core,
+  retaining C++ only for the runtime kernel and explicitly classified native
+  primitives.
 
 ## Non-goals
 
@@ -108,11 +112,15 @@ not part of the desired semantics.
 
 ## Compiler pipeline
 
+The detailed pass contracts and dependency rules are defined in
+[Compiler architecture](compiler-architecture.md). The parser and IR decisions
+are recorded under [Architecture decision records](decisions/README.md).
+
 All execution modes share one pipeline:
 
 ```text
 source
-  -> lexer and parser
+  -> source-accurate lexer and parser
   -> package target and module-closure resolution
   -> module descriptor and candidate-universe loading
   -> name and module resolution
@@ -146,6 +154,11 @@ language project must not clone its matching or ranking rules.
 The hgraph semantic IR is backend-neutral in representation but hgraph-specific
 in meaning. It distinguishes wiring operations from evaluation operations and
 retains source ranges for every declaration and expression.
+
+Typed HIR is the last representation of HGL language semantics. Hgraph
+semantic IR is the only input to both backends. The current prototype's direct
+walk over `ResolvedModule` is migration debt, not a permitted third backend
+contract.
 
 ## C++ backend contract
 
@@ -195,6 +208,11 @@ Both the header and source pass through the compiler-selected `clang-format`
 before they are printed, written, cached, or compiled. A formatting failure is
 a compiler failure, so generated code remains deterministic and suitable for
 human inspection.
+
+Exact calls into a native value library use the constrained descriptor contract
+in [Native interface](native-interface.md). Generated code may make a direct
+C++ call through the package's public header or wrapper, but neither source HGL
+nor the compiler accepts arbitrary inline C++.
 
 ## Two backends, one wiring
 
@@ -286,8 +304,8 @@ The initial project owns:
 
 Compiler components are split into `syntax`, `semantics`, `wiring` (the
 direct-wiring backend), `codegen` (the C++ backend) and `driver` (the commands
-and the REPL); `ir` arrives when the two backends stop walking the resolved
-tree directly. Empty framework libraries are intentionally deferred. The
+and the REPL). The next architecture stack adds `ir` and removes direct
+backend access to the resolved syntax tree. The
 `cmake/` directory holds the consumer-facing `HglLanguage.cmake` and the
 Python-module template it configures.
 

--- a/language/docs/design/compiler-architecture.md
+++ b/language/docs/design/compiler-architecture.md
@@ -1,0 +1,230 @@
+# Compiler architecture
+
+Status: accepted direction; implementation is staged in the roadmap
+
+## Purpose
+
+This record defines the compiler's internal boundaries. It complements
+[Architecture](architecture.md), which defines the project and runtime
+boundaries, and the [Compiler and C++ lowering](../developer-guide/compiler-and-lowering.md)
+guide, which describes the current implementation.
+
+The compiler is expected to change incompatibly while the language is a
+prototype. That freedom is used to establish explicit pass contracts now,
+before additional syntax and backend behavior make the resolved syntax tree a
+de facto intermediate representation.
+
+## Parsing direction
+
+HGL will use a declarative parsing grammar or parsing DSL. PEG is a suitable
+family of techniques, but conformance to a particular parsing formalism is not
+the objective. The implementation is selected by an executable comparison of
+at least:
+
+- a programming-language-oriented C++ parsing DSL with explicit lookahead,
+  precedence, recovery, and parse-tree support;
+- a C++ PEG implementation whose grammar can be kept as a standalone,
+  reviewable artifact.
+
+The comparison must cover the language's difficult cases rather than a toy
+expression grammar:
+
+- significant newlines and continuation after selected tokens;
+- comments and blank lines without losing source ranges;
+- nested generic applications and adjacent closing `>` tokens;
+- contextual words such as `in` and the collection/type constructors;
+- expression precedence, named arguments, and concise functions;
+- recovery from several independent errors in one file;
+- preservation of unexpected and missing syntax for diagnostics and future
+  editor tooling;
+- debug and release build cost, including MSVC object-size behavior.
+
+The selected parser is private to the syntax target. Its headers do not enter
+the public compiler interfaces or every test translation unit. A parser
+migration first preserves the existing `ast::Module` projection for semantic
+clients while retaining richer recovered syntax internally, so parser selection
+does not force simultaneous semantic and backend rewrites.
+
+The parser produces syntax, not graph or node declarations. Function
+classification, type resolution, phase checking, and native binding remain
+later semantic passes.
+
+## Source representation
+
+The source manager owns immutable source buffers, file identities, byte
+offsets, line and column lookup, and excerpts. Every token, syntax node,
+diagnostic, HIR instruction, and hgraph IR operation refers to a source range
+owned by it.
+
+The syntax layer must retain enough information to reproduce the source and to
+represent malformed input. A valid token may not disappear merely because it
+is unexpected, and an expected token may be represented as missing without
+inventing source text. This permits one parser to serve the compiler, formatter,
+REPL diagnostics, and later editor tooling. Whether the implementation calls
+this representation a concrete syntax tree or a source-accurate syntax arena is
+an implementation choice; byte fidelity and recovery are the contract.
+
+The typed AST interface is a view or lowering over that source representation.
+Semantic annotations do not mutate syntax nodes.
+
+## Pass pipeline
+
+```text
+SourceManager + DiagnosticEngine
+                 |
+                 v
+       source-accurate syntax
+                 |
+                 v
+       declarations and names <----- package closure and module descriptors
+                 |
+                 v
+    canonical types and constraints <--- hgraph type/resolution contracts
+                 |
+                 v
+             typed HIR
+                 |
+                 v
+         hgraph semantic IR
+             /          \
+            v            v
+     direct wiring    generated C++ + build manifest
+```
+
+The driver assembles the inputs and invokes these passes. It does not implement
+their semantics.
+
+### Syntax
+
+Input: source buffers.
+
+Output: a source-accurate syntax module containing declarations, expressions,
+statements, comments, unexpected syntax, missing syntax, and precise ranges.
+
+The syntax layer may diagnose lexical and grammatical errors only. It has no
+dependency on hgraph, module descriptors, operator registration, or a backend.
+
+### Declaration and name resolution
+
+Input: syntax modules, package target, and importable declarations from module
+descriptors.
+
+Output: stable declaration and symbol identities, lexical bindings, nominal
+module identities, visibility, and the candidate universe selected by the
+locked target closure.
+
+Imports control spelling and visibility. The package closure controls which
+implementation providers participate. Resolution never discovers installed
+packages or loads executable code.
+
+### Type and constraint checking
+
+Input: resolved declarations plus canonical hgraph type and operator metadata.
+
+Output: complete substitutions, canonical value and temporal types, selected
+nominal operator identities, candidate resolution results, constant values,
+and typed diagnostics.
+
+HGL adapts hgraph's `TypePattern`, `ResolutionMap`, and constraint/resolver
+contracts. It does not maintain a language-local overload matcher with subtly
+different ranking.
+
+### Typed HIR
+
+HIR is the last representation of HGL as a language. It contains:
+
+- stable declaration and symbol identities rather than unresolved names;
+- canonical types and complete generic substitutions;
+- constants as typed values rather than syntax literals;
+- resolved exact calls and nominal operator calls;
+- function kind, phase, effects, and admitted capabilities;
+- structured control flow and lexical ownership;
+- source ranges on every operation that can diagnose.
+
+HIR contains no emitted C++ text, C++ identifier escaping, hgraph node indices,
+or direct-wiring runtime objects. Invalid phase transitions and unsupported
+language constructs are rejected before HIR is considered complete.
+
+`hgl check --dump-hir` is the stable debugging view for this pass during the
+prototype. The serialization is diagnostic, not a compatibility format.
+
+### Hgraph semantic IR
+
+Hgraph IR is the lowering boundary between language semantics and execution.
+It distinguishes:
+
+- wiring-time constants, exact calls, and nominal operator calls;
+- runtime node state layout and initialization;
+- injected capabilities;
+- start, ordered activation, evaluation, and stop operations;
+- activation, validity admission, and residual guards;
+- borrowed collection traversal;
+- terminating returns and explicit output mutation;
+- provider identities and leases required by imported native code.
+
+Both execution backends consume this representation. Neither backend may
+include syntax AST headers or redo name lookup, type inference, function
+classification, phase checking, or generic substitution.
+
+`hgl check --dump-hgraph-ir` exposes a readable, source-ranged form for tests
+and compiler diagnosis.
+
+### Backends
+
+The direct-wiring backend turns composition operations into calls to hgraph's
+public erased wiring API. It does not evaluate runtime bodies.
+
+The C++ backend turns the same composition operations and the runtime-node
+operations into readable public hgraph C++. Formatting, source mapping, and
+build-manifest production are backend responsibilities; semantic decisions are
+not.
+
+A program accepted by the complete semantic and hgraph-IR pipeline must not be
+rejected later merely because one backend failed to implement a language
+construct. During migration, such gaps remain explicit diagnostics and are
+tracked as architecture debt. The end state makes backend parity an invariant.
+
+## Dependency rules
+
+The CMake targets enforce an acyclic graph:
+
+```text
+hgl_source
+    -> hgl_syntax
+    -> hgl_semantics
+    -> hgl_ir
+       -> hgl_wiring
+       -> hgl_codegen_cpp
+    -> hgl_driver
+```
+
+Source management and diagnostics may initially remain in `hgl_syntax`, but
+their interfaces must not depend on parser or AST node classes. Module loading
+and descriptor decoding are separate services supplied to semantics by the
+driver.
+
+Architecture tests reject these wrong-layer dependencies:
+
+- parser code referring to graph/node classification or native bindings;
+- HIR or hgraph IR storing emitted C++ fragments;
+- a backend including syntax AST headers after its IR migration;
+- the C++ emitter resolving types or overloads;
+- the direct backend implementing tick-time behavior;
+- compiler code reaching into hgraph registry storage or private headers.
+
+## Migration sequence
+
+1. Freeze representative valid and malformed syntax cases and select the parser
+   implementation using the criteria above.
+2. Replace parsing behind the existing syntax result and keep semantic tests
+   unchanged.
+3. Introduce typed HIR beside `ResolvedModule`, with dumps and focused tests.
+4. Move semantic validation into HIR construction until a successful `check`
+   denotes a completely typed program.
+5. Introduce hgraph semantic IR and migrate direct wiring.
+6. Migrate C++ generation, then remove backend access to resolved syntax.
+7. Make backend parity and architecture dependency tests required gates.
+
+Each step is a reviewable pull request. Temporary adapters are removed by the
+end of the stack rather than becoming a third representation that backends can
+continue to consume.

--- a/language/docs/design/decisions/0001-declarative-parser.md
+++ b/language/docs/design/decisions/0001-declarative-parser.md
@@ -1,0 +1,53 @@
+# ADR 0001: Declarative parser and source-accurate syntax
+
+Status: accepted direction; parser library pending measured comparison
+
+## Context
+
+The prototype uses a hand-written recursive-descent parser. It is small and has
+useful recovery, but grammar, recovery, AST construction, and newline policy are
+encoded together. HGL syntax is still changing and will need formatting, REPL,
+diagnostic, and editor support.
+
+PEG is not treated as synonymous with a modern compiler frontend. The current
+[Swift parser](https://github.com/swiftlang/swift-syntax/blob/main/Sources/SwiftParser/Parser.swift)
+and [Clang parser](https://clang.llvm.org/features.html) are documented
+recursive-descent parsers. Cppfront likewise keeps a custom token parser in a
+[linear lexer/parser/sema/lowering stack](https://github.com/hsutter/cppfront/discussions/762).
+Their useful precedents are source fidelity, diagnostics, inspectable trees,
+and strict layer ownership.
+
+## Decision
+
+Use a declarative C++ parsing grammar or parsing DSL which produces
+source-accurate, recoverable syntax. Select the concrete implementation using
+the representative corpus and build criteria in
+[Compiler architecture](../compiler-architecture.md#parsing-direction).
+
+The first comparison uses
+[lexy](https://github.com/foonathan/lexy) and
+[cpp-peglib](https://github.com/yhirose/cpp-peglib). The
+[PEGTL](https://github.com/taocpp/PEGTL) is retained as the lower-level PEG
+reference if neither candidate meets the recovery and source contracts.
+
+The implementation is private to `hgl_syntax`. PEG semantics are acceptable
+but are not a requirement when a parser DSL provides better explicit recovery,
+precedence, and source fidelity.
+
+## Consequences
+
+- The grammar becomes independently reviewable and testable.
+- Unexpected and missing syntax are retained for diagnostics and tooling.
+- Parser-library template costs cannot spread through public headers.
+- The parser does not classify functions or perform name and type resolution.
+- The current AST contract is preserved during the initial parser replacement.
+
+## Alternatives
+
+- Retain the current parser permanently: rejected as the default direction,
+  although hand-written code remains available for narrow rules a parser DSL
+  cannot express cleanly.
+- Require a strict PEG implementation without evaluation: rejected because
+  recovery and source fidelity are more important than formalism.
+- Use an editor parser as the compiler's first parser: deferred; incremental
+  parsing is not yet the dominant requirement.

--- a/language/docs/design/decisions/0002-shared-ir-boundaries.md
+++ b/language/docs/design/decisions/0002-shared-ir-boundaries.md
@@ -1,0 +1,32 @@
+# ADR 0002: Typed HIR and hgraph IR are mandatory backend boundaries
+
+Status: accepted
+
+## Context
+
+The prototype annotates the syntax AST in `ResolvedModule`. Direct wiring and
+C++ generation then walk that representation independently, which permits type,
+phase, lowering, and diagnostic behavior to diverge.
+
+## Decision
+
+Introduce typed HIR as the complete language-semantic representation and hgraph
+semantic IR as the only backend input. Both direct wiring and C++ generation
+consume hgraph IR and may not include syntax AST headers after migration.
+
+## Consequences
+
+- `hgl check` can validate one representation shared by every execution mode.
+- Function classification, generic substitution, and call resolution happen
+  once.
+- Backend parity compares code generation rather than duplicated semantic
+  implementations.
+- Temporary resolved-AST adapters are removed at the end of the migration
+  stack.
+
+## Alternatives
+
+- Continue annotating AST nodes: rejected because backend behavior is already
+  implemented twice.
+- Emit C++ directly from HIR: rejected because direct wiring and future
+  backends need an explicit representation of hgraph semantics.

--- a/language/docs/design/decisions/0003-native-descriptor-boundary.md
+++ b/language/docs/design/decisions/0003-native-descriptor-boundary.md
@@ -1,0 +1,47 @@
+# ADR 0003: Native code is exposed by descriptors, not inline source
+
+Status: accepted; descriptor authoring format and lifecycle ABI pending
+
+## Context
+
+Runtime-node implementations need efficient access to selected C and C++
+libraries, but arbitrary native source would blur wiring and evaluation phases,
+escape the type and ownership system, and turn HGL into a general-purpose
+language.
+
+Cppfront permits C++ and Cpp2 only
+[side by side rather than nested](https://hsutter.github.io/cppfront/cppfront/mixed/),
+because even two syntaxes for the same C++ object model become semantically
+ambiguous when nested. HGL has the additional distinction between wiring and
+tick-time execution, so pass-through source is a still poorer fit.
+
+Swift's [C++ interoperability](https://www.swift.org/documentation/cxx-interop/)
+shows the other end of the spectrum: an embedded Clang importer, module maps,
+direct calls, and explicit annotations where ownership and dependent lifetimes
+cannot be inferred. HGL adopts the explicit module and ownership lesson without
+importing the general C++ language.
+
+## Decision
+
+Expose reviewed native declarations through versioned module descriptors and
+package-provided wrappers. Ordinary HGL contains no inline C++, preprocessor,
+raw pointer, or header-import escape. The first slice supports canonical scalar
+evaluation functions and owned opaque node state under the restrictions in
+[Native interface](../native-interface.md).
+
+## Consequences
+
+- Compiled calls can remain direct C++ calls without a general FFI.
+- `hgl check` can validate imports without loading executable code.
+- Phase, effect, ownership, exceptions, and build dependencies are explicit.
+- A later Clang-based generator may produce descriptors but cannot widen the
+  language implicitly.
+
+## Alternatives
+
+- Pass through side-by-side or nested C++: rejected for ordinary HGL.
+- Import arbitrary headers with an embedded C++ compiler: deferred as excessive
+  machinery for a deliberately narrow DSL.
+- Require every scalar helper to be an hgraph operator: rejected because
+  private runtime-node implementation state needs exact native value calls, not
+  additional graph topology.

--- a/language/docs/design/decisions/README.md
+++ b/language/docs/design/decisions/README.md
@@ -1,0 +1,10 @@
+# Architecture decision records
+
+Numbered records in this directory capture decisions that constrain multiple
+compiler passes or public artifacts. A record may accept an architectural
+direction while leaving a specific library, serialization, ABI, or source
+syntax unresolved and named as such.
+
+- [0001: Declarative parser and source-accurate syntax](0001-declarative-parser.md)
+- [0002: Typed HIR and hgraph IR are mandatory backend boundaries](0002-shared-ir-boundaries.md)
+- [0003: Native code is exposed by descriptors, not inline source](0003-native-descriptor-boundary.md)

--- a/language/docs/design/documentation.md
+++ b/language/docs/design/documentation.md
@@ -1,0 +1,96 @@
+# Documentation architecture
+
+Status: accepted direction
+
+## Audiences and authority
+
+HGL documentation has four distinct jobs:
+
+1. The **User Guide** teaches existing, observable source behavior through
+   examples. It does not describe compiler internals.
+2. The **Language Reference** is the normative contract for grammar, types,
+   phases, visibility, and diagnostics. Until it is split into its own folder,
+   the normative sections live in the developer guide's
+   `syntax-and-semantics.md` and are linked from the User Guide.
+3. The **Compiler Guide** describes passes, IR, lowering, tooling, invariants,
+   and tests. It distinguishes the target architecture from the current
+   prototype.
+4. **Design records and ADRs** explain boundaries and decisions. They do not
+   silently establish new source syntax.
+
+Observable language behavior wins over implementation notes. Accepted RFCs,
+once the language has them, supersede all four. Generated C++ is inspectable
+compiler output, not a source-compatibility contract.
+
+## Feature status
+
+Every proposed feature is identified as one of:
+
+- **implemented**: parsed, checked, lowered through every applicable backend,
+  and covered by behavior tests;
+- **partial**: the implemented subset and fail-closed boundary are stated;
+- **provisional**: syntax or semantics are still under discussion and examples
+  are not accepted programs;
+- **blocked**: an unresolved language decision or missing public hgraph
+  contract is named.
+
+A user-guide example must not be described as implemented merely because it
+parses. Status summaries are derived from executable example and feature-matrix
+tests wherever practical. Duplicate hand-written checkpoint paragraphs are
+kept short and linked to one current matrix to reduce drift.
+
+## Executable documentation
+
+Examples owned by the User Guide are extracted or mirrored into the checked-in
+example corpus. Depending on their declared status, CI must:
+
+- parse and resolve them;
+- compare their expected diagnostics;
+- run them through direct wiring;
+- emit and compile their generated C++;
+- compare observable ticks between supported backends.
+
+Provisional examples use clearly invalid or fenced documentation fixtures and
+are not silently weakened until they happen to parse.
+
+## Code documentation
+
+Each compiler component has a nearby README describing:
+
+- its input and output representations;
+- ownership and lifetime rules;
+- allowed and forbidden dependencies;
+- which diagnostics it owns;
+- how to dump and test its result.
+
+Public compiler interfaces document preconditions, postconditions, recovery,
+and source-range behavior. Comments inside a pass explain non-obvious
+invariants and language rules; they do not restate each line of code.
+
+The source tree is expected to remain readable without opening the complete
+design guide. Conversely, detailed rationale belongs in an ADR or design record
+and is linked from the code rather than copied into several implementations.
+
+## Architecture decisions
+
+Decisions that constrain several passes use numbered files under
+`design/decisions/`. Each records status, context, decision, consequences,
+alternatives, and the acceptance evidence required before an implementation is
+declared complete.
+
+An ADR can accept a direction while leaving a named implementation choice open.
+It cannot invent syntax to hide an unresolved language question.
+
+## Required compiler views
+
+The compiler provides readable views at its durable boundaries:
+
+- source-accurate syntax, including error and missing nodes;
+- typed HIR;
+- hgraph semantic IR;
+- formatted generated C++ and its source map;
+- module descriptor, build manifest, and provider fingerprint.
+
+These views are test and diagnostic formats during the prototype. Any format
+that becomes an interchange or cache contract receives its own version and
+compatibility policy first.

--- a/language/docs/design/modules.md
+++ b/language/docs/design/modules.md
@@ -1,6 +1,6 @@
 # Modules and native extensions
 
-Status: initial design
+Status: accepted module boundary; descriptor format remains open
 
 ## Boundary
 
@@ -30,6 +30,11 @@ A native package that supports the language supplies a descriptor containing:
 - explicit module initialization, registry installation, deinitialization, and
   registration-removal entry points;
 - optional documentation and source links for diagnostics and tooling.
+
+Exact native value functions and opaque state use the same descriptor and
+lifecycle. Their phase, effect, ownership, and safety requirements are defined
+in [Native interface](native-interface.md). They do not introduce a second
+foreign-function or package mechanism.
 
 The kernel descriptor additionally maps language operator tokens such as `+`
 and `==` to public hgraph operator contracts. This is a syntax binding into the
@@ -285,6 +290,12 @@ An imported adaptor owns:
 The language function supplies temporal arguments and `const` policy values.
 Dynamic behavior is represented by temporal inputs and explicit hgraph runtime
 functions, not by escaping to native code.
+
+Runtime functions may call exact native value operations admitted by a module
+descriptor. Those calls are deliberately narrower than adaptor exposure: the
+first slice permits non-blocking, non-throwing scalar evaluation over owned
+opaque node state. It does not permit callbacks, native threads, raw pointers,
+or direct adaptor implementation in HGL.
 
 ## Package manifest
 

--- a/language/docs/design/native-interface.md
+++ b/language/docs/design/native-interface.md
@@ -1,0 +1,194 @@
+# Native interface
+
+Status: accepted boundary; descriptor spelling and ABI remain to be implemented
+
+## Purpose
+
+HGL is intentionally not a general-purpose language. Native C and C++ libraries
+are nevertheless necessary for efficient algorithms, stateful resources, and
+capabilities that cannot be implemented as graph composition. This record
+defines how those libraries can participate without adding arbitrary C++
+syntax, header semantics, or ownership conventions to HGL.
+
+This interface extends the package and lifecycle model in
+[Modules and native extensions](modules.md). It is not a second module system.
+
+## No nested native source
+
+Ordinary HGL files do not contain `#include`, `extern`, raw C++, preprocessor
+directives, or native statement blocks. In particular, native source cannot be
+nested inside a composition or runtime function.
+
+An inline escape would be ambiguous about whether it runs while wiring or on a
+tick, which values are current and valid, whether it may block or throw, how its
+references survive an evaluation, and whether state participates in
+record/replay. Those questions are semantic and must be answered in an
+importable contract, not inferred from arbitrary source text.
+
+If mixed source is ever reconsidered, it requires a separate language decision.
+It is not an implementation shortcut for the first native interface.
+
+## Descriptor is the contract
+
+A supporting native package publishes a versioned descriptor alongside its
+headers and libraries. `hgl check` reads the descriptor without loading native
+code. Generated builds and scripted execution use its build metadata to link or
+load the matching provider and verify the same fingerprint.
+
+For every exposed native declaration the descriptor records:
+
+- canonical HGL module and declaration identity;
+- declaration category: hgraph operator, exact native value function, native
+  constructor, or lifecycle operation;
+- complete HGL parameter and result types;
+- permitted phases: wiring, start, evaluation, or stop;
+- observable effects, including mutation, I/O, blocking, and allocation where
+  relevant;
+- value, owned, shared, or borrowed ownership and any dependent lifetime;
+- exception and thread-safety policy;
+- canonical C++ symbol or generated wrapper identity;
+- required public headers, CMake packages, imported targets, and runtime image;
+- module lifecycle entry points, provider identity, compatibility versions, and
+  descriptor fingerprint.
+
+The serialized representation and authoring API for the descriptor are not yet
+chosen. No HGL declaration syntax is implied by this list.
+
+## Native declaration categories
+
+### Hgraph operators
+
+A temporal callable is a normal registered hgraph operator. The descriptor
+exposes its nominal operator contract and provider candidates, and HGL resolves
+it through the shared hgraph resolver. This is the path for graphs, nodes,
+sources, sinks, adaptors, and services that accept temporal arguments.
+
+An ordinary C++ scalar function is never lifted implicitly into one node per
+call. A package that wants temporal use supplies and registers the corresponding
+hgraph operator implementation explicitly.
+
+### Exact native value functions
+
+An exact native value function is callable only in phases allowed by its
+descriptor. The first implementation targets scalar computations inside an HGL
+runtime node and construction or cleanup of that node's private native state.
+
+The generated C++ calls the declared symbol or its package-provided wrapper
+directly. The direct-wiring backend does not emulate it: a runtime-bearing
+program follows the existing generated, compiled, and loaded image path.
+
+Calls from wiring-time constant evaluation, automatic temporal lifting, and
+general compile-time execution are outside the first interface.
+
+### Opaque native state
+
+An opaque native type exposes no fields, inheritance, pointer operations, or
+layout to HGL. It may be passed only to native functions that name the same
+descriptor identity.
+
+The first state bridge is an owned RAII value. Construction occurs during
+replay-aware node startup; destruction occurs with the aggregate state after
+the stop phase. A resource that needs observable shutdown exposes a permitted
+stop-phase operation in addition to its destructor.
+
+Borrowed values are confined to the call or evaluation that produced them.
+They cannot be returned, stored in state or output, captured, placed in a
+collection, or embedded in an HGL struct. Shared and independently owned
+reference forms require explicit retain/release or move/destruction contracts
+and arrive after the RAII slice.
+
+### Atomic native values
+
+A native value that crosses a temporal port is not merely an opaque C++ type.
+It must have a registered hgraph scalar identity and the public value, storage,
+equality, hashing, conversion, and serialization operations required by every
+context in which the descriptor permits it. HGL then exposes it as a nominal
+atomic value through that canonical metadata.
+
+The compiler does not infer those operations from a C++ class definition.
+
+## Initial safety envelope
+
+The first native-value implementation is intentionally narrow:
+
+- arguments and results are canonical scalar values or an opaque state value
+  declared by the same module;
+- opaque state uses owned RAII storage and cannot cross a temporal port;
+- evaluation functions are non-blocking and `noexcept`;
+- mutation is restricted to an explicitly identified state argument;
+- raw pointers, references, pointer arithmetic, callbacks, variadic calls, and
+  open C++ templates are not representable;
+- a C++ template is exposed only through an explicit specialization or wrapper
+  with one complete HGL signature;
+- native declarations do not participate in implicit conversions;
+- descriptor and loaded-provider fingerprints must agree before wiring.
+
+These restrictions can be relaxed individually when a real core or extension
+migration requires them and their semantics are defined. They must not be
+relaxed by accepting arbitrary C++ text.
+
+## Desired HGL experience
+
+Once a native package descriptor exists, existing HGL import and runtime syntax
+is sufficient at the call site for a canonical scalar helper. For example, a
+package may expose a non-throwing scalar update function so an HGL node can be
+written as:
+
+```hgl
+use acme.stats as stats
+
+fn smooth(value: f64, const window: i64) -> f64 {
+    state previous: f64 = 0.0
+
+    when modified(value) and valid(value) {
+        previous = stats::update(previous, value, window)
+        return previous
+    }
+}
+```
+
+This example introduces no new HGL syntax. The source spelling and inference
+rules for an imported opaque state type are not settled, so this record does not
+invent an example for them. The native implementation must stop at that design
+question if existing nominal type syntax is insufficient.
+
+## Producing descriptors
+
+The first producer should be an explicit C++ registration API or build-time
+tool owned by the native package. It emits both the reviewable descriptor and
+any wrapper required to normalize C++ overloads, templates, exceptions, or
+ownership into the declared HGL contract.
+
+An optional Clang-based binding generator may later derive the same artifact
+from annotated public headers. Clang is then a descriptor-generation tool, not
+part of HGL parsing or the definition of which arbitrary C++ constructs the
+language accepts. The generated descriptor remains reviewable and versioned.
+
+## Module lifecycle and ABI
+
+The descriptor participates in the existing closed package universe. Its
+provider initializes transactionally, installs all registrations through one
+module-owned handle, and deinitializes in reverse dependency order. Graphs,
+plans, native call targets, and metadata retain provider leases.
+
+The dynamic entry point used for descriptor verification and lifecycle should
+use a small versioned ABI that can be discovered reliably across toolchains.
+Calls within generated code may still use direct C++ types and functions when
+the descriptor permits them. Logical provider removal and native-image
+unloading remain distinct operations.
+
+## Acceptance
+
+The first native package proves:
+
+- descriptor-only `hgl check` without loading its library;
+- one canonical scalar value function used inside a runtime node;
+- one owned opaque state value constructed at startup, mutated during
+  evaluation, and destroyed after stop;
+- rejection of the same calls in an unpermitted phase;
+- rejection of a borrowed value that escapes;
+- generated C++ that is a direct, readable call through public headers;
+- scripted and ahead-of-time execution with identical ticks;
+- descriptor/provider fingerprint mismatch before graph wiring;
+- failed activation rollback and provider removal without stale registrations;
+- an installed-SDK consumer build, not only an in-tree test.

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -4,18 +4,25 @@ Status: active staged delivery
 
 ## North-star outcome
 
-The target is to express the graph and node implementations currently supplied
-by hgraph core as HGL standard-library modules. The migration leaves a smaller
-C++ runtime kernel containing graph execution, storage, type and operator
-resolution, public authoring contracts, approved injected capabilities, and
-native primitives which HGL code calls. It does not make hgraph core depend on
-the HGL compiler at runtime.
+The target is to author the graph and node implementations currently supplied
+by hgraph core as HGL standard-library modules. HGL is an ahead-of-time source
+language: those modules transpile to reviewed C++ implementations and are
+compiled into the distribution. The shipped implementation, runtime semantics,
+and first-class native authoring surface therefore remain C++. The migration
+leaves a smaller hand-written C++ runtime kernel containing graph execution,
+storage, type and operator resolution, public authoring contracts, approved
+injected capabilities, and native primitives which generated C++ calls. It does
+not make hgraph core depend on the HGL compiler at runtime.
 
-Production distributions may build standard-library HGL ahead of time and ship
-its generated, formatted C++ or compiled artifacts. Python and C++ compatibility
+Production distributions build standard-library HGL ahead of time and ship its
+generated, formatted C++ and compiled artifacts. Generated sources are retained
+as inspectable implementation inputs; they use the same public native contracts
+as hand-written C++ and do not create an HGL runtime. Python and C++ compatibility
 surfaces continue to expose the public hgraph operators and resolve to those
-registered implementations. The compiler and generated standard library remain
-a downstream consumer of the public hgraph SDK.
+registered C++ implementations. During compiler incubation, the compiler and
+generated standard library remain a parallel downstream consumer of the public
+hgraph SDK; promotion into core is a deliberate build-time migration rather than
+a reversal of the C++-first runtime boundary.
 
 Every current graph and node implementation enters a migration inventory. An
 implementation may remain in C++ only when it is explicitly classified as one

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -1,6 +1,137 @@
 # Roadmap
 
-Status: initial design
+Status: active staged delivery
+
+## North-star outcome
+
+The target is to express the graph and node implementations currently supplied
+by hgraph core as HGL standard-library modules. The migration leaves a smaller
+C++ runtime kernel containing graph execution, storage, type and operator
+resolution, public authoring contracts, approved injected capabilities, and
+native primitives which HGL code calls. It does not make hgraph core depend on
+the HGL compiler at runtime.
+
+Production distributions may build standard-library HGL ahead of time and ship
+its generated, formatted C++ or compiled artifacts. Python and C++ compatibility
+surfaces continue to expose the public hgraph operators and resolve to those
+registered implementations. The compiler and generated standard library remain
+a downstream consumer of the public hgraph SDK.
+
+Every current graph and node implementation enters a migration inventory. An
+implementation may remain in C++ only when it is explicitly classified as one
+of:
+
+- a runtime bootstrap or storage/execution primitive that HGL lowers onto;
+- an adaptor, callback, thread, or external-resource owner outside HGL's
+  deliberate language boundary;
+- an approved native scalar or opaque-state primitive exposed through the
+  constrained native descriptor;
+- a temporarily blocked migration with the missing HGL semantic or public
+  hgraph contract named.
+
+The classification is not permission to leave ordinary algorithmic nodes in
+C++. The standard-library migration is complete only when the inventory has no
+unclassified implementation and every non-migrated item has a reviewed kernel
+reason.
+
+Undefined language behavior is a valid stopping point. The implementation must
+not invent syntax, ownership, phase, delta, or generic semantics merely to move
+an inventory item. Such an item becomes a focused design question with examples
+and stays fail-closed until resolved.
+
+## Compiler architecture stack
+
+Before additional language breadth, the prototype is moved onto the architecture
+in [Compiler architecture](compiler-architecture.md). The stack is ordered so
+each pull request is independently reviewable and later changes do not hide
+semantic movement inside a parser or backend rewrite.
+
+### A. Architecture and documentation
+
+- record the declarative-parser, shared-IR, and native-descriptor decisions;
+- define source, syntax, HIR, hgraph IR, backend, and module boundaries;
+- define documentation audiences and executable status rules;
+- reconcile stale implementation-status claims;
+- record this core-library migration programme.
+
+Acceptance: documentation links resolve, no source syntax is invented, and the
+current versus target architecture is explicit.
+
+### B. Parser evaluation and migration
+
+- build representative grammar spikes for the shortlisted C++ parser tools;
+- measure valid parsing, multi-error recovery, source fidelity, grammar
+  readability, debug/release compile cost, and portability;
+- record the selected implementation and evidence in ADR 0001;
+- replace the parser behind the existing syntax result before changing later
+  pass behavior;
+- preserve unexpected and missing syntax for diagnostics and tooling.
+
+Acceptance: the complete syntax suite and guide corpus pass, malformed-source
+snapshots report at least the previous useful diagnostics, and parser-library
+headers remain private to the syntax implementation.
+
+### C. Typed HIR
+
+- introduce stable symbol and declaration identities, canonical types, complete
+  substitutions, typed constants, function kinds, phases, effects, and source
+  ranges;
+- move semantic validation out of backend walks;
+- implement `hgl check --dump-hir` and HIR snapshot tests;
+- make a successful semantic check produce complete HIR or fail closed.
+
+Acceptance: all resolved guide examples produce HIR, invalid programs stop
+before lowering, and the HIR contains no emitted C++ or runtime wiring objects.
+
+### D. Hgraph IR and direct wiring
+
+- lower composition and runtime semantics into one explicit hgraph IR;
+- represent state, injectables, lifecycle, activation, validity, traversal,
+  output, operator identities, and provider requirements;
+- implement `hgl check --dump-hgraph-ir`;
+- migrate direct wiring from `ResolvedModule` to hgraph IR.
+
+Acceptance: direct-wiring behavior and diagnostics remain equivalent, and the
+wiring target no longer includes syntax AST headers.
+
+### E. C++ backend migration
+
+- migrate C++ generation to hgraph IR;
+- remove duplicate name, type, generic, phase, and classification logic from
+  the emitter;
+- retain deterministic formatting, source maps, public-SDK code, and readable
+  output;
+- remove the compatibility path by which a backend walks `ResolvedModule`.
+
+Acceptance: both backends consume the same hgraph IR, existing generated tests
+and installed consumers pass, and architecture tests reject backend-to-syntax
+dependencies.
+
+### F. Constrained native interface
+
+- choose and version a reviewable descriptor representation and lifecycle ABI;
+- provide a native-package authoring API which emits descriptors and normalized
+  wrappers;
+- add phase, effect, ownership, exception, build, and fingerprint metadata;
+- support a canonical scalar evaluation function and owned opaque node state;
+- prove descriptor-only checking and identical scripted/AOT behavior.
+
+Acceptance is defined in [Native interface](native-interface.md#acceptance).
+Raw pointers, callbacks, implicit temporal lifting, and arbitrary C++ source
+remain rejected.
+
+### G. Standard-library migration
+
+- generate the complete core graph/node inventory and classify each item;
+- select representative composition, stateless scalar-node, stateful-node,
+  collection, and native-kernel migrations;
+- close missing language semantics through explicit design discussions;
+- replace implementations in dependency order while preserving public operator
+  identities and Python/C++ behavior;
+- remove each old implementation when its HGL replacement is accepted.
+
+Acceptance is behavioral parity, generated-code inspection, installed-SDK
+coverage, and performance evidence against the implementation removed.
 
 ## Prototype checkpoint (2026-09-05)
 
@@ -260,6 +391,51 @@ Candidates, in risk order:
 Each capability must map to a first-class public C++ hgraph path and have
 native generated-code behavior tests. User-defined overloads must reuse the
 hgraph registry rather than add language-local dispatch.
+
+## Core standard-library migration programme
+
+The first task is an automatically maintained inventory of public operator
+contracts and their graph/node candidates. It records implementation kind,
+source location, generic signature, state and injectable use, dependent native
+libraries, Python exposure, behavior tests, benchmarks, and migration status.
+
+Migration proceeds by increasing semantic demand:
+
+1. **Composition graphs.** Move pure topology first. This validates imports,
+   exact helpers, generics, and operator binding without adding runtime
+   semantics.
+2. **Stateless scalar nodes.** Move nodes expressible with activation, validity,
+   and a terminating result. Compare fused generated code with the hand-written
+   static node.
+3. **Stateful and lifecycle nodes.** Exercise recordable state, startup,
+   ordered activation, prior output, injectables, and deterministic teardown.
+4. **Collections and windows.** Exercise borrowed delta views, keyed/list/set
+   mutation, dynamic shapes, rolling storage, and output mutation.
+5. **Native-library algorithms.** Keep the algorithm in a reviewed C++ library
+   where appropriate and express its hgraph lifecycle and activation in HGL
+   through the constrained native interface.
+6. **Sources, sinks, services, and adaptors.** Express graph-facing policy and
+   lifecycle in HGL where the approved capability model permits it. Keep
+   callback, thread, queue, protocol, and external-resource ownership in native
+   providers unless a later language decision deliberately expands the
+   boundary.
+
+For each migrated candidate:
+
+- the operator contract and overload ranking are unchanged;
+- native C++, generated HGL, and Python compatibility behavior are compared at
+  the public wiring level;
+- tick sequences, validity, delta behavior, exceptions, lifecycle, teardown,
+  and replay are covered as applicable;
+- generated C++ is reviewed for clarity and contains no private runtime access;
+- hot paths have performance and allocation evidence;
+- the prior implementation is removed rather than retained as an unselected
+  duplicate;
+- any required native primitive is independently useful and has a public,
+  reviewed contract rather than exposing the old node wholesale.
+
+The first migration set is chosen only after the inventory exists. The
+roadmap does not name source syntax for a blocked capability in advance.
 
 ## Production and release gates
 

--- a/language/docs/developer-guide/README.md
+++ b/language/docs/developer-guide/README.md
@@ -47,8 +47,12 @@ for hgraph, not a second runtime.
 The design records provide project boundaries and rationale:
 
 - [Architecture](../design/architecture.md)
+- [Compiler architecture](../design/compiler-architecture.md)
 - [Language model](../design/language-model.md)
 - [Modules and native extensions](../design/modules.md)
+- [Native interface](../design/native-interface.md)
+- [Documentation architecture](../design/documentation.md)
+- [Architecture decisions](../design/decisions/README.md)
 - [Roadmap](../design/roadmap.md)
 
 ## Sources of truth

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -3,7 +3,12 @@
 Status: target pipeline with agreed structured-value lowering and provisional
 generic, module, and runtime semantics
 
-All execution modes share one pipeline:
+The normative pass boundaries, dependency rules, and migration away from the
+resolved syntax tree are recorded in
+[Compiler architecture](../design/compiler-architecture.md). This section
+describes the current prototype and its lowering details.
+
+All execution modes share one target pipeline:
 
 ```text
 source
@@ -49,9 +54,9 @@ The source manager owns file identities, byte offsets, line/column lookup, and
 snippets. Diagnostics refer to source identities rather than scattering raw
 filesystem paths through the AST.
 
-`src/syntax/` is implemented as follows. `source` holds a file's path, text,
-and line table; every token and node carries a half-open byte range into
-it. `diagnostic` collects `Category`-tagged diagnostics with optional notes
+`src/syntax/` is currently implemented as follows. `source` holds a file's
+path, text, and line table; every token and node carries a half-open byte range
+into it. `diagnostic` collects `Category`-tagged diagnostics with optional notes
 and renders them as `path:line:col: category: message` plus the source line
 and a caret. `temporal` parses and validates the temporal literal spellings
 of the syntax guide into a `TemporalValue` (kind plus microseconds, offset,
@@ -62,7 +67,10 @@ payloads addressed by `NodeId`, so the tree owns no pointers and a module is
 one movable value. `parser` is a hand-written recursive-descent parser over
 the token vector that applies the newline rules of the syntax guide and
 recovers at the synchronization points listed there; `ast_printer` dumps
-the tree one node per line for `hgl check --dump-ast` and the tests.
+the tree one node per line for `hgl check --dump-ast` and the tests. The
+accepted parser migration replaces the hand-written implementation with a
+declarative grammar and source-accurate recovery while initially preserving the
+AST result consumed below.
 
 The first pass of `src/semantics/` is `resolve`. It binds every value, type,
 and constraint-name occurrence of one compilation unit by the lookup rules of
@@ -76,7 +84,9 @@ bindings, constraint identities, struct metadata, and function kinds instead
 of building the typed HIR. Hgraph's resolver still types every operator the
 direct-wiring backend wires, so the HIR becomes necessary when callable
 substitution or the C++ backend needs canonical types ahead of hgraph. Until
-then `src/wiring/` walks the resolved syntax tree directly.
+then `src/wiring/` walks the resolved syntax tree directly. This is explicitly
+temporary: typed HIR followed by hgraph semantic IR will become the only input
+to both backends.
 
 ## Common function representation
 

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -3,6 +3,12 @@
 The language is complete only when source reaches observable hgraph behavior.
 Parser-only milestones remain intermediate progress.
 
+The pass and documentation gates below follow
+[Compiler architecture](../design/compiler-architecture.md) and
+[Documentation architecture](../design/documentation.md). They are target
+acceptance requirements while the prototype still walks `ResolvedModule`
+directly.
+
 The lists below are the acceptance matrix, not a claim that every item has
 landed. At the 2026-09-03 prototype checkpoint, syntax tests cover struct,
 generic application, constraint, `null`, and delta nodes; resolver tests cover
@@ -66,6 +72,42 @@ operator of that name in scope.
 Legacy draft spellings—`graph`, `node`, `ts<T>`, parameter-section semicolons,
 `emit`, and endpoint metadata members—must not accidentally remain accepted
 unless a later RFC deliberately reintroduces one.
+
+The declarative-parser comparison runs the same corpus through each candidate
+implementation and additionally records:
+
+- byte ranges and retained comments for valid source;
+- unexpected and missing syntax for malformed source;
+- at least three useful diagnostics from one file with independent errors;
+- exact newline-continuation behavior around operators, commas, braces, and
+  declaration boundaries;
+- nested generic closers without changing comparison-token behavior;
+- debug and release compiler time and object size in an isolated parser target;
+- representative GCC, Clang, and MSVC builds.
+
+The production parser is not selected from a toy grammar or throughput alone.
+Parser-library headers remain private to the syntax implementation and are not
+included by syntax clients or test support headers.
+
+## Typed HIR and hgraph IR
+
+Each valid guide example has a source-ranged typed-HIR snapshot containing
+stable declaration identities, canonical types, substitutions, typed
+constants, call targets, function kind, phase, and effects. Invalid examples
+prove that incomplete or contradictory types never reach hgraph IR.
+
+Hgraph-IR snapshots cover composition calls, runtime state and initialization,
+injectables, lifecycle operations, activation and validity guards, collection
+borrows, output effects, and provider requirements. They deliberately contain
+no C++ spellings or direct-wiring runtime objects.
+
+Architecture tests inspect target dependencies and includes. Once a backend is
+migrated, it may not include `syntax/ast.h`, consume `ResolvedModule`, perform
+name lookup, classify a function, or infer a generic substitution. Removing a
+temporary adapter is part of the stack's acceptance, not later cleanup.
+
+`hgl check --dump-hir` and `--dump-hgraph-ir` outputs are deterministic and
+covered as diagnostic formats. They are not persisted compatibility formats.
 
 ## Resolver
 

--- a/language/docs/user-guide/types-and-expressions.md
+++ b/language/docs/user-guide/types-and-expressions.md
@@ -195,9 +195,11 @@ and removed after wiring.
 
 ## Structured values
 
-> **Staging status:** the declaration, generic, inheritance, construction,
-> optional-field, and delta semantics in this section are agreed design, but
-> the current `hgl check` parser does not implement them yet.
+> **Implementation status:** declarations, type-generic applications,
+> abstract-only single inheritance, construction, optional fields, and sparse
+> delta syntax are implemented. Constructor inference, typed `const` generic
+> metadata, explicit optional-field clearing, and the remaining nested/runtime
+> lowering cases fail closed as listed in the developer roadmap.
 
 A `struct` declares one nominal structured type. It is module-internal unless
 it is exported, and its fields are public and immutable:

--- a/language/src/README.md
+++ b/language/src/README.md
@@ -1,0 +1,32 @@
+# Compiler source architecture
+
+The normative pass boundaries are in
+[`docs/design/compiler-architecture.md`](../docs/design/compiler-architecture.md).
+This file records the current source layout while the prototype migrates to
+them.
+
+| Directory | Owns now | Target input and output |
+| --- | --- | --- |
+| `syntax/` | source buffers, diagnostics, temporal literals, lexer, parser, arena AST | source text to source-accurate syntax |
+| `semantics/` | bindings, nominal structs, generic checks, function classification | syntax plus descriptors to typed HIR |
+| `ir/` | not created yet | typed HIR to backend-neutral hgraph semantic IR |
+| `wiring/` | direct walk over `ResolvedModule` | hgraph IR to public erased wiring calls |
+| `codegen/` | direct walk over `ResolvedModule` | hgraph IR to formatted C++ and build artifacts |
+| `driver/` | commands, native build/cache/load, REPL orchestration | assemble inputs and invoke passes |
+
+During migration, `ResolvedModule` is a compatibility boundary only. New
+language semantics belong in HIR construction, not in either backend. Temporary
+adapters must be named and removed when both backends consume hgraph IR.
+
+Every new pass documents:
+
+- who owns its input and output storage;
+- whether it continues after diagnostics;
+- the invariant established by successful completion;
+- how its source ranges and debug dump are tested;
+- its allowed dependencies.
+
+The parser implementation and any parsing library remain private to `syntax/`.
+Once migrated, backend targets must not include syntax AST headers. Generated
+C++ remains formatted, readable output, but it is not used as an intermediate
+representation by another compiler pass.


### PR DESCRIPTION
## Summary

- define source-accurate syntax, typed HIR, hgraph IR, and backend dependency contracts
- record the declarative parser, shared IR, and descriptor-only native-code decisions as ADRs
- define documentation audiences, executable status, and source-level documentation expectations
- add the staged roadmap from parser evaluation through native interop and migration of core graph/node implementations into HGL standard-library modules
- correct the stale user-guide status for structured values

## Important boundaries

- ordinary HGL does not embed or pass through C++
- parser implementation is selected by a measured lexy/cpp-peglib comparison, not assumed from formalism
- both backends ultimately consume one hgraph semantic IR and may not walk syntax
- unresolved language semantics are named blockers; the roadmap does not invent syntax to force migrations

## Validation

- `git diff --cached --check`
- local Markdown link targets verified across `language/**/*.md`

Documentation-only change; runtime suites are not required by the repository definition of done.