### PR TITLE
style(language): format semantic resolver

### DIFF
--- a/language/src/semantics/resolve.cpp
+++ b/language/src/semantics/resolve.cpp
@@ -25,14 +25,12 @@ namespace hgl::semantics
         constexpr std::string_view kernel_std       = "hgraph.std";
         constexpr std::string_view kernel_analytics = "hgraph.analytics";
 
-        constexpr std::string_view intrinsics[] = {"valid",   "modified", "all_valid", "last_modified", "delta", "key_set",
-                                                   "keys",    "values",   "items",     "added",         "removed"};
+        constexpr std::string_view intrinsics[] = {"valid", "modified", "all_valid", "last_modified", "delta",  "key_set",
+                                                   "keys",  "values",   "items",     "added",         "removed"};
 
-        [[nodiscard]] std::string join_path(const std::vector<ast::Name> &path)
-        {
+        [[nodiscard]] std::string join_path(const std::vector<ast::Name> &path) {
             std::string result;
-            for (const ast::Name &segment : path)
-            {
+            for (const ast::Name &segment : path) {
                 if (!result.empty()) { result += '.'; }
                 result += segment.text;
             }
@@ -44,8 +42,7 @@ namespace hgl::semantics
           public:
             Resolver(const syntax::SourceFile &file, const ast::Module &module, const OperatorLookup &has_operator,
                      syntax::DiagnosticSink &diagnostics)
-                : file_{file}, module_{module}, has_operator_{has_operator}, diagnostics_{diagnostics}
-            {
+                : file_{file}, module_{module}, has_operator_{has_operator}, diagnostics_{diagnostics} {
                 result_.bindings.resize(module.exprs.size());
                 result_.type_bindings.resize(module.types.size());
                 result_.constraint_bindings.resize(module.constraints.size());
@@ -53,16 +50,19 @@ namespace hgl::semantics
                 result_.struct_info.resize(module.decls.size());
             }
 
-            ResolvedModule run()
-            {
+            ResolvedModule run() {
                 collect_declarations();
-                for (const ast::DeclId id : module_.declarations)
-                {
+                for (const ast::DeclId id : module_.declarations) {
                     const ast::Decl &decl = module_.decl(id);
-                    if (const auto *structure = std::get_if<ast::StructDecl>(&decl.node)) { resolve_struct(id, *structure); }
-                    else if (const auto *fn = std::get_if<ast::FunctionDecl>(&decl.node)) { resolve_function(id, *fn); }
-                    else if (const auto *op = std::get_if<ast::OperatorDecl>(&decl.node)) { resolve_operator(id, *op); }
-                    else if (const auto *test = std::get_if<ast::TestDecl>(&decl.node)) { resolve_test(id, *test); }
+                    if (const auto *structure = std::get_if<ast::StructDecl>(&decl.node)) {
+                        resolve_struct(id, *structure);
+                    } else if (const auto *fn = std::get_if<ast::FunctionDecl>(&decl.node)) {
+                        resolve_function(id, *fn);
+                    } else if (const auto *op = std::get_if<ast::OperatorDecl>(&decl.node)) {
+                        resolve_operator(id, *op);
+                    } else if (const auto *test = std::get_if<ast::TestDecl>(&decl.node)) {
+                        resolve_test(id, *test);
+                    }
                 }
                 validate_structs();
                 validate_constructors();
@@ -71,9 +71,7 @@ namespace hgl::semantics
 
           private:
             struct Scope
-            {
-                std::vector<std::pair<std::string_view, Binding>> names;
-            };
+            { std::vector<std::pair<std::string_view, Binding>> names; };
 
             struct Context
             {
@@ -84,37 +82,31 @@ namespace hgl::semantics
 
             // ------------------------------------------------------ module level
 
-            void collect_declarations()
-            {
+            void collect_declarations() {
                 scopes_.push_back(Scope{});
-                for (const ast::DeclId id : module_.declarations)
-                {
+                for (const ast::DeclId id : module_.declarations) {
                     const ast::Decl &decl = module_.decl(id);
-                    if (const auto *mod = std::get_if<ast::ModuleDecl>(&decl.node))
-                    {
-                        if (!result_.module_path.empty())
-                        {
+                    if (const auto *mod = std::get_if<ast::ModuleDecl>(&decl.node)) {
+                        if (!result_.module_path.empty()) {
                             report(Category::Module, decl.range, "a compilation unit has one module declaration");
                         }
                         result_.module_path = join_path(mod->path);
                     }
                 }
-                if (result_.module_path.empty())
-                {
-                    const SourceRange at = module_.declarations.empty() ? SourceRange{} : module_.decl(module_.declarations.front()).range;
-                    report(Category::Module, SourceRange{at.begin, at.begin}, "a compilation unit begins with a module declaration");
+                if (result_.module_path.empty()) {
+                    const SourceRange at =
+                        module_.declarations.empty() ? SourceRange{} : module_.decl(module_.declarations.front()).range;
+                    report(Category::Module, SourceRange{at.begin, at.begin},
+                           "a compilation unit begins with a module declaration");
                 }
-                for (const ast::DeclId id : module_.declarations)
-                {
+                for (const ast::DeclId id : module_.declarations) {
                     const ast::Decl &decl = module_.decl(id);
                     if (const auto *use = std::get_if<ast::UseDecl>(&decl.node)) { resolve_use(*use, decl.range); }
                 }
                 // Operators first so a plain `fn` of an operator's name is a conflict.
-                for (const ast::DeclId id : module_.declarations)
-                {
+                for (const ast::DeclId id : module_.declarations) {
                     const ast::Decl &decl = module_.decl(id);
-                    if (const auto *structure = std::get_if<ast::StructDecl>(&decl.node))
-                    {
+                    if (const auto *structure = std::get_if<ast::StructDecl>(&decl.node)) {
                         result_.structs.push_back(id);
                         Binding binding;
                         binding.kind = BindingKind::Struct;
@@ -125,11 +117,9 @@ namespace hgl::semantics
                 // Operators share the value namespace with exact functions
                 // and structs, and are collected before functions so a plain
                 // `fn` of an operator's name is diagnosed as a conflict.
-                for (const ast::DeclId id : module_.declarations)
-                {
+                for (const ast::DeclId id : module_.declarations) {
                     const ast::Decl &decl = module_.decl(id);
-                    if (const auto *op = std::get_if<ast::OperatorDecl>(&decl.node))
-                    {
+                    if (const auto *op = std::get_if<ast::OperatorDecl>(&decl.node)) {
                         result_.operators.push_back(id);
                         Binding binding;
                         binding.kind = BindingKind::LocalOperator;
@@ -137,16 +127,12 @@ namespace hgl::semantics
                         declare(op->name, binding, "in the module");
                     }
                 }
-                for (const ast::DeclId id : module_.declarations)
-                {
+                for (const ast::DeclId id : module_.declarations) {
                     const ast::Decl &decl = module_.decl(id);
-                    if (const auto *fn = std::get_if<ast::FunctionDecl>(&decl.node))
-                    {
+                    if (const auto *fn = std::get_if<ast::FunctionDecl>(&decl.node)) {
                         result_.functions.push_back(id);
                         declare_function(id, *fn);
-                    }
-                    else if (const auto *test = std::get_if<ast::TestDecl>(&decl.node))
-                    {
+                    } else if (const auto *test = std::get_if<ast::TestDecl>(&decl.node)) {
                         result_.tests.push_back(id);
                         Binding binding;
                         binding.kind = BindingKind::Test;
@@ -156,29 +142,24 @@ namespace hgl::semantics
                 }
             }
 
-            void declare_function(ast::DeclId id, const ast::FunctionDecl &fn)
-            {
+            void declare_function(ast::DeclId id, const ast::FunctionDecl &fn) {
                 const std::optional<Binding> existing = lookup(fn.name.text);
-                const bool operator_in_scope =
+                const bool                   operator_in_scope =
                     existing && (existing->kind == BindingKind::Operator || existing->kind == BindingKind::LocalOperator);
-                if (fn.visibility == ast::FunctionVisibility::Impl)
-                {
-                    if (!operator_in_scope)
-                    {
+                if (fn.visibility == ast::FunctionVisibility::Impl) {
+                    if (!operator_in_scope) {
                         report(Category::Module, fn.name.range,
-                               "'impl fn " + std::string{fn.name.text} + "' has no operator named '" +
-                                   std::string{fn.name.text} + "' in scope");
+                               "'impl fn " + std::string{fn.name.text} + "' has no operator named '" + std::string{fn.name.text} +
+                                   "' in scope");
                     }
                     // An implementation is reached through its operator's identity,
                     // never as an unqualified value of its own.
                     return;
                 }
-                if (operator_in_scope)
-                {
+                if (operator_in_scope) {
                     report(Category::Name, fn.name.range,
-                           "'fn " + std::string{fn.name.text} + "' conflicts with operator " +
-                               operator_identity(*existing) + "; declare 'impl fn " + std::string{fn.name.text} +
-                               "' or rename it");
+                           "'fn " + std::string{fn.name.text} + "' conflicts with operator " + operator_identity(*existing) +
+                               "; declare 'impl fn " + std::string{fn.name.text} + "' or rename it");
                     return;
                 }
                 Binding binding;
@@ -187,12 +168,9 @@ namespace hgl::semantics
                 declare(fn.name, binding, "in the module");
             }
 
-            [[nodiscard]] std::string operator_identity(const Binding &binding) const
-            {
-                if (binding.kind == BindingKind::Operator)
-                {
-                    for (const ImportedOperator &import : result_.imports)
-                    {
+            [[nodiscard]] std::string operator_identity(const Binding &binding) const {
+                if (binding.kind == BindingKind::Operator) {
+                    for (const ImportedOperator &import : result_.imports) {
                         if (import.registry_name == binding.registry_name) { return import.module + "::" + import.name; }
                     }
                     return binding.registry_name;
@@ -201,22 +179,17 @@ namespace hgl::semantics
                 return result_.module_path + "::" + std::string{op.name.text};
             }
 
-            void resolve_use(const ast::UseDecl &use, SourceRange range)
-            {
+            void resolve_use(const ast::UseDecl &use, SourceRange range) {
                 const std::string path = join_path(use.path);
-                if (path != kernel_std && path != kernel_analytics)
-                {
+                if (path != kernel_std && path != kernel_analytics) {
                     report(Category::Module, range,
                            "module '" + path + "' is not available: the first pass links the kernel modules " +
                                std::string{kernel_std} + " and " + std::string{kernel_analytics} + " only");
                     return;
                 }
-                if (!use.alias.empty())
-                {
-                    for (const ModuleAlias &alias : result_.aliases)
-                    {
-                        if (alias.alias == use.alias.text)
-                        {
+                if (!use.alias.empty()) {
+                    for (const ModuleAlias &alias : result_.aliases) {
+                        if (alias.alias == use.alias.text) {
                             report(Category::Name, use.alias.range,
                                    "module alias '" + std::string{use.alias.text} + "' is declared twice");
                             return;
@@ -225,17 +198,14 @@ namespace hgl::semantics
                     result_.aliases.push_back(ModuleAlias{std::string{use.alias.text}, path});
                     return;
                 }
-                for (const ast::Name &name : use.names)
-                {
+                for (const ast::Name &name : use.names) {
                     const std::optional<std::string> registry_name = kernel_registry_name(path, name.text);
-                    if (!registry_name)
-                    {
+                    if (!registry_name) {
                         report(Category::Module, name.range, path + " does not export '" + std::string{name.text} + "'");
                         continue;
                     }
                     if (const std::optional<Binding> existing = lookup(name.text);
-                        existing && existing->kind == BindingKind::Operator)
-                    {
+                        existing && existing->kind == BindingKind::Operator) {
                         std::string other = operator_identity(*existing);
                         report(Category::Module, name.range,
                                "operator '" + std::string{name.text} + "' is imported unqualified from both " +
@@ -251,9 +221,7 @@ namespace hgl::semantics
             }
 
             /// The interim kernel table (developer guide, "Interim kernel table").
-            [[nodiscard]] std::optional<std::string> kernel_registry_name(std::string_view module,
-                                                                          std::string_view name) const
-            {
+            [[nodiscard]] std::optional<std::string> kernel_registry_name(std::string_view module, std::string_view name) const {
                 if (module == kernel_analytics) { return std::string{kernel_analytics} + "." + std::string{name}; }
                 if (has_operator_(name)) { return std::string{name}; }
                 const std::string underscored = std::string{name} + "_";
@@ -263,8 +231,7 @@ namespace hgl::semantics
 
             // -------------------------------------------------------- functions
 
-            void resolve_function(ast::DeclId id, const ast::FunctionDecl &fn)
-            {
+            void resolve_function(ast::DeclId id, const ast::FunctionDecl &fn) {
                 result_.kinds[id] = classify(fn);
                 Context context;
                 context.fn = id;
@@ -277,8 +244,7 @@ namespace hgl::semantics
                 pop_scope();
             }
 
-            void resolve_operator(ast::DeclId id, const ast::OperatorDecl &op)
-            {
+            void resolve_operator(ast::DeclId id, const ast::OperatorDecl &op) {
                 Context context;
                 context.fn = id;
                 push_scope();
@@ -288,25 +254,20 @@ namespace hgl::semantics
                 pop_scope();
             }
 
-            void resolve_struct(ast::DeclId id, const ast::StructDecl &structure)
-            {
+            void resolve_struct(ast::DeclId id, const ast::StructDecl &structure) {
                 Context context;
                 context.fn = id;
                 push_scope();
                 declare_generics(id, structure.generics, context);
                 for (const ast::TypeId parent : structure.parents) { resolve_type(parent, context); }
-                for (const ast::StructMember &member : structure.members)
-                {
+                for (const ast::StructMember &member : structure.members) {
                     std::visit(
                         [&](const auto &item) {
                             using T = std::decay_t<decltype(item)>;
-                            if constexpr (std::is_same_v<T, ast::StructField>)
-                            {
+                            if constexpr (std::is_same_v<T, ast::StructField>) {
                                 resolve_type(item.type, context);
                                 if (item.default_value != ast::no_node) { resolve_expr(item.default_value, context); }
-                            }
-                            else
-                            {
+                            } else {
                                 resolve_expr(item.value, context);
                             }
                         },
@@ -316,8 +277,7 @@ namespace hgl::semantics
                 pop_scope();
             }
 
-            void resolve_test(ast::DeclId id, const ast::TestDecl &test)
-            {
+            void resolve_test(ast::DeclId id, const ast::TestDecl &test) {
                 Context context;
                 context.fn      = id;
                 context.in_test = true;
@@ -326,10 +286,8 @@ namespace hgl::semantics
                 pop_scope();
             }
 
-            void declare_generics(ast::DeclId fn, const std::vector<ast::GenericParameter> &generics, Context &context)
-            {
-                for (std::size_t i = 0; i < generics.size(); ++i)
-                {
+            void declare_generics(ast::DeclId fn, const std::vector<ast::GenericParameter> &generics, Context &context) {
+                for (std::size_t i = 0; i < generics.size(); ++i) {
                     if (generics[i].type != ast::no_node) { resolve_type(generics[i].type, context); }
                     Binding binding;
                     binding.kind  = BindingKind::Generic;
@@ -339,18 +297,15 @@ namespace hgl::semantics
                 }
             }
 
-            void resolve_signature(ast::DeclId fn, const ast::Signature &signature, Context &context)
-            {
-                for (std::size_t i = 0; i < signature.parameters.size(); ++i)
-                {
+            void resolve_signature(ast::DeclId fn, const ast::Signature &signature, Context &context) {
+                for (std::size_t i = 0; i < signature.parameters.size(); ++i) {
                     const ast::Parameter &parameter = signature.parameters[i];
                     if (parameter.type != ast::no_node) { resolve_type(parameter.type, context); }
                     if (parameter.default_value != ast::no_node) { resolve_expr(parameter.default_value, context); }
                 }
                 if (signature.result != ast::no_node) { resolve_type(signature.result, context); }
                 // Parameters become visible together, after their defaults.
-                for (std::size_t i = 0; i < signature.parameters.size(); ++i)
-                {
+                for (std::size_t i = 0; i < signature.parameters.size(); ++i) {
                     Binding binding;
                     binding.kind  = BindingKind::Parameter;
                     binding.decl  = fn;
@@ -359,48 +314,46 @@ namespace hgl::semantics
                 }
             }
 
-            [[nodiscard]] FunctionKind classify(const ast::FunctionDecl &fn) const
-            {
+            [[nodiscard]] FunctionKind classify(const ast::FunctionDecl &fn) const {
                 if (fn.block_body != ast::no_node && block_has_runtime_form(fn.block_body)) { return FunctionKind::Runtime; }
                 return FunctionKind::Composition;
             }
 
-            [[nodiscard]] bool block_has_runtime_form(ast::BlockId id) const
-            {
-                for (const ast::StmtId stmt_id : module_.block(id).statements)
-                {
+            [[nodiscard]] bool block_has_runtime_form(ast::BlockId id) const {
+                for (const ast::StmtId stmt_id : module_.block(id).statements) {
                     if (stmt_has_runtime_form(stmt_id)) { return true; }
                 }
                 return false;
             }
 
-            [[nodiscard]] bool stmt_has_runtime_form(ast::StmtId id) const
-            {
+            [[nodiscard]] bool stmt_has_runtime_form(ast::StmtId id) const {
                 const ast::Stmt &stmt = module_.stmt(id);
                 return std::visit(
                     [&](const auto &node) -> bool {
                         using T = std::decay_t<decltype(node)>;
                         if constexpr (std::is_same_v<T, ast::StateDecl> || std::is_same_v<T, ast::InjectDecl> ||
                                       std::is_same_v<T, ast::LifecycleBlock> || std::is_same_v<T, ast::WhenStmt> ||
-                                      std::is_same_v<T, ast::ForStmt>)
-                        {
+                                      std::is_same_v<T, ast::ForStmt>) {
                             return true;
+                        } else if constexpr (std::is_same_v<T, ast::ExprStmt>) {
+                            return expr_has_runtime_form(node.expr);
+                        } else if constexpr (std::is_same_v<T, ast::LocalDecl>) {
+                            return expr_has_runtime_form(node.init);
+                        } else if constexpr (std::is_same_v<T, ast::AssignStmt>) {
+                            return expr_has_runtime_form(node.value);
+                        } else if constexpr (std::is_same_v<T, ast::ReturnStmt>) {
+                            return expr_has_runtime_form(node.value);
+                        } else {
+                            return false;
                         }
-                        else if constexpr (std::is_same_v<T, ast::ExprStmt>) { return expr_has_runtime_form(node.expr); }
-                        else if constexpr (std::is_same_v<T, ast::LocalDecl>) { return expr_has_runtime_form(node.init); }
-                        else if constexpr (std::is_same_v<T, ast::AssignStmt>) { return expr_has_runtime_form(node.value); }
-                        else if constexpr (std::is_same_v<T, ast::ReturnStmt>) { return expr_has_runtime_form(node.value); }
-                        else { return false; }
                     },
                     stmt.node);
             }
 
-            [[nodiscard]] bool expr_has_runtime_form(ast::ExprId id) const
-            {
+            [[nodiscard]] bool expr_has_runtime_form(ast::ExprId id) const {
                 if (id == ast::no_node) { return false; }
                 const ast::Expr &expr = module_.expr(id);
-                if (const auto *if_ = std::get_if<ast::If>(&expr.node))
-                {
+                if (const auto *if_ = std::get_if<ast::If>(&expr.node)) {
                     return block_has_runtime_form(if_->then_block) || expr_has_runtime_form(if_->otherwise);
                 }
                 if (const auto *block = std::get_if<ast::BlockExpr>(&expr.node)) { return block_has_runtime_form(block->block); }
@@ -409,30 +362,25 @@ namespace hgl::semantics
 
             // ----------------------------------------------------------- bodies
 
-            void resolve_block(ast::BlockId id, Context &context)
-            {
+            void resolve_block(ast::BlockId id, Context &context) {
                 push_scope();
                 for (const ast::StmtId stmt_id : module_.block(id).statements) { resolve_stmt(stmt_id, context); }
                 pop_scope();
             }
 
-            void resolve_stmt(ast::StmtId id, Context &context)
-            {
+            void resolve_stmt(ast::StmtId id, Context &context) {
                 const ast::Stmt &stmt = module_.stmt(id);
                 std::visit(
                     [&](const auto &node) {
                         using T = std::decay_t<decltype(node)>;
-                        if constexpr (std::is_same_v<T, ast::LocalDecl>)
-                        {
+                        if constexpr (std::is_same_v<T, ast::LocalDecl>) {
                             if (node.type != ast::no_node) { resolve_type(node.type, context); }
                             resolve_expr(node.init, context);
                             Binding binding;
                             binding.kind = BindingKind::Local;
                             binding.stmt = id;
                             declare(node.name, binding, "in the block");
-                        }
-                        else if constexpr (std::is_same_v<T, ast::StateDecl>)
-                        {
+                        } else if constexpr (std::is_same_v<T, ast::StateDecl>) {
                             reject_in_test(context, stmt.range, "state");
                             if (node.type != ast::no_node) { resolve_type(node.type, context); }
                             resolve_expr(node.init, context);
@@ -440,32 +388,23 @@ namespace hgl::semantics
                             binding.kind = BindingKind::Local;
                             binding.stmt = id;
                             declare(node.name, binding, "in the block");
-                        }
-                        else if constexpr (std::is_same_v<T, ast::InjectDecl>)
-                        {
+                        } else if constexpr (std::is_same_v<T, ast::InjectDecl>) {
                             reject_in_test(context, stmt.range, "inject");
-                            for (std::size_t index = 0; index < node.names.size(); ++index)
-                            {
+                            for (std::size_t index = 0; index < node.names.size(); ++index) {
                                 Binding binding;
-                                binding.kind = BindingKind::Local;
-                                binding.stmt = id;
+                                binding.kind  = BindingKind::Local;
+                                binding.stmt  = id;
                                 binding.index = static_cast<std::uint32_t>(index);
                                 declare(node.names[index], binding, "in the block");
                             }
-                        }
-                        else if constexpr (std::is_same_v<T, ast::LifecycleBlock>)
-                        {
+                        } else if constexpr (std::is_same_v<T, ast::LifecycleBlock>) {
                             reject_in_test(context, stmt.range, node.is_stop ? "stop" : "start");
                             resolve_block(node.block, context);
-                        }
-                        else if constexpr (std::is_same_v<T, ast::WhenStmt>)
-                        {
+                        } else if constexpr (std::is_same_v<T, ast::WhenStmt>) {
                             reject_in_test(context, stmt.range, "when");
                             resolve_expr(node.condition, context);
                             resolve_block(node.block, context);
-                        }
-                        else if constexpr (std::is_same_v<T, ast::ForStmt>)
-                        {
+                        } else if constexpr (std::is_same_v<T, ast::ForStmt>) {
                             reject_in_test(context, stmt.range, "for");
                             resolve_expr(node.iterable, context);
                             push_scope();
@@ -473,8 +412,7 @@ namespace hgl::semantics
                             first.kind = BindingKind::Local;
                             first.stmt = id;
                             declare(node.first, first, "in the iteration pattern");
-                            if (!node.second.empty())
-                            {
+                            if (!node.second.empty()) {
                                 Binding second = first;
                                 second.second  = true;
                                 second.index   = 1;
@@ -482,101 +420,77 @@ namespace hgl::semantics
                             }
                             resolve_block(node.block, context);
                             pop_scope();
-                        }
-                        else if constexpr (std::is_same_v<T, ast::AssignStmt>)
-                        {
+                        } else if constexpr (std::is_same_v<T, ast::AssignStmt>) {
                             resolve_expr(node.place, context);
                             resolve_expr(node.value, context);
-                        }
-                        else if constexpr (std::is_same_v<T, ast::ReturnStmt>)
-                        {
+                        } else if constexpr (std::is_same_v<T, ast::ReturnStmt>) {
                             if (node.value != ast::no_node) { resolve_expr(node.value, context); }
-                        }
-                        else if constexpr (std::is_same_v<T, ast::AssertStmt>)
-                        {
-                            if (!context.in_test)
-                            {
+                        } else if constexpr (std::is_same_v<T, ast::AssertStmt>) {
+                            if (!context.in_test) {
                                 report(Category::Phase, stmt.range, "'assert' is only valid inside a test body");
                             }
                             resolve_expr(node.condition, context);
+                        } else if constexpr (std::is_same_v<T, ast::ExprStmt>) {
+                            resolve_expr(node.expr, context);
                         }
-                        else if constexpr (std::is_same_v<T, ast::ExprStmt>) { resolve_expr(node.expr, context); }
                     },
                     stmt.node);
             }
 
-            void reject_in_test(const Context &context, SourceRange range, std::string_view form)
-            {
-                if (context.in_test)
-                {
+            void reject_in_test(const Context &context, SourceRange range, std::string_view form) {
+                if (context.in_test) {
                     report(Category::Phase, range, "'" + std::string{form} + "' is not available in a test body");
                 }
             }
 
-            void resolve_expr(ast::ExprId id, Context &context)
-            {
+            void resolve_expr(ast::ExprId id, Context &context) {
                 if (id == ast::no_node) { return; }
                 const ast::Expr &expr = module_.expr(id);
                 std::visit(
                     [&](const auto &node) {
                         using T = std::decay_t<decltype(node)>;
-                        if constexpr (std::is_same_v<T, ast::Placeholder>)
-                        {
-                            if (!context.in_sequence)
-                            {
+                        if constexpr (std::is_same_v<T, ast::Placeholder>) {
+                            if (!context.in_sequence) {
                                 report(Category::Type, expr.range, "'_' is only valid in a harness sequence");
                             }
-                        }
-                        else if constexpr (std::is_same_v<T, ast::NameRef>) { resolve_name(id, node.name); }
-                        else if constexpr (std::is_same_v<T, ast::QualifiedRef>) { resolve_qualified(id, node); }
-                        else if constexpr (std::is_same_v<T, ast::Unary>) { resolve_expr(node.operand, context); }
-                        else if constexpr (std::is_same_v<T, ast::Binary>)
-                        {
+                        } else if constexpr (std::is_same_v<T, ast::NameRef>) {
+                            resolve_name(id, node.name);
+                        } else if constexpr (std::is_same_v<T, ast::QualifiedRef>) {
+                            resolve_qualified(id, node);
+                        } else if constexpr (std::is_same_v<T, ast::Unary>) {
+                            resolve_expr(node.operand, context);
+                        } else if constexpr (std::is_same_v<T, ast::Binary>) {
                             resolve_expr(node.lhs, context);
                             resolve_expr(node.rhs, context);
-                        }
-                        else if constexpr (std::is_same_v<T, ast::Call>)
-                        {
+                        } else if constexpr (std::is_same_v<T, ast::Call>) {
                             resolve_expr(node.callee, context);
-                            if (result_.bindings[node.callee].kind == BindingKind::Struct)
-                            {
-                                for (const ast::Argument &argument : node.arguments)
-                                {
-                                    if (argument.name.empty())
-                                    {
+                            if (result_.bindings[node.callee].kind == BindingKind::Struct) {
+                                for (const ast::Argument &argument : node.arguments) {
+                                    if (argument.name.empty()) {
                                         report(Category::Type, module_.expr(argument.value).range,
                                                "struct construction uses named arguments");
                                     }
                                 }
                             }
                             for (const ast::Argument &argument : node.arguments) { resolve_expr(argument.value, context); }
-                        }
-                        else if constexpr (std::is_same_v<T, ast::Index>)
-                        {
+                        } else if constexpr (std::is_same_v<T, ast::Index>) {
                             resolve_expr(node.target, context);
                             resolve_expr(node.index, context);
-                        }
-                        else if constexpr (std::is_same_v<T, ast::Field>) { resolve_expr(node.target, context); }
-                        else if constexpr (std::is_same_v<T, ast::SequenceLiteral>)
-                        {
-                            const bool saved   = context.in_sequence;
+                        } else if constexpr (std::is_same_v<T, ast::Field>) {
+                            resolve_expr(node.target, context);
+                        } else if constexpr (std::is_same_v<T, ast::SequenceLiteral>) {
+                            const bool saved    = context.in_sequence;
                             context.in_sequence = context.in_test;
-                            for (const ast::SequenceElement &element : node.elements)
-                            {
+                            for (const ast::SequenceElement &element : node.elements) {
                                 resolve_expr(element.key, context);
                                 resolve_expr(element.value, context);
                             }
                             context.in_sequence = saved;
-                        }
-                        else if constexpr (std::is_same_v<T, ast::TupleLiteral>)
-                        {
+                        } else if constexpr (std::is_same_v<T, ast::TupleLiteral>) {
                             for (const ast::ExprId element : node.elements) { resolve_expr(element, context); }
-                        }
-                        else if constexpr (std::is_same_v<T, ast::AnonymousFn>)
-                        {
+                        } else if constexpr (std::is_same_v<T, ast::AnonymousFn>) {
                             push_scope();
-                            for (std::size_t i = 0; i < node.parameters.size(); ++i)
-                            {
+                            for (std::size_t i = 0; i < node.parameters.size(); ++i) {
                                 if (node.parameters[i].type != ast::no_node) { resolve_type(node.parameters[i].type, context); }
                                 // Anonymous parameters bind by the expression that declares them.
                                 Binding binding;
@@ -589,33 +503,25 @@ namespace hgl::semantics
                             if (node.result != ast::no_node) { resolve_type(node.result, context); }
                             resolve_expr(node.body, context);
                             pop_scope();
-                        }
-                        else if constexpr (std::is_same_v<T, ast::If>)
-                        {
+                        } else if constexpr (std::is_same_v<T, ast::If>) {
                             resolve_expr(node.condition, context);
                             resolve_block(node.then_block, context);
                             resolve_expr(node.otherwise, context);
-                        }
-                        else if constexpr (std::is_same_v<T, ast::BlockExpr>) { resolve_block(node.block, context); }
-                        else if constexpr (std::is_same_v<T, ast::Eval>)
-                        {
+                        } else if constexpr (std::is_same_v<T, ast::BlockExpr>) {
+                            resolve_block(node.block, context);
+                        } else if constexpr (std::is_same_v<T, ast::Eval>) {
                             if (!context.in_test) { report(Category::Phase, expr.range, "eval is only valid inside a test body"); }
                             resolve_expr(node.callee, context);
                             for (const ast::Argument &argument : node.arguments) { resolve_expr(argument.value, context); }
-                        }
-                        else if constexpr (std::is_same_v<T, ast::Construct>)
-                        {
+                        } else if constexpr (std::is_same_v<T, ast::Construct>) {
                             resolve_type(node.type, context);
                             const Binding &target = result_.type_bindings[node.type];
-                            if (target.kind != BindingKind::Struct)
-                            {
+                            if (target.kind != BindingKind::Struct) {
                                 report(Category::Type, module_.type(node.type).range,
                                        "a struct constructor target is a concrete struct type");
                             }
-                            for (const ast::Argument &argument : node.arguments)
-                            {
-                                if (argument.name.empty())
-                                {
+                            for (const ast::Argument &argument : node.arguments) {
+                                if (argument.name.empty()) {
                                     report(Category::Type, module_.expr(argument.value).range,
                                            "struct construction uses named arguments");
                                 }
@@ -627,13 +533,10 @@ namespace hgl::semantics
                     expr.node);
             }
 
-            void resolve_name(ast::ExprId id, const ast::Name &name)
-            {
+            void resolve_name(ast::ExprId id, const ast::Name &name) {
                 const std::optional<Binding> binding = lookup(name.text);
-                if (!binding)
-                {
-                    if (is_intrinsic(name.text))
-                    {
+                if (!binding) {
+                    if (is_intrinsic(name.text)) {
                         Binding intrinsic;
                         intrinsic.kind          = BindingKind::Intrinsic;
                         intrinsic.registry_name = std::string{name.text};
@@ -643,22 +546,18 @@ namespace hgl::semantics
                     report(Category::Name, name.range, "unknown name '" + std::string{name.text} + "'");
                     return;
                 }
-                if (binding->kind == BindingKind::Test)
-                {
+                if (binding->kind == BindingKind::Test) {
                     report(Category::Name, name.range, "'" + std::string{name.text} + "' is a test, not a value");
                     return;
                 }
                 result_.bindings[id] = *binding;
             }
 
-            void resolve_qualified(ast::ExprId id, const ast::QualifiedRef &ref)
-            {
-                for (const ModuleAlias &alias : result_.aliases)
-                {
+            void resolve_qualified(ast::ExprId id, const ast::QualifiedRef &ref) {
+                for (const ModuleAlias &alias : result_.aliases) {
                     if (alias.alias != ref.qualifier.text) { continue; }
                     const std::optional<std::string> registry_name = kernel_registry_name(alias.module, ref.name.text);
-                    if (!registry_name)
-                    {
+                    if (!registry_name) {
                         report(Category::Module, ref.name.range,
                                alias.module + " does not export '" + std::string{ref.name.text} + "'");
                         return;
@@ -672,36 +571,28 @@ namespace hgl::semantics
                 report(Category::Name, ref.qualifier.range, "unknown module alias '" + std::string{ref.qualifier.text} + "'");
             }
 
-            [[nodiscard]] const std::vector<ast::GenericParameter> &generics_of(ast::DeclId id) const
-            {
+            [[nodiscard]] const std::vector<ast::GenericParameter> &generics_of(ast::DeclId id) const {
                 const ast::DeclNode &node = module_.decl(id).node;
                 if (const auto *structure = std::get_if<ast::StructDecl>(&node)) { return structure->generics; }
                 if (const auto *fn = std::get_if<ast::FunctionDecl>(&node)) { return fn->generics; }
                 return std::get<ast::OperatorDecl>(node).generics;
             }
 
-            [[nodiscard]] bool is_const_generic(const Binding &binding) const
-            {
+            [[nodiscard]] bool is_const_generic(const Binding &binding) const {
                 return binding.kind == BindingKind::Generic && binding.index < generics_of(binding.decl).size() &&
                        generics_of(binding.decl)[binding.index].is_const;
             }
 
             void resolve_generic_argument(const ast::GenericArgument &argument, const ast::GenericParameter &parameter,
-                                          Context &context)
-            {
-                if (argument.type != ast::no_node)
-                {
+                                          Context &context) {
+                if (argument.type != ast::no_node) {
                     resolve_type(argument.type, context);
-                    if (parameter.is_const)
-                    {
+                    if (parameter.is_const) {
                         report(Category::Type, argument.range,
                                "const generic '" + std::string{parameter.name.text} + "' takes a value argument");
-                    }
-                    else
-                    {
+                    } else {
                         const ast::TypeKind kind = module_.type(argument.type).kind;
-                        if (kind == ast::TypeKind::Atomic || kind == ast::TypeKind::Rolling)
-                        {
+                        if (kind == ast::TypeKind::Atomic || kind == ast::TypeKind::Rolling) {
                             report(Category::Type, argument.range,
                                    "generic struct type arguments are canonical value types; put "
                                    "'atomic' or 'rolling' in the field declaration");
@@ -709,11 +600,9 @@ namespace hgl::semantics
                     }
                     return;
                 }
-                if (argument.value != ast::no_node)
-                {
+                if (argument.value != ast::no_node) {
                     resolve_expr(argument.value, context);
-                    if (!parameter.is_const)
-                    {
+                    if (!parameter.is_const) {
                         report(Category::Type, argument.range,
                                "type generic '" + std::string{parameter.name.text} + "' takes a type argument");
                     }
@@ -721,61 +610,50 @@ namespace hgl::semantics
                 }
 
                 const std::optional<Binding> binding = lookup(argument.name.text);
-                if (!binding)
-                {
+                if (!binding) {
                     report(Category::Type, argument.name.range,
                            "unknown generic argument '" + std::string{argument.name.text} + "'");
                     return;
                 }
-                if (parameter.is_const)
-                {
-                    if (!is_const_generic(*binding))
-                    {
+                if (parameter.is_const) {
+                    if (!is_const_generic(*binding)) {
                         report(Category::Type, argument.name.range,
                                "const generic '" + std::string{parameter.name.text} + "' takes a const value argument");
                     }
                     return;
                 }
-                if (binding->kind == BindingKind::Generic && is_const_generic(*binding))
-                {
+                if (binding->kind == BindingKind::Generic && is_const_generic(*binding)) {
                     report(Category::Type, argument.name.range,
                            "type generic '" + std::string{parameter.name.text} + "' takes a type argument");
-                }
-                else if (binding->kind != BindingKind::Generic && binding->kind != BindingKind::Struct)
-                {
+                } else if (binding->kind != BindingKind::Generic && binding->kind != BindingKind::Struct) {
                     report(Category::Type, argument.name.range, "'" + std::string{argument.name.text} + "' is not a type");
-                }
-                else if (binding->kind == BindingKind::Struct && !generics_of(binding->decl).empty())
-                {
+                } else if (binding->kind == BindingKind::Struct && !generics_of(binding->decl).empty()) {
                     report(Category::Type, argument.name.range,
                            "generic struct '" + std::string{argument.name.text} + "' must be fully applied");
                 }
             }
 
-            [[nodiscard]] std::string expression_key(ast::ExprId id) const
-            {
+            [[nodiscard]] std::string expression_key(ast::ExprId id) const {
                 std::string key{file_.slice(module_.expr(id).range)};
                 key.erase(std::remove_if(key.begin(), key.end(), [](unsigned char c) { return std::isspace(c); }), key.end());
                 return "v:" + key;
             }
 
-            [[nodiscard]] std::string type_key(ast::TypeId id) const
-            {
+            [[nodiscard]] std::string type_key(ast::TypeId id) const {
                 const ast::Type &type = module_.type(id);
                 std::string      key  = "t:" + std::to_string(static_cast<unsigned>(type.kind)) + ':';
                 if (type.kind == ast::TypeKind::Scalar) { return key + std::string{ast::scalar_type_name(type.scalar)}; }
-                if (type.kind == ast::TypeKind::Named)
-                {
+                if (type.kind == ast::TypeKind::Named) {
                     const Binding &binding = result_.type_bindings[id];
                     key += binding.kind == BindingKind::Struct ? "struct:" : "generic:";
                     key += std::to_string(binding.decl) + ':' + std::to_string(binding.index);
-                    for (const ast::GenericArgument &argument : type.arguments)
-                    {
+                    for (const ast::GenericArgument &argument : type.arguments) {
                         key += '<';
-                        if (argument.type != ast::no_node) { key += type_key(argument.type); }
-                        else if (argument.value != ast::no_node) { key += expression_key(argument.value); }
-                        else
-                        {
+                        if (argument.type != ast::no_node) {
+                            key += type_key(argument.type);
+                        } else if (argument.value != ast::no_node) {
+                            key += expression_key(argument.value);
+                        } else {
                             key += "n:" + std::string{argument.name.text};
                         }
                         key += '>';
@@ -789,18 +667,15 @@ namespace hgl::semantics
                 return key;
             }
 
-            [[nodiscard]] std::string generic_argument_key(const ast::GenericArgument &argument) const
-            {
+            [[nodiscard]] std::string generic_argument_key(const ast::GenericArgument &argument) const {
                 if (argument.type != ast::no_node) { return type_key(argument.type); }
                 if (argument.value != ast::no_node) { return expression_key(argument.value); }
                 const std::optional<Binding> binding = lookup(argument.name.text);
-                if (binding && binding->kind == BindingKind::Struct)
-                {
+                if (binding && binding->kind == BindingKind::Struct) {
                     return "t:" + std::to_string(static_cast<unsigned>(ast::TypeKind::Named)) +
                            ":struct:" + std::to_string(binding->decl) + ":0";
                 }
-                if (binding && binding->kind == BindingKind::Generic)
-                {
+                if (binding && binding->kind == BindingKind::Generic) {
                     return "t:" + std::to_string(static_cast<unsigned>(ast::TypeKind::Named)) +
                            ":generic:" + std::to_string(binding->decl) + ':' + std::to_string(binding->index);
                 }
@@ -810,63 +685,51 @@ namespace hgl::semantics
             using ConstraintSubstitution = std::vector<std::pair<std::string_view, std::string>>;
 
             [[nodiscard]] std::optional<std::string> constraint_operand_key(ast::ConstraintId             id,
-                                                                            const ConstraintSubstitution &substitution) const
-            {
+                                                                            const ConstraintSubstitution &substitution) const {
                 const ast::Constraint &constraint = module_.constraint(id);
-                if (const auto *name = std::get_if<ast::ConstraintName>(&constraint.node))
-                {
-                    for (const auto &[parameter, value] : substitution)
-                    {
+                if (const auto *name = std::get_if<ast::ConstraintName>(&constraint.node)) {
+                    for (const auto &[parameter, value] : substitution) {
                         if (parameter == name->name.text) { return value; }
                     }
                     const Binding &binding = result_.constraint_bindings[id];
-                    if (binding.kind == BindingKind::Struct)
-                    {
+                    if (binding.kind == BindingKind::Struct) {
                         return "t:" + std::to_string(static_cast<unsigned>(ast::TypeKind::Named)) +
                                ":struct:" + std::to_string(binding.decl) + ":0";
                     }
                     return std::nullopt;
                 }
                 if (const auto *type = std::get_if<ast::ConstraintType>(&constraint.node)) { return type_key(type->type); }
-                if (const auto *value = std::get_if<ast::ConstraintValue>(&constraint.node))
-                {
+                if (const auto *value = std::get_if<ast::ConstraintValue>(&constraint.node)) {
                     return expression_key(value->value);
                 }
                 return std::nullopt;
             }
 
             [[nodiscard]] std::optional<bool> evaluate_constraint(ast::ConstraintId             id,
-                                                                  const ConstraintSubstitution &substitution) const
-            {
+                                                                  const ConstraintSubstitution &substitution) const {
                 if (id == ast::no_node) { return true; }
                 const ast::Constraint &constraint = module_.constraint(id);
-                if (const auto *relation = std::get_if<ast::ConstraintRelation>(&constraint.node))
-                {
+                if (const auto *relation = std::get_if<ast::ConstraintRelation>(&constraint.node)) {
                     const std::optional<std::string> lhs = constraint_operand_key(relation->lhs, substitution);
                     if (!lhs) { return std::nullopt; }
-                    if (relation->op == ast::ConstraintRelationOp::Is)
-                    {
-                        if (relation->category.text == "struct")
-                        {
+                    if (relation->op == ast::ConstraintRelationOp::Is) {
+                        if (relation->category.text == "struct") {
                             const std::string prefix =
                                 "t:" + std::to_string(static_cast<unsigned>(ast::TypeKind::Named)) + ":struct:";
                             return lhs->starts_with(prefix);
                         }
                         return std::nullopt;
                     }
-                    if (relation->op == ast::ConstraintRelationOp::Equal)
-                    {
+                    if (relation->op == ast::ConstraintRelationOp::Equal) {
                         const std::optional<std::string> rhs = constraint_operand_key(relation->rhs, substitution);
                         return rhs ? std::optional<bool>{*lhs == *rhs} : std::nullopt;
                     }
                     const auto *set = std::get_if<ast::ConstraintSet>(&module_.constraint(relation->rhs).node);
                     if (set == nullptr) { return std::nullopt; }
                     bool complete = true;
-                    for (const ast::ConstraintId element : set->elements)
-                    {
+                    for (const ast::ConstraintId element : set->elements) {
                         const std::optional<std::string> candidate = constraint_operand_key(element, substitution);
-                        if (!candidate)
-                        {
+                        if (!candidate) {
                             complete = false;
                             continue;
                         }
@@ -874,22 +737,17 @@ namespace hgl::semantics
                     }
                     return complete ? std::optional<bool>{false} : std::nullopt;
                 }
-                if (const auto *not_ = std::get_if<ast::ConstraintNot>(&constraint.node))
-                {
+                if (const auto *not_ = std::get_if<ast::ConstraintNot>(&constraint.node)) {
                     const std::optional<bool> value = evaluate_constraint(not_->operand, substitution);
                     return value ? std::optional<bool>{!*value} : std::nullopt;
                 }
-                if (const auto *logic = std::get_if<ast::ConstraintLogic>(&constraint.node))
-                {
+                if (const auto *logic = std::get_if<ast::ConstraintLogic>(&constraint.node)) {
                     const std::optional<bool> lhs = evaluate_constraint(logic->lhs, substitution);
                     const std::optional<bool> rhs = evaluate_constraint(logic->rhs, substitution);
-                    if (logic->op == ast::ConstraintLogicOp::And)
-                    {
+                    if (logic->op == ast::ConstraintLogicOp::And) {
                         if ((lhs && !*lhs) || (rhs && !*rhs)) { return false; }
                         if (lhs && rhs) { return *lhs && *rhs; }
-                    }
-                    else
-                    {
+                    } else {
                         if ((lhs && *lhs) || (rhs && *rhs)) { return true; }
                         if (lhs && rhs) { return *lhs || *rhs; }
                     }
@@ -897,75 +755,61 @@ namespace hgl::semantics
                 return std::nullopt;
             }
 
-            void validate_struct_application(const Binding &binding, const ast::Type &type)
-            {
+            void validate_struct_application(const Binding &binding, const ast::Type &type) {
                 const auto &structure = std::get<ast::StructDecl>(module_.decl(binding.decl).node);
                 if (structure.requirements == ast::no_node || structure.generics.size() != type.arguments.size()) { return; }
                 ConstraintSubstitution substitution;
-                for (std::size_t i = 0; i < structure.generics.size(); ++i)
-                {
+                for (std::size_t i = 0; i < structure.generics.size(); ++i) {
                     substitution.emplace_back(structure.generics[i].name.text, generic_argument_key(type.arguments[i]));
                 }
                 if (const std::optional<bool> accepted = evaluate_constraint(structure.requirements, substitution);
-                    accepted && !*accepted)
-                {
+                    accepted && !*accepted) {
                     report(Category::Type, type.range,
                            "generic struct '" + std::string{structure.name.text} + "' requirements are not satisfied");
                 }
             }
 
-            void resolve_type(ast::TypeId id, Context &context)
-            {
+            void resolve_type(ast::TypeId id, Context &context) {
                 const ast::Type &type = module_.type(id);
-                if (type.value_position && (type.kind == ast::TypeKind::Atomic || type.kind == ast::TypeKind::Rolling))
-                {
+                if (type.value_position && (type.kind == ast::TypeKind::Atomic || type.kind == ast::TypeKind::Rolling)) {
                     report(Category::Type, type.range,
                            std::string{"'"} + (type.kind == ast::TypeKind::Atomic ? "atomic" : "rolling") +
                                "' is a temporal shape, not a canonical value type");
                 }
-                if (type.kind == ast::TypeKind::Named)
-                {
-                    if (!type.qualifier.empty())
-                    {
+                if (type.kind == ast::TypeKind::Named) {
+                    if (!type.qualifier.empty()) {
                         report(Category::Type, type.qualifier.range,
                                "qualified source types require a module descriptor; only local "
                                "struct types are available in this prototype");
                     }
                     const std::optional<Binding> binding = lookup(type.name.text);
-                    if (!binding || (binding->kind != BindingKind::Generic && binding->kind != BindingKind::Struct))
-                    {
+                    if (!binding || (binding->kind != BindingKind::Generic && binding->kind != BindingKind::Struct)) {
                         report(Category::Type, type.name.range, "unknown type '" + std::string{type.name.text} + "'");
-                    }
-                    else
-                    {
+                    } else {
                         result_.type_bindings[id] = *binding;
-                        if (binding->kind == BindingKind::Generic)
-                        {
-                            if (!type.arguments.empty())
-                            {
+                        if (binding->kind == BindingKind::Generic) {
+                            if (!type.arguments.empty()) {
                                 report(Category::Type, type.range, "a type parameter cannot be applied as a generic struct");
                             }
-                        }
-                        else
-                        {
+                        } else {
                             const auto &parameters = generics_of(binding->decl);
-                            if (parameters.size() != type.arguments.size())
-                            {
+                            if (parameters.size() != type.arguments.size()) {
                                 report(Category::Type, type.range,
                                        "generic struct '" + std::string{type.name.text} + "' expects " +
                                            std::to_string(parameters.size()) + " arguments, got " +
                                            std::to_string(type.arguments.size()));
                             }
                             const std::size_t count = std::min(parameters.size(), type.arguments.size());
-                            for (std::size_t i = 0; i < count; ++i)
-                            {
+                            for (std::size_t i = 0; i < count; ++i) {
                                 resolve_generic_argument(type.arguments[i], parameters[i], context);
                             }
-                            for (std::size_t i = count; i < type.arguments.size(); ++i)
-                            {
+                            for (std::size_t i = count; i < type.arguments.size(); ++i) {
                                 const ast::GenericArgument &argument = type.arguments[i];
-                                if (argument.type != ast::no_node) { resolve_type(argument.type, context); }
-                                else if (argument.value != ast::no_node) { resolve_expr(argument.value, context); }
+                                if (argument.type != ast::no_node) {
+                                    resolve_type(argument.type, context);
+                                } else if (argument.value != ast::no_node) {
+                                    resolve_expr(argument.value, context);
+                                }
                             }
                             if (parameters.size() == type.arguments.size()) { validate_struct_application(*binding, type); }
                         }
@@ -976,89 +820,66 @@ namespace hgl::semantics
                 if (type.min_size != ast::no_node) { resolve_expr(type.min_size, context); }
             }
 
-            void resolve_constraint(ast::ConstraintId id, Context &context)
-            {
+            void resolve_constraint(ast::ConstraintId id, Context &context) {
                 if (id == ast::no_node) { return; }
                 const ast::Constraint &constraint = module_.constraint(id);
                 std::visit(
                     [&](const auto &node) {
                         using T = std::decay_t<decltype(node)>;
-                        if constexpr (std::is_same_v<T, ast::ConstraintName>)
-                        {
+                        if constexpr (std::is_same_v<T, ast::ConstraintName>) {
                             const std::optional<Binding> binding = lookup(node.name.text);
                             if (!binding || (binding->kind != BindingKind::Generic && binding->kind != BindingKind::Parameter &&
-                                             binding->kind != BindingKind::Struct))
-                            {
+                                             binding->kind != BindingKind::Struct)) {
                                 report(Category::Name, node.name.range,
                                        "unknown constraint name '" + std::string{node.name.text} + "'");
-                            }
-                            else
-                            {
+                            } else {
                                 result_.constraint_bindings[id] = *binding;
                             }
-                        }
-                        else if constexpr (std::is_same_v<T, ast::ConstraintType>) { resolve_type(node.type, context); }
-                        else if constexpr (std::is_same_v<T, ast::ConstraintValue>) { resolve_expr(node.value, context); }
-                        else if constexpr (std::is_same_v<T, ast::ConstraintSet>)
-                        {
+                        } else if constexpr (std::is_same_v<T, ast::ConstraintType>) {
+                            resolve_type(node.type, context);
+                        } else if constexpr (std::is_same_v<T, ast::ConstraintValue>) {
+                            resolve_expr(node.value, context);
+                        } else if constexpr (std::is_same_v<T, ast::ConstraintSet>) {
                             for (const ast::ConstraintId element : node.elements) { resolve_constraint(element, context); }
-                        }
-                        else if constexpr (std::is_same_v<T, ast::ConstraintCall>)
-                        {
+                        } else if constexpr (std::is_same_v<T, ast::ConstraintCall>) {
                             if (!node.qualifier.empty() ||
                                 (node.name.text != "fields" && node.name.text != "has_fields" && node.name.text != "field_type" &&
-                                 node.name.text != "schema" && node.name.text != "keys"))
-                            {
+                                 node.name.text != "schema" && node.name.text != "keys")) {
                                 report(Category::Type, constraint.range,
                                        "'" + std::string{node.name.text} + "' is not a compile-time reflection function");
-                            }
-                            else
-                            {
+                            } else {
                                 Binding binding;
                                 binding.kind                    = BindingKind::Intrinsic;
                                 binding.registry_name           = std::string{node.name.text};
                                 result_.constraint_bindings[id] = std::move(binding);
                             }
                             for (const ast::ConstraintId argument : node.arguments) { resolve_constraint(argument, context); }
-                        }
-                        else if constexpr (std::is_same_v<T, ast::OperatorRequirement>)
-                        {
+                        } else if constexpr (std::is_same_v<T, ast::OperatorRequirement>) {
                             Binding binding;
-                            if (node.qualifier.empty())
-                            {
+                            if (node.qualifier.empty()) {
                                 const std::optional<Binding> found = lookup(node.name.text);
-                                if (found && (found->kind == BindingKind::Operator || found->kind == BindingKind::LocalOperator))
-                                {
+                                if (found && (found->kind == BindingKind::Operator || found->kind == BindingKind::LocalOperator)) {
                                     binding = *found;
-                                }
-                                else
-                                {
+                                } else {
                                     report(Category::Name, node.name.range,
                                            "operator requirement names no operator '" + std::string{node.name.text} + "'");
                                 }
-                            }
-                            else
-                            {
+                            } else {
                                 bool found_alias = false;
-                                for (const ModuleAlias &alias : result_.aliases)
-                                {
+                                for (const ModuleAlias &alias : result_.aliases) {
                                     if (alias.alias != node.qualifier.text) { continue; }
                                     found_alias                           = true;
                                     const std::optional<std::string> name = kernel_registry_name(alias.module, node.name.text);
-                                    if (!name)
-                                    {
+                                    if (!name) {
                                         report(Category::Module, node.name.range,
                                                alias.module + " does not export '" + std::string{node.name.text} + "'");
-                                    }
-                                    else
-                                    {
+                                    } else {
                                         binding.kind          = BindingKind::Operator;
                                         binding.registry_name = *name;
                                     }
                                     break;
                                 }
-                                if (!found_alias)
-                                {
+                                if (!found_alias) {
                                     report(Category::Name, node.qualifier.range,
                                            "unknown module alias '" + std::string{node.qualifier.text} + "'");
                                 }
@@ -1066,26 +887,19 @@ namespace hgl::semantics
                             result_.constraint_bindings[id] = std::move(binding);
                             for (const ast::ConstraintId argument : node.arguments) { resolve_constraint(argument, context); }
                             if (node.result != ast::no_node) { resolve_type(node.result, context); }
-                        }
-                        else if constexpr (std::is_same_v<T, ast::ConstraintRelation>)
-                        {
+                        } else if constexpr (std::is_same_v<T, ast::ConstraintRelation>) {
                             resolve_constraint(node.lhs, context);
-                            if (node.op == ast::ConstraintRelationOp::Is)
-                            {
-                                if (node.category.text != "struct")
-                                {
+                            if (node.op == ast::ConstraintRelationOp::Is) {
+                                if (node.category.text != "struct") {
                                     report(Category::Type, node.category.range,
                                            "unknown type category '" + std::string{node.category.text} + "'");
                                 }
-                            }
-                            else
-                            {
+                            } else {
                                 resolve_constraint(node.rhs, context);
                             }
-                        }
-                        else if constexpr (std::is_same_v<T, ast::ConstraintNot>) { resolve_constraint(node.operand, context); }
-                        else if constexpr (std::is_same_v<T, ast::ConstraintLogic>)
-                        {
+                        } else if constexpr (std::is_same_v<T, ast::ConstraintNot>) {
+                            resolve_constraint(node.operand, context);
+                        } else if constexpr (std::is_same_v<T, ast::ConstraintLogic>) {
                             resolve_constraint(node.lhs, context);
                             resolve_constraint(node.rhs, context);
                         }
@@ -1095,34 +909,29 @@ namespace hgl::semantics
 
             // ---------------------------------------------------- structures
 
-            [[nodiscard]] bool is_null(ast::ExprId id) const noexcept
-            { return id != ast::no_node && std::holds_alternative<ast::NullLiteral>(module_.expr(id).node); }
+            [[nodiscard]] bool is_null(ast::ExprId id) const noexcept {
+                return id != ast::no_node && std::holds_alternative<ast::NullLiteral>(module_.expr(id).node);
+            }
 
-            [[nodiscard]] bool contains_struct(ast::TypeId id, ast::DeclId target) const
-            {
+            [[nodiscard]] bool contains_struct(ast::TypeId id, ast::DeclId target) const {
                 const ast::Type &type = module_.type(id);
                 if (type.kind == ast::TypeKind::Named && result_.type_bindings[id].kind == BindingKind::Struct &&
-                    result_.type_bindings[id].decl == target)
-                {
+                    result_.type_bindings[id].decl == target) {
                     return true;
                 }
-                for (const ast::TypeId child : type.children)
-                {
+                for (const ast::TypeId child : type.children) {
                     if (contains_struct(child, target)) { return true; }
                 }
-                for (const ast::GenericArgument &argument : type.arguments)
-                {
+                for (const ast::GenericArgument &argument : type.arguments) {
                     if (argument.type != ast::no_node && contains_struct(argument.type, target)) { return true; }
                 }
                 return false;
             }
 
-            bool validate_struct(ast::DeclId id)
-            {
+            bool validate_struct(ast::DeclId id) {
                 if (struct_states_[id] == 2) { return result_.struct_info[id].valid; }
                 const auto &structure = std::get<ast::StructDecl>(module_.decl(id).node);
-                if (struct_states_[id] == 1)
-                {
+                if (struct_states_[id] == 1) {
                     report(Category::Type, structure.name.range,
                            "struct inheritance cycle reaches '" + std::string{structure.name.text} + "'");
                     return false;
@@ -1131,24 +940,20 @@ namespace hgl::semantics
                 bool        valid  = true;
                 StructInfo &info   = result_.struct_info[id];
 
-                if (structure.parents.size() > 1)
-                {
+                if (structure.parents.size() > 1) {
                     report(Category::Type, structure.name.range,
                            "multiple abstract parents are parsed, but lowering awaits the "
                            "stable field-order rule");
                     valid = false;
                 }
-                for (const ast::TypeId parent_type : structure.parents)
-                {
+                for (const ast::TypeId parent_type : structure.parents) {
                     const Binding &binding = result_.type_bindings[parent_type];
-                    if (binding.kind != BindingKind::Struct)
-                    {
+                    if (binding.kind != BindingKind::Struct) {
                         valid = false;
                         continue;
                     }
                     const auto &parent = std::get<ast::StructDecl>(module_.decl(binding.decl).node);
-                    if (!parent.abstract)
-                    {
+                    if (!parent.abstract) {
                         report(Category::Type, module_.type(parent_type).range,
                                "only an abstract struct may be inherited; '" + std::string{parent.name.text} +
                                    "' is concrete and implicitly final");
@@ -1162,15 +967,12 @@ namespace hgl::semantics
 
                 std::vector<std::string_view> local_names;
                 std::vector<std::string_view> overridden;
-                for (const ast::StructMember &member : structure.members)
-                {
+                for (const ast::StructMember &member : structure.members) {
                     std::visit(
                         [&](const auto &item) {
                             using T = std::decay_t<decltype(item)>;
-                            if constexpr (std::is_same_v<T, ast::StructField>)
-                            {
-                                if (std::find(local_names.begin(), local_names.end(), item.name.text) != local_names.end())
-                                {
+                            if constexpr (std::is_same_v<T, ast::StructField>) {
+                                if (std::find(local_names.begin(), local_names.end(), item.name.text) != local_names.end()) {
                                     report(Category::Name, item.name.range,
                                            "struct field '" + std::string{item.name.text} + "' is declared twice");
                                     valid = false;
@@ -1180,8 +982,7 @@ namespace hgl::semantics
                                 const auto inherited =
                                     std::find_if(info.fields.begin(), info.fields.end(),
                                                  [&](const StructField &field) { return field.name == item.name.text; });
-                                if (inherited != info.fields.end())
-                                {
+                                if (inherited != info.fields.end()) {
                                     report(Category::Type, item.name.range,
                                            "inherited field '" + std::string{item.name.text} +
                                                "' cannot be redeclared with a type; override only "
@@ -1189,8 +990,7 @@ namespace hgl::semantics
                                     valid = false;
                                     return;
                                 }
-                                if (contains_struct(item.type, id))
-                                {
+                                if (contains_struct(item.type, id)) {
                                     report(Category::Type, module_.type(item.type).range,
                                            "self-recursive struct fields are not supported in this "
                                            "prototype");
@@ -1198,11 +998,8 @@ namespace hgl::semantics
                                 }
                                 info.fields.push_back(StructField{std::string{item.name.text}, item.type, item.default_value, id,
                                                                   is_null(item.default_value)});
-                            }
-                            else
-                            {
-                                if (std::find(overridden.begin(), overridden.end(), item.name.text) != overridden.end())
-                                {
+                            } else {
+                                if (std::find(overridden.begin(), overridden.end(), item.name.text) != overridden.end()) {
                                     report(Category::Name, item.name.range,
                                            "inherited default '" + std::string{item.name.text} + "' is set twice");
                                     valid = false;
@@ -1212,15 +1009,13 @@ namespace hgl::semantics
                                 const auto inherited =
                                     std::find_if(info.fields.begin(), info.fields.end(),
                                                  [&](const StructField &field) { return field.name == item.name.text; });
-                                if (inherited == info.fields.end())
-                                {
+                                if (inherited == info.fields.end()) {
                                     report(Category::Type, item.name.range,
                                            "default override names no inherited field '" + std::string{item.name.text} + "'");
                                     valid = false;
                                     return;
                                 }
-                                if (is_null(item.value) && !inherited->optional)
-                                {
+                                if (is_null(item.value) && !inherited->optional) {
                                     report(Category::Type, module_.expr(item.value).range,
                                            "only an optional inherited field may have a null default");
                                     valid = false;
@@ -1236,78 +1031,63 @@ namespace hgl::semantics
                 return valid;
             }
 
-            void validate_structs()
-            {
+            void validate_structs() {
                 struct_states_.assign(module_.decls.size(), 0);
                 for (const ast::DeclId id : result_.structs) { (void)validate_struct(id); }
             }
 
-            void validate_constructor(ast::DeclId decl, const std::vector<ast::Argument> &arguments, bool delta, SourceRange range)
-            {
+            void validate_constructor(ast::DeclId decl, const std::vector<ast::Argument> &arguments, bool delta,
+                                      SourceRange range) {
                 const auto       &structure = std::get<ast::StructDecl>(module_.decl(decl).node);
                 const StructInfo &info      = result_.struct_info[decl];
                 if (!info.valid) { return; }
-                if (structure.abstract)
-                {
+                if (structure.abstract) {
                     report(Category::Type, range,
                            "abstract struct '" + std::string{structure.name.text} + "' is not constructible");
                     return;
                 }
                 std::vector<bool> supplied(info.fields.size(), false);
-                for (const ast::Argument &argument : arguments)
-                {
+                for (const ast::Argument &argument : arguments) {
                     if (argument.name.empty()) { continue; }
                     const auto found = std::find_if(info.fields.begin(), info.fields.end(),
                                                     [&](const StructField &field) { return field.name == argument.name.text; });
-                    if (found == info.fields.end())
-                    {
+                    if (found == info.fields.end()) {
                         report(Category::Name, argument.name.range,
                                "struct '" + std::string{structure.name.text} + "' has no field named '" +
                                    std::string{argument.name.text} + "'");
                         continue;
                     }
                     const auto index = static_cast<std::size_t>(found - info.fields.begin());
-                    if (supplied[index])
-                    {
+                    if (supplied[index]) {
                         report(Category::Name, argument.name.range,
                                "field '" + std::string{argument.name.text} + "' is given twice");
                     }
                     supplied[index] = true;
-                    if (is_null(argument.value) && !found->optional)
-                    {
+                    if (is_null(argument.value) && !found->optional) {
                         report(Category::Type, module_.expr(argument.value).range,
                                "required field '" + found->name + "' cannot be null");
                     }
                 }
                 if (delta) { return; }
-                for (std::size_t i = 0; i < info.fields.size(); ++i)
-                {
-                    if (!supplied[i] && info.fields[i].default_value == ast::no_node && !info.fields[i].optional)
-                    {
+                for (std::size_t i = 0; i < info.fields.size(); ++i) {
+                    if (!supplied[i] && info.fields[i].default_value == ast::no_node && !info.fields[i].optional) {
                         report(Category::Type, range,
                                "struct '" + std::string{structure.name.text} + "' needs field '" + info.fields[i].name + "'");
                     }
                 }
             }
 
-            void validate_constructors()
-            {
-                for (ast::ExprId id = 0; id < module_.exprs.size(); ++id)
-                {
+            void validate_constructors() {
+                for (ast::ExprId id = 0; id < module_.exprs.size(); ++id) {
                     const ast::Expr &expr = module_.expr(id);
-                    if (const auto *construct = std::get_if<ast::Construct>(&expr.node))
-                    {
+                    if (const auto *construct = std::get_if<ast::Construct>(&expr.node)) {
                         const Binding &binding = result_.type_bindings[construct->type];
-                        if (binding.kind == BindingKind::Struct)
-                        {
+                        if (binding.kind == BindingKind::Struct) {
                             validate_constructor(binding.decl, construct->arguments, construct->delta, expr.range);
                         }
-                    }
-                    else if (const auto *call = std::get_if<ast::Call>(&expr.node))
-                    {
+                    } else if (const auto *call = std::get_if<ast::Call>(&expr.node)) {
                         const Binding &binding = result_.bindings[call->callee];
-                        if (binding.kind == BindingKind::Struct)
-                        {
+                        if (binding.kind == BindingKind::Struct) {
                             validate_constructor(binding.decl, call->arguments, false, expr.range);
                         }
                     }
@@ -1319,14 +1099,11 @@ namespace hgl::semantics
             void push_scope() { scopes_.push_back(Scope{}); }
             void pop_scope() { scopes_.pop_back(); }
 
-            void declare(const ast::Name &name, Binding binding, std::string_view where)
-            {
+            void declare(const ast::Name &name, Binding binding, std::string_view where) {
                 if (name.empty()) { return; }
                 Scope &scope = scopes_.back();
-                for (const auto &[existing, _] : scope.names)
-                {
-                    if (existing == name.text)
-                    {
+                for (const auto &[existing, _] : scope.names) {
+                    if (existing == name.text) {
                         report(Category::Name, name.range,
                                "'" + std::string{name.text} + "' is declared twice " + std::string{where});
                         return;
@@ -1335,20 +1112,16 @@ namespace hgl::semantics
                 scope.names.emplace_back(name.text, std::move(binding));
             }
 
-            [[nodiscard]] std::optional<Binding> lookup(std::string_view name) const
-            {
-                for (auto scope = scopes_.rbegin(); scope != scopes_.rend(); ++scope)
-                {
-                    for (auto entry = scope->names.rbegin(); entry != scope->names.rend(); ++entry)
-                    {
+            [[nodiscard]] std::optional<Binding> lookup(std::string_view name) const {
+                for (auto scope = scopes_.rbegin(); scope != scopes_.rend(); ++scope) {
+                    for (auto entry = scope->names.rbegin(); entry != scope->names.rend(); ++entry) {
                         if (entry->first == name) { return entry->second; }
                     }
                 }
                 return std::nullopt;
             }
 
-            void report(Category category, SourceRange range, std::string message)
-            {
+            void report(Category category, SourceRange range, std::string message) {
                 diagnostics_.report(category, range, std::move(message));
             }
 
@@ -1362,18 +1135,15 @@ namespace hgl::semantics
         };
     }  // namespace
 
-    bool is_intrinsic(std::string_view name) noexcept
-    {
-        for (const std::string_view intrinsic : intrinsics)
-        {
+    bool is_intrinsic(std::string_view name) noexcept {
+        for (const std::string_view intrinsic : intrinsics) {
             if (intrinsic == name) { return true; }
         }
         return false;
     }
 
     ResolvedModule resolve(const syntax::SourceFile &file, const ast::Module &module, const OperatorLookup &has_operator,
-                           syntax::DiagnosticSink &diagnostics)
-    {
+                           syntax::DiagnosticSink &diagnostics) {
         return Resolver{file, module, has_operator, diagnostics}.run();
     }
 }  // namespace hgl::semantics

--- a/language/tests/semantics/resolve_tests.cpp
+++ b/language/tests/semantics/resolve_tests.cpp
@@ -19,14 +19,10 @@ namespace
     // a table so they stay hgraph-free (developer guide, "Frontend
     // components").
     const std::vector<std::string_view> registry{
-        "add_", "div_", "map_", "keys_", "valid", "modified", "mean", "if_then_else", "schedule",
-        "hgraph.analytics.rolling_mean",
+        "add_", "div_", "map_", "keys_", "valid", "modified", "mean", "if_then_else", "schedule", "hgraph.analytics.rolling_mean",
     };
 
-    bool table_lookup(std::string_view name)
-    {
-        return std::find(registry.begin(), registry.end(), name) != registry.end();
-    }
+    bool table_lookup(std::string_view name) { return std::find(registry.begin(), registry.end(), name) != registry.end(); }
 
     struct Resolved
     {
@@ -37,44 +33,34 @@ namespace
 
         explicit Resolved(std::string text)
             : file{"test.hgl", std::move(text)}, module{parse(file, diagnostics)},
-              result{resolve(file, module, table_lookup, diagnostics)}
-        {
-        }
+              result{resolve(file, module, table_lookup, diagnostics)} {}
 
-        [[nodiscard]] std::vector<std::string> messages() const
-        {
+        [[nodiscard]] std::vector<std::string> messages() const {
             std::vector<std::string> out;
             for (const Diagnostic &diagnostic : diagnostics.diagnostics()) { out.push_back(diagnostic.message); }
             return out;
         }
 
-        [[nodiscard]] bool has(Category category, std::string_view fragment) const
-        {
-            return std::any_of(diagnostics.diagnostics().begin(), diagnostics.diagnostics().end(),
-                               [&](const Diagnostic &d) {
-                                   return d.category == category && d.message.find(fragment) != std::string::npos;
-                               });
+        [[nodiscard]] bool has(Category category, std::string_view fragment) const {
+            return std::any_of(diagnostics.diagnostics().begin(), diagnostics.diagnostics().end(), [&](const Diagnostic &d) {
+                return d.category == category && d.message.find(fragment) != std::string::npos;
+            });
         }
 
         // The binding of the first (possibly qualified) name spelled `text`.
-        [[nodiscard]] const Binding *binding_of(std::string_view text) const
-        {
-            for (ast::ExprId id = 0; id < module.exprs.size(); ++id)
-            {
+        [[nodiscard]] const Binding *binding_of(std::string_view text) const {
+            for (ast::ExprId id = 0; id < module.exprs.size(); ++id) {
                 const auto *name      = std::get_if<ast::NameRef>(&module.expr(id).node);
                 const auto *qualified = std::get_if<ast::QualifiedRef>(&module.expr(id).node);
-                if ((name != nullptr && name->name.text == text) || (qualified != nullptr && qualified->name.text == text))
-                {
+                if ((name != nullptr && name->name.text == text) || (qualified != nullptr && qualified->name.text == text)) {
                     return &result.binding(id);
                 }
             }
             return nullptr;
         }
 
-        [[nodiscard]] const ast::FunctionDecl &function(std::string_view text) const
-        {
-            for (const ast::DeclId id : result.functions)
-            {
+        [[nodiscard]] const ast::FunctionDecl &function(std::string_view text) const {
+            for (const ast::DeclId id : result.functions) {
                 const auto &fn = std::get<ast::FunctionDecl>(module.decl(id).node);
                 if (fn.name.text == text) { return fn; }
             }
@@ -82,20 +68,16 @@ namespace
             throw 0;
         }
 
-        [[nodiscard]] FunctionKind kind_of(std::string_view text) const
-        {
-            for (const ast::DeclId id : result.functions)
-            {
+        [[nodiscard]] FunctionKind kind_of(std::string_view text) const {
+            for (const ast::DeclId id : result.functions) {
                 if (std::get<ast::FunctionDecl>(module.decl(id).node).name.text == text) { return result.kind(id); }
             }
             FAIL("no function " << text);
             throw 0;
         }
 
-        [[nodiscard]] ast::DeclId struct_id(std::string_view text) const
-        {
-            for (const ast::DeclId id : result.structs)
-            {
+        [[nodiscard]] ast::DeclId struct_id(std::string_view text) const {
+            for (const ast::DeclId id : result.structs) {
                 if (std::get<ast::StructDecl>(module.decl(id).node).name.text == text) { return id; }
             }
             FAIL("no struct " << text);
@@ -103,8 +85,7 @@ namespace
         }
     };
 
-    Resolved resolve_clean(std::string text)
-    {
+    Resolved resolve_clean(std::string text) {
         Resolved resolved{std::move(text)};
         INFO(resolved.diagnostics.render(resolved.file));
         REQUIRE_FALSE(resolved.diagnostics.has_errors());
@@ -112,8 +93,7 @@ namespace
     }
 }  // namespace
 
-TEST_CASE("kernel imports bind to registry names", "[semantics]")
-{
+TEST_CASE("kernel imports bind to registry names", "[semantics]") {
     const Resolved resolved = resolve_clean(R"(
 module t
 
@@ -135,16 +115,14 @@ fn f(x: f64) -> f64 => std::add(x, 1.0)
     CHECK(resolved.result.aliases[0].module == "hgraph.std");
 }
 
-TEST_CASE("only the kernel modules link in the first pass", "[semantics]")
-{
+TEST_CASE("only the kernel modules link in the first pass", "[semantics]") {
     const Resolved resolved{"module t\n\nuse market.pricing::{value}\nuse "
                             "hgraph.std::{nothing_like_this}\n"};
     CHECK(resolved.has(Category::Module, "module 'market.pricing' is not available"));
     CHECK(resolved.has(Category::Module, "hgraph.std does not export 'nothing_like_this'"));
 }
 
-TEST_CASE("names resolve through the scope chain", "[semantics]")
-{
+TEST_CASE("names resolve through the scope chain", "[semantics]") {
     const Resolved resolved = resolve_clean(R"(
 module t
 
@@ -169,8 +147,7 @@ fn f(y: f64, const k: i64 = 2) -> f64 {
     CHECK_FALSE(is_intrinsic("helper"));
 }
 
-TEST_CASE("an import shadows an intrinsic and a parameter shadows both", "[semantics]")
-{
+TEST_CASE("an import shadows an intrinsic and a parameter shadows both", "[semantics]") {
     const Resolved resolved = resolve_clean(R"(
 module t
 
@@ -184,8 +161,7 @@ fn g(x: f64) -> f64 => valid(x)
     CHECK(resolved.binding_of("valid")->kind == BindingKind::Operator);
 }
 
-TEST_CASE("unknown names and misuse are reported", "[semantics]")
-{
+TEST_CASE("unknown names and misuse are reported", "[semantics]") {
     const Resolved resolved{R"(
 module t
 
@@ -206,8 +182,7 @@ test t {
     CHECK(resolved.has(Category::Type, "'_' is only valid in a harness sequence"));
 }
 
-TEST_CASE("functions classify from their statement forms", "[semantics]")
-{
+TEST_CASE("functions classify from their statement forms", "[semantics]") {
     const Resolved resolved = resolve_clean(R"(
 module t
 
@@ -232,8 +207,7 @@ fn lifecycle(x: f64) -> f64 {
     CHECK(resolved.result.functions.size() == 3);
 }
 
-TEST_CASE("implementations bind to an operator in scope", "[semantics]")
-{
+TEST_CASE("implementations bind to an operator in scope", "[semantics]") {
     const Resolved bound = resolve_clean(R"(
 module t
 
@@ -251,8 +225,7 @@ impl fn valid(x: f64) -> bool => true
     CHECK(clash.has(Category::Name, "'fn valid' conflicts with operator hgraph.std::valid"));
 }
 
-TEST_CASE("tests are declarations, not values", "[semantics]")
-{
+TEST_CASE("tests are declarations, not values", "[semantics]") {
     const Resolved resolved{R"(
 module t
 
@@ -268,8 +241,7 @@ fn g(x: f64) -> f64 => check_f
     CHECK(resolved.has(Category::Name, "'check_f' is a test, not a value"));
 }
 
-TEST_CASE("struct hierarchy resolves effective fields and defaults", "[semantics]")
-{
+TEST_CASE("struct hierarchy resolves effective fields and defaults", "[semantics]") {
     const Resolved    resolved   = resolve_clean(R"(
 module t
 
@@ -301,42 +273,35 @@ fn make() -> atomic<Future> => Future(symbol: "F", expiry: @2026-12-18)
     CHECK(fields[3].name == "expiry");
 }
 
-TEST_CASE("struct hierarchy rejects unsafe inheritance", "[semantics]")
-{
-    SECTION("concrete parents are final")
-    {
+TEST_CASE("struct hierarchy rejects unsafe inheritance", "[semantics]") {
+    SECTION("concrete parents are final") {
         const Resolved resolved{"module t\nstruct Base {}\nstruct Child: Base {}\n"};
         CHECK(resolved.has(Category::Type, "only an abstract struct may be inherited"));
     }
-    SECTION("inherited field types cannot be redeclared")
-    {
+    SECTION("inherited field types cannot be redeclared") {
         const Resolved resolved{"module t\nabstract struct Base { value: f64 "
                                 "}\nstruct Child: Base { value: i64 }\n"};
         CHECK(resolved.has(Category::Type, "cannot be redeclared with a type"));
     }
-    SECTION("required fields cannot become optional")
-    {
+    SECTION("required fields cannot become optional") {
         const Resolved resolved{"module t\nabstract struct Base { value: f64 "
                                 "}\nstruct Child: Base { value = null }\n"};
         CHECK(resolved.has(Category::Type, "only an optional inherited field may have a null default"));
     }
-    SECTION("self recursion and inheritance cycles are rejected")
-    {
+    SECTION("self recursion and inheritance cycles are rejected") {
         const Resolved recursive{"module t\nstruct Node { next: Node }\n"};
         CHECK(recursive.has(Category::Type, "self-recursive struct fields are not supported"));
         const Resolved cycle{"module t\nabstract struct A: B {}\nabstract struct B: A {}\n"};
         CHECK(cycle.has(Category::Type, "struct inheritance cycle reaches"));
     }
-    SECTION("multiple parent order fails closed")
-    {
+    SECTION("multiple parent order fails closed") {
         const Resolved resolved{"module t\nabstract struct A {}\nabstract struct B "
                                 "{}\nstruct C: A, B {}\n"};
         CHECK(resolved.has(Category::Type, "awaits the stable field-order rule"));
     }
 }
 
-TEST_CASE("generic structs validate applications and decidable requirements", "[semantics]")
-{
+TEST_CASE("generic structs validate applications and decidable requirements", "[semantics]") {
     const Resolved valid = resolve_clean(R"(
 module t
 
@@ -378,8 +343,7 @@ fn bad(x: Box<atomic<f64>>) => x
     CHECK(temporal_argument.has(Category::Type, "generic struct type arguments are canonical value types"));
 }
 
-TEST_CASE("requires clauses bind reflection and nominal operators", "[semantics]")
-{
+TEST_CASE("requires clauses bind reflection and nominal operators", "[semantics]") {
     const Resolved resolved = resolve_clean(R"(
 module t
 use hgraph.std as std
@@ -402,8 +366,7 @@ fn f<T>(x: T) -> T requires T is class && mystery(T) { x }
     CHECK(bad.has(Category::Type, "is not a compile-time reflection function"));
 }
 
-TEST_CASE("struct construction enforces complete and sparse forms", "[semantics]")
-{
+TEST_CASE("struct construction enforces complete and sparse forms", "[semantics]") {
     const Resolved valid = resolve_clean(R"(
 module t
 struct Quote {
@@ -439,15 +402,13 @@ fn abstract_value() => Base(id: 1)
     CHECK(invalid.has(Category::Type, "abstract struct 'Base' is not constructible"));
 }
 
-TEST_CASE("every guide example resolves", "[semantics]")
-{
+TEST_CASE("every guide example resolves", "[semantics]") {
     // The examples exercise generics, inject, impl fn, and the intrinsics;
     // the resolver must accept them all (the backend limits what runs).
     const std::vector<std::string_view> names{
         "collection-views", "midpoint", "operators-and-generics", "runtime-choice", "stateful-node", "structural-types",
     };
-    for (const std::string_view name : names)
-    {
+    for (const std::string_view name : names) {
         const std::string path = std::string{HGL_EXAMPLES_DIR} + "/" + std::string{name} + ".hgl";
         std::ifstream     in{path};
         REQUIRE(in.is_open());


### PR DESCRIPTION
## Summary

- apply the repository clang-format policy to the semantic resolver
- format its focused Catch2 test translation unit at the same boundary
- make the following typed-HIR ownership change reviewable without a mechanical diff

This is a mechanical-only parent in the HGL stacked PR series; it does not change resolver behavior.

## Validation

- fresh warnings-as-errors build of `hgl_semantics_tests`
- `hgl_semantics_tests`: 88 assertions, 14 test cases passed
- `git diff --check`