### PR TITLE
feat(language): lower hgraph IR bodies

### DIFF
--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -135,9 +135,9 @@ target_include_directories(hgl_ir PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_link_libraries(hgl_ir PUBLIC hgl::semantics)
 hgl_apply_warnings(hgl_ir)
 
-# The execution-facing semantic IR (src/hgraph_ir). Its first checkpoint owns
-# canonical type and callable interfaces; following slices add executable
-# composition and runtime-node plans before either backend migrates here.
+# The execution-facing semantic IR (src/hgraph_ir). It owns canonical
+# contracts and structured callable/test bodies; provider planning advances
+# those bodies to an executable plan before either backend migrates here.
 add_library(hgl_graph_ir STATIC
     src/hgraph_ir/lower.cpp
     src/hgraph_ir/printer.cpp

--- a/language/README.md
+++ b/language/README.md
@@ -17,8 +17,9 @@ subset builds the same graph; the parity tests hold the two paths to it.
 The project is an intentionally changeable prototype in its first executable
 slice. `hgl check` lexes, parses, and resolves a module and reports diagnostics
 (`--dump-tokens`, `--dump-ast`, `--dump-hir`, and `--dump-hgraph-ir` show its
-successive views). The hgraph-IR dump is currently an interface checkpoint;
-backends still use their temporary resolved-AST adapters. That frontend now
+successive views). The hgraph-IR dump now owns callable and test bodies as well
+as their interfaces; backends still use their temporary resolved-AST adapters.
+That frontend now
 models nominal and generic structs, abstract-only inheritance, defaults and
 optional fields, `requires` constraints, and sparse `delta<S>` construction.
 `hgl test`, `hgl run`, and `hgl repl` additionally execute supported generated

--- a/language/docs/design/compiler-architecture.md
+++ b/language/docs/design/compiler-architecture.md
@@ -186,8 +186,10 @@ classification, phase checking, or generic substitution.
 
 `hgl check --dump-hgraph-ir` exposes a readable, source-ranged form for tests
 and compiler diagnosis. The interface checkpoint owns all type, constant,
-constraint, struct, operator, and callable references in hgraph-IR arenas;
-execution-plan lowering may not recover them from HIR declarations.
+constraint, struct, operator, and callable references in hgraph-IR arenas. The
+body checkpoint owns bindings, values, semantic operations, substitutions,
+statements, blocks, and test plans, with no HIR IDs remaining. Execution-plan
+lowering may not recover either contracts or bodies from HIR declarations.
 
 ### Backends
 

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -146,14 +146,18 @@ tables. Struct fields retain their defining contract and effective default;
 requirements retain exact symbol and native registry identities without HIR
 symbol or expression references.
 `hgl check --dump-hgraph-ir` exposes that deterministic interface form. The
-module remains explicitly `Interfaces`, not `Executable`; body, activation,
-state, lifecycle, traversal, and provider-plan lowering plus direct-backend
-migration are the following slices.
+second checkpoint lowers all callable and test bodies into owned bindings,
+values, resolved operations, substitutions, statements, blocks, and test
+plans. It explicitly represents state, injectables, lifecycle, ordered
+activation, traversal, assignment, returns, output and capability access, and
+test evaluation. The module is now `Bodies`, not `Executable`; concrete
+provider planning and direct-backend migration are the following slices.
 
-- lower composition and runtime semantics into one explicit hgraph IR;
-- represent state, injectables, lifecycle, activation, validity, traversal,
-  output, operator identities, and provider requirements;
-- implement `hgl check --dump-hgraph-ir`;
+- [x] lower composition and runtime semantics into one explicit hgraph IR;
+- [x] represent state, injectables, lifecycle, activation, validity, traversal,
+  output, and semantic operator identities;
+- [x] implement `hgl check --dump-hgraph-ir`;
+- [ ] attach concrete provider requirements and advance to `Executable`;
 - migrate direct wiring from `ResolvedModule` to hgraph IR.
 
 Acceptance: direct-wiring behavior and diagnostics remain equivalent, and the

--- a/language/docs/developer-guide/README.md
+++ b/language/docs/developer-guide/README.md
@@ -17,9 +17,10 @@ for hgraph, not a second runtime.
 > It validates constrained generic structs in every type position and leaves a
 > failed module explicitly `Resolved` rather than claiming `Typed` completion.
 > `src/hgraph_ir/` lowers typed HIR into independently owned canonical types,
-> compile-time expressions, nominal operator contracts, and callable
-> interfaces. That checkpoint is explicitly interface-only; executable graph
-> and runtime-node plans and backend migration are the next stacked changes.
+> compile-time expressions, nominal contracts, callable interfaces, bindings,
+> values, semantic operations, structured control flow, and test plans. The
+> module is explicitly at the `Bodies` checkpoint; provider planning and
+> backend migration are the next stacked changes.
 > `src/wiring/` executes the composition subset for `test`, `run`, and the
 > REPL, including scalar and atomic struct values, type-only generic
 > specializations, and field-wise temporal struct composition. `src/codegen/`

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -176,22 +176,29 @@ in the later native-interface stage. A dependency cycle, an unavailable native
 shape, or any other unresolved requirement reports a type diagnostic and
 leaves the module `Resolved`; it is never discarded by a temporary backend.
 
-`src/hgraph_ir/lower` now establishes the execution-facing boundary. Its first
-checkpoint copies typed HIR into an independently owned canonical type table,
+`src/hgraph_ir/lower` establishes the execution-facing boundary. It copies
+typed HIR into an independently owned canonical type table,
 a compile-time expression arena for type and window sizes and scalar or
 aggregate parameter and struct-field defaults, normalized generic requirements,
 effective nominal struct contracts, nominal operator contracts with registry
 spelling kept separate, and callable interfaces with visibility,
-composition/runtime classification, generics, effects, and capabilities.
+composition/runtime classification, generics, effects, and capabilities. The
+body checkpoint additionally owns addressable bindings, values, resolved
+operations, substitutions, statements, blocks, and test plans. Runtime control
+flow is explicit: state and local declarations, injectables, lifecycle blocks,
+ordered activations, collection traversal, assignment, return, assertion, and
+expression evaluation have distinct variants. Tail expressions are removed
+from the executable statement list so they cannot be evaluated twice.
 Effective fields retain their defining struct identity, while every constraint
 reference uses hgraph-IR type, constant-expression, and requirement IDs rather
 than semantic symbols. Inherited field types and defaults are substituted
 through each applied parent, so a child contract refers only to its own generic
 scope even when parent parameters have different names. `hgl check
 --dump-hgraph-ir` prints that representation. The
-result is explicitly marked `Interfaces`: body/control-flow, state, lifecycle,
-activation, traversal, output, and provider plans must be lowered before it may
-be marked `Executable` or consumed by either backend.
+result is marked `Bodies`. No HIR symbol, expression, statement, block, or
+declaration ID remains in it. Provider selection and native execution planning
+are still required before it may be marked `Executable` or consumed by either
+backend.
 
 The direct-wiring and C++ backends still walk `ResolvedModule` beside typed HIR
 during migration. That adapter path is explicitly temporary; hgraph semantic

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -114,15 +114,17 @@ arguments, fail-closed unbound identities, and the deterministic source-ranged
 `--dump-hir` format. Every checked-in guide example now reaches `HIR typed`.
 
 `tests/hgraph_ir/lower_tests.cpp` (`hgl_graph_ir_tests`, CTest
-`hgraph_language_hgraph_ir`) proves that every guide example reaches an
-interface-only hgraph IR module with self-contained types and callable
-signatures. Focused cases cover canonical versus native registry identities,
+`hgraph_language_hgraph_ir`) proves that every guide example reaches a
+`Bodies` hgraph IR module with self-contained contracts, callables, bindings,
+values, control flow, and tests. Focused cases cover canonical versus native registry identities,
 runtime classification and capabilities, distinct source implementation
 identities, compile-time generic expressions, aggregate defaults, complete
 temporal spellings, normalized operator and callable requirements, abstract and
-concrete nominal contracts, inherited field origin/default metadata,
-renamed inherited type and `const` parameters, and rejection of unresolved
-HIR.
+concrete nominal contracts, inherited field origin/default metadata, renamed
+inherited type and `const` parameters, exact call targets, deferred
+nominal operators, state, lifecycle, capability calls, activation, assignment,
+collection traversal, predicate lambdas, test-harness plans, single evaluation
+of block tails, and rejection of unresolved HIR.
 CTest `hgraph_language_dump_hgraph_ir` locks the CLI dump entry point.
 
 Each valid guide example has a source-ranged typed-HIR snapshot containing
@@ -130,10 +132,11 @@ stable declaration identities, canonical types, substitutions, typed
 constants, call targets, function kind, phase, and effects. Invalid examples
 prove that incomplete or contradictory types never reach hgraph IR.
 
-Once executable lowering is added, hgraph-IR snapshots cover composition calls, runtime state and initialization,
-injectables, lifecycle operations, activation and validity guards, collection
-borrows, output effects, and provider requirements. They deliberately contain
-no C++ spellings or direct-wiring runtime objects.
+Hgraph-IR snapshots now cover composition calls, runtime state and
+initialization, injectables, lifecycle operations, activation and validity
+guards, collection traversal, output effects, and test harnesses. They
+deliberately contain no C++ spellings or direct-wiring runtime objects. The
+remaining executable-plan checkpoint adds concrete provider requirements.
 
 Architecture tests inspect target dependencies and includes. Once a backend is
 migrated, it may not include `syntax/ast.h`, consume `ResolvedModule`, perform

--- a/language/src/driver/driver.cpp
+++ b/language/src/driver/driver.cpp
@@ -122,7 +122,7 @@ namespace hgl::driver
             unit.hir = ir::lower_to_hir(unit.module, unit.resolved, unit.diagnostics);
             if (unit.diagnostics.has_errors()) { return; }
             if (ir::complete_hir(unit.hir, wiring::resolve_operator_types, unit.diagnostics)) {
-                unit.hgraph = hgraph_ir::lower_interfaces(unit.hir, unit.diagnostics);
+                unit.hgraph = hgraph_ir::lower(unit.hir, unit.diagnostics);
             }
             unit.ok = !unit.diagnostics.has_errors();
         }

--- a/language/src/hgraph_ir/ir.h
+++ b/language/src/hgraph_ir/ir.h
@@ -24,6 +24,10 @@ namespace hgl::hgraph_ir
     using CallableId   = Id<struct CallableTag>;
     using ConstExprId  = Id<struct ConstExprTag>;
     using ConstraintId = Id<struct ConstraintTag>;
+    using BindingId    = Id<struct BindingTag>;
+    using ValueId      = Id<struct ValueTag>;
+    using StatementId  = Id<struct StatementTag>;
+    using BlockId      = Id<struct BlockTag>;
 
     enum class ConstExprKind : std::uint8_t {
         Literal,
@@ -97,6 +101,7 @@ namespace hgl::hgraph_ir
         std::string name{};
         bool        is_const{false};
         TypeId      type{};
+        BindingId   binding{};
     };
 
     struct Parameter
@@ -105,6 +110,7 @@ namespace hgl::hgraph_ir
         bool        is_const{false};
         TypeId      type{};
         ConstExprId default_value{};
+        BindingId   binding{};
     };
 
     enum class ConstraintLogicOp : std::uint8_t {
@@ -204,6 +210,241 @@ namespace hgl::hgraph_ir
     {
         std::string name{};
         TypeId      type{};
+        BindingId   binding{};
+    };
+
+    enum class BindingKind : std::uint8_t {
+        TypeParameter,
+        ConstParameter,
+        SignalParameter,
+        LocalLet,
+        LocalVar,
+        State,
+        Capability,
+        LoopValue,
+        LambdaParameter,
+    };
+
+    /// One addressable value owned by a callable, lambda, or nominal contract.
+    /// The hgraph IR deliberately keeps no HIR SymbolId references.
+    struct Binding
+    {
+        std::string         name{};
+        BindingKind         kind{BindingKind::LocalLet};
+        TypeId              type{};
+        std::string         owner_identity{};
+        std::uint32_t       index{0};
+        syntax::SourceRange range{};
+    };
+
+    enum class ReferenceKind : std::uint8_t {
+        Binding,
+        Callable,
+        Operator,
+        Struct,
+        Intrinsic,
+    };
+
+    struct Reference
+    {
+        ReferenceKind kind{ReferenceKind::Binding};
+        BindingId     binding{};
+        CallableId    callable{};
+        std::string   identity{};
+        std::string   registry_name{};
+    };
+
+    enum class OperationKind : std::uint8_t {
+        None,
+        ExactFunction,
+        NominalOperator,
+        Intrinsic,
+        Constructor,
+        Capability,
+        Index,
+        Field,
+        HarnessEval,
+    };
+
+    struct Substitution
+    {
+        BindingId                        parameter{};
+        std::string                      parameter_identity{};
+        TypeId                           type{};
+        ConstExprId                      value{};
+        std::optional<ir::hir::Constant> constant{};
+    };
+
+    /// Resolved semantic operation attached to a value. Canonical language
+    /// identity and native registry spelling remain separate, while local
+    /// callables are addressed by arena ID.
+    struct Operation
+    {
+        OperationKind             kind{OperationKind::None};
+        CallableId                callable{};
+        CallableId                candidate{};
+        BindingId                 capability{};
+        std::string               identity{};
+        std::string               registry_name{};
+        std::string               candidate_identity{};
+        std::string               candidate_label{};
+        std::vector<Substitution> substitutions{};
+        bool                      deferred{false};
+    };
+
+    struct Literal
+    { ir::hir::Constant value{}; };
+    struct Unary
+    {
+        ir::hir::UnaryOp op{ir::hir::UnaryOp::Negate};
+        ValueId          operand{};
+    };
+    struct Binary
+    {
+        ir::hir::BinaryOp op{ir::hir::BinaryOp::Add};
+        ValueId           lhs{};
+        ValueId           rhs{};
+    };
+    struct Argument
+    {
+        std::string         name{};
+        ValueId             value{};
+        syntax::SourceRange range{};
+    };
+    struct Call
+    {
+        ValueId               callee{};
+        std::vector<Argument> arguments{};
+    };
+    struct Index
+    {
+        ValueId target{};
+        ValueId index{};
+    };
+    struct Field
+    {
+        ValueId             target{};
+        std::string         name{};
+        syntax::SourceRange name_range{};
+    };
+    struct SequenceElement
+    {
+        ValueId key{};
+        ValueId value{};
+    };
+    struct Sequence
+    { std::vector<SequenceElement> elements{}; };
+    struct Tuple
+    { std::vector<ValueId> elements{}; };
+    struct Lambda
+    {
+        std::vector<BindingId> parameters{};
+        TypeId                 result{};
+        ValueId                body{};
+    };
+    struct Conditional
+    {
+        ValueId condition{};
+        BlockId then_block{};
+        ValueId otherwise{};
+    };
+    struct BlockValue
+    { BlockId block{}; };
+    struct HarnessEval
+    {
+        ValueId               callee{};
+        std::vector<Argument> arguments{};
+    };
+    struct Construct
+    {
+        TypeId                type{};
+        std::vector<Argument> arguments{};
+        bool                  delta{false};
+    };
+    using ValueNode = std::variant<Literal, Reference, Unary, Binary, Call, Index, Field, Sequence, Tuple, Lambda, Conditional,
+                                   BlockValue, HarnessEval, Construct>;
+
+    struct Value
+    {
+        syntax::SourceRange              range{};
+        TypeId                           type{};
+        ir::hir::Phase                   phase{ir::hir::Phase::Unknown};
+        ir::hir::ValueKind               value_kind{ir::hir::ValueKind::Unknown};
+        ValueNode                        node{};
+        ir::hir::Effect                  effects{ir::hir::Effect::None};
+        std::optional<ir::hir::Constant> constant{};
+        Operation                        operation{};
+    };
+
+    struct LocalBinding
+    {
+        BindingId binding{};
+        TypeId    type{};
+        ValueId   init{};
+    };
+    struct StateBinding
+    {
+        BindingId binding{};
+        TypeId    type{};
+        ValueId   init{};
+    };
+    struct Inject
+    { std::vector<BindingId> bindings{}; };
+    enum class LifecycleKind : std::uint8_t {
+        Start,
+        Stop,
+    };
+    struct Lifecycle
+    {
+        LifecycleKind kind{LifecycleKind::Start};
+        BlockId       block{};
+    };
+    struct Activation
+    {
+        ValueId condition{};
+        BlockId block{};
+    };
+    struct Traversal
+    {
+        std::vector<BindingId> bindings{};
+        ValueId                iterable{};
+        BlockId                block{};
+    };
+    enum class AssignOp : std::uint8_t {
+        Assign,
+        Add,
+        Sub,
+        Mul,
+        Div,
+    };
+    struct Assignment
+    {
+        AssignOp op{AssignOp::Assign};
+        ValueId  place{};
+        ValueId  value{};
+    };
+    struct Return
+    { ValueId value{}; };
+    struct Assert
+    { ValueId condition{}; };
+    struct Evaluate
+    { ValueId value{}; };
+    using StatementNode =
+        std::variant<LocalBinding, StateBinding, Inject, Lifecycle, Activation, Traversal, Assignment, Return, Assert, Evaluate>;
+
+    struct Statement
+    {
+        syntax::SourceRange range{};
+        StatementNode       node{};
+        ir::hir::Effect     effects{ir::hir::Effect::None};
+    };
+
+    struct Block
+    {
+        syntax::SourceRange      range{};
+        std::vector<StatementId> statements{};
+        ValueId                  tail{};
+        ir::hir::Effect          effects{ir::hir::Effect::None};
     };
 
     enum class CallableVisibility : std::uint8_t {
@@ -234,11 +475,21 @@ namespace hgl::hgraph_ir
         ConstraintId                  requirements{};
         ir::hir::Effect               effects{ir::hir::Effect::None};
         std::vector<Capability>       capabilities{};
+        ValueId                       concise_body{};
+        BlockId                       block_body{};
         syntax::SourceRange           range{};
+    };
+
+    struct TestPlan
+    {
+        std::string         identity{};
+        BlockId             body{};
+        syntax::SourceRange range{};
     };
 
     enum class Completion : std::uint8_t {
         Interfaces,
+        Bodies,
         Executable,
     };
 
@@ -252,6 +503,11 @@ namespace hgl::hgraph_ir
         std::vector<StructContract>   structures{};
         std::vector<OperatorContract> operators{};
         std::vector<Callable>         callables{};
+        std::vector<Binding>          bindings{};
+        std::vector<Value>            values{};
+        std::vector<Statement>        statements{};
+        std::vector<Block>            blocks{};
+        std::vector<TestPlan>         tests{};
     };
 }  // namespace hgl::hgraph_ir
 

--- a/language/src/hgraph_ir/lower.cpp
+++ b/language/src/hgraph_ir/lower.cpp
@@ -14,11 +14,10 @@ namespace hgl::hgraph_ir
     {
         namespace hir = ir::hir;
 
-        class InterfaceLowerer
+        class Lowerer
         {
           public:
-            InterfaceLowerer(const hir::Module &source, syntax::DiagnosticSink &diagnostics)
-                : source_{source}, diagnostics_{diagnostics} {
+            Lowerer(const hir::Module &source, syntax::DiagnosticSink &diagnostics) : source_{source}, diagnostics_{diagnostics} {
                 result_.path = source.path;
             }
 
@@ -29,10 +28,13 @@ namespace hgl::hgraph_ir
                 }
 
                 lower_types();
+                lower_bindings();
                 lower_constraints();
                 lower_structures();
                 lower_operators();
                 lower_callables();
+                lower_tests();
+                if (!diagnostics_.has_errors()) { result_.completion = Completion::Bodies; }
                 return std::move(result_);
             }
 
@@ -123,10 +125,58 @@ namespace hgl::hgraph_ir
                 const hir::Symbol &symbol = source_.symbol(id);
                 if (!symbol.canonical_name.empty()) { return symbol.canonical_name; }
                 if (symbol.kind == hir::SymbolKind::Struct || symbol.kind == hir::SymbolKind::Operator ||
-                    symbol.kind == hir::SymbolKind::Function) {
+                    symbol.kind == hir::SymbolKind::Function || symbol.kind == hir::SymbolKind::Test) {
                     return source_.path + "." + symbol.name;
                 }
                 return symbol.name;
+            }
+
+            [[nodiscard]] std::string declaration_identity(hir::DeclarationId id) const {
+                if (!id.valid()) { return {}; }
+                const hir::Declaration &declaration = source_.declaration(id);
+                std::string             identity    = symbol_identity(declaration.symbol);
+                if (const auto *function = std::get_if<hir::FunctionDecl>(&declaration.node);
+                    function != nullptr && function->visibility == hir::Visibility::Implementation) {
+                    identity += "#" + std::to_string(id.value);
+                }
+                return identity;
+            }
+
+            [[nodiscard]] static std::optional<BindingKind> lower_binding_kind(hir::SymbolKind kind) noexcept {
+                switch (kind) {
+                    case hir::SymbolKind::TypeParameter: return BindingKind::TypeParameter;
+                    case hir::SymbolKind::ConstParameter: return BindingKind::ConstParameter;
+                    case hir::SymbolKind::SignalParameter: return BindingKind::SignalParameter;
+                    case hir::SymbolKind::LocalLet: return BindingKind::LocalLet;
+                    case hir::SymbolKind::LocalVar: return BindingKind::LocalVar;
+                    case hir::SymbolKind::State: return BindingKind::State;
+                    case hir::SymbolKind::InjectedCapability: return BindingKind::Capability;
+                    case hir::SymbolKind::LoopValue: return BindingKind::LoopValue;
+                    case hir::SymbolKind::LambdaParameter: return BindingKind::LambdaParameter;
+                    default: return std::nullopt;
+                }
+            }
+
+            void lower_bindings() {
+                for (std::uint32_t index = 0; index < source_.symbols.size(); ++index) {
+                    const hir::Symbol               &symbol = source_.symbols[index];
+                    const std::optional<BindingKind> kind   = lower_binding_kind(symbol.kind);
+                    if (!kind) { continue; }
+                    const BindingId id{static_cast<std::uint32_t>(result_.bindings.size())};
+                    bindings_.emplace(index, id);
+                    result_.bindings.push_back(Binding{.name           = symbol.name,
+                                                       .kind           = *kind,
+                                                       .type           = lower_type(symbol.type),
+                                                       .owner_identity = declaration_identity(symbol.owner),
+                                                       .index          = symbol.index,
+                                                       .range          = symbol.range});
+                }
+            }
+
+            [[nodiscard]] BindingId binding(hir::SymbolId source_id) const noexcept {
+                if (!source_id.valid()) { return {}; }
+                const auto found = bindings_.find(source_id.value);
+                return found == bindings_.end() ? BindingId{} : found->second;
             }
 
             [[nodiscard]] TypeId lower_type(hir::TypeId source_id) {
@@ -308,7 +358,7 @@ namespace hgl::hgraph_ir
 
             [[nodiscard]] GenericParameter lower_generic(const hir::GenericParameter &source) {
                 const hir::Symbol &symbol = source_.symbol(source.symbol);
-                return GenericParameter{symbol.name, source.is_const, lower_type(source.type)};
+                return GenericParameter{symbol.name, source.is_const, lower_type(source.type), binding(source.symbol)};
             }
 
             [[nodiscard]] Parameter lower_parameter(const hir::Parameter &source) {
@@ -318,6 +368,7 @@ namespace hgl::hgraph_ir
                 target.is_const      = source.is_const;
                 target.type          = lower_type(source.type);
                 target.default_value = lower_const_expr(source.default_value, symbol.range, "a parameter default");
+                target.binding       = binding(source.symbol);
                 return target;
             }
 
@@ -394,11 +445,6 @@ namespace hgl::hgraph_ir
                 for (std::uint32_t index = 0; index < source_.constraints.size(); ++index) {
                     (void)lower_constraint(hir::ConstraintId{index});
                 }
-            }
-
-            [[nodiscard]] std::string declaration_identity(hir::DeclarationId id) const {
-                if (!id.valid()) { return {}; }
-                return symbol_identity(source_.declaration(id).symbol);
             }
 
             void lower_structures() {
@@ -487,16 +533,269 @@ namespace hgl::hgraph_ir
                 }
             }
 
+            [[nodiscard]] CallableId callable(hir::SymbolId source_id) const noexcept {
+                if (!source_id.valid()) { return {}; }
+                const auto found = callables_.find(source_id.value);
+                return found == callables_.end() ? CallableId{} : found->second;
+            }
+
+            [[nodiscard]] Reference lower_reference(hir::SymbolId source_id) const {
+                Reference target;
+                if (!source_id.valid()) { return target; }
+                const hir::Symbol &source = source_.symbol(source_id);
+                if (const BindingId id = binding(source_id); id.valid()) {
+                    target.kind    = ReferenceKind::Binding;
+                    target.binding = id;
+                    return target;
+                }
+                target.identity      = symbol_identity(source_id);
+                target.registry_name = source.external_name;
+                switch (source.kind) {
+                    case hir::SymbolKind::Function:
+                        target.kind     = ReferenceKind::Callable;
+                        target.callable = callable(source_id);
+                        break;
+                    case hir::SymbolKind::Operator:
+                    case hir::SymbolKind::ImportedOperator: target.kind = ReferenceKind::Operator; break;
+                    case hir::SymbolKind::Struct: target.kind = ReferenceKind::Struct; break;
+                    case hir::SymbolKind::Intrinsic: target.kind = ReferenceKind::Intrinsic; break;
+                    default: target.kind = ReferenceKind::Binding; break;
+                }
+                return target;
+            }
+
+            [[nodiscard]] static OperationKind lower_operation_kind(hir::OperationKind kind) noexcept {
+                switch (kind) {
+                    case hir::OperationKind::None: return OperationKind::None;
+                    case hir::OperationKind::ExactFunction: return OperationKind::ExactFunction;
+                    case hir::OperationKind::NominalOperator: return OperationKind::NominalOperator;
+                    case hir::OperationKind::Intrinsic: return OperationKind::Intrinsic;
+                    case hir::OperationKind::Constructor: return OperationKind::Constructor;
+                    case hir::OperationKind::Capability: return OperationKind::Capability;
+                    case hir::OperationKind::Index: return OperationKind::Index;
+                    case hir::OperationKind::Field: return OperationKind::Field;
+                    case hir::OperationKind::HarnessEval: return OperationKind::HarnessEval;
+                }
+                std::unreachable();
+            }
+
+            [[nodiscard]] std::string binding_identity(hir::SymbolId source_id) const {
+                if (!source_id.valid()) { return {}; }
+                const hir::Symbol &symbol = source_.symbol(source_id);
+                const std::string  owner  = declaration_identity(symbol.owner);
+                return owner.empty() ? symbol.name : owner + "::" + symbol.name;
+            }
+
+            [[nodiscard]] Operation lower_operation(const hir::Operation &source, syntax::SourceRange range) {
+                Operation target;
+                target.kind            = lower_operation_kind(source.kind);
+                target.callable        = callable(source.target);
+                target.candidate       = callable(source.candidate);
+                target.capability      = binding(source.target);
+                target.identity        = source.identity;
+                target.candidate_label = source.candidate_label;
+                target.deferred        = source.deferred;
+                if (source.target.valid()) {
+                    const hir::Symbol &symbol = source_.symbol(source.target);
+                    if (target.identity.empty()) { target.identity = symbol_identity(source.target); }
+                    target.registry_name = symbol.external_name;
+                }
+                if (source.kind == hir::OperationKind::Index || source.kind == hir::OperationKind::Field) {
+                    target.registry_name = source.identity;
+                }
+                if (source.kind == hir::OperationKind::NominalOperator && target.registry_name.empty() &&
+                    !source.identity.empty() && !source.target.valid()) {
+                    target.registry_name = source.identity;
+                }
+                if (source.candidate.valid()) {
+                    target.candidate_identity = target.candidate.valid() ? result_.callables[target.candidate.value].identity
+                                                                         : symbol_identity(source.candidate);
+                }
+                for (const hir::Substitution &substitution : source.substitutions) {
+                    target.substitutions.push_back(Substitution{
+                        .parameter = binding(substitution.parameter),
+                        .parameter_identity =
+                            substitution.parameter.valid() ? binding_identity(substitution.parameter) : substitution.name,
+                        .type     = lower_type(substitution.type),
+                        .value    = lower_const_expr(substitution.value, range, "an operation substitution"),
+                        .constant = substitution.constant,
+                    });
+                }
+                return target;
+            }
+
+            [[nodiscard]] std::vector<Argument> lower_arguments(const std::vector<hir::Argument> &source) {
+                std::vector<Argument> target;
+                target.reserve(source.size());
+                for (const hir::Argument &argument : source) {
+                    target.push_back(Argument{argument.name, lower_value(argument.value), argument.range});
+                }
+                return target;
+            }
+
+            [[nodiscard]] ValueId lower_value(hir::ExprId source_id) {
+                if (!source_id.valid()) { return {}; }
+                if (const auto found = values_.find(source_id.value); found != values_.end()) { return found->second; }
+
+                const ValueId id{static_cast<std::uint32_t>(result_.values.size())};
+                values_.emplace(source_id.value, id);
+                result_.values.emplace_back();
+
+                const hir::Expr &source = source_.expr(source_id);
+                Value            target;
+                target.range      = source.range;
+                target.type       = lower_type(source.type);
+                target.phase      = source.phase;
+                target.value_kind = source.value_kind;
+                target.effects    = source.effects;
+                target.constant   = source.constant;
+                target.operation  = lower_operation(source.operation, source.range);
+                target.node       = std::visit(
+                    [&](const auto &node) -> ValueNode {
+                        using T = std::decay_t<decltype(node)>;
+                        if constexpr (std::is_same_v<T, hir::Literal>) {
+                            return Literal{node.value};
+                        } else if constexpr (std::is_same_v<T, hir::SymbolRef>) {
+                            return lower_reference(node.symbol);
+                        } else if constexpr (std::is_same_v<T, hir::Unary>) {
+                            return Unary{node.op, lower_value(node.operand)};
+                        } else if constexpr (std::is_same_v<T, hir::Binary>) {
+                            return Binary{node.op, lower_value(node.lhs), lower_value(node.rhs)};
+                        } else if constexpr (std::is_same_v<T, hir::Call>) {
+                            return Call{lower_value(node.callee), lower_arguments(node.arguments)};
+                        } else if constexpr (std::is_same_v<T, hir::Index>) {
+                            return Index{lower_value(node.target), lower_value(node.index)};
+                        } else if constexpr (std::is_same_v<T, hir::Field>) {
+                            return Field{lower_value(node.target), node.name, node.name_range};
+                        } else if constexpr (std::is_same_v<T, hir::Sequence>) {
+                            Sequence lowered;
+                            for (const hir::SequenceElement &element : node.elements) {
+                                lowered.elements.push_back(SequenceElement{lower_value(element.key), lower_value(element.value)});
+                            }
+                            return lowered;
+                        } else if constexpr (std::is_same_v<T, hir::Tuple>) {
+                            Tuple lowered;
+                            for (hir::ExprId element : node.elements) { lowered.elements.push_back(lower_value(element)); }
+                            return lowered;
+                        } else if constexpr (std::is_same_v<T, hir::Lambda>) {
+                            Lambda lowered;
+                            for (hir::SymbolId parameter : node.parameters) { lowered.parameters.push_back(binding(parameter)); }
+                            lowered.result = lower_type(node.result);
+                            lowered.body   = lower_value(node.body);
+                            return lowered;
+                        } else if constexpr (std::is_same_v<T, hir::If>) {
+                            return Conditional{lower_value(node.condition), lower_block(node.then_block),
+                                               lower_value(node.otherwise)};
+                        } else if constexpr (std::is_same_v<T, hir::BlockExpr>) {
+                            return BlockValue{lower_block(node.block)};
+                        } else if constexpr (std::is_same_v<T, hir::Eval>) {
+                            return HarnessEval{lower_value(node.callee), lower_arguments(node.arguments)};
+                        } else {
+                            return Construct{lower_type(node.type), lower_arguments(node.arguments), node.delta};
+                        }
+                    },
+                    source.node);
+                result_.values[id.value] = std::move(target);
+                return id;
+            }
+
+            [[nodiscard]] static AssignOp lower_assign_op(hir::AssignOp op) noexcept {
+                switch (op) {
+                    case hir::AssignOp::Assign: return AssignOp::Assign;
+                    case hir::AssignOp::Add: return AssignOp::Add;
+                    case hir::AssignOp::Sub: return AssignOp::Sub;
+                    case hir::AssignOp::Mul: return AssignOp::Mul;
+                    case hir::AssignOp::Div: return AssignOp::Div;
+                }
+                std::unreachable();
+            }
+
+            [[nodiscard]] StatementId lower_statement(hir::StmtId source_id) {
+                if (!source_id.valid()) { return {}; }
+                if (const auto found = statements_.find(source_id.value); found != statements_.end()) { return found->second; }
+
+                const StatementId id{static_cast<std::uint32_t>(result_.statements.size())};
+                statements_.emplace(source_id.value, id);
+                result_.statements.emplace_back();
+
+                const hir::Stmt &source = source_.stmt(source_id);
+                Statement        target;
+                target.range   = source.range;
+                target.effects = source.effects;
+                target.node    = std::visit(
+                    [&](const auto &node) -> StatementNode {
+                        using T = std::decay_t<decltype(node)>;
+                        if constexpr (std::is_same_v<T, hir::LocalDecl>) {
+                            return LocalBinding{binding(node.symbol), lower_type(node.type), lower_value(node.init)};
+                        } else if constexpr (std::is_same_v<T, hir::StateDecl>) {
+                            return StateBinding{binding(node.symbol), lower_type(node.type), lower_value(node.init)};
+                        } else if constexpr (std::is_same_v<T, hir::InjectDecl>) {
+                            Inject lowered;
+                            for (hir::SymbolId symbol : node.symbols) { lowered.bindings.push_back(binding(symbol)); }
+                            return lowered;
+                        } else if constexpr (std::is_same_v<T, hir::LifecycleBlock>) {
+                            return Lifecycle{node.is_stop ? LifecycleKind::Stop : LifecycleKind::Start, lower_block(node.block)};
+                        } else if constexpr (std::is_same_v<T, hir::WhenStmt>) {
+                            return Activation{lower_value(node.condition), lower_block(node.block)};
+                        } else if constexpr (std::is_same_v<T, hir::ForStmt>) {
+                            Traversal lowered;
+                            for (hir::SymbolId symbol : node.bindings) { lowered.bindings.push_back(binding(symbol)); }
+                            lowered.iterable = lower_value(node.iterable);
+                            lowered.block    = lower_block(node.block);
+                            return lowered;
+                        } else if constexpr (std::is_same_v<T, hir::AssignStmt>) {
+                            return Assignment{lower_assign_op(node.op), lower_value(node.place), lower_value(node.value)};
+                        } else if constexpr (std::is_same_v<T, hir::ReturnStmt>) {
+                            return Return{lower_value(node.value)};
+                        } else if constexpr (std::is_same_v<T, hir::AssertStmt>) {
+                            return Assert{lower_value(node.condition)};
+                        } else {
+                            return Evaluate{lower_value(node.expr)};
+                        }
+                    },
+                    source.node);
+                result_.statements[id.value] = std::move(target);
+                return id;
+            }
+
+            [[nodiscard]] BlockId lower_block(hir::BlockId source_id) {
+                if (!source_id.valid()) { return {}; }
+                if (const auto found = blocks_.find(source_id.value); found != blocks_.end()) { return found->second; }
+
+                const BlockId id{static_cast<std::uint32_t>(result_.blocks.size())};
+                blocks_.emplace(source_id.value, id);
+                result_.blocks.emplace_back();
+
+                const hir::Block &source = source_.block(source_id);
+                Block             target;
+                target.range   = source.range;
+                target.effects = source.effects;
+                for (std::size_t index = 0; index < source.statements.size(); ++index) {
+                    const hir::StmtId statement = source.statements[index];
+                    if (source.tail.valid() && index + 1U == source.statements.size()) {
+                        if (const auto *tail = std::get_if<hir::ExprStmt>(&source_.stmt(statement).node);
+                            tail != nullptr && tail->expr == source.tail) {
+                            continue;
+                        }
+                    }
+                    target.statements.push_back(lower_statement(statement));
+                }
+                target.tail              = lower_value(source.tail);
+                result_.blocks[id.value] = std::move(target);
+                return id;
+            }
+
             void lower_callables() {
+                // Register all interfaces first so calls to later declarations
+                // can name their target by stable CallableId.
                 for (const hir::Declaration &declaration : source_.declarations) {
                     const auto *source = std::get_if<hir::FunctionDecl>(&declaration.node);
                     if (source == nullptr || !declaration.symbol.valid()) { continue; }
+                    const CallableId id{static_cast<std::uint32_t>(result_.callables.size())};
+                    callables_.emplace(declaration.symbol.value, id);
                     Callable target;
                     target.visibility = lower_visibility(source->visibility);
-                    target.identity   = symbol_identity(declaration.symbol);
-                    if (target.visibility == CallableVisibility::Implementation) {
-                        target.identity += "#" + std::to_string(declaration.id.value);
-                    }
+                    target.identity   = declaration_identity(declaration.id);
                     target.kind =
                         source->kind == hir::FunctionKind::Composition ? CallableKind::Composition : CallableKind::RuntimeNode;
                     target.effects = source->effects;
@@ -510,9 +809,26 @@ namespace hgl::hgraph_ir
                     target.requirements = lower_constraint(source->requirements);
                     for (hir::SymbolId capability : source->capabilities) {
                         const hir::Symbol &symbol = source_.symbol(capability);
-                        target.capabilities.push_back(Capability{symbol.name, lower_type(symbol.type)});
+                        target.capabilities.push_back(Capability{symbol.name, lower_type(symbol.type), binding(capability)});
                     }
                     result_.callables.push_back(std::move(target));
+                }
+
+                for (const hir::Declaration &declaration : source_.declarations) {
+                    const auto *source = std::get_if<hir::FunctionDecl>(&declaration.node);
+                    if (source == nullptr || !declaration.symbol.valid()) { continue; }
+                    Callable &target    = result_.callables[callable(declaration.symbol).value];
+                    target.concise_body = lower_value(source->concise_body);
+                    target.block_body   = lower_block(source->block_body);
+                }
+            }
+
+            void lower_tests() {
+                for (const hir::Declaration &declaration : source_.declarations) {
+                    const auto *source = std::get_if<hir::TestDecl>(&declaration.node);
+                    if (source == nullptr || !declaration.symbol.valid()) { continue; }
+                    result_.tests.push_back(
+                        TestPlan{declaration_identity(declaration.id), lower_block(source->block), declaration.range});
                 }
             }
 
@@ -522,10 +838,13 @@ namespace hgl::hgraph_ir
             std::unordered_map<std::uint32_t, TypeId>       types_{};
             std::unordered_map<std::uint32_t, ConstExprId>  const_exprs_{};
             std::unordered_map<std::uint32_t, ConstraintId> constraints_{};
+            std::unordered_map<std::uint32_t, BindingId>    bindings_{};
+            std::unordered_map<std::uint32_t, CallableId>   callables_{};
+            std::unordered_map<std::uint32_t, ValueId>      values_{};
+            std::unordered_map<std::uint32_t, StatementId>  statements_{};
+            std::unordered_map<std::uint32_t, BlockId>      blocks_{};
         };
     }  // namespace
 
-    Module lower_interfaces(const ir::hir::Module &source, syntax::DiagnosticSink &diagnostics) {
-        return InterfaceLowerer{source, diagnostics}.run();
-    }
+    Module lower(const ir::hir::Module &source, syntax::DiagnosticSink &diagnostics) { return Lowerer{source, diagnostics}.run(); }
 }  // namespace hgl::hgraph_ir

--- a/language/src/hgraph_ir/lower.h
+++ b/language/src/hgraph_ir/lower.h
@@ -6,11 +6,10 @@
 
 namespace hgl::hgraph_ir
 {
-    /// Lower the typed language interface into the execution-facing type and
-    /// callable tables. This foundation intentionally returns Interfaces;
-    /// body, activation, state, and lifecycle lowering advances it to
-    /// Executable in the next hgraph-IR slices.
-    [[nodiscard]] Module lower_interfaces(const ir::hir::Module &source, syntax::DiagnosticSink &diagnostics);
+    /// Lower typed HIR into self-contained hgraph contracts and bodies. The
+    /// Bodies checkpoint owns all references and control flow but intentionally
+    /// precedes overload-provider and native execution planning.
+    [[nodiscard]] Module lower(const ir::hir::Module &source, syntax::DiagnosticSink &diagnostics);
 }  // namespace hgl::hgraph_ir
 
 #endif  // HGL_HGRAPH_IR_LOWER_H

--- a/language/src/hgraph_ir/printer.cpp
+++ b/language/src/hgraph_ir/printer.cpp
@@ -249,6 +249,9 @@ namespace hgl::hgraph_ir
                     if (substitution.value.valid()) {
                         out << '=';
                         print_const_expr_id(out, substitution.value);
+                    } else if (substitution.constant) {
+                        out << '=';
+                        print_constant(out, *substitution.constant);
                     }
                 }
                 out << ']';

--- a/language/src/hgraph_ir/printer.cpp
+++ b/language/src/hgraph_ir/printer.cpp
@@ -78,6 +78,48 @@ namespace hgl::hgraph_ir
             }
         }
 
+        void print_binding_id(std::ostream &out, BindingId id) {
+            if (id.valid()) {
+                out << 'n' << id.value;
+            } else {
+                out << '_';
+            }
+        }
+
+        void print_value_id(std::ostream &out, ValueId id) {
+            if (id.valid()) {
+                out << 'v' << id.value;
+            } else {
+                out << '_';
+            }
+        }
+
+        void print_statement_id(std::ostream &out, StatementId id) {
+            if (id.valid()) {
+                out << 'q' << id.value;
+            } else {
+                out << '_';
+            }
+        }
+
+        void print_block_id(std::ostream &out, BlockId id) {
+            if (id.valid()) {
+                out << 'b' << id.value;
+            } else {
+                out << '_';
+            }
+        }
+
+        void print_callable_id(std::ostream &out, CallableId id) {
+            if (id.valid()) {
+                out << 'f' << id.value;
+            } else {
+                out << '_';
+            }
+        }
+
+        void print_range(std::ostream &out, syntax::SourceRange range) { out << " [" << range.begin << ".." << range.end << ')'; }
+
         template <typename IdType> void print_ids(std::ostream &out, char prefix, const std::vector<IdType> &ids) {
             out << '[';
             for (std::size_t index = 0; index < ids.size(); ++index) {
@@ -108,6 +150,110 @@ namespace hgl::hgraph_ir
                 case hir::BinaryOp::Or: return "or";
             }
             std::unreachable();
+        }
+
+        [[nodiscard]] std::string_view phase_name(hir::Phase phase) noexcept {
+            switch (phase) {
+                case hir::Phase::Unknown: return "unknown";
+                case hir::Phase::Constant: return "constant";
+                case hir::Phase::Wiring: return "wiring";
+                case hir::Phase::Runtime: return "runtime";
+            }
+            std::unreachable();
+        }
+
+        [[nodiscard]] std::string_view value_kind_name(hir::ValueKind kind) noexcept {
+            switch (kind) {
+                case hir::ValueKind::Unknown: return "unknown";
+                case hir::ValueKind::Void: return "void";
+                case hir::ValueKind::Constant: return "constant";
+                case hir::ValueKind::Signal: return "signal";
+                case hir::ValueKind::RuntimeValue: return "runtime-value";
+                case hir::ValueKind::Function: return "function";
+                case hir::ValueKind::Operator: return "operator";
+                case hir::ValueKind::Type: return "type";
+                case hir::ValueKind::Iterator: return "iterator";
+            }
+            std::unreachable();
+        }
+
+        [[nodiscard]] std::string_view operation_kind_name(OperationKind kind) noexcept {
+            switch (kind) {
+                case OperationKind::None: return "none";
+                case OperationKind::ExactFunction: return "exact-function";
+                case OperationKind::NominalOperator: return "nominal-operator";
+                case OperationKind::Intrinsic: return "intrinsic";
+                case OperationKind::Constructor: return "constructor";
+                case OperationKind::Capability: return "capability";
+                case OperationKind::Index: return "index";
+                case OperationKind::Field: return "field";
+                case OperationKind::HarnessEval: return "harness-eval";
+            }
+            std::unreachable();
+        }
+
+        [[nodiscard]] std::string_view assign_name(AssignOp op) noexcept {
+            switch (op) {
+                case AssignOp::Assign: return "assign";
+                case AssignOp::Add: return "add-assign";
+                case AssignOp::Sub: return "sub-assign";
+                case AssignOp::Mul: return "mul-assign";
+                case AssignOp::Div: return "div-assign";
+            }
+            std::unreachable();
+        }
+
+        void print_arguments(std::ostream &out, const std::vector<Argument> &arguments) {
+            out << '[';
+            for (std::size_t index = 0; index < arguments.size(); ++index) {
+                if (index != 0) { out << ", "; }
+                if (!arguments[index].name.empty()) { out << arguments[index].name << ':'; }
+                print_value_id(out, arguments[index].value);
+            }
+            out << ']';
+        }
+
+        void print_operation(std::ostream &out, const Operation &operation) {
+            if (operation.kind == OperationKind::None) { return; }
+            out << " operation=" << operation_kind_name(operation.kind);
+            if (!operation.identity.empty()) { out << " identity=" << operation.identity; }
+            if (!operation.registry_name.empty()) { out << " registry=" << operation.registry_name; }
+            if (operation.callable.valid()) {
+                out << " callable=";
+                print_callable_id(out, operation.callable);
+            }
+            if (operation.candidate.valid()) {
+                out << " candidate=";
+                print_callable_id(out, operation.candidate);
+            }
+            if (!operation.candidate_identity.empty()) { out << " candidate-identity=" << operation.candidate_identity; }
+            if (!operation.candidate_label.empty()) { out << " candidate-label=" << std::quoted(operation.candidate_label); }
+            if (operation.capability.valid()) {
+                out << " capability=";
+                print_binding_id(out, operation.capability);
+            }
+            if (!operation.substitutions.empty()) {
+                out << " substitutions=[";
+                for (std::size_t index = 0; index < operation.substitutions.size(); ++index) {
+                    if (index != 0) { out << ", "; }
+                    const Substitution &substitution = operation.substitutions[index];
+                    if (substitution.parameter.valid()) {
+                        print_binding_id(out, substitution.parameter);
+                    } else {
+                        out << substitution.parameter_identity;
+                    }
+                    if (substitution.type.valid()) {
+                        out << ":";
+                        print_type_id(out, substitution.type);
+                    }
+                    if (substitution.value.valid()) {
+                        out << '=';
+                        print_const_expr_id(out, substitution.value);
+                    }
+                }
+                out << ']';
+            }
+            if (operation.deferred) { out << " deferred"; }
         }
 
         void print_signature(std::ostream &out, const std::vector<GenericParameter> &generics,
@@ -180,9 +326,9 @@ namespace hgl::hgraph_ir
     }  // namespace
 
     std::string print(const Module &module) {
-        std::ostringstream out;
-        out << "HGRAPH-IR " << (module.completion == Completion::Interfaces ? "interfaces" : "executable") << " module "
-            << module.path << '\n';
+        std::ostringstream                out;
+        static constexpr std::string_view completion_names[]{"interfaces", "bodies", "executable"};
+        out << "HGRAPH-IR " << completion_names[static_cast<std::size_t>(module.completion)] << " module " << module.path << '\n';
         out << "constant-expressions\n";
         for (std::size_t index = 0; index < module.const_exprs.size(); ++index) {
             const ConstExpr &expression = module.const_exprs[index];
@@ -409,9 +555,219 @@ namespace hgl::hgraph_ir
                     if (index != 0) { out << ", "; }
                     out << callable.capabilities[index].name << ':';
                     print_type_id(out, callable.capabilities[index].type);
+                    out << '@';
+                    print_binding_id(out, callable.capabilities[index].binding);
                 }
                 out << ']';
             }
+            if (callable.concise_body.valid()) {
+                out << " body=";
+                print_value_id(out, callable.concise_body);
+            }
+            if (callable.block_body.valid()) {
+                out << " body=";
+                print_block_id(out, callable.block_body);
+            }
+            out << '\n';
+        }
+
+        out << "bindings\n";
+        for (std::size_t index = 0; index < module.bindings.size(); ++index) {
+            static constexpr std::string_view names[]{
+                "type-parameter", "const-parameter", "signal-parameter", "let", "var", "state",
+                "capability",     "loop-value",      "lambda-parameter"};
+            const Binding &binding = module.bindings[index];
+            out << "  n" << index << ' ' << names[static_cast<std::size_t>(binding.kind)] << ' ' << binding.name << ':';
+            print_type_id(out, binding.type);
+            if (!binding.owner_identity.empty()) { out << " owner=" << binding.owner_identity; }
+            out << " index=" << binding.index;
+            print_range(out, binding.range);
+            out << '\n';
+        }
+
+        out << "values\n";
+        for (std::size_t index = 0; index < module.values.size(); ++index) {
+            const Value &value = module.values[index];
+            out << "  v" << index << ' ';
+            std::visit(
+                [&](const auto &node) {
+                    using T = std::decay_t<decltype(node)>;
+                    if constexpr (std::is_same_v<T, Literal>) {
+                        out << "literal ";
+                        print_constant(out, node.value);
+                    } else if constexpr (std::is_same_v<T, Reference>) {
+                        static constexpr std::string_view names[]{"binding", "callable", "operator", "struct", "intrinsic"};
+                        out << "reference " << names[static_cast<std::size_t>(node.kind)] << ' ';
+                        if (node.binding.valid()) {
+                            print_binding_id(out, node.binding);
+                        } else if (node.callable.valid()) {
+                            print_callable_id(out, node.callable);
+                        } else {
+                            out << node.identity;
+                        }
+                        if (!node.registry_name.empty()) { out << " registry=" << node.registry_name; }
+                    } else if constexpr (std::is_same_v<T, Unary>) {
+                        out << unary_name(node.op) << ' ';
+                        print_value_id(out, node.operand);
+                    } else if constexpr (std::is_same_v<T, Binary>) {
+                        out << binary_name(node.op) << ' ';
+                        print_value_id(out, node.lhs);
+                        out << ' ';
+                        print_value_id(out, node.rhs);
+                    } else if constexpr (std::is_same_v<T, Call>) {
+                        out << "call ";
+                        print_value_id(out, node.callee);
+                        out << " arguments=";
+                        print_arguments(out, node.arguments);
+                    } else if constexpr (std::is_same_v<T, Index>) {
+                        out << "index ";
+                        print_value_id(out, node.target);
+                        out << ' ';
+                        print_value_id(out, node.index);
+                    } else if constexpr (std::is_same_v<T, Field>) {
+                        out << "field ";
+                        print_value_id(out, node.target);
+                        out << ' ' << node.name;
+                    } else if constexpr (std::is_same_v<T, Sequence>) {
+                        out << "sequence [";
+                        for (std::size_t item = 0; item < node.elements.size(); ++item) {
+                            if (item != 0) { out << ", "; }
+                            if (node.elements[item].key.valid()) {
+                                print_value_id(out, node.elements[item].key);
+                                out << ':';
+                            }
+                            print_value_id(out, node.elements[item].value);
+                        }
+                        out << ']';
+                    } else if constexpr (std::is_same_v<T, Tuple>) {
+                        out << "tuple ";
+                        print_ids(out, 'v', node.elements);
+                    } else if constexpr (std::is_same_v<T, Lambda>) {
+                        out << "lambda parameters=";
+                        print_ids(out, 'n', node.parameters);
+                        out << " result=";
+                        print_type_id(out, node.result);
+                        out << " body=";
+                        print_value_id(out, node.body);
+                    } else if constexpr (std::is_same_v<T, Conditional>) {
+                        out << "if condition=";
+                        print_value_id(out, node.condition);
+                        out << " then=";
+                        print_block_id(out, node.then_block);
+                        if (node.otherwise.valid()) {
+                            out << " else=";
+                            print_value_id(out, node.otherwise);
+                        }
+                    } else if constexpr (std::is_same_v<T, BlockValue>) {
+                        out << "block ";
+                        print_block_id(out, node.block);
+                    } else if constexpr (std::is_same_v<T, HarnessEval>) {
+                        out << "eval ";
+                        print_value_id(out, node.callee);
+                        out << " arguments=";
+                        print_arguments(out, node.arguments);
+                    } else {
+                        out << (node.delta ? "delta " : "construct ");
+                        print_type_id(out, node.type);
+                        out << " arguments=";
+                        print_arguments(out, node.arguments);
+                    }
+                },
+                value.node);
+            out << " type=";
+            print_type_id(out, value.type);
+            out << " phase=" << phase_name(value.phase) << " kind=" << value_kind_name(value.value_kind) << " effects=";
+            print_effects(out, value.effects);
+            print_operation(out, value.operation);
+            if (value.constant) {
+                out << " constant=";
+                print_constant(out, *value.constant);
+            }
+            print_range(out, value.range);
+            out << '\n';
+        }
+
+        out << "statements\n";
+        for (std::size_t index = 0; index < module.statements.size(); ++index) {
+            const Statement &statement = module.statements[index];
+            out << "  q" << index << ' ';
+            std::visit(
+                [&](const auto &node) {
+                    using T = std::decay_t<decltype(node)>;
+                    if constexpr (std::is_same_v<T, LocalBinding> || std::is_same_v<T, StateBinding>) {
+                        out << (std::is_same_v<T, StateBinding> ? "state " : "local ");
+                        print_binding_id(out, node.binding);
+                        out << " type=";
+                        print_type_id(out, node.type);
+                        if (node.init.valid()) {
+                            out << " init=";
+                            print_value_id(out, node.init);
+                        }
+                    } else if constexpr (std::is_same_v<T, Inject>) {
+                        out << "inject ";
+                        print_ids(out, 'n', node.bindings);
+                    } else if constexpr (std::is_same_v<T, Lifecycle>) {
+                        out << (node.kind == LifecycleKind::Start ? "start " : "stop ");
+                        print_block_id(out, node.block);
+                    } else if constexpr (std::is_same_v<T, Activation>) {
+                        out << "when condition=";
+                        print_value_id(out, node.condition);
+                        out << " body=";
+                        print_block_id(out, node.block);
+                    } else if constexpr (std::is_same_v<T, Traversal>) {
+                        out << "for bindings=";
+                        print_ids(out, 'n', node.bindings);
+                        out << " iterable=";
+                        print_value_id(out, node.iterable);
+                        out << " body=";
+                        print_block_id(out, node.block);
+                    } else if constexpr (std::is_same_v<T, Assignment>) {
+                        out << assign_name(node.op) << " place=";
+                        print_value_id(out, node.place);
+                        out << " value=";
+                        print_value_id(out, node.value);
+                    } else if constexpr (std::is_same_v<T, Return>) {
+                        out << "return ";
+                        print_value_id(out, node.value);
+                    } else if constexpr (std::is_same_v<T, Assert>) {
+                        out << "assert ";
+                        print_value_id(out, node.condition);
+                    } else {
+                        out << "evaluate ";
+                        print_value_id(out, node.value);
+                    }
+                },
+                statement.node);
+            out << " effects=";
+            print_effects(out, statement.effects);
+            print_range(out, statement.range);
+            out << '\n';
+        }
+
+        out << "blocks\n";
+        for (std::size_t index = 0; index < module.blocks.size(); ++index) {
+            const Block &block = module.blocks[index];
+            out << "  b" << index << " statements=[";
+            for (std::size_t item = 0; item < block.statements.size(); ++item) {
+                if (item != 0) { out << ", "; }
+                print_statement_id(out, block.statements[item]);
+            }
+            out << ']';
+            if (block.tail.valid()) {
+                out << " tail=";
+                print_value_id(out, block.tail);
+            }
+            out << " effects=";
+            print_effects(out, block.effects);
+            print_range(out, block.range);
+            out << '\n';
+        }
+
+        out << "tests\n";
+        for (const TestPlan &test : module.tests) {
+            out << "  " << test.identity << " body=";
+            print_block_id(out, test.body);
+            print_range(out, test.range);
             out << '\n';
         }
         return out.str();

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -38,7 +38,7 @@ add_test(
     COMMAND $<TARGET_FILE:hgl> check ${CMAKE_CURRENT_SOURCE_DIR}/../examples/stateful-node.hgl --dump-hgraph-ir
 )
 set_tests_properties(hgraph_language_dump_hgraph_ir PROPERTIES
-    PASS_REGULAR_EXPRESSION "HGRAPH-IR interfaces module examples.stateful_node"
+    PASS_REGULAR_EXPRESSION "HGRAPH-IR bodies module examples.stateful_node"
 )
 
 # Catch2 for the frontend unit tests: reuse the repository's target when the

--- a/language/tests/hgraph_ir/lower_tests.cpp
+++ b/language/tests/hgraph_ir/lower_tests.cpp
@@ -296,6 +296,19 @@ fn selected(value: f64) -> f64 => choose(value)
     CHECK(call->operation.candidate_identity == implementation.identity);
 }
 
+TEST_CASE("hgraph IR prints constant-only operation substitutions", "[hgraph-ir][operators][printer]") {
+    hgl::hgraph_ir::Module module;
+    hgl::hgraph_ir::Value  value;
+    value.operation.kind = hgl::hgraph_ir::OperationKind::NominalOperator;
+    value.operation.substitutions.push_back(hgl::hgraph_ir::Substitution{
+        .parameter_identity = "N",
+        .constant           = hir::Constant{std::int64_t{42}},
+    });
+    module.values.push_back(std::move(value));
+
+    CHECK(hgl::hgraph_ir::print(module).find("substitutions=[N=42]") != std::string::npos);
+}
+
 TEST_CASE("hgraph IR owns symbolic compile-time type arguments", "[hgraph-ir][types]") {
     Lowered lowered{R"(
 module checks.const_types

--- a/language/tests/hgraph_ir/lower_tests.cpp
+++ b/language/tests/hgraph_ir/lower_tests.cpp
@@ -40,7 +40,7 @@ namespace
                 return selected;
             };
             if (!hgl::ir::complete_hir(language, operators, diagnostics)) { return; }
-            graph = hgl::hgraph_ir::lower_interfaces(language, diagnostics);
+            graph = hgl::hgraph_ir::lower(language, diagnostics);
         }
     };
 
@@ -59,7 +59,7 @@ namespace
     }
 }  // namespace
 
-TEST_CASE("every guide example lowers an hgraph IR interface", "[hgraph-ir][examples]") {
+TEST_CASE("every guide example lowers complete hgraph IR bodies", "[hgraph-ir][examples]") {
     const std::filesystem::path directory{HGL_EXAMPLES_DIR};
     REQUIRE(std::filesystem::is_directory(directory));
 
@@ -75,11 +75,12 @@ TEST_CASE("every guide example lowers an hgraph IR interface", "[hgraph-ir][exam
         INFO(lowered.diagnostics.render(lowered.file));
         REQUIRE_FALSE(lowered.diagnostics.has_errors());
         REQUIRE(lowered.graph);
-        CHECK(lowered.graph->completion == hgl::hgraph_ir::Completion::Interfaces);
+        CHECK(lowered.graph->completion == hgl::hgraph_ir::Completion::Bodies);
         CHECK_FALSE(lowered.graph->types.empty());
         for (const hgl::hgraph_ir::Callable &function : lowered.graph->callables) {
             CHECK_FALSE(function.identity.empty());
             CHECK(function.result.valid());
+            CHECK((function.concise_body.valid() || function.block_body.valid()));
             for (const hgl::hgraph_ir::Parameter &parameter : function.parameters) { CHECK(parameter.type.valid()); }
         }
     }
@@ -134,6 +135,139 @@ export fn total(value: f64) -> f64 {
     CHECK(total->capabilities[1].type.valid());
     CHECK(hir::has_effect(total->effects, hir::Effect::WriteState));
     CHECK(hir::has_effect(total->effects, hir::Effect::WriteOutput));
+    REQUIRE(total->block_body.valid());
+
+    const hgl::hgraph_ir::Block &body = lowered.graph->blocks[total->block_body.value];
+    CHECK(std::ranges::any_of(body.statements, [&](hgl::hgraph_ir::StatementId id) {
+        return std::holds_alternative<hgl::hgraph_ir::StateBinding>(lowered.graph->statements[id.value].node);
+    }));
+    CHECK(std::ranges::any_of(body.statements, [&](hgl::hgraph_ir::StatementId id) {
+        return std::holds_alternative<hgl::hgraph_ir::Activation>(lowered.graph->statements[id.value].node);
+    }));
+    CHECK(std::ranges::any_of(lowered.graph->statements, [](const hgl::hgraph_ir::Statement &statement) {
+        return std::holds_alternative<hgl::hgraph_ir::Assignment>(statement.node);
+    }));
+}
+
+TEST_CASE("hgraph IR bodies resolve exact calls and native operator identities", "[hgraph-ir][bodies][operations]") {
+    Lowered lowered{R"(
+module checks.calls
+
+fn double(value: f64) -> f64 => value + value
+fn adjusted(value: f64) -> f64 => double(value) - 1.0
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE_FALSE(lowered.diagnostics.has_errors());
+    REQUIRE(lowered.graph);
+    REQUIRE(lowered.graph->completion == hgl::hgraph_ir::Completion::Bodies);
+    REQUIRE(lowered.graph->callables.size() == 2);
+
+    const auto exact = std::ranges::find_if(lowered.graph->values, [](const hgl::hgraph_ir::Value &value) {
+        return value.operation.kind == hgl::hgraph_ir::OperationKind::ExactFunction;
+    });
+    REQUIRE(exact != lowered.graph->values.end());
+    CHECK(exact->operation.identity == "checks.calls.double");
+    REQUIRE(exact->operation.callable.valid());
+    CHECK(lowered.graph->callables[exact->operation.callable.value].identity == "checks.calls.double");
+
+    const auto add = std::ranges::find_if(lowered.graph->values, [](const hgl::hgraph_ir::Value &value) {
+        return value.operation.kind == hgl::hgraph_ir::OperationKind::NominalOperator && value.operation.registry_name == "add_";
+    });
+    REQUIRE(add != lowered.graph->values.end());
+    CHECK(add->operation.deferred);
+}
+
+TEST_CASE("hgraph IR bodies preserve lifecycle and capability calls once", "[hgraph-ir][bodies][lifecycle]") {
+    Lowered lowered{R"(
+module checks.lifecycle
+
+fn observed(value: f64) -> f64 {
+    inject out, logger
+    start { logger.info("start") }
+    when modified(value) { out = value }
+    stop { logger.info("stop") }
+}
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE_FALSE(lowered.diagnostics.has_errors());
+    REQUIRE(lowered.graph);
+
+    std::size_t starts = 0;
+    std::size_t stops  = 0;
+    for (const hgl::hgraph_ir::Statement &statement : lowered.graph->statements) {
+        if (const auto *lifecycle = std::get_if<hgl::hgraph_ir::Lifecycle>(&statement.node)) {
+            lifecycle->kind == hgl::hgraph_ir::LifecycleKind::Start ? ++starts : ++stops;
+            const hgl::hgraph_ir::Block &block = lowered.graph->blocks[lifecycle->block.value];
+            CHECK(block.statements.empty());
+            CHECK(block.tail.valid());
+        }
+    }
+    CHECK(starts == 1);
+    CHECK(stops == 1);
+    const auto capability = std::ranges::find_if(lowered.graph->values, [](const hgl::hgraph_ir::Value &value) {
+        return value.operation.kind == hgl::hgraph_ir::OperationKind::Capability;
+    });
+    REQUIRE(capability != lowered.graph->values.end());
+    CHECK(capability->operation.capability.valid());
+    CHECK(capability->operation.identity == "logger.info");
+}
+
+TEST_CASE("hgraph IR bodies preserve traversal and predicate lambdas", "[hgraph-ir][bodies][collections]") {
+    Lowered lowered{R"(
+module checks.collections
+
+fn recent(values: map<str, f64>, const cutoff: datetime) -> i64 {
+    when modified(values) {
+        var count = 0
+        for key, value in items(values, fn(key, value) => last_modified(value) > cutoff) {
+            count += 1
+        }
+        return count
+    }
+}
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE_FALSE(lowered.diagnostics.has_errors());
+    REQUIRE(lowered.graph);
+
+    const auto traversal = std::ranges::find_if(lowered.graph->statements, [](const hgl::hgraph_ir::Statement &statement) {
+        return std::holds_alternative<hgl::hgraph_ir::Traversal>(statement.node);
+    });
+    REQUIRE(traversal != lowered.graph->statements.end());
+    const auto &loop = std::get<hgl::hgraph_ir::Traversal>(traversal->node);
+    REQUIRE(loop.bindings.size() == 2);
+    CHECK(loop.iterable.valid());
+    CHECK(loop.block.valid());
+
+    const auto lambda = std::ranges::find_if(lowered.graph->values, [](const hgl::hgraph_ir::Value &value) {
+        return std::holds_alternative<hgl::hgraph_ir::Lambda>(value.node);
+    });
+    REQUIRE(lambda != lowered.graph->values.end());
+    CHECK(std::get<hgl::hgraph_ir::Lambda>(lambda->node).parameters.size() == 2);
+}
+
+TEST_CASE("hgraph IR bodies own test harness plans", "[hgraph-ir][bodies][tests]") {
+    Lowered lowered{R"(
+module checks.tests
+
+fn identity(value: f64) -> f64 => value
+test identity_ticks {
+    assert eval(identity, value: [1.0, _, 2.0]) == [1.0, _, 2.0]
+}
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE_FALSE(lowered.diagnostics.has_errors());
+    REQUIRE(lowered.graph);
+    REQUIRE(lowered.graph->tests.size() == 1);
+    CHECK(lowered.graph->tests.front().identity == "checks.tests.identity_ticks");
+    CHECK(lowered.graph->tests.front().body.valid());
+
+    const auto evaluation = std::ranges::find_if(lowered.graph->values, [](const hgl::hgraph_ir::Value &value) {
+        return value.operation.kind == hgl::hgraph_ir::OperationKind::HarnessEval;
+    });
+    REQUIRE(evaluation != lowered.graph->values.end());
+    REQUIRE(evaluation->operation.callable.valid());
+    CHECK(lowered.graph->callables[evaluation->operation.callable.value].identity == "checks.tests.identity");
 }
 
 TEST_CASE("hgraph IR preserves source implementation candidates", "[hgraph-ir][operators]") {
@@ -142,6 +276,7 @@ module checks.implementation
 
 operator choose<T>(value: T) -> T
 impl fn choose(value: f64) -> f64 => value
+fn selected(value: f64) -> f64 => choose(value)
 )"};
     INFO(lowered.diagnostics.render(lowered.file));
     REQUIRE_FALSE(lowered.diagnostics.has_errors());
@@ -149,11 +284,16 @@ impl fn choose(value: f64) -> f64 => value
 
     REQUIRE(lowered.graph->operators.size() == 1);
     CHECK(lowered.graph->operators.front().identity == "checks.implementation.choose");
-    REQUIRE(lowered.graph->callables.size() == 1);
+    REQUIRE(lowered.graph->callables.size() == 2);
     const hgl::hgraph_ir::Callable &implementation = lowered.graph->callables.front();
     CHECK(implementation.visibility == hgl::hgraph_ir::CallableVisibility::Implementation);
     CHECK(implementation.operator_identity == "checks.implementation.choose");
     CHECK(implementation.identity == "checks.implementation.choose#2");
+
+    const auto call = std::ranges::find_if(lowered.graph->values,
+                                           [](const hgl::hgraph_ir::Value &value) { return value.operation.candidate.valid(); });
+    REQUIRE(call != lowered.graph->values.end());
+    CHECK(call->operation.candidate_identity == implementation.identity);
 }
 
 TEST_CASE("hgraph IR owns symbolic compile-time type arguments", "[hgraph-ir][types]") {
@@ -315,7 +455,7 @@ requires T in {i64, f64}
 TEST_CASE("hgraph IR lowering rejects unresolved HIR", "[hgraph-ir][completion]") {
     hir::Module                  unresolved;
     hgl::syntax::DiagnosticSink  diagnostics;
-    const hgl::hgraph_ir::Module graph = hgl::hgraph_ir::lower_interfaces(unresolved, diagnostics);
+    const hgl::hgraph_ir::Module graph = hgl::hgraph_ir::lower(unresolved, diagnostics);
     CHECK(diagnostics.has_errors());
     CHECK(graph.completion == hgl::hgraph_ir::Completion::Interfaces);
 }


### PR DESCRIPTION
## Summary
- lower typed callable and test bodies into independently owned hgraph-IR arenas
- preserve stable bindings, exact and nominal operations, substitutions, state, lifecycle, activation, traversal, assignments, and test plans
- prevent block-tail expressions from also appearing as executable statements
- extend the deterministic source-ranged dump, architecture documentation, roadmap, and focused coverage

## Validation
- clang-format on changed C++ files
- git diff --check
- focused hgraph-IR suite: 262 assertions in 14 test cases
- complete language CTest suite: 29/29 passed
- clean native configure, rebuild, and CTest suite: 1711/1711 passed
- stable-ABI wheel built with Python 3.12 and complete non-WIP compatibility suite run from a fresh Python 3.14 environment: 3223 passed, 10 skipped

Stacked on #691.