### PR TITLE
feat(language): establish hgraph IR boundary

### DIFF
--- a/.github/workflows/language.yml
+++ b/.github/workflows/language.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Build hgl and its suites
         run: >-
           cmake --build build-language --parallel ${{ matrix.parallel }} --target
-          hgl hgl_syntax_tests hgl_semantics_tests hgl_ir_tests hgl_wiring_tests
+          hgl hgl_syntax_tests hgl_semantics_tests hgl_ir_tests hgl_graph_ir_tests hgl_wiring_tests
           hgl_operator_type_tests hgl_native_module_tests hgl_codegen_tests hgl_codegen_fixture
           hgl_generated_tests
       - name: Run the language suites

--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -135,6 +135,19 @@ target_include_directories(hgl_ir PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_link_libraries(hgl_ir PUBLIC hgl::semantics)
 hgl_apply_warnings(hgl_ir)
 
+# The execution-facing semantic IR (src/hgraph_ir). Its first checkpoint owns
+# canonical type and callable interfaces; following slices add executable
+# composition and runtime-node plans before either backend migrates here.
+add_library(hgl_graph_ir STATIC
+    src/hgraph_ir/lower.cpp
+    src/hgraph_ir/printer.cpp
+)
+add_library(hgl::graph_ir ALIAS hgl_graph_ir)
+target_compile_features(hgl_graph_ir PUBLIC cxx_std_23)
+target_include_directories(hgl_graph_ir PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_link_libraries(hgl_graph_ir PUBLIC hgl::ir)
+hgl_apply_warnings(hgl_graph_ir)
+
 # The direct-wiring backend (src/wiring): walks the resolved tree straight
 # into an hgraph Wiring for test, run and the REPL (developer guide,
 # "Direct-wiring backend", "First pass").
@@ -185,7 +198,7 @@ add_library(hgl_driver STATIC
 add_library(hgl::driver ALIAS hgl_driver)
 target_compile_features(hgl_driver PUBLIC cxx_std_23)
 target_include_directories(hgl_driver PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
-target_link_libraries(hgl_driver PUBLIC hgl::ir hgl::wiring hgl::codegen hgraph::core)
+target_link_libraries(hgl_driver PUBLIC hgl::graph_ir hgl::wiring hgl::codegen hgraph::core)
 if(UNIX)
     target_link_libraries(hgl_driver PRIVATE ${CMAKE_DL_LIBS})
 endif()

--- a/language/README.md
+++ b/language/README.md
@@ -16,7 +16,9 @@ subset builds the same graph; the parity tests hold the two paths to it.
 
 The project is an intentionally changeable prototype in its first executable
 slice. `hgl check` lexes, parses, and resolves a module and reports diagnostics
-(`--dump-tokens` and `--dump-ast` show the frontend's view). That frontend now
+(`--dump-tokens`, `--dump-ast`, `--dump-hir`, and `--dump-hgraph-ir` show its
+successive views). The hgraph-IR dump is currently an interface checkpoint;
+backends still use their temporary resolved-AST adapters. That frontend now
 models nominal and generic structs, abstract-only inheritance, defaults and
 optional fields, `requires` constraints, and sparse `delta<S>` construction.
 `hgl test`, `hgl run`, and `hgl repl` additionally execute supported generated

--- a/language/docs/design/compiler-architecture.md
+++ b/language/docs/design/compiler-architecture.md
@@ -209,6 +209,7 @@ hgl_source
     -> hgl_syntax
     -> hgl_semantics
     -> hgl_ir
+    -> hgl_graph_ir
        -> hgl_wiring
        -> hgl_codegen_cpp
     -> hgl_driver
@@ -237,7 +238,8 @@ Architecture tests reject these wrong-layer dependencies:
 3. Introduce typed HIR beside `ResolvedModule`, with dumps and focused tests.
 4. Move semantic validation into HIR construction until a successful `check`
    denotes a completely typed program.
-5. Introduce hgraph semantic IR and migrate direct wiring.
+5. Introduce hgraph semantic IR interfaces and executable plans, then migrate
+   direct wiring.
 6. Migrate C++ generation, then remove backend access to resolved syntax.
 7. Make backend parity and architecture dependency tests required gates.
 

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -85,7 +85,8 @@ headers remain private to the syntax implementation.
 
 ### C. Typed HIR
 
-Status: in progress. The resolved HIR checkpoint owns the complete program in a
+Status: complete for the source semantics currently defined. The resolved HIR
+checkpoint owns the complete program in a
 backend-independent arena and assigns stable identities to declarations,
 parameters, locals, state, injectables, loop values, anonymous parameters,
 types, imported operators, and intrinsics. Type completion then interns
@@ -112,11 +113,16 @@ their local operator contract. Every implementation now also retains its
 resolved nominal operator symbol, with imported defining-module identity kept
 separate from native registry spelling.
 
-The remaining work in this stage is imported operator-contract conformance,
-arbitrary residual `const` predicates, public native nominal-struct metadata,
-and registry-backed completion for operation forms retained as explicit
-deferred nominal calls. Those cases fail closed or remain explicitly deferred;
-the temporary AST backends never silently discard a constraint.
+The defined source constraint language is closed: equality, membership, type
+categories, structural reflection, nominal operator requirements, and Boolean
+composition. An arbitrary residual `const` predicate has no agreed source or
+execution semantics and remains a design question rather than invented Stage C
+syntax. Imported operator-contract conformance and public native nominal-struct
+metadata require the versioned descriptors owned by Stage F. Registry-backed
+completion for deferred nominal calls occurs in hgraph IR once all wiring-time
+values and erased callable shapes exist, and therefore belongs to Stage D.
+Until those owning stages complete, the cases fail closed or remain explicitly
+deferred; the temporary AST backends never silently discard a constraint.
 
 - introduce stable symbol and declaration identities, canonical types, complete
   substitutions, typed constants, function kinds, phases, effects, and source
@@ -127,14 +133,18 @@ the temporary AST backends never silently discard a constraint.
 
 Acceptance: all resolved guide examples produce typed HIR, invalid programs
 leave the module unresolved, concrete native selection delegates to hgraph,
-and HIR contains no emitted C++ or runtime wiring objects. This acceptance is
-not yet complete while the remaining descriptor- and registry-dependent cases
-above are deferred. Backend removal of the temporary resolved-AST semantic
-walks belongs to stages D and E.
+and HIR contains no emitted C++ or runtime wiring objects. Backend removal of
+the temporary resolved-AST semantic walks belongs to stages D and E.
 
 ### D. Hgraph IR and direct wiring
 
-Status: follows completion of C.
+Status: in progress. The first checkpoint introduces a dedicated
+`hgl_graph_ir` target and lowers typed HIR into self-contained canonical type,
+compile-time expression, operator-contract, and callable-interface tables.
+`hgl check --dump-hgraph-ir` exposes that deterministic interface form. The
+module remains explicitly `Interfaces`, not `Executable`; body, activation,
+state, lifecycle, traversal, and provider-plan lowering plus direct-backend
+migration are the following slices.
 
 - lower composition and runtime semantics into one explicit hgraph IR;
 - represent state, injectables, lifecycle, activation, validity, traversal,

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -140,7 +140,8 @@ the temporary resolved-AST semantic walks belongs to stages D and E.
 
 Status: in progress. The first checkpoint introduces a dedicated
 `hgl_graph_ir` target and lowers typed HIR into self-contained canonical type,
-compile-time expression, operator-contract, and callable-interface tables.
+compile-time expression (including aggregate parameter defaults),
+operator-contract, and callable-interface tables.
 `hgl check --dump-hgraph-ir` exposes that deterministic interface form. The
 module remains explicitly `Interfaces`, not `Executable`; body, activation,
 state, lifecycle, traversal, and provider-plan lowering plus direct-backend

--- a/language/docs/developer-guide/README.md
+++ b/language/docs/developer-guide/README.md
@@ -16,6 +16,10 @@ for hgraph, not a second runtime.
 > types, substitutions, constraints, calls, phases, effects, and capabilities.
 > It validates constrained generic structs in every type position and leaves a
 > failed module explicitly `Resolved` rather than claiming `Typed` completion.
+> `src/hgraph_ir/` lowers typed HIR into independently owned canonical types,
+> compile-time expressions, nominal operator contracts, and callable
+> interfaces. That checkpoint is explicitly interface-only; executable graph
+> and runtime-node plans and backend migration are the next stacked changes.
 > `src/wiring/` executes the composition subset for `test`, `run`, and the
 > REPL, including scalar and atomic struct values, type-only generic
 > specializations, and field-wise temporal struct composition. `src/codegen/`
@@ -26,7 +30,7 @@ for hgraph, not a second runtime.
 > The driver compiles and caches/loads that subset for file-based `test`, `run`, and REPL sessions on
 > Unix. REPL replacement stages the new image, swaps removable provider handles
 > at a quiescent boundary, and restores the old revision if activation fails.
-> Imported operator-contract conformance, residual `const` predicates, `const`
+> Imported operator-contract conformance, arbitrary residual `const` predicates, `const`
 > generic native metadata, multiple-parent linearization, explicit optional-field
 > clearing, multi-registry module transactions, and the remaining runtime and
 > generated-C++ type support remain to be implemented.

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -178,10 +178,11 @@ leaves the module `Resolved`; it is never discarded by a temporary backend.
 
 `src/hgraph_ir/lower` now establishes the execution-facing boundary. Its first
 checkpoint copies typed HIR into an independently owned canonical type table,
-a compile-time expression arena for type and window sizes, nominal operator
-contracts with registry spelling kept separate, and callable interfaces with
-visibility, composition/runtime classification, generics, effects, and
-capabilities. `hgl check --dump-hgraph-ir` prints that representation. The
+a compile-time expression arena for type and window sizes and scalar or
+aggregate parameter defaults, nominal operator contracts with registry spelling
+kept separate, and callable interfaces with visibility, composition/runtime
+classification, generics, effects, and capabilities. `hgl check
+--dump-hgraph-ir` prints that representation. The
 result is explicitly marked `Interfaces`: body/control-flow, state, lifecycle,
 activation, traversal, output, and provider plans must be lowered before it may
 be marked `Executable` or consumed by either backend.

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -42,7 +42,8 @@ The implementation should grow around tested responsibilities:
 src/
   syntax/       source manager, lexer, parser, AST
   semantics/    names, canonical types, temporal shapes, function classifier
-  ir/           typed HIR and hgraph semantic IR
+  ir/           typed HIR, generic substitution, constraints, phase/effects
+  hgraph_ir/    execution-facing types, callable interfaces, and plans
   wiring/       direct-wiring backend: IR walk over hgraph's erased dispatch,
                 harness sequences, test runner
   codegen/cpp/  generated C++ and source maps
@@ -166,11 +167,24 @@ constraints, and construction syntax under the containing declaration's proof
 premises. Canonical types remain context-neutral. The resolved-AST pass checks
 names and generic argument roles, but no longer owns constraint evaluation.
 
-Residual arbitrary constant predicates, imported-contract conformance, and
-native nominal-struct reflection still need descriptor support. A dependency
-cycle, an unavailable native shape, or any other unresolved requirement
-reports a type diagnostic and leaves the module `Resolved`; it is never
-discarded by a temporary backend.
+The agreed source constraint language is closed over equality, membership,
+type categories, structural reflection, nominal operator requirements, and
+Boolean composition. Arbitrary residual constant predicates remain an open
+language-design question. Imported-contract conformance and native
+nominal-struct reflection require the constrained native descriptors described
+in the later native-interface stage. A dependency cycle, an unavailable native
+shape, or any other unresolved requirement reports a type diagnostic and
+leaves the module `Resolved`; it is never discarded by a temporary backend.
+
+`src/hgraph_ir/lower` now establishes the execution-facing boundary. Its first
+checkpoint copies typed HIR into an independently owned canonical type table,
+a compile-time expression arena for type and window sizes, nominal operator
+contracts with registry spelling kept separate, and callable interfaces with
+visibility, composition/runtime classification, generics, effects, and
+capabilities. `hgl check --dump-hgraph-ir` prints that representation. The
+result is explicitly marked `Interfaces`: body/control-flow, state, lifecycle,
+activation, traversal, output, and provider plans must be lowered before it may
+be marked `Executable` or consumed by either backend.
 
 The direct-wiring and C++ backends still walk `ResolvedModule` beside typed HIR
 during migration. That adapter path is explicitly temporary; hgraph semantic

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -111,15 +111,22 @@ value, type, and constraint name to carry a valid stable symbol. Focused cases
 cover multiple injectables declared together, state identity, anonymous
 parameters that shadow enclosing loop bindings, bare type and `const` generic
 arguments, fail-closed unbound identities, and the deterministic source-ranged
-`--dump-hir` format. The current dump says `HIR resolved`; it does not claim
-that the target assertions below have passed.
+`--dump-hir` format. Every checked-in guide example now reaches `HIR typed`.
+
+`tests/hgraph_ir/lower_tests.cpp` (`hgl_graph_ir_tests`, CTest
+`hgraph_language_hgraph_ir`) proves that every guide example reaches an
+interface-only hgraph IR module with self-contained types and callable
+signatures. Focused cases cover canonical versus native registry identities,
+runtime classification and capabilities, distinct source implementation
+identities, compile-time generic expressions, and rejection of unresolved HIR.
+CTest `hgraph_language_dump_hgraph_ir` locks the CLI dump entry point.
 
 Each valid guide example has a source-ranged typed-HIR snapshot containing
 stable declaration identities, canonical types, substitutions, typed
 constants, call targets, function kind, phase, and effects. Invalid examples
 prove that incomplete or contradictory types never reach hgraph IR.
 
-Hgraph-IR snapshots cover composition calls, runtime state and initialization,
+Once executable lowering is added, hgraph-IR snapshots cover composition calls, runtime state and initialization,
 injectables, lifecycle operations, activation and validity guards, collection
 borrows, output effects, and provider requirements. They deliberately contain
 no C++ spellings or direct-wiring runtime objects.

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -118,7 +118,8 @@ arguments, fail-closed unbound identities, and the deterministic source-ranged
 interface-only hgraph IR module with self-contained types and callable
 signatures. Focused cases cover canonical versus native registry identities,
 runtime classification and capabilities, distinct source implementation
-identities, compile-time generic expressions, and rejection of unresolved HIR.
+identities, compile-time generic expressions, aggregate defaults, complete
+temporal spellings, and rejection of unresolved HIR.
 CTest `hgraph_language_dump_hgraph_ir` locks the CLI dump entry point.
 
 Each valid guide example has a source-ranged typed-HIR snapshot containing

--- a/language/src/README.md
+++ b/language/src/README.md
@@ -9,7 +9,8 @@ them.
 | --- | --- | --- |
 | `syntax/` | source buffers, diagnostics, temporal literals, lexer, parser, arena AST | source text to source-accurate syntax |
 | `semantics/` | name binding, nominal hierarchy, generic argument roles, function classification | syntax plus descriptors to resolved names and shapes |
-| `ir/` | source-ranged HIR, canonical types, substitutions, constraint solving, phase/effect completion | resolved frontend state to typed HIR, then backend-neutral hgraph semantic IR |
+| `ir/` | source-ranged HIR, canonical types, substitutions, constraint solving, phase/effect completion | resolved frontend state to typed HIR |
+| `hgraph_ir/` | canonical execution-facing types, compile-time expressions, operator and callable interfaces | typed HIR to executable composition and runtime-node plans |
 | `wiring/` | direct walk over `ResolvedModule` | hgraph IR to public erased wiring calls |
 | `codegen/` | direct walk over `ResolvedModule` | hgraph IR to formatted C++ and build artifacts |
 | `driver/` | commands, native build/cache/load, REPL orchestration | assemble inputs and invoke passes |

--- a/language/src/driver/driver.cpp
+++ b/language/src/driver/driver.cpp
@@ -4,6 +4,8 @@
 #include "driver/cpp_formatter.h"
 #include "driver/line_reader.h"
 #include "driver/native_module.h"
+#include "hgraph_ir/lower.h"
+#include "hgraph_ir/printer.h"
 #include "ir/hir_printer.h"
 #include "ir/lower.h"
 #include "ir/type_check.h"
@@ -41,7 +43,7 @@ namespace hgl::driver
         void print_help() {
             std::cout << "hgl - experimental hgraph language toolchain\n\n"
                          "Usage:\n"
-                         "  hgl check <file> [--dump-tokens] [--dump-ast] [--dump-hir]\n"
+                         "  hgl check <file> [--dump-tokens] [--dump-ast] [--dump-hir] [--dump-hgraph-ir]\n"
                          "  hgl test <file> [test-name]...\n"
                          "  hgl run <file> [--entry <name>] [--mode sim|realtime]\n"
                          "          [--start <datetime>] [--end <datetime|duration>]\n"
@@ -101,12 +103,13 @@ namespace hgl::driver
         /// table"). ``ok`` is false when either step reported.
         struct Unit
         {
-            syntax::SourceFile        file;
-            syntax::DiagnosticSink    diagnostics{};
-            syntax::ast::Module       module{};
-            semantics::ResolvedModule resolved{};
-            ir::hir::Module           hir{};
-            bool                      ok{false};
+            syntax::SourceFile               file;
+            syntax::DiagnosticSink           diagnostics{};
+            syntax::ast::Module              module{};
+            semantics::ResolvedModule        resolved{};
+            ir::hir::Module                  hir{};
+            std::optional<hgraph_ir::Module> hgraph{};
+            bool                             ok{false};
 
             Unit(std::string path, std::string text) : file{std::move(path), std::move(text)} {}
         };
@@ -118,7 +121,9 @@ namespace hgl::driver
             if (unit.diagnostics.has_errors()) { return; }
             unit.hir = ir::lower_to_hir(unit.module, unit.resolved, unit.diagnostics);
             if (unit.diagnostics.has_errors()) { return; }
-            (void)ir::complete_hir(unit.hir, wiring::resolve_operator_types, unit.diagnostics);
+            if (ir::complete_hir(unit.hir, wiring::resolve_operator_types, unit.diagnostics)) {
+                unit.hgraph = hgraph_ir::lower_interfaces(unit.hir, unit.diagnostics);
+            }
             unit.ok = !unit.diagnostics.has_errors();
         }
 
@@ -178,9 +183,10 @@ namespace hgl::driver
 
         int check(std::span<const std::string_view> arguments) {
             std::optional<std::string> path;
-            bool                       want_tokens = false;
-            bool                       want_ast    = false;
-            bool                       want_hir    = false;
+            bool                       want_tokens    = false;
+            bool                       want_ast       = false;
+            bool                       want_hir       = false;
+            bool                       want_hgraph_ir = false;
             for (const std::string_view argument : arguments) {
                 if (argument == "--dump-tokens") {
                     want_tokens = true;
@@ -188,6 +194,8 @@ namespace hgl::driver
                     want_ast = true;
                 } else if (argument == "--dump-hir") {
                     want_hir = true;
+                } else if (argument == "--dump-hgraph-ir") {
+                    want_hgraph_ir = true;
                 } else if (argument.starts_with("--")) {
                     return usage_error("unknown option '" + std::string{argument} + "'");
                 } else if (path) {
@@ -213,6 +221,7 @@ namespace hgl::driver
             frontend(unit);
             if (want_ast) { std::cout << syntax::print_ast(unit.module); }
             if (want_hir && !unit.hir.path.empty()) { std::cout << ir::print_hir(unit.hir); }
+            if (want_hgraph_ir && unit.hgraph) { std::cout << hgraph_ir::print(*unit.hgraph); }
             if (unit.diagnostics.has_errors()) {
                 std::cerr << unit.diagnostics.render(unit.file);
                 return exit_diagnostics;

--- a/language/src/hgraph_ir/ir.h
+++ b/language/src/hgraph_ir/ir.h
@@ -1,0 +1,144 @@
+#ifndef HGL_HGRAPH_IR_IR_H
+#define HGL_HGRAPH_IR_IR_H
+
+#include "ir/hir.h"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace hgl::hgraph_ir
+{
+    template <typename Tag> struct Id
+    {
+        static constexpr std::uint32_t invalid = static_cast<std::uint32_t>(-1);
+        std::uint32_t                  value{invalid};
+
+        [[nodiscard]] constexpr bool valid() const noexcept { return value != invalid; }
+        friend constexpr bool        operator==(Id, Id) noexcept = default;
+    };
+
+    using TypeId      = Id<struct TypeTag>;
+    using CallableId  = Id<struct CallableTag>;
+    using ConstExprId = Id<struct ConstExprTag>;
+
+    enum class ConstExprKind : std::uint8_t {
+        Literal,
+        Parameter,
+        Unary,
+        Binary,
+    };
+
+    struct ConstExpr
+    {
+        ConstExprKind                    kind{ConstExprKind::Literal};
+        std::optional<ir::hir::Constant> literal{};
+        std::string                      parameter{};
+        ir::hir::UnaryOp                 unary{ir::hir::UnaryOp::Negate};
+        ir::hir::BinaryOp                binary{ir::hir::BinaryOp::Add};
+        ConstExprId                      lhs{};
+        ConstExprId                      rhs{};
+        syntax::SourceRange              range{};
+    };
+
+    struct TypeArgument
+    {
+        std::optional<TypeId>      type{};
+        std::optional<ConstExprId> value{};
+    };
+
+    /// A self-contained canonical HGL type prepared for hgraph lowering.
+    /// Source-only spelling, declaration ownership, and type-expression IDs
+    /// have been removed; compile-time sizes use the graph-IR expression arena.
+    struct Type
+    {
+        ir::hir::TypeKind         kind{ir::hir::TypeKind::Deferred};
+        ir::hir::ScalarType       scalar{ir::hir::ScalarType::Bool};
+        std::string               nominal_identity{};
+        std::vector<TypeId>       children{};
+        std::vector<TypeArgument> arguments{};
+        ConstExprId               size{};
+        ConstExprId               min_size{};
+        bool                      unbounded{false};
+    };
+
+    struct GenericParameter
+    {
+        std::string name{};
+        bool        is_const{false};
+        TypeId      type{};
+    };
+
+    struct Parameter
+    {
+        std::string                      name{};
+        bool                             is_const{false};
+        TypeId                           type{};
+        std::optional<ir::hir::Constant> default_value{};
+    };
+
+    struct OperatorContract
+    {
+        std::string                   identity{};
+        std::string                   registry_name{};
+        bool                          imported{false};
+        std::vector<GenericParameter> generics{};
+        std::vector<Parameter>        parameters{};
+        TypeId                        result{};
+        syntax::SourceRange           range{};
+    };
+
+    struct Capability
+    {
+        std::string name{};
+        TypeId      type{};
+    };
+
+    enum class CallableVisibility : std::uint8_t {
+        Internal,
+        Export,
+        Implementation,
+    };
+
+    enum class CallableKind : std::uint8_t {
+        Composition,
+        RuntimeNode,
+    };
+
+    /// The execution-facing callable interface. Body/control-flow lowering is
+    /// deliberately a following pass; this first checkpoint proves that
+    /// backends can consume stable canonical types and nominal identities
+    /// without reaching back into the syntax AST.
+    struct Callable
+    {
+        std::string                   identity{};
+        std::string                   operator_identity{};
+        std::string                   operator_registry_name{};
+        CallableVisibility            visibility{CallableVisibility::Internal};
+        CallableKind                  kind{CallableKind::Composition};
+        std::vector<GenericParameter> generics{};
+        std::vector<Parameter>        parameters{};
+        TypeId                        result{};
+        ir::hir::Effect               effects{ir::hir::Effect::None};
+        std::vector<Capability>       capabilities{};
+        syntax::SourceRange           range{};
+    };
+
+    enum class Completion : std::uint8_t {
+        Interfaces,
+        Executable,
+    };
+
+    struct Module
+    {
+        std::string                   path{};
+        Completion                    completion{Completion::Interfaces};
+        std::vector<ConstExpr>        const_exprs{};
+        std::vector<Type>             types{};
+        std::vector<OperatorContract> operators{};
+        std::vector<Callable>         callables{};
+    };
+}  // namespace hgl::hgraph_ir
+
+#endif  // HGL_HGRAPH_IR_IR_H

--- a/language/src/hgraph_ir/ir.h
+++ b/language/src/hgraph_ir/ir.h
@@ -28,6 +28,23 @@ namespace hgl::hgraph_ir
         Parameter,
         Unary,
         Binary,
+        Index,
+        Field,
+        Sequence,
+        Tuple,
+        Construct,
+    };
+
+    struct ConstElement
+    {
+        ConstExprId key{};
+        ConstExprId value{};
+    };
+
+    struct ConstArgument
+    {
+        std::string name{};
+        ConstExprId value{};
     };
 
     struct ConstExpr
@@ -39,6 +56,12 @@ namespace hgl::hgraph_ir
         ir::hir::BinaryOp                binary{ir::hir::BinaryOp::Add};
         ConstExprId                      lhs{};
         ConstExprId                      rhs{};
+        std::string                      member{};
+        std::vector<ConstElement>        elements{};
+        std::vector<ConstExprId>         items{};
+        TypeId                           constructed_type{};
+        std::vector<ConstArgument>       arguments{};
+        bool                             delta{false};
         syntax::SourceRange              range{};
     };
 
@@ -72,10 +95,10 @@ namespace hgl::hgraph_ir
 
     struct Parameter
     {
-        std::string                      name{};
-        bool                             is_const{false};
-        TypeId                           type{};
-        std::optional<ir::hir::Constant> default_value{};
+        std::string name{};
+        bool        is_const{false};
+        TypeId      type{};
+        ConstExprId default_value{};
     };
 
     struct OperatorContract

--- a/language/src/hgraph_ir/lower.cpp
+++ b/language/src/hgraph_ir/lower.cpp
@@ -1,0 +1,236 @@
+#include "hgraph_ir/lower.h"
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+namespace hgl::hgraph_ir
+{
+    namespace
+    {
+        namespace hir = ir::hir;
+
+        class InterfaceLowerer
+        {
+          public:
+            InterfaceLowerer(const hir::Module &source, syntax::DiagnosticSink &diagnostics)
+                : source_{source}, diagnostics_{diagnostics} {
+                result_.path = source.path;
+            }
+
+            Module run() {
+                if (source_.completion != hir::Completion::Typed) {
+                    diagnostics_.report(syntax::Category::Type, {}, "hgraph IR lowering requires typed HIR");
+                    return std::move(result_);
+                }
+
+                lower_types();
+                lower_operators();
+                lower_callables();
+                return std::move(result_);
+            }
+
+          private:
+            [[nodiscard]] hir::TypeId canonical(hir::TypeId source) const noexcept {
+                if (!source.valid()) { return {}; }
+                const hir::TypeId canonical = source_.type(source).canonical;
+                return canonical.valid() ? canonical : source;
+            }
+
+            [[nodiscard]] std::optional<hir::Constant> concrete_constant(hir::ExprId expression, syntax::SourceRange range,
+                                                                         std::string_view role) {
+                if (!expression.valid()) { return std::nullopt; }
+                const std::optional<hir::Constant> &value = source_.expr(expression).constant;
+                if (!value) {
+                    diagnostics_.report(syntax::Category::Type, range,
+                                        "typed HIR has no compile-time value for " + std::string{role});
+                    return std::nullopt;
+                }
+                return value;
+            }
+
+            [[nodiscard]] ConstExprId lower_const_expr(hir::ExprId expression, syntax::SourceRange range, std::string_view role) {
+                if (!expression.valid()) { return {}; }
+                if (const auto found = const_exprs_.find(expression.value); found != const_exprs_.end()) { return found->second; }
+
+                const ConstExprId id{static_cast<std::uint32_t>(result_.const_exprs.size())};
+                const_exprs_.emplace(expression.value, id);
+                result_.const_exprs.emplace_back();
+
+                const hir::Expr &source = source_.expr(expression);
+                ConstExpr        target;
+                target.range = source.range;
+                if (source.constant) {
+                    target.literal = source.constant;
+                } else if (const auto *reference = std::get_if<hir::SymbolRef>(&source.node)) {
+                    if (!reference->symbol.valid() || source_.symbol(reference->symbol).kind != hir::SymbolKind::ConstParameter) {
+                        diagnostics_.report(syntax::Category::Type, range,
+                                            "typed HIR has no compile-time value for " + std::string{role});
+                    } else {
+                        target.kind      = ConstExprKind::Parameter;
+                        target.parameter = source_.symbol(reference->symbol).name;
+                    }
+                } else if (const auto *unary = std::get_if<hir::Unary>(&source.node)) {
+                    target.kind  = ConstExprKind::Unary;
+                    target.unary = unary->op;
+                    target.lhs   = lower_const_expr(unary->operand, source.range, role);
+                } else if (const auto *binary = std::get_if<hir::Binary>(&source.node)) {
+                    target.kind   = ConstExprKind::Binary;
+                    target.binary = binary->op;
+                    target.lhs    = lower_const_expr(binary->lhs, source.range, role);
+                    target.rhs    = lower_const_expr(binary->rhs, source.range, role);
+                } else {
+                    diagnostics_.report(syntax::Category::Type, range, "hgraph IR cannot represent " + std::string{role} + " yet");
+                }
+                result_.const_exprs[id.value] = std::move(target);
+                return id;
+            }
+
+            [[nodiscard]] std::string symbol_identity(hir::SymbolId id) const {
+                if (!id.valid()) { return {}; }
+                const hir::Symbol &symbol = source_.symbol(id);
+                if (!symbol.canonical_name.empty()) { return symbol.canonical_name; }
+                if (symbol.kind == hir::SymbolKind::Struct || symbol.kind == hir::SymbolKind::Operator ||
+                    symbol.kind == hir::SymbolKind::Function) {
+                    return source_.path + "." + symbol.name;
+                }
+                return symbol.name;
+            }
+
+            [[nodiscard]] TypeId lower_type(hir::TypeId source_id) {
+                source_id = canonical(source_id);
+                if (!source_id.valid()) { return {}; }
+                if (const auto found = types_.find(source_id.value); found != types_.end()) { return found->second; }
+
+                const TypeId id{static_cast<std::uint32_t>(result_.types.size())};
+                types_.emplace(source_id.value, id);
+                result_.types.emplace_back();
+
+                const hir::Type &source_type = source_.type(source_id);
+                Type             target;
+                target.kind             = source_type.kind;
+                target.scalar           = source_type.scalar;
+                target.nominal_identity = symbol_identity(source_type.symbol);
+                target.unbounded        = source_type.unbounded;
+                for (hir::TypeId child : source_type.children) { target.children.push_back(lower_type(child)); }
+                for (const hir::TypeArgument &argument : source_type.arguments) {
+                    TypeArgument lowered;
+                    if (argument.kind == hir::TypeArgumentKind::Type) {
+                        lowered.type = lower_type(argument.type);
+                    } else {
+                        lowered.value = lower_const_expr(argument.value, argument.range, "a generic type argument");
+                    }
+                    target.arguments.push_back(std::move(lowered));
+                }
+                target.size             = lower_const_expr(source_type.size, source_type.range, "a type size");
+                target.min_size         = lower_const_expr(source_type.min_size, source_type.range, "a minimum type size");
+                result_.types[id.value] = std::move(target);
+                return id;
+            }
+
+            void lower_types() {
+                for (std::uint32_t index = 0; index < source_.types.size(); ++index) { (void)lower_type(hir::TypeId{index}); }
+            }
+
+            [[nodiscard]] GenericParameter lower_generic(const hir::GenericParameter &source) {
+                const hir::Symbol &symbol = source_.symbol(source.symbol);
+                return GenericParameter{symbol.name, source.is_const, lower_type(source.type)};
+            }
+
+            [[nodiscard]] Parameter lower_parameter(const hir::Parameter &source) {
+                const hir::Symbol &symbol = source_.symbol(source.symbol);
+                Parameter          target;
+                target.name          = symbol.name;
+                target.is_const      = source.is_const;
+                target.type          = lower_type(source.type);
+                target.default_value = concrete_constant(source.default_value, symbol.range, "a parameter default");
+                return target;
+            }
+
+            [[nodiscard]] static CallableVisibility lower_visibility(hir::Visibility source) noexcept {
+                switch (source) {
+                    case hir::Visibility::Internal: return CallableVisibility::Internal;
+                    case hir::Visibility::Export: return CallableVisibility::Export;
+                    case hir::Visibility::Implementation: return CallableVisibility::Implementation;
+                }
+                std::unreachable();
+            }
+
+            void lower_signature(const std::vector<hir::GenericParameter> &generics, const hir::Signature &signature,
+                                 std::vector<GenericParameter> &target_generics, std::vector<Parameter> &target_parameters,
+                                 TypeId &target_result) {
+                for (const hir::GenericParameter &generic : generics) { target_generics.push_back(lower_generic(generic)); }
+                for (const hir::Parameter &parameter : signature.parameters) {
+                    target_parameters.push_back(lower_parameter(parameter));
+                }
+                target_result = lower_type(signature.result);
+            }
+
+            void lower_operators() {
+                std::unordered_set<std::string> known;
+                for (const hir::Declaration &declaration : source_.declarations) {
+                    const auto *source = std::get_if<hir::OperatorDecl>(&declaration.node);
+                    if (source == nullptr || !declaration.symbol.valid()) { continue; }
+                    OperatorContract target;
+                    target.identity = symbol_identity(declaration.symbol);
+                    target.range    = declaration.range;
+                    lower_signature(source->generics, source->signature, target.generics, target.parameters, target.result);
+                    known.insert(target.identity);
+                    result_.operators.push_back(std::move(target));
+                }
+
+                for (const hir::Symbol &symbol : source_.symbols) {
+                    if (symbol.kind != hir::SymbolKind::ImportedOperator || symbol.canonical_name.empty() ||
+                        !known.insert(symbol.canonical_name).second) {
+                        continue;
+                    }
+                    result_.operators.push_back(OperatorContract{.identity      = symbol.canonical_name,
+                                                                 .registry_name = symbol.external_name,
+                                                                 .imported      = true,
+                                                                 .range         = symbol.range});
+                }
+            }
+
+            void lower_callables() {
+                for (const hir::Declaration &declaration : source_.declarations) {
+                    const auto *source = std::get_if<hir::FunctionDecl>(&declaration.node);
+                    if (source == nullptr || !declaration.symbol.valid()) { continue; }
+                    Callable target;
+                    target.visibility = lower_visibility(source->visibility);
+                    target.identity   = symbol_identity(declaration.symbol);
+                    if (target.visibility == CallableVisibility::Implementation) {
+                        target.identity += "#" + std::to_string(declaration.id.value);
+                    }
+                    target.kind =
+                        source->kind == hir::FunctionKind::Composition ? CallableKind::Composition : CallableKind::RuntimeNode;
+                    target.effects = source->effects;
+                    target.range   = declaration.range;
+                    if (source->operator_contract.valid()) {
+                        const hir::Symbol &op         = source_.symbol(source->operator_contract);
+                        target.operator_identity      = symbol_identity(source->operator_contract);
+                        target.operator_registry_name = op.external_name;
+                    }
+                    lower_signature(source->generics, source->signature, target.generics, target.parameters, target.result);
+                    for (hir::SymbolId capability : source->capabilities) {
+                        const hir::Symbol &symbol = source_.symbol(capability);
+                        target.capabilities.push_back(Capability{symbol.name, lower_type(symbol.type)});
+                    }
+                    result_.callables.push_back(std::move(target));
+                }
+            }
+
+            const hir::Module                             &source_;
+            syntax::DiagnosticSink                        &diagnostics_;
+            Module                                         result_{};
+            std::unordered_map<std::uint32_t, TypeId>      types_{};
+            std::unordered_map<std::uint32_t, ConstExprId> const_exprs_{};
+        };
+    }  // namespace
+
+    Module lower_interfaces(const ir::hir::Module &source, syntax::DiagnosticSink &diagnostics) {
+        return InterfaceLowerer{source, diagnostics}.run();
+    }
+}  // namespace hgl::hgraph_ir

--- a/language/src/hgraph_ir/lower.cpp
+++ b/language/src/hgraph_ir/lower.cpp
@@ -40,18 +40,6 @@ namespace hgl::hgraph_ir
                 return canonical.valid() ? canonical : source;
             }
 
-            [[nodiscard]] std::optional<hir::Constant> concrete_constant(hir::ExprId expression, syntax::SourceRange range,
-                                                                         std::string_view role) {
-                if (!expression.valid()) { return std::nullopt; }
-                const std::optional<hir::Constant> &value = source_.expr(expression).constant;
-                if (!value) {
-                    diagnostics_.report(syntax::Category::Type, range,
-                                        "typed HIR has no compile-time value for " + std::string{role});
-                    return std::nullopt;
-                }
-                return value;
-            }
-
             [[nodiscard]] ConstExprId lower_const_expr(hir::ExprId expression, syntax::SourceRange range, std::string_view role) {
                 if (!expression.valid()) { return {}; }
                 if (const auto found = const_exprs_.find(expression.value); found != const_exprs_.end()) { return found->second; }
@@ -63,7 +51,10 @@ namespace hgl::hgraph_ir
                 const hir::Expr &source = source_.expr(expression);
                 ConstExpr        target;
                 target.range = source.range;
-                if (source.constant) {
+                if (source.phase != hir::Phase::Constant) {
+                    diagnostics_.report(syntax::Category::Type, range,
+                                        "typed HIR has no compile-time expression for " + std::string{role});
+                } else if (source.constant) {
                     target.literal = source.constant;
                 } else if (const auto *reference = std::get_if<hir::SymbolRef>(&source.node)) {
                     if (!reference->symbol.valid() || source_.symbol(reference->symbol).kind != hir::SymbolKind::ConstParameter) {
@@ -82,6 +73,33 @@ namespace hgl::hgraph_ir
                     target.binary = binary->op;
                     target.lhs    = lower_const_expr(binary->lhs, source.range, role);
                     target.rhs    = lower_const_expr(binary->rhs, source.range, role);
+                } else if (const auto *index = std::get_if<hir::Index>(&source.node)) {
+                    target.kind = ConstExprKind::Index;
+                    target.lhs  = lower_const_expr(index->target, source.range, role);
+                    target.rhs  = lower_const_expr(index->index, source.range, role);
+                } else if (const auto *field = std::get_if<hir::Field>(&source.node)) {
+                    target.kind   = ConstExprKind::Field;
+                    target.lhs    = lower_const_expr(field->target, source.range, role);
+                    target.member = field->name;
+                } else if (const auto *sequence = std::get_if<hir::Sequence>(&source.node)) {
+                    target.kind = ConstExprKind::Sequence;
+                    for (const hir::SequenceElement &element : sequence->elements) {
+                        target.elements.push_back(ConstElement{
+                            .key   = lower_const_expr(element.key, source.range, role),
+                            .value = lower_const_expr(element.value, source.range, role),
+                        });
+                    }
+                } else if (const auto *tuple = std::get_if<hir::Tuple>(&source.node)) {
+                    target.kind = ConstExprKind::Tuple;
+                    for (hir::ExprId item : tuple->elements) { target.items.push_back(lower_const_expr(item, source.range, role)); }
+                } else if (const auto *construct = std::get_if<hir::Construct>(&source.node)) {
+                    target.kind             = ConstExprKind::Construct;
+                    target.constructed_type = lower_type(construct->type);
+                    target.delta            = construct->delta;
+                    for (const hir::Argument &argument : construct->arguments) {
+                        target.arguments.push_back(
+                            ConstArgument{argument.name, lower_const_expr(argument.value, argument.range, role)});
+                    }
                 } else {
                     diagnostics_.report(syntax::Category::Type, range, "hgraph IR cannot represent " + std::string{role} + " yet");
                 }
@@ -146,7 +164,7 @@ namespace hgl::hgraph_ir
                 target.name          = symbol.name;
                 target.is_const      = source.is_const;
                 target.type          = lower_type(source.type);
-                target.default_value = concrete_constant(source.default_value, symbol.range, "a parameter default");
+                target.default_value = lower_const_expr(source.default_value, symbol.range, "a parameter default");
                 return target;
             }
 

--- a/language/src/hgraph_ir/lower.h
+++ b/language/src/hgraph_ir/lower.h
@@ -1,0 +1,16 @@
+#ifndef HGL_HGRAPH_IR_LOWER_H
+#define HGL_HGRAPH_IR_LOWER_H
+
+#include "hgraph_ir/ir.h"
+#include "syntax/diagnostic.h"
+
+namespace hgl::hgraph_ir
+{
+    /// Lower the typed language interface into the execution-facing type and
+    /// callable tables. This foundation intentionally returns Interfaces;
+    /// body, activation, state, and lifecycle lowering advances it to
+    /// Executable in the next hgraph-IR slices.
+    [[nodiscard]] Module lower_interfaces(const ir::hir::Module &source, syntax::DiagnosticSink &diagnostics);
+}  // namespace hgl::hgraph_ir
+
+#endif  // HGL_HGRAPH_IR_LOWER_H

--- a/language/src/hgraph_ir/printer.cpp
+++ b/language/src/hgraph_ir/printer.cpp
@@ -46,7 +46,7 @@ namespace hgl::hgraph_ir
                     } else if constexpr (std::is_same_v<T, std::string>) {
                         out << std::quoted(value);
                     } else if constexpr (std::is_same_v<T, syntax::TemporalValue>) {
-                        out << "temporal(" << static_cast<unsigned>(value.kind) << ',' << value.micros << ')';
+                        out << syntax::canonical_spelling(value);
                     } else {
                         out << value;
                     }
@@ -116,9 +116,9 @@ namespace hgl::hgraph_ir
                 if (parameter.is_const) { out << "const "; }
                 out << parameter.name << ':';
                 print_type_id(out, parameter.type);
-                if (parameter.default_value) {
+                if (parameter.default_value.valid()) {
                     out << '=';
-                    print_constant(out, *parameter.default_value);
+                    print_const_expr_id(out, parameter.default_value);
                 }
             }
             out << ") -> ";
@@ -173,6 +173,48 @@ namespace hgl::hgraph_ir
                     print_const_expr_id(out, expression.lhs);
                     out << ' ';
                     print_const_expr_id(out, expression.rhs);
+                    break;
+                case ConstExprKind::Index:
+                    out << "index ";
+                    print_const_expr_id(out, expression.lhs);
+                    out << ' ';
+                    print_const_expr_id(out, expression.rhs);
+                    break;
+                case ConstExprKind::Field:
+                    out << "field ";
+                    print_const_expr_id(out, expression.lhs);
+                    out << ' ' << expression.member;
+                    break;
+                case ConstExprKind::Sequence:
+                    out << "sequence [";
+                    for (std::size_t item = 0; item < expression.elements.size(); ++item) {
+                        if (item != 0) { out << ", "; }
+                        if (expression.elements[item].key.valid()) {
+                            print_const_expr_id(out, expression.elements[item].key);
+                            out << ':';
+                        }
+                        print_const_expr_id(out, expression.elements[item].value);
+                    }
+                    out << ']';
+                    break;
+                case ConstExprKind::Tuple:
+                    out << "tuple [";
+                    for (std::size_t item = 0; item < expression.items.size(); ++item) {
+                        if (item != 0) { out << ", "; }
+                        print_const_expr_id(out, expression.items[item]);
+                    }
+                    out << ']';
+                    break;
+                case ConstExprKind::Construct:
+                    out << (expression.delta ? "delta " : "construct ");
+                    print_type_id(out, expression.constructed_type);
+                    out << " [";
+                    for (std::size_t argument = 0; argument < expression.arguments.size(); ++argument) {
+                        if (argument != 0) { out << ", "; }
+                        if (!expression.arguments[argument].name.empty()) { out << expression.arguments[argument].name << '='; }
+                        print_const_expr_id(out, expression.arguments[argument].value);
+                    }
+                    out << ']';
                     break;
             }
             out << '\n';

--- a/language/src/hgraph_ir/printer.cpp
+++ b/language/src/hgraph_ir/printer.cpp
@@ -1,0 +1,255 @@
+#include "hgraph_ir/printer.h"
+
+#include <iomanip>
+#include <sstream>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+namespace hgl::hgraph_ir
+{
+    namespace
+    {
+        namespace hir = ir::hir;
+
+        [[nodiscard]] std::string_view type_kind_name(hir::TypeKind kind) noexcept {
+            switch (kind) {
+                case hir::TypeKind::Void: return "void";
+                case hir::TypeKind::Scalar: return "scalar";
+                case hir::TypeKind::Symbol: return "symbol";
+                case hir::TypeKind::Tuple: return "tuple";
+                case hir::TypeKind::List: return "list";
+                case hir::TypeKind::Set: return "set";
+                case hir::TypeKind::Map: return "map";
+                case hir::TypeKind::Rolling: return "rolling";
+                case hir::TypeKind::Atomic: return "atomic";
+                case hir::TypeKind::Iterator: return "iterator";
+                case hir::TypeKind::Callable: return "callable";
+                case hir::TypeKind::Capability: return "capability";
+                case hir::TypeKind::HarnessSequence: return "harness-sequence";
+                case hir::TypeKind::Deferred: return "deferred";
+            }
+            std::unreachable();
+        }
+
+        void print_constant(std::ostream &out, const hir::Constant &constant) {
+            std::visit(
+                [&](const auto &value) {
+                    using T = std::decay_t<decltype(value)>;
+                    if constexpr (std::is_same_v<T, hir::NullValue>) {
+                        out << "null";
+                    } else if constexpr (std::is_same_v<T, hir::PlaceholderValue>) {
+                        out << '_';
+                    } else if constexpr (std::is_same_v<T, bool>) {
+                        out << (value ? "true" : "false");
+                    } else if constexpr (std::is_same_v<T, std::string>) {
+                        out << std::quoted(value);
+                    } else if constexpr (std::is_same_v<T, syntax::TemporalValue>) {
+                        out << "temporal(" << static_cast<unsigned>(value.kind) << ',' << value.micros << ')';
+                    } else {
+                        out << value;
+                    }
+                },
+                constant);
+        }
+
+        void print_type_id(std::ostream &out, TypeId id) {
+            if (id.valid()) {
+                out << 't' << id.value;
+            } else {
+                out << '_';
+            }
+        }
+
+        void print_const_expr_id(std::ostream &out, ConstExprId id) {
+            if (id.valid()) {
+                out << 'c' << id.value;
+            } else {
+                out << '_';
+            }
+        }
+
+        [[nodiscard]] std::string_view unary_name(hir::UnaryOp op) noexcept {
+            return op == hir::UnaryOp::Negate ? "negate" : "not";
+        }
+
+        [[nodiscard]] std::string_view binary_name(hir::BinaryOp op) noexcept {
+            switch (op) {
+                case hir::BinaryOp::Mul: return "mul";
+                case hir::BinaryOp::Div: return "div";
+                case hir::BinaryOp::Rem: return "rem";
+                case hir::BinaryOp::Add: return "add";
+                case hir::BinaryOp::Sub: return "sub";
+                case hir::BinaryOp::Less: return "less";
+                case hir::BinaryOp::LessEqual: return "less-equal";
+                case hir::BinaryOp::Greater: return "greater";
+                case hir::BinaryOp::GreaterEqual: return "greater-equal";
+                case hir::BinaryOp::Equal: return "equal";
+                case hir::BinaryOp::NotEqual: return "not-equal";
+                case hir::BinaryOp::And: return "and";
+                case hir::BinaryOp::Or: return "or";
+            }
+            std::unreachable();
+        }
+
+        void print_signature(std::ostream &out, const std::vector<GenericParameter> &generics,
+                             const std::vector<Parameter> &parameters, TypeId result) {
+            if (!generics.empty()) {
+                out << '<';
+                for (std::size_t index = 0; index < generics.size(); ++index) {
+                    if (index != 0) { out << ", "; }
+                    const GenericParameter &generic = generics[index];
+                    if (generic.is_const) { out << "const "; }
+                    out << generic.name;
+                    if (generic.type.valid()) {
+                        out << ':';
+                        print_type_id(out, generic.type);
+                    }
+                }
+                out << '>';
+            }
+            out << '(';
+            for (std::size_t index = 0; index < parameters.size(); ++index) {
+                if (index != 0) { out << ", "; }
+                const Parameter &parameter = parameters[index];
+                if (parameter.is_const) { out << "const "; }
+                out << parameter.name << ':';
+                print_type_id(out, parameter.type);
+                if (parameter.default_value) {
+                    out << '=';
+                    print_constant(out, *parameter.default_value);
+                }
+            }
+            out << ") -> ";
+            print_type_id(out, result);
+        }
+
+        void print_effects(std::ostream &out, hir::Effect effects) {
+            bool       first = true;
+            const auto add   = [&](std::string_view name, hir::Effect flag) {
+                if (!hir::has_effect(effects, flag)) { return; }
+                if (!first) { out << '|'; }
+                out << name;
+                first = false;
+            };
+            add("wire", hir::Effect::WireGraph);
+            add("read-input", hir::Effect::ReadRuntimeInput);
+            add("read-state", hir::Effect::ReadState);
+            add("write-local", hir::Effect::WriteLocal);
+            add("write-state", hir::Effect::WriteState);
+            add("write-output", hir::Effect::WriteOutput);
+            add("capability", hir::Effect::UseCapability);
+            add("iterate", hir::Effect::IterateCollection);
+            add("harness", hir::Effect::TestHarness);
+            if (first) { out << "none"; }
+        }
+    }  // namespace
+
+    std::string print(const Module &module) {
+        std::ostringstream out;
+        out << "HGRAPH-IR " << (module.completion == Completion::Interfaces ? "interfaces" : "executable") << " module "
+            << module.path << '\n';
+        out << "constant-expressions\n";
+        for (std::size_t index = 0; index < module.const_exprs.size(); ++index) {
+            const ConstExpr &expression = module.const_exprs[index];
+            out << "  c" << index << ' ';
+            switch (expression.kind) {
+                case ConstExprKind::Literal:
+                    out << "literal ";
+                    if (expression.literal) {
+                        print_constant(out, *expression.literal);
+                    } else {
+                        out << '?';
+                    }
+                    break;
+                case ConstExprKind::Parameter: out << "parameter " << expression.parameter; break;
+                case ConstExprKind::Unary:
+                    out << unary_name(expression.unary) << ' ';
+                    print_const_expr_id(out, expression.lhs);
+                    break;
+                case ConstExprKind::Binary:
+                    out << binary_name(expression.binary) << ' ';
+                    print_const_expr_id(out, expression.lhs);
+                    out << ' ';
+                    print_const_expr_id(out, expression.rhs);
+                    break;
+            }
+            out << '\n';
+        }
+        out << "types\n";
+        for (std::size_t index = 0; index < module.types.size(); ++index) {
+            const Type &type = module.types[index];
+            out << "  t" << index << ' ' << type_kind_name(type.kind);
+            if (type.kind == hir::TypeKind::Scalar) { out << ' ' << hir::scalar_type_name(type.scalar); }
+            if (!type.nominal_identity.empty()) { out << " nominal=" << type.nominal_identity; }
+            if (!type.children.empty()) {
+                out << " children=[";
+                for (std::size_t child = 0; child < type.children.size(); ++child) {
+                    if (child != 0) { out << ", "; }
+                    print_type_id(out, type.children[child]);
+                }
+                out << ']';
+            }
+            if (!type.arguments.empty()) {
+                out << " arguments=[";
+                for (std::size_t argument = 0; argument < type.arguments.size(); ++argument) {
+                    if (argument != 0) { out << ", "; }
+                    if (type.arguments[argument].type) {
+                        print_type_id(out, *type.arguments[argument].type);
+                    } else if (type.arguments[argument].value) {
+                        print_const_expr_id(out, *type.arguments[argument].value);
+                    } else {
+                        out << '?';
+                    }
+                }
+                out << ']';
+            }
+            if (type.size.valid()) {
+                out << " size=";
+                print_const_expr_id(out, type.size);
+            }
+            if (type.min_size.valid()) {
+                out << " min-size=";
+                print_const_expr_id(out, type.min_size);
+            }
+            if (type.unbounded) { out << " unbounded"; }
+            out << '\n';
+        }
+
+        out << "operators\n";
+        for (const OperatorContract &op : module.operators) {
+            out << "  " << (op.imported ? "import " : "define ") << op.identity;
+            if (!op.registry_name.empty()) { out << " registry=" << op.registry_name; }
+            if (!op.imported) {
+                out << ' ';
+                print_signature(out, op.generics, op.parameters, op.result);
+            }
+            out << '\n';
+        }
+
+        out << "callables\n";
+        for (const Callable &callable : module.callables) {
+            static constexpr std::string_view visibility[]{"internal", "export", "impl"};
+            out << "  " << visibility[static_cast<std::size_t>(callable.visibility)] << ' '
+                << (callable.kind == CallableKind::Composition ? "composition" : "runtime-node") << ' ' << callable.identity;
+            if (!callable.operator_identity.empty()) { out << " operator=" << callable.operator_identity; }
+            if (!callable.operator_registry_name.empty()) { out << " registry=" << callable.operator_registry_name; }
+            out << ' ';
+            print_signature(out, callable.generics, callable.parameters, callable.result);
+            out << " effects=";
+            print_effects(out, callable.effects);
+            if (!callable.capabilities.empty()) {
+                out << " capabilities=[";
+                for (std::size_t index = 0; index < callable.capabilities.size(); ++index) {
+                    if (index != 0) { out << ", "; }
+                    out << callable.capabilities[index].name << ':';
+                    print_type_id(out, callable.capabilities[index].type);
+                }
+                out << ']';
+            }
+            out << '\n';
+        }
+        return out.str();
+    }
+}  // namespace hgl::hgraph_ir

--- a/language/src/hgraph_ir/printer.h
+++ b/language/src/hgraph_ir/printer.h
@@ -1,0 +1,13 @@
+#ifndef HGL_HGRAPH_IR_PRINTER_H
+#define HGL_HGRAPH_IR_PRINTER_H
+
+#include "hgraph_ir/ir.h"
+
+#include <string>
+
+namespace hgl::hgraph_ir
+{
+    [[nodiscard]] std::string print(const Module &module);
+}  // namespace hgl::hgraph_ir
+
+#endif  // HGL_HGRAPH_IR_PRINTER_H

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -33,6 +33,14 @@ set_tests_properties(hgraph_language_dump_hir PROPERTIES
     PASS_REGULAR_EXPRESSION "HIR typed module examples.stateful_node"
 )
 
+add_test(
+    NAME hgraph_language_dump_hgraph_ir
+    COMMAND $<TARGET_FILE:hgl> check ${CMAKE_CURRENT_SOURCE_DIR}/../examples/stateful-node.hgl --dump-hgraph-ir
+)
+set_tests_properties(hgraph_language_dump_hgraph_ir PROPERTIES
+    PASS_REGULAR_EXPRESSION "HGRAPH-IR interfaces module examples.stateful_node"
+)
+
 # Catch2 for the frontend unit tests: reuse the repository's target when the
 # language is built as part of hgraph, else find or fetch it.
 if(NOT TARGET Catch2::Catch2WithMain)
@@ -82,6 +90,16 @@ target_compile_definitions(hgl_ir_tests PRIVATE HGL_EXAMPLES_DIR="${CMAKE_CURREN
 hgl_apply_warnings(hgl_ir_tests)
 
 add_test(NAME hgraph_language_ir COMMAND hgl_ir_tests)
+
+# The hgraph-IR boundary starts with self-contained canonical type and callable
+# interfaces. Body/control-flow plans are added in the following stacked slice.
+add_executable(hgl_graph_ir_tests hgraph_ir/lower_tests.cpp)
+target_compile_features(hgl_graph_ir_tests PRIVATE cxx_std_23)
+target_link_libraries(hgl_graph_ir_tests PRIVATE hgl::graph_ir Catch2::Catch2WithMain)
+target_compile_definitions(hgl_graph_ir_tests PRIVATE HGL_EXAMPLES_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../examples")
+hgl_apply_warnings(hgl_graph_ir_tests)
+
+add_test(NAME hgraph_language_hgraph_ir COMMAND hgl_graph_ir_tests)
 
 # The direct-wiring backend against the live registry: folding, eval, the
 # failure detail, run_program (developer guide, "First pass").

--- a/language/tests/hgraph_ir/lower_tests.cpp
+++ b/language/tests/hgraph_ir/lower_tests.cpp
@@ -169,6 +169,37 @@ operator recent<T, const N: i64>(values: rolling<T, N>) -> T
     CHECK(rolling->min_size == rolling->size);
 }
 
+TEST_CASE("hgraph IR preserves aggregate and temporal parameter defaults", "[hgraph-ir][defaults]") {
+    Lowered lowered{R"(
+module checks.defaults
+
+fn configured<const N: i64>(
+    value: f64,
+    const sizes: list<i64> = [1, 2],
+    const width: i64 = N,
+    const venue: timezone = @[Europe/London]
+) -> f64 => value
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE_FALSE(lowered.diagnostics.has_errors());
+    REQUIRE(lowered.graph);
+
+    const hgl::hgraph_ir::Callable *configured = callable(*lowered.graph, "checks.defaults.configured");
+    REQUIRE(configured != nullptr);
+    REQUIRE(configured->parameters.size() == 4);
+    const hgl::hgraph_ir::ConstExprId sizes = configured->parameters[1].default_value;
+    REQUIRE(sizes.valid());
+    const hgl::hgraph_ir::ConstExpr &sequence = lowered.graph->const_exprs[sizes.value];
+    CHECK(sequence.kind == hgl::hgraph_ir::ConstExprKind::Sequence);
+    CHECK(sequence.elements.size() == 2);
+    const hgl::hgraph_ir::ConstExprId width = configured->parameters[2].default_value;
+    REQUIRE(width.valid());
+    CHECK(lowered.graph->const_exprs[width.value].kind == hgl::hgraph_ir::ConstExprKind::Parameter);
+    CHECK(lowered.graph->const_exprs[width.value].parameter == "N");
+    const std::string dump = hgl::hgraph_ir::print(*lowered.graph);
+    CHECK(dump.find("@[Europe/London]") != std::string::npos);
+}
+
 TEST_CASE("hgraph IR lowering rejects unresolved HIR", "[hgraph-ir][completion]") {
     hir::Module                  unresolved;
     hgl::syntax::DiagnosticSink  diagnostics;

--- a/language/tests/hgraph_ir/lower_tests.cpp
+++ b/language/tests/hgraph_ir/lower_tests.cpp
@@ -1,0 +1,178 @@
+#include "hgraph_ir/lower.h"
+#include "hgraph_ir/printer.h"
+#include "ir/lower.h"
+#include "ir/type_check.h"
+#include "semantics/resolve.h"
+#include "syntax/parser.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace
+{
+    namespace hir = hgl::ir::hir;
+
+    bool has_operator(std::string_view name) { return name != "map"; }
+
+    struct Lowered
+    {
+        hgl::syntax::SourceFile               file;
+        hgl::syntax::DiagnosticSink           diagnostics{};
+        std::optional<hgl::hgraph_ir::Module> graph{};
+
+        explicit Lowered(std::string text, std::string path = "test.hgl") : file{std::move(path), std::move(text)} {
+            hgl::syntax::ast::Module ast = hgl::syntax::parse(file, diagnostics);
+            if (diagnostics.has_errors()) { return; }
+            hgl::semantics::ResolvedModule resolved = hgl::semantics::resolve(file, ast, has_operator, diagnostics);
+            if (diagnostics.has_errors()) { return; }
+            hir::Module                     language  = hgl::ir::lower_to_hir(ast, resolved, diagnostics);
+            const hgl::ir::OperatorResolver operators = [](const hir::Module &, const hgl::ir::OperatorQuery &query) {
+                hgl::ir::OperatorSelection selected;
+                selected.result   = query.expected_result;
+                selected.deferred = true;
+                return selected;
+            };
+            if (!hgl::ir::complete_hir(language, operators, diagnostics)) { return; }
+            graph = hgl::hgraph_ir::lower_interfaces(language, diagnostics);
+        }
+    };
+
+    const hgl::hgraph_ir::Callable *callable(const hgl::hgraph_ir::Module &module, std::string_view identity) {
+        for (const hgl::hgraph_ir::Callable &candidate : module.callables) {
+            if (candidate.identity == identity) { return &candidate; }
+        }
+        return nullptr;
+    }
+}  // namespace
+
+TEST_CASE("every guide example lowers an hgraph IR interface", "[hgraph-ir][examples]") {
+    const std::filesystem::path directory{HGL_EXAMPLES_DIR};
+    REQUIRE(std::filesystem::is_directory(directory));
+
+    std::size_t count = 0;
+    for (const std::filesystem::directory_entry &entry : std::filesystem::directory_iterator{directory}) {
+        if (entry.path().extension() != ".hgl") { continue; }
+        ++count;
+        std::ifstream input{entry.path()};
+        REQUIRE(input.good());
+        Lowered lowered{std::string{std::istreambuf_iterator<char>{input}, std::istreambuf_iterator<char>{}},
+                        entry.path().string()};
+        INFO(entry.path().filename().string());
+        INFO(lowered.diagnostics.render(lowered.file));
+        REQUIRE_FALSE(lowered.diagnostics.has_errors());
+        REQUIRE(lowered.graph);
+        CHECK(lowered.graph->completion == hgl::hgraph_ir::Completion::Interfaces);
+        CHECK_FALSE(lowered.graph->types.empty());
+        for (const hgl::hgraph_ir::Callable &function : lowered.graph->callables) {
+            CHECK_FALSE(function.identity.empty());
+            CHECK(function.result.valid());
+            for (const hgl::hgraph_ir::Parameter &parameter : function.parameters) { CHECK(parameter.type.valid()); }
+        }
+    }
+    CHECK(count >= 6);
+}
+
+TEST_CASE("hgraph IR separates a contract identity from its native registry key", "[hgraph-ir][operators]") {
+    Lowered lowered{R"(
+module checks.operator_identity
+
+use hgraph.std::{map}
+
+fn map_values(values: map<str, f64>) -> map<str, f64> =>
+    map(values, fn(value) => value)
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE_FALSE(lowered.diagnostics.has_errors());
+    REQUIRE(lowered.graph);
+
+    REQUIRE(lowered.graph->operators.size() == 1);
+    const hgl::hgraph_ir::OperatorContract &op = lowered.graph->operators.front();
+    CHECK(op.imported);
+    CHECK(op.identity == "hgraph.std.map");
+    CHECK(op.registry_name == "map_");
+}
+
+TEST_CASE("hgraph IR classifies runtime nodes and copies capabilities", "[hgraph-ir][runtime]") {
+    Lowered lowered{R"(
+module checks.runtime
+
+export fn total(value: f64) -> f64 {
+    state current: f64 = 0.0
+    inject out, logger
+    when modified(value) {
+        current += value
+        out = current
+    }
+}
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE_FALSE(lowered.diagnostics.has_errors());
+    REQUIRE(lowered.graph);
+
+    const hgl::hgraph_ir::Callable *total = callable(*lowered.graph, "checks.runtime.total");
+    REQUIRE(total != nullptr);
+    CHECK(total->visibility == hgl::hgraph_ir::CallableVisibility::Export);
+    CHECK(total->kind == hgl::hgraph_ir::CallableKind::RuntimeNode);
+    REQUIRE(total->capabilities.size() == 2);
+    CHECK(total->capabilities[0].name == "out");
+    CHECK(total->capabilities[0].type == total->result);
+    CHECK(total->capabilities[1].name == "logger");
+    CHECK(total->capabilities[1].type.valid());
+    CHECK(hir::has_effect(total->effects, hir::Effect::WriteState));
+    CHECK(hir::has_effect(total->effects, hir::Effect::WriteOutput));
+}
+
+TEST_CASE("hgraph IR preserves source implementation candidates", "[hgraph-ir][operators]") {
+    Lowered lowered{R"(
+module checks.implementation
+
+operator choose<T>(value: T) -> T
+impl fn choose(value: f64) -> f64 => value
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE_FALSE(lowered.diagnostics.has_errors());
+    REQUIRE(lowered.graph);
+
+    REQUIRE(lowered.graph->operators.size() == 1);
+    CHECK(lowered.graph->operators.front().identity == "checks.implementation.choose");
+    REQUIRE(lowered.graph->callables.size() == 1);
+    const hgl::hgraph_ir::Callable &implementation = lowered.graph->callables.front();
+    CHECK(implementation.visibility == hgl::hgraph_ir::CallableVisibility::Implementation);
+    CHECK(implementation.operator_identity == "checks.implementation.choose");
+    CHECK(implementation.identity == "checks.implementation.choose#2");
+}
+
+TEST_CASE("hgraph IR owns symbolic compile-time type arguments", "[hgraph-ir][types]") {
+    Lowered lowered{R"(
+module checks.const_types
+
+operator recent<T, const N: i64>(values: rolling<T, N>) -> T
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE_FALSE(lowered.diagnostics.has_errors());
+    REQUIRE(lowered.graph);
+
+    const auto rolling = std::ranges::find_if(lowered.graph->types,
+                                              [](const hgl::hgraph_ir::Type &type) { return type.kind == hir::TypeKind::Rolling; });
+    REQUIRE(rolling != lowered.graph->types.end());
+    REQUIRE(rolling->size.valid());
+    const hgl::hgraph_ir::ConstExpr &size = lowered.graph->const_exprs[rolling->size.value];
+    CHECK(size.kind == hgl::hgraph_ir::ConstExprKind::Parameter);
+    CHECK(size.parameter == "N");
+    CHECK(rolling->min_size == rolling->size);
+}
+
+TEST_CASE("hgraph IR lowering rejects unresolved HIR", "[hgraph-ir][completion]") {
+    hir::Module                  unresolved;
+    hgl::syntax::DiagnosticSink  diagnostics;
+    const hgl::hgraph_ir::Module graph = hgl::hgraph_ir::lower_interfaces(unresolved, diagnostics);
+    CHECK(diagnostics.has_errors());
+    CHECK(graph.completion == hgl::hgraph_ir::Completion::Interfaces);
+}


### PR DESCRIPTION
## Summary
- add a dedicated `hgl_graph_ir` layer between typed HIR and the execution backends
- lower independently owned canonical types, compile-time type expressions, operator contracts, callable interfaces, effects, and typed capabilities
- preserve canonical operator identity separately from native registry spelling
- expose deterministic `hgl check --dump-hgraph-ir` output
- restage descriptor-dependent typed-HIR work under the native-interface stage and deferred-call completion under hgraph IR

This checkpoint is deliberately marked `Interfaces`, not `Executable`; backend migration follows body, state, lifecycle, activation, traversal, output, and provider-plan lowering.

## Validation
- 29/29 HGL CTest tests
- 141 hgraph-IR assertions across 6 cases
- full native and Python 3.14 stack gates are running on this tip