### PR TITLE
feat(language): add declarative syntax grammar

### DIFF
--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -86,6 +86,16 @@ add_library(hgl_syntax STATIC
     src/syntax/parser.cpp
     src/syntax/ast_printer.cpp
 )
+# GCC diagnoses the overloaded lexy DSL operators as though they were built-in
+# arithmetic (`-Wparentheses`) and, after deep inlining, reports the library's
+# scoped parse-handler link as escaping (`-Wdangling-pointer`). Both are false
+# positives in template code instantiated by this one implementation TU. Keep
+# the narrow suppression here rather than weakening warnings for hgl_syntax or
+# exposing parser-library headers to its clients.
+set_property(SOURCE src/syntax/token_grammar.cpp APPEND PROPERTY COMPILE_OPTIONS
+    "$<$<CXX_COMPILER_ID:GNU>:-Wno-parentheses>"
+    "$<$<CXX_COMPILER_ID:GNU>:-Wno-dangling-pointer>"
+)
 add_library(hgl::syntax ALIAS hgl_syntax)
 target_compile_features(hgl_syntax PUBLIC cxx_std_23)
 target_include_directories(hgl_syntax PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -20,6 +20,18 @@ option(HGL_ENABLE_LINE_EDITING
     "Give the REPL line editing, history and completion (isocline, fetched at configure time)"
     ON)
 
+# The declarative grammar selected in ADR 0001. It is private to hgl_syntax:
+# parser-template types must not leak into the compiler's public pass contracts.
+include(FetchContent)
+set(LEXY_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
+FetchContent_Declare(
+    lexy
+    GIT_REPOSITORY https://github.com/foonathan/lexy.git
+    GIT_TAG        v2025.05.0
+    GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(lexy)
+
 if(NOT TARGET hgraph::core)
     find_package(hgraph CONFIG REQUIRED)
 endif()
@@ -70,12 +82,14 @@ add_library(hgl_syntax STATIC
     src/syntax/token.cpp
     src/syntax/lexer.cpp
     src/syntax/ast.cpp
+    src/syntax/token_grammar.cpp
     src/syntax/parser.cpp
     src/syntax/ast_printer.cpp
 )
 add_library(hgl::syntax ALIAS hgl_syntax)
 target_compile_features(hgl_syntax PUBLIC cxx_std_23)
 target_include_directories(hgl_syntax PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_link_libraries(hgl_syntax PRIVATE foonathan::lexy::core)
 hgl_apply_warnings(hgl_syntax)
 
 # The resolver (src/semantics): scopes, the interim kernel table, phase

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -66,6 +66,9 @@ current versus target architecture is explicit.
 
 ### B. Parser evaluation and migration
 
+Status: lexy selected and the token grammar runs in conformance mode; the
+source-accurate arena, AST projection, and hand-written-parser removal remain.
+
 - build representative grammar spikes for the shortlisted C++ parser tools;
 - measure valid parsing, multi-error recovery, source fidelity, grammar
   readability, debug/release compile cost, and portability;

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -64,13 +64,22 @@ and zone) and prints the canonical spelling. `lexer` produces one token
 vector per file, with comments as trivia and one `Newline` token per run of
 terminators. `ast` is an index-based arena: nodes are `std::variant`
 payloads addressed by `NodeId`, so the tree owns no pointers and a module is
-one movable value. `parser` is a hand-written recursive-descent parser over
-the token vector that applies the newline rules of the syntax guide and
-recovers at the synchronization points listed there; `ast_printer` dumps
-the tree one node per line for `hgl check --dump-ast` and the tests. The
-accepted parser migration replaces the hand-written implementation with a
-declarative grammar and source-accurate recovery while initially preserving the
-AST result consumed below.
+one movable value. `token_grammar` is the private lexy production grammar
+selected by ADR 0001. It currently parses the lexer's token stream in
+conformance mode: every clean legacy-parser test and every checked-in HGL
+example must also pass the declarative grammar, and a focused malformed case
+proves recovery after three independent missing tokens. `parser` remains the
+AST projection path during this intermediate slice; it is the hand-written
+recursive-descent implementation that applies the newline rules and produces
+the existing arena. `ast_printer` dumps that arena one node per line for
+`hgl check --dump-ast` and the tests.
+
+This dual-parser state is deliberately temporary. The next parser slice
+materializes a lexy-free, source-accurate syntax arena from the declarative
+parse, including trivia and recovered input, then projects that arena into the
+existing `ast::Module`. Only after equivalence tests pass may the hand-written
+syntax decisions be removed. Downstream compiler passes never receive lexy
+types.
 
 The first pass of `src/semantics/` is `resolve`. It binds every value, type,
 and constraint-name occurrence of one compilation unit by the lookup rules of

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -22,10 +22,13 @@ typed `const` generic metadata, and explicit optional-field clearing.
 ## Lexer and parser
 
 The frontend tests are Catch2 cases in `tests/syntax/` (`temporal_tests`,
-`lexer_tests`, `parser_tests`; one `hgl_syntax_tests` binary registered as
-the `hgraph_language_syntax` CTest case). They assert on token kinds and
-values, on the `print_ast` dump of parsed snippets, and on the diagnostics
-emitted for rejected input. Snapshots cover:
+`lexer_tests`, `token_grammar_tests`, and `parser_tests`; one
+`hgl_syntax_tests` binary registered as the `hgraph_language_syntax` CTest
+case). They assert on token kinds and values, declarative-grammar acceptance
+and recovery, the `print_ast` dump of parsed snippets, and the diagnostics
+emitted for rejected input. During parser migration, every source accepted by
+a clean AST snapshot is also required to pass the declarative grammar.
+Snapshots cover:
 
 - bodyless `operator`, named `fn`, `export fn`, and anonymous `fn`
   declarations;
@@ -88,6 +91,12 @@ implementation and additionally records:
 The production parser is not selected from a toy grammar or throughput alone.
 Parser-library headers remain private to the syntax implementation and are not
 included by syntax clients or test support headers.
+
+The selected lexy grammar is presently a conformance parser over the existing
+token stream. Its parse tree is intentionally not yet a downstream contract.
+Promotion to the sole syntax parser requires the source-accurate arena and AST
+projection described by ADR 0001; until then the hand-written parser remains
+the compiler's AST-producing path.
 
 ## Typed HIR and hgraph IR
 

--- a/language/src/syntax/token_grammar.cpp
+++ b/language/src/syntax/token_grammar.cpp
@@ -1,0 +1,698 @@
+#include "syntax/token_grammar.h"
+
+#include <lexy/action/parse_as_tree.hpp>
+#include <lexy/callback.hpp>
+#include <lexy/dsl.hpp>
+#include <lexy/input/string_input.hpp>
+#include <lexy/parse_tree.hpp>
+
+#include <cstdint>
+#include <string>
+
+namespace hgl::syntax
+{
+    namespace grammar
+    {
+        namespace dsl = lexy::dsl;
+
+        enum class ContextToken : std::uint8_t {
+            In = 0x80,
+            Atomic,
+            Tuple,
+            List,
+            Set,
+            Map,
+            Rolling,
+            Unbounded,
+            Delta,
+            AppliedConstructor,
+        };
+
+        template <TokenKind Kind> inline constexpr auto token = dsl::lit_b<static_cast<std::uint8_t>(Kind)>;
+
+        template <ContextToken Kind> inline constexpr auto contextual = dsl::lit_b<static_cast<std::uint8_t>(Kind)>;
+
+        inline constexpr auto identifier      = token<TokenKind::Identifier>;
+        inline constexpr auto newline         = token<TokenKind::Newline>;
+        inline constexpr auto contextual_name = contextual<ContextToken::In> / contextual<ContextToken::Atomic> /
+                                                contextual<ContextToken::Tuple> / contextual<ContextToken::List> /
+                                                contextual<ContextToken::Set> / contextual<ContextToken::Map> /
+                                                contextual<ContextToken::Rolling> / contextual<ContextToken::Unbounded> /
+                                                contextual<ContextToken::Delta> / contextual<ContextToken::AppliedConstructor>;
+        inline constexpr auto name            = identifier / contextual_name;
+
+        struct newlines
+        { static constexpr auto rule = dsl::while_(newline); };
+
+        struct line_end
+        { static constexpr auto rule = newline >> dsl::while_(newline) | dsl::peek(dsl::eof); };
+
+        struct comma_separator
+        {
+            static constexpr auto rule = dsl::peek(dsl::p<newlines> + token<TokenKind::Comma>) >>
+                                         dsl::p<newlines> + token<TokenKind::Comma> + dsl::p<newlines>;
+        };
+
+        struct module_path
+        { static constexpr auto rule = name + dsl::while_(token<TokenKind::Dot> >> name); };
+
+        struct qualified_name
+        { static constexpr auto rule = name >> dsl::if_(token<TokenKind::ColonColon> >> name); };
+
+        inline constexpr auto scalar_type = token<TokenKind::KwBool> / token<TokenKind::KwI64> / token<TokenKind::KwF64> /
+                                            token<TokenKind::KwStr> / token<TokenKind::KwDate> / token<TokenKind::KwTime> /
+                                            token<TokenKind::KwDateTime> / token<TokenKind::KwDuration> /
+                                            token<TokenKind::KwCivilDateTime> / token<TokenKind::KwZonedDateTime> /
+                                            token<TokenKind::KwZonedTime> / token<TokenKind::KwTimeZone>;
+
+        inline constexpr auto type_start = scalar_type / name;
+
+        struct expression;
+        struct type;
+
+        inline constexpr auto expression_start =
+            name / token<TokenKind::Placeholder> / token<TokenKind::IntLiteral> / token<TokenKind::FloatLiteral> /
+            token<TokenKind::StringLiteral> / token<TokenKind::TemporalLiteral> / token<TokenKind::KwTrue> /
+            token<TokenKind::KwFalse> / token<TokenKind::KwNull> / token<TokenKind::Minus> / token<TokenKind::Bang> /
+            token<TokenKind::LParen> / token<TokenKind::LBracket> / token<TokenKind::KwFn> / token<TokenKind::KwIf> /
+            token<TokenKind::KwEval> / token<TokenKind::LBrace>;
+
+        struct size_expression;
+        struct generic_argument;
+
+        struct generic_arguments
+        {
+            static constexpr auto rule = token<TokenKind::Less> >>
+                                         dsl::p<newlines> +
+                                             dsl::list(dsl::peek(type_start / expression_start) >> dsl::recurse<generic_argument>,
+                                                       dsl::trailing_sep(dsl::p<comma_separator>)) +
+                                             dsl::p<newlines> + token<TokenKind::Greater>;
+        };
+
+        struct named_type
+        { static constexpr auto rule = dsl::p<qualified_name> >> dsl::if_(dsl::p<generic_arguments>); };
+
+        struct tuple_type
+        {
+            static constexpr auto rule = dsl::peek(contextual<ContextToken::Tuple> + token<TokenKind::Less>) >>
+                                         contextual<ContextToken::Tuple> + token<TokenKind::Less> + dsl::p<newlines> +
+                                             dsl::list(dsl::peek(type_start) >> dsl::recurse<type>,
+                                                       dsl::trailing_sep(dsl::p<comma_separator>)) +
+                                             dsl::p<newlines> + token<TokenKind::Greater>;
+        };
+
+        struct list_type
+        {
+            static constexpr auto size =
+                contextual<ContextToken::Unbounded> | dsl::peek(expression_start) >> dsl::recurse<size_expression>;
+            static constexpr auto
+                rule = dsl::peek(contextual<ContextToken::List> + token<TokenKind::Less>) >>
+                       contextual<ContextToken::List> + token<TokenKind::Less> + dsl::p<newlines> + dsl::recurse<type> +
+                           dsl::if_(dsl::p<comma_separator> >> size + dsl::p<newlines>) + token<TokenKind::Greater>;
+        };
+
+        struct set_type
+        {
+            static constexpr auto rule = dsl::peek(contextual<ContextToken::Set> + token<TokenKind::Less>) >>
+                                         contextual<ContextToken::Set> + token<TokenKind::Less> + dsl::p<newlines> +
+                                             dsl::recurse<type> + dsl::p<newlines> + token<TokenKind::Greater>;
+        };
+
+        struct map_type
+        {
+            static constexpr auto rule = dsl::peek(contextual<ContextToken::Map> + token<TokenKind::Less>) >>
+                                         contextual<ContextToken::Map> + token<TokenKind::Less> + dsl::p<newlines> +
+                                             dsl::recurse<type> + dsl::p<comma_separator> + dsl::recurse<type> + dsl::p<newlines> +
+                                             token<TokenKind::Greater>;
+        };
+
+        struct rolling_type
+        {
+            static constexpr auto rule = dsl::peek(contextual<ContextToken::Rolling> + token<TokenKind::Less>) >>
+                                         contextual<ContextToken::Rolling> + token<TokenKind::Less> + dsl::p<newlines> +
+                                             dsl::recurse<type> + dsl::p<comma_separator> + dsl::recurse<size_expression> +
+                                             dsl::if_(dsl::p<comma_separator> >> dsl::recurse<size_expression>) + dsl::p<newlines> +
+                                             token<TokenKind::Greater>;
+        };
+
+        struct atomic_type
+        {
+            static constexpr auto rule = dsl::peek(contextual<ContextToken::Atomic> + token<TokenKind::Less>) >>
+                                         contextual<ContextToken::Atomic> + token<TokenKind::Less> + dsl::p<newlines> +
+                                             dsl::recurse<type> + dsl::p<newlines> + token<TokenKind::Greater>;
+        };
+
+        struct type
+        {
+            static constexpr auto rule = scalar_type | dsl::p<tuple_type> | dsl::p<list_type> | dsl::p<set_type> |
+                                         dsl::p<map_type> | dsl::p<rolling_type> | dsl::p<atomic_type> | dsl::p<named_type>;
+        };
+
+        struct generic_argument
+        {
+            static constexpr auto rule = scalar_type | dsl::p<tuple_type> | dsl::p<list_type> | dsl::p<set_type> |
+                                         dsl::p<map_type> | dsl::p<rolling_type> | dsl::p<atomic_type> |
+                                         dsl::peek(name + (token<TokenKind::Less> / token<TokenKind::ColonColon>)) >>
+                                             dsl::p<named_type> |
+                                         dsl::peek(expression_start) >> dsl::recurse<size_expression>;
+        };
+
+        template <TokenKind... Kinds> inline constexpr auto token_choice = (token<Kinds> / ...);
+
+        template <TokenKind... Kinds> struct continued_operator
+        {
+            static constexpr auto direct = token_choice<Kinds...> >> dsl::p<newlines>;
+            static constexpr auto continued =
+                dsl::peek(newline + token_choice<Kinds...>) >> (newline + token_choice<Kinds...> + dsl::p<newlines>);
+            static constexpr auto rule = direct | continued;
+        };
+
+        struct unary_expression;
+        struct postfix_expression;
+        struct primary_expression;
+
+        struct product_expression
+        {
+            static constexpr auto rule =
+                dsl::recurse<unary_expression> +
+                dsl::while_(dsl::p<continued_operator<TokenKind::Star, TokenKind::Slash, TokenKind::Percent>> >>
+                            dsl::recurse<unary_expression>);
+        };
+
+        struct sum_expression
+        {
+            static constexpr auto rule =
+                dsl::p<product_expression> +
+                dsl::while_(dsl::p<continued_operator<TokenKind::Plus, TokenKind::Minus>> >> dsl::p<product_expression>);
+        };
+
+        struct comparison_expression
+        {
+            static constexpr auto rule =
+                dsl::p<sum_expression> +
+                dsl::while_(
+                    dsl::p<
+                        continued_operator<TokenKind::Less, TokenKind::LessEqual, TokenKind::Greater, TokenKind::GreaterEqual>> >>
+                    dsl::p<sum_expression>);
+        };
+
+        struct equality_expression
+        {
+            static constexpr auto rule = dsl::p<comparison_expression> +
+                                         dsl::while_(dsl::p<continued_operator<TokenKind::EqualEqual, TokenKind::NotEqual>> >>
+                                                     dsl::p<comparison_expression>);
+        };
+
+        struct and_expression
+        {
+            static constexpr auto rule = dsl::p<equality_expression> +
+                                         dsl::while_(dsl::p<continued_operator<TokenKind::AndAnd>> >> dsl::p<equality_expression>);
+        };
+
+        struct expression
+        {
+            static constexpr auto rule =
+                dsl::p<and_expression> + dsl::while_(dsl::p<continued_operator<TokenKind::OrOr>> >> dsl::p<and_expression>);
+        };
+
+        struct size_expression
+        { static constexpr auto rule = dsl::p<sum_expression>; };
+
+        struct argument
+        {
+            static constexpr auto named = dsl::peek(name + token<TokenKind::Colon>) >>
+                                          name + token<TokenKind::Colon> + dsl::p<newlines> + dsl::recurse<expression>;
+            static constexpr auto rule  = named | dsl::peek(expression_start) >> dsl::recurse<expression>;
+        };
+
+        struct arguments
+        {
+            static constexpr auto rule = token<TokenKind::LParen> >>
+                                         dsl::p<newlines> +
+                                             dsl::if_(dsl::list(dsl::p<argument>, dsl::trailing_sep(dsl::p<comma_separator>))) +
+                                             dsl::p<newlines> + token<TokenKind::RParen>;
+        };
+
+        struct index_postfix
+        {
+            static constexpr auto rule = token<TokenKind::LBracket> >> dsl::p<newlines> + dsl::recurse<expression> +
+                                                                           dsl::p<newlines> + token<TokenKind::RBracket>;
+        };
+
+        struct call_postfix
+        { static constexpr auto rule = dsl::p<arguments>; };
+
+        struct field_postfix
+        { static constexpr auto rule = token<TokenKind::Dot> >> name; };
+
+        struct postfix
+        { static constexpr auto rule = dsl::p<call_postfix> | dsl::p<index_postfix> | dsl::p<field_postfix>; };
+
+        struct tuple_or_group;
+        struct sequence_literal;
+        struct anonymous_function;
+        struct if_expression;
+        struct eval_expression;
+        struct block;
+
+        struct explicit_construct
+        {
+            static constexpr auto
+                normal = contextual<ContextToken::AppliedConstructor> >>
+                         dsl::if_(token<TokenKind::ColonColon> >> name) + dsl::p<generic_arguments> + dsl::p<arguments>;
+            static constexpr auto delta = contextual<ContextToken::Delta> >> token<TokenKind::Less> + dsl::p<newlines> +
+                                                                                 dsl::p<type> + dsl::p<newlines> +
+                                                                                 token<TokenKind::Greater> + dsl::p<arguments>;
+            static constexpr auto rule  = normal | delta;
+        };
+
+        struct primary_expression
+        {
+            static constexpr auto literal = token<TokenKind::IntLiteral> / token<TokenKind::FloatLiteral> /
+                                            token<TokenKind::StringLiteral> / token<TokenKind::TemporalLiteral> /
+                                            token<TokenKind::KwTrue> / token<TokenKind::KwFalse> / token<TokenKind::KwNull> /
+                                            token<TokenKind::Placeholder>;
+            static constexpr auto rule    = dsl::p<explicit_construct> | literal |
+                                            dsl::peek(token<TokenKind::LParen>) >> dsl::recurse<tuple_or_group> |
+                                            dsl::peek(token<TokenKind::LBracket>) >> dsl::recurse<sequence_literal> |
+                                            dsl::peek(token<TokenKind::KwFn>) >> dsl::recurse<anonymous_function> |
+                                            dsl::peek(token<TokenKind::KwIf>) >> dsl::recurse<if_expression> |
+                                            dsl::peek(token<TokenKind::KwEval>) >> dsl::recurse<eval_expression> |
+                                            dsl::peek(token<TokenKind::LBrace>) >> dsl::recurse<block> | dsl::p<qualified_name>;
+        };
+
+        struct postfix_expression
+        { static constexpr auto rule = dsl::p<primary_expression> + dsl::while_(dsl::p<postfix>); };
+
+        struct unary_expression
+        {
+            static constexpr auto rule = token_choice<TokenKind::Minus, TokenKind::Bang> >> dsl::recurse<unary_expression> |
+                                         dsl::peek(expression_start) >> dsl::p<postfix_expression>;
+        };
+
+        struct tuple_element
+        { static constexpr auto rule = dsl::peek(expression_start) >> dsl::recurse<expression>; };
+
+        struct tuple_or_group
+        {
+            static constexpr auto
+                rule = token<TokenKind::LParen> >>
+                       dsl::p<newlines> + dsl::p<tuple_element> +
+                           dsl::if_(dsl::p<comma_separator> >>
+                                    dsl::if_(dsl::list(dsl::p<tuple_element>, dsl::trailing_sep(dsl::p<comma_separator>)))) +
+                           token<TokenKind::RParen>;
+        };
+
+        struct sequence_element
+        {
+            static constexpr auto timed =
+                dsl::peek(token<TokenKind::TemporalLiteral> + token<TokenKind::Colon>) >>
+                token<TokenKind::TemporalLiteral> + token<TokenKind::Colon> + dsl::p<newlines> + dsl::recurse<expression>;
+            static constexpr auto rule = timed | dsl::peek(expression_start) >> dsl::recurse<expression>;
+        };
+
+        struct sequence_literal
+        {
+            static constexpr auto rule = token<TokenKind::LBracket> >>
+                                         dsl::p<newlines> +
+                                             dsl::if_(dsl::list(dsl::p<sequence_element>,
+                                                                dsl::trailing_sep(dsl::p<comma_separator>))) +
+                                             dsl::p<newlines> + token<TokenKind::RBracket>;
+        };
+
+        struct anonymous_parameter
+        { static constexpr auto rule = name >> dsl::if_(token<TokenKind::Colon> >> dsl::p<newlines> + dsl::p<type>); };
+
+        struct anonymous_function
+        {
+            static constexpr auto rule = token<TokenKind::KwFn> >>
+                                         token<TokenKind::LParen> + dsl::p<newlines> +
+                                             dsl::if_(dsl::list(dsl::p<anonymous_parameter>,
+                                                                dsl::trailing_sep(dsl::p<comma_separator>))) +
+                                             dsl::p<newlines> + token<TokenKind::RParen> +
+                                             dsl::if_(dsl::p<continued_operator<TokenKind::Arrow>> >> dsl::p<type>) +
+                                             dsl::p<continued_operator<TokenKind::FatArrow>> + dsl::recurse<expression>;
+        };
+
+        struct else_arm
+        {
+            static constexpr auto rule =
+                token<TokenKind::KwElse> >> (dsl::peek(token<TokenKind::KwIf>) >> dsl::recurse<if_expression> |
+                                             dsl::peek(token<TokenKind::LBrace>) >> dsl::recurse<block>);
+        };
+
+        struct if_expression
+        {
+            static constexpr auto rule = token<TokenKind::KwIf> >> dsl::recurse<expression> + dsl::recurse<block> +
+                                                                       dsl::if_(dsl::peek(newline + token<TokenKind::KwElse>) >>
+                                                                                    newline + dsl::p<newlines> + dsl::p<else_arm> |
+                                                                                dsl::p<else_arm>);
+        };
+
+        struct eval_expression
+        {
+            static constexpr auto rule = token<TokenKind::KwEval> >>
+                                         token<TokenKind::LParen> + dsl::p<newlines> +
+                                             dsl::list(dsl::p<argument>, dsl::trailing_sep(dsl::p<comma_separator>)) +
+                                             dsl::p<newlines> + token<TokenKind::RParen>;
+        };
+
+        struct local_decl
+        {
+            static constexpr auto rule = token_choice<TokenKind::KwLet, TokenKind::KwVar> >>
+                                         name + dsl::if_(token<TokenKind::Colon> >> dsl::p<newlines> + dsl::p<type>) +
+                                             token<TokenKind::Assign> + dsl::p<newlines> + dsl::recurse<expression>;
+        };
+
+        struct state_decl
+        {
+            static constexpr auto rule = token<TokenKind::KwState> >>
+                                         name + dsl::if_(token<TokenKind::Colon> >> dsl::p<newlines> + dsl::p<type>) +
+                                             token<TokenKind::Assign> + dsl::p<newlines> + dsl::recurse<expression>;
+        };
+
+        struct inject_decl
+        {
+            static constexpr auto next_name = dsl::peek(dsl::p<newlines> + token<TokenKind::Comma> + dsl::p<newlines> + name) >>
+                                              dsl::p<newlines> + token<TokenKind::Comma> + dsl::p<newlines> + name;
+            static constexpr auto trailing_comma =
+                dsl::peek(dsl::p<newlines> + token<TokenKind::Comma>) >> dsl::p<newlines> + token<TokenKind::Comma>;
+            static constexpr auto rule = token<TokenKind::KwInject> >>
+                                         dsl::p<newlines> + name + dsl::while_(next_name) + dsl::if_(trailing_comma);
+        };
+
+        struct lifecycle_stmt
+        { static constexpr auto rule = token_choice<TokenKind::KwStart, TokenKind::KwStop> >> dsl::recurse<block>; };
+
+        struct when_stmt
+        { static constexpr auto rule = token<TokenKind::KwWhen> >> dsl::recurse<expression> + dsl::recurse<block>; };
+
+        struct for_stmt
+        {
+            static constexpr auto rule = token<TokenKind::KwFor> >>
+                                         name + dsl::if_(token<TokenKind::Comma> >> name) +
+                                             contextual<ContextToken::In> + dsl::recurse<expression> + dsl::recurse<block>;
+        };
+
+        struct return_stmt
+        {
+            static constexpr auto rule = token<TokenKind::KwReturn> >>
+                                         dsl::if_(dsl::peek(expression_start) >> dsl::recurse<expression>);
+        };
+
+        struct assert_stmt
+        { static constexpr auto rule = token<TokenKind::KwAssert> >> dsl::recurse<expression>; };
+
+        struct assign_or_expression_stmt
+        {
+            static constexpr auto assignment = token_choice<TokenKind::Assign, TokenKind::PlusAssign, TokenKind::MinusAssign,
+                                                            TokenKind::StarAssign, TokenKind::SlashAssign>;
+            static constexpr auto rule       = dsl::peek(expression_start) >>
+                                               dsl::recurse<expression> +
+                                                   dsl::if_(assignment >> dsl::p<newlines> + dsl::recurse<expression>);
+        };
+
+        struct statement
+        {
+            static constexpr auto rule = dsl::p<local_decl> | dsl::p<state_decl> | dsl::p<inject_decl> | dsl::p<lifecycle_stmt> |
+                                         dsl::p<when_stmt> | dsl::p<for_stmt> | dsl::p<return_stmt> | dsl::p<assert_stmt> |
+                                         dsl::p<assign_or_expression_stmt>;
+        };
+
+        inline constexpr auto statement_start = token<TokenKind::KwLet> / token<TokenKind::KwVar> / token<TokenKind::KwState> /
+                                                token<TokenKind::KwInject> / token<TokenKind::KwStart> / token<TokenKind::KwStop> /
+                                                token<TokenKind::KwWhen> / token<TokenKind::KwFor> / token<TokenKind::KwReturn> /
+                                                token<TokenKind::KwAssert> / expression_start;
+
+        struct block_item
+        {
+            static constexpr auto rule = dsl::peek(statement_start) >>
+                                         dsl::p<statement> + (newline >> dsl::p<newlines> | dsl::peek(token<TokenKind::RBrace>));
+        };
+
+        struct block
+        {
+            static constexpr auto rule = token<TokenKind::LBrace> >>
+                                         dsl::p<newlines> + dsl::while_(dsl::p<block_item>) + token<TokenKind::RBrace>;
+        };
+
+        struct generic_parameter
+        {
+            static constexpr auto constant =
+                token<TokenKind::KwConst> >> name + token<TokenKind::Colon> + dsl::p<newlines> + dsl::p<type>;
+            static constexpr auto rule = constant | name;
+        };
+
+        struct generic_parameters
+        {
+            static constexpr auto rule = token<TokenKind::Less> >>
+                                         dsl::p<newlines> +
+                                             dsl::list(dsl::p<generic_parameter>, dsl::trailing_sep(dsl::p<comma_separator>)) +
+                                             dsl::p<newlines> + token<TokenKind::Greater>;
+        };
+
+        struct parameter
+        {
+            static constexpr auto regular  = name >>
+                                             dsl::try_(token<TokenKind::Colon>) + dsl::p<newlines> + dsl::p<type> +
+                                                 dsl::if_(token<TokenKind::Assign> >> dsl::p<newlines> + dsl::recurse<expression>);
+            static constexpr auto constant = token<TokenKind::KwConst> >> regular;
+            static constexpr auto rule     = constant | regular;
+        };
+
+        struct signature
+        {
+            static constexpr auto
+                rule = token<TokenKind::LParen> >>
+                       dsl::p<newlines> +
+                           dsl::if_(dsl::list(dsl::p<parameter>, dsl::trailing_sep(dsl::p<comma_separator>))) + dsl::p<newlines> +
+                           token<TokenKind::RParen> + dsl::if_(dsl::p<continued_operator<TokenKind::Arrow>> >> dsl::p<type>);
+        };
+
+        struct constraint;
+        struct constraint_operand;
+
+        struct constraint_set
+        {
+            static constexpr auto rule = token<TokenKind::LBrace> >>
+                                         dsl::p<newlines> +
+                                             dsl::list(dsl::peek(type_start / expression_start / token<TokenKind::LBrace>) >>
+                                                           dsl::recurse<constraint_operand>,
+                                                       dsl::trailing_sep(dsl::p<comma_separator>)) +
+                                             token<TokenKind::RBrace>;
+        };
+
+        struct constraint_call
+        {
+            static constexpr auto
+                rule = dsl::peek(name + dsl::if_(token<TokenKind::ColonColon> >> name) + token<TokenKind::LParen>) >>
+                       dsl::p<qualified_name> + token<TokenKind::LParen> + dsl::p<newlines> +
+                           dsl::if_(dsl::list(dsl::peek(type_start / expression_start / token<TokenKind::LBrace>) >>
+                                                  dsl::recurse<constraint_operand>,
+                                              dsl::trailing_sep(dsl::p<comma_separator>))) +
+                           dsl::p<newlines> + token<TokenKind::RParen>;
+        };
+
+        struct constraint_operand
+        {
+            static constexpr auto value = token<TokenKind::IntLiteral> / token<TokenKind::FloatLiteral> /
+                                          token<TokenKind::StringLiteral> / token<TokenKind::TemporalLiteral> /
+                                          token<TokenKind::KwTrue> / token<TokenKind::KwFalse> / token<TokenKind::KwNull> /
+                                          token<TokenKind::Minus>;
+            static constexpr auto rule =
+                dsl::p<constraint_set> | scalar_type | dsl::p<tuple_type> | dsl::p<list_type> | dsl::p<set_type> |
+                dsl::p<map_type> | dsl::p<rolling_type> | dsl::p<atomic_type> | dsl::p<constraint_call> |
+                dsl::peek(name + (token<TokenKind::Less> / token<TokenKind::ColonColon>)) >> dsl::p<named_type> | name | value;
+        };
+
+        struct constraint_term
+        {
+            static constexpr auto relation    = token<TokenKind::EqualEqual> >> dsl::p<constraint_operand> |
+                                                contextual<ContextToken::In> >> dsl::p<constraint_operand> |
+                                                token<TokenKind::KwIs> >> (token<TokenKind::KwStruct> | name);
+            static constexpr auto requirement = token<TokenKind::Arrow> >> dsl::p<newlines> + dsl::p<type>;
+            static constexpr auto atom        = token<TokenKind::Bang> >> dsl::recurse<constraint_term> |
+                                                token<TokenKind::LParen> >> dsl::p<newlines> + dsl::recurse<constraint> +
+                                                                                dsl::p<newlines> + token<TokenKind::RParen> |
+                                                dsl::p<constraint_operand>;
+            static constexpr auto rule        = atom + dsl::if_(requirement | relation);
+        };
+
+        struct constraint_and
+        {
+            static constexpr auto rule =
+                dsl::p<constraint_term> + dsl::while_(dsl::p<continued_operator<TokenKind::AndAnd>> >> dsl::p<constraint_term>);
+        };
+
+        struct constraint
+        {
+            static constexpr auto rule =
+                dsl::p<constraint_and> + dsl::while_(dsl::p<continued_operator<TokenKind::OrOr>> >> dsl::p<constraint_and>);
+        };
+
+        struct requires_clause
+        { static constexpr auto rule = token<TokenKind::KwRequires> >> dsl::p<newlines> + dsl::p<constraint>; };
+
+        struct optional_requires_clause
+        {
+            static constexpr auto continued =
+                dsl::peek(newline + token<TokenKind::KwRequires>) >> newline + dsl::p<newlines> + dsl::p<requires_clause>;
+            static constexpr auto rule = dsl::if_(continued | dsl::p<requires_clause>);
+        };
+
+        struct function_decl
+        {
+            static constexpr auto visibility = token<TokenKind::KwExport> / token<TokenKind::KwImpl>;
+            static constexpr auto body = dsl::p<continued_operator<TokenKind::FatArrow>> >> dsl::p<expression> | dsl::p<block>;
+            static constexpr auto start =
+                dsl::peek(token<TokenKind::KwExport> + token<TokenKind::KwFn>) | token<TokenKind::KwImpl> | token<TokenKind::KwFn>;
+            static constexpr auto
+                rule = dsl::peek(start) >>
+                       dsl::opt(visibility) + token<TokenKind::KwFn> + name
+                           + dsl::if_(dsl::p<generic_parameters>) + dsl::p<signature> + dsl::p<optional_requires_clause> +
+                           (newline >> dsl::p<newlines> + body | body);
+        };
+
+        struct operator_decl
+        {
+            static constexpr auto
+                rule = token<TokenKind::KwOperator> >>
+                       name + dsl::if_(dsl::p<generic_parameters>) + dsl::p<signature> + dsl::p<optional_requires_clause>;
+        };
+
+        struct struct_member
+        {
+            static constexpr auto rule =
+                name >>
+                (token<TokenKind::Colon> >>
+                     dsl::p<newlines> + dsl::p<type> + dsl::if_(token<TokenKind::Assign> >> dsl::p<newlines> + dsl::p<expression>) |
+                 token<TokenKind::Assign> >> dsl::p<newlines> + dsl::p<expression>);
+        };
+
+        struct struct_body_item
+        {
+            static constexpr auto rule =
+                dsl::peek(name) >> dsl::p<struct_member> + (newline >> dsl::p<newlines> | dsl::peek(token<TokenKind::RBrace>));
+        };
+
+        struct struct_decl
+        {
+            static constexpr auto modifiers = dsl::opt(token<TokenKind::KwExport>) + dsl::opt(token<TokenKind::KwAbstract>);
+            static constexpr auto parents   = token<TokenKind::Colon> >>
+                                              dsl::p<newlines> + dsl::list(dsl::peek(type_start) >> dsl::p<type>,
+                                                                           dsl::trailing_sep(dsl::p<comma_separator>));
+            static constexpr auto body      = token<TokenKind::LBrace> >>
+                                              dsl::p<newlines> + dsl::while_(dsl::p<struct_body_item>) + token<TokenKind::RBrace>;
+            static constexpr auto start =
+                dsl::peek(token<TokenKind::KwExport> + dsl::opt(token<TokenKind::KwAbstract>) + token<TokenKind::KwStruct>) |
+                dsl::peek(token<TokenKind::KwAbstract> + token<TokenKind::KwStruct>) | token<TokenKind::KwStruct>;
+            static constexpr auto
+                rule = dsl::peek(start) >>
+                       modifiers + token<TokenKind::KwStruct> + name +
+                           dsl::if_(dsl::p<generic_parameters>) + dsl::if_(parents) + dsl::p<optional_requires_clause> +
+                           (newline >> dsl::p<newlines> + body | body);
+        };
+
+        struct use_decl
+        {
+            static constexpr auto import_set =
+                token<TokenKind::ColonColon> >>
+                token<TokenKind::LBrace> + dsl::p<newlines> +
+                    dsl::list(name, dsl::trailing_sep(dsl::p<comma_separator>)) + dsl::p<newlines> + token<TokenKind::RBrace>;
+            static constexpr auto alias = token<TokenKind::KwAs> >> name;
+            static constexpr auto rule  = token<TokenKind::KwUse> >> dsl::p<module_path> + (import_set | alias);
+        };
+
+        struct test_decl
+        { static constexpr auto rule = token<TokenKind::KwTest> >> name + dsl::p<block>; };
+
+        struct declaration
+        {
+            static constexpr auto rule =
+                dsl::p<use_decl> | dsl::p<function_decl> | dsl::p<operator_decl> | dsl::p<struct_decl> | dsl::p<test_decl>;
+        };
+
+        struct declaration_line
+        { static constexpr auto rule = dsl::p<declaration> >> dsl::p<line_end>; };
+
+        struct module_decl
+        { static constexpr auto rule = token<TokenKind::KwModule> >> dsl::p<module_path>; };
+
+        struct module
+        {
+            static constexpr auto rule =
+                dsl::p<newlines> + dsl::p<module_decl> + dsl::p<line_end> + dsl::while_(dsl::p<declaration_line>) + dsl::eof;
+        };
+    }  // namespace grammar
+
+    namespace
+    {
+        [[nodiscard]] bool looks_like_applied_constructor(std::span<const Token> tokens, std::size_t position) noexcept {
+            if (tokens[position].kind != TokenKind::Identifier) { return false; }
+            std::size_t cursor = position + 1;
+            if (cursor < tokens.size() && tokens[cursor].kind == TokenKind::ColonColon) {
+                cursor += 2;
+                if (cursor > tokens.size() || tokens[cursor - 1].kind != TokenKind::Identifier) { return false; }
+            }
+            if (cursor >= tokens.size() || tokens[cursor].kind != TokenKind::Less) { return false; }
+
+            int depth = 0;
+            for (; cursor < tokens.size(); ++cursor) {
+                if (tokens[cursor].kind == TokenKind::Less) {
+                    ++depth;
+                } else if (tokens[cursor].kind == TokenKind::Greater) {
+                    --depth;
+                    if (depth == 0) { return cursor + 1 < tokens.size() && tokens[cursor + 1].kind == TokenKind::LParen; }
+                } else if (tokens[cursor].kind == TokenKind::EndOfFile) {
+                    return false;
+                }
+            }
+            return false;
+        }
+
+        [[nodiscard]] std::uint8_t encode(std::span<const Token> tokens, std::size_t position) noexcept {
+            const Token &token = tokens[position];
+            if (looks_like_applied_constructor(tokens, position)) {
+                return static_cast<std::uint8_t>(grammar::ContextToken::AppliedConstructor);
+            }
+            if (token.kind == TokenKind::Identifier) {
+                if (token.text == "in") { return static_cast<std::uint8_t>(grammar::ContextToken::In); }
+                if (token.text == "atomic") { return static_cast<std::uint8_t>(grammar::ContextToken::Atomic); }
+                if (token.text == "tuple") { return static_cast<std::uint8_t>(grammar::ContextToken::Tuple); }
+                if (token.text == "list") { return static_cast<std::uint8_t>(grammar::ContextToken::List); }
+                if (token.text == "set") { return static_cast<std::uint8_t>(grammar::ContextToken::Set); }
+                if (token.text == "map") { return static_cast<std::uint8_t>(grammar::ContextToken::Map); }
+                if (token.text == "rolling") { return static_cast<std::uint8_t>(grammar::ContextToken::Rolling); }
+                if (token.text == "unbounded") { return static_cast<std::uint8_t>(grammar::ContextToken::Unbounded); }
+                if (token.text == "delta") { return static_cast<std::uint8_t>(grammar::ContextToken::Delta); }
+            }
+            return static_cast<std::uint8_t>(token.kind);
+        }
+    }  // namespace
+
+    GrammarResult parse_token_grammar(std::span<const Token> tokens) {
+        std::string input_bytes;
+        input_bytes.reserve(tokens.size());
+        for (std::size_t position = 0; position < tokens.size(); ++position) {
+            const Token &token = tokens[position];
+            if (token.kind != TokenKind::EndOfFile) { input_bytes.push_back(static_cast<char>(encode(tokens, position))); }
+        }
+
+        const auto                            input = lexy::string_input<lexy::byte_encoding>{input_bytes};
+        lexy::parse_tree_for<decltype(input)> tree;
+        std::size_t                           first_error    = std::numeric_limits<std::size_t>::max();
+        const auto                            error_callback = lexy::callback([&](const auto &, const auto &error) {
+            if (first_error == std::numeric_limits<std::size_t>::max()) {
+                const auto *begin = reinterpret_cast<const unsigned char *>(input_bytes.data());
+                first_error       = static_cast<std::size_t>(error.position() - begin);
+            }
+        });
+        const auto                            result         = lexy::parse_as_tree<grammar::module>(tree, input, error_callback);
+
+        std::size_t node_count = 0;
+        for (const auto event : tree.traverse()) {
+            if (event.event == lexy::traverse_event::enter || event.event == lexy::traverse_event::leaf) { ++node_count; }
+        }
+        return GrammarResult{!result.is_fatal_error(), result.is_recovered_error(), result.error_count(), node_count, first_error};
+    }
+}  // namespace hgl::syntax

--- a/language/src/syntax/token_grammar.cpp
+++ b/language/src/syntax/token_grammar.cpp
@@ -300,7 +300,7 @@ namespace hgl::syntax
                        dsl::p<newlines> + dsl::p<tuple_element> +
                            dsl::if_(dsl::p<comma_separator> >>
                                     dsl::if_(dsl::list(dsl::p<tuple_element>, dsl::trailing_sep(dsl::p<comma_separator>)))) +
-                           token<TokenKind::RParen>;
+                           dsl::p<newlines> + token<TokenKind::RParen>;
         };
 
         struct sequence_element
@@ -495,14 +495,15 @@ namespace hgl::syntax
 
         struct constraint_operand
         {
-            static constexpr auto value = token<TokenKind::IntLiteral> / token<TokenKind::FloatLiteral> /
-                                          token<TokenKind::StringLiteral> / token<TokenKind::TemporalLiteral> /
-                                          token<TokenKind::KwTrue> / token<TokenKind::KwFalse> / token<TokenKind::KwNull> /
-                                          token<TokenKind::Minus>;
+            static constexpr auto value_start = token<TokenKind::IntLiteral> / token<TokenKind::FloatLiteral> /
+                                                token<TokenKind::StringLiteral> / token<TokenKind::TemporalLiteral> /
+                                                token<TokenKind::KwTrue> / token<TokenKind::KwFalse> /
+                                                token<TokenKind::KwNull> / token<TokenKind::Minus>;
             static constexpr auto rule =
                 dsl::p<constraint_set> | scalar_type | dsl::p<tuple_type> | dsl::p<list_type> | dsl::p<set_type> |
                 dsl::p<map_type> | dsl::p<rolling_type> | dsl::p<atomic_type> | dsl::p<constraint_call> |
-                dsl::peek(name + (token<TokenKind::Less> / token<TokenKind::ColonColon>)) >> dsl::p<named_type> | name | value;
+                dsl::peek(name + (token<TokenKind::Less> / token<TokenKind::ColonColon>)) >> dsl::p<named_type> |
+                dsl::peek(value_start) >> dsl::p<size_expression> | name;
         };
 
         struct constraint_term

--- a/language/src/syntax/token_grammar.h
+++ b/language/src/syntax/token_grammar.h
@@ -1,0 +1,29 @@
+#ifndef HGL_SYNTAX_TOKEN_GRAMMAR_H
+#define HGL_SYNTAX_TOKEN_GRAMMAR_H
+
+#include "syntax/token.h"
+
+#include <cstddef>
+#include <limits>
+#include <span>
+
+namespace hgl::syntax
+{
+    /// Result of parsing the lexer's token stream with the declarative HGL
+    /// grammar. This deliberately exposes no parser-library types.
+    struct GrammarResult
+    {
+        bool        accepted{false};
+        bool        recovered{false};
+        std::size_t error_count{0};
+        std::size_t syntax_node_count{0};
+        std::size_t first_error_token{std::numeric_limits<std::size_t>::max()};
+    };
+
+    /// Parse a complete, EOF-terminated token stream. The current AST parser
+    /// remains the projection path while the lexy grammar is introduced in
+    /// verified slices; this entry point is the shadow/conformance boundary.
+    [[nodiscard]] GrammarResult parse_token_grammar(std::span<const Token> tokens);
+}  // namespace hgl::syntax
+
+#endif  // HGL_SYNTAX_TOKEN_GRAMMAR_H

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ endif()
 add_executable(hgl_syntax_tests
     syntax/temporal_tests.cpp
     syntax/lexer_tests.cpp
+    syntax/token_grammar_tests.cpp
     syntax/parser_tests.cpp
 )
 target_compile_features(hgl_syntax_tests PRIVATE cxx_std_23)

--- a/language/tests/syntax/parser_tests.cpp
+++ b/language/tests/syntax/parser_tests.cpp
@@ -62,6 +62,8 @@ namespace
                                                     << token.text << "'");
         }
         REQUIRE(grammar.accepted);
+        REQUIRE_FALSE(grammar.recovered);
+        REQUIRE(grammar.error_count == 0);
         return dump(parsed);
     }
 
@@ -284,6 +286,13 @@ TEST_CASE("operator declarations have signatures and no body", "[parser]")
     Parsed with_body{"module t\noperator f(x: f64) -> f64 => x\n"};
     REQUIRE(with_body.messages() ==
             std::vector<std::string>{"an operator declaration has no body; implement it with 'impl fn'"});
+}
+
+TEST_CASE("the declarative grammar preserves parenthesized newlines and constant constraint expressions", "[parser]")
+{
+    CHECK(dump_clean("module t\nfn grouped() -> i64 => (\n  1\n)\n").find("IntLiteral 1") != std::string::npos);
+    CHECK(dump_clean("module t\noperator sized<const N: i64>() requires N == -1 + 2\n")
+              .find("ConstraintRelation ==") != std::string::npos);
 }
 
 TEST_CASE("test declarations wrap a block", "[parser]")

--- a/language/tests/syntax/parser_tests.cpp
+++ b/language/tests/syntax/parser_tests.cpp
@@ -1,5 +1,7 @@
 #include "syntax/ast_printer.h"
+#include "syntax/lexer.h"
 #include "syntax/parser.h"
+#include "syntax/token_grammar.h"
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -49,6 +51,17 @@ namespace
         Parsed parsed{text};
         INFO(parsed.diagnostics.render(parsed.file));
         REQUIRE_FALSE(parsed.diagnostics.has_errors());
+        DiagnosticSink grammar_diagnostics;
+        LexResult grammar_tokens = lex(parsed.file, grammar_diagnostics);
+        REQUIRE_FALSE(grammar_diagnostics.has_errors());
+        const GrammarResult grammar = parse_token_grammar(grammar_tokens.tokens);
+        if (grammar.first_error_token < grammar_tokens.tokens.size())
+        {
+            const Token &token = grammar_tokens.tokens[grammar.first_error_token];
+            INFO("declarative grammar stopped at " << token_kind_name(token.kind) << " '"
+                                                    << token.text << "'");
+        }
+        REQUIRE(grammar.accepted);
         return dump(parsed);
     }
 

--- a/language/tests/syntax/token_grammar_tests.cpp
+++ b/language/tests/syntax/token_grammar_tests.cpp
@@ -1,0 +1,137 @@
+#include "syntax/diagnostic.h"
+#include "syntax/lexer.h"
+#include "syntax/source.h"
+#include "syntax/token_grammar.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace hgl::syntax;
+
+namespace
+{
+    void require_grammar(std::string text) {
+        SourceFile     file{"grammar.hgl", std::move(text)};
+        DiagnosticSink diagnostics;
+        LexResult      lexed = lex(file, diagnostics);
+        INFO(diagnostics.render(file));
+        REQUIRE_FALSE(diagnostics.has_errors());
+
+        const GrammarResult result = parse_token_grammar(lexed.tokens);
+        INFO("first grammar error token: " << result.first_error_token);
+        std::ostringstream context;
+        const std::size_t  context_begin = result.first_error_token > 3 ? result.first_error_token - 3 : 0;
+        const std::size_t  context_end   = std::min(result.first_error_token + 4, lexed.tokens.size());
+        for (std::size_t index = context_begin; index < context_end; ++index) {
+            context << index << ':' << token_kind_name(lexed.tokens[index].kind) << "('" << lexed.tokens[index].text << "') ";
+        }
+        INFO(context.str());
+        if (result.first_error_token < lexed.tokens.size()) {
+            const Token &token = lexed.tokens[result.first_error_token];
+            INFO("first grammar error at token " << result.first_error_token << " (" << token_kind_name(token.kind) << ", '"
+                                                 << token.text << "')");
+        }
+        INFO("grammar errors: " << result.error_count);
+        REQUIRE(result.accepted);
+        REQUIRE(result.error_count == 0);
+        REQUIRE(result.syntax_node_count > 0);
+    }
+}  // namespace
+
+TEST_CASE("the declarative grammar covers the language surface", "[token-grammar]") {
+    const std::vector<std::string> sources{
+        R"(module examples.syntax
+use hgraph.core::{add, map}
+use acme.stats as stats
+
+operator scale<T>(value: T, by: f64) -> T
+
+export fn midpoint(tob: atomic<tuple<f64, f64>>) -> f64 =>
+    (tob[0] + tob[1]) / 2.0
+
+impl fn smooth<T, const N: i64>(value: map<str, list<T, N>>, const window: i64 = 3) -> f64
+requires T in {i64, f64} && add(T, T) -> T
+{
+    state previous: f64 = 0.0
+    inject out, logger
+    start { logger("start") }
+    when modified(value) && valid(value) {
+        previous += stats::update(previous, value, window)
+        out = previous
+    }
+    stop { logger("stop") }
+    return previous
+}
+)",
+        R"(module examples.types
+
+export abstract struct Instrument<T> {
+    value: T
+    venue: str = null
+}
+
+export struct Future<T, const size: i64>: Instrument<T>
+requires T in {i64, f64} && T is struct || add(T, T) -> T
+{
+    venue = "XEUR"
+    history: rolling<T, size, 1>
+}
+
+fn construct() => Box<f64>(value: 1.0)
+fn change() => delta<Quote>(bid: 1.0, ask: null)
+)",
+        R"(module examples.expressions
+
+fn transform(xs: list<f64, unbounded>) {
+    let mapped = map(xs, fn(x: f64) -> f64 => x * 2.0)
+    var total = 0.0
+    for i, value in items(mapped) {
+        total += if value > 0.0 { value } else { 0.0 }
+    }
+    [0s: total, 2m: total + 1.0]
+}
+
+test doubles {
+    assert eval(transform, xs: [[1.0, 2.0]]) == [[2.0, 4.0]]
+}
+)",
+    };
+
+    for (const std::string &source : sources) { require_grammar(source); }
+}
+
+TEST_CASE("the declarative grammar covers every checked-in HGL example", "[token-grammar][examples]") {
+    namespace fs = std::filesystem;
+    for (const fs::directory_entry &entry : fs::directory_iterator{HGL_EXAMPLES_DIR}) {
+        if (entry.path().extension() != ".hgl") { continue; }
+        std::ifstream input{entry.path()};
+        REQUIRE(input.good());
+        const std::string text{std::istreambuf_iterator<char>{input}, std::istreambuf_iterator<char>{}};
+        INFO(entry.path().filename().string());
+        require_grammar(text);
+    }
+}
+
+TEST_CASE("the declarative grammar recovers more than one local syntax error", "[token-grammar][recovery]") {
+    SourceFile      file{"recovery.hgl", R"(module recovery
+fn broken(a f64, b i64, c str) -> f64 => a
+)"};
+    DiagnosticSink  diagnostics;
+    const LexResult lexed = lex(file, diagnostics);
+    REQUIRE_FALSE(diagnostics.has_errors());
+
+    const GrammarResult result = parse_token_grammar(lexed.tokens);
+    REQUIRE(result.accepted);
+    REQUIRE(result.recovered);
+    REQUIRE(result.error_count == 3);
+    REQUIRE(result.syntax_node_count > 0);
+    REQUIRE(result.first_error_token == 7);
+    REQUIRE(lexed.tokens[result.first_error_token].kind == TokenKind::KwF64);
+}

--- a/packaging/homebrew/Formula/hgraph.rb
+++ b/packaging/homebrew/Formula/hgraph.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Homebrew formula for hgraph: the native runtime SDK and the hgl toolchain.
 #
 # Source of truth for the tap `hhenson/homebrew-hgraph` (RFC 0032). The tap
@@ -33,15 +35,21 @@ class Hgraph < Formula
     depends_on "gcc"
   end
 
-  # The REPL's line editor has no Homebrew package and the build sandbox has
-  # no network, so it is staged as a resource and handed to FetchContent.
-  # Keep the tag in step with language/CMakeLists.txt and conanfile.py.
+  # The language-only dependencies have no Homebrew packages and the build
+  # sandbox has no network, so stage them as resources for FetchContent.
+  # Keep these tags in step with language/CMakeLists.txt and conanfile.py.
+  resource "lexy" do
+    url "https://github.com/foonathan/lexy/archive/refs/tags/v2025.05.0.tar.gz"
+    sha256 "ae867846b890b7564d633cf28d39dfc4938fe7c54515126f720c1762de5eab30"
+  end
+
   resource "isocline" do
     url "https://github.com/daanx/isocline/archive/refs/tags/v1.1.0.tar.gz"
     sha256 "1e5f0efa2b719c3e1d292f501e5329e141a039deefc801099f8bbb9a50255531"
   end
 
   def install
+    (buildpath/"lexy").install resource("lexy")
     (buildpath/"isocline").install resource("isocline")
 
     # Mirrors the "Channels: Homebrew" arguments in RFC 0032. Every
@@ -62,6 +70,7 @@ class Hgraph < Formula
       -DHGRAPH_ENABLE_COMPILER_CACHE=OFF
       -DBUILD_TESTING=OFF
       -DFETCHCONTENT_FULLY_DISCONNECTED=ON
+      -DFETCHCONTENT_SOURCE_DIR_LEXY=#{buildpath}/lexy
       -DFETCHCONTENT_SOURCE_DIR_ISOCLINE=#{buildpath}/isocline
     ]
 


### PR DESCRIPTION
## Summary
- add the private lexy token grammar selected by ADR 0001
- run every clean legacy-parser case and every checked-in HGL example through the declarative grammar
- prove retained-tree recovery across three independent missing tokens
- isolate two GCC false positives to the parser DSL implementation translation unit
- stage lexy as a Homebrew resource so the opt-in language builds without sandbox network access
- document the temporary dual-parser boundary and next source-accurate projection slice

## Validation
- `cmake --preset cpp --fresh -DHGRAPH_BUILD_LANGUAGE=ON`
- `cmake --build --preset cpp --target clean`
- `cmake --build --preset cpp --parallel`
- `ctest --preset cpp --parallel 2` (1,721 passed)
- stable-ABI Python 3.12 wheel installed into Python 3.14; `pytest python/tests -q -m "not wip"` (3,208 passed, 10 skipped)
- `brew style packaging/homebrew/Formula/hgraph.rb`

Stacked on #674.