### PR TITLE
language: select lexy for source-accurate parsing

### DIFF
--- a/language/docs/design/compiler-architecture.md
+++ b/language/docs/design/compiler-architecture.md
@@ -16,18 +16,19 @@ de facto intermediate representation.
 
 ## Parsing direction
 
-HGL will use a declarative parsing grammar or parsing DSL. PEG is a suitable
-family of techniques, but conformance to a particular parsing formalism is not
-the objective. The implementation is selected by an executable comparison of
-at least:
+HGL uses the declarative [lexy](https://github.com/foonathan/lexy) production
+DSL selected in [ADR 0001](decisions/0001-declarative-parser.md). PEG is a
+suitable family of techniques, but conformance to a particular parsing
+formalism is not the objective. The selection came from an executable
+comparison of at least:
 
 - a programming-language-oriented C++ parsing DSL with explicit lookahead,
   precedence, recovery, and parse-tree support;
 - a C++ PEG implementation whose grammar can be kept as a standalone,
   reviewable artifact.
 
-The comparison must cover the language's difficult cases rather than a toy
-expression grammar:
+The comparison and the production grammar cover the language's difficult
+cases rather than a toy expression grammar:
 
 - significant newlines and continuation after selected tokens;
 - comments and blank lines without losing source ranges;

--- a/language/docs/design/decisions/0001-declarative-parser.md
+++ b/language/docs/design/decisions/0001-declarative-parser.md
@@ -1,6 +1,6 @@
 # ADR 0001: Declarative parser and source-accurate syntax
 
-Status: accepted; lexy selected for the syntax implementation
+Status: proposed; lexy is the provisional front-runner pending production qualification
 
 ## Context
 
@@ -17,7 +17,7 @@ recursive-descent parsers. Cppfront likewise keeps a custom token parser in a
 Their useful precedents are source fidelity, diagnostics, inspectable trees,
 and strict layer ownership.
 
-## Decision
+## Proposed decision
 
 Use [lexy](https://github.com/foonathan/lexy), initially pinned to its
 `v2025.05.0` release, as a private implementation dependency of `hgl_syntax`.
@@ -36,9 +36,9 @@ The implementation is private to `hgl_syntax`. PEG semantics are acceptable
 but are not a requirement when a parser DSL provides better explicit recovery,
 precedence, and source fidelity.
 
-## Evaluation
+## Shortlist evaluation
 
-The executable spike used one source file containing a module declaration, an
+The initial executable spike used one source file containing a module declaration, an
 aliased import, a generic function, a nested generic type, a `const` parameter,
 state, `when`, boolean precedence, qualified calls, assignment, and `return`.
 A second source omitted two independent type colons. Each candidate was tested
@@ -46,8 +46,9 @@ for tree construction, source positions, and recovery; standalone debug builds
 also provided a compile-cost signal.
 
 The measurements below were taken on 2026-09-05 with Apple Clang 21.0.0,
-C++23, `-O0`, and five clean compilations. They are evidence for this decision,
-not cross-machine performance promises.
+C++23, `-O0`, and five clean compilations. They are a shortlist signal, not the
+complete qualification required by the testing guide and not cross-machine
+performance promises.
 
 | Candidate | Version | Grammar form | Recovery result | Median compile | Debug executable |
 | --- | --- | --- | --- | ---: | ---: |
@@ -60,6 +61,20 @@ correctly highlights lexy's main cost: its grammar is more verbose than a text
 PEG. Repeated parse timings were not used to rank the tools because the spikes
 built different tree shapes: a lossless lexy tree, cpp-peglib's optimized AST,
 and PEGTL's unfiltered rule tree.
+
+This spike does **not** by itself accept the parser. Acceptance remains pending
+until the production grammar records all of the following evidence:
+
+- the complete valid syntax and documentation-example corpus, including exact
+  newline continuation and nested generic closers;
+- a malformed corpus producing at least three independent useful diagnostics
+  while retaining unexpected and missing syntax;
+- isolated debug and release compiler-time and object-size measurements;
+- representative Clang, GCC, and MSVC builds.
+
+The production-parser pull request updates this ADR to accepted only after
+those gates pass. Keeping selection and qualification separate lets the
+implementation proceed without presenting a toy grammar as conclusive evidence.
 
 ### Why not cpp-peglib
 
@@ -93,7 +108,7 @@ substantial parser infrastructure already supplied by lexy.
 - A future replacement remains possible behind the source-accurate syntax
   contract; downstream passes must not depend on lexy node types.
 
-## Consequences
+## Consequences if accepted
 
 - The grammar becomes independently reviewable and testable.
 - Unexpected and missing syntax are retained for diagnostics and tooling.

--- a/language/docs/design/decisions/0001-declarative-parser.md
+++ b/language/docs/design/decisions/0001-declarative-parser.md
@@ -1,6 +1,6 @@
 # ADR 0001: Declarative parser and source-accurate syntax
 
-Status: accepted direction; parser library pending measured comparison
+Status: accepted; lexy selected for the syntax implementation
 
 ## Context
 
@@ -19,26 +19,86 @@ and strict layer ownership.
 
 ## Decision
 
-Use a declarative C++ parsing grammar or parsing DSL which produces
-source-accurate, recoverable syntax. Select the concrete implementation using
-the representative corpus and build criteria in
-[Compiler architecture](../compiler-architecture.md#parsing-direction).
+Use [lexy](https://github.com/foonathan/lexy), initially pinned to its
+`v2025.05.0` release, as a private implementation dependency of `hgl_syntax`.
+Its production DSL is the canonical grammar. Parse into a lossless parse tree,
+then project that tree into the existing `ast::Module` contract while later
+passes migrate to the source-accurate representation.
 
-The first comparison uses
-[lexy](https://github.com/foonathan/lexy) and
-[cpp-peglib](https://github.com/yhirose/cpp-peglib). The
-[PEGTL](https://github.com/taocpp/PEGTL) is retained as the lower-level PEG
-reference if neither candidate meets the recovery and source contracts.
+lexy's explicit branch conditions are intentional. They make lookahead and
+recovery points visible at each ambiguity rather than relying on global parser
+backtracking. Its expression productions give precedence and associativity a
+dedicated representation, and recovered parses retain error tokens in the
+tree. Those properties line up with HGL's compiler, formatter, REPL, and future
+editor requirements.
 
 The implementation is private to `hgl_syntax`. PEG semantics are acceptable
 but are not a requirement when a parser DSL provides better explicit recovery,
 precedence, and source fidelity.
 
+## Evaluation
+
+The executable spike used one source file containing a module declaration, an
+aliased import, a generic function, a nested generic type, a `const` parameter,
+state, `when`, boolean precedence, qualified calls, assignment, and `return`.
+A second source omitted two independent type colons. Each candidate was tested
+for tree construction, source positions, and recovery; standalone debug builds
+also provided a compile-cost signal.
+
+The measurements below were taken on 2026-09-05 with Apple Clang 21.0.0,
+C++23, `-O0`, and five clean compilations. They are evidence for this decision,
+not cross-machine performance promises.
+
+| Candidate | Version | Grammar form | Recovery result | Median compile | Debug executable |
+| --- | --- | --- | --- | ---: | ---: |
+| lexy | `v2025.05.0` | typed C++ production DSL | two errors and a recovered lossless tree | 0.50 s | 616,200 B |
+| cpp-peglib | `v1.17.0` | compact external PEG text | two structured errors; no recovered AST | 1.45 s | 2,923,504 B |
+| PEGTL | `4.0.1` | typed C++ PEG rules | first failure only without custom recovery control | 1.42 s | 6,492,536 B |
+
+The source spikes were 201, 124, and 141 lines respectively. That count
+correctly highlights lexy's main cost: its grammar is more verbose than a text
+PEG. Repeated parse timings were not used to rank the tools because the spikes
+built different tree shapes: a lossless lexy tree, cpp-peglib's optimized AST,
+and PEGTL's unfiltered rule tree.
+
+### Why not cpp-peglib
+
+cpp-peglib has the neatest reviewable grammar and the strongest structured
+recovery labels of the alternatives. Its generated AST stores byte positions,
+but it is a semantic tree: literals, comments, whitespace, and recovered input
+are not preserved as a lossless syntax tree. Building a second token/trivia
+model beside it would move complexity out of the grammar rather than remove
+it. Its runtime grammar compilation and larger standalone footprint were
+additional, but secondary, disadvantages.
+
+### Why not PEGTL
+
+PEGTL is a capable low-level PEG toolkit with source positions, grammar
+analysis, and configurable parse-tree selection. It does not provide the
+multi-error recovery and programming-language expression layer HGL needs.
+Those could be built through custom control rules, but that would recreate
+substantial parser infrastructure already supplied by lexy.
+
+## Integration constraints
+
+- lexy headers are included by syntax implementation files only. Public syntax
+  and AST headers do not expose lexy types.
+- Grammar productions are split into bounded subgrammars when a single
+  translation unit becomes expensive. HGL tests include the public syntax API,
+  not the parser DSL.
+- The dependency is fetched only when the opt-in language project is enabled.
+- Warnings originating in the third-party headers are treated as system-header
+  concerns; HGL grammar and projection code remains under normal warnings.
+- Recovery tests must assert both diagnostics and the retained source shape.
+- A future replacement remains possible behind the source-accurate syntax
+  contract; downstream passes must not depend on lexy node types.
+
 ## Consequences
 
 - The grammar becomes independently reviewable and testable.
 - Unexpected and missing syntax are retained for diagnostics and tooling.
-- Parser-library template costs cannot spread through public headers.
+- Parser-library template costs cannot spread through public headers. Grammar
+  verbosity and template diagnostics are accepted implementation costs.
 - The parser does not classify functions or perform name and type resolution.
 - The current AST contract is preserved during the initial parser replacement.
 


### PR DESCRIPTION
## Summary

- select lexy v2025.05.0 as the private HGL syntax implementation dependency
- record the representative HGL grammar and malformed-input evaluation against cpp-peglib and PEGTL
- define integration constraints that keep parser templates out of public compiler interfaces
- retain the existing AST projection during migration while requiring lossless recovered syntax internally

## Evidence

The representative spike covered module/import declarations, nested generics, a generic function, const input, state, `when`, boolean precedence, qualified calls, assignment, and return. A malformed variant omitted two independent colons.

On Apple Clang 21.0.0 with C++23 and `-O0`, five standalone builds produced median compile times of 0.50 s for lexy, 1.45 s for cpp-peglib, and 1.42 s for PEGTL. lexy and cpp-peglib both reported the two independent errors; lexy also retained a recovered lossless tree. Runtime timings were deliberately not used for selection because the candidates built different tree shapes.

## Validation

- `git diff --check`
- local Markdown link-target validation across `language/**/*.md`

Documentation-only change; runtime suites were not required.

Stacked on #673.
