### PR TITLE
feat(language): project declarative syntax into AST

### DIFF
--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -83,6 +83,7 @@ add_library(hgl_syntax STATIC
     src/syntax/lexer.cpp
     src/syntax/syntax_tree.cpp
     src/syntax/ast.cpp
+    src/syntax/ast_projection.cpp
     src/syntax/token_grammar.cpp
     src/syntax/parser.cpp
     src/syntax/ast_printer.cpp

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -66,9 +66,10 @@ current versus target architecture is explicit.
 
 ### B. Parser evaluation and migration
 
-Status: lexy selected; the grammar now materializes an HGL-owned,
-source-accurate arena with missing and unexpected syntax. AST projection and
-hand-written-parser removal remain.
+Status: lexy selected; the grammar materializes an HGL-owned, source-accurate
+arena with missing and unexpected syntax, and clean compilation structurally
+projects that arena into the semantic AST. Malformed-source diagnostic
+translation and hand-written-parser removal remain.
 
 - build representative grammar spikes for the shortlisted C++ parser tools;
 - measure valid parsing, multi-error recovery, source fidelity, grammar

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -68,7 +68,9 @@ reconstruct the input even where several line breaks share one grammar token.
 `syntax_tree` owns the parser-independent source arena. Its production nodes
 and source tokens retain ranges, its lexical fragments retain all trivia, and
 its issue nodes distinguish zero-width missing tokens from unexpected source
-tokens. `ast` is an index-based semantic syntax arena: nodes are `std::variant`
+tokens. `ast_projection` structurally lowers a clean source arena into `ast`,
+performing no token parsing or syntax recovery. `ast` is an index-based
+semantic syntax arena: nodes are `std::variant`
 payloads addressed by `NodeId`, so the tree owns no pointers and a module is
 one movable value. `token_grammar` is the private lexy production grammar
 selected by ADR 0001. It parses the lexer's token stream, materializes the
@@ -76,15 +78,18 @@ source arena, and discards all lexy storage before returning. Every clean
 legacy-parser test and every checked-in HGL example must pass this declarative
 grammar. Focused malformed cases prove local recovery after three independent
 missing tokens and complete source retention after a fatal error. `parser`
-still produces `ast::Module` directly during this intermediate slice; it is
-the hand-written recursive-descent implementation that applies the newline
-rules. `ast_printer` dumps that arena one node per line for
+orchestrates lexing, source parsing, and AST projection. The hand-written
+recursive-descent implementation remains only as a temporary diagnostic
+fallback for malformed source while grammar issues gain compatible messages.
+`ast_printer` dumps the semantic arena one node per line for
 `hgl check --dump-ast` and the tests.
 
-This dual-parser state is deliberately temporary. The next parser slice
-projects the source arena into the existing `ast::Module` and makes that the
-compiler path. Only after equivalence tests pass may the hand-written syntax
-decisions be removed. Downstream compiler passes never receive lexy types.
+Clean compilation now has one grammatical path: declarative source syntax to
+structural AST projection. Differential tests require its complete AST dump,
+including source ranges, to equal the legacy parser for the clean syntax
+corpus. The next parser slice translates source-tree issues into user-facing
+diagnostics and removes the malformed-source fallback. Downstream compiler
+passes never receive lexy types.
 
 The first pass of `src/semantics/` is `resolve`. It binds every value, type,
 and constraint-name occurrence of one compilation unit by the lookup rules of

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -96,9 +96,11 @@ The selected lexy grammar now materializes the parser-independent,
 source-accurate syntax arena from the existing token stream. Tests require an
 exact reconstruction from lexical fragments, a complete production tree for
 valid source, explicit missing syntax after local recovery, and complete source
-retention after fatal syntax. Promotion to the sole syntax parser still
-requires the `ast::Module` projection described by ADR 0001; until then the
-hand-written parser remains the compiler's AST-producing path.
+retention after fatal syntax. Clean sources are structurally projected into
+`ast::Module`; every clean parser fixture compares the complete projected AST
+dump, including ranges, with the temporary legacy parser. The legacy parser is
+used only to preserve malformed-source messages until source-tree issues carry
+equivalent diagnostics.
 
 ## Typed HIR and hgraph IR
 

--- a/language/src/syntax/ast_projection.cpp
+++ b/language/src/syntax/ast_projection.cpp
@@ -1,0 +1,1068 @@
+#include "syntax/ast_projection.h"
+
+#include <algorithm>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace hgl::syntax
+{
+    namespace
+    {
+        class AstProjector
+        {
+          public:
+            AstProjector(const SyntaxTree &tree, const LexResult &lexed, DiagnosticSink &diagnostics)
+                : tree_{tree}, lexed_{lexed}, diagnostics_{diagnostics} {
+                module_.comments = lexed.comments;
+            }
+
+            [[nodiscard]] ast::Module run() {
+                require(tree_.has_root(), "syntax tree has no root");
+                require(node(tree_.root).kind == SyntaxKind::Module, "syntax root is not a module");
+                for (const SyntaxNodeId child : child_nodes(tree_.root)) {
+                    if (node(child).kind == SyntaxKind::ModuleDecl) {
+                        add_declaration(project_module_decl(child));
+                    } else if (node(child).kind == SyntaxKind::DeclarationLine) {
+                        const SyntaxNodeId declaration = only_child(child, SyntaxKind::Declaration);
+                        add_declaration(project_declaration(declaration));
+                    }
+                }
+                return std::move(module_);
+            }
+
+          private:
+            [[noreturn]] static void malformed(std::string message) {
+                throw std::logic_error{"malformed HGL syntax tree: " + std::move(message)};
+            }
+
+            static void require(bool condition, std::string message) {
+                if (!condition) { malformed(std::move(message)); }
+            }
+
+            [[nodiscard]] const SyntaxNode &node(SyntaxNodeId id) const {
+                require(id < tree_.nodes.size(), "node index is out of range");
+                return tree_.nodes[id];
+            }
+
+            [[nodiscard]] const SyntaxToken &syntax_token(SyntaxTokenId id) const {
+                require(id < tree_.tokens.size(), "token index is out of range");
+                return tree_.tokens[id];
+            }
+
+            [[nodiscard]] const Token &source_token(SyntaxTokenId id) const {
+                const SyntaxToken &syntax = syntax_token(id);
+                require(syntax.source_token_index < lexed_.tokens.size(), "source token index is out of range");
+                return lexed_.tokens[syntax.source_token_index];
+            }
+
+            [[nodiscard]] std::vector<SyntaxNodeId> child_nodes(SyntaxNodeId id) const {
+                std::vector<SyntaxNodeId> result;
+                for (const SyntaxChild child : node(id).children) {
+                    if (child.kind == SyntaxChildKind::Node) { result.push_back(child.index); }
+                }
+                return result;
+            }
+
+            [[nodiscard]] std::vector<SyntaxNodeId> child_nodes(SyntaxNodeId id, SyntaxKind kind) const {
+                std::vector<SyntaxNodeId> result;
+                for (const SyntaxNodeId child : child_nodes(id)) {
+                    if (node(child).kind == kind) { result.push_back(child); }
+                }
+                return result;
+            }
+
+            [[nodiscard]] std::vector<SyntaxTokenId> child_tokens(SyntaxNodeId id) const {
+                std::vector<SyntaxTokenId> result;
+                for (const SyntaxChild child : node(id).children) {
+                    if (child.kind == SyntaxChildKind::Token) { result.push_back(child.index); }
+                }
+                return result;
+            }
+
+            [[nodiscard]] std::vector<SyntaxTokenId> child_tokens(SyntaxNodeId id, TokenKind kind) const {
+                std::vector<SyntaxTokenId> result;
+                for (const SyntaxTokenId child : child_tokens(id)) {
+                    if (source_token(child).kind == kind) { result.push_back(child); }
+                }
+                return result;
+            }
+
+            void append_descendant_tokens(SyntaxNodeId id, std::vector<SyntaxTokenId> &result) const {
+                for (const SyntaxChild child : node(id).children) {
+                    if (child.kind == SyntaxChildKind::Token) {
+                        if (source_token(child.index).kind != TokenKind::Newline) { result.push_back(child.index); }
+                    } else {
+                        append_descendant_tokens(child.index, result);
+                    }
+                }
+            }
+
+            [[nodiscard]] std::vector<SyntaxTokenId> descendant_tokens(SyntaxNodeId id) const {
+                std::vector<SyntaxTokenId> result;
+                append_descendant_tokens(id, result);
+                return result;
+            }
+
+            [[nodiscard]] std::optional<SyntaxNodeId> find_child(SyntaxNodeId id, SyntaxKind kind) const {
+                for (const SyntaxNodeId child : child_nodes(id)) {
+                    if (node(child).kind == kind) { return child; }
+                }
+                return std::nullopt;
+            }
+
+            [[nodiscard]] SyntaxNodeId only_child(SyntaxNodeId id, SyntaxKind kind) const {
+                const std::vector<SyntaxNodeId> matches = child_nodes(id, kind);
+                require(matches.size() == 1, std::string{syntax_kind_name(node(id).kind)} + " does not have exactly one " +
+                                                 std::string{syntax_kind_name(kind)} + " child");
+                return matches.front();
+            }
+
+            [[nodiscard]] SyntaxNodeId semantic_child(SyntaxNodeId id) const {
+                for (const SyntaxNodeId child : child_nodes(id)) {
+                    switch (node(child).kind) {
+                        case SyntaxKind::Newlines:
+                        case SyntaxKind::LineEnd:
+                        case SyntaxKind::CommaSeparator:
+                        case SyntaxKind::ContinuedOperator: break;
+                        default: return child;
+                    }
+                }
+                malformed(std::string{syntax_kind_name(node(id).kind)} + " has no semantic child");
+            }
+
+            [[nodiscard]] ast::Name name(SyntaxTokenId id) const {
+                const Token &token = source_token(id);
+                require(token.kind == TokenKind::Identifier || is_keyword(token.kind), "name token is not an identifier");
+                return ast::Name{token.text, token.range};
+            }
+
+            [[nodiscard]] std::vector<ast::Name> direct_names(SyntaxNodeId id) const {
+                std::vector<ast::Name> names;
+                for (const SyntaxTokenId child : child_tokens(id)) {
+                    if (source_token(child).kind == TokenKind::Identifier) { names.push_back(name(child)); }
+                }
+                return names;
+            }
+
+            [[nodiscard]] static std::optional<ast::ScalarType> scalar_type(TokenKind kind) noexcept {
+                switch (kind) {
+                    case TokenKind::KwBool: return ast::ScalarType::Bool;
+                    case TokenKind::KwI64: return ast::ScalarType::I64;
+                    case TokenKind::KwF64: return ast::ScalarType::F64;
+                    case TokenKind::KwStr: return ast::ScalarType::Str;
+                    case TokenKind::KwDate: return ast::ScalarType::Date;
+                    case TokenKind::KwTime: return ast::ScalarType::Time;
+                    case TokenKind::KwDateTime: return ast::ScalarType::DateTime;
+                    case TokenKind::KwDuration: return ast::ScalarType::Duration;
+                    case TokenKind::KwCivilDateTime: return ast::ScalarType::CivilDateTime;
+                    case TokenKind::KwZonedDateTime: return ast::ScalarType::ZonedDateTime;
+                    case TokenKind::KwZonedTime: return ast::ScalarType::ZonedTime;
+                    case TokenKind::KwTimeZone: return ast::ScalarType::TimeZone;
+                    default: return std::nullopt;
+                }
+            }
+
+            [[nodiscard]] static ast::BinaryOp binary_op(TokenKind kind) {
+                switch (kind) {
+                    case TokenKind::Star: return ast::BinaryOp::Mul;
+                    case TokenKind::Slash: return ast::BinaryOp::Div;
+                    case TokenKind::Percent: return ast::BinaryOp::Rem;
+                    case TokenKind::Plus: return ast::BinaryOp::Add;
+                    case TokenKind::Minus: return ast::BinaryOp::Sub;
+                    case TokenKind::Less: return ast::BinaryOp::Less;
+                    case TokenKind::LessEqual: return ast::BinaryOp::LessEqual;
+                    case TokenKind::Greater: return ast::BinaryOp::Greater;
+                    case TokenKind::GreaterEqual: return ast::BinaryOp::GreaterEqual;
+                    case TokenKind::EqualEqual: return ast::BinaryOp::Equal;
+                    case TokenKind::NotEqual: return ast::BinaryOp::NotEqual;
+                    case TokenKind::AndAnd: return ast::BinaryOp::And;
+                    case TokenKind::OrOr: return ast::BinaryOp::Or;
+                    default: malformed("unknown binary operator");
+                }
+            }
+
+            [[nodiscard]] static ast::AssignOp assign_op(TokenKind kind) {
+                switch (kind) {
+                    case TokenKind::Assign: return ast::AssignOp::Assign;
+                    case TokenKind::PlusAssign: return ast::AssignOp::Add;
+                    case TokenKind::MinusAssign: return ast::AssignOp::Sub;
+                    case TokenKind::StarAssign: return ast::AssignOp::Mul;
+                    case TokenKind::SlashAssign: return ast::AssignOp::Div;
+                    default: malformed("unknown assignment operator");
+                }
+            }
+
+            [[nodiscard]] ast::TypeId project_type(SyntaxNodeId id, bool value_position) {
+                const SyntaxNode &syntax = node(id);
+                if (syntax.kind == SyntaxKind::Type) {
+                    const std::vector<SyntaxTokenId> tokens = child_tokens(id);
+                    if (!tokens.empty()) {
+                        require(tokens.size() == 1, "scalar type contains multiple tokens");
+                        const auto scalar = scalar_type(source_token(tokens.front()).kind);
+                        require(scalar.has_value(), "type token is not scalar");
+                        ast::Type type;
+                        type.kind           = ast::TypeKind::Scalar;
+                        type.range          = syntax.range;
+                        type.scalar         = *scalar;
+                        type.value_position = value_position;
+                        return module_.add(std::move(type));
+                    }
+                    return project_type(semantic_child(id), value_position);
+                }
+
+                ast::Type type;
+                type.range          = syntax.range;
+                type.value_position = value_position;
+                switch (syntax.kind) {
+                    case SyntaxKind::NamedType:
+                        {
+                            type.kind                              = ast::TypeKind::Named;
+                            const SyntaxNodeId           qualified = only_child(id, SyntaxKind::QualifiedName);
+                            const std::vector<ast::Name> names     = direct_names(qualified);
+                            require(names.size() == 1 || names.size() == 2, "named type has an invalid qualified name");
+                            if (names.size() == 2) {
+                                type.qualifier = names[0];
+                                type.name      = names[1];
+                            } else {
+                                type.name = names[0];
+                            }
+                            if (const auto arguments = find_child(id, SyntaxKind::GenericArguments)) {
+                                type.arguments = project_generic_arguments(*arguments);
+                            }
+                            break;
+                        }
+                    case SyntaxKind::TupleType:
+                        type.kind = ast::TypeKind::Tuple;
+                        for (const SyntaxNodeId child : child_nodes(id, SyntaxKind::Type)) {
+                            type.children.push_back(project_type(child, value_position));
+                        }
+                        break;
+                    case SyntaxKind::ListType:
+                        {
+                            type.kind = ast::TypeKind::List;
+                            type.children.push_back(project_type(only_child(id, SyntaxKind::Type), value_position));
+                            const std::vector<ast::Name> names = direct_names(id);
+                            type.unbounded                     = std::ranges::any_of(
+                                names, [](const ast::Name &candidate) { return candidate.text == "unbounded"; });
+                            if (const auto size = find_child(id, SyntaxKind::SizeExpression)) {
+                                type.size = project_expression(*size);
+                            }
+                            break;
+                        }
+                    case SyntaxKind::SetType:
+                        type.kind = ast::TypeKind::Set;
+                        type.children.push_back(project_type(only_child(id, SyntaxKind::Type), true));
+                        break;
+                    case SyntaxKind::MapType:
+                        {
+                            type.kind                             = ast::TypeKind::Map;
+                            const std::vector<SyntaxNodeId> types = child_nodes(id, SyntaxKind::Type);
+                            require(types.size() == 2, "map type does not contain two types");
+                            type.children.push_back(project_type(types[0], true));
+                            type.children.push_back(project_type(types[1], value_position));
+                            break;
+                        }
+                    case SyntaxKind::RollingType:
+                        {
+                            type.kind = ast::TypeKind::Rolling;
+                            type.children.push_back(project_type(only_child(id, SyntaxKind::Type), true));
+                            const std::vector<SyntaxNodeId> sizes = child_nodes(id, SyntaxKind::SizeExpression);
+                            require(!sizes.empty() && sizes.size() <= 2, "rolling type has an invalid size list");
+                            type.size = project_expression(sizes[0]);
+                            if (sizes.size() == 2) { type.min_size = project_expression(sizes[1]); }
+                            break;
+                        }
+                    case SyntaxKind::AtomicType:
+                        type.kind = ast::TypeKind::Atomic;
+                        type.children.push_back(project_type(only_child(id, SyntaxKind::Type), true));
+                        break;
+                    default: malformed("expected a type production");
+                }
+                return module_.add(std::move(type));
+            }
+
+            [[nodiscard]] std::vector<ast::GenericArgument> project_generic_arguments(SyntaxNodeId id) {
+                std::vector<ast::GenericArgument> result;
+                for (const SyntaxNodeId child : child_nodes(id, SyntaxKind::GenericArgument)) {
+                    ast::GenericArgument argument;
+                    argument.range                        = node(child).range;
+                    const std::vector<SyntaxNodeId> nodes = child_nodes(child);
+                    if (!nodes.empty()) {
+                        const SyntaxNodeId value = semantic_child(child);
+                        if (node(value).kind == SyntaxKind::SizeExpression) {
+                            const std::vector<SyntaxTokenId> tokens = descendant_tokens(value);
+                            if (tokens.size() == 1 && source_token(tokens.front()).kind == TokenKind::Identifier) {
+                                argument.name = name(tokens.front());
+                            } else {
+                                argument.value = project_expression(value);
+                            }
+                        } else {
+                            argument.type = project_type(value, true);
+                        }
+                    } else {
+                        const std::vector<SyntaxTokenId> tokens = child_tokens(child);
+                        if (tokens.size() == 1) {
+                            if (const auto scalar = scalar_type(source_token(tokens.front()).kind)) {
+                                ast::Type type;
+                                type.kind           = ast::TypeKind::Scalar;
+                                type.range          = node(child).range;
+                                type.scalar         = *scalar;
+                                type.value_position = true;
+                                argument.type       = module_.add(std::move(type));
+                                result.push_back(std::move(argument));
+                                continue;
+                            }
+                        }
+                        const std::vector<ast::Name> names = direct_names(child);
+                        require(names.size() == 1, "generic name argument has an invalid shape");
+                        argument.name = names.front();
+                    }
+                    result.push_back(std::move(argument));
+                }
+                return result;
+            }
+
+            [[nodiscard]] ast::ExprId project_expression(SyntaxNodeId id) {
+                switch (node(id).kind) {
+                    case SyntaxKind::Expression:
+                    case SyntaxKind::AndExpression:
+                    case SyntaxKind::EqualityExpression:
+                    case SyntaxKind::ComparisonExpression:
+                    case SyntaxKind::SumExpression:
+                    case SyntaxKind::ProductExpression: return project_binary_expression(id);
+                    case SyntaxKind::SizeExpression:
+                    case SyntaxKind::TupleElement: return project_expression(semantic_child(id));
+                    case SyntaxKind::PrimaryExpression:
+                        if (!child_nodes(id).empty()) { return project_expression(semantic_child(id)); }
+                        break;
+                    case SyntaxKind::UnaryExpression: return project_unary_expression(id);
+                    case SyntaxKind::PostfixExpression: return project_postfix_expression(id);
+                    case SyntaxKind::QualifiedName: return project_name_reference(id);
+                    case SyntaxKind::TupleOrGroup: return project_tuple(id);
+                    case SyntaxKind::SequenceLiteral: return project_sequence(id);
+                    case SyntaxKind::AnonymousFunction: return project_anonymous_function(id);
+                    case SyntaxKind::IfExpression: return project_if(id);
+                    case SyntaxKind::EvalExpression: return project_eval(id);
+                    case SyntaxKind::ExplicitConstruct: return project_construct(id);
+                    case SyntaxKind::Block:
+                        {
+                            const ast::BlockId block = project_block(id);
+                            return module_.add(ast::Expr{module_.block(block).range, ast::BlockExpr{block}});
+                        }
+                    default: break;
+                }
+
+                const std::vector<SyntaxTokenId> tokens = child_tokens(id);
+                require(tokens.size() == 1, "expression leaf does not contain exactly one token");
+                return project_literal(tokens.front());
+            }
+
+            [[nodiscard]] ast::ExprId project_binary_expression(SyntaxNodeId id) {
+                ast::ExprId              result = ast::no_node;
+                std::optional<TokenKind> operation;
+                for (const SyntaxChild child : node(id).children) {
+                    if (child.kind != SyntaxChildKind::Node) { continue; }
+                    if (node(child.index).kind == SyntaxKind::ContinuedOperator) {
+                        const std::vector<SyntaxTokenId> tokens = child_tokens(child.index);
+                        const auto                       found  = std::ranges::find_if(
+                            tokens, [&](SyntaxTokenId token) { return source_token(token).kind != TokenKind::Newline; });
+                        require(found != tokens.end(), "continued operator contains no operator");
+                        operation = source_token(*found).kind;
+                        continue;
+                    }
+                    if (node(child.index).kind == SyntaxKind::Newlines) { continue; }
+                    const ast::ExprId operand = project_expression(child.index);
+                    if (result == ast::no_node) {
+                        result = operand;
+                        continue;
+                    }
+                    require(operation.has_value(), "binary operand has no operator");
+                    const SourceRange range = module_.expr(result).range.join(module_.expr(operand).range);
+                    result                  = module_.add(ast::Expr{range, ast::Binary{binary_op(*operation), result, operand}});
+                    operation.reset();
+                }
+                require(result != ast::no_node && !operation.has_value(), "binary expression is incomplete");
+                return result;
+            }
+
+            [[nodiscard]] ast::ExprId project_unary_expression(SyntaxNodeId id) {
+                const std::vector<SyntaxTokenId> tokens = child_tokens(id);
+                if (tokens.empty()) { return project_expression(semantic_child(id)); }
+                require(tokens.size() == 1, "unary expression contains multiple operators");
+                const Token &token = source_token(tokens.front());
+                require(token.kind == TokenKind::Minus || token.kind == TokenKind::Bang, "invalid unary operator");
+                const ast::ExprId  operand = project_expression(semantic_child(id));
+                const ast::UnaryOp op      = token.kind == TokenKind::Minus ? ast::UnaryOp::Negate : ast::UnaryOp::Not;
+                return module_.add(ast::Expr{token.range.join(module_.expr(operand).range), ast::Unary{op, operand}});
+            }
+
+            [[nodiscard]] ast::ExprId project_postfix_expression(SyntaxNodeId id) {
+                ast::ExprId result = project_expression(only_child(id, SyntaxKind::PrimaryExpression));
+                for (const SyntaxNodeId postfix : child_nodes(id, SyntaxKind::Postfix)) {
+                    const SyntaxNodeId operation = semantic_child(postfix);
+                    switch (node(operation).kind) {
+                        case SyntaxKind::CallPostfix:
+                            {
+                                ast::Call call;
+                                call.callee    = result;
+                                call.arguments = project_arguments(only_child(operation, SyntaxKind::Arguments));
+                                result         = module_.add(
+                                    ast::Expr{{module_.expr(result).range.begin, node(operation).range.end}, std::move(call)});
+                                break;
+                            }
+                        case SyntaxKind::IndexPostfix:
+                            {
+                                const ast::ExprId index = project_expression(only_child(operation, SyntaxKind::Expression));
+                                result = module_.add(ast::Expr{{module_.expr(result).range.begin, node(operation).range.end},
+                                                               ast::Index{result, index}});
+                                break;
+                            }
+                        case SyntaxKind::FieldPostfix:
+                            {
+                                const std::vector<ast::Name> names = direct_names(operation);
+                                require(names.size() == 1, "field postfix has an invalid name");
+                                result = module_.add(ast::Expr{{module_.expr(result).range.begin, names.front().range.end},
+                                                               ast::Field{result, names.front()}});
+                                break;
+                            }
+                        default: malformed("invalid postfix production");
+                    }
+                }
+                return result;
+            }
+
+            [[nodiscard]] ast::ExprId project_name_reference(SyntaxNodeId id) {
+                const std::vector<ast::Name> names = direct_names(id);
+                require(names.size() == 1 || names.size() == 2, "reference has an invalid qualified name");
+                if (names.size() == 1) { return module_.add(ast::Expr{names[0].range, ast::NameRef{names[0]}}); }
+                return module_.add(ast::Expr{names[0].range.join(names[1].range), ast::QualifiedRef{names[0], names[1]}});
+            }
+
+            [[nodiscard]] ast::ExprId project_literal(SyntaxTokenId id) {
+                const Token &token = source_token(id);
+                switch (token.kind) {
+                    case TokenKind::IntLiteral: return module_.add(ast::Expr{token.range, ast::IntLiteral{token.int_value}});
+                    case TokenKind::FloatLiteral: return module_.add(ast::Expr{token.range, ast::FloatLiteral{token.float_value}});
+                    case TokenKind::StringLiteral:
+                        return module_.add(ast::Expr{token.range, ast::StringLiteral{token.string_value}});
+                    case TokenKind::TemporalLiteral:
+                        {
+                            ast::TemporalLiteral literal;
+                            if (token.temporal_value) { literal.value = *token.temporal_value; }
+                            return module_.add(ast::Expr{token.range, std::move(literal)});
+                        }
+                    case TokenKind::KwTrue:
+                    case TokenKind::KwFalse:
+                        return module_.add(ast::Expr{token.range, ast::BoolLiteral{token.kind == TokenKind::KwTrue}});
+                    case TokenKind::KwNull: return module_.add(ast::Expr{token.range, ast::NullLiteral{}});
+                    case TokenKind::Placeholder: return module_.add(ast::Expr{token.range, ast::Placeholder{}});
+                    default: malformed("invalid expression token");
+                }
+            }
+
+            [[nodiscard]] std::vector<ast::Argument> project_arguments(SyntaxNodeId id) {
+                std::vector<ast::Argument> result;
+                for (const SyntaxNodeId child : child_nodes(id, SyntaxKind::Argument)) {
+                    ast::Argument argument;
+                    if (!child_tokens(child, TokenKind::Colon).empty()) {
+                        const std::vector<ast::Name> names = direct_names(child);
+                        require(names.size() == 1, "named argument has an invalid name");
+                        argument.name = names.front();
+                    }
+                    argument.value = project_expression(only_child(child, SyntaxKind::Expression));
+                    result.push_back(std::move(argument));
+                }
+                return result;
+            }
+
+            [[nodiscard]] ast::ExprId project_tuple(SyntaxNodeId id) {
+                const std::vector<SyntaxNodeId> elements = child_nodes(id, SyntaxKind::TupleElement);
+                require(!elements.empty(), "tuple or group has no expression");
+                if (elements.size() == 1 && child_nodes(id, SyntaxKind::CommaSeparator).empty()) {
+                    return project_expression(elements.front());
+                }
+                ast::TupleLiteral tuple;
+                for (const SyntaxNodeId element : elements) { tuple.elements.push_back(project_expression(element)); }
+                return module_.add(ast::Expr{node(id).range, std::move(tuple)});
+            }
+
+            [[nodiscard]] ast::ExprId project_sequence(SyntaxNodeId id) {
+                ast::SequenceLiteral sequence;
+                for (const SyntaxNodeId child : child_nodes(id, SyntaxKind::SequenceElement)) {
+                    ast::SequenceElement             element;
+                    const std::vector<SyntaxTokenId> timed = child_tokens(child, TokenKind::TemporalLiteral);
+                    if (!timed.empty()) {
+                        require(timed.size() == 1, "sequence element has multiple time keys");
+                        element.key = project_literal(timed.front());
+                    }
+                    element.value = project_expression(only_child(child, SyntaxKind::Expression));
+                    sequence.elements.push_back(element);
+                }
+                return module_.add(ast::Expr{node(id).range, std::move(sequence)});
+            }
+
+            [[nodiscard]] ast::ExprId project_anonymous_function(SyntaxNodeId id) {
+                ast::AnonymousFn fn;
+                for (const SyntaxNodeId child : child_nodes(id, SyntaxKind::AnonymousParameter)) {
+                    ast::AnonymousParameter      parameter;
+                    const std::vector<ast::Name> names = direct_names(child);
+                    require(names.size() == 1, "anonymous parameter has an invalid name");
+                    parameter.name = names.front();
+                    if (const auto type = find_child(child, SyntaxKind::Type)) { parameter.type = project_type(*type, false); }
+                    fn.parameters.push_back(std::move(parameter));
+                }
+                const std::vector<SyntaxNodeId> types = child_nodes(id, SyntaxKind::Type);
+                if (!types.empty()) {
+                    require(types.size() == 1, "anonymous function has multiple result types");
+                    fn.result = project_type(types.front(), false);
+                }
+                fn.body = project_expression(only_child(id, SyntaxKind::Expression));
+                return module_.add(ast::Expr{node(id).range, std::move(fn)});
+            }
+
+            [[nodiscard]] ast::ExprId project_if(SyntaxNodeId id) {
+                ast::If result;
+                result.condition                       = project_expression(only_child(id, SyntaxKind::Expression));
+                const std::vector<SyntaxNodeId> blocks = child_nodes(id, SyntaxKind::Block);
+                require(blocks.size() == 1, "if expression has an invalid then block");
+                result.then_block = project_block(blocks.front());
+                if (const auto arm = find_child(id, SyntaxKind::ElseArm)) {
+                    if (const auto nested = find_child(*arm, SyntaxKind::IfExpression)) {
+                        result.otherwise = project_if(*nested);
+                    } else {
+                        const ast::BlockId block = project_block(only_child(*arm, SyntaxKind::Block));
+                        result.otherwise         = module_.add(ast::Expr{module_.block(block).range, ast::BlockExpr{block}});
+                    }
+                }
+                return module_.add(ast::Expr{node(id).range, result});
+            }
+
+            [[nodiscard]] ast::ExprId project_eval(SyntaxNodeId id) {
+                const ast::ExprId               callee    = project_expression(only_child(id, SyntaxKind::Expression));
+                const std::vector<SyntaxNodeId> arguments = child_nodes(id, SyntaxKind::Argument);
+                ast::Eval                       result;
+                result.callee = callee;
+                for (const SyntaxNodeId current : arguments) {
+                    ast::Argument argument;
+                    if (!child_tokens(current, TokenKind::Colon).empty()) {
+                        const std::vector<ast::Name> names = direct_names(current);
+                        require(names.size() == 1, "eval named argument has an invalid name");
+                        argument.name = names.front();
+                    }
+                    argument.value = project_expression(only_child(current, SyntaxKind::Expression));
+                    result.arguments.push_back(std::move(argument));
+                }
+                return module_.add(ast::Expr{node(id).range, std::move(result)});
+            }
+
+            [[nodiscard]] ast::ExprId project_construct(SyntaxNodeId id) {
+                ast::Construct               result;
+                const std::vector<ast::Name> names = direct_names(id);
+                require(!names.empty(), "construct has no target name");
+                result.delta = names.front().text == "delta";
+                if (result.delta) {
+                    result.type = project_type(only_child(id, SyntaxKind::Type), false);
+                } else {
+                    ast::Type type;
+                    type.kind  = ast::TypeKind::Named;
+                    type.range = names.front().range;
+                    if (names.size() == 2) {
+                        type.qualifier = names[0];
+                        type.name      = names[1];
+                        type.range     = names[0].range.join(names[1].range);
+                    } else {
+                        require(names.size() == 1, "construct has an invalid qualified name");
+                        type.name = names[0];
+                    }
+                    if (const auto arguments = find_child(id, SyntaxKind::GenericArguments)) {
+                        type.arguments = project_generic_arguments(*arguments);
+                        type.range     = type.range.join(node(*arguments).range);
+                    }
+                    result.type = module_.add(std::move(type));
+                }
+                if (module_.type(result.type).kind != ast::TypeKind::Named) {
+                    diagnostics_.report(Category::Parse, module_.type(result.type).range,
+                                        "a struct constructor takes a named struct type");
+                }
+                result.arguments = project_arguments(only_child(id, SyntaxKind::Arguments));
+                return module_.add(ast::Expr{node(id).range, std::move(result)});
+            }
+
+            [[nodiscard]] ast::BlockId project_block(SyntaxNodeId id) {
+                ast::Block result;
+                result.range = node(id).range;
+                for (const SyntaxNodeId item : child_nodes(id, SyntaxKind::BlockItem)) {
+                    result.statements.push_back(project_statement(only_child(item, SyntaxKind::Statement)));
+                }
+                if (!result.statements.empty()) {
+                    const ast::Stmt &last = module_.stmt(result.statements.back());
+                    if (const auto *expression = std::get_if<ast::ExprStmt>(&last.node)) { result.tail = expression->expr; }
+                }
+                return module_.add(std::move(result));
+            }
+
+            [[nodiscard]] ast::StmtId project_statement(SyntaxNodeId id) {
+                const SyntaxNodeId statement = semantic_child(id);
+                const SourceRange  range     = node(statement).range;
+                switch (node(statement).kind) {
+                    case SyntaxKind::LocalDecl:
+                        {
+                            ast::LocalDecl                   result;
+                            const std::vector<SyntaxTokenId> tokens = child_tokens(statement);
+                            require(!tokens.empty(), "local declaration has no introducer");
+                            result.mutable_                    = source_token(tokens.front()).kind == TokenKind::KwVar;
+                            const std::vector<ast::Name> names = direct_names(statement);
+                            require(names.size() == 1, "local declaration has an invalid name");
+                            result.name = names.front();
+                            if (const auto type = find_child(statement, SyntaxKind::Type)) {
+                                result.type = project_type(*type, false);
+                            }
+                            result.init = project_expression(only_child(statement, SyntaxKind::Expression));
+                            return module_.add(ast::Stmt{range, std::move(result)});
+                        }
+                    case SyntaxKind::StateDecl:
+                        {
+                            ast::StateDecl               result;
+                            const std::vector<ast::Name> names = direct_names(statement);
+                            require(names.size() == 1, "state declaration has an invalid name");
+                            result.name = names.front();
+                            if (const auto type = find_child(statement, SyntaxKind::Type)) {
+                                result.type = project_type(*type, true);
+                            }
+                            result.init = project_expression(only_child(statement, SyntaxKind::Expression));
+                            return module_.add(ast::Stmt{range, std::move(result)});
+                        }
+                    case SyntaxKind::InjectDecl:
+                        {
+                            ast::InjectDecl result;
+                            result.names = direct_names(statement);
+                            require(!result.names.empty(), "inject declaration has no names");
+                            return module_.add(ast::Stmt{range, std::move(result)});
+                        }
+                    case SyntaxKind::LifecycleStmt:
+                        {
+                            ast::LifecycleBlock              result;
+                            const std::vector<SyntaxTokenId> tokens = child_tokens(statement);
+                            require(tokens.size() == 1, "lifecycle statement has an invalid introducer");
+                            result.is_stop = source_token(tokens.front()).kind == TokenKind::KwStop;
+                            result.block   = project_block(only_child(statement, SyntaxKind::Block));
+                            return module_.add(ast::Stmt{range, result});
+                        }
+                    case SyntaxKind::WhenStmt:
+                        {
+                            ast::WhenStmt result;
+                            result.condition = project_expression(only_child(statement, SyntaxKind::Expression));
+                            result.block     = project_block(only_child(statement, SyntaxKind::Block));
+                            return module_.add(ast::Stmt{range, result});
+                        }
+                    case SyntaxKind::ForStmt:
+                        {
+                            ast::ForStmt           result;
+                            std::vector<ast::Name> names = direct_names(statement);
+                            std::erase_if(names, [](const ast::Name &candidate) { return candidate.text == "in"; });
+                            require(names.size() == 1 || names.size() == 2, "for statement has an invalid pattern");
+                            result.first = names[0];
+                            if (names.size() == 2) { result.second = names[1]; }
+                            result.iterable = project_expression(only_child(statement, SyntaxKind::Expression));
+                            result.block    = project_block(only_child(statement, SyntaxKind::Block));
+                            return module_.add(ast::Stmt{range, result});
+                        }
+                    case SyntaxKind::ReturnStmt:
+                        {
+                            ast::ReturnStmt result;
+                            if (const auto expression = find_child(statement, SyntaxKind::Expression)) {
+                                result.value = project_expression(*expression);
+                            }
+                            return module_.add(ast::Stmt{range, result});
+                        }
+                    case SyntaxKind::AssertStmt:
+                        {
+                            const ast::ExprId condition = project_expression(only_child(statement, SyntaxKind::Expression));
+                            return module_.add(ast::Stmt{range, ast::AssertStmt{condition}});
+                        }
+                    case SyntaxKind::AssignOrExpressionStmt:
+                        {
+                            const std::vector<SyntaxNodeId> expressions = child_nodes(statement, SyntaxKind::Expression);
+                            require(expressions.size() == 1 || expressions.size() == 2,
+                                    "expression statement has an invalid expression count");
+                            const ast::ExprId first = project_expression(expressions.front());
+                            if (expressions.size() == 1) { return module_.add(ast::Stmt{range, ast::ExprStmt{first}}); }
+
+                            if (!is_place(first)) {
+                                diagnostics_.report(Category::Parse, module_.expr(first).range,
+                                                    "only a name, an index, or a field can be assigned to");
+                            }
+                            TokenKind operation = TokenKind::Error;
+                            for (const SyntaxTokenId token : child_tokens(statement)) {
+                                const TokenKind kind = source_token(token).kind;
+                                if (kind == TokenKind::Assign || kind == TokenKind::PlusAssign || kind == TokenKind::MinusAssign ||
+                                    kind == TokenKind::StarAssign || kind == TokenKind::SlashAssign) {
+                                    operation = kind;
+                                    break;
+                                }
+                            }
+                            require(operation != TokenKind::Error, "assignment has no operator");
+                            const ast::ExprId value = project_expression(expressions[1]);
+                            if (!is_place(first)) { return module_.add(ast::Stmt{range, ast::ExprStmt{first}}); }
+                            return module_.add(ast::Stmt{range, ast::AssignStmt{assign_op(operation), first, value}});
+                        }
+                    default: malformed("invalid statement production");
+                }
+            }
+
+            [[nodiscard]] bool is_place(ast::ExprId id) const noexcept {
+                const ast::ExprNode &value = module_.expr(id).node;
+                if (std::holds_alternative<ast::NameRef>(value)) { return true; }
+                if (const auto *index = std::get_if<ast::Index>(&value)) { return is_place(index->target); }
+                if (const auto *field = std::get_if<ast::Field>(&value)) { return is_place(field->target); }
+                return false;
+            }
+
+            [[nodiscard]] ast::ConstraintId project_constraint(SyntaxNodeId id) {
+                switch (node(id).kind) {
+                    case SyntaxKind::Constraint:
+                        return project_constraint_logic(id, SyntaxKind::ConstraintAnd, ast::ConstraintLogicOp::Or);
+                    case SyntaxKind::ConstraintAnd:
+                        return project_constraint_logic(id, SyntaxKind::ConstraintTerm, ast::ConstraintLogicOp::And);
+                    case SyntaxKind::ConstraintTerm: return project_constraint_term(id);
+                    case SyntaxKind::ConstraintOperand: return project_constraint_operand(id);
+                    default: malformed("invalid constraint production");
+                }
+            }
+
+            [[nodiscard]] ast::ConstraintId project_constraint_logic(SyntaxNodeId id, SyntaxKind operand_kind,
+                                                                     ast::ConstraintLogicOp operation) {
+                const std::vector<SyntaxNodeId> operands = child_nodes(id, operand_kind);
+                require(!operands.empty(), "constraint logic has no operands");
+                ast::ConstraintId result = project_constraint(operands.front());
+                for (auto operand = operands.begin() + 1; operand != operands.end(); ++operand) {
+                    const ast::ConstraintId rhs = project_constraint(*operand);
+                    result = module_.add(ast::Constraint{module_.constraint(result).range.join(module_.constraint(rhs).range),
+                                                         ast::ConstraintLogic{operation, result, rhs}});
+                }
+                return result;
+            }
+
+            [[nodiscard]] ast::ConstraintId project_constraint_term(SyntaxNodeId id) {
+                const std::vector<SyntaxTokenId> tokens = child_tokens(id);
+                if (!tokens.empty() && source_token(tokens.front()).kind == TokenKind::Bang) {
+                    const ast::ConstraintId operand = project_constraint(only_child(id, SyntaxKind::ConstraintTerm));
+                    return module_.add(ast::Constraint{source_token(tokens.front()).range.join(module_.constraint(operand).range),
+                                                       ast::ConstraintNot{operand}});
+                }
+                if (const auto grouped = find_child(id, SyntaxKind::Constraint)) { return project_constraint(*grouped); }
+
+                const std::vector<SyntaxNodeId> operands = child_nodes(id, SyntaxKind::ConstraintOperand);
+                require(!operands.empty(), "constraint term has no operand");
+                ast::ConstraintId lhs = project_constraint(operands.front());
+                const auto        arrow =
+                    std::ranges::find_if(tokens, [&](SyntaxTokenId token) { return source_token(token).kind == TokenKind::Arrow; });
+                if (arrow != tokens.end()) {
+                    auto *call = std::get_if<ast::ConstraintCall>(&module_.constraints[lhs].node);
+                    require(call != nullptr, "operator requirement does not start with a call");
+                    ast::OperatorRequirement requirement;
+                    requirement.qualifier    = call->qualifier;
+                    requirement.name         = call->name;
+                    requirement.arguments    = std::move(call->arguments);
+                    requirement.result       = project_type(only_child(id, SyntaxKind::Type), true);
+                    module_.constraints[lhs] = ast::Constraint{
+                        module_.constraint(lhs).range.join(module_.type(requirement.result).range), std::move(requirement)};
+                    return lhs;
+                }
+
+                std::optional<ast::ConstraintRelationOp> relation;
+                for (const SyntaxTokenId token : tokens) {
+                    const Token &source = source_token(token);
+                    if (source.kind == TokenKind::EqualEqual) {
+                        relation = ast::ConstraintRelationOp::Equal;
+                    } else if (source.kind == TokenKind::KwIs) {
+                        relation = ast::ConstraintRelationOp::Is;
+                    } else if (source.kind == TokenKind::Identifier && source.text == "in") {
+                        relation = ast::ConstraintRelationOp::In;
+                    }
+                }
+                if (!relation.has_value()) { return lhs; }
+
+                ast::ConstraintRelation result;
+                result.op  = *relation;
+                result.lhs = lhs;
+                if (*relation == ast::ConstraintRelationOp::Is) {
+                    bool found = false;
+                    for (const SyntaxTokenId token : tokens) {
+                        const Token &source = source_token(token);
+                        if (source.kind == TokenKind::Identifier || source.kind == TokenKind::KwStruct) {
+                            result.category = name(token);
+                            found           = true;
+                        }
+                    }
+                    require(found, "is relation has no category");
+                    return module_.add(
+                        ast::Constraint{module_.constraint(lhs).range.join(result.category.range), std::move(result)});
+                }
+                require(operands.size() == 2, "constraint relation does not have two operands");
+                result.rhs = project_constraint(operands[1]);
+                return module_.add(
+                    ast::Constraint{module_.constraint(lhs).range.join(module_.constraint(result.rhs).range), std::move(result)});
+            }
+
+            [[nodiscard]] ast::ConstraintId project_constraint_operand(SyntaxNodeId id) {
+                if (const auto set = find_child(id, SyntaxKind::ConstraintSet)) {
+                    ast::ConstraintSet result;
+                    for (const SyntaxNodeId element : child_nodes(*set, SyntaxKind::ConstraintOperand)) {
+                        result.elements.push_back(project_constraint(element));
+                    }
+                    return module_.add(ast::Constraint{node(*set).range, std::move(result)});
+                }
+                if (const auto call = find_child(id, SyntaxKind::ConstraintCall)) {
+                    ast::ConstraintCall          result;
+                    const SyntaxNodeId           qualified = only_child(*call, SyntaxKind::QualifiedName);
+                    const std::vector<ast::Name> names     = direct_names(qualified);
+                    require(names.size() == 1 || names.size() == 2, "constraint call has an invalid name");
+                    if (names.size() == 2) {
+                        result.qualifier = names[0];
+                        result.name      = names[1];
+                    } else {
+                        result.name = names[0];
+                    }
+                    for (const SyntaxNodeId argument : child_nodes(*call, SyntaxKind::ConstraintOperand)) {
+                        result.arguments.push_back(project_constraint(argument));
+                    }
+                    return module_.add(ast::Constraint{node(*call).range, std::move(result)});
+                }
+
+                const std::vector<SyntaxNodeId> nodes = child_nodes(id);
+                if (!nodes.empty()) {
+                    const SyntaxNodeId value = semantic_child(id);
+                    switch (node(value).kind) {
+                        case SyntaxKind::NamedType:
+                        case SyntaxKind::TupleType:
+                        case SyntaxKind::ListType:
+                        case SyntaxKind::SetType:
+                        case SyntaxKind::MapType:
+                        case SyntaxKind::RollingType:
+                        case SyntaxKind::AtomicType:
+                            {
+                                const ast::TypeId type = project_type(value, true);
+                                return module_.add(ast::Constraint{module_.type(type).range, ast::ConstraintType{type}});
+                            }
+                        case SyntaxKind::SizeExpression:
+                            {
+                                const ast::ExprId expression = project_expression(value);
+                                return module_.add(
+                                    ast::Constraint{module_.expr(expression).range, ast::ConstraintValue{expression}});
+                            }
+                        default: malformed("invalid constraint operand child");
+                    }
+                }
+
+                const std::vector<SyntaxTokenId> tokens = child_tokens(id);
+                require(!tokens.empty(), "constraint operand has no value");
+                if (const auto scalar = scalar_type(source_token(tokens.front()).kind)) {
+                    ast::Type type;
+                    type.kind                 = ast::TypeKind::Scalar;
+                    type.range                = node(id).range;
+                    type.scalar               = *scalar;
+                    type.value_position       = true;
+                    const ast::TypeId type_id = module_.add(std::move(type));
+                    return module_.add(ast::Constraint{node(id).range, ast::ConstraintType{type_id}});
+                }
+                if (source_token(tokens.front()).kind == TokenKind::Identifier) {
+                    return module_.add(ast::Constraint{node(id).range, ast::ConstraintName{name(tokens.front())}});
+                }
+                const ast::ExprId expression = project_literal(tokens.front());
+                return module_.add(ast::Constraint{module_.expr(expression).range, ast::ConstraintValue{expression}});
+            }
+
+            [[nodiscard]] std::vector<ast::GenericParameter> project_generic_parameters(SyntaxNodeId id) {
+                std::vector<ast::GenericParameter> result;
+                for (const SyntaxNodeId child : child_nodes(id, SyntaxKind::GenericParameter)) {
+                    ast::GenericParameter parameter;
+                    parameter.is_const                 = !child_tokens(child, TokenKind::KwConst).empty();
+                    const std::vector<ast::Name> names = direct_names(child);
+                    require(names.size() == 1, "generic parameter has an invalid name");
+                    parameter.name = names.front();
+                    if (parameter.is_const) { parameter.type = project_type(only_child(child, SyntaxKind::Type), true); }
+                    result.push_back(std::move(parameter));
+                }
+                return result;
+            }
+
+            [[nodiscard]] ast::Signature project_signature(SyntaxNodeId id) {
+                ast::Signature result;
+                for (const SyntaxNodeId child : child_nodes(id, SyntaxKind::Parameter)) {
+                    ast::Parameter parameter;
+                    parameter.is_const                 = !child_tokens(child, TokenKind::KwConst).empty();
+                    const std::vector<ast::Name> names = direct_names(child);
+                    require(names.size() == 1, "parameter has an invalid name");
+                    parameter.name = names.front();
+                    parameter.type = project_type(only_child(child, SyntaxKind::Type), parameter.is_const);
+                    if (const auto expression = find_child(child, SyntaxKind::Expression)) {
+                        parameter.default_value = project_expression(*expression);
+                        if (!parameter.is_const) {
+                            diagnostics_.report(Category::Parse, module_.expr(parameter.default_value).range,
+                                                "only a const parameter may have a default");
+                        }
+                    }
+                    result.parameters.push_back(std::move(parameter));
+                }
+                const std::vector<SyntaxNodeId> types = child_nodes(id, SyntaxKind::Type);
+                if (!types.empty()) {
+                    require(types.size() == 1, "signature has multiple result types");
+                    result.result = project_type(types.front(), false);
+                }
+                return result;
+            }
+
+            [[nodiscard]] ast::ConstraintId project_optional_requires(SyntaxNodeId owner) {
+                const auto optional = find_child(owner, SyntaxKind::OptionalRequiresClause);
+                if (!optional.has_value()) { return ast::no_node; }
+                const auto clause = find_child(*optional, SyntaxKind::RequiresClause);
+                if (!clause.has_value()) { return ast::no_node; }
+                return project_constraint(only_child(*clause, SyntaxKind::Constraint));
+            }
+
+            [[nodiscard]] ast::Decl project_module_decl(SyntaxNodeId id) {
+                ast::ModuleDecl result;
+                result.path = direct_names(only_child(id, SyntaxKind::ModulePath));
+                require(!result.path.empty(), "module path is empty");
+                return ast::Decl{node(id).range, std::move(result)};
+            }
+
+            [[nodiscard]] ast::Decl project_declaration(SyntaxNodeId id) {
+                const SyntaxNodeId declaration = semantic_child(id);
+                switch (node(declaration).kind) {
+                    case SyntaxKind::UseDecl: return project_use_decl(declaration);
+                    case SyntaxKind::FunctionDecl: return project_function_decl(declaration);
+                    case SyntaxKind::OperatorDecl: return project_operator_decl(declaration);
+                    case SyntaxKind::StructDecl: return project_struct_decl(declaration);
+                    case SyntaxKind::TestDecl: return project_test_decl(declaration);
+                    default: malformed("invalid declaration production");
+                }
+            }
+
+            [[nodiscard]] ast::Decl project_use_decl(SyntaxNodeId id) {
+                ast::UseDecl result;
+                result.path                        = direct_names(only_child(id, SyntaxKind::ModulePath));
+                const std::vector<ast::Name> names = direct_names(id);
+                if (!child_tokens(id, TokenKind::KwAs).empty()) {
+                    require(names.size() == 1, "aliased use declaration has an invalid alias");
+                    result.alias = names.front();
+                } else {
+                    require(!names.empty(), "selective use declaration imports no names");
+                    result.names = names;
+                }
+                return ast::Decl{node(id).range, std::move(result)};
+            }
+
+            [[nodiscard]] ast::Decl project_function_decl(SyntaxNodeId id) {
+                ast::FunctionDecl result;
+                if (!child_tokens(id, TokenKind::KwExport).empty()) {
+                    result.visibility = ast::FunctionVisibility::Export;
+                } else if (!child_tokens(id, TokenKind::KwImpl).empty()) {
+                    result.visibility = ast::FunctionVisibility::Impl;
+                }
+                const std::vector<ast::Name> names = direct_names(id);
+                require(names.size() == 1, "function has an invalid name");
+                result.name = names.front();
+                if (const auto generics = find_child(id, SyntaxKind::GenericParameters)) {
+                    result.generics = project_generic_parameters(*generics);
+                }
+                result.signature    = project_signature(only_child(id, SyntaxKind::Signature));
+                result.requirements = project_optional_requires(id);
+                if (const auto expression = find_child(id, SyntaxKind::Expression)) {
+                    result.concise_body = project_expression(*expression);
+                } else {
+                    result.block_body = project_block(only_child(id, SyntaxKind::Block));
+                }
+                return ast::Decl{node(id).range, std::move(result)};
+            }
+
+            [[nodiscard]] ast::Decl project_operator_decl(SyntaxNodeId id) {
+                ast::OperatorDecl            result;
+                const std::vector<ast::Name> names = direct_names(id);
+                require(names.size() == 1, "operator has an invalid name");
+                result.name = names.front();
+                if (const auto generics = find_child(id, SyntaxKind::GenericParameters)) {
+                    result.generics = project_generic_parameters(*generics);
+                }
+                result.signature    = project_signature(only_child(id, SyntaxKind::Signature));
+                result.requirements = project_optional_requires(id);
+                return ast::Decl{node(id).range, std::move(result)};
+            }
+
+            [[nodiscard]] ast::Decl project_struct_decl(SyntaxNodeId id) {
+                ast::StructDecl result;
+                result.exported                    = !child_tokens(id, TokenKind::KwExport).empty();
+                result.abstract                    = !child_tokens(id, TokenKind::KwAbstract).empty();
+                const std::vector<ast::Name> names = direct_names(id);
+                require(names.size() == 1, "struct has an invalid name");
+                result.name = names.front();
+                if (const auto generics = find_child(id, SyntaxKind::GenericParameters)) {
+                    result.generics = project_generic_parameters(*generics);
+                }
+                for (const SyntaxNodeId parent : child_nodes(id, SyntaxKind::Type)) {
+                    const ast::TypeId type = project_type(parent, true);
+                    if (module_.type(type).kind != ast::TypeKind::Named) {
+                        diagnostics_.report(Category::Parse, module_.type(type).range, "a struct parent is a named type");
+                    }
+                    result.parents.push_back(type);
+                }
+                result.requirements = project_optional_requires(id);
+                for (const SyntaxNodeId item : child_nodes(id, SyntaxKind::StructBodyItem)) {
+                    const SyntaxNodeId           member       = only_child(item, SyntaxKind::StructMember);
+                    const std::vector<ast::Name> member_names = direct_names(member);
+                    require(member_names.size() == 1, "struct member has an invalid name");
+                    if (const auto type = find_child(member, SyntaxKind::Type)) {
+                        ast::StructField field;
+                        field.name = member_names.front();
+                        field.type = project_type(*type, false);
+                        if (const auto expression = find_child(member, SyntaxKind::Expression)) {
+                            field.default_value = project_expression(*expression);
+                        }
+                        result.members.emplace_back(std::move(field));
+                    } else {
+                        ast::InheritedDefault inherited;
+                        inherited.name  = member_names.front();
+                        inherited.value = project_expression(only_child(member, SyntaxKind::Expression));
+                        result.members.emplace_back(std::move(inherited));
+                    }
+                }
+                return ast::Decl{node(id).range, std::move(result)};
+            }
+
+            [[nodiscard]] ast::Decl project_test_decl(SyntaxNodeId id) {
+                ast::TestDecl                result;
+                const std::vector<ast::Name> names = direct_names(id);
+                require(names.size() == 1, "test has an invalid name");
+                result.name  = names.front();
+                result.block = project_block(only_child(id, SyntaxKind::Block));
+                return ast::Decl{node(id).range, std::move(result)};
+            }
+
+            void add_declaration(ast::Decl declaration) {
+                const bool is_use = std::holds_alternative<ast::UseDecl>(declaration.node);
+                if (is_use && seen_ordinary_) {
+                    diagnostics_.report(Category::Parse, declaration.range, "'use' declarations must precede other declarations");
+                }
+                const bool        ordinary = !is_use && !std::holds_alternative<ast::ModuleDecl>(declaration.node);
+                const ast::DeclId id       = module_.add(std::move(declaration));
+                module_.declarations.push_back(id);
+                seen_ordinary_ = seen_ordinary_ || ordinary;
+            }
+
+            const SyntaxTree &tree_;
+            const LexResult  &lexed_;
+            DiagnosticSink   &diagnostics_;
+            ast::Module       module_{};
+            bool              seen_ordinary_{false};
+        };
+    }  // namespace
+
+    ast::Module project_ast(const SyntaxTree &tree, const LexResult &lexed, DiagnosticSink &diagnostics) {
+        return AstProjector{tree, lexed, diagnostics}.run();
+    }
+}  // namespace hgl::syntax

--- a/language/src/syntax/ast_projection.cpp
+++ b/language/src/syntax/ast_projection.cpp
@@ -663,7 +663,11 @@ namespace hgl::syntax
                         {
                             ast::ForStmt           result;
                             std::vector<ast::Name> names = direct_names(statement);
-                            std::erase_if(names, [](const ast::Name &candidate) { return candidate.text == "in"; });
+                            // The grammar's contextual `in` separator is the
+                            // final direct name. Earlier occurrences remain
+                            // ordinary pattern names (`for key, in in xs`).
+                            require(!names.empty() && names.back().text == "in", "for statement has no 'in' separator");
+                            names.pop_back();
                             require(names.size() == 1 || names.size() == 2, "for statement has an invalid pattern");
                             result.first = names[0];
                             if (names.size() == 2) { result.second = names[1]; }
@@ -763,7 +767,12 @@ namespace hgl::syntax
                     std::ranges::find_if(tokens, [&](SyntaxTokenId token) { return source_token(token).kind == TokenKind::Arrow; });
                 if (arrow != tokens.end()) {
                     auto *call = std::get_if<ast::ConstraintCall>(&module_.constraints[lhs].node);
-                    require(call != nullptr, "operator requirement does not start with a call");
+                    if (call == nullptr) {
+                        diagnostics_.report(Category::Parse, module_.constraint(lhs).range,
+                                            "the left side of an operator requirement is a call");
+                        (void)project_type(only_child(id, SyntaxKind::Type), true);
+                        return lhs;
+                    }
                     ast::OperatorRequirement requirement;
                     requirement.qualifier    = call->qualifier;
                     requirement.name         = call->name;
@@ -781,7 +790,7 @@ namespace hgl::syntax
                         relation = ast::ConstraintRelationOp::Equal;
                     } else if (source.kind == TokenKind::KwIs) {
                         relation = ast::ConstraintRelationOp::Is;
-                    } else if (source.kind == TokenKind::Identifier && source.text == "in") {
+                    } else if (!relation.has_value() && source.kind == TokenKind::Identifier && source.text == "in") {
                         relation = ast::ConstraintRelationOp::In;
                     }
                 }

--- a/language/src/syntax/ast_projection.h
+++ b/language/src/syntax/ast_projection.h
@@ -1,0 +1,21 @@
+#ifndef HGL_SYNTAX_AST_PROJECTION_H
+#define HGL_SYNTAX_AST_PROJECTION_H
+
+#include "syntax/ast.h"
+#include "syntax/diagnostic.h"
+#include "syntax/lexer.h"
+#include "syntax/syntax_tree.h"
+
+namespace hgl::syntax
+{
+    /// Lower one clean, source-accurate syntax tree into the compact semantic
+    /// syntax arena consumed by the existing name and type resolver.
+    ///
+    /// The source tree is the grammatical authority. This pass does not parse
+    /// tokens or recover syntax; it only converts explicit production shapes
+    /// and performs the few context checks historically owned by the AST
+    /// builder (for example, assignable places and const-only defaults).
+    [[nodiscard]] ast::Module project_ast(const SyntaxTree &tree, const LexResult &lexed, DiagnosticSink &diagnostics);
+}  // namespace hgl::syntax
+
+#endif  // HGL_SYNTAX_AST_PROJECTION_H

--- a/language/src/syntax/parser.cpp
+++ b/language/src/syntax/parser.cpp
@@ -1,7 +1,9 @@
 #include "syntax/parser.h"
 
+#include "syntax/ast_projection.h"
 #include "syntax/lexer.h"
 #include "syntax/token.h"
+#include "syntax/token_grammar.h"
 
 #include <cstddef>
 #include <optional>
@@ -23,14 +25,12 @@ namespace hgl::syntax
     namespace
     {
         struct ParseError
-        {
-        };
+        {};
 
         // Binary precedence, low to high (developer guide, "Blocks and
         // expressions"). `Additive` is the floor for type-size expressions
         // so that `>` closes the type argument list.
-        enum Precedence : int
-        {
+        enum Precedence : int {
             PrecOr             = 1,
             PrecAnd            = 2,
             PrecEquality       = 3,
@@ -45,10 +45,8 @@ namespace hgl::syntax
             int           precedence;
         };
 
-        [[nodiscard]] std::optional<BinaryInfo> binary_info(TokenKind kind) noexcept
-        {
-            switch (kind)
-            {
+        [[nodiscard]] std::optional<BinaryInfo> binary_info(TokenKind kind) noexcept {
+            switch (kind) {
                 case TokenKind::Star: return BinaryInfo{ast::BinaryOp::Mul, PrecMultiplicative};
                 case TokenKind::Slash: return BinaryInfo{ast::BinaryOp::Div, PrecMultiplicative};
                 case TokenKind::Percent: return BinaryInfo{ast::BinaryOp::Rem, PrecMultiplicative};
@@ -66,10 +64,8 @@ namespace hgl::syntax
             }
         }
 
-        [[nodiscard]] std::optional<ast::AssignOp> assign_op(TokenKind kind) noexcept
-        {
-            switch (kind)
-            {
+        [[nodiscard]] std::optional<ast::AssignOp> assign_op(TokenKind kind) noexcept {
+            switch (kind) {
                 case TokenKind::Assign: return ast::AssignOp::Assign;
                 case TokenKind::PlusAssign: return ast::AssignOp::Add;
                 case TokenKind::MinusAssign: return ast::AssignOp::Sub;
@@ -79,10 +75,8 @@ namespace hgl::syntax
             }
         }
 
-        [[nodiscard]] std::optional<ast::ScalarType> scalar_type(TokenKind kind) noexcept
-        {
-            switch (kind)
-            {
+        [[nodiscard]] std::optional<ast::ScalarType> scalar_type(TokenKind kind) noexcept {
+            switch (kind) {
                 case TokenKind::KwBool: return ast::ScalarType::Bool;
                 case TokenKind::KwI64: return ast::ScalarType::I64;
                 case TokenKind::KwF64: return ast::ScalarType::F64;
@@ -102,10 +96,8 @@ namespace hgl::syntax
         /// True for the tokens that begin a top-level declaration; `fn` only
         /// when a name follows, so an anonymous `fn(` inside a body is not a
         /// resynchronisation point.
-        [[nodiscard]] bool starts_declaration(TokenKind kind, TokenKind next) noexcept
-        {
-            switch (kind)
-            {
+        [[nodiscard]] bool starts_declaration(TokenKind kind, TokenKind next) noexcept {
+            switch (kind) {
                 case TokenKind::KwModule:
                 case TokenKind::KwUse:
                 case TokenKind::KwExport:
@@ -122,28 +114,23 @@ namespace hgl::syntax
         class Parser
         {
           public:
-            Parser(const SourceFile &file, DiagnosticSink &diagnostics) : diagnostics_{diagnostics}
-            {
-                LexResult lexed = lex(file, diagnostics);
-                tokens_         = std::move(lexed.tokens);
+            Parser(const SourceFile &file, DiagnosticSink &diagnostics) : Parser{lex(file, diagnostics), diagnostics} {}
+
+            Parser(LexResult lexed, DiagnosticSink &diagnostics) : diagnostics_{diagnostics} {
+                tokens_          = std::move(lexed.tokens);
                 module_.comments = std::move(lexed.comments);
             }
 
-            ast::Module run()
-            {
+            ast::Module run() {
                 skip_newlines();
-                if (at(TokenKind::KwModule))
-                {
+                if (at(TokenKind::KwModule)) {
                     parse_top_level(false);
-                }
-                else
-                {
+                } else {
                     diagnostics_.report(Category::Parse, {tok().range.begin, tok().range.begin},
                                         "expected a 'module' declaration at the start of the file");
                 }
                 bool seen_declaration = false;
-                while (true)
-                {
+                while (true) {
                     skip_newlines();
                     if (at_end()) { break; }
                     seen_declaration = parse_top_level(seen_declaration) || seen_declaration;
@@ -155,28 +142,24 @@ namespace hgl::syntax
             // ------------------------------------------------------ tokens
 
             [[nodiscard]] const Token &tok() const noexcept { return tokens_[pos_]; }
-            [[nodiscard]] const Token &tok_at(std::size_t index) const noexcept
-            {
+            [[nodiscard]] const Token &tok_at(std::size_t index) const noexcept {
                 return tokens_[index < tokens_.size() ? index : tokens_.size() - 1];
             }
             [[nodiscard]] const Token &next_tok() const noexcept { return tok_at(pos_ + 1); }
-            [[nodiscard]] bool at(TokenKind kind) const noexcept { return tok().kind == kind; }
-            [[nodiscard]] bool at_end() const noexcept { return at(TokenKind::EndOfFile); }
-            [[nodiscard]] bool at_identifier(std::string_view text) const noexcept
-            {
+            [[nodiscard]] bool         at(TokenKind kind) const noexcept { return tok().kind == kind; }
+            [[nodiscard]] bool         at_end() const noexcept { return at(TokenKind::EndOfFile); }
+            [[nodiscard]] bool         at_identifier(std::string_view text) const noexcept {
                 return at(TokenKind::Identifier) && tok().text == text;
             }
 
-            const Token &advance()
-            {
+            const Token &advance() {
                 const Token &token = tok();
                 if (token.kind != TokenKind::EndOfFile) { ++pos_; }
                 if (token.kind != TokenKind::Newline) { last_end_ = token.range.end; }
                 return token;
             }
 
-            void skip_newlines()
-            {
+            void skip_newlines() {
                 while (at(TokenKind::Newline)) { ++pos_; }
             }
 
@@ -184,10 +167,8 @@ namespace hgl::syntax
             /// token (for instance a `;`) has already been diagnosed and
             /// stands in for the terminator so the construct is not reported
             /// twice.
-            void expect_terminator(std::string_view what)
-            {
-                if (at(TokenKind::Error))
-                {
+            void expect_terminator(std::string_view what) {
+                if (at(TokenKind::Error)) {
                     advance();
                     return;
                 }
@@ -195,68 +176,54 @@ namespace hgl::syntax
             }
 
             /// The kind of the next token, looking through one newline run.
-            [[nodiscard]] const Token &tok_past_newline() const noexcept
-            {
-                return at(TokenKind::Newline) ? next_tok() : tok();
-            }
+            [[nodiscard]] const Token &tok_past_newline() const noexcept { return at(TokenKind::Newline) ? next_tok() : tok(); }
 
             /// When the next token past an optional newline is `kind`, skip
             /// the newline and return true (continuation lines).
-            bool continue_with(TokenKind kind)
-            {
+            bool continue_with(TokenKind kind) {
                 if (tok_past_newline().kind != kind) { return false; }
                 skip_newlines();
                 return true;
             }
 
-            [[nodiscard]] static std::string describe(const Token &token)
-            {
-                switch (token.kind)
-                {
+            [[nodiscard]] static std::string describe(const Token &token) {
+                switch (token.kind) {
                     case TokenKind::EndOfFile: return "end of file";
                     case TokenKind::Newline: return "newline";
                     default: return "'" + std::string{token.text} + "'";
                 }
             }
 
-            [[nodiscard]] SourceRange here() const noexcept
-            {
+            [[nodiscard]] SourceRange here() const noexcept {
                 const Token &token = tok();
-                if (token.kind == TokenKind::Newline || token.kind == TokenKind::EndOfFile)
-                {
+                if (token.kind == TokenKind::Newline || token.kind == TokenKind::EndOfFile) {
                     return {token.range.begin, token.range.begin};
                 }
                 return token.range;
             }
 
-            [[noreturn]] void fail(SourceRange range, std::string message)
-            {
+            [[noreturn]] void fail(SourceRange range, std::string message) {
                 diagnostics_.report(Category::Parse, range, std::move(message));
                 throw ParseError{};
             }
 
-            [[noreturn]] void fail_expected(std::string_view what)
-            {
+            [[noreturn]] void fail_expected(std::string_view what) {
                 fail(here(), "expected " + std::string{what} + ", found " + describe(tok()));
             }
 
-            const Token &expect(TokenKind kind, std::string_view what)
-            {
+            const Token &expect(TokenKind kind, std::string_view what) {
                 if (!at(kind)) { fail_expected(what); }
                 return advance();
             }
 
             /// An identifier; a reserved word is reported and still taken as
             /// the name so parsing continues.
-            ast::Name expect_name(std::string_view what)
-            {
-                if (at(TokenKind::Identifier))
-                {
+            ast::Name expect_name(std::string_view what) {
+                if (at(TokenKind::Identifier)) {
                     const Token &token = advance();
                     return ast::Name{token.text, token.range};
                 }
-                if (is_keyword(tok().kind))
-                {
+                if (is_keyword(tok().kind)) {
                     const Token &token = advance();
                     diagnostics_.report(Category::Parse, token.range,
                                         "'" + std::string{token.text} + "' is a reserved word and cannot be used as " +
@@ -273,18 +240,14 @@ namespace hgl::syntax
             /// Parse one declaration and its terminator; returns whether it
             /// was an ordinary declaration (not `module`/`use`). Recovers at
             /// the next declaration start on a line of its own.
-            bool parse_top_level(bool seen_declaration)
-            {
+            bool parse_top_level(bool seen_declaration) {
                 bool ordinary = false;
-                try
-                {
+                try {
                     ast::DeclId id = ast::no_node;
-                    switch (tok().kind)
-                    {
+                    switch (tok().kind) {
                         case TokenKind::KwModule: id = parse_module_decl(); break;
                         case TokenKind::KwUse:
-                            if (seen_declaration)
-                            {
+                            if (seen_declaration) {
                                 diagnostics_.report(Category::Parse, tok().range,
                                                     "'use' declarations must precede other declarations");
                             }
@@ -294,8 +257,7 @@ namespace hgl::syntax
                         case TokenKind::KwAbstract:
                         case TokenKind::KwStruct: id = parse_struct_decl(); break;
                         case TokenKind::KwExport:
-                            if (next_tok().kind == TokenKind::KwStruct || next_tok().kind == TokenKind::KwAbstract)
-                            {
+                            if (next_tok().kind == TokenKind::KwStruct || next_tok().kind == TokenKind::KwAbstract) {
                                 id = parse_struct_decl();
                                 break;
                             }
@@ -309,20 +271,13 @@ namespace hgl::syntax
                                !std::holds_alternative<ast::UseDecl>(module_.decl(id).node);
                     module_.declarations.push_back(id);
                     expect_terminator("a newline after the declaration");
-                }
-                catch (const ParseError &)
-                {
-                    synchronize_declaration();
-                }
+                } catch (const ParseError &) { synchronize_declaration(); }
                 return ordinary;
             }
 
-            void synchronize_declaration()
-            {
-                while (!at_end())
-                {
-                    if (at(TokenKind::Newline))
-                    {
+            void synchronize_declaration() {
+                while (!at_end()) {
+                    if (at(TokenKind::Newline)) {
                         const Token &candidate = next_tok();
                         if (starts_declaration(candidate.kind, tok_at(pos_ + 2).kind)) { return; }
                     }
@@ -330,13 +285,9 @@ namespace hgl::syntax
                 }
             }
 
-            ast::DeclId parse_module_decl()
-            {
+            ast::DeclId parse_module_decl() {
                 const std::uint32_t begin = tok().range.begin;
-                if (seen_module_)
-                {
-                    diagnostics_.report(Category::Parse, tok().range, "a file has one 'module' declaration");
-                }
+                if (seen_module_) { diagnostics_.report(Category::Parse, tok().range, "a file has one 'module' declaration"); }
                 seen_module_ = true;
                 advance();
                 ast::ModuleDecl decl;
@@ -344,33 +295,28 @@ namespace hgl::syntax
                 return module_.add(ast::Decl{range_from(begin), std::move(decl)});
             }
 
-            std::vector<ast::Name> parse_module_path()
-            {
+            std::vector<ast::Name> parse_module_path() {
                 std::vector<ast::Name> path;
                 path.push_back(expect_name("a module name"));
-                while (at(TokenKind::Dot))
-                {
+                while (at(TokenKind::Dot)) {
                     advance();
                     path.push_back(expect_name("a module name"));
                 }
                 return path;
             }
 
-            ast::DeclId parse_use_decl()
-            {
+            ast::DeclId parse_use_decl() {
                 const std::uint32_t begin = tok().range.begin;
                 advance();
                 ast::UseDecl decl;
                 decl.path = parse_module_path();
-                if (at(TokenKind::ColonColon))
-                {
+                if (at(TokenKind::ColonColon)) {
                     advance();
                     // The import set is always braced (`use a.b::{x}`); a
                     // bare `use a.b::x` is not a spelling of the language.
                     expect(TokenKind::LBrace, "'{' after '::'");
                     skip_newlines();
-                    while (!at(TokenKind::RBrace))
-                    {
+                    while (!at(TokenKind::RBrace)) {
                         decl.names.push_back(expect_name("an imported name"));
                         skip_newlines();
                         if (!at(TokenKind::Comma)) { break; }
@@ -378,22 +324,17 @@ namespace hgl::syntax
                         skip_newlines();
                     }
                     expect(TokenKind::RBrace, "',' or '}'");
-                    if (decl.names.empty())
-                    {
-                        fail(range_from(begin), "an import set names at least one declaration");
-                    }
-                }
-                else if (at(TokenKind::KwAs))
-                {
+                    if (decl.names.empty()) { fail(range_from(begin), "an import set names at least one declaration"); }
+                } else if (at(TokenKind::KwAs)) {
                     advance();
                     decl.alias = expect_name("a module alias");
+                } else {
+                    fail_expected("'::' or 'as' after the module path");
                 }
-                else { fail_expected("'::' or 'as' after the module path"); }
                 return module_.add(ast::Decl{range_from(begin), std::move(decl)});
             }
 
-            ast::DeclId parse_operator_decl()
-            {
+            ast::DeclId parse_operator_decl() {
                 const std::uint32_t begin = tok().range.begin;
                 advance();
                 ast::OperatorDecl decl;
@@ -401,24 +342,19 @@ namespace hgl::syntax
                 if (at(TokenKind::Less)) { decl.generics = parse_generic_parameters(); }
                 decl.signature    = parse_signature();
                 decl.requirements = parse_requires_clause();
-                if (at(TokenKind::FatArrow) || at(TokenKind::LBrace))
-                {
+                if (at(TokenKind::FatArrow) || at(TokenKind::LBrace)) {
                     fail(tok().range, "an operator declaration has no body; implement it with 'impl fn'");
                 }
                 return module_.add(ast::Decl{range_from(begin), std::move(decl)});
             }
 
-            ast::DeclId parse_function_decl()
-            {
+            ast::DeclId parse_function_decl() {
                 const std::uint32_t begin = tok().range.begin;
                 ast::FunctionDecl   decl;
-                if (at(TokenKind::KwExport))
-                {
+                if (at(TokenKind::KwExport)) {
                     decl.visibility = ast::FunctionVisibility::Export;
                     advance();
-                }
-                else if (at(TokenKind::KwImpl))
-                {
+                } else if (at(TokenKind::KwImpl)) {
                     decl.visibility = ast::FunctionVisibility::Impl;
                     advance();
                 }
@@ -427,46 +363,38 @@ namespace hgl::syntax
                 if (at(TokenKind::Less)) { decl.generics = parse_generic_parameters(); }
                 decl.signature    = parse_signature();
                 decl.requirements = parse_requires_clause();
-                if (continue_with(TokenKind::FatArrow))
-                {
+                if (continue_with(TokenKind::FatArrow)) {
                     advance();
                     skip_newlines();
                     decl.concise_body = parse_expression();
-                }
-                else if (continue_with(TokenKind::LBrace)) { decl.block_body = parse_block(); }
-                else
-                {
+                } else if (continue_with(TokenKind::LBrace)) {
+                    decl.block_body = parse_block();
+                } else {
                     fail_expected("'=>' or '{' to begin the function body");
                 }
                 return module_.add(ast::Decl{range_from(begin), std::move(decl)});
             }
 
-            ast::DeclId parse_struct_decl()
-            {
+            ast::DeclId parse_struct_decl() {
                 const std::uint32_t begin = tok().range.begin;
                 ast::StructDecl     decl;
-                if (at(TokenKind::KwExport))
-                {
+                if (at(TokenKind::KwExport)) {
                     decl.exported = true;
                     advance();
                 }
-                if (at(TokenKind::KwAbstract))
-                {
+                if (at(TokenKind::KwAbstract)) {
                     decl.abstract = true;
                     advance();
                 }
                 expect(TokenKind::KwStruct, "'struct'");
                 decl.name = expect_name("a struct name");
                 if (at(TokenKind::Less)) { decl.generics = parse_generic_parameters(); }
-                if (at(TokenKind::Colon))
-                {
+                if (at(TokenKind::Colon)) {
                     advance();
                     skip_newlines();
-                    while (true)
-                    {
+                    while (true) {
                         const ast::TypeId parent = parse_type(true);
-                        if (module_.type(parent).kind != ast::TypeKind::Named)
-                        {
+                        if (module_.type(parent).kind != ast::TypeKind::Named) {
                             fail(module_.type(parent).range, "a struct parent is a named type");
                         }
                         decl.parents.push_back(parent);
@@ -479,39 +407,32 @@ namespace hgl::syntax
                 decl.requirements = parse_requires_clause();
                 if (!continue_with(TokenKind::LBrace)) { fail_expected("'{' to begin the struct body"); }
                 advance();
-                while (true)
-                {
+                while (true) {
                     skip_newlines();
                     if (at(TokenKind::RBrace)) { break; }
                     if (at_end()) { fail(here(), "expected '}' to close the struct, found end of file"); }
 
                     ast::Name name = expect_name("a field name");
-                    if (at(TokenKind::Colon))
-                    {
+                    if (at(TokenKind::Colon)) {
                         advance();
                         skip_newlines();
                         ast::StructField field;
                         field.name = name;
                         field.type = parse_type(false);
-                        if (at(TokenKind::Assign))
-                        {
+                        if (at(TokenKind::Assign)) {
                             advance();
                             skip_newlines();
                             field.default_value = parse_expression();
                         }
                         decl.members.emplace_back(std::move(field));
-                    }
-                    else if (at(TokenKind::Assign))
-                    {
+                    } else if (at(TokenKind::Assign)) {
                         advance();
                         skip_newlines();
                         ast::InheritedDefault override;
                         override.name  = name;
                         override.value = parse_expression();
                         decl.members.emplace_back(std::move(override));
-                    }
-                    else
-                    {
+                    } else {
                         fail_expected("':' for a field or '=' for an inherited default");
                     }
 
@@ -521,8 +442,7 @@ namespace hgl::syntax
                 return module_.add(ast::Decl{range_from(begin), std::move(decl)});
             }
 
-            ast::DeclId parse_test_decl()
-            {
+            ast::DeclId parse_test_decl() {
                 const std::uint32_t begin = tok().range.begin;
                 advance();
                 ast::TestDecl decl;
@@ -531,24 +451,22 @@ namespace hgl::syntax
                 return module_.add(ast::Decl{range_from(begin), std::move(decl)});
             }
 
-            std::vector<ast::GenericParameter> parse_generic_parameters()
-            {
+            std::vector<ast::GenericParameter> parse_generic_parameters() {
                 std::vector<ast::GenericParameter> generics;
                 expect(TokenKind::Less, "'<'");
                 skip_newlines();
-                while (!at(TokenKind::Greater))
-                {
+                while (!at(TokenKind::Greater)) {
                     ast::GenericParameter generic;
-                    if (at(TokenKind::KwConst))
-                    {
+                    if (at(TokenKind::KwConst)) {
                         advance();
                         generic.is_const = true;
                         generic.name     = expect_name("a const generic name");
                         expect(TokenKind::Colon, "':' and the const generic's type");
                         skip_newlines();
                         generic.type = parse_type(true);
+                    } else {
+                        generic.name = expect_name("a generic parameter name");
                     }
-                    else { generic.name = expect_name("a generic parameter name"); }
                     generics.push_back(std::move(generic));
                     skip_newlines();
                     if (!at(TokenKind::Comma)) { break; }
@@ -560,16 +478,13 @@ namespace hgl::syntax
                 return generics;
             }
 
-            ast::Signature parse_signature()
-            {
+            ast::Signature parse_signature() {
                 ast::Signature signature;
                 expect(TokenKind::LParen, "'('");
                 skip_newlines();
-                while (!at(TokenKind::RParen))
-                {
+                while (!at(TokenKind::RParen)) {
                     ast::Parameter parameter;
-                    if (at(TokenKind::KwConst))
-                    {
+                    if (at(TokenKind::KwConst)) {
                         advance();
                         parameter.is_const = true;
                     }
@@ -577,13 +492,11 @@ namespace hgl::syntax
                     expect(TokenKind::Colon, "':' and the parameter's type");
                     skip_newlines();
                     parameter.type = parse_type(parameter.is_const);
-                    if (at(TokenKind::Assign))
-                    {
+                    if (at(TokenKind::Assign)) {
                         advance();
                         skip_newlines();
                         parameter.default_value = parse_expression();
-                        if (!parameter.is_const)
-                        {
+                        if (!parameter.is_const) {
                             diagnostics_.report(Category::Parse, module_.expr(parameter.default_value).range,
                                                 "only a const parameter may have a default");
                         }
@@ -595,8 +508,7 @@ namespace hgl::syntax
                     skip_newlines();
                 }
                 expect(TokenKind::RParen, "',' or ')'");
-                if (continue_with(TokenKind::Arrow))
-                {
+                if (continue_with(TokenKind::Arrow)) {
                     advance();
                     skip_newlines();
                     signature.result = parse_type(false);
@@ -606,19 +518,16 @@ namespace hgl::syntax
 
             // -------------------------------------------------- constraints
 
-            ast::ConstraintId parse_requires_clause()
-            {
+            ast::ConstraintId parse_requires_clause() {
                 if (!continue_with(TokenKind::KwRequires)) { return ast::no_node; }
                 advance();
                 skip_newlines();
                 return parse_constraint_or();
             }
 
-            ast::ConstraintId parse_constraint_or()
-            {
+            ast::ConstraintId parse_constraint_or() {
                 ast::ConstraintId lhs = parse_constraint_and();
-                while (continue_with(TokenKind::OrOr))
-                {
+                while (continue_with(TokenKind::OrOr)) {
                     advance();
                     skip_newlines();
                     const ast::ConstraintId rhs = parse_constraint_and();
@@ -628,11 +537,9 @@ namespace hgl::syntax
                 return lhs;
             }
 
-            ast::ConstraintId parse_constraint_and()
-            {
+            ast::ConstraintId parse_constraint_and() {
                 ast::ConstraintId lhs = parse_constraint_term();
-                while (continue_with(TokenKind::AndAnd))
-                {
+                while (continue_with(TokenKind::AndAnd)) {
                     advance();
                     skip_newlines();
                     const ast::ConstraintId rhs = parse_constraint_term();
@@ -642,17 +549,14 @@ namespace hgl::syntax
                 return lhs;
             }
 
-            ast::ConstraintId parse_constraint_term()
-            {
-                if (at(TokenKind::Bang))
-                {
+            ast::ConstraintId parse_constraint_term() {
+                if (at(TokenKind::Bang)) {
                     const Token            &token   = advance();
                     const ast::ConstraintId operand = parse_constraint_term();
                     return module_.add(
                         ast::Constraint{token.range.join(module_.constraint(operand).range), ast::ConstraintNot{operand}});
                 }
-                if (at(TokenKind::LParen))
-                {
+                if (at(TokenKind::LParen)) {
                     advance();
                     skip_newlines();
                     const ast::ConstraintId result = parse_constraint_or();
@@ -662,11 +566,9 @@ namespace hgl::syntax
                 }
 
                 ast::ConstraintId lhs = parse_constraint_operand();
-                if (at(TokenKind::Arrow))
-                {
+                if (at(TokenKind::Arrow)) {
                     auto *call = std::get_if<ast::ConstraintCall>(&module_.constraints[lhs].node);
-                    if (call == nullptr)
-                    {
+                    if (call == nullptr) {
                         fail(module_.constraint(lhs).range, "the left side of an operator requirement is a call");
                     }
                     advance();
@@ -684,11 +586,13 @@ namespace hgl::syntax
 
                 ast::ConstraintRelationOp relation;
                 bool                      has_relation = true;
-                if (at(TokenKind::EqualEqual)) { relation = ast::ConstraintRelationOp::Equal; }
-                else if (at_identifier("in")) { relation = ast::ConstraintRelationOp::In; }
-                else if (at(TokenKind::KwIs)) { relation = ast::ConstraintRelationOp::Is; }
-                else
-                {
+                if (at(TokenKind::EqualEqual)) {
+                    relation = ast::ConstraintRelationOp::Equal;
+                } else if (at_identifier("in")) {
+                    relation = ast::ConstraintRelationOp::In;
+                } else if (at(TokenKind::KwIs)) {
+                    relation = ast::ConstraintRelationOp::Is;
+                } else {
                     has_relation = false;
                 }
                 if (!has_relation) { return lhs; }
@@ -698,15 +602,11 @@ namespace hgl::syntax
                 ast::ConstraintRelation node;
                 node.op  = relation;
                 node.lhs = lhs;
-                if (relation == ast::ConstraintRelationOp::Is)
-                {
-                    if (at(TokenKind::KwStruct))
-                    {
+                if (relation == ast::ConstraintRelationOp::Is) {
+                    if (at(TokenKind::KwStruct)) {
                         const Token &category = advance();
                         node.category         = ast::Name{category.text, category.range};
-                    }
-                    else
-                    {
+                    } else {
                         node.category = expect_name("a type category after 'is'");
                     }
                     return module_.add(ast::Constraint{module_.constraint(lhs).range.join(node.category.range), std::move(node)});
@@ -716,16 +616,13 @@ namespace hgl::syntax
                     ast::Constraint{module_.constraint(lhs).range.join(module_.constraint(node.rhs).range), std::move(node)});
             }
 
-            ast::ConstraintId parse_constraint_operand()
-            {
+            ast::ConstraintId parse_constraint_operand() {
                 const std::uint32_t begin = tok().range.begin;
-                if (at(TokenKind::LBrace))
-                {
+                if (at(TokenKind::LBrace)) {
                     advance();
                     skip_newlines();
                     ast::ConstraintSet set;
-                    while (!at(TokenKind::RBrace))
-                    {
+                    while (!at(TokenKind::RBrace)) {
                         set.elements.push_back(parse_constraint_operand());
                         skip_newlines();
                         if (!at(TokenKind::Comma)) { break; }
@@ -737,24 +634,20 @@ namespace hgl::syntax
                     return module_.add(ast::Constraint{range_from(begin), std::move(set)});
                 }
 
-                if (is_scalar_type_keyword(tok().kind) || (at(TokenKind::Identifier) && next_tok().kind == TokenKind::Less))
-                {
+                if (is_scalar_type_keyword(tok().kind) || (at(TokenKind::Identifier) && next_tok().kind == TokenKind::Less)) {
                     const ast::TypeId type = parse_type(true);
                     return module_.add(ast::Constraint{module_.type(type).range, ast::ConstraintType{type}});
                 }
 
-                if (at(TokenKind::Identifier))
-                {
+                if (at(TokenKind::Identifier)) {
                     ast::Name qualifier;
                     ast::Name name = expect_name("a constraint name");
-                    if (at(TokenKind::ColonColon))
-                    {
+                    if (at(TokenKind::ColonColon)) {
                         advance();
                         qualifier = name;
                         name      = expect_name("a declaration name after '::'");
                     }
-                    if (!at(TokenKind::LParen))
-                    {
+                    if (!at(TokenKind::LParen)) {
                         if (!qualifier.empty()) { fail(range_from(begin), "a qualified constraint name must be called"); }
                         return module_.add(ast::Constraint{name.range, ast::ConstraintName{name}});
                     }
@@ -763,8 +656,7 @@ namespace hgl::syntax
                     ast::ConstraintCall call;
                     call.qualifier = qualifier;
                     call.name      = name;
-                    while (!at(TokenKind::RParen))
-                    {
+                    while (!at(TokenKind::RParen)) {
                         call.arguments.push_back(parse_constraint_operand());
                         skip_newlines();
                         if (!at(TokenKind::Comma)) { break; }
@@ -777,8 +669,7 @@ namespace hgl::syntax
 
                 if (at(TokenKind::IntLiteral) || at(TokenKind::FloatLiteral) || at(TokenKind::StringLiteral) ||
                     at(TokenKind::TemporalLiteral) || at(TokenKind::KwTrue) || at(TokenKind::KwFalse) || at(TokenKind::KwNull) ||
-                    at(TokenKind::Minus))
-                {
+                    at(TokenKind::Minus)) {
                     const ast::ExprId value = parse_size_expression();
                     return module_.add(ast::Constraint{module_.expr(value).range, ast::ConstraintValue{value}});
                 }
@@ -791,29 +682,23 @@ namespace hgl::syntax
             /// parameters, generics, set elements, map keys, rolling
             /// elements, atomic payloads); the restriction itself is a
             /// later type check.
-            ast::TypeId parse_type(bool value_position)
-            {
+            ast::TypeId parse_type(bool value_position) {
                 ast::Type type;
                 type.value_position       = value_position;
                 const std::uint32_t begin = tok().range.begin;
-                if (const auto scalar = scalar_type(tok().kind))
-                {
+                if (const auto scalar = scalar_type(tok().kind)) {
                     type.kind   = ast::TypeKind::Scalar;
                     type.scalar = *scalar;
                     advance();
-                }
-                else if (at(TokenKind::Identifier))
-                {
-                    const std::string_view text = tok().text;
+                } else if (at(TokenKind::Identifier)) {
+                    const std::string_view text    = tok().text;
                     const bool             generic = next_tok().kind == TokenKind::Less;
-                    if (generic && text == "tuple")
-                    {
+                    if (generic && text == "tuple") {
                         type.kind = ast::TypeKind::Tuple;
                         advance();
                         advance();
                         skip_newlines();
-                        while (!at(TokenKind::Greater))
-                        {
+                        while (!at(TokenKind::Greater)) {
                             type.children.push_back(parse_type(value_position));
                             skip_newlines();
                             if (!at(TokenKind::Comma)) { break; }
@@ -822,31 +707,26 @@ namespace hgl::syntax
                         }
                         expect(TokenKind::Greater, "',' or '>'");
                         if (type.children.empty()) { fail(range_from(begin), "a tuple type has at least one element"); }
-                    }
-                    else if (generic && text == "list")
-                    {
+                    } else if (generic && text == "list") {
                         type.kind = ast::TypeKind::List;
                         advance();
                         advance();
                         skip_newlines();
                         type.children.push_back(parse_type(value_position));
                         skip_newlines();
-                        if (at(TokenKind::Comma))
-                        {
+                        if (at(TokenKind::Comma)) {
                             advance();
                             skip_newlines();
-                            if (at_identifier("unbounded") && next_tok().kind == TokenKind::Greater)
-                            {
+                            if (at_identifier("unbounded") && next_tok().kind == TokenKind::Greater) {
                                 type.unbounded = true;
                                 advance();
+                            } else {
+                                type.size = parse_size_expression();
                             }
-                            else { type.size = parse_size_expression(); }
                             skip_newlines();
                         }
                         expect(TokenKind::Greater, "'>'");
-                    }
-                    else if (generic && text == "set")
-                    {
+                    } else if (generic && text == "set") {
                         type.kind = ast::TypeKind::Set;
                         advance();
                         advance();
@@ -854,9 +734,7 @@ namespace hgl::syntax
                         type.children.push_back(parse_type(true));
                         skip_newlines();
                         expect(TokenKind::Greater, "'>'");
-                    }
-                    else if (generic && text == "map")
-                    {
+                    } else if (generic && text == "map") {
                         type.kind = ast::TypeKind::Map;
                         advance();
                         advance();
@@ -868,9 +746,7 @@ namespace hgl::syntax
                         type.children.push_back(parse_type(value_position));
                         skip_newlines();
                         expect(TokenKind::Greater, "'>'");
-                    }
-                    else if (generic && text == "rolling")
-                    {
+                    } else if (generic && text == "rolling") {
                         type.kind = ast::TypeKind::Rolling;
                         advance();
                         advance();
@@ -881,17 +757,14 @@ namespace hgl::syntax
                         skip_newlines();
                         type.size = parse_size_expression();
                         skip_newlines();
-                        if (at(TokenKind::Comma))
-                        {
+                        if (at(TokenKind::Comma)) {
                             advance();
                             skip_newlines();
                             type.min_size = parse_size_expression();
                             skip_newlines();
                         }
                         expect(TokenKind::Greater, "'>'");
-                    }
-                    else if (generic && text == "atomic")
-                    {
+                    } else if (generic && text == "atomic") {
                         type.kind = ast::TypeKind::Atomic;
                         advance();
                         advance();
@@ -899,47 +772,38 @@ namespace hgl::syntax
                         type.children.push_back(parse_type(true));
                         skip_newlines();
                         expect(TokenKind::Greater, "'>'");
-                    }
-                    else
-                    {
+                    } else {
                         type.kind = ast::TypeKind::Named;
                         type.name = ast::Name{text, tok().range};
                         advance();
-                        if (at(TokenKind::ColonColon))
-                        {
+                        if (at(TokenKind::ColonColon)) {
                             advance();
                             type.qualifier = type.name;
                             type.name      = expect_name("a type name after '::'");
                         }
                         if (at(TokenKind::Less)) { type.arguments = parse_generic_arguments(); }
                     }
-                }
-                else
-                {
+                } else {
                     fail_expected("a type");
                 }
                 type.range = range_from(begin);
                 return module_.add(std::move(type));
             }
 
-            std::vector<ast::GenericArgument> parse_generic_arguments()
-            {
+            std::vector<ast::GenericArgument> parse_generic_arguments() {
                 std::vector<ast::GenericArgument> arguments;
                 expect(TokenKind::Less, "'<'");
                 skip_newlines();
-                while (!at(TokenKind::Greater))
-                {
+                while (!at(TokenKind::Greater)) {
                     ast::GenericArgument argument;
                     const std::uint32_t  begin = tok().range.begin;
                     if (is_scalar_type_keyword(tok().kind) ||
                         (at(TokenKind::Identifier) &&
-                         (next_tok().kind == TokenKind::Less || next_tok().kind == TokenKind::ColonColon)))
-                    {
+                         (next_tok().kind == TokenKind::Less || next_tok().kind == TokenKind::ColonColon))) {
                         argument.type = parse_type(true);
-                    }
-                    else if (at(TokenKind::Identifier)) { argument.name = expect_name("a generic argument"); }
-                    else
-                    {
+                    } else if (at(TokenKind::Identifier)) {
+                        argument.name = expect_name("a generic argument");
+                    } else {
                         argument.value = parse_size_expression();
                     }
                     argument.range = range_from(begin);
@@ -963,121 +827,102 @@ namespace hgl::syntax
 
             ast::ExprId parse_expression() { return parse_binary(PrecOr); }
 
-            ast::ExprId parse_binary(int min_precedence)
-            {
+            ast::ExprId parse_binary(int min_precedence) {
                 ast::ExprId lhs = parse_unary();
-                while (true)
-                {
+                while (true) {
                     // A line that begins with a binary operator continues
                     // the expression of the previous line.
                     const std::size_t save = pos_;
                     skip_newlines();
                     const auto info = binary_info(tok().kind);
-                    if (!info || info->precedence < min_precedence)
-                    {
+                    if (!info || info->precedence < min_precedence) {
                         pos_ = save;
                         break;
                     }
                     advance();
                     skip_newlines();
-                    ast::ExprId rhs = parse_binary(info->precedence + 1);
+                    ast::ExprId rhs   = parse_binary(info->precedence + 1);
                     SourceRange range = module_.expr(lhs).range.join(module_.expr(rhs).range);
-                    lhs = module_.add(ast::Expr{range, ast::Binary{info->op, lhs, rhs}});
+                    lhs               = module_.add(ast::Expr{range, ast::Binary{info->op, lhs, rhs}});
                 }
                 return lhs;
             }
 
-            ast::ExprId parse_unary()
-            {
-                if (at(TokenKind::Minus) || at(TokenKind::Bang))
-                {
-                    const Token &token = advance();
-                    const auto   op    = token.kind == TokenKind::Minus ? ast::UnaryOp::Negate : ast::UnaryOp::Not;
+            ast::ExprId parse_unary() {
+                if (at(TokenKind::Minus) || at(TokenKind::Bang)) {
+                    const Token &token   = advance();
+                    const auto   op      = token.kind == TokenKind::Minus ? ast::UnaryOp::Negate : ast::UnaryOp::Not;
                     ast::ExprId  operand = parse_unary();
-                    return module_.add(
-                        ast::Expr{token.range.join(module_.expr(operand).range), ast::Unary{op, operand}});
+                    return module_.add(ast::Expr{token.range.join(module_.expr(operand).range), ast::Unary{op, operand}});
                 }
                 return parse_postfix();
             }
 
-            ast::ExprId parse_postfix()
-            {
+            ast::ExprId parse_postfix() {
                 ast::ExprId expr = parse_primary();
-                while (true)
-                {
+                while (true) {
                     const std::uint32_t begin = module_.expr(expr).range.begin;
-                    if (at(TokenKind::LParen))
-                    {
+                    if (at(TokenKind::LParen)) {
                         ast::Call call;
                         call.callee    = expr;
                         call.arguments = parse_arguments();
                         expr           = module_.add(ast::Expr{range_from(begin), std::move(call)});
-                    }
-                    else if (at(TokenKind::LBracket))
-                    {
+                    } else if (at(TokenKind::LBracket)) {
                         advance();
                         skip_newlines();
                         ast::ExprId index = parse_expression();
                         skip_newlines();
                         expect(TokenKind::RBracket, "']'");
                         expr = module_.add(ast::Expr{range_from(begin), ast::Index{expr, index}});
-                    }
-                    else if (at(TokenKind::Dot))
-                    {
+                    } else if (at(TokenKind::Dot)) {
                         advance();
                         ast::Name field = expect_name("a field name after '.'");
                         expr            = module_.add(ast::Expr{range_from(begin), ast::Field{expr, field}});
+                    } else {
+                        break;
                     }
-                    else { break; }
                 }
                 return expr;
             }
 
-            [[nodiscard]] bool looks_like_applied_constructor() const noexcept
-            {
+            [[nodiscard]] bool looks_like_applied_constructor() const noexcept {
                 std::size_t p = pos_;
                 if (tok_at(p).kind != TokenKind::Identifier) { return false; }
                 ++p;
-                if (tok_at(p).kind == TokenKind::ColonColon)
-                {
+                if (tok_at(p).kind == TokenKind::ColonColon) {
                     p += 2;
                     if (tok_at(p - 1).kind != TokenKind::Identifier) { return false; }
                 }
                 if (tok_at(p).kind != TokenKind::Less) { return false; }
                 int depth = 0;
-                for (; p < tokens_.size(); ++p)
-                {
-                    if (tok_at(p).kind == TokenKind::Less) { ++depth; }
-                    else if (tok_at(p).kind == TokenKind::Greater)
-                    {
+                for (; p < tokens_.size(); ++p) {
+                    if (tok_at(p).kind == TokenKind::Less) {
+                        ++depth;
+                    } else if (tok_at(p).kind == TokenKind::Greater) {
                         --depth;
                         if (depth == 0) { return tok_at(p + 1).kind == TokenKind::LParen; }
+                    } else if (tok_at(p).kind == TokenKind::EndOfFile) {
+                        return false;
                     }
-                    else if (tok_at(p).kind == TokenKind::EndOfFile) { return false; }
                 }
                 return false;
             }
 
-            ast::ExprId parse_construct(bool delta)
-            {
+            ast::ExprId parse_construct(bool delta) {
                 const std::uint32_t begin = tok().range.begin;
                 ast::Construct      construct;
                 construct.delta = delta;
-                if (delta)
-                {
+                if (delta) {
                     advance();
                     expect(TokenKind::Less, "'<' after 'delta'");
                     skip_newlines();
                     construct.type = parse_type(false);
                     skip_newlines();
                     expect(TokenKind::Greater, "'>' after the delta target");
-                }
-                else
-                {
+                } else {
                     construct.type = parse_type(false);
                 }
-                if (module_.type(construct.type).kind != ast::TypeKind::Named)
-                {
+                if (module_.type(construct.type).kind != ast::TypeKind::Named) {
                     fail(module_.type(construct.type).range, "a struct constructor takes a named struct type");
                 }
                 construct.arguments = parse_arguments();
@@ -1085,13 +930,11 @@ namespace hgl::syntax
             }
 
             /// `(` [argument {, argument} [,]] `)`; the opening paren is current.
-            std::vector<ast::Argument> parse_arguments()
-            {
+            std::vector<ast::Argument> parse_arguments() {
                 std::vector<ast::Argument> arguments;
                 expect(TokenKind::LParen, "'('");
                 skip_newlines();
-                while (!at(TokenKind::RParen))
-                {
+                while (!at(TokenKind::RParen)) {
                     arguments.push_back(parse_argument());
                     skip_newlines();
                     if (!at(TokenKind::Comma)) { break; }
@@ -1102,11 +945,9 @@ namespace hgl::syntax
                 return arguments;
             }
 
-            ast::Argument parse_argument()
-            {
+            ast::Argument parse_argument() {
                 ast::Argument argument;
-                if (at(TokenKind::Identifier) && next_tok().kind == TokenKind::Colon)
-                {
+                if (at(TokenKind::Identifier) && next_tok().kind == TokenKind::Colon) {
                     argument.name = expect_name("an argument name");
                     advance();
                     skip_newlines();
@@ -1115,11 +956,9 @@ namespace hgl::syntax
                 return argument;
             }
 
-            ast::ExprId parse_primary()
-            {
+            ast::ExprId parse_primary() {
                 const Token &token = tok();
-                switch (token.kind)
-                {
+                switch (token.kind) {
                     case TokenKind::IntLiteral:
                         advance();
                         return module_.add(ast::Expr{token.range, ast::IntLiteral{token.int_value}});
@@ -1130,58 +969,56 @@ namespace hgl::syntax
                         advance();
                         return module_.add(ast::Expr{token.range, ast::StringLiteral{token.string_value}});
                     case TokenKind::TemporalLiteral:
-                    {
-                        // An invalid literal already carries a diagnostic;
-                        // its node holds the default value.
-                        ast::TemporalLiteral literal;
-                        if (token.temporal_value) { literal.value = *token.temporal_value; }
-                        advance();
-                        return module_.add(ast::Expr{token.range, std::move(literal)});
-                    }
+                        {
+                            // An invalid literal already carries a diagnostic;
+                            // its node holds the default value.
+                            ast::TemporalLiteral literal;
+                            if (token.temporal_value) { literal.value = *token.temporal_value; }
+                            advance();
+                            return module_.add(ast::Expr{token.range, std::move(literal)});
+                        }
                     case TokenKind::KwTrue:
                     case TokenKind::KwFalse:
                         advance();
                         return module_.add(ast::Expr{token.range, ast::BoolLiteral{token.kind == TokenKind::KwTrue}});
                     case TokenKind::KwNull: advance(); return module_.add(ast::Expr{token.range, ast::NullLiteral{}});
                     case TokenKind::Placeholder: advance(); return module_.add(ast::Expr{token.range, ast::Placeholder{}});
-                    case TokenKind::Identifier: {
-                        if (token.text == "delta" && next_tok().kind == TokenKind::Less) { return parse_construct(true); }
-                        if (looks_like_applied_constructor()) { return parse_construct(false); }
-                        ast::Name name = expect_name("a name");
-                        if (at(TokenKind::ColonColon))
+                    case TokenKind::Identifier:
                         {
-                            advance();
-                            ast::Name member = expect_name("a declaration name after '::'");
-                            return module_.add(ast::Expr{name.range.join(member.range), ast::QualifiedRef{name, member}});
+                            if (token.text == "delta" && next_tok().kind == TokenKind::Less) { return parse_construct(true); }
+                            if (looks_like_applied_constructor()) { return parse_construct(false); }
+                            ast::Name name = expect_name("a name");
+                            if (at(TokenKind::ColonColon)) {
+                                advance();
+                                ast::Name member = expect_name("a declaration name after '::'");
+                                return module_.add(ast::Expr{name.range.join(member.range), ast::QualifiedRef{name, member}});
+                            }
+                            return module_.add(ast::Expr{name.range, ast::NameRef{name}});
                         }
-                        return module_.add(ast::Expr{name.range, ast::NameRef{name}});
-                    }
                     case TokenKind::LParen: return parse_paren();
                     case TokenKind::LBracket: return parse_sequence();
                     case TokenKind::KwFn: return parse_anonymous_fn();
                     case TokenKind::KwIf: return parse_if();
                     case TokenKind::KwEval: return parse_eval();
                     case TokenKind::LBrace:
-                    {
-                        ast::BlockId block = parse_block();
-                        return module_.add(ast::Expr{module_.block(block).range, ast::BlockExpr{block}});
-                    }
+                        {
+                            ast::BlockId block = parse_block();
+                            return module_.add(ast::Expr{module_.block(block).range, ast::BlockExpr{block}});
+                        }
                     default: fail_expected("an expression");
                 }
             }
 
             /// Grouping or a tuple literal: `(e)` is `e`; `(e,)` and
             /// `(a, b)` are tuples.
-            ast::ExprId parse_paren()
-            {
+            ast::ExprId parse_paren() {
                 const std::uint32_t begin = tok().range.begin;
                 advance();
                 skip_newlines();
                 if (at(TokenKind::RParen)) { fail(here(), "expected an expression; '()' is not a value"); }
                 ast::ExprId first = parse_expression();
                 skip_newlines();
-                if (at(TokenKind::RParen))
-                {
+                if (at(TokenKind::RParen)) {
                     advance();
                     return first;
                 }
@@ -1189,8 +1026,7 @@ namespace hgl::syntax
                 ast::TupleLiteral tuple;
                 tuple.elements.push_back(first);
                 skip_newlines();
-                while (!at(TokenKind::RParen))
-                {
+                while (!at(TokenKind::RParen)) {
                     tuple.elements.push_back(parse_expression());
                     skip_newlines();
                     if (!at(TokenKind::Comma)) { break; }
@@ -1203,17 +1039,14 @@ namespace hgl::syntax
 
             /// `[e, ...]` or `[key: e, ...]`; a timed key is a duration or
             /// datetime literal directly followed by `:`.
-            ast::ExprId parse_sequence()
-            {
+            ast::ExprId parse_sequence() {
                 const std::uint32_t begin = tok().range.begin;
                 advance();
                 ast::SequenceLiteral sequence;
                 skip_newlines();
-                while (!at(TokenKind::RBracket))
-                {
+                while (!at(TokenKind::RBracket)) {
                     ast::SequenceElement element;
-                    if (at(TokenKind::TemporalLiteral) && next_tok().kind == TokenKind::Colon)
-                    {
+                    if (at(TokenKind::TemporalLiteral) && next_tok().kind == TokenKind::Colon) {
                         element.key = parse_primary();
                         advance();
                         skip_newlines();
@@ -1229,19 +1062,16 @@ namespace hgl::syntax
                 return module_.add(ast::Expr{range_from(begin), std::move(sequence)});
             }
 
-            ast::ExprId parse_anonymous_fn()
-            {
+            ast::ExprId parse_anonymous_fn() {
                 const std::uint32_t begin = tok().range.begin;
                 advance();
                 ast::AnonymousFn fn;
                 expect(TokenKind::LParen, "'(' after 'fn'");
                 skip_newlines();
-                while (!at(TokenKind::RParen))
-                {
+                while (!at(TokenKind::RParen)) {
                     ast::AnonymousParameter parameter;
                     parameter.name = expect_name("a parameter name");
-                    if (at(TokenKind::Colon))
-                    {
+                    if (at(TokenKind::Colon)) {
                         advance();
                         skip_newlines();
                         parameter.type = parse_type(false);
@@ -1253,8 +1083,7 @@ namespace hgl::syntax
                     skip_newlines();
                 }
                 expect(TokenKind::RParen, "',' or ')'");
-                if (continue_with(TokenKind::Arrow))
-                {
+                if (continue_with(TokenKind::Arrow)) {
                     advance();
                     skip_newlines();
                     fn.result = parse_type(false);
@@ -1267,19 +1096,17 @@ namespace hgl::syntax
             }
 
             /// `if c { } [else ({ } | if ...)]`; `else` may start the next line.
-            ast::ExprId parse_if()
-            {
+            ast::ExprId parse_if() {
                 const std::uint32_t begin = tok().range.begin;
                 advance();
                 ast::If node;
                 node.condition  = parse_expression();
                 node.then_block = parse_block();
-                if (continue_with(TokenKind::KwElse))
-                {
+                if (continue_with(TokenKind::KwElse)) {
                     advance();
-                    if (at(TokenKind::KwIf)) { node.otherwise = parse_if(); }
-                    else
-                    {
+                    if (at(TokenKind::KwIf)) {
+                        node.otherwise = parse_if();
+                    } else {
                         ast::BlockId block = parse_block();
                         node.otherwise     = module_.add(ast::Expr{module_.block(block).range, ast::BlockExpr{block}});
                     }
@@ -1288,8 +1115,7 @@ namespace hgl::syntax
             }
 
             /// `eval(callee, argument, ...)`.
-            ast::ExprId parse_eval()
-            {
+            ast::ExprId parse_eval() {
                 const std::uint32_t begin = tok().range.begin;
                 advance();
                 ast::Eval eval;
@@ -1297,8 +1123,7 @@ namespace hgl::syntax
                 skip_newlines();
                 eval.callee = parse_expression();
                 skip_newlines();
-                while (at(TokenKind::Comma))
-                {
+                while (at(TokenKind::Comma)) {
                     advance();
                     skip_newlines();
                     if (at(TokenKind::RParen)) { break; }
@@ -1311,30 +1136,22 @@ namespace hgl::syntax
 
             // ------------------------------------------------------- blocks
 
-            ast::BlockId parse_block()
-            {
+            ast::BlockId parse_block() {
                 ast::Block          block;
                 const std::uint32_t begin = tok().range.begin;
                 expect(TokenKind::LBrace, "'{'");
-                while (true)
-                {
+                while (true) {
                     skip_newlines();
                     if (at(TokenKind::RBrace)) { break; }
                     if (at_end()) { fail(here(), "expected '}' to close the block, found end of file"); }
-                    try
-                    {
+                    try {
                         block.statements.push_back(parse_statement());
                         if (!at(TokenKind::RBrace)) { expect_terminator("a newline after the statement"); }
-                    }
-                    catch (const ParseError &)
-                    {
-                        synchronize_statement();
-                    }
+                    } catch (const ParseError &) { synchronize_statement(); }
                 }
                 advance();
                 block.range = range_from(begin);
-                if (!block.statements.empty())
-                {
+                if (!block.statements.empty()) {
                     const ast::Stmt &last = module_.stmt(block.statements.back());
                     if (const auto *expr_stmt = std::get_if<ast::ExprStmt>(&last.node)) { block.tail = expr_stmt->expr; }
                 }
@@ -1343,13 +1160,10 @@ namespace hgl::syntax
 
             /// Skip to the end of the failed statement: the next newline or
             /// closing brace outside any bracket opened since the error.
-            void synchronize_statement()
-            {
+            void synchronize_statement() {
                 int depth = 0;
-                while (!at_end())
-                {
-                    switch (tok().kind)
-                    {
+                while (!at_end()) {
+                    switch (tok().kind) {
                         case TokenKind::Newline:
                             if (depth <= 0) { return; }
                             break;
@@ -1368,104 +1182,92 @@ namespace hgl::syntax
                 }
             }
 
-            ast::StmtId parse_statement()
-            {
+            ast::StmtId parse_statement() {
                 const std::uint32_t begin = tok().range.begin;
-                switch (tok().kind)
-                {
+                switch (tok().kind) {
                     case TokenKind::KwLet:
                     case TokenKind::KwVar:
-                    {
-                        ast::LocalDecl decl;
-                        decl.mutable_ = advance().kind == TokenKind::KwVar;
-                        decl.name     = expect_name("a variable name");
-                        if (at(TokenKind::Colon))
                         {
-                            advance();
+                            ast::LocalDecl decl;
+                            decl.mutable_ = advance().kind == TokenKind::KwVar;
+                            decl.name     = expect_name("a variable name");
+                            if (at(TokenKind::Colon)) {
+                                advance();
+                                skip_newlines();
+                                decl.type = parse_type(false);
+                            }
+                            expect(TokenKind::Assign, "'=' and an initializer");
                             skip_newlines();
-                            decl.type = parse_type(false);
+                            decl.init = parse_expression();
+                            return module_.add(ast::Stmt{range_from(begin), std::move(decl)});
                         }
-                        expect(TokenKind::Assign, "'=' and an initializer");
-                        skip_newlines();
-                        decl.init = parse_expression();
-                        return module_.add(ast::Stmt{range_from(begin), std::move(decl)});
-                    }
                     case TokenKind::KwState:
-                    {
-                        advance();
-                        ast::StateDecl decl;
-                        decl.name = expect_name("a state variable name");
-                        if (at(TokenKind::Colon))
                         {
                             advance();
+                            ast::StateDecl decl;
+                            decl.name = expect_name("a state variable name");
+                            if (at(TokenKind::Colon)) {
+                                advance();
+                                skip_newlines();
+                                decl.type = parse_type(true);
+                            }
+                            expect(TokenKind::Assign, "'=' and an initializer");
                             skip_newlines();
-                            decl.type = parse_type(true);
+                            decl.init = parse_expression();
+                            return module_.add(ast::Stmt{range_from(begin), std::move(decl)});
                         }
-                        expect(TokenKind::Assign, "'=' and an initializer");
-                        skip_newlines();
-                        decl.init = parse_expression();
-                        return module_.add(ast::Stmt{range_from(begin), std::move(decl)});
-                    }
                     case TokenKind::KwInject: return parse_inject();
                     case TokenKind::KwStart:
                     case TokenKind::KwStop:
-                    {
-                        ast::LifecycleBlock lifecycle;
-                        lifecycle.is_stop = advance().kind == TokenKind::KwStop;
-                        lifecycle.block   = parse_block();
-                        return module_.add(ast::Stmt{range_from(begin), lifecycle});
-                    }
+                        {
+                            ast::LifecycleBlock lifecycle;
+                            lifecycle.is_stop = advance().kind == TokenKind::KwStop;
+                            lifecycle.block   = parse_block();
+                            return module_.add(ast::Stmt{range_from(begin), lifecycle});
+                        }
                     case TokenKind::KwWhen:
-                    {
-                        advance();
-                        ast::WhenStmt when;
-                        when.condition = parse_expression();
-                        when.block     = parse_block();
-                        return module_.add(ast::Stmt{range_from(begin), when});
-                    }
-                    case TokenKind::KwFor:
-                    {
-                        advance();
-                        ast::ForStmt loop;
-                        loop.first = expect_name("a loop variable name");
-                        if (at(TokenKind::Comma))
                         {
                             advance();
-                            loop.second = expect_name("a loop variable name");
+                            ast::WhenStmt when;
+                            when.condition = parse_expression();
+                            when.block     = parse_block();
+                            return module_.add(ast::Stmt{range_from(begin), when});
                         }
-                        if (!at_identifier("in")) { fail_expected("'in' after the loop pattern"); }
-                        advance();
-                        loop.iterable = parse_expression();
-                        loop.block    = parse_block();
-                        return module_.add(ast::Stmt{range_from(begin), loop});
-                    }
-                    case TokenKind::KwReturn:
-                    {
-                        advance();
-                        ast::ReturnStmt ret;
-                        if (!at(TokenKind::Newline) && !at(TokenKind::RBrace) && !at_end())
+                    case TokenKind::KwFor:
                         {
-                            ret.value = parse_expression();
+                            advance();
+                            ast::ForStmt loop;
+                            loop.first = expect_name("a loop variable name");
+                            if (at(TokenKind::Comma)) {
+                                advance();
+                                loop.second = expect_name("a loop variable name");
+                            }
+                            if (!at_identifier("in")) { fail_expected("'in' after the loop pattern"); }
+                            advance();
+                            loop.iterable = parse_expression();
+                            loop.block    = parse_block();
+                            return module_.add(ast::Stmt{range_from(begin), loop});
                         }
-                        return module_.add(ast::Stmt{range_from(begin), ret});
-                    }
+                    case TokenKind::KwReturn:
+                        {
+                            advance();
+                            ast::ReturnStmt ret;
+                            if (!at(TokenKind::Newline) && !at(TokenKind::RBrace) && !at_end()) { ret.value = parse_expression(); }
+                            return module_.add(ast::Stmt{range_from(begin), ret});
+                        }
                     case TokenKind::KwAssert:
-                    {
-                        advance();
-                        ast::AssertStmt assert_stmt;
-                        assert_stmt.condition = parse_expression();
-                        return module_.add(ast::Stmt{range_from(begin), assert_stmt});
-                    }
+                        {
+                            advance();
+                            ast::AssertStmt assert_stmt;
+                            assert_stmt.condition = parse_expression();
+                            return module_.add(ast::Stmt{range_from(begin), assert_stmt});
+                        }
                     default: break;
                 }
 
                 ast::ExprId expr = parse_expression();
-                if (const auto op = assign_op(tok().kind))
-                {
-                    if (!is_place(expr))
-                    {
-                        fail(module_.expr(expr).range, "only a name, an index, or a field can be assigned to");
-                    }
+                if (const auto op = assign_op(tok().kind)) {
+                    if (!is_place(expr)) { fail(module_.expr(expr).range, "only a name, an index, or a field can be assigned to"); }
                     advance();
                     skip_newlines();
                     ast::ExprId value = parse_expression();
@@ -1477,14 +1279,12 @@ namespace hgl::syntax
             /// `inject a, b` with newlines allowed after `inject` and
             /// around commas; a trailing comma is followed by a line that
             /// does not start with an identifier.
-            ast::StmtId parse_inject()
-            {
+            ast::StmtId parse_inject() {
                 const std::uint32_t begin = tok().range.begin;
                 advance();
                 ast::InjectDecl inject;
                 skip_newlines();
-                while (true)
-                {
+                while (true) {
                     inject.names.push_back(expect_name("an injectable name"));
                     if (!at(TokenKind::Comma)) { break; }
                     advance();
@@ -1494,8 +1294,7 @@ namespace hgl::syntax
                 return module_.add(ast::Stmt{range_from(begin), std::move(inject)});
             }
 
-            [[nodiscard]] bool is_place(ast::ExprId id) const noexcept
-            {
+            [[nodiscard]] bool is_place(ast::ExprId id) const noexcept {
                 const ast::ExprNode &node = module_.expr(id).node;
                 if (std::holds_alternative<ast::NameRef>(node)) { return true; }
                 if (const auto *index = std::get_if<ast::Index>(&node)) { return is_place(index->target); }
@@ -1512,8 +1311,18 @@ namespace hgl::syntax
         };
     }  // namespace
 
-    ast::Module parse(const SourceFile &file, DiagnosticSink &diagnostics)
-    {
+    ast::Module parse_with_legacy_parser(const SourceFile &file, DiagnosticSink &diagnostics) {
         return Parser{file, diagnostics}.run();
+    }
+
+    ast::Module parse(const SourceFile &file, DiagnosticSink &diagnostics) {
+        LexResult               lexed  = lex(file, diagnostics);
+        const SyntaxParseResult syntax = parse_source_syntax(file, lexed);
+        if (syntax.grammar.accepted && syntax.grammar.error_count == 0) { return project_ast(syntax.tree, lexed, diagnostics); }
+
+        // The source parser is authoritative for clean compilation. Keep the
+        // old recovery path temporarily so existing malformed-source
+        // diagnostics do not regress while syntax issues gain messages.
+        return Parser{std::move(lexed), diagnostics}.run();
     }
 }  // namespace hgl::syntax

--- a/language/src/syntax/parser.h
+++ b/language/src/syntax/parser.h
@@ -13,6 +13,10 @@ namespace hgl::syntax
     /// newlines so several diagnostics can be reported from one run. The
     /// returned module is complete for every declaration that parsed.
     [[nodiscard]] ast::Module parse(const SourceFile &file, DiagnosticSink &diagnostics);
+
+    /// Temporary differential-testing entry point retained only while the
+    /// declarative parser takes over malformed-source diagnostics.
+    [[nodiscard]] ast::Module parse_with_legacy_parser(const SourceFile &file, DiagnosticSink &diagnostics);
 }  // namespace hgl::syntax
 
 #endif  // HGL_SYNTAX_PARSER_H

--- a/language/src/syntax/token_grammar.cpp
+++ b/language/src/syntax/token_grammar.cpp
@@ -354,10 +354,13 @@ namespace hgl::syntax
 
         struct eval_expression
         {
-            static constexpr auto rule = token<TokenKind::KwEval> >>
-                                         token<TokenKind::LParen> + dsl::p<newlines> +
-                                             dsl::list(dsl::p<argument>, dsl::trailing_sep(dsl::p<comma_separator>)) +
-                                             dsl::p<newlines> + token<TokenKind::RParen>;
+            static constexpr auto next_argument =
+                dsl::peek(dsl::p<comma_separator> + expression_start) >> dsl::p<comma_separator> + dsl::p<argument>;
+            static constexpr auto trailing_comma = dsl::if_(dsl::p<comma_separator>);
+            static constexpr auto rule           = token<TokenKind::KwEval> >> token<TokenKind::LParen> + dsl::p<newlines> +
+                                                                                   dsl::recurse<expression> +
+                                                                                   dsl::while_(next_argument) + trailing_comma
+                                                                                   + dsl::p<newlines> + token<TokenKind::RParen>;
         };
 
         struct local_decl
@@ -506,7 +509,7 @@ namespace hgl::syntax
                 dsl::p<constraint_set> | scalar_type | dsl::p<tuple_type> | dsl::p<list_type> | dsl::p<set_type> |
                 dsl::p<map_type> | dsl::p<rolling_type> | dsl::p<atomic_type> | dsl::p<constraint_call> |
                 dsl::peek(name + (token<TokenKind::Less> / token<TokenKind::ColonColon>)) >> dsl::p<named_type> |
-                dsl::peek(value_start) >> dsl::p<size_expression> | name;
+                dsl::peek(value_start) >> dsl::recurse<size_expression> | name;
         };
 
         struct constraint_term
@@ -656,6 +659,9 @@ namespace hgl::syntax
 
         [[nodiscard]] std::uint8_t encode(std::span<const Token> tokens, std::size_t position) noexcept {
             const Token &token = tokens[position];
+            if (token.kind == TokenKind::Identifier && token.text == "delta") {
+                return static_cast<std::uint8_t>(grammar::ContextToken::Delta);
+            }
             if (looks_like_applied_constructor(tokens, position)) {
                 return static_cast<std::uint8_t>(grammar::ContextToken::AppliedConstructor);
             }
@@ -668,7 +674,6 @@ namespace hgl::syntax
                 if (token.text == "map") { return static_cast<std::uint8_t>(grammar::ContextToken::Map); }
                 if (token.text == "rolling") { return static_cast<std::uint8_t>(grammar::ContextToken::Rolling); }
                 if (token.text == "unbounded") { return static_cast<std::uint8_t>(grammar::ContextToken::Unbounded); }
-                if (token.text == "delta") { return static_cast<std::uint8_t>(grammar::ContextToken::Delta); }
             }
             return static_cast<std::uint8_t>(token.kind);
         }

--- a/language/tests/syntax/parser_tests.cpp
+++ b/language/tests/syntax/parser_tests.cpp
@@ -275,6 +275,9 @@ TEST_CASE("operator declarations have signatures and no body", "[parser]") {
 
     Parsed with_body{"module t\noperator f(x: f64) -> f64 => x\n"};
     REQUIRE(with_body.messages() == std::vector<std::string>{"an operator declaration has no body; implement it with 'impl fn'"});
+
+    REQUIRE(Parsed{"module t\noperator bad<T>() requires T -> f64\n"}.messages() ==
+            std::vector<std::string>{"the left side of an operator requirement is a call"});
 }
 
 TEST_CASE("the declarative grammar preserves trailing parenthesized newlines", "[parser]") {
@@ -1163,6 +1166,10 @@ TEST_CASE("contextual keywords are ordinary names", "[parser]") {
                                                                                                     "    Parameter atomic\n"
                                                                                                     "      type: Type scalar f64\n"
                                                                                                     "    body: NameRef in\n");
+    CHECK(body_dump("    for key, in in values {\n        in\n    }").find("For key, in") != std::string::npos);
+    const std::string category = dump_clean("module t\noperator category<T>() requires T is in\n");
+    CHECK(category.find("ConstraintRelation is") != std::string::npos);
+    CHECK(category.find("Category in") != std::string::npos);
 }
 
 TEST_CASE("diagnostics carry the offending range", "[parser]") {

--- a/language/tests/syntax/parser_tests.cpp
+++ b/language/tests/syntax/parser_tests.cpp
@@ -1,4 +1,5 @@
 #include "syntax/ast_printer.h"
+#include "syntax/ast_projection.h"
 #include "syntax/lexer.h"
 #include "syntax/parser.h"
 #include "syntax/token_grammar.h"
@@ -28,8 +29,7 @@ namespace
 
         explicit Parsed(std::string text) : file{"test.hgl", std::move(text)}, module{parse(file, diagnostics)} {}
 
-        [[nodiscard]] std::vector<std::string> messages() const
-        {
+        [[nodiscard]] std::vector<std::string> messages() const {
             std::vector<std::string> out;
             for (const Diagnostic &diagnostic : diagnostics.diagnostics()) { out.push_back(diagnostic.message); }
             return out;
@@ -37,8 +37,7 @@ namespace
     };
 
     // Drop the ` [begin..end)` spans so structural expectations stay readable.
-    std::string strip_ranges(const std::string &dump)
-    {
+    std::string strip_ranges(const std::string &dump) {
         static const std::regex span{R"( \[\d+\.\.\d+\))"};
         return std::regex_replace(dump, span, "");
     }
@@ -46,42 +45,45 @@ namespace
     std::string dump(const Parsed &parsed) { return strip_ranges(print_ast(parsed.module)); }
 
     // Parse a whole file and dump it, requiring a clean parse.
-    std::string dump_clean(const std::string &text)
-    {
+    std::string dump_clean(const std::string &text) {
         Parsed parsed{text};
         INFO(parsed.diagnostics.render(parsed.file));
         REQUIRE_FALSE(parsed.diagnostics.has_errors());
         DiagnosticSink grammar_diagnostics;
-        LexResult grammar_tokens = lex(parsed.file, grammar_diagnostics);
+        LexResult      grammar_tokens = lex(parsed.file, grammar_diagnostics);
         REQUIRE_FALSE(grammar_diagnostics.has_errors());
-        const GrammarResult grammar = parse_token_grammar(grammar_tokens.tokens);
-        if (grammar.first_error_token < grammar_tokens.tokens.size())
-        {
-            const Token &token = grammar_tokens.tokens[grammar.first_error_token];
-            INFO("declarative grammar stopped at " << token_kind_name(token.kind) << " '"
-                                                    << token.text << "'");
+        const SyntaxParseResult syntax = parse_source_syntax(parsed.file, grammar_tokens);
+        if (syntax.grammar.first_error_token < grammar_tokens.tokens.size()) {
+            const Token &token = grammar_tokens.tokens[syntax.grammar.first_error_token];
+            INFO("declarative grammar stopped at " << token_kind_name(token.kind) << " '" << token.text << "'");
         }
-        REQUIRE(grammar.accepted);
-        REQUIRE_FALSE(grammar.recovered);
-        REQUIRE(grammar.error_count == 0);
+        REQUIRE(syntax.grammar.accepted);
+        REQUIRE_FALSE(syntax.grammar.recovered);
+        REQUIRE(syntax.grammar.error_count == 0);
+        DiagnosticSink    projection_diagnostics;
+        const ast::Module projected = project_ast(syntax.tree, grammar_tokens, projection_diagnostics);
+        INFO(projection_diagnostics.render(parsed.file));
+        REQUIRE_FALSE(projection_diagnostics.has_errors());
+        REQUIRE(print_ast(projected) == print_ast(parsed.module));
+        DiagnosticSink    legacy_diagnostics;
+        const ast::Module legacy = parse_with_legacy_parser(parsed.file, legacy_diagnostics);
+        INFO(legacy_diagnostics.render(parsed.file));
+        REQUIRE_FALSE(legacy_diagnostics.has_errors());
+        REQUIRE(print_ast(projected) == print_ast(legacy));
         return dump(parsed);
     }
 
     // The subtree under the first line carrying `label` at any depth,
     // re-based to depth zero with the label removed.
-    std::string subtree(const std::string &dump, std::string_view label)
-    {
+    std::string subtree(const std::string &dump, std::string_view label) {
         std::istringstream in{dump};
         std::string        line;
         std::string        out;
         std::size_t        base = std::string::npos;
-        while (std::getline(in, line))
-        {
+        while (std::getline(in, line)) {
             const std::size_t indent = line.find_first_not_of(' ');
-            if (base == std::string::npos)
-            {
-                if (indent != std::string::npos && line.compare(indent, label.size(), label) == 0)
-                {
+            if (base == std::string::npos) {
+                if (indent != std::string::npos && line.compare(indent, label.size(), label) == 0) {
                     base = indent;
                     out += line.substr(indent + label.size());
                     out += '\n';
@@ -96,28 +98,22 @@ namespace
     }
 
     // Dump of one expression, parsed as a concise function body.
-    std::string expr_dump(const std::string &expr)
-    {
-        return subtree(dump_clean("module t\nfn f() => " + expr + "\n"), "body: ");
-    }
+    std::string expr_dump(const std::string &expr) { return subtree(dump_clean("module t\nfn f() => " + expr + "\n"), "body: "); }
 
     // Dump of one type, parsed as a parameter type.
-    std::string type_dump(const std::string &type)
-    {
+    std::string type_dump(const std::string &type) {
         return subtree(dump_clean("module t\nfn f(x: " + type + ") => x\n"), "type: ");
     }
 
     // Dump of a block body's statements.
-    std::string body_dump(const std::string &statements)
-    {
+    std::string body_dump(const std::string &statements) {
         return subtree(dump_clean("module t\nfn f() {\n" + statements + "\n}\n"), "body: ");
     }
 }  // namespace
 
 // ------------------------------------------------------------ declarations
 
-TEST_CASE("a module declaration names a dotted path", "[parser]")
-{
+TEST_CASE("a module declaration names a dotted path", "[parser]") {
     Parsed parsed{"module examples.prices\n"};
     REQUIRE_FALSE(parsed.diagnostics.has_errors());
     REQUIRE(dump(parsed) == "Module\n  ModuleDecl examples.prices\n");
@@ -125,8 +121,7 @@ TEST_CASE("a module declaration names a dotted path", "[parser]")
     REQUIRE(parsed.file.slice(decl.range) == "module examples.prices");
 }
 
-TEST_CASE("use declarations import sets and aliases", "[parser]")
-{
+TEST_CASE("use declarations import sets and aliases", "[parser]") {
     const std::string text = "module t\n"
                              "use a.b::{x, y}\n"
                              "use a.b as c\n"
@@ -143,44 +138,37 @@ TEST_CASE("use declarations import sets and aliases", "[parser]")
                                 "  UseDecl a.b::{p, q}\n");
 }
 
-TEST_CASE("a lexer error token stands in for a statement terminator", "[parser]")
-{
+TEST_CASE("a lexer error token stands in for a statement terminator", "[parser]") {
     Parsed parsed{"module t\nfn f(a: f64) -> f64 {\n    let b = a; b\n}\n"};
     REQUIRE(parsed.messages() == std::vector<std::string>{"';' is not a statement terminator; use a newline"});
 }
 
-TEST_CASE("an import set is always braced", "[parser]")
-{
+TEST_CASE("an import set is always braced", "[parser]") {
     Parsed parsed{"module t\nuse a.b::x\n"};
     REQUIRE(parsed.messages() == std::vector<std::string>{"expected '{' after '::', found 'x'"});
 }
 
-TEST_CASE("use declarations must precede ordinary declarations", "[parser]")
-{
+TEST_CASE("use declarations must precede ordinary declarations", "[parser]") {
     Parsed parsed{"module t\nfn f() => 1\nuse a::{x}\n"};
     REQUIRE(parsed.messages() == std::vector<std::string>{"'use' declarations must precede other declarations"});
     REQUIRE(parsed.module.declarations.size() == 3);  // still recorded
 }
 
-TEST_CASE("an empty import set is a diagnostic", "[parser]")
-{
+TEST_CASE("an empty import set is a diagnostic", "[parser]") {
     Parsed parsed{"module t\nuse a.b::{}\n"};
     REQUIRE(parsed.messages() == std::vector<std::string>{"an import set names at least one declaration"});
 }
 
-TEST_CASE("a file starts with its module declaration", "[parser]")
-{
+TEST_CASE("a file starts with its module declaration", "[parser]") {
     Parsed parsed{"fn f() => 1\n"};
-    REQUIRE(parsed.messages() ==
-            std::vector<std::string>{"expected a 'module' declaration at the start of the file"});
+    REQUIRE(parsed.messages() == std::vector<std::string>{"expected a 'module' declaration at the start of the file"});
     REQUIRE(parsed.module.declarations.size() == 1);
 
     Parsed twice{"module a\nmodule b\n"};
     REQUIRE(twice.messages() == std::vector<std::string>{"a file has one 'module' declaration"});
 }
 
-TEST_CASE("function visibility and bodies", "[parser]")
-{
+TEST_CASE("function visibility and bodies", "[parser]") {
     const std::string text = "module t\n"
                              "fn a() => 1\n"
                              "export fn b() => 2\n"
@@ -199,50 +187,54 @@ TEST_CASE("function visibility and bodies", "[parser]")
                                 "        IntLiteral 3\n");
 }
 
-TEST_CASE("declaration ranges cover the whole declaration", "[parser]")
-{
+TEST_CASE("struct inheritance requires named parent types", "[parser]") {
+    Parsed parsed{"module t\nstruct Child: tuple<f64, f64> {}\n"};
+    REQUIRE(parsed.messages() == std::vector<std::string>{"a struct parent is a named type"});
+}
+
+TEST_CASE("delta construction requires a named target type", "[parser]") {
+    Parsed parsed{"module t\nfn f() => delta<tuple<f64, f64>>(1.0, 2.0)\n"};
+    REQUIRE(parsed.messages() == std::vector<std::string>{"a struct constructor takes a named struct type"});
+}
+
+TEST_CASE("declaration ranges cover the whole declaration", "[parser]") {
     Parsed parsed{"module t\nfn f(x: f64) -> f64 {\n    x\n}\n"};
     REQUIRE_FALSE(parsed.diagnostics.has_errors());
     const ast::Decl &decl = parsed.module.decl(parsed.module.declarations.at(1));
     REQUIRE(parsed.file.slice(decl.range) == "fn f(x: f64) -> f64 {\n    x\n}");
 }
 
-TEST_CASE("generic parameters", "[parser]")
-{
-    REQUIRE(dump_clean("module t\nfn f<T, const N: i64>(x: T) -> list<T, N> => x\n") ==
-            "Module\n"
-            "  ModuleDecl t\n"
-            "  FunctionDecl fn f\n"
-            "    GenericParameter T\n"
-            "    GenericParameter const N\n"
-            "      type: Type scalar i64 (value)\n"
-            "    Parameter x\n"
-            "      type: Type named T\n"
-            "    result: Type list\n"
-            "      Type named T\n"
-            "      size: NameRef N\n"
-            "    body: NameRef x\n");
+TEST_CASE("generic parameters", "[parser]") {
+    REQUIRE(dump_clean("module t\nfn f<T, const N: i64>(x: T) -> list<T, N> => x\n") == "Module\n"
+                                                                                        "  ModuleDecl t\n"
+                                                                                        "  FunctionDecl fn f\n"
+                                                                                        "    GenericParameter T\n"
+                                                                                        "    GenericParameter const N\n"
+                                                                                        "      type: Type scalar i64 (value)\n"
+                                                                                        "    Parameter x\n"
+                                                                                        "      type: Type named T\n"
+                                                                                        "    result: Type list\n"
+                                                                                        "      Type named T\n"
+                                                                                        "      size: NameRef N\n"
+                                                                                        "    body: NameRef x\n");
 }
 
-TEST_CASE("only const parameters have defaults", "[parser]")
-{
-    REQUIRE(dump_clean("module t\nfn f(a: f64, const n: i64 = 3) => a\n") ==
-            "Module\n"
-            "  ModuleDecl t\n"
-            "  FunctionDecl fn f\n"
-            "    Parameter a\n"
-            "      type: Type scalar f64\n"
-            "    Parameter const n\n"
-            "      type: Type scalar i64 (value)\n"
-            "      default: IntLiteral 3\n"
-            "    body: NameRef a\n");
+TEST_CASE("only const parameters have defaults", "[parser]") {
+    REQUIRE(dump_clean("module t\nfn f(a: f64, const n: i64 = 3) => a\n") == "Module\n"
+                                                                             "  ModuleDecl t\n"
+                                                                             "  FunctionDecl fn f\n"
+                                                                             "    Parameter a\n"
+                                                                             "      type: Type scalar f64\n"
+                                                                             "    Parameter const n\n"
+                                                                             "      type: Type scalar i64 (value)\n"
+                                                                             "      default: IntLiteral 3\n"
+                                                                             "    body: NameRef a\n");
 
     Parsed temporal_default{"module t\nfn f(s: str = \"x\") => s\n"};
     REQUIRE(temporal_default.messages() == std::vector<std::string>{"only a const parameter may have a default"});
 }
 
-TEST_CASE("struct declarations carry hierarchy, defaults, and generic requirements", "[parser]")
-{
+TEST_CASE("struct declarations carry hierarchy, defaults, and generic requirements", "[parser]") {
     const std::string tree = dump_clean(R"(
 module t
 
@@ -270,33 +262,33 @@ requires T in {i64, f64} && T is struct || add(T, T) -> T
     CHECK(tree.find("size: NameRef size") != std::string::npos);
 }
 
-TEST_CASE("operator declarations have signatures and no body", "[parser]")
-{
-    REQUIRE(dump_clean("module t\noperator scale<T>(value: T, by: f64) -> T\n") ==
-            "Module\n"
-            "  ModuleDecl t\n"
-            "  OperatorDecl scale\n"
-            "    GenericParameter T\n"
-            "    Parameter value\n"
-            "      type: Type named T\n"
-            "    Parameter by\n"
-            "      type: Type scalar f64\n"
-            "    result: Type named T\n");
+TEST_CASE("operator declarations have signatures and no body", "[parser]") {
+    REQUIRE(dump_clean("module t\noperator scale<T>(value: T, by: f64) -> T\n") == "Module\n"
+                                                                                   "  ModuleDecl t\n"
+                                                                                   "  OperatorDecl scale\n"
+                                                                                   "    GenericParameter T\n"
+                                                                                   "    Parameter value\n"
+                                                                                   "      type: Type named T\n"
+                                                                                   "    Parameter by\n"
+                                                                                   "      type: Type scalar f64\n"
+                                                                                   "    result: Type named T\n");
 
     Parsed with_body{"module t\noperator f(x: f64) -> f64 => x\n"};
-    REQUIRE(with_body.messages() ==
-            std::vector<std::string>{"an operator declaration has no body; implement it with 'impl fn'"});
+    REQUIRE(with_body.messages() == std::vector<std::string>{"an operator declaration has no body; implement it with 'impl fn'"});
 }
 
-TEST_CASE("the declarative grammar preserves parenthesized newlines and constant constraint expressions", "[parser]")
-{
+TEST_CASE("the declarative grammar preserves trailing parenthesized newlines", "[parser]") {
     CHECK(dump_clean("module t\nfn grouped() -> i64 => (\n  1\n)\n").find("IntLiteral 1") != std::string::npos);
-    CHECK(dump_clean("module t\noperator sized<const N: i64>() requires N == -1 + 2\n")
-              .find("ConstraintRelation ==") != std::string::npos);
 }
 
-TEST_CASE("test declarations wrap a block", "[parser]")
-{
+TEST_CASE("constraint values use the constant-expression grammar", "[parser]") {
+    const std::string tree = dump_clean("module t\noperator sized<const N: i64>() requires N == -1 + 2\n");
+    CHECK(tree.find("ConstraintRelation ==") != std::string::npos);
+    CHECK(tree.find("Binary +") != std::string::npos);
+    CHECK(tree.find("Unary -") != std::string::npos);
+}
+
+TEST_CASE("test declarations wrap a block", "[parser]") {
     REQUIRE(dump_clean("module t\ntest doubles {\n    assert eval(f, x: [1.0]) == [2.0]\n}\n") ==
             "Module\n"
             "  ModuleDecl t\n"
@@ -315,8 +307,7 @@ TEST_CASE("test declarations wrap a block", "[parser]")
 
 // -------------------------------------------------------------------- types
 
-TEST_CASE("scalar and named types", "[parser]")
-{
+TEST_CASE("scalar and named types", "[parser]") {
     REQUIRE(type_dump("f64") == "Type scalar f64\n");
     REQUIRE(type_dump("i64") == "Type scalar i64\n");
     REQUIRE(type_dump("bool") == "Type scalar bool\n");
@@ -332,8 +323,7 @@ TEST_CASE("scalar and named types", "[parser]")
                                                 "    Name N\n");
 }
 
-TEST_CASE("container types", "[parser]")
-{
+TEST_CASE("container types", "[parser]") {
     REQUIRE(type_dump("tuple<f64, f64>") == "Type tuple\n"
                                             "  Type scalar f64\n"
                                             "  Type scalar f64\n");
@@ -370,8 +360,7 @@ TEST_CASE("container types", "[parser]")
                                                    "    size: IntLiteral 2\n");
 }
 
-TEST_CASE("container names are ordinary names without a generic list", "[parser]")
-{
+TEST_CASE("container names are ordinary names without a generic list", "[parser]") {
     REQUIRE(type_dump("rolling") == "Type named rolling\n");
     REQUIRE(expr_dump("list(1, 2)") == "Call\n"
                                        "  callee: NameRef list\n"
@@ -381,8 +370,7 @@ TEST_CASE("container names are ordinary names without a generic list", "[parser]
                                        "    IntLiteral 2\n");
 }
 
-TEST_CASE("type size expressions stop before a closing '>'", "[parser]")
-{
+TEST_CASE("type size expressions stop before a closing '>'", "[parser]") {
     REQUIRE(type_dump("list<f64, N + 1>") == "Type list\n"
                                              "  Type scalar f64\n"
                                              "  size: Binary +\n"
@@ -396,8 +384,7 @@ TEST_CASE("type size expressions stop before a closing '>'", "[parser]")
                                                    "  min: NameRef N\n");
 }
 
-TEST_CASE("type diagnostics", "[parser]")
-{
+TEST_CASE("type diagnostics", "[parser]") {
     REQUIRE(Parsed{"module t\nfn f(x: tuple<>) => x\n"}.messages() ==
             std::vector<std::string>{"a tuple type has at least one element"});
     REQUIRE(Parsed{"module t\nfn f(x: map<str>) => x\n"}.messages() ==
@@ -407,8 +394,7 @@ TEST_CASE("type diagnostics", "[parser]")
 
 // -------------------------------------------------------------- expressions
 
-TEST_CASE("literals", "[parser]")
-{
+TEST_CASE("literals", "[parser]") {
     REQUIRE(expr_dump("42") == "IntLiteral 42\n");
     REQUIRE(expr_dump("2.5") == "FloatLiteral 2.5\n");
     REQUIRE(expr_dump("1.0") == "FloatLiteral 1.0\n");
@@ -423,8 +409,7 @@ TEST_CASE("literals", "[parser]")
     REQUIRE(expr_dump("@2026-09-03T09:30Z") == "TemporalLiteral @2026-09-03T09:30Z\n");
 }
 
-TEST_CASE("struct and delta construction use named arguments", "[parser]")
-{
+TEST_CASE("struct and delta construction use named arguments", "[parser]") {
     REQUIRE(expr_dump("Quote(bid: 1.0, ask: 2.0)") == "Call\n"
                                                       "  callee: NameRef Quote\n"
                                                       "  Argument bid\n"
@@ -445,16 +430,14 @@ TEST_CASE("struct and delta construction use named arguments", "[parser]")
                                                               "    NullLiteral\n");
 }
 
-TEST_CASE("names and qualified references", "[parser]")
-{
+TEST_CASE("names and qualified references", "[parser]") {
     REQUIRE(expr_dump("x") == "NameRef x\n");
     REQUIRE(expr_dump("mc::my_op") == "QualifiedRef mc::my_op\n");
     REQUIRE(expr_dump("in") == "NameRef in\n");
     REQUIRE(expr_dump("out") == "NameRef out\n");
 }
 
-TEST_CASE("multiplicative binds tighter than additive", "[parser]")
-{
+TEST_CASE("multiplicative binds tighter than additive", "[parser]") {
     REQUIRE(expr_dump("a + b * c") == "Binary +\n"
                                       "  NameRef a\n"
                                       "  Binary *\n"
@@ -472,8 +455,7 @@ TEST_CASE("multiplicative binds tighter than additive", "[parser]")
                                       "  NameRef c\n");
 }
 
-TEST_CASE("binary operators are left associative", "[parser]")
-{
+TEST_CASE("binary operators are left associative", "[parser]") {
     REQUIRE(expr_dump("a - b - c") == "Binary -\n"
                                       "  Binary -\n"
                                       "    NameRef a\n"
@@ -486,8 +468,7 @@ TEST_CASE("binary operators are left associative", "[parser]")
                                       "  NameRef c\n");
 }
 
-TEST_CASE("comparison, equality, and logical precedence", "[parser]")
-{
+TEST_CASE("comparison, equality, and logical precedence", "[parser]") {
     REQUIRE(expr_dump("a < b == c > d") == "Binary ==\n"
                                            "  Binary <\n"
                                            "    NameRef a\n"
@@ -512,8 +493,7 @@ TEST_CASE("comparison, equality, and logical precedence", "[parser]")
                                    "  NameRef b\n");
 }
 
-TEST_CASE("unary operators", "[parser]")
-{
+TEST_CASE("unary operators", "[parser]") {
     REQUIRE(expr_dump("-a * b") == "Binary *\n"
                                    "  Unary -\n"
                                    "    NameRef a\n"
@@ -532,8 +512,7 @@ TEST_CASE("unary operators", "[parser]")
                                   "      NameRef x\n");
 }
 
-TEST_CASE("parentheses group", "[parser]")
-{
+TEST_CASE("parentheses group", "[parser]") {
     REQUIRE(expr_dump("(a + b) * c") == "Binary *\n"
                                         "  Binary +\n"
                                         "    NameRef a\n"
@@ -542,8 +521,7 @@ TEST_CASE("parentheses group", "[parser]")
     REQUIRE(expr_dump("(1.0)") == "FloatLiteral 1.0\n");
 }
 
-TEST_CASE("calls with positional and named arguments", "[parser]")
-{
+TEST_CASE("calls with positional and named arguments", "[parser]") {
     REQUIRE(expr_dump("f(a, b: 2, c)") == "Call\n"
                                           "  callee: NameRef f\n"
                                           "  Argument\n"
@@ -562,15 +540,14 @@ TEST_CASE("calls with positional and named arguments", "[parser]")
                                         "  Argument\n"
                                         "    NameRef y\n");
     REQUIRE(expr_dump("f(\n    a,\n    b: 2,\n)") == "Call\n"
-                                                    "  callee: NameRef f\n"
-                                                    "  Argument\n"
-                                                    "    NameRef a\n"
-                                                    "  Argument b\n"
-                                                    "    IntLiteral 2\n");
+                                                     "  callee: NameRef f\n"
+                                                     "  Argument\n"
+                                                     "    NameRef a\n"
+                                                     "  Argument b\n"
+                                                     "    IntLiteral 2\n");
 }
 
-TEST_CASE("index and field postfix operators", "[parser]")
-{
+TEST_CASE("index and field postfix operators", "[parser]") {
     REQUIRE(expr_dump("m[k].info.value") == "Field value\n"
                                             "  Field info\n"
                                             "    Index\n"
@@ -590,8 +567,7 @@ TEST_CASE("index and field postfix operators", "[parser]")
                                      "    IntLiteral 1\n");
 }
 
-TEST_CASE("sequence literals", "[parser]")
-{
+TEST_CASE("sequence literals", "[parser]") {
     REQUIRE(expr_dump("[1.0, _, 2.0]") == "SequenceLiteral\n"
                                           "  FloatLiteral 1.0\n"
                                           "  Placeholder\n"
@@ -609,8 +585,8 @@ TEST_CASE("sequence literals", "[parser]")
                                                       "    key: TemporalLiteral @2026-09-03T09:30Z\n"
                                                       "    FloatLiteral 1.0\n");
     REQUIRE(expr_dump("[\n    1.0,\n    2.0,\n]") == "SequenceLiteral\n"
-                                                    "  FloatLiteral 1.0\n"
-                                                    "  FloatLiteral 2.0\n");
+                                                     "  FloatLiteral 1.0\n"
+                                                     "  FloatLiteral 2.0\n");
     REQUIRE(expr_dump("[[1, 2], [3]]") == "SequenceLiteral\n"
                                           "  SequenceLiteral\n"
                                           "    IntLiteral 1\n"
@@ -619,8 +595,7 @@ TEST_CASE("sequence literals", "[parser]")
                                           "    IntLiteral 3\n");
 }
 
-TEST_CASE("tuple literals need a comma", "[parser]")
-{
+TEST_CASE("tuple literals need a comma", "[parser]") {
     REQUIRE(expr_dump("(1.0, 2.0)") == "TupleLiteral\n"
                                        "  FloatLiteral 1.0\n"
                                        "  FloatLiteral 2.0\n");
@@ -635,8 +610,7 @@ TEST_CASE("tuple literals need a comma", "[parser]")
             std::vector<std::string>{"expected an expression; '()' is not a value"});
 }
 
-TEST_CASE("anonymous functions", "[parser]")
-{
+TEST_CASE("anonymous functions", "[parser]") {
     REQUIRE(expr_dump("fn(x) => x * 2") == "AnonymousFn\n"
                                            "  Parameter x\n"
                                            "  body: Binary *\n"
@@ -660,8 +634,7 @@ TEST_CASE("anonymous functions", "[parser]")
                                                 "      body: NameRef x\n");
 }
 
-TEST_CASE("if is an expression", "[parser]")
-{
+TEST_CASE("if is an expression", "[parser]") {
     REQUIRE(expr_dump("if a > 0.0 { a } else { 0.0 }") == "If\n"
                                                           "  condition: Binary >\n"
                                                           "    NameRef a\n"
@@ -705,8 +678,7 @@ TEST_CASE("if is an expression", "[parser]")
                                                         "  IntLiteral 1\n");
 }
 
-TEST_CASE("else may start the line after the then-block", "[parser]")
-{
+TEST_CASE("else may start the line after the then-block", "[parser]") {
     REQUIRE(body_dump("    let x = if a {\n"
                       "        1\n"
                       "    }\n"
@@ -728,8 +700,7 @@ TEST_CASE("else may start the line after the then-block", "[parser]")
                                   "    NameRef x\n");
 }
 
-TEST_CASE("eval expressions", "[parser]")
-{
+TEST_CASE("eval expressions", "[parser]") {
     REQUIRE(expr_dump("eval(f, x: [1.0], y: [2.0])") == "Eval\n"
                                                         "  callee: NameRef f\n"
                                                         "  Argument x\n"
@@ -741,14 +712,13 @@ TEST_CASE("eval expressions", "[parser]")
     REQUIRE(expr_dump("eval(mc::f)") == "Eval\n"
                                         "  callee: QualifiedRef mc::f\n");
     REQUIRE(expr_dump("eval(\n    f,\n    x: [1.0],\n)") == "Eval\n"
-                                                           "  callee: NameRef f\n"
-                                                           "  Argument x\n"
-                                                           "    SequenceLiteral\n"
-                                                           "      FloatLiteral 1.0\n");
+                                                            "  callee: NameRef f\n"
+                                                            "  Argument x\n"
+                                                            "    SequenceLiteral\n"
+                                                            "      FloatLiteral 1.0\n");
 }
 
-TEST_CASE("a block in expression position is a block expression", "[parser]")
-{
+TEST_CASE("a block in expression position is a block expression", "[parser]") {
     REQUIRE(expr_dump("{ let y = 1\n y }") == "BlockExpr\n"
                                               "  Block\n"
                                               "    LocalDecl let y\n"
@@ -757,11 +727,10 @@ TEST_CASE("a block in expression position is a block expression", "[parser]")
                                               "      NameRef y\n");
 }
 
-TEST_CASE("expression ranges span the whole expression", "[parser]")
-{
+TEST_CASE("expression ranges span the whole expression", "[parser]") {
     Parsed parsed{"module t\nfn f() => a + b * c\n"};
     REQUIRE_FALSE(parsed.diagnostics.has_errors());
-    const auto &decl = std::get<ast::FunctionDecl>(parsed.module.decl(parsed.module.declarations.at(1)).node);
+    const auto      &decl = std::get<ast::FunctionDecl>(parsed.module.decl(parsed.module.declarations.at(1)).node);
     const ast::Expr &body = parsed.module.expr(decl.concise_body);
     REQUIRE(parsed.file.slice(body.range) == "a + b * c");
     const auto &sum = std::get<ast::Binary>(body.node);
@@ -770,8 +739,7 @@ TEST_CASE("expression ranges span the whole expression", "[parser]")
 
 // --------------------------------------------------------------- statements
 
-TEST_CASE("let and var declarations", "[parser]")
-{
+TEST_CASE("let and var declarations", "[parser]") {
     REQUIRE(body_dump("    let a = 1\n"
                       "    var b: f64 = 2.0\n"
                       "    a") == "Block\n"
@@ -786,8 +754,7 @@ TEST_CASE("let and var declarations", "[parser]")
             std::vector<std::string>{"expected '=' and an initializer, found newline"});
 }
 
-TEST_CASE("state declarations use value types", "[parser]")
-{
+TEST_CASE("state declarations use value types", "[parser]") {
     REQUIRE(body_dump("    state total: f64 = 0.0\n"
                       "    state seen = 0\n"
                       "    total") == "Block\n"
@@ -800,8 +767,7 @@ TEST_CASE("state declarations use value types", "[parser]")
                                       "    NameRef total\n");
 }
 
-TEST_CASE("inject declarations", "[parser]")
-{
+TEST_CASE("inject declarations", "[parser]") {
     REQUIRE(body_dump("    inject out, logger\n"
                       "    inject clock\n"
                       "    inject\n"
@@ -815,8 +781,7 @@ TEST_CASE("inject declarations", "[parser]")
                                   "    IntLiteral 0\n");
 }
 
-TEST_CASE("start and stop blocks", "[parser]")
-{
+TEST_CASE("start and stop blocks", "[parser]") {
     REQUIRE(body_dump("    start {\n"
                       "        logger.info(\"up\")\n"
                       "    }\n"
@@ -841,8 +806,7 @@ TEST_CASE("start and stop blocks", "[parser]")
                                   "            StringLiteral \"down\"\n");
 }
 
-TEST_CASE("when blocks", "[parser]")
-{
+TEST_CASE("when blocks", "[parser]") {
     REQUIRE(body_dump("    when modified(a) {\n"
                       "        total += a\n"
                       "    }\n"
@@ -861,8 +825,7 @@ TEST_CASE("when blocks", "[parser]")
                                             "    value: NameRef total\n");
 }
 
-TEST_CASE("for loops over one or two names", "[parser]")
-{
+TEST_CASE("for loops over one or two names", "[parser]") {
     REQUIRE(body_dump("    for k, v in m {\n"
                       "        sum += v\n"
                       "    }\n"
@@ -897,8 +860,7 @@ TEST_CASE("for loops over one or two names", "[parser]")
             std::vector<std::string>{"expected 'in' after the loop pattern, found 'xs'"});
 }
 
-TEST_CASE("assignments", "[parser]")
-{
+TEST_CASE("assignments", "[parser]") {
     REQUIRE(body_dump("    a = 1\n"
                       "    a += 1\n"
                       "    a -= 1\n"
@@ -943,8 +905,7 @@ TEST_CASE("assignments", "[parser]")
             std::vector<std::string>{"only a name, an index, or a field can be assigned to"});
 }
 
-TEST_CASE("return and assert statements", "[parser]")
-{
+TEST_CASE("return and assert statements", "[parser]") {
     REQUIRE(body_dump("    if a {\n"
                       "        return\n"
                       "    }\n"
@@ -974,8 +935,7 @@ TEST_CASE("return and assert statements", "[parser]")
                                                 "        Return\n");
 }
 
-TEST_CASE("expression statements and the block tail", "[parser]")
-{
+TEST_CASE("expression statements and the block tail", "[parser]") {
     REQUIRE(body_dump("    f(x)\n"
                       "    g(y)") == "Block\n"
                                      "  ExprStmt\n"
@@ -994,11 +954,10 @@ TEST_CASE("expression statements and the block tail", "[parser]")
                                           "    init: IntLiteral 1\n");
 }
 
-TEST_CASE("statement ranges", "[parser]")
-{
+TEST_CASE("statement ranges", "[parser]") {
     Parsed parsed{"module t\nfn f() {\n    var a = 1\n    a += 2\n}\n"};
     REQUIRE_FALSE(parsed.diagnostics.has_errors());
-    const auto &decl = std::get<ast::FunctionDecl>(parsed.module.decl(parsed.module.declarations.at(1)).node);
+    const auto       &decl  = std::get<ast::FunctionDecl>(parsed.module.decl(parsed.module.declarations.at(1)).node);
     const ast::Block &block = parsed.module.block(decl.block_body);
     REQUIRE(block.statements.size() == 2);
     REQUIRE(parsed.file.slice(parsed.module.stmt(block.statements[0]).range) == "var a = 1");
@@ -1009,42 +968,38 @@ TEST_CASE("statement ranges", "[parser]")
 
 // ----------------------------------------------------------------- newlines
 
-TEST_CASE("newlines separate statements", "[parser]")
-{
+TEST_CASE("newlines separate statements", "[parser]") {
     REQUIRE(Parsed{"module t\nfn f() {\n    let a = 1 let b = 2\n}\n"}.messages() ==
             std::vector<std::string>{"expected a newline after the statement, found 'let'"});
     REQUIRE(Parsed{"module t\nfn f() => 1 fn g() => 2\n"}.messages() ==
             std::vector<std::string>{"expected a newline after the declaration, found 'fn'"});
 }
 
-TEST_CASE("newlines are skipped inside brackets and after commas", "[parser]")
-{
+TEST_CASE("newlines are skipped inside brackets and after commas", "[parser]") {
     REQUIRE(expr_dump("f(\n    a\n    ,\n    b\n)") == "Call\n"
-                                                      "  callee: NameRef f\n"
-                                                      "  Argument\n"
-                                                      "    NameRef a\n"
-                                                      "  Argument\n"
-                                                      "    NameRef b\n");
+                                                       "  callee: NameRef f\n"
+                                                       "  Argument\n"
+                                                       "    NameRef a\n"
+                                                       "  Argument\n"
+                                                       "    NameRef b\n");
     REQUIRE(expr_dump("xs[\n    0\n]") == "Index\n"
                                           "  NameRef xs\n"
                                           "  index: IntLiteral 0\n");
     REQUIRE(type_dump("map<\n    str,\n    f64\n>") == "Type map\n"
-                                                      "  Type scalar str (value)\n"
-                                                      "  Type scalar f64\n");
-    REQUIRE(dump_clean("module t\nfn f<\n    T,\n    const N: i64\n>(x: T) => x\n") ==
-            "Module\n"
-            "  ModuleDecl t\n"
-            "  FunctionDecl fn f\n"
-            "    GenericParameter T\n"
-            "    GenericParameter const N\n"
-            "      type: Type scalar i64 (value)\n"
-            "    Parameter x\n"
-            "      type: Type named T\n"
-            "    body: NameRef x\n");
+                                                       "  Type scalar str (value)\n"
+                                                       "  Type scalar f64\n");
+    REQUIRE(dump_clean("module t\nfn f<\n    T,\n    const N: i64\n>(x: T) => x\n") == "Module\n"
+                                                                                       "  ModuleDecl t\n"
+                                                                                       "  FunctionDecl fn f\n"
+                                                                                       "    GenericParameter T\n"
+                                                                                       "    GenericParameter const N\n"
+                                                                                       "      type: Type scalar i64 (value)\n"
+                                                                                       "    Parameter x\n"
+                                                                                       "      type: Type named T\n"
+                                                                                       "    body: NameRef x\n");
 }
 
-TEST_CASE("a binary operator at the end of a line continues the expression", "[parser]")
-{
+TEST_CASE("a binary operator at the end of a line continues the expression", "[parser]") {
     REQUIRE(body_dump("    let a = b +\n"
                       "        c\n"
                       "    a") == "Block\n"
@@ -1068,8 +1023,7 @@ TEST_CASE("a binary operator at the end of a line continues the expression", "[p
                                    "    NameRef ok\n");
 }
 
-TEST_CASE("a line starting with a binary operator continues the expression", "[parser]")
-{
+TEST_CASE("a line starting with a binary operator continues the expression", "[parser]") {
     REQUIRE(body_dump("    let a = b\n"
                       "        + c\n"
                       "        * d\n"
@@ -1084,8 +1038,7 @@ TEST_CASE("a line starting with a binary operator continues the expression", "[p
                                   "    NameRef a\n");
 }
 
-TEST_CASE("a line starting with a unary operator is a new statement", "[parser]")
-{
+TEST_CASE("a line starting with a unary operator is a new statement", "[parser]") {
     // `!` is never binary, so the second line is its own statement.
     REQUIRE(body_dump("    let a = b\n"
                       "    !a") == "Block\n"
@@ -1096,8 +1049,7 @@ TEST_CASE("a line starting with a unary operator is a new statement", "[parser]"
                                    "      NameRef a\n");
 }
 
-TEST_CASE("postfix operators do not cross a newline", "[parser]")
-{
+TEST_CASE("postfix operators do not cross a newline", "[parser]") {
     REQUIRE(body_dump("    let a = b\n"
                       "    (c)") == "Block\n"
                                     "  LocalDecl let a\n"
@@ -1113,8 +1065,7 @@ TEST_CASE("postfix operators do not cross a newline", "[parser]")
                                     "      NameRef c\n");
 }
 
-TEST_CASE("newlines after '=', '=>', '->', and ':' are skipped", "[parser]")
-{
+TEST_CASE("newlines after '=', '=>', '->', and ':' are skipped", "[parser]") {
     REQUIRE(dump_clean("module t\n"
                        "fn f(window: rolling<T, max_size, min_size>)\n"
                        "    -> rolling<T, max_size, min_size> =>\n"
@@ -1145,8 +1096,7 @@ TEST_CASE("newlines after '=', '=>', '->', and ':' are skipped", "[parser]")
                                   "    NameRef a\n");
 }
 
-TEST_CASE("blank lines and comments between declarations and statements are fine", "[parser]")
-{
+TEST_CASE("blank lines and comments between declarations and statements are fine", "[parser]") {
     Parsed parsed{"// leading\n"
                   "module t\n"
                   "\n"
@@ -1174,26 +1124,22 @@ TEST_CASE("blank lines and comments between declarations and statements are fine
                             "  Comment\n");
 }
 
-TEST_CASE("a file may end without a trailing newline", "[parser]")
-{
+TEST_CASE("a file may end without a trailing newline", "[parser]") {
     REQUIRE(dump_clean("module t\nfn f() => 1") == "Module\n"
                                                    "  ModuleDecl t\n"
                                                    "  FunctionDecl fn f\n"
                                                    "    body: IntLiteral 1\n");
     REQUIRE(dump_clean("module t") == "Module\n  ModuleDecl t\n");
     Parsed parsed{""};
-    REQUIRE(parsed.messages() ==
-            std::vector<std::string>{"expected a 'module' declaration at the start of the file"});
+    REQUIRE(parsed.messages() == std::vector<std::string>{"expected a 'module' declaration at the start of the file"});
     REQUIRE(dump(parsed) == "Module\n");
 }
 
 // -------------------------------------------------------------- diagnostics
 
-TEST_CASE("reserved words cannot be used as names", "[parser]")
-{
+TEST_CASE("reserved words cannot be used as names", "[parser]") {
     Parsed parsed{"module t\nfn f(let: f64) => 1\n"};
-    REQUIRE(parsed.messages() ==
-            std::vector<std::string>{"'let' is a reserved word and cannot be used as a parameter name"});
+    REQUIRE(parsed.messages() == std::vector<std::string>{"'let' is a reserved word and cannot be used as a parameter name"});
     REQUIRE(parsed.module.declarations.size() == 2);  // the declaration is still built
 
     REQUIRE(Parsed{"module t\nfn fn() => 1\n"}.messages() ==
@@ -1204,25 +1150,22 @@ TEST_CASE("reserved words cannot be used as names", "[parser]")
             std::vector<std::string>{"'fn' is a reserved word and cannot be used as an imported name"});
 }
 
-TEST_CASE("contextual keywords are ordinary names", "[parser]")
-{
-    REQUIRE(dump_clean("module t\nfn f(in: f64, out: f64, unbounded: f64, atomic: f64) => in\n") ==
-            "Module\n"
-            "  ModuleDecl t\n"
-            "  FunctionDecl fn f\n"
-            "    Parameter in\n"
-            "      type: Type scalar f64\n"
-            "    Parameter out\n"
-            "      type: Type scalar f64\n"
-            "    Parameter unbounded\n"
-            "      type: Type scalar f64\n"
-            "    Parameter atomic\n"
-            "      type: Type scalar f64\n"
-            "    body: NameRef in\n");
+TEST_CASE("contextual keywords are ordinary names", "[parser]") {
+    REQUIRE(dump_clean("module t\nfn f(in: f64, out: f64, unbounded: f64, atomic: f64) => in\n") == "Module\n"
+                                                                                                    "  ModuleDecl t\n"
+                                                                                                    "  FunctionDecl fn f\n"
+                                                                                                    "    Parameter in\n"
+                                                                                                    "      type: Type scalar f64\n"
+                                                                                                    "    Parameter out\n"
+                                                                                                    "      type: Type scalar f64\n"
+                                                                                                    "    Parameter unbounded\n"
+                                                                                                    "      type: Type scalar f64\n"
+                                                                                                    "    Parameter atomic\n"
+                                                                                                    "      type: Type scalar f64\n"
+                                                                                                    "    body: NameRef in\n");
 }
 
-TEST_CASE("diagnostics carry the offending range", "[parser]")
-{
+TEST_CASE("diagnostics carry the offending range", "[parser]") {
     Parsed parsed{"module t\nfn f() => )\n"};
     REQUIRE(parsed.messages() == std::vector<std::string>{"expected an expression, found ')'"});
     REQUIRE(parsed.file.slice(parsed.diagnostics.diagnostics().at(0).range) == ")");
@@ -1232,8 +1175,7 @@ TEST_CASE("diagnostics carry the offending range", "[parser]")
     REQUIRE(missing.diagnostics.diagnostics().at(0).range.begin == 15);
 }
 
-TEST_CASE("a bad declaration reports once and parsing resumes at the next declaration", "[parser]")
-{
+TEST_CASE("a bad declaration reports once and parsing resumes at the next declaration", "[parser]") {
     Parsed parsed{"module t\n"
                   "fn broken(x: f64 => x\n"
                   "    still junk here\n"
@@ -1248,8 +1190,7 @@ TEST_CASE("a bad declaration reports once and parsing resumes at the next declar
                             "    body: IntLiteral 2\n");
 }
 
-TEST_CASE("recovery finds every declaration keyword", "[parser]")
-{
+TEST_CASE("recovery finds every declaration keyword", "[parser]") {
     Parsed parsed{"module t\n"
                   "fn a( => 1\n"
                   "operator b(x: f64) -> f64\n"
@@ -1277,8 +1218,7 @@ TEST_CASE("recovery finds every declaration keyword", "[parser]")
                             "  UseDecl z::{q}\n");
 }
 
-TEST_CASE("a bad statement reports once and the rest of the block parses", "[parser]")
-{
+TEST_CASE("a bad statement reports once and the rest of the block parses", "[parser]") {
     Parsed parsed{"module t\n"
                   "fn f() {\n"
                   "    let a = (1 + \n"
@@ -1299,27 +1239,23 @@ TEST_CASE("a bad statement reports once and the rest of the block parses", "[par
                             "    body: IntLiteral 3\n");
 }
 
-TEST_CASE("an unterminated block is reported at end of file", "[parser]")
-{
+TEST_CASE("an unterminated block is reported at end of file", "[parser]") {
     Parsed parsed{"module t\nfn f() {\n    let a = 1\n"};
     REQUIRE(parsed.messages() == std::vector<std::string>{"expected '}' to close the block, found end of file"});
 }
 
-TEST_CASE("bad top-level tokens report one diagnostic", "[parser]")
-{
+TEST_CASE("bad top-level tokens report one diagnostic", "[parser]") {
     Parsed parsed{"module t\n42\nfn f() => 1\n"};
     REQUIRE(parsed.messages() == std::vector<std::string>{"expected a declaration, found '42'"});
     REQUIRE(parsed.module.declarations.size() == 2);
 }
 
-TEST_CASE("missing function body", "[parser]")
-{
+TEST_CASE("missing function body", "[parser]") {
     REQUIRE(Parsed{"module t\nfn f()\nfn g() => 1\n"}.messages() ==
             std::vector<std::string>{"expected '=>' or '{' to begin the function body, found newline"});
 }
 
-TEST_CASE("lexer errors surface through the parser", "[parser]")
-{
+TEST_CASE("lexer errors surface through the parser", "[parser]") {
     Parsed parsed{"module t\nfn f() => \"unterminated\n"};
     REQUIRE(parsed.diagnostics.has_errors());
     // The lexer's own message comes first; the parser adds nothing for the
@@ -1329,21 +1265,18 @@ TEST_CASE("lexer errors surface through the parser", "[parser]")
 
 // ----------------------------------------------------------------- examples
 
-TEST_CASE("every example parses cleanly", "[parser][examples]")
-{
+TEST_CASE("every example parses cleanly", "[parser][examples]") {
     const std::filesystem::path directory{HGL_EXAMPLES_DIR};
     REQUIRE(std::filesystem::is_directory(directory));
 
     std::vector<std::filesystem::path> examples;
-    for (const auto &entry : std::filesystem::directory_iterator{directory})
-    {
+    for (const auto &entry : std::filesystem::directory_iterator{directory}) {
         if (entry.path().extension() == ".hgl") { examples.push_back(entry.path()); }
     }
     std::sort(examples.begin(), examples.end());
     REQUIRE(examples.size() >= 6);
 
-    for (const std::filesystem::path &path : examples)
-    {
+    for (const std::filesystem::path &path : examples) {
         std::ifstream in{path};
         REQUIRE(in.is_open());
         std::string text{std::istreambuf_iterator<char>{in}, std::istreambuf_iterator<char>{}};


### PR DESCRIPTION
## Summary
- add an HGL-owned structural projection from the source-accurate syntax arena into the existing semantic AST
- route every clean compiler input through the declarative grammar and projection while retaining the legacy parser only for malformed-source diagnostics
- close grammar ambiguities around delta construction, eval callees, and constant expressions in constraints
- compare complete projected ASTs, including source ranges, with the temporary parser across the clean syntax corpus

## Validation
- fresh warnings-as-errors native build
- complete native suite: 1,721 passed
- stable-ABI wheel on Python 3.12 installed and tested with Python 3.14: 3,208 passed, 10 skipped
- HGL suites: syntax 129 cases / 2,857 assertions; semantics 14; codegen 15; wiring 13; native module 3; generated code 25