### PR TITLE
feat(language): preserve operator implementation identity

### DIFF
--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -108,7 +108,9 @@ premise environment for nested constrained calls and constructions. Imported
 viability queries delegate to `OperatorRegistry`; local viability accepts
 exactly one applicable source implementation without inventing a ranking rule.
 Local implementations are checked against, and inherit requirements from,
-their local operator contract.
+their local operator contract. Every implementation now also retains its
+resolved nominal operator symbol, with imported defining-module identity kept
+separate from native registry spelling.
 
 The remaining work in this stage is imported operator-contract conformance,
 arbitrary residual `const` predicates, public native nominal-struct metadata,

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -204,6 +204,13 @@ reports a conflict for a plain `fn` whose name is an in-scope operator. A bound
 implementation is a provider candidate and rejects an `export` modifier; only
 an unbound exact function may be exported directly.
 
+The resolved module stores that selected binding on the implementation
+declaration itself. Lowering copies it to `FunctionDecl::operator_contract` as
+a stable HIR symbol. Imported symbols keep the defining-module identity
+(`hgraph.std.valid`) separate from the current native registry key (`valid`),
+so neither type checking nor later descriptor generation reconstructs a
+contract from the implementation's short name.
+
 ## Function classification
 
 The classifier consumes resolved syntax and assigns `CompositionFn` or

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -339,6 +339,8 @@ Use a deterministic fixture and the real hgraph standard registry to cover:
 - nominal operator identity by defining module and declaration name;
 - an `impl fn` binding to a local operator or the one selectively imported
   operator;
+- the resolved implementation and typed HIR retaining that operator's
+  canonical identity separately from its native registry key;
 - `impl fn` with no operator in scope, and a plain `fn` conflicting with an
   in-scope operator name;
 - adding or removing an unrelated `use` never changing whether an existing

--- a/language/src/ir/constraint_solver.cpp
+++ b/language/src/ir/constraint_solver.cpp
@@ -406,6 +406,12 @@ namespace hgl::ir::detail
     std::string ConstraintSolver::operator_identity(SymbolId symbol) const {
         if (!symbol.valid()) { return {}; }
         const Symbol &value = module_.symbol(symbol);
+        return value.canonical_name.empty() ? value.name : value.canonical_name;
+    }
+
+    std::string ConstraintSolver::operator_registry_name(SymbolId symbol) const {
+        if (!symbol.valid()) { return {}; }
+        const Symbol &value = module_.symbol(symbol);
         return value.external_name.empty() ? value.name : value.external_name;
     }
 
@@ -420,7 +426,7 @@ namespace hgl::ir::detail
         if (!requirement.op.valid()) { return Truth::False; }
         OperatorQuery        query;
         std::vector<Operand> arguments;
-        query.identity = operator_identity(requirement.op);
+        query.identity = operator_registry_name(requirement.op);
         query.range    = range;
         for (ConstraintId argument : requirement.arguments) {
             Operand value = operand(argument, substitution);
@@ -497,8 +503,8 @@ namespace hgl::ir::detail
         std::size_t admitted = 0;
         for (const Declaration &declaration : module_.declarations) {
             const auto *candidate = std::get_if<FunctionDecl>(&declaration.node);
-            if (!candidate || candidate->visibility != Visibility::Implementation || !declaration.symbol.valid() ||
-                module_.symbol(declaration.symbol).name != symbol.name ||
+            if (!candidate || candidate->visibility != Visibility::Implementation ||
+                candidate->operator_contract != requirement.op ||
                 candidate->signature.parameters.size() != query.arguments.size()) {
                 continue;
             }
@@ -714,7 +720,7 @@ namespace hgl::ir::detail
             return find_required_operation(logic->rhs, identity, arguments, substitution);
         }
         const auto *required = std::get_if<OperatorRequirement>(&constraint.node);
-        if (!required || !identity_matches(operator_identity(required->op), identity) ||
+        if (!required || !identity_matches(operator_registry_name(required->op), identity) ||
             required->arguments.size() != arguments.size()) {
             return std::nullopt;
         }

--- a/language/src/ir/constraint_solver.h
+++ b/language/src/ir/constraint_solver.h
@@ -117,6 +117,7 @@ namespace hgl::ir::detail
         [[nodiscard]] bool                             same_value(hir::ExprId lhs, hir::ExprId rhs) const;
         [[nodiscard]] bool                             same_symbolic_type(hir::TypeId lhs, hir::TypeId rhs) const noexcept;
         [[nodiscard]] std::string                      operator_identity(hir::SymbolId symbol) const;
+        [[nodiscard]] std::string                      operator_registry_name(hir::SymbolId symbol) const;
         [[nodiscard]] static bool                      identity_matches(std::string_view lhs, std::string_view rhs) noexcept;
         [[nodiscard]] std::optional<RequiredOperation> find_required_operation(hir::ConstraintId               requirement,
                                                                                std::string_view                identity,

--- a/language/src/ir/hir.h
+++ b/language/src/ir/hir.h
@@ -85,9 +85,12 @@ namespace hgl::ir::hir
 
     struct Symbol
     {
-        SymbolKind          kind{SymbolKind::Module};
-        std::string         name{};
-        std::string         external_name{};
+        SymbolKind  kind{SymbolKind::Module};
+        std::string name{};
+        /// Native registry key for an imported operator or intrinsic.
+        std::string external_name{};
+        /// Stable defining-module identity, independent of registry spelling.
+        std::string         canonical_name{};
         DeclarationId       owner{};
         syntax::SourceRange range{};
         TypeId              type{};
@@ -527,8 +530,10 @@ namespace hgl::ir::hir
     };
     struct FunctionDecl
     {
-        Visibility                    visibility{Visibility::Internal};
-        FunctionKind                  kind{FunctionKind::Composition};
+        Visibility   visibility{Visibility::Internal};
+        FunctionKind kind{FunctionKind::Composition};
+        /// The nominal operator implemented by an `impl fn`.
+        SymbolId                      operator_contract{};
         std::vector<GenericParameter> generics{};
         Signature                     signature{};
         ConstraintId                  requirements{};

--- a/language/src/ir/hir_printer.cpp
+++ b/language/src/ir/hir_printer.cpp
@@ -249,6 +249,7 @@ namespace hgl::ir
                     const hir::Symbol &symbol = module_.symbols[index];
                     out_ << "  s" << index << ' ' << symbol_kind_name(symbol.kind) << ' ' << symbol.name;
                     if (!symbol.external_name.empty()) { out_ << " external=" << symbol.external_name; }
+                    if (!symbol.canonical_name.empty()) { out_ << " canonical-name=" << symbol.canonical_name; }
                     out_ << " owner=" << ref('d', symbol.owner) << " type=" << ref('t', symbol.type) << " index=" << symbol.index;
                     range(out_, symbol.range);
                     out_ << '\n';
@@ -555,6 +556,7 @@ namespace hgl::ir
                                 static constexpr std::string_view visibility[]{"internal", "export", "impl"};
                                 out_ << visibility[static_cast<std::size_t>(node.visibility)] << ' '
                                      << (node.kind == hir::FunctionKind::Composition ? "composition" : "runtime") << " function";
+                                if (node.operator_contract.valid()) { out_ << " operator=" << ref('s', node.operator_contract); }
                                 print_generics(node.generics);
                                 print_signature(node.signature);
                                 out_ << " requires=" << ref('c', node.requirements) << " concise=" << ref('e', node.concise_body)

--- a/language/src/ir/lower.cpp
+++ b/language/src/ir/lower.cpp
@@ -175,10 +175,17 @@ namespace hgl::ir
 
           private:
             [[nodiscard]] hir::SymbolId add_symbol(hir::SymbolKind kind, std::string_view name, syntax::SourceRange range,
-                                                   ast::DeclId owner, std::uint32_t index = 0, std::string external_name = {}) {
+                                                   ast::DeclId owner, std::uint32_t index = 0, std::string external_name = {},
+                                                   std::string canonical_name = {}) {
                 const hir::SymbolId symbol{static_cast<std::uint32_t>(result_.symbols.size())};
-                result_.symbols.push_back(hir::Symbol{
-                    kind, std::string{name}, std::move(external_name), id<hir::DeclarationId>(owner), range, {}, index});
+                result_.symbols.push_back(hir::Symbol{kind,
+                                                      std::string{name},
+                                                      std::move(external_name),
+                                                      std::move(canonical_name),
+                                                      id<hir::DeclarationId>(owner),
+                                                      range,
+                                                      {},
+                                                      index});
                 return symbol;
             }
 
@@ -371,7 +378,8 @@ namespace hgl::ir
                                 declare_generics(declaration, node.generics);
                             } else if constexpr (std::is_same_v<T, ast::OperatorDecl>) {
                                 declaration_symbols_[declaration] =
-                                    add_symbol(hir::SymbolKind::Operator, node.name.text, node.name.range, declaration);
+                                    add_symbol(hir::SymbolKind::Operator, node.name.text, node.name.range, declaration, 0, {},
+                                               result_.path + "." + std::string{node.name.text});
                                 global_symbols_.emplace(std::string{node.name.text}, declaration_symbols_[declaration]);
                                 declare_generics(declaration, node.generics);
                                 declare_parameters(declaration, node.signature.parameters);
@@ -493,10 +501,12 @@ namespace hgl::ir
             }
 
             [[nodiscard]] hir::SymbolId external_symbol(hir::SymbolKind kind, std::string_view name, std::string_view external_name,
-                                                        syntax::SourceRange range) {
-                const std::string key = std::to_string(static_cast<unsigned>(kind)) + ':' + std::string{external_name};
+                                                        std::string_view canonical_name, syntax::SourceRange range) {
+                const std::string identity = canonical_name.empty() ? std::string{external_name} : std::string{canonical_name};
+                const std::string key      = std::to_string(static_cast<unsigned>(kind)) + ':' + identity;
                 if (const auto found = external_symbols_.find(key); found != external_symbols_.end()) { return found->second; }
-                const hir::SymbolId symbol = add_symbol(kind, name, range, ast::no_node, 0, std::string{external_name});
+                const hir::SymbolId symbol =
+                    add_symbol(kind, name, range, ast::no_node, 0, std::string{external_name}, std::string{canonical_name});
                 external_symbols_.emplace(key, symbol);
                 return symbol;
             }
@@ -533,9 +543,10 @@ namespace hgl::ir
                         if (binding.decl < declaration_symbols_.size()) { return declaration_symbols_[binding.decl]; }
                         break;
                     case BindingKind::Operator:
-                        return external_symbol(hir::SymbolKind::ImportedOperator, spelling, binding.registry_name, range);
+                        return external_symbol(hir::SymbolKind::ImportedOperator, spelling, binding.registry_name,
+                                               binding.operator_identity, range);
                     case BindingKind::Intrinsic:
-                        return external_symbol(hir::SymbolKind::Intrinsic, spelling, binding.registry_name, range);
+                        return external_symbol(hir::SymbolKind::Intrinsic, spelling, binding.registry_name, {}, range);
                     case BindingKind::Unbound: break;
                 }
                 diagnostics_.report(syntax::Category::Name, range,
@@ -986,11 +997,21 @@ namespace hgl::ir
                                 hir::OperatorDecl{lower_generics(index, node.generics), lower_signature(index, node.signature),
                                                   id<hir::ConstraintId>(node.requirements)};
                         } else if constexpr (std::is_same_v<T, ast::FunctionDecl>) {
-                            target.node = hir::FunctionDecl{
-                                lower_visibility(node.visibility),        lower_function_kind(resolved_.kind(index)),
-                                lower_generics(index, node.generics),     lower_signature(index, node.signature),
-                                id<hir::ConstraintId>(node.requirements), id<hir::ExprId>(node.concise_body),
-                                id<hir::BlockId>(node.block_body)};
+                            hir::FunctionDecl function;
+                            function.visibility = lower_visibility(node.visibility);
+                            function.kind       = lower_function_kind(resolved_.kind(index));
+                            if (function.visibility == hir::Visibility::Implementation) {
+                                const semantics::Binding &binding = resolved_.implementation_binding(index);
+                                if (binding.kind != semantics::BindingKind::Unbound) {
+                                    function.operator_contract = symbol_for(binding, node.name.range, node.name.text);
+                                }
+                            }
+                            function.generics     = lower_generics(index, node.generics);
+                            function.signature    = lower_signature(index, node.signature);
+                            function.requirements = id<hir::ConstraintId>(node.requirements);
+                            function.concise_body = id<hir::ExprId>(node.concise_body);
+                            function.block_body   = id<hir::BlockId>(node.block_body);
+                            target.node           = std::move(function);
                         } else if constexpr (std::is_same_v<T, ast::TestDecl>) {
                             target.node = hir::TestDecl{id<hir::BlockId>(node.block)};
                         }

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -105,6 +105,12 @@ namespace hgl::ir
 
             [[nodiscard]] std::string type_name(TypeId id) const { return canonical_types_.name(id); }
 
+            [[nodiscard]] std::string operator_identity(SymbolId id) const {
+                if (!id.valid()) { return {}; }
+                const Symbol &symbol = module_.symbol(id);
+                return symbol.canonical_name.empty() ? symbol.name : symbol.canonical_name;
+            }
+
             [[nodiscard]] const FunctionDecl *function(DeclarationId id) const noexcept {
                 if (!id.valid() || id.value >= module_.declarations.size()) { return nullptr; }
                 return std::get_if<FunctionDecl>(&module_.declaration(id).node);
@@ -113,14 +119,6 @@ namespace hgl::ir
             [[nodiscard]] FunctionDecl *function(DeclarationId id) noexcept {
                 if (!id.valid() || id.value >= module_.declarations.size()) { return nullptr; }
                 return std::get_if<FunctionDecl>(&module_.declarations[id.value].node);
-            }
-
-            [[nodiscard]] const OperatorDecl *local_operator(std::string_view name) const noexcept {
-                for (const Declaration &declaration : module_.declarations) {
-                    const auto *op = std::get_if<OperatorDecl>(&declaration.node);
-                    if (op && declaration.symbol.valid() && module_.symbol(declaration.symbol).name == name) { return op; }
-                }
-                return nullptr;
             }
 
             void check_implementation_conformance(const Declaration &declaration, const FunctionDecl &implementation,
@@ -277,8 +275,8 @@ namespace hgl::ir
                             check_signature_defaults(node.signature);
                         } else if constexpr (std::is_same_v<T, FunctionDecl>) {
                             active_requirements_ = node.requirements;
-                            if (node.visibility == Visibility::Implementation && declaration.symbol.valid()) {
-                                if (const OperatorDecl *contract = local_operator(module_.symbol(declaration.symbol).name)) {
+                            if (node.visibility == Visibility::Implementation && node.operator_contract.valid()) {
+                                if (const OperatorDecl *contract = operator_decl(node.operator_contract)) {
                                     inherited_requirements_ = contract->requirements;
                                     inherited_substitution_.emplace(module_, canonical_types_);
                                     check_implementation_conformance(declaration, node, *contract, *inherited_substitution_);
@@ -833,11 +831,9 @@ namespace hgl::ir
 
             [[nodiscard]] SymbolId sole_local_candidate(SymbolId op, const std::vector<ExprId> &arguments, TypeId expected) {
                 std::vector<SymbolId> candidates;
-                const std::string     name = module_.symbol(op).name;
                 for (const Declaration &declaration : module_.declarations) {
                     const auto *candidate = std::get_if<FunctionDecl>(&declaration.node);
-                    if (!candidate || candidate->visibility != Visibility::Implementation || !declaration.symbol.valid() ||
-                        module_.symbol(declaration.symbol).name != name) {
+                    if (!candidate || candidate->visibility != Visibility::Implementation || candidate->operator_contract != op) {
                         continue;
                     }
                     candidates.push_back(declaration.symbol);
@@ -885,7 +881,7 @@ namespace hgl::ir
                 expression.operation = Operation{.kind          = OperationKind::NominalOperator,
                                                  .target        = target,
                                                  .candidate     = candidate,
-                                                 .identity      = module_.path + "." + module_.symbol(target).name,
+                                                 .identity      = operator_identity(target),
                                                  .substitutions = contract_bindings.materialize(op.generics),
                                                  .deferred      = !candidate.valid()};
             }
@@ -963,7 +959,7 @@ namespace hgl::ir
                 finish_call_semantics(expression, argument_ids);
                 expression.operation = Operation{.kind            = OperationKind::NominalOperator,
                                                  .target          = target,
-                                                 .identity        = symbol.external_name,
+                                                 .identity        = operator_identity(target),
                                                  .candidate_label = std::move(selection.candidate_label),
                                                  .substitutions   = std::move(selection.substitutions),
                                                  .deferred        = selection.deferred};

--- a/language/src/semantics/resolve.cpp
+++ b/language/src/semantics/resolve.cpp
@@ -44,6 +44,7 @@ namespace hgl::semantics
                 result_.bindings.resize(module.exprs.size());
                 result_.type_bindings.resize(module.types.size());
                 result_.constraint_bindings.resize(module.constraints.size());
+                result_.implementation_bindings.resize(module.decls.size());
                 result_.kinds.resize(module.decls.size(), FunctionKind::Composition);
                 result_.struct_info.resize(module.decls.size());
             }
@@ -120,8 +121,9 @@ namespace hgl::semantics
                     if (const auto *op = std::get_if<ast::OperatorDecl>(&decl.node)) {
                         result_.operators.push_back(id);
                         Binding binding;
-                        binding.kind = BindingKind::LocalOperator;
-                        binding.decl = id;
+                        binding.kind              = BindingKind::LocalOperator;
+                        binding.decl              = id;
+                        binding.operator_identity = result_.module_path + "." + std::string{op->name.text};
                         declare(op->name, binding, "in the module");
                     }
                 }
@@ -149,6 +151,8 @@ namespace hgl::semantics
                         report(Category::Module, fn.name.range,
                                "'impl fn " + std::string{fn.name.text} + "' has no operator named '" + std::string{fn.name.text} +
                                    "' in scope");
+                    } else {
+                        result_.implementation_bindings[id] = *existing;
                     }
                     // An implementation is reached through its operator's identity,
                     // never as an unqualified value of its own.
@@ -167,14 +171,14 @@ namespace hgl::semantics
             }
 
             [[nodiscard]] std::string operator_identity(const Binding &binding) const {
-                if (binding.kind == BindingKind::Operator) {
-                    for (const ImportedOperator &import : result_.imports) {
-                        if (import.registry_name == binding.registry_name) { return import.module + "::" + import.name; }
+                if (!binding.operator_identity.empty()) {
+                    std::string identity = binding.operator_identity;
+                    if (const std::size_t split = identity.rfind('.'); split != std::string::npos) {
+                        identity.replace(split, 1, "::");
                     }
-                    return binding.registry_name;
+                    return identity;
                 }
-                const auto &op = std::get<ast::OperatorDecl>(module_.decl(binding.decl).node);
-                return result_.module_path + "::" + std::string{op.name.text};
+                return binding.registry_name;
             }
 
             void resolve_use(const ast::UseDecl &use, SourceRange range) {
@@ -212,8 +216,9 @@ namespace hgl::semantics
                     }
                     result_.imports.push_back(ImportedOperator{std::string{name.text}, path, *registry_name, name.range});
                     Binding binding;
-                    binding.kind          = BindingKind::Operator;
-                    binding.registry_name = *registry_name;
+                    binding.kind              = BindingKind::Operator;
+                    binding.registry_name     = *registry_name;
+                    binding.operator_identity = path + "." + std::string{name.text};
                     declare(name, binding, "in the module");
                 }
             }
@@ -561,9 +566,10 @@ namespace hgl::semantics
                         return;
                     }
                     Binding binding;
-                    binding.kind          = BindingKind::Operator;
-                    binding.registry_name = *registry_name;
-                    result_.bindings[id]  = binding;
+                    binding.kind              = BindingKind::Operator;
+                    binding.registry_name     = *registry_name;
+                    binding.operator_identity = alias.module + "." + std::string{ref.name.text};
+                    result_.bindings[id]      = binding;
                     return;
                 }
                 report(Category::Name, ref.qualifier.range, "unknown module alias '" + std::string{ref.qualifier.text} + "'");
@@ -735,8 +741,9 @@ namespace hgl::semantics
                                         report(Category::Module, node.name.range,
                                                alias.module + " does not export '" + std::string{node.name.text} + "'");
                                     } else {
-                                        binding.kind          = BindingKind::Operator;
-                                        binding.registry_name = *name;
+                                        binding.kind              = BindingKind::Operator;
+                                        binding.registry_name     = *name;
+                                        binding.operator_identity = alias.module + "." + std::string{node.name.text};
                                     }
                                     break;
                                 }

--- a/language/src/semantics/resolve.h
+++ b/language/src/semantics/resolve.h
@@ -20,8 +20,7 @@ namespace hgl::semantics
 {
     namespace ast = syntax::ast;
 
-    enum class BindingKind : std::uint8_t
-    {
+    enum class BindingKind : std::uint8_t {
         Unbound,
         Local,          ///< `let`/`var`/state/inject/for binding: `stmt` + binder `index`
         Parameter,      ///< `decl` is the function, `index` the parameter
@@ -42,19 +41,22 @@ namespace hgl::semantics
         std::uint32_t index{0};
         bool          second{false};  ///< compatibility marker for the second `for` binder
         std::string   registry_name{};
+        /// Canonical defining-module identity for an operator binding. This is
+        /// distinct from `registry_name`, which is the current native dispatch
+        /// key and may use a compatibility spelling such as `add_`.
+        std::string operator_identity{};
     };
 
-    enum class FunctionKind : std::uint8_t
-    {
+    enum class FunctionKind : std::uint8_t {
         Composition,
         Runtime,
     };
 
     struct ImportedOperator
     {
-        std::string   name;           ///< the short name in scope
-        std::string   module;         ///< `hgraph.std` / `hgraph.analytics`
-        std::string   registry_name;  ///< the hgraph registry name
+        std::string         name;           ///< the short name in scope
+        std::string         module;         ///< `hgraph.std` / `hgraph.analytics`
+        std::string         registry_name;  ///< the hgraph registry name
         syntax::SourceRange range{};
     };
 
@@ -83,10 +85,11 @@ namespace hgl::semantics
     struct ResolvedModule
     {
         std::string                   module_path;
-        std::vector<Binding>          bindings;             ///< indexed by ExprId
-        std::vector<Binding>          type_bindings;        ///< indexed by TypeId
-        std::vector<Binding>          constraint_bindings;  ///< indexed by ConstraintId
-        std::vector<FunctionKind>     kinds;                ///< indexed by DeclId
+        std::vector<Binding>          bindings;                 ///< indexed by ExprId
+        std::vector<Binding>          type_bindings;            ///< indexed by TypeId
+        std::vector<Binding>          constraint_bindings;      ///< indexed by ConstraintId
+        std::vector<Binding>          implementation_bindings;  ///< selected operator, indexed by DeclId
+        std::vector<FunctionKind>     kinds;                    ///< indexed by DeclId
         std::vector<ImportedOperator> imports;
         std::vector<ModuleAlias>      aliases;
         std::vector<ast::DeclId>      functions;
@@ -95,10 +98,11 @@ namespace hgl::semantics
         std::vector<ast::DeclId>      tests;
         std::vector<StructInfo>       struct_info;  ///< indexed by DeclId
 
-        [[nodiscard]] const Binding    &binding(ast::ExprId id) const noexcept { return bindings[id]; }
-        [[nodiscard]] const Binding    &type_binding(ast::TypeId id) const noexcept { return type_bindings[id]; }
-        [[nodiscard]] const Binding    &constraint_binding(ast::ConstraintId id) const noexcept { return constraint_bindings[id]; }
-        [[nodiscard]] FunctionKind      kind(ast::DeclId id) const noexcept { return kinds[id]; }
+        [[nodiscard]] const Binding &binding(ast::ExprId id) const noexcept { return bindings[id]; }
+        [[nodiscard]] const Binding &type_binding(ast::TypeId id) const noexcept { return type_bindings[id]; }
+        [[nodiscard]] const Binding &constraint_binding(ast::ConstraintId id) const noexcept { return constraint_bindings[id]; }
+        [[nodiscard]] const Binding &implementation_binding(ast::DeclId id) const noexcept { return implementation_bindings[id]; }
+        [[nodiscard]] FunctionKind   kind(ast::DeclId id) const noexcept { return kinds[id]; }
         [[nodiscard]] const StructInfo &structure(ast::DeclId id) const noexcept { return struct_info[id]; }
     };
 

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -303,6 +303,18 @@ fn apply_it(value: f64) -> f64 => choose(value)
     require_clean(lowered);
     REQUIRE(complete(lowered));
 
+    bool implementation_found = false;
+    for (const hir::Declaration &declaration : lowered.hir.declarations) {
+        const auto *implementation = std::get_if<hir::FunctionDecl>(&declaration.node);
+        if (implementation == nullptr || implementation->visibility != hir::Visibility::Implementation) { continue; }
+        implementation_found = true;
+        REQUIRE(implementation->operator_contract.valid());
+        const hir::Symbol &contract = lowered.hir.symbol(implementation->operator_contract);
+        CHECK(contract.kind == hir::SymbolKind::Operator);
+        CHECK(contract.canonical_name == "checks.operators.choose");
+    }
+    CHECK(implementation_found);
+
     bool found = false;
     for (const hir::Expr &expression : lowered.hir.exprs) {
         if (expression.operation.kind != hir::OperationKind::NominalOperator || !expression.operation.target.valid() ||
@@ -315,6 +327,30 @@ fn apply_it(value: f64) -> f64 => choose(value)
         CHECK_FALSE(expression.operation.deferred);
     }
     CHECK(found);
+}
+
+TEST_CASE("HIR preserves an imported implementation's nominal operator identity", "[ir][operators][imports]") {
+    Lowered lowered{R"(
+module checks.imported_impl
+
+use hgraph.std::{valid}
+
+impl fn valid(value: f64) -> bool => true
+)"};
+    require_clean(lowered);
+
+    const hir::FunctionDecl *implementation = nullptr;
+    for (const hir::Declaration &declaration : lowered.hir.declarations) {
+        const auto *candidate = std::get_if<hir::FunctionDecl>(&declaration.node);
+        if (candidate != nullptr && candidate->visibility == hir::Visibility::Implementation) { implementation = candidate; }
+    }
+    REQUIRE(implementation != nullptr);
+    REQUIRE(implementation->operator_contract.valid());
+    const hir::Symbol &contract = lowered.hir.symbol(implementation->operator_contract);
+    CHECK(contract.kind == hir::SymbolKind::ImportedOperator);
+    CHECK(contract.name == "valid");
+    CHECK(contract.external_name == "valid");
+    CHECK(contract.canonical_name == "hgraph.std.valid");
 }
 
 TEST_CASE("typed HIR defers source overload ranking to hgraph", "[ir][typed][operators]") {

--- a/language/tests/semantics/resolve_tests.cpp
+++ b/language/tests/semantics/resolve_tests.cpp
@@ -111,6 +111,7 @@ fn f(x: f64) -> f64 => std::add(x, 1.0)
     CHECK(resolved.result.imports[3].registry_name == "hgraph.analytics.rolling_mean");
     CHECK(resolved.binding_of("add")->kind == BindingKind::Operator);
     CHECK(resolved.binding_of("add")->registry_name == "add_");
+    CHECK(resolved.binding_of("add")->operator_identity == "hgraph.std.add");
     REQUIRE(resolved.result.aliases.size() == 1);
     CHECK(resolved.result.aliases[0].module == "hgraph.std");
 }
@@ -216,6 +217,20 @@ use hgraph.std::{valid}
 impl fn valid(x: f64) -> bool => true
 )");
     CHECK(bound.result.functions.size() == 1);
+    const Binding &imported = bound.result.implementation_binding(bound.result.functions.front());
+    CHECK(imported.kind == BindingKind::Operator);
+    CHECK(imported.registry_name == "valid");
+    CHECK(imported.operator_identity == "hgraph.std.valid");
+
+    const Resolved local    = resolve_clean(R"(
+module t
+
+operator choose<T>(value: T) -> T
+impl fn choose(value: f64) -> f64 => value
+)");
+    const Binding &declared = local.result.implementation_binding(local.result.functions.front());
+    CHECK(declared.kind == BindingKind::LocalOperator);
+    CHECK(declared.operator_identity == "t.choose");
 
     const Resolved unbound{"module t\n\nimpl fn nothing(x: f64) -> bool => true\n"};
     CHECK(unbound.has(Category::Module, "'impl fn nothing' has no operator named 'nothing' in scope"));

--- a/language/tests/wiring/operator_types_tests.cpp
+++ b/language/tests/wiring/operator_types_tests.cpp
@@ -45,7 +45,7 @@ fn average(window: rolling<f64, 20>) -> f64 => mean(window)
 
     bool found = false;
     for (const hgl::ir::hir::Expr &expression : unit.hir.exprs) {
-        if (expression.operation.identity != "mean") { continue; }
+        if (expression.operation.identity != "hgraph.std.mean") { continue; }
         found = true;
         CHECK_FALSE(expression.operation.candidate_label.empty());
         CHECK_FALSE(expression.operation.deferred);
@@ -67,7 +67,7 @@ fn scaled_average(window: rolling<f64, 20>) -> f64 => mean(window) * 2.0
 
     bool found = false;
     for (const hgl::ir::hir::Expr &expression : unit.hir.exprs) {
-        if (expression.operation.identity != "mean") { continue; }
+        if (expression.operation.identity != "hgraph.std.mean") { continue; }
         found = true;
         CHECK(expression.type.valid());
         CHECK(unit.hir.type(expression.type).scalar == hgl::ir::hir::ScalarType::F64);
@@ -90,7 +90,8 @@ fn double(values: map<str, f64>) -> map<str, f64> =>
 
     bool found = false;
     for (const hgl::ir::hir::Expr &expression : unit.hir.exprs) {
-        if (expression.operation.kind != hgl::ir::hir::OperationKind::NominalOperator || expression.operation.identity != "map_") {
+        if (expression.operation.kind != hgl::ir::hir::OperationKind::NominalOperator ||
+            expression.operation.identity != "hgraph.std.map") {
             continue;
         }
         found = true;
@@ -117,7 +118,7 @@ fn apply_double(value: f64) -> f64 => double(value)
 
     bool found_body_operation = false;
     for (const hgl::ir::hir::Expr &expression : unit.hir.exprs) {
-        if (expression.operation.identity != "add_") { continue; }
+        if (expression.operation.identity != "hgraph.std.add") { continue; }
         found_body_operation = true;
         CHECK(expression.operation.target.valid());
     }


### PR DESCRIPTION
## Summary

- record the selected nominal operator directly on each `impl fn` during semantic resolution
- preserve canonical defining-module identity separately from native registry spelling in HIR
- use explicit operator symbols for implementation conformance, source-candidate matching, constraint proof identity, and call operations
- document and test local, imported, qualified, and native-registry identity handling

## Validation

- `ctest --test-dir build-language-review --output-on-failure --parallel 2` (1,709/1,709 passed)
- stable-ABI wheel built with Python 3.12 and installed into a fresh Python 3.14 environment
- `python -m pytest python/tests -q -m "not wip"` (3,214 passed, 10 skipped)
