### PR TITLE
Retire the operator-name branches: apply, const, with_columns, getattr_ (RFC 0033, PR E)

### DIFF
--- a/docs/source/developer_guide/operators.rst
+++ b/docs/source/developer_guide/operators.rst
@@ -1004,6 +1004,16 @@ carried pattern's variables are priced in their own key space (the
 accumulator keeps the minimum per variable), so ``type[SCHEMA]`` never
 cheapens the ``SCHEMA`` a ``TS[Frame[SCHEMA]]`` input already prices.
 
+**A type the call does not name.** ``apply(fn, ...)`` with no requested
+output resolves it from the callable's declared result type: the
+``ValueCallable`` scalar reports ``output_schema()`` (a lifted kernel's
+output, a Python callable's return annotation) and ``apply``'s
+``default_resolver`` binds the output variable from it. ``const(value)``
+infers ``T`` from the value's schema; a Python object whose class the
+registries have never seen is typed by the DSL on demand (the bridge's
+annotation-schema resolver), so a ``CompoundScalar`` instance infers its
+nominal Bundle and any other class its opaque nominal type.
+
 **Family consistency.** A parameter name that is a ``TypeArg`` in one
 candidate must be a ``TypeArg`` in every candidate of the family that
 declares it; ``register_overload`` rejects a candidate that disagrees, and

--- a/docs/source/developer_guide/operators.rst
+++ b/docs/source/developer_guide/operators.rst
@@ -1010,9 +1010,11 @@ output resolves it from the callable's declared result type: the
 output, a Python callable's return annotation) and ``apply``'s
 ``default_resolver`` binds the output variable from it. ``const(value)``
 infers ``T`` from the value's schema; a Python object whose class the
-registries have never seen is typed by the DSL on demand (the bridge's
-annotation-schema resolver), so a ``CompoundScalar`` instance infers its
-nominal Bundle and any other class its opaque nominal type.
+registries have never seen is typed by the DSL once per registry generation
+before conversion looks at the value (the bridge's annotation-schema
+resolver), so an ``Enum``/``IntEnum``/``StrEnum`` member infers its nominal
+enum, a ``CompoundScalar`` instance its nominal Bundle and any other class
+its opaque nominal type.
 
 **Family consistency.** A parameter name that is a ``TypeArg`` in one
 candidate must be a ``TypeArg`` in every candidate of the family that

--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -414,6 +414,24 @@ rule of its own any more (``wiring-type-carrier-sites`` is at zero):
   as the type it carries and a still-deferred one as its declared default
   (``AUTO_RESOLVE`` or the variable), the upstream ``if tp is AUTO_RESOLVE``
   idiom; the wire trampoline always receives the materialised value.
+* No operator-name branch decides a type. ``apply`` resolves its output in
+  the registry from the callable's declared result type (a Python value
+  callable reports its return annotation through
+  ``ValueCallable::output_schema``); schema-free conversion asks the DSL for
+  the schema of a class it has never seen through the annotation-schema
+  resolver ``_types.py`` registers at import
+  (``set_python_annotation_schema_resolver``), so ``const(Row(...))`` infers
+  the nominal Bundle; ``with_columns[Row]`` is the one subscript rule over a
+  public signature that declares ``DEFAULT[ROW_1]``; ``getattr_[SCALAR: X]``
+  is an ordinary named pin. A pin on a variable the public return
+  annotation mentions makes that annotation, resolved, the requested output
+  (``_OperatorFunction._requested_output``: ``getattr_[SCALAR: str]`` asks
+  for ``TS[str]``, ``with_columns[Row]`` for ``TS[Frame[Row]]``), the rule
+  ``op[OUT: X]`` is one case of; it is how the descriptor overload of
+  ``getattr_`` still wins over a native field read when the caller asks for
+  a type the declared field does not have. The ``wiring-operator-name-branches`` ratchet is
+  at four: the record/replay durability hooks and the ``getattr_`` /
+  ``getitem_`` call fast paths, which belong to other families.
 * Arrival is role-directed (``_core.wire`` → ``_apply_type_argument_roles``):
   the family's ``operator_carrier_parameters`` name the type-argument slots,
   and a class, ``TimeSeriesSchema`` or size handed to one crosses as the

--- a/docs/source/rfc/rfc_0033_type_carrier_resolution.rst
+++ b/docs/source/rfc/rfc_0033_type_carrier_resolution.rst
@@ -1,7 +1,7 @@
 RFC 0033: Type Carriers Resolved by the Registry
 ================================================
 
-:Status: Proposed
+:Status: Accepted
 :Author: Howard Henson
 :Created: 2026-09-05
 :Target: ``include/hgraph/types/type_resolution.h``,
@@ -1006,9 +1006,26 @@ that stays absent; and a bare Python variable follows the form the map
 binds inside the core matcher (``follow_carrier_form``), so the bridge's
 ``match_carrier``/``materialise`` carry no form rule of their own.
 The operator-name branches (``apply``, ``const``, ``with_columns``,
-``getattr_``; ``wiring-operator-name-branches`` 8 to 4) move to a follow-up
-PR so that PR D stays a review of one thing; the RFC moves to ``Accepted``
-with it. The PRs record these deviations from the text above:
+``getattr_``; ``wiring-operator-name-branches`` 8 to 4) landed in PR E, and
+the RFC is Accepted with it: ``apply`` resolves its output in the registry
+from the callable's declared result type (the Python value callable now
+reports its return annotation through ``ValueCallable::output_schema``);
+schema-free conversion asks the DSL for the schema of a class it has never
+seen (``python_annotation_schema_resolver_slot``, registered by
+``_types.py``), so ``const(Row(...))`` infers the nominal Bundle and an
+unregistered class its opaque nominal type without a Python-side
+pre-registration; ``with_columns`` declares a public signature with
+``DEFAULT[ROW_1]`` and ``_OperatorFunction.__getitem__`` takes a bare
+non-time-series item through the one subscript rule when the public
+signature has a ``DEFAULT``; ``getattr_[SCALAR: X]`` is an ordinary named
+pin, and a pin on a variable the public return annotation mentions makes
+that annotation, resolved, the requested output (``getattr_`` declares a
+public ``-> TS[SCALAR]``; ``with_columns`` ``-> TS[Frame[ROW_1]]``), which
+is the general form of ``op[OUT: X]``.
+The four remaining ``self.__name__`` sites are the two record/replay
+durability hooks and the ``getattr_``/``getitem_`` call fast paths, which
+belong to other families. The PRs record these deviations from the text
+above:
 
 * ``TypeCarrier`` and ``ResolutionKind`` live in
   ``include/hgraph/types/type_carrier.h`` (dependency-free) rather than in

--- a/include/hgraph/python/bridge_state.h
+++ b/include/hgraph/python/bridge_state.h
@@ -145,6 +145,18 @@ struct HGRAPH_LOCAL NB_EXPORT_SHARED PyBundleClassInfo {
 [[nodiscard]] HGRAPH_EXPORT std::unordered_map<const void *, nb::object> &python_type_registry();
 HGRAPH_EXPORT void clear_python_type_registry() noexcept;
 
+/**
+ * The DSL's annotation-to-schema producer (``hgraph._types._value_type``),
+ * registered at import through ``_hgraph.set_python_annotation_schema_resolver``
+ * (RFC 0033, PR E). Schema-free conversion asks it for the schema of a
+ * Python class it has never seen -- a CompoundScalar's nominal Bundle, an
+ * opaque nominal type -- and a Python value callable asks it for its
+ * declared result type, so ``const(Row(...))`` and ``apply(fn, ...)`` resolve
+ * in the registry rather than through operator-name branches in the wiring
+ * layer. The callable returns the ``ValueType`` carrier or ``None``.
+ */
+[[nodiscard]] HGRAPH_EXPORT nb::object &python_annotation_schema_resolver_slot();
+
 /** Structural ``TSB[CompoundScalar]`` schema -> its scalar Bundle schema.
  * The TS runtime remains structural; this bridge-only association restores the
  * declared Python value class when a Python node reads the complete TSB value.

--- a/python/hgraph/_types.py
+++ b/python/hgraph/_types.py
@@ -1545,6 +1545,17 @@ def _bind_python_type(value_type, scalar):
     _hgraph.bind_python_type(value_type, python_scalar)
 
 
+def _annotation_schema_or_none(annotation):
+    """The bridge's view of ``_value_type`` (RFC 0033): schema-free
+    conversion asks for a class it has never seen and a Python value
+    callable for its declared result type; ``None`` for anything the DSL
+    cannot type, so the value stays an ``object`` as before."""
+    try:
+        return _value_type(annotation)
+    except Exception:
+        return None
+
+
 def _records_reverse_binding(produce):
     """Wrap a schema producer so every schema it returns is recorded against
     the annotation that produced it (the reverse binding, RFC 0033)."""
@@ -1817,6 +1828,9 @@ def _value_type(scalar):
         raise TypeError(f"unsupported scalar type for hgraph: {scalar!r}")
     return _hgraph.value_type(name)
 
+
+
+_hgraph.set_python_annotation_schema_resolver(_annotation_schema_or_none)
 
 class _TsExpr:
     def from_ts(self, *ports, **kwargs):

--- a/python/hgraph/_wiring/_core.py
+++ b/python/hgraph/_wiring/_core.py
@@ -286,9 +286,25 @@ def _from_json_public_signature(ts):
     """The released public call shape; the subscript selects the output type."""
 
 
+def _getattr_public_signature(ts, attr, default_value=None):
+    """The released public call shape: ``getattr_[SCALAR: X](ts, "attr")``
+    names the attribute's scalar type, which is the output's payload."""
+
+
+def _annotate_getattr_public_signature():
+    from .._types import SCALAR, TIME_SERIES_TYPE, TS
+
+    _getattr_public_signature.__annotations__ = {
+        "ts": TIME_SERIES_TYPE, "attr": str, "default_value": TS[SCALAR], "return": TS[SCALAR]}
+
+
+_annotate_getattr_public_signature()
+
+
 _PUBLIC_OPERATOR_SIGNATURES = {
     "to_json": _to_json_public_signature,
     "from_json": _from_json_public_signature,
+    "getattr_": _getattr_public_signature,
 }
 
 
@@ -522,7 +538,8 @@ class _OperatorFunction:
     requested output type of the call."""
 
     __slots__ = ("__dict__", "__name__", "__qualname__", "__signature__", "_output_type",
-                 "_sizes", "_ts_hint", "_resolutions")
+                 "_sizes", "_ts_hint", "_resolutions", "_type_variables", "_default_type_var",
+                 "_public_return")
 
     def __init__(self, name, output_type=None, sizes=None, ts_hint=None,
                  resolutions=None, signature=None, documentation=None):
@@ -531,10 +548,23 @@ class _OperatorFunction:
         self.__name__ = name
         self.__qualname__ = name
         signatures = _operator_overload_signatures(name) if documentation is None else ()
+        self._type_variables, self._default_type_var = (), None
+        self._public_return = inspect.Signature.empty
+        if callable(signature):
+            # A public signature may declare type variables and a DEFAULT[...]
+            # (``with_columns(ts: TS[Frame[ROW]], _tp_out: type[ROW_1] =
+            # DEFAULT[ROW_1], **columns)``): they drive the subscript rule.
+            # Introspection keeps the signature as written, marker included.
+            from .._types import wiring_signature_of
+            from ._resolution import _signature_type_variables
+
+            wiring_signature, self._default_type_var = wiring_signature_of(signature)
+            self._type_variables = _signature_type_variables(
+                wiring_signature.parameters.values(), wiring_signature.return_annotation)
+            self._public_return = wiring_signature.return_annotation
+            signature = inspect.signature(signature)
         self.__signature__ = (
-            inspect.signature(signature)
-            if callable(signature)
-            else signature if signature is not None
+            signature if signature is not None
             else _operator_runtime_signature(signatures)
         )
         self.__doc__ = (
@@ -568,37 +598,6 @@ class _OperatorFunction:
             # loads (RFC 0025: core wiring must not import adaptor modules) and
             # is a no-op unless a compatibility storage is active.
             kwargs = _record_replay_wiring_adapter(self.__name__, args, kwargs)
-        if (self.__name__ == "apply" and args
-                and "tp" not in kwargs and "output_type" not in kwargs
-                and self._output_type is None and callable(args[0])
-                and not isinstance(args[0], WiringPort)):
-            import inspect
-            from .._types import TS
-
-            result_type = inspect.signature(args[0], eval_str=True).return_annotation
-            if result_type is not inspect.Signature.empty:
-                kwargs["output_type"] = TS[result_type]
-        if (self.__name__ == "const" and args
-                and "tp" not in kwargs and "output_type" not in kwargs
-                and not (len(args) > 1 and isinstance(args[1], _TsExpr))):
-            from .._compat import CompoundScalar
-            from .._types import TS, _GenericType, _value_type
-
-            if isinstance(args[0], CompoundScalar):
-                # Schema-free C++ value inference intentionally treats an
-                # arbitrary Python object as ``object``. A CompoundScalar's
-                # Python class is its nominal Bundle schema, so retain that
-                # information at the Python boundary before wiring const.
-                kwargs["output_type"] = TS[type(args[0])]
-            else:
-                # Ensure an arbitrary Python class has a nominal registration
-                # before native schema-free inference sees the value. Native
-                # inference still owns precedence for containers, callables,
-                # Arrow values, and every other concrete representation.
-                try:
-                    _value_type(type(args[0]))
-                except _GenericType:
-                    pass
         if self._output_type is not None and "tp" not in kwargs and "output_type" not in kwargs:
             kwargs["output_type"] = self._output_type
         if self._sizes is not None:
@@ -642,15 +641,18 @@ class _OperatorFunction:
         # inputs). A plain type subscript is the requested output type.
         from .._types import OUT, TS, _type_var_name
 
-        # ``with_columns[RowSchema](...)`` is the released hgraph spelling:
-        # its plain subscript selects the Frame row schema, not a bare Bundle
-        # output.  Keep this as Python syntax adaptation; native dispatch still
-        # receives the complete TS[Frame[RowSchema]] output constraint once.
-        if (self.__name__ == "with_columns" and isinstance(item, type)):
-            from .._compat import CompoundScalar
-            if issubclass(item, CompoundScalar):
-                from .._types import Frame, TS
-                item = TS[Frame[item]]
+        # A public signature with a DEFAULT[...] variable (``with_columns[Row]``
+        # names ROW_1) takes a bare non-time-series item through the one
+        # subscript rule (RFC 0033); the pin seeds the call's resolution and
+        # the registry resolves the output from it.
+        if self._default_type_var is not None and not isinstance(item, (slice, tuple, _TsExpr)):
+            from ._resolution import _pin_type_arguments
+
+            pins = _pin_type_arguments(
+                self._type_variables, item,
+                default_var=self._default_type_var, owner=self.__name__)
+            by_name = {_type_var_name(variable): variable for variable in self._type_variables}
+            item = tuple(slice(by_name.get(name, name), value) for name, value in pins.items())
 
         output_type = None
         sizes = []
@@ -667,13 +669,15 @@ class _OperatorFunction:
                     # positional hint remains for eval_node input seeding.
                     resolutions[_type_var_name(i.start)] = i.stop
                     ts_hints.append(i.stop)
-                    if (self.__name__ == "getattr_"
-                            and _type_var_name(i.start) == "SCALAR"
-                            and output_type is None):
-                        output_type = TS[i.stop]
                 continue
             if output_type is None:
                 output_type = i
+        if output_type is None and resolutions:
+            # A pin on a variable the public return annotation mentions makes
+            # that annotation, resolved, the requested output -- the rule
+            # ``op[OUT: X]`` is one case of (``getattr_[SCALAR: str]`` asks for
+            # ``TS[str]``, ``with_columns[Row]`` for ``TS[Frame[Row]]``).
+            output_type = self._requested_output(resolutions)
         if output_type is not None and not _hgraph.operator_output_is_selective(self.__name__):
             # The REGISTRY decides what a bare subscript type means: when no
             # candidate's output can be influenced by it (sinks, or every
@@ -681,10 +685,39 @@ class _OperatorFunction:
             # type is an INPUT constraint; otherwise it names the output.
             ts_hints.append(output_type)
             output_type = None
-        return _OperatorFunction(
+        derived = _OperatorFunction(
             self.__name__, output_type=output_type, sizes=sizes or None,
             ts_hint=ts_hints or None, resolutions=resolutions or None,
             signature=self.__signature__, documentation=self.__doc__)
+        derived._type_variables, derived._default_type_var = self._type_variables, self._default_type_var
+        derived._public_return = self._public_return
+        return derived
+
+    def _requested_output(self, resolutions):
+        """The public return annotation resolved from the pinned variables,
+        as a ``TS[...]`` expression; ``None`` when there is no public return
+        annotation, it mentions no pinned variable, or the pins leave part of
+        it unresolved."""
+        import inspect
+
+        from .._types import _pattern_of, _type_var_name, _type_variables_of
+        from ._resolution import _bind_resolution
+
+        annotation = self._public_return
+        if annotation is inspect.Signature.empty or annotation is None:
+            return None
+        mentioned = {_type_var_name(variable) for variable in _type_variables_of(annotation)}
+        if not mentioned or not (mentioned & set(resolutions)):
+            return None
+        try:
+            scope = _hgraph.ResolutionScope()
+            for name, value in resolutions.items():
+                if name in mentioned:
+                    _bind_resolution(scope, name, value)
+            resolved = scope.resolve_ts(_pattern_of(annotation))
+        except (RuntimeError, ValueError, TypeError):
+            return None
+        return None if resolved is None else _TsExpr(resolved, repr(resolved))
 
     def __repr__(self):
         return f"<operator {self.__name__}>"

--- a/python/hgraph/adaptors/data_frame/_data_frame_operators.py
+++ b/python/hgraph/adaptors/data_frame/_data_frame_operators.py
@@ -10,6 +10,7 @@ from hgraph._frame import as_arrow_table
 
 from hgraph import (
     AUTO_RESOLVE,
+    DEFAULT,
     SCALAR,
     TS_SCHEMA,
     TSB,
@@ -256,8 +257,12 @@ def concat_frames(ts1, ts2):
     return concat(ts1, ts2)
 
 
-def _with_columns_signature(ts, **columns):
-    pass
+def _with_columns_signature(
+    ts: TS[Frame[ROW]], _tp_out: type[ROW_1] = DEFAULT[ROW_1], **columns: TSB[TS_SCHEMA],
+):
+    """The public ``with_columns`` shape: ``with_columns[Row](ts, **columns)``
+    names the projected row schema through the DEFAULT variable (RFC 0033),
+    ``with_columns(ts, **columns)`` keeps the input's."""
 
 
 with_columns = operator_function("with_columns", signature=_with_columns_signature)

--- a/python/module_internal.h
+++ b/python/module_internal.h
@@ -158,6 +158,10 @@ namespace hgraph::python_bridge
     enum_from_python_registry();
 
     [[nodiscard]] Value                   py_to_value_as(nb::handle object, const ValueTypeMetaData *meta);
+    /** The DSL's schema for a Python annotation or class through the
+        registered resolver (``bridge_state.h``), ``nullptr`` when there is no
+        resolver or the DSL has no schema for it. */
+    [[nodiscard]] const ValueTypeMetaData *python_annotation_schema(nb::handle annotation);
     [[nodiscard]] Value                   py_to_delta(nb::handle object, const TSValueTypeMetaData *ts);
     void                                  install_value_conversion_hooks(nb::module_ &module);
 }  // namespace hgraph::python_bridge

--- a/python/py_type_system.cpp
+++ b/python/py_type_system.cpp
@@ -987,6 +987,12 @@ namespace hgraph::python_bridge
             python_bridge::native_scalar_type_for_python(python_type);
         return meta != nullptr ? nb::cast(PyValueType{meta}) : nb::none();
     });
+    m.def(
+        "set_python_annotation_schema_resolver",
+        [](nb::object resolver) { python_bridge::python_annotation_schema_resolver_slot() = std::move(resolver); },
+        nb::arg("resolver"),
+        "Register the DSL's annotation-to-schema producer (RFC 0033): schema-free conversion asks it "
+        "for an unregistered class, a Python value callable for its declared result type.");
     m.def("python_type_for_value", [](PyValueType value) -> nb::object {
         return python_type_for_value_meta(value.meta);
     });

--- a/python/tests/adaptors/data_frame/test_upstream_surface_parity.py
+++ b/python/tests/adaptors/data_frame/test_upstream_surface_parity.py
@@ -100,7 +100,11 @@ def test_native_operator_callables_expose_user_signatures():
         "ungroup": "(ts)",
         "sorted_": "(ts, by, descending=False)",
         "concat": "(ts1, ts2)",
-        "with_columns": "(ts, **columns)",
+        # The released ``with_columns[Row](ts, **columns)`` spelling names the
+        # projected row through the public signature's DEFAULT variable
+        # (RFC 0033), so the signature declares it rather than a name branch.
+        "with_columns": "(ts: TS[Frame['ROW']], _tp_out: type[~ROW_1] = DEFAULT[~ROW_1], "
+                        "**columns: TSB[TS_SCHEMA])",
     }
     assert {
         name: str(inspect.signature(getattr(df, name))) for name in expected

--- a/python/tests/test_architecture_ratchets.py
+++ b/python/tests/test_architecture_ratchets.py
@@ -94,7 +94,7 @@ RATCHETS: tuple[Ratchet, ...] = (
     # --- Type carriers are resolved by the resolver (family 3) ---
     Ratchet(
         id="wiring-operator-name-branches",
-        baseline=8,
+        baseline=4,
         roots=("python/hgraph/_wiring",),
         suffixes=(".py",),
         pattern=r"self\.__name__\s*(==|in)\s",

--- a/python/tests/test_type_carrier_sweep.py
+++ b/python/tests/test_type_carrier_sweep.py
@@ -1096,6 +1096,72 @@ class TestBareSubscriptOrder:
 
 
 class TestNameKeyedCarriers:
+    """The operator-name branches of the wiring layer are gone (RFC 0033,
+    PR E): what each did is now a property of the family in the registry."""
+
+    def test_apply_output_resolves_from_the_callables_return_annotation(self):
+        # was: the ``apply`` branch reading ``inspect.signature(fn).return_annotation``
+        # into ``output_type``; now the Python value callable reports its
+        # declared result type and ``apply``'s registry resolver binds the output.
+        def half(x: int) -> float:
+            return x / 2
+
+        @graph
+        def g(ts: TS[int]) -> TS[float]:
+            return hg.apply(half, ts)
+
+        assert eval_node(g, [3]) == [1.5]
+
+    def test_const_of_a_compound_scalar_instance_infers_its_nominal_bundle(self):
+        # was: the ``const`` branch promoting ``TS[type(value)]`` to
+        # ``output_type``; now schema-free conversion asks the DSL for the
+        # class's schema and infers the nominal Bundle itself.
+        @graph
+        def g() -> TS[SweepRow]:
+            return const(SweepRow(4))
+
+        assert eval_node(g) == [SweepRow(4)]
+
+    def test_with_columns_bare_subscript_names_the_projected_row(self):
+        # was: a ``with_columns`` branch rewriting ``[Row]`` into
+        # ``TS[Frame[Row]]``; now the public signature's DEFAULT[ROW_1] takes
+        # the bare item through the one subscript rule.
+        import pyarrow as pa
+        from hgraph import Frame
+        from hgraph.adaptors.data_frame import with_columns
+
+        class Projected(CompoundScalar):
+            value: int
+            doubled: int
+
+        @graph
+        def g(ts: TS[Frame[SweepRow]], doubled: TS[int]) -> TS[Frame[Projected]]:
+            return with_columns[Projected](ts, doubled=doubled)
+
+        frame = pa.table({"value": [2]})
+        result = eval_node(g, [frame], [4])
+        assert result[0].to_pydict() == {"value": [2], "doubled": [4]}
+
+    def test_getattr_named_subscript_pins_the_descriptor_output(self):
+        # was: a ``getattr_`` branch turning ``[SCALAR: X]`` into the
+        # requested output; now the pin binds SCALAR and the descriptor
+        # overload's ``TS[SCALAR]`` output resolves from it.
+        from dataclasses import dataclass
+
+        @dataclass(frozen=True)
+        class WithProperty(CompoundScalar):
+            value: int
+
+            @property
+            def doubled(self) -> int:
+                return self.value * 2
+
+        @graph
+        def g(ts: TS[WithProperty]) -> TS[int]:
+            return hg.getattr_[SCALAR: int](ts, "doubled")
+
+        assert eval_node(g, [WithProperty(3)]) == [6]
+
     def test_const_positional_ts_type_selects_the_output_type(self):
         @graph
         def g() -> TS[float]:

--- a/python/tests/test_type_carrier_sweep.py
+++ b/python/tests/test_type_carrier_sweep.py
@@ -1122,6 +1122,38 @@ class TestNameKeyedCarriers:
 
         assert eval_node(g) == [SweepRow(4)]
 
+    def test_const_of_an_enum_member_infers_the_nominal_enum_on_first_use(self):
+        # Review finding on PR E: an Enum registered lazily must be seen
+        # before the primitive checks, or IntEnum/StrEnum members infer int/str
+        # and a plain Enum member ``object``. Fresh classes, never annotated.
+        from enum import Enum, IntEnum, StrEnum
+
+        class Plain(Enum):
+            RED = 1
+
+        class Level(IntEnum):
+            LOW = 3
+
+        class Mode(StrEnum):
+            FAST = "fast"
+
+        @graph
+        def plain() -> TS[Plain]:
+            return const(Plain.RED)
+
+        @graph
+        def level() -> TS[Level]:
+            return const(Level.LOW)
+
+        @graph
+        def mode() -> TS[Mode]:
+            return const(Mode.FAST)
+
+        assert eval_node(plain) == [Plain.RED]
+        assert eval_node(level) == [Level.LOW]
+        assert eval_node(mode) == [Mode.FAST]
+        assert eval_node(level)[0] is Level.LOW
+
     def test_with_columns_bare_subscript_names_the_projected_row(self):
         # was: a ``with_columns`` branch rewriting ``[Row]`` into
         # ``TS[Frame[Row]]``; now the public signature's DEFAULT[ROW_1] takes

--- a/python/value_conversion.cpp
+++ b/python/value_conversion.cpp
@@ -4,6 +4,8 @@
 #include <hgraph/python/object_semantics.h>
 #include <hgraph/python/ts_data_conversion.h>
 #include <hgraph/types/metadata/type_realization.h>
+#include <hgraph/util/scope.h>
+#include "py_carriers.h"   // PyValueType: the resolver hands back the DSL's ValueType carrier
 
 #include <hgraph/lib/std/operators/arithmetic.h>
 #include <hgraph/lib/std/operators/io.h>
@@ -270,6 +272,20 @@ namespace hgraph::python_bridge
                     if (result.is_none() || output_schema == nullptr) { return Value{}; }
                     return py_to_value_as(result, output_schema);
                 },
+                .output_schema = [](const void *context) -> const ValueTypeMetaData * {
+                    // The callable's declared result type: ``apply(fn, ...)``
+                    // resolves its output from it when the call requests
+                    // none (RFC 0033, PR E; was an operator-name branch).
+                    nb::gil_scoped_acquire gil;
+                    const auto &callable = *static_cast<const PyObj *>(context);
+                    return fallback_on_exception(static_cast<const ValueTypeMetaData *>(nullptr), [&] {
+                        nb::object signature = nb::module_::import_("inspect").attr("signature")(
+                            callable.get(), nb::arg("eval_str") = true);
+                        nb::object annotation = signature.attr("return_annotation");
+                        if (annotation.is(signature.attr("empty"))) { return static_cast<const ValueTypeMetaData *>(nullptr); }
+                        return python_annotation_schema(annotation);
+                    });
+                },
             };
             return ops;
         }
@@ -289,6 +305,20 @@ namespace hgraph::python_bridge
                 .variadic = true,
             };
         }
+    }  // namespace
+
+    const ValueTypeMetaData *python_annotation_schema(nb::handle annotation)
+    {
+        const nb::object &resolver = python_bridge::python_annotation_schema_resolver_slot();
+        if (!resolver.is_valid() || resolver.is_none() || !annotation.is_valid()) { return nullptr; }
+        return fallback_on_exception(static_cast<const ValueTypeMetaData *>(nullptr), [&]() -> const ValueTypeMetaData * {
+            nb::object resolved = resolver(annotation);
+            return resolved.is_none() ? nullptr : nb::cast<PyValueType &>(resolved).meta;
+        });
+    }
+
+    namespace
+    {
 
         struct PythonDateTimeTypes
         {
@@ -642,6 +672,20 @@ namespace hgraph::python_bridge
                 nb::handle(Py_TYPE(object.ptr()))))
         {
             return box_python_object(object, opaque);
+        }
+        // A class the registries have never seen: the DSL names its schema
+        // (a CompoundScalar's nominal Bundle, an opaque nominal type for any
+        // other class) and registers it, exactly as annotating ``TS[cls]``
+        // would, so ``const(Row(...))`` infers ``TS[Row]`` in the registry
+        // (RFC 0033, PR E). A class the DSL cannot type stays ``object``.
+        if (python_annotation_schema(nb::handle(reinterpret_cast<PyObject *>(Py_TYPE(object.ptr())))) != nullptr)
+        {
+            if (auto bundle = try_python_bundle_value(object)) { return std::move(*bundle); }
+            if (const auto *opaque = python_bridge::opaque_type_for_python(
+                    nb::handle(reinterpret_cast<PyObject *>(Py_TYPE(object.ptr())))))
+            {
+                return box_python_object(object, opaque);
+            }
         }
         return box_python_object(object);
     }

--- a/python/value_conversion.cpp
+++ b/python/value_conversion.cpp
@@ -24,6 +24,7 @@
 #include <limits>
 #include <memory>
 #include <optional>
+#include <unordered_set>
 #include <ranges>
 #include <span>
 #include <stdexcept>
@@ -578,8 +579,55 @@ namespace hgraph::python_bridge
 
     }  // namespace
 
+    namespace
+    {
+        /** Exact builtin and bridge-carrier types schema-free conversion
+            already knows: never worth a DSL round trip. */
+        [[nodiscard]] bool conversion_knows_type(PyTypeObject *type) noexcept
+        {
+            return type == &PyBool_Type || type == &PyLong_Type || type == &PyFloat_Type ||
+                   type == &PyUnicode_Type || type == &PyBytes_Type || type == &PyTuple_Type ||
+                   type == &PyList_Type || type == &PyDict_Type || type == &PySet_Type ||
+                   type == &PyFrozenSet_Type || type == Py_TYPE(Py_None) || type == &PyType_Type ||
+                   type == &PyCFunction_Type;
+        }
+
+        /** Classes the DSL has been asked about in the current registry
+            generation (registrations die with the metadata on reset). */
+        std::unordered_set<PyTypeObject *> &asked_classes()
+        {
+            static auto *asked = new std::unordered_set<PyTypeObject *>{};
+            return *asked;
+        }
+
+        /**
+         * A class the registries have never seen is typed by the DSL once per
+         * registry generation, before conversion looks at the value: an Enum /
+         * IntEnum / StrEnum registers its enum mapping, a CompoundScalar its
+         * nominal Bundle, any other class its opaque nominal type -- exactly
+         * as annotating ``TS[cls]`` would -- so ``const(Colour.RED)`` and
+         * ``const(Row(...))`` infer their nominal types in the registry
+         * (RFC 0033, PR E; replaces ``const``'s Python-side pre-registration).
+         * A class the DSL cannot type is remembered as such and stays
+         * ``object``. One set lookup per conversion on the hot path.
+         */
+        void ask_dsl_about(PyTypeObject *type)
+        {
+            static std::uint64_t asked_generation = 0;
+            const std::uint64_t  generation       = TypeRegistry::instance().reset_generation();
+            if (generation != asked_generation)
+            {
+                asked_classes().clear();
+                asked_generation = generation;
+            }
+            if (!asked_classes().insert(type).second) { return; }
+            static_cast<void>(python_annotation_schema(nb::handle(reinterpret_cast<PyObject *>(type))));
+        }
+    }  // namespace
+
     Value py_to_value(nb::handle object)
     {
+        if (PyTypeObject *type = Py_TYPE(object.ptr()); !conversion_knows_type(type)) { ask_dsl_about(type); }
         // Preserve nominal Python enum identity before considering primitive
         // base classes: IntEnum and StrEnum deliberately satisfy isinstance
         // checks for int and str.  TS[EnumType] materialisation registers the
@@ -672,20 +720,6 @@ namespace hgraph::python_bridge
                 nb::handle(Py_TYPE(object.ptr()))))
         {
             return box_python_object(object, opaque);
-        }
-        // A class the registries have never seen: the DSL names its schema
-        // (a CompoundScalar's nominal Bundle, an opaque nominal type for any
-        // other class) and registers it, exactly as annotating ``TS[cls]``
-        // would, so ``const(Row(...))`` infers ``TS[Row]`` in the registry
-        // (RFC 0033, PR E). A class the DSL cannot type stays ``object``.
-        if (python_annotation_schema(nb::handle(reinterpret_cast<PyObject *>(Py_TYPE(object.ptr())))) != nullptr)
-        {
-            if (auto bundle = try_python_bundle_value(object)) { return std::move(*bundle); }
-            if (const auto *opaque = python_bridge::opaque_type_for_python(
-                    nb::handle(reinterpret_cast<PyObject *>(Py_TYPE(object.ptr())))))
-            {
-                return box_python_object(object, opaque);
-            }
         }
         return box_python_object(object);
     }

--- a/src/hgraph/lib/std/operators/io_impl.cpp
+++ b/src/hgraph/lib/std/operators/io_impl.cpp
@@ -13,6 +13,22 @@ namespace hgraph::stdlib
         OperatorImpl apply = make_operator_graph_impl<apply_value_callable_signature>(
             std::string{apply_op::name});
         const TypePattern output_pattern = apply.output;
+        // The output of ``apply`` is the callable's declared result type when
+        // the call requests none (a Python callable's return annotation):
+        // resolved here, in the registry, rather than by an operator-name
+        // branch in the wiring layer (RFC 0033, PR E). The callable is the
+        // first argument, still a scalar at dispatch (lifted at wire).
+        apply.default_resolver = [output_pattern](ResolutionMap &map, OperatorCallContext context) {
+            if (output_pattern.kind != TypePattern::Kind::Var || map.find_ts(output_pattern.name) != nullptr ||
+                context.args.empty() || context.args.front().kind != WiringArg::Kind::Scalar)
+            {
+                return;
+            }
+            const auto *callable = context.args.front().scalar_value.try_as<ValueCallable>();
+            if (callable == nullptr) { return; }
+            const ValueTypeMetaData *result = callable->output_schema();
+            if (result != nullptr) { map.bind_ts(output_pattern.name, TypeRegistry::instance().ts(result)); }
+        };
         apply.wire = [output_pattern](
                          Wiring &w, const ResolutionMap &resolution,
                          std::span<const WiringArg> args,

--- a/src/hgraph/python/bridge_state.cpp
+++ b/src/hgraph/python/bridge_state.cpp
@@ -644,6 +644,11 @@ nb::object &delta_shaper_slot() {
   return *slot;
 }
 
+nb::object &python_annotation_schema_resolver_slot() {
+  static auto *slot = new nb::object{};
+  return *slot;
+}
+
 PyInferValueFn &py_infer_value_slot() {
   static PyInferValueFn slot = nullptr;
   return slot;


### PR DESCRIPTION
## Summary

The follow-up RFC 0033 named: no operator-name branch in the wiring layer decides a type any more, and the RFC moves to **Accepted**. `wiring-operator-name-branches` goes 8 → 4; the four that remain are the two record/replay durability hooks and the `getattr_`/`getitem_` call fast paths, which belong to other families.

| Branch | Replacement |
|---|---|
| `apply`: read `inspect.signature(fn).return_annotation` into `output_type` | The Python value callable reports its return annotation through `ValueCallable::output_schema`; `apply`'s registry `default_resolver` binds the output variable from the callable's declared result type when the call requests none. |
| `const`: promote `TS[type(value)]` for a CompoundScalar, pre-register any other class | Schema-free conversion asks the DSL for the schema of a class it has never seen (`python_annotation_schema_resolver_slot`, registered by `_types.py` at import), so a CompoundScalar instance infers its nominal Bundle and any other class its opaque nominal type — in the registry, for every operator. |
| `with_columns[Row]` rewritten to `TS[Frame[Row]]` | The public signature declares `_tp_out: type[ROW_1] = DEFAULT[ROW_1]`; `_OperatorFunction` takes a bare non-time-series item through the one subscript rule when its public signature has a `DEFAULT`. |
| `getattr_[SCALAR: X]` turned into `output_type = TS[X]` | An ordinary named pin, plus one general rule: a pin on a variable the public return annotation mentions makes that annotation, resolved, the requested output (`getattr_` declares a public `-> TS[SCALAR]`). This is the general form of `op[OUT: X]`, and it keeps the descriptor overload ahead of a native field read when the caller asks for a type the declared field does not have. |

Sweep cells pin each replacement; `operators.rst`, `python_bridge.rst` and the RFC record the rulings. The one visible surface change: `with_columns`'s public signature now reads `(ts: TS[Frame['ROW']], _tp_out: type[~ROW_1] = DEFAULT[~ROW_1], **columns: TSB[TS_SCHEMA])` (the parity pin is updated), which is the declaration the released `with_columns[Row]` spelling needs.

## Test plan

- [x] C++ `hgraph_unit_tests`: 1692 cases green on a fresh binary.
- [x] Python core + five extension suites + `python/tests/adaptors`: 3593 passed, 10 skipped.
- [x] Installed-SDK consumer checks (Python extension, native executable, Fabric SDK): pass.
- [x] Ratchet `wiring-operator-name-branches` at 4; sweep 96 cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
