### PR TITLE
feat(language): evaluate generic constraints in typed HIR

### DIFF
--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -122,6 +122,8 @@ hgl_apply_warnings(hgl_semantics)
 # node identities.
 add_library(hgl_ir STATIC
     src/ir/canonical_types.cpp
+    src/ir/constraint_solver.cpp
+    src/ir/generic_substitution.cpp
     src/ir/hir.cpp
     src/ir/hir_printer.cpp
     src/ir/lower.cpp

--- a/language/docs/design/compiler-architecture.md
+++ b/language/docs/design/compiler-architecture.md
@@ -137,6 +137,14 @@ typed nominal call marked `deferred`; the hgraph-IR pass resolves them at the
 first point where those inputs exist. Multiple source `impl fn` candidates are
 also left to the same hgraph ranking contract.
 
+Generic unification and application live in `src/ir/generic_substitution`.
+Constraint inference and admission live in `src/ir/constraint_solver`; that
+layer evaluates the normalized constraint arena but reaches native overloads
+only through the `OperatorResolver` port. The type checker supplies active
+requirements as facts to generic body checking and combines a local operator
+contract with its implementation without copying overload ranking into the
+compiler.
+
 ### Typed HIR
 
 HIR is the last representation of HGL as a language. It contains:

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -98,12 +98,21 @@ deferred rather than privately approximated. Every checked-in guide example
 reaches `Module::completion == Typed`, `hgl check --dump-hir` is deterministic,
 and a failed semantic pass cannot claim typed completion.
 
-The remaining work in this stage is callable `requires` evaluation and
-constraint-driven substitution, source-implementation conformance against its
-operator contract, and registry-backed completion for native operation forms
-which are currently retained as explicit deferred nominal calls. Callable
-requirements fail closed until that evaluator is present; they are not silently
-accepted by the temporary AST backends.
+Typed HIR now owns one reusable generic-substitution engine and a separate
+constraint solver. The solver orients positive-conjunction equalities to a
+fixed point, evaluates closed type sets, `struct` categories, inherited field
+reflection, Boolean composition, and nominal operator requirements, and uses
+those facts while checking generic bodies. Imported viability queries delegate
+to `OperatorRegistry`; local viability accepts exactly one applicable source
+implementation without inventing a ranking rule. Local implementations are
+checked against, and inherit requirements from, their local operator contract.
+
+The remaining work in this stage is imported operator-contract conformance,
+arbitrary residual `const` predicates, validation of constrained generic-struct
+applications outside construction sites, public native nominal-struct
+metadata, and registry-backed completion for operation forms retained as
+explicit deferred nominal calls. Those cases fail closed or remain explicitly
+deferred; the temporary AST backends never silently discard a constraint.
 
 - introduce stable symbol and declaration identities, canonical types, complete
   substitutions, typed constants, function kinds, phases, effects, and source
@@ -115,8 +124,9 @@ accepted by the temporary AST backends.
 Acceptance: all resolved guide examples produce typed HIR, invalid programs
 leave the module unresolved, concrete native selection delegates to hgraph,
 and HIR contains no emitted C++ or runtime wiring objects. This acceptance is
-not yet complete while callable constraints remain fail-closed. Backend removal
-of the temporary resolved-AST semantic walks belongs to stages D and E.
+not yet complete while the remaining descriptor- and registry-dependent cases
+above are deferred. Backend removal of the temporary resolved-AST semantic
+walks belongs to stages D and E.
 
 ### D. Hgraph IR and direct wiring
 

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -102,10 +102,13 @@ Typed HIR now owns one reusable generic-substitution engine and a separate
 constraint solver. The solver orients positive-conjunction equalities to a
 fixed point, evaluates closed type sets, `struct` categories, inherited field
 reflection, Boolean composition, and nominal operator requirements, and uses
-those facts while checking generic bodies. Imported viability queries delegate
-to `OperatorRegistry`; local viability accepts exactly one applicable source
-implementation without inventing a ranking rule. Local implementations are
-checked against, and inherit requirements from, their local operator contract.
+those facts while checking generic bodies. A declaration's requirements and an
+implementation's substituted operator-contract requirements form an explicit
+premise environment for nested constrained calls and constructions. Imported
+viability queries delegate to `OperatorRegistry`; local viability accepts
+exactly one applicable source implementation without inventing a ranking rule.
+Local implementations are checked against, and inherit requirements from,
+their local operator contract.
 
 The remaining work in this stage is imported operator-contract conformance,
 arbitrary residual `const` predicates, validation of constrained generic-struct

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -149,6 +149,16 @@ and combine them with candidate requirements at selection. Imported operator
 requirements use `OperatorResolver`, so native viability remains an hgraph
 decision.
 
+While checking a generic body, the declaration's normalized `requires`
+expression is an explicit proof premise. An `impl fn` also receives its
+operator contract through the conformance substitution. A nested function,
+operator, implementation, or struct-construction requirement is accepted when
+it evaluates concretely or follows from those premises. Conjunction requires
+both goals, disjunction requires either goal, a disjunctive premise must imply
+the goal on every branch, and a narrower closed set implies a wider one. This
+is compile-time implication only; no requirement becomes a per-tick runtime
+test.
+
 Residual arbitrary constant predicates, imported-contract conformance,
 constrained generic-struct applications outside construction sites, and native
 nominal-struct reflection still need descriptor support. A dependency cycle,

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -108,8 +108,11 @@ arguments become explicit type or value references. `hgl check --dump-hir`
 prints the deterministic diagnostic representation used by snapshot tests.
 
 `src/ir/canonical_types` owns structural interning and source-to-canonical
-rewriting. `src/ir/type_check` advances that checkpoint from `Resolved` to
-`Typed`. It
+rewriting. `src/ir/generic_substitution` owns unification and substitution for
+both call matching and constraints. `src/ir/constraint_solver` owns fixed-point
+equality inference, Boolean admission, structural reflection, and nominal
+operator viability. `src/ir/type_check` orchestrates those services and
+advances the checkpoint from `Resolved` to `Typed`. It
 interns context-neutral source types independently of whether an occurrence is
 used as a temporal input or a `const` value, normalizes omitted rolling minima,
 rewrites signatures to canonical IDs, infers exact-function and local-operator
@@ -135,12 +138,23 @@ while two or more candidates remain deferred for hgraph ranking rather than
 being ranked by a compiler-private matcher. The current slice also checks that
 a sole source candidate is applicable before naming it.
 
-Callable `requires` evaluation and constraint-driven substitution are the
-remaining typed-HIR stage. Until that evaluator exists, a function or operator
-carrying a callable requirement reports a type diagnostic and the module stays
-`Resolved`. This fail-closed boundary prevents the temporary AST backends from
-silently executing a constraint they do not implement. Closed generic-struct
-requirements continue to be decided by the resolver as before.
+Callable constraints now use the same substitution object as signature
+matching. Positive conjunctive equalities may bind an output-only type or
+`const` value; closed sets, `struct`, `fields`, `has_fields`, `field_type`,
+`&&`, `||`, and `!` are then evaluated as admission predicates. The checker
+uses closed numeric domains, reflected field types, and explicit operator
+requirements as facts when validating a generic body. Local `impl fn`
+signatures are checked against their local contract, inherit its requirements,
+and combine them with candidate requirements at selection. Imported operator
+requirements use `OperatorResolver`, so native viability remains an hgraph
+decision.
+
+Residual arbitrary constant predicates, imported-contract conformance,
+constrained generic-struct applications outside construction sites, and native
+nominal-struct reflection still need descriptor support. A dependency cycle,
+an unavailable native shape, or any other unresolved requirement reports a
+type diagnostic and leaves the module `Resolved`; it is never discarded by a
+temporary backend.
 
 The direct-wiring and C++ backends still walk `ResolvedModule` beside typed HIR
 during migration. That adapter path is explicitly temporary; hgraph semantic
@@ -541,6 +555,13 @@ make that candidate more specific. Consequently two same-ranked candidates
 whose predicates both accept remain ambiguous. The compiler must not use
 source order, import order, registration order, or an attempted general proof
 of predicate implication as a tie-break.
+
+The typed-HIR prototype implements this division directly. Its constraint
+solver may establish viability for one exactly applicable local source
+implementation, but multiple applicable implementations remain unresolved
+until source providers are registered with hgraph. Imported requirements are
+schema-only `OperatorResolver` probes and therefore use native matching and
+ranking. Neither path stores a registry pointer in HIR.
 
 The current TSB pattern is closed: its field names and count must exactly match
 the concrete schema. `has_fields(U, {"a", "b"})` can initially lower to

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -267,10 +267,12 @@ source or registration order.
 The current typed-HIR suite covers closed-set admission and rejection,
 fixed-point field-type inference from a `const` field name, inherited field
 reflection, Boolean alternatives and negation, unresolved dependencies,
-generic struct construction, local operator viability, inherited contract
-requirements, and a native registry-backed operator requirement. Remaining
-tests in this list become gates as the descriptor and hgraph-IR boundaries are
-implemented; the guide must not imply they already pass.
+generic struct construction, declaration requirements used as premises for
+nested constrained calls, rejection of a premise that is too broad, local
+operator viability, inherited contract requirements, and a native
+registry-backed operator requirement. Remaining tests in this list become
+gates as the descriptor and hgraph-IR boundaries are implemented; the guide
+must not imply they already pass.
 
 When open structural patterns are implemented, test that required fields bind
 their types, additional fields remain admissible, a more constrained pattern

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -264,6 +264,14 @@ residual `requires_` predicate only rejects. Include an overlap in which two
 same-ranked admitted predicates remain ambiguous rather than selecting by
 source or registration order.
 
+The current typed-HIR suite covers closed-set admission and rejection,
+fixed-point field-type inference from a `const` field name, inherited field
+reflection, Boolean alternatives and negation, unresolved dependencies,
+generic struct construction, local operator viability, inherited contract
+requirements, and a native registry-backed operator requirement. Remaining
+tests in this list become gates as the descriptor and hgraph-IR boundaries are
+implemented; the guide must not imply they already pass.
+
 When open structural patterns are implemented, test that required fields bind
 their types, additional fields remain admissible, a more constrained pattern
 outranks an unbounded fallback, and compiler prediction agrees with the native

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -138,11 +138,14 @@ described in [Types and expressions](types-and-expressions.md#generic-structured
 A trailing `requires` clause constrains an otherwise generic declaration. It
 follows the signature and precedes the body:
 
-> **Staging status:** `hgl check` parses and resolves `requires` clauses and
-> rejects decidably false closed struct requirements. Complete callable
-> substitution and operator-conformance checking remains part of typed-HIR
-> completion. Callable requirements currently fail closed during type
-> completion rather than being ignored by a backend.
+> **Staging status:** `hgl check` evaluates closed type sets, `struct`
+> admission, field reflection, positive-conjunction equality inference,
+> Boolean composition, and nominal operator requirements during typed-HIR
+> completion. Local implementations inherit their local operator contract and
+> are checked for signature conformance. A requirement still fails closed when
+> it needs an arbitrary residual constant predicate, imported operator-contract
+> metadata, native nominal-struct metadata, or source-candidate ranking that has
+> not yet crossed the shared hgraph registry boundary.
 
 ```hgl
 fn add_numeric<U>(a: U, b: U) -> U

--- a/language/docs/user-guide/language-tour.md
+++ b/language/docs/user-guide/language-tour.md
@@ -131,10 +131,11 @@ Repeating `U` requires the arguments and result to share one canonical source
 type. The first contract restricts that type to `f64` or `i64`. The second
 requires the nominal `add` operator to accept two `U` values and produce `U`;
 its implementation may rely on that guarantee without repeating it. `hgl
-check` parses and binds this constraint model now. Closed requirements on an
-explicit generic struct application are evaluated when all operands are
-known; callable substitution and operator admission remain part of the typed
-IR and hgraph resolver work. Requirements are never tested per tick.
+check` evaluates closed requirements during typed-HIR completion and asks the
+hgraph operator registry to decide native operator viability. Cases needing
+native nominal-struct metadata, arbitrary constant predicates, or source
+candidate ranking remain explicitly deferred or fail closed as described in
+the roadmap. Requirements are never tested per tick.
 
 ## Anonymous functions
 

--- a/language/docs/user-guide/types-and-expressions.md
+++ b/language/docs/user-guide/types-and-expressions.md
@@ -360,6 +360,13 @@ requires T in {i64, f64}
 equalities, constant predicates, and nominal operator requirements have the
 same meaning here as on a generic function.
 
+> **Staging status:** The prototype currently performs complete requirement
+> evaluation when it checks a struct constructor. Other appearances of an
+> applied generic struct retain the normalized requirement in typed HIR, but
+> validation there remains fail-closed until canonical nominal-type metadata is
+> available to every consumer. Arbitrary constant expressions beyond equality
+> and closed-set membership are also still deferred.
+
 In the initial design, a struct's type arguments are canonical value types,
 not temporal policies. Put `atomic` at the field where temporal expansion is
 controlled:

--- a/language/src/ir/constraint_solver.cpp
+++ b/language/src/ir/constraint_solver.cpp
@@ -43,6 +43,152 @@ namespace hgl::ir::detail
         return types_.same_value(lhs, rhs);
     }
 
+    bool ConstraintSolver::operand_equivalent(const Operand &lhs, const Operand &rhs) const {
+        if (lhs.kind != rhs.kind) { return false; }
+        switch (lhs.kind) {
+            case OperandKind::Type: return types_.same(lhs.type, rhs.type);
+            case OperandKind::Value:
+                if (lhs.value.valid() && rhs.value.valid()) { return same_value(lhs.value, rhs.value); }
+                if (lhs.variable.valid() && rhs.variable.valid()) { return lhs.variable == rhs.variable; }
+                if (lhs.variable.valid() && rhs.value.valid()) {
+                    const auto *reference = std::get_if<SymbolRef>(&module_.expr(rhs.value).node);
+                    return reference != nullptr && reference->symbol == lhs.variable;
+                }
+                if (rhs.variable.valid() && lhs.value.valid()) {
+                    const auto *reference = std::get_if<SymbolRef>(&module_.expr(lhs.value).node);
+                    return reference != nullptr && reference->symbol == rhs.variable;
+                }
+                return false;
+            case OperandKind::TypeSet:
+                return lhs.types.size() == rhs.types.size() && std::ranges::all_of(lhs.types, [&](TypeId item) {
+                           return std::ranges::any_of(rhs.types, [&](TypeId candidate) { return types_.same(item, candidate); });
+                       });
+            case OperandKind::ValueSet:
+                return lhs.values.size() == rhs.values.size() && std::ranges::all_of(lhs.values, [&](ExprId item) {
+                           return std::ranges::any_of(rhs.values, [&](ExprId candidate) { return same_value(item, candidate); });
+                       });
+            case OperandKind::FieldSet:
+                {
+                    std::vector<std::string> left  = lhs.fields;
+                    std::vector<std::string> right = rhs.fields;
+                    std::ranges::sort(left);
+                    std::ranges::sort(right);
+                    return left == right;
+                }
+            case OperandKind::Boolean: return lhs.known == rhs.known && (!lhs.known || lhs.boolean == rhs.boolean);
+            case OperandKind::Invalid: return false;
+        }
+        return false;
+    }
+
+    bool ConstraintSolver::relation_implies(const ConstraintRelation &premise, GenericSubstitution &premise_substitution,
+                                            const ConstraintRelation &goal, GenericSubstitution &goal_substitution) {
+        if (premise.op != goal.op) { return false; }
+        const Operand premise_lhs = operand(premise.lhs, premise_substitution);
+        const Operand goal_lhs    = operand(goal.lhs, goal_substitution);
+        if (premise.op == ConstraintRelationOp::Is) {
+            return premise.category == goal.category && operand_equivalent(premise_lhs, goal_lhs);
+        }
+        const Operand premise_rhs = operand(premise.rhs, premise_substitution);
+        const Operand goal_rhs    = operand(goal.rhs, goal_substitution);
+        if (premise.op == ConstraintRelationOp::Equal) {
+            return (operand_equivalent(premise_lhs, goal_lhs) && operand_equivalent(premise_rhs, goal_rhs)) ||
+                   (operand_equivalent(premise_lhs, goal_rhs) && operand_equivalent(premise_rhs, goal_lhs));
+        }
+        if (!operand_equivalent(premise_lhs, goal_lhs)) { return false; }
+        if (premise_rhs.kind == OperandKind::TypeSet && goal_rhs.kind == OperandKind::TypeSet) {
+            return std::ranges::all_of(premise_rhs.types, [&](TypeId item) {
+                return std::ranges::any_of(goal_rhs.types, [&](TypeId candidate) { return types_.same(item, candidate); });
+            });
+        }
+        if (premise_rhs.kind == OperandKind::ValueSet && goal_rhs.kind == OperandKind::ValueSet) {
+            return std::ranges::all_of(premise_rhs.values, [&](ExprId item) {
+                return std::ranges::any_of(goal_rhs.values, [&](ExprId candidate) { return same_value(item, candidate); });
+            });
+        }
+        if (premise_rhs.kind == OperandKind::FieldSet && goal_rhs.kind == OperandKind::FieldSet) {
+            return std::ranges::all_of(premise_rhs.fields,
+                                       [&](const std::string &item) { return std::ranges::contains(goal_rhs.fields, item); });
+        }
+        return operand_equivalent(premise_rhs, goal_rhs);
+    }
+
+    bool ConstraintSolver::atomic_equivalent(ConstraintId premise_id, GenericSubstitution &premise_substitution,
+                                             ConstraintId goal_id, GenericSubstitution &goal_substitution) {
+        const Constraint &premise = module_.constraint(premise_id);
+        const Constraint &goal    = module_.constraint(goal_id);
+        if (const auto *premise_relation = std::get_if<ConstraintRelation>(&premise.node)) {
+            const auto *goal_relation = std::get_if<ConstraintRelation>(&goal.node);
+            return goal_relation != nullptr &&
+                   relation_implies(*premise_relation, premise_substitution, *goal_relation, goal_substitution);
+        }
+        if (const auto *premise_requirement = std::get_if<OperatorRequirement>(&premise.node)) {
+            const auto *goal_requirement = std::get_if<OperatorRequirement>(&goal.node);
+            if (goal_requirement == nullptr ||
+                !identity_matches(operator_identity(premise_requirement->op), operator_identity(goal_requirement->op)) ||
+                premise_requirement->arguments.size() != goal_requirement->arguments.size()) {
+                return false;
+            }
+            for (std::size_t index = 0; index < premise_requirement->arguments.size(); ++index) {
+                if (!operand_equivalent(operand(premise_requirement->arguments[index], premise_substitution),
+                                        operand(goal_requirement->arguments[index], goal_substitution))) {
+                    return false;
+                }
+            }
+            if (premise_requirement->result.valid() != goal_requirement->result.valid()) { return false; }
+            return !premise_requirement->result.valid() || types_.same(premise_substitution.apply(premise_requirement->result),
+                                                                       goal_substitution.apply(goal_requirement->result));
+        }
+        if (const auto *premise_call = std::get_if<ConstraintCall>(&premise.node)) {
+            const auto *goal_call = std::get_if<ConstraintCall>(&goal.node);
+            if (goal_call == nullptr ||
+                !identity_matches(operator_identity(premise_call->function), operator_identity(goal_call->function)) ||
+                premise_call->arguments.size() != goal_call->arguments.size()) {
+                return false;
+            }
+            for (std::size_t index = 0; index < premise_call->arguments.size(); ++index) {
+                if (!operand_equivalent(operand(premise_call->arguments[index], premise_substitution),
+                                        operand(goal_call->arguments[index], goal_substitution))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        if (const auto *premise_not = std::get_if<ConstraintNot>(&premise.node)) {
+            const auto *goal_not = std::get_if<ConstraintNot>(&goal.node);
+            return goal_not != nullptr &&
+                   atomic_equivalent(premise_not->operand, premise_substitution, goal_not->operand, goal_substitution);
+        }
+        return operand_equivalent(operand(premise_id, premise_substitution), operand(goal_id, goal_substitution));
+    }
+
+    bool ConstraintSolver::premise_implies(ConstraintId premise_id, GenericSubstitution &premise_substitution, ConstraintId goal,
+                                           GenericSubstitution &goal_substitution) {
+        const Constraint &premise = module_.constraint(premise_id);
+        if (const auto *logic = std::get_if<ConstraintLogic>(&premise.node)) {
+            const bool lhs = premise_implies(logic->lhs, premise_substitution, goal, goal_substitution);
+            const bool rhs = premise_implies(logic->rhs, premise_substitution, goal, goal_substitution);
+            return logic->op == ConstraintLogicOp::And ? lhs || rhs : lhs && rhs;
+        }
+        return atomic_equivalent(premise_id, premise_substitution, goal, goal_substitution);
+    }
+
+    bool ConstraintSolver::premises_prove(ConstraintId goal_id, GenericSubstitution &goal_substitution,
+                                          std::span<const ConstraintPremise> premises) {
+        const Constraint &goal = module_.constraint(goal_id);
+        if (const auto *logic = std::get_if<ConstraintLogic>(&goal.node)) {
+            const bool lhs = premises_prove(logic->lhs, goal_substitution, premises);
+            const bool rhs = premises_prove(logic->rhs, goal_substitution, premises);
+            return logic->op == ConstraintLogicOp::And ? lhs && rhs : lhs || rhs;
+        }
+        GenericSubstitution empty{module_, types_};
+        return std::ranges::any_of(premises, [&](const ConstraintPremise &premise) {
+            if (!premise.requirement.valid()) { return false; }
+            GenericSubstitution &bindings = premise.substitution == nullptr ? empty : *premise.substitution;
+            return premise_implies(premise.requirement, bindings, goal_id, goal_substitution);
+        });
+    }
+
     ConstraintSolver::Operand ConstraintSolver::type_operand(TypeId type, GenericSubstitution &substitution) {
         type = types_.canonical(type);
         if (!type.valid()) { return {}; }
@@ -269,7 +415,8 @@ namespace hgl::ir::detail
     }
 
     ConstraintSolver::Truth ConstraintSolver::evaluate_operator(const OperatorRequirement &requirement,
-                                                                GenericSubstitution &substitution, syntax::SourceRange range) {
+                                                                GenericSubstitution &substitution, syntax::SourceRange range,
+                                                                std::span<const ConstraintPremise> premises) {
         if (!requirement.op.valid()) { return Truth::False; }
         OperatorQuery        query;
         std::vector<Operand> arguments;
@@ -336,7 +483,9 @@ namespace hgl::ir::detail
         if (query.expected_result.valid() && !contract_substitution.unify(contract->signature.result, query.expected_result)) {
             return Truth::False;
         }
-        if (!solve(contract->requirements, contract_substitution, range, "operator contract", false)) { return Truth::False; }
+        if (!solve(contract->requirements, contract_substitution, range, "operator contract", false, premises)) {
+            return Truth::False;
+        }
         for (const GenericParameter &generic : contract->generics) {
             if (generic.is_const ? !contract_substitution.has_value(generic.symbol)
                                  : !contract_substitution.has_type(generic.symbol)) {
@@ -377,7 +526,9 @@ namespace hgl::ir::detail
             if (matches && query.expected_result.valid()) {
                 matches = types_.same(candidate_substitution.apply(candidate->signature.result), query.expected_result);
             }
-            if (matches) { matches = solve(candidate->requirements, candidate_substitution, {}, "implementation", false); }
+            if (matches) {
+                matches = solve(candidate->requirements, candidate_substitution, {}, "implementation", false, premises);
+            }
             for (const GenericParameter &generic : candidate->generics) {
                 if (generic.is_const ? !candidate_substitution.has_value(generic.symbol)
                                      : !candidate_substitution.has_type(generic.symbol)) {
@@ -395,7 +546,8 @@ namespace hgl::ir::detail
         return Truth::False;
     }
 
-    ConstraintSolver::Truth ConstraintSolver::evaluate(ConstraintId id, GenericSubstitution &substitution) {
+    ConstraintSolver::Truth ConstraintSolver::evaluate(ConstraintId id, GenericSubstitution &substitution,
+                                                       std::span<const ConstraintPremise> premises) {
         if (!id.valid()) { return Truth::True; }
         const Constraint &constraint = module_.constraint(id);
         return std::visit(
@@ -404,24 +556,24 @@ namespace hgl::ir::detail
                 if constexpr (std::is_same_v<T, ConstraintRelation>) {
                     return evaluate_relation(node, substitution);
                 } else if constexpr (std::is_same_v<T, OperatorRequirement>) {
-                    return evaluate_operator(node, substitution, constraint.range);
+                    return evaluate_operator(node, substitution, constraint.range, premises);
                 } else if constexpr (std::is_same_v<T, ConstraintNot>) {
                     const std::string previous_failure = failure_detail_;
-                    const Truth       value            = evaluate(node.operand, substitution);
+                    const Truth       value            = evaluate(node.operand, substitution, premises);
                     if (value == Truth::Unresolved) { return value; }
                     if (value == Truth::False) { failure_detail_ = previous_failure; }
                     return value == Truth::True ? Truth::False : Truth::True;
                 } else if constexpr (std::is_same_v<T, ConstraintLogic>) {
                     if (node.op == ConstraintLogicOp::Or) {
                         const std::string previous_failure = failure_detail_;
-                        const Truth       lhs              = evaluate(node.lhs, substitution);
+                        const Truth       lhs              = evaluate(node.lhs, substitution, premises);
                         if (lhs == Truth::True) {
                             failure_detail_ = previous_failure;
                             return Truth::True;
                         }
                         const std::string lhs_failure = failure_detail_;
                         failure_detail_               = previous_failure;
-                        const Truth rhs               = evaluate(node.rhs, substitution);
+                        const Truth rhs               = evaluate(node.rhs, substitution, premises);
                         if (rhs == Truth::True) {
                             failure_detail_ = previous_failure;
                             return Truth::True;
@@ -432,9 +584,9 @@ namespace hgl::ir::detail
                         if (lhs == Truth::False && rhs == Truth::False) { return Truth::False; }
                         return Truth::Unresolved;
                     }
-                    const Truth lhs = evaluate(node.lhs, substitution);
+                    const Truth lhs = evaluate(node.lhs, substitution, premises);
                     if (lhs == Truth::False) { return Truth::False; }
-                    const Truth rhs = evaluate(node.rhs, substitution);
+                    const Truth rhs = evaluate(node.rhs, substitution, premises);
                     if (rhs == Truth::False) { return Truth::False; }
                     return lhs == Truth::True && rhs == Truth::True ? Truth::True : Truth::Unresolved;
                 } else {
@@ -486,7 +638,7 @@ namespace hgl::ir::detail
     }
 
     bool ConstraintSolver::solve(ConstraintId requirement, GenericSubstitution &substitution, syntax::SourceRange use_range,
-                                 std::string_view subject, bool report) {
+                                 std::string_view subject, bool report, std::span<const ConstraintPremise> premises) {
         if (!requirement.valid()) { return true; }
         if (evaluation_depth_ == 0U) { failure_detail_.clear(); }
         if (evaluation_depth_ > module_.constraints.size()) {
@@ -510,8 +662,13 @@ namespace hgl::ir::detail
             }
             if (!changed) { break; }
         }
-        const Truth result = evaluate(requirement, substitution);
+        const std::string previous_failure = failure_detail_;
+        const Truth       result           = evaluate(requirement, substitution, premises);
         if (result == Truth::True) { return true; }
+        if (premises_prove(requirement, substitution, premises)) {
+            failure_detail_ = previous_failure;
+            return true;
+        }
         if (!report) { return false; }
         const syntax::SourceRange range = use_range.empty() ? module_.constraint(requirement).range : use_range;
         if (result == Truth::False) {

--- a/language/src/ir/constraint_solver.cpp
+++ b/language/src/ir/constraint_solver.cpp
@@ -1,0 +1,623 @@
+#include "ir/constraint_solver.h"
+
+#include <algorithm>
+#include <ranges>
+#include <type_traits>
+#include <utility>
+
+namespace hgl::ir::detail
+{
+    using namespace hir;
+
+    ConstraintSolver::ConstraintSolver(Module &module, CanonicalTypes &types, const OperatorResolver &resolve_operator,
+                                       syntax::DiagnosticSink &diagnostics)
+        : module_{module}, types_{types}, resolve_operator_{resolve_operator}, diagnostics_{diagnostics} {}
+
+    void ConstraintSolver::fail(std::string message) {
+        if (failure_detail_.empty()) { failure_detail_ = std::move(message); }
+    }
+
+    bool ConstraintSolver::same_symbolic_type(TypeId lhs, TypeId rhs) const noexcept {
+        lhs = types_.canonical(lhs);
+        rhs = types_.canonical(rhs);
+        return lhs.valid() && rhs.valid() && lhs == rhs;
+    }
+
+    std::optional<std::string> ConstraintSolver::string_value(ExprId value) const {
+        if (!value.valid()) { return std::nullopt; }
+        const Expr &expression = module_.expr(value);
+        if (expression.constant) {
+            if (const auto *text = std::get_if<std::string>(&*expression.constant)) { return *text; }
+        }
+        if (const auto *literal = std::get_if<Literal>(&expression.node)) {
+            if (const auto *text = std::get_if<std::string>(&literal->value)) { return *text; }
+        }
+        return std::nullopt;
+    }
+
+    bool ConstraintSolver::same_value(ExprId lhs, ExprId rhs) const {
+        if (const auto left = string_value(lhs)) {
+            const auto right = string_value(rhs);
+            return right && *left == *right;
+        }
+        return types_.same_value(lhs, rhs);
+    }
+
+    ConstraintSolver::Operand ConstraintSolver::type_operand(TypeId type, GenericSubstitution &substitution) {
+        type = types_.canonical(type);
+        if (!type.valid()) { return {}; }
+        const Type &source = module_.type(type);
+        if (source.kind == TypeKind::Symbol && source.symbol.valid() &&
+            module_.symbol(source.symbol).kind == SymbolKind::TypeParameter && !substitution.has_type(source.symbol)) {
+            return Operand{.kind = OperandKind::Type, .known = false, .variable = source.symbol, .type = type};
+        }
+        return Operand{.kind = OperandKind::Type, .known = true, .type = substitution.apply(type)};
+    }
+
+    ConstraintSolver::Operand ConstraintSolver::value_operand(ExprId value, GenericSubstitution &substitution) {
+        if (!value.valid()) { return {}; }
+        const Expr &source = module_.expr(value);
+        if (const auto *reference = std::get_if<SymbolRef>(&source.node);
+            reference && reference->symbol.valid() && module_.symbol(reference->symbol).kind == SymbolKind::ConstParameter &&
+            !substitution.has_value(reference->symbol)) {
+            return Operand{.kind = OperandKind::Value, .known = false, .variable = reference->symbol, .value = value};
+        }
+        return Operand{.kind = OperandKind::Value, .known = true, .value = substitution.apply_value(value)};
+    }
+
+    bool ConstraintSolver::is_struct(TypeId type) const noexcept {
+        type = types_.canonical(type);
+        if (!type.valid()) { return false; }
+        const Type &value = module_.type(type);
+        if (value.kind != TypeKind::Symbol || !value.symbol.valid()) { return false; }
+        const Symbol &symbol = module_.symbol(value.symbol);
+        return symbol.kind == SymbolKind::Struct && symbol.owner.valid() &&
+               std::holds_alternative<StructDecl>(module_.declaration(symbol.owner).node);
+    }
+
+    void ConstraintSolver::append_fields(TypeId type_id, std::vector<EffectiveField> &fields) {
+        type_id = types_.canonical(type_id);
+        if (!is_struct(type_id)) { return; }
+        const Type       &applied = module_.type(type_id);
+        const Symbol     &symbol  = module_.symbol(applied.symbol);
+        const StructDecl &decl    = std::get<StructDecl>(module_.declaration(symbol.owner).node);
+
+        GenericSubstitution substitution{module_, types_};
+        for (std::size_t index = 0; index < decl.generics.size() && index < applied.arguments.size(); ++index) {
+            const GenericParameter &generic  = decl.generics[index];
+            const TypeArgument     &argument = applied.arguments[index];
+            if (generic.is_const && argument.kind == TypeArgumentKind::Value) {
+                (void)substitution.bind_value(generic.symbol, argument.value);
+            } else if (!generic.is_const && argument.kind == TypeArgumentKind::Type) {
+                (void)substitution.bind_type(generic.symbol, argument.type);
+            }
+        }
+
+        for (TypeId parent : decl.parents) { append_fields(substitution.apply(parent), fields); }
+        for (const StructField &field : decl.fields) {
+            const auto   existing = std::ranges::find(fields, field.name, &EffectiveField::name);
+            const TypeId resolved = substitution.apply(field.type);
+            if (existing == fields.end()) {
+                fields.push_back(EffectiveField{field.name, resolved});
+            } else {
+                existing->type = resolved;
+            }
+        }
+    }
+
+    std::vector<ConstraintSolver::EffectiveField> ConstraintSolver::effective_fields(TypeId type) {
+        std::vector<EffectiveField> result;
+        append_fields(type, result);
+        return result;
+    }
+
+    ConstraintSolver::Operand ConstraintSolver::operand(ConstraintId id, GenericSubstitution &substitution) {
+        if (!id.valid()) { return {}; }
+        const Constraint &constraint = module_.constraint(id);
+        return std::visit(
+            [&](const auto &node) -> Operand {
+                using T = std::decay_t<decltype(node)>;
+                if constexpr (std::is_same_v<T, ConstraintSymbol>) {
+                    if (!node.symbol.valid()) { return {}; }
+                    const Symbol &symbol = module_.symbol(node.symbol);
+                    if (symbol.kind == SymbolKind::TypeParameter) {
+                        if (const auto bound = substitution.type_binding(node.symbol)) {
+                            return Operand{.kind = OperandKind::Type, .known = true, .type = *bound};
+                        }
+                        const TypeId symbolic = types_.make(TypeKind::Symbol, {}, node.symbol);
+                        return Operand{.kind = OperandKind::Type, .known = false, .variable = node.symbol, .type = symbolic};
+                    }
+                    if (symbol.kind == SymbolKind::ConstParameter) {
+                        if (const auto bound = substitution.value_binding(node.symbol)) {
+                            return Operand{.kind = OperandKind::Value, .known = true, .value = *bound};
+                        }
+                        return Operand{.kind = OperandKind::Value, .known = false, .variable = node.symbol};
+                    }
+                    if (symbol.kind == SymbolKind::Struct) {
+                        return Operand{
+                            .kind = OperandKind::Type, .known = true, .type = types_.make(TypeKind::Symbol, {}, node.symbol)};
+                    }
+                    return {};
+                } else if constexpr (std::is_same_v<T, ConstraintType>) {
+                    return type_operand(node.type, substitution);
+                } else if constexpr (std::is_same_v<T, ConstraintValue>) {
+                    return value_operand(node.value, substitution);
+                } else if constexpr (std::is_same_v<T, ConstraintSet>) {
+                    Operand result;
+                    bool    all_types  = true;
+                    bool    all_values = true;
+                    result.known       = true;
+                    for (ConstraintId element : node.elements) {
+                        Operand item = operand(element, substitution);
+                        result.known = result.known && item.known;
+                        if (item.kind == OperandKind::Type) {
+                            result.types.push_back(item.type);
+                            all_values = false;
+                        } else if (item.kind == OperandKind::Value) {
+                            result.values.push_back(item.value);
+                            all_types = false;
+                        } else {
+                            all_types  = false;
+                            all_values = false;
+                        }
+                    }
+                    if (all_types) {
+                        result.kind = OperandKind::TypeSet;
+                    } else if (all_values) {
+                        result.kind = OperandKind::ValueSet;
+                    }
+                    return result;
+                } else if constexpr (std::is_same_v<T, ConstraintCall>) {
+                    if (!node.function.valid()) { return {}; }
+                    const Symbol      &function = module_.symbol(node.function);
+                    const std::string &name     = function.external_name.empty() ? function.name : function.external_name;
+                    if (name == "schema" && node.arguments.size() == 1U) { return operand(node.arguments.front(), substitution); }
+                    if ((name == "fields" || name == "keys") && node.arguments.size() == 1U) {
+                        Operand source = operand(node.arguments.front(), substitution);
+                        if (!source.known) { return Operand{.kind = OperandKind::FieldSet, .known = false}; }
+                        if (source.kind != OperandKind::Type || !is_struct(source.type)) { return {}; }
+                        Operand result{.kind = OperandKind::FieldSet, .known = true};
+                        for (const EffectiveField &field : effective_fields(source.type)) { result.fields.push_back(field.name); }
+                        return result;
+                    }
+                    if (name == "has_fields" && node.arguments.size() == 2U) {
+                        Operand source = operand(node.arguments[0], substitution);
+                        Operand names  = operand(node.arguments[1], substitution);
+                        if (!source.known || !names.known) { return Operand{.kind = OperandKind::Boolean, .known = false}; }
+                        if (source.kind != OperandKind::Type || !is_struct(source.type) || names.kind != OperandKind::ValueSet) {
+                            return {};
+                        }
+                        std::vector<std::string> available;
+                        for (const EffectiveField &field : effective_fields(source.type)) { available.push_back(field.name); }
+                        bool result = true;
+                        for (ExprId item : names.values) {
+                            const auto name_value = string_value(item);
+                            if (!name_value || !std::ranges::contains(available, *name_value)) { result = false; }
+                        }
+                        return Operand{.kind = OperandKind::Boolean, .known = true, .boolean = result};
+                    }
+                    if (name == "field_type" && node.arguments.size() == 2U) {
+                        Operand source     = operand(node.arguments[0], substitution);
+                        Operand name_value = operand(node.arguments[1], substitution);
+                        if (!source.known || !name_value.known) { return Operand{.kind = OperandKind::Type, .known = false}; }
+                        if (source.kind != OperandKind::Type || name_value.kind != OperandKind::Value) { return {}; }
+                        const auto field_name = string_value(name_value.value);
+                        if (!field_name || !is_struct(source.type)) { return {}; }
+                        const auto fields = effective_fields(source.type);
+                        const auto found  = std::ranges::find(fields, *field_name, &EffectiveField::name);
+                        if (found == fields.end()) { return {}; }
+                        return Operand{.kind = OperandKind::Type, .known = true, .type = found->type};
+                    }
+                    return {};
+                } else {
+                    return {};
+                }
+            },
+            constraint.node);
+    }
+
+    ConstraintSolver::Truth ConstraintSolver::evaluate_relation(const ConstraintRelation &relation,
+                                                                GenericSubstitution      &substitution) {
+        Operand lhs = operand(relation.lhs, substitution);
+        if (relation.op == ConstraintRelationOp::Is) {
+            if (!lhs.known) { return Truth::Unresolved; }
+            if (lhs.kind != OperandKind::Type || relation.category != "struct") { return Truth::False; }
+            return is_struct(lhs.type) ? Truth::True : Truth::False;
+        }
+        Operand rhs = operand(relation.rhs, substitution);
+        if (!lhs.known || !rhs.known) { return Truth::Unresolved; }
+        if (relation.op == ConstraintRelationOp::Equal) {
+            if (lhs.kind == OperandKind::Type && rhs.kind == OperandKind::Type) {
+                return types_.same(lhs.type, rhs.type) ? Truth::True : Truth::False;
+            }
+            if (lhs.kind == OperandKind::Value && rhs.kind == OperandKind::Value) {
+                return same_value(lhs.value, rhs.value) ? Truth::True : Truth::False;
+            }
+            if (lhs.kind == OperandKind::FieldSet && rhs.kind == OperandKind::FieldSet) {
+                std::ranges::sort(lhs.fields);
+                std::ranges::sort(rhs.fields);
+                return lhs.fields == rhs.fields ? Truth::True : Truth::False;
+            }
+            return Truth::False;
+        }
+        if (lhs.kind == OperandKind::Type && rhs.kind == OperandKind::TypeSet) {
+            return std::ranges::any_of(rhs.types, [&](TypeId candidate) { return types_.same(lhs.type, candidate); })
+                       ? Truth::True
+                       : Truth::False;
+        }
+        if (lhs.kind == OperandKind::Value && rhs.kind == OperandKind::ValueSet) {
+            return std::ranges::any_of(rhs.values, [&](ExprId candidate) { return same_value(lhs.value, candidate); })
+                       ? Truth::True
+                       : Truth::False;
+        }
+        if (lhs.kind == OperandKind::Value && rhs.kind == OperandKind::FieldSet) {
+            const auto name = string_value(lhs.value);
+            return name && std::ranges::contains(rhs.fields, *name) ? Truth::True : Truth::False;
+        }
+        return Truth::False;
+    }
+
+    std::string ConstraintSolver::operator_identity(SymbolId symbol) const {
+        if (!symbol.valid()) { return {}; }
+        const Symbol &value = module_.symbol(symbol);
+        return value.external_name.empty() ? value.name : value.external_name;
+    }
+
+    bool ConstraintSolver::identity_matches(std::string_view lhs, std::string_view rhs) noexcept {
+        const auto trim = [](std::string_view value) { return value.ends_with('_') ? value.substr(0, value.size() - 1U) : value; };
+        return lhs == rhs || trim(lhs) == trim(rhs);
+    }
+
+    ConstraintSolver::Truth ConstraintSolver::evaluate_operator(const OperatorRequirement &requirement,
+                                                                GenericSubstitution &substitution, syntax::SourceRange range) {
+        if (!requirement.op.valid()) { return Truth::False; }
+        OperatorQuery        query;
+        std::vector<Operand> arguments;
+        query.identity = operator_identity(requirement.op);
+        query.range    = range;
+        for (ConstraintId argument : requirement.arguments) {
+            Operand value = operand(argument, substitution);
+            if (!value.known) { return Truth::Unresolved; }
+            OperatorArgument query_argument;
+            if (value.kind == OperandKind::Type) {
+                query_argument.type       = value.type;
+                query_argument.phase      = Phase::Wiring;
+                query_argument.value_kind = ValueKind::Signal;
+            } else if (value.kind == OperandKind::Value) {
+                const Expr &expression    = module_.expr(value.value);
+                query_argument.type       = substitution.apply(expression.type);
+                query_argument.phase      = Phase::Constant;
+                query_argument.value_kind = ValueKind::Constant;
+                query_argument.constant   = expression.constant;
+            } else {
+                fail("operator requirement arguments must resolve to types or const values");
+                return Truth::False;
+            }
+            arguments.push_back(value);
+            query.arguments.push_back(std::move(query_argument));
+        }
+        if (requirement.result.valid()) {
+            Operand result = type_operand(requirement.result, substitution);
+            if (!result.known) { return Truth::Unresolved; }
+            query.expected_result = result.type;
+        }
+
+        const Symbol &symbol = module_.symbol(requirement.op);
+        if (symbol.kind == SymbolKind::ImportedOperator) {
+            if (!resolve_operator_) {
+                fail("native operator resolver is unavailable");
+                return Truth::Unresolved;
+            }
+            OperatorSelection selection = resolve_operator_(module_, query);
+            if (!selection.error.empty()) {
+                fail(std::move(selection.error));
+                return Truth::False;
+            }
+            return selection.deferred ? Truth::Unresolved : Truth::True;
+        }
+
+        if (symbol.kind != SymbolKind::Operator || !symbol.owner.valid()) { return Truth::False; }
+        const auto *contract = std::get_if<OperatorDecl>(&module_.declaration(symbol.owner).node);
+        if (contract == nullptr || contract->signature.parameters.size() != arguments.size()) { return Truth::False; }
+
+        GenericSubstitution contract_substitution{module_, types_};
+        for (std::size_t index = 0; index < arguments.size(); ++index) {
+            const Parameter &parameter = contract->signature.parameters[index];
+            const Operand   &argument  = arguments[index];
+            if (parameter.is_const) {
+                if (argument.kind != OperandKind::Value || !contract_substitution.bind_value(parameter.symbol, argument.value)) {
+                    return Truth::False;
+                }
+            } else if (argument.kind != OperandKind::Type) {
+                return Truth::False;
+            }
+            if (!contract_substitution.unify(parameter.type, query.arguments[index].type)) { return Truth::False; }
+        }
+        if (query.expected_result.valid() && !contract_substitution.unify(contract->signature.result, query.expected_result)) {
+            return Truth::False;
+        }
+        if (!solve(contract->requirements, contract_substitution, range, "operator contract", false)) { return Truth::False; }
+        for (const GenericParameter &generic : contract->generics) {
+            if (generic.is_const ? !contract_substitution.has_value(generic.symbol)
+                                 : !contract_substitution.has_type(generic.symbol)) {
+                fail("operator contract has an unresolved generic");
+                return Truth::Unresolved;
+            }
+        }
+
+        std::size_t admitted = 0;
+        for (const Declaration &declaration : module_.declarations) {
+            const auto *candidate = std::get_if<FunctionDecl>(&declaration.node);
+            if (!candidate || candidate->visibility != Visibility::Implementation || !declaration.symbol.valid() ||
+                module_.symbol(declaration.symbol).name != symbol.name ||
+                candidate->signature.parameters.size() != query.arguments.size()) {
+                continue;
+            }
+            GenericSubstitution candidate_substitution{module_, types_};
+            bool                matches = true;
+            for (std::size_t index = 0; index < query.arguments.size(); ++index) {
+                const Parameter &parameter = candidate->signature.parameters[index];
+                const Operand   &argument  = arguments[index];
+                if (parameter.is_const) {
+                    matches = argument.kind == OperandKind::Value &&
+                              candidate_substitution.bind_value(parameter.symbol, argument.value) && matches;
+                } else {
+                    matches = argument.kind == OperandKind::Type && matches;
+                }
+                matches = candidate_substitution.unify(candidate->signature.parameters[index].type, query.arguments[index].type) &&
+                          matches;
+            }
+            if (query.expected_result.valid()) {
+                matches = candidate_substitution.unify(candidate->signature.result, query.expected_result) && matches;
+            }
+            for (std::size_t index = 0; matches && index < query.arguments.size(); ++index) {
+                matches = types_.same(candidate_substitution.apply(candidate->signature.parameters[index].type),
+                                      query.arguments[index].type);
+            }
+            if (matches && query.expected_result.valid()) {
+                matches = types_.same(candidate_substitution.apply(candidate->signature.result), query.expected_result);
+            }
+            if (matches) { matches = solve(candidate->requirements, candidate_substitution, {}, "implementation", false); }
+            for (const GenericParameter &generic : candidate->generics) {
+                if (generic.is_const ? !candidate_substitution.has_value(generic.symbol)
+                                     : !candidate_substitution.has_type(generic.symbol)) {
+                    matches = false;
+                }
+            }
+            if (matches) { ++admitted; }
+        }
+        if (admitted == 1U) { return Truth::True; }
+        if (admitted > 1U) {
+            fail("multiple source implementations require native registry ranking");
+            return Truth::Unresolved;
+        }
+        fail("operator requirement has no implementation");
+        return Truth::False;
+    }
+
+    ConstraintSolver::Truth ConstraintSolver::evaluate(ConstraintId id, GenericSubstitution &substitution) {
+        if (!id.valid()) { return Truth::True; }
+        const Constraint &constraint = module_.constraint(id);
+        return std::visit(
+            [&](const auto &node) -> Truth {
+                using T = std::decay_t<decltype(node)>;
+                if constexpr (std::is_same_v<T, ConstraintRelation>) {
+                    return evaluate_relation(node, substitution);
+                } else if constexpr (std::is_same_v<T, OperatorRequirement>) {
+                    return evaluate_operator(node, substitution, constraint.range);
+                } else if constexpr (std::is_same_v<T, ConstraintNot>) {
+                    const std::string previous_failure = failure_detail_;
+                    const Truth       value            = evaluate(node.operand, substitution);
+                    if (value == Truth::Unresolved) { return value; }
+                    if (value == Truth::False) { failure_detail_ = previous_failure; }
+                    return value == Truth::True ? Truth::False : Truth::True;
+                } else if constexpr (std::is_same_v<T, ConstraintLogic>) {
+                    if (node.op == ConstraintLogicOp::Or) {
+                        const std::string previous_failure = failure_detail_;
+                        const Truth       lhs              = evaluate(node.lhs, substitution);
+                        if (lhs == Truth::True) {
+                            failure_detail_ = previous_failure;
+                            return Truth::True;
+                        }
+                        const std::string lhs_failure = failure_detail_;
+                        failure_detail_               = previous_failure;
+                        const Truth rhs               = evaluate(node.rhs, substitution);
+                        if (rhs == Truth::True) {
+                            failure_detail_ = previous_failure;
+                            return Truth::True;
+                        }
+                        if (failure_detail_ == previous_failure && lhs_failure != previous_failure) {
+                            failure_detail_ = lhs_failure;
+                        }
+                        if (lhs == Truth::False && rhs == Truth::False) { return Truth::False; }
+                        return Truth::Unresolved;
+                    }
+                    const Truth lhs = evaluate(node.lhs, substitution);
+                    if (lhs == Truth::False) { return Truth::False; }
+                    const Truth rhs = evaluate(node.rhs, substitution);
+                    if (rhs == Truth::False) { return Truth::False; }
+                    return lhs == Truth::True && rhs == Truth::True ? Truth::True : Truth::Unresolved;
+                } else {
+                    const Operand value = operand(id, substitution);
+                    if (!value.known) { return Truth::Unresolved; }
+                    if (value.kind == OperandKind::Boolean) { return value.boolean ? Truth::True : Truth::False; }
+                    return Truth::Unresolved;
+                }
+            },
+            constraint.node);
+    }
+
+    bool ConstraintSolver::infer_equalities(ConstraintId id, GenericSubstitution &substitution, bool &changed) {
+        if (!id.valid()) { return true; }
+        const Constraint &constraint = module_.constraint(id);
+        if (const auto *logic = std::get_if<ConstraintLogic>(&constraint.node)) {
+            if (logic->op != ConstraintLogicOp::And) { return true; }
+            return infer_equalities(logic->lhs, substitution, changed) && infer_equalities(logic->rhs, substitution, changed);
+        }
+        const auto *relation = std::get_if<ConstraintRelation>(&constraint.node);
+        if (!relation || relation->op != ConstraintRelationOp::Equal) { return true; }
+        Operand lhs = operand(relation->lhs, substitution);
+        Operand rhs = operand(relation->rhs, substitution);
+        if (!lhs.known && lhs.variable.valid() && rhs.known) {
+            const bool already =
+                lhs.kind == OperandKind::Type ? substitution.has_type(lhs.variable) : substitution.has_value(lhs.variable);
+            const bool ok = lhs.kind == OperandKind::Type && rhs.kind == OperandKind::Type
+                                ? substitution.bind_type(lhs.variable, rhs.type)
+                            : lhs.kind == OperandKind::Value && rhs.kind == OperandKind::Value
+                                ? substitution.bind_value(lhs.variable, rhs.value)
+                                : false;
+            changed       = changed || (ok && !already);
+            if (!ok) { fail("constraint equality binds incompatible kinds or values"); }
+            return ok;
+        }
+        if (!rhs.known && rhs.variable.valid() && lhs.known) {
+            const bool already =
+                rhs.kind == OperandKind::Type ? substitution.has_type(rhs.variable) : substitution.has_value(rhs.variable);
+            const bool ok = rhs.kind == OperandKind::Type && lhs.kind == OperandKind::Type
+                                ? substitution.bind_type(rhs.variable, lhs.type)
+                            : rhs.kind == OperandKind::Value && lhs.kind == OperandKind::Value
+                                ? substitution.bind_value(rhs.variable, lhs.value)
+                                : false;
+            changed       = changed || (ok && !already);
+            if (!ok) { fail("constraint equality binds incompatible kinds or values"); }
+            return ok;
+        }
+        return true;
+    }
+
+    bool ConstraintSolver::solve(ConstraintId requirement, GenericSubstitution &substitution, syntax::SourceRange use_range,
+                                 std::string_view subject, bool report) {
+        if (!requirement.valid()) { return true; }
+        if (evaluation_depth_ == 0U) { failure_detail_.clear(); }
+        if (evaluation_depth_ > module_.constraints.size()) {
+            fail("cyclic operator requirement");
+            return false;
+        }
+        ++evaluation_depth_;
+        struct DepthGuard
+        {
+            std::size_t &depth;
+            ~DepthGuard() { --depth; }
+        } depth_guard{evaluation_depth_};
+        for (std::size_t pass = 0; pass <= module_.constraints.size(); ++pass) {
+            bool changed = false;
+            if (!infer_equalities(requirement, substitution, changed)) {
+                if (report) {
+                    diagnostics_.report(syntax::Category::Type, use_range,
+                                        std::string{subject} + " requirements are inconsistent: " + failure_detail_);
+                }
+                return false;
+            }
+            if (!changed) { break; }
+        }
+        const Truth result = evaluate(requirement, substitution);
+        if (result == Truth::True) { return true; }
+        if (!report) { return false; }
+        const syntax::SourceRange range = use_range.empty() ? module_.constraint(requirement).range : use_range;
+        if (result == Truth::False) {
+            diagnostics_.report(syntax::Category::Type, range,
+                                std::string{subject} + " requirements are not satisfied" +
+                                    (failure_detail_.empty() ? std::string{} : ": " + failure_detail_));
+        } else {
+            diagnostics_.report(syntax::Category::Type, range,
+                                std::string{subject} + " requirements could not be resolved" +
+                                    (failure_detail_.empty() ? std::string{} : ": " + failure_detail_));
+        }
+        return false;
+    }
+
+    bool ConstraintSolver::proves_numeric(ConstraintId requirement, TypeId subject, GenericSubstitution *substitution) {
+        if (!requirement.valid()) { return false; }
+        const Constraint &constraint = module_.constraint(requirement);
+        if (const auto *logic = std::get_if<ConstraintLogic>(&constraint.node)) {
+            return logic->op == ConstraintLogicOp::And &&
+                   (proves_numeric(logic->lhs, subject, substitution) || proves_numeric(logic->rhs, subject, substitution));
+        }
+        const auto *relation = std::get_if<ConstraintRelation>(&constraint.node);
+        if (!relation || relation->op != ConstraintRelationOp::In) { return false; }
+        GenericSubstitution  empty{module_, types_};
+        GenericSubstitution &bindings = substitution == nullptr ? empty : *substitution;
+        Operand              lhs      = operand(relation->lhs, bindings);
+        Operand              rhs      = operand(relation->rhs, bindings);
+        if (lhs.kind != OperandKind::Type || !same_symbolic_type(lhs.type, subject) || rhs.kind != OperandKind::TypeSet ||
+            rhs.types.empty()) {
+            return false;
+        }
+        return std::ranges::all_of(rhs.types, [&](TypeId item) { return types_.numeric(item); });
+    }
+
+    std::optional<RequiredOperation> ConstraintSolver::find_required_operation(ConstraintId requirement, std::string_view identity,
+                                                                               const std::vector<TypeId> &arguments,
+                                                                               GenericSubstitution       &substitution) {
+        if (!requirement.valid()) { return std::nullopt; }
+        const Constraint &constraint = module_.constraint(requirement);
+        if (const auto *logic = std::get_if<ConstraintLogic>(&constraint.node)) {
+            if (logic->op != ConstraintLogicOp::And) { return std::nullopt; }
+            if (auto left = find_required_operation(logic->lhs, identity, arguments, substitution)) { return left; }
+            return find_required_operation(logic->rhs, identity, arguments, substitution);
+        }
+        const auto *required = std::get_if<OperatorRequirement>(&constraint.node);
+        if (!required || !identity_matches(operator_identity(required->op), identity) ||
+            required->arguments.size() != arguments.size()) {
+            return std::nullopt;
+        }
+        for (std::size_t index = 0; index < arguments.size(); ++index) {
+            Operand pattern = operand(required->arguments[index], substitution);
+            if (pattern.kind != OperandKind::Type || !same_symbolic_type(pattern.type, arguments[index])) { return std::nullopt; }
+        }
+        TypeId result = required->result.valid() ? substitution.apply(required->result) : TypeId{};
+        return RequiredOperation{required->op, result, operator_identity(required->op)};
+    }
+
+    std::optional<RequiredOperation> ConstraintSolver::required_operation(ConstraintId requirement, std::string_view identity,
+                                                                          const std::vector<TypeId> &arguments,
+                                                                          GenericSubstitution       *substitution) {
+        GenericSubstitution  empty{module_, types_};
+        GenericSubstitution &bindings = substitution == nullptr ? empty : *substitution;
+        return find_required_operation(requirement, identity, arguments, bindings);
+    }
+
+    std::optional<TypeId> ConstraintSolver::find_required_field(ConstraintId requirement, TypeId subject, std::string_view field,
+                                                                GenericSubstitution &substitution) {
+        if (!requirement.valid()) { return std::nullopt; }
+        const Constraint &constraint = module_.constraint(requirement);
+        if (const auto *logic = std::get_if<ConstraintLogic>(&constraint.node)) {
+            if (logic->op != ConstraintLogicOp::And) { return std::nullopt; }
+            if (auto left = find_required_field(logic->lhs, subject, field, substitution)) { return left; }
+            return find_required_field(logic->rhs, subject, field, substitution);
+        }
+        const auto *relation = std::get_if<ConstraintRelation>(&constraint.node);
+        if (!relation || relation->op != ConstraintRelationOp::Equal) { return std::nullopt; }
+
+        const auto match = [&](ConstraintId call_id, ConstraintId type_id) -> std::optional<TypeId> {
+            const auto *call = std::get_if<ConstraintCall>(&module_.constraint(call_id).node);
+            if (!call || !call->function.valid() || call->arguments.size() != 2U ||
+                module_.symbol(call->function).name != "field_type") {
+                return std::nullopt;
+            }
+            Operand    source     = operand(call->arguments[0], substitution);
+            Operand    name       = operand(call->arguments[1], substitution);
+            Operand    result     = operand(type_id, substitution);
+            const auto field_name = name.kind == OperandKind::Value ? string_value(name.value) : std::nullopt;
+            if (source.kind != OperandKind::Type || !same_symbolic_type(source.type, subject) || !field_name ||
+                *field_name != field || result.kind != OperandKind::Type) {
+                return std::nullopt;
+            }
+            return result.type;
+        };
+        if (auto result = match(relation->lhs, relation->rhs)) { return result; }
+        return match(relation->rhs, relation->lhs);
+    }
+
+    std::optional<TypeId> ConstraintSolver::field_type(ConstraintId requirement, TypeId subject, std::string_view field,
+                                                       GenericSubstitution *substitution) {
+        if (substitution != nullptr) { subject = substitution->apply(subject); }
+        const auto concrete = effective_fields(subject);
+        if (const auto found = std::ranges::find(concrete, field, &EffectiveField::name); found != concrete.end()) {
+            return found->type;
+        }
+        GenericSubstitution  empty{module_, types_};
+        GenericSubstitution &bindings = substitution == nullptr ? empty : *substitution;
+        return find_required_field(requirement, subject, field, bindings);
+    }
+}  // namespace hgl::ir::detail

--- a/language/src/ir/constraint_solver.h
+++ b/language/src/ir/constraint_solver.h
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -20,6 +21,15 @@ namespace hgl::ir::detail
         std::string   identity{};
     };
 
+    /// One requirement already guaranteed by the generic declaration whose
+    /// body is being checked. The optional substitution maps an inherited
+    /// operator contract into the implementation's symbols.
+    struct ConstraintPremise
+    {
+        hir::ConstraintId    requirement{};
+        GenericSubstitution *substitution{};
+    };
+
     /// Evaluates normalized HIR constraints after ordinary signature
     /// unification. Native operator viability is delegated through the same
     /// resolver port used for calls; this layer never ranks overloads.
@@ -30,9 +40,10 @@ namespace hgl::ir::detail
                          syntax::DiagnosticSink &diagnostics);
 
         /// Infer positive-conjunction equalities to a fixed point, then
-        /// require the complete Boolean constraint to be true.
+        /// require the complete Boolean constraint to be true or follow from
+        /// the declaration requirements supplied as premises.
         [[nodiscard]] bool solve(hir::ConstraintId requirement, GenericSubstitution &substitution, syntax::SourceRange use_range,
-                                 std::string_view subject, bool report = true);
+                                 std::string_view subject, bool report = true, std::span<const ConstraintPremise> premises = {});
 
         /// Symbolic facts used while checking a generic declaration body.
         [[nodiscard]] bool                             proves_numeric(hir::ConstraintId requirement, hir::TypeId type,
@@ -82,11 +93,22 @@ namespace hgl::ir::detail
         [[nodiscard]] Operand operand(hir::ConstraintId id, GenericSubstitution &substitution);
         [[nodiscard]] Operand type_operand(hir::TypeId type, GenericSubstitution &substitution);
         [[nodiscard]] Operand value_operand(hir::ExprId value, GenericSubstitution &substitution);
-        [[nodiscard]] Truth   evaluate(hir::ConstraintId id, GenericSubstitution &substitution);
+        [[nodiscard]] Truth   evaluate(hir::ConstraintId id, GenericSubstitution &substitution,
+                                       std::span<const ConstraintPremise> premises);
         [[nodiscard]] Truth   evaluate_relation(const hir::ConstraintRelation &relation, GenericSubstitution &substitution);
         [[nodiscard]] Truth   evaluate_operator(const hir::OperatorRequirement &requirement, GenericSubstitution &substitution,
-                                                syntax::SourceRange range);
+                                                syntax::SourceRange range, std::span<const ConstraintPremise> premises);
         [[nodiscard]] bool    infer_equalities(hir::ConstraintId id, GenericSubstitution &substitution, bool &changed);
+
+        [[nodiscard]] bool operand_equivalent(const Operand &lhs, const Operand &rhs) const;
+        [[nodiscard]] bool relation_implies(const hir::ConstraintRelation &premise, GenericSubstitution &premise_substitution,
+                                            const hir::ConstraintRelation &goal, GenericSubstitution &goal_substitution);
+        [[nodiscard]] bool atomic_equivalent(hir::ConstraintId premise, GenericSubstitution &premise_substitution,
+                                             hir::ConstraintId goal, GenericSubstitution &goal_substitution);
+        [[nodiscard]] bool premise_implies(hir::ConstraintId premise, GenericSubstitution &premise_substitution,
+                                           hir::ConstraintId goal, GenericSubstitution &goal_substitution);
+        [[nodiscard]] bool premises_prove(hir::ConstraintId goal, GenericSubstitution &goal_substitution,
+                                          std::span<const ConstraintPremise> premises);
 
         [[nodiscard]] bool                             is_struct(hir::TypeId type) const noexcept;
         [[nodiscard]] std::vector<EffectiveField>      effective_fields(hir::TypeId type);

--- a/language/src/ir/constraint_solver.h
+++ b/language/src/ir/constraint_solver.h
@@ -1,0 +1,117 @@
+#ifndef HGL_IR_CONSTRAINT_SOLVER_H
+#define HGL_IR_CONSTRAINT_SOLVER_H
+
+#include "ir/generic_substitution.h"
+#include "ir/type_check.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace hgl::ir::detail
+{
+    struct RequiredOperation
+    {
+        hir::SymbolId op{};
+        hir::TypeId   result{};
+        std::string   identity{};
+    };
+
+    /// Evaluates normalized HIR constraints after ordinary signature
+    /// unification. Native operator viability is delegated through the same
+    /// resolver port used for calls; this layer never ranks overloads.
+    class ConstraintSolver
+    {
+      public:
+        ConstraintSolver(hir::Module &module, CanonicalTypes &types, const OperatorResolver &resolve_operator,
+                         syntax::DiagnosticSink &diagnostics);
+
+        /// Infer positive-conjunction equalities to a fixed point, then
+        /// require the complete Boolean constraint to be true.
+        [[nodiscard]] bool solve(hir::ConstraintId requirement, GenericSubstitution &substitution, syntax::SourceRange use_range,
+                                 std::string_view subject, bool report = true);
+
+        /// Symbolic facts used while checking a generic declaration body.
+        [[nodiscard]] bool                             proves_numeric(hir::ConstraintId requirement, hir::TypeId type,
+                                                                      GenericSubstitution *substitution = nullptr);
+        [[nodiscard]] std::optional<RequiredOperation> required_operation(hir::ConstraintId requirement, std::string_view identity,
+                                                                          const std::vector<hir::TypeId> &arguments,
+                                                                          GenericSubstitution            *substitution = nullptr);
+        [[nodiscard]] std::optional<hir::TypeId> field_type(hir::ConstraintId requirement, hir::TypeId subject,
+                                                            std::string_view field, GenericSubstitution *substitution = nullptr);
+
+      private:
+        enum class Truth : std::uint8_t {
+            False,
+            True,
+            Unresolved,
+        };
+
+        enum class OperandKind : std::uint8_t {
+            Invalid,
+            Type,
+            Value,
+            TypeSet,
+            ValueSet,
+            FieldSet,
+            Boolean,
+        };
+
+        struct Operand
+        {
+            OperandKind              kind{OperandKind::Invalid};
+            bool                     known{false};
+            hir::SymbolId            variable{};
+            hir::TypeId              type{};
+            hir::ExprId              value{};
+            std::vector<hir::TypeId> types{};
+            std::vector<hir::ExprId> values{};
+            std::vector<std::string> fields{};
+            bool                     boolean{false};
+        };
+
+        struct EffectiveField
+        {
+            std::string name{};
+            hir::TypeId type{};
+        };
+
+        [[nodiscard]] Operand operand(hir::ConstraintId id, GenericSubstitution &substitution);
+        [[nodiscard]] Operand type_operand(hir::TypeId type, GenericSubstitution &substitution);
+        [[nodiscard]] Operand value_operand(hir::ExprId value, GenericSubstitution &substitution);
+        [[nodiscard]] Truth   evaluate(hir::ConstraintId id, GenericSubstitution &substitution);
+        [[nodiscard]] Truth   evaluate_relation(const hir::ConstraintRelation &relation, GenericSubstitution &substitution);
+        [[nodiscard]] Truth   evaluate_operator(const hir::OperatorRequirement &requirement, GenericSubstitution &substitution,
+                                                syntax::SourceRange range);
+        [[nodiscard]] bool    infer_equalities(hir::ConstraintId id, GenericSubstitution &substitution, bool &changed);
+
+        [[nodiscard]] bool                             is_struct(hir::TypeId type) const noexcept;
+        [[nodiscard]] std::vector<EffectiveField>      effective_fields(hir::TypeId type);
+        void                                           append_fields(hir::TypeId type, std::vector<EffectiveField> &fields);
+        [[nodiscard]] std::optional<std::string>       string_value(hir::ExprId value) const;
+        [[nodiscard]] bool                             same_value(hir::ExprId lhs, hir::ExprId rhs) const;
+        [[nodiscard]] bool                             same_symbolic_type(hir::TypeId lhs, hir::TypeId rhs) const noexcept;
+        [[nodiscard]] std::string                      operator_identity(hir::SymbolId symbol) const;
+        [[nodiscard]] static bool                      identity_matches(std::string_view lhs, std::string_view rhs) noexcept;
+        [[nodiscard]] std::optional<RequiredOperation> find_required_operation(hir::ConstraintId               requirement,
+                                                                               std::string_view                identity,
+                                                                               const std::vector<hir::TypeId> &arguments,
+                                                                               GenericSubstitution            &substitution);
+        [[nodiscard]] std::optional<hir::TypeId> find_required_field(hir::ConstraintId requirement, hir::TypeId subject,
+                                                                     std::string_view field, GenericSubstitution &substitution);
+
+        void fail(std::string message);
+
+        hir::Module            &module_;
+        CanonicalTypes         &types_;
+        const OperatorResolver &resolve_operator_;
+        syntax::DiagnosticSink &diagnostics_;
+        std::string             failure_detail_{};
+        std::size_t             evaluation_depth_{0};
+    };
+}  // namespace hgl::ir::detail
+
+#endif  // HGL_IR_CONSTRAINT_SOLVER_H

--- a/language/src/ir/generic_substitution.cpp
+++ b/language/src/ir/generic_substitution.cpp
@@ -1,0 +1,134 @@
+#include "ir/generic_substitution.h"
+
+#include <utility>
+
+namespace hgl::ir::detail
+{
+    using namespace hir;
+
+    GenericSubstitution::GenericSubstitution(Module &module, CanonicalTypes &types) : module_{module}, types_{types} {}
+
+    bool GenericSubstitution::bind_type(SymbolId parameter, TypeId value) {
+        value = types_.canonical(value);
+        if (!parameter.valid() || !value.valid()) { return false; }
+        const auto [found, inserted] = type_bindings_.emplace(parameter.value, value);
+        return inserted || types_.same(found->second, value);
+    }
+
+    bool GenericSubstitution::bind_value(SymbolId parameter, ExprId value) {
+        if (!parameter.valid() || !value.valid()) { return false; }
+        const auto [found, inserted] = value_bindings_.emplace(parameter.value, value);
+        return inserted || types_.same_value(found->second, value);
+    }
+
+    bool GenericSubstitution::has_type(SymbolId parameter) const noexcept {
+        return parameter.valid() && type_bindings_.contains(parameter.value);
+    }
+
+    bool GenericSubstitution::has_value(SymbolId parameter) const noexcept {
+        return parameter.valid() && value_bindings_.contains(parameter.value);
+    }
+
+    std::optional<TypeId> GenericSubstitution::type_binding(SymbolId parameter) const noexcept {
+        if (!parameter.valid()) { return std::nullopt; }
+        const auto found = type_bindings_.find(parameter.value);
+        return found == type_bindings_.end() ? std::nullopt : std::optional<TypeId>{found->second};
+    }
+
+    std::optional<ExprId> GenericSubstitution::value_binding(SymbolId parameter) const noexcept {
+        if (!parameter.valid()) { return std::nullopt; }
+        const auto found = value_bindings_.find(parameter.value);
+        return found == value_bindings_.end() ? std::nullopt : std::optional<ExprId>{found->second};
+    }
+
+    bool GenericSubstitution::unify_value(ExprId pattern, ExprId actual) {
+        if (!pattern.valid() || !actual.valid()) { return pattern == actual; }
+        const Expr &pattern_expr = module_.expr(pattern);
+        if (const auto *reference = std::get_if<SymbolRef>(&pattern_expr.node);
+            reference && reference->symbol.valid() && module_.symbol(reference->symbol).kind == SymbolKind::ConstParameter) {
+            return bind_value(reference->symbol, actual);
+        }
+        return types_.same_value(pattern, actual);
+    }
+
+    bool GenericSubstitution::unify(TypeId pattern, TypeId actual) {
+        pattern = types_.canonical(pattern);
+        actual  = types_.canonical(actual);
+        if (!pattern.valid() || !actual.valid()) { return false; }
+        const Type &lhs = module_.type(pattern);
+        const Type &rhs = module_.type(actual);
+        if (lhs.kind == TypeKind::Symbol && lhs.symbol.valid() && module_.symbol(lhs.symbol).kind == SymbolKind::TypeParameter) {
+            return bind_type(lhs.symbol, actual);
+        }
+        if (lhs.kind != rhs.kind || lhs.scalar != rhs.scalar || lhs.symbol != rhs.symbol ||
+            lhs.children.size() != rhs.children.size() || lhs.arguments.size() != rhs.arguments.size() ||
+            lhs.unbounded != rhs.unbounded) {
+            return types_.assignable(pattern, actual);
+        }
+        for (std::size_t index = 0; index < lhs.children.size(); ++index) {
+            if (!unify(lhs.children[index], rhs.children[index])) { return false; }
+        }
+        for (std::size_t index = 0; index < lhs.arguments.size(); ++index) {
+            const TypeArgument &a = lhs.arguments[index];
+            const TypeArgument &b = rhs.arguments[index];
+            if (a.kind != b.kind) { return false; }
+            if (a.kind == TypeArgumentKind::Type) {
+                if (!unify(a.type, b.type)) { return false; }
+            } else if (!unify_value(a.value, b.value)) {
+                return false;
+            }
+        }
+        return unify_value(lhs.size, rhs.size) && unify_value(lhs.min_size, rhs.min_size);
+    }
+
+    ExprId GenericSubstitution::apply_value(ExprId input) const noexcept {
+        if (!input.valid()) { return {}; }
+        if (const auto *reference = std::get_if<SymbolRef>(&module_.expr(input).node); reference && reference->symbol.valid()) {
+            if (const auto found = value_bindings_.find(reference->symbol.value); found != value_bindings_.end()) {
+                return found->second;
+            }
+        }
+        return input;
+    }
+
+    TypeId GenericSubstitution::apply(TypeId input) {
+        input = types_.canonical(input);
+        if (!input.valid()) { return {}; }
+        const Type &source = module_.type(input);
+        if (source.kind == TypeKind::Symbol && source.symbol.valid()) {
+            if (const auto found = type_bindings_.find(source.symbol.value); found != type_bindings_.end()) {
+                return found->second;
+            }
+        }
+        Type value = source;
+        for (TypeId &child : value.children) { child = apply(child); }
+        for (TypeArgument &argument : value.arguments) {
+            if (argument.kind == TypeArgumentKind::Type) {
+                argument.type = apply(argument.type);
+            } else {
+                argument.value = apply_value(argument.value);
+            }
+        }
+        value.size     = apply_value(value.size);
+        value.min_size = apply_value(value.min_size);
+        return types_.intern(std::move(value));
+    }
+
+    std::vector<Substitution> GenericSubstitution::materialize(const std::vector<GenericParameter> &generics) const {
+        std::vector<Substitution> result;
+        result.reserve(generics.size());
+        for (const GenericParameter &generic : generics) {
+            Substitution value;
+            value.parameter = generic.symbol;
+            if (generic.is_const) {
+                if (const auto found = value_bindings_.find(generic.symbol.value); found != value_bindings_.end()) {
+                    value.value = found->second;
+                }
+            } else if (const auto found = type_bindings_.find(generic.symbol.value); found != type_bindings_.end()) {
+                value.type = found->second;
+            }
+            result.push_back(value);
+        }
+        return result;
+    }
+}  // namespace hgl::ir::detail

--- a/language/src/ir/generic_substitution.h
+++ b/language/src/ir/generic_substitution.h
@@ -1,0 +1,43 @@
+#ifndef HGL_IR_GENERIC_SUBSTITUTION_H
+#define HGL_IR_GENERIC_SUBSTITUTION_H
+
+#include "ir/canonical_types.h"
+
+#include <cstdint>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+namespace hgl::ir::detail
+{
+    /// One source-level generic substitution. This is the shared unification
+    /// boundary for call matching, constraint solving, and later IR lowering;
+    /// it does not rank overload candidates.
+    class GenericSubstitution
+    {
+      public:
+        GenericSubstitution(hir::Module &module, CanonicalTypes &types);
+
+        [[nodiscard]] bool unify(hir::TypeId pattern, hir::TypeId actual);
+        [[nodiscard]] bool unify_value(hir::ExprId pattern, hir::ExprId actual);
+
+        [[nodiscard]] bool                       bind_type(hir::SymbolId parameter, hir::TypeId value);
+        [[nodiscard]] bool                       bind_value(hir::SymbolId parameter, hir::ExprId value);
+        [[nodiscard]] bool                       has_type(hir::SymbolId parameter) const noexcept;
+        [[nodiscard]] bool                       has_value(hir::SymbolId parameter) const noexcept;
+        [[nodiscard]] std::optional<hir::TypeId> type_binding(hir::SymbolId parameter) const noexcept;
+        [[nodiscard]] std::optional<hir::ExprId> value_binding(hir::SymbolId parameter) const noexcept;
+
+        [[nodiscard]] hir::TypeId                    apply(hir::TypeId input);
+        [[nodiscard]] hir::ExprId                    apply_value(hir::ExprId input) const noexcept;
+        [[nodiscard]] std::vector<hir::Substitution> materialize(const std::vector<hir::GenericParameter> &generics) const;
+
+      private:
+        hir::Module                                   &module_;
+        CanonicalTypes                                &types_;
+        std::unordered_map<std::uint32_t, hir::TypeId> type_bindings_{};
+        std::unordered_map<std::uint32_t, hir::ExprId> value_bindings_{};
+    };
+}  // namespace hgl::ir::detail
+
+#endif  // HGL_IR_GENERIC_SUBSTITUTION_H

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -175,6 +175,15 @@ namespace hgl::ir
                                                      inherited_substitution_ ? &*inherited_substitution_ : nullptr);
             }
 
+            [[nodiscard]] std::vector<detail::ConstraintPremise> active_constraint_premises() {
+                std::vector<detail::ConstraintPremise> premises;
+                if (active_requirements_.valid()) { premises.push_back({active_requirements_, nullptr}); }
+                if (inherited_requirements_.valid()) {
+                    premises.push_back({inherited_requirements_, inherited_substitution_ ? &*inherited_substitution_ : nullptr});
+                }
+                return premises;
+            }
+
             [[nodiscard]] bool runtime_owner(DeclarationId id) const noexcept {
                 const FunctionDecl *fn = function(id);
                 return fn != nullptr && fn->kind == FunctionKind::Runtime;
@@ -706,7 +715,8 @@ namespace hgl::ir
                     }
                 }
                 if (expected.valid()) { (void)bindings.unify(fn.signature.result, expected); }
-                (void)constraint_solver_.solve(fn.requirements, bindings, expression.range, "function call");
+                const auto premises = active_constraint_premises();
+                (void)constraint_solver_.solve(fn.requirements, bindings, expression.range, "function call", true, premises);
                 require_complete_bindings(fn.generics, bindings, expression.range, "function call");
                 for (std::size_t index = 0; index < bound.size(); ++index) {
                     if (!bound[index].valid()) { continue; }
@@ -755,7 +765,10 @@ namespace hgl::ir
                     if (!bindings.unify(parameter.type, argument.type)) { return false; }
                 }
                 if (expected.valid() && !bindings.unify(candidate.signature.result, expected)) { return false; }
-                if (!constraint_solver_.solve(candidate.requirements, bindings, {}, "implementation", false)) { return false; }
+                const auto premises = active_constraint_premises();
+                if (!constraint_solver_.solve(candidate.requirements, bindings, {}, "implementation", false, premises)) {
+                    return false;
+                }
                 for (const GenericParameter &generic : candidate.generics) {
                     if (generic.is_const ? !bindings.has_value(generic.symbol) : !bindings.has_type(generic.symbol)) {
                         return false;
@@ -814,7 +827,9 @@ namespace hgl::ir
                     }
                 }
                 if (expected.valid()) { (void)contract_bindings.unify(op.signature.result, expected); }
-                (void)constraint_solver_.solve(op.requirements, contract_bindings, expression.range, "operator call");
+                const auto premises = active_constraint_premises();
+                (void)constraint_solver_.solve(op.requirements, contract_bindings, expression.range, "operator call", true,
+                                               premises);
                 require_complete_bindings(op.generics, contract_bindings, expression.range, "operator call");
                 expression.type          = contract_bindings.apply(op.signature.result);
                 const SymbolId candidate = sole_local_candidate(target, bound, expected);
@@ -1273,8 +1288,9 @@ namespace hgl::ir
                 unwrapped = unwrap_atomic(applied);
                 detail::GenericSubstitution struct_substitution{module_, canonical_types_};
                 bind_struct_arguments(unwrapped, struct_substitution);
+                const auto premises = active_constraint_premises();
                 (void)constraint_solver_.solve(structure->requirements, struct_substitution, expression.range,
-                                               "struct construction");
+                                               "struct construction", true, premises);
                 std::size_t positional = 0;
                 for (const Argument &argument : arguments) {
                     const StructField *field = nullptr;

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -1,6 +1,8 @@
 #include "ir/type_check.h"
 
 #include "ir/canonical_types.h"
+#include "ir/constraint_solver.h"
+#include "ir/generic_substitution.h"
 #include "syntax/temporal.h"
 
 #include <algorithm>
@@ -59,7 +61,8 @@ namespace hgl::ir
           public:
             TypeChecker(Module &module, const OperatorResolver &resolve_operator, syntax::DiagnosticSink &diagnostics)
                 : module_{module}, resolve_operator_{resolve_operator}, diagnostics_{diagnostics},
-                  canonical_types_{module, diagnostics} {}
+                  canonical_types_{module, diagnostics},
+                  constraint_solver_{module, canonical_types_, resolve_operator, diagnostics} {}
 
             bool run() {
                 if (module_.completion != Completion::Resolved) {
@@ -79,12 +82,6 @@ namespace hgl::ir
             }
 
           private:
-            struct Bindings
-            {
-                std::unordered_map<std::uint32_t, TypeId> type;
-                std::unordered_map<std::uint32_t, ExprId> value;
-            };
-
             [[nodiscard]] const Type &type(TypeId id) const { return module_.type(id); }
             [[nodiscard]] Type       &type(TypeId id) { return module_.types[id.value]; }
 
@@ -115,6 +112,67 @@ namespace hgl::ir
             [[nodiscard]] FunctionDecl *function(DeclarationId id) noexcept {
                 if (!id.valid() || id.value >= module_.declarations.size()) { return nullptr; }
                 return std::get_if<FunctionDecl>(&module_.declarations[id.value].node);
+            }
+
+            [[nodiscard]] const OperatorDecl *local_operator(std::string_view name) const noexcept {
+                for (const Declaration &declaration : module_.declarations) {
+                    const auto *op = std::get_if<OperatorDecl>(&declaration.node);
+                    if (op && declaration.symbol.valid() && module_.symbol(declaration.symbol).name == name) { return op; }
+                }
+                return nullptr;
+            }
+
+            void check_implementation_conformance(const Declaration &declaration, const FunctionDecl &implementation,
+                                                  const OperatorDecl &contract, detail::GenericSubstitution &substitution) {
+                if (implementation.signature.parameters.size() != contract.signature.parameters.size()) {
+                    type_error(declaration.range, "implementation parameter count does not match its operator contract");
+                    return;
+                }
+                bool conforms = true;
+                for (std::size_t index = 0; index < contract.signature.parameters.size(); ++index) {
+                    const Parameter &expected = contract.signature.parameters[index];
+                    const Parameter &actual   = implementation.signature.parameters[index];
+                    if (expected.is_const != actual.is_const ||
+                        module_.symbol(expected.symbol).name != module_.symbol(actual.symbol).name) {
+                        conforms = false;
+                    }
+                    conforms = substitution.unify(expected.type, actual.type) && conforms;
+                }
+                conforms = substitution.unify(contract.signature.result, implementation.signature.result) && conforms;
+                for (std::size_t index = 0; conforms && index < contract.signature.parameters.size(); ++index) {
+                    conforms = same(substitution.apply(contract.signature.parameters[index].type),
+                                    implementation.signature.parameters[index].type);
+                }
+                if (conforms) { conforms = same(substitution.apply(contract.signature.result), implementation.signature.result); }
+                for (const GenericParameter &generic : contract.generics) {
+                    conforms =
+                        (generic.is_const ? substitution.has_value(generic.symbol) : substitution.has_type(generic.symbol)) &&
+                        conforms;
+                }
+                if (!conforms) {
+                    type_error(declaration.range, "implementation signature does not conform to its operator contract");
+                }
+            }
+
+            [[nodiscard]] bool active_proves_numeric(TypeId type) {
+                return constraint_solver_.proves_numeric(active_requirements_, type) ||
+                       constraint_solver_.proves_numeric(inherited_requirements_, type,
+                                                         inherited_substitution_ ? &*inherited_substitution_ : nullptr);
+            }
+
+            [[nodiscard]] std::optional<detail::RequiredOperation> active_required_operation(std::string_view           identity,
+                                                                                             const std::vector<TypeId> &arguments) {
+                if (auto required = constraint_solver_.required_operation(active_requirements_, identity, arguments)) {
+                    return required;
+                }
+                return constraint_solver_.required_operation(inherited_requirements_, identity, arguments,
+                                                             inherited_substitution_ ? &*inherited_substitution_ : nullptr);
+            }
+
+            [[nodiscard]] std::optional<TypeId> active_field_type(TypeId subject, std::string_view field) {
+                if (auto result = constraint_solver_.field_type(active_requirements_, subject, field)) { return result; }
+                return constraint_solver_.field_type(inherited_requirements_, subject, field,
+                                                     inherited_substitution_ ? &*inherited_substitution_ : nullptr);
             }
 
             [[nodiscard]] bool runtime_owner(DeclarationId id) const noexcept {
@@ -157,10 +215,20 @@ namespace hgl::ir
                                 }
                             }
                         } else if constexpr (std::is_same_v<T, OperatorDecl>) {
-                            reject_unimplemented_requirements(node.requirements);
                             check_signature_defaults(node.signature);
                         } else if constexpr (std::is_same_v<T, FunctionDecl>) {
-                            reject_unimplemented_requirements(node.requirements);
+                            const ConstraintId previous_requirements = active_requirements_;
+                            const ConstraintId previous_inherited    = inherited_requirements_;
+                            active_requirements_                     = node.requirements;
+                            inherited_requirements_                  = {};
+                            inherited_substitution_.reset();
+                            if (node.visibility == Visibility::Implementation && declaration.symbol.valid()) {
+                                if (const OperatorDecl *contract = local_operator(module_.symbol(declaration.symbol).name)) {
+                                    inherited_requirements_ = contract->requirements;
+                                    inherited_substitution_.emplace(module_, canonical_types_);
+                                    check_implementation_conformance(declaration, node, *contract, *inherited_substitution_);
+                                }
+                            }
                             check_signature_defaults(node.signature);
                             if (node.concise_body.valid()) {
                                 Expr &body = check_expr(node.concise_body, node.signature.result);
@@ -175,17 +243,14 @@ namespace hgl::ir
                                 node.effects = body.effects;
                             }
                             collect_capabilities(node, id);
+                            active_requirements_    = previous_requirements;
+                            inherited_requirements_ = previous_inherited;
+                            inherited_substitution_.reset();
                         } else if constexpr (std::is_same_v<T, TestDecl>) {
                             check_block(node.block, void_type_);
                         }
                     },
                     declaration.node);
-            }
-
-            void reject_unimplemented_requirements(ConstraintId requirements) {
-                if (!requirements.valid()) { return; }
-                diagnostics_.report(syntax::Category::Type, module_.constraint(requirements).range,
-                                    "callable 'requires' evaluation is not implemented in typed HIR yet");
             }
 
             void check_signature_defaults(Signature &signature) {
@@ -390,6 +455,15 @@ namespace hgl::ir
                 expression.operation = Operation{.kind     = OperationKind::NominalOperator,
                                                  .identity = std::string{unary_identity(node.op)},
                                                  .deferred = operand.phase != Phase::Constant};
+                const auto required  = active_required_operation(unary_identity(node.op), {operand.type});
+                if (required) {
+                    expression.type               = required->result.valid() ? required->result : operand.type;
+                    expression.operation.target   = required->op;
+                    expression.operation.identity = required->identity;
+                    if (expression.phase == Phase::Wiring) { expression.effects |= Effect::WireGraph; }
+                    expression.value_kind = value_kind_for_phase(expression.phase);
+                    return;
+                }
                 if (node.op == UnaryOp::Not) {
                     if (!boolean(operand.type)) { type_error(operand.range, "'!' requires bool"); }
                     expression.type = scalar(ScalarType::Bool);
@@ -397,7 +471,9 @@ namespace hgl::ir
                         expression.constant = Constant{!std::get<bool>(*operand.constant)};
                     }
                 } else {
-                    if (!numeric(operand.type)) { type_error(operand.range, "unary '-' requires i64 or f64"); }
+                    if (!numeric(operand.type) && !active_proves_numeric(operand.type)) {
+                        type_error(operand.range, "unary '-' requires i64 or f64");
+                    }
                     expression.type = operand.type;
                     if (operand.constant && std::holds_alternative<std::int64_t>(*operand.constant)) {
                         expression.constant = Constant{-std::get<std::int64_t>(*operand.constant)};
@@ -413,10 +489,13 @@ namespace hgl::ir
                 if (op == BinaryOp::Add && same(lhs, scalar(ScalarType::Str)) && same(rhs, scalar(ScalarType::Str))) {
                     return scalar(ScalarType::Str);
                 }
-                if (!numeric(lhs) || !numeric(rhs)) {
+                const bool lhs_numeric = numeric(lhs) || active_proves_numeric(lhs);
+                const bool rhs_numeric = numeric(rhs) || active_proves_numeric(rhs);
+                if (!lhs_numeric || !rhs_numeric) {
                     type_error(range, "arithmetic operands must both be numeric");
                     return {};
                 }
+                if (op != BinaryOp::Div && same(lhs, rhs) && !numeric(lhs)) { return lhs; }
                 if (op == BinaryOp::Div || same(lhs, scalar(ScalarType::F64)) || same(rhs, scalar(ScalarType::F64))) {
                     return scalar(ScalarType::F64);
                 }
@@ -497,6 +576,25 @@ namespace hgl::ir
                 expression.operation = Operation{.kind     = OperationKind::NominalOperator,
                                                  .identity = std::string{binary_identity(node.op)},
                                                  .deferred = expression.phase != Phase::Constant};
+                const auto required  = active_required_operation(binary_identity(node.op), {lhs.type, rhs.type});
+                if (required) {
+                    expression.operation.target   = required->op;
+                    expression.operation.identity = required->identity;
+                    if (required->result.valid()) {
+                        expression.type = required->result;
+                    } else if (expected.valid()) {
+                        expression.type = canonical(expected);
+                    } else if (node.op == BinaryOp::Less || node.op == BinaryOp::LessEqual || node.op == BinaryOp::Greater ||
+                               node.op == BinaryOp::GreaterEqual || node.op == BinaryOp::Equal || node.op == BinaryOp::NotEqual ||
+                               node.op == BinaryOp::And || node.op == BinaryOp::Or) {
+                        expression.type = scalar(ScalarType::Bool);
+                    } else {
+                        expression.type = lhs.type;
+                    }
+                    if (expression.phase == Phase::Wiring) { expression.effects |= Effect::WireGraph; }
+                    expression.value_kind = value_kind_for_phase(expression.phase);
+                    return;
+                }
                 switch (node.op) {
                     case BinaryOp::And:
                     case BinaryOp::Or:
@@ -575,108 +673,11 @@ namespace hgl::ir
                 return bound;
             }
 
-            [[nodiscard]] bool unify_value(ExprId pattern, ExprId actual, Bindings &bindings) {
-                if (!pattern.valid() || !actual.valid()) { return pattern == actual; }
-                const Expr &pattern_expr = module_.expr(pattern);
-                if (const auto *reference = std::get_if<SymbolRef>(&pattern_expr.node);
-                    reference && reference->symbol.valid() &&
-                    module_.symbol(reference->symbol).kind == SymbolKind::ConstParameter) {
-                    auto [found, inserted] = bindings.value.emplace(reference->symbol.value, actual);
-                    return inserted || canonical_types_.same_value(found->second, actual);
-                }
-                return canonical_types_.same_value(pattern, actual);
-            }
-
-            [[nodiscard]] bool unify(TypeId pattern, TypeId actual, Bindings &bindings) {
-                pattern = canonical(pattern);
-                actual  = canonical(actual);
-                if (!pattern.valid() || !actual.valid()) { return false; }
-                const Type &lhs = type(pattern);
-                const Type &rhs = type(actual);
-                if (lhs.kind == TypeKind::Symbol && lhs.symbol.valid() &&
-                    module_.symbol(lhs.symbol).kind == SymbolKind::TypeParameter) {
-                    auto [found, inserted] = bindings.type.emplace(lhs.symbol.value, actual);
-                    return inserted || same(found->second, actual);
-                }
-                if (lhs.kind != rhs.kind || lhs.scalar != rhs.scalar || lhs.symbol != rhs.symbol ||
-                    lhs.children.size() != rhs.children.size() || lhs.arguments.size() != rhs.arguments.size() ||
-                    lhs.unbounded != rhs.unbounded) {
-                    return assignable(pattern, actual);
-                }
-                for (std::size_t index = 0; index < lhs.children.size(); ++index) {
-                    if (!unify(lhs.children[index], rhs.children[index], bindings)) { return false; }
-                }
-                for (std::size_t index = 0; index < lhs.arguments.size(); ++index) {
-                    const TypeArgument &a = lhs.arguments[index];
-                    const TypeArgument &b = rhs.arguments[index];
-                    if (a.kind != b.kind) { return false; }
-                    if (a.kind == TypeArgumentKind::Type) {
-                        if (!unify(a.type, b.type, bindings)) { return false; }
-                    } else if (!unify_value(a.value, b.value, bindings)) {
-                        return false;
-                    }
-                }
-                return unify_value(lhs.size, rhs.size, bindings) && unify_value(lhs.min_size, rhs.min_size, bindings);
-            }
-
-            [[nodiscard]] ExprId substitute_value(ExprId value, const Bindings &bindings) const {
-                if (!value.valid()) { return {}; }
-                if (const auto *reference = std::get_if<SymbolRef>(&module_.expr(value).node);
-                    reference && reference->symbol.valid()) {
-                    if (const auto found = bindings.value.find(reference->symbol.value); found != bindings.value.end()) {
-                        return found->second;
-                    }
-                }
-                return value;
-            }
-
-            [[nodiscard]] TypeId substitute(TypeId input, const Bindings &bindings) {
-                input = canonical(input);
-                if (!input.valid()) { return {}; }
-                const Type &source = type(input);
-                if (source.kind == TypeKind::Symbol && source.symbol.valid()) {
-                    if (const auto found = bindings.type.find(source.symbol.value); found != bindings.type.end()) {
-                        return found->second;
-                    }
-                }
-                Type value = source;
-                for (TypeId &child : value.children) { child = substitute(child, bindings); }
-                for (TypeArgument &argument : value.arguments) {
-                    if (argument.kind == TypeArgumentKind::Type) {
-                        argument.type = substitute(argument.type, bindings);
-                    } else {
-                        argument.value = substitute_value(argument.value, bindings);
-                    }
-                }
-                value.size     = substitute_value(value.size, bindings);
-                value.min_size = substitute_value(value.min_size, bindings);
-                return intern(std::move(value));
-            }
-
-            [[nodiscard]] std::vector<Substitution> substitutions(const std::vector<GenericParameter> &generics,
-                                                                  const Bindings                      &bindings) const {
-                std::vector<Substitution> result;
-                result.reserve(generics.size());
+            void require_complete_bindings(const std::vector<GenericParameter> &generics,
+                                           const detail::GenericSubstitution &bindings, syntax::SourceRange range,
+                                           std::string_view callable) {
                 for (const GenericParameter &generic : generics) {
-                    Substitution value;
-                    value.parameter = generic.symbol;
-                    if (generic.is_const) {
-                        if (const auto found = bindings.value.find(generic.symbol.value); found != bindings.value.end()) {
-                            value.value = found->second;
-                        }
-                    } else if (const auto found = bindings.type.find(generic.symbol.value); found != bindings.type.end()) {
-                        value.type = found->second;
-                    }
-                    result.push_back(value);
-                }
-                return result;
-            }
-
-            void require_complete_bindings(const std::vector<GenericParameter> &generics, const Bindings &bindings,
-                                           syntax::SourceRange range, std::string_view callable) {
-                for (const GenericParameter &generic : generics) {
-                    const bool bound = generic.is_const ? bindings.value.contains(generic.symbol.value)
-                                                        : bindings.type.contains(generic.symbol.value);
+                    const bool bound = generic.is_const ? bindings.has_value(generic.symbol) : bindings.has_type(generic.symbol);
                     if (bound) { continue; }
                     type_error(range,
                                "cannot infer generic '" + module_.symbol(generic.symbol).name + "' for " + std::string{callable});
@@ -684,35 +685,35 @@ namespace hgl::ir
             }
 
             void check_exact_call(Expr &expression, const Call &call, SymbolId target, const FunctionDecl &fn, TypeId expected) {
-                const std::vector<ExprId> bound = bind_arguments(fn.signature, call.arguments, expression.range);
-                Bindings                  bindings;
+                const std::vector<ExprId>   bound = bind_arguments(fn.signature, call.arguments, expression.range);
+                detail::GenericSubstitution bindings{module_, canonical_types_};
                 for (std::size_t index = 0; index < bound.size(); ++index) {
                     if (!bound[index].valid()) { continue; }
                     Expr            &argument  = check_expr(bound[index]);
                     const Parameter &parameter = fn.signature.parameters[index];
-                    if (parameter.is_const && argument.phase != Phase::Constant) {
-                        diagnostics_.report(syntax::Category::Phase, argument.range,
-                                            "a const parameter requires a compile-time value");
-                    }
-                    if (parameter.is_const && parameter.symbol.valid()) {
-                        const auto [found, inserted] = bindings.value.emplace(parameter.symbol.value, bound[index]);
-                        if (!inserted && !canonical_types_.same_value(found->second, bound[index])) {
+                    if (parameter.is_const) {
+                        if (argument.phase != Phase::Constant) {
+                            diagnostics_.report(syntax::Category::Phase, argument.range,
+                                                "a const parameter requires a compile-time value");
+                        }
+                        if (!bindings.bind_value(parameter.symbol, bound[index])) {
                             type_error(argument.range, "const parameter has an inconsistent value binding");
                         }
                     }
-                    if (!unify(parameter.type, argument.type, bindings)) {
-                        type_error(argument.range,
-                                   "argument has type " + type_name(argument.type) + ", expected " + type_name(parameter.type));
+                    if (!bindings.unify(fn.signature.parameters[index].type, argument.type)) {
+                        type_error(argument.range, "argument has type " + type_name(argument.type) + ", expected " +
+                                                       type_name(fn.signature.parameters[index].type));
                     }
                 }
-                if (expected.valid()) { (void)unify(fn.signature.result, expected, bindings); }
+                if (expected.valid()) { (void)bindings.unify(fn.signature.result, expected); }
+                (void)constraint_solver_.solve(fn.requirements, bindings, expression.range, "function call");
                 require_complete_bindings(fn.generics, bindings, expression.range, "function call");
                 for (std::size_t index = 0; index < bound.size(); ++index) {
                     if (!bound[index].valid()) { continue; }
-                    TypeId parameter = substitute(fn.signature.parameters[index].type, bindings);
+                    TypeId parameter = bindings.apply(fn.signature.parameters[index].type);
                     require_assignable(parameter, module_.expr(bound[index]), "argument");
                 }
-                expression.type    = substitute(fn.signature.result, bindings);
+                expression.type    = bindings.apply(fn.signature.result);
                 expression.phase   = Phase::Constant;
                 expression.effects = Effect::None;
                 for (ExprId argument : bound) {
@@ -731,7 +732,7 @@ namespace hgl::ir
                 expression.operation  = Operation{.kind          = OperationKind::ExactFunction,
                                                   .target        = target,
                                                   .identity      = module_.path + "." + module_.symbol(target).name,
-                                                  .substitutions = substitutions(fn.generics, bindings)};
+                                                  .substitutions = bindings.materialize(fn.generics)};
             }
 
             [[nodiscard]] const OperatorDecl *operator_decl(SymbolId symbol) const noexcept {
@@ -744,19 +745,25 @@ namespace hgl::ir
             [[nodiscard]] bool local_candidate_matches(const FunctionDecl &candidate, const std::vector<ExprId> &arguments,
                                                        TypeId expected) {
                 if (candidate.signature.parameters.size() != arguments.size()) { return false; }
-                Bindings bindings;
+                detail::GenericSubstitution bindings{module_, canonical_types_};
                 for (std::size_t index = 0; index < arguments.size(); ++index) {
                     if (!arguments[index].valid()) { continue; }
                     const Expr      &argument  = module_.expr(arguments[index]);
                     const Parameter &parameter = candidate.signature.parameters[index];
                     if (parameter.is_const && argument.phase != Phase::Constant) { return false; }
-                    if (!unify(parameter.type, argument.type, bindings)) { return false; }
+                    if (parameter.is_const && !bindings.bind_value(parameter.symbol, arguments[index])) { return false; }
+                    if (!bindings.unify(parameter.type, argument.type)) { return false; }
                 }
-                if (expected.valid() && !unify(candidate.signature.result, expected, bindings)) { return false; }
+                if (expected.valid() && !bindings.unify(candidate.signature.result, expected)) { return false; }
+                if (!constraint_solver_.solve(candidate.requirements, bindings, {}, "implementation", false)) { return false; }
+                for (const GenericParameter &generic : candidate.generics) {
+                    if (generic.is_const ? !bindings.has_value(generic.symbol) : !bindings.has_type(generic.symbol)) {
+                        return false;
+                    }
+                }
                 for (std::size_t index = 0; index < arguments.size(); ++index) {
                     if (!arguments[index].valid()) { continue; }
-                    if (!same(substitute(candidate.signature.parameters[index].type, bindings),
-                              module_.expr(arguments[index]).type)) {
+                    if (!same(bindings.apply(candidate.signature.parameters[index].type), module_.expr(arguments[index]).type)) {
                         return false;
                     }
                 }
@@ -787,25 +794,36 @@ namespace hgl::ir
 
             void check_local_operator_call(Expr &expression, const Call &call, SymbolId target, const OperatorDecl &op,
                                            TypeId expected) {
-                const std::vector<ExprId> bound = bind_arguments(op.signature, call.arguments, expression.range);
-                Bindings                  contract_bindings;
+                const std::vector<ExprId>   bound = bind_arguments(op.signature, call.arguments, expression.range);
+                detail::GenericSubstitution contract_bindings{module_, canonical_types_};
                 for (std::size_t index = 0; index < bound.size(); ++index) {
                     if (!bound[index].valid()) { continue; }
-                    Expr &argument = check_expr(bound[index]);
-                    if (!unify(op.signature.parameters[index].type, argument.type, contract_bindings)) {
+                    Expr            &argument  = check_expr(bound[index]);
+                    const Parameter &parameter = op.signature.parameters[index];
+                    if (parameter.is_const) {
+                        if (argument.phase != Phase::Constant) {
+                            diagnostics_.report(syntax::Category::Phase, argument.range,
+                                                "a const parameter requires a compile-time value");
+                        }
+                        if (!contract_bindings.bind_value(parameter.symbol, bound[index])) {
+                            type_error(argument.range, "const parameter has an inconsistent value binding");
+                        }
+                    }
+                    if (!contract_bindings.unify(op.signature.parameters[index].type, argument.type)) {
                         type_error(argument.range, "operator argument does not match its contract");
                     }
                 }
-                if (expected.valid()) { (void)unify(op.signature.result, expected, contract_bindings); }
+                if (expected.valid()) { (void)contract_bindings.unify(op.signature.result, expected); }
+                (void)constraint_solver_.solve(op.requirements, contract_bindings, expression.range, "operator call");
                 require_complete_bindings(op.generics, contract_bindings, expression.range, "operator call");
-                expression.type          = substitute(op.signature.result, contract_bindings);
+                expression.type          = contract_bindings.apply(op.signature.result);
                 const SymbolId candidate = sole_local_candidate(target, bound, expected);
                 finish_call_semantics(expression, bound);
                 expression.operation = Operation{.kind          = OperationKind::NominalOperator,
                                                  .target        = target,
                                                  .candidate     = candidate,
                                                  .identity      = module_.path + "." + module_.symbol(target).name,
-                                                 .substitutions = substitutions(op.generics, contract_bindings),
+                                                 .substitutions = contract_bindings.materialize(op.generics),
                                                  .deferred      = !candidate.valid()};
             }
 
@@ -976,20 +994,7 @@ namespace hgl::ir
                 }
                 const TypeId base_id = unwrap_atomic(target.type);
                 if (base_id.valid()) {
-                    const Type &base = type(base_id);
-                    if (base.kind == TypeKind::Symbol && base.symbol.valid()) {
-                        const Symbol &structure_symbol = module_.symbol(base.symbol);
-                        if (structure_symbol.owner.valid()) {
-                            if (const auto *structure =
-                                    std::get_if<StructDecl>(&module_.declaration(structure_symbol.owner).node)) {
-                                const auto found = std::find_if(structure->fields.begin(), structure->fields.end(),
-                                                                [&](const StructField &field) { return field.name == node.name; });
-                                if (found != structure->fields.end()) {
-                                    expression.type = apply_struct_field_type(found->type, base_id);
-                                }
-                            }
-                        }
-                    }
+                    if (const auto field = active_field_type(base_id, node.name)) { expression.type = *field; }
                 }
                 if (!expression.type.valid()) { type_error(node.name_range, "type has no field '" + node.name + "'"); }
                 expression.phase      = target.phase;
@@ -1167,7 +1172,7 @@ namespace hgl::ir
                                                   .identity = module_.path + "." + module_.symbol(reference->symbol).name};
             }
 
-            void bind_struct_arguments(TypeId applied, Bindings &bindings) const {
+            void bind_struct_arguments(TypeId applied, detail::GenericSubstitution &bindings) {
                 applied = unwrap_atomic(applied);
                 if (!applied.valid()) { return; }
                 const Type &value = type(applied);
@@ -1180,17 +1185,17 @@ namespace hgl::ir
                     const GenericParameter &generic  = structure->generics[index];
                     const TypeArgument     &argument = value.arguments[index];
                     if (!generic.is_const && argument.kind == TypeArgumentKind::Type) {
-                        bindings.type.emplace(generic.symbol.value, argument.type);
+                        (void)bindings.bind_type(generic.symbol, argument.type);
                     } else if (generic.is_const && argument.kind == TypeArgumentKind::Value) {
-                        bindings.value.emplace(generic.symbol.value, argument.value);
+                        (void)bindings.bind_value(generic.symbol, argument.value);
                     }
                 }
             }
 
             [[nodiscard]] TypeId apply_struct_field_type(TypeId field, TypeId applied) {
-                Bindings bindings;
+                detail::GenericSubstitution bindings{module_, canonical_types_};
                 bind_struct_arguments(applied, bindings);
-                return substitute(field, bindings);
+                return bindings.apply(field);
             }
 
             [[nodiscard]] TypeId infer_struct_application(TypeId applied, const StructDecl &structure,
@@ -1200,7 +1205,7 @@ namespace hgl::ir
                 const Type nominal = type(unwrapped);
                 if (nominal.arguments.size() >= structure.generics.size()) { return applied; }
 
-                Bindings bindings;
+                detail::GenericSubstitution bindings{module_, canonical_types_};
                 bind_struct_arguments(unwrapped, bindings);
                 std::size_t positional = 0;
                 for (const Argument &argument : arguments) {
@@ -1216,7 +1221,7 @@ namespace hgl::ir
                     const Expr &source = module_.expr(argument.value);
                     if (source.constant && std::holds_alternative<NullValue>(*source.constant)) { continue; }
                     Expr &value = check_expr(argument.value);
-                    (void)unify(field->type, value.type, bindings);
+                    (void)bindings.unify(field->type, value.type);
                 }
 
                 Type inferred = nominal;
@@ -1227,23 +1232,23 @@ namespace hgl::ir
                     argument.range = range;
                     if (generic.is_const) {
                         argument.kind    = TypeArgumentKind::Value;
-                        const auto found = bindings.value.find(generic.symbol.value);
-                        if (found == bindings.value.end()) {
+                        const auto found = bindings.value_binding(generic.symbol);
+                        if (!found) {
                             complete = false;
                             type_error(range,
                                        "cannot infer generic '" + module_.symbol(generic.symbol).name + "' for struct constructor");
                         } else {
-                            argument.value = found->second;
+                            argument.value = *found;
                         }
                     } else {
                         argument.kind    = TypeArgumentKind::Type;
-                        const auto found = bindings.type.find(generic.symbol.value);
-                        if (found == bindings.type.end()) {
+                        const auto found = bindings.type_binding(generic.symbol);
+                        if (!found) {
                             complete = false;
                             type_error(range,
                                        "cannot infer generic '" + module_.symbol(generic.symbol).name + "' for struct constructor");
                         } else {
-                            argument.type = found->second;
+                            argument.type = *found;
                         }
                     }
                     inferred.arguments.push_back(argument);
@@ -1264,8 +1269,12 @@ namespace hgl::ir
                 const auto   *structure =
                     symbol.owner.valid() ? std::get_if<StructDecl>(&module_.declaration(symbol.owner).node) : nullptr;
                 if (!structure) { return applied; }
-                applied                = infer_struct_application(applied, *structure, arguments, expression.range);
-                unwrapped              = unwrap_atomic(applied);
+                applied   = infer_struct_application(applied, *structure, arguments, expression.range);
+                unwrapped = unwrap_atomic(applied);
+                detail::GenericSubstitution struct_substitution{module_, canonical_types_};
+                bind_struct_arguments(unwrapped, struct_substitution);
+                (void)constraint_solver_.solve(structure->requirements, struct_substitution, expression.range,
+                                               "struct construction");
                 std::size_t positional = 0;
                 for (const Argument &argument : arguments) {
                     const StructField *field = nullptr;
@@ -1534,15 +1543,19 @@ namespace hgl::ir
                 }
             }
 
-            Module                                  &module_;
-            const OperatorResolver                  &resolve_operator_;
-            syntax::DiagnosticSink                  &diagnostics_;
-            detail::CanonicalTypes                   canonical_types_;
-            std::vector<std::uint8_t>                expr_state_{};
-            std::unordered_map<std::uint32_t, Phase> symbol_phase_{};
-            std::unordered_map<std::uint32_t, bool>  checked_blocks_{};
-            TypeId                                   void_type_{};
-            Expr                                     missing_expression_{};
+            Module                                    &module_;
+            const OperatorResolver                    &resolve_operator_;
+            syntax::DiagnosticSink                    &diagnostics_;
+            detail::CanonicalTypes                     canonical_types_;
+            detail::ConstraintSolver                   constraint_solver_;
+            std::vector<std::uint8_t>                  expr_state_{};
+            std::unordered_map<std::uint32_t, Phase>   symbol_phase_{};
+            std::unordered_map<std::uint32_t, bool>    checked_blocks_{};
+            TypeId                                     void_type_{};
+            ConstraintId                               active_requirements_{};
+            ConstraintId                               inherited_requirements_{};
+            std::optional<detail::GenericSubstitution> inherited_substitution_{};
+            Expr                                       missing_expression_{};
         };
     }  // namespace
 

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -382,18 +382,291 @@ fn wrong() -> f64 {
     CHECK(lowered.hir.completion == hir::Completion::Resolved);
 }
 
-TEST_CASE("typed HIR fails closed until callable requirements are evaluated", "[ir][typed][constraints]") {
+TEST_CASE("typed HIR admits and rejects closed callable requirements", "[ir][typed][constraints]") {
     Lowered lowered{R"(
 module checks.constraints
 
-fn identity<T>(value: T) -> T
+fn add_numeric<T>(value: T) -> T
 requires T in {i64, f64}
+=> value + value
+
+fn accepted(value: i64) -> i64 => add_numeric(value)
+)"};
+    require_clean(lowered);
+    REQUIRE(complete(lowered));
+    CHECK(lowered.hir.completion == hir::Completion::Typed);
+
+    Lowered rejected{R"(
+module checks.rejected_constraint
+
+fn add_numeric<T>(value: T) -> T
+requires T in {i64, f64}
+=> value + value
+
+fn rejected(value: str) -> str => add_numeric(value)
+)"};
+    require_clean(rejected);
+    CHECK_FALSE(complete(rejected));
+    CHECK(rejected.diagnostics.render(rejected.file).find("requirements are not satisfied") != std::string::npos);
+    CHECK(rejected.hir.completion == hir::Completion::Resolved);
+}
+
+TEST_CASE("typed HIR equality constraints infer reflected field types", "[ir][typed][constraints]") {
+    Lowered lowered{R"(
+module checks.reflected_constraint
+
+abstract struct Priced {
+    bid: f64
+}
+
+struct Quote: Priced {
+    size: i64
+}
+
+fn reflected<U, V>(value: U, const name: str) -> V
+requires U is struct
+      && name in fields(U)
+      && V == field_type(U, name)
+=> null
+
+fn apply_reflected(value: Quote) -> i64 {
+    let result = reflected(value, "size")
+    result
+}
+
+fn read_bid<U>(value: U) -> f64
+requires U is struct
+      && has_fields(U, {"bid"})
+      && field_type(U, "bid") == f64
+=> value.bid
+
+fn apply_read_bid(value: Quote) -> f64 => read_bid(value)
+)"};
+    require_clean(lowered);
+    REQUIRE(complete(lowered));
+
+    bool found = false;
+    for (const hir::Expr &expression : lowered.hir.exprs) {
+        if (expression.operation.kind != hir::OperationKind::ExactFunction || !expression.operation.target.valid() ||
+            lowered.hir.symbol(expression.operation.target).name != "reflected") {
+            continue;
+        }
+        found = true;
+        CHECK(expression.type.valid());
+        CHECK(lowered.hir.type(expression.type).kind == hir::TypeKind::Scalar);
+        CHECK(lowered.hir.type(expression.type).scalar == hir::ScalarType::I64);
+        REQUIRE(expression.operation.substitutions.size() == 2U);
+        CHECK(expression.operation.substitutions[1].type == expression.type);
+    }
+    CHECK(found);
+}
+
+TEST_CASE("typed HIR operator requirements admit generic body operations", "[ir][typed][constraints][operators]") {
+    Lowered lowered{R"(
+module checks.operator_constraint
+
+operator add<T>(lhs: T, rhs: T) -> T
+impl fn add(lhs: f64, rhs: f64) -> f64 => lhs + rhs
+
+fn double<T>(value: T) -> T
+requires add(T, T) -> T
+=> value + value
+
+fn apply_double(value: f64) -> f64 => double(value)
+)"};
+    require_clean(lowered);
+    REQUIRE(complete(lowered));
+
+    Lowered rejected{R"(
+module checks.operator_constraint_rejected
+
+operator add<T>(lhs: T, rhs: T) -> T
+impl fn add(lhs: f64, rhs: f64) -> f64 => lhs + rhs
+
+fn double<T>(value: T) -> T
+requires add(T, T) -> T
+=> value + value
+
+fn apply_double(value: i64) -> i64 => double(value)
+)"};
+    require_clean(rejected);
+    CHECK_FALSE(complete(rejected));
+    CHECK(rejected.diagnostics.render(rejected.file).find("operator requirement has no implementation") != std::string::npos);
+    CHECK(rejected.hir.completion == hir::Completion::Resolved);
+}
+
+TEST_CASE("operator implementations inherit contract requirements", "[ir][typed][constraints][operators]") {
+    Lowered lowered{R"(
+module checks.inherited_operator_constraint
+
+operator add<T>(lhs: T, rhs: T) -> T
+impl fn add(lhs: f64, rhs: f64) -> f64 => lhs + rhs
+
+operator double<T>(value: T) -> T
+requires add(T, T) -> T
+
+impl fn double(value: f64) -> f64 => value + value
+fn apply_double(value: f64) -> f64 => double(value)
+)"};
+    require_clean(lowered);
+    REQUIRE(complete(lowered));
+}
+
+TEST_CASE("operator requirements apply the target contract constraints", "[ir][typed][constraints][operators]") {
+    Lowered rejected{R"(
+module checks.effective_operator_constraint
+
+operator choose<T>(value: T) -> T
+requires T in {f64}
+
+impl fn choose(value: i64) -> i64 => value
+
+fn requires_choose<T>(value: T) -> T
+requires choose(T) -> T
 => value
+
+fn apply(value: i64) -> i64 => requires_choose(value)
+)"};
+    require_clean(rejected);
+    CHECK_FALSE(complete(rejected));
+    CHECK(rejected.diagnostics.render(rejected.file).find("function call requirements are not satisfied") != std::string::npos);
+}
+
+TEST_CASE("operator requirements carry const arguments", "[ir][typed][constraints][operators]") {
+    Lowered lowered{R"(
+module checks.const_operator_requirement
+
+operator retain(const value: i64) -> i64
+impl fn retain(const value: i64) -> i64 => value
+
+fn accepts(const value: i64) -> i64
+requires retain(value) -> i64
+=> value
+
+fn apply() -> i64 => accepts(3)
+)"};
+    require_clean(lowered);
+    REQUIRE(complete(lowered));
+}
+
+TEST_CASE("operator implementations must conform to their contract", "[ir][typed][constraints][operators]") {
+    Lowered wrong_name{R"(
+module checks.operator_parameter_name
+
+operator choose<T>(value: T) -> T
+impl fn choose(other: f64) -> f64 => other
+)"};
+    require_clean(wrong_name);
+    CHECK_FALSE(complete(wrong_name));
+    CHECK(wrong_name.diagnostics.render(wrong_name.file).find("implementation signature does not conform") != std::string::npos);
+
+    Lowered wrong_result{R"(
+module checks.operator_result_type
+
+operator choose<T>(value: T) -> T
+impl fn choose(value: i64) -> f64 => 1.0
+)"};
+    require_clean(wrong_result);
+    CHECK_FALSE(complete(wrong_result));
+    CHECK(wrong_result.diagnostics.render(wrong_result.file).find("implementation signature does not conform") !=
+          std::string::npos);
+}
+
+TEST_CASE("source candidates with unresolved generics remain deferred", "[ir][typed][constraints][operators]") {
+    Lowered lowered{R"(
+module checks.unresolved_candidate_generic
+
+operator choose<T>(value: T) -> T
+impl fn choose<T, U>(value: T) -> T => value
+fn apply_it(value: f64) -> f64 => choose(value)
+)"};
+    require_clean(lowered);
+    REQUIRE(complete(lowered));
+
+    bool found = false;
+    for (const hir::Expr &expression : lowered.hir.exprs) {
+        if (expression.operation.kind != hir::OperationKind::NominalOperator || !expression.operation.target.valid() ||
+            lowered.hir.symbol(expression.operation.target).name != "choose") {
+            continue;
+        }
+        found = true;
+        CHECK_FALSE(expression.operation.candidate.valid());
+        CHECK(expression.operation.deferred);
+    }
+    CHECK(found);
+}
+
+TEST_CASE("constraint logic admits resolved alternatives without inferring through them", "[ir][typed][constraints]") {
+    Lowered lowered{R"(
+module checks.constraint_logic
+
+fn scalar_value<T>(value: T) -> T
+requires T in {i64} || T in {str}
+=> value
+
+fn not_text<T>(value: T) -> T
+requires !(T in {str})
+=> value
+
+fn apply_scalar(value: str) -> str => scalar_value(value)
+fn apply_not(value: i64) -> i64 => not_text(value)
+)"};
+    require_clean(lowered);
+    REQUIRE(complete(lowered));
+}
+
+TEST_CASE("unresolved constraint dependencies fail closed", "[ir][typed][constraints]") {
+    Lowered lowered{R"(
+module checks.unresolved_constraint
+
+fn unresolved<U, V>(value: U) -> V
+requires V == field_type(U, "missing")
+=> null
+
+fn apply_unresolved(value: i64) -> i64 {
+    unresolved(value)
+    1
+}
 )"};
     require_clean(lowered);
     CHECK_FALSE(complete(lowered));
-    CHECK(lowered.diagnostics.render(lowered.file).find("callable 'requires' evaluation is not implemented") != std::string::npos);
+    CHECK(lowered.diagnostics.render(lowered.file).find("requirements could not be resolved") != std::string::npos);
     CHECK(lowered.hir.completion == hir::Completion::Resolved);
+}
+
+TEST_CASE("generic struct construction evaluates structural requirements", "[ir][typed][constraints][structs]") {
+    Lowered lowered{R"(
+module checks.struct_constraint
+
+struct WithId<T>
+requires T is struct && has_fields(T, {"id"})
+{
+    value: T
+}
+
+struct Record { id: i64 }
+fn make(value: Record) -> WithId<Record> => WithId<Record>(value: value)
+)"};
+    require_clean(lowered);
+    REQUIRE(complete(lowered));
+
+    Lowered rejected{R"(
+module checks.struct_constraint_rejected
+
+struct WithId<T>
+requires T is struct && has_fields(T, {"id"})
+{
+    value: T
+}
+
+struct Missing { name: str }
+fn make(value: Missing) -> WithId<Missing> => WithId<Missing>(value: value)
+)"};
+    require_clean(rejected);
+    CHECK_FALSE(complete(rejected));
+    CHECK(rejected.diagnostics.render(rejected.file).find("struct construction requirements are not satisfied") !=
+          std::string::npos);
+    CHECK(rejected.hir.completion == hir::Completion::Resolved);
 }
 
 TEST_CASE("typed HIR records runtime state and capability effects", "[ir][typed][effects]") {

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -634,6 +634,37 @@ fn apply_unresolved(value: i64) -> i64 {
     CHECK(lowered.hir.completion == hir::Completion::Resolved);
 }
 
+TEST_CASE("generic requirements are premises for nested constrained calls", "[ir][typed][constraints]") {
+    Lowered lowered{R"(
+module checks.nested_constraint_premise
+
+fn inner<T>(value: T) -> T
+requires T in {i64, f64}
+=> value
+
+fn outer<U>(value: U) -> U
+requires U in {i64, f64}
+=> inner(value)
+)"};
+    require_clean(lowered);
+    REQUIRE(complete(lowered));
+
+    Lowered rejected{R"(
+module checks.insufficient_constraint_premise
+
+fn inner<T>(value: T) -> T
+requires T in {i64}
+=> value
+
+fn outer<U>(value: U) -> U
+requires U in {i64, f64}
+=> inner(value)
+)"};
+    require_clean(rejected);
+    CHECK_FALSE(complete(rejected));
+    CHECK(rejected.diagnostics.render(rejected.file).find("function call requirements are not satisfied") != std::string::npos);
+}
+
 TEST_CASE("generic struct construction evaluates structural requirements", "[ir][typed][constraints][structs]") {
     Lowered lowered{R"(
 module checks.struct_constraint

--- a/language/tests/wiring/operator_types_tests.cpp
+++ b/language/tests/wiring/operator_types_tests.cpp
@@ -99,3 +99,27 @@ fn double(values: map<str, f64>) -> map<str, f64> =>
     }
     CHECK(found);
 }
+
+TEST_CASE("operator requirements use native registry viability", "[ir][operator-types][constraints]") {
+    Unit unit{R"(
+module checks.native_requirement
+use hgraph.std::{add}
+
+fn double<T>(value: T) -> T
+requires add(T, T) -> T
+=> value + value
+
+fn apply_double(value: f64) -> f64 => double(value)
+)"};
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+    REQUIRE(unit.complete());
+
+    bool found_body_operation = false;
+    for (const hgl::ir::hir::Expr &expression : unit.hir.exprs) {
+        if (expression.operation.identity != "add_") { continue; }
+        found_body_operation = true;
+        CHECK(expression.operation.target.valid());
+    }
+    CHECK(found_body_operation);
+}


### PR DESCRIPTION
## Summary

- add shared generic substitution and fixed-point constraint evaluation to typed HIR
- evaluate closed type/value sets, Boolean constraints, structural reflection, and nominal operator requirements
- validate local implementation signatures and inherit operator contract requirements without duplicating hgraph overload ranking
- document implemented staging boundaries and remaining native descriptor work

## Stack

Built on #684.

## Validation

- clean AppleClang warnings-as-errors language build: 26/26 tests
- focused HIR suite: 1,337 assertions in 27 cases
- native operator-type suite: 15 assertions in 3 cases
- fresh native acceptance: 1,711/1,711 tests
- stable-ABI wheel built with Python 3.12 and tested with Python 3.14: 3,214 passed, 10 skipped
