### PR TITLE
feat(language): preserve hgraph IR contracts

### DIFF
--- a/language/docs/design/compiler-architecture.md
+++ b/language/docs/design/compiler-architecture.md
@@ -169,6 +169,8 @@ prototype. The serialization is diagnostic, not a compatibility format.
 Hgraph IR is the lowering boundary between language semantics and execution.
 It distinguishes:
 
+- canonical types, compile-time expressions, normalized requirements, and
+  effective nominal struct contracts;
 - wiring-time constants, exact calls, and nominal operator calls;
 - runtime node state layout and initialization;
 - injected capabilities;
@@ -183,7 +185,9 @@ include syntax AST headers or redo name lookup, type inference, function
 classification, phase checking, or generic substitution.
 
 `hgl check --dump-hgraph-ir` exposes a readable, source-ranged form for tests
-and compiler diagnosis.
+and compiler diagnosis. The interface checkpoint owns all type, constant,
+constraint, struct, operator, and callable references in hgraph-IR arenas;
+execution-plan lowering may not recover them from HIR declarations.
 
 ### Backends
 

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -141,7 +141,10 @@ the temporary resolved-AST semantic walks belongs to stages D and E.
 Status: in progress. The first checkpoint introduces a dedicated
 `hgl_graph_ir` target and lowers typed HIR into self-contained canonical type,
 compile-time expression (including aggregate parameter defaults),
-operator-contract, and callable-interface tables.
+constraint, effective nominal-struct, operator-contract, and callable-interface
+tables. Struct fields retain their defining contract and effective default;
+requirements retain exact symbol and native registry identities without HIR
+symbol or expression references.
 `hgl check --dump-hgraph-ir` exposes that deterministic interface form. The
 module remains explicitly `Interfaces`, not `Executable`; body, activation,
 state, lifecycle, traversal, and provider-plan lowering plus direct-backend

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -185,7 +185,9 @@ spelling kept separate, and callable interfaces with visibility,
 composition/runtime classification, generics, effects, and capabilities.
 Effective fields retain their defining struct identity, while every constraint
 reference uses hgraph-IR type, constant-expression, and requirement IDs rather
-than semantic symbols. `hgl check
+than semantic symbols. Inherited field types and defaults are substituted
+through each applied parent, so a child contract refers only to its own generic
+scope even when parent parameters have different names. `hgl check
 --dump-hgraph-ir` prints that representation. The
 result is explicitly marked `Interfaces`: body/control-flow, state, lifecycle,
 activation, traversal, output, and provider plans must be lowered before it may

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -179,9 +179,13 @@ leaves the module `Resolved`; it is never discarded by a temporary backend.
 `src/hgraph_ir/lower` now establishes the execution-facing boundary. Its first
 checkpoint copies typed HIR into an independently owned canonical type table,
 a compile-time expression arena for type and window sizes and scalar or
-aggregate parameter defaults, nominal operator contracts with registry spelling
-kept separate, and callable interfaces with visibility, composition/runtime
-classification, generics, effects, and capabilities. `hgl check
+aggregate parameter and struct-field defaults, normalized generic requirements,
+effective nominal struct contracts, nominal operator contracts with registry
+spelling kept separate, and callable interfaces with visibility,
+composition/runtime classification, generics, effects, and capabilities.
+Effective fields retain their defining struct identity, while every constraint
+reference uses hgraph-IR type, constant-expression, and requirement IDs rather
+than semantic symbols. `hgl check
 --dump-hgraph-ir` prints that representation. The
 result is explicitly marked `Interfaces`: body/control-flow, state, lifecycle,
 activation, traversal, output, and provider plans must be lowered before it may

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -120,8 +120,9 @@ signatures. Focused cases cover canonical versus native registry identities,
 runtime classification and capabilities, distinct source implementation
 identities, compile-time generic expressions, aggregate defaults, complete
 temporal spellings, normalized operator and callable requirements, abstract and
-concrete nominal contracts, inherited field origin/default metadata, and
-rejection of unresolved HIR.
+concrete nominal contracts, inherited field origin/default metadata,
+renamed inherited type and `const` parameters, and rejection of unresolved
+HIR.
 CTest `hgraph_language_dump_hgraph_ir` locks the CLI dump entry point.
 
 Each valid guide example has a source-ranged typed-HIR snapshot containing

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -119,7 +119,9 @@ interface-only hgraph IR module with self-contained types and callable
 signatures. Focused cases cover canonical versus native registry identities,
 runtime classification and capabilities, distinct source implementation
 identities, compile-time generic expressions, aggregate defaults, complete
-temporal spellings, and rejection of unresolved HIR.
+temporal spellings, normalized operator and callable requirements, abstract and
+concrete nominal contracts, inherited field origin/default metadata, and
+rejection of unresolved HIR.
 CTest `hgraph_language_dump_hgraph_ir` locks the CLI dump entry point.
 
 Each valid guide example has a source-ranged typed-HIR snapshot containing

--- a/language/src/README.md
+++ b/language/src/README.md
@@ -10,7 +10,7 @@ them.
 | `syntax/` | source buffers, diagnostics, temporal literals, lexer, parser, arena AST | source text to source-accurate syntax |
 | `semantics/` | name binding, nominal hierarchy, generic argument roles, function classification | syntax plus descriptors to resolved names and shapes |
 | `ir/` | source-ranged HIR, canonical types, substitutions, constraint solving, phase/effect completion | resolved frontend state to typed HIR |
-| `hgraph_ir/` | canonical execution-facing types, compile-time expressions, operator and callable interfaces | typed HIR to executable composition and runtime-node plans |
+| `hgraph_ir/` | canonical execution-facing types, compile-time expressions, constraints, struct contracts, operator and callable interfaces | typed HIR to executable composition and runtime-node plans |
 | `wiring/` | direct walk over `ResolvedModule` | hgraph IR to public erased wiring calls |
 | `codegen/` | direct walk over `ResolvedModule` | hgraph IR to formatted C++ and build artifacts |
 | `driver/` | commands, native build/cache/load, REPL orchestration | assemble inputs and invoke passes |

--- a/language/src/hgraph_ir/ir.h
+++ b/language/src/hgraph_ir/ir.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <variant>
 #include <vector>
 
 namespace hgl::hgraph_ir
@@ -19,9 +20,10 @@ namespace hgl::hgraph_ir
         friend constexpr bool        operator==(Id, Id) noexcept = default;
     };
 
-    using TypeId      = Id<struct TypeTag>;
-    using CallableId  = Id<struct CallableTag>;
-    using ConstExprId = Id<struct ConstExprTag>;
+    using TypeId       = Id<struct TypeTag>;
+    using CallableId   = Id<struct CallableTag>;
+    using ConstExprId  = Id<struct ConstExprTag>;
+    using ConstraintId = Id<struct ConstraintTag>;
 
     enum class ConstExprKind : std::uint8_t {
         Literal,
@@ -101,6 +103,87 @@ namespace hgl::hgraph_ir
         ConstExprId default_value{};
     };
 
+    enum class ConstraintLogicOp : std::uint8_t {
+        And,
+        Or,
+    };
+
+    enum class ConstraintRelationOp : std::uint8_t {
+        Equal,
+        In,
+        Is,
+    };
+
+    struct ConstraintSymbol
+    { std::string identity{}; };
+    struct ConstraintType
+    { TypeId type{}; };
+    struct ConstraintValue
+    { ConstExprId value{}; };
+    struct ConstraintSet
+    { std::vector<ConstraintId> elements{}; };
+    struct ConstraintCall
+    {
+        std::string               function_identity{};
+        std::vector<ConstraintId> arguments{};
+    };
+    struct OperatorRequirement
+    {
+        std::string               operator_identity{};
+        std::string               operator_registry_name{};
+        std::vector<ConstraintId> arguments{};
+        TypeId                    result{};
+    };
+    struct ConstraintRelation
+    {
+        ConstraintRelationOp op{ConstraintRelationOp::Equal};
+        ConstraintId         lhs{};
+        ConstraintId         rhs{};
+        std::string          category{};
+    };
+    struct ConstraintNot
+    { ConstraintId operand{}; };
+    struct ConstraintLogic
+    {
+        ConstraintLogicOp op{ConstraintLogicOp::And};
+        ConstraintId      lhs{};
+        ConstraintId      rhs{};
+    };
+    using ConstraintNode = std::variant<ConstraintSymbol, ConstraintType, ConstraintValue, ConstraintSet, ConstraintCall,
+                                        OperatorRequirement, ConstraintRelation, ConstraintNot, ConstraintLogic>;
+
+    /// A resolved generic requirement. All references use hgraph-IR identities
+    /// and arenas, so backends never need semantic symbols or expression IDs.
+    struct Constraint
+    {
+        syntax::SourceRange range{};
+        ConstraintNode      node{};
+    };
+
+    struct StructField
+    {
+        std::string         name{};
+        TypeId              type{};
+        ConstExprId         default_value{};
+        std::string         origin_identity{};
+        bool                optional{false};
+        syntax::SourceRange range{};
+    };
+
+    /// A nominal value/schema contract with its complete inherited field set.
+    /// Concrete specializations can be built without walking HIR declarations.
+    struct StructContract
+    {
+        std::string                   identity{};
+        bool                          exported{false};
+        bool                          abstract{false};
+        std::vector<GenericParameter> generics{};
+        std::vector<TypeId>           parents{};
+        ConstraintId                  requirements{};
+        std::vector<StructField>      fields{};
+        syntax::SourceRange           range{};
+    };
+
     struct OperatorContract
     {
         std::string                   identity{};
@@ -109,6 +192,7 @@ namespace hgl::hgraph_ir
         std::vector<GenericParameter> generics{};
         std::vector<Parameter>        parameters{};
         TypeId                        result{};
+        ConstraintId                  requirements{};
         syntax::SourceRange           range{};
     };
 
@@ -143,6 +227,7 @@ namespace hgl::hgraph_ir
         std::vector<GenericParameter> generics{};
         std::vector<Parameter>        parameters{};
         TypeId                        result{};
+        ConstraintId                  requirements{};
         ir::hir::Effect               effects{ir::hir::Effect::None};
         std::vector<Capability>       capabilities{};
         syntax::SourceRange           range{};
@@ -159,6 +244,8 @@ namespace hgl::hgraph_ir
         Completion                    completion{Completion::Interfaces};
         std::vector<ConstExpr>        const_exprs{};
         std::vector<Type>             types{};
+        std::vector<Constraint>       constraints{};
+        std::vector<StructContract>   structures{};
         std::vector<OperatorContract> operators{};
         std::vector<Callable>         callables{};
     };

--- a/language/src/hgraph_ir/ir.h
+++ b/language/src/hgraph_ir/ir.h
@@ -71,6 +71,8 @@ namespace hgl::hgraph_ir
     {
         std::optional<TypeId>      type{};
         std::optional<ConstExprId> value{};
+
+        friend bool operator==(const TypeArgument &, const TypeArgument &) = default;
     };
 
     /// A self-contained canonical HGL type prepared for hgraph lowering.
@@ -86,6 +88,8 @@ namespace hgl::hgraph_ir
         ConstExprId               size{};
         ConstExprId               min_size{};
         bool                      unbounded{false};
+
+        friend bool operator==(const Type &, const Type &) = default;
     };
 
     struct GenericParameter

--- a/language/src/hgraph_ir/lower.cpp
+++ b/language/src/hgraph_ir/lower.cpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -28,6 +29,8 @@ namespace hgl::hgraph_ir
                 }
 
                 lower_types();
+                lower_constraints();
+                lower_structures();
                 lower_operators();
                 lower_callables();
                 return std::move(result_);
@@ -168,6 +171,115 @@ namespace hgl::hgraph_ir
                 return target;
             }
 
+            [[nodiscard]] static ConstraintLogicOp lower_logic_op(hir::ConstraintLogicOp source) noexcept {
+                return source == hir::ConstraintLogicOp::And ? ConstraintLogicOp::And : ConstraintLogicOp::Or;
+            }
+
+            [[nodiscard]] static ConstraintRelationOp lower_relation_op(hir::ConstraintRelationOp source) noexcept {
+                switch (source) {
+                    case hir::ConstraintRelationOp::Equal: return ConstraintRelationOp::Equal;
+                    case hir::ConstraintRelationOp::In: return ConstraintRelationOp::In;
+                    case hir::ConstraintRelationOp::Is: return ConstraintRelationOp::Is;
+                }
+                std::unreachable();
+            }
+
+            [[nodiscard]] ConstraintId lower_constraint(hir::ConstraintId source_id) {
+                if (!source_id.valid()) { return {}; }
+                if (const auto found = constraints_.find(source_id.value); found != constraints_.end()) { return found->second; }
+
+                const ConstraintId id{static_cast<std::uint32_t>(result_.constraints.size())};
+                constraints_.emplace(source_id.value, id);
+                result_.constraints.emplace_back();
+
+                const hir::Constraint &source = source_.constraint(source_id);
+                Constraint             target;
+                target.range = source.range;
+                target.node  = std::visit(
+                    [&](const auto &node) -> ConstraintNode {
+                        using T = std::decay_t<decltype(node)>;
+                        if constexpr (std::is_same_v<T, hir::ConstraintSymbol>) {
+                            return ConstraintSymbol{symbol_identity(node.symbol)};
+                        } else if constexpr (std::is_same_v<T, hir::ConstraintType>) {
+                            return ConstraintType{lower_type(node.type)};
+                        } else if constexpr (std::is_same_v<T, hir::ConstraintValue>) {
+                            return ConstraintValue{lower_const_expr(node.value, source.range, "a constraint value")};
+                        } else if constexpr (std::is_same_v<T, hir::ConstraintSet>) {
+                            ConstraintSet lowered;
+                            for (hir::ConstraintId element : node.elements) {
+                                lowered.elements.push_back(lower_constraint(element));
+                            }
+                            return lowered;
+                        } else if constexpr (std::is_same_v<T, hir::ConstraintCall>) {
+                            ConstraintCall lowered;
+                            lowered.function_identity = symbol_identity(node.function);
+                            for (hir::ConstraintId argument : node.arguments) {
+                                lowered.arguments.push_back(lower_constraint(argument));
+                            }
+                            return lowered;
+                        } else if constexpr (std::is_same_v<T, hir::OperatorRequirement>) {
+                            OperatorRequirement lowered;
+                            lowered.operator_identity = symbol_identity(node.op);
+                            if (node.op.valid()) { lowered.operator_registry_name = source_.symbol(node.op).external_name; }
+                            for (hir::ConstraintId argument : node.arguments) {
+                                lowered.arguments.push_back(lower_constraint(argument));
+                            }
+                            lowered.result = lower_type(node.result);
+                            return lowered;
+                        } else if constexpr (std::is_same_v<T, hir::ConstraintRelation>) {
+                            return ConstraintRelation{lower_relation_op(node.op), lower_constraint(node.lhs),
+                                                      lower_constraint(node.rhs), node.category};
+                        } else if constexpr (std::is_same_v<T, hir::ConstraintNot>) {
+                            return ConstraintNot{lower_constraint(node.operand)};
+                        } else {
+                            return ConstraintLogic{lower_logic_op(node.op), lower_constraint(node.lhs), lower_constraint(node.rhs)};
+                        }
+                    },
+                    source.node);
+                result_.constraints[id.value] = std::move(target);
+                return id;
+            }
+
+            void lower_constraints() {
+                for (std::uint32_t index = 0; index < source_.constraints.size(); ++index) {
+                    (void)lower_constraint(hir::ConstraintId{index});
+                }
+            }
+
+            [[nodiscard]] std::string declaration_identity(hir::DeclarationId id) const {
+                if (!id.valid()) { return {}; }
+                return symbol_identity(source_.declaration(id).symbol);
+            }
+
+            void lower_structures() {
+                for (const hir::Declaration &declaration : source_.declarations) {
+                    const auto *source = std::get_if<hir::StructDecl>(&declaration.node);
+                    if (source == nullptr || !declaration.symbol.valid()) { continue; }
+
+                    StructContract target;
+                    target.identity     = symbol_identity(declaration.symbol);
+                    target.exported     = source->exported;
+                    target.abstract     = source->abstract;
+                    target.requirements = lower_constraint(source->requirements);
+                    target.range        = declaration.range;
+                    for (const hir::GenericParameter &generic : source->generics) {
+                        target.generics.push_back(lower_generic(generic));
+                    }
+                    for (hir::TypeId parent : source->parents) { target.parents.push_back(lower_type(parent)); }
+                    for (const hir::StructField &field : source->fields) {
+                        target.fields.push_back(StructField{
+                            .name            = field.name,
+                            .type            = lower_type(field.type),
+                            .default_value   = lower_const_expr(field.default_value, field.range, "a struct field default"),
+                            .origin_identity = declaration_identity(field.origin),
+                            .optional        = field.optional,
+                            .range           = field.range,
+                        });
+                    }
+                    result_.structures.push_back(std::move(target));
+                }
+            }
+
             [[nodiscard]] static CallableVisibility lower_visibility(hir::Visibility source) noexcept {
                 switch (source) {
                     case hir::Visibility::Internal: return CallableVisibility::Internal;
@@ -196,6 +308,7 @@ namespace hgl::hgraph_ir
                     target.identity = symbol_identity(declaration.symbol);
                     target.range    = declaration.range;
                     lower_signature(source->generics, source->signature, target.generics, target.parameters, target.result);
+                    target.requirements = lower_constraint(source->requirements);
                     known.insert(target.identity);
                     result_.operators.push_back(std::move(target));
                 }
@@ -232,6 +345,7 @@ namespace hgl::hgraph_ir
                         target.operator_registry_name = op.external_name;
                     }
                     lower_signature(source->generics, source->signature, target.generics, target.parameters, target.result);
+                    target.requirements = lower_constraint(source->requirements);
                     for (hir::SymbolId capability : source->capabilities) {
                         const hir::Symbol &symbol = source_.symbol(capability);
                         target.capabilities.push_back(Capability{symbol.name, lower_type(symbol.type)});
@@ -240,11 +354,12 @@ namespace hgl::hgraph_ir
                 }
             }
 
-            const hir::Module                             &source_;
-            syntax::DiagnosticSink                        &diagnostics_;
-            Module                                         result_{};
-            std::unordered_map<std::uint32_t, TypeId>      types_{};
-            std::unordered_map<std::uint32_t, ConstExprId> const_exprs_{};
+            const hir::Module                              &source_;
+            syntax::DiagnosticSink                         &diagnostics_;
+            Module                                          result_{};
+            std::unordered_map<std::uint32_t, TypeId>       types_{};
+            std::unordered_map<std::uint32_t, ConstExprId>  const_exprs_{};
+            std::unordered_map<std::uint32_t, ConstraintId> constraints_{};
         };
     }  // namespace
 

--- a/language/src/hgraph_ir/lower.cpp
+++ b/language/src/hgraph_ir/lower.cpp
@@ -37,6 +37,14 @@ namespace hgl::hgraph_ir
             }
 
           private:
+            struct AppliedBindings
+            {
+                std::unordered_map<std::uint32_t, TypeId>      types{};
+                std::unordered_map<std::uint32_t, ConstExprId> values{};
+
+                [[nodiscard]] bool empty() const noexcept { return types.empty() && values.empty(); }
+            };
+
             [[nodiscard]] hir::TypeId canonical(hir::TypeId source) const noexcept {
                 if (!source.valid()) { return {}; }
                 const hir::TypeId canonical = source_.type(source).canonical;
@@ -150,6 +158,148 @@ namespace hgl::hgraph_ir
                 target.min_size         = lower_const_expr(source_type.min_size, source_type.range, "a minimum type size");
                 result_.types[id.value] = std::move(target);
                 return id;
+            }
+
+            [[nodiscard]] ConstExprId lower_const_expr(hir::ExprId expression, const AppliedBindings &bindings,
+                                                       syntax::SourceRange range, std::string_view role) {
+                if (!expression.valid() || bindings.empty()) { return lower_const_expr(expression, range, role); }
+                const hir::Expr &source = source_.expr(expression);
+                if (source.constant) { return lower_const_expr(expression, range, role); }
+                if (const auto *reference = std::get_if<hir::SymbolRef>(&source.node); reference && reference->symbol.valid()) {
+                    if (const auto found = bindings.values.find(reference->symbol.value); found != bindings.values.end()) {
+                        return found->second;
+                    }
+                    return lower_const_expr(expression, range, role);
+                }
+
+                ConstExpr target;
+                target.range = source.range;
+                if (source.phase != hir::Phase::Constant) {
+                    diagnostics_.report(syntax::Category::Type, range,
+                                        "typed HIR has no compile-time expression for " + std::string{role});
+                } else if (const auto *unary = std::get_if<hir::Unary>(&source.node)) {
+                    target.kind  = ConstExprKind::Unary;
+                    target.unary = unary->op;
+                    target.lhs   = lower_const_expr(unary->operand, bindings, source.range, role);
+                } else if (const auto *binary = std::get_if<hir::Binary>(&source.node)) {
+                    target.kind   = ConstExprKind::Binary;
+                    target.binary = binary->op;
+                    target.lhs    = lower_const_expr(binary->lhs, bindings, source.range, role);
+                    target.rhs    = lower_const_expr(binary->rhs, bindings, source.range, role);
+                } else if (const auto *index = std::get_if<hir::Index>(&source.node)) {
+                    target.kind = ConstExprKind::Index;
+                    target.lhs  = lower_const_expr(index->target, bindings, source.range, role);
+                    target.rhs  = lower_const_expr(index->index, bindings, source.range, role);
+                } else if (const auto *field = std::get_if<hir::Field>(&source.node)) {
+                    target.kind   = ConstExprKind::Field;
+                    target.lhs    = lower_const_expr(field->target, bindings, source.range, role);
+                    target.member = field->name;
+                } else if (const auto *sequence = std::get_if<hir::Sequence>(&source.node)) {
+                    target.kind = ConstExprKind::Sequence;
+                    for (const hir::SequenceElement &element : sequence->elements) {
+                        target.elements.push_back(ConstElement{
+                            .key   = lower_const_expr(element.key, bindings, source.range, role),
+                            .value = lower_const_expr(element.value, bindings, source.range, role),
+                        });
+                    }
+                } else if (const auto *tuple = std::get_if<hir::Tuple>(&source.node)) {
+                    target.kind = ConstExprKind::Tuple;
+                    for (hir::ExprId item : tuple->elements) {
+                        target.items.push_back(lower_const_expr(item, bindings, source.range, role));
+                    }
+                } else if (const auto *construct = std::get_if<hir::Construct>(&source.node)) {
+                    target.kind             = ConstExprKind::Construct;
+                    target.constructed_type = lower_type(construct->type, bindings);
+                    target.delta            = construct->delta;
+                    for (const hir::Argument &argument : construct->arguments) {
+                        target.arguments.push_back(
+                            ConstArgument{argument.name, lower_const_expr(argument.value, bindings, argument.range, role)});
+                    }
+                } else {
+                    diagnostics_.report(syntax::Category::Type, range, "hgraph IR cannot represent " + std::string{role} + " yet");
+                }
+                const ConstExprId id{static_cast<std::uint32_t>(result_.const_exprs.size())};
+                result_.const_exprs.push_back(std::move(target));
+                return id;
+            }
+
+            [[nodiscard]] TypeId intern_type(Type target) {
+                for (std::uint32_t index = 0; index < result_.types.size(); ++index) {
+                    if (result_.types[index] == target) { return TypeId{index}; }
+                }
+                const TypeId id{static_cast<std::uint32_t>(result_.types.size())};
+                result_.types.push_back(std::move(target));
+                return id;
+            }
+
+            [[nodiscard]] TypeId lower_type(hir::TypeId source_id, const AppliedBindings &bindings) {
+                source_id = canonical(source_id);
+                if (!source_id.valid() || bindings.empty()) { return lower_type(source_id); }
+                const hir::Type &source_type = source_.type(source_id);
+                if (source_type.kind == hir::TypeKind::Symbol && source_type.symbol.valid()) {
+                    if (const auto found = bindings.types.find(source_type.symbol.value); found != bindings.types.end()) {
+                        return found->second;
+                    }
+                }
+
+                Type target;
+                target.kind             = source_type.kind;
+                target.scalar           = source_type.scalar;
+                target.nominal_identity = symbol_identity(source_type.symbol);
+                target.unbounded        = source_type.unbounded;
+                for (hir::TypeId child : source_type.children) { target.children.push_back(lower_type(child, bindings)); }
+                for (const hir::TypeArgument &argument : source_type.arguments) {
+                    TypeArgument lowered;
+                    if (argument.kind == hir::TypeArgumentKind::Type) {
+                        lowered.type = lower_type(argument.type, bindings);
+                    } else {
+                        lowered.value = lower_const_expr(argument.value, bindings, argument.range, "a generic type argument");
+                    }
+                    target.arguments.push_back(std::move(lowered));
+                }
+                target.size     = lower_const_expr(source_type.size, bindings, source_type.range, "a type size");
+                target.min_size = lower_const_expr(source_type.min_size, bindings, source_type.range, "a minimum type size");
+                return intern_type(std::move(target));
+            }
+
+            [[nodiscard]] AppliedBindings parent_bindings(hir::TypeId parent_type, const AppliedBindings &outer) {
+                AppliedBindings result;
+                parent_type = canonical(parent_type);
+                if (!parent_type.valid()) { return result; }
+                const hir::Type &application = source_.type(parent_type);
+                if (!application.symbol.valid()) { return result; }
+                const hir::Symbol &parent_symbol = source_.symbol(application.symbol);
+                if (!parent_symbol.owner.valid()) { return result; }
+                const auto *parent = std::get_if<hir::StructDecl>(&source_.declaration(parent_symbol.owner).node);
+                if (parent == nullptr) { return result; }
+                for (std::size_t index = 0; index < parent->generics.size() && index < application.arguments.size(); ++index) {
+                    const hir::GenericParameter &generic  = parent->generics[index];
+                    const hir::TypeArgument     &argument = application.arguments[index];
+                    if (generic.is_const && argument.kind == hir::TypeArgumentKind::Value) {
+                        result.values.emplace(generic.symbol.value,
+                                              lower_const_expr(argument.value, outer, argument.range, "an inherited argument"));
+                    } else if (!generic.is_const && argument.kind == hir::TypeArgumentKind::Type) {
+                        result.types.emplace(generic.symbol.value, lower_type(argument.type, outer));
+                    }
+                }
+                return result;
+            }
+
+            [[nodiscard]] std::optional<AppliedBindings> bindings_for_origin(hir::DeclarationId current, hir::DeclarationId origin,
+                                                                             const AppliedBindings &current_bindings) {
+                if (!current.valid() || !origin.valid()) { return std::nullopt; }
+                if (current == origin) { return current_bindings; }
+                const auto *structure = std::get_if<hir::StructDecl>(&source_.declaration(current).node);
+                if (structure == nullptr) { return std::nullopt; }
+                for (hir::TypeId parent_type : structure->parents) {
+                    const hir::Type &application = source_.type(canonical(parent_type));
+                    if (!application.symbol.valid()) { continue; }
+                    const hir::DeclarationId parent  = source_.symbol(application.symbol).owner;
+                    const AppliedBindings    applied = parent_bindings(parent_type, current_bindings);
+                    if (parent == origin) { return applied; }
+                    if (auto inherited = bindings_for_origin(parent, origin, applied)) { return inherited; }
+                }
+                return std::nullopt;
             }
 
             void lower_types() {
@@ -266,11 +416,23 @@ namespace hgl::hgraph_ir
                         target.generics.push_back(lower_generic(generic));
                     }
                     for (hir::TypeId parent : source->parents) { target.parents.push_back(lower_type(parent)); }
+                    std::unordered_map<std::uint32_t, AppliedBindings> origin_bindings;
                     for (const hir::StructField &field : source->fields) {
+                        if (!origin_bindings.contains(field.origin.value)) {
+                            std::optional<AppliedBindings> applied =
+                                bindings_for_origin(declaration.id, field.origin, AppliedBindings{});
+                            if (!applied) {
+                                diagnostics_.report(syntax::Category::Type, field.range,
+                                                    "cannot map an inherited field into the child generic scope");
+                                continue;
+                            }
+                            origin_bindings.emplace(field.origin.value, std::move(*applied));
+                        }
+                        const AppliedBindings &applied = origin_bindings.at(field.origin.value);
                         target.fields.push_back(StructField{
-                            .name            = field.name,
-                            .type            = lower_type(field.type),
-                            .default_value   = lower_const_expr(field.default_value, field.range, "a struct field default"),
+                            .name          = field.name,
+                            .type          = lower_type(field.type, applied),
+                            .default_value = lower_const_expr(field.default_value, applied, field.range, "a struct field default"),
                             .origin_identity = declaration_identity(field.origin),
                             .optional        = field.optional,
                             .range           = field.range,

--- a/language/src/hgraph_ir/printer.cpp
+++ b/language/src/hgraph_ir/printer.cpp
@@ -70,6 +70,23 @@ namespace hgl::hgraph_ir
             }
         }
 
+        void print_constraint_id(std::ostream &out, ConstraintId id) {
+            if (id.valid()) {
+                out << 'r' << id.value;
+            } else {
+                out << '_';
+            }
+        }
+
+        template <typename IdType> void print_ids(std::ostream &out, char prefix, const std::vector<IdType> &ids) {
+            out << '[';
+            for (std::size_t index = 0; index < ids.size(); ++index) {
+                if (index != 0) { out << ", "; }
+                out << prefix << ids[index].value;
+            }
+            out << ']';
+        }
+
         [[nodiscard]] std::string_view unary_name(hir::UnaryOp op) noexcept {
             return op == hir::UnaryOp::Negate ? "negate" : "not";
         }
@@ -123,6 +140,22 @@ namespace hgl::hgraph_ir
             }
             out << ") -> ";
             print_type_id(out, result);
+        }
+
+        void print_generics(std::ostream &out, const std::vector<GenericParameter> &generics) {
+            if (generics.empty()) { return; }
+            out << '<';
+            for (std::size_t index = 0; index < generics.size(); ++index) {
+                if (index != 0) { out << ", "; }
+                const GenericParameter &generic = generics[index];
+                if (generic.is_const) { out << "const "; }
+                out << generic.name;
+                if (generic.type.valid()) {
+                    out << ':';
+                    print_type_id(out, generic.type);
+                }
+            }
+            out << '>';
         }
 
         void print_effects(std::ostream &out, hir::Effect effects) {
@@ -259,6 +292,87 @@ namespace hgl::hgraph_ir
             out << '\n';
         }
 
+        out << "constraints\n";
+        for (std::size_t index = 0; index < module.constraints.size(); ++index) {
+            const Constraint &constraint = module.constraints[index];
+            out << "  r" << index << ' ';
+            std::visit(
+                [&](const auto &node) {
+                    using T = std::decay_t<decltype(node)>;
+                    if constexpr (std::is_same_v<T, ConstraintSymbol>) {
+                        out << "symbol " << node.identity;
+                    } else if constexpr (std::is_same_v<T, ConstraintType>) {
+                        out << "type ";
+                        print_type_id(out, node.type);
+                    } else if constexpr (std::is_same_v<T, ConstraintValue>) {
+                        out << "value ";
+                        print_const_expr_id(out, node.value);
+                    } else if constexpr (std::is_same_v<T, ConstraintSet>) {
+                        out << "set ";
+                        print_ids(out, 'r', node.elements);
+                    } else if constexpr (std::is_same_v<T, ConstraintCall>) {
+                        out << "call " << node.function_identity << " arguments=";
+                        print_ids(out, 'r', node.arguments);
+                    } else if constexpr (std::is_same_v<T, OperatorRequirement>) {
+                        out << "operator " << node.operator_identity;
+                        if (!node.operator_registry_name.empty()) { out << " registry=" << node.operator_registry_name; }
+                        out << " arguments=";
+                        print_ids(out, 'r', node.arguments);
+                        out << " result=";
+                        print_type_id(out, node.result);
+                    } else if constexpr (std::is_same_v<T, ConstraintRelation>) {
+                        static constexpr std::string_view names[]{"equal", "in", "is"};
+                        out << names[static_cast<std::size_t>(node.op)] << ' ';
+                        print_constraint_id(out, node.lhs);
+                        out << ' ';
+                        print_constraint_id(out, node.rhs);
+                        if (!node.category.empty()) { out << " category=" << node.category; }
+                    } else if constexpr (std::is_same_v<T, ConstraintNot>) {
+                        out << "not ";
+                        print_constraint_id(out, node.operand);
+                    } else {
+                        out << (node.op == ConstraintLogicOp::And ? "and " : "or ");
+                        print_constraint_id(out, node.lhs);
+                        out << ' ';
+                        print_constraint_id(out, node.rhs);
+                    }
+                },
+                constraint.node);
+            out << '\n';
+        }
+
+        out << "structures\n";
+        for (const StructContract &structure : module.structures) {
+            out << "  ";
+            if (structure.exported) { out << "export "; }
+            if (structure.abstract) { out << "abstract "; }
+            out << "struct " << structure.identity;
+            print_generics(out, structure.generics);
+            if (!structure.parents.empty()) {
+                out << " parents=";
+                print_ids(out, 't', structure.parents);
+            }
+            if (structure.requirements.valid()) {
+                out << " requires=";
+                print_constraint_id(out, structure.requirements);
+            }
+            out << " fields=[";
+            for (std::size_t index = 0; index < structure.fields.size(); ++index) {
+                if (index != 0) { out << ", "; }
+                const StructField &field = structure.fields[index];
+                out << field.name;
+                if (field.optional) { out << '?'; }
+                out << ':';
+                print_type_id(out, field.type);
+                if (field.default_value.valid()) {
+                    out << '=';
+                    print_const_expr_id(out, field.default_value);
+                }
+                if (!field.origin_identity.empty()) { out << " origin=" << field.origin_identity; }
+            }
+            out << "]\n";
+        }
+
         out << "operators\n";
         for (const OperatorContract &op : module.operators) {
             out << "  " << (op.imported ? "import " : "define ") << op.identity;
@@ -266,6 +380,10 @@ namespace hgl::hgraph_ir
             if (!op.imported) {
                 out << ' ';
                 print_signature(out, op.generics, op.parameters, op.result);
+            }
+            if (op.requirements.valid()) {
+                out << " requires=";
+                print_constraint_id(out, op.requirements);
             }
             out << '\n';
         }
@@ -279,6 +397,10 @@ namespace hgl::hgraph_ir
             if (!callable.operator_registry_name.empty()) { out << " registry=" << callable.operator_registry_name; }
             out << ' ';
             print_signature(out, callable.generics, callable.parameters, callable.result);
+            if (callable.requirements.valid()) {
+                out << " requires=";
+                print_constraint_id(out, callable.requirements);
+            }
             out << " effects=";
             print_effects(out, callable.effects);
             if (!callable.capabilities.empty()) {

--- a/language/tests/hgraph_ir/lower_tests.cpp
+++ b/language/tests/hgraph_ir/lower_tests.cpp
@@ -216,11 +216,11 @@ export abstract struct Entity<T> {
     label: str = "entity"
 }
 
-export struct Range<T>: Entity<T>
-requires T in {i64, f64}
+export struct Range<U>: Entity<U>
+requires U in {i64, f64}
 {
     label = "range"
-    upper: T = null
+    upper: U = null
 }
 )"};
     INFO(lowered.diagnostics.render(lowered.file));
@@ -242,6 +242,8 @@ requires T in {i64, f64}
     REQUIRE(range->fields.size() == 3);
     CHECK(range->fields[0].name == "value");
     CHECK(range->fields[0].origin_identity == entity->identity);
+    REQUIRE(range->fields[0].type.valid());
+    CHECK(lowered.graph->types[range->fields[0].type.value].nominal_identity == "U");
     CHECK(range->fields[1].name == "label");
     CHECK(range->fields[1].origin_identity == entity->identity);
     CHECK(range->fields[1].default_value.valid());
@@ -260,6 +262,33 @@ requires T in {i64, f64}
     CHECK(dump.find("export struct checks.struct_contracts.Range") != std::string::npos);
     CHECK(dump.find("requires=r") != std::string::npos);
     CHECK(dump.find("origin=checks.struct_contracts.Entity") != std::string::npos);
+}
+
+TEST_CASE("hgraph IR applies inherited type and const arguments", "[hgraph-ir][structs][generics]") {
+    Lowered lowered{R"(
+module checks.inherited_arguments
+
+abstract struct Samples<T, const N: i64> {
+    history: rolling<T, N>
+}
+
+struct Renamed<U, const M: i64>: Samples<U, M> {}
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE_FALSE(lowered.diagnostics.has_errors());
+    REQUIRE(lowered.graph);
+
+    const hgl::hgraph_ir::StructContract *renamed = structure(*lowered.graph, "checks.inherited_arguments.Renamed");
+    REQUIRE(renamed != nullptr);
+    REQUIRE(renamed->fields.size() == 1);
+    const hgl::hgraph_ir::Type &history = lowered.graph->types[renamed->fields.front().type.value];
+    REQUIRE(history.kind == hir::TypeKind::Rolling);
+    REQUIRE(history.children.size() == 1);
+    CHECK(lowered.graph->types[history.children.front().value].nominal_identity == "U");
+    REQUIRE(history.size.valid());
+    const hgl::hgraph_ir::ConstExpr &size = lowered.graph->const_exprs[history.size.value];
+    CHECK(size.kind == hgl::hgraph_ir::ConstExprKind::Parameter);
+    CHECK(size.parameter == "M");
 }
 
 TEST_CASE("hgraph IR preserves operator and implementation requirements", "[hgraph-ir][constraints][operators]") {

--- a/language/tests/hgraph_ir/lower_tests.cpp
+++ b/language/tests/hgraph_ir/lower_tests.cpp
@@ -50,6 +50,13 @@ namespace
         }
         return nullptr;
     }
+
+    const hgl::hgraph_ir::StructContract *structure(const hgl::hgraph_ir::Module &module, std::string_view identity) {
+        for (const hgl::hgraph_ir::StructContract &candidate : module.structures) {
+            if (candidate.identity == identity) { return &candidate; }
+        }
+        return nullptr;
+    }
 }  // namespace
 
 TEST_CASE("every guide example lowers an hgraph IR interface", "[hgraph-ir][examples]") {
@@ -198,6 +205,82 @@ fn configured<const N: i64>(
     CHECK(lowered.graph->const_exprs[width.value].parameter == "N");
     const std::string dump = hgl::hgraph_ir::print(*lowered.graph);
     CHECK(dump.find("@[Europe/London]") != std::string::npos);
+}
+
+TEST_CASE("hgraph IR owns effective struct contracts and requirements", "[hgraph-ir][structs][constraints]") {
+    Lowered lowered{R"(
+module checks.struct_contracts
+
+export abstract struct Entity<T> {
+    value: T
+    label: str = "entity"
+}
+
+export struct Range<T>: Entity<T>
+requires T in {i64, f64}
+{
+    label = "range"
+    upper: T = null
+}
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE_FALSE(lowered.diagnostics.has_errors());
+    REQUIRE(lowered.graph);
+
+    const hgl::hgraph_ir::StructContract *entity = structure(*lowered.graph, "checks.struct_contracts.Entity");
+    REQUIRE(entity != nullptr);
+    CHECK(entity->exported);
+    CHECK(entity->abstract);
+    REQUIRE(entity->fields.size() == 2);
+    CHECK(entity->fields[0].origin_identity == entity->identity);
+
+    const hgl::hgraph_ir::StructContract *range = structure(*lowered.graph, "checks.struct_contracts.Range");
+    REQUIRE(range != nullptr);
+    CHECK(range->exported);
+    CHECK_FALSE(range->abstract);
+    REQUIRE(range->parents.size() == 1);
+    REQUIRE(range->fields.size() == 3);
+    CHECK(range->fields[0].name == "value");
+    CHECK(range->fields[0].origin_identity == entity->identity);
+    CHECK(range->fields[1].name == "label");
+    CHECK(range->fields[1].origin_identity == entity->identity);
+    CHECK(range->fields[1].default_value.valid());
+    CHECK(range->fields[2].name == "upper");
+    CHECK(range->fields[2].optional);
+    CHECK(range->fields[2].origin_identity == range->identity);
+    REQUIRE(range->requirements.valid());
+    const hgl::hgraph_ir::Constraint &requirement = lowered.graph->constraints[range->requirements.value];
+    const auto                       *relation    = std::get_if<hgl::hgraph_ir::ConstraintRelation>(&requirement.node);
+    REQUIRE(relation != nullptr);
+    CHECK(relation->op == hgl::hgraph_ir::ConstraintRelationOp::In);
+
+    const std::string dump = hgl::hgraph_ir::print(*lowered.graph);
+    CHECK(dump.find("constraints\n") != std::string::npos);
+    CHECK(dump.find("export abstract struct checks.struct_contracts.Entity") != std::string::npos);
+    CHECK(dump.find("export struct checks.struct_contracts.Range") != std::string::npos);
+    CHECK(dump.find("requires=r") != std::string::npos);
+    CHECK(dump.find("origin=checks.struct_contracts.Entity") != std::string::npos);
+}
+
+TEST_CASE("hgraph IR preserves operator and implementation requirements", "[hgraph-ir][constraints][operators]") {
+    Lowered lowered{R"(
+module checks.requirements
+
+operator ordered<T>(value: T) -> T
+requires T in {i64, f64}
+
+impl fn ordered<T>(value: T) -> T
+requires T in {i64, f64}
+=> value
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE_FALSE(lowered.diagnostics.has_errors());
+    REQUIRE(lowered.graph);
+
+    REQUIRE(lowered.graph->operators.size() == 1);
+    CHECK(lowered.graph->operators.front().requirements.valid());
+    REQUIRE(lowered.graph->callables.size() == 1);
+    CHECK(lowered.graph->callables.front().requirements.valid());
 }
 
 TEST_CASE("hgraph IR lowering rejects unresolved HIR", "[hgraph-ir][completion]") {


### PR DESCRIPTION
## Summary
- lower normalized generic constraints into a self-contained hgraph-IR arena
- preserve effective nominal struct contracts, inherited field origins, defaults, and optionality
- attach requirements to struct, operator, and callable interfaces while keeping nominal and native registry identities distinct
- extend the deterministic hgraph-IR dump, architecture documentation, and focused coverage

## Validation
- clang-format dry run on changed C++ files
- git diff --check
- complete language CTest suite: 29/29 passed
- clean native configure, rebuild, and CTest suite: 1711/1711 passed
- stable-ABI wheel built with Python 3.12 and complete non-WIP compatibility suite run from a fresh Python 3.14 environment: 3223 passed, 10 skipped

Stacked on #690.