### PR TITLE
feat(language): materialize hgraph IR runtime types

### DIFF
--- a/.github/workflows/language.yml
+++ b/.github/workflows/language.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Build hgl and its suites
         run: >-
           cmake --build build-language --parallel ${{ matrix.parallel }} --target
-          hgl hgl_syntax_tests hgl_semantics_tests hgl_ir_tests hgl_graph_ir_tests hgl_wiring_tests
+          hgl hgl_syntax_tests hgl_semantics_tests hgl_ir_tests hgl_graph_ir_tests hgl_wiring_tests hgl_wiring_type_tests
           hgl_operator_type_tests hgl_native_module_tests hgl_codegen_tests hgl_codegen_fixture
           hgl_generated_tests
       - name: Run the language suites

--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -148,6 +148,17 @@ target_include_directories(hgl_graph_ir PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_link_libraries(hgl_graph_ir PUBLIC hgl::ir)
 hgl_apply_warnings(hgl_graph_ir)
 
+# Canonical hgraph metadata materialization for execution backends. Keeping
+# this bridge separate prevents hgraph runtime types from entering hgraph IR.
+add_library(hgl_wiring_types STATIC
+    src/wiring/type_bridge.cpp
+)
+add_library(hgl::wiring_types ALIAS hgl_wiring_types)
+target_compile_features(hgl_wiring_types PUBLIC cxx_std_23)
+target_include_directories(hgl_wiring_types PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_link_libraries(hgl_wiring_types PUBLIC hgl::graph_ir hgraph::core)
+hgl_apply_warnings(hgl_wiring_types)
+
 # The direct-wiring backend (src/wiring): walks the resolved tree straight
 # into an hgraph Wiring for test, run and the REPL (developer guide,
 # "Direct-wiring backend", "First pass").
@@ -158,7 +169,7 @@ add_library(hgl_wiring STATIC
 add_library(hgl::wiring ALIAS hgl_wiring)
 target_compile_features(hgl_wiring PUBLIC cxx_std_23)
 target_include_directories(hgl_wiring PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
-target_link_libraries(hgl_wiring PUBLIC hgl::ir hgraph::core)
+target_link_libraries(hgl_wiring PUBLIC hgl::ir hgl::wiring_types hgraph::core)
 if(TARGET hgraph::analytics)
     target_link_libraries(hgl_wiring PUBLIC hgraph::analytics)
     target_compile_definitions(hgl_wiring PRIVATE HGL_HAVE_ANALYTICS=1)

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -158,7 +158,10 @@ provider planning and direct-backend migration are the following slices.
   output, and semantic operator identities;
 - [x] implement `hgl check --dump-hgraph-ir`;
 - [ ] attach concrete provider requirements and advance to `Executable`;
-- migrate direct wiring from `ResolvedModule` to hgraph IR.
+- [ ] migrate direct wiring from `ResolvedModule` to hgraph IR. The first
+  migration slice isolates canonical scalar, container, window, atomic, and
+  generic nominal-struct metadata materialization behind an hgraph-IR type
+  bridge; evaluator migration follows without reintroducing syntax types.
 
 Acceptance: direct-wiring behavior and diagnostics remain equivalent, and the
 wiring target no longer includes syntax AST headers.

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -204,6 +204,17 @@ The direct-wiring and C++ backends still walk `ResolvedModule` beside typed HIR
 during migration. That adapter path is explicitly temporary; hgraph semantic
 IR becomes the only input to both backends in the following stages.
 
+`src/wiring/type_bridge` is the first direct-backend migration boundary. It
+materializes hgraph-IR scalar, tuple, list, set, map, window, atomic, and applied
+nominal-struct types as canonical public hgraph metadata. Generic struct fields
+and parents are resolved from the graph-IR contract and its applied arguments;
+the bridge never looks up a syntax type or semantic binding. It also translates
+folded scalar and temporal constant expressions needed by defaults and type
+sizes. Runtime metadata pointers remain in this backend-only layer and never
+enter hgraph IR. Graph-IR types and symbolic constant expressions retain their
+own lexical binding IDs, so identically named generic parameters in nested
+struct applications cannot shadow one another during materialization.
+
 ## Common function representation
 
 Parsing produces `UnclassifiedFn` for both named and anonymous functions. Its

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -127,6 +127,14 @@ collection traversal, predicate lambdas, test-harness plans, single evaluation
 of block tails, and rejection of unresolved HIR.
 CTest `hgraph_language_dump_hgraph_ir` locks the CLI dump entry point.
 
+`tests/wiring/type_bridge_tests.cpp` (`hgl_wiring_type_tests`, CTest
+`hgraph_language_wiring_types`) independently locks the hgraph-IR/runtime type
+seam. It covers scalar and temporal constants, fixed lists, sets, maps, tick and
+duration windows, atomic tuples, applied generic nominal bundles and TSBs,
+inherited generic-field substitution, and the explicit fail-closed boundary for
+`const` generic Bundle identity. A nested `Wrapper<T>` / `Box<T>` case locks
+lexical generic identity independently of parameter spelling.
+
 Each valid guide example has a source-ranged typed-HIR snapshot containing
 stable declaration identities, canonical types, substitutions, typed
 constants, call targets, function kind, phase, and effects. Invalid examples

--- a/language/src/hgraph_ir/ir.h
+++ b/language/src/hgraph_ir/ir.h
@@ -58,6 +58,7 @@ namespace hgl::hgraph_ir
         ConstExprKind                    kind{ConstExprKind::Literal};
         std::optional<ir::hir::Constant> literal{};
         std::string                      parameter{};
+        BindingId                        parameter_binding{};
         ir::hir::UnaryOp                 unary{ir::hir::UnaryOp::Negate};
         ir::hir::BinaryOp                binary{ir::hir::BinaryOp::Add};
         ConstExprId                      lhs{};
@@ -87,13 +88,22 @@ namespace hgl::hgraph_ir
         ir::hir::TypeKind         kind{ir::hir::TypeKind::Deferred};
         ir::hir::ScalarType       scalar{ir::hir::ScalarType::Bool};
         std::string               nominal_identity{};
+        BindingId                 binding{};
         std::vector<TypeId>       children{};
         std::vector<TypeArgument> arguments{};
         ConstExprId               size{};
         ConstExprId               min_size{};
         bool                      unbounded{false};
+        /// A representative occurrence for backend diagnostics. It is not
+        /// part of canonical type identity because one type may occur many
+        /// times in a module.
+        syntax::SourceRange range{};
 
-        friend bool operator==(const Type &, const Type &) = default;
+        friend bool operator==(const Type &lhs, const Type &rhs) noexcept {
+            return lhs.kind == rhs.kind && lhs.scalar == rhs.scalar && lhs.nominal_identity == rhs.nominal_identity &&
+                   lhs.binding == rhs.binding && lhs.children == rhs.children && lhs.arguments == rhs.arguments &&
+                   lhs.size == rhs.size && lhs.min_size == rhs.min_size && lhs.unbounded == rhs.unbounded;
+        }
     };
 
     struct GenericParameter

--- a/language/src/hgraph_ir/lower.cpp
+++ b/language/src/hgraph_ir/lower.cpp
@@ -27,8 +27,8 @@ namespace hgl::hgraph_ir
                     return std::move(result_);
                 }
 
-                lower_types();
                 lower_bindings();
+                lower_types();
                 lower_constraints();
                 lower_structures();
                 lower_operators();
@@ -74,8 +74,9 @@ namespace hgl::hgraph_ir
                         diagnostics_.report(syntax::Category::Type, range,
                                             "typed HIR has no compile-time value for " + std::string{role});
                     } else {
-                        target.kind      = ConstExprKind::Parameter;
-                        target.parameter = source_.symbol(reference->symbol).name;
+                        target.kind              = ConstExprKind::Parameter;
+                        target.parameter         = source_.symbol(reference->symbol).name;
+                        target.parameter_binding = binding(reference->symbol);
                     }
                 } else if (const auto *unary = std::get_if<hir::Unary>(&source.node)) {
                     target.kind  = ConstExprKind::Unary;
@@ -166,10 +167,15 @@ namespace hgl::hgraph_ir
                     bindings_.emplace(index, id);
                     result_.bindings.push_back(Binding{.name           = symbol.name,
                                                        .kind           = *kind,
-                                                       .type           = lower_type(symbol.type),
                                                        .owner_identity = declaration_identity(symbol.owner),
                                                        .index          = symbol.index,
                                                        .range          = symbol.range});
+                }
+                for (std::uint32_t index = 0; index < source_.symbols.size(); ++index) {
+                    const auto found = bindings_.find(index);
+                    if (found == bindings_.end()) { continue; }
+                    const hir::Symbol &symbol                  = source_.symbols[index];
+                    result_.bindings[found->second.value].type = lower_type(symbol.type, symbol.range);
                 }
             }
 
@@ -179,10 +185,18 @@ namespace hgl::hgraph_ir
                 return found == bindings_.end() ? BindingId{} : found->second;
             }
 
-            [[nodiscard]] TypeId lower_type(hir::TypeId source_id) {
+            [[nodiscard]] TypeId lower_type(hir::TypeId source_id, syntax::SourceRange fallback_range = {}) {
+                syntax::SourceRange occurrence_range = source_id.valid() ? source_.type(source_id).range : syntax::SourceRange{};
+                if (occurrence_range.end <= occurrence_range.begin) { occurrence_range = fallback_range; }
                 source_id = canonical(source_id);
                 if (!source_id.valid()) { return {}; }
-                if (const auto found = types_.find(source_id.value); found != types_.end()) { return found->second; }
+                if (const auto found = types_.find(source_id.value); found != types_.end()) {
+                    Type &existing = result_.types[found->second.value];
+                    if (existing.range.end <= existing.range.begin && occurrence_range.end > occurrence_range.begin) {
+                        existing.range = occurrence_range;
+                    }
+                    return found->second;
+                }
 
                 const TypeId id{static_cast<std::uint32_t>(result_.types.size())};
                 types_.emplace(source_id.value, id);
@@ -193,12 +207,14 @@ namespace hgl::hgraph_ir
                 target.kind             = source_type.kind;
                 target.scalar           = source_type.scalar;
                 target.nominal_identity = symbol_identity(source_type.symbol);
+                target.binding          = binding(source_type.symbol);
                 target.unbounded        = source_type.unbounded;
-                for (hir::TypeId child : source_type.children) { target.children.push_back(lower_type(child)); }
+                target.range            = occurrence_range;
+                for (hir::TypeId child : source_type.children) { target.children.push_back(lower_type(child, occurrence_range)); }
                 for (const hir::TypeArgument &argument : source_type.arguments) {
                     TypeArgument lowered;
                     if (argument.kind == hir::TypeArgumentKind::Type) {
-                        lowered.type = lower_type(argument.type);
+                        lowered.type = lower_type(argument.type, argument.range);
                     } else {
                         lowered.value = lower_const_expr(argument.value, argument.range, "a generic type argument");
                     }
@@ -282,9 +298,12 @@ namespace hgl::hgraph_ir
                 return id;
             }
 
-            [[nodiscard]] TypeId lower_type(hir::TypeId source_id, const AppliedBindings &bindings) {
+            [[nodiscard]] TypeId lower_type(hir::TypeId source_id, const AppliedBindings &bindings,
+                                            syntax::SourceRange fallback_range = {}) {
+                syntax::SourceRange occurrence_range = source_id.valid() ? source_.type(source_id).range : syntax::SourceRange{};
+                if (occurrence_range.end <= occurrence_range.begin) { occurrence_range = fallback_range; }
                 source_id = canonical(source_id);
-                if (!source_id.valid() || bindings.empty()) { return lower_type(source_id); }
+                if (!source_id.valid() || bindings.empty()) { return lower_type(source_id, occurrence_range); }
                 const hir::Type &source_type = source_.type(source_id);
                 if (source_type.kind == hir::TypeKind::Symbol && source_type.symbol.valid()) {
                     if (const auto found = bindings.types.find(source_type.symbol.value); found != bindings.types.end()) {
@@ -296,12 +315,16 @@ namespace hgl::hgraph_ir
                 target.kind             = source_type.kind;
                 target.scalar           = source_type.scalar;
                 target.nominal_identity = symbol_identity(source_type.symbol);
+                target.binding          = binding(source_type.symbol);
                 target.unbounded        = source_type.unbounded;
-                for (hir::TypeId child : source_type.children) { target.children.push_back(lower_type(child, bindings)); }
+                target.range            = occurrence_range;
+                for (hir::TypeId child : source_type.children) {
+                    target.children.push_back(lower_type(child, bindings, occurrence_range));
+                }
                 for (const hir::TypeArgument &argument : source_type.arguments) {
                     TypeArgument lowered;
                     if (argument.kind == hir::TypeArgumentKind::Type) {
-                        lowered.type = lower_type(argument.type, bindings);
+                        lowered.type = lower_type(argument.type, bindings, argument.range);
                     } else {
                         lowered.value = lower_const_expr(argument.value, bindings, argument.range, "a generic type argument");
                     }
@@ -358,7 +381,8 @@ namespace hgl::hgraph_ir
 
             [[nodiscard]] GenericParameter lower_generic(const hir::GenericParameter &source) {
                 const hir::Symbol &symbol = source_.symbol(source.symbol);
-                return GenericParameter{symbol.name, source.is_const, lower_type(source.type), binding(source.symbol)};
+                return GenericParameter{symbol.name, source.is_const, lower_type(source.type, symbol.range),
+                                        binding(source.symbol)};
             }
 
             [[nodiscard]] Parameter lower_parameter(const hir::Parameter &source) {
@@ -366,7 +390,7 @@ namespace hgl::hgraph_ir
                 Parameter          target;
                 target.name          = symbol.name;
                 target.is_const      = source.is_const;
-                target.type          = lower_type(source.type);
+                target.type          = lower_type(source.type, symbol.range);
                 target.default_value = lower_const_expr(source.default_value, symbol.range, "a parameter default");
                 target.binding       = binding(source.symbol);
                 return target;
@@ -461,7 +485,7 @@ namespace hgl::hgraph_ir
                     for (const hir::GenericParameter &generic : source->generics) {
                         target.generics.push_back(lower_generic(generic));
                     }
-                    for (hir::TypeId parent : source->parents) { target.parents.push_back(lower_type(parent)); }
+                    for (hir::TypeId parent : source->parents) { target.parents.push_back(lower_type(parent, declaration.range)); }
                     std::unordered_map<std::uint32_t, AppliedBindings> origin_bindings;
                     for (const hir::StructField &field : source->fields) {
                         if (!origin_bindings.contains(field.origin.value)) {
@@ -477,7 +501,7 @@ namespace hgl::hgraph_ir
                         const AppliedBindings &applied = origin_bindings.at(field.origin.value);
                         target.fields.push_back(StructField{
                             .name          = field.name,
-                            .type          = lower_type(field.type, applied),
+                            .type          = lower_type(field.type, applied, field.range),
                             .default_value = lower_const_expr(field.default_value, applied, field.range, "a struct field default"),
                             .origin_identity = declaration_identity(field.origin),
                             .optional        = field.optional,

--- a/language/src/hgraph_ir/printer.cpp
+++ b/language/src/hgraph_ir/printer.cpp
@@ -345,7 +345,13 @@ namespace hgl::hgraph_ir
                         out << '?';
                     }
                     break;
-                case ConstExprKind::Parameter: out << "parameter " << expression.parameter; break;
+                case ConstExprKind::Parameter:
+                    out << "parameter " << expression.parameter;
+                    if (expression.parameter_binding.valid()) {
+                        out << " binding=";
+                        print_binding_id(out, expression.parameter_binding);
+                    }
+                    break;
                 case ConstExprKind::Unary:
                     out << unary_name(expression.unary) << ' ';
                     print_const_expr_id(out, expression.lhs);
@@ -407,6 +413,10 @@ namespace hgl::hgraph_ir
             out << "  t" << index << ' ' << type_kind_name(type.kind);
             if (type.kind == hir::TypeKind::Scalar) { out << ' ' << hir::scalar_type_name(type.scalar); }
             if (!type.nominal_identity.empty()) { out << " nominal=" << type.nominal_identity; }
+            if (type.binding.valid()) {
+                out << " binding=";
+                print_binding_id(out, type.binding);
+            }
             if (!type.children.empty()) {
                 out << " children=[";
                 for (std::size_t child = 0; child < type.children.size(); ++child) {

--- a/language/src/wiring/type_bridge.cpp
+++ b/language/src/wiring/type_bridge.cpp
@@ -1,0 +1,408 @@
+#include "wiring/type_bridge.h"
+
+#include <hgraph/lib/std/standard_types.h>
+#include <hgraph/util/date_time.h>
+
+#include <chrono>
+#include <cstddef>
+#include <exception>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hgl::wiring
+{
+    namespace
+    {
+        namespace hir = ir::hir;
+
+        const hgraph::stdlib::RegisteredStandardTypes &standard_types() {
+            static const auto types = hgraph::stdlib::register_standard_types();
+            return types;
+        }
+
+        const hgraph::ValueTypeMetaData *scalar_meta(hir::ScalarType type) noexcept {
+            const auto &types = standard_types();
+            switch (type) {
+                case hir::ScalarType::Bool: return types.bool_type;
+                case hir::ScalarType::I64: return types.int_type;
+                case hir::ScalarType::F64: return types.float_type;
+                case hir::ScalarType::Str: return types.str_type;
+                case hir::ScalarType::Date: return types.date_type;
+                case hir::ScalarType::Time: return types.time_type;
+                case hir::ScalarType::DateTime: return types.datetime_type;
+                case hir::ScalarType::Duration: return types.timedelta_type;
+                case hir::ScalarType::CivilDateTime: return types.civil_datetime_type;
+                case hir::ScalarType::ZonedDateTime: return types.zoned_datetime_type;
+                case hir::ScalarType::TimeZone: return types.zone_id_type;
+                case hir::ScalarType::ZonedTime: return nullptr;
+            }
+            std::unreachable();
+        }
+
+        std::pair<std::string, std::string> split_identity(std::string_view identity) {
+            const std::size_t separator = identity.rfind('.');
+            if (separator == std::string_view::npos) { return {{}, std::string{identity}}; }
+            return {std::string{identity.substr(0, separator)}, std::string{identity.substr(separator + 1U)}};
+        }
+    }  // namespace
+
+    TypeBridge::TypeBridge(const hgraph_ir::Module &module, syntax::DiagnosticSink &diagnostics)
+        : module_{module}, diagnostics_{diagnostics}, registry_{hgraph::TypeRegistry::instance()} {
+        (void)standard_types();
+    }
+
+    void TypeBridge::report(syntax::SourceRange range, std::string message) {
+        diagnostics_.report(syntax::Category::Backend, range, std::move(message));
+    }
+
+    const hgraph_ir::StructContract *TypeBridge::structure(std::string_view identity) const noexcept {
+        for (const hgraph_ir::StructContract &candidate : module_.structures) {
+            if (candidate.identity == identity) { return &candidate; }
+        }
+        return nullptr;
+    }
+
+    std::optional<TypeBridge::Bindings> TypeBridge::bind(const hgraph_ir::Type &type, const hgraph_ir::StructContract &contract,
+                                                         const Bindings &outer) {
+        if (type.arguments.size() != contract.generics.size()) {
+            report(type.range, "nominal type '" + type.nominal_identity + "' has an incomplete generic application");
+            return std::nullopt;
+        }
+        Bindings result = outer;
+        for (std::size_t index = 0; index < contract.generics.size(); ++index) {
+            const hgraph_ir::GenericParameter &generic  = contract.generics[index];
+            const hgraph_ir::TypeArgument     &argument = type.arguments[index];
+            if (generic.is_const) {
+                if (!generic.binding.valid() || !argument.value) {
+                    report(type.range, "const generic '" + generic.name + "' requires a value argument");
+                    return std::nullopt;
+                }
+                result.values[generic.binding.value] = *argument.value;
+            } else {
+                if (!generic.binding.valid() || !argument.type) {
+                    report(type.range, "type generic '" + generic.name + "' requires a type argument");
+                    return std::nullopt;
+                }
+                result.types[generic.binding.value] = *argument.type;
+            }
+        }
+        return result;
+    }
+
+    std::optional<hgraph::Value> TypeBridge::literal(hgraph_ir::ConstExprId expression) {
+        if (!expression.valid() || expression.value >= module_.const_exprs.size()) { return std::nullopt; }
+        const hgraph_ir::ConstExpr &source = module_.const_exprs[expression.value];
+        if (source.kind != hgraph_ir::ConstExprKind::Literal || !source.literal) {
+            report(source.range, "the hgraph type bridge requires a folded constant literal");
+            return std::nullopt;
+        }
+        return std::visit(
+            [&](const auto &item) -> std::optional<hgraph::Value> {
+                using T = std::decay_t<decltype(item)>;
+                if constexpr (std::is_same_v<T, bool> || std::is_same_v<T, std::int64_t> || std::is_same_v<T, double> ||
+                              std::is_same_v<T, std::string>) {
+                    return hgraph::Value{item};
+                } else if constexpr (std::is_same_v<T, syntax::TemporalValue>) {
+                    using syntax::TemporalKind;
+                    switch (item.kind) {
+                        case TemporalKind::Date:
+                            return hgraph::Value{hgraph::Date{std::chrono::sys_days{std::chrono::days{item.micros}}}};
+                        case TemporalKind::Time: return hgraph::Value{hgraph::Time{item.micros}};
+                        case TemporalKind::DateTime: return hgraph::Value{hgraph::DateTime{std::chrono::microseconds{item.micros}}};
+                        case TemporalKind::Duration: return hgraph::Value{hgraph::TimeDelta{item.micros}};
+                        case TemporalKind::CivilDateTime:
+                        case TemporalKind::ZonedDateTime:
+                        case TemporalKind::ZonedTime:
+                        case TemporalKind::TimeZone:
+                            report(source.range, "zoned and civil constants are not supported by the direct backend yet");
+                            return std::nullopt;
+                    }
+                    std::unreachable();
+                } else {
+                    return std::nullopt;
+                }
+            },
+            *source.literal);
+    }
+
+    std::optional<std::int64_t> TypeBridge::integer(hgraph_ir::ConstExprId expression, syntax::SourceRange range,
+                                                    std::string_view role) {
+        const std::optional<hgraph::Value> value = literal(expression);
+        if (value && value->schema() == standard_types().int_type) {
+            const std::int64_t result = value->view().checked_as<hgraph::Int>();
+            if (result >= 0) { return result; }
+        }
+        report(range, std::string{role} + " must be a non-negative i64 constant");
+        return std::nullopt;
+    }
+
+    const hgraph::ValueTypeMetaData *TypeBridge::nominal_value(const hgraph_ir::Type &type, const Bindings &outer) {
+        const hgraph_ir::StructContract *contract = structure(type.nominal_identity);
+        if (contract == nullptr) {
+            report(type.range, "unknown nominal type '" + type.nominal_identity + "'");
+            return nullptr;
+        }
+        const std::optional<Bindings> applied = bind(type, *contract, outer);
+        if (!applied) { return nullptr; }
+
+        std::vector<const hgraph::ValueTypeMetaData *> generic_types;
+        std::string                                    local_name = split_identity(contract->identity).second;
+        if (!contract->generics.empty()) { local_name += '['; }
+        for (std::size_t index = 0; index < contract->generics.size(); ++index) {
+            if (index != 0) { local_name += ','; }
+            const hgraph_ir::GenericParameter &generic = contract->generics[index];
+            if (generic.is_const) {
+                report(type.range, "const generic struct arguments require typed constant Bundle metadata in hgraph");
+                return nullptr;
+            }
+            const hgraph::ValueTypeMetaData *argument = value(applied->types.at(generic.binding.value), *applied);
+            if (argument == nullptr) { return nullptr; }
+            generic_types.push_back(argument);
+            local_name += argument->name();
+        }
+        if (!contract->generics.empty()) { local_name += ']'; }
+
+        std::vector<std::pair<std::string, const hgraph::ValueTypeMetaData *>> fields;
+        fields.reserve(contract->fields.size());
+        for (const hgraph_ir::StructField &field : contract->fields) {
+            const hgraph::ValueTypeMetaData *field_type = value(field.type, *applied);
+            if (field_type == nullptr) { return nullptr; }
+            fields.emplace_back(field.name, field_type);
+        }
+
+        std::vector<const hgraph::ValueTypeMetaData *> parents;
+        parents.reserve(contract->parents.size());
+        for (hgraph_ir::TypeId parent : contract->parents) {
+            const hgraph::ValueTypeMetaData *parent_type = value(parent, *applied);
+            if (parent_type == nullptr) { return nullptr; }
+            parents.push_back(parent_type);
+        }
+
+        const std::string module_name = split_identity(contract->identity).first;
+        try {
+            return registry_.bundle(module_name, local_name, fields, parents, contract->abstract, "__type__", generic_types);
+        } catch (const std::exception &error) {
+            report(type.range, "cannot register struct '" + local_name + "': " + error.what());
+            return nullptr;
+        }
+    }
+
+    const hgraph::TSValueTypeMetaData *TypeBridge::nominal_schema(const hgraph_ir::Type &type, const Bindings &outer) {
+        const hgraph_ir::StructContract *contract = structure(type.nominal_identity);
+        if (contract == nullptr) {
+            report(type.range, "unknown nominal type '" + type.nominal_identity + "'");
+            return nullptr;
+        }
+        const std::optional<Bindings> applied = bind(type, *contract, outer);
+        if (!applied) { return nullptr; }
+        const hgraph::ValueTypeMetaData *value_type = nominal_value(type, outer);
+        if (value_type == nullptr) { return nullptr; }
+
+        std::vector<std::pair<std::string, const hgraph::TSValueTypeMetaData *>> fields;
+        fields.reserve(contract->fields.size());
+        for (const hgraph_ir::StructField &field : contract->fields) {
+            const hgraph::TSValueTypeMetaData *field_type = schema(field.type, *applied);
+            if (field_type == nullptr) { return nullptr; }
+            fields.emplace_back(field.name, field_type);
+        }
+        try {
+            return registry_.tsb(value_type->name(), fields);
+        } catch (const std::exception &error) {
+            report(type.range, "cannot register temporal struct '" + std::string{value_type->name()} + "': " + error.what());
+            return nullptr;
+        }
+    }
+
+    const hgraph::ValueTypeMetaData *TypeBridge::value(hgraph_ir::TypeId id) {
+        if (!id.valid() || id.value >= module_.types.size()) { return nullptr; }
+        if (const auto found = values_.find(id.value); found != values_.end()) { return found->second; }
+        const hgraph::ValueTypeMetaData *result = value(id, Bindings{});
+        if (result != nullptr) { values_.emplace(id.value, result); }
+        return result;
+    }
+
+    const hgraph::ValueTypeMetaData *TypeBridge::value(hgraph_ir::TypeId id, const Bindings &bindings) {
+        if (!id.valid() || id.value >= module_.types.size()) { return nullptr; }
+        const hgraph_ir::Type &type = module_.types[id.value];
+        switch (type.kind) {
+            case hir::TypeKind::Scalar:
+                {
+                    const hgraph::ValueTypeMetaData *result = scalar_meta(type.scalar);
+                    if (result == nullptr) { report(type.range, "unsupported scalar value type"); }
+                    return result;
+                }
+            case hir::TypeKind::Symbol:
+                if (type.binding.valid()) {
+                    if (const auto generic = bindings.types.find(type.binding.value); generic != bindings.types.end()) {
+                        if (generic->second == id) {
+                            report(type.range, "generic type '" + type.nominal_identity + "' is not concretely bound");
+                            return nullptr;
+                        }
+                        return value(generic->second, bindings);
+                    }
+                }
+                return nominal_value(type, bindings);
+            case hir::TypeKind::Tuple:
+                {
+                    std::vector<const hgraph::ValueTypeMetaData *> elements;
+                    elements.reserve(type.children.size());
+                    for (hgraph_ir::TypeId child : type.children) {
+                        const hgraph::ValueTypeMetaData *element = value(child, bindings);
+                        if (element == nullptr) { return nullptr; }
+                        elements.push_back(element);
+                    }
+                    return registry_.tuple(elements);
+                }
+            case hir::TypeKind::List:
+                {
+                    if (type.children.empty()) { break; }
+                    const hgraph::ValueTypeMetaData *element = value(type.children.front(), bindings);
+                    if (element == nullptr) { return nullptr; }
+                    std::size_t size = 0;
+                    if (type.size.valid()) {
+                        const std::optional<std::int64_t> count = integer(type.size, type.range, "a list size");
+                        if (!count || *count < 0) { return nullptr; }
+                        size = static_cast<std::size_t>(*count);
+                    }
+                    return registry_.list(element, size);
+                }
+            case hir::TypeKind::Set:
+                if (!type.children.empty()) {
+                    if (const hgraph::ValueTypeMetaData *element = value(type.children.front(), bindings)) {
+                        return registry_.set(element);
+                    }
+                }
+                return nullptr;
+            case hir::TypeKind::Map:
+                if (type.children.size() == 2U) {
+                    const hgraph::ValueTypeMetaData *key    = value(type.children[0], bindings);
+                    const hgraph::ValueTypeMetaData *mapped = value(type.children[1], bindings);
+                    if (key != nullptr && mapped != nullptr) { return registry_.map(key, mapped); }
+                }
+                return nullptr;
+            case hir::TypeKind::Atomic:
+                if (!type.children.empty()) { return value(type.children.front(), bindings); }
+                return nullptr;
+            case hir::TypeKind::Rolling:
+                report(type.range, "'rolling' has no value type; it is a time-series window");
+                return nullptr;
+            case hir::TypeKind::Void:
+            case hir::TypeKind::Iterator:
+            case hir::TypeKind::Callable:
+            case hir::TypeKind::Capability:
+            case hir::TypeKind::HarnessSequence:
+            case hir::TypeKind::Deferred: break;
+        }
+        report(type.range, "unsupported hgraph value type");
+        return nullptr;
+    }
+
+    const hgraph::TSValueTypeMetaData *TypeBridge::schema(hgraph_ir::TypeId id) {
+        if (!id.valid() || id.value >= module_.types.size()) { return nullptr; }
+        if (const auto found = schemas_.find(id.value); found != schemas_.end()) { return found->second; }
+        const hgraph::TSValueTypeMetaData *result = schema(id, Bindings{});
+        if (result != nullptr) { schemas_.emplace(id.value, result); }
+        return result;
+    }
+
+    const hgraph::TSValueTypeMetaData *TypeBridge::schema(hgraph_ir::TypeId id, const Bindings &bindings) {
+        if (!id.valid() || id.value >= module_.types.size()) { return nullptr; }
+        const hgraph_ir::Type &type = module_.types[id.value];
+        switch (type.kind) {
+            case hir::TypeKind::Scalar:
+                {
+                    const hgraph::ValueTypeMetaData *meta = scalar_meta(type.scalar);
+                    if (meta != nullptr) { return registry_.ts(meta); }
+                    report(type.range, "unsupported scalar time-series type");
+                    return nullptr;
+                }
+            case hir::TypeKind::Symbol:
+                if (type.binding.valid()) {
+                    if (const auto generic = bindings.types.find(type.binding.value); generic != bindings.types.end()) {
+                        if (generic->second == id) {
+                            report(type.range, "generic type '" + type.nominal_identity + "' is not concretely bound");
+                            return nullptr;
+                        }
+                        return schema(generic->second, bindings);
+                    }
+                }
+                return nominal_schema(type, bindings);
+            case hir::TypeKind::Tuple:
+                report(type.range, "a structural tuple has no time-series schema; use atomic<tuple<...>> for one value");
+                return nullptr;
+            case hir::TypeKind::List:
+                {
+                    if (type.children.empty()) { break; }
+                    const hgraph::TSValueTypeMetaData *element = schema(type.children.front(), bindings);
+                    if (element == nullptr) { return nullptr; }
+                    std::size_t size = 0;
+                    if (type.size.valid()) {
+                        const std::optional<std::int64_t> count = integer(type.size, type.range, "a list size");
+                        if (!count || *count < 0) { return nullptr; }
+                        size = static_cast<std::size_t>(*count);
+                    }
+                    return registry_.tsl(element, size);
+                }
+            case hir::TypeKind::Set:
+                if (!type.children.empty()) {
+                    if (const hgraph::ValueTypeMetaData *element = value(type.children.front(), bindings)) {
+                        return registry_.tss(element);
+                    }
+                }
+                return nullptr;
+            case hir::TypeKind::Map:
+                if (type.children.size() == 2U) {
+                    const hgraph::ValueTypeMetaData   *key    = value(type.children[0], bindings);
+                    const hgraph::TSValueTypeMetaData *mapped = schema(type.children[1], bindings);
+                    if (key != nullptr && mapped != nullptr) { return registry_.tsd(key, mapped); }
+                }
+                return nullptr;
+            case hir::TypeKind::Rolling:
+                {
+                    if (type.children.empty()) { break; }
+                    const hgraph::ValueTypeMetaData *element = value(type.children.front(), bindings);
+                    if (element == nullptr) { return nullptr; }
+                    const std::optional<hgraph::Value> period_value  = literal(type.size);
+                    const std::optional<hgraph::Value> minimum_value = literal(type.min_size);
+                    if (!period_value || !minimum_value) { return nullptr; }
+                    if (period_value->schema() == standard_types().timedelta_type) {
+                        if (minimum_value->schema() != standard_types().timedelta_type) {
+                            report(type.range, "a minimum rolling duration must be a duration constant");
+                            return nullptr;
+                        }
+                        return registry_.tsw_duration(element, period_value->view().checked_as<hgraph::TimeDelta>(),
+                                                      minimum_value->view().checked_as<hgraph::TimeDelta>());
+                    }
+                    if (period_value->schema() != standard_types().int_type ||
+                        minimum_value->schema() != standard_types().int_type) {
+                        report(type.range, "a rolling size must be an i64 or duration constant");
+                        return nullptr;
+                    }
+                    const std::int64_t period  = period_value->view().checked_as<hgraph::Int>();
+                    const std::int64_t minimum = minimum_value->view().checked_as<hgraph::Int>();
+                    if (period <= 0 || minimum < 0) {
+                        report(type.range, "rolling sizes require a positive maximum and non-negative minimum");
+                        return nullptr;
+                    }
+                    return registry_.tsw(element, static_cast<std::size_t>(period), static_cast<std::size_t>(minimum));
+                }
+            case hir::TypeKind::Atomic:
+                if (!type.children.empty()) {
+                    if (const hgraph::ValueTypeMetaData *meta = value(type.children.front(), bindings)) {
+                        return registry_.ts(meta);
+                    }
+                }
+                return nullptr;
+            case hir::TypeKind::Void:
+            case hir::TypeKind::Iterator:
+            case hir::TypeKind::Callable:
+            case hir::TypeKind::Capability:
+            case hir::TypeKind::HarnessSequence:
+            case hir::TypeKind::Deferred: break;
+        }
+        report(type.range, "unsupported hgraph time-series type");
+        return nullptr;
+    }
+}  // namespace hgl::wiring

--- a/language/src/wiring/type_bridge.cpp
+++ b/language/src/wiring/type_bridge.cpp
@@ -17,13 +17,8 @@ namespace hgl::wiring
     {
         namespace hir = ir::hir;
 
-        const hgraph::stdlib::RegisteredStandardTypes &standard_types() {
-            static const auto types = hgraph::stdlib::register_standard_types();
-            return types;
-        }
-
-        const hgraph::ValueTypeMetaData *scalar_meta(hir::ScalarType type) noexcept {
-            const auto &types = standard_types();
+        const hgraph::ValueTypeMetaData *scalar_meta(hir::ScalarType                                type,
+                                                     const hgraph::stdlib::RegisteredStandardTypes &types) noexcept {
             switch (type) {
                 case hir::ScalarType::Bool: return types.bool_type;
                 case hir::ScalarType::I64: return types.int_type;
@@ -49,8 +44,16 @@ namespace hgl::wiring
     }  // namespace
 
     TypeBridge::TypeBridge(const hgraph_ir::Module &module, syntax::DiagnosticSink &diagnostics)
-        : module_{module}, diagnostics_{diagnostics}, registry_{hgraph::TypeRegistry::instance()} {
-        (void)standard_types();
+        : module_{module}, diagnostics_{diagnostics}, registry_{hgraph::TypeRegistry::instance()},
+          types_{hgraph::stdlib::register_standard_types(registry_)}, generation_{registry_.reset_generation()} {}
+
+    void TypeBridge::refresh_registry() {
+        const std::uint64_t current = registry_.reset_generation();
+        if (generation_ == current) { return; }
+        values_.clear();
+        schemas_.clear();
+        types_      = hgraph::stdlib::register_standard_types(registry_);
+        generation_ = registry_.reset_generation();
     }
 
     void TypeBridge::report(syntax::SourceRange range, std::string message) {
@@ -92,6 +95,7 @@ namespace hgl::wiring
     }
 
     std::optional<hgraph::Value> TypeBridge::literal(hgraph_ir::ConstExprId expression) {
+        refresh_registry();
         if (!expression.valid() || expression.value >= module_.const_exprs.size()) { return std::nullopt; }
         const hgraph_ir::ConstExpr &source = module_.const_exprs[expression.value];
         if (source.kind != hgraph_ir::ConstExprKind::Literal || !source.literal) {
@@ -130,7 +134,7 @@ namespace hgl::wiring
     std::optional<std::int64_t> TypeBridge::integer(hgraph_ir::ConstExprId expression, syntax::SourceRange range,
                                                     std::string_view role) {
         const std::optional<hgraph::Value> value = literal(expression);
-        if (value && value->schema() == standard_types().int_type) {
+        if (value && value->schema() == types_.int_type) {
             const std::int64_t result = value->view().checked_as<hgraph::Int>();
             if (result >= 0) { return result; }
         }
@@ -216,6 +220,7 @@ namespace hgl::wiring
     }
 
     const hgraph::ValueTypeMetaData *TypeBridge::value(hgraph_ir::TypeId id) {
+        refresh_registry();
         if (!id.valid() || id.value >= module_.types.size()) { return nullptr; }
         if (const auto found = values_.find(id.value); found != values_.end()) { return found->second; }
         const hgraph::ValueTypeMetaData *result = value(id, Bindings{});
@@ -229,7 +234,7 @@ namespace hgl::wiring
         switch (type.kind) {
             case hir::TypeKind::Scalar:
                 {
-                    const hgraph::ValueTypeMetaData *result = scalar_meta(type.scalar);
+                    const hgraph::ValueTypeMetaData *result = scalar_meta(type.scalar, types_);
                     if (result == nullptr) { report(type.range, "unsupported scalar value type"); }
                     return result;
                 }
@@ -263,7 +268,11 @@ namespace hgl::wiring
                     std::size_t size = 0;
                     if (type.size.valid()) {
                         const std::optional<std::int64_t> count = integer(type.size, type.range, "a list size");
-                        if (!count || *count < 0) { return nullptr; }
+                        if (!count) { return nullptr; }
+                        if (*count <= 0) {
+                            report(type.range, "a fixed list size must be positive");
+                            return nullptr;
+                        }
                         size = static_cast<std::size_t>(*count);
                     }
                     return registry_.list(element, size);
@@ -300,6 +309,7 @@ namespace hgl::wiring
     }
 
     const hgraph::TSValueTypeMetaData *TypeBridge::schema(hgraph_ir::TypeId id) {
+        refresh_registry();
         if (!id.valid() || id.value >= module_.types.size()) { return nullptr; }
         if (const auto found = schemas_.find(id.value); found != schemas_.end()) { return found->second; }
         const hgraph::TSValueTypeMetaData *result = schema(id, Bindings{});
@@ -313,7 +323,7 @@ namespace hgl::wiring
         switch (type.kind) {
             case hir::TypeKind::Scalar:
                 {
-                    const hgraph::ValueTypeMetaData *meta = scalar_meta(type.scalar);
+                    const hgraph::ValueTypeMetaData *meta = scalar_meta(type.scalar, types_);
                     if (meta != nullptr) { return registry_.ts(meta); }
                     report(type.range, "unsupported scalar time-series type");
                     return nullptr;
@@ -340,7 +350,11 @@ namespace hgl::wiring
                     std::size_t size = 0;
                     if (type.size.valid()) {
                         const std::optional<std::int64_t> count = integer(type.size, type.range, "a list size");
-                        if (!count || *count < 0) { return nullptr; }
+                        if (!count) { return nullptr; }
+                        if (*count <= 0) {
+                            report(type.range, "a fixed list size must be positive");
+                            return nullptr;
+                        }
                         size = static_cast<std::size_t>(*count);
                     }
                     return registry_.tsl(element, size);
@@ -367,23 +381,28 @@ namespace hgl::wiring
                     const std::optional<hgraph::Value> period_value  = literal(type.size);
                     const std::optional<hgraph::Value> minimum_value = literal(type.min_size);
                     if (!period_value || !minimum_value) { return nullptr; }
-                    if (period_value->schema() == standard_types().timedelta_type) {
-                        if (minimum_value->schema() != standard_types().timedelta_type) {
+                    if (period_value->schema() == types_.timedelta_type) {
+                        if (minimum_value->schema() != types_.timedelta_type) {
                             report(type.range, "a minimum rolling duration must be a duration constant");
                             return nullptr;
                         }
-                        return registry_.tsw_duration(element, period_value->view().checked_as<hgraph::TimeDelta>(),
-                                                      minimum_value->view().checked_as<hgraph::TimeDelta>());
+                        const hgraph::TimeDelta period  = period_value->view().checked_as<hgraph::TimeDelta>();
+                        const hgraph::TimeDelta minimum = minimum_value->view().checked_as<hgraph::TimeDelta>();
+                        if (period <= hgraph::TimeDelta{0} || minimum < hgraph::TimeDelta{0} || minimum > period) {
+                            report(type.range,
+                                   "rolling durations require a positive maximum and a non-negative minimum no larger than it");
+                            return nullptr;
+                        }
+                        return registry_.tsw_duration(element, period, minimum);
                     }
-                    if (period_value->schema() != standard_types().int_type ||
-                        minimum_value->schema() != standard_types().int_type) {
+                    if (period_value->schema() != types_.int_type || minimum_value->schema() != types_.int_type) {
                         report(type.range, "a rolling size must be an i64 or duration constant");
                         return nullptr;
                     }
                     const std::int64_t period  = period_value->view().checked_as<hgraph::Int>();
                     const std::int64_t minimum = minimum_value->view().checked_as<hgraph::Int>();
-                    if (period <= 0 || minimum < 0) {
-                        report(type.range, "rolling sizes require a positive maximum and non-negative minimum");
+                    if (period <= 0 || minimum < 0 || minimum > period) {
+                        report(type.range, "rolling sizes require a positive maximum and a non-negative minimum no larger than it");
                         return nullptr;
                     }
                     return registry_.tsw(element, static_cast<std::size_t>(period), static_cast<std::size_t>(minimum));

--- a/language/src/wiring/type_bridge.h
+++ b/language/src/wiring/type_bridge.h
@@ -1,0 +1,59 @@
+#ifndef HGL_WIRING_TYPE_BRIDGE_H
+#define HGL_WIRING_TYPE_BRIDGE_H
+
+#include "hgraph_ir/ir.h"
+#include "syntax/diagnostic.h"
+
+#include <hgraph/types/metadata/type_registry.h>
+#include <hgraph/types/value/value.h>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace hgl::wiring
+{
+    /// Materialize backend-neutral hgraph-IR types as canonical hgraph runtime
+    /// metadata. This is the only direct-wiring layer that understands both
+    /// representations; evaluators consume its results rather than rebuilding
+    /// types from source syntax.
+    class TypeBridge
+    {
+      public:
+        TypeBridge(const hgraph_ir::Module &module, syntax::DiagnosticSink &diagnostics);
+
+        [[nodiscard]] const hgraph::ValueTypeMetaData   *value(hgraph_ir::TypeId type);
+        [[nodiscard]] const hgraph::TSValueTypeMetaData *schema(hgraph_ir::TypeId type);
+        [[nodiscard]] std::optional<hgraph::Value>       literal(hgraph_ir::ConstExprId expression);
+
+      private:
+        struct Bindings
+        {
+            std::unordered_map<std::uint32_t, hgraph_ir::TypeId>      types{};
+            std::unordered_map<std::uint32_t, hgraph_ir::ConstExprId> values{};
+
+            [[nodiscard]] bool empty() const noexcept { return types.empty() && values.empty(); }
+        };
+
+        [[nodiscard]] const hgraph::ValueTypeMetaData   *value(hgraph_ir::TypeId type, const Bindings &bindings);
+        [[nodiscard]] const hgraph::TSValueTypeMetaData *schema(hgraph_ir::TypeId type, const Bindings &bindings);
+        [[nodiscard]] const hgraph_ir::StructContract   *structure(std::string_view identity) const noexcept;
+        [[nodiscard]] std::optional<Bindings>          bind(const hgraph_ir::Type &type, const hgraph_ir::StructContract &structure,
+                                                            const Bindings &outer);
+        [[nodiscard]] std::optional<std::int64_t>      integer(hgraph_ir::ConstExprId expression, syntax::SourceRange range,
+                                                               std::string_view role);
+        [[nodiscard]] const hgraph::ValueTypeMetaData *nominal_value(const hgraph_ir::Type &type, const Bindings &outer);
+        [[nodiscard]] const hgraph::TSValueTypeMetaData *nominal_schema(const hgraph_ir::Type &type, const Bindings &outer);
+        void                                             report(syntax::SourceRange range, std::string message);
+
+        const hgraph_ir::Module                                               &module_;
+        syntax::DiagnosticSink                                                &diagnostics_;
+        hgraph::TypeRegistry                                                  &registry_;
+        std::unordered_map<std::uint32_t, const hgraph::ValueTypeMetaData *>   values_{};
+        std::unordered_map<std::uint32_t, const hgraph::TSValueTypeMetaData *> schemas_{};
+    };
+}  // namespace hgl::wiring
+
+#endif  // HGL_WIRING_TYPE_BRIDGE_H

--- a/language/src/wiring/type_bridge.h
+++ b/language/src/wiring/type_bridge.h
@@ -4,6 +4,7 @@
 #include "hgraph_ir/ir.h"
 #include "syntax/diagnostic.h"
 
+#include <hgraph/lib/std/standard_types.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/value/value.h>
 
@@ -46,11 +47,14 @@ namespace hgl::wiring
                                                                std::string_view role);
         [[nodiscard]] const hgraph::ValueTypeMetaData *nominal_value(const hgraph_ir::Type &type, const Bindings &outer);
         [[nodiscard]] const hgraph::TSValueTypeMetaData *nominal_schema(const hgraph_ir::Type &type, const Bindings &outer);
+        void                                             refresh_registry();
         void                                             report(syntax::SourceRange range, std::string message);
 
         const hgraph_ir::Module                                               &module_;
         syntax::DiagnosticSink                                                &diagnostics_;
         hgraph::TypeRegistry                                                  &registry_;
+        hgraph::stdlib::RegisteredStandardTypes                                types_{};
+        std::uint64_t                                                          generation_{0};
         std::unordered_map<std::uint32_t, const hgraph::ValueTypeMetaData *>   values_{};
         std::unordered_map<std::uint32_t, const hgraph::TSValueTypeMetaData *> schemas_{};
     };

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -91,8 +91,7 @@ hgl_apply_warnings(hgl_ir_tests)
 
 add_test(NAME hgraph_language_ir COMMAND hgl_ir_tests)
 
-# The hgraph-IR boundary starts with self-contained canonical type and callable
-# interfaces. Body/control-flow plans are added in the following stacked slice.
+# The hgraph-IR boundary owns self-contained canonical contracts and bodies.
 add_executable(hgl_graph_ir_tests hgraph_ir/lower_tests.cpp)
 target_compile_features(hgl_graph_ir_tests PRIVATE cxx_std_23)
 target_link_libraries(hgl_graph_ir_tests PRIVATE hgl::graph_ir Catch2::Catch2WithMain)
@@ -110,6 +109,15 @@ hgl_link_runtime_executable(hgl_wiring_tests)
 hgl_apply_warnings(hgl_wiring_tests)
 
 add_test(NAME hgraph_language_wiring COMMAND hgl_wiring_tests)
+
+# Runtime metadata materialization is isolated from the evaluator so type
+# coverage remains cheap to compile and failures stay at the IR/runtime seam.
+add_executable(hgl_wiring_type_tests wiring/type_bridge_tests.cpp)
+target_compile_features(hgl_wiring_type_tests PRIVATE cxx_std_23)
+target_link_libraries(hgl_wiring_type_tests PRIVATE hgl::wiring_types Catch2::Catch2WithMain)
+hgl_apply_warnings(hgl_wiring_type_tests)
+
+add_test(NAME hgraph_language_wiring_types COMMAND hgl_wiring_type_tests)
 
 # The type checker hands native candidate ranking to the hgraph registry while
 # retaining only copied, backend-independent selection data in HIR.

--- a/language/tests/hgraph_ir/lower_tests.cpp
+++ b/language/tests/hgraph_ir/lower_tests.cpp
@@ -326,7 +326,9 @@ operator recent<T, const N: i64>(values: rolling<T, N>) -> T
     const hgl::hgraph_ir::ConstExpr &size = lowered.graph->const_exprs[rolling->size.value];
     CHECK(size.kind == hgl::hgraph_ir::ConstExprKind::Parameter);
     CHECK(size.parameter == "N");
+    CHECK(size.parameter_binding.valid());
     CHECK(rolling->min_size == rolling->size);
+    CHECK(hgl::hgraph_ir::print(*lowered.graph).find("parameter N binding=n") != std::string::npos);
 }
 
 TEST_CASE("hgraph IR preserves aggregate and temporal parameter defaults", "[hgraph-ir][defaults]") {

--- a/language/tests/wiring/type_bridge_tests.cpp
+++ b/language/tests/wiring/type_bridge_tests.cpp
@@ -1,0 +1,178 @@
+#include "hgraph_ir/lower.h"
+#include "ir/lower.h"
+#include "ir/type_check.h"
+#include "semantics/resolve.h"
+#include "syntax/parser.h"
+#include "wiring/type_bridge.h"
+
+#include <hgraph/lib/std/standard_types.h>
+#include <hgraph/types/metadata/type_registry.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace
+{
+    struct Unit
+    {
+        hgl::syntax::SourceFile     file;
+        hgl::syntax::DiagnosticSink diagnostics{};
+        hgl::hgraph_ir::Module      graph{};
+
+        explicit Unit(std::string text) : file{"test.hgl", std::move(text)} {
+            hgl::syntax::ast::Module ast = hgl::syntax::parse(file, diagnostics);
+            if (diagnostics.has_errors()) { return; }
+            hgl::semantics::ResolvedModule resolved =
+                hgl::semantics::resolve(file, ast, [](std::string_view) { return true; }, diagnostics);
+            if (diagnostics.has_errors()) { return; }
+            hgl::ir::hir::Module            hir       = hgl::ir::lower_to_hir(ast, resolved, diagnostics);
+            const hgl::ir::OperatorResolver operators = [](const hgl::ir::hir::Module &, const hgl::ir::OperatorQuery &query) {
+                hgl::ir::OperatorSelection selected;
+                selected.result   = query.expected_result;
+                selected.deferred = true;
+                return selected;
+            };
+            if (!hgl::ir::complete_hir(hir, operators, diagnostics)) { return; }
+            graph = hgl::hgraph_ir::lower(hir, diagnostics);
+        }
+
+        [[nodiscard]] const hgl::hgraph_ir::Callable &callable(std::string_view name) const {
+            for (const hgl::hgraph_ir::Callable &candidate : graph.callables) {
+                if (candidate.identity.ends_with(name)) { return candidate; }
+            }
+            throw std::runtime_error{"missing callable"};
+        }
+
+        [[nodiscard]] hgl::hgraph_ir::TypeId parameter(std::string_view callable_name, std::string_view parameter_name) const {
+            for (const hgl::hgraph_ir::Parameter &candidate : callable(callable_name).parameters) {
+                if (candidate.name == parameter_name) { return candidate.type; }
+            }
+            throw std::runtime_error{"missing parameter"};
+        }
+    };
+}  // namespace
+
+TEST_CASE("hgraph IR types materialize canonical runtime metadata", "[wiring][hgraph-ir][types]") {
+    Unit unit{R"(
+module checks.type_bridge
+
+abstract struct Base<T> {
+    first: T
+}
+
+struct Child<U>: Base<U> {
+    second: U
+}
+
+struct Box<T> {
+    value: T
+}
+
+struct Wrapper<T> {
+    boxed: Box<T>
+}
+
+fn forms(
+    atomic_child: atomic<Child<f64>>,
+    bundle_child: Child<f64>,
+    tuple_value: atomic<tuple<i64, f64>>,
+    series_list: list<f64, 3>,
+    series_set: set<str>,
+    series_map: map<str, f64>,
+    tick_window: rolling<f64, 20, 5>,
+    duration_window: rolling<f64, 2s, 1s>,
+    wrapped: atomic<Wrapper<i64>>,
+    const count: i64 = 3,
+    const delay: duration = 2s
+) -> atomic<Child<f64>> => atomic_child
+)"};
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+    REQUIRE(unit.graph.completion == hgl::hgraph_ir::Completion::Bodies);
+
+    hgl::wiring::TypeBridge bridge{unit.graph, unit.diagnostics};
+    auto                   &registry = hgraph::TypeRegistry::instance();
+    const auto              types    = hgraph::stdlib::register_standard_types();
+
+    const auto *child = bridge.value(unit.parameter("forms", "bundle_child"));
+    REQUIRE(child != nullptr);
+    CHECK(child->is_named_bundle());
+    CHECK(child->bundle_namespace() == "checks.type_bridge");
+    CHECK(child->bundle_local_name() == "Child[float]");
+    REQUIRE(child->field_count == 2);
+    CHECK(std::string_view{child->fields[0].name} == "first");
+    CHECK(child->fields[0].type == types.float_type);
+    CHECK(std::string_view{child->fields[1].name} == "second");
+    CHECK(child->fields[1].type == types.float_type);
+
+    const hgl::hgraph_ir::Type &atomic_child = unit.graph.types[unit.parameter("forms", "atomic_child").value];
+    CHECK(atomic_child.range.end > atomic_child.range.begin);
+
+    CHECK(bridge.schema(unit.parameter("forms", "atomic_child")) == registry.ts(child));
+    CHECK(bridge.schema(unit.parameter("forms", "bundle_child")) == registry.tsb(child));
+    CHECK(bridge.schema(unit.parameter("forms", "tuple_value")) == registry.ts(registry.tuple({types.int_type, types.float_type})));
+    CHECK(bridge.schema(unit.parameter("forms", "series_list")) == registry.tsl(registry.ts(types.float_type), 3));
+    CHECK(bridge.schema(unit.parameter("forms", "series_set")) == registry.tss(types.str_type));
+    CHECK(bridge.schema(unit.parameter("forms", "series_map")) == registry.tsd(types.str_type, registry.ts(types.float_type)));
+    CHECK(bridge.schema(unit.parameter("forms", "tick_window")) == registry.tsw(types.float_type, 20, 5));
+    CHECK(bridge.schema(unit.parameter("forms", "duration_window")) ==
+          registry.tsw_duration(types.float_type, hgraph::TimeDelta{2'000'000}, hgraph::TimeDelta{1'000'000}));
+
+    const auto *wrapper = bridge.value(unit.graph.types[unit.parameter("forms", "wrapped").value].children.front());
+    REQUIRE(wrapper != nullptr);
+    REQUIRE(wrapper->field_count == 1);
+    const auto *box = wrapper->fields[0].type;
+    REQUIRE(box != nullptr);
+    CHECK(box->bundle_local_name() == "Box[int]");
+    REQUIRE(box->field_count == 1);
+    CHECK(box->fields[0].type == types.int_type);
+
+    const auto box_contract     = std::ranges::find_if(unit.graph.structures, [](const hgl::hgraph_ir::StructContract &candidate) {
+        return candidate.identity.ends_with(".Box");
+    });
+    const auto wrapper_contract = std::ranges::find_if(unit.graph.structures, [](const hgl::hgraph_ir::StructContract &candidate) {
+        return candidate.identity.ends_with(".Wrapper");
+    });
+    REQUIRE(box_contract != unit.graph.structures.end());
+    REQUIRE(wrapper_contract != unit.graph.structures.end());
+    REQUIRE(box_contract->generics.size() == 1);
+    REQUIRE(wrapper_contract->generics.size() == 1);
+    CHECK(box_contract->generics.front().binding != wrapper_contract->generics.front().binding);
+
+    const hgl::hgraph_ir::Callable    &forms = unit.callable("forms");
+    const std::optional<hgraph::Value> count = bridge.literal(forms.parameters[9].default_value);
+    const std::optional<hgraph::Value> delay = bridge.literal(forms.parameters[10].default_value);
+    REQUIRE(count);
+    REQUIRE(delay);
+    CHECK(count->view().checked_as<hgraph::Int>() == 3);
+    CHECK(delay->view().checked_as<hgraph::TimeDelta>() == hgraph::TimeDelta{2'000'000});
+    CHECK_FALSE(unit.diagnostics.has_errors());
+}
+
+TEST_CASE("const generic runtime identity remains fail closed", "[wiring][hgraph-ir][types]") {
+    Unit unit{R"(
+module checks.const_generic
+
+struct Vector<T, const size: i64> {
+    values: list<T, size>
+}
+
+fn consume(value: atomic<Vector<f64, 2>>) -> atomic<Vector<f64, 2>> => value
+)"};
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+
+    hgl::wiring::TypeBridge     bridge{unit.graph, unit.diagnostics};
+    const hgl::hgraph_ir::Type &atomic = unit.graph.types[unit.parameter("consume", "value").value];
+    REQUIRE(atomic.children.size() == 1);
+    CHECK(bridge.value(atomic.children.front()) == nullptr);
+    CHECK(unit.diagnostics.has_errors());
+    CHECK(unit.diagnostics.render(unit.file).find("typed constant Bundle metadata") != std::string::npos);
+}

--- a/language/tests/wiring/type_bridge_tests.cpp
+++ b/language/tests/wiring/type_bridge_tests.cpp
@@ -7,6 +7,7 @@
 
 #include <hgraph/lib/std/standard_types.h>
 #include <hgraph/types/metadata/type_registry.h>
+#include <hgraph/types/registry_reset.h>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -175,4 +176,61 @@ fn consume(value: atomic<Vector<f64, 2>>) -> atomic<Vector<f64, 2>> => value
     CHECK(bridge.value(atomic.children.front()) == nullptr);
     CHECK(unit.diagnostics.has_errors());
     CHECK(unit.diagnostics.render(unit.file).find("typed constant Bundle metadata") != std::string::npos);
+}
+
+TEST_CASE("hgraph IR type caches follow registry resets", "[wiring][hgraph-ir][types]") {
+    Unit unit{R"(
+module checks.type_reset
+fn consume(values: list<f64, 3>) -> list<f64, 3> => values
+)"};
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+
+    hgl::wiring::TypeBridge bridge{unit.graph, unit.diagnostics};
+    const auto              parameter = unit.parameter("consume", "values");
+    REQUIRE(bridge.schema(parameter) != nullptr);
+
+    hgraph::reset_all_registries();
+    const auto refreshed = hgraph::stdlib::register_standard_types();
+    CHECK(bridge.schema(parameter) ==
+          hgraph::TypeRegistry::instance().tsl(hgraph::TypeRegistry::instance().ts(refreshed.float_type), 3));
+    CHECK_FALSE(unit.diagnostics.has_errors());
+}
+
+TEST_CASE("hgraph IR type materialization rejects unusable fixed extents", "[wiring][hgraph-ir][types]") {
+    SECTION("zero-sized fixed list") {
+        Unit unit{R"(
+module checks.zero_list
+fn consume(values: list<f64, 0>) -> list<f64, 0> => values
+)"};
+        INFO(unit.diagnostics.render(unit.file));
+        REQUIRE_FALSE(unit.diagnostics.has_errors());
+        hgl::wiring::TypeBridge bridge{unit.graph, unit.diagnostics};
+        CHECK(bridge.schema(unit.parameter("consume", "values")) == nullptr);
+        CHECK(unit.diagnostics.render(unit.file).find("fixed list size must be positive") != std::string::npos);
+    }
+
+    SECTION("tick minimum exceeds capacity") {
+        Unit unit{R"(
+module checks.tick_window
+fn consume(values: rolling<f64, 20, 25>) -> rolling<f64, 20, 25> => values
+)"};
+        INFO(unit.diagnostics.render(unit.file));
+        REQUIRE_FALSE(unit.diagnostics.has_errors());
+        hgl::wiring::TypeBridge bridge{unit.graph, unit.diagnostics};
+        CHECK(bridge.schema(unit.parameter("consume", "values")) == nullptr);
+        CHECK(unit.diagnostics.render(unit.file).find("minimum no larger than it") != std::string::npos);
+    }
+
+    SECTION("duration minimum exceeds maximum") {
+        Unit unit{R"(
+module checks.duration_window
+fn consume(values: rolling<f64, 1s, 2s>) -> rolling<f64, 1s, 2s> => values
+)"};
+        INFO(unit.diagnostics.render(unit.file));
+        REQUIRE_FALSE(unit.diagnostics.has_errors());
+        hgl::wiring::TypeBridge bridge{unit.graph, unit.diagnostics};
+        CHECK(bridge.schema(unit.parameter("consume", "values")) == nullptr);
+        CHECK(unit.diagnostics.render(unit.file).find("minimum no larger than it") != std::string::npos);
+    }
 }


### PR DESCRIPTION
## Summary

- add a dedicated hgraph-IR/runtime type bridge for scalar, tuple, collection, rolling, atomic, and nominal struct metadata
- preserve graph-IR lexical binding identities and representative source ranges so nested generic applications resolve without name collisions and diagnostics retain a useful location
- isolate the bridge and its tests from the direct evaluator as the first backend migration slice

## Stack

- based on #693
- next: migrate direct wiring evaluation from `ResolvedModule` to hgraph IR

## Validation

- 30/30 HGL CTest targets
- 1,711/1,711 native C++ tests after a fresh clean preset build
- ABI3 wheel built with Python 3.12 and installed into Python 3.14
- 3,223 Python tests passed, 10 skipped

## Current boundary

Const-generic struct identity remains fail-closed because hgraph Bundle metadata does not yet carry typed constant generic arguments. The bridge reports this explicitly rather than inventing an identity scheme.
