### PR TITLE
feat(language): validate constrained struct types

### DIFF
--- a/language/README.md
+++ b/language/README.md
@@ -40,8 +40,8 @@ optionally, a Python extension module with generated wrappers. Every file under
 fixtures compile and execute generated graph and runtime-node modules.
 
 Portable runtime-module loading, multi-registry module transactions,
-constructor inference, typed `const` arguments in native generic Bundle
-identity, multiple-parent field order, explicit optional-field clearing,
+typed `const` arguments in native generic Bundle identity, multiple-parent
+field order, explicit optional-field clearing,
 general runtime calls and non-scalar state, timed harness sequences, and TOML
 run configuration remain staged work
 ([roadmap](docs/design/roadmap.md)).

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -111,11 +111,10 @@ Local implementations are checked against, and inherit requirements from,
 their local operator contract.
 
 The remaining work in this stage is imported operator-contract conformance,
-arbitrary residual `const` predicates, validation of constrained generic-struct
-applications outside construction sites, public native nominal-struct
-metadata, and registry-backed completion for operation forms retained as
-explicit deferred nominal calls. Those cases fail closed or remain explicitly
-deferred; the temporary AST backends never silently discard a constraint.
+arbitrary residual `const` predicates, public native nominal-struct metadata,
+and registry-backed completion for operation forms retained as explicit
+deferred nominal calls. Those cases fail closed or remain explicitly deferred;
+the temporary AST backends never silently discard a constraint.
 
 - introduce stable symbol and declaration identities, canonical types, complete
   substitutions, typed constants, function kinds, phases, effects, and source

--- a/language/docs/developer-guide/README.md
+++ b/language/docs/developer-guide/README.md
@@ -9,12 +9,13 @@ for hgraph, not a second runtime.
 > [Syntax and semantics](syntax-and-semantics.md), including `requires`,
 > nominal and generic `struct`, abstract-only inheritance, `null`, and
 > structured `delta` forms. `src/semantics/` binds constraint names, resolves
-> struct families and effective fields, validates hierarchy and construction,
-> rejects decidably false closed requirements, and classifies functions.
+> struct families and effective fields, validates hierarchy and generic
+> argument roles, and classifies functions.
 > `src/ir/` now lowers every resolved guide example into a source-ranged HIR
-> arena with stable declaration and symbol identities; its explicit completion
-> state is still `Resolved`, pending canonical type, substitution, phase, and
-> effect completion.
+> arena with stable declaration and symbol identities, then completes canonical
+> types, substitutions, constraints, calls, phases, effects, and capabilities.
+> It validates constrained generic structs in every type position and leaves a
+> failed module explicitly `Resolved` rather than claiming `Typed` completion.
 > `src/wiring/` executes the composition subset for `test`, `run`, and the
 > REPL, including scalar and atomic struct values, type-only generic
 > specializations, and field-wise temporal struct composition. `src/codegen/`
@@ -24,9 +25,9 @@ for hgraph, not a second runtime.
 > logger injection, and lifecycle hooks over state and `const` configuration.
 > The driver compiles and caches/loads that subset for file-based `test`, `run`, and REPL sessions on
 > Unix. REPL replacement stages the new image, swaps removable provider handles
-> at a quiescent boundary, and restores the old revision if activation fails. Typed-HIR
-> completion, constructor inference, `const` generic metadata, multiple-parent
-> linearization, explicit optional-field
+> at a quiescent boundary, and restores the old revision if activation fails.
+> Imported operator-contract conformance, residual `const` predicates, `const`
+> generic native metadata, multiple-parent linearization, explicit optional-field
 > clearing, multi-registry module transactions, and the remaining runtime and
 > generated-C++ type support remain to be implemented.
 

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -159,12 +159,18 @@ the goal on every branch, and a narrower closed set implies a wider one. This
 is compile-time implication only; no requirement becomes a per-tick runtime
 test.
 
-Residual arbitrary constant predicates, imported-contract conformance,
-constrained generic-struct applications outside construction sites, and native
-nominal-struct reflection still need descriptor support. A dependency cycle,
-an unavailable native shape, or any other unresolved requirement reports a
-type diagnostic and leaves the module `Resolved`; it is never discarded by a
-temporary backend.
+Every source type occurrence records its containing declaration until
+canonicalization. Typed HIR uses that ownership to validate a constrained
+generic-struct application in signatures, fields, parents, locals, state,
+constraints, and construction syntax under the containing declaration's proof
+premises. Canonical types remain context-neutral. The resolved-AST pass checks
+names and generic argument roles, but no longer owns constraint evaluation.
+
+Residual arbitrary constant predicates, imported-contract conformance, and
+native nominal-struct reflection still need descriptor support. A dependency
+cycle, an unavailable native shape, or any other unresolved requirement
+reports a type diagnostic and leaves the module `Resolved`; it is never
+discarded by a temporary backend.
 
 The direct-wiring and C++ backends still walk `ResolvedModule` beside typed HIR
 during migration. That adapter path is explicitly temporary; hgraph semantic

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -268,11 +268,13 @@ The current typed-HIR suite covers closed-set admission and rejection,
 fixed-point field-type inference from a `const` field name, inherited field
 reflection, Boolean alternatives and negation, unresolved dependencies,
 generic struct construction, declaration requirements used as premises for
-nested constrained calls, rejection of a premise that is too broad, local
-operator viability, inherited contract requirements, and a native
-registry-backed operator requirement. Remaining tests in this list become
-gates as the descriptor and hgraph-IR boundaries are implemented; the guide
-must not imply they already pass.
+nested constrained calls, rejection of a premise that is too broad,
+constrained-struct applications in signatures and fields, generic applications
+admitted by their containing declaration, rejection when that premise is
+missing, local operator viability, inherited contract requirements, and a
+native registry-backed operator requirement. Remaining tests in this list
+become gates as the descriptor and hgraph-IR boundaries are implemented; the
+guide must not imply they already pass.
 
 When open structural patterns are implemented, test that required fields bind
 their types, additional fields remain admissible, a more constrained pattern

--- a/language/docs/user-guide/types-and-expressions.md
+++ b/language/docs/user-guide/types-and-expressions.md
@@ -360,12 +360,12 @@ requires T in {i64, f64}
 equalities, constant predicates, and nominal operator requirements have the
 same meaning here as on a generic function.
 
-> **Staging status:** The prototype currently performs complete requirement
-> evaluation when it checks a struct constructor. Other appearances of an
-> applied generic struct retain the normalized requirement in typed HIR, but
-> validation there remains fail-closed until canonical nominal-type metadata is
-> available to every consumer. Arbitrary constant expressions beyond equality
-> and closed-set membership are also still deferred.
+> **Staging status:** Typed HIR validates a complete application wherever it
+> appears, including signatures, fields, parents, locals, state, constraints,
+> and constructors. A symbolic application is valid only when the containing
+> declaration's `requires` clause proves the struct requirement. Arbitrary
+> constant expressions beyond equality and closed-set membership are still
+> deferred.
 
 In the initial design, a struct's type arguments are canonical value types,
 not temporal policies. Put `atomic` at the field where temporal expansion is

--- a/language/src/README.md
+++ b/language/src/README.md
@@ -8,8 +8,8 @@ them.
 | Directory | Owns now | Target input and output |
 | --- | --- | --- |
 | `syntax/` | source buffers, diagnostics, temporal literals, lexer, parser, arena AST | source text to source-accurate syntax |
-| `semantics/` | bindings, nominal structs, generic checks, function classification | syntax plus descriptors to typed HIR |
-| `ir/` | not created yet | typed HIR to backend-neutral hgraph semantic IR |
+| `semantics/` | name binding, nominal hierarchy, generic argument roles, function classification | syntax plus descriptors to resolved names and shapes |
+| `ir/` | source-ranged HIR, canonical types, substitutions, constraint solving, phase/effect completion | resolved frontend state to typed HIR, then backend-neutral hgraph semantic IR |
 | `wiring/` | direct walk over `ResolvedModule` | hgraph IR to public erased wiring calls |
 | `codegen/` | direct walk over `ResolvedModule` | hgraph IR to formatted C++ and build artifacts |
 | `driver/` | commands, native build/cache/load, REPL orchestration | assemble inputs and invoke passes |

--- a/language/src/ir/canonical_types.cpp
+++ b/language/src/ir/canonical_types.cpp
@@ -91,6 +91,7 @@ namespace hgl::ir::detail
             if (argument.kind == TypeArgumentKind::Type) { argument.type = canonical(argument.type); }
         }
         value.range           = {};
+        value.owner           = {};
         value.value_position  = false;
         value.canonical       = {};
         const std::string key = type_key(value);

--- a/language/src/ir/hir.h
+++ b/language/src/ir/hir.h
@@ -126,8 +126,11 @@ namespace hgl::ir::hir
 
     struct Type
     {
-        TypeKind                  kind{TypeKind::Deferred};
-        syntax::SourceRange       range{};
+        TypeKind            kind{TypeKind::Deferred};
+        syntax::SourceRange range{};
+        /// Declaration containing this source occurrence. Canonical types are
+        /// context-neutral and leave this empty.
+        DeclarationId             owner{};
         ScalarType                scalar{ScalarType::Bool};
         SymbolId                  symbol{};
         std::vector<TypeArgument> arguments{};

--- a/language/src/ir/hir_printer.cpp
+++ b/language/src/ir/hir_printer.cpp
@@ -262,6 +262,7 @@ namespace hgl::ir
                     out_ << "  t" << index << ' ' << type_kind_name(type.kind);
                     if (type.kind == hir::TypeKind::Scalar) { out_ << ' ' << hir::scalar_type_name(type.scalar); }
                     if (type.symbol.valid()) { out_ << " symbol=" << ref('s', type.symbol); }
+                    if (type.owner.valid()) { out_ << " owner=" << ref('d', type.owner); }
                     if (!type.children.empty()) {
                         out_ << " children=";
                         refs(out_, 't', type.children);

--- a/language/src/ir/lower.cpp
+++ b/language/src/ir/lower.cpp
@@ -594,11 +594,12 @@ namespace hgl::ir
                 return result;
             }
 
-            [[nodiscard]] hir::TypeId synthesized_symbol_type(hir::SymbolId symbol, syntax::SourceRange range) {
+            [[nodiscard]] hir::TypeId synthesized_symbol_type(hir::SymbolId symbol, syntax::SourceRange range, ast::DeclId owner) {
                 const hir::TypeId result{static_cast<std::uint32_t>(result_.types.size())};
                 hir::Type         type;
                 type.kind           = hir::TypeKind::Symbol;
                 type.range          = range;
+                type.owner          = id<hir::DeclarationId>(owner);
                 type.symbol         = symbol;
                 type.value_position = true;
                 result_.types.push_back(std::move(type));
@@ -610,6 +611,7 @@ namespace hgl::ir
                 hir::Type        target;
                 target.kind           = lower_type_kind(source.kind);
                 target.range          = source.range;
+                target.owner          = id<hir::DeclarationId>(type_owners_[index]);
                 target.scalar         = lower_scalar_type(source.scalar);
                 target.unbounded      = source.unbounded;
                 target.value_position = source.value_position;
@@ -651,7 +653,8 @@ namespace hgl::ir
                             lowered.value = synthesized_ref(symbol.value_or(hir::no_symbol), argument.range);
                         } else {
                             lowered.kind = hir::TypeArgumentKind::Type;
-                            lowered.type = synthesized_symbol_type(symbol.value_or(hir::no_symbol), argument.range);
+                            lowered.type =
+                                synthesized_symbol_type(symbol.value_or(hir::no_symbol), argument.range, type_owners_[index]);
                         }
                     }
                     target.arguments.push_back(lowered);

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -13,6 +13,7 @@
 #include <string_view>
 #include <type_traits>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 namespace hgl::ir
@@ -207,13 +208,60 @@ namespace hgl::ir
                 return make_type(TypeKind::Callable);
             }
 
+            [[nodiscard]] static std::uint64_t application_key(DeclarationId owner, TypeId application) noexcept {
+                return (static_cast<std::uint64_t>(owner.value) << 32U) | application.value;
+            }
+
+            void validate_owned_type_applications(DeclarationId owner) {
+                const std::size_t type_count = module_.types.size();
+                for (std::uint32_t index = 0; index < type_count; ++index) {
+                    const Type source = module_.types[index];
+                    if (source.owner != owner) { continue; }
+                    const TypeId application_id = canonical(TypeId{index});
+                    if (!application_id.valid()) { continue; }
+                    const Type &application = type(application_id);
+                    if (application.kind != TypeKind::Symbol || !application.symbol.valid()) { continue; }
+                    const Symbol &symbol = module_.symbol(application.symbol);
+                    if (symbol.kind != SymbolKind::Struct || !symbol.owner.valid()) { continue; }
+                    const auto *structure = std::get_if<StructDecl>(&module_.declaration(symbol.owner).node);
+                    if (structure == nullptr || structure->generics.size() != application.arguments.size()) { continue; }
+
+                    if (!checked_type_applications_.insert(application_key(owner, application_id)).second) { continue; }
+                    if (!structure->requirements.valid()) { continue; }
+                    detail::GenericSubstitution substitution{module_, canonical_types_};
+                    bool                        complete = true;
+                    for (std::size_t argument = 0; argument < structure->generics.size(); ++argument) {
+                        const GenericParameter &generic = structure->generics[argument];
+                        const TypeArgument     &value   = application.arguments[argument];
+                        if (generic.is_const && value.kind == TypeArgumentKind::Value) {
+                            complete = substitution.bind_value(generic.symbol, value.value) && complete;
+                        } else if (!generic.is_const && value.kind == TypeArgumentKind::Type) {
+                            complete = substitution.bind_type(generic.symbol, value.type) && complete;
+                        } else {
+                            complete = false;
+                        }
+                    }
+                    if (!complete) { continue; }
+                    const auto premises = active_constraint_premises();
+                    (void)constraint_solver_.solve(structure->requirements, substitution, source.range,
+                                                   "generic struct '" + symbol.name + "'", true, premises);
+                }
+            }
+
             void check_declaration(DeclarationId id) {
                 if (!id.valid()) { return; }
+                const ConstraintId previous_requirements = active_requirements_;
+                const ConstraintId previous_inherited    = inherited_requirements_;
+                active_requirements_                     = {};
+                inherited_requirements_                  = {};
+                inherited_substitution_.reset();
                 Declaration &declaration = module_.declarations[id.value];
                 std::visit(
                     [&](auto &node) {
                         using T = std::decay_t<decltype(node)>;
                         if constexpr (std::is_same_v<T, StructDecl>) {
+                            active_requirements_ = node.requirements;
+                            validate_owned_type_applications(id);
                             for (StructField &field : node.fields) {
                                 if (!field.default_value.valid()) { continue; }
                                 Expr &value = check_expr(field.default_value, field.type);
@@ -224,13 +272,11 @@ namespace hgl::ir
                                 }
                             }
                         } else if constexpr (std::is_same_v<T, OperatorDecl>) {
+                            active_requirements_ = node.requirements;
+                            validate_owned_type_applications(id);
                             check_signature_defaults(node.signature);
                         } else if constexpr (std::is_same_v<T, FunctionDecl>) {
-                            const ConstraintId previous_requirements = active_requirements_;
-                            const ConstraintId previous_inherited    = inherited_requirements_;
-                            active_requirements_                     = node.requirements;
-                            inherited_requirements_                  = {};
-                            inherited_substitution_.reset();
+                            active_requirements_ = node.requirements;
                             if (node.visibility == Visibility::Implementation && declaration.symbol.valid()) {
                                 if (const OperatorDecl *contract = local_operator(module_.symbol(declaration.symbol).name)) {
                                     inherited_requirements_ = contract->requirements;
@@ -238,6 +284,7 @@ namespace hgl::ir
                                     check_implementation_conformance(declaration, node, *contract, *inherited_substitution_);
                                 }
                             }
+                            validate_owned_type_applications(id);
                             check_signature_defaults(node.signature);
                             if (node.concise_body.valid()) {
                                 Expr &body = check_expr(node.concise_body, node.signature.result);
@@ -252,14 +299,15 @@ namespace hgl::ir
                                 node.effects = body.effects;
                             }
                             collect_capabilities(node, id);
-                            active_requirements_    = previous_requirements;
-                            inherited_requirements_ = previous_inherited;
-                            inherited_substitution_.reset();
                         } else if constexpr (std::is_same_v<T, TestDecl>) {
+                            validate_owned_type_applications(id);
                             check_block(node.block, void_type_);
                         }
                     },
                     declaration.node);
+                active_requirements_    = previous_requirements;
+                inherited_requirements_ = previous_inherited;
+                inherited_substitution_.reset();
             }
 
             void check_signature_defaults(Signature &signature) {
@@ -1288,9 +1336,11 @@ namespace hgl::ir
                 unwrapped = unwrap_atomic(applied);
                 detail::GenericSubstitution struct_substitution{module_, canonical_types_};
                 bind_struct_arguments(unwrapped, struct_substitution);
-                const auto premises = active_constraint_premises();
-                (void)constraint_solver_.solve(structure->requirements, struct_substitution, expression.range,
-                                               "struct construction", true, premises);
+                if (!checked_type_applications_.contains(application_key(expression.owner, unwrapped))) {
+                    const auto premises = active_constraint_premises();
+                    (void)constraint_solver_.solve(structure->requirements, struct_substitution, expression.range,
+                                                   "struct construction", true, premises);
+                }
                 std::size_t positional = 0;
                 for (const Argument &argument : arguments) {
                     const StructField *field = nullptr;
@@ -1567,6 +1617,7 @@ namespace hgl::ir
             std::vector<std::uint8_t>                  expr_state_{};
             std::unordered_map<std::uint32_t, Phase>   symbol_phase_{};
             std::unordered_map<std::uint32_t, bool>    checked_blocks_{};
+            std::unordered_set<std::uint64_t>          checked_type_applications_{};
             TypeId                                     void_type_{};
             ConstraintId                               active_requirements_{};
             ConstraintId                               inherited_requirements_{};

--- a/language/src/semantics/resolve.cpp
+++ b/language/src/semantics/resolve.cpp
@@ -1,7 +1,6 @@
 #include "semantics/resolve.h"
 
 #include <algorithm>
-#include <cctype>
 #include <optional>
 #include <string>
 #include <utility>
@@ -40,9 +39,8 @@ namespace hgl::semantics
         class Resolver
         {
           public:
-            Resolver(const syntax::SourceFile &file, const ast::Module &module, const OperatorLookup &has_operator,
-                     syntax::DiagnosticSink &diagnostics)
-                : file_{file}, module_{module}, has_operator_{has_operator}, diagnostics_{diagnostics} {
+            Resolver(const ast::Module &module, const OperatorLookup &has_operator, syntax::DiagnosticSink &diagnostics)
+                : module_{module}, has_operator_{has_operator}, diagnostics_{diagnostics} {
                 result_.bindings.resize(module.exprs.size());
                 result_.type_bindings.resize(module.types.size());
                 result_.constraint_bindings.resize(module.constraints.size());
@@ -633,142 +631,6 @@ namespace hgl::semantics
                 }
             }
 
-            [[nodiscard]] std::string expression_key(ast::ExprId id) const {
-                std::string key{file_.slice(module_.expr(id).range)};
-                key.erase(std::remove_if(key.begin(), key.end(), [](unsigned char c) { return std::isspace(c); }), key.end());
-                return "v:" + key;
-            }
-
-            [[nodiscard]] std::string type_key(ast::TypeId id) const {
-                const ast::Type &type = module_.type(id);
-                std::string      key  = "t:" + std::to_string(static_cast<unsigned>(type.kind)) + ':';
-                if (type.kind == ast::TypeKind::Scalar) { return key + std::string{ast::scalar_type_name(type.scalar)}; }
-                if (type.kind == ast::TypeKind::Named) {
-                    const Binding &binding = result_.type_bindings[id];
-                    key += binding.kind == BindingKind::Struct ? "struct:" : "generic:";
-                    key += std::to_string(binding.decl) + ':' + std::to_string(binding.index);
-                    for (const ast::GenericArgument &argument : type.arguments) {
-                        key += '<';
-                        if (argument.type != ast::no_node) {
-                            key += type_key(argument.type);
-                        } else if (argument.value != ast::no_node) {
-                            key += expression_key(argument.value);
-                        } else {
-                            key += "n:" + std::string{argument.name.text};
-                        }
-                        key += '>';
-                    }
-                    return key;
-                }
-                for (const ast::TypeId child : type.children) { key += '<' + type_key(child) + '>'; }
-                if (type.size != ast::no_node) { key += '<' + expression_key(type.size) + '>'; }
-                if (type.min_size != ast::no_node) { key += '<' + expression_key(type.min_size) + '>'; }
-                if (type.unbounded) { key += "<unbounded>"; }
-                return key;
-            }
-
-            [[nodiscard]] std::string generic_argument_key(const ast::GenericArgument &argument) const {
-                if (argument.type != ast::no_node) { return type_key(argument.type); }
-                if (argument.value != ast::no_node) { return expression_key(argument.value); }
-                const std::optional<Binding> binding = lookup(argument.name.text);
-                if (binding && binding->kind == BindingKind::Struct) {
-                    return "t:" + std::to_string(static_cast<unsigned>(ast::TypeKind::Named)) +
-                           ":struct:" + std::to_string(binding->decl) + ":0";
-                }
-                if (binding && binding->kind == BindingKind::Generic) {
-                    return "t:" + std::to_string(static_cast<unsigned>(ast::TypeKind::Named)) +
-                           ":generic:" + std::to_string(binding->decl) + ':' + std::to_string(binding->index);
-                }
-                return "n:" + std::string{argument.name.text};
-            }
-
-            using ConstraintSubstitution = std::vector<std::pair<std::string_view, std::string>>;
-
-            [[nodiscard]] std::optional<std::string> constraint_operand_key(ast::ConstraintId             id,
-                                                                            const ConstraintSubstitution &substitution) const {
-                const ast::Constraint &constraint = module_.constraint(id);
-                if (const auto *name = std::get_if<ast::ConstraintName>(&constraint.node)) {
-                    for (const auto &[parameter, value] : substitution) {
-                        if (parameter == name->name.text) { return value; }
-                    }
-                    const Binding &binding = result_.constraint_bindings[id];
-                    if (binding.kind == BindingKind::Struct) {
-                        return "t:" + std::to_string(static_cast<unsigned>(ast::TypeKind::Named)) +
-                               ":struct:" + std::to_string(binding.decl) + ":0";
-                    }
-                    return std::nullopt;
-                }
-                if (const auto *type = std::get_if<ast::ConstraintType>(&constraint.node)) { return type_key(type->type); }
-                if (const auto *value = std::get_if<ast::ConstraintValue>(&constraint.node)) {
-                    return expression_key(value->value);
-                }
-                return std::nullopt;
-            }
-
-            [[nodiscard]] std::optional<bool> evaluate_constraint(ast::ConstraintId             id,
-                                                                  const ConstraintSubstitution &substitution) const {
-                if (id == ast::no_node) { return true; }
-                const ast::Constraint &constraint = module_.constraint(id);
-                if (const auto *relation = std::get_if<ast::ConstraintRelation>(&constraint.node)) {
-                    const std::optional<std::string> lhs = constraint_operand_key(relation->lhs, substitution);
-                    if (!lhs) { return std::nullopt; }
-                    if (relation->op == ast::ConstraintRelationOp::Is) {
-                        if (relation->category.text == "struct") {
-                            const std::string prefix =
-                                "t:" + std::to_string(static_cast<unsigned>(ast::TypeKind::Named)) + ":struct:";
-                            return lhs->starts_with(prefix);
-                        }
-                        return std::nullopt;
-                    }
-                    if (relation->op == ast::ConstraintRelationOp::Equal) {
-                        const std::optional<std::string> rhs = constraint_operand_key(relation->rhs, substitution);
-                        return rhs ? std::optional<bool>{*lhs == *rhs} : std::nullopt;
-                    }
-                    const auto *set = std::get_if<ast::ConstraintSet>(&module_.constraint(relation->rhs).node);
-                    if (set == nullptr) { return std::nullopt; }
-                    bool complete = true;
-                    for (const ast::ConstraintId element : set->elements) {
-                        const std::optional<std::string> candidate = constraint_operand_key(element, substitution);
-                        if (!candidate) {
-                            complete = false;
-                            continue;
-                        }
-                        if (*candidate == *lhs) { return true; }
-                    }
-                    return complete ? std::optional<bool>{false} : std::nullopt;
-                }
-                if (const auto *not_ = std::get_if<ast::ConstraintNot>(&constraint.node)) {
-                    const std::optional<bool> value = evaluate_constraint(not_->operand, substitution);
-                    return value ? std::optional<bool>{!*value} : std::nullopt;
-                }
-                if (const auto *logic = std::get_if<ast::ConstraintLogic>(&constraint.node)) {
-                    const std::optional<bool> lhs = evaluate_constraint(logic->lhs, substitution);
-                    const std::optional<bool> rhs = evaluate_constraint(logic->rhs, substitution);
-                    if (logic->op == ast::ConstraintLogicOp::And) {
-                        if ((lhs && !*lhs) || (rhs && !*rhs)) { return false; }
-                        if (lhs && rhs) { return *lhs && *rhs; }
-                    } else {
-                        if ((lhs && *lhs) || (rhs && *rhs)) { return true; }
-                        if (lhs && rhs) { return *lhs || *rhs; }
-                    }
-                }
-                return std::nullopt;
-            }
-
-            void validate_struct_application(const Binding &binding, const ast::Type &type) {
-                const auto &structure = std::get<ast::StructDecl>(module_.decl(binding.decl).node);
-                if (structure.requirements == ast::no_node || structure.generics.size() != type.arguments.size()) { return; }
-                ConstraintSubstitution substitution;
-                for (std::size_t i = 0; i < structure.generics.size(); ++i) {
-                    substitution.emplace_back(structure.generics[i].name.text, generic_argument_key(type.arguments[i]));
-                }
-                if (const std::optional<bool> accepted = evaluate_constraint(structure.requirements, substitution);
-                    accepted && !*accepted) {
-                    report(Category::Type, type.range,
-                           "generic struct '" + std::string{structure.name.text} + "' requirements are not satisfied");
-                }
-            }
-
             void resolve_type(ast::TypeId id, Context &context) {
                 const ast::Type &type = module_.type(id);
                 if (type.value_position && (type.kind == ast::TypeKind::Atomic || type.kind == ast::TypeKind::Rolling)) {
@@ -811,7 +673,6 @@ namespace hgl::semantics
                                     resolve_expr(argument.value, context);
                                 }
                             }
-                            if (parameters.size() == type.arguments.size()) { validate_struct_application(*binding, type); }
                         }
                     }
                 }
@@ -1125,7 +986,6 @@ namespace hgl::semantics
                 diagnostics_.report(category, range, std::move(message));
             }
 
-            const syntax::SourceFile &file_;
             const ast::Module        &module_;
             const OperatorLookup     &has_operator_;
             syntax::DiagnosticSink   &diagnostics_;
@@ -1142,8 +1002,8 @@ namespace hgl::semantics
         return false;
     }
 
-    ResolvedModule resolve(const syntax::SourceFile &file, const ast::Module &module, const OperatorLookup &has_operator,
+    ResolvedModule resolve(const syntax::SourceFile &, const ast::Module &module, const OperatorLookup &has_operator,
                            syntax::DiagnosticSink &diagnostics) {
-        return Resolver{file, module, has_operator, diagnostics}.run();
+        return Resolver{module, has_operator, diagnostics}.run();
     }
 }  // namespace hgl::semantics

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -695,9 +695,97 @@ fn make(value: Missing) -> WithId<Missing> => WithId<Missing>(value: value)
 )"};
     require_clean(rejected);
     CHECK_FALSE(complete(rejected));
-    CHECK(rejected.diagnostics.render(rejected.file).find("struct construction requirements are not satisfied") !=
+    CHECK(rejected.diagnostics.render(rejected.file).find("generic struct 'WithId' requirements are not satisfied") !=
           std::string::npos);
     CHECK(rejected.hir.completion == hir::Completion::Resolved);
+}
+
+TEST_CASE("typed HIR validates constrained structs in every type position", "[ir][typed][constraints][structs]") {
+    Lowered concrete{R"(
+module checks.constrained_type_position
+
+struct Range<T>
+requires T in {i64, f64}
+{
+    value: T
+}
+
+fn bad(value: Range<str>) -> Range<str> => value
+)"};
+    require_clean(concrete);
+    CHECK_FALSE(complete(concrete));
+    CHECK(concrete.diagnostics.render(concrete.file).find("generic struct 'Range' requirements are not satisfied") !=
+          std::string::npos);
+
+    Lowered field{R"(
+module checks.constrained_field_position
+
+struct Range<T>
+requires T in {i64, f64}
+{
+    value: T
+}
+
+struct Holder {
+    value: Range<str>
+}
+)"};
+    require_clean(field);
+    CHECK_FALSE(complete(field));
+    CHECK(field.diagnostics.render(field.file).find("generic struct 'Range' requirements are not satisfied") != std::string::npos);
+
+    Lowered generic{R"(
+module checks.constrained_generic_position
+
+struct Range<T>
+requires T in {i64, f64}
+{
+    value: T
+}
+
+fn admitted<U>(value: Range<U>) -> Range<U>
+requires U in {i64, f64}
+=> value
+
+operator inherited<T>(value: Range<T>) -> Range<T>
+requires T in {i64, f64}
+
+impl fn inherited<U>(value: Range<U>) -> Range<U> => value
+)"};
+    require_clean(generic);
+    REQUIRE(complete(generic));
+
+    Lowered missing_premise{R"(
+module checks.constrained_generic_position_rejected
+
+struct Range<T>
+requires T in {i64, f64}
+{
+    value: T
+}
+
+fn rejected<U>(value: Range<U>) -> Range<U> => value
+)"};
+    require_clean(missing_premise);
+    CHECK_FALSE(complete(missing_premise));
+    CHECK(missing_premise.diagnostics.render(missing_premise.file).find("generic struct 'Range' requirements are not satisfied") !=
+          std::string::npos);
+
+    Lowered parent{R"(
+module checks.constrained_parent_position
+
+abstract struct Range<T>
+requires T in {i64, f64}
+{
+    value: T
+}
+
+struct Invalid: Range<str> {}
+)"};
+    require_clean(parent);
+    CHECK_FALSE(complete(parent));
+    CHECK(parent.diagnostics.render(parent.file).find("generic struct 'Range' requirements are not satisfied") !=
+          std::string::npos);
 }
 
 TEST_CASE("typed HIR records runtime state and capability effects", "[ir][typed][effects]") {
@@ -764,8 +852,8 @@ symbols
   s1 function add_one owner=d1 type=_ index=0 [27..34)
   s2 signal-parameter value owner=d1 type=t0 index=0 [35..40)
 types
-  t0 scalar f64 signal [42..45)
-  t1 scalar f64 signal [50..53)
+  t0 scalar f64 owner=d1 signal [42..45)
+  t1 scalar f64 owner=d1 signal [50..53)
   t2 scalar f64 value [0..0)
 expressions
   e0 type=t0 phase=wiring value=signal ref s2 [57..62)

--- a/language/tests/semantics/resolve_tests.cpp
+++ b/language/tests/semantics/resolve_tests.cpp
@@ -301,7 +301,7 @@ TEST_CASE("struct hierarchy rejects unsafe inheritance", "[semantics]") {
     }
 }
 
-TEST_CASE("generic structs validate applications and decidable requirements", "[semantics]") {
+TEST_CASE("generic structs resolve complete applications and argument roles", "[semantics]") {
     const Resolved valid = resolve_clean(R"(
 module t
 
@@ -319,13 +319,6 @@ fn range(x: Range<f64>) -> Range<f64> => x
 fn vector(x: Vector<f64, 3>) -> Vector<f64, 3> => x
 )");
     CHECK(valid.result.structure(valid.struct_id("Range")).valid);
-
-    const Resolved rejected{R"(
-module t
-struct Range<T> requires T in {i64, f64} { value: T }
-fn bad(x: Range<str>) -> Range<str> => x
-)"};
-    CHECK(rejected.has(Category::Type, "generic struct 'Range' requirements are not satisfied"));
 
     const Resolved wrong_roles{R"(
 module t


### PR DESCRIPTION
## Summary

- retain each source type occurrence and its declaration owner until canonicalization
- validate constrained generic struct applications in typed HIR across signatures, fields, parents, locals, state, constraints, and constructors
- use active function, struct, and operator requirements plus substituted inherited operator requirements as proof premises
- remove the duplicate closed-requirement evaluator from the resolved-AST name pass
- update user, developer, architecture, and testing status documentation

This is stacked on #686, which contains the mechanical resolver formatting needed to keep this behavioral diff reviewable.

## Validation

- hgl_semantics_tests: 87 assertions, 14 test cases passed
- hgl_ir_tests [ir]: 1,387 assertions, 34 test cases passed
- complete language toolchain: 27/27 CTest tests passed
- git diff --check