### PR TITLE
feat(language): retain source-accurate syntax

### DIFF
--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -81,6 +81,7 @@ add_library(hgl_syntax STATIC
     src/syntax/temporal.cpp
     src/syntax/token.cpp
     src/syntax/lexer.cpp
+    src/syntax/syntax_tree.cpp
     src/syntax/ast.cpp
     src/syntax/token_grammar.cpp
     src/syntax/parser.cpp

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -66,8 +66,9 @@ current versus target architecture is explicit.
 
 ### B. Parser evaluation and migration
 
-Status: lexy selected and the token grammar runs in conformance mode; the
-source-accurate arena, AST projection, and hand-written-parser removal remain.
+Status: lexy selected; the grammar now materializes an HGL-owned,
+source-accurate arena with missing and unexpected syntax. AST projection and
+hand-written-parser removal remain.
 
 - build representative grammar spikes for the shortlisted C++ parser tools;
 - measure valid parsing, multi-error recovery, source fidelity, grammar

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -62,24 +62,29 @@ and a caret. `temporal` parses and validates the temporal literal spellings
 of the syntax guide into a `TemporalValue` (kind plus microseconds, offset,
 and zone) and prints the canonical spelling. `lexer` produces one token
 vector per file, with comments as trivia and one `Newline` token per run of
-terminators. `ast` is an index-based arena: nodes are `std::variant`
+terminators. It also records non-overlapping source fragments for every token,
+whitespace run, physical line break, and line comment; those fragments exactly
+reconstruct the input even where several line breaks share one grammar token.
+`syntax_tree` owns the parser-independent source arena. Its production nodes
+and source tokens retain ranges, its lexical fragments retain all trivia, and
+its issue nodes distinguish zero-width missing tokens from unexpected source
+tokens. `ast` is an index-based semantic syntax arena: nodes are `std::variant`
 payloads addressed by `NodeId`, so the tree owns no pointers and a module is
 one movable value. `token_grammar` is the private lexy production grammar
-selected by ADR 0001. It currently parses the lexer's token stream in
-conformance mode: every clean legacy-parser test and every checked-in HGL
-example must also pass the declarative grammar, and a focused malformed case
-proves recovery after three independent missing tokens. `parser` remains the
-AST projection path during this intermediate slice; it is the hand-written
-recursive-descent implementation that applies the newline rules and produces
-the existing arena. `ast_printer` dumps that arena one node per line for
+selected by ADR 0001. It parses the lexer's token stream, materializes the
+source arena, and discards all lexy storage before returning. Every clean
+legacy-parser test and every checked-in HGL example must pass this declarative
+grammar. Focused malformed cases prove local recovery after three independent
+missing tokens and complete source retention after a fatal error. `parser`
+still produces `ast::Module` directly during this intermediate slice; it is
+the hand-written recursive-descent implementation that applies the newline
+rules. `ast_printer` dumps that arena one node per line for
 `hgl check --dump-ast` and the tests.
 
 This dual-parser state is deliberately temporary. The next parser slice
-materializes a lexy-free, source-accurate syntax arena from the declarative
-parse, including trivia and recovered input, then projects that arena into the
-existing `ast::Module`. Only after equivalence tests pass may the hand-written
-syntax decisions be removed. Downstream compiler passes never receive lexy
-types.
+projects the source arena into the existing `ast::Module` and makes that the
+compiler path. Only after equivalence tests pass may the hand-written syntax
+decisions be removed. Downstream compiler passes never receive lexy types.
 
 The first pass of `src/semantics/` is `resolve`. It binds every value, type,
 and constraint-name occurrence of one compilation unit by the lookup rules of

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -92,11 +92,13 @@ The production parser is not selected from a toy grammar or throughput alone.
 Parser-library headers remain private to the syntax implementation and are not
 included by syntax clients or test support headers.
 
-The selected lexy grammar is presently a conformance parser over the existing
-token stream. Its parse tree is intentionally not yet a downstream contract.
-Promotion to the sole syntax parser requires the source-accurate arena and AST
-projection described by ADR 0001; until then the hand-written parser remains
-the compiler's AST-producing path.
+The selected lexy grammar now materializes the parser-independent,
+source-accurate syntax arena from the existing token stream. Tests require an
+exact reconstruction from lexical fragments, a complete production tree for
+valid source, explicit missing syntax after local recovery, and complete source
+retention after fatal syntax. Promotion to the sole syntax parser still
+requires the `ast::Module` projection described by ADR 0001; until then the
+hand-written parser remains the compiler's AST-producing path.
 
 ## Typed HIR and hgraph IR
 

--- a/language/src/syntax/ast.h
+++ b/language/src/syntax/ast.h
@@ -520,10 +520,7 @@ namespace hgl::syntax::ast
         DeclNode    node{};
     };
 
-    struct Comment
-    {
-        SourceRange range{};
-    };
+    using Comment = SourceComment;
 
     /// One parsed source file. `declarations` are in source order; the
     /// module declaration is first when present.

--- a/language/src/syntax/lexer.cpp
+++ b/language/src/syntax/lexer.cpp
@@ -45,13 +45,14 @@ namespace hgl::syntax
                 Token token;
                 token.kind  = kind;
                 token.range = {begin, finish};
-                token.text  = src_.substr(begin, finish - begin);
-                result_.tokens.push_back(std::move(token));
+                push(std::move(token));
             }
 
             void push(Token token)
             {
                 token.text = src_.substr(token.range.begin, token.range.end - token.range.begin);
+                result_.fragments.push_back(SourceFragment{SourceFragmentKind::Token, token.range,
+                                                           result_.tokens.size()});
                 result_.tokens.push_back(std::move(token));
             }
 
@@ -65,7 +66,7 @@ namespace hgl::syntax
                 const char c = peek();
                 if (c == ' ' || c == '\t' || c == '\r')
                 {
-                    ++pos_;
+                    whitespace();
                     return;
                 }
                 if (c == '\n')
@@ -101,6 +102,14 @@ namespace hgl::syntax
                 punctuation();
             }
 
+            void whitespace()
+            {
+                const std::uint32_t begin = pos_;
+                while (peek() == ' ' || peek() == '\t' || peek() == '\r') { ++pos_; }
+                result_.fragments.push_back(
+                    SourceFragment{SourceFragmentKind::Whitespace, {begin, pos_}, no_token_index});
+            }
+
             // One Newline token per run of terminators; the run may contain
             // blank lines, spaces, and comments.
             void newline()
@@ -110,16 +119,31 @@ namespace hgl::syntax
                 if (!result_.tokens.empty() && result_.tokens.back().kind == TokenKind::Newline)
                 {
                     result_.tokens.back().range.end = pos_;
+                    result_.tokens.back().text = src_.substr(result_.tokens.back().range.begin,
+                                                             result_.tokens.back().range.end -
+                                                                 result_.tokens.back().range.begin);
+                    result_.fragments.push_back(SourceFragment{SourceFragmentKind::LineBreak,
+                                                               {begin, pos_},
+                                                               result_.tokens.size() - 1});
                     return;
                 }
-                push(TokenKind::Newline, begin, pos_);
+                Token token;
+                token.kind  = TokenKind::Newline;
+                token.range = {begin, pos_};
+                token.text  = src_.substr(begin, pos_ - begin);
+                result_.tokens.push_back(std::move(token));
+                result_.fragments.push_back(SourceFragment{SourceFragmentKind::LineBreak,
+                                                           {begin, pos_},
+                                                           result_.tokens.size() - 1});
             }
 
             void comment()
             {
                 const std::uint32_t begin = pos_;
                 while (pos_ < src_.size() && src_[pos_] != '\n') { ++pos_; }
-                result_.comments.push_back(ast::Comment{{begin, pos_}});
+                result_.comments.push_back(SourceComment{{begin, pos_}});
+                result_.fragments.push_back(
+                    SourceFragment{SourceFragmentKind::LineComment, {begin, pos_}, no_token_index});
             }
 
             void identifier()

--- a/language/src/syntax/lexer.h
+++ b/language/src/syntax/lexer.h
@@ -1,7 +1,6 @@
 #ifndef HGL_SYNTAX_LEXER_H
 #define HGL_SYNTAX_LEXER_H
 
-#include "syntax/ast.h"
 #include "syntax/diagnostic.h"
 #include "syntax/source.h"
 #include "syntax/token.h"
@@ -12,8 +11,9 @@ namespace hgl::syntax
 {
     struct LexResult
     {
-        std::vector<Token>        tokens;    ///< ends with EndOfFile
-        std::vector<ast::Comment> comments;  ///< `//` trivia in source order
+        std::vector<Token>          tokens;     ///< ends with EndOfFile
+        std::vector<SourceComment>  comments;   ///< `//` trivia in source order
+        std::vector<SourceFragment> fragments;  ///< lossless lexical source order
     };
 
     /// Tokenize a whole file (developer guide, "Lexical rules" and

--- a/language/src/syntax/source.h
+++ b/language/src/syntax/source.h
@@ -1,7 +1,9 @@
 #ifndef HGL_SYNTAX_SOURCE_H
 #define HGL_SYNTAX_SOURCE_H
 
+#include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -23,6 +25,32 @@ namespace hgl::syntax
         }
 
         friend constexpr bool operator==(SourceRange, SourceRange) noexcept = default;
+    };
+
+    struct SourceComment
+    {
+        SourceRange range{};
+    };
+
+    enum class SourceFragmentKind : std::uint8_t
+    {
+        Token,
+        Whitespace,
+        LineBreak,
+        LineComment,
+    };
+
+    inline constexpr std::size_t no_token_index = std::numeric_limits<std::size_t>::max();
+
+    /// One non-overlapping piece of the original source. Together the
+    /// fragments cover the file byte-for-byte and in source order. Physical
+    /// line breaks remain separate even when the grammar tokenizes a run of
+    /// them as one newline.
+    struct SourceFragment
+    {
+        SourceFragmentKind kind{SourceFragmentKind::Whitespace};
+        SourceRange        range{};
+        std::size_t        token_index{no_token_index};
     };
 
     /// One-based line and column of a byte offset (columns count bytes).

--- a/language/src/syntax/syntax_tree.cpp
+++ b/language/src/syntax/syntax_tree.cpp
@@ -1,0 +1,125 @@
+#include "syntax/syntax_tree.h"
+
+#include <array>
+#include <utility>
+
+namespace hgl::syntax
+{
+    namespace
+    {
+        using KindName = std::pair<SyntaxKind, std::string_view>;
+
+        constexpr std::array kind_names{
+            KindName{SyntaxKind::Unknown, "unknown"},
+            KindName{SyntaxKind::Newlines, "newlines"},
+            KindName{SyntaxKind::LineEnd, "line_end"},
+            KindName{SyntaxKind::CommaSeparator, "comma_separator"},
+            KindName{SyntaxKind::ModulePath, "module_path"},
+            KindName{SyntaxKind::QualifiedName, "qualified_name"},
+            KindName{SyntaxKind::GenericArguments, "generic_arguments"},
+            KindName{SyntaxKind::GenericArgument, "generic_argument"},
+            KindName{SyntaxKind::NamedType, "named_type"},
+            KindName{SyntaxKind::TupleType, "tuple_type"},
+            KindName{SyntaxKind::ListType, "list_type"},
+            KindName{SyntaxKind::SetType, "set_type"},
+            KindName{SyntaxKind::MapType, "map_type"},
+            KindName{SyntaxKind::RollingType, "rolling_type"},
+            KindName{SyntaxKind::AtomicType, "atomic_type"},
+            KindName{SyntaxKind::Type, "type"},
+            KindName{SyntaxKind::SizeExpression, "size_expression"},
+            KindName{SyntaxKind::ContinuedOperator, "continued_operator"},
+            KindName{SyntaxKind::ProductExpression, "product_expression"},
+            KindName{SyntaxKind::SumExpression, "sum_expression"},
+            KindName{SyntaxKind::ComparisonExpression, "comparison_expression"},
+            KindName{SyntaxKind::EqualityExpression, "equality_expression"},
+            KindName{SyntaxKind::AndExpression, "and_expression"},
+            KindName{SyntaxKind::Expression, "expression"},
+            KindName{SyntaxKind::Argument, "argument"},
+            KindName{SyntaxKind::Arguments, "arguments"},
+            KindName{SyntaxKind::IndexPostfix, "index_postfix"},
+            KindName{SyntaxKind::CallPostfix, "call_postfix"},
+            KindName{SyntaxKind::FieldPostfix, "field_postfix"},
+            KindName{SyntaxKind::Postfix, "postfix"},
+            KindName{SyntaxKind::ExplicitConstruct, "explicit_construct"},
+            KindName{SyntaxKind::PrimaryExpression, "primary_expression"},
+            KindName{SyntaxKind::PostfixExpression, "postfix_expression"},
+            KindName{SyntaxKind::UnaryExpression, "unary_expression"},
+            KindName{SyntaxKind::TupleElement, "tuple_element"},
+            KindName{SyntaxKind::TupleOrGroup, "tuple_or_group"},
+            KindName{SyntaxKind::SequenceElement, "sequence_element"},
+            KindName{SyntaxKind::SequenceLiteral, "sequence_literal"},
+            KindName{SyntaxKind::AnonymousParameter, "anonymous_parameter"},
+            KindName{SyntaxKind::AnonymousFunction, "anonymous_function"},
+            KindName{SyntaxKind::ElseArm, "else_arm"},
+            KindName{SyntaxKind::IfExpression, "if_expression"},
+            KindName{SyntaxKind::EvalExpression, "eval_expression"},
+            KindName{SyntaxKind::LocalDecl, "local_decl"},
+            KindName{SyntaxKind::StateDecl, "state_decl"},
+            KindName{SyntaxKind::InjectDecl, "inject_decl"},
+            KindName{SyntaxKind::LifecycleStmt, "lifecycle_stmt"},
+            KindName{SyntaxKind::WhenStmt, "when_stmt"},
+            KindName{SyntaxKind::ForStmt, "for_stmt"},
+            KindName{SyntaxKind::ReturnStmt, "return_stmt"},
+            KindName{SyntaxKind::AssertStmt, "assert_stmt"},
+            KindName{SyntaxKind::AssignOrExpressionStmt, "assign_or_expression_stmt"},
+            KindName{SyntaxKind::Statement, "statement"},
+            KindName{SyntaxKind::BlockItem, "block_item"},
+            KindName{SyntaxKind::Block, "block"},
+            KindName{SyntaxKind::GenericParameter, "generic_parameter"},
+            KindName{SyntaxKind::GenericParameters, "generic_parameters"},
+            KindName{SyntaxKind::Parameter, "parameter"},
+            KindName{SyntaxKind::Signature, "signature"},
+            KindName{SyntaxKind::ConstraintSet, "constraint_set"},
+            KindName{SyntaxKind::ConstraintCall, "constraint_call"},
+            KindName{SyntaxKind::ConstraintOperand, "constraint_operand"},
+            KindName{SyntaxKind::ConstraintTerm, "constraint_term"},
+            KindName{SyntaxKind::ConstraintAnd, "constraint_and"},
+            KindName{SyntaxKind::Constraint, "constraint"},
+            KindName{SyntaxKind::RequiresClause, "requires_clause"},
+            KindName{SyntaxKind::OptionalRequiresClause, "optional_requires_clause"},
+            KindName{SyntaxKind::FunctionDecl, "function_decl"},
+            KindName{SyntaxKind::OperatorDecl, "operator_decl"},
+            KindName{SyntaxKind::StructMember, "struct_member"},
+            KindName{SyntaxKind::StructBodyItem, "struct_body_item"},
+            KindName{SyntaxKind::StructDecl, "struct_decl"},
+            KindName{SyntaxKind::UseDecl, "use_decl"},
+            KindName{SyntaxKind::TestDecl, "test_decl"},
+            KindName{SyntaxKind::Declaration, "declaration"},
+            KindName{SyntaxKind::DeclarationLine, "declaration_line"},
+            KindName{SyntaxKind::ModuleDecl, "module_decl"},
+            KindName{SyntaxKind::Module, "module"},
+        };
+    }  // namespace
+
+    std::string_view syntax_kind_name(SyntaxKind kind) noexcept {
+        for (const auto &[candidate, name] : kind_names) {
+            if (candidate == kind) { return name; }
+        }
+        return "unknown";
+    }
+
+    SyntaxKind syntax_kind_from_name(std::string_view name) noexcept {
+        for (const auto &[kind, candidate] : kind_names) {
+            if (candidate == name) { return kind; }
+        }
+        return SyntaxKind::Unknown;
+    }
+
+    bool SyntaxTree::source_is_complete() const noexcept {
+        std::uint32_t next = 0;
+        for (const SourceFragment &fragment : fragments) {
+            if (fragment.range.empty() || fragment.range.begin != next || fragment.range.end > source_size) { return false; }
+            next = fragment.range.end;
+        }
+        return next == source_size;
+    }
+
+    std::string SyntaxTree::reconstruct(const SourceFile &file) const {
+        if (file.text().size() != source_size || !source_is_complete()) { return {}; }
+
+        std::string result;
+        result.reserve(source_size);
+        for (const SourceFragment &fragment : fragments) { result += file.slice(fragment.range); }
+        return result;
+    }
+}  // namespace hgl::syntax

--- a/language/src/syntax/syntax_tree.h
+++ b/language/src/syntax/syntax_tree.h
@@ -1,0 +1,168 @@
+#ifndef HGL_SYNTAX_SYNTAX_TREE_H
+#define HGL_SYNTAX_SYNTAX_TREE_H
+
+#include "syntax/source.h"
+#include "syntax/token.h"
+
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace hgl::syntax
+{
+    /// Parser-library-independent production kinds. Helper productions remain
+    /// visible because the source tree is also a debugging and tooling
+    /// contract; semantic passes consume the typed AST/HIR projection instead.
+    enum class SyntaxKind : std::uint8_t {
+        Unknown,
+        Newlines,
+        LineEnd,
+        CommaSeparator,
+        ModulePath,
+        QualifiedName,
+        GenericArguments,
+        GenericArgument,
+        NamedType,
+        TupleType,
+        ListType,
+        SetType,
+        MapType,
+        RollingType,
+        AtomicType,
+        Type,
+        SizeExpression,
+        ContinuedOperator,
+        ProductExpression,
+        SumExpression,
+        ComparisonExpression,
+        EqualityExpression,
+        AndExpression,
+        Expression,
+        Argument,
+        Arguments,
+        IndexPostfix,
+        CallPostfix,
+        FieldPostfix,
+        Postfix,
+        ExplicitConstruct,
+        PrimaryExpression,
+        PostfixExpression,
+        UnaryExpression,
+        TupleElement,
+        TupleOrGroup,
+        SequenceElement,
+        SequenceLiteral,
+        AnonymousParameter,
+        AnonymousFunction,
+        ElseArm,
+        IfExpression,
+        EvalExpression,
+        LocalDecl,
+        StateDecl,
+        InjectDecl,
+        LifecycleStmt,
+        WhenStmt,
+        ForStmt,
+        ReturnStmt,
+        AssertStmt,
+        AssignOrExpressionStmt,
+        Statement,
+        BlockItem,
+        Block,
+        GenericParameter,
+        GenericParameters,
+        Parameter,
+        Signature,
+        ConstraintSet,
+        ConstraintCall,
+        ConstraintOperand,
+        ConstraintTerm,
+        ConstraintAnd,
+        Constraint,
+        RequiresClause,
+        OptionalRequiresClause,
+        FunctionDecl,
+        OperatorDecl,
+        StructMember,
+        StructBodyItem,
+        StructDecl,
+        UseDecl,
+        TestDecl,
+        Declaration,
+        DeclarationLine,
+        ModuleDecl,
+        Module,
+    };
+
+    [[nodiscard]] std::string_view syntax_kind_name(SyntaxKind kind) noexcept;
+    [[nodiscard]] SyntaxKind       syntax_kind_from_name(std::string_view name) noexcept;
+
+    using SyntaxNodeId                           = std::uint32_t;
+    using SyntaxTokenId                          = std::uint32_t;
+    inline constexpr SyntaxNodeId no_syntax_node = std::numeric_limits<SyntaxNodeId>::max();
+
+    enum class SyntaxChildKind : std::uint8_t {
+        Node,
+        Token,
+    };
+
+    struct SyntaxChild
+    {
+        SyntaxChildKind kind{SyntaxChildKind::Node};
+        std::uint32_t   index{0};
+    };
+
+    struct SyntaxNode
+    {
+        SyntaxKind               kind{SyntaxKind::Unknown};
+        SourceRange              range{};
+        SyntaxNodeId             parent{no_syntax_node};
+        std::vector<SyntaxChild> children{};
+    };
+
+    struct SyntaxToken
+    {
+        TokenKind   kind{TokenKind::Error};
+        SourceRange range{};
+        std::size_t source_token_index{no_token_index};
+        bool        unexpected{false};
+    };
+
+    enum class SyntaxIssueKind : std::uint8_t {
+        Missing,
+        Unexpected,
+    };
+
+    /// Malformed syntax is data as well as a diagnostic. Missing ranges are
+    /// zero-width and never manufacture source text; unexpected ranges point
+    /// at the original token(s) retained by the lexical fragments.
+    struct SyntaxIssue
+    {
+        SyntaxIssueKind          kind{SyntaxIssueKind::Unexpected};
+        SourceRange              range{};
+        std::optional<TokenKind> expected{};
+        SyntaxKind               context{SyntaxKind::Unknown};
+    };
+
+    /// Source-accurate syntax owned entirely by HGL. No parser-library type is
+    /// present in this contract.
+    struct SyntaxTree
+    {
+        std::uint32_t               source_size{0};
+        SyntaxNodeId                root{no_syntax_node};
+        std::vector<SyntaxNode>     nodes{};
+        std::vector<SyntaxToken>    tokens{};
+        std::vector<SourceFragment> fragments{};
+        std::vector<SyntaxIssue>    issues{};
+
+        [[nodiscard]] bool        has_root() const noexcept { return root != no_syntax_node; }
+        [[nodiscard]] bool        source_is_complete() const noexcept;
+        [[nodiscard]] std::string reconstruct(const SourceFile &file) const;
+    };
+}  // namespace hgl::syntax
+
+#endif  // HGL_SYNTAX_SYNTAX_TREE_H

--- a/language/src/syntax/token_grammar.cpp
+++ b/language/src/syntax/token_grammar.cpp
@@ -6,8 +6,11 @@
 #include <lexy/input/string_input.hpp>
 #include <lexy/parse_tree.hpp>
 
+#include <algorithm>
 #include <cstdint>
+#include <optional>
 #include <string>
+#include <vector>
 
 namespace hgl::syntax
 {
@@ -669,31 +672,156 @@ namespace hgl::syntax
             }
             return static_cast<std::uint8_t>(token.kind);
         }
+
+        [[nodiscard]] std::optional<TokenKind> decode_expected(std::uint8_t encoded) noexcept {
+            if (encoded <= static_cast<std::uint8_t>(TokenKind::Error)) { return static_cast<TokenKind>(encoded); }
+            if (encoded >= static_cast<std::uint8_t>(grammar::ContextToken::In) &&
+                encoded <= static_cast<std::uint8_t>(grammar::ContextToken::AppliedConstructor)) {
+                return TokenKind::Identifier;
+            }
+            return std::nullopt;
+        }
+
+        [[nodiscard]] SyntaxKind production_kind(std::string_view name) noexcept {
+            if (const std::size_t grammar = name.find("grammar::"); grammar != std::string_view::npos) {
+                name.remove_prefix(grammar + std::string_view{"grammar::"}.size());
+            } else if (const std::size_t scope = name.rfind("::"); scope != std::string_view::npos) {
+                name.remove_prefix(scope + 2);
+            }
+            if (const std::size_t arguments = name.find('<'); arguments != std::string_view::npos) {
+                name = name.substr(0, arguments);
+            }
+            return syntax_kind_from_name(name);
+        }
+
+        [[nodiscard]] std::uint32_t source_offset(std::span<const Token> tokens, std::size_t token_index,
+                                                  std::uint32_t source_size) noexcept {
+            if (token_index >= tokens.size() || tokens[token_index].kind == TokenKind::EndOfFile) { return source_size; }
+            return tokens[token_index].range.begin;
+        }
+
+        [[nodiscard]] SourceRange source_range(std::span<const Token> tokens, std::size_t begin_token, std::size_t end_token,
+                                               std::uint32_t source_size) noexcept {
+            const std::uint32_t begin = source_offset(tokens, begin_token, source_size);
+            if (tokens.empty() || begin_token >= end_token) { return {begin, begin}; }
+            const std::size_t last = std::min(end_token - 1, tokens.size() - 1);
+            if (tokens[last].kind == TokenKind::EndOfFile) { return {begin, source_size}; }
+            return {begin, tokens[last].range.end};
+        }
+
+        struct RawIssue
+        {
+            std::size_t              token_index{0};
+            std::optional<TokenKind> expected{};
+            SyntaxKind               context{SyntaxKind::Unknown};
+        };
+
+        template <typename ParseTree>
+        void materialize_parse_tree(SyntaxTree &syntax, const ParseTree &parsed, const std::string &input_bytes,
+                                    std::span<const Token> source_tokens) {
+            if (parsed.empty()) { return; }
+
+            const auto               *input_begin = reinterpret_cast<const unsigned char *>(input_bytes.data());
+            std::vector<SyntaxNodeId> parents;
+            for (const auto event : parsed.traverse()) {
+                if (event.event == lexy::traverse_event::enter) {
+                    const auto lexeme = event.node.covering_lexeme();
+                    const auto begin  = static_cast<std::size_t>(lexeme.begin() - input_begin);
+                    const auto end    = static_cast<std::size_t>(lexeme.end() - input_begin);
+                    SyntaxNode node;
+                    node.kind   = production_kind(event.node.kind().name());
+                    node.range  = source_range(source_tokens, begin, end, syntax.source_size);
+                    node.parent = parents.empty() ? no_syntax_node : parents.back();
+
+                    const SyntaxNodeId id = static_cast<SyntaxNodeId>(syntax.nodes.size());
+                    syntax.nodes.push_back(std::move(node));
+                    if (parents.empty()) {
+                        syntax.root            = id;
+                        syntax.nodes[id].range = {0, syntax.source_size};
+                    } else {
+                        syntax.nodes[parents.back()].children.push_back(SyntaxChild{SyntaxChildKind::Node, id});
+                    }
+                    parents.push_back(id);
+                } else if (event.event == lexy::traverse_event::exit) {
+                    parents.pop_back();
+                } else {
+                    const auto lexeme     = event.node.lexeme();
+                    const auto begin      = static_cast<std::size_t>(lexeme.begin() - input_begin);
+                    const auto end        = static_cast<std::size_t>(lexeme.end() - input_begin);
+                    const bool unexpected = event.node.kind() == lexy::error_token_kind;
+                    for (std::size_t token_index = begin; token_index < end && token_index < source_tokens.size(); ++token_index) {
+                        if (source_tokens[token_index].kind == TokenKind::EndOfFile) { continue; }
+                        const SyntaxTokenId id = static_cast<SyntaxTokenId>(syntax.tokens.size());
+                        syntax.tokens.push_back(SyntaxToken{source_tokens[token_index].kind, source_tokens[token_index].range,
+                                                            token_index, unexpected});
+                        if (!parents.empty()) {
+                            syntax.nodes[parents.back()].children.push_back(SyntaxChild{SyntaxChildKind::Token, id});
+                        }
+                    }
+                }
+            }
+        }
+
+        [[nodiscard]] SyntaxParseResult parse_impl(std::span<const Token> tokens, std::span<const SourceFragment> fragments,
+                                                   std::uint32_t source_size) {
+            std::string input_bytes;
+            input_bytes.reserve(tokens.size());
+            for (std::size_t position = 0; position < tokens.size(); ++position) {
+                if (tokens[position].kind != TokenKind::EndOfFile) {
+                    input_bytes.push_back(static_cast<char>(encode(tokens, position)));
+                }
+            }
+
+            const auto                            input = lexy::string_input<lexy::byte_encoding>{input_bytes};
+            lexy::parse_tree_for<decltype(input)> parsed;
+            std::vector<RawIssue>                 raw_issues;
+            std::size_t                           first_error    = std::numeric_limits<std::size_t>::max();
+            const auto                            error_callback = lexy::callback([&](const auto &context, const auto &error) {
+                const auto *begin    = reinterpret_cast<const unsigned char *>(input_bytes.data());
+                const auto  position = static_cast<std::size_t>(error.position() - begin);
+                if (first_error == std::numeric_limits<std::size_t>::max()) { first_error = position; }
+
+                RawIssue issue;
+                issue.token_index = position;
+                issue.context     = production_kind(context.production());
+                if constexpr (requires { error.character(); }) {
+                    issue.expected = decode_expected(static_cast<std::uint8_t>(error.character()));
+                }
+                raw_issues.push_back(issue);
+            });
+            const auto                            result = lexy::parse_as_tree<grammar::module>(parsed, input, error_callback);
+
+            SyntaxParseResult output;
+            output.grammar          = GrammarResult{!result.is_fatal_error(), result.is_recovered_error(), result.error_count(),
+                                                    parsed.size(), first_error};
+            output.tree.source_size = source_size;
+            output.tree.fragments.assign(fragments.begin(), fragments.end());
+            materialize_parse_tree(output.tree, parsed, input_bytes, tokens);
+
+            for (const RawIssue &raw : raw_issues) {
+                const std::uint32_t offset = source_offset(tokens, raw.token_index, source_size);
+                SyntaxIssue         issue;
+                issue.expected = raw.expected;
+                issue.context  = raw.context;
+                if (raw.expected.has_value()) {
+                    issue.kind  = SyntaxIssueKind::Missing;
+                    issue.range = {offset, offset};
+                } else {
+                    issue.kind  = SyntaxIssueKind::Unexpected;
+                    issue.range = raw.token_index < tokens.size() ? tokens[raw.token_index].range : SourceRange{offset, offset};
+                }
+                output.tree.issues.push_back(issue);
+            }
+            return output;
+        }
     }  // namespace
 
     GrammarResult parse_token_grammar(std::span<const Token> tokens) {
-        std::string input_bytes;
-        input_bytes.reserve(tokens.size());
-        for (std::size_t position = 0; position < tokens.size(); ++position) {
-            const Token &token = tokens[position];
-            if (token.kind != TokenKind::EndOfFile) { input_bytes.push_back(static_cast<char>(encode(tokens, position))); }
-        }
+        const std::uint32_t source_size = tokens.empty() ? 0 : tokens.back().range.end;
+        return parse_impl(tokens, {}, source_size).grammar;
+    }
 
-        const auto                            input = lexy::string_input<lexy::byte_encoding>{input_bytes};
-        lexy::parse_tree_for<decltype(input)> tree;
-        std::size_t                           first_error    = std::numeric_limits<std::size_t>::max();
-        const auto                            error_callback = lexy::callback([&](const auto &, const auto &error) {
-            if (first_error == std::numeric_limits<std::size_t>::max()) {
-                const auto *begin = reinterpret_cast<const unsigned char *>(input_bytes.data());
-                first_error       = static_cast<std::size_t>(error.position() - begin);
-            }
-        });
-        const auto                            result         = lexy::parse_as_tree<grammar::module>(tree, input, error_callback);
-
-        std::size_t node_count = 0;
-        for (const auto event : tree.traverse()) {
-            if (event.event == lexy::traverse_event::enter || event.event == lexy::traverse_event::leaf) { ++node_count; }
-        }
-        return GrammarResult{!result.is_fatal_error(), result.is_recovered_error(), result.error_count(), node_count, first_error};
+    SyntaxParseResult parse_source_syntax(const SourceFile &file, const LexResult &lexed) {
+        return parse_impl(lexed.tokens, lexed.fragments, static_cast<std::uint32_t>(file.text().size()));
     }
 }  // namespace hgl::syntax

--- a/language/src/syntax/token_grammar.h
+++ b/language/src/syntax/token_grammar.h
@@ -1,7 +1,8 @@
 #ifndef HGL_SYNTAX_TOKEN_GRAMMAR_H
 #define HGL_SYNTAX_TOKEN_GRAMMAR_H
 
-#include "syntax/token.h"
+#include "syntax/lexer.h"
+#include "syntax/syntax_tree.h"
 
 #include <cstddef>
 #include <limits>
@@ -20,10 +21,20 @@ namespace hgl::syntax
         std::size_t first_error_token{std::numeric_limits<std::size_t>::max()};
     };
 
+    struct SyntaxParseResult
+    {
+        GrammarResult grammar{};
+        SyntaxTree    tree{};
+    };
+
     /// Parse a complete, EOF-terminated token stream. The current AST parser
     /// remains the projection path while the lexy grammar is introduced in
     /// verified slices; this entry point is the shadow/conformance boundary.
     [[nodiscard]] GrammarResult parse_token_grammar(std::span<const Token> tokens);
+
+    /// Parse the lossless lexer result and materialize the HGL-owned source
+    /// tree. Parser-library storage is discarded before this call returns.
+    [[nodiscard]] SyntaxParseResult parse_source_syntax(const SourceFile &file, const LexResult &lexed);
 }  // namespace hgl::syntax
 
 #endif  // HGL_SYNTAX_TOKEN_GRAMMAR_H

--- a/language/tests/syntax/lexer_tests.cpp
+++ b/language/tests/syntax/lexer_tests.cpp
@@ -69,6 +69,42 @@ TEST_CASE("one newline token per run of terminators including comments", "[lexer
     REQUIRE(lexed.file.slice(lexed.result.comments[1].range) == "// second");
 }
 
+TEST_CASE("source fragments retain every byte without coalescing trivia", "[lexer][source-accurate]")
+{
+    Lexed lexed{"a \t// first\n\n  // second\nb"};
+    REQUIRE_FALSE(lexed.diagnostics.has_errors());
+
+    std::string   reconstructed;
+    std::uint32_t next = 0;
+    for (const SourceFragment &fragment : lexed.result.fragments)
+    {
+        REQUIRE(fragment.range.begin == next);
+        REQUIRE_FALSE(fragment.range.empty());
+        reconstructed += lexed.file.slice(fragment.range);
+        next = fragment.range.end;
+    }
+    REQUIRE(next == lexed.file.text().size());
+    REQUIRE(reconstructed == lexed.file.text());
+
+    const std::vector<SourceFragmentKind> fragment_kinds{
+        SourceFragmentKind::Token,       SourceFragmentKind::Whitespace,
+        SourceFragmentKind::LineComment, SourceFragmentKind::LineBreak,
+        SourceFragmentKind::LineBreak,   SourceFragmentKind::Whitespace,
+        SourceFragmentKind::LineComment, SourceFragmentKind::LineBreak,
+        SourceFragmentKind::Token,
+    };
+    std::vector<SourceFragmentKind> actual_kinds;
+    for (const SourceFragment &fragment : lexed.result.fragments)
+    {
+        actual_kinds.push_back(fragment.kind);
+    }
+    REQUIRE(actual_kinds == fragment_kinds);
+    REQUIRE(lexed.result.fragments[3].token_index == 1);
+    REQUIRE(lexed.result.fragments[4].token_index == 1);
+    REQUIRE(lexed.result.fragments[7].token_index == 1);
+    REQUIRE(lexed.result.tokens[1].text == "\n\n  // second\n");
+}
+
 TEST_CASE("integer and float literals", "[lexer]")
 {
     Lexed lexed{"42 3.5 1e5 2.5E-3 7."};

--- a/language/tests/syntax/token_grammar_tests.cpp
+++ b/language/tests/syntax/token_grammar_tests.cpp
@@ -127,11 +127,77 @@ fn broken(a f64, b i64, c str) -> f64 => a
     const LexResult lexed = lex(file, diagnostics);
     REQUIRE_FALSE(diagnostics.has_errors());
 
-    const GrammarResult result = parse_token_grammar(lexed.tokens);
-    REQUIRE(result.accepted);
-    REQUIRE(result.recovered);
-    REQUIRE(result.error_count == 3);
-    REQUIRE(result.syntax_node_count > 0);
-    REQUIRE(result.first_error_token == 7);
-    REQUIRE(lexed.tokens[result.first_error_token].kind == TokenKind::KwF64);
+    const SyntaxParseResult parsed = parse_source_syntax(file, lexed);
+    REQUIRE(parsed.grammar.accepted);
+    REQUIRE(parsed.grammar.recovered);
+    REQUIRE(parsed.grammar.error_count == 3);
+    REQUIRE(parsed.grammar.syntax_node_count > 0);
+    REQUIRE(parsed.grammar.first_error_token == 7);
+    REQUIRE(lexed.tokens[parsed.grammar.first_error_token].kind == TokenKind::KwF64);
+    REQUIRE(parsed.tree.has_root());
+    REQUIRE(parsed.tree.source_is_complete());
+    REQUIRE(parsed.tree.reconstruct(file) == file.text());
+    REQUIRE(parsed.tree.issues.size() == 3);
+    for (const SyntaxIssue &issue : parsed.tree.issues) {
+        REQUIRE(issue.kind == SyntaxIssueKind::Missing);
+        REQUIRE(issue.range.empty());
+        REQUIRE(issue.expected == TokenKind::Colon);
+        REQUIRE(issue.context == SyntaxKind::Parameter);
+    }
+}
+
+TEST_CASE("the source syntax tree preserves structure and every source byte", "[token-grammar][source-accurate]") {
+    SourceFile file{"tree.hgl", R"(module example.tree
+
+// retained trivia
+export fn midpoint(tob: atomic<tuple<f64, f64>>) -> f64 =>
+    (tob[0] + tob[1]) / 2.0
+)"};
+    DiagnosticSink  diagnostics;
+    const LexResult lexed = lex(file, diagnostics);
+    REQUIRE_FALSE(diagnostics.has_errors());
+
+    const SyntaxParseResult parsed = parse_source_syntax(file, lexed);
+    REQUIRE(parsed.grammar.accepted);
+    REQUIRE_FALSE(parsed.grammar.recovered);
+    REQUIRE(parsed.tree.has_root());
+    REQUIRE(parsed.tree.nodes[parsed.tree.root].kind == SyntaxKind::Module);
+    REQUIRE(parsed.tree.nodes[parsed.tree.root].range == SourceRange{0, static_cast<std::uint32_t>(file.text().size())});
+    REQUIRE(parsed.tree.source_is_complete());
+    REQUIRE(parsed.tree.reconstruct(file) == file.text());
+    REQUIRE(parsed.tree.issues.empty());
+
+    REQUIRE(std::ranges::none_of(parsed.tree.nodes,
+                                 [](const SyntaxNode &node) { return node.kind == SyntaxKind::Unknown; }));
+
+    std::vector<bool> retained(lexed.tokens.size() - 1, false);
+    for (const SyntaxToken &token : parsed.tree.tokens) {
+        REQUIRE(token.source_token_index < retained.size());
+        REQUIRE_FALSE(retained[token.source_token_index]);
+        retained[token.source_token_index] = true;
+        REQUIRE(token.kind == lexed.tokens[token.source_token_index].kind);
+        REQUIRE(token.range == lexed.tokens[token.source_token_index].range);
+        REQUIRE_FALSE(token.unexpected);
+    }
+    REQUIRE(std::ranges::all_of(retained, [](bool value) { return value; }));
+    REQUIRE(std::ranges::count_if(parsed.tree.fragments, [](const SourceFragment &fragment) {
+                return fragment.kind == SourceFragmentKind::LineComment;
+            }) == 1);
+}
+
+TEST_CASE("fatal syntax still retains the complete source", "[token-grammar][source-accurate][recovery]") {
+    SourceFile file{"fatal.hgl", R"(module fatal
+fn broken() => )
+)"};
+    DiagnosticSink  diagnostics;
+    const LexResult lexed = lex(file, diagnostics);
+    REQUIRE_FALSE(diagnostics.has_errors());
+
+    const SyntaxParseResult parsed = parse_source_syntax(file, lexed);
+    REQUIRE_FALSE(parsed.grammar.accepted);
+    REQUIRE(parsed.tree.source_is_complete());
+    REQUIRE(parsed.tree.reconstruct(file) == file.text());
+    REQUIRE_FALSE(parsed.tree.issues.empty());
+    REQUIRE(std::ranges::any_of(parsed.tree.issues,
+                                [](const SyntaxIssue &issue) { return issue.kind == SyntaxIssueKind::Unexpected; }));
 }


### PR DESCRIPTION
Stacked on #676.

## Summary
- retain every source byte as ordered token, whitespace, line-break, or comment fragments
- materialize the lexy parse into an HGL-owned, parser-independent syntax arena
- represent recovered missing tokens and unexpected source tokens explicitly
- remove the lexer dependency on the semantic AST and update the architecture status

## Validation
- fresh warnings-as-errors native build with `HGRAPH_BUILD_LANGUAGE=ON`
- all 1,721 native tests passed
- stable-ABI wheel built with Python 3.12
- all 3,208 non-WIP Python 3.14 tests passed (10 skipped)
- source syntax suite: 126 test cases, 2,357 assertions