### PR TITLE
feat(language): introduce resolved HIR boundary

### DIFF
--- a/.github/workflows/language.yml
+++ b/.github/workflows/language.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Build hgl and its suites
         run: >-
           cmake --build build-language --parallel ${{ matrix.parallel }} --target
-          hgl hgl_syntax_tests hgl_semantics_tests hgl_wiring_tests
+          hgl hgl_syntax_tests hgl_semantics_tests hgl_ir_tests hgl_wiring_tests
           hgl_native_module_tests hgl_codegen_tests hgl_codegen_fixture
           hgl_generated_tests
       - name: Run the language suites
@@ -119,6 +119,7 @@ jobs:
         run: |
           build-language/language/hgl --version
           build-language/language/hgl check language/examples/midpoint.hgl
+          build-language/language/hgl check language/examples/stateful-node.hgl --dump-hir
           build-language/language/hgl emit-cpp language/examples/midpoint.hgl --out-dir build-language/emitted
           test -f build-language/emitted/midpoint.h
           test -f build-language/emitted/midpoint.cpp

--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -116,6 +116,21 @@ target_include_directories(hgl_semantics PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_link_libraries(hgl_semantics PUBLIC hgl::syntax)
 hgl_apply_warnings(hgl_semantics)
 
+# The backend-independent HGL representation (src/ir): stable declaration and
+# symbol identities first, followed by type completion and hgraph-IR lowering
+# in later passes. Backends migrate to this boundary without depending on AST
+# node identities.
+add_library(hgl_ir STATIC
+    src/ir/hir.cpp
+    src/ir/hir_printer.cpp
+    src/ir/lower.cpp
+)
+add_library(hgl::ir ALIAS hgl_ir)
+target_compile_features(hgl_ir PUBLIC cxx_std_23)
+target_include_directories(hgl_ir PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_link_libraries(hgl_ir PUBLIC hgl::semantics)
+hgl_apply_warnings(hgl_ir)
+
 # The direct-wiring backend (src/wiring): walks the resolved tree straight
 # into an hgraph Wiring for test, run and the REPL (developer guide,
 # "Direct-wiring backend", "First pass").
@@ -165,7 +180,7 @@ add_library(hgl_driver STATIC
 add_library(hgl::driver ALIAS hgl_driver)
 target_compile_features(hgl_driver PUBLIC cxx_std_23)
 target_include_directories(hgl_driver PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
-target_link_libraries(hgl_driver PUBLIC hgl::wiring hgl::codegen hgraph::core)
+target_link_libraries(hgl_driver PUBLIC hgl::ir hgl::wiring hgl::codegen hgraph::core)
 if(UNIX)
     target_link_libraries(hgl_driver PRIVATE ${CMAKE_DL_LIBS})
 endif()

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -85,6 +85,16 @@ headers remain private to the syntax implementation.
 
 ### C. Typed HIR
 
+Status: in progress. The resolved HIR checkpoint owns the complete program in
+a backend-independent arena, assigns stable identities to declarations,
+parameters, locals, state, injectables, loop values, anonymous parameters,
+types, imported operators, and intrinsics, and retains source type patterns,
+function kinds, control flow, constraints, and source ranges. Every checked-in
+guide example lowers, `hgl check --dump-hir` has a deterministic snapshot, and
+failed name resolution cannot fabricate a symbol. `Module::completion` remains
+`Resolved`: canonical type completion, substitutions, exact call selection,
+phases, and effects are the remaining work in this stage.
+
 - introduce stable symbol and declaration identities, canonical types, complete
   substitutions, typed constants, function kinds, phases, effects, and source
   ranges;

--- a/language/docs/developer-guide/README.md
+++ b/language/docs/developer-guide/README.md
@@ -11,6 +11,10 @@ for hgraph, not a second runtime.
 > structured `delta` forms. `src/semantics/` binds constraint names, resolves
 > struct families and effective fields, validates hierarchy and construction,
 > rejects decidably false closed requirements, and classifies functions.
+> `src/ir/` now lowers every resolved guide example into a source-ranged HIR
+> arena with stable declaration and symbol identities; its explicit completion
+> state is still `Resolved`, pending canonical type, substitution, phase, and
+> effect completion.
 > `src/wiring/` executes the composition subset for `test`, `run`, and the
 > REPL, including scalar and atomic struct values, type-only generic
 > specializations, and field-wise temporal struct composition. `src/codegen/`
@@ -20,8 +24,8 @@ for hgraph, not a second runtime.
 > logger injection, and lifecycle hooks over state and `const` configuration.
 > The driver compiles and caches/loads that subset for file-based `test`, `run`, and REPL sessions on
 > Unix. REPL replacement stages the new image, swaps removable provider handles
-> at a quiescent boundary, and restores the old revision if activation fails. Typed HIR,
-> constructor inference, `const` generic metadata, multiple-parent
+> at a quiescent boundary, and restores the old revision if activation fails. Typed-HIR
+> completion, constructor inference, `const` generic metadata, multiple-parent
 > linearization, explicit optional-field
 > clearing, multi-registry module transactions, and the remaining runtime and
 > generated-C++ type support remain to be implemented.

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -97,13 +97,24 @@ struct hierarchies and effective fields, validates construction and closed
 generic-struct requirements, classifies every function by the rule of
 "Function classification", and applies the phase rules of `test` bodies. Its
 result, `ResolvedModule`, annotates the syntax tree with expression and type
-bindings, constraint identities, struct metadata, and function kinds instead
-of building the typed HIR. Hgraph's resolver still types every operator the
-direct-wiring backend wires, so the HIR becomes necessary when callable
-substitution or the C++ backend needs canonical types ahead of hgraph. Until
-then `src/wiring/` walks the resolved syntax tree directly. This is explicitly
-temporary: typed HIR followed by hgraph semantic IR will become the only input
-to both backends.
+bindings, constraint identities, struct metadata, and function kinds.
+
+`src/ir/lower` now copies that successful result into `hir::Module`. The HIR
+uses strongly typed arena IDs, gives every declaration, parameter, local,
+state value, injectable, loop value, anonymous parameter, type name, imported
+operator, and intrinsic a stable `SymbolId`, and retains structured control
+flow, constraints, effective struct fields, and source ranges. Bare generic
+arguments become explicit type or value references. `hgl check --dump-hir`
+prints the deterministic diagnostic representation used by snapshot tests.
+
+This is the first checkpoint of the same HIR, not a complete typed program:
+`Module::completion` is `Resolved`, and unknown expression type, phase, and
+value-kind fields remain explicit. Canonical hgraph types, complete generic
+substitution, exact call selection, constant evaluation, phases, and effects
+advance it to `Typed` in the next pass. The direct-wiring and C++ backends still
+walk `ResolvedModule` beside this arena during migration. That adapter path is
+explicitly temporary; typed HIR followed by hgraph semantic IR becomes the
+only input to both backends.
 
 ## Common function representation
 

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -6,8 +6,9 @@ Parser-only milestones remain intermediate progress.
 The pass and documentation gates below follow
 [Compiler architecture](../design/compiler-architecture.md) and
 [Documentation architecture](../design/documentation.md). They are target
-acceptance requirements while the prototype still walks `ResolvedModule`
-directly.
+acceptance requirements while both execution backends still walk
+`ResolvedModule` directly. The driver also constructs the first resolved HIR
+checkpoint so its migration contract is continuously exercised.
 
 The lists below are the acceptance matrix, not a claim that every item has
 landed. At the 2026-09-03 prototype checkpoint, syntax tests cover struct,
@@ -103,6 +104,15 @@ declarations and statements after recovery. No second parser exists in the
 compiler or test path.
 
 ## Typed HIR and hgraph IR
+
+Current checkpoint: `tests/ir/lower_tests.cpp` (`hgl_ir_tests`, CTest
+`hgraph_language_ir`) lowers every checked-in guide example and requires every
+value, type, and constraint name to carry a valid stable symbol. Focused cases
+cover multiple injectables declared together, state identity, anonymous
+parameters that shadow enclosing loop bindings, bare type and `const` generic
+arguments, fail-closed unbound identities, and the deterministic source-ranged
+`--dump-hir` format. The current dump says `HIR resolved`; it does not claim
+that the target assertions below have passed.
 
 Each valid guide example has a source-ranged typed-HIR snapshot containing
 stable declaration identities, canonical types, substitutions, typed

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -138,8 +138,10 @@ described in [Types and expressions](types-and-expressions.md#generic-structured
 A trailing `requires` clause constrains an otherwise generic declaration. It
 follows the signature and precedes the body:
 
-> **Staging status:** this syntax and its semantics are agreed design, but the
-> current `hgl check` parser does not implement `requires` yet.
+> **Staging status:** `hgl check` parses and resolves `requires` clauses and
+> rejects decidably false closed struct requirements. Complete callable
+> substitution and operator-conformance checking remains part of typed-HIR
+> completion.
 
 ```hgl
 fn add_numeric<U>(a: U, b: U) -> U

--- a/language/docs/user-guide/modules-and-tools.md
+++ b/language/docs/user-guide/modules-and-tools.md
@@ -182,7 +182,7 @@ Language source cannot declare an adaptor or embed C++.
 The intended command surface is:
 
 ```text
-hgl check path/to/program.hgl
+hgl check path/to/program.hgl [--dump-tokens] [--dump-ast] [--dump-hir]
 hgl test path/to/program.hgl [test-name]...
 hgl run path/to/program.hgl [--entry name] [--mode sim|realtime]
         [--start <datetime>] [--end <datetime|duration>]
@@ -194,7 +194,7 @@ hgl repl
 
 | Command | Behavior |
 | --- | --- |
-| `check` | Parse, resolve, phase-check, and type-check without compiling |
+| `check` | Parse and resolve without compiling; the current prototype also constructs and can dump its resolved HIR |
 | `test` | Run the module's `test` declarations and report failing assertions |
 | `run` | Bind an entry to a mode, clock, and parameters, then execute it |
 | `emit-cpp` | Write the module as `program.h` and `program.cpp`, public hgraph C++ in the module's namespace |
@@ -209,6 +209,10 @@ The current `hgl` implements `--help`, `--version`, `check`, `test`, `run`
 supported scalar runtime-node subset through a native cache on Unix; the REPL
 uses the same route when its session contains runtime declarations. `test`
 accepts test names after the file to run a selection.
+`check --dump-hir` is a compiler-development view with stable IDs and source
+ranges. Its leading `HIR resolved` state is intentional: complete type, phase,
+and effect checking is the next compiler stage, so the dump is not yet a
+promise that every expression is typed.
 The first-pass limits are listed in
 [Testing and running](testing-and-running.md#first-pass-limits); the
 constructs `emit-cpp` does not yet lower are listed under
@@ -304,18 +308,22 @@ civil literals.
 
 ## One execution model
 
-`test`, `run`, `emit-cpp`, and the REPL share one checked semantic IR and one
-hgraph runtime. A program made only of composition functions is wired onto the
+The target architecture gives `test`, `run`, `emit-cpp`, and the REPL one
+checked semantic IR and one hgraph runtime. The current prototype shares
+parsing, name resolution, and the new resolved-HIR construction, but its direct
+and C++ backends still walk `ResolvedModule` independently while they migrate
+to hgraph IR. A program made only of composition functions is wired onto the
 runtime directly, in process. A file-based `test` or `run` containing supported
 runtime functions goes through generated C++, as does an ahead-of-time package.
-The REPL selects the same two routes from the complete accepted session:
+The REPL selects the same two routes from the accepted session:
 
 ```text
-source -> checked semantic IR -> direct wiring          -> hgraph runtime
-                              -> generated C++ -> native -> hgraph runtime
+source -> resolved AST + resolved HIR -> direct wiring          -> hgraph runtime
+                                  \-> generated C++ -> native -> hgraph runtime
 ```
 
-Both paths build the same graph. The scripted image resolves hgraph symbols
+Parity tests require both paths to build the same graph across their shared
+subset; hgraph IR will make that a structural invariant. The scripted image resolves hgraph symbols
 from the running `hgl` process, so it registers into that process's registry
 rather than linking a second static runtime. The compiler's parity suite holds
 the shared composition subset to the same ticks and executes the runtime

--- a/language/src/driver/driver.cpp
+++ b/language/src/driver/driver.cpp
@@ -4,6 +4,8 @@
 #include "driver/cpp_formatter.h"
 #include "driver/line_reader.h"
 #include "driver/native_module.h"
+#include "ir/hir_printer.h"
+#include "ir/lower.h"
 #include "semantics/resolve.h"
 #include "syntax/ast_printer.h"
 #include "syntax/diagnostic.h"
@@ -38,7 +40,7 @@ namespace hgl::driver
         {
             std::cout << "hgl - experimental hgraph language toolchain\n\n"
                          "Usage:\n"
-                         "  hgl check <file> [--dump-tokens] [--dump-ast]\n"
+                         "  hgl check <file> [--dump-tokens] [--dump-ast] [--dump-hir]\n"
                          "  hgl test <file> [test-name]...\n"
                          "  hgl run <file> [--entry <name>] [--mode sim|realtime]\n"
                          "          [--start <datetime>] [--end <datetime|duration>]\n"
@@ -108,7 +110,8 @@ namespace hgl::driver
             syntax::DiagnosticSink     diagnostics{};
             syntax::ast::Module        module{};
             semantics::ResolvedModule  resolved{};
-            bool                       ok{false};
+            ir::hir::Module             hir{};
+            bool                        ok{false};
 
             Unit(std::string path, std::string text) : file{std::move(path), std::move(text)} {}
         };
@@ -118,7 +121,9 @@ namespace hgl::driver
             unit.module = syntax::parse(unit.file, unit.diagnostics);
             if (unit.diagnostics.has_errors()) { return; }
             unit.resolved = semantics::resolve(unit.file, unit.module, wiring::has_operator, unit.diagnostics);
-            unit.ok       = !unit.diagnostics.has_errors();
+            if (unit.diagnostics.has_errors()) { return; }
+            unit.hir = ir::lower_to_hir(unit.module, unit.resolved, unit.diagnostics);
+            unit.ok  = !unit.diagnostics.has_errors();
         }
 
         std::optional<Unit> load(const std::string &path)
@@ -188,10 +193,12 @@ namespace hgl::driver
             std::optional<std::string> path;
             bool                       want_tokens = false;
             bool                       want_ast    = false;
+            bool                       want_hir    = false;
             for (const std::string_view argument : arguments)
             {
                 if (argument == "--dump-tokens") { want_tokens = true; }
                 else if (argument == "--dump-ast") { want_ast = true; }
+                else if (argument == "--dump-hir") { want_hir = true; }
                 else if (argument.starts_with("--")) { return usage_error("unknown option '" + std::string{argument} + "'"); }
                 else if (path) { return usage_error("check takes one file"); }
                 else { path = std::string{argument}; }
@@ -214,6 +221,7 @@ namespace hgl::driver
             }
             frontend(unit);
             if (want_ast) { std::cout << syntax::print_ast(unit.module); }
+            if (want_hir && !unit.hir.path.empty()) { std::cout << ir::print_hir(unit.hir); }
             if (unit.diagnostics.has_errors())
             {
                 std::cerr << unit.diagnostics.render(unit.file);

--- a/language/src/ir/hir.cpp
+++ b/language/src/ir/hir.cpp
@@ -1,0 +1,24 @@
+#include "ir/hir.h"
+
+#include <array>
+
+namespace hgl::ir::hir
+{
+    std::string_view scalar_type_name(ScalarType type) noexcept {
+        static constexpr std::array names{
+            std::string_view{"bool"},
+            std::string_view{"i64"},
+            std::string_view{"f64"},
+            std::string_view{"str"},
+            std::string_view{"date"},
+            std::string_view{"time"},
+            std::string_view{"datetime"},
+            std::string_view{"duration"},
+            std::string_view{"civil_datetime"},
+            std::string_view{"zoned_datetime"},
+            std::string_view{"zoned_time"},
+            std::string_view{"timezone"},
+        };
+        return names[static_cast<std::size_t>(type)];
+    }
+}  // namespace hgl::ir::hir

--- a/language/src/ir/hir.h
+++ b/language/src/ir/hir.h
@@ -1,0 +1,488 @@
+#ifndef HGL_IR_HIR_H
+#define HGL_IR_HIR_H
+
+#include "syntax/source.h"
+#include "syntax/temporal.h"
+
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+/// Backend-independent high-level IR. Unlike the syntax AST, every name in
+/// this representation denotes a SymbolId. The representation deliberately
+/// retains structured HGL control flow; graph/runtime lowering happens in the
+/// next IR rather than in a backend.
+namespace hgl::ir::hir
+{
+    template <typename Tag> struct Id
+    {
+        std::uint32_t value{std::numeric_limits<std::uint32_t>::max()};
+
+        [[nodiscard]] constexpr bool valid() const noexcept { return value != std::numeric_limits<std::uint32_t>::max(); }
+        friend constexpr bool        operator==(Id, Id) noexcept = default;
+    };
+
+    using DeclarationId = Id<struct DeclarationTag>;
+    using SymbolId      = Id<struct SymbolTag>;
+    using TypeId        = Id<struct TypeTag>;
+    using ExprId        = Id<struct ExprTag>;
+    using StmtId        = Id<struct StmtTag>;
+    using BlockId       = Id<struct BlockTag>;
+    using ConstraintId  = Id<struct ConstraintTag>;
+
+    inline constexpr DeclarationId no_declaration{};
+    inline constexpr SymbolId      no_symbol{};
+    inline constexpr TypeId        no_type{};
+    inline constexpr ExprId        no_expr{};
+    inline constexpr StmtId        no_stmt{};
+    inline constexpr BlockId       no_block{};
+    inline constexpr ConstraintId  no_constraint{};
+
+    enum class Completion : std::uint8_t {
+        Resolved,  ///< names and source type patterns are complete
+        Typed,     ///< expression types, phases, and substitutions are complete
+    };
+
+    enum class ScalarType : std::uint8_t {
+        Bool,
+        I64,
+        F64,
+        Str,
+        Date,
+        Time,
+        DateTime,
+        Duration,
+        CivilDateTime,
+        ZonedDateTime,
+        ZonedTime,
+        TimeZone,
+    };
+
+    [[nodiscard]] std::string_view scalar_type_name(ScalarType type) noexcept;
+
+    enum class SymbolKind : std::uint8_t {
+        Module,
+        Struct,
+        Operator,
+        Function,
+        Test,
+        TypeParameter,
+        ConstParameter,
+        SignalParameter,
+        LocalLet,
+        LocalVar,
+        State,
+        InjectedCapability,
+        LoopValue,
+        LambdaParameter,
+        ImportedOperator,
+        Intrinsic,
+    };
+
+    struct Symbol
+    {
+        SymbolKind          kind{SymbolKind::Module};
+        std::string         name{};
+        std::string         external_name{};
+        DeclarationId       owner{};
+        syntax::SourceRange range{};
+        TypeId              type{};
+        std::uint32_t       index{0};
+    };
+
+    enum class TypeKind : std::uint8_t {
+        Scalar,
+        Symbol,
+        Tuple,
+        List,
+        Set,
+        Map,
+        Rolling,
+        Atomic,
+        Deferred,
+    };
+
+    enum class TypeArgumentKind : std::uint8_t {
+        Type,
+        Value,
+    };
+
+    struct TypeArgument
+    {
+        TypeArgumentKind    kind{TypeArgumentKind::Type};
+        TypeId              type{};
+        ExprId              value{};
+        syntax::SourceRange range{};
+    };
+
+    struct Type
+    {
+        TypeKind                  kind{TypeKind::Deferred};
+        syntax::SourceRange       range{};
+        ScalarType                scalar{ScalarType::Bool};
+        SymbolId                  symbol{};
+        std::vector<TypeArgument> arguments{};
+        std::vector<TypeId>       children{};
+        ExprId                    size{};
+        ExprId                    min_size{};
+        bool                      unbounded{false};
+        bool                      value_position{false};
+    };
+
+    enum class Phase : std::uint8_t {
+        Unknown,
+        Constant,
+        Wiring,
+        Runtime,
+    };
+
+    enum class ValueKind : std::uint8_t {
+        Unknown,
+        Void,
+        Constant,
+        Signal,
+        RuntimeValue,
+        Function,
+        Operator,
+        Type,
+        Iterator,
+    };
+
+    enum class UnaryOp : std::uint8_t {
+        Negate,
+        Not,
+    };
+
+    enum class BinaryOp : std::uint8_t {
+        Mul,
+        Div,
+        Rem,
+        Add,
+        Sub,
+        Less,
+        LessEqual,
+        Greater,
+        GreaterEqual,
+        Equal,
+        NotEqual,
+        And,
+        Or,
+    };
+
+    struct NullValue
+    { friend constexpr bool operator==(NullValue, NullValue) noexcept = default; };
+    struct PlaceholderValue
+    { friend constexpr bool operator==(PlaceholderValue, PlaceholderValue) noexcept = default; };
+    using Constant = std::variant<NullValue, PlaceholderValue, bool, std::int64_t, double, std::string, syntax::TemporalValue>;
+
+    struct Literal
+    { Constant value{}; };
+    struct SymbolRef
+    { SymbolId symbol{}; };
+    struct Unary
+    {
+        UnaryOp op{UnaryOp::Negate};
+        ExprId  operand{};
+    };
+    struct Binary
+    {
+        BinaryOp op{BinaryOp::Add};
+        ExprId   lhs{};
+        ExprId   rhs{};
+    };
+    struct Argument
+    {
+        std::string         name{};
+        ExprId              value{};
+        syntax::SourceRange range{};
+    };
+    struct Call
+    {
+        ExprId                callee{};
+        std::vector<Argument> arguments{};
+    };
+    struct Index
+    {
+        ExprId target{};
+        ExprId index{};
+    };
+    struct Field
+    {
+        ExprId              target{};
+        std::string         name{};
+        syntax::SourceRange name_range{};
+    };
+    struct SequenceElement
+    {
+        ExprId key{};
+        ExprId value{};
+    };
+    struct Sequence
+    { std::vector<SequenceElement> elements{}; };
+    struct Tuple
+    { std::vector<ExprId> elements{}; };
+    struct Lambda
+    {
+        std::vector<SymbolId> parameters{};
+        TypeId                result{};
+        ExprId                body{};
+    };
+    struct If
+    {
+        ExprId  condition{};
+        BlockId then_block{};
+        ExprId  otherwise{};
+    };
+    struct BlockExpr
+    { BlockId block{}; };
+    struct Eval
+    {
+        ExprId                callee{};
+        std::vector<Argument> arguments{};
+    };
+    struct Construct
+    {
+        TypeId                type{};
+        std::vector<Argument> arguments{};
+        bool                  delta{false};
+    };
+
+    using ExprNode = std::variant<Literal, SymbolRef, Unary, Binary, Call, Index, Field, Sequence, Tuple, Lambda, If, BlockExpr,
+                                  Eval, Construct>;
+
+    struct Expr
+    {
+        syntax::SourceRange range{};
+        TypeId              type{};
+        Phase               phase{Phase::Unknown};
+        ValueKind           value_kind{ValueKind::Unknown};
+        ExprNode            node{};
+    };
+
+    enum class AssignOp : std::uint8_t {
+        Assign,
+        Add,
+        Sub,
+        Mul,
+        Div,
+    };
+
+    struct LocalDecl
+    {
+        SymbolId symbol{};
+        TypeId   type{};
+        ExprId   init{};
+    };
+    struct StateDecl
+    {
+        SymbolId symbol{};
+        TypeId   type{};
+        ExprId   init{};
+    };
+    struct InjectDecl
+    { std::vector<SymbolId> symbols{}; };
+    struct LifecycleBlock
+    {
+        bool    is_stop{false};
+        BlockId block{};
+    };
+    struct WhenStmt
+    {
+        ExprId  condition{};
+        BlockId block{};
+    };
+    struct ForStmt
+    {
+        std::vector<SymbolId> bindings{};
+        ExprId                iterable{};
+        BlockId               block{};
+    };
+    struct AssignStmt
+    {
+        AssignOp op{AssignOp::Assign};
+        ExprId   place{};
+        ExprId   value{};
+    };
+    struct ReturnStmt
+    { ExprId value{}; };
+    struct AssertStmt
+    { ExprId condition{}; };
+    struct ExprStmt
+    { ExprId expr{}; };
+
+    using StmtNode = std::variant<LocalDecl, StateDecl, InjectDecl, LifecycleBlock, WhenStmt, ForStmt, AssignStmt, ReturnStmt,
+                                  AssertStmt, ExprStmt>;
+
+    struct Stmt
+    {
+        syntax::SourceRange range{};
+        StmtNode            node{};
+    };
+
+    struct Block
+    {
+        syntax::SourceRange range{};
+        std::vector<StmtId> statements{};
+        ExprId              tail{};
+    };
+
+    enum class ConstraintLogicOp : std::uint8_t {
+        And,
+        Or,
+    };
+    enum class ConstraintRelationOp : std::uint8_t {
+        Equal,
+        In,
+        Is,
+    };
+    struct ConstraintSymbol
+    { SymbolId symbol{}; };
+    struct ConstraintType
+    { TypeId type{}; };
+    struct ConstraintValue
+    { ExprId value{}; };
+    struct ConstraintSet
+    { std::vector<ConstraintId> elements{}; };
+    struct ConstraintCall
+    {
+        SymbolId                  function{};
+        std::vector<ConstraintId> arguments{};
+    };
+    struct OperatorRequirement
+    {
+        SymbolId                  op{};
+        std::vector<ConstraintId> arguments{};
+        TypeId                    result{};
+    };
+    struct ConstraintRelation
+    {
+        ConstraintRelationOp op{ConstraintRelationOp::Equal};
+        ConstraintId         lhs{};
+        ConstraintId         rhs{};
+        std::string          category{};
+    };
+    struct ConstraintNot
+    { ConstraintId operand{}; };
+    struct ConstraintLogic
+    {
+        ConstraintLogicOp op{ConstraintLogicOp::And};
+        ConstraintId      lhs{};
+        ConstraintId      rhs{};
+    };
+    using ConstraintNode = std::variant<ConstraintSymbol, ConstraintType, ConstraintValue, ConstraintSet, ConstraintCall,
+                                        OperatorRequirement, ConstraintRelation, ConstraintNot, ConstraintLogic>;
+    struct Constraint
+    {
+        syntax::SourceRange range{};
+        ConstraintNode      node{};
+    };
+
+    struct GenericParameter
+    {
+        SymbolId symbol{};
+        bool     is_const{false};
+        TypeId   type{};
+    };
+    struct Parameter
+    {
+        SymbolId symbol{};
+        bool     is_const{false};
+        TypeId   type{};
+        ExprId   default_value{};
+    };
+    struct Signature
+    {
+        std::vector<Parameter> parameters{};
+        TypeId                 result{};
+    };
+    struct StructField
+    {
+        std::string         name{};
+        TypeId              type{};
+        ExprId              default_value{};
+        DeclarationId       origin{};
+        bool                optional{false};
+        syntax::SourceRange range{};
+    };
+
+    enum class Visibility : std::uint8_t {
+        Internal,
+        Export,
+        Implementation,
+    };
+    enum class FunctionKind : std::uint8_t {
+        Composition,
+        Runtime,
+    };
+
+    struct ModuleDecl
+    {};
+    struct UseDecl
+    {
+        std::string              module{};
+        std::string              alias{};
+        std::vector<std::string> names{};
+    };
+    struct StructDecl
+    {
+        bool                          exported{false};
+        bool                          abstract{false};
+        std::vector<GenericParameter> generics{};
+        std::vector<TypeId>           parents{};
+        ConstraintId                  requirements{};
+        std::vector<StructField>      fields{};
+    };
+    struct OperatorDecl
+    {
+        std::vector<GenericParameter> generics{};
+        Signature                     signature{};
+        ConstraintId                  requirements{};
+    };
+    struct FunctionDecl
+    {
+        Visibility                    visibility{Visibility::Internal};
+        FunctionKind                  kind{FunctionKind::Composition};
+        std::vector<GenericParameter> generics{};
+        Signature                     signature{};
+        ConstraintId                  requirements{};
+        ExprId                        concise_body{};
+        BlockId                       block_body{};
+    };
+    struct TestDecl
+    { BlockId block{}; };
+    using DeclarationNode = std::variant<ModuleDecl, UseDecl, StructDecl, OperatorDecl, FunctionDecl, TestDecl>;
+    struct Declaration
+    {
+        DeclarationId       id{};
+        SymbolId            symbol{};
+        syntax::SourceRange range{};
+        DeclarationNode     node{};
+    };
+
+    struct Module
+    {
+        std::string                path{};
+        Completion                 completion{Completion::Resolved};
+        std::vector<Symbol>        symbols{};
+        std::vector<Type>          types{};
+        std::vector<Expr>          exprs{};
+        std::vector<Stmt>          stmts{};
+        std::vector<Block>         blocks{};
+        std::vector<Constraint>    constraints{};
+        std::vector<Declaration>   declarations{};
+        std::vector<DeclarationId> source_order{};
+
+        [[nodiscard]] const Symbol      &symbol(SymbolId id) const noexcept { return symbols[id.value]; }
+        [[nodiscard]] const Type        &type(TypeId id) const noexcept { return types[id.value]; }
+        [[nodiscard]] const Expr        &expr(ExprId id) const noexcept { return exprs[id.value]; }
+        [[nodiscard]] const Stmt        &stmt(StmtId id) const noexcept { return stmts[id.value]; }
+        [[nodiscard]] const Block       &block(BlockId id) const noexcept { return blocks[id.value]; }
+        [[nodiscard]] const Constraint  &constraint(ConstraintId id) const noexcept { return constraints[id.value]; }
+        [[nodiscard]] const Declaration &declaration(DeclarationId id) const noexcept { return declarations[id.value]; }
+    };
+}  // namespace hgl::ir::hir
+
+#endif  // HGL_IR_HIR_H

--- a/language/src/ir/hir_printer.cpp
+++ b/language/src/ir/hir_printer.cpp
@@ -1,0 +1,464 @@
+#include "ir/hir_printer.h"
+
+#include "syntax/temporal.h"
+
+#include <iomanip>
+#include <sstream>
+#include <string_view>
+#include <type_traits>
+
+namespace hgl::ir
+{
+    namespace
+    {
+        template <typename Id> std::string ref(char prefix, Id id) {
+            return id.valid() ? std::string{prefix} + std::to_string(id.value) : "_";
+        }
+
+        template <typename Id> void refs(std::ostream &out, char prefix, const std::vector<Id> &ids) {
+            out << '[';
+            for (std::size_t index = 0; index < ids.size(); ++index) {
+                if (index != 0) { out << ", "; }
+                out << ref(prefix, ids[index]);
+            }
+            out << ']';
+        }
+
+        void range(std::ostream &out, syntax::SourceRange value) { out << " [" << value.begin << ".." << value.end << ')'; }
+
+        std::string_view completion_name(hir::Completion completion) noexcept {
+            return completion == hir::Completion::Resolved ? "resolved" : "typed";
+        }
+
+        std::string_view symbol_kind_name(hir::SymbolKind kind) noexcept {
+            using hir::SymbolKind;
+            switch (kind) {
+                case SymbolKind::Module: return "module";
+                case SymbolKind::Struct: return "struct";
+                case SymbolKind::Operator: return "operator";
+                case SymbolKind::Function: return "function";
+                case SymbolKind::Test: return "test";
+                case SymbolKind::TypeParameter: return "type-parameter";
+                case SymbolKind::ConstParameter: return "const-parameter";
+                case SymbolKind::SignalParameter: return "signal-parameter";
+                case SymbolKind::LocalLet: return "let";
+                case SymbolKind::LocalVar: return "var";
+                case SymbolKind::State: return "state";
+                case SymbolKind::InjectedCapability: return "inject";
+                case SymbolKind::LoopValue: return "loop-value";
+                case SymbolKind::LambdaParameter: return "lambda-parameter";
+                case SymbolKind::ImportedOperator: return "imported-operator";
+                case SymbolKind::Intrinsic: return "intrinsic";
+            }
+        }
+
+        std::string_view type_kind_name(hir::TypeKind kind) noexcept {
+            using hir::TypeKind;
+            switch (kind) {
+                case TypeKind::Scalar: return "scalar";
+                case TypeKind::Symbol: return "symbol";
+                case TypeKind::Tuple: return "tuple";
+                case TypeKind::List: return "list";
+                case TypeKind::Set: return "set";
+                case TypeKind::Map: return "map";
+                case TypeKind::Rolling: return "rolling";
+                case TypeKind::Atomic: return "atomic";
+                case TypeKind::Deferred: return "deferred";
+            }
+        }
+
+        std::string_view phase_name(hir::Phase phase) noexcept {
+            using hir::Phase;
+            switch (phase) {
+                case Phase::Unknown: return "unknown";
+                case Phase::Constant: return "constant";
+                case Phase::Wiring: return "wiring";
+                case Phase::Runtime: return "runtime";
+            }
+        }
+
+        std::string_view value_kind_name(hir::ValueKind kind) noexcept {
+            using hir::ValueKind;
+            switch (kind) {
+                case ValueKind::Unknown: return "unknown";
+                case ValueKind::Void: return "void";
+                case ValueKind::Constant: return "constant";
+                case ValueKind::Signal: return "signal";
+                case ValueKind::RuntimeValue: return "runtime-value";
+                case ValueKind::Function: return "function";
+                case ValueKind::Operator: return "operator";
+                case ValueKind::Type: return "type";
+                case ValueKind::Iterator: return "iterator";
+            }
+        }
+
+        std::string_view unary_name(hir::UnaryOp op) noexcept { return op == hir::UnaryOp::Negate ? "negate" : "not"; }
+
+        std::string_view binary_name(hir::BinaryOp op) noexcept {
+            using hir::BinaryOp;
+            switch (op) {
+                case BinaryOp::Mul: return "mul";
+                case BinaryOp::Div: return "div";
+                case BinaryOp::Rem: return "rem";
+                case BinaryOp::Add: return "add";
+                case BinaryOp::Sub: return "sub";
+                case BinaryOp::Less: return "less";
+                case BinaryOp::LessEqual: return "less-equal";
+                case BinaryOp::Greater: return "greater";
+                case BinaryOp::GreaterEqual: return "greater-equal";
+                case BinaryOp::Equal: return "equal";
+                case BinaryOp::NotEqual: return "not-equal";
+                case BinaryOp::And: return "and";
+                case BinaryOp::Or: return "or";
+            }
+        }
+
+        std::string_view assign_name(hir::AssignOp op) noexcept {
+            using hir::AssignOp;
+            switch (op) {
+                case AssignOp::Assign: return "assign";
+                case AssignOp::Add: return "add-assign";
+                case AssignOp::Sub: return "sub-assign";
+                case AssignOp::Mul: return "mul-assign";
+                case AssignOp::Div: return "div-assign";
+            }
+        }
+
+        void arguments(std::ostream &out, const std::vector<hir::Argument> &values) {
+            out << '[';
+            for (std::size_t index = 0; index < values.size(); ++index) {
+                if (index != 0) { out << ", "; }
+                if (!values[index].name.empty()) { out << values[index].name << ':'; }
+                out << ref('e', values[index].value);
+            }
+            out << ']';
+        }
+
+        void constant(std::ostream &out, const hir::Constant &value) {
+            std::visit(
+                [&](const auto &item) {
+                    using T = std::decay_t<decltype(item)>;
+                    if constexpr (std::is_same_v<T, hir::NullValue>) {
+                        out << "null";
+                    } else if constexpr (std::is_same_v<T, hir::PlaceholderValue>) {
+                        out << '_';
+                    } else if constexpr (std::is_same_v<T, bool>) {
+                        out << (item ? "true" : "false");
+                    } else if constexpr (std::is_same_v<T, std::string>) {
+                        out << std::quoted(item);
+                    } else if constexpr (std::is_same_v<T, syntax::TemporalValue>) {
+                        out << syntax::canonical_spelling(item);
+                    } else {
+                        out << std::setprecision(17) << item;
+                    }
+                },
+                value);
+        }
+
+        class Printer
+        {
+          public:
+            explicit Printer(const hir::Module &module) : module_{module} {}
+
+            std::string run() {
+                out_ << "HIR " << completion_name(module_.completion) << " module " << module_.path << '\n';
+                print_symbols();
+                print_types();
+                print_expressions();
+                print_statements();
+                print_blocks();
+                print_constraints();
+                print_declarations();
+                out_ << "source-order ";
+                refs(out_, 'd', module_.source_order);
+                out_ << '\n';
+                return std::move(out_).str();
+            }
+
+          private:
+            void print_symbols() {
+                out_ << "symbols\n";
+                for (std::size_t index = 0; index < module_.symbols.size(); ++index) {
+                    const hir::Symbol &symbol = module_.symbols[index];
+                    out_ << "  s" << index << ' ' << symbol_kind_name(symbol.kind) << ' ' << symbol.name;
+                    if (!symbol.external_name.empty()) { out_ << " external=" << symbol.external_name; }
+                    out_ << " owner=" << ref('d', symbol.owner) << " type=" << ref('t', symbol.type) << " index=" << symbol.index;
+                    range(out_, symbol.range);
+                    out_ << '\n';
+                }
+            }
+
+            void print_types() {
+                out_ << "types\n";
+                for (std::size_t index = 0; index < module_.types.size(); ++index) {
+                    const hir::Type &type = module_.types[index];
+                    out_ << "  t" << index << ' ' << type_kind_name(type.kind);
+                    if (type.kind == hir::TypeKind::Scalar) { out_ << ' ' << hir::scalar_type_name(type.scalar); }
+                    if (type.symbol.valid()) { out_ << " symbol=" << ref('s', type.symbol); }
+                    if (!type.children.empty()) {
+                        out_ << " children=";
+                        refs(out_, 't', type.children);
+                    }
+                    if (!type.arguments.empty()) {
+                        out_ << " arguments=[";
+                        for (std::size_t argument = 0; argument < type.arguments.size(); ++argument) {
+                            if (argument != 0) { out_ << ", "; }
+                            const hir::TypeArgument &value = type.arguments[argument];
+                            out_ << (value.kind == hir::TypeArgumentKind::Type ? ref('t', value.type) : ref('e', value.value));
+                        }
+                        out_ << ']';
+                    }
+                    if (type.size.valid()) { out_ << " size=" << ref('e', type.size); }
+                    if (type.min_size.valid()) { out_ << " min-size=" << ref('e', type.min_size); }
+                    if (type.unbounded) { out_ << " unbounded"; }
+                    out_ << (type.value_position ? " value" : " signal");
+                    range(out_, type.range);
+                    out_ << '\n';
+                }
+            }
+
+            void print_expressions() {
+                out_ << "expressions\n";
+                for (std::size_t index = 0; index < module_.exprs.size(); ++index) {
+                    const hir::Expr &expression = module_.exprs[index];
+                    out_ << "  e" << index << " type=" << ref('t', expression.type) << " phase=" << phase_name(expression.phase)
+                         << " value=" << value_kind_name(expression.value_kind) << ' ';
+                    std::visit(
+                        [&](const auto &node) {
+                            using T = std::decay_t<decltype(node)>;
+                            if constexpr (std::is_same_v<T, hir::Literal>) {
+                                out_ << "literal ";
+                                constant(out_, node.value);
+                            } else if constexpr (std::is_same_v<T, hir::SymbolRef>) {
+                                out_ << "ref " << ref('s', node.symbol);
+                            } else if constexpr (std::is_same_v<T, hir::Unary>) {
+                                out_ << unary_name(node.op) << ' ' << ref('e', node.operand);
+                            } else if constexpr (std::is_same_v<T, hir::Binary>) {
+                                out_ << binary_name(node.op) << ' ' << ref('e', node.lhs) << ' ' << ref('e', node.rhs);
+                            } else if constexpr (std::is_same_v<T, hir::Call> || std::is_same_v<T, hir::Eval>) {
+                                out_ << (std::is_same_v<T, hir::Call> ? "call " : "eval ") << ref('e', node.callee)
+                                     << " arguments=";
+                                arguments(out_, node.arguments);
+                            } else if constexpr (std::is_same_v<T, hir::Index>) {
+                                out_ << "index " << ref('e', node.target) << ' ' << ref('e', node.index);
+                            } else if constexpr (std::is_same_v<T, hir::Field>) {
+                                out_ << "field " << ref('e', node.target) << '.' << node.name;
+                            } else if constexpr (std::is_same_v<T, hir::Sequence>) {
+                                out_ << "sequence [";
+                                for (std::size_t element = 0; element < node.elements.size(); ++element) {
+                                    if (element != 0) { out_ << ", "; }
+                                    if (node.elements[element].key.valid()) { out_ << ref('e', node.elements[element].key) << ':'; }
+                                    out_ << ref('e', node.elements[element].value);
+                                }
+                                out_ << ']';
+                            } else if constexpr (std::is_same_v<T, hir::Tuple>) {
+                                out_ << "tuple ";
+                                refs(out_, 'e', node.elements);
+                            } else if constexpr (std::is_same_v<T, hir::Lambda>) {
+                                out_ << "lambda parameters=";
+                                refs(out_, 's', node.parameters);
+                                out_ << " result=" << ref('t', node.result) << " body=" << ref('e', node.body);
+                            } else if constexpr (std::is_same_v<T, hir::If>) {
+                                out_ << "if condition=" << ref('e', node.condition) << " then=" << ref('b', node.then_block)
+                                     << " else=" << ref('e', node.otherwise);
+                            } else if constexpr (std::is_same_v<T, hir::BlockExpr>) {
+                                out_ << "block " << ref('b', node.block);
+                            } else if constexpr (std::is_same_v<T, hir::Construct>) {
+                                out_ << (node.delta ? "delta " : "construct ") << ref('t', node.type) << " arguments=";
+                                arguments(out_, node.arguments);
+                            }
+                        },
+                        expression.node);
+                    range(out_, expression.range);
+                    out_ << '\n';
+                }
+            }
+
+            void print_statements() {
+                out_ << "statements\n";
+                for (std::size_t index = 0; index < module_.stmts.size(); ++index) {
+                    const hir::Stmt &statement = module_.stmts[index];
+                    out_ << "  q" << index << ' ';
+                    std::visit(
+                        [&](const auto &node) {
+                            using T = std::decay_t<decltype(node)>;
+                            if constexpr (std::is_same_v<T, hir::LocalDecl>) {
+                                out_ << "local " << ref('s', node.symbol) << " type=" << ref('t', node.type)
+                                     << " init=" << ref('e', node.init);
+                            } else if constexpr (std::is_same_v<T, hir::StateDecl>) {
+                                out_ << "state " << ref('s', node.symbol) << " type=" << ref('t', node.type)
+                                     << " init=" << ref('e', node.init);
+                            } else if constexpr (std::is_same_v<T, hir::InjectDecl>) {
+                                out_ << "inject ";
+                                refs(out_, 's', node.symbols);
+                            } else if constexpr (std::is_same_v<T, hir::LifecycleBlock>) {
+                                out_ << (node.is_stop ? "stop " : "start ") << ref('b', node.block);
+                            } else if constexpr (std::is_same_v<T, hir::WhenStmt>) {
+                                out_ << "when condition=" << ref('e', node.condition) << " block=" << ref('b', node.block);
+                            } else if constexpr (std::is_same_v<T, hir::ForStmt>) {
+                                out_ << "for bindings=";
+                                refs(out_, 's', node.bindings);
+                                out_ << " iterable=" << ref('e', node.iterable) << " block=" << ref('b', node.block);
+                            } else if constexpr (std::is_same_v<T, hir::AssignStmt>) {
+                                out_ << assign_name(node.op) << " place=" << ref('e', node.place)
+                                     << " value=" << ref('e', node.value);
+                            } else if constexpr (std::is_same_v<T, hir::ReturnStmt>) {
+                                out_ << "return " << ref('e', node.value);
+                            } else if constexpr (std::is_same_v<T, hir::AssertStmt>) {
+                                out_ << "assert " << ref('e', node.condition);
+                            } else if constexpr (std::is_same_v<T, hir::ExprStmt>) {
+                                out_ << "expression " << ref('e', node.expr);
+                            }
+                        },
+                        statement.node);
+                    range(out_, statement.range);
+                    out_ << '\n';
+                }
+            }
+
+            void print_blocks() {
+                out_ << "blocks\n";
+                for (std::size_t index = 0; index < module_.blocks.size(); ++index) {
+                    const hir::Block &block = module_.blocks[index];
+                    out_ << "  b" << index << " statements=";
+                    refs(out_, 'q', block.statements);
+                    out_ << " tail=" << ref('e', block.tail);
+                    range(out_, block.range);
+                    out_ << '\n';
+                }
+            }
+
+            void print_constraints() {
+                out_ << "constraints\n";
+                for (std::size_t index = 0; index < module_.constraints.size(); ++index) {
+                    const hir::Constraint &constraint = module_.constraints[index];
+                    out_ << "  c" << index << ' ';
+                    std::visit(
+                        [&](const auto &node) {
+                            using T = std::decay_t<decltype(node)>;
+                            if constexpr (std::is_same_v<T, hir::ConstraintSymbol>) {
+                                out_ << "symbol " << ref('s', node.symbol);
+                            } else if constexpr (std::is_same_v<T, hir::ConstraintType>) {
+                                out_ << "type " << ref('t', node.type);
+                            } else if constexpr (std::is_same_v<T, hir::ConstraintValue>) {
+                                out_ << "value " << ref('e', node.value);
+                            } else if constexpr (std::is_same_v<T, hir::ConstraintSet>) {
+                                out_ << "set ";
+                                refs(out_, 'c', node.elements);
+                            } else if constexpr (std::is_same_v<T, hir::ConstraintCall>) {
+                                out_ << "call " << ref('s', node.function) << " arguments=";
+                                refs(out_, 'c', node.arguments);
+                            } else if constexpr (std::is_same_v<T, hir::OperatorRequirement>) {
+                                out_ << "operator " << ref('s', node.op) << " arguments=";
+                                refs(out_, 'c', node.arguments);
+                                out_ << " result=" << ref('t', node.result);
+                            } else if constexpr (std::is_same_v<T, hir::ConstraintRelation>) {
+                                static constexpr std::string_view names[]{"equal", "in", "is"};
+                                out_ << names[static_cast<std::size_t>(node.op)] << ' ' << ref('c', node.lhs) << ' '
+                                     << ref('c', node.rhs);
+                                if (!node.category.empty()) { out_ << " category=" << node.category; }
+                            } else if constexpr (std::is_same_v<T, hir::ConstraintNot>) {
+                                out_ << "not " << ref('c', node.operand);
+                            } else if constexpr (std::is_same_v<T, hir::ConstraintLogic>) {
+                                out_ << (node.op == hir::ConstraintLogicOp::And ? "and " : "or ") << ref('c', node.lhs) << ' '
+                                     << ref('c', node.rhs);
+                            }
+                        },
+                        constraint.node);
+                    range(out_, constraint.range);
+                    out_ << '\n';
+                }
+            }
+
+            void print_signature(const hir::Signature &signature) {
+                out_ << " parameters=[";
+                for (std::size_t index = 0; index < signature.parameters.size(); ++index) {
+                    if (index != 0) { out_ << ", "; }
+                    const hir::Parameter &parameter = signature.parameters[index];
+                    if (parameter.is_const) { out_ << "const "; }
+                    out_ << ref('s', parameter.symbol) << ':' << ref('t', parameter.type);
+                    if (parameter.default_value.valid()) { out_ << '=' << ref('e', parameter.default_value); }
+                }
+                out_ << "] result=" << ref('t', signature.result);
+            }
+
+            void print_generics(const std::vector<hir::GenericParameter> &generics) {
+                if (generics.empty()) { return; }
+                out_ << " generics=[";
+                for (std::size_t index = 0; index < generics.size(); ++index) {
+                    if (index != 0) { out_ << ", "; }
+                    if (generics[index].is_const) { out_ << "const "; }
+                    out_ << ref('s', generics[index].symbol) << ':' << ref('t', generics[index].type);
+                }
+                out_ << ']';
+            }
+
+            void print_declarations() {
+                out_ << "declarations\n";
+                for (std::size_t index = 0; index < module_.declarations.size(); ++index) {
+                    const hir::Declaration &declaration = module_.declarations[index];
+                    out_ << "  d" << index << " symbol=" << ref('s', declaration.symbol) << ' ';
+                    std::visit(
+                        [&](const auto &node) {
+                            using T = std::decay_t<decltype(node)>;
+                            if constexpr (std::is_same_v<T, hir::ModuleDecl>) {
+                                out_ << "module";
+                            } else if constexpr (std::is_same_v<T, hir::UseDecl>) {
+                                out_ << "use " << node.module;
+                                if (!node.alias.empty()) { out_ << " as " << node.alias; }
+                                if (!node.names.empty()) {
+                                    out_ << " names=[";
+                                    for (std::size_t name = 0; name < node.names.size(); ++name) {
+                                        if (name != 0) { out_ << ", "; }
+                                        out_ << node.names[name];
+                                    }
+                                    out_ << ']';
+                                }
+                            } else if constexpr (std::is_same_v<T, hir::StructDecl>) {
+                                out_ << (node.exported ? "export " : "") << (node.abstract ? "abstract " : "") << "struct";
+                                print_generics(node.generics);
+                                if (!node.parents.empty()) {
+                                    out_ << " parents=";
+                                    refs(out_, 't', node.parents);
+                                }
+                                out_ << " requires=" << ref('c', node.requirements) << " fields=[";
+                                for (std::size_t field = 0; field < node.fields.size(); ++field) {
+                                    if (field != 0) { out_ << ", "; }
+                                    out_ << node.fields[field].name << ':' << ref('t', node.fields[field].type);
+                                    if (node.fields[field].optional) { out_ << '?'; }
+                                    if (node.fields[field].default_value.valid()) {
+                                        out_ << '=' << ref('e', node.fields[field].default_value);
+                                    }
+                                    out_ << '@' << ref('d', node.fields[field].origin);
+                                }
+                                out_ << ']';
+                            } else if constexpr (std::is_same_v<T, hir::OperatorDecl>) {
+                                out_ << "operator";
+                                print_generics(node.generics);
+                                print_signature(node.signature);
+                                out_ << " requires=" << ref('c', node.requirements);
+                            } else if constexpr (std::is_same_v<T, hir::FunctionDecl>) {
+                                static constexpr std::string_view visibility[]{"internal", "export", "impl"};
+                                out_ << visibility[static_cast<std::size_t>(node.visibility)] << ' '
+                                     << (node.kind == hir::FunctionKind::Composition ? "composition" : "runtime") << " function";
+                                print_generics(node.generics);
+                                print_signature(node.signature);
+                                out_ << " requires=" << ref('c', node.requirements) << " concise=" << ref('e', node.concise_body)
+                                     << " block=" << ref('b', node.block_body);
+                            } else if constexpr (std::is_same_v<T, hir::TestDecl>) {
+                                out_ << "test block=" << ref('b', node.block);
+                            }
+                        },
+                        declaration.node);
+                    range(out_, declaration.range);
+                    out_ << '\n';
+                }
+            }
+
+            const hir::Module &module_;
+            std::ostringstream out_{};
+        };
+    }  // namespace
+
+    std::string print_hir(const hir::Module &module) { return Printer{module}.run(); }
+}  // namespace hgl::ir

--- a/language/src/ir/hir_printer.cpp
+++ b/language/src/ir/hir_printer.cpp
@@ -6,6 +6,7 @@
 #include <sstream>
 #include <string_view>
 #include <type_traits>
+#include <utility>
 
 namespace hgl::ir
 {
@@ -50,6 +51,7 @@ namespace hgl::ir
                 case SymbolKind::ImportedOperator: return "imported-operator";
                 case SymbolKind::Intrinsic: return "intrinsic";
             }
+            std::unreachable();
         }
 
         std::string_view type_kind_name(hir::TypeKind kind) noexcept {
@@ -65,6 +67,7 @@ namespace hgl::ir
                 case TypeKind::Atomic: return "atomic";
                 case TypeKind::Deferred: return "deferred";
             }
+            std::unreachable();
         }
 
         std::string_view phase_name(hir::Phase phase) noexcept {
@@ -75,6 +78,7 @@ namespace hgl::ir
                 case Phase::Wiring: return "wiring";
                 case Phase::Runtime: return "runtime";
             }
+            std::unreachable();
         }
 
         std::string_view value_kind_name(hir::ValueKind kind) noexcept {
@@ -90,6 +94,7 @@ namespace hgl::ir
                 case ValueKind::Type: return "type";
                 case ValueKind::Iterator: return "iterator";
             }
+            std::unreachable();
         }
 
         std::string_view unary_name(hir::UnaryOp op) noexcept { return op == hir::UnaryOp::Negate ? "negate" : "not"; }
@@ -111,6 +116,7 @@ namespace hgl::ir
                 case BinaryOp::And: return "and";
                 case BinaryOp::Or: return "or";
             }
+            std::unreachable();
         }
 
         std::string_view assign_name(hir::AssignOp op) noexcept {
@@ -122,6 +128,22 @@ namespace hgl::ir
                 case AssignOp::Mul: return "mul-assign";
                 case AssignOp::Div: return "div-assign";
             }
+            std::unreachable();
+        }
+
+        void string_literal(std::ostream &out, std::string_view value) {
+            out << '"';
+            for (const char character : value) {
+                switch (character) {
+                    case '\\': out << "\\\\"; break;
+                    case '"': out << "\\\""; break;
+                    case '\n': out << "\\n"; break;
+                    case '\r': out << "\\r"; break;
+                    case '\t': out << "\\t"; break;
+                    default: out << character; break;
+                }
+            }
+            out << '"';
         }
 
         void arguments(std::ostream &out, const std::vector<hir::Argument> &values) {
@@ -145,7 +167,7 @@ namespace hgl::ir
                     } else if constexpr (std::is_same_v<T, bool>) {
                         out << (item ? "true" : "false");
                     } else if constexpr (std::is_same_v<T, std::string>) {
-                        out << std::quoted(item);
+                        string_literal(out, item);
                     } else if constexpr (std::is_same_v<T, syntax::TemporalValue>) {
                         out << syntax::canonical_spelling(item);
                     } else {

--- a/language/src/ir/hir_printer.h
+++ b/language/src/ir/hir_printer.h
@@ -1,0 +1,15 @@
+#ifndef HGL_IR_HIR_PRINTER_H
+#define HGL_IR_HIR_PRINTER_H
+
+#include "ir/hir.h"
+
+#include <string>
+
+namespace hgl::ir
+{
+    /// Deterministic, source-ranged diagnostic rendering of the HGL HIR. This
+    /// is a prototype debugging format, not a persisted compatibility format.
+    [[nodiscard]] std::string print_hir(const hir::Module &module);
+}  // namespace hgl::ir
+
+#endif  // HGL_IR_HIR_PRINTER_H

--- a/language/src/ir/lower.cpp
+++ b/language/src/ir/lower.cpp
@@ -41,6 +41,7 @@ namespace hgl::ir
                 case ScalarType::ZonedTime: return hir::ScalarType::ZonedTime;
                 case ScalarType::TimeZone: return hir::ScalarType::TimeZone;
             }
+            std::unreachable();
         }
 
         [[nodiscard]] constexpr hir::TypeKind lower_type_kind(ast::TypeKind kind) noexcept {
@@ -55,6 +56,7 @@ namespace hgl::ir
                 case TypeKind::Rolling: return hir::TypeKind::Rolling;
                 case TypeKind::Atomic: return hir::TypeKind::Atomic;
             }
+            std::unreachable();
         }
 
         [[nodiscard]] constexpr hir::UnaryOp lower_unary_op(ast::UnaryOp op) noexcept {
@@ -62,6 +64,7 @@ namespace hgl::ir
                 case ast::UnaryOp::Negate: return hir::UnaryOp::Negate;
                 case ast::UnaryOp::Not: return hir::UnaryOp::Not;
             }
+            std::unreachable();
         }
 
         [[nodiscard]] constexpr hir::BinaryOp lower_binary_op(ast::BinaryOp op) noexcept {
@@ -81,6 +84,7 @@ namespace hgl::ir
                 case BinaryOp::And: return hir::BinaryOp::And;
                 case BinaryOp::Or: return hir::BinaryOp::Or;
             }
+            std::unreachable();
         }
 
         [[nodiscard]] constexpr hir::AssignOp lower_assign_op(ast::AssignOp op) noexcept {
@@ -92,6 +96,7 @@ namespace hgl::ir
                 case AssignOp::Mul: return hir::AssignOp::Mul;
                 case AssignOp::Div: return hir::AssignOp::Div;
             }
+            std::unreachable();
         }
 
         [[nodiscard]] constexpr hir::ConstraintRelationOp lower_constraint_relation_op(ast::ConstraintRelationOp op) noexcept {
@@ -101,6 +106,7 @@ namespace hgl::ir
                 case ConstraintRelationOp::In: return hir::ConstraintRelationOp::In;
                 case ConstraintRelationOp::Is: return hir::ConstraintRelationOp::Is;
             }
+            std::unreachable();
         }
 
         [[nodiscard]] constexpr hir::ConstraintLogicOp lower_constraint_logic_op(ast::ConstraintLogicOp op) noexcept {
@@ -108,6 +114,7 @@ namespace hgl::ir
                 case ast::ConstraintLogicOp::And: return hir::ConstraintLogicOp::And;
                 case ast::ConstraintLogicOp::Or: return hir::ConstraintLogicOp::Or;
             }
+            std::unreachable();
         }
 
         [[nodiscard]] constexpr hir::Visibility lower_visibility(ast::FunctionVisibility visibility) noexcept {
@@ -116,6 +123,7 @@ namespace hgl::ir
                 case ast::FunctionVisibility::Export: return hir::Visibility::Export;
                 case ast::FunctionVisibility::Impl: return hir::Visibility::Implementation;
             }
+            std::unreachable();
         }
 
         [[nodiscard]] constexpr hir::FunctionKind lower_function_kind(semantics::FunctionKind kind) noexcept {
@@ -123,6 +131,7 @@ namespace hgl::ir
                 case semantics::FunctionKind::Composition: return hir::FunctionKind::Composition;
                 case semantics::FunctionKind::Runtime: return hir::FunctionKind::Runtime;
             }
+            std::unreachable();
         }
 
         class Lowerer
@@ -668,6 +677,7 @@ namespace hgl::ir
                     case TemporalKind::ZonedTime: return hir::ScalarType::ZonedTime;
                     case TemporalKind::TimeZone: return hir::ScalarType::TimeZone;
                 }
+                std::unreachable();
             }
 
             [[nodiscard]] std::vector<hir::Argument> lower_arguments(const std::vector<ast::Argument> &arguments) const {

--- a/language/src/ir/lower.cpp
+++ b/language/src/ir/lower.cpp
@@ -1,0 +1,992 @@
+#include "ir/lower.h"
+
+#include <algorithm>
+#include <optional>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+
+namespace hgl::ir
+{
+    namespace
+    {
+        namespace ast = syntax::ast;
+
+        template <typename To, typename From> [[nodiscard]] To id(From value) noexcept {
+            return value == ast::no_node ? To{} : To{value};
+        }
+
+        [[nodiscard]] std::string join_path(const std::vector<ast::Name> &path) {
+            std::string result;
+            for (const ast::Name &part : path) {
+                if (!result.empty()) { result += '.'; }
+                result += part.text;
+            }
+            return result;
+        }
+
+        [[nodiscard]] constexpr hir::ScalarType lower_scalar_type(ast::ScalarType type) noexcept {
+            using ast::ScalarType;
+            switch (type) {
+                case ScalarType::Bool: return hir::ScalarType::Bool;
+                case ScalarType::I64: return hir::ScalarType::I64;
+                case ScalarType::F64: return hir::ScalarType::F64;
+                case ScalarType::Str: return hir::ScalarType::Str;
+                case ScalarType::Date: return hir::ScalarType::Date;
+                case ScalarType::Time: return hir::ScalarType::Time;
+                case ScalarType::DateTime: return hir::ScalarType::DateTime;
+                case ScalarType::Duration: return hir::ScalarType::Duration;
+                case ScalarType::CivilDateTime: return hir::ScalarType::CivilDateTime;
+                case ScalarType::ZonedDateTime: return hir::ScalarType::ZonedDateTime;
+                case ScalarType::ZonedTime: return hir::ScalarType::ZonedTime;
+                case ScalarType::TimeZone: return hir::ScalarType::TimeZone;
+            }
+        }
+
+        [[nodiscard]] constexpr hir::TypeKind lower_type_kind(ast::TypeKind kind) noexcept {
+            using ast::TypeKind;
+            switch (kind) {
+                case TypeKind::Scalar: return hir::TypeKind::Scalar;
+                case TypeKind::Named: return hir::TypeKind::Symbol;
+                case TypeKind::Tuple: return hir::TypeKind::Tuple;
+                case TypeKind::List: return hir::TypeKind::List;
+                case TypeKind::Set: return hir::TypeKind::Set;
+                case TypeKind::Map: return hir::TypeKind::Map;
+                case TypeKind::Rolling: return hir::TypeKind::Rolling;
+                case TypeKind::Atomic: return hir::TypeKind::Atomic;
+            }
+        }
+
+        [[nodiscard]] constexpr hir::UnaryOp lower_unary_op(ast::UnaryOp op) noexcept {
+            switch (op) {
+                case ast::UnaryOp::Negate: return hir::UnaryOp::Negate;
+                case ast::UnaryOp::Not: return hir::UnaryOp::Not;
+            }
+        }
+
+        [[nodiscard]] constexpr hir::BinaryOp lower_binary_op(ast::BinaryOp op) noexcept {
+            using ast::BinaryOp;
+            switch (op) {
+                case BinaryOp::Mul: return hir::BinaryOp::Mul;
+                case BinaryOp::Div: return hir::BinaryOp::Div;
+                case BinaryOp::Rem: return hir::BinaryOp::Rem;
+                case BinaryOp::Add: return hir::BinaryOp::Add;
+                case BinaryOp::Sub: return hir::BinaryOp::Sub;
+                case BinaryOp::Less: return hir::BinaryOp::Less;
+                case BinaryOp::LessEqual: return hir::BinaryOp::LessEqual;
+                case BinaryOp::Greater: return hir::BinaryOp::Greater;
+                case BinaryOp::GreaterEqual: return hir::BinaryOp::GreaterEqual;
+                case BinaryOp::Equal: return hir::BinaryOp::Equal;
+                case BinaryOp::NotEqual: return hir::BinaryOp::NotEqual;
+                case BinaryOp::And: return hir::BinaryOp::And;
+                case BinaryOp::Or: return hir::BinaryOp::Or;
+            }
+        }
+
+        [[nodiscard]] constexpr hir::AssignOp lower_assign_op(ast::AssignOp op) noexcept {
+            using ast::AssignOp;
+            switch (op) {
+                case AssignOp::Assign: return hir::AssignOp::Assign;
+                case AssignOp::Add: return hir::AssignOp::Add;
+                case AssignOp::Sub: return hir::AssignOp::Sub;
+                case AssignOp::Mul: return hir::AssignOp::Mul;
+                case AssignOp::Div: return hir::AssignOp::Div;
+            }
+        }
+
+        [[nodiscard]] constexpr hir::ConstraintRelationOp lower_constraint_relation_op(ast::ConstraintRelationOp op) noexcept {
+            using ast::ConstraintRelationOp;
+            switch (op) {
+                case ConstraintRelationOp::Equal: return hir::ConstraintRelationOp::Equal;
+                case ConstraintRelationOp::In: return hir::ConstraintRelationOp::In;
+                case ConstraintRelationOp::Is: return hir::ConstraintRelationOp::Is;
+            }
+        }
+
+        [[nodiscard]] constexpr hir::ConstraintLogicOp lower_constraint_logic_op(ast::ConstraintLogicOp op) noexcept {
+            switch (op) {
+                case ast::ConstraintLogicOp::And: return hir::ConstraintLogicOp::And;
+                case ast::ConstraintLogicOp::Or: return hir::ConstraintLogicOp::Or;
+            }
+        }
+
+        [[nodiscard]] constexpr hir::Visibility lower_visibility(ast::FunctionVisibility visibility) noexcept {
+            switch (visibility) {
+                case ast::FunctionVisibility::Internal: return hir::Visibility::Internal;
+                case ast::FunctionVisibility::Export: return hir::Visibility::Export;
+                case ast::FunctionVisibility::Impl: return hir::Visibility::Implementation;
+            }
+        }
+
+        [[nodiscard]] constexpr hir::FunctionKind lower_function_kind(semantics::FunctionKind kind) noexcept {
+            switch (kind) {
+                case semantics::FunctionKind::Composition: return hir::FunctionKind::Composition;
+                case semantics::FunctionKind::Runtime: return hir::FunctionKind::Runtime;
+            }
+        }
+
+        class Lowerer
+        {
+          public:
+            Lowerer(const ast::Module &module, const semantics::ResolvedModule &resolved, syntax::DiagnosticSink &diagnostics)
+                : module_{module}, resolved_{resolved}, diagnostics_{diagnostics} {
+                declaration_symbols_.resize(module_.decls.size());
+                generic_symbols_.resize(module_.decls.size());
+                parameter_symbols_.resize(module_.decls.size());
+                statement_symbols_.resize(module_.stmts.size());
+                lambda_symbols_.resize(module_.exprs.size());
+                type_owners_.resize(module_.types.size(), ast::no_node);
+                expr_owners_.resize(module_.exprs.size(), ast::no_node);
+                stmt_owners_.resize(module_.stmts.size(), ast::no_node);
+            }
+
+            hir::Module run() {
+                result_.path = resolved_.module_path;
+                mark_owners();
+                declare_symbols();
+
+                result_.types.resize(module_.types.size());
+                result_.exprs.resize(module_.exprs.size());
+                result_.stmts.resize(module_.stmts.size());
+                result_.blocks.resize(module_.blocks.size());
+                result_.constraints.resize(module_.constraints.size());
+                result_.declarations.resize(module_.decls.size());
+
+                assign_symbol_types();
+                for (ast::TypeId n = 0; n < module_.types.size(); ++n) { lower_type(n); }
+                for (ast::ConstraintId n = 0; n < module_.constraints.size(); ++n) { lower_constraint(n); }
+                for (ast::ExprId n = 0; n < module_.exprs.size(); ++n) { lower_expr(n); }
+                for (ast::StmtId n = 0; n < module_.stmts.size(); ++n) { lower_stmt(n); }
+                for (ast::BlockId n = 0; n < module_.blocks.size(); ++n) { lower_block(n); }
+                for (ast::DeclId n = 0; n < module_.decls.size(); ++n) { lower_declaration(n); }
+                for (ast::DeclId n : module_.declarations) { result_.source_order.push_back(id<hir::DeclarationId>(n)); }
+                return std::move(result_);
+            }
+
+          private:
+            [[nodiscard]] hir::SymbolId add_symbol(hir::SymbolKind kind, std::string_view name, syntax::SourceRange range,
+                                                   ast::DeclId owner, std::uint32_t index = 0, std::string external_name = {}) {
+                const hir::SymbolId symbol{static_cast<std::uint32_t>(result_.symbols.size())};
+                result_.symbols.push_back(hir::Symbol{
+                    kind, std::string{name}, std::move(external_name), id<hir::DeclarationId>(owner), range, {}, index});
+                return symbol;
+            }
+
+            void mark_owners() {
+                for (ast::DeclId decl = 0; decl < module_.decls.size(); ++decl) { mark_declaration(decl); }
+            }
+
+            void mark_type(ast::TypeId type, ast::DeclId owner) {
+                if (type == ast::no_node) { return; }
+                type_owners_[type]    = owner;
+                const ast::Type &node = module_.type(type);
+                for (ast::TypeId child : node.children) { mark_type(child, owner); }
+                for (const ast::GenericArgument &argument : node.arguments) {
+                    mark_type(argument.type, owner);
+                    mark_expr(argument.value, owner);
+                }
+                mark_expr(node.size, owner);
+                mark_expr(node.min_size, owner);
+            }
+
+            void mark_expr(ast::ExprId expression, ast::DeclId owner) {
+                if (expression == ast::no_node) { return; }
+                expr_owners_[expression] = owner;
+                std::visit(
+                    [&](const auto &node) {
+                        using T = std::decay_t<decltype(node)>;
+                        if constexpr (std::is_same_v<T, ast::Unary>) {
+                            mark_expr(node.operand, owner);
+                        } else if constexpr (std::is_same_v<T, ast::Binary>) {
+                            mark_expr(node.lhs, owner);
+                            mark_expr(node.rhs, owner);
+                        } else if constexpr (std::is_same_v<T, ast::Call> || std::is_same_v<T, ast::Eval>) {
+                            mark_expr(node.callee, owner);
+                            for (const ast::Argument &argument : node.arguments) { mark_expr(argument.value, owner); }
+                        } else if constexpr (std::is_same_v<T, ast::Index>) {
+                            mark_expr(node.target, owner);
+                            mark_expr(node.index, owner);
+                        } else if constexpr (std::is_same_v<T, ast::Field>) {
+                            mark_expr(node.target, owner);
+                        } else if constexpr (std::is_same_v<T, ast::SequenceLiteral>) {
+                            for (const ast::SequenceElement &element : node.elements) {
+                                mark_expr(element.key, owner);
+                                mark_expr(element.value, owner);
+                            }
+                        } else if constexpr (std::is_same_v<T, ast::TupleLiteral>) {
+                            for (ast::ExprId element : node.elements) { mark_expr(element, owner); }
+                        } else if constexpr (std::is_same_v<T, ast::AnonymousFn>) {
+                            for (const ast::AnonymousParameter &parameter : node.parameters) { mark_type(parameter.type, owner); }
+                            mark_type(node.result, owner);
+                            mark_expr(node.body, owner);
+                        } else if constexpr (std::is_same_v<T, ast::If>) {
+                            mark_expr(node.condition, owner);
+                            mark_block(node.then_block, owner);
+                            mark_expr(node.otherwise, owner);
+                        } else if constexpr (std::is_same_v<T, ast::BlockExpr>) {
+                            mark_block(node.block, owner);
+                        } else if constexpr (std::is_same_v<T, ast::Construct>) {
+                            mark_type(node.type, owner);
+                            for (const ast::Argument &argument : node.arguments) { mark_expr(argument.value, owner); }
+                        }
+                    },
+                    module_.expr(expression).node);
+            }
+
+            void mark_stmt(ast::StmtId statement, ast::DeclId owner) {
+                stmt_owners_[statement] = owner;
+                std::visit(
+                    [&](const auto &node) {
+                        using T = std::decay_t<decltype(node)>;
+                        if constexpr (std::is_same_v<T, ast::LocalDecl> || std::is_same_v<T, ast::StateDecl>) {
+                            mark_type(node.type, owner);
+                            mark_expr(node.init, owner);
+                        } else if constexpr (std::is_same_v<T, ast::LifecycleBlock>) {
+                            mark_block(node.block, owner);
+                        } else if constexpr (std::is_same_v<T, ast::WhenStmt>) {
+                            mark_expr(node.condition, owner);
+                            mark_block(node.block, owner);
+                        } else if constexpr (std::is_same_v<T, ast::ForStmt>) {
+                            mark_expr(node.iterable, owner);
+                            mark_block(node.block, owner);
+                        } else if constexpr (std::is_same_v<T, ast::AssignStmt>) {
+                            mark_expr(node.place, owner);
+                            mark_expr(node.value, owner);
+                        } else if constexpr (std::is_same_v<T, ast::ReturnStmt>) {
+                            mark_expr(node.value, owner);
+                        } else if constexpr (std::is_same_v<T, ast::AssertStmt>) {
+                            mark_expr(node.condition, owner);
+                        } else if constexpr (std::is_same_v<T, ast::ExprStmt>) {
+                            mark_expr(node.expr, owner);
+                        }
+                    },
+                    module_.stmt(statement).node);
+            }
+
+            void mark_block(ast::BlockId block, ast::DeclId owner) {
+                if (block == ast::no_node) { return; }
+                for (ast::StmtId statement : module_.block(block).statements) { mark_stmt(statement, owner); }
+            }
+
+            void mark_constraint(ast::ConstraintId constraint, ast::DeclId owner) {
+                if (constraint == ast::no_node) { return; }
+                std::visit(
+                    [&](const auto &node) {
+                        using T = std::decay_t<decltype(node)>;
+                        if constexpr (std::is_same_v<T, ast::ConstraintType>) {
+                            mark_type(node.type, owner);
+                        } else if constexpr (std::is_same_v<T, ast::ConstraintValue>) {
+                            mark_expr(node.value, owner);
+                        } else if constexpr (std::is_same_v<T, ast::ConstraintSet>) {
+                            for (ast::ConstraintId element : node.elements) { mark_constraint(element, owner); }
+                        } else if constexpr (std::is_same_v<T, ast::ConstraintCall>) {
+                            for (ast::ConstraintId argument : node.arguments) { mark_constraint(argument, owner); }
+                        } else if constexpr (std::is_same_v<T, ast::OperatorRequirement>) {
+                            for (ast::ConstraintId argument : node.arguments) { mark_constraint(argument, owner); }
+                            mark_type(node.result, owner);
+                        } else if constexpr (std::is_same_v<T, ast::ConstraintRelation> ||
+                                             std::is_same_v<T, ast::ConstraintLogic>) {
+                            mark_constraint(node.lhs, owner);
+                            mark_constraint(node.rhs, owner);
+                        } else if constexpr (std::is_same_v<T, ast::ConstraintNot>) {
+                            mark_constraint(node.operand, owner);
+                        }
+                    },
+                    module_.constraint(constraint).node);
+            }
+
+            void mark_signature(const ast::Signature &signature, ast::DeclId owner) {
+                for (const ast::Parameter &parameter : signature.parameters) {
+                    mark_type(parameter.type, owner);
+                    mark_expr(parameter.default_value, owner);
+                }
+                mark_type(signature.result, owner);
+            }
+
+            void mark_generics(const std::vector<ast::GenericParameter> &generics, ast::DeclId owner) {
+                for (const ast::GenericParameter &generic : generics) { mark_type(generic.type, owner); }
+            }
+
+            void mark_declaration(ast::DeclId declaration) {
+                std::visit(
+                    [&](const auto &node) {
+                        using T = std::decay_t<decltype(node)>;
+                        if constexpr (std::is_same_v<T, ast::StructDecl>) {
+                            mark_generics(node.generics, declaration);
+                            for (ast::TypeId parent : node.parents) { mark_type(parent, declaration); }
+                            mark_constraint(node.requirements, declaration);
+                            for (const ast::StructMember &member : node.members) {
+                                std::visit(
+                                    [&](const auto &item) {
+                                        using M = std::decay_t<decltype(item)>;
+                                        if constexpr (std::is_same_v<M, ast::StructField>) {
+                                            mark_type(item.type, declaration);
+                                            mark_expr(item.default_value, declaration);
+                                        } else {
+                                            mark_expr(item.value, declaration);
+                                        }
+                                    },
+                                    member);
+                            }
+                        } else if constexpr (std::is_same_v<T, ast::OperatorDecl>) {
+                            mark_generics(node.generics, declaration);
+                            mark_signature(node.signature, declaration);
+                            mark_constraint(node.requirements, declaration);
+                        } else if constexpr (std::is_same_v<T, ast::FunctionDecl>) {
+                            mark_generics(node.generics, declaration);
+                            mark_signature(node.signature, declaration);
+                            mark_constraint(node.requirements, declaration);
+                            mark_expr(node.concise_body, declaration);
+                            mark_block(node.block_body, declaration);
+                        } else if constexpr (std::is_same_v<T, ast::TestDecl>) {
+                            mark_block(node.block, declaration);
+                        }
+                    },
+                    module_.decl(declaration).node);
+            }
+
+            void declare_symbols() {
+                for (ast::DeclId declaration = 0; declaration < module_.decls.size(); ++declaration) {
+                    std::visit(
+                        [&](const auto &node) {
+                            using T = std::decay_t<decltype(node)>;
+                            if constexpr (std::is_same_v<T, ast::ModuleDecl>) {
+                                declaration_symbols_[declaration] = add_symbol(hir::SymbolKind::Module, join_path(node.path),
+                                                                               module_.decl(declaration).range, declaration);
+                            } else if constexpr (std::is_same_v<T, ast::StructDecl>) {
+                                declaration_symbols_[declaration] =
+                                    add_symbol(hir::SymbolKind::Struct, node.name.text, node.name.range, declaration);
+                                global_symbols_.emplace(std::string{node.name.text}, declaration_symbols_[declaration]);
+                                declare_generics(declaration, node.generics);
+                            } else if constexpr (std::is_same_v<T, ast::OperatorDecl>) {
+                                declaration_symbols_[declaration] =
+                                    add_symbol(hir::SymbolKind::Operator, node.name.text, node.name.range, declaration);
+                                global_symbols_.emplace(std::string{node.name.text}, declaration_symbols_[declaration]);
+                                declare_generics(declaration, node.generics);
+                                declare_parameters(declaration, node.signature.parameters);
+                            } else if constexpr (std::is_same_v<T, ast::FunctionDecl>) {
+                                declaration_symbols_[declaration] =
+                                    add_symbol(hir::SymbolKind::Function, node.name.text, node.name.range, declaration);
+                                global_symbols_.emplace(std::string{node.name.text}, declaration_symbols_[declaration]);
+                                declare_generics(declaration, node.generics);
+                                declare_parameters(declaration, node.signature.parameters);
+                            } else if constexpr (std::is_same_v<T, ast::TestDecl>) {
+                                declaration_symbols_[declaration] =
+                                    add_symbol(hir::SymbolKind::Test, node.name.text, node.name.range, declaration);
+                                global_symbols_.emplace(std::string{node.name.text}, declaration_symbols_[declaration]);
+                            }
+                        },
+                        module_.decl(declaration).node);
+                }
+
+                for (ast::StmtId statement = 0; statement < module_.stmts.size(); ++statement) {
+                    const ast::DeclId owner = stmt_owners_[statement];
+                    std::visit(
+                        [&](const auto &node) {
+                            using T = std::decay_t<decltype(node)>;
+                            if constexpr (std::is_same_v<T, ast::LocalDecl>) {
+                                statement_symbols_[statement].push_back(
+                                    add_symbol(node.mutable_ ? hir::SymbolKind::LocalVar : hir::SymbolKind::LocalLet,
+                                               node.name.text, node.name.range, owner));
+                            } else if constexpr (std::is_same_v<T, ast::StateDecl>) {
+                                statement_symbols_[statement].push_back(
+                                    add_symbol(hir::SymbolKind::State, node.name.text, node.name.range, owner));
+                            } else if constexpr (std::is_same_v<T, ast::InjectDecl>) {
+                                for (const ast::Name &name : node.names) {
+                                    statement_symbols_[statement].push_back(
+                                        add_symbol(hir::SymbolKind::InjectedCapability, name.text, name.range, owner));
+                                }
+                            } else if constexpr (std::is_same_v<T, ast::ForStmt>) {
+                                statement_symbols_[statement].push_back(
+                                    add_symbol(hir::SymbolKind::LoopValue, node.first.text, node.first.range, owner, 0));
+                                if (!node.second.empty()) {
+                                    statement_symbols_[statement].push_back(
+                                        add_symbol(hir::SymbolKind::LoopValue, node.second.text, node.second.range, owner, 1));
+                                }
+                            }
+                        },
+                        module_.stmt(statement).node);
+                }
+
+                for (ast::ExprId expression = 0; expression < module_.exprs.size(); ++expression) {
+                    if (const auto *lambda = std::get_if<ast::AnonymousFn>(&module_.expr(expression).node)) {
+                        for (std::size_t index = 0; index < lambda->parameters.size(); ++index) {
+                            const ast::AnonymousParameter &parameter = lambda->parameters[index];
+                            lambda_symbols_[expression].push_back(add_symbol(hir::SymbolKind::LambdaParameter, parameter.name.text,
+                                                                             parameter.name.range, expr_owners_[expression],
+                                                                             static_cast<std::uint32_t>(index)));
+                        }
+                    }
+                }
+            }
+
+            void declare_generics(ast::DeclId owner, const std::vector<ast::GenericParameter> &generics) {
+                generic_symbols_[owner].reserve(generics.size());
+                for (std::size_t index = 0; index < generics.size(); ++index) {
+                    const ast::GenericParameter &generic = generics[index];
+                    generic_symbols_[owner].push_back(
+                        add_symbol(generic.is_const ? hir::SymbolKind::ConstParameter : hir::SymbolKind::TypeParameter,
+                                   generic.name.text, generic.name.range, owner, static_cast<std::uint32_t>(index)));
+                }
+            }
+
+            void declare_parameters(ast::DeclId owner, const std::vector<ast::Parameter> &parameters) {
+                parameter_symbols_[owner].reserve(parameters.size());
+                for (std::size_t index = 0; index < parameters.size(); ++index) {
+                    const ast::Parameter &parameter = parameters[index];
+                    parameter_symbols_[owner].push_back(
+                        add_symbol(parameter.is_const ? hir::SymbolKind::ConstParameter : hir::SymbolKind::SignalParameter,
+                                   parameter.name.text, parameter.name.range, owner, static_cast<std::uint32_t>(index)));
+                }
+            }
+
+            void assign_symbol_types() {
+                for (ast::DeclId declaration = 0; declaration < module_.decls.size(); ++declaration) {
+                    std::visit(
+                        [&](const auto &node) {
+                            using T = std::decay_t<decltype(node)>;
+                            if constexpr (std::is_same_v<T, ast::StructDecl> || std::is_same_v<T, ast::OperatorDecl> ||
+                                          std::is_same_v<T, ast::FunctionDecl>) {
+                                for (std::size_t index = 0; index < node.generics.size(); ++index) {
+                                    result_.symbols[generic_symbols_[declaration][index].value].type =
+                                        id<hir::TypeId>(node.generics[index].type);
+                                }
+                            }
+                            if constexpr (std::is_same_v<T, ast::OperatorDecl> || std::is_same_v<T, ast::FunctionDecl>) {
+                                for (std::size_t index = 0; index < node.signature.parameters.size(); ++index) {
+                                    result_.symbols[parameter_symbols_[declaration][index].value].type =
+                                        id<hir::TypeId>(node.signature.parameters[index].type);
+                                }
+                            }
+                        },
+                        module_.decl(declaration).node);
+                }
+                for (ast::StmtId statement = 0; statement < module_.stmts.size(); ++statement) {
+                    std::visit(
+                        [&](const auto &node) {
+                            using T = std::decay_t<decltype(node)>;
+                            if constexpr (std::is_same_v<T, ast::LocalDecl> || std::is_same_v<T, ast::StateDecl>) {
+                                result_.symbols[statement_symbols_[statement].front().value].type = id<hir::TypeId>(node.type);
+                            }
+                        },
+                        module_.stmt(statement).node);
+                }
+                for (ast::ExprId expression = 0; expression < module_.exprs.size(); ++expression) {
+                    if (const auto *lambda = std::get_if<ast::AnonymousFn>(&module_.expr(expression).node)) {
+                        for (std::size_t index = 0; index < lambda->parameters.size(); ++index) {
+                            result_.symbols[lambda_symbols_[expression][index].value].type =
+                                id<hir::TypeId>(lambda->parameters[index].type);
+                        }
+                    }
+                }
+            }
+
+            [[nodiscard]] hir::SymbolId external_symbol(hir::SymbolKind kind, std::string_view name, std::string_view external_name,
+                                                        syntax::SourceRange range) {
+                const std::string key = std::to_string(static_cast<unsigned>(kind)) + ':' + std::string{external_name};
+                if (const auto found = external_symbols_.find(key); found != external_symbols_.end()) { return found->second; }
+                const hir::SymbolId symbol = add_symbol(kind, name, range, ast::no_node, 0, std::string{external_name});
+                external_symbols_.emplace(key, symbol);
+                return symbol;
+            }
+
+            [[nodiscard]] hir::SymbolId symbol_for(const semantics::Binding &binding, syntax::SourceRange range,
+                                                   std::string_view spelling) {
+                using semantics::BindingKind;
+                switch (binding.kind) {
+                    case BindingKind::Local:
+                        if (binding.stmt < statement_symbols_.size()) {
+                            const auto       &symbols = statement_symbols_[binding.stmt];
+                            const std::size_t index   = binding.second ? 1U : binding.index;
+                            if (index < symbols.size()) { return symbols[index]; }
+                        }
+                        break;
+                    case BindingKind::Parameter:
+                        if (binding.decl == ast::no_node && binding.stmt < lambda_symbols_.size() &&
+                            binding.index < lambda_symbols_[binding.stmt].size()) {
+                            return lambda_symbols_[binding.stmt][binding.index];
+                        }
+                        if (binding.decl < parameter_symbols_.size() && binding.index < parameter_symbols_[binding.decl].size()) {
+                            return parameter_symbols_[binding.decl][binding.index];
+                        }
+                        break;
+                    case BindingKind::Generic:
+                        if (binding.decl < generic_symbols_.size() && binding.index < generic_symbols_[binding.decl].size()) {
+                            return generic_symbols_[binding.decl][binding.index];
+                        }
+                        break;
+                    case BindingKind::Struct:
+                    case BindingKind::Function:
+                    case BindingKind::LocalOperator:
+                    case BindingKind::Test:
+                        if (binding.decl < declaration_symbols_.size()) { return declaration_symbols_[binding.decl]; }
+                        break;
+                    case BindingKind::Operator:
+                        return external_symbol(hir::SymbolKind::ImportedOperator, spelling, binding.registry_name, range);
+                    case BindingKind::Intrinsic:
+                        return external_symbol(hir::SymbolKind::Intrinsic, spelling, binding.registry_name, range);
+                    case BindingKind::Unbound: break;
+                }
+                diagnostics_.report(syntax::Category::Name, range,
+                                    "cannot form HIR identity for resolved name '" + std::string{spelling} + "'");
+                return {};
+            }
+
+            [[nodiscard]] std::optional<hir::SymbolId> lexical_symbol(ast::DeclId owner, std::string_view name,
+                                                                      bool want_const) const {
+                if (owner != ast::no_node && owner < generic_symbols_.size()) {
+                    const ast::DeclNode                      &declaration = module_.decl(owner).node;
+                    const std::vector<ast::GenericParameter> *generics    = nullptr;
+                    if (const auto *node = std::get_if<ast::StructDecl>(&declaration)) {
+                        generics = &node->generics;
+                    } else if (const auto *node = std::get_if<ast::OperatorDecl>(&declaration)) {
+                        generics = &node->generics;
+                    } else if (const auto *node = std::get_if<ast::FunctionDecl>(&declaration)) {
+                        generics = &node->generics;
+                    }
+                    if (generics) {
+                        for (std::size_t index = 0; index < generics->size(); ++index) {
+                            if ((*generics)[index].name.text == name && (*generics)[index].is_const == want_const) {
+                                return generic_symbols_[owner][index];
+                            }
+                        }
+                    }
+                }
+                if (!want_const) {
+                    if (const auto found = global_symbols_.find(std::string{name}); found != global_symbols_.end()) {
+                        return found->second;
+                    }
+                }
+                return std::nullopt;
+            }
+
+            [[nodiscard]] hir::ExprId synthesized_ref(hir::SymbolId symbol, syntax::SourceRange range) {
+                const hir::ExprId result{static_cast<std::uint32_t>(result_.exprs.size())};
+                hir::ValueKind    value_kind = hir::ValueKind::Unknown;
+                hir::Phase        phase      = hir::Phase::Unknown;
+                if (symbol.valid()) {
+                    const hir::SymbolKind kind = result_.symbol(symbol).kind;
+                    if (kind == hir::SymbolKind::ConstParameter) {
+                        value_kind = hir::ValueKind::Constant;
+                        phase      = hir::Phase::Constant;
+                    } else if (kind == hir::SymbolKind::TypeParameter || kind == hir::SymbolKind::Struct) {
+                        value_kind = hir::ValueKind::Type;
+                    }
+                }
+                result_.exprs.push_back(hir::Expr{range, symbol.valid() ? result_.symbol(symbol).type : hir::no_type, phase,
+                                                  value_kind, hir::SymbolRef{symbol}});
+                return result;
+            }
+
+            [[nodiscard]] hir::TypeId synthesized_symbol_type(hir::SymbolId symbol, syntax::SourceRange range) {
+                const hir::TypeId result{static_cast<std::uint32_t>(result_.types.size())};
+                hir::Type         type;
+                type.kind           = hir::TypeKind::Symbol;
+                type.range          = range;
+                type.symbol         = symbol;
+                type.value_position = true;
+                result_.types.push_back(std::move(type));
+                return result;
+            }
+
+            void lower_type(ast::TypeId index) {
+                const ast::Type &source = module_.type(index);
+                hir::Type        target;
+                target.kind           = lower_type_kind(source.kind);
+                target.range          = source.range;
+                target.scalar         = lower_scalar_type(source.scalar);
+                target.unbounded      = source.unbounded;
+                target.value_position = source.value_position;
+                for (ast::TypeId child : source.children) { target.children.push_back(id<hir::TypeId>(child)); }
+                target.size     = id<hir::ExprId>(source.size);
+                target.min_size = id<hir::ExprId>(source.min_size);
+                if (source.kind == ast::TypeKind::Named) {
+                    target.kind   = hir::TypeKind::Symbol;
+                    target.symbol = symbol_for(resolved_.type_binding(index), source.name.range, source.name.text);
+                }
+                for (std::size_t argument_index = 0; argument_index < source.arguments.size(); ++argument_index) {
+                    const ast::GenericArgument &argument = source.arguments[argument_index];
+                    hir::TypeArgument           lowered;
+                    lowered.range = argument.range;
+                    if (argument.type != ast::no_node) {
+                        lowered.kind = hir::TypeArgumentKind::Type;
+                        lowered.type = id<hir::TypeId>(argument.type);
+                    } else if (argument.value != ast::no_node) {
+                        lowered.kind  = hir::TypeArgumentKind::Value;
+                        lowered.value = id<hir::ExprId>(argument.value);
+                    } else {
+                        bool want_const = false;
+                        if (source.kind == ast::TypeKind::Named) {
+                            const semantics::Binding &binding = resolved_.type_binding(index);
+                            if (binding.kind == semantics::BindingKind::Struct) {
+                                const auto &generics = std::get<ast::StructDecl>(module_.decl(binding.decl).node).generics;
+                                if (argument_index < generics.size()) { want_const = generics[argument_index].is_const; }
+                            }
+                        }
+                        const std::optional<hir::SymbolId> symbol =
+                            lexical_symbol(type_owners_[index], argument.name.text, want_const);
+                        if (!symbol) {
+                            diagnostics_.report(syntax::Category::Name, argument.name.range,
+                                                "cannot form HIR identity for generic argument '" +
+                                                    std::string{argument.name.text} + "'");
+                        }
+                        if (want_const) {
+                            lowered.kind  = hir::TypeArgumentKind::Value;
+                            lowered.value = synthesized_ref(symbol.value_or(hir::no_symbol), argument.range);
+                        } else {
+                            lowered.kind = hir::TypeArgumentKind::Type;
+                            lowered.type = synthesized_symbol_type(symbol.value_or(hir::no_symbol), argument.range);
+                        }
+                    }
+                    target.arguments.push_back(lowered);
+                }
+                result_.types[index] = std::move(target);
+            }
+
+            [[nodiscard]] hir::TypeId literal_type(hir::ScalarType scalar) {
+                const auto key = static_cast<std::uint8_t>(scalar);
+                if (const auto found = literal_types_.find(key); found != literal_types_.end()) { return found->second; }
+                const hir::TypeId result{static_cast<std::uint32_t>(result_.types.size())};
+                hir::Type         type;
+                type.kind           = hir::TypeKind::Scalar;
+                type.scalar         = scalar;
+                type.value_position = true;
+                result_.types.push_back(type);
+                literal_types_.emplace(key, result);
+                return result;
+            }
+
+            [[nodiscard]] static hir::ScalarType temporal_type(syntax::TemporalKind kind) noexcept {
+                using syntax::TemporalKind;
+                switch (kind) {
+                    case TemporalKind::Date: return hir::ScalarType::Date;
+                    case TemporalKind::Time: return hir::ScalarType::Time;
+                    case TemporalKind::DateTime: return hir::ScalarType::DateTime;
+                    case TemporalKind::Duration: return hir::ScalarType::Duration;
+                    case TemporalKind::CivilDateTime: return hir::ScalarType::CivilDateTime;
+                    case TemporalKind::ZonedDateTime: return hir::ScalarType::ZonedDateTime;
+                    case TemporalKind::ZonedTime: return hir::ScalarType::ZonedTime;
+                    case TemporalKind::TimeZone: return hir::ScalarType::TimeZone;
+                }
+            }
+
+            [[nodiscard]] std::vector<hir::Argument> lower_arguments(const std::vector<ast::Argument> &arguments) const {
+                std::vector<hir::Argument> result;
+                result.reserve(arguments.size());
+                for (const ast::Argument &argument : arguments) {
+                    result.push_back(
+                        hir::Argument{std::string{argument.name.text}, id<hir::ExprId>(argument.value),
+                                      argument.name.empty() ? module_.expr(argument.value).range : argument.name.range});
+                }
+                return result;
+            }
+
+            void lower_expr(ast::ExprId index) {
+                const ast::Expr &source = module_.expr(index);
+                hir::Expr        target;
+                target.range = source.range;
+                std::visit(
+                    [&](const auto &node) {
+                        using T = std::decay_t<decltype(node)>;
+                        if constexpr (std::is_same_v<T, ast::IntLiteral>) {
+                            target.node       = hir::Literal{node.value};
+                            target.type       = literal_type(hir::ScalarType::I64);
+                            target.phase      = hir::Phase::Constant;
+                            target.value_kind = hir::ValueKind::Constant;
+                        } else if constexpr (std::is_same_v<T, ast::FloatLiteral>) {
+                            target.node       = hir::Literal{node.value};
+                            target.type       = literal_type(hir::ScalarType::F64);
+                            target.phase      = hir::Phase::Constant;
+                            target.value_kind = hir::ValueKind::Constant;
+                        } else if constexpr (std::is_same_v<T, ast::StringLiteral>) {
+                            target.node       = hir::Literal{node.value};
+                            target.type       = literal_type(hir::ScalarType::Str);
+                            target.phase      = hir::Phase::Constant;
+                            target.value_kind = hir::ValueKind::Constant;
+                        } else if constexpr (std::is_same_v<T, ast::BoolLiteral>) {
+                            target.node       = hir::Literal{node.value};
+                            target.type       = literal_type(hir::ScalarType::Bool);
+                            target.phase      = hir::Phase::Constant;
+                            target.value_kind = hir::ValueKind::Constant;
+                        } else if constexpr (std::is_same_v<T, ast::NullLiteral>) {
+                            target.node       = hir::Literal{hir::NullValue{}};
+                            target.phase      = hir::Phase::Constant;
+                            target.value_kind = hir::ValueKind::Constant;
+                        } else if constexpr (std::is_same_v<T, ast::TemporalLiteral>) {
+                            target.node       = hir::Literal{node.value};
+                            target.type       = literal_type(temporal_type(node.value.kind));
+                            target.phase      = hir::Phase::Constant;
+                            target.value_kind = hir::ValueKind::Constant;
+                        } else if constexpr (std::is_same_v<T, ast::Placeholder>) {
+                            target.node = hir::Literal{hir::PlaceholderValue{}};
+                        } else if constexpr (std::is_same_v<T, ast::NameRef>) {
+                            target.node = hir::SymbolRef{symbol_for(resolved_.binding(index), node.name.range, node.name.text)};
+                        } else if constexpr (std::is_same_v<T, ast::QualifiedRef>) {
+                            target.node = hir::SymbolRef{symbol_for(resolved_.binding(index), node.name.range, node.name.text)};
+                        } else if constexpr (std::is_same_v<T, ast::Unary>) {
+                            target.node = hir::Unary{lower_unary_op(node.op), id<hir::ExprId>(node.operand)};
+                        } else if constexpr (std::is_same_v<T, ast::Binary>) {
+                            target.node =
+                                hir::Binary{lower_binary_op(node.op), id<hir::ExprId>(node.lhs), id<hir::ExprId>(node.rhs)};
+                        } else if constexpr (std::is_same_v<T, ast::Call>) {
+                            target.node = hir::Call{id<hir::ExprId>(node.callee), lower_arguments(node.arguments)};
+                        } else if constexpr (std::is_same_v<T, ast::Index>) {
+                            target.node = hir::Index{id<hir::ExprId>(node.target), id<hir::ExprId>(node.index)};
+                        } else if constexpr (std::is_same_v<T, ast::Field>) {
+                            target.node = hir::Field{id<hir::ExprId>(node.target), std::string{node.field.text}, node.field.range};
+                        } else if constexpr (std::is_same_v<T, ast::SequenceLiteral>) {
+                            hir::Sequence sequence;
+                            for (const ast::SequenceElement &element : node.elements) {
+                                sequence.elements.push_back(
+                                    hir::SequenceElement{id<hir::ExprId>(element.key), id<hir::ExprId>(element.value)});
+                            }
+                            target.node = std::move(sequence);
+                        } else if constexpr (std::is_same_v<T, ast::TupleLiteral>) {
+                            hir::Tuple tuple;
+                            for (ast::ExprId element : node.elements) { tuple.elements.push_back(id<hir::ExprId>(element)); }
+                            target.node = std::move(tuple);
+                        } else if constexpr (std::is_same_v<T, ast::AnonymousFn>) {
+                            target.node =
+                                hir::Lambda{lambda_symbols_[index], id<hir::TypeId>(node.result), id<hir::ExprId>(node.body)};
+                            target.value_kind = hir::ValueKind::Function;
+                        } else if constexpr (std::is_same_v<T, ast::If>) {
+                            target.node = hir::If{id<hir::ExprId>(node.condition), id<hir::BlockId>(node.then_block),
+                                                  id<hir::ExprId>(node.otherwise)};
+                        } else if constexpr (std::is_same_v<T, ast::BlockExpr>) {
+                            target.node = hir::BlockExpr{id<hir::BlockId>(node.block)};
+                        } else if constexpr (std::is_same_v<T, ast::Eval>) {
+                            target.node = hir::Eval{id<hir::ExprId>(node.callee), lower_arguments(node.arguments)};
+                        } else if constexpr (std::is_same_v<T, ast::Construct>) {
+                            target.node = hir::Construct{id<hir::TypeId>(node.type), lower_arguments(node.arguments), node.delta};
+                        }
+                    },
+                    source.node);
+                if (const auto *reference = std::get_if<hir::SymbolRef>(&target.node); reference && reference->symbol.valid()) {
+                    const hir::Symbol &symbol = result_.symbol(reference->symbol);
+                    target.type               = symbol.type;
+                    switch (symbol.kind) {
+                        case hir::SymbolKind::ConstParameter:
+                            target.phase      = hir::Phase::Constant;
+                            target.value_kind = hir::ValueKind::Constant;
+                            break;
+                        case hir::SymbolKind::SignalParameter:
+                            target.phase      = hir::Phase::Wiring;
+                            target.value_kind = hir::ValueKind::Signal;
+                            break;
+                        case hir::SymbolKind::Function: target.value_kind = hir::ValueKind::Function; break;
+                        case hir::SymbolKind::Operator:
+                        case hir::SymbolKind::ImportedOperator: target.value_kind = hir::ValueKind::Operator; break;
+                        case hir::SymbolKind::Struct:
+                        case hir::SymbolKind::TypeParameter: target.value_kind = hir::ValueKind::Type; break;
+                        default: break;
+                    }
+                }
+                result_.exprs[index] = std::move(target);
+            }
+
+            void lower_stmt(ast::StmtId index) {
+                const ast::Stmt &source = module_.stmt(index);
+                hir::Stmt        target;
+                target.range = source.range;
+                std::visit(
+                    [&](const auto &node) {
+                        using T = std::decay_t<decltype(node)>;
+                        if constexpr (std::is_same_v<T, ast::LocalDecl>) {
+                            target.node = hir::LocalDecl{statement_symbols_[index].front(), id<hir::TypeId>(node.type),
+                                                         id<hir::ExprId>(node.init)};
+                        } else if constexpr (std::is_same_v<T, ast::StateDecl>) {
+                            target.node = hir::StateDecl{statement_symbols_[index].front(), id<hir::TypeId>(node.type),
+                                                         id<hir::ExprId>(node.init)};
+                        } else if constexpr (std::is_same_v<T, ast::InjectDecl>) {
+                            target.node = hir::InjectDecl{statement_symbols_[index]};
+                        } else if constexpr (std::is_same_v<T, ast::LifecycleBlock>) {
+                            target.node = hir::LifecycleBlock{node.is_stop, id<hir::BlockId>(node.block)};
+                        } else if constexpr (std::is_same_v<T, ast::WhenStmt>) {
+                            target.node = hir::WhenStmt{id<hir::ExprId>(node.condition), id<hir::BlockId>(node.block)};
+                        } else if constexpr (std::is_same_v<T, ast::ForStmt>) {
+                            target.node = hir::ForStmt{statement_symbols_[index], id<hir::ExprId>(node.iterable),
+                                                       id<hir::BlockId>(node.block)};
+                        } else if constexpr (std::is_same_v<T, ast::AssignStmt>) {
+                            target.node =
+                                hir::AssignStmt{lower_assign_op(node.op), id<hir::ExprId>(node.place), id<hir::ExprId>(node.value)};
+                        } else if constexpr (std::is_same_v<T, ast::ReturnStmt>) {
+                            target.node = hir::ReturnStmt{id<hir::ExprId>(node.value)};
+                        } else if constexpr (std::is_same_v<T, ast::AssertStmt>) {
+                            target.node = hir::AssertStmt{id<hir::ExprId>(node.condition)};
+                        } else if constexpr (std::is_same_v<T, ast::ExprStmt>) {
+                            target.node = hir::ExprStmt{id<hir::ExprId>(node.expr)};
+                        }
+                    },
+                    source.node);
+                result_.stmts[index] = std::move(target);
+            }
+
+            void lower_block(ast::BlockId index) {
+                const ast::Block &source = module_.block(index);
+                hir::Block        target;
+                target.range = source.range;
+                for (ast::StmtId statement : source.statements) { target.statements.push_back(id<hir::StmtId>(statement)); }
+                target.tail           = id<hir::ExprId>(source.tail);
+                result_.blocks[index] = std::move(target);
+            }
+
+            void lower_constraint(ast::ConstraintId index) {
+                const ast::Constraint &source = module_.constraint(index);
+                hir::Constraint        target;
+                target.range = source.range;
+                std::visit(
+                    [&](const auto &node) {
+                        using T = std::decay_t<decltype(node)>;
+                        if constexpr (std::is_same_v<T, ast::ConstraintName>) {
+                            target.node = hir::ConstraintSymbol{
+                                symbol_for(resolved_.constraint_binding(index), node.name.range, node.name.text)};
+                        } else if constexpr (std::is_same_v<T, ast::ConstraintType>) {
+                            target.node = hir::ConstraintType{id<hir::TypeId>(node.type)};
+                        } else if constexpr (std::is_same_v<T, ast::ConstraintValue>) {
+                            target.node = hir::ConstraintValue{id<hir::ExprId>(node.value)};
+                        } else if constexpr (std::is_same_v<T, ast::ConstraintSet>) {
+                            hir::ConstraintSet set;
+                            for (ast::ConstraintId element : node.elements) {
+                                set.elements.push_back(id<hir::ConstraintId>(element));
+                            }
+                            target.node = std::move(set);
+                        } else if constexpr (std::is_same_v<T, ast::ConstraintCall>) {
+                            hir::ConstraintCall call;
+                            call.function = symbol_for(resolved_.constraint_binding(index), node.name.range, node.name.text);
+                            for (ast::ConstraintId argument : node.arguments) {
+                                call.arguments.push_back(id<hir::ConstraintId>(argument));
+                            }
+                            target.node = std::move(call);
+                        } else if constexpr (std::is_same_v<T, ast::OperatorRequirement>) {
+                            hir::OperatorRequirement requirement;
+                            requirement.op = symbol_for(resolved_.constraint_binding(index), node.name.range, node.name.text);
+                            for (ast::ConstraintId argument : node.arguments) {
+                                requirement.arguments.push_back(id<hir::ConstraintId>(argument));
+                            }
+                            requirement.result = id<hir::TypeId>(node.result);
+                            target.node        = std::move(requirement);
+                        } else if constexpr (std::is_same_v<T, ast::ConstraintRelation>) {
+                            target.node =
+                                hir::ConstraintRelation{lower_constraint_relation_op(node.op), id<hir::ConstraintId>(node.lhs),
+                                                        id<hir::ConstraintId>(node.rhs), std::string{node.category.text}};
+                        } else if constexpr (std::is_same_v<T, ast::ConstraintNot>) {
+                            target.node = hir::ConstraintNot{id<hir::ConstraintId>(node.operand)};
+                        } else if constexpr (std::is_same_v<T, ast::ConstraintLogic>) {
+                            target.node = hir::ConstraintLogic{lower_constraint_logic_op(node.op), id<hir::ConstraintId>(node.lhs),
+                                                               id<hir::ConstraintId>(node.rhs)};
+                        }
+                    },
+                    source.node);
+                result_.constraints[index] = std::move(target);
+            }
+
+            [[nodiscard]] std::vector<hir::GenericParameter>
+            lower_generics(ast::DeclId owner, const std::vector<ast::GenericParameter> &generics) const {
+                std::vector<hir::GenericParameter> result;
+                result.reserve(generics.size());
+                for (std::size_t index = 0; index < generics.size(); ++index) {
+                    result.push_back(hir::GenericParameter{generic_symbols_[owner][index], generics[index].is_const,
+                                                           id<hir::TypeId>(generics[index].type)});
+                }
+                return result;
+            }
+
+            [[nodiscard]] hir::Signature lower_signature(ast::DeclId owner, const ast::Signature &signature) const {
+                hir::Signature result;
+                result.parameters.reserve(signature.parameters.size());
+                for (std::size_t index = 0; index < signature.parameters.size(); ++index) {
+                    const ast::Parameter &parameter = signature.parameters[index];
+                    result.parameters.push_back(hir::Parameter{parameter_symbols_[owner][index], parameter.is_const,
+                                                               id<hir::TypeId>(parameter.type),
+                                                               id<hir::ExprId>(parameter.default_value)});
+                }
+                result.result = id<hir::TypeId>(signature.result);
+                return result;
+            }
+
+            [[nodiscard]] syntax::SourceRange field_range(ast::DeclId origin, std::string_view name) const {
+                if (origin == ast::no_node) { return {}; }
+                const auto *structure = std::get_if<ast::StructDecl>(&module_.decl(origin).node);
+                if (!structure) { return module_.decl(origin).range; }
+                for (const ast::StructMember &member : structure->members) {
+                    if (const auto *field = std::get_if<ast::StructField>(&member); field && field->name.text == name) {
+                        return field->name.range;
+                    }
+                }
+                return structure->name.range;
+            }
+
+            void lower_declaration(ast::DeclId index) {
+                const ast::Decl &source = module_.decl(index);
+                hir::Declaration target;
+                target.id     = id<hir::DeclarationId>(index);
+                target.symbol = declaration_symbols_[index];
+                target.range  = source.range;
+                std::visit(
+                    [&](const auto &node) {
+                        using T = std::decay_t<decltype(node)>;
+                        if constexpr (std::is_same_v<T, ast::ModuleDecl>) {
+                            target.node = hir::ModuleDecl{};
+                        } else if constexpr (std::is_same_v<T, ast::UseDecl>) {
+                            hir::UseDecl use;
+                            use.module = join_path(node.path);
+                            use.alias  = std::string{node.alias.text};
+                            for (const ast::Name &name : node.names) { use.names.emplace_back(name.text); }
+                            target.node = std::move(use);
+                        } else if constexpr (std::is_same_v<T, ast::StructDecl>) {
+                            hir::StructDecl structure;
+                            structure.exported = node.exported;
+                            structure.abstract = node.abstract;
+                            structure.generics = lower_generics(index, node.generics);
+                            for (ast::TypeId parent : node.parents) { structure.parents.push_back(id<hir::TypeId>(parent)); }
+                            structure.requirements = id<hir::ConstraintId>(node.requirements);
+                            if (index < resolved_.struct_info.size()) {
+                                for (const semantics::StructField &field : resolved_.structure(index).fields) {
+                                    structure.fields.push_back(
+                                        hir::StructField{field.name, id<hir::TypeId>(field.type),
+                                                         id<hir::ExprId>(field.default_value), id<hir::DeclarationId>(field.origin),
+                                                         field.optional, field_range(field.origin, field.name)});
+                                }
+                            }
+                            target.node = std::move(structure);
+                        } else if constexpr (std::is_same_v<T, ast::OperatorDecl>) {
+                            target.node =
+                                hir::OperatorDecl{lower_generics(index, node.generics), lower_signature(index, node.signature),
+                                                  id<hir::ConstraintId>(node.requirements)};
+                        } else if constexpr (std::is_same_v<T, ast::FunctionDecl>) {
+                            target.node = hir::FunctionDecl{
+                                lower_visibility(node.visibility),        lower_function_kind(resolved_.kind(index)),
+                                lower_generics(index, node.generics),     lower_signature(index, node.signature),
+                                id<hir::ConstraintId>(node.requirements), id<hir::ExprId>(node.concise_body),
+                                id<hir::BlockId>(node.block_body)};
+                        } else if constexpr (std::is_same_v<T, ast::TestDecl>) {
+                            target.node = hir::TestDecl{id<hir::BlockId>(node.block)};
+                        }
+                    },
+                    source.node);
+                result_.declarations[index] = std::move(target);
+            }
+
+            const ast::Module                             &module_;
+            const semantics::ResolvedModule               &resolved_;
+            syntax::DiagnosticSink                        &diagnostics_;
+            hir::Module                                    result_{};
+            std::vector<hir::SymbolId>                     declaration_symbols_{};
+            std::vector<std::vector<hir::SymbolId>>        generic_symbols_{};
+            std::vector<std::vector<hir::SymbolId>>        parameter_symbols_{};
+            std::vector<std::vector<hir::SymbolId>>        statement_symbols_{};
+            std::vector<std::vector<hir::SymbolId>>        lambda_symbols_{};
+            std::vector<ast::DeclId>                       type_owners_{};
+            std::vector<ast::DeclId>                       expr_owners_{};
+            std::vector<ast::DeclId>                       stmt_owners_{};
+            std::unordered_map<std::string, hir::SymbolId> global_symbols_{};
+            std::unordered_map<std::string, hir::SymbolId> external_symbols_{};
+            std::unordered_map<std::uint8_t, hir::TypeId>  literal_types_{};
+        };
+    }  // namespace
+
+    hir::Module lower_to_hir(const ast::Module &module, const semantics::ResolvedModule &resolved,
+                             syntax::DiagnosticSink &diagnostics) {
+        return Lowerer{module, resolved, diagnostics}.run();
+    }
+}  // namespace hgl::ir

--- a/language/src/ir/lower.h
+++ b/language/src/ir/lower.h
@@ -1,0 +1,19 @@
+#ifndef HGL_IR_LOWER_H
+#define HGL_IR_LOWER_H
+
+#include "ir/hir.h"
+#include "semantics/resolve.h"
+#include "syntax/ast.h"
+#include "syntax/diagnostic.h"
+
+namespace hgl::ir
+{
+    /// Project a successfully resolved syntax module into backend-independent
+    /// HIR. This migration-stage pass resolves every name to a stable symbol
+    /// identity and owns every body node. Type/effect completion is a later
+    /// pass and is represented explicitly by Module::completion.
+    [[nodiscard]] hir::Module lower_to_hir(const syntax::ast::Module &module, const semantics::ResolvedModule &resolved,
+                                           syntax::DiagnosticSink &diagnostics);
+}  // namespace hgl::ir
+
+#endif  // HGL_IR_LOWER_H

--- a/language/src/semantics/resolve.cpp
+++ b/language/src/semantics/resolve.cpp
@@ -444,12 +444,13 @@ namespace hgl::semantics
                         else if constexpr (std::is_same_v<T, ast::InjectDecl>)
                         {
                             reject_in_test(context, stmt.range, "inject");
-                            for (const ast::Name &name : node.names)
+                            for (std::size_t index = 0; index < node.names.size(); ++index)
                             {
                                 Binding binding;
                                 binding.kind = BindingKind::Local;
                                 binding.stmt = id;
-                                declare(name, binding, "in the block");
+                                binding.index = static_cast<std::uint32_t>(index);
+                                declare(node.names[index], binding, "in the block");
                             }
                         }
                         else if constexpr (std::is_same_v<T, ast::LifecycleBlock>)
@@ -476,6 +477,7 @@ namespace hgl::semantics
                             {
                                 Binding second = first;
                                 second.second  = true;
+                                second.index   = 1;
                                 declare(node.second, second, "in the iteration pattern");
                             }
                             resolve_block(node.block, context);

--- a/language/src/semantics/resolve.h
+++ b/language/src/semantics/resolve.h
@@ -23,7 +23,7 @@ namespace hgl::semantics
     enum class BindingKind : std::uint8_t
     {
         Unbound,
-        Local,          ///< `let`/`var`/`for` binding: `stmt` (+ `second` for a pair pattern)
+        Local,          ///< `let`/`var`/state/inject/for binding: `stmt` + binder `index`
         Parameter,      ///< `decl` is the function, `index` the parameter
         Generic,        ///< `decl` is the function, `index` the generic parameter
         Struct,         ///< `decl` is the nominal struct declaration
@@ -40,7 +40,7 @@ namespace hgl::semantics
         ast::DeclId   decl{ast::no_node};
         ast::StmtId   stmt{ast::no_node};
         std::uint32_t index{0};
-        bool          second{false};
+        bool          second{false};  ///< compatibility marker for the second `for` binder
         std::string   registry_name{};
     };
 

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -25,6 +25,14 @@ foreach(_example IN LISTS _hgl_examples)
 endforeach()
 unset(_hgl_examples)
 
+add_test(
+    NAME hgraph_language_dump_hir
+    COMMAND $<TARGET_FILE:hgl> check ${CMAKE_CURRENT_SOURCE_DIR}/../examples/stateful-node.hgl --dump-hir
+)
+set_tests_properties(hgraph_language_dump_hir PROPERTIES
+    PASS_REGULAR_EXPRESSION "HIR resolved module examples.stateful_node"
+)
+
 # Catch2 for the frontend unit tests: reuse the repository's target when the
 # language is built as part of hgraph, else find or fetch it.
 if(NOT TARGET Catch2::Catch2WithMain)
@@ -64,6 +72,16 @@ target_compile_definitions(hgl_semantics_tests PRIVATE HGL_EXAMPLES_DIR="${CMAKE
 hgl_apply_warnings(hgl_semantics_tests)
 
 add_test(NAME hgraph_language_semantics COMMAND hgl_semantics_tests)
+
+# The first HIR boundary: every resolved name becomes a stable symbol and the
+# complete source program is copied into a backend-independent arena.
+add_executable(hgl_ir_tests ir/lower_tests.cpp)
+target_compile_features(hgl_ir_tests PRIVATE cxx_std_23)
+target_link_libraries(hgl_ir_tests PRIVATE hgl::ir Catch2::Catch2WithMain)
+target_compile_definitions(hgl_ir_tests PRIVATE HGL_EXAMPLES_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../examples")
+hgl_apply_warnings(hgl_ir_tests)
+
+add_test(NAME hgraph_language_ir COMMAND hgl_ir_tests)
 
 # The direct-wiring backend against the live registry: folding, eval, the
 # failure detail, run_program (developer guide, "First pass").

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -1,0 +1,269 @@
+#include "ir/hir_printer.h"
+#include "ir/lower.h"
+#include "syntax/parser.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace
+{
+    namespace ast = hgl::syntax::ast;
+    namespace hir = hgl::ir::hir;
+
+    bool has_operator(std::string_view) {
+        // The resolver only needs descriptor membership at this layer. Exact
+        // registry typing belongs to HIR type completion.
+        return true;
+    }
+
+    struct Lowered
+    {
+        hgl::syntax::SourceFile        file;
+        hgl::syntax::DiagnosticSink    diagnostics{};
+        ast::Module                    ast{};
+        hgl::semantics::ResolvedModule resolved{};
+        hir::Module                    hir{};
+
+        explicit Lowered(std::string text, std::string path = "test.hgl")
+            : file{std::move(path), std::move(text)}, ast{hgl::syntax::parse(file, diagnostics)} {
+            if (diagnostics.has_errors()) { return; }
+            resolved = hgl::semantics::resolve(file, ast, has_operator, diagnostics);
+            if (!diagnostics.has_errors()) { hir = hgl::ir::lower_to_hir(ast, resolved, diagnostics); }
+        }
+
+        [[nodiscard]] std::optional<hir::SymbolId> referenced_symbol(std::string_view spelling) const {
+            for (ast::ExprId expression = 0; expression < ast.exprs.size(); ++expression) {
+                const ast::Expr &source  = ast.expr(expression);
+                bool             matches = false;
+                if (const auto *name = std::get_if<ast::NameRef>(&source.node)) {
+                    matches = name->name.text == spelling;
+                } else if (const auto *name = std::get_if<ast::QualifiedRef>(&source.node)) {
+                    matches = name->name.text == spelling;
+                }
+                if (!matches) { continue; }
+                if (const auto *reference = std::get_if<hir::SymbolRef>(&hir.expr(hir::ExprId{expression}).node)) {
+                    return reference->symbol;
+                }
+            }
+            return std::nullopt;
+        }
+    };
+
+    void require_clean(const Lowered &lowered) {
+        INFO(lowered.diagnostics.render(lowered.file));
+        REQUIRE_FALSE(lowered.diagnostics.has_errors());
+        REQUIRE(lowered.hir.completion == hir::Completion::Resolved);
+    }
+}  // namespace
+
+TEST_CASE("every guide example lowers to resolved HIR", "[ir][examples]") {
+    const std::filesystem::path directory{HGL_EXAMPLES_DIR};
+    REQUIRE(std::filesystem::is_directory(directory));
+
+    std::size_t count = 0;
+    for (const std::filesystem::directory_entry &entry : std::filesystem::directory_iterator{directory}) {
+        if (entry.path().extension() != ".hgl") { continue; }
+        ++count;
+        std::ifstream input{entry.path()};
+        REQUIRE(input.good());
+        Lowered lowered{std::string{std::istreambuf_iterator<char>{input}, std::istreambuf_iterator<char>{}},
+                        entry.path().string()};
+        INFO(entry.path().filename().string());
+        require_clean(lowered);
+        CHECK(lowered.hir.declarations.size() == lowered.ast.decls.size());
+        CHECK(lowered.hir.stmts.size() == lowered.ast.stmts.size());
+        CHECK(lowered.hir.blocks.size() == lowered.ast.blocks.size());
+        CHECK(lowered.hir.constraints.size() == lowered.ast.constraints.size());
+        CHECK(lowered.hir.exprs.size() >= lowered.ast.exprs.size());
+
+        for (ast::ExprId expression = 0; expression < lowered.ast.exprs.size(); ++expression) {
+            const ast::ExprNode &node = lowered.ast.expr(expression).node;
+            if (std::holds_alternative<ast::NameRef>(node) || std::holds_alternative<ast::QualifiedRef>(node)) {
+                const auto *reference = std::get_if<hir::SymbolRef>(&lowered.hir.expr(hir::ExprId{expression}).node);
+                REQUIRE(reference != nullptr);
+                CHECK(reference->symbol.valid());
+            }
+        }
+        for (ast::TypeId type = 0; type < lowered.ast.types.size(); ++type) {
+            if (lowered.ast.type(type).kind != ast::TypeKind::Named) { continue; }
+            const hir::Type &resolved_type = lowered.hir.type(hir::TypeId{type});
+            CHECK(resolved_type.kind == hir::TypeKind::Symbol);
+            CHECK(resolved_type.symbol.valid());
+        }
+        for (ast::ConstraintId constraint = 0; constraint < lowered.ast.constraints.size(); ++constraint) {
+            const ast::ConstraintNode &source = lowered.ast.constraint(constraint).node;
+            const hir::ConstraintNode &target = lowered.hir.constraint(hir::ConstraintId{constraint}).node;
+            if (std::holds_alternative<ast::ConstraintName>(source)) {
+                const auto *symbol = std::get_if<hir::ConstraintSymbol>(&target);
+                REQUIRE(symbol != nullptr);
+                CHECK(symbol->symbol.valid());
+            } else if (std::holds_alternative<ast::ConstraintCall>(source)) {
+                const auto *call = std::get_if<hir::ConstraintCall>(&target);
+                REQUIRE(call != nullptr);
+                CHECK(call->function.valid());
+            } else if (std::holds_alternative<ast::OperatorRequirement>(source)) {
+                const auto *requirement = std::get_if<hir::OperatorRequirement>(&target);
+                REQUIRE(requirement != nullptr);
+                CHECK(requirement->op.valid());
+            }
+        }
+        for (ast::DeclId declaration = 0; declaration < lowered.ast.decls.size(); ++declaration) {
+            if (std::holds_alternative<ast::UseDecl>(lowered.ast.decl(declaration).node)) { continue; }
+            CHECK(lowered.hir.declaration(hir::DeclarationId{declaration}).symbol.valid());
+        }
+    }
+    CHECK(count >= 6);
+}
+
+TEST_CASE("the resolved HIR dump is deterministic and source ranged", "[ir][snapshot]") {
+    Lowered lowered{"module checks.snapshot\n\nfn add_one(value: f64) -> f64 => value + 1.0\n"};
+    require_clean(lowered);
+
+    CHECK(hgl::ir::print_hir(lowered.hir) == R"(HIR resolved module checks.snapshot
+symbols
+  s0 module checks.snapshot owner=d0 type=_ index=0 [0..22)
+  s1 function add_one owner=d1 type=_ index=0 [27..34)
+  s2 signal-parameter value owner=d1 type=t0 index=0 [35..40)
+types
+  t0 scalar f64 signal [42..45)
+  t1 scalar f64 signal [50..53)
+  t2 scalar f64 value [0..0)
+expressions
+  e0 type=t0 phase=wiring value=signal ref s2 [57..62)
+  e1 type=t2 phase=constant value=constant literal 1 [65..68)
+  e2 type=_ phase=unknown value=unknown add e0 e1 [57..68)
+statements
+blocks
+constraints
+declarations
+  d0 symbol=s0 module [0..22)
+  d1 symbol=s1 internal composition function parameters=[s2:t0] result=t1 requires=_ concise=e2 block=_ [24..68)
+source-order [d0, d1]
+)");
+}
+
+TEST_CASE("HIR gives state and each injected capability its own identity", "[ir][symbols]") {
+    Lowered lowered{R"(
+module checks.stateful
+
+fn total(value: f64) -> f64 {
+    state current: f64 = 0.0
+    inject out, logger
+
+    when modified(value) && valid(value) {
+        current += value
+        logger.info("updated")
+        out = current
+    }
+}
+)"};
+    require_clean(lowered);
+
+    const std::optional<hir::SymbolId> current = lowered.referenced_symbol("current");
+    const std::optional<hir::SymbolId> logger  = lowered.referenced_symbol("logger");
+    const std::optional<hir::SymbolId> out     = lowered.referenced_symbol("out");
+    REQUIRE(current);
+    REQUIRE(logger);
+    REQUIRE(out);
+    CHECK(*current != *logger);
+    CHECK(*current != *out);
+    CHECK(*logger != *out);
+    CHECK(lowered.hir.symbol(*current).kind == hir::SymbolKind::State);
+    CHECK(lowered.hir.symbol(*logger).kind == hir::SymbolKind::InjectedCapability);
+    CHECK(lowered.hir.symbol(*out).kind == hir::SymbolKind::InjectedCapability);
+}
+
+TEST_CASE("HIR resolves anonymous parameters independently of enclosing loop bindings", "[ir][symbols]") {
+    Lowered lowered{R"(
+module checks.lambda_scope
+
+fn recent(book: map<str, f64>, const cutoff: datetime) {
+    inject logger
+    when modified(book) {
+        for key, value in items(book, fn(key, value) => last_modified(value) > cutoff) {
+            logger.info(key)
+        }
+    }
+}
+)"};
+    require_clean(lowered);
+
+    std::size_t lambda_parameters = 0;
+    for (const hir::Symbol &symbol : lowered.hir.symbols) {
+        if (symbol.kind == hir::SymbolKind::LambdaParameter) { ++lambda_parameters; }
+    }
+    CHECK(lambda_parameters == 2);
+
+    for (ast::ExprId expression = 0; expression < lowered.ast.exprs.size(); ++expression) {
+        const auto *name = std::get_if<ast::NameRef>(&lowered.ast.expr(expression).node);
+        if (name == nullptr || name->name.text != "value") { continue; }
+        const auto *reference = std::get_if<hir::SymbolRef>(&lowered.hir.expr(hir::ExprId{expression}).node);
+        REQUIRE(reference != nullptr);
+        CHECK(lowered.hir.symbol(reference->symbol).kind == hir::SymbolKind::LambdaParameter);
+    }
+}
+
+TEST_CASE("bare generic type and value arguments retain resolved identities", "[ir][generics]") {
+    Lowered lowered{R"(
+module checks.generics
+
+struct Box<T, const N: i64> {
+    values: list<T, N>
+}
+
+fn identity<T, const N: i64>(value: Box<T, N>) -> Box<T, N> => value
+)"};
+    require_clean(lowered);
+
+    std::size_t synthesized_type_arguments  = 0;
+    std::size_t synthesized_value_arguments = 0;
+    for (const hir::Type &type : lowered.hir.types) {
+        for (const hir::TypeArgument &argument : type.arguments) {
+            if (argument.kind == hir::TypeArgumentKind::Type) {
+                REQUIRE(argument.type.valid());
+                const hir::Type &referenced = lowered.hir.type(argument.type);
+                if (referenced.range == argument.range && referenced.kind == hir::TypeKind::Symbol) {
+                    ++synthesized_type_arguments;
+                    CHECK(referenced.symbol.valid());
+                }
+            } else {
+                REQUIRE(argument.value.valid());
+                const hir::Expr &referenced = lowered.hir.expr(argument.value);
+                if (referenced.range == argument.range) {
+                    ++synthesized_value_arguments;
+                    const auto *symbol = std::get_if<hir::SymbolRef>(&referenced.node);
+                    REQUIRE(symbol != nullptr);
+                    CHECK(symbol->symbol.valid());
+                    CHECK(referenced.type.valid());
+                }
+            }
+        }
+    }
+    CHECK(synthesized_type_arguments >= 2);
+    CHECK(synthesized_value_arguments >= 2);
+}
+
+TEST_CASE("HIR lowering reports an unresolved identity instead of fabricating one", "[ir][diagnostics]") {
+    hgl::syntax::SourceFile        file{"test.hgl", "module checks\nfn f() => missing\n"};
+    hgl::syntax::DiagnosticSink    diagnostics;
+    ast::Module                    module   = hgl::syntax::parse(file, diagnostics);
+    hgl::semantics::ResolvedModule resolved = hgl::semantics::resolve(file, module, has_operator, diagnostics);
+    REQUIRE(diagnostics.has_errors());
+
+    // The driver never lowers a failed resolver result. If a pass client does,
+    // the HIR boundary still fails closed rather than inventing a SymbolId.
+    diagnostics              = {};
+    const hir::Module result = hgl::ir::lower_to_hir(module, resolved, diagnostics);
+    CHECK(diagnostics.has_errors());
+    REQUIRE(result.exprs.size() == module.exprs.size());
+    const auto *reference = std::get_if<hir::SymbolRef>(&result.expr(hir::ExprId{0}).node);
+    REQUIRE(reference != nullptr);
+    CHECK_FALSE(reference->symbol.valid());
+}

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -122,6 +122,16 @@ TEST_CASE("every guide example lowers to resolved HIR", "[ir][examples]") {
     CHECK(count >= 6);
 }
 
+TEST_CASE("HIR string constants stay on one escaped line", "[ir][printer]") {
+    Lowered lowered{R"(module checks.strings
+fn escaped(const value: str = "a\nb\r\t\"\\") -> str => value
+)"};
+    require_clean(lowered);
+
+    const std::string printed = hgl::ir::print_hir(lowered.hir);
+    CHECK(printed.find(R"(literal "a\nb\r\t\"\\")") != std::string::npos);
+}
+
 TEST_CASE("the resolved HIR dump is deterministic and source ranged", "[ir][snapshot]") {
     Lowered lowered{"module checks.snapshot\n\nfn add_one(value: f64) -> f64 => value + 1.0\n"};
     require_clean(lowered);


### PR DESCRIPTION
## Summary

- introduce a backend-independent HGL HIR with strong declaration, symbol, type, expression, statement, block, and constraint identities
- lower the resolved syntax tree into stable symbol references for declarations, parameters, locals, state, injectables, loop bindings, lambdas, imports, and intrinsics
- expose a deterministic `hgl check --dump-hir` diagnostic surface and exercise every checked-in guide example
- add the `hgl_ir` compiler layer between semantics and the current backends, and update the roadmap and guides to describe the migration boundary honestly

## Scope

This PR deliberately stops at **Resolved HIR**. Names and source type patterns have stable identities; expression type completion, substitutions, phase/effect inference, exact overload selection, and hgraph IR lowering remain the next stacked change. The direct-wiring and C++ backends still consume `ResolvedModule` in this PR.

Stacked on #680.

## Validation

- fresh macOS native build and all 1,711 C++ tests
- ABI3 wheel built with Python 3.12, installed under Python 3.14, and all 3,214 non-WIP Python tests passed (10 skipped)
- warnings-as-errors HGL build with analytics enabled
- all 26 HGL CTest cases
- installed `hgl`, `check --dump-hir`, and `emit-cpp` smokes
- clang-format verification and `git diff --check`
