### PR TITLE
feat(language): add canonical typed HIR completion

### DIFF
--- a/.github/workflows/language.yml
+++ b/.github/workflows/language.yml
@@ -110,7 +110,7 @@ jobs:
         run: >-
           cmake --build build-language --parallel ${{ matrix.parallel }} --target
           hgl hgl_syntax_tests hgl_semantics_tests hgl_ir_tests hgl_wiring_tests
-          hgl_native_module_tests hgl_codegen_tests hgl_codegen_fixture
+          hgl_operator_type_tests hgl_native_module_tests hgl_codegen_tests hgl_codegen_fixture
           hgl_generated_tests
       - name: Run the language suites
         run: ctest --test-dir build-language -R hgraph_language --output-on-failure --parallel ${{ matrix.parallel }}

--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -121,9 +121,11 @@ hgl_apply_warnings(hgl_semantics)
 # in later passes. Backends migrate to this boundary without depending on AST
 # node identities.
 add_library(hgl_ir STATIC
+    src/ir/canonical_types.cpp
     src/ir/hir.cpp
     src/ir/hir_printer.cpp
     src/ir/lower.cpp
+    src/ir/type_check.cpp
 )
 add_library(hgl::ir ALIAS hgl_ir)
 target_compile_features(hgl_ir PUBLIC cxx_std_23)
@@ -136,11 +138,12 @@ hgl_apply_warnings(hgl_ir)
 # "Direct-wiring backend", "First pass").
 add_library(hgl_wiring STATIC
     src/wiring/backend.cpp
+    src/wiring/operator_types.cpp
 )
 add_library(hgl::wiring ALIAS hgl_wiring)
 target_compile_features(hgl_wiring PUBLIC cxx_std_23)
 target_include_directories(hgl_wiring PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
-target_link_libraries(hgl_wiring PUBLIC hgl::semantics hgraph::core)
+target_link_libraries(hgl_wiring PUBLIC hgl::ir hgraph::core)
 if(TARGET hgraph::analytics)
     target_link_libraries(hgl_wiring PUBLIC hgraph::analytics)
     target_compile_definitions(hgl_wiring PRIVATE HGL_HAVE_ANALYTICS=1)

--- a/language/docs/design/compiler-architecture.md
+++ b/language/docs/design/compiler-architecture.md
@@ -130,6 +130,13 @@ HGL adapts hgraph's `TypePattern`, `ResolutionMap`, and constraint/resolver
 contracts. It does not maintain a language-local overload matcher with subtly
 different ranking.
 
+The adapter performs a schema-only resolution probe and copies data out of the
+result. Registry implementation pointers and provider leases do not enter HIR.
+Calls depending on a wiring-time scalar value or on callable erasure retain a
+typed nominal call marked `deferred`; the hgraph-IR pass resolves them at the
+first point where those inputs exist. Multiple source `impl fn` candidates are
+also left to the same hgraph ranking contract.
+
 ### Typed HIR
 
 HIR is the last representation of HGL as a language. It contains:

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -85,15 +85,25 @@ headers remain private to the syntax implementation.
 
 ### C. Typed HIR
 
-Status: in progress. The resolved HIR checkpoint owns the complete program in
-a backend-independent arena, assigns stable identities to declarations,
+Status: in progress. The resolved HIR checkpoint owns the complete program in a
+backend-independent arena and assigns stable identities to declarations,
 parameters, locals, state, injectables, loop values, anonymous parameters,
-types, imported operators, and intrinsics, and retains source type patterns,
-function kinds, control flow, constraints, and source ranges. Every checked-in
-guide example lowers, `hgl check --dump-hir` has a deterministic snapshot, and
-failed name resolution cannot fabricate a symbol. `Module::completion` remains
-`Resolved`: canonical type completion, substitutions, exact call selection,
-phases, and effects are the remaining work in this stage.
+types, imported operators, and intrinsics. Type completion then interns
+context-neutral canonical source types, records complete local substitutions,
+typed constants, exact and nominal call identities, wiring/runtime phases,
+effects, capabilities, control flow, constraints, and source ranges. Concrete
+imported calls are ranked by `OperatorRegistry`; calls awaiting wiring-time
+values, callable erasure, or source-provider registration are explicitly
+deferred rather than privately approximated. Every checked-in guide example
+reaches `Module::completion == Typed`, `hgl check --dump-hir` is deterministic,
+and a failed semantic pass cannot claim typed completion.
+
+The remaining work in this stage is callable `requires` evaluation and
+constraint-driven substitution, source-implementation conformance against its
+operator contract, and registry-backed completion for native operation forms
+which are currently retained as explicit deferred nominal calls. Callable
+requirements fail closed until that evaluator is present; they are not silently
+accepted by the temporary AST backends.
 
 - introduce stable symbol and declaration identities, canonical types, complete
   substitutions, typed constants, function kinds, phases, effects, and source
@@ -102,10 +112,15 @@ phases, and effects are the remaining work in this stage.
 - implement `hgl check --dump-hir` and HIR snapshot tests;
 - make a successful semantic check produce complete HIR or fail closed.
 
-Acceptance: all resolved guide examples produce HIR, invalid programs stop
-before lowering, and the HIR contains no emitted C++ or runtime wiring objects.
+Acceptance: all resolved guide examples produce typed HIR, invalid programs
+leave the module unresolved, concrete native selection delegates to hgraph,
+and HIR contains no emitted C++ or runtime wiring objects. This acceptance is
+not yet complete while callable constraints remain fail-closed. Backend removal
+of the temporary resolved-AST semantic walks belongs to stages D and E.
 
 ### D. Hgraph IR and direct wiring
+
+Status: follows completion of C.
 
 - lower composition and runtime semantics into one explicit hgraph IR;
 - represent state, injectables, lifecycle, activation, validity, traversal,

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -107,14 +107,44 @@ flow, constraints, effective struct fields, and source ranges. Bare generic
 arguments become explicit type or value references. `hgl check --dump-hir`
 prints the deterministic diagnostic representation used by snapshot tests.
 
-This is the first checkpoint of the same HIR, not a complete typed program:
-`Module::completion` is `Resolved`, and unknown expression type, phase, and
-value-kind fields remain explicit. Canonical hgraph types, complete generic
-substitution, exact call selection, constant evaluation, phases, and effects
-advance it to `Typed` in the next pass. The direct-wiring and C++ backends still
-walk `ResolvedModule` beside this arena during migration. That adapter path is
-explicitly temporary; typed HIR followed by hgraph semantic IR becomes the
-only input to both backends.
+`src/ir/canonical_types` owns structural interning and source-to-canonical
+rewriting. `src/ir/type_check` advances that checkpoint from `Resolved` to
+`Typed`. It
+interns context-neutral source types independently of whether an occurrence is
+used as a temporal input or a `const` value, normalizes omitted rolling minima,
+rewrites signatures to canonical IDs, infers exact-function and local-operator
+generic substitutions, types lambdas from their collection context, folds
+scalar constants, and records a semantic identity for every call, intrinsic,
+constructor, field, and index operation. It also assigns wiring/runtime phases,
+summarizes effects on expressions, statements, blocks, and functions, and lists
+the capabilities admitted by each function. A failed pass leaves
+`Module::completion` as `Resolved`; `hgl check` succeeds only after the module
+is `Typed`.
+
+Native candidate selection crosses the narrow `OperatorResolver` port. The
+hgraph adapter constructs schema-only `WiringArg` values and calls
+`OperatorRegistry::resolve`, so argument normalization, `TypePattern`
+matching, `ResolutionMap` substitution, ranking, and `requires` predicates
+remain native contracts. HIR copies only the winning diagnostic label and
+resolved substitutions; it never stores an `OperatorImpl *`, provider lease,
+port, or wiring object. A call whose wiring-time value is not yet known (for
+example a `const` function parameter) and a higher-order call awaiting callable
+erasure retain their complete HGL result type and nominal identity but are
+marked `deferred`. Likewise, a sole source `impl fn` may be named directly,
+while two or more candidates remain deferred for hgraph ranking rather than
+being ranked by a compiler-private matcher. The current slice also checks that
+a sole source candidate is applicable before naming it.
+
+Callable `requires` evaluation and constraint-driven substitution are the
+remaining typed-HIR stage. Until that evaluator exists, a function or operator
+carrying a callable requirement reports a type diagnostic and the module stays
+`Resolved`. This fail-closed boundary prevents the temporary AST backends from
+silently executing a constraint they do not implement. Closed generic-struct
+requirements continue to be decided by the resolver as before.
+
+The direct-wiring and C++ backends still walk `ResolvedModule` beside typed HIR
+during migration. That adapter path is explicitly temporary; hgraph semantic
+IR becomes the only input to both backends in the following stages.
 
 ## Common function representation
 
@@ -431,14 +461,15 @@ preferred core extension is a source-type binding kind integrated
 with `ResolutionMap`; generating unrelated native variables and correlating
 them in a compiler-private table is not an acceptable second resolution model.
 
-The current public hgraph type pattern represents TSW sizes as either concrete
-tick values (`TypePattern::tsw`, which matches no duration window) or one
-wildcard over the complete window shape (`tsw_any`). It has no concrete
-duration form and does not yet bind named maximum and minimum size variables
-of either kind. Generic `rolling<T, max_size, min_size>` lowering, and exact
-matching of a duration window at a candidate boundary, therefore require a
-public TSW size-pattern extension integrated with `ResolutionMap`; the
-compiler must not approximate this with private matching logic.
+The public hgraph type pattern represents concrete tick windows with
+`TypePattern::tsw`, concrete duration windows with
+`TypePattern::tsw_duration`, and a wildcard over the complete window shape
+with `tsw_any`. It does not yet bind named maximum and minimum TSW size
+variables of either kind. Generic `rolling<T, max_size, min_size>` candidate
+selection therefore still requires a public TSW size-pattern extension
+integrated with `ResolutionMap`; the compiler must not approximate this with
+private matching logic. Concrete duration calls can already be resolved by the
+HIR registry adapter.
 
 List sizes need no such extension. hgraph's `TSL` pattern already carries a
 named `SIZE<"n">` variable that binds the argument's concrete size, a dynamic

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -141,7 +141,8 @@ follows the signature and precedes the body:
 > **Staging status:** `hgl check` parses and resolves `requires` clauses and
 > rejects decidably false closed struct requirements. Complete callable
 > substitution and operator-conformance checking remains part of typed-HIR
-> completion.
+> completion. Callable requirements currently fail closed during type
+> completion rather than being ignored by a backend.
 
 ```hgl
 fn add_numeric<U>(a: U, b: U) -> U

--- a/language/src/driver/driver.cpp
+++ b/language/src/driver/driver.cpp
@@ -6,6 +6,7 @@
 #include "driver/native_module.h"
 #include "ir/hir_printer.h"
 #include "ir/lower.h"
+#include "ir/type_check.h"
 #include "semantics/resolve.h"
 #include "syntax/ast_printer.h"
 #include "syntax/diagnostic.h"
@@ -14,6 +15,7 @@
 #include "syntax/source.h"
 #include "syntax/temporal.h"
 #include "wiring/backend.h"
+#include "wiring/operator_types.h"
 
 #include <hgraph/version.h>
 
@@ -51,7 +53,7 @@ namespace hgl::driver
                          "  hgl --help\n"
                          "  hgl --version\n\n"
                          "Commands:\n"
-                         "  check     parse and resolve a module and report diagnostics\n"
+                         "  check     parse, resolve and type-check a module and report diagnostics\n"
                          "  test      run the module's test declarations\n"
                          "  run       bind an entry to a mode, clock and parameters, then execute it\n"
                          "  emit-cpp  write the module as a C++ header/source pair of public hgraph\n"
@@ -123,6 +125,8 @@ namespace hgl::driver
             unit.resolved = semantics::resolve(unit.file, unit.module, wiring::has_operator, unit.diagnostics);
             if (unit.diagnostics.has_errors()) { return; }
             unit.hir = ir::lower_to_hir(unit.module, unit.resolved, unit.diagnostics);
+            if (unit.diagnostics.has_errors()) { return; }
+            (void)ir::complete_hir(unit.hir, wiring::resolve_operator_types, unit.diagnostics);
             unit.ok  = !unit.diagnostics.has_errors();
         }
 

--- a/language/src/ir/canonical_types.cpp
+++ b/language/src/ir/canonical_types.cpp
@@ -1,0 +1,252 @@
+#include "ir/canonical_types.h"
+
+#include "syntax/temporal.h"
+
+#include <cstdint>
+#include <iomanip>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace hgl::ir::detail
+{
+    using namespace hir;
+
+    CanonicalTypes::CanonicalTypes(Module &module, syntax::DiagnosticSink &diagnostics)
+        : module_{module}, diagnostics_{diagnostics} {}
+
+    void CanonicalTypes::initialize() {
+        const std::size_t source_count = module_.types.size();
+        source_canonical_.resize(source_count);
+        source_visiting_.resize(source_count);
+        for (std::uint32_t index = 0; index < source_count; ++index) { (void)canonicalize(TypeId{index}); }
+        void_type_ = make(TypeKind::Void);
+        rewrite_type_references();
+    }
+
+    TypeId CanonicalTypes::canonical(TypeId id) const noexcept {
+        if (!id.valid()) { return {}; }
+        const TypeId result = module_.type(id).canonical;
+        return result.valid() ? result : id;
+    }
+
+    std::string CanonicalTypes::value_key(ExprId id) const {
+        if (!id.valid()) { return "_"; }
+        const Expr &expression = module_.expr(id);
+        if (expression.constant) {
+            return std::visit(
+                [](const auto &value) -> std::string {
+                    using T = std::decay_t<decltype(value)>;
+                    if constexpr (std::is_same_v<T, NullValue>) {
+                        return "null";
+                    } else if constexpr (std::is_same_v<T, PlaceholderValue>) {
+                        return "placeholder";
+                    } else if constexpr (std::is_same_v<T, bool>) {
+                        return value ? "b:1" : "b:0";
+                    } else if constexpr (std::is_same_v<T, std::string>) {
+                        return "s:" + std::to_string(value.size()) + ':' + value;
+                    } else if constexpr (std::is_same_v<T, syntax::TemporalValue>) {
+                        return "t:" + syntax::canonical_spelling(value);
+                    } else if constexpr (std::is_same_v<T, std::int64_t>) {
+                        return "i:" + std::to_string(value);
+                    } else {
+                        std::ostringstream out;
+                        out << "f:" << std::setprecision(std::numeric_limits<double>::max_digits10) << value;
+                        return std::move(out).str();
+                    }
+                },
+                *expression.constant);
+        }
+        if (const auto *reference = std::get_if<SymbolRef>(&expression.node)) {
+            return "s" + std::to_string(reference->symbol.value);
+        }
+        return "e" + std::to_string(id.value);
+    }
+
+    std::string CanonicalTypes::type_key(const Type &value) const {
+        std::ostringstream out;
+        out << static_cast<unsigned>(value.kind);
+        if (value.kind == TypeKind::Scalar) { out << ':' << static_cast<unsigned>(value.scalar); }
+        if (value.symbol.valid()) { out << ":s" << value.symbol.value; }
+        out << '<';
+        for (const TypeArgument &argument : value.arguments) {
+            if (argument.kind == TypeArgumentKind::Type) {
+                out << 't' << canonical(argument.type).value;
+            } else {
+                out << 'v' << value_key(argument.value);
+            }
+            out << ',';
+        }
+        out << ">{";
+        for (TypeId child : value.children) { out << canonical(child).value << ','; }
+        out << "}:" << value_key(value.size) << ':' << value_key(value.min_size) << ':' << value.unbounded;
+        return out.str();
+    }
+
+    TypeId CanonicalTypes::intern(Type value) {
+        for (TypeId &child : value.children) { child = canonical(child); }
+        for (TypeArgument &argument : value.arguments) {
+            if (argument.kind == TypeArgumentKind::Type) { argument.type = canonical(argument.type); }
+        }
+        value.range           = {};
+        value.value_position  = false;
+        value.canonical       = {};
+        const std::string key = type_key(value);
+        if (const auto found = type_intern_.find(key); found != type_intern_.end()) { return found->second; }
+        const TypeId result{static_cast<std::uint32_t>(module_.types.size())};
+        value.canonical = result;
+        module_.types.push_back(std::move(value));
+        type_intern_.emplace(key, result);
+        return result;
+    }
+
+    TypeId CanonicalTypes::make(TypeKind kind, std::vector<TypeId> children, SymbolId symbol) {
+        Type value;
+        value.kind     = kind;
+        value.children = std::move(children);
+        value.symbol   = symbol;
+        return intern(std::move(value));
+    }
+
+    TypeId CanonicalTypes::scalar(ScalarType value) {
+        Type result;
+        result.kind   = TypeKind::Scalar;
+        result.scalar = value;
+        return intern(std::move(result));
+    }
+
+    TypeId CanonicalTypes::canonicalize(TypeId id) {
+        if (!id.valid()) { return {}; }
+        if (id.value >= source_canonical_.size()) { return canonical(id); }
+        if (source_canonical_[id.value].valid()) { return source_canonical_[id.value]; }
+        if (source_visiting_[id.value]) {
+            diagnostics_.report(syntax::Category::Type, module_.type(id).range, "recursive structural type alias");
+            return {};
+        }
+        source_visiting_[id.value] = true;
+        Type value                 = module_.type(id);
+        // A rolling window defaults its minimum to its maximum. Normalize
+        // before interning so generic max/min patterns see the same shape.
+        if (value.kind == TypeKind::Rolling && value.size.valid() && !value.min_size.valid()) { value.min_size = value.size; }
+        for (TypeId &child : value.children) { child = canonicalize(child); }
+        for (TypeArgument &argument : value.arguments) {
+            if (argument.kind == TypeArgumentKind::Type) { argument.type = canonicalize(argument.type); }
+        }
+        const TypeId result               = intern(std::move(value));
+        source_canonical_[id.value]       = result;
+        source_visiting_[id.value]        = false;
+        module_.types[id.value].canonical = result;
+        return result;
+    }
+
+    void CanonicalTypes::rewrite_signature(Signature &signature) {
+        for (Parameter &parameter : signature.parameters) { parameter.type = canonical(parameter.type); }
+        signature.result = signature.result.valid() ? canonical(signature.result) : void_type_;
+    }
+
+    void CanonicalTypes::rewrite_type_references() {
+        for (Symbol &symbol : module_.symbols) {
+            if (symbol.type.valid()) { symbol.type = canonical(symbol.type); }
+        }
+        for (Expr &expression : module_.exprs) {
+            if (expression.type.valid()) { expression.type = canonical(expression.type); }
+            if (auto *lambda = std::get_if<Lambda>(&expression.node); lambda && lambda->result.valid()) {
+                lambda->result = canonical(lambda->result);
+            } else if (auto *construct = std::get_if<Construct>(&expression.node)) {
+                construct->type = canonical(construct->type);
+            }
+        }
+        for (Stmt &statement : module_.stmts) {
+            if (auto *local = std::get_if<LocalDecl>(&statement.node); local && local->type.valid()) {
+                local->type = canonical(local->type);
+            } else if (auto *state = std::get_if<StateDecl>(&statement.node); state && state->type.valid()) {
+                state->type = canonical(state->type);
+            }
+        }
+        for (Constraint &constraint : module_.constraints) {
+            if (auto *constraint_type = std::get_if<ConstraintType>(&constraint.node)) {
+                constraint_type->type = canonical(constraint_type->type);
+            } else if (auto *requirement = std::get_if<OperatorRequirement>(&constraint.node);
+                       requirement && requirement->result.valid()) {
+                requirement->result = canonical(requirement->result);
+            }
+        }
+        for (Declaration &declaration : module_.declarations) {
+            std::visit(
+                [&](auto &node) {
+                    using T = std::decay_t<decltype(node)>;
+                    if constexpr (std::is_same_v<T, StructDecl>) {
+                        for (GenericParameter &generic : node.generics) {
+                            if (generic.type.valid()) { generic.type = canonical(generic.type); }
+                        }
+                        for (TypeId &parent : node.parents) { parent = canonical(parent); }
+                        for (StructField &field : node.fields) { field.type = canonical(field.type); }
+                    } else if constexpr (std::is_same_v<T, OperatorDecl> || std::is_same_v<T, FunctionDecl>) {
+                        for (GenericParameter &generic : node.generics) {
+                            if (generic.type.valid()) { generic.type = canonical(generic.type); }
+                        }
+                        rewrite_signature(node.signature);
+                    }
+                },
+                declaration.node);
+        }
+    }
+
+    bool CanonicalTypes::same(TypeId lhs, TypeId rhs) const noexcept {
+        return lhs.valid() && rhs.valid() && canonical(lhs) == canonical(rhs);
+    }
+
+    bool CanonicalTypes::numeric(TypeId id) const noexcept {
+        if (!id.valid()) { return false; }
+        const Type &value = module_.type(canonical(id));
+        return value.kind == TypeKind::Scalar && (value.scalar == ScalarType::I64 || value.scalar == ScalarType::F64);
+    }
+
+    bool CanonicalTypes::boolean(TypeId id) const noexcept {
+        if (!id.valid()) { return false; }
+        const Type &value = module_.type(canonical(id));
+        return value.kind == TypeKind::Scalar && value.scalar == ScalarType::Bool;
+    }
+
+    bool CanonicalTypes::assignable(TypeId expected, TypeId actual) const noexcept {
+        expected = canonical(expected);
+        actual   = canonical(actual);
+        if (same(expected, actual)) { return true; }
+        if (!expected.valid() || !actual.valid()) { return false; }
+        const Type &to   = module_.type(expected);
+        const Type &from = module_.type(actual);
+        if (to.kind == TypeKind::Scalar && from.kind == TypeKind::Scalar && to.scalar == ScalarType::F64 &&
+            from.scalar == ScalarType::I64) {
+            return true;
+        }
+        if (to.kind == TypeKind::Atomic && !to.children.empty() && same(to.children.front(), actual)) { return true; }
+        if (from.kind == TypeKind::Atomic && !from.children.empty() && same(expected, from.children.front())) { return true; }
+        return false;
+    }
+
+    bool CanonicalTypes::same_value(ExprId lhs, ExprId rhs) const { return value_key(lhs) == value_key(rhs); }
+
+    std::string CanonicalTypes::name(TypeId id) const {
+        if (!id.valid()) { return "<unresolved>"; }
+        const Type &value = module_.type(canonical(id));
+        switch (value.kind) {
+            case TypeKind::Void: return "void";
+            case TypeKind::Scalar: return std::string{scalar_type_name(value.scalar)};
+            case TypeKind::Symbol: return value.symbol.valid() ? module_.symbol(value.symbol).name : "<type>";
+            case TypeKind::Tuple: return "tuple";
+            case TypeKind::List: return "list";
+            case TypeKind::Set: return "set";
+            case TypeKind::Map: return "map";
+            case TypeKind::Rolling: return "rolling";
+            case TypeKind::Atomic: return "atomic";
+            case TypeKind::Iterator: return "iterator";
+            case TypeKind::Callable: return "fn";
+            case TypeKind::Capability: return "capability";
+            case TypeKind::HarnessSequence: return "harness sequence";
+            case TypeKind::Deferred: return "<deferred>";
+        }
+        std::unreachable();
+    }
+}  // namespace hgl::ir::detail

--- a/language/src/ir/canonical_types.h
+++ b/language/src/ir/canonical_types.h
@@ -1,0 +1,52 @@
+#ifndef HGL_IR_CANONICAL_TYPES_H
+#define HGL_IR_CANONICAL_TYPES_H
+
+#include "ir/hir.h"
+#include "syntax/diagnostic.h"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace hgl::ir::detail
+{
+    /// Owns structural interning and source-to-canonical rewriting for one HIR
+    /// module. Source ranges remain on the original type nodes; semantic
+    /// clients use the canonical representatives produced here.
+    class CanonicalTypes
+    {
+      public:
+        CanonicalTypes(hir::Module &module, syntax::DiagnosticSink &diagnostics);
+
+        void initialize();
+
+        [[nodiscard]] hir::TypeId canonical(hir::TypeId id) const noexcept;
+        [[nodiscard]] hir::TypeId intern(hir::Type value);
+        [[nodiscard]] hir::TypeId make(hir::TypeKind kind, std::vector<hir::TypeId> children = {}, hir::SymbolId symbol = {});
+        [[nodiscard]] hir::TypeId scalar(hir::ScalarType value);
+        [[nodiscard]] hir::TypeId void_type() const noexcept { return void_type_; }
+
+        [[nodiscard]] bool        same(hir::TypeId lhs, hir::TypeId rhs) const noexcept;
+        [[nodiscard]] bool        numeric(hir::TypeId id) const noexcept;
+        [[nodiscard]] bool        boolean(hir::TypeId id) const noexcept;
+        [[nodiscard]] bool        assignable(hir::TypeId expected, hir::TypeId actual) const noexcept;
+        [[nodiscard]] bool        same_value(hir::ExprId lhs, hir::ExprId rhs) const;
+        [[nodiscard]] std::string name(hir::TypeId id) const;
+
+      private:
+        [[nodiscard]] std::string value_key(hir::ExprId id) const;
+        [[nodiscard]] std::string type_key(const hir::Type &value) const;
+        [[nodiscard]] hir::TypeId canonicalize(hir::TypeId id);
+        void                      rewrite_signature(hir::Signature &signature);
+        void                      rewrite_type_references();
+
+        hir::Module                                 &module_;
+        syntax::DiagnosticSink                      &diagnostics_;
+        std::unordered_map<std::string, hir::TypeId> type_intern_{};
+        std::vector<hir::TypeId>                     source_canonical_{};
+        std::vector<bool>                            source_visiting_{};
+        hir::TypeId                                  void_type_{};
+    };
+}  // namespace hgl::ir::detail
+
+#endif  // HGL_IR_CANONICAL_TYPES_H

--- a/language/src/ir/hir.h
+++ b/language/src/ir/hir.h
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <limits>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <variant>
@@ -94,6 +95,7 @@ namespace hgl::ir::hir
     };
 
     enum class TypeKind : std::uint8_t {
+        Void,
         Scalar,
         Symbol,
         Tuple,
@@ -102,6 +104,10 @@ namespace hgl::ir::hir
         Map,
         Rolling,
         Atomic,
+        Iterator,
+        Callable,
+        Capability,
+        HarnessSequence,
         Deferred,
     };
 
@@ -130,6 +136,9 @@ namespace hgl::ir::hir
         ExprId                    min_size{};
         bool                      unbounded{false};
         bool                      value_position{false};
+        /// Structural representative, independent of source spelling and
+        /// value/temporal use. Populated by type completion.
+        TypeId canonical{};
     };
 
     enum class Phase : std::uint8_t {
@@ -149,6 +158,76 @@ namespace hgl::ir::hir
         Operator,
         Type,
         Iterator,
+    };
+
+    /// Observable work performed by an HGL expression, statement, block, or
+    /// function. These flags describe language semantics; they are not a
+    /// backend execution plan.
+    enum class Effect : std::uint32_t {
+        None              = 0,
+        WireGraph         = 1U << 0U,
+        ReadRuntimeInput  = 1U << 1U,
+        ReadState         = 1U << 2U,
+        WriteLocal        = 1U << 3U,
+        WriteState        = 1U << 4U,
+        WriteOutput       = 1U << 5U,
+        UseCapability     = 1U << 6U,
+        IterateCollection = 1U << 7U,
+        TestHarness       = 1U << 8U,
+    };
+
+    [[nodiscard]] constexpr Effect operator|(Effect lhs, Effect rhs) noexcept {
+        return static_cast<Effect>(static_cast<std::uint32_t>(lhs) | static_cast<std::uint32_t>(rhs));
+    }
+
+    constexpr Effect &operator|=(Effect &lhs, Effect rhs) noexcept {
+        lhs = lhs | rhs;
+        return lhs;
+    }
+
+    [[nodiscard]] constexpr bool has_effect(Effect effects, Effect test) noexcept {
+        return (static_cast<std::uint32_t>(effects) & static_cast<std::uint32_t>(test)) != 0U;
+    }
+
+    struct NullValue
+    { friend constexpr bool operator==(NullValue, NullValue) noexcept = default; };
+    struct PlaceholderValue
+    { friend constexpr bool operator==(PlaceholderValue, PlaceholderValue) noexcept = default; };
+    using Constant = std::variant<NullValue, PlaceholderValue, bool, std::int64_t, double, std::string, syntax::TemporalValue>;
+
+    struct Substitution
+    {
+        SymbolId                parameter{};
+        std::string             name{};
+        TypeId                  type{};
+        ExprId                  value{};
+        std::optional<Constant> constant{};
+    };
+
+    enum class OperationKind : std::uint8_t {
+        None,
+        ExactFunction,
+        NominalOperator,
+        Intrinsic,
+        Constructor,
+        Capability,
+        Index,
+        Field,
+        HarnessEval,
+    };
+
+    /// Semantic identity assigned to an expression operation. Operator
+    /// implementations are named by stable symbols/strings and copied
+    /// candidate labels; no registry pointer or wiring object enters HIR.
+    struct Operation
+    {
+        OperationKind             kind{OperationKind::None};
+        SymbolId                  target{};
+        SymbolId                  candidate{};
+        std::string               identity{};
+        std::string               candidate_label{};
+        std::vector<Substitution> substitutions{};
+        bool                      deferred{false};
     };
 
     enum class UnaryOp : std::uint8_t {
@@ -171,12 +250,6 @@ namespace hgl::ir::hir
         And,
         Or,
     };
-
-    struct NullValue
-    { friend constexpr bool operator==(NullValue, NullValue) noexcept = default; };
-    struct PlaceholderValue
-    { friend constexpr bool operator==(PlaceholderValue, PlaceholderValue) noexcept = default; };
-    using Constant = std::variant<NullValue, PlaceholderValue, bool, std::int64_t, double, std::string, syntax::TemporalValue>;
 
     struct Literal
     { Constant value{}; };
@@ -255,11 +328,15 @@ namespace hgl::ir::hir
 
     struct Expr
     {
-        syntax::SourceRange range{};
-        TypeId              type{};
-        Phase               phase{Phase::Unknown};
-        ValueKind           value_kind{ValueKind::Unknown};
-        ExprNode            node{};
+        syntax::SourceRange     range{};
+        TypeId                  type{};
+        Phase                   phase{Phase::Unknown};
+        ValueKind               value_kind{ValueKind::Unknown};
+        ExprNode                node{};
+        DeclarationId           owner{};
+        Effect                  effects{Effect::None};
+        std::optional<Constant> constant{};
+        Operation               operation{};
     };
 
     enum class AssignOp : std::uint8_t {
@@ -320,6 +397,8 @@ namespace hgl::ir::hir
     {
         syntax::SourceRange range{};
         StmtNode            node{};
+        DeclarationId       owner{};
+        Effect              effects{Effect::None};
     };
 
     struct Block
@@ -327,6 +406,8 @@ namespace hgl::ir::hir
         syntax::SourceRange range{};
         std::vector<StmtId> statements{};
         ExprId              tail{};
+        DeclarationId       owner{};
+        Effect              effects{Effect::None};
     };
 
     enum class ConstraintLogicOp : std::uint8_t {
@@ -450,6 +531,8 @@ namespace hgl::ir::hir
         ConstraintId                  requirements{};
         ExprId                        concise_body{};
         BlockId                       block_body{};
+        Effect                        effects{Effect::None};
+        std::vector<SymbolId>         capabilities{};
     };
     struct TestDecl
     { BlockId block{}; };

--- a/language/src/ir/hir_printer.cpp
+++ b/language/src/ir/hir_printer.cpp
@@ -57,6 +57,7 @@ namespace hgl::ir
         std::string_view type_kind_name(hir::TypeKind kind) noexcept {
             using hir::TypeKind;
             switch (kind) {
+                case TypeKind::Void: return "void";
                 case TypeKind::Scalar: return "scalar";
                 case TypeKind::Symbol: return "symbol";
                 case TypeKind::Tuple: return "tuple";
@@ -65,9 +66,53 @@ namespace hgl::ir
                 case TypeKind::Map: return "map";
                 case TypeKind::Rolling: return "rolling";
                 case TypeKind::Atomic: return "atomic";
+                case TypeKind::Iterator: return "iterator";
+                case TypeKind::Callable: return "callable";
+                case TypeKind::Capability: return "capability";
+                case TypeKind::HarnessSequence: return "harness-sequence";
                 case TypeKind::Deferred: return "deferred";
             }
             std::unreachable();
+        }
+
+        std::string_view operation_kind_name(hir::OperationKind kind) noexcept {
+            using hir::OperationKind;
+            switch (kind) {
+                case OperationKind::None: return "none";
+                case OperationKind::ExactFunction: return "exact-function";
+                case OperationKind::NominalOperator: return "nominal-operator";
+                case OperationKind::Intrinsic: return "intrinsic";
+                case OperationKind::Constructor: return "constructor";
+                case OperationKind::Capability: return "capability";
+                case OperationKind::Index: return "index";
+                case OperationKind::Field: return "field";
+                case OperationKind::HarnessEval: return "harness-eval";
+            }
+            std::unreachable();
+        }
+
+        void effects(std::ostream &out, hir::Effect value) {
+            struct Entry
+            {
+                hir::Effect      effect;
+                std::string_view name;
+            };
+            static constexpr Entry entries[]{
+                {hir::Effect::WireGraph, "wire"},           {hir::Effect::ReadRuntimeInput, "read-runtime"},
+                {hir::Effect::ReadState, "read-state"},     {hir::Effect::WriteLocal, "write-local"},
+                {hir::Effect::WriteState, "write-state"},   {hir::Effect::WriteOutput, "write-output"},
+                {hir::Effect::UseCapability, "capability"}, {hir::Effect::IterateCollection, "iterate"},
+                {hir::Effect::TestHarness, "test-harness"},
+            };
+            out << '[';
+            bool first = true;
+            for (const Entry &entry : entries) {
+                if (!hir::has_effect(value, entry.effect)) { continue; }
+                if (!first) { out << ", "; }
+                first = false;
+                out << entry.name;
+            }
+            out << ']';
         }
 
         std::string_view phase_name(hir::Phase phase) noexcept {
@@ -234,6 +279,7 @@ namespace hgl::ir
                     if (type.min_size.valid()) { out_ << " min-size=" << ref('e', type.min_size); }
                     if (type.unbounded) { out_ << " unbounded"; }
                     out_ << (type.value_position ? " value" : " signal");
+                    if (type.canonical.valid()) { out_ << " canonical=" << ref('t', type.canonical); }
                     range(out_, type.range);
                     out_ << '\n';
                 }
@@ -291,6 +337,43 @@ namespace hgl::ir
                             }
                         },
                         expression.node);
+                    if (expression.constant && !std::holds_alternative<hir::Literal>(expression.node)) {
+                        out_ << " constant=";
+                        constant(out_, *expression.constant);
+                    }
+                    if (expression.operation.kind != hir::OperationKind::None) {
+                        const hir::Operation &operation = expression.operation;
+                        out_ << " operation=" << operation_kind_name(operation.kind);
+                        if (operation.target.valid()) { out_ << ':' << ref('s', operation.target); }
+                        if (!operation.identity.empty()) { out_ << ':' << operation.identity; }
+                        if (operation.candidate.valid()) { out_ << " candidate=" << ref('s', operation.candidate); }
+                        if (!operation.candidate_label.empty()) {
+                            out_ << " candidate-label=" << std::quoted(operation.candidate_label);
+                        }
+                        if (!operation.substitutions.empty()) {
+                            out_ << " substitutions=[";
+                            for (std::size_t substitution = 0; substitution < operation.substitutions.size(); ++substitution) {
+                                if (substitution != 0) { out_ << ", "; }
+                                const hir::Substitution &value = operation.substitutions[substitution];
+                                out_ << (value.parameter.valid() ? ref('s', value.parameter) : value.name) << '=';
+                                if (value.type.valid()) {
+                                    out_ << ref('t', value.type);
+                                } else if (value.value.valid()) {
+                                    out_ << ref('e', value.value);
+                                } else if (value.constant) {
+                                    constant(out_, *value.constant);
+                                } else {
+                                    out_ << '_';
+                                }
+                            }
+                            out_ << ']';
+                        }
+                        if (operation.deferred) { out_ << " deferred"; }
+                    }
+                    if (module_.completion == hir::Completion::Typed) {
+                        out_ << " effects=";
+                        effects(out_, expression.effects);
+                    }
                     range(out_, expression.range);
                     out_ << '\n';
                 }
@@ -333,6 +416,10 @@ namespace hgl::ir
                             }
                         },
                         statement.node);
+                    if (module_.completion == hir::Completion::Typed) {
+                        out_ << " effects=";
+                        effects(out_, statement.effects);
+                    }
                     range(out_, statement.range);
                     out_ << '\n';
                 }
@@ -345,6 +432,10 @@ namespace hgl::ir
                     out_ << "  b" << index << " statements=";
                     refs(out_, 'q', block.statements);
                     out_ << " tail=" << ref('e', block.tail);
+                    if (module_.completion == hir::Completion::Typed) {
+                        out_ << " effects=";
+                        effects(out_, block.effects);
+                    }
                     range(out_, block.range);
                     out_ << '\n';
                 }
@@ -467,6 +558,12 @@ namespace hgl::ir
                                 print_signature(node.signature);
                                 out_ << " requires=" << ref('c', node.requirements) << " concise=" << ref('e', node.concise_body)
                                      << " block=" << ref('b', node.block_body);
+                                if (module_.completion == hir::Completion::Typed) {
+                                    out_ << " effects=";
+                                    effects(out_, node.effects);
+                                    out_ << " capabilities=";
+                                    refs(out_, 's', node.capabilities);
+                                }
                             } else if constexpr (std::is_same_v<T, hir::TestDecl>) {
                                 out_ << "test block=" << ref('b', node.block);
                             }

--- a/language/src/ir/lower.cpp
+++ b/language/src/ir/lower.cpp
@@ -147,6 +147,7 @@ namespace hgl::ir
                 type_owners_.resize(module_.types.size(), ast::no_node);
                 expr_owners_.resize(module_.exprs.size(), ast::no_node);
                 stmt_owners_.resize(module_.stmts.size(), ast::no_node);
+                block_owners_.resize(module_.blocks.size(), ast::no_node);
             }
 
             hir::Module run() {
@@ -274,6 +275,7 @@ namespace hgl::ir
 
             void mark_block(ast::BlockId block, ast::DeclId owner) {
                 if (block == ast::no_node) { return; }
+                block_owners_[block] = owner;
                 for (ast::StmtId statement : module_.block(block).statements) { mark_stmt(statement, owner); }
             }
 
@@ -582,8 +584,13 @@ namespace hgl::ir
                         value_kind = hir::ValueKind::Type;
                     }
                 }
-                result_.exprs.push_back(hir::Expr{range, symbol.valid() ? result_.symbol(symbol).type : hir::no_type, phase,
-                                                  value_kind, hir::SymbolRef{symbol}});
+                hir::Expr expression;
+                expression.range      = range;
+                expression.type       = symbol.valid() ? result_.symbol(symbol).type : hir::no_type;
+                expression.phase      = phase;
+                expression.value_kind = value_kind;
+                expression.node       = hir::SymbolRef{symbol};
+                result_.exprs.push_back(std::move(expression));
                 return result;
             }
 
@@ -695,6 +702,7 @@ namespace hgl::ir
                 const ast::Expr &source = module_.expr(index);
                 hir::Expr        target;
                 target.range = source.range;
+                target.owner = id<hir::DeclarationId>(expr_owners_[index]);
                 std::visit(
                     [&](const auto &node) {
                         using T = std::decay_t<decltype(node)>;
@@ -703,32 +711,41 @@ namespace hgl::ir
                             target.type       = literal_type(hir::ScalarType::I64);
                             target.phase      = hir::Phase::Constant;
                             target.value_kind = hir::ValueKind::Constant;
+                            target.constant   = hir::Constant{node.value};
                         } else if constexpr (std::is_same_v<T, ast::FloatLiteral>) {
                             target.node       = hir::Literal{node.value};
                             target.type       = literal_type(hir::ScalarType::F64);
                             target.phase      = hir::Phase::Constant;
                             target.value_kind = hir::ValueKind::Constant;
+                            target.constant   = hir::Constant{node.value};
                         } else if constexpr (std::is_same_v<T, ast::StringLiteral>) {
                             target.node       = hir::Literal{node.value};
                             target.type       = literal_type(hir::ScalarType::Str);
                             target.phase      = hir::Phase::Constant;
                             target.value_kind = hir::ValueKind::Constant;
+                            target.constant   = hir::Constant{node.value};
                         } else if constexpr (std::is_same_v<T, ast::BoolLiteral>) {
                             target.node       = hir::Literal{node.value};
                             target.type       = literal_type(hir::ScalarType::Bool);
                             target.phase      = hir::Phase::Constant;
                             target.value_kind = hir::ValueKind::Constant;
+                            target.constant   = hir::Constant{node.value};
                         } else if constexpr (std::is_same_v<T, ast::NullLiteral>) {
                             target.node       = hir::Literal{hir::NullValue{}};
                             target.phase      = hir::Phase::Constant;
                             target.value_kind = hir::ValueKind::Constant;
+                            target.constant   = hir::Constant{hir::NullValue{}};
                         } else if constexpr (std::is_same_v<T, ast::TemporalLiteral>) {
                             target.node       = hir::Literal{node.value};
                             target.type       = literal_type(temporal_type(node.value.kind));
                             target.phase      = hir::Phase::Constant;
                             target.value_kind = hir::ValueKind::Constant;
+                            target.constant   = hir::Constant{node.value};
                         } else if constexpr (std::is_same_v<T, ast::Placeholder>) {
-                            target.node = hir::Literal{hir::PlaceholderValue{}};
+                            target.node       = hir::Literal{hir::PlaceholderValue{}};
+                            target.phase      = hir::Phase::Constant;
+                            target.value_kind = hir::ValueKind::Constant;
+                            target.constant   = hir::Constant{hir::PlaceholderValue{}};
                         } else if constexpr (std::is_same_v<T, ast::NameRef>) {
                             target.node = hir::SymbolRef{symbol_for(resolved_.binding(index), node.name.range, node.name.text)};
                         } else if constexpr (std::is_same_v<T, ast::QualifiedRef>) {
@@ -798,6 +815,7 @@ namespace hgl::ir
                 const ast::Stmt &source = module_.stmt(index);
                 hir::Stmt        target;
                 target.range = source.range;
+                target.owner = id<hir::DeclarationId>(stmt_owners_[index]);
                 std::visit(
                     [&](const auto &node) {
                         using T = std::decay_t<decltype(node)>;
@@ -835,6 +853,7 @@ namespace hgl::ir
                 const ast::Block &source = module_.block(index);
                 hir::Block        target;
                 target.range = source.range;
+                target.owner = id<hir::DeclarationId>(block_owners_[index]);
                 for (ast::StmtId statement : source.statements) { target.statements.push_back(id<hir::StmtId>(statement)); }
                 target.tail           = id<hir::ExprId>(source.tail);
                 result_.blocks[index] = std::move(target);
@@ -989,6 +1008,7 @@ namespace hgl::ir
             std::vector<ast::DeclId>                       type_owners_{};
             std::vector<ast::DeclId>                       expr_owners_{};
             std::vector<ast::DeclId>                       stmt_owners_{};
+            std::vector<ast::DeclId>                       block_owners_{};
             std::unordered_map<std::string, hir::SymbolId> global_symbols_{};
             std::unordered_map<std::string, hir::SymbolId> external_symbols_{};
             std::unordered_map<std::uint8_t, hir::TypeId>  literal_types_{};

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -67,9 +67,10 @@ namespace hgl::ir
                     return false;
                 }
 
+                expr_state_.resize(module_.exprs.size());
+                check_type_expressions();
                 canonical_types_.initialize();
                 void_type_ = canonical_types_.void_type();
-                expr_state_.resize(module_.exprs.size());
                 for (DeclarationId declaration : module_.source_order) { check_declaration(declaration); }
                 validate_completion();
                 if (diagnostics_.has_errors()) { return false; }
@@ -167,7 +168,11 @@ namespace hgl::ir
                                 node.effects = body.effects;
                             } else if (node.block_body.valid()) {
                                 check_block(node.block_body, node.signature.result);
-                                node.effects = module_.block(node.block_body).effects;
+                                const Block &body = module_.block(node.block_body);
+                                if (body.tail.valid()) {
+                                    require_assignable(node.signature.result, module_.expr(body.tail), "function result");
+                                }
+                                node.effects = body.effects;
                             }
                             collect_capabilities(node, id);
                         } else if constexpr (std::is_same_v<T, TestDecl>) {
@@ -210,6 +215,26 @@ namespace hgl::ir
                 if (!assignable(expected, actual.type)) {
                     type_error(actual.range,
                                std::string{what} + " has type " + type_name(actual.type) + ", expected " + type_name(expected));
+                }
+            }
+
+            void check_type_expressions() {
+                const std::size_t type_count = module_.types.size();
+                for (std::size_t index = 0; index < type_count; ++index) {
+                    const Type value          = module_.types[index];
+                    const auto check_constant = [&](ExprId id) {
+                        if (!id.valid()) { return; }
+                        Expr &expression = check_expr(id);
+                        if (expression.phase != Phase::Constant) {
+                            diagnostics_.report(syntax::Category::Phase, expression.range,
+                                                "a type argument requires a compile-time value");
+                        }
+                    };
+                    check_constant(value.size);
+                    check_constant(value.min_size);
+                    for (const TypeArgument &argument : value.arguments) {
+                        if (argument.kind == TypeArgumentKind::Value) { check_constant(argument.value); }
+                    }
                 }
             }
 
@@ -663,10 +688,21 @@ namespace hgl::ir
                 Bindings                  bindings;
                 for (std::size_t index = 0; index < bound.size(); ++index) {
                     if (!bound[index].valid()) { continue; }
-                    Expr &argument = check_expr(bound[index]);
-                    if (!unify(fn.signature.parameters[index].type, argument.type, bindings)) {
-                        type_error(argument.range, "argument has type " + type_name(argument.type) + ", expected " +
-                                                       type_name(fn.signature.parameters[index].type));
+                    Expr            &argument  = check_expr(bound[index]);
+                    const Parameter &parameter = fn.signature.parameters[index];
+                    if (parameter.is_const && argument.phase != Phase::Constant) {
+                        diagnostics_.report(syntax::Category::Phase, argument.range,
+                                            "a const parameter requires a compile-time value");
+                    }
+                    if (parameter.is_const && parameter.symbol.valid()) {
+                        const auto [found, inserted] = bindings.value.emplace(parameter.symbol.value, bound[index]);
+                        if (!inserted && !canonical_types_.same_value(found->second, bound[index])) {
+                            type_error(argument.range, "const parameter has an inconsistent value binding");
+                        }
+                    }
+                    if (!unify(parameter.type, argument.type, bindings)) {
+                        type_error(argument.range,
+                                   "argument has type " + type_name(argument.type) + ", expected " + type_name(parameter.type));
                     }
                 }
                 if (expected.valid()) { (void)unify(fn.signature.result, expected, bindings); }
@@ -948,7 +984,9 @@ namespace hgl::ir
                                     std::get_if<StructDecl>(&module_.declaration(structure_symbol.owner).node)) {
                                 const auto found = std::find_if(structure->fields.begin(), structure->fields.end(),
                                                                 [&](const StructField &field) { return field.name == node.name; });
-                                if (found != structure->fields.end()) { expression.type = found->type; }
+                                if (found != structure->fields.end()) {
+                                    expression.type = apply_struct_field_type(found->type, base_id);
+                                }
                             }
                         }
                     }
@@ -1129,44 +1167,105 @@ namespace hgl::ir
                                                   .identity = module_.path + "." + module_.symbol(reference->symbol).name};
             }
 
-            [[nodiscard]] std::unordered_map<std::uint32_t, TypeId> struct_bindings(TypeId applied) const {
-                std::unordered_map<std::uint32_t, TypeId> result;
+            void bind_struct_arguments(TypeId applied, Bindings &bindings) const {
                 applied = unwrap_atomic(applied);
-                if (!applied.valid()) { return result; }
+                if (!applied.valid()) { return; }
                 const Type &value = type(applied);
-                if (value.kind != TypeKind::Symbol || !value.symbol.valid()) { return result; }
+                if (value.kind != TypeKind::Symbol || !value.symbol.valid()) { return; }
                 const Symbol &symbol = module_.symbol(value.symbol);
-                if (!symbol.owner.valid()) { return result; }
+                if (!symbol.owner.valid()) { return; }
                 const auto *structure = std::get_if<StructDecl>(&module_.declaration(symbol.owner).node);
-                if (!structure) { return result; }
+                if (!structure) { return; }
                 for (std::size_t index = 0; index < structure->generics.size() && index < value.arguments.size(); ++index) {
                     const GenericParameter &generic  = structure->generics[index];
                     const TypeArgument     &argument = value.arguments[index];
                     if (!generic.is_const && argument.kind == TypeArgumentKind::Type) {
-                        result.emplace(generic.symbol.value, argument.type);
+                        bindings.type.emplace(generic.symbol.value, argument.type);
+                    } else if (generic.is_const && argument.kind == TypeArgumentKind::Value) {
+                        bindings.value.emplace(generic.symbol.value, argument.value);
                     }
                 }
-                return result;
             }
 
             [[nodiscard]] TypeId apply_struct_field_type(TypeId field, TypeId applied) {
                 Bindings bindings;
-                bindings.type = struct_bindings(applied);
+                bind_struct_arguments(applied, bindings);
                 return substitute(field, bindings);
             }
 
-            void check_constructor_arguments(Expr &expression, TypeId applied, const std::vector<Argument> &arguments, bool delta) {
+            [[nodiscard]] TypeId infer_struct_application(TypeId applied, const StructDecl &structure,
+                                                          const std::vector<Argument> &arguments, syntax::SourceRange range) {
                 const TypeId unwrapped = unwrap_atomic(applied);
-                if (!unwrapped.valid()) { return; }
+                if (!unwrapped.valid()) { return applied; }
+                const Type nominal = type(unwrapped);
+                if (nominal.arguments.size() >= structure.generics.size()) { return applied; }
+
+                Bindings bindings;
+                bind_struct_arguments(unwrapped, bindings);
+                std::size_t positional = 0;
+                for (const Argument &argument : arguments) {
+                    const StructField *field = nullptr;
+                    if (argument.name.empty()) {
+                        if (positional < structure.fields.size()) { field = &structure.fields[positional++]; }
+                    } else {
+                        const auto found = std::find_if(structure.fields.begin(), structure.fields.end(),
+                                                        [&](const StructField &item) { return item.name == argument.name; });
+                        if (found != structure.fields.end()) { field = &*found; }
+                    }
+                    if (!field) { continue; }
+                    const Expr &source = module_.expr(argument.value);
+                    if (source.constant && std::holds_alternative<NullValue>(*source.constant)) { continue; }
+                    Expr &value = check_expr(argument.value);
+                    (void)unify(field->type, value.type, bindings);
+                }
+
+                Type inferred = nominal;
+                inferred.arguments.clear();
+                bool complete = true;
+                for (const GenericParameter &generic : structure.generics) {
+                    TypeArgument argument;
+                    argument.range = range;
+                    if (generic.is_const) {
+                        argument.kind    = TypeArgumentKind::Value;
+                        const auto found = bindings.value.find(generic.symbol.value);
+                        if (found == bindings.value.end()) {
+                            complete = false;
+                            type_error(range,
+                                       "cannot infer generic '" + module_.symbol(generic.symbol).name + "' for struct constructor");
+                        } else {
+                            argument.value = found->second;
+                        }
+                    } else {
+                        argument.kind    = TypeArgumentKind::Type;
+                        const auto found = bindings.type.find(generic.symbol.value);
+                        if (found == bindings.type.end()) {
+                            complete = false;
+                            type_error(range,
+                                       "cannot infer generic '" + module_.symbol(generic.symbol).name + "' for struct constructor");
+                        } else {
+                            argument.type = found->second;
+                        }
+                    }
+                    inferred.arguments.push_back(argument);
+                }
+                return complete ? intern(std::move(inferred)) : applied;
+            }
+
+            [[nodiscard]] TypeId check_constructor_arguments(Expr &expression, TypeId applied,
+                                                             const std::vector<Argument> &arguments, bool delta) {
+                TypeId unwrapped = unwrap_atomic(applied);
+                if (!unwrapped.valid()) { return applied; }
                 const Type &nominal = type(unwrapped);
                 if (nominal.kind != TypeKind::Symbol || !nominal.symbol.valid()) {
                     type_error(expression.range, "constructor requires a struct type");
-                    return;
+                    return applied;
                 }
                 const Symbol &symbol = module_.symbol(nominal.symbol);
                 const auto   *structure =
                     symbol.owner.valid() ? std::get_if<StructDecl>(&module_.declaration(symbol.owner).node) : nullptr;
-                if (!structure) { return; }
+                if (!structure) { return applied; }
+                applied                = infer_struct_application(applied, *structure, arguments, expression.range);
+                unwrapped              = unwrap_atomic(applied);
                 std::size_t positional = 0;
                 for (const Argument &argument : arguments) {
                     const StructField *field = nullptr;
@@ -1189,6 +1288,7 @@ namespace hgl::ir
                     }
                     expression.effects |= value.effects;
                 }
+                return applied;
             }
 
             void check_struct_call(Expr &expression, const Call &call, SymbolId target, TypeId expected) {
@@ -1197,7 +1297,7 @@ namespace hgl::ir
                     const TypeId unwrapped = unwrap_atomic(expected);
                     if (type(unwrapped).kind == TypeKind::Symbol && type(unwrapped).symbol == target) { applied = expected; }
                 }
-                check_constructor_arguments(expression, applied, call.arguments, false);
+                applied               = check_constructor_arguments(expression, applied, call.arguments, false);
                 expression.type       = canonical(applied);
                 expression.phase      = runtime_owner(expression.owner) ? Phase::Runtime : Phase::Wiring;
                 expression.value_kind = value_kind_for_phase(expression.phase);
@@ -1210,7 +1310,7 @@ namespace hgl::ir
             void check_construct(Expr &expression, const Construct &node, TypeId expected) {
                 TypeId applied = canonical(node.type);
                 if (expected.valid() && assignable(expected, applied)) { applied = canonical(expected); }
-                check_constructor_arguments(expression, applied, node.arguments, node.delta);
+                applied               = check_constructor_arguments(expression, applied, node.arguments, node.delta);
                 expression.type       = applied;
                 expression.phase      = runtime_owner(expression.owner) ? Phase::Runtime : Phase::Wiring;
                 expression.value_kind = value_kind_for_phase(expression.phase);

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -1,0 +1,1452 @@
+#include "ir/type_check.h"
+
+#include "ir/canonical_types.h"
+#include "syntax/temporal.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+
+namespace hgl::ir
+{
+    namespace
+    {
+        using namespace hir;
+
+        [[nodiscard]] Phase join_phase(Phase lhs, Phase rhs) noexcept {
+            return static_cast<Phase>(std::max(static_cast<unsigned>(lhs), static_cast<unsigned>(rhs)));
+        }
+
+        [[nodiscard]] ValueKind value_kind_for_phase(Phase phase) noexcept {
+            switch (phase) {
+                case Phase::Constant: return ValueKind::Constant;
+                case Phase::Wiring: return ValueKind::Signal;
+                case Phase::Runtime: return ValueKind::RuntimeValue;
+                case Phase::Unknown: return ValueKind::Unknown;
+            }
+            std::unreachable();
+        }
+
+        [[nodiscard]] std::string_view binary_identity(BinaryOp op) noexcept {
+            switch (op) {
+                case BinaryOp::Mul: return "mul_";
+                case BinaryOp::Div: return "div_";
+                case BinaryOp::Rem: return "mod_";
+                case BinaryOp::Add: return "add_";
+                case BinaryOp::Sub: return "sub_";
+                case BinaryOp::Less: return "lt_";
+                case BinaryOp::LessEqual: return "le_";
+                case BinaryOp::Greater: return "gt_";
+                case BinaryOp::GreaterEqual: return "ge_";
+                case BinaryOp::Equal: return "eq_";
+                case BinaryOp::NotEqual: return "ne_";
+                case BinaryOp::And: return "and_";
+                case BinaryOp::Or: return "or_";
+            }
+            std::unreachable();
+        }
+
+        [[nodiscard]] std::string_view unary_identity(UnaryOp op) noexcept { return op == UnaryOp::Negate ? "neg_" : "not_"; }
+
+        class TypeChecker
+        {
+          public:
+            TypeChecker(Module &module, const OperatorResolver &resolve_operator, syntax::DiagnosticSink &diagnostics)
+                : module_{module}, resolve_operator_{resolve_operator}, diagnostics_{diagnostics},
+                  canonical_types_{module, diagnostics} {}
+
+            bool run() {
+                if (module_.completion != Completion::Resolved) {
+                    diagnostics_.report(syntax::Category::Type, {}, "type completion requires resolved HIR");
+                    return false;
+                }
+
+                canonical_types_.initialize();
+                void_type_ = canonical_types_.void_type();
+                expr_state_.resize(module_.exprs.size());
+                for (DeclarationId declaration : module_.source_order) { check_declaration(declaration); }
+                validate_completion();
+                if (diagnostics_.has_errors()) { return false; }
+                module_.completion = Completion::Typed;
+                return true;
+            }
+
+          private:
+            struct Bindings
+            {
+                std::unordered_map<std::uint32_t, TypeId> type;
+                std::unordered_map<std::uint32_t, ExprId> value;
+            };
+
+            [[nodiscard]] const Type &type(TypeId id) const { return module_.type(id); }
+            [[nodiscard]] Type       &type(TypeId id) { return module_.types[id.value]; }
+
+            [[nodiscard]] TypeId canonical(TypeId id) const noexcept { return canonical_types_.canonical(id); }
+            [[nodiscard]] TypeId intern(Type value) { return canonical_types_.intern(std::move(value)); }
+            [[nodiscard]] TypeId make_type(TypeKind kind, std::vector<TypeId> children = {}, SymbolId symbol = {}) {
+                return canonical_types_.make(kind, std::move(children), symbol);
+            }
+            [[nodiscard]] TypeId scalar(ScalarType value) { return canonical_types_.scalar(value); }
+            [[nodiscard]] bool   same(TypeId lhs, TypeId rhs) const noexcept { return canonical_types_.same(lhs, rhs); }
+            [[nodiscard]] bool   numeric(TypeId id) const noexcept { return canonical_types_.numeric(id); }
+            [[nodiscard]] bool   boolean(TypeId id) const noexcept { return canonical_types_.boolean(id); }
+            [[nodiscard]] bool   assignable(TypeId expected, TypeId actual) const noexcept {
+                return canonical_types_.assignable(expected, actual);
+            }
+
+            void type_error(syntax::SourceRange range, std::string message) {
+                diagnostics_.report(syntax::Category::Type, range, std::move(message));
+            }
+
+            [[nodiscard]] std::string type_name(TypeId id) const { return canonical_types_.name(id); }
+
+            [[nodiscard]] const FunctionDecl *function(DeclarationId id) const noexcept {
+                if (!id.valid() || id.value >= module_.declarations.size()) { return nullptr; }
+                return std::get_if<FunctionDecl>(&module_.declaration(id).node);
+            }
+
+            [[nodiscard]] FunctionDecl *function(DeclarationId id) noexcept {
+                if (!id.valid() || id.value >= module_.declarations.size()) { return nullptr; }
+                return std::get_if<FunctionDecl>(&module_.declarations[id.value].node);
+            }
+
+            [[nodiscard]] bool runtime_owner(DeclarationId id) const noexcept {
+                const FunctionDecl *fn = function(id);
+                return fn != nullptr && fn->kind == FunctionKind::Runtime;
+            }
+
+            [[nodiscard]] TypeId callable_type(const Signature &signature) {
+                std::vector<TypeId> children;
+                children.reserve(signature.parameters.size() + 1U);
+                for (const Parameter &parameter : signature.parameters) { children.push_back(parameter.type); }
+                children.push_back(signature.result);
+                return make_type(TypeKind::Callable, std::move(children));
+            }
+
+            [[nodiscard]] TypeId callable_type(SymbolId symbol) {
+                if (!symbol.valid()) { return make_type(TypeKind::Callable); }
+                const Symbol &target = module_.symbol(symbol);
+                if (!target.owner.valid()) { return make_type(TypeKind::Callable); }
+                const DeclarationNode &node = module_.declaration(target.owner).node;
+                if (const auto *fn = std::get_if<FunctionDecl>(&node)) { return callable_type(fn->signature); }
+                if (const auto *op = std::get_if<OperatorDecl>(&node)) { return callable_type(op->signature); }
+                return make_type(TypeKind::Callable);
+            }
+
+            void check_declaration(DeclarationId id) {
+                if (!id.valid()) { return; }
+                Declaration &declaration = module_.declarations[id.value];
+                std::visit(
+                    [&](auto &node) {
+                        using T = std::decay_t<decltype(node)>;
+                        if constexpr (std::is_same_v<T, StructDecl>) {
+                            for (StructField &field : node.fields) {
+                                if (!field.default_value.valid()) { continue; }
+                                Expr &value = check_expr(field.default_value, field.type);
+                                if (value.constant && std::holds_alternative<NullValue>(*value.constant)) {
+                                    if (!field.optional) { type_error(value.range, "null is only valid for an optional field"); }
+                                } else {
+                                    require_assignable(field.type, value, "field default");
+                                }
+                            }
+                        } else if constexpr (std::is_same_v<T, OperatorDecl>) {
+                            reject_unimplemented_requirements(node.requirements);
+                            check_signature_defaults(node.signature);
+                        } else if constexpr (std::is_same_v<T, FunctionDecl>) {
+                            reject_unimplemented_requirements(node.requirements);
+                            check_signature_defaults(node.signature);
+                            if (node.concise_body.valid()) {
+                                Expr &body = check_expr(node.concise_body, node.signature.result);
+                                require_assignable(node.signature.result, body, "function result");
+                                node.effects = body.effects;
+                            } else if (node.block_body.valid()) {
+                                check_block(node.block_body, node.signature.result);
+                                node.effects = module_.block(node.block_body).effects;
+                            }
+                            collect_capabilities(node, id);
+                        } else if constexpr (std::is_same_v<T, TestDecl>) {
+                            check_block(node.block, void_type_);
+                        }
+                    },
+                    declaration.node);
+            }
+
+            void reject_unimplemented_requirements(ConstraintId requirements) {
+                if (!requirements.valid()) { return; }
+                diagnostics_.report(syntax::Category::Type, module_.constraint(requirements).range,
+                                    "callable 'requires' evaluation is not implemented in typed HIR yet");
+            }
+
+            void check_signature_defaults(Signature &signature) {
+                for (Parameter &parameter : signature.parameters) {
+                    if (!parameter.default_value.valid()) { continue; }
+                    Expr &value = check_expr(parameter.default_value, parameter.type);
+                    require_assignable(parameter.type, value, "parameter default");
+                    if (value.phase != Phase::Constant) {
+                        diagnostics_.report(syntax::Category::Phase, value.range,
+                                            "a parameter default must be a compile-time constant");
+                    }
+                }
+            }
+
+            void collect_capabilities(FunctionDecl &fn, DeclarationId owner) {
+                fn.capabilities.clear();
+                for (const Stmt &statement : module_.stmts) {
+                    if (statement.owner != owner) { continue; }
+                    if (const auto *inject = std::get_if<InjectDecl>(&statement.node)) {
+                        fn.capabilities.insert(fn.capabilities.end(), inject->symbols.begin(), inject->symbols.end());
+                    }
+                }
+            }
+
+            void require_assignable(TypeId expected, const Expr &actual, std::string_view what) {
+                if (!expected.valid() || !actual.type.valid()) { return; }
+                if (!assignable(expected, actual.type)) {
+                    type_error(actual.range,
+                               std::string{what} + " has type " + type_name(actual.type) + ", expected " + type_name(expected));
+                }
+            }
+
+            Expr &check_expr(ExprId id, TypeId expected = {}) {
+                if (!id.valid()) { return missing_expression_; }
+                if (id.value >= expr_state_.size()) { expr_state_.resize(module_.exprs.size()); }
+                Expr &expression = module_.exprs[id.value];
+                if (expr_state_[id.value] == 2U) {
+                    contextualize(expression, expected);
+                    return expression;
+                }
+                if (expr_state_[id.value] == 1U) {
+                    type_error(expression.range, "cyclic expression");
+                    return expression;
+                }
+                expr_state_[id.value] = 1U;
+                std::visit(
+                    [&](auto &node) {
+                        using T = std::decay_t<decltype(node)>;
+                        if constexpr (std::is_same_v<T, Literal>) {
+                            check_literal(expression, expected);
+                        } else if constexpr (std::is_same_v<T, SymbolRef>) {
+                            check_symbol(expression, node);
+                        } else if constexpr (std::is_same_v<T, Unary>) {
+                            check_unary(expression, node);
+                        } else if constexpr (std::is_same_v<T, Binary>) {
+                            check_binary(expression, node, expected);
+                        } else if constexpr (std::is_same_v<T, Call>) {
+                            check_call(expression, node, expected);
+                        } else if constexpr (std::is_same_v<T, Index>) {
+                            check_index(expression, node);
+                        } else if constexpr (std::is_same_v<T, Field>) {
+                            check_field(expression, node);
+                        } else if constexpr (std::is_same_v<T, Sequence>) {
+                            check_sequence(expression, node, expected);
+                        } else if constexpr (std::is_same_v<T, Tuple>) {
+                            check_tuple(expression, node, expected);
+                        } else if constexpr (std::is_same_v<T, Lambda>) {
+                            check_lambda(expression, node, expected);
+                        } else if constexpr (std::is_same_v<T, If>) {
+                            check_if(expression, node, expected);
+                        } else if constexpr (std::is_same_v<T, BlockExpr>) {
+                            check_block_expr(expression, node, expected);
+                        } else if constexpr (std::is_same_v<T, Eval>) {
+                            check_eval(expression, node);
+                        } else if constexpr (std::is_same_v<T, Construct>) {
+                            check_construct(expression, node, expected);
+                        }
+                    },
+                    expression.node);
+                contextualize(expression, expected);
+                expr_state_[id.value] = 2U;
+                return expression;
+            }
+
+            void contextualize(Expr &expression, TypeId expected) {
+                if (!expected.valid()) { return; }
+                expected = canonical(expected);
+                if (!expression.type.valid() && expression.constant &&
+                    (std::holds_alternative<NullValue>(*expression.constant) ||
+                     std::holds_alternative<PlaceholderValue>(*expression.constant))) {
+                    expression.type = expected;
+                }
+                if (expression.type.valid() && assignable(expected, expression.type) && type(expected).kind == TypeKind::Atomic &&
+                    type(expression.type).kind != TypeKind::Atomic) {
+                    expression.type = expected;
+                }
+            }
+
+            void check_literal(Expr &expression, TypeId expected) {
+                if (expression.type.valid()) { expression.type = canonical(expression.type); }
+                contextualize(expression, expected);
+                if (!expression.type.valid()) { type_error(expression.range, "null or '_' requires an expected type"); }
+                expression.phase      = Phase::Constant;
+                expression.value_kind = ValueKind::Constant;
+            }
+
+            void check_symbol(Expr &expression, const SymbolRef &reference) {
+                if (!reference.symbol.valid()) { return; }
+                Symbol &symbol = module_.symbols[reference.symbol.value];
+                switch (symbol.kind) {
+                    case SymbolKind::ConstParameter:
+                        expression.type       = canonical(symbol.type);
+                        expression.phase      = Phase::Constant;
+                        expression.value_kind = ValueKind::Constant;
+                        break;
+                    case SymbolKind::SignalParameter:
+                        expression.type = canonical(symbol.type);
+                        if (runtime_owner(expression.owner)) {
+                            expression.phase      = Phase::Runtime;
+                            expression.value_kind = ValueKind::RuntimeValue;
+                            expression.effects    = Effect::ReadRuntimeInput;
+                        } else {
+                            expression.phase      = Phase::Wiring;
+                            expression.value_kind = ValueKind::Signal;
+                        }
+                        break;
+                    case SymbolKind::LocalLet:
+                    case SymbolKind::LocalVar:
+                    case SymbolKind::LoopValue:
+                    case SymbolKind::LambdaParameter:
+                        expression.type = canonical(symbol.type);
+                        if (const auto found = symbol_phase_.find(reference.symbol.value); found != symbol_phase_.end()) {
+                            expression.phase = found->second;
+                        } else {
+                            expression.phase = runtime_owner(expression.owner) ? Phase::Runtime : Phase::Wiring;
+                        }
+                        expression.value_kind = value_kind_for_phase(expression.phase);
+                        break;
+                    case SymbolKind::State:
+                        expression.type       = canonical(symbol.type);
+                        expression.phase      = Phase::Runtime;
+                        expression.value_kind = ValueKind::RuntimeValue;
+                        expression.effects    = Effect::ReadState;
+                        break;
+                    case SymbolKind::InjectedCapability:
+                        expression.type       = canonical(symbol.type);
+                        expression.phase      = Phase::Runtime;
+                        expression.value_kind = symbol.name == "out" ? ValueKind::RuntimeValue : ValueKind::Function;
+                        expression.effects    = Effect::UseCapability;
+                        break;
+                    case SymbolKind::Function:
+                        expression.type       = callable_type(reference.symbol);
+                        expression.phase      = Phase::Constant;
+                        expression.value_kind = ValueKind::Function;
+                        break;
+                    case SymbolKind::Operator:
+                    case SymbolKind::ImportedOperator:
+                        expression.type       = callable_type(reference.symbol);
+                        expression.phase      = Phase::Constant;
+                        expression.value_kind = ValueKind::Operator;
+                        break;
+                    case SymbolKind::Intrinsic:
+                        expression.type       = make_type(TypeKind::Callable);
+                        expression.phase      = Phase::Constant;
+                        expression.value_kind = ValueKind::Function;
+                        break;
+                    case SymbolKind::Struct:
+                    case SymbolKind::TypeParameter:
+                        expression.type       = make_type(TypeKind::Symbol, {}, reference.symbol);
+                        expression.phase      = Phase::Constant;
+                        expression.value_kind = ValueKind::Type;
+                        break;
+                    case SymbolKind::Module:
+                    case SymbolKind::Test: break;
+                }
+            }
+
+            void check_unary(Expr &expression, const Unary &node) {
+                Expr &operand        = check_expr(node.operand);
+                expression.effects   = operand.effects;
+                expression.phase     = operand.phase;
+                expression.operation = Operation{.kind     = OperationKind::NominalOperator,
+                                                 .identity = std::string{unary_identity(node.op)},
+                                                 .deferred = operand.phase != Phase::Constant};
+                if (node.op == UnaryOp::Not) {
+                    if (!boolean(operand.type)) { type_error(operand.range, "'!' requires bool"); }
+                    expression.type = scalar(ScalarType::Bool);
+                    if (operand.constant && std::holds_alternative<bool>(*operand.constant)) {
+                        expression.constant = Constant{!std::get<bool>(*operand.constant)};
+                    }
+                } else {
+                    if (!numeric(operand.type)) { type_error(operand.range, "unary '-' requires i64 or f64"); }
+                    expression.type = operand.type;
+                    if (operand.constant && std::holds_alternative<std::int64_t>(*operand.constant)) {
+                        expression.constant = Constant{-std::get<std::int64_t>(*operand.constant)};
+                    } else if (operand.constant && std::holds_alternative<double>(*operand.constant)) {
+                        expression.constant = Constant{-std::get<double>(*operand.constant)};
+                    }
+                }
+                if (expression.phase == Phase::Wiring) { expression.effects |= Effect::WireGraph; }
+                expression.value_kind = value_kind_for_phase(expression.phase);
+            }
+
+            [[nodiscard]] TypeId arithmetic_result(BinaryOp op, TypeId lhs, TypeId rhs, syntax::SourceRange range) {
+                if (op == BinaryOp::Add && same(lhs, scalar(ScalarType::Str)) && same(rhs, scalar(ScalarType::Str))) {
+                    return scalar(ScalarType::Str);
+                }
+                if (!numeric(lhs) || !numeric(rhs)) {
+                    type_error(range, "arithmetic operands must both be numeric");
+                    return {};
+                }
+                if (op == BinaryOp::Div || same(lhs, scalar(ScalarType::F64)) || same(rhs, scalar(ScalarType::F64))) {
+                    return scalar(ScalarType::F64);
+                }
+                return scalar(ScalarType::I64);
+            }
+
+            void fold_binary(Expr &expression, BinaryOp op, const Expr &lhs, const Expr &rhs) {
+                if (!lhs.constant || !rhs.constant) { return; }
+                const Constant &a         = *lhs.constant;
+                const Constant &b         = *rhs.constant;
+                const auto      as_double = [](const Constant &value) -> std::optional<double> {
+                    if (const auto *integer = std::get_if<std::int64_t>(&value)) { return static_cast<double>(*integer); }
+                    if (const auto *floating = std::get_if<double>(&value)) { return *floating; }
+                    return std::nullopt;
+                };
+                if (op == BinaryOp::And || op == BinaryOp::Or) {
+                    if (const auto *left = std::get_if<bool>(&a)) {
+                        if (const auto *right = std::get_if<bool>(&b)) {
+                            expression.constant = Constant{op == BinaryOp::And ? (*left && *right) : (*left || *right)};
+                        }
+                    }
+                    return;
+                }
+                if (op == BinaryOp::Equal || op == BinaryOp::NotEqual) {
+                    const bool equal    = a == b;
+                    expression.constant = Constant{op == BinaryOp::Equal ? equal : !equal};
+                    return;
+                }
+                const std::optional<double> left  = as_double(a);
+                const std::optional<double> right = as_double(b);
+                if (!left || !right) {
+                    if (op == BinaryOp::Add) {
+                        const auto *left_string  = std::get_if<std::string>(&a);
+                        const auto *right_string = std::get_if<std::string>(&b);
+                        if (left_string && right_string) { expression.constant = Constant{*left_string + *right_string}; }
+                    }
+                    return;
+                }
+                switch (op) {
+                    case BinaryOp::Less: expression.constant = Constant{*left < *right}; return;
+                    case BinaryOp::LessEqual: expression.constant = Constant{*left <= *right}; return;
+                    case BinaryOp::Greater: expression.constant = Constant{*left > *right}; return;
+                    case BinaryOp::GreaterEqual: expression.constant = Constant{*left >= *right}; return;
+                    case BinaryOp::Add: expression.constant = Constant{*left + *right}; break;
+                    case BinaryOp::Sub: expression.constant = Constant{*left - *right}; break;
+                    case BinaryOp::Mul: expression.constant = Constant{*left * *right}; break;
+                    case BinaryOp::Div:
+                        if (*right == 0.0) {
+                            type_error(expression.range, "division by zero in a constant expression");
+                        } else {
+                            expression.constant = Constant{*left / *right};
+                        }
+                        break;
+                    case BinaryOp::Rem:
+                        if (*right == 0.0) {
+                            type_error(expression.range, "remainder by zero in a constant expression");
+                        } else {
+                            expression.constant = Constant{std::fmod(*left, *right)};
+                        }
+                        break;
+                    case BinaryOp::Equal:
+                    case BinaryOp::NotEqual:
+                    case BinaryOp::And:
+                    case BinaryOp::Or: return;
+                }
+                if (expression.constant && same(expression.type, scalar(ScalarType::I64)) &&
+                    std::holds_alternative<double>(*expression.constant)) {
+                    expression.constant = Constant{static_cast<std::int64_t>(std::get<double>(*expression.constant))};
+                }
+            }
+
+            void check_binary(Expr &expression, const Binary &node, TypeId expected) {
+                Expr &lhs = check_expr(node.lhs);
+                Expr &rhs = check_expr(node.rhs, lhs.type.valid() ? lhs.type : expected);
+                if (!lhs.type.valid() && rhs.type.valid()) { contextualize(lhs, rhs.type); }
+                expression.phase     = join_phase(lhs.phase, rhs.phase);
+                expression.effects   = lhs.effects | rhs.effects;
+                expression.operation = Operation{.kind     = OperationKind::NominalOperator,
+                                                 .identity = std::string{binary_identity(node.op)},
+                                                 .deferred = expression.phase != Phase::Constant};
+                switch (node.op) {
+                    case BinaryOp::And:
+                    case BinaryOp::Or:
+                        if (!boolean(lhs.type) || !boolean(rhs.type)) {
+                            type_error(expression.range, "logical operands must both be bool");
+                        }
+                        expression.type = scalar(ScalarType::Bool);
+                        break;
+                    case BinaryOp::Less:
+                    case BinaryOp::LessEqual:
+                    case BinaryOp::Greater:
+                    case BinaryOp::GreaterEqual:
+                        if (!assignable(lhs.type, rhs.type) && !assignable(rhs.type, lhs.type)) {
+                            type_error(expression.range, "comparison operands have incompatible types");
+                        }
+                        expression.type = scalar(ScalarType::Bool);
+                        break;
+                    case BinaryOp::Equal:
+                    case BinaryOp::NotEqual:
+                        if (!assignable(lhs.type, rhs.type) && !assignable(rhs.type, lhs.type)) {
+                            type_error(expression.range, "equality operands have incompatible types");
+                        }
+                        expression.type = scalar(ScalarType::Bool);
+                        break;
+                    case BinaryOp::Mul:
+                    case BinaryOp::Div:
+                    case BinaryOp::Rem:
+                    case BinaryOp::Add:
+                    case BinaryOp::Sub: expression.type = arithmetic_result(node.op, lhs.type, rhs.type, expression.range); break;
+                }
+                fold_binary(expression, node.op, lhs, rhs);
+                if (expression.phase == Phase::Wiring) { expression.effects |= Effect::WireGraph; }
+                expression.value_kind = value_kind_for_phase(expression.phase);
+            }
+
+            [[nodiscard]] std::vector<ExprId> bind_arguments(const Signature &signature, const std::vector<Argument> &arguments,
+                                                             syntax::SourceRange range) {
+                std::vector<ExprId> bound(signature.parameters.size());
+                std::size_t         next = 0;
+                for (const Argument &argument : arguments) {
+                    if (argument.name.empty()) {
+                        if (next >= bound.size()) {
+                            type_error(argument.range, "too many positional arguments");
+                            continue;
+                        }
+                        while (next < bound.size() && bound[next].valid()) { ++next; }
+                        if (next >= bound.size()) {
+                            type_error(argument.range, "too many positional arguments");
+                            continue;
+                        }
+                        bound[next++] = argument.value;
+                    } else {
+                        const auto found =
+                            std::find_if(signature.parameters.begin(), signature.parameters.end(), [&](const Parameter &parameter) {
+                                return module_.symbol(parameter.symbol).name == argument.name;
+                            });
+                        if (found == signature.parameters.end()) {
+                            diagnostics_.report(syntax::Category::Name, argument.range,
+                                                "unknown parameter '" + argument.name + "'");
+                            continue;
+                        }
+                        const std::size_t index = static_cast<std::size_t>(found - signature.parameters.begin());
+                        if (bound[index].valid()) {
+                            type_error(argument.range, "parameter '" + argument.name + "' is supplied twice");
+                        } else {
+                            bound[index] = argument.value;
+                        }
+                    }
+                }
+                for (std::size_t index = 0; index < bound.size(); ++index) {
+                    if (!bound[index].valid()) { bound[index] = signature.parameters[index].default_value; }
+                    if (!bound[index].valid()) {
+                        type_error(range, "missing argument '" + module_.symbol(signature.parameters[index].symbol).name + "'");
+                    }
+                }
+                return bound;
+            }
+
+            [[nodiscard]] bool unify_value(ExprId pattern, ExprId actual, Bindings &bindings) {
+                if (!pattern.valid() || !actual.valid()) { return pattern == actual; }
+                const Expr &pattern_expr = module_.expr(pattern);
+                if (const auto *reference = std::get_if<SymbolRef>(&pattern_expr.node);
+                    reference && reference->symbol.valid() &&
+                    module_.symbol(reference->symbol).kind == SymbolKind::ConstParameter) {
+                    auto [found, inserted] = bindings.value.emplace(reference->symbol.value, actual);
+                    return inserted || canonical_types_.same_value(found->second, actual);
+                }
+                return canonical_types_.same_value(pattern, actual);
+            }
+
+            [[nodiscard]] bool unify(TypeId pattern, TypeId actual, Bindings &bindings) {
+                pattern = canonical(pattern);
+                actual  = canonical(actual);
+                if (!pattern.valid() || !actual.valid()) { return false; }
+                const Type &lhs = type(pattern);
+                const Type &rhs = type(actual);
+                if (lhs.kind == TypeKind::Symbol && lhs.symbol.valid() &&
+                    module_.symbol(lhs.symbol).kind == SymbolKind::TypeParameter) {
+                    auto [found, inserted] = bindings.type.emplace(lhs.symbol.value, actual);
+                    return inserted || same(found->second, actual);
+                }
+                if (lhs.kind != rhs.kind || lhs.scalar != rhs.scalar || lhs.symbol != rhs.symbol ||
+                    lhs.children.size() != rhs.children.size() || lhs.arguments.size() != rhs.arguments.size() ||
+                    lhs.unbounded != rhs.unbounded) {
+                    return assignable(pattern, actual);
+                }
+                for (std::size_t index = 0; index < lhs.children.size(); ++index) {
+                    if (!unify(lhs.children[index], rhs.children[index], bindings)) { return false; }
+                }
+                for (std::size_t index = 0; index < lhs.arguments.size(); ++index) {
+                    const TypeArgument &a = lhs.arguments[index];
+                    const TypeArgument &b = rhs.arguments[index];
+                    if (a.kind != b.kind) { return false; }
+                    if (a.kind == TypeArgumentKind::Type) {
+                        if (!unify(a.type, b.type, bindings)) { return false; }
+                    } else if (!unify_value(a.value, b.value, bindings)) {
+                        return false;
+                    }
+                }
+                return unify_value(lhs.size, rhs.size, bindings) && unify_value(lhs.min_size, rhs.min_size, bindings);
+            }
+
+            [[nodiscard]] ExprId substitute_value(ExprId value, const Bindings &bindings) const {
+                if (!value.valid()) { return {}; }
+                if (const auto *reference = std::get_if<SymbolRef>(&module_.expr(value).node);
+                    reference && reference->symbol.valid()) {
+                    if (const auto found = bindings.value.find(reference->symbol.value); found != bindings.value.end()) {
+                        return found->second;
+                    }
+                }
+                return value;
+            }
+
+            [[nodiscard]] TypeId substitute(TypeId input, const Bindings &bindings) {
+                input = canonical(input);
+                if (!input.valid()) { return {}; }
+                const Type &source = type(input);
+                if (source.kind == TypeKind::Symbol && source.symbol.valid()) {
+                    if (const auto found = bindings.type.find(source.symbol.value); found != bindings.type.end()) {
+                        return found->second;
+                    }
+                }
+                Type value = source;
+                for (TypeId &child : value.children) { child = substitute(child, bindings); }
+                for (TypeArgument &argument : value.arguments) {
+                    if (argument.kind == TypeArgumentKind::Type) {
+                        argument.type = substitute(argument.type, bindings);
+                    } else {
+                        argument.value = substitute_value(argument.value, bindings);
+                    }
+                }
+                value.size     = substitute_value(value.size, bindings);
+                value.min_size = substitute_value(value.min_size, bindings);
+                return intern(std::move(value));
+            }
+
+            [[nodiscard]] std::vector<Substitution> substitutions(const std::vector<GenericParameter> &generics,
+                                                                  const Bindings                      &bindings) const {
+                std::vector<Substitution> result;
+                result.reserve(generics.size());
+                for (const GenericParameter &generic : generics) {
+                    Substitution value;
+                    value.parameter = generic.symbol;
+                    if (generic.is_const) {
+                        if (const auto found = bindings.value.find(generic.symbol.value); found != bindings.value.end()) {
+                            value.value = found->second;
+                        }
+                    } else if (const auto found = bindings.type.find(generic.symbol.value); found != bindings.type.end()) {
+                        value.type = found->second;
+                    }
+                    result.push_back(value);
+                }
+                return result;
+            }
+
+            void require_complete_bindings(const std::vector<GenericParameter> &generics, const Bindings &bindings,
+                                           syntax::SourceRange range, std::string_view callable) {
+                for (const GenericParameter &generic : generics) {
+                    const bool bound = generic.is_const ? bindings.value.contains(generic.symbol.value)
+                                                        : bindings.type.contains(generic.symbol.value);
+                    if (bound) { continue; }
+                    type_error(range,
+                               "cannot infer generic '" + module_.symbol(generic.symbol).name + "' for " + std::string{callable});
+                }
+            }
+
+            void check_exact_call(Expr &expression, const Call &call, SymbolId target, const FunctionDecl &fn, TypeId expected) {
+                const std::vector<ExprId> bound = bind_arguments(fn.signature, call.arguments, expression.range);
+                Bindings                  bindings;
+                for (std::size_t index = 0; index < bound.size(); ++index) {
+                    if (!bound[index].valid()) { continue; }
+                    Expr &argument = check_expr(bound[index]);
+                    if (!unify(fn.signature.parameters[index].type, argument.type, bindings)) {
+                        type_error(argument.range, "argument has type " + type_name(argument.type) + ", expected " +
+                                                       type_name(fn.signature.parameters[index].type));
+                    }
+                }
+                if (expected.valid()) { (void)unify(fn.signature.result, expected, bindings); }
+                require_complete_bindings(fn.generics, bindings, expression.range, "function call");
+                for (std::size_t index = 0; index < bound.size(); ++index) {
+                    if (!bound[index].valid()) { continue; }
+                    TypeId parameter = substitute(fn.signature.parameters[index].type, bindings);
+                    require_assignable(parameter, module_.expr(bound[index]), "argument");
+                }
+                expression.type    = substitute(fn.signature.result, bindings);
+                expression.phase   = Phase::Constant;
+                expression.effects = Effect::None;
+                for (ExprId argument : bound) {
+                    if (!argument.valid()) { continue; }
+                    const Expr &value = module_.expr(argument);
+                    expression.phase  = join_phase(expression.phase, value.phase);
+                    expression.effects |= value.effects;
+                }
+                if (runtime_owner(expression.owner)) {
+                    expression.phase = Phase::Runtime;
+                } else if (expression.type != void_type_) {
+                    expression.phase = Phase::Wiring;
+                    expression.effects |= Effect::WireGraph;
+                }
+                expression.value_kind = expression.type == void_type_ ? ValueKind::Void : value_kind_for_phase(expression.phase);
+                expression.operation  = Operation{.kind          = OperationKind::ExactFunction,
+                                                  .target        = target,
+                                                  .identity      = module_.path + "." + module_.symbol(target).name,
+                                                  .substitutions = substitutions(fn.generics, bindings)};
+            }
+
+            [[nodiscard]] const OperatorDecl *operator_decl(SymbolId symbol) const noexcept {
+                if (!symbol.valid()) { return nullptr; }
+                const Symbol &target = module_.symbol(symbol);
+                if (!target.owner.valid()) { return nullptr; }
+                return std::get_if<OperatorDecl>(&module_.declaration(target.owner).node);
+            }
+
+            [[nodiscard]] bool local_candidate_matches(const FunctionDecl &candidate, const std::vector<ExprId> &arguments,
+                                                       TypeId expected) {
+                if (candidate.signature.parameters.size() != arguments.size()) { return false; }
+                Bindings bindings;
+                for (std::size_t index = 0; index < arguments.size(); ++index) {
+                    if (!arguments[index].valid()) { continue; }
+                    const Expr      &argument  = module_.expr(arguments[index]);
+                    const Parameter &parameter = candidate.signature.parameters[index];
+                    if (parameter.is_const && argument.phase != Phase::Constant) { return false; }
+                    if (!unify(parameter.type, argument.type, bindings)) { return false; }
+                }
+                if (expected.valid() && !unify(candidate.signature.result, expected, bindings)) { return false; }
+                for (std::size_t index = 0; index < arguments.size(); ++index) {
+                    if (!arguments[index].valid()) { continue; }
+                    if (!same(substitute(candidate.signature.parameters[index].type, bindings),
+                              module_.expr(arguments[index]).type)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            [[nodiscard]] SymbolId sole_local_candidate(SymbolId op, const std::vector<ExprId> &arguments, TypeId expected) {
+                std::vector<SymbolId> candidates;
+                const std::string     name = module_.symbol(op).name;
+                for (const Declaration &declaration : module_.declarations) {
+                    const auto *candidate = std::get_if<FunctionDecl>(&declaration.node);
+                    if (!candidate || candidate->visibility != Visibility::Implementation || !declaration.symbol.valid() ||
+                        module_.symbol(declaration.symbol).name != name) {
+                        continue;
+                    }
+                    candidates.push_back(declaration.symbol);
+                }
+                // A sole implementation has an unambiguous stable identity;
+                // two or more still require hgraph's TypePattern ranking. Do
+                // not reproduce that ranking in the language pass.
+                if (candidates.size() != 1U) { return {}; }
+                const Symbol &symbol = module_.symbol(candidates.front());
+                const auto   *candidate =
+                    symbol.owner.valid() ? std::get_if<FunctionDecl>(&module_.declaration(symbol.owner).node) : nullptr;
+                return candidate != nullptr && local_candidate_matches(*candidate, arguments, expected) ? candidates.front()
+                                                                                                        : SymbolId{};
+            }
+
+            void check_local_operator_call(Expr &expression, const Call &call, SymbolId target, const OperatorDecl &op,
+                                           TypeId expected) {
+                const std::vector<ExprId> bound = bind_arguments(op.signature, call.arguments, expression.range);
+                Bindings                  contract_bindings;
+                for (std::size_t index = 0; index < bound.size(); ++index) {
+                    if (!bound[index].valid()) { continue; }
+                    Expr &argument = check_expr(bound[index]);
+                    if (!unify(op.signature.parameters[index].type, argument.type, contract_bindings)) {
+                        type_error(argument.range, "operator argument does not match its contract");
+                    }
+                }
+                if (expected.valid()) { (void)unify(op.signature.result, expected, contract_bindings); }
+                require_complete_bindings(op.generics, contract_bindings, expression.range, "operator call");
+                expression.type          = substitute(op.signature.result, contract_bindings);
+                const SymbolId candidate = sole_local_candidate(target, bound, expected);
+                finish_call_semantics(expression, bound);
+                expression.operation = Operation{.kind          = OperationKind::NominalOperator,
+                                                 .target        = target,
+                                                 .candidate     = candidate,
+                                                 .identity      = module_.path + "." + module_.symbol(target).name,
+                                                 .substitutions = substitutions(op.generics, contract_bindings),
+                                                 .deferred      = !candidate.valid()};
+            }
+
+            void finish_call_semantics(Expr &expression, const std::vector<ExprId> &arguments) {
+                expression.phase   = Phase::Constant;
+                expression.effects = Effect::None;
+                for (ExprId argument : arguments) {
+                    if (!argument.valid()) { continue; }
+                    const Expr &value = module_.expr(argument);
+                    expression.phase  = join_phase(expression.phase, value.phase);
+                    expression.effects |= value.effects;
+                }
+                if (runtime_owner(expression.owner)) {
+                    expression.phase = Phase::Runtime;
+                } else if (expression.type != void_type_) {
+                    expression.phase = Phase::Wiring;
+                    expression.effects |= Effect::WireGraph;
+                }
+                expression.value_kind = expression.type == void_type_ ? ValueKind::Void : value_kind_for_phase(expression.phase);
+            }
+
+            void infer_map_lambda(const Call &call, TypeId expected) {
+                if (call.arguments.empty()) { return; }
+                const Argument &last   = call.arguments.back();
+                auto           *lambda = std::get_if<Lambda>(&module_.exprs[last.value.value].node);
+                if (!lambda) { return; }
+                std::vector<TypeId> parameter_types;
+                for (std::size_t index = 0; index + 1U < call.arguments.size(); ++index) {
+                    Expr       &collection      = check_expr(call.arguments[index].value);
+                    const Type &collection_type = type(canonical(collection.type));
+                    if (collection_type.kind == TypeKind::Map && collection_type.children.size() == 2U) {
+                        parameter_types.push_back(collection_type.children[1]);
+                    }
+                }
+                TypeId result;
+                if (expected.valid()) {
+                    const Type &expected_type = type(canonical(expected));
+                    if (expected_type.kind == TypeKind::Map && expected_type.children.size() == 2U) {
+                        result = expected_type.children[1];
+                    }
+                }
+                apply_lambda_context(last.value, parameter_types, result);
+            }
+
+            void check_imported_operator_call(Expr &expression, const Call &call, SymbolId target, TypeId expected) {
+                const Symbol &symbol = module_.symbol(target);
+                if (symbol.name == "map" || symbol.external_name == "map_") { infer_map_lambda(call, expected); }
+                std::vector<ExprId> argument_ids;
+                OperatorQuery       query;
+                query.identity        = symbol.external_name;
+                query.expected_result = canonical(expected);
+                query.range           = expression.range;
+                for (const Argument &argument : call.arguments) {
+                    Expr &value = check_expr(argument.value);
+                    argument_ids.push_back(argument.value);
+                    query.arguments.push_back(
+                        OperatorArgument{argument.name, value.type, value.phase, value.value_kind, value.constant});
+                }
+                OperatorSelection selection;
+                if (resolve_operator_) {
+                    selection = resolve_operator_(module_, query);
+                } else {
+                    selection.result   = query.expected_result;
+                    selection.deferred = true;
+                }
+                if (!selection.error.empty()) {
+                    diagnostics_.report(syntax::Category::Operator, expression.range, std::move(selection.error));
+                }
+                expression.type = selection.result.valid() ? canonical(selection.result) : canonical(expected);
+                if (!expression.type.valid()) {
+                    type_error(expression.range, "operator '" + symbol.name + "' needs an expected result type");
+                    expression.type = void_type_;
+                }
+                finish_call_semantics(expression, argument_ids);
+                expression.operation = Operation{.kind            = OperationKind::NominalOperator,
+                                                 .target          = target,
+                                                 .identity        = symbol.external_name,
+                                                 .candidate_label = std::move(selection.candidate_label),
+                                                 .substitutions   = std::move(selection.substitutions),
+                                                 .deferred        = selection.deferred};
+            }
+
+            void check_call(Expr &expression, const Call &call, TypeId expected) {
+                Expr       &callee    = check_expr(call.callee);
+                const auto *reference = std::get_if<SymbolRef>(&callee.node);
+                if (reference && reference->symbol.valid()) {
+                    const Symbol &symbol = module_.symbol(reference->symbol);
+                    if (symbol.kind == SymbolKind::Function) {
+                        const auto *fn = function(symbol.owner);
+                        if (fn) { check_exact_call(expression, call, reference->symbol, *fn, expected); }
+                        return;
+                    }
+                    if (symbol.kind == SymbolKind::Operator) {
+                        const OperatorDecl *op = operator_decl(reference->symbol);
+                        if (op) { check_local_operator_call(expression, call, reference->symbol, *op, expected); }
+                        return;
+                    }
+                    if (symbol.kind == SymbolKind::ImportedOperator) {
+                        check_imported_operator_call(expression, call, reference->symbol, expected);
+                        return;
+                    }
+                    if (symbol.kind == SymbolKind::Intrinsic) {
+                        check_intrinsic_call(expression, call, reference->symbol, expected);
+                        return;
+                    }
+                    if (symbol.kind == SymbolKind::Struct) {
+                        check_struct_call(expression, call, reference->symbol, expected);
+                        return;
+                    }
+                }
+                if (const auto *field = std::get_if<Field>(&callee.node)) {
+                    check_capability_call(expression, call, *field);
+                    return;
+                }
+                type_error(callee.range, "expression is not callable");
+            }
+
+            [[nodiscard]] TypeId unwrap_atomic(TypeId id) const noexcept {
+                id = canonical(id);
+                if (!id.valid()) { return {}; }
+                const Type &value = type(id);
+                return value.kind == TypeKind::Atomic && !value.children.empty() ? value.children.front() : id;
+            }
+
+            void check_index(Expr &expression, const Index &node) {
+                Expr  &target  = check_expr(node.target);
+                Expr  &index   = check_expr(node.index);
+                TypeId base_id = unwrap_atomic(target.type);
+                if (!base_id.valid()) { return; }
+                const Type &base = type(base_id);
+                if (base.kind == TypeKind::Tuple) {
+                    const auto *constant = index.constant ? std::get_if<std::int64_t>(&*index.constant) : nullptr;
+                    if (!constant || *constant < 0 || static_cast<std::size_t>(*constant) >= base.children.size()) {
+                        type_error(index.range, "tuple index must be a constant in range");
+                    } else {
+                        expression.type = base.children[static_cast<std::size_t>(*constant)];
+                    }
+                } else if (base.kind == TypeKind::List && !base.children.empty()) {
+                    if (!same(index.type, scalar(ScalarType::I64))) { type_error(index.range, "list index must be i64"); }
+                    expression.type = base.children.front();
+                } else if (base.kind == TypeKind::Map && base.children.size() == 2U) {
+                    require_assignable(base.children.front(), index, "map key");
+                    expression.type = base.children[1];
+                } else {
+                    type_error(target.range, "this type cannot be indexed");
+                }
+                expression.phase      = join_phase(target.phase, index.phase);
+                expression.value_kind = value_kind_for_phase(expression.phase);
+                expression.effects    = target.effects | index.effects;
+                expression.operation  = Operation{
+                    .kind = OperationKind::Index, .identity = "getitem_", .deferred = expression.phase != Phase::Constant};
+                if (expression.phase == Phase::Wiring) { expression.effects |= Effect::WireGraph; }
+            }
+
+            void check_field(Expr &expression, const Field &node) {
+                Expr &target = check_expr(node.target);
+                if (const auto *reference = std::get_if<SymbolRef>(&target.node);
+                    reference && reference->symbol.valid() &&
+                    module_.symbol(reference->symbol).kind == SymbolKind::InjectedCapability) {
+                    expression.type       = make_type(TypeKind::Callable);
+                    expression.phase      = Phase::Runtime;
+                    expression.value_kind = ValueKind::Function;
+                    expression.effects    = target.effects;
+                    expression.operation  = Operation{.kind     = OperationKind::Capability,
+                                                      .target   = reference->symbol,
+                                                      .identity = module_.symbol(reference->symbol).name + "." + node.name};
+                    return;
+                }
+                const TypeId base_id = unwrap_atomic(target.type);
+                if (base_id.valid()) {
+                    const Type &base = type(base_id);
+                    if (base.kind == TypeKind::Symbol && base.symbol.valid()) {
+                        const Symbol &structure_symbol = module_.symbol(base.symbol);
+                        if (structure_symbol.owner.valid()) {
+                            if (const auto *structure =
+                                    std::get_if<StructDecl>(&module_.declaration(structure_symbol.owner).node)) {
+                                const auto found = std::find_if(structure->fields.begin(), structure->fields.end(),
+                                                                [&](const StructField &field) { return field.name == node.name; });
+                                if (found != structure->fields.end()) { expression.type = found->type; }
+                            }
+                        }
+                    }
+                }
+                if (!expression.type.valid()) { type_error(node.name_range, "type has no field '" + node.name + "'"); }
+                expression.phase      = target.phase;
+                expression.value_kind = value_kind_for_phase(expression.phase);
+                expression.effects    = target.effects;
+                expression.operation  = Operation{
+                    .kind = OperationKind::Field, .identity = "getattr_", .deferred = expression.phase != Phase::Constant};
+                if (expression.phase == Phase::Wiring) { expression.effects |= Effect::WireGraph; }
+            }
+
+            void check_sequence(Expr &expression, const Sequence &node, TypeId expected) {
+                TypeId element_expected;
+                if (expected.valid()) {
+                    const Type &shape = type(canonical(expected));
+                    if ((shape.kind == TypeKind::List || shape.kind == TypeKind::HarnessSequence) && !shape.children.empty()) {
+                        element_expected = shape.children.front();
+                    }
+                }
+                TypeId element_type = element_expected;
+                Phase  phase        = Phase::Constant;
+                for (const SequenceElement &element : node.elements) {
+                    if (element.key.valid()) { (void)check_expr(element.key); }
+                    Expr &value = check_expr(element.value, element_type);
+                    if (!element_type.valid() && value.type.valid()) {
+                        element_type = value.type;
+                    } else if (value.type.valid() && !assignable(element_type, value.type)) {
+                        type_error(value.range, "sequence elements have incompatible types");
+                    }
+                    phase = join_phase(phase, value.phase);
+                    expression.effects |= value.effects;
+                }
+                if (!element_type.valid()) { element_type = void_type_; }
+                const TypeKind kind   = expected.valid() && type(canonical(expected)).kind == TypeKind::HarnessSequence
+                                            ? TypeKind::HarnessSequence
+                                            : TypeKind::List;
+                expression.type       = make_type(kind, {element_type});
+                expression.phase      = phase;
+                expression.value_kind = kind == TypeKind::HarnessSequence ? ValueKind::Constant : value_kind_for_phase(phase);
+            }
+
+            void check_tuple(Expr &expression, const Tuple &node, TypeId expected) {
+                std::vector<TypeId> children;
+                const Type         *expected_tuple = nullptr;
+                if (expected.valid() && type(canonical(expected)).kind == TypeKind::Tuple) {
+                    expected_tuple = &type(canonical(expected));
+                }
+                expression.phase = Phase::Constant;
+                for (std::size_t index = 0; index < node.elements.size(); ++index) {
+                    const TypeId item_expected =
+                        expected_tuple && index < expected_tuple->children.size() ? expected_tuple->children[index] : TypeId{};
+                    Expr &item = check_expr(node.elements[index], item_expected);
+                    children.push_back(item.type);
+                    expression.phase = join_phase(expression.phase, item.phase);
+                    expression.effects |= item.effects;
+                }
+                expression.type       = make_type(TypeKind::Tuple, std::move(children));
+                expression.value_kind = value_kind_for_phase(expression.phase);
+            }
+
+            void apply_lambda_context(ExprId id, const std::vector<TypeId> &parameters, TypeId result) {
+                if (!id.valid()) { return; }
+                Expr &expression = module_.exprs[id.value];
+                auto *lambda     = std::get_if<Lambda>(&expression.node);
+                if (!lambda) { return; }
+                for (std::size_t index = 0; index < lambda->parameters.size() && index < parameters.size(); ++index) {
+                    Symbol &symbol = module_.symbols[lambda->parameters[index].value];
+                    if (!symbol.type.valid()) {
+                        symbol.type = canonical(parameters[index]);
+                    } else if (!same(parameters[index], symbol.type)) {
+                        type_error(symbol.range, "lambda parameter type conflicts with its call context");
+                    }
+                    symbol_phase_[lambda->parameters[index].value] =
+                        runtime_owner(expression.owner) ? Phase::Runtime : Phase::Wiring;
+                }
+                if (!lambda->result.valid() && result.valid()) {
+                    lambda->result = canonical(result);
+                } else if (lambda->result.valid() && result.valid() && !assignable(result, lambda->result)) {
+                    type_error(expression.range, "lambda result type conflicts with its call context");
+                }
+            }
+
+            void check_lambda(Expr &expression, Lambda &node, TypeId expected) {
+                std::vector<TypeId> contextual_parameters;
+                TypeId              result = node.result;
+                if (expected.valid() && type(canonical(expected)).kind == TypeKind::Callable) {
+                    const Type &callable = type(canonical(expected));
+                    if (!callable.children.empty()) {
+                        const std::size_t count = callable.children.size() - 1U;
+                        for (std::size_t index = 0; index < count; ++index) {
+                            contextual_parameters.push_back(callable.children[index]);
+                        }
+                        result = callable.children.back();
+                    }
+                }
+                std::vector<TypeId> parameters;
+                parameters.reserve(node.parameters.size() + 1U);
+                for (std::size_t index = 0; index < node.parameters.size(); ++index) {
+                    Symbol &symbol = module_.symbols[node.parameters[index].value];
+                    if (!symbol.type.valid() && index < contextual_parameters.size()) {
+                        symbol.type = canonical(contextual_parameters[index]);
+                    }
+                    if (!symbol.type.valid()) { type_error(symbol.range, "lambda parameter needs contextual type inference"); }
+                    symbol_phase_[node.parameters[index].value] = runtime_owner(expression.owner) ? Phase::Runtime : Phase::Wiring;
+                    parameters.push_back(symbol.type);
+                }
+                Expr &body = check_expr(node.body, result);
+                if (!result.valid()) { result = body.type; }
+                require_assignable(result, body, "lambda result");
+                node.result = canonical(result);
+                parameters.push_back(node.result);
+                expression.type       = make_type(TypeKind::Callable, std::move(parameters));
+                expression.phase      = Phase::Constant;
+                expression.value_kind = ValueKind::Function;
+                expression.effects    = body.effects;
+            }
+
+            void check_if(Expr &expression, const If &node, TypeId expected) {
+                if (!expected.valid()) {
+                    if (const FunctionDecl *fn = function(expression.owner)) { expected = fn->signature.result; }
+                }
+                Expr &condition = check_expr(node.condition, scalar(ScalarType::Bool));
+                require_assignable(scalar(ScalarType::Bool), condition, "if condition");
+                check_block(node.then_block, expected);
+                expression.effects      = condition.effects | module_.block(node.then_block).effects;
+                expression.phase        = condition.phase;
+                const Block &then_block = module_.block(node.then_block);
+                TypeId       then_type  = then_block.tail.valid() ? module_.expr(then_block.tail).type : void_type_;
+                if (node.otherwise.valid()) {
+                    Expr &otherwise = check_expr(node.otherwise, expected.valid() ? expected : then_type);
+                    expression.effects |= otherwise.effects;
+                    expression.phase = join_phase(expression.phase, otherwise.phase);
+                    if (then_type == void_type_) { then_type = otherwise.type; }
+                    if (!assignable(then_type, otherwise.type) && !assignable(otherwise.type, then_type)) {
+                        type_error(expression.range, "if branches have incompatible result types");
+                    }
+                    expression.type = expected.valid() ? canonical(expected) : then_type;
+                } else {
+                    expression.type = void_type_;
+                }
+                expression.value_kind = expression.type == void_type_ ? ValueKind::Void : value_kind_for_phase(expression.phase);
+            }
+
+            void check_block_expr(Expr &expression, const BlockExpr &node, TypeId expected) {
+                check_block(node.block, expected);
+                const Block &block    = module_.block(node.block);
+                expression.type       = block.tail.valid() ? module_.expr(block.tail).type : void_type_;
+                expression.phase      = block.tail.valid() ? module_.expr(block.tail).phase : Phase::Constant;
+                expression.effects    = block.effects;
+                expression.value_kind = expression.type == void_type_ ? ValueKind::Void : value_kind_for_phase(expression.phase);
+            }
+
+            void check_eval(Expr &expression, const Eval &node) {
+                Expr       &callee    = check_expr(node.callee);
+                const auto *reference = std::get_if<SymbolRef>(&callee.node);
+                if (!reference || !reference->symbol.valid() || module_.symbol(reference->symbol).kind != SymbolKind::Function) {
+                    type_error(callee.range, "eval requires an exact HGL function");
+                    return;
+                }
+                const FunctionDecl *fn = function(module_.symbol(reference->symbol).owner);
+                if (!fn) { return; }
+                const std::vector<ExprId> bound = bind_arguments(fn->signature, node.arguments, expression.range);
+                for (std::size_t index = 0; index < bound.size(); ++index) {
+                    const Parameter &parameter = fn->signature.parameters[index];
+                    const TypeId     expected =
+                        parameter.is_const ? parameter.type : make_type(TypeKind::HarnessSequence, {parameter.type});
+                    Expr &value = check_expr(bound[index], expected);
+                    require_assignable(expected, value, "eval input");
+                }
+                expression.type       = make_type(TypeKind::HarnessSequence, {fn->signature.result});
+                expression.phase      = Phase::Constant;
+                expression.value_kind = ValueKind::Constant;
+                expression.effects    = Effect::TestHarness;
+                expression.operation  = Operation{.kind     = OperationKind::HarnessEval,
+                                                  .target   = reference->symbol,
+                                                  .identity = module_.path + "." + module_.symbol(reference->symbol).name};
+            }
+
+            [[nodiscard]] std::unordered_map<std::uint32_t, TypeId> struct_bindings(TypeId applied) const {
+                std::unordered_map<std::uint32_t, TypeId> result;
+                applied = unwrap_atomic(applied);
+                if (!applied.valid()) { return result; }
+                const Type &value = type(applied);
+                if (value.kind != TypeKind::Symbol || !value.symbol.valid()) { return result; }
+                const Symbol &symbol = module_.symbol(value.symbol);
+                if (!symbol.owner.valid()) { return result; }
+                const auto *structure = std::get_if<StructDecl>(&module_.declaration(symbol.owner).node);
+                if (!structure) { return result; }
+                for (std::size_t index = 0; index < structure->generics.size() && index < value.arguments.size(); ++index) {
+                    const GenericParameter &generic  = structure->generics[index];
+                    const TypeArgument     &argument = value.arguments[index];
+                    if (!generic.is_const && argument.kind == TypeArgumentKind::Type) {
+                        result.emplace(generic.symbol.value, argument.type);
+                    }
+                }
+                return result;
+            }
+
+            [[nodiscard]] TypeId apply_struct_field_type(TypeId field, TypeId applied) {
+                Bindings bindings;
+                bindings.type = struct_bindings(applied);
+                return substitute(field, bindings);
+            }
+
+            void check_constructor_arguments(Expr &expression, TypeId applied, const std::vector<Argument> &arguments, bool delta) {
+                const TypeId unwrapped = unwrap_atomic(applied);
+                if (!unwrapped.valid()) { return; }
+                const Type &nominal = type(unwrapped);
+                if (nominal.kind != TypeKind::Symbol || !nominal.symbol.valid()) {
+                    type_error(expression.range, "constructor requires a struct type");
+                    return;
+                }
+                const Symbol &symbol = module_.symbol(nominal.symbol);
+                const auto   *structure =
+                    symbol.owner.valid() ? std::get_if<StructDecl>(&module_.declaration(symbol.owner).node) : nullptr;
+                if (!structure) { return; }
+                std::size_t positional = 0;
+                for (const Argument &argument : arguments) {
+                    const StructField *field = nullptr;
+                    if (argument.name.empty()) {
+                        if (positional < structure->fields.size()) { field = &structure->fields[positional++]; }
+                    } else {
+                        const auto found = std::find_if(structure->fields.begin(), structure->fields.end(),
+                                                        [&](const StructField &item) { return item.name == argument.name; });
+                        if (found != structure->fields.end()) { field = &*found; }
+                    }
+                    if (!field) { continue; }
+                    const TypeId expected = apply_struct_field_type(field->type, unwrapped);
+                    Expr        &value    = check_expr(argument.value, expected);
+                    if (value.constant && std::holds_alternative<NullValue>(*value.constant)) {
+                        if (!delta && !field->optional) {
+                            type_error(value.range, "null is only valid for an optional field or sparse delta");
+                        }
+                    } else {
+                        require_assignable(expected, value, "constructor field");
+                    }
+                    expression.effects |= value.effects;
+                }
+            }
+
+            void check_struct_call(Expr &expression, const Call &call, SymbolId target, TypeId expected) {
+                TypeId applied = make_type(TypeKind::Symbol, {}, target);
+                if (expected.valid()) {
+                    const TypeId unwrapped = unwrap_atomic(expected);
+                    if (type(unwrapped).kind == TypeKind::Symbol && type(unwrapped).symbol == target) { applied = expected; }
+                }
+                check_constructor_arguments(expression, applied, call.arguments, false);
+                expression.type       = canonical(applied);
+                expression.phase      = runtime_owner(expression.owner) ? Phase::Runtime : Phase::Wiring;
+                expression.value_kind = value_kind_for_phase(expression.phase);
+                if (expression.phase == Phase::Wiring) { expression.effects |= Effect::WireGraph; }
+                expression.operation = Operation{.kind     = OperationKind::Constructor,
+                                                 .target   = target,
+                                                 .identity = module_.path + "." + module_.symbol(target).name};
+            }
+
+            void check_construct(Expr &expression, const Construct &node, TypeId expected) {
+                TypeId applied = canonical(node.type);
+                if (expected.valid() && assignable(expected, applied)) { applied = canonical(expected); }
+                check_constructor_arguments(expression, applied, node.arguments, node.delta);
+                expression.type       = applied;
+                expression.phase      = runtime_owner(expression.owner) ? Phase::Runtime : Phase::Wiring;
+                expression.value_kind = value_kind_for_phase(expression.phase);
+                if (expression.phase == Phase::Wiring) { expression.effects |= Effect::WireGraph; }
+                const TypeId nominal = unwrap_atomic(applied);
+                expression.operation = Operation{.kind     = OperationKind::Constructor,
+                                                 .target   = nominal.valid() ? type(nominal).symbol : SymbolId{},
+                                                 .identity = node.delta ? "delta" : "construct"};
+            }
+
+            [[nodiscard]] std::vector<TypeId> collection_items(TypeId id) {
+                id = unwrap_atomic(id);
+                if (!id.valid()) { return {}; }
+                const Type &value = type(id);
+                if (value.kind == TypeKind::Map && value.children.size() == 2U) { return {value.children[0], value.children[1]}; }
+                if (value.kind == TypeKind::List && !value.children.empty()) {
+                    return {scalar(ScalarType::I64), value.children[0]};
+                }
+                if (value.kind == TypeKind::Set && !value.children.empty()) { return {value.children[0]}; }
+                return {};
+            }
+
+            void check_intrinsic_call(Expr &expression, const Call &call, SymbolId target, TypeId expected) {
+                const std::string  &name = module_.symbol(target).external_name;
+                std::vector<ExprId> args;
+                for (const Argument &argument : call.arguments) { args.push_back(argument.value); }
+                if (name == "valid" || name == "modified" || name == "all_valid") {
+                    if (args.empty()) { type_error(expression.range, "'" + name + "' takes at least one argument"); }
+                    for (ExprId argument : args) { (void)check_expr(argument); }
+                    expression.type = scalar(ScalarType::Bool);
+                } else if (name == "last_modified") {
+                    if (args.size() != 1U) { type_error(expression.range, "last_modified takes one argument"); }
+                    for (ExprId argument : args) { (void)check_expr(argument); }
+                    expression.type = scalar(ScalarType::DateTime);
+                } else if (name == "key_set") {
+                    if (args.size() != 1U) { type_error(expression.range, "key_set takes one map argument"); }
+                    Expr        &value      = check_expr(args.empty() ? ExprId{} : args.front());
+                    const TypeId collection = unwrap_atomic(value.type);
+                    if (collection.valid() && type(collection).kind == TypeKind::Map) {
+                        expression.type = make_type(TypeKind::Set, {type(collection).children.front()});
+                    } else {
+                        type_error(value.range, "key_set takes a map");
+                    }
+                } else if (name == "keys" || name == "values" || name == "items") {
+                    Expr               &collection = check_expr(args.empty() ? ExprId{} : args.front());
+                    std::vector<TypeId> items      = collection_items(collection.type);
+                    if (items.empty()) { type_error(collection.range, "'" + name + "' takes a collection"); }
+                    if (name == "keys" && !items.empty()) { items.resize(1U); }
+                    if (name == "values" && items.size() == 2U) { items.erase(items.begin()); }
+                    if (args.size() > 1U) {
+                        Expr &predicate = module_.exprs[args[1].value];
+                        if (std::holds_alternative<Lambda>(predicate.node)) {
+                            apply_lambda_context(args[1], items, scalar(ScalarType::Bool));
+                        }
+                        (void)check_expr(args[1]);
+                    }
+                    expression.type    = make_type(TypeKind::Iterator, items);
+                    expression.effects = Effect::IterateCollection;
+                } else if (name == "added" || name == "removed") {
+                    expression.type = make_type(TypeKind::Callable);
+                } else {
+                    type_error(expression.range, "unsupported intrinsic '" + name + "'");
+                }
+                finish_call_semantics(expression, args);
+                if (expression.type.valid() && type(expression.type).kind == TypeKind::Iterator) {
+                    expression.phase      = Phase::Runtime;
+                    expression.value_kind = ValueKind::Iterator;
+                    expression.effects |= Effect::IterateCollection;
+                }
+                expression.operation =
+                    Operation{.kind = OperationKind::Intrinsic, .target = target, .identity = name, .deferred = false};
+                contextualize(expression, expected);
+            }
+
+            void check_capability_call(Expr &expression, const Call &call, const Field &field) {
+                Expr               &member    = module_.exprs[call.callee.value];
+                const auto         *reference = std::get_if<SymbolRef>(&module_.expr(field.target).node);
+                std::vector<ExprId> args;
+                for (const Argument &argument : call.arguments) {
+                    args.push_back(argument.value);
+                    (void)check_expr(argument.value);
+                }
+                expression.type       = void_type_;
+                expression.phase      = Phase::Runtime;
+                expression.value_kind = ValueKind::Void;
+                expression.effects    = member.effects | Effect::UseCapability;
+                for (ExprId argument : args) { expression.effects |= module_.expr(argument).effects; }
+                expression.operation = Operation{.kind     = OperationKind::Capability,
+                                                 .target   = reference ? reference->symbol : SymbolId{},
+                                                 .identity = member.operation.identity};
+            }
+
+            void check_stmt(StmtId id, TypeId expected_return, bool is_tail) {
+                Stmt &statement = module_.stmts[id.value];
+                std::visit(
+                    [&](auto &node) {
+                        using T = std::decay_t<decltype(node)>;
+                        if constexpr (std::is_same_v<T, LocalDecl>) {
+                            Expr &init = check_expr(node.init, node.type);
+                            if (!node.type.valid()) { node.type = init.type; }
+                            require_assignable(node.type, init, "local initializer");
+                            Symbol &symbol                   = module_.symbols[node.symbol.value];
+                            symbol.type                      = node.type;
+                            symbol_phase_[node.symbol.value] = init.phase;
+                            statement.effects                = init.effects;
+                        } else if constexpr (std::is_same_v<T, StateDecl>) {
+                            Expr &init = check_expr(node.init, node.type);
+                            if (!node.type.valid()) { node.type = init.type; }
+                            require_assignable(node.type, init, "state initializer");
+                            module_.symbols[node.symbol.value].type = node.type;
+                            symbol_phase_[node.symbol.value]        = Phase::Runtime;
+                            statement.effects                       = init.effects | Effect::WriteState;
+                        } else if constexpr (std::is_same_v<T, InjectDecl>) {
+                            FunctionDecl *fn = function(statement.owner);
+                            for (SymbolId symbol_id : node.symbols) {
+                                Symbol &symbol = module_.symbols[symbol_id.value];
+                                if (symbol.name == "out") {
+                                    symbol.type = fn ? fn->signature.result : void_type_;
+                                } else {
+                                    symbol.type = make_type(TypeKind::Capability, {}, symbol_id);
+                                }
+                                symbol_phase_[symbol_id.value] = Phase::Runtime;
+                            }
+                        } else if constexpr (std::is_same_v<T, LifecycleBlock>) {
+                            check_block(node.block, expected_return);
+                            statement.effects = module_.block(node.block).effects;
+                        } else if constexpr (std::is_same_v<T, WhenStmt>) {
+                            Expr &condition = check_expr(node.condition, scalar(ScalarType::Bool));
+                            require_assignable(scalar(ScalarType::Bool), condition, "when condition");
+                            check_block(node.block, expected_return);
+                            statement.effects = condition.effects | module_.block(node.block).effects;
+                        } else if constexpr (std::is_same_v<T, ForStmt>) {
+                            Expr       &iterable = check_expr(node.iterable);
+                            const Type *iterator = iterable.type.valid() ? &type(canonical(iterable.type)) : nullptr;
+                            if (iterator == nullptr || iterator->kind != TypeKind::Iterator ||
+                                iterator->children.size() != node.bindings.size()) {
+                                type_error(iterable.range, "for bindings do not match the iterator item shape");
+                            } else {
+                                for (std::size_t index = 0; index < node.bindings.size(); ++index) {
+                                    module_.symbols[node.bindings[index].value].type = iterator->children[index];
+                                    symbol_phase_[node.bindings[index].value]        = Phase::Runtime;
+                                }
+                            }
+                            check_block(node.block, expected_return);
+                            statement.effects = iterable.effects | module_.block(node.block).effects | Effect::IterateCollection;
+                        } else if constexpr (std::is_same_v<T, AssignStmt>) {
+                            Expr &place = check_expr(node.place);
+                            Expr &value = check_expr(node.value, place.type);
+                            require_assignable(place.type, value, "assignment");
+                            statement.effects   = place.effects | value.effects;
+                            const SymbolId root = place_root(node.place);
+                            if (root.valid()) {
+                                const Symbol &symbol = module_.symbol(root);
+                                if (symbol.kind == SymbolKind::LocalVar) {
+                                    statement.effects |= Effect::WriteLocal;
+                                } else if (symbol.kind == SymbolKind::State) {
+                                    statement.effects |= Effect::WriteState;
+                                } else if (symbol.kind == SymbolKind::InjectedCapability && symbol.name == "out") {
+                                    statement.effects |= Effect::WriteOutput;
+                                } else {
+                                    type_error(place.range, "assignment target is immutable");
+                                }
+                            }
+                        } else if constexpr (std::is_same_v<T, ReturnStmt>) {
+                            Expr &value = check_expr(node.value, expected_return);
+                            require_assignable(expected_return, value, "return value");
+                            statement.effects = value.effects;
+                        } else if constexpr (std::is_same_v<T, AssertStmt>) {
+                            Expr &condition = check_expr(node.condition, scalar(ScalarType::Bool));
+                            require_assignable(scalar(ScalarType::Bool), condition, "assert condition");
+                            statement.effects = condition.effects;
+                            if (!function(statement.owner)) { statement.effects |= Effect::TestHarness; }
+                        } else if constexpr (std::is_same_v<T, ExprStmt>) {
+                            statement.effects = check_expr(node.expr, is_tail ? expected_return : TypeId{}).effects;
+                        }
+                    },
+                    statement.node);
+            }
+
+            [[nodiscard]] SymbolId place_root(ExprId id) const noexcept {
+                if (!id.valid()) { return {}; }
+                const Expr &expression = module_.expr(id);
+                if (const auto *reference = std::get_if<SymbolRef>(&expression.node)) { return reference->symbol; }
+                if (const auto *index = std::get_if<Index>(&expression.node)) { return place_root(index->target); }
+                if (const auto *field = std::get_if<Field>(&expression.node)) { return place_root(field->target); }
+                return {};
+            }
+
+            void check_block(BlockId id, TypeId expected_return) {
+                if (!id.valid()) { return; }
+                Block &block = module_.blocks[id.value];
+                if (checked_blocks_.contains(id.value)) { return; }
+                checked_blocks_.emplace(id.value, true);
+                block.effects = Effect::None;
+                for (StmtId statement : block.statements) {
+                    const auto *expression_statement = std::get_if<ExprStmt>(&module_.stmt(statement).node);
+                    const bool  is_tail              = expression_statement && expression_statement->expr == block.tail;
+                    check_stmt(statement, expected_return, is_tail);
+                    block.effects |= module_.stmt(statement).effects;
+                }
+                if (block.tail.valid()) {
+                    Expr &tail = check_expr(block.tail, expected_return);
+                    block.effects |= tail.effects;
+                }
+            }
+
+            void validate_completion() {
+                for (const Expr &expression : module_.exprs) {
+                    if (expression.value_kind == ValueKind::Unknown || expression.phase == Phase::Unknown) {
+                        diagnostics_.report(syntax::Category::Type, expression.range,
+                                            "expression did not receive complete type and phase information");
+                        continue;
+                    }
+                    if (expression.value_kind != ValueKind::Function && expression.value_kind != ValueKind::Operator &&
+                        expression.value_kind != ValueKind::Type && !expression.type.valid()) {
+                        diagnostics_.report(syntax::Category::Type, expression.range, "expression has no canonical type");
+                    }
+                    if (std::holds_alternative<Call>(expression.node) && expression.operation.kind == OperationKind::None) {
+                        diagnostics_.report(syntax::Category::Type, expression.range, "call has no semantic target");
+                    }
+                }
+            }
+
+            Module                                  &module_;
+            const OperatorResolver                  &resolve_operator_;
+            syntax::DiagnosticSink                  &diagnostics_;
+            detail::CanonicalTypes                   canonical_types_;
+            std::vector<std::uint8_t>                expr_state_{};
+            std::unordered_map<std::uint32_t, Phase> symbol_phase_{};
+            std::unordered_map<std::uint32_t, bool>  checked_blocks_{};
+            TypeId                                   void_type_{};
+            Expr                                     missing_expression_{};
+        };
+    }  // namespace
+
+    bool complete_hir(hir::Module &module, const OperatorResolver &resolve_operator, syntax::DiagnosticSink &diagnostics) {
+        return TypeChecker{module, resolve_operator, diagnostics}.run();
+    }
+}  // namespace hgl::ir

--- a/language/src/ir/type_check.h
+++ b/language/src/ir/type_check.h
@@ -1,0 +1,56 @@
+#ifndef HGL_IR_TYPE_CHECK_H
+#define HGL_IR_TYPE_CHECK_H
+
+#include "ir/hir.h"
+#include "syntax/diagnostic.h"
+
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace hgl::ir
+{
+    struct OperatorArgument
+    {
+        std::string                  name{};
+        hir::TypeId                  type{};
+        hir::Phase                   phase{hir::Phase::Unknown};
+        hir::ValueKind               value_kind{hir::ValueKind::Unknown};
+        std::optional<hir::Constant> constant{};
+    };
+
+    struct OperatorQuery
+    {
+        std::string                   identity{};
+        std::vector<OperatorArgument> arguments{};
+        hir::TypeId                   expected_result{};
+        syntax::SourceRange           range{};
+    };
+
+    struct OperatorSelection
+    {
+        /// The native candidate's copied diagnostic label. No candidate
+        /// pointer or provider lease may cross into HIR.
+        std::string                    candidate_label{};
+        hir::TypeId                    result{};
+        std::vector<hir::Substitution> substitutions{};
+        bool                           deferred{false};
+        std::string                    error{};
+    };
+
+    /// Registry adapter used by type completion. The type checker owns HGL
+    /// generic inference and phase rules; this callback owns native overload
+    /// ranking so the language cannot drift from hgraph's OperatorRegistry.
+    using OperatorResolver = std::function<OperatorSelection(const hir::Module &, const OperatorQuery &)>;
+
+    /// Complete canonical types, substitutions, semantic call identities,
+    /// phases, typed constants, effects, and admitted capabilities. The pass
+    /// changes completion to Typed only when every value expression has a
+    /// type and every call has a semantic identity, or reports diagnostics and
+    /// leaves the module Resolved.
+    [[nodiscard]] bool complete_hir(hir::Module &module, const OperatorResolver &resolve_operator,
+                                    syntax::DiagnosticSink &diagnostics);
+}  // namespace hgl::ir
+
+#endif  // HGL_IR_TYPE_CHECK_H

--- a/language/src/wiring/operator_types.cpp
+++ b/language/src/wiring/operator_types.cpp
@@ -75,6 +75,15 @@ namespace hgl::wiring
                         dispatch_expected);
                     selection.candidate_label = resolved.impl->label;
                     if (selection.candidate_label.empty()) { selection.candidate_label = resolved.impl->name; }
+                    if (resolved.impl->has_output) {
+                        const hgraph::TSValueTypeMetaData *output = hgraph::ts_pattern_resolve(resolved.impl->output, resolved.map);
+                        if (output != nullptr) {
+                            selection.result = type_for_schema(output);
+                            if (!selection.result.valid()) { selection.deferred = true; }
+                        } else {
+                            selection.deferred = true;
+                        }
+                    }
                     append_substitutions(resolved.map, selection.substitutions);
                 } catch (const hgraph::OperatorResolutionError &error) {
                     selection.error = query.identity + ": " + error.what();
@@ -262,6 +271,22 @@ namespace hgl::wiring
                     schema_ids_.emplace(result, id);
                 }
                 return result;
+            }
+
+            [[nodiscard]] hir::TypeId type_for_schema(const hgraph::TSValueTypeMetaData *target) {
+                if (target == nullptr) { return {}; }
+                if (const auto found = schema_ids_.find(target); found != schema_ids_.end()) { return found->second; }
+
+                // HIR owns its type arena, so the adapter may only return an
+                // existing language type. Materialize every representable HIR
+                // schema to find outputs inferred solely by hgraph (for
+                // example mean(TSW[float]) -> TS[float]).
+                const std::size_t count = module_.types.size();
+                for (std::uint32_t index = 0; index < count; ++index) {
+                    const hir::TypeId candidate{index};
+                    if (schema(candidate) == target) { return canonical(candidate); }
+                }
+                return {};
             }
 
             [[nodiscard]] std::optional<hgraph::Value> constant(const ir::OperatorArgument &argument) {

--- a/language/src/wiring/operator_types.cpp
+++ b/language/src/wiring/operator_types.cpp
@@ -1,0 +1,353 @@
+#include "wiring/operator_types.h"
+
+#include "wiring/backend.h"
+
+#include <hgraph/lib/std/standard_types.h>
+#include <hgraph/types/metadata/type_registry.h>
+#include <hgraph/types/operator_dispatch.h>
+#include <hgraph/types/type_pattern.h>
+#include <hgraph/types/value/value.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <optional>
+#include <ranges>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace hgl::wiring
+{
+    namespace
+    {
+        namespace hir = ir::hir;
+
+        class NativeTypes
+        {
+          public:
+            explicit NativeTypes(const hir::Module &module)
+                : module_{module}, types_{hgraph::stdlib::register_standard_types()}, registry_{hgraph::TypeRegistry::instance()} {}
+
+            [[nodiscard]] ir::OperatorSelection resolve(const ir::OperatorQuery &query) {
+                ir::OperatorSelection selection;
+                selection.result = query.expected_result;
+                if (query.identity.empty()) {
+                    selection.error = "operator has no registry identity";
+                    return selection;
+                }
+
+                std::vector<hgraph::WiringArg> arguments;
+                arguments.reserve(query.arguments.size());
+                for (const ir::OperatorArgument &argument : query.arguments) {
+                    if (argument.value_kind == hir::ValueKind::Function || argument.value_kind == hir::ValueKind::Operator ||
+                        argument.value_kind == hir::ValueKind::Type) {
+                        selection.deferred = true;
+                        return selection;
+                    }
+                    std::optional<hgraph::WiringArg> lowered = lower_argument(argument);
+                    if (!lowered) {
+                        selection.deferred = true;
+                        return selection;
+                    }
+                    arguments.push_back(std::move(*lowered));
+                }
+
+                const hgraph::TSValueTypeMetaData *expected = nullptr;
+                if (query.expected_result.valid()) {
+                    expected = schema(query.expected_result);
+                    if (expected == nullptr) {
+                        selection.deferred = true;
+                        return selection;
+                    }
+                }
+                try {
+                    const auto signatures = hgraph::OperatorRegistry::instance().overload_signatures(query.identity);
+                    const bool reference_output =
+                        expected != nullptr && !signatures.empty() && std::ranges::all_of(signatures, [](const auto &signature) {
+                            return signature.output_pattern && signature.output_pattern->starts_with("REF[");
+                        });
+                    const hgraph::TSValueTypeMetaData *dispatch_expected = reference_output ? registry_.ref(expected) : expected;
+                    const hgraph::ResolvedOperatorCall resolved          = hgraph::OperatorRegistry::instance().resolve(
+                        query.identity, arguments, dispatch_expected == nullptr ? std::nullopt : std::optional<bool>{true},
+                        dispatch_expected);
+                    selection.candidate_label = resolved.impl->label;
+                    if (selection.candidate_label.empty()) { selection.candidate_label = resolved.impl->name; }
+                    append_substitutions(resolved.map, selection.substitutions);
+                } catch (const hgraph::OperatorResolutionError &error) {
+                    selection.error = query.identity + ": " + error.what();
+                } catch (const std::exception &error) { selection.error = query.identity + ": " + error.what(); }
+                return selection;
+            }
+
+          private:
+            [[nodiscard]] hir::TypeId canonical(hir::TypeId id) const noexcept {
+                if (!id.valid()) { return {}; }
+                const hir::TypeId result = module_.type(id).canonical;
+                return result.valid() ? result : id;
+            }
+
+            [[nodiscard]] const hgraph::ValueTypeMetaData *scalar(hir::ScalarType type) const noexcept {
+                using hir::ScalarType;
+                switch (type) {
+                    case ScalarType::Bool: return types_.bool_type;
+                    case ScalarType::I64: return types_.int_type;
+                    case ScalarType::F64: return types_.float_type;
+                    case ScalarType::Str: return types_.str_type;
+                    case ScalarType::Date: return types_.date_type;
+                    case ScalarType::Time: return types_.time_type;
+                    case ScalarType::DateTime: return types_.datetime_type;
+                    case ScalarType::Duration: return types_.timedelta_type;
+                    case ScalarType::CivilDateTime: return types_.civil_datetime_type;
+                    case ScalarType::ZonedDateTime: return types_.zoned_datetime_type;
+                    case ScalarType::TimeZone: return types_.zone_id_type;
+                    case ScalarType::ZonedTime: return nullptr;
+                }
+                std::unreachable();
+            }
+
+            [[nodiscard]] std::optional<std::int64_t> integer(hir::ExprId id) const noexcept {
+                if (!id.valid()) { return std::nullopt; }
+                const std::optional<hir::Constant> &constant = module_.expr(id).constant;
+                if (!constant) { return std::nullopt; }
+                if (const auto *value = std::get_if<std::int64_t>(&*constant)) { return *value; }
+                return std::nullopt;
+            }
+
+            [[nodiscard]] std::optional<std::int64_t> duration(hir::ExprId id) const noexcept {
+                if (!id.valid()) { return std::nullopt; }
+                const std::optional<hir::Constant> &constant = module_.expr(id).constant;
+                if (!constant) { return std::nullopt; }
+                const auto *value = std::get_if<syntax::TemporalValue>(&*constant);
+                if (value == nullptr || value->kind != syntax::TemporalKind::Duration) { return std::nullopt; }
+                return value->micros;
+            }
+
+            [[nodiscard]] const hgraph::ValueTypeMetaData *value(hir::TypeId id) {
+                id = canonical(id);
+                if (!id.valid()) { return nullptr; }
+                if (const auto found = values_.find(id.value); found != values_.end()) { return found->second; }
+                const hir::Type                 &type   = module_.type(id);
+                const hgraph::ValueTypeMetaData *result = nullptr;
+                switch (type.kind) {
+                    case hir::TypeKind::Scalar: result = scalar(type.scalar); break;
+                    case hir::TypeKind::Tuple:
+                        {
+                            std::vector<const hgraph::ValueTypeMetaData *> children;
+                            for (hir::TypeId child : type.children) {
+                                const auto *meta = value(child);
+                                if (meta == nullptr) { return nullptr; }
+                                children.push_back(meta);
+                            }
+                            result = registry_.tuple(children);
+                            break;
+                        }
+                    case hir::TypeKind::List:
+                        {
+                            if (type.children.empty()) { return nullptr; }
+                            const auto *element = value(type.children.front());
+                            if (element == nullptr) { return nullptr; }
+                            std::size_t fixed_size = 0;
+                            if (type.size.valid()) {
+                                const std::optional<std::int64_t> size = integer(type.size);
+                                if (!size || *size < 0) { return nullptr; }
+                                fixed_size = static_cast<std::size_t>(*size);
+                            }
+                            result = registry_.list(element, fixed_size);
+                            break;
+                        }
+                    case hir::TypeKind::Set:
+                        if (!type.children.empty()) {
+                            if (const auto *element = value(type.children.front())) { result = registry_.set(element); }
+                        }
+                        break;
+                    case hir::TypeKind::Map:
+                        if (type.children.size() == 2U) {
+                            const auto *key    = value(type.children[0]);
+                            const auto *mapped = value(type.children[1]);
+                            if (key != nullptr && mapped != nullptr) { result = registry_.map(key, mapped); }
+                        }
+                        break;
+                    case hir::TypeKind::Atomic:
+                        if (!type.children.empty()) { result = value(type.children.front()); }
+                        break;
+                    case hir::TypeKind::Symbol:
+                    case hir::TypeKind::Rolling:
+                    case hir::TypeKind::Void:
+                    case hir::TypeKind::Iterator:
+                    case hir::TypeKind::Callable:
+                    case hir::TypeKind::Capability:
+                    case hir::TypeKind::HarnessSequence:
+                    case hir::TypeKind::Deferred: break;
+                }
+                if (result != nullptr) {
+                    values_.emplace(id.value, result);
+                    value_ids_.emplace(result, id);
+                }
+                return result;
+            }
+
+            [[nodiscard]] const hgraph::TSValueTypeMetaData *schema(hir::TypeId id) {
+                id = canonical(id);
+                if (!id.valid()) { return nullptr; }
+                if (const auto found = schemas_.find(id.value); found != schemas_.end()) { return found->second; }
+                const hir::Type                   &type   = module_.type(id);
+                const hgraph::TSValueTypeMetaData *result = nullptr;
+                switch (type.kind) {
+                    case hir::TypeKind::Scalar:
+                        if (const auto *meta = scalar(type.scalar)) { result = registry_.ts(meta); }
+                        break;
+                    case hir::TypeKind::List:
+                        {
+                            if (type.children.empty()) { return nullptr; }
+                            const auto *element = schema(type.children.front());
+                            if (element == nullptr) { return nullptr; }
+                            std::size_t fixed_size = 0;
+                            if (type.size.valid()) {
+                                const std::optional<std::int64_t> size = integer(type.size);
+                                if (!size || *size < 0) { return nullptr; }
+                                fixed_size = static_cast<std::size_t>(*size);
+                            }
+                            result = registry_.tsl(element, fixed_size);
+                            break;
+                        }
+                    case hir::TypeKind::Set:
+                        if (!type.children.empty()) {
+                            if (const auto *element = value(type.children.front())) { result = registry_.tss(element); }
+                        }
+                        break;
+                    case hir::TypeKind::Map:
+                        if (type.children.size() == 2U) {
+                            const auto *key    = value(type.children[0]);
+                            const auto *mapped = schema(type.children[1]);
+                            if (key != nullptr && mapped != nullptr) { result = registry_.tsd(key, mapped); }
+                        }
+                        break;
+                    case hir::TypeKind::Rolling:
+                        {
+                            if (type.children.empty()) { return nullptr; }
+                            const auto *element = value(type.children.front());
+                            if (element == nullptr) { return nullptr; }
+                            if (const std::optional<std::int64_t> period = duration(type.size)) {
+                                const std::optional<std::int64_t> minimum = duration(type.min_size);
+                                if (!minimum) { return nullptr; }
+                                result = registry_.tsw_duration(element, hgraph::TimeDelta{*period}, hgraph::TimeDelta{*minimum});
+                            } else {
+                                const std::optional<std::int64_t> tick_period = integer(type.size);
+                                const std::optional<std::int64_t> minimum     = integer(type.min_size);
+                                if (!tick_period || !minimum || *tick_period <= 0 || *minimum < 0) { return nullptr; }
+                                result = registry_.tsw(element, static_cast<std::size_t>(*tick_period),
+                                                       static_cast<std::size_t>(*minimum));
+                            }
+                            break;
+                        }
+                    case hir::TypeKind::Atomic:
+                        if (!type.children.empty()) {
+                            if (const auto *meta = value(type.children.front())) { result = registry_.ts(meta); }
+                        }
+                        break;
+                    case hir::TypeKind::Symbol:
+                    case hir::TypeKind::Tuple:
+                    case hir::TypeKind::Void:
+                    case hir::TypeKind::Iterator:
+                    case hir::TypeKind::Callable:
+                    case hir::TypeKind::Capability:
+                    case hir::TypeKind::HarnessSequence:
+                    case hir::TypeKind::Deferred: break;
+                }
+                if (result != nullptr) {
+                    schemas_.emplace(id.value, result);
+                    schema_ids_.emplace(result, id);
+                }
+                return result;
+            }
+
+            [[nodiscard]] std::optional<hgraph::Value> constant(const ir::OperatorArgument &argument) {
+                if (!argument.constant) { return std::nullopt; }
+                return std::visit(
+                    [&](const auto &item) -> std::optional<hgraph::Value> {
+                        using T = std::decay_t<decltype(item)>;
+                        if constexpr (std::is_same_v<T, bool> || std::is_same_v<T, std::int64_t> || std::is_same_v<T, double> ||
+                                      std::is_same_v<T, std::string>) {
+                            return hgraph::Value{item};
+                        } else if constexpr (std::is_same_v<T, syntax::TemporalValue>) {
+                            using syntax::TemporalKind;
+                            switch (item.kind) {
+                                case TemporalKind::Date:
+                                    return hgraph::Value{hgraph::Date{std::chrono::sys_days{std::chrono::days{item.micros}}}};
+                                case TemporalKind::Time: return hgraph::Value{hgraph::Time{item.micros}};
+                                case TemporalKind::DateTime:
+                                    return hgraph::Value{hgraph::DateTime{std::chrono::microseconds{item.micros}}};
+                                case TemporalKind::Duration: return hgraph::Value{hgraph::TimeDelta{item.micros}};
+                                case TemporalKind::CivilDateTime:
+                                case TemporalKind::ZonedDateTime:
+                                case TemporalKind::ZonedTime:
+                                case TemporalKind::TimeZone: return std::nullopt;
+                            }
+                            std::unreachable();
+                        } else {
+                            return std::nullopt;
+                        }
+                    },
+                    *argument.constant);
+            }
+
+            [[nodiscard]] std::optional<hgraph::WiringArg> lower_argument(const ir::OperatorArgument &argument) {
+                hgraph::WiringArg result;
+                result.name = argument.name;
+                if (argument.value_kind == hir::ValueKind::Constant) {
+                    std::optional<hgraph::Value> constant_value = constant(argument);
+                    if (!constant_value) { return std::nullopt; }
+                    result.kind         = hgraph::WiringArg::Kind::Scalar;
+                    result.scalar_value = std::move(*constant_value);
+                    result.scalar_meta  = result.scalar_value.schema();
+                    value_ids_.emplace(result.scalar_meta, canonical(argument.type));
+                    return result;
+                }
+                const hgraph::TSValueTypeMetaData *meta = schema(argument.type);
+                if (meta == nullptr) { return std::nullopt; }
+                result.kind = hgraph::WiringArg::Kind::TimeSeries;
+                result.port = hgraph::WiringPortRef::null_source(meta);
+                return result;
+            }
+
+            void append_substitutions(const hgraph::ResolutionMap &map, std::vector<hir::Substitution> &out) const {
+                for (const auto &[name, meta] : map.ts_vars) {
+                    hir::Substitution value;
+                    value.name = name;
+                    if (const auto found = schema_ids_.find(meta); found != schema_ids_.end()) { value.type = found->second; }
+                    out.push_back(std::move(value));
+                }
+                for (const auto &[name, meta] : map.scalar_vars) {
+                    hir::Substitution value;
+                    value.name = name;
+                    if (const auto found = value_ids_.find(meta); found != value_ids_.end()) { value.type = found->second; }
+                    out.push_back(std::move(value));
+                }
+                for (const auto &[name, size] : map.size_vars) {
+                    hir::Substitution value;
+                    value.name     = name;
+                    value.constant = hir::Constant{static_cast<std::int64_t>(size)};
+                    out.push_back(std::move(value));
+                }
+                std::ranges::sort(out,
+                                  [](const hir::Substitution &lhs, const hir::Substitution &rhs) { return lhs.name < rhs.name; });
+            }
+
+            const hir::Module                                                     &module_;
+            const hgraph::stdlib::RegisteredStandardTypes                          types_;
+            hgraph::TypeRegistry                                                  &registry_;
+            std::unordered_map<std::uint32_t, const hgraph::ValueTypeMetaData *>   values_{};
+            std::unordered_map<std::uint32_t, const hgraph::TSValueTypeMetaData *> schemas_{};
+            std::unordered_map<const hgraph::ValueTypeMetaData *, hir::TypeId>     value_ids_{};
+            std::unordered_map<const hgraph::TSValueTypeMetaData *, hir::TypeId>   schema_ids_{};
+        };
+    }  // namespace
+
+    ir::OperatorSelection resolve_operator_types(const ir::hir::Module &module, const ir::OperatorQuery &query) {
+        ensure_session();
+        return NativeTypes{module}.resolve(query);
+    }
+}  // namespace hgl::wiring

--- a/language/src/wiring/operator_types.h
+++ b/language/src/wiring/operator_types.h
@@ -1,0 +1,16 @@
+#ifndef HGL_WIRING_OPERATOR_TYPES_H
+#define HGL_WIRING_OPERATOR_TYPES_H
+
+#include "ir/type_check.h"
+
+namespace hgl::wiring
+{
+    /// The hgraph-backed implementation of HIR's overload-resolution port.
+    /// It constructs schema-only wiring arguments, delegates ranking to
+    /// OperatorRegistry, and copies the result back into backend-independent
+    /// data. Higher-order calls whose callable erasure is not yet available
+    /// remain explicit nominal/deferred operations.
+    [[nodiscard]] ir::OperatorSelection resolve_operator_types(const ir::hir::Module &module, const ir::OperatorQuery &query);
+}  // namespace hgl::wiring
+
+#endif  // HGL_WIRING_OPERATOR_TYPES_H

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -30,7 +30,7 @@ add_test(
     COMMAND $<TARGET_FILE:hgl> check ${CMAKE_CURRENT_SOURCE_DIR}/../examples/stateful-node.hgl --dump-hir
 )
 set_tests_properties(hgraph_language_dump_hir PROPERTIES
-    PASS_REGULAR_EXPRESSION "HIR resolved module examples.stateful_node"
+    PASS_REGULAR_EXPRESSION "HIR typed module examples.stateful_node"
 )
 
 # Catch2 for the frontend unit tests: reuse the repository's target when the
@@ -92,6 +92,16 @@ hgl_link_runtime_executable(hgl_wiring_tests)
 hgl_apply_warnings(hgl_wiring_tests)
 
 add_test(NAME hgraph_language_wiring COMMAND hgl_wiring_tests)
+
+# The type checker hands native candidate ranking to the hgraph registry while
+# retaining only copied, backend-independent selection data in HIR.
+add_executable(hgl_operator_type_tests wiring/operator_types_tests.cpp)
+target_compile_features(hgl_operator_type_tests PRIVATE cxx_std_23)
+target_link_libraries(hgl_operator_type_tests PRIVATE hgl::wiring Catch2::Catch2WithMain)
+hgl_link_runtime_executable(hgl_operator_type_tests)
+hgl_apply_warnings(hgl_operator_type_tests)
+
+add_test(NAME hgraph_language_operator_types COMMAND hgl_operator_type_tests)
 
 # The native module boundary translates registration failures through the
 # common scope/exception helper rather than maintaining a local catch ladder.

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -203,6 +203,95 @@ fn apply_it(value: f64) -> f64 => identity(value)
     CHECK(argument.type == call.type);
 }
 
+TEST_CASE("typed HIR rejects incompatible block tails", "[ir][typed][results]") {
+    Lowered lowered{R"(
+module checks.block_result
+
+fn wrong() -> str {
+    1
+}
+)"};
+    require_clean(lowered);
+    CHECK_FALSE(complete(lowered));
+    CHECK(lowered.diagnostics.render(lowered.file).find("function result has type i64, expected str") != std::string::npos);
+    CHECK(lowered.hir.completion == hir::Completion::Resolved);
+}
+
+TEST_CASE("typed HIR enforces const arguments at exact calls", "[ir][typed][calls][phase]") {
+    Lowered lowered{R"(
+module checks.const_call
+
+fn configured(const value: f64) -> f64 => value
+fn wrong(value: f64) -> f64 => configured(value)
+)"};
+    require_clean(lowered);
+    CHECK_FALSE(complete(lowered));
+    CHECK(lowered.diagnostics.render(lowered.file).find("a const parameter requires a compile-time value") != std::string::npos);
+    CHECK(lowered.hir.completion == hir::Completion::Resolved);
+}
+
+TEST_CASE("typed HIR infers generic constructors from fields", "[ir][typed][structs][generics]") {
+    Lowered lowered{R"(
+module checks.constructor_inference
+
+struct Box<T> {
+    value: T
+}
+
+struct Vector<T, const N: i64> {
+    values: list<T, N>
+}
+
+fn unbox(value: f64) -> f64 {
+    let boxed = Box(value: value)
+    boxed.value
+}
+
+fn unvector(values: list<f64, 3>) -> list<f64, 3> {
+    let vector = Vector(values: values)
+    vector.values
+}
+)"};
+    require_clean(lowered);
+    REQUIRE(complete(lowered));
+
+    bool found = false;
+    for (const hir::Expr &expression : lowered.hir.exprs) {
+        if (expression.operation.kind != hir::OperationKind::Constructor) { continue; }
+        const hir::Type &type = lowered.hir.type(expression.type);
+        if (type.kind != hir::TypeKind::Symbol || type.arguments.empty()) { continue; }
+        found = true;
+        REQUIRE(type.arguments.front().kind == hir::TypeArgumentKind::Type);
+        CHECK(lowered.hir.type(type.arguments.front().type).scalar == hir::ScalarType::F64);
+    }
+    CHECK(found);
+}
+
+TEST_CASE("typed HIR substitutes generic struct fields", "[ir][typed][structs][generics]") {
+    Lowered lowered{R"(
+module checks.generic_field
+
+struct Box<T> {
+    value: T
+}
+
+fn unwrap(box: Box<f64>) -> f64 => box.value
+)"};
+    require_clean(lowered);
+    REQUIRE(complete(lowered));
+}
+
+TEST_CASE("typed HIR completes constant expressions used by types", "[ir][typed][types][const]") {
+    Lowered lowered{R"(
+module checks.type_constants
+
+fn fixed(values: list<f64, 1 + 2>) -> list<f64, 3> => values
+fn generic<const N: i64>(values: list<f64, N + 1>) -> f64 => 1.0
+)"};
+    require_clean(lowered);
+    REQUIRE(complete(lowered));
+}
+
 TEST_CASE("typed HIR selects a source operator implementation", "[ir][typed][operators]") {
     Lowered lowered{R"(
 module checks.operators

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -1,5 +1,6 @@
 #include "ir/hir_printer.h"
 #include "ir/lower.h"
+#include "ir/type_check.h"
 #include "syntax/parser.h"
 
 #include <catch2/catch_test_macros.hpp>
@@ -60,6 +61,17 @@ namespace
         INFO(lowered.diagnostics.render(lowered.file));
         REQUIRE_FALSE(lowered.diagnostics.has_errors());
         REQUIRE(lowered.hir.completion == hir::Completion::Resolved);
+    }
+
+    bool complete(Lowered &lowered) {
+        const hgl::ir::OperatorResolver resolver = [](const hir::Module &, const hgl::ir::OperatorQuery &query) {
+            hgl::ir::OperatorSelection result;
+            result.result          = query.expected_result;
+            result.candidate_label = query.identity + "(<typed>)";
+            result.deferred        = true;
+            return result;
+        };
+        return hgl::ir::complete_hir(lowered.hir, resolver, lowered.diagnostics);
     }
 }  // namespace
 
@@ -130,6 +142,223 @@ fn escaped(const value: str = "a\nb\r\t\"\\") -> str => value
 
     const std::string printed = hgl::ir::print_hir(lowered.hir);
     CHECK(printed.find(R"(literal "a\nb\r\t\"\\")") != std::string::npos);
+}
+
+TEST_CASE("every guide example completes typed HIR", "[ir][examples][typed]") {
+    const std::filesystem::path directory{HGL_EXAMPLES_DIR};
+    REQUIRE(std::filesystem::is_directory(directory));
+
+    for (const std::filesystem::directory_entry &entry : std::filesystem::directory_iterator{directory}) {
+        if (entry.path().extension() != ".hgl") { continue; }
+        std::ifstream input{entry.path()};
+        REQUIRE(input.good());
+        Lowered lowered{std::string{std::istreambuf_iterator<char>{input}, std::istreambuf_iterator<char>{}},
+                        entry.path().string()};
+        INFO(entry.path().filename().string());
+        require_clean(lowered);
+        const bool completed = complete(lowered);
+        INFO(lowered.diagnostics.render(lowered.file));
+        REQUIRE(completed);
+        REQUIRE(lowered.hir.completion == hir::Completion::Typed);
+        for (const hir::Expr &expression : lowered.hir.exprs) {
+            CHECK(expression.phase != hir::Phase::Unknown);
+            CHECK(expression.value_kind != hir::ValueKind::Unknown);
+            if (expression.value_kind != hir::ValueKind::Function && expression.value_kind != hir::ValueKind::Operator &&
+                expression.value_kind != hir::ValueKind::Type) {
+                CHECK(expression.type.valid());
+            }
+        }
+    }
+}
+
+TEST_CASE("typed HIR canonicalizes types and resolves exact calls", "[ir][typed][calls]") {
+    Lowered lowered{R"(
+module checks.calls
+
+fn identity<T>(value: T) -> T => value
+
+fn apply_it(value: f64) -> f64 => identity(value)
+)"};
+    require_clean(lowered);
+    REQUIRE(complete(lowered));
+
+    const hir::FunctionDecl *use = nullptr;
+    for (const hir::Declaration &declaration : lowered.hir.declarations) {
+        const auto *fn = std::get_if<hir::FunctionDecl>(&declaration.node);
+        if (fn && declaration.symbol.valid() && lowered.hir.symbol(declaration.symbol).name == "apply_it") { use = fn; }
+    }
+    REQUIRE(use != nullptr);
+    const hir::Expr &call = lowered.hir.expr(use->concise_body);
+    CHECK(call.operation.kind == hir::OperationKind::ExactFunction);
+    CHECK(call.operation.target.valid());
+    REQUIRE(call.operation.substitutions.size() == 1);
+    CHECK(call.operation.substitutions.front().type.valid());
+    CHECK(call.type == use->signature.result);
+    CHECK(call.phase == hir::Phase::Wiring);
+    CHECK(hir::has_effect(call.effects, hir::Effect::WireGraph));
+
+    const auto *call_node = std::get_if<hir::Call>(&call.node);
+    REQUIRE(call_node != nullptr);
+    const hir::Expr &argument = lowered.hir.expr(call_node->arguments.front().value);
+    CHECK(argument.type == call.type);
+}
+
+TEST_CASE("typed HIR selects a source operator implementation", "[ir][typed][operators]") {
+    Lowered lowered{R"(
+module checks.operators
+
+operator choose<T>(value: T) -> T
+impl fn choose(value: f64) -> f64 => value
+fn apply_it(value: f64) -> f64 => choose(value)
+)"};
+    require_clean(lowered);
+    REQUIRE(complete(lowered));
+
+    bool found = false;
+    for (const hir::Expr &expression : lowered.hir.exprs) {
+        if (expression.operation.kind != hir::OperationKind::NominalOperator || !expression.operation.target.valid() ||
+            lowered.hir.symbol(expression.operation.target).name != "choose") {
+            continue;
+        }
+        found = true;
+        CHECK(expression.operation.candidate.valid());
+        CHECK(lowered.hir.symbol(expression.operation.candidate).name == "choose");
+        CHECK_FALSE(expression.operation.deferred);
+    }
+    CHECK(found);
+}
+
+TEST_CASE("typed HIR defers source overload ranking to hgraph", "[ir][typed][operators]") {
+    Lowered lowered{R"(
+module checks.overloads
+
+operator choose<T>(value: T) -> T
+impl fn choose(value: f64) -> f64 => value
+impl fn choose(value: i64) -> i64 => value
+fn apply_it(value: f64) -> f64 => choose(value)
+)"};
+    require_clean(lowered);
+    REQUIRE(complete(lowered));
+
+    bool found = false;
+    for (const hir::Expr &expression : lowered.hir.exprs) {
+        if (expression.operation.kind != hir::OperationKind::NominalOperator || !expression.operation.target.valid() ||
+            lowered.hir.symbol(expression.operation.target).name != "choose") {
+            continue;
+        }
+        found = true;
+        CHECK_FALSE(expression.operation.candidate.valid());
+        CHECK(expression.operation.deferred);
+    }
+    CHECK(found);
+}
+
+TEST_CASE("typed HIR does not select an inapplicable sole source implementation", "[ir][typed][operators]") {
+    Lowered lowered{R"(
+module checks.inapplicable
+
+operator choose<T>(value: T) -> T
+impl fn choose(value: f64) -> f64 => value
+fn apply_it(value: i64) -> i64 => choose(value)
+)"};
+    require_clean(lowered);
+    REQUIRE(complete(lowered));
+
+    bool found = false;
+    for (const hir::Expr &expression : lowered.hir.exprs) {
+        if (expression.operation.kind != hir::OperationKind::NominalOperator || !expression.operation.target.valid() ||
+            lowered.hir.symbol(expression.operation.target).name != "choose") {
+            continue;
+        }
+        found = true;
+        CHECK_FALSE(expression.operation.candidate.valid());
+        CHECK(expression.operation.deferred);
+    }
+    CHECK(found);
+}
+
+TEST_CASE("typed HIR rejects an uninferred generic substitution", "[ir][typed][generics]") {
+    Lowered lowered{R"(
+module checks.uninferred
+
+operator make<T>() -> T
+fn wrong() -> f64 {
+    make()
+    1.0
+}
+)"};
+    require_clean(lowered);
+    CHECK_FALSE(complete(lowered));
+    CHECK(lowered.diagnostics.render(lowered.file).find("cannot infer generic 'T' for operator call") != std::string::npos);
+    CHECK(lowered.hir.completion == hir::Completion::Resolved);
+}
+
+TEST_CASE("typed HIR fails closed until callable requirements are evaluated", "[ir][typed][constraints]") {
+    Lowered lowered{R"(
+module checks.constraints
+
+fn identity<T>(value: T) -> T
+requires T in {i64, f64}
+=> value
+)"};
+    require_clean(lowered);
+    CHECK_FALSE(complete(lowered));
+    CHECK(lowered.diagnostics.render(lowered.file).find("callable 'requires' evaluation is not implemented") != std::string::npos);
+    CHECK(lowered.hir.completion == hir::Completion::Resolved);
+}
+
+TEST_CASE("typed HIR records runtime state and capability effects", "[ir][typed][effects]") {
+    Lowered lowered{R"(
+module checks.effects
+
+fn total(value: f64) -> f64 {
+    state current: f64 = 0.0
+    inject out, logger
+    when modified(value) {
+        current += value
+        logger.info("updated")
+        out = current
+    }
+}
+)"};
+    require_clean(lowered);
+    REQUIRE(complete(lowered));
+
+    const hir::FunctionDecl *fn = nullptr;
+    for (const hir::Declaration &declaration : lowered.hir.declarations) {
+        if (const auto *candidate = std::get_if<hir::FunctionDecl>(&declaration.node)) { fn = candidate; }
+    }
+    REQUIRE(fn != nullptr);
+    CHECK(fn->kind == hir::FunctionKind::Runtime);
+    CHECK(fn->capabilities.size() == 2);
+    CHECK(hir::has_effect(fn->effects, hir::Effect::ReadRuntimeInput));
+    CHECK(hir::has_effect(fn->effects, hir::Effect::WriteState));
+    CHECK(hir::has_effect(fn->effects, hir::Effect::WriteOutput));
+    CHECK(hir::has_effect(fn->effects, hir::Effect::UseCapability));
+}
+
+TEST_CASE("typed HIR validates an explicit lambda against collection context", "[ir][typed][lambdas]") {
+    Lowered lowered{R"(
+module checks.lambda_context
+use hgraph.std::{map}
+
+fn wrong(values: map<str, f64>) -> map<str, f64> =>
+    map(values, fn(value: i64) -> f64 => value)
+)"};
+    require_clean(lowered);
+    CHECK_FALSE(complete(lowered));
+    CHECK(lowered.diagnostics.has_errors());
+    CHECK(lowered.diagnostics.render(lowered.file).find("lambda parameter type conflicts with its call context") !=
+          std::string::npos);
+    CHECK(lowered.hir.completion == hir::Completion::Resolved);
+}
+
+TEST_CASE("typed HIR rejects an invalid result without claiming completion", "[ir][typed][diagnostics]") {
+    Lowered lowered{"module checks.bad\nfn wrong(value: f64) -> str => value\n"};
+    require_clean(lowered);
+    CHECK_FALSE(complete(lowered));
+    CHECK(lowered.diagnostics.has_errors());
+    CHECK(lowered.hir.completion == hir::Completion::Resolved);
 }
 
 TEST_CASE("the resolved HIR dump is deterministic and source ranged", "[ir][snapshot]") {

--- a/language/tests/wiring/operator_types_tests.cpp
+++ b/language/tests/wiring/operator_types_tests.cpp
@@ -1,0 +1,79 @@
+#include "ir/lower.h"
+#include "ir/type_check.h"
+#include "semantics/resolve.h"
+#include "syntax/parser.h"
+#include "wiring/backend.h"
+#include "wiring/operator_types.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <string>
+
+namespace
+{
+    struct Unit
+    {
+        hgl::syntax::SourceFile        file;
+        hgl::syntax::DiagnosticSink    diagnostics{};
+        hgl::syntax::ast::Module       ast{};
+        hgl::semantics::ResolvedModule resolved{};
+        hgl::ir::hir::Module           hir{};
+
+        explicit Unit(std::string text) : file{"test.hgl", std::move(text)} {
+            hgl::wiring::ensure_session();
+            ast = hgl::syntax::parse(file, diagnostics);
+            if (diagnostics.has_errors()) { return; }
+            resolved = hgl::semantics::resolve(file, ast, hgl::wiring::has_operator, diagnostics);
+            if (diagnostics.has_errors()) { return; }
+            hir = hgl::ir::lower_to_hir(ast, resolved, diagnostics);
+        }
+
+        bool complete() { return hgl::ir::complete_hir(hir, hgl::wiring::resolve_operator_types, diagnostics); }
+    };
+}  // namespace
+
+TEST_CASE("native operator typing delegates concrete selection to hgraph", "[ir][operator-types]") {
+    Unit unit{R"(
+module checks.native_types
+use hgraph.std::{mean}
+
+fn average(window: rolling<f64, 20>) -> f64 => mean(window)
+)"};
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+    REQUIRE(unit.complete());
+
+    bool found = false;
+    for (const hgl::ir::hir::Expr &expression : unit.hir.exprs) {
+        if (expression.operation.identity != "mean") { continue; }
+        found = true;
+        CHECK_FALSE(expression.operation.candidate_label.empty());
+        CHECK_FALSE(expression.operation.deferred);
+        CHECK_FALSE(expression.operation.substitutions.empty());
+    }
+    CHECK(found);
+}
+
+TEST_CASE("higher-order operator typing remains explicit and deferred", "[ir][operator-types]") {
+    Unit unit{R"(
+module checks.higher_order_types
+use hgraph.std::{map}
+
+fn double(values: map<str, f64>) -> map<str, f64> =>
+    map(values, fn(value) => value * 2.0)
+)"};
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+    REQUIRE(unit.complete());
+
+    bool found = false;
+    for (const hgl::ir::hir::Expr &expression : unit.hir.exprs) {
+        if (expression.operation.kind != hgl::ir::hir::OperationKind::NominalOperator || expression.operation.identity != "map_") {
+            continue;
+        }
+        found = true;
+        CHECK(expression.operation.deferred);
+        CHECK(expression.operation.candidate_label.empty());
+    }
+    CHECK(found);
+}

--- a/language/tests/wiring/operator_types_tests.cpp
+++ b/language/tests/wiring/operator_types_tests.cpp
@@ -54,6 +54,28 @@ fn average(window: rolling<f64, 20>) -> f64 => mean(window)
     CHECK(found);
 }
 
+TEST_CASE("native operator typing recovers an inferred result for nested calls", "[ir][operator-types]") {
+    Unit unit{R"(
+module checks.nested_native_types
+use hgraph.std::{mean}
+
+fn scaled_average(window: rolling<f64, 20>) -> f64 => mean(window) * 2.0
+)"};
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+    REQUIRE(unit.complete());
+
+    bool found = false;
+    for (const hgl::ir::hir::Expr &expression : unit.hir.exprs) {
+        if (expression.operation.identity != "mean") { continue; }
+        found = true;
+        CHECK(expression.type.valid());
+        CHECK(unit.hir.type(expression.type).scalar == hgl::ir::hir::ScalarType::F64);
+        CHECK_FALSE(expression.operation.deferred);
+    }
+    CHECK(found);
+}
+
 TEST_CASE("higher-order operator typing remains explicit and deferred", "[ir][operator-types]") {
     Unit unit{R"(
 module checks.higher_order_types


### PR DESCRIPTION
Stacks on #682.

## Summary

- add canonical, structurally interned HGL types and explicit typed/effectful HIR operations
- complete HIR function bodies with local inference, generic substitutions, contextual lambda types, and exact source implementation selection
- delegate imported operator matching to the native hgraph OperatorRegistry and retain copied resolution metadata only
- reject callable requirements until the constraint solver can evaluate them, rather than silently compiling unchecked code
- update the compiler architecture, lowering guide, user guide, and roadmap to describe the implemented boundary and remaining Stage C work

## Validation

- fresh HGL warnings-as-errors build
- 26/26 HGL tests, including the package-consumer test
- full native C++ suite: 1,711/1,711 passed
- stable-ABI wheel installed under Python 3.14: 3,214 passed, 10 skipped
- all six checked guide examples pass HGL type completion
- git diff --check