### PR TITLE
feat(language): evaluate hgraph IR directly

### DIFF
--- a/include/hgraph/types/operator_dispatch.h
+++ b/include/hgraph/types/operator_dispatch.h
@@ -585,6 +585,13 @@ namespace hgraph
             output operators - a bare subscript type is then an INPUT
             constraint (``to_json[tp]``). Unknown names return true. */
         [[nodiscard]] bool output_is_selective(std::string_view name) const;
+
+        /** The concrete output schema shared by every producing overload.
+            Returns ``nullptr`` when the operator is unknown, has no producing
+            overload, any output contains unresolved variables, or concrete
+            outputs disagree. This is a type-only inspection operation: it
+            does not run defaults, resolvers, or ``requires`` predicates. */
+        [[nodiscard]] const TSValueTypeMetaData *fixed_output_schema(std::string_view name) const;
         /**
          * The type-argument parameters of an operator family (RFC 0033): the
          * names some candidate declares as ``TypeArg`` and the positions they

--- a/language/README.md
+++ b/language/README.md
@@ -18,8 +18,8 @@ The project is an intentionally changeable prototype in its first executable
 slice. `hgl check` lexes, parses, and resolves a module and reports diagnostics
 (`--dump-tokens`, `--dump-ast`, `--dump-hir`, and `--dump-hgraph-ir` show its
 successive views). The hgraph-IR dump now owns callable and test bodies as well
-as their interfaces; backends still use their temporary resolved-AST adapters.
-That frontend now
+as their interfaces. Direct test, REPL, and run evaluation consumes that IR;
+only C++ generation still has its temporary resolved-AST adapter. That frontend now
 models nominal and generic structs, abstract-only inheritance, defaults and
 optional fields, `requires` constraints, and sparse `delta<S>` construction.
 `hgl test`, `hgl run`, and `hgl repl` additionally execute supported generated

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -150,18 +150,18 @@ second checkpoint lowers all callable and test bodies into owned bindings,
 values, resolved operations, substitutions, statements, blocks, and test
 plans. It explicitly represents state, injectables, lifecycle, ordered
 activation, traversal, assignment, returns, output and capability access, and
-test evaluation. The module is now `Bodies`, not `Executable`; concrete
-provider planning and direct-backend migration are the following slices.
+test evaluation. The module is now `Bodies`, not `Executable`. The direct
+backend consumes that form and resolves against the active in-process registry;
+concrete locked provider planning is the following slice.
 
 - [x] lower composition and runtime semantics into one explicit hgraph IR;
 - [x] represent state, injectables, lifecycle, activation, validity, traversal,
   output, and semantic operator identities;
 - [x] implement `hgl check --dump-hgraph-ir`;
 - [ ] attach concrete provider requirements and advance to `Executable`;
-- [ ] migrate direct wiring from `ResolvedModule` to hgraph IR. The first
-  migration slice isolates canonical scalar, container, window, atomic, and
-  generic nominal-struct metadata materialization behind an hgraph-IR type
-  bridge; evaluator migration follows without reintroducing syntax types.
+- [x] migrate direct wiring from `ResolvedModule` to hgraph IR, including
+  canonical type materialization, lexical activation bindings, composition
+  expansion, harness evaluation, entry execution, and driver-prepared settings.
 
 Acceptance: direct-wiring behavior and diagnostics remain equivalent, and the
 wiring target no longer includes syntax AST headers.

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -196,13 +196,14 @@ through each applied parent, so a child contract refers only to its own generic
 scope even when parent parameters have different names. `hgl check
 --dump-hgraph-ir` prints that representation. The
 result is marked `Bodies`. No HIR symbol, expression, statement, block, or
-declaration ID remains in it. Provider selection and native execution planning
-are still required before it may be marked `Executable` or consumed by either
-backend.
+declaration ID remains in it. The direct evaluator can consume this form and
+perform in-process registry resolution while it wires. Locked provider
+selection and native execution planning are still required before a portable
+module may be marked `Executable`.
 
-The direct-wiring and C++ backends still walk `ResolvedModule` beside typed HIR
-during migration. That adapter path is explicitly temporary; hgraph semantic
-IR becomes the only input to both backends in the following stages.
+The direct-wiring backend now consumes only hgraph IR. The C++ backend still
+walks `ResolvedModule` beside typed HIR during migration; that remaining adapter
+is explicitly temporary.
 
 `src/wiring/type_bridge` is the first direct-backend migration boundary. It
 materializes hgraph-IR scalar, tuple, list, set, map, window, atomic, and applied
@@ -214,6 +215,14 @@ sizes. Runtime metadata pointers remain in this backend-only layer and never
 enter hgraph IR. Graph-IR types and symbolic constant expressions retain their
 own lexical binding IDs, so identically named generic parameters in nested
 struct applications cannot shadow one another during materialization.
+
+`src/wiring/backend` walks graph-IR `BindingId`, `CallableId`, `ValueId`,
+`StatementId`, and `BlockId` values directly. Function activation is keyed by
+lexical binding identity, operation wiring uses the resolved registry spelling,
+and nominal construction uses the type bridge plus effective graph-IR struct
+contracts. The driver parses `--set` text through an isolated ordinary frontend
+unit and passes the resulting typed hgraph `Value` to the backend; the execution
+layer never reparses source or imports AST/semantic resolver headers.
 
 ## Common function representation
 
@@ -1019,7 +1028,7 @@ callback or metadata pointer escapes the probe.
 
 ## Direct-wiring backend
 
-Status: executable prototype (2026-09-03) with the test harness and run model in
+Status: executable hgraph-IR prototype (2026-09-05) with the test harness and run model in
 [Syntax and semantics](syntax-and-semantics.md#tests-and-the-evaluation-harness).
 
 The direct-wiring backend executes a composition-only program without
@@ -1056,17 +1065,15 @@ The backend owns exactly these steps:
 
 The harness uses the `"testing"` record/replay backend for dense sequences
 (`dense_record`; index i is evaluation cycle `MIN_ST + i*MIN_TD`, which is
-the alignment `eval` promises) and the sparse absolute-time entries of the
-`"memory"` backend for timed sequences. A test run is one
+the alignment `eval` promises). Timed harness sequences remain staged. A test run is one
 `GraphExecutorBuilder` over the wired graph, evaluated in process; the
-observed sequence is read back with `get_recorded_deltas` or
-`get_recorded_sparse`, padded by the rule in the specification, and compared
+observed sequence is read back with `get_recorded_deltas`, padded by the rule
+in the specification, and compared
 with `Value::equals` element by element.
 
 `hgl run` under this backend wires the entry function with its `[run.params]`
 constants as scalar arguments, applies the mode, start, and end to the
-executor builder, and prints each tick of the result port through a `record`
-sink read after the run (simulation) or a streaming sink (real time).
+executor builder, and prints each tick through the `hgl.print_tick` sink.
 
 The backend never emulates a node body. A runtime function or source-defined
 operator is wired by its module-qualified registry name, so the driver must
@@ -1083,8 +1090,8 @@ not a private include.
 
 ### First pass
 
-Implemented (2026-09-03) in `src/wiring/` as `backend`, over the resolved
-syntax tree of `src/semantics/`. A `Session` bootstraps hgraph once per
+Implemented in `src/wiring/` as `backend`, over the `Bodies` form of hgraph IR.
+A session bootstrap initializes hgraph once per
 process (`register_standard_types`, `register_standard_operators`, and the
 backend's own installer, below). The walk assigns every expression one of the
 following wiring-time values: a *constant* (`Value` plus its interned
@@ -1129,8 +1136,9 @@ walk:
   passed to a `const` parameter converts to the declared value type (`i64`
   to `f64`, elementwise through tuples and lists; anything else is a `type`
   diagnostic), and a sequence literal passed to a `const list<T>` parameter
-  inside a test is that list; a runtime function, an `impl fn`, or a
-  generic function is a `backend` diagnostic naming it;
+  inside a test is that list; an `impl fn` reached directly or a generic
+  function is a `backend` diagnostic naming it; a runtime function is wired by
+  its module-qualified identity after the driver loads its provider;
 - the prelude intrinsics take the meaning of "Interim kernel table";
 - `if` selects a branch when its condition is a constant `bool`; a port
   condition remains a `backend` diagnostic in the current prototype. The
@@ -1174,7 +1182,7 @@ failed`; the exit status is non-zero on any failure or diagnostic.
 `hgl run` picks the entry (`--entry <name>`, else the one `export fn`
 whose parameters are all `const`; none or several is a `backend`
 diagnostic), binds every parameter from `--set name=<constant expression>`
-(the text is parsed and folded as the body of a `fn` in a scratch unit
+(the text is parsed and folded as the tail of a `test` block in a scratch unit
 `module hgl.cli`, then converted to the parameter's value type; an unknown
 name is a `name` diagnostic) or its default (a parameter with neither is a
 `type` diagnostic), walks the body, sends the result port to the backend's

--- a/language/docs/user-guide/modules-and-tools.md
+++ b/language/docs/user-guide/modules-and-tools.md
@@ -309,21 +309,21 @@ civil literals.
 ## One execution model
 
 The target architecture gives `test`, `run`, `emit-cpp`, and the REPL one
-checked semantic IR and one hgraph runtime. The current prototype shares
-parsing, name resolution, and the new resolved-HIR construction, but its direct
-and C++ backends still walk `ResolvedModule` independently while they migrate
-to hgraph IR. A program made only of composition functions is wired onto the
-runtime directly, in process. A file-based `test` or `run` containing supported
+checked semantic IR and one hgraph runtime. The direct evaluator now consumes
+hgraph IR; C++ generation retains the remaining temporary `ResolvedModule`
+adapter. A program made only of composition functions is wired onto the runtime
+directly, in process. A file-based `test` or `run` containing supported
 runtime functions goes through generated C++, as does an ahead-of-time package.
 The REPL selects the same two routes from the accepted session:
 
 ```text
-source -> resolved AST + resolved HIR -> direct wiring          -> hgraph runtime
-                                  \-> generated C++ -> native -> hgraph runtime
+source -> typed HIR -> hgraph IR -> direct wiring          -> hgraph runtime
+                    \-> temporary AST adapter -> C++ -> native -> hgraph runtime
 ```
 
 Parity tests require both paths to build the same graph across their shared
-subset; hgraph IR will make that a structural invariant. The scripted image resolves hgraph symbols
+subset; completing the C++ migration will make that a structural invariant.
+The scripted image resolves hgraph symbols
 from the running `hgl` process, so it registers into that process's registry
 rather than linking a second static runtime. The compiler's parity suite holds
 the shared composition subset to the same ticks and executes the runtime

--- a/language/src/driver/driver.cpp
+++ b/language/src/driver/driver.cpp
@@ -30,6 +30,7 @@
 #include <optional>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace hgl::driver
@@ -273,7 +274,7 @@ namespace hgl::driver
                 return exit_diagnostics;
             }
             const std::vector<wiring::TestResult> results =
-                wiring::run_tests(unit->file, unit->module, unit->resolved, options, unit->diagnostics);
+                wiring::run_tests(unit->file, *unit->hgraph, options, unit->diagnostics);
             print_test_results(results, std::cout);
             if (unit->diagnostics.has_errors()) { std::cerr << unit->diagnostics.render(unit->file); }
             const bool failed = unit->diagnostics.has_errors() ||
@@ -290,8 +291,9 @@ namespace hgl::driver
         }
 
         int run_command(std::span<const std::string_view> arguments, std::string_view language_version) {
-            std::optional<std::string> path;
-            wiring::RunOptions         options;
+            std::optional<std::string>                       path;
+            wiring::RunOptions                               options;
+            std::vector<std::pair<std::string, std::string>> raw_settings;
             for (std::size_t i = 0; i < arguments.size(); ++i) {
                 const std::string_view argument = arguments[i];
                 const auto             value    = [&]() -> std::optional<std::string_view> {
@@ -334,8 +336,7 @@ namespace hgl::driver
                     if (!text || eq == std::string_view::npos || eq == 0) {
                         return usage_error("--set takes name=<constant expression>");
                     }
-                    options.settings.push_back(
-                        wiring::Setting{std::string{text->substr(0, eq)}, std::string{text->substr(eq + 1)}});
+                    raw_settings.emplace_back(std::string{text->substr(0, eq)}, std::string{text->substr(eq + 1)});
                 } else if (argument.starts_with("--")) {
                     return usage_error("unknown option '" + std::string{argument} + "'");
                 } else if (path) {
@@ -347,9 +348,25 @@ namespace hgl::driver
             if (!path) { return usage_error("run needs a file"); }
             std::optional<Unit> unit = load(*path);
             if (!unit) { return exit_usage; }
+            for (const auto &[name, text] : raw_settings) {
+                Unit setting{"--set " + name, "module hgl.cli\ntest __set { " + text + " }\n"};
+                frontend(setting);
+                std::optional<hgraph::Value> value;
+                if (setting.ok) {
+                    const hgraph_ir::Block &body = setting.hgraph->blocks[setting.hgraph->tests.front().body.value];
+                    value = wiring::evaluate_constant(setting.file, *setting.hgraph, body.tail, setting.diagnostics);
+                }
+                if (!value || setting.diagnostics.has_errors()) {
+                    unit->diagnostics.report(syntax::Category::Type, syntax::SourceRange{},
+                                             "--set " + name + ": invalid value\n" + setting.diagnostics.render(setting.file));
+                    unit->ok = false;
+                    continue;
+                }
+                options.settings.push_back(wiring::Setting{name, std::move(*value)});
+            }
             NativeModule native_module;
             if (unit->ok && load_native_module(*unit, language_version, native_module)) {
-                (void)wiring::run_program(unit->file, unit->module, unit->resolved, options, unit->diagnostics, std::cout);
+                (void)wiring::run_program(unit->file, *unit->hgraph, options, unit->diagnostics, std::cout);
             }
             if (unit->diagnostics.has_errors()) {
                 std::cerr << unit->diagnostics.render(unit->file);
@@ -643,8 +660,7 @@ namespace hgl::driver
                 if (input.starts_with("test")) {
                     wiring::TestOptions options;
                     options.names.push_back(test_name_of(input));
-                    print_test_results(wiring::run_tests(unit.file, unit.module, unit.resolved, options, unit.diagnostics),
-                                       std::cout);
+                    print_test_results(wiring::run_tests(unit.file, *unit.hgraph, options, unit.diagnostics), std::cout);
                     if (unit.diagnostics.has_errors()) { std::cout << unit.diagnostics.render(unit.file); }
                 }
             }
@@ -664,7 +680,7 @@ namespace hgl::driver
                 options.names.push_back("__repl");
                 options.describe_tail = true;
                 const std::vector<wiring::TestResult> results =
-                    wiring::run_tests(unit.file, unit.module, unit.resolved, options, unit.diagnostics);
+                    wiring::run_tests(unit.file, *unit.hgraph, options, unit.diagnostics);
                 if (unit.diagnostics.has_errors()) {
                     std::cout << unit.diagnostics.render(unit.file);
                     return;

--- a/language/src/hgraph_ir/lower.cpp
+++ b/language/src/hgraph_ir/lower.cpp
@@ -106,6 +106,14 @@ namespace hgl::hgraph_ir
                 } else if (const auto *tuple = std::get_if<hir::Tuple>(&source.node)) {
                     target.kind = ConstExprKind::Tuple;
                     for (hir::ExprId item : tuple->elements) { target.items.push_back(lower_const_expr(item, source.range, role)); }
+                } else if (const auto *call = std::get_if<hir::Call>(&source.node);
+                           call != nullptr && source.operation.kind == hir::OperationKind::Constructor) {
+                    target.kind             = ConstExprKind::Construct;
+                    target.constructed_type = lower_type(source.type);
+                    for (const hir::Argument &argument : call->arguments) {
+                        target.arguments.push_back(
+                            ConstArgument{argument.name, lower_const_expr(argument.value, argument.range, role)});
+                    }
                 } else if (const auto *construct = std::get_if<hir::Construct>(&source.node)) {
                     target.kind             = ConstExprKind::Construct;
                     target.constructed_type = lower_type(construct->type);
@@ -272,6 +280,14 @@ namespace hgl::hgraph_ir
                     target.kind = ConstExprKind::Tuple;
                     for (hir::ExprId item : tuple->elements) {
                         target.items.push_back(lower_const_expr(item, bindings, source.range, role));
+                    }
+                } else if (const auto *call = std::get_if<hir::Call>(&source.node);
+                           call != nullptr && source.operation.kind == hir::OperationKind::Constructor) {
+                    target.kind             = ConstExprKind::Construct;
+                    target.constructed_type = lower_type(source.type, bindings);
+                    for (const hir::Argument &argument : call->arguments) {
+                        target.arguments.push_back(
+                            ConstArgument{argument.name, lower_const_expr(argument.value, bindings, argument.range, role)});
                     }
                 } else if (const auto *construct = std::get_if<hir::Construct>(&source.node)) {
                     target.kind             = ConstExprKind::Construct;

--- a/language/src/ir/canonical_types.cpp
+++ b/language/src/ir/canonical_types.cpp
@@ -23,6 +23,22 @@ namespace hgl::ir::detail
         source_visiting_.resize(source_count);
         for (std::uint32_t index = 0; index < source_count; ++index) { (void)canonicalize(TypeId{index}); }
         void_type_ = make(TypeKind::Void);
+        // Native operator resolution can infer a scalar output that does not
+        // otherwise occur in source (for example schedule(duration) -> bool).
+        // Seed the finite scalar universe so the read-only registry adapter
+        // can always map that runtime schema back to an arena-owned HIR type.
+        (void)scalar(ScalarType::Bool);
+        (void)scalar(ScalarType::I64);
+        (void)scalar(ScalarType::F64);
+        (void)scalar(ScalarType::Str);
+        (void)scalar(ScalarType::Date);
+        (void)scalar(ScalarType::Time);
+        (void)scalar(ScalarType::DateTime);
+        (void)scalar(ScalarType::Duration);
+        (void)scalar(ScalarType::CivilDateTime);
+        (void)scalar(ScalarType::ZonedDateTime);
+        (void)scalar(ScalarType::ZonedTime);
+        (void)scalar(ScalarType::TimeZone);
         rewrite_type_references();
     }
 
@@ -222,8 +238,19 @@ namespace hgl::ir::detail
             from.scalar == ScalarType::I64) {
             return true;
         }
-        if (to.kind == TypeKind::Atomic && !to.children.empty() && same(to.children.front(), actual)) { return true; }
-        if (from.kind == TypeKind::Atomic && !from.children.empty() && same(expected, from.children.front())) { return true; }
+        if (to.kind == TypeKind::Atomic && !to.children.empty()) { return assignable(to.children.front(), actual); }
+        if (from.kind == TypeKind::Atomic && !from.children.empty()) { return assignable(expected, from.children.front()); }
+        const bool sequence_pair = (to.kind == TypeKind::List || to.kind == TypeKind::HarnessSequence) &&
+                                   (from.kind == TypeKind::List || from.kind == TypeKind::HarnessSequence);
+        if ((to.kind == from.kind || sequence_pair) &&
+            (to.kind == TypeKind::Tuple || to.kind == TypeKind::List || to.kind == TypeKind::Set || to.kind == TypeKind::Map ||
+             to.kind == TypeKind::HarnessSequence) &&
+            to.children.size() == from.children.size()) {
+            for (std::size_t index = 0; index < to.children.size(); ++index) {
+                if (!assignable(to.children[index], from.children[index])) { return false; }
+            }
+            return true;
+        }
         return false;
     }
 

--- a/language/src/ir/canonical_types.cpp
+++ b/language/src/ir/canonical_types.cpp
@@ -242,6 +242,9 @@ namespace hgl::ir::detail
         if (from.kind == TypeKind::Atomic && !from.children.empty()) { return assignable(expected, from.children.front()); }
         const bool sequence_pair = (to.kind == TypeKind::List || to.kind == TypeKind::HarnessSequence) &&
                                    (from.kind == TypeKind::List || from.kind == TypeKind::HarnessSequence);
+        if (to.kind == TypeKind::List && from.kind == TypeKind::List && to.size.valid()) {
+            if (to.unbounded || from.unbounded || !from.size.valid() || !same_value(to.size, from.size)) { return false; }
+        }
         if ((to.kind == from.kind || sequence_pair) &&
             (to.kind == TypeKind::Tuple || to.kind == TypeKind::List || to.kind == TypeKind::Set || to.kind == TypeKind::Map ||
              to.kind == TypeKind::HarnessSequence) &&

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -1110,10 +1110,23 @@ namespace hgl::ir
 
             void check_sequence(Expr &expression, const Sequence &node, TypeId expected) {
                 TypeId element_expected;
+                bool   use_expected_list = false;
                 if (expected.valid()) {
                     const Type &shape = type(canonical(expected));
                     if ((shape.kind == TypeKind::List || shape.kind == TypeKind::HarnessSequence) && !shape.children.empty()) {
                         element_expected = shape.children.front();
+                    }
+                    if (shape.kind == TypeKind::List && shape.size.valid() && !shape.unbounded) {
+                        const Expr &size = module_.expr(shape.size);
+                        if (size.constant) {
+                            if (const auto *count = std::get_if<std::int64_t>(&*size.constant)) {
+                                use_expected_list = *count >= 0 && static_cast<std::size_t>(*count) == node.elements.size();
+                                if (!use_expected_list) {
+                                    type_error(expression.range, "list literal has " + std::to_string(node.elements.size()) +
+                                                                     " elements, expected " + std::to_string(*count));
+                                }
+                            }
+                        }
                     }
                 }
                 TypeId element_type = element_expected;
@@ -1133,7 +1146,7 @@ namespace hgl::ir
                 const TypeKind kind   = expected.valid() && type(canonical(expected)).kind == TypeKind::HarnessSequence
                                             ? TypeKind::HarnessSequence
                                             : TypeKind::List;
-                expression.type       = make_type(kind, {element_type});
+                expression.type       = use_expected_list ? canonical(expected) : make_type(kind, {element_type});
                 expression.phase      = phase;
                 expression.value_kind = kind == TypeKind::HarnessSequence ? ValueKind::Constant : value_kind_for_phase(phase);
             }

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -583,7 +583,22 @@ namespace hgl::ir
                     return;
                 }
                 if (op == BinaryOp::Equal || op == BinaryOp::NotEqual) {
-                    const bool equal    = a == b;
+                    bool equal = false;
+                    if (const std::optional<double> left = as_double(a), right = as_double(b); left && right) {
+                        equal = *left == *right;
+                    } else if (const auto *left = std::get_if<syntax::TemporalValue>(&a)) {
+                        const auto *right = std::get_if<syntax::TemporalValue>(&b);
+                        if (right && left->kind == right->kind &&
+                            (left->kind == syntax::TemporalKind::DateTime || left->kind == syntax::TemporalKind::ZonedDateTime)) {
+                            // Datetimes denote instants. Their source offset and
+                            // zone metadata do not participate in equality.
+                            equal = left->micros == right->micros;
+                        } else {
+                            equal = a == b;
+                        }
+                    } else {
+                        equal = a == b;
+                    }
                     expression.constant = Constant{op == BinaryOp::Equal ? equal : !equal};
                     return;
                 }

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -544,6 +544,14 @@ namespace hgl::ir
                 if (op == BinaryOp::Add && same(lhs, scalar(ScalarType::Str)) && same(rhs, scalar(ScalarType::Str))) {
                     return scalar(ScalarType::Str);
                 }
+                const TypeId duration = scalar(ScalarType::Duration);
+                const TypeId datetime = scalar(ScalarType::DateTime);
+                if (op == BinaryOp::Add && same(lhs, duration) && same(rhs, duration)) { return duration; }
+                if (op == BinaryOp::Add && same(lhs, datetime) && same(rhs, duration)) { return datetime; }
+                if (op == BinaryOp::Sub && same(lhs, duration) && same(rhs, duration)) { return duration; }
+                if (op == BinaryOp::Sub && same(lhs, datetime) && same(rhs, duration)) { return datetime; }
+                if (op == BinaryOp::Sub && same(lhs, datetime) && same(rhs, datetime)) { return duration; }
+                if (op == BinaryOp::Mul && same(lhs, duration) && same(rhs, scalar(ScalarType::I64))) { return duration; }
                 const bool lhs_numeric = numeric(lhs) || active_proves_numeric(lhs);
                 const bool rhs_numeric = numeric(rhs) || active_proves_numeric(rhs);
                 if (!lhs_numeric || !rhs_numeric) {
@@ -578,6 +586,42 @@ namespace hgl::ir
                     const bool equal    = a == b;
                     expression.constant = Constant{op == BinaryOp::Equal ? equal : !equal};
                     return;
+                }
+                const auto *left_temporal  = std::get_if<syntax::TemporalValue>(&a);
+                const auto *right_temporal = std::get_if<syntax::TemporalValue>(&b);
+                if (left_temporal && right_temporal) {
+                    syntax::TemporalValue result = *left_temporal;
+                    if (op == BinaryOp::Add && left_temporal->kind == syntax::TemporalKind::Duration &&
+                        right_temporal->kind == syntax::TemporalKind::Duration) {
+                        result.micros += right_temporal->micros;
+                        expression.constant = Constant{result};
+                    } else if (op == BinaryOp::Add && left_temporal->kind == syntax::TemporalKind::DateTime &&
+                               right_temporal->kind == syntax::TemporalKind::Duration) {
+                        result.micros += right_temporal->micros;
+                        expression.constant = Constant{result};
+                    } else if (op == BinaryOp::Sub && left_temporal->kind == syntax::TemporalKind::Duration &&
+                               right_temporal->kind == syntax::TemporalKind::Duration) {
+                        result.micros -= right_temporal->micros;
+                        expression.constant = Constant{result};
+                    } else if (op == BinaryOp::Sub && left_temporal->kind == syntax::TemporalKind::DateTime &&
+                               right_temporal->kind == syntax::TemporalKind::Duration) {
+                        result.micros -= right_temporal->micros;
+                        expression.constant = Constant{result};
+                    } else if (op == BinaryOp::Sub && left_temporal->kind == syntax::TemporalKind::DateTime &&
+                               right_temporal->kind == syntax::TemporalKind::DateTime) {
+                        result.kind = syntax::TemporalKind::Duration;
+                        result.micros -= right_temporal->micros;
+                        expression.constant = Constant{result};
+                    }
+                    if (expression.constant) { return; }
+                }
+                if (left_temporal && left_temporal->kind == syntax::TemporalKind::Duration && op == BinaryOp::Mul) {
+                    if (const auto *factor = std::get_if<std::int64_t>(&b)) {
+                        syntax::TemporalValue result = *left_temporal;
+                        result.micros *= *factor;
+                        expression.constant = Constant{result};
+                        return;
+                    }
                 }
                 const std::optional<double> left  = as_double(a);
                 const std::optional<double> right = as_double(b);
@@ -1368,9 +1412,13 @@ namespace hgl::ir
                     const TypeId unwrapped = unwrap_atomic(expected);
                     if (type(unwrapped).kind == TypeKind::Symbol && type(unwrapped).symbol == target) { applied = expected; }
                 }
-                applied               = check_constructor_arguments(expression, applied, call.arguments, false);
-                expression.type       = canonical(applied);
-                expression.phase      = runtime_owner(expression.owner) ? Phase::Runtime : Phase::Wiring;
+                applied          = check_constructor_arguments(expression, applied, call.arguments, false);
+                expression.type  = canonical(applied);
+                expression.phase = Phase::Constant;
+                for (const Argument &argument : call.arguments) {
+                    expression.phase = join_phase(expression.phase, module_.expr(argument.value).phase);
+                }
+                if (runtime_owner(expression.owner)) { expression.phase = Phase::Runtime; }
                 expression.value_kind = value_kind_for_phase(expression.phase);
                 if (expression.phase == Phase::Wiring) { expression.effects |= Effect::WireGraph; }
                 expression.operation = Operation{.kind     = OperationKind::Constructor,
@@ -1381,9 +1429,13 @@ namespace hgl::ir
             void check_construct(Expr &expression, const Construct &node, TypeId expected) {
                 TypeId applied = canonical(node.type);
                 if (expected.valid() && assignable(expected, applied)) { applied = canonical(expected); }
-                applied               = check_constructor_arguments(expression, applied, node.arguments, node.delta);
-                expression.type       = applied;
-                expression.phase      = runtime_owner(expression.owner) ? Phase::Runtime : Phase::Wiring;
+                applied          = check_constructor_arguments(expression, applied, node.arguments, node.delta);
+                expression.type  = applied;
+                expression.phase = Phase::Constant;
+                for (const Argument &argument : node.arguments) {
+                    expression.phase = join_phase(expression.phase, module_.expr(argument.value).phase);
+                }
+                if (runtime_owner(expression.owner)) { expression.phase = Phase::Runtime; }
                 expression.value_kind = value_kind_for_phase(expression.phase);
                 if (expression.phase == Phase::Wiring) { expression.effects |= Effect::WireGraph; }
                 const TypeId nominal = unwrap_atomic(applied);

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -589,7 +589,12 @@ namespace hgl::ir
                     }
                     expression.type = operand.type;
                     if (operand.constant && std::holds_alternative<std::int64_t>(*operand.constant)) {
-                        expression.constant = Constant{-std::get<std::int64_t>(*operand.constant)};
+                        const std::int64_t value = std::get<std::int64_t>(*operand.constant);
+                        if (value == std::numeric_limits<std::int64_t>::min()) {
+                            type_error(expression.range, "overflow in an integer constant expression");
+                        } else {
+                            expression.constant = Constant{-value};
+                        }
                     } else if (operand.constant && std::holds_alternative<double>(*operand.constant)) {
                         expression.constant = Constant{-std::get<double>(*operand.constant)};
                     }
@@ -637,6 +642,40 @@ namespace hgl::ir
                         if (const auto *right = std::get_if<bool>(&b)) {
                             expression.constant = Constant{op == BinaryOp::And ? (*left && *right) : (*left || *right)};
                         }
+                    }
+                    return;
+                }
+                const auto *left_integer  = std::get_if<std::int64_t>(&a);
+                const auto *right_integer = std::get_if<std::int64_t>(&b);
+                if (left_integer && right_integer && op != BinaryOp::Div) {
+                    std::optional<std::int64_t> result;
+                    switch (op) {
+                        case BinaryOp::Add: result = checked_add(*left_integer, *right_integer); break;
+                        case BinaryOp::Sub: result = checked_sub(*left_integer, *right_integer); break;
+                        case BinaryOp::Mul: result = checked_mul(*left_integer, *right_integer); break;
+                        case BinaryOp::Rem:
+                            if (*right_integer == 0) {
+                                type_error(expression.range, "remainder by zero in a constant expression");
+                                return;
+                            }
+                            result = *left_integer == std::numeric_limits<std::int64_t>::min() && *right_integer == -1
+                                         ? 0
+                                         : *left_integer % *right_integer;
+                            break;
+                        case BinaryOp::Less: expression.constant = Constant{*left_integer < *right_integer}; return;
+                        case BinaryOp::LessEqual: expression.constant = Constant{*left_integer <= *right_integer}; return;
+                        case BinaryOp::Greater: expression.constant = Constant{*left_integer > *right_integer}; return;
+                        case BinaryOp::GreaterEqual: expression.constant = Constant{*left_integer >= *right_integer}; return;
+                        case BinaryOp::Equal: expression.constant = Constant{*left_integer == *right_integer}; return;
+                        case BinaryOp::NotEqual: expression.constant = Constant{*left_integer != *right_integer}; return;
+                        case BinaryOp::Div:
+                        case BinaryOp::And:
+                        case BinaryOp::Or: std::unreachable();
+                    }
+                    if (!result) {
+                        type_error(expression.range, "overflow in an integer constant expression");
+                    } else {
+                        expression.constant = Constant{*result};
                     }
                     return;
                 }

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <limits>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -34,6 +35,33 @@ namespace hgl::ir
                 case Phase::Unknown: return ValueKind::Unknown;
             }
             std::unreachable();
+        }
+
+        [[nodiscard]] std::optional<std::int64_t> checked_add(std::int64_t lhs, std::int64_t rhs) noexcept {
+            constexpr auto min = std::numeric_limits<std::int64_t>::min();
+            constexpr auto max = std::numeric_limits<std::int64_t>::max();
+            if ((rhs > 0 && lhs > max - rhs) || (rhs < 0 && lhs < min - rhs)) { return std::nullopt; }
+            return lhs + rhs;
+        }
+
+        [[nodiscard]] std::optional<std::int64_t> checked_sub(std::int64_t lhs, std::int64_t rhs) noexcept {
+            constexpr auto min = std::numeric_limits<std::int64_t>::min();
+            constexpr auto max = std::numeric_limits<std::int64_t>::max();
+            if ((rhs > 0 && lhs < min + rhs) || (rhs < 0 && lhs > max + rhs)) { return std::nullopt; }
+            return lhs - rhs;
+        }
+
+        [[nodiscard]] std::optional<std::int64_t> checked_mul(std::int64_t lhs, std::int64_t rhs) noexcept {
+            constexpr auto min = std::numeric_limits<std::int64_t>::min();
+            constexpr auto max = std::numeric_limits<std::int64_t>::max();
+            if (lhs == 0 || rhs == 0) { return 0; }
+            if ((lhs == -1 && rhs == min) || (rhs == -1 && lhs == min)) { return std::nullopt; }
+            if (lhs > 0) {
+                if ((rhs > 0 && lhs > max / rhs) || (rhs < 0 && rhs < min / lhs)) { return std::nullopt; }
+            } else if ((rhs > 0 && lhs < min / rhs) || (rhs < 0 && lhs < max / rhs)) {
+                return std::nullopt;
+            }
+            return lhs * rhs;
         }
 
         [[nodiscard]] std::string_view binary_identity(BinaryOp op) noexcept {
@@ -335,7 +363,37 @@ namespace hgl::ir
                 if (!assignable(expected, actual.type)) {
                     type_error(actual.range,
                                std::string{what} + " has type " + type_name(actual.type) + ", expected " + type_name(expected));
+                } else if (actual.phase == Phase::Wiring && requires_nested_conversion(expected, actual.type)) {
+                    type_error(actual.range,
+                               std::string{what} + " requires an implicit conversion inside a time-series collection");
                 }
+            }
+
+            [[nodiscard]] bool requires_nested_conversion(TypeId expected, TypeId actual) const noexcept {
+                expected = canonical(expected);
+                actual   = canonical(actual);
+                while (expected.valid() && type(expected).kind == TypeKind::Atomic && !type(expected).children.empty()) {
+                    expected = type(expected).children.front();
+                }
+                while (actual.valid() && type(actual).kind == TypeKind::Atomic && !type(actual).children.empty()) {
+                    actual = type(actual).children.front();
+                }
+                if (same(expected, actual) || !expected.valid() || !actual.valid()) { return false; }
+                const Type &to            = type(expected);
+                const Type &from          = type(actual);
+                const bool  sequence_pair = (to.kind == TypeKind::List || to.kind == TypeKind::HarnessSequence) &&
+                                            (from.kind == TypeKind::List || from.kind == TypeKind::HarnessSequence);
+                const bool  structural    = to.kind == from.kind || sequence_pair;
+                if (!structural ||
+                    (to.kind != TypeKind::Tuple && to.kind != TypeKind::List && to.kind != TypeKind::Set &&
+                     to.kind != TypeKind::Map && to.kind != TypeKind::HarnessSequence) ||
+                    to.children.size() != from.children.size()) {
+                    return false;
+                }
+                for (std::size_t index = 0; index < to.children.size(); ++index) {
+                    if (!same(to.children[index], from.children[index])) { return true; }
+                }
+                return false;
             }
 
             void check_type_expressions() {
@@ -605,35 +663,49 @@ namespace hgl::ir
                 const auto *left_temporal  = std::get_if<syntax::TemporalValue>(&a);
                 const auto *right_temporal = std::get_if<syntax::TemporalValue>(&b);
                 if (left_temporal && right_temporal) {
-                    syntax::TemporalValue result = *left_temporal;
+                    syntax::TemporalValue               result = *left_temporal;
+                    std::optional<std::int64_t>         micros;
+                    std::optional<syntax::TemporalKind> result_kind;
+                    bool                                supported = true;
                     if (op == BinaryOp::Add && left_temporal->kind == syntax::TemporalKind::Duration &&
                         right_temporal->kind == syntax::TemporalKind::Duration) {
-                        result.micros += right_temporal->micros;
-                        expression.constant = Constant{result};
+                        micros = checked_add(left_temporal->micros, right_temporal->micros);
                     } else if (op == BinaryOp::Add && left_temporal->kind == syntax::TemporalKind::DateTime &&
                                right_temporal->kind == syntax::TemporalKind::Duration) {
-                        result.micros += right_temporal->micros;
-                        expression.constant = Constant{result};
+                        micros = checked_add(left_temporal->micros, right_temporal->micros);
                     } else if (op == BinaryOp::Sub && left_temporal->kind == syntax::TemporalKind::Duration &&
                                right_temporal->kind == syntax::TemporalKind::Duration) {
-                        result.micros -= right_temporal->micros;
-                        expression.constant = Constant{result};
+                        micros = checked_sub(left_temporal->micros, right_temporal->micros);
                     } else if (op == BinaryOp::Sub && left_temporal->kind == syntax::TemporalKind::DateTime &&
                                right_temporal->kind == syntax::TemporalKind::Duration) {
-                        result.micros -= right_temporal->micros;
-                        expression.constant = Constant{result};
+                        micros = checked_sub(left_temporal->micros, right_temporal->micros);
                     } else if (op == BinaryOp::Sub && left_temporal->kind == syntax::TemporalKind::DateTime &&
                                right_temporal->kind == syntax::TemporalKind::DateTime) {
-                        result.kind = syntax::TemporalKind::Duration;
-                        result.micros -= right_temporal->micros;
-                        expression.constant = Constant{result};
+                        micros      = checked_sub(left_temporal->micros, right_temporal->micros);
+                        result_kind = syntax::TemporalKind::Duration;
+                    } else {
+                        supported = false;
                     }
-                    if (expression.constant) { return; }
+                    if (supported) {
+                        if (!micros) {
+                            type_error(expression.range, "overflow in a temporal constant expression");
+                            return;
+                        }
+                        result.micros = *micros;
+                        if (result_kind) { result.kind = *result_kind; }
+                        expression.constant = Constant{result};
+                        return;
+                    }
                 }
                 if (left_temporal && left_temporal->kind == syntax::TemporalKind::Duration && op == BinaryOp::Mul) {
                     if (const auto *factor = std::get_if<std::int64_t>(&b)) {
                         syntax::TemporalValue result = *left_temporal;
-                        result.micros *= *factor;
+                        const auto            micros = checked_mul(left_temporal->micros, *factor);
+                        if (!micros) {
+                            type_error(expression.range, "overflow in a temporal constant expression");
+                            return;
+                        }
+                        result.micros       = *micros;
                         expression.constant = Constant{result};
                         return;
                     }

--- a/language/src/wiring/backend.cpp
+++ b/language/src/wiring/backend.cpp
@@ -1,7 +1,7 @@
 #include "wiring/backend.h"
 
-#include "syntax/parser.h"
 #include "syntax/temporal.h"
+#include "wiring/type_bridge.h"
 
 #include <hgraph/lib/std/operators/registration.h>
 #include <hgraph/lib/std/standard_types.h>
@@ -19,86 +19,84 @@
 #include <hgraph/types/value/value.h>
 #include <hgraph/types/value/value_builder.h>
 #include <hgraph/types/value/value_view.h>
+#include <hgraph/util/scope.h>
 
 #if defined(HGL_HAVE_ANALYTICS)
-#include <hgraph/analytics/operators.h>
+    #include <hgraph/analytics/operators.h>
 #endif
 
 #include <algorithm>
 #include <chrono>
+#include <compare>
 #include <exception>
-#include <functional>
 #include <iostream>
-#include <iterator>
-#include <map>
+#include <optional>
+#include <span>
 #include <sstream>
 #include <stdexcept>
+#include <string>
+#include <string_view>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <variant>
+#include <vector>
 
-// The direct-wiring backend of the first pass (developer guide,
-// "Direct-wiring backend" and "First pass"): a walk over the resolved syntax
-// tree that folds constants, wires every time-series operation through
-// ``wire_operator``, and drives ``test``/``eval`` with the ``replay``/``record``
-// harness and ``run`` with the ``hgl.print_tick`` sink. Nothing here is a
-// second runtime: every time-series value is an hgraph port.
+// The direct backend consumes only execution-facing hgraph IR. Syntax and
+// semantic identities end at hgraph_ir::lower; this layer folds scalar values,
+// expands composition callables, and delegates every temporal operation to
+// hgraph's ordinary operator registry and graph runtime.
 namespace hgl::wiring
 {
     namespace
     {
+        namespace hir = ir::hir;
+        namespace gir = hgraph_ir;
+
         using syntax::Category;
         using syntax::SourceRange;
-        using semantics::BindingKind;
-
-        // ----------------------------------------------------------- the sink
 
         std::ostream *sink_stream = &std::cout;
 
-        /// ``hgl.print_tick``: the ``hgl run`` sink, one ``time value`` line
-        /// per tick of its input (user guide, "Running a program").
         struct print_tick : hgraph::Operator<"hgl.print_tick", hgraph::In<"ts", hgraph::TsVar<"S">>>
-        {
-        };
+        {};
 
         struct print_tick_impl
         {
-            static void eval(hgraph::In<"ts", hgraph::TsVar<"S">> ts, hgraph::EvaluationClockView clock)
-            {
+            static void eval(hgraph::In<"ts", hgraph::TsVar<"S">> ts, hgraph::EvaluationClockView clock) {
                 *sink_stream << format_time(clock.evaluation_time()) << ' ' << ts.value().to_string() << '\n';
             }
         };
 
-        // --------------------------------------------------------- the session
-
-        const hgraph::stdlib::RegisteredStandardTypes &standard_types()
-        {
-            static const hgraph::stdlib::RegisteredStandardTypes types = hgraph::stdlib::register_standard_types();
-            return types;
+        const hgraph::stdlib::RegisteredStandardTypes &standard_types() {
+            struct Cached
+            {
+                std::uint64_t                           generation{0};
+                hgraph::stdlib::RegisteredStandardTypes types{};
+            };
+            thread_local Cached cached;
+            auto               &registry = hgraph::TypeRegistry::instance();
+            const std::uint64_t current  = registry.reset_generation();
+            if (cached.types.bool_type == nullptr || cached.generation != current) {
+                cached.types      = hgraph::stdlib::register_standard_types(registry);
+                cached.generation = registry.reset_generation();
+            }
+            return cached.types;
         }
 
-        // ------------------------------------------------------------ values
-
-        /// Unwinds one test or run after a diagnostic has been reported.
         struct Abort
-        {
-        };
+        {};
 
-        /// Unwinds a test body on a failed ``assert``.
         struct TestFailure
-        {
-            std::string message;
-        };
+        { std::string message; };
 
-        /// A wiring-time value (developer guide, "First pass": constant,
-        /// port, function, harness sequence) plus the callable kinds.
         struct Slot
         {
-            enum class Kind : std::uint8_t
-            {
+            enum class Kind : std::uint8_t {
                 Void,
                 Const,
                 Null,
+                Placeholder,
                 Delta,
                 Port,
                 Struct,
@@ -108,110 +106,116 @@ namespace hgl::wiring
                 Sequence,
             };
 
-            Kind                                       kind{Kind::Void};
-            hgraph::Value                              value{};
-            hgraph::WiringPortRef                      port{};
-            ast::DeclId                                fn{ast::no_node};
-            std::string                                name{};
-            /// Sequence: the literal, until ``eval`` or a comparison gives it
-            /// an element schema.
-            ast::ExprId                                literal{ast::no_node};
-            bool                                       resolved{false};
+            Kind                                      kind{Kind::Void};
+            hgraph::Value                             value{};
+            hgraph::WiringPortRef                     port{};
+            gir::CallableId                           callable{};
+            gir::TypeId                               type{};
+            std::string                               name{};
+            gir::ValueId                              expression{};
+            bool                                      resolved{false};
             std::vector<std::optional<hgraph::Value>> elements{};
-            const hgraph::ValueTypeMetaData           *elem_meta{nullptr};
-            SourceRange                                range{};
+            const hgraph::ValueTypeMetaData          *element_meta{nullptr};
+            SourceRange                               range{};
 
-            [[nodiscard]] bool is_const() const noexcept { return kind == Kind::Const; }
-            [[nodiscard]] bool is_port() const noexcept { return kind == Kind::Port; }
+            [[nodiscard]] bool                             is_const() const noexcept { return kind == Kind::Const; }
+            [[nodiscard]] bool                             is_port() const noexcept { return kind == Kind::Port; }
             [[nodiscard]] const hgraph::ValueTypeMetaData *meta() const noexcept { return value.schema(); }
         };
 
-        Slot make_const(hgraph::Value value, SourceRange range)
-        {
-            Slot slot;
-            slot.kind  = Slot::Kind::Const;
-            slot.value = std::move(value);
-            slot.range = range;
-            return slot;
+        Slot make_const(hgraph::Value value, SourceRange range) {
+            Slot result;
+            result.kind  = Slot::Kind::Const;
+            result.value = std::move(value);
+            result.range = range;
+            return result;
         }
 
-        Slot make_port(hgraph::WiringPortRef port, SourceRange range)
-        {
-            Slot slot;
-            slot.kind  = Slot::Kind::Port;
-            slot.port  = std::move(port);
-            slot.range = range;
-            return slot;
+        Slot make_port(hgraph::WiringPortRef port, SourceRange range) {
+            Slot result;
+            result.kind  = Slot::Kind::Port;
+            result.port  = std::move(port);
+            result.range = range;
+            return result;
         }
 
-        Slot make_null(SourceRange range)
-        {
-            Slot slot;
-            slot.kind  = Slot::Kind::Null;
-            slot.range = range;
-            return slot;
+        Slot make_marker(Slot::Kind kind, SourceRange range) {
+            Slot result;
+            result.kind  = kind;
+            result.range = range;
+            return result;
         }
 
-        /// One function activation (or test body): its parameters by index
-        /// and its locals by declaring statement.
         struct Frame
         {
-            ast::DeclId                              fn{ast::no_node};
-            std::vector<Slot>                        params{};
-            std::unordered_map<ast::StmtId, Slot>    locals{};
-            std::optional<Slot>                      returned{};
-            bool                                     in_test{false};
+            gir::CallableId                         callable{};
+            std::unordered_map<std::uint32_t, Slot> bindings{};
+            std::optional<Slot>                     returned{};
+            bool                                    in_test{false};
         };
 
-        hgraph::WiringArg ts_arg(hgraph::WiringPortRef port, std::string name = {})
-        {
-            hgraph::WiringArg arg;
-            arg.kind = hgraph::WiringArg::Kind::TimeSeries;
-            arg.port = std::move(port);
-            arg.name = std::move(name);
-            return arg;
+        hgraph::WiringArg time_series_arg(hgraph::WiringPortRef port, std::string name = {}) {
+            hgraph::WiringArg result;
+            result.kind = hgraph::WiringArg::Kind::TimeSeries;
+            result.port = std::move(port);
+            result.name = std::move(name);
+            return result;
         }
 
-        hgraph::WiringArg scalar_arg(const hgraph::Value &value, std::string name = {})
-        {
-            hgraph::WiringArg arg;
-            arg.kind         = hgraph::WiringArg::Kind::Scalar;
-            arg.scalar_value = value;
-            arg.scalar_meta  = value.schema();
-            arg.name         = std::move(name);
-            return arg;
+        hgraph::WiringArg scalar_arg(const hgraph::Value &value, std::string name = {}) {
+            hgraph::WiringArg result;
+            result.kind         = hgraph::WiringArg::Kind::Scalar;
+            result.scalar_value = value;
+            result.scalar_meta  = value.schema();
+            result.name         = std::move(name);
+            return result;
         }
 
-        /// A value in source spelling where hgraph's `to_string` differs: an
-        /// `f64` keeps a decimal point, tuples and lists describe their
-        /// elements the same way.
-        std::string describe_view(const hgraph::ValueView &view)
-        {
-            if (view.schema() == standard_types().float_type)
-            {
+        std::string local_name(std::string_view identity) {
+            const std::size_t separator = identity.rfind('.');
+            return std::string{separator == std::string_view::npos ? identity : identity.substr(separator + 1U)};
+        }
+
+        std::string binary_spelling(hir::BinaryOp op) {
+            switch (op) {
+                case hir::BinaryOp::Mul: return "*";
+                case hir::BinaryOp::Div: return "/";
+                case hir::BinaryOp::Rem: return "%";
+                case hir::BinaryOp::Add: return "+";
+                case hir::BinaryOp::Sub: return "-";
+                case hir::BinaryOp::Less: return "<";
+                case hir::BinaryOp::LessEqual: return "<=";
+                case hir::BinaryOp::Greater: return ">";
+                case hir::BinaryOp::GreaterEqual: return ">=";
+                case hir::BinaryOp::Equal: return "==";
+                case hir::BinaryOp::NotEqual: return "!=";
+                case hir::BinaryOp::And: return "&&";
+                case hir::BinaryOp::Or: return "||";
+            }
+            return "?";
+        }
+
+        std::string describe_view(const hgraph::ValueView &view) {
+            if (view.schema() == standard_types().float_type) {
                 std::string text = view.to_string();
                 if (text.find_first_of(".ean") == std::string::npos) { text += ".0"; }
                 return text;
             }
-            if (view.is_tuple())
-            {
+            if (view.is_tuple()) {
                 const auto  tuple = view.as_tuple();
                 std::string out   = "(";
-                for (std::size_t i = 0; i < tuple.size(); ++i)
-                {
-                    if (i != 0) { out += ", "; }
-                    out += describe_view(tuple.at(i));
+                for (std::size_t index = 0; index < tuple.size(); ++index) {
+                    if (index != 0) { out += ", "; }
+                    out += describe_view(tuple.at(index));
                 }
                 return out + (tuple.size() == 1 ? ",)" : ")");
             }
-            if (view.is_list())
-            {
+            if (view.is_list()) {
                 const auto  list = view.as_list();
                 std::string out  = "[";
-                for (std::size_t i = 0; i < list.size(); ++i)
-                {
-                    if (i != 0) { out += ", "; }
-                    out += describe_view(list.at(i));
+                for (std::size_t index = 0; index < list.size(); ++index) {
+                    if (index != 0) { out += ", "; }
+                    out += describe_view(list.at(index));
                 }
                 return out + "]";
             }
@@ -220,2090 +224,1348 @@ namespace hgl::wiring
 
         std::string describe_value(const hgraph::Value &value) { return describe_view(value.view()); }
 
-        std::string describe_sequence(const std::vector<std::optional<hgraph::Value>> &elements)
-        {
+        std::string describe_sequence(const std::vector<std::optional<hgraph::Value>> &elements) {
             std::string out = "[";
-            for (std::size_t i = 0; i < elements.size(); ++i)
-            {
-                if (i != 0) { out += ", "; }
-                out += elements[i].has_value() ? describe_value(*elements[i]) : "_";
+            for (std::size_t index = 0; index < elements.size(); ++index) {
+                if (index != 0) { out += ", "; }
+                out += elements[index] ? describe_value(*elements[index]) : "_";
             }
-            out += ']';
-            return out;
+            return out + ']';
         }
-
-        // ---------------------------------------------------------- compiler
 
         class Compiler
         {
           public:
-            Compiler(const syntax::SourceFile &file, const ast::Module &module,
-                     const semantics::ResolvedModule &resolved, syntax::DiagnosticSink &diagnostics)
-                : file_{file}, module_{module}, resolved_{resolved}, diagnostics_{diagnostics},
-                  types_{standard_types()}, registry_{hgraph::TypeRegistry::instance()}
-            {
-            }
+            Compiler(const syntax::SourceFile &file, const gir::Module &module, syntax::DiagnosticSink &diagnostics)
+                : file_{file}, module_{module}, diagnostics_{diagnostics}, bridge_{module, diagnostics},
+                  registry_{hgraph::TypeRegistry::instance()} {}
 
-            [[nodiscard]] std::vector<TestResult> run_tests(const TestOptions &options);
-            [[nodiscard]] bool run_program(const RunOptions &options, std::ostream &out);
+            [[nodiscard]] std::vector<TestResult>      run_tests(const TestOptions &options);
+            [[nodiscard]] bool                         run_program(const RunOptions &options, std::ostream &out);
+            [[nodiscard]] std::optional<hgraph::Value> evaluate_constant(gir::ValueId value);
 
           private:
-            // -- diagnostics
-            [[noreturn]] void fail(Category category, SourceRange range, std::string message)
-            {
+            [[noreturn]] void fail(Category category, SourceRange range, std::string message) {
                 diagnostics_.report(category, range, std::move(message));
                 throw Abort{};
             }
-            [[noreturn]] void backend(SourceRange range, std::string message)
-            {
+
+            [[noreturn]] void backend(SourceRange range, std::string message) {
                 fail(Category::Backend, range, std::move(message));
             }
 
-            // -- types
-            [[nodiscard]] const hgraph::ValueTypeMetaData *scalar_meta(ast::ScalarType scalar, SourceRange range);
-            [[nodiscard]] const hgraph::ValueTypeMetaData *value_meta_for_type(ast::TypeId id, Frame &frame);
-            [[nodiscard]] const hgraph::TSValueTypeMetaData *schema_for_type(ast::TypeId id, Frame &frame);
-            [[nodiscard]] std::size_t size_argument(ast::ExprId id, Frame &frame, std::string_view what);
-            [[nodiscard]] hgraph::Value convert(const hgraph::Value &value, const hgraph::ValueTypeMetaData *target,
-                                                SourceRange range, std::string_view what);
-
-            struct ActiveTypeArgument
-            {
-                ast::DeclId                      decl{ast::no_node};
-                std::uint32_t                    index{0};
-                const hgraph::ValueTypeMetaData *meta{nullptr};
-                ast::TypeId                      source_type{ast::no_node};
-                ast::DeclId                      source_struct{ast::no_node};
-            };
-
-            struct AppliedStruct
-            {
-                ast::DeclId                                    decl{ast::no_node};
-                std::size_t                                    mark{0};
-                std::string                                    local_name{};
-                std::vector<const hgraph::ValueTypeMetaData *> generic_types{};
-            };
-
-            struct RuntimeStructField
-            {
-                std::string                        name{};
-                const hgraph::ValueTypeMetaData   *value_meta{nullptr};
-                const hgraph::TSValueTypeMetaData *schema{nullptr};
-                bool                               optional{false};
-                bool                               has_default{false};
-                Slot                               default_value{};
-            };
-
-            [[nodiscard]] AppliedStruct                    apply_struct(ast::TypeId id, Frame &frame);
-            [[nodiscard]] AppliedStruct                    apply_plain_struct(ast::DeclId decl, SourceRange range);
-            void                                           restore_types(std::size_t mark) { active_type_arguments_.resize(mark); }
-            [[nodiscard]] const hgraph::ValueTypeMetaData *type_argument(const ast::GenericArgument &argument, Frame &frame);
-            [[nodiscard]] const hgraph::ValueTypeMetaData *named_type_argument(std::string_view name, SourceRange range,
-                                                                               Frame &frame);
-            [[nodiscard]] const hgraph::ValueTypeMetaData *struct_value_meta(const AppliedStruct &applied, Frame &frame);
-            [[nodiscard]] const hgraph::TSValueTypeMetaData *struct_schema(const AppliedStruct &applied, Frame &frame);
-            [[nodiscard]] std::vector<RuntimeStructField>    struct_fields(const AppliedStruct &applied, Frame &frame,
-                                                                           bool evaluate_defaults);
-            [[nodiscard]] Slot eval_construct(ast::DeclId decl, ast::TypeId type, const std::vector<ast::Argument> &arguments,
-                                              bool delta, SourceRange range, Frame &frame);
-
-            // -- constants
-            [[nodiscard]] bool is_type(const Slot &slot, const hgraph::ValueTypeMetaData *meta) const noexcept
-            {
-                return slot.is_const() && slot.meta() == meta;
+            [[nodiscard]] const gir::Value &value(gir::ValueId id) {
+                if (!id.valid() || id.value >= module_.values.size()) { backend({}, "invalid hgraph IR value ID"); }
+                return module_.values[id.value];
             }
-            [[nodiscard]] bool is_int(const Slot &slot) const noexcept { return is_type(slot, types_.int_type); }
-            [[nodiscard]] bool is_float(const Slot &slot) const noexcept { return is_type(slot, types_.float_type); }
-            [[nodiscard]] bool is_bool(const Slot &slot) const noexcept { return is_type(slot, types_.bool_type); }
-            [[nodiscard]] bool is_str(const Slot &slot) const noexcept { return is_type(slot, types_.str_type); }
-            [[nodiscard]] static hgraph::Int as_int(const Slot &slot) { return slot.value.view().checked_as<hgraph::Int>(); }
-            [[nodiscard]] static hgraph::Float as_float(const Slot &slot)
-            {
-                return slot.value.view().checked_as<hgraph::Float>();
+
+            [[nodiscard]] const gir::Callable &callable(gir::CallableId id) {
+                if (!id.valid() || id.value >= module_.callables.size()) { backend({}, "invalid hgraph IR callable ID"); }
+                return module_.callables[id.value];
             }
-            [[nodiscard]] static hgraph::Bool as_bool(const Slot &slot)
-            {
-                return slot.value.view().checked_as<hgraph::Bool>();
+
+            [[nodiscard]] const gir::Binding &binding(gir::BindingId id) {
+                if (!id.valid() || id.value >= module_.bindings.size()) { backend({}, "invalid hgraph IR binding ID"); }
+                return module_.bindings[id.value];
             }
-            [[nodiscard]] hgraph::Float as_number(const Slot &slot) const
-            {
-                return is_int(slot) ? static_cast<hgraph::Float>(as_int(slot)) : as_float(slot);
+
+            [[nodiscard]] const gir::StructContract &structure(gir::TypeId type) {
+                if (!type.valid() || type.value >= module_.types.size()) { backend({}, "invalid hgraph IR type ID"); }
+                const std::string &identity = module_.types[type.value].nominal_identity;
+                const auto         found = std::find_if(module_.structures.begin(), module_.structures.end(),
+                                                        [&](const gir::StructContract &item) { return item.identity == identity; });
+                if (found == module_.structures.end()) {
+                    backend(module_.types[type.value].range, "unknown struct '" + identity + "'");
+                }
+                return *found;
             }
-            [[nodiscard]] Slot fold_binary(ast::BinaryOp op, const Slot &lhs, const Slot &rhs, SourceRange range);
-            [[nodiscard]] Slot fold_unary(ast::UnaryOp op, const Slot &operand, SourceRange range);
+
+            [[nodiscard]] const hgraph::ValueTypeMetaData *value_meta(gir::TypeId type) {
+                const auto *result = bridge_.value(type);
+                if (result == nullptr) { throw Abort{}; }
+                return result;
+            }
+
+            [[nodiscard]] const hgraph::TSValueTypeMetaData *schema(gir::TypeId type) {
+                const auto *result = bridge_.schema(type);
+                if (result == nullptr) { throw Abort{}; }
+                return result;
+            }
+
+            [[nodiscard]] std::string slice(SourceRange range) const { return std::string{file_.slice(range)}; }
+
+            [[nodiscard]] Slot          constant(const hir::Constant &constant, SourceRange range);
+            [[nodiscard]] Slot          eval_const_expr(gir::ConstExprId id, Frame &frame);
+            [[nodiscard]] hgraph::Value convert(const hgraph::Value &source, const hgraph::ValueTypeMetaData *target,
+                                                SourceRange range, std::string_view role);
+            [[nodiscard]] Slot          fold_unary(hir::UnaryOp op, const Slot &operand, SourceRange range);
+            [[nodiscard]] Slot          fold_binary(hir::BinaryOp op, const Slot &lhs, const Slot &rhs, SourceRange range);
             [[nodiscard]] Slot compare_sequences(const Slot &lhs, const Slot &rhs, bool negate, SourceRange range, Frame &frame);
-            void               resolve_sequence(Slot &slot, const hgraph::ValueTypeMetaData *elem_meta, Frame &frame);
+            void               resolve_sequence(Slot &slot, const hgraph::ValueTypeMetaData *element, Frame &frame);
             [[nodiscard]] Slot constant_of(const Slot &slot, const hgraph::ValueTypeMetaData *meta, Frame &frame,
-                                           const std::string &what);
+                                           std::string_view role);
 
-            // -- wiring
-            [[nodiscard]] hgraph::Wiring &wiring(SourceRange range)
-            {
+            [[nodiscard]] hgraph::Wiring &wiring(SourceRange range) {
                 if (wiring_ == nullptr) { backend(range, "a time-series expression is only wired inside eval or a run"); }
                 return *wiring_;
             }
-            [[nodiscard]] Slot              wire(std::string_view name, std::vector<hgraph::WiringArg> args, SourceRange range,
+
+            [[nodiscard]] Slot              wire(std::string_view name, std::vector<hgraph::WiringArg> arguments, SourceRange range,
                                                  std::optional<bool>                output_required = std::nullopt,
                                                  const hgraph::TSValueTypeMetaData *expected        = nullptr);
             [[nodiscard]] hgraph::WiringArg argument_of(const Slot &slot, std::string name);
-            [[nodiscard]] Slot              wire_constant(const Slot &slot, const hgraph::TSValueTypeMetaData *schema);
-            [[nodiscard]] Slot              wire_binary(ast::BinaryOp op, const Slot &lhs, const Slot &rhs, SourceRange range);
+            [[nodiscard]] Slot              wire_constant(const Slot &slot, const hgraph::TSValueTypeMetaData *target);
+            [[nodiscard]] Slot wire_binary(const gir::Value &expression, hir::BinaryOp op, const Slot &lhs, const Slot &rhs);
 
-            // -- evaluation
-            [[nodiscard]] Slot eval_expr(ast::ExprId id, Frame &frame);
-            [[nodiscard]] Slot eval_name(ast::ExprId id, Frame &frame);
-            [[nodiscard]] Slot eval_call(const ast::Call &call, SourceRange range, Frame &frame);
-            [[nodiscard]] Slot eval_intrinsic(const Slot &callee, const ast::Call &call, SourceRange range, Frame &frame);
-            [[nodiscard]] Slot eval_eval(const ast::Eval &eval, SourceRange range, Frame &frame);
-            [[nodiscard]] Slot call_function(ast::DeclId decl, const std::vector<ast::Argument> &arguments, SourceRange range,
+            [[nodiscard]] Slot eval_value(gir::ValueId id, Frame &frame);
+            [[nodiscard]] Slot eval_reference(const gir::Reference &reference, SourceRange range, Frame &frame);
+            [[nodiscard]] Slot eval_call(const gir::Value &expression, const gir::Call &call, Frame &frame);
+            [[nodiscard]] Slot eval_intrinsic(std::string_view name, const std::vector<gir::Argument> &arguments, SourceRange range,
+                                              Frame &frame);
+            [[nodiscard]] Slot eval_harness(const gir::HarnessEval &eval, SourceRange range, Frame &frame);
+            [[nodiscard]] Slot eval_sequence(gir::ValueId id, const gir::Sequence &sequence, SourceRange range, Frame &frame);
+            [[nodiscard]] Slot eval_tuple(const gir::Tuple &tuple, SourceRange range, Frame &frame);
+            [[nodiscard]] Slot assemble_construct(gir::TypeId type, std::vector<std::pair<std::string, Slot>> supplied, bool delta,
+                                                  SourceRange range, Frame &frame);
+            [[nodiscard]] Slot eval_construct(gir::TypeId type, const std::vector<gir::Argument> &arguments, bool delta,
+                                              SourceRange range, Frame &frame);
+            [[nodiscard]] Slot call_function(gir::CallableId id, const std::vector<gir::Argument> &arguments, SourceRange range,
                                              Frame &frame);
-            [[nodiscard]] Slot wire_function(ast::DeclId decl, Frame &callee, SourceRange range);
-            [[nodiscard]] Slot invoke(ast::DeclId decl, Frame &callee);
-            [[nodiscard]] Slot exec_block(ast::BlockId id, Frame &frame);
-            void               exec_stmt(ast::StmtId id, Frame &frame);
-            [[nodiscard]] Slot eval_if(const ast::If &node, Frame &frame);
-            [[nodiscard]] Slot eval_tuple(const ast::TupleLiteral &node, SourceRange range, Frame &frame);
-            [[nodiscard]] Slot eval_list(const ast::SequenceLiteral &node, SourceRange range, Frame &frame);
-            [[nodiscard]] Slot eval_literal(const ast::TemporalLiteral &node, SourceRange range);
-            [[nodiscard]] Slot bind_parameter(const ast::Parameter &param, const Slot &arg, Frame &callee, SourceRange range);
-            [[nodiscard]] std::vector<ast::ExprId> bind_arguments(const ast::FunctionDecl          &fn,
-                                                                  const std::vector<ast::Argument> &arguments, SourceRange range);
-            [[nodiscard]] std::string              describe(const Slot &slot);
-            [[nodiscard]] const ast::FunctionDecl &function(ast::DeclId decl) const
-            { return std::get<ast::FunctionDecl>(module_.decl(decl).node); }
-            [[nodiscard]] std::string slice(SourceRange range) const { return std::string{file_.slice(range)}; }
-
-            // -- programs
-            [[nodiscard]] std::optional<hgraph::Value> setting_value(const Setting &setting, const ast::Parameter &param,
-                                                                     Frame &frame, SourceRange range);
+            [[nodiscard]] Slot wire_function(gir::CallableId id, Frame &frame, SourceRange range);
+            [[nodiscard]] Slot invoke(gir::CallableId id, Frame &frame);
+            [[nodiscard]] Slot exec_block(gir::BlockId id, Frame &frame);
+            void               exec_statement(gir::StatementId id, Frame &frame);
+            [[nodiscard]] std::vector<std::optional<gir::ValueId>>
+            bind_arguments(const gir::Callable &target, const std::vector<gir::Argument> &arguments, SourceRange range);
+            [[nodiscard]] Slot        bind_parameter(const gir::Parameter &parameter, const Slot &argument, Frame &frame,
+                                                     SourceRange range);
+            [[nodiscard]] std::string describe(const Slot &slot);
 
             const syntax::SourceFile                      &file_;
-            const ast::Module                             &module_;
-            const semantics::ResolvedModule               &resolved_;
+            const gir::Module                             &module_;
             syntax::DiagnosticSink                        &diagnostics_;
-            const hgraph::stdlib::RegisteredStandardTypes &types_;
+            TypeBridge                                     bridge_;
             hgraph::TypeRegistry                          &registry_;
+            const hgraph::stdlib::RegisteredStandardTypes &types_{standard_types()};
             hgraph::Wiring                                *wiring_{nullptr};
-            std::string                                    compare_detail_{};
-            std::vector<ActiveTypeArgument>                active_type_arguments_{};
+            std::string                                    comparison_detail_{};
         };
 
-        // ------------------------------------------------------------- types
-
-        Compiler::AppliedStruct Compiler::apply_plain_struct(ast::DeclId decl, SourceRange range)
-        {
-            const auto &structure = std::get<ast::StructDecl>(module_.decl(decl).node);
-            if (!structure.generics.empty())
-            {
-                backend(range, "generic struct '" + std::string{structure.name.text} +
-                                   "' needs explicit arguments in the executable prototype");
-            }
-            AppliedStruct applied;
-            applied.decl       = decl;
-            applied.mark       = active_type_arguments_.size();
-            applied.local_name = std::string{structure.name.text};
-            return applied;
-        }
-
-        const hgraph::ValueTypeMetaData *Compiler::named_type_argument(std::string_view name, SourceRange range, Frame &frame)
-        {
-            for (auto active = active_type_arguments_.rbegin(); active != active_type_arguments_.rend(); ++active)
-            {
-                const ast::DeclNode                      &decl     = module_.decl(active->decl).node;
-                const std::vector<ast::GenericParameter> *generics = nullptr;
-                if (const auto *structure = std::get_if<ast::StructDecl>(&decl)) { generics = &structure->generics; }
-                else if (const auto *fn = std::get_if<ast::FunctionDecl>(&decl)) { generics = &fn->generics; }
-                else if (const auto *op = std::get_if<ast::OperatorDecl>(&decl)) { generics = &op->generics; }
-                if (generics != nullptr && active->index < generics->size() && (*generics)[active->index].name.text == name)
-                {
-                    return active->meta;
-                }
-            }
-            for (const ast::DeclId id : resolved_.structs)
-            {
-                const auto &structure = std::get<ast::StructDecl>(module_.decl(id).node);
-                if (structure.name.text != name) { continue; }
-                const AppliedStruct applied = apply_plain_struct(id, range);
-                return struct_value_meta(applied, frame);
-            }
-            backend(range, "unresolved type argument '" + std::string{name} + "'");
-        }
-
-        const hgraph::ValueTypeMetaData *Compiler::type_argument(const ast::GenericArgument &argument, Frame &frame)
-        {
-            if (argument.type != ast::no_node) { return value_meta_for_type(argument.type, frame); }
-            if (!argument.name.empty()) { return named_type_argument(argument.name.text, argument.name.range, frame); }
-            backend(argument.range, "a type parameter cannot be bound from a value argument");
-        }
-
-        Compiler::AppliedStruct Compiler::apply_struct(ast::TypeId id, Frame &frame)
-        {
-            const ast::Type          &type    = module_.type(id);
-            const semantics::Binding &binding = resolved_.type_binding(id);
-            if (type.kind != ast::TypeKind::Named || binding.kind != BindingKind::Struct)
-            {
-                backend(type.range, "expected a resolved struct type");
-            }
-            const auto   &structure = std::get<ast::StructDecl>(module_.decl(binding.decl).node);
-            AppliedStruct applied;
-            applied.decl       = binding.decl;
-            applied.mark       = active_type_arguments_.size();
-            applied.local_name = std::string{structure.name.text};
-            try
-            {
-                for (std::size_t i = 0; i < structure.generics.size(); ++i)
-                {
-                    const ast::GenericParameter &parameter = structure.generics[i];
-                    if (parameter.is_const)
-                    {
-                        backend(type.arguments[i].range, "const generic struct arguments require typed constant Bundle "
-                                                         "metadata in hgraph");
-                    }
-                    const hgraph::ValueTypeMetaData *meta = type_argument(type.arguments[i], frame);
-                    ActiveTypeArgument               active;
-                    active.decl  = binding.decl;
-                    active.index = static_cast<std::uint32_t>(i);
-                    active.meta  = meta;
-                    if (type.arguments[i].type != ast::no_node) { active.source_type = type.arguments[i].type; }
-                    else if (!type.arguments[i].name.empty())
-                    {
-                        for (auto outer = active_type_arguments_.rbegin(); outer != active_type_arguments_.rend(); ++outer)
-                        {
-                            const ast::DeclNode                      &outer_decl     = module_.decl(outer->decl).node;
-                            const std::vector<ast::GenericParameter> *outer_generics = nullptr;
-                            if (const auto *s = std::get_if<ast::StructDecl>(&outer_decl)) { outer_generics = &s->generics; }
-                            else if (const auto *f = std::get_if<ast::FunctionDecl>(&outer_decl)) { outer_generics = &f->generics; }
-                            else if (const auto *o = std::get_if<ast::OperatorDecl>(&outer_decl)) { outer_generics = &o->generics; }
-                            if (outer_generics != nullptr && outer->index < outer_generics->size() &&
-                                (*outer_generics)[outer->index].name.text == type.arguments[i].name.text)
-                            {
-                                active.source_type   = outer->source_type;
-                                active.source_struct = outer->source_struct;
-                                break;
-                            }
-                        }
-                        if (active.source_type == ast::no_node && active.source_struct == ast::no_node)
-                        {
-                            for (const ast::DeclId candidate : resolved_.structs)
-                            {
-                                if (std::get<ast::StructDecl>(module_.decl(candidate).node).name.text ==
-                                    type.arguments[i].name.text)
-                                {
-                                    active.source_struct = candidate;
-                                    break;
-                                }
-                            }
+        Slot Compiler::constant(const hir::Constant &source, SourceRange range) {
+            return std::visit(
+                [&](const auto &item) -> Slot {
+                    using T = std::decay_t<decltype(item)>;
+                    if constexpr (std::is_same_v<T, bool> || std::is_same_v<T, std::int64_t> || std::is_same_v<T, double> ||
+                                  std::is_same_v<T, std::string>) {
+                        return make_const(hgraph::Value{item}, range);
+                    } else if constexpr (std::is_same_v<T, hir::NullValue>) {
+                        return make_marker(Slot::Kind::Null, range);
+                    } else if constexpr (std::is_same_v<T, hir::PlaceholderValue>) {
+                        return make_marker(Slot::Kind::Placeholder, range);
+                    } else if constexpr (std::is_same_v<T, syntax::TemporalValue>) {
+                        switch (item.kind) {
+                            case syntax::TemporalKind::Date:
+                                return make_const(
+                                    hgraph::Value{hgraph::Date{std::chrono::sys_days{std::chrono::days{item.micros}}}}, range);
+                            case syntax::TemporalKind::Time: return make_const(hgraph::Value{hgraph::Time{item.micros}}, range);
+                            case syntax::TemporalKind::DateTime:
+                                return make_const(hgraph::Value{hgraph::DateTime{std::chrono::microseconds{item.micros}}}, range);
+                            case syntax::TemporalKind::Duration:
+                                return make_const(hgraph::Value{hgraph::TimeDelta{item.micros}}, range);
+                            case syntax::TemporalKind::CivilDateTime:
+                            case syntax::TemporalKind::ZonedDateTime:
+                            case syntax::TemporalKind::ZonedTime:
+                            case syntax::TemporalKind::TimeZone:
+                                backend(range, "zoned and civil literals are not supported by the first pass");
                         }
                     }
-                    active_type_arguments_.push_back(active);
-                    applied.generic_types.push_back(meta);
-                }
-            }
-            catch (...)
-            {
-                restore_types(applied.mark);
-                throw;
-            }
-            if (!applied.generic_types.empty())
-            {
-                applied.local_name += '[';
-                for (std::size_t i = 0; i < applied.generic_types.size(); ++i)
-                {
-                    if (i != 0) { applied.local_name += ','; }
-                    applied.local_name += applied.generic_types[i]->name();
-                }
-                applied.local_name += ']';
-            }
-            return applied;
+                    backend(range, "unsupported hgraph IR constant");
+                },
+                source);
         }
 
-        std::vector<Compiler::RuntimeStructField> Compiler::struct_fields(const AppliedStruct &applied, Frame &frame,
-                                                                          bool evaluate_defaults)
-        {
-            const auto &structure = std::get<ast::StructDecl>(module_.decl(applied.decl).node);
-            if (!resolved_.structure(applied.decl).valid)
-            {
-                backend(structure.name.range, "struct '" + std::string{structure.name.text} + "' is not valid");
+        hgraph::Value Compiler::convert(const hgraph::Value &source, const hgraph::ValueTypeMetaData *target, SourceRange range,
+                                        std::string_view role) {
+            const hgraph::ValueTypeMetaData *actual = source.schema();
+            if (actual == target) { return source; }
+            if (actual == types_.int_type && target == types_.float_type) {
+                return hgraph::Value{static_cast<hgraph::Float>(source.view().checked_as<hgraph::Int>())};
             }
-            std::vector<RuntimeStructField> fields;
-            for (const ast::TypeId parent_type : structure.parents)
-            {
-                AppliedStruct parent = apply_struct(parent_type, frame);
-                try
-                {
-                    std::vector<RuntimeStructField> inherited = struct_fields(parent, frame, evaluate_defaults);
-                    fields.insert(fields.end(), std::make_move_iterator(inherited.begin()),
-                                  std::make_move_iterator(inherited.end()));
-                }
-                catch (...)
-                {
-                    restore_types(parent.mark);
-                    throw;
-                }
-                restore_types(parent.mark);
-            }
-
-            for (const ast::StructMember &member : structure.members)
-            {
-                if (const auto *field = std::get_if<ast::StructField>(&member))
-                {
-                    RuntimeStructField runtime;
-                    runtime.name        = std::string{field->name.text};
-                    runtime.value_meta  = value_meta_for_type(field->type, frame);
-                    runtime.schema      = schema_for_type(field->type, frame);
-                    runtime.optional    = field->default_value != ast::no_node &&
-                                          std::holds_alternative<ast::NullLiteral>(module_.expr(field->default_value).node);
-                    runtime.has_default = field->default_value != ast::no_node;
-                    if (evaluate_defaults && runtime.has_default)
-                    {
-                        runtime.default_value = eval_expr(field->default_value, frame);
-                    }
-                    fields.push_back(std::move(runtime));
-                    continue;
-                }
-                const auto &override = std::get<ast::InheritedDefault>(member);
-                auto        found = std::find_if(fields.begin(), fields.end(),
-                                                 [&](const RuntimeStructField &field) { return field.name == override.name.text; });
-                if (found == fields.end()) { backend(override.name.range, "unresolved inherited default"); }
-                found->has_default = true;
-                if (evaluate_defaults) { found->default_value = eval_expr(override.value, frame); }
-            }
-            return fields;
-        }
-
-        const hgraph::ValueTypeMetaData *Compiler::struct_value_meta(const AppliedStruct &applied, Frame &frame)
-        {
-            const auto                           &structure      = std::get<ast::StructDecl>(module_.decl(applied.decl).node);
-            const std::vector<RuntimeStructField> runtime_fields = struct_fields(applied, frame, false);
-            std::vector<std::pair<std::string, const hgraph::ValueTypeMetaData *>> fields;
-            fields.reserve(runtime_fields.size());
-            for (const RuntimeStructField &field : runtime_fields) { fields.emplace_back(field.name, field.value_meta); }
-
-            std::vector<const hgraph::ValueTypeMetaData *> parents;
-            for (const ast::TypeId parent_type : structure.parents)
-            {
-                AppliedStruct parent = apply_struct(parent_type, frame);
-                try
-                {
-                    parents.push_back(struct_value_meta(parent, frame));
-                }
-                catch (...)
-                {
-                    restore_types(parent.mark);
-                    throw;
-                }
-                restore_types(parent.mark);
-            }
-            try
-            {
-                return registry_.bundle(resolved_.module_path, applied.local_name, fields, parents, structure.abstract, "__type__",
-                                        applied.generic_types);
-            }
-            catch (const std::exception &error)
-            {
-                backend(structure.name.range, "cannot register struct '" + applied.local_name + "': " + error.what());
-            }
-        }
-
-        const hgraph::TSValueTypeMetaData *Compiler::struct_schema(const AppliedStruct &applied, Frame &frame)
-        {
-            const hgraph::ValueTypeMetaData      *value_meta     = struct_value_meta(applied, frame);
-            const std::vector<RuntimeStructField> runtime_fields = struct_fields(applied, frame, false);
-            std::vector<std::pair<std::string, const hgraph::TSValueTypeMetaData *>> fields;
-            fields.reserve(runtime_fields.size());
-            for (const RuntimeStructField &field : runtime_fields) { fields.emplace_back(field.name, field.schema); }
-            try
-            {
-                return registry_.tsb(value_meta->name(), fields);
-            }
-            catch (const std::exception &error)
-            {
-                backend(module_.decl(applied.decl).range,
-                        "cannot register temporal struct '" + applied.local_name + "': " + error.what());
-            }
-        }
-
-        const hgraph::ValueTypeMetaData *Compiler::scalar_meta(ast::ScalarType scalar, SourceRange range)
-        {
-            switch (scalar)
-            {
-                case ast::ScalarType::Bool: return types_.bool_type;
-                case ast::ScalarType::I64: return types_.int_type;
-                case ast::ScalarType::F64: return types_.float_type;
-                case ast::ScalarType::Str: return types_.str_type;
-                case ast::ScalarType::Date: return types_.date_type;
-                case ast::ScalarType::Time: return types_.time_type;
-                case ast::ScalarType::DateTime: return types_.datetime_type;
-                case ast::ScalarType::Duration: return types_.timedelta_type;
-                case ast::ScalarType::CivilDateTime:
-                case ast::ScalarType::ZonedDateTime:
-                case ast::ScalarType::ZonedTime:
-                case ast::ScalarType::TimeZone: break;
-            }
-            backend(range, std::string{"'"} + std::string{ast::scalar_type_name(scalar)} +
-                               "' is not supported by the first pass (datetime and duration are)");
-        }
-
-        std::size_t Compiler::size_argument(ast::ExprId id, Frame &frame, std::string_view what)
-        {
-            const Slot slot = eval_expr(id, frame);
-            if (!is_int(slot) || as_int(slot) < 0)
-            {
-                fail(Category::Type, module_.expr(id).range,
-                     std::string{what} + " must be a non-negative i64 constant");
-            }
-            return static_cast<std::size_t>(as_int(slot));
-        }
-
-        const hgraph::ValueTypeMetaData *Compiler::value_meta_for_type(ast::TypeId id, Frame &frame)
-        {
-            const ast::Type &type = module_.type(id);
-            switch (type.kind)
-            {
-                case ast::TypeKind::Scalar: return scalar_meta(type.scalar, type.range);
-                case ast::TypeKind::Named: {
-                    const semantics::Binding &binding = resolved_.type_binding(id);
-                    if (binding.kind == BindingKind::Generic)
-                    {
-                        for (auto active = active_type_arguments_.rbegin(); active != active_type_arguments_.rend(); ++active)
-                        {
-                            if (active->decl == binding.decl && active->index == binding.index) { return active->meta; }
-                        }
-                        backend(type.range, "generic type '" + std::string{type.name.text} + "' is not bound");
-                    }
-                    if (binding.kind == BindingKind::Struct)
-                    {
-                        AppliedStruct applied = apply_struct(id, frame);
-                        try
-                        {
-                            const hgraph::ValueTypeMetaData *meta = struct_value_meta(applied, frame);
-                            restore_types(applied.mark);
-                            return meta;
-                        }
-                        catch (...)
-                        {
-                            restore_types(applied.mark);
-                            throw;
-                        }
-                    }
-                    backend(type.range, "unresolved named value type '" + std::string{type.name.text} + "'");
-                }
-                case ast::TypeKind::Tuple: {
-                    std::vector<const hgraph::ValueTypeMetaData *> elements;
-                    elements.reserve(type.children.size());
-                    for (ast::TypeId child : type.children) { elements.push_back(value_meta_for_type(child, frame)); }
-                    return registry_.tuple(elements);
-                }
-                case ast::TypeKind::List: {
-                    const auto       *element = value_meta_for_type(type.children[0], frame);
-                    const std::size_t size    = type.size == ast::no_node ? 0 : size_argument(type.size, frame, "a list size");
-                    return registry_.list(element, size);
-                }
-                case ast::TypeKind::Set: return registry_.set(value_meta_for_type(type.children[0], frame));
-                case ast::TypeKind::Map:
-                    return registry_.map(value_meta_for_type(type.children[0], frame),
-                                         value_meta_for_type(type.children[1], frame));
-                case ast::TypeKind::Rolling: backend(type.range, "'rolling' has no value type; it is a time-series window");
-                case ast::TypeKind::Atomic: return value_meta_for_type(type.children[0], frame);
-            }
-            backend(type.range, "unsupported type");
-        }
-
-        const hgraph::TSValueTypeMetaData *Compiler::schema_for_type(ast::TypeId id, Frame &frame)
-        {
-            const ast::Type &type = module_.type(id);
-            switch (type.kind)
-            {
-                case ast::TypeKind::Scalar: return registry_.ts(scalar_meta(type.scalar, type.range));
-                case ast::TypeKind::Named: {
-                    const semantics::Binding &binding = resolved_.type_binding(id);
-                    if (binding.kind == BindingKind::Generic)
-                    {
-                        for (auto active = active_type_arguments_.rbegin(); active != active_type_arguments_.rend(); ++active)
-                        {
-                            if (active->decl == binding.decl && active->index == binding.index)
-                            {
-                                if (active->source_type != ast::no_node) { return schema_for_type(active->source_type, frame); }
-                                if (active->source_struct != ast::no_node)
-                                {
-                                    const AppliedStruct source = apply_plain_struct(active->source_struct, type.range);
-                                    return struct_schema(source, frame);
-                                }
-                                return registry_.ts(active->meta);
-                            }
-                        }
-                        backend(type.range, "generic type '" + std::string{type.name.text} + "' is not bound");
-                    }
-                    if (binding.kind == BindingKind::Struct)
-                    {
-                        AppliedStruct applied = apply_struct(id, frame);
-                        try
-                        {
-                            const hgraph::TSValueTypeMetaData *schema = struct_schema(applied, frame);
-                            restore_types(applied.mark);
-                            return schema;
-                        }
-                        catch (...)
-                        {
-                            restore_types(applied.mark);
-                            throw;
-                        }
-                    }
-                    backend(type.range, "unresolved named time-series type '" + std::string{type.name.text} + "'");
-                }
-                case ast::TypeKind::Tuple:
-                    backend(type.range, "a structural tuple has no first-pass schema; write "
-                                        "atomic<tuple<...>> for one value");
-                case ast::TypeKind::List: {
-                    const auto       *element = schema_for_type(type.children[0], frame);
-                    const std::size_t size    = type.size == ast::no_node ? 0 : size_argument(type.size, frame, "a list size");
-                    return registry_.tsl(element, size);
-                }
-                case ast::TypeKind::Set: return registry_.tss(value_meta_for_type(type.children[0], frame));
-                case ast::TypeKind::Map:
-                    return registry_.tsd(value_meta_for_type(type.children[0], frame), schema_for_type(type.children[1], frame));
-                case ast::TypeKind::Rolling: {
-                    const auto *element = value_meta_for_type(type.children[0], frame);
-                    const Slot  size    = eval_expr(type.size, frame);
-                    if (is_type(size, types_.timedelta_type))
-                    {
-                        const auto range = size.value.view().checked_as<hgraph::TimeDelta>();
-                        hgraph::TimeDelta min{0};
-                        if (type.min_size != ast::no_node)
-                        {
-                            const Slot min_slot = eval_expr(type.min_size, frame);
-                            if (!is_type(min_slot, types_.timedelta_type))
-                            {
-                                fail(Category::Type, module_.expr(type.min_size).range,
-                                     "a duration window takes a duration minimum");
-                            }
-                            min = min_slot.value.view().checked_as<hgraph::TimeDelta>();
-                        }
-                        return registry_.tsw_duration(element, range, min);
-                    }
-                    if (!is_int(size) || as_int(size) <= 0)
-                    {
-                        fail(Category::Type, module_.expr(type.size).range,
-                             "a rolling size is a positive i64 constant or a duration");
-                    }
-                    const auto max = static_cast<std::size_t>(as_int(size));
-                    std::size_t min = max;
-                    if (type.min_size != ast::no_node) { min = size_argument(type.min_size, frame, "a rolling minimum"); }
-                    return registry_.tsw(element, max, min);
-                }
-                case ast::TypeKind::Atomic: return registry_.ts(value_meta_for_type(type.children[0], frame));
-            }
-            backend(type.range, "unsupported type");
-        }
-
-        hgraph::Value Compiler::convert(const hgraph::Value &value, const hgraph::ValueTypeMetaData *target,
-                                        SourceRange range, std::string_view what)
-        {
-            const auto *source = value.schema();
-            if (source == target) { return value; }
-            if (source == types_.int_type && target == types_.float_type)
-            {
-                return hgraph::Value{static_cast<hgraph::Float>(value.view().checked_as<hgraph::Int>())};
-            }
-            const auto source_kind = source->try_value_kind();
-            const auto target_kind = target->try_value_kind();
-            if (source_kind == hgraph::ValueTypeKind::Tuple && target_kind == hgraph::ValueTypeKind::Tuple &&
-                source->field_count == target->field_count)
-            {
+            if (actual->try_value_kind() == hgraph::ValueTypeKind::Tuple &&
+                target->try_value_kind() == hgraph::ValueTypeKind::Tuple && actual->field_count == target->field_count) {
                 hgraph::Value result{hgraph::ValuePlanFactory::instance().type_for(target)};
-                auto          tuple  = result.as_tuple().begin_mutation();
-                const auto    fields = value.view().as_tuple();
-                for (std::size_t i = 0; i < target->field_count; ++i)
-                {
-                    const hgraph::Value element{fields.at(i)};
-                    tuple.at(i).copy_from(convert(element, target->fields[i].type, range, what).view());
+                auto          output = result.as_tuple().begin_mutation();
+                const auto    input  = source.view().as_tuple();
+                for (std::size_t index = 0; index < target->field_count; ++index) {
+                    output.at(index).copy_from(
+                        convert(hgraph::Value{input.at(index)}, target->fields[index].type, range, role).view());
                 }
                 return result;
             }
-            if (source_kind == hgraph::ValueTypeKind::List && target_kind == hgraph::ValueTypeKind::List)
-            {
-                hgraph::ListBuilder builder{hgraph::ValuePlanFactory::instance().type_for(target->element_type),
-                                            *target};
-                const auto          items = value.view().as_list();
-                for (std::size_t i = 0; i < items.size(); ++i)
-                {
-                    const hgraph::Value element{items.at(i)};
-                    builder.push_back(convert(element, target->element_type, range, what).view());
+            if (actual->try_value_kind() == hgraph::ValueTypeKind::List &&
+                target->try_value_kind() == hgraph::ValueTypeKind::List) {
+                hgraph::ListBuilder output{hgraph::ValuePlanFactory::instance().type_for(target->element_type), *target};
+                const auto          input = source.view().as_list();
+                for (std::size_t index = 0; index < input.size(); ++index) {
+                    output.push_back(convert(hgraph::Value{input.at(index)}, target->element_type, range, role).view());
                 }
-                return builder.build();
+                return output.build();
             }
             fail(Category::Type, range,
-                 std::string{what} + " expects " + std::string{target->name()} + ", got " +
-                     std::string{source->name()});
+                 std::string{role} + " expects " + std::string{target->name()} + ", got " + std::string{actual->name()});
         }
 
-        // --------------------------------------------------------- constants
-
-        Slot Compiler::fold_unary(ast::UnaryOp op, const Slot &operand, SourceRange range)
-        {
-            switch (op)
-            {
-                case ast::UnaryOp::Negate:
-                    if (is_int(operand)) { return make_const(hgraph::Value{hgraph::Int{-as_int(operand)}}, range); }
-                    if (is_float(operand)) { return make_const(hgraph::Value{hgraph::Float{-as_float(operand)}}, range); }
-                    if (is_type(operand, types_.timedelta_type))
-                    {
-                        return make_const(hgraph::Value{-operand.value.view().checked_as<hgraph::TimeDelta>()}, range);
-                    }
-                    fail(Category::Type, range, "unary '-' needs a number, got " + std::string{operand.meta()->name()});
-                case ast::UnaryOp::Not:
-                    if (is_bool(operand)) { return make_const(hgraph::Value{hgraph::Bool{!as_bool(operand)}}, range); }
-                    fail(Category::Type, range, "'!' needs a bool, got " + std::string{operand.meta()->name()});
+        Slot Compiler::fold_unary(hir::UnaryOp op, const Slot &operand, SourceRange range) {
+            if (op == hir::UnaryOp::Negate) {
+                if (operand.meta() == types_.int_type) {
+                    return make_const(hgraph::Value{hgraph::Int{-operand.value.view().checked_as<hgraph::Int>()}}, range);
+                }
+                if (operand.meta() == types_.float_type) {
+                    return make_const(hgraph::Value{hgraph::Float{-operand.value.view().checked_as<hgraph::Float>()}}, range);
+                }
+                if (operand.meta() == types_.timedelta_type) {
+                    return make_const(hgraph::Value{-operand.value.view().checked_as<hgraph::TimeDelta>()}, range);
+                }
+                fail(Category::Type, range, "unary '-' needs a number, got " + std::string{operand.meta()->name()});
             }
-            backend(range, "unsupported unary operator");
+            if (operand.meta() == types_.bool_type) {
+                return make_const(hgraph::Value{hgraph::Bool{!operand.value.view().checked_as<hgraph::Bool>()}}, range);
+            }
+            fail(Category::Type, range, "'!' needs a bool, got " + std::string{operand.meta()->name()});
         }
 
-        Slot Compiler::fold_binary(ast::BinaryOp op, const Slot &lhs, const Slot &rhs, SourceRange range)
-        {
-            using ast::BinaryOp;
-            const bool numeric = (is_int(lhs) || is_float(lhs)) && (is_int(rhs) || is_float(rhs));
-            const bool ints    = is_int(lhs) && is_int(rhs);
+        Slot Compiler::fold_binary(hir::BinaryOp op, const Slot &lhs, const Slot &rhs, SourceRange range) {
+            const bool lhs_int   = lhs.meta() == types_.int_type;
+            const bool rhs_int   = rhs.meta() == types_.int_type;
+            const bool lhs_float = lhs.meta() == types_.float_type;
+            const bool rhs_float = rhs.meta() == types_.float_type;
+            const bool numeric   = (lhs_int || lhs_float) && (rhs_int || rhs_float);
+            const auto number    = [&](const Slot &item) {
+                return item.meta() == types_.int_type ? static_cast<hgraph::Float>(item.value.view().checked_as<hgraph::Int>())
+                                                      : item.value.view().checked_as<hgraph::Float>();
+            };
             const auto type_error = [&]() -> Slot {
                 fail(Category::Type, range,
-                     std::string{"'"} + std::string{ast::binary_op_spelling(op)} + "' is not defined for " +
-                         std::string{lhs.meta()->name()} + " and " + std::string{rhs.meta()->name()});
+                     "'" + binary_spelling(op) + "' is not defined for " + std::string{lhs.meta()->name()} + " and " +
+                         std::string{rhs.meta()->name()});
             };
-            switch (op)
-            {
-                case BinaryOp::Add:
-                    if (ints) { return make_const(hgraph::Value{hgraph::Int{as_int(lhs) + as_int(rhs)}}, range); }
-                    if (numeric) { return make_const(hgraph::Value{as_number(lhs) + as_number(rhs)}, range); }
-                    if (is_str(lhs) && is_str(rhs))
-                    {
-                        return make_const(hgraph::Value{lhs.value.view().checked_as<hgraph::Str>() +
-                                                        rhs.value.view().checked_as<hgraph::Str>()},
+            switch (op) {
+                case hir::BinaryOp::Add:
+                    if (lhs_int && rhs_int) {
+                        return make_const(hgraph::Value{hgraph::Int{lhs.value.view().checked_as<hgraph::Int>() +
+                                                                    rhs.value.view().checked_as<hgraph::Int>()}},
                                           range);
                     }
-                    if (is_type(lhs, types_.timedelta_type) && is_type(rhs, types_.timedelta_type))
-                    {
+                    if (numeric) { return make_const(hgraph::Value{number(lhs) + number(rhs)}, range); }
+                    if (lhs.meta() == types_.str_type && rhs.meta() == types_.str_type) {
+                        return make_const(
+                            hgraph::Value{lhs.value.view().checked_as<hgraph::Str>() + rhs.value.view().checked_as<hgraph::Str>()},
+                            range);
+                    }
+                    if (lhs.meta() == types_.timedelta_type && rhs.meta() == types_.timedelta_type) {
                         return make_const(hgraph::Value{lhs.value.view().checked_as<hgraph::TimeDelta>() +
                                                         rhs.value.view().checked_as<hgraph::TimeDelta>()},
                                           range);
                     }
-                    if (is_type(lhs, types_.datetime_type) && is_type(rhs, types_.timedelta_type))
-                    {
+                    if (lhs.meta() == types_.datetime_type && rhs.meta() == types_.timedelta_type) {
                         return make_const(hgraph::Value{lhs.value.view().checked_as<hgraph::DateTime>() +
                                                         rhs.value.view().checked_as<hgraph::TimeDelta>()},
                                           range);
                     }
                     return type_error();
-                case BinaryOp::Sub:
-                    if (ints) { return make_const(hgraph::Value{hgraph::Int{as_int(lhs) - as_int(rhs)}}, range); }
-                    if (numeric) { return make_const(hgraph::Value{as_number(lhs) - as_number(rhs)}, range); }
-                    if (is_type(lhs, types_.timedelta_type) && is_type(rhs, types_.timedelta_type))
-                    {
+                case hir::BinaryOp::Sub:
+                    if (lhs_int && rhs_int) {
+                        return make_const(hgraph::Value{hgraph::Int{lhs.value.view().checked_as<hgraph::Int>() -
+                                                                    rhs.value.view().checked_as<hgraph::Int>()}},
+                                          range);
+                    }
+                    if (numeric) { return make_const(hgraph::Value{number(lhs) - number(rhs)}, range); }
+                    if (lhs.meta() == types_.timedelta_type && rhs.meta() == types_.timedelta_type) {
                         return make_const(hgraph::Value{lhs.value.view().checked_as<hgraph::TimeDelta>() -
                                                         rhs.value.view().checked_as<hgraph::TimeDelta>()},
                                           range);
                     }
-                    if (is_type(lhs, types_.datetime_type) && is_type(rhs, types_.timedelta_type))
-                    {
+                    if (lhs.meta() == types_.datetime_type && rhs.meta() == types_.timedelta_type) {
                         return make_const(hgraph::Value{lhs.value.view().checked_as<hgraph::DateTime>() -
                                                         rhs.value.view().checked_as<hgraph::TimeDelta>()},
                                           range);
                     }
-                    if (is_type(lhs, types_.datetime_type) && is_type(rhs, types_.datetime_type))
-                    {
+                    if (lhs.meta() == types_.datetime_type && rhs.meta() == types_.datetime_type) {
                         return make_const(hgraph::Value{lhs.value.view().checked_as<hgraph::DateTime>() -
                                                         rhs.value.view().checked_as<hgraph::DateTime>()},
                                           range);
                     }
                     return type_error();
-                case BinaryOp::Mul:
-                    if (ints) { return make_const(hgraph::Value{hgraph::Int{as_int(lhs) * as_int(rhs)}}, range); }
-                    if (numeric) { return make_const(hgraph::Value{as_number(lhs) * as_number(rhs)}, range); }
-                    if (is_type(lhs, types_.timedelta_type) && is_int(rhs))
-                    {
-                        return make_const(
-                            hgraph::Value{lhs.value.view().checked_as<hgraph::TimeDelta>() * as_int(rhs)}, range);
+                case hir::BinaryOp::Mul:
+                    if (lhs_int && rhs_int) {
+                        return make_const(hgraph::Value{hgraph::Int{lhs.value.view().checked_as<hgraph::Int>() *
+                                                                    rhs.value.view().checked_as<hgraph::Int>()}},
+                                          range);
+                    }
+                    if (numeric) { return make_const(hgraph::Value{number(lhs) * number(rhs)}, range); }
+                    if (lhs.meta() == types_.timedelta_type && rhs_int) {
+                        return make_const(hgraph::Value{lhs.value.view().checked_as<hgraph::TimeDelta>() *
+                                                        rhs.value.view().checked_as<hgraph::Int>()},
+                                          range);
                     }
                     return type_error();
-                case BinaryOp::Div:
-                    // Like hgraph's ``div_``: integer division is a float.
-                    if (numeric)
-                    {
-                        if (as_number(rhs) == 0.0) { fail(Category::Type, range, "division by zero"); }
-                        return make_const(hgraph::Value{as_number(lhs) / as_number(rhs)}, range);
+                case hir::BinaryOp::Div:
+                    if (numeric) {
+                        if (number(rhs) == 0.0) { fail(Category::Type, range, "division by zero"); }
+                        return make_const(hgraph::Value{number(lhs) / number(rhs)}, range);
                     }
                     return type_error();
-                case BinaryOp::Rem:
-                    if (ints)
-                    {
-                        if (as_int(rhs) == 0) { fail(Category::Type, range, "division by zero"); }
-                        return make_const(hgraph::Value{hgraph::Int{as_int(lhs) % as_int(rhs)}}, range);
+                case hir::BinaryOp::Rem:
+                    if (lhs_int && rhs_int) {
+                        const auto divisor = rhs.value.view().checked_as<hgraph::Int>();
+                        if (divisor == 0) { fail(Category::Type, range, "division by zero"); }
+                        return make_const(hgraph::Value{hgraph::Int{lhs.value.view().checked_as<hgraph::Int>() % divisor}}, range);
                     }
                     return type_error();
-                case BinaryOp::Equal:
-                case BinaryOp::NotEqual:
-                {
-                    bool equal = false;
-                    if (numeric) { equal = as_number(lhs) == as_number(rhs); }
-                    else if (lhs.meta() == rhs.meta()) { equal = lhs.value.view().equals(rhs.value.view()); }
-                    else { return type_error(); }
-                    return make_const(hgraph::Value{hgraph::Bool{op == BinaryOp::Equal ? equal : !equal}}, range);
-                }
-                case BinaryOp::Less:
-                case BinaryOp::LessEqual:
-                case BinaryOp::Greater:
-                case BinaryOp::GreaterEqual:
-                {
-                    std::partial_ordering order = std::partial_ordering::unordered;
-                    if (numeric) { order = as_number(lhs) <=> as_number(rhs); }
-                    else if (lhs.meta() == rhs.meta()) { order = lhs.value.view().compare(rhs.value.view()); }
-                    else { return type_error(); }
-                    if (order == std::partial_ordering::unordered) { return type_error(); }
-                    const bool result = op == BinaryOp::Less           ? order < 0
-                                        : op == BinaryOp::LessEqual    ? order <= 0
-                                        : op == BinaryOp::Greater      ? order > 0
-                                                                       : order >= 0;
-                    return make_const(hgraph::Value{hgraph::Bool{result}}, range);
-                }
-                case BinaryOp::And:
-                case BinaryOp::Or:
-                    if (is_bool(lhs) && is_bool(rhs))
+                case hir::BinaryOp::Equal:
+                case hir::BinaryOp::NotEqual:
                     {
-                        const bool result =
-                            op == BinaryOp::And ? (as_bool(lhs) && as_bool(rhs)) : (as_bool(lhs) || as_bool(rhs));
+                        bool equal = false;
+                        if (numeric) {
+                            equal = number(lhs) == number(rhs);
+                        } else if (lhs.meta() == rhs.meta()) {
+                            equal = lhs.value.view().equals(rhs.value.view());
+                        } else {
+                            return type_error();
+                        }
+                        return make_const(hgraph::Value{hgraph::Bool{op == hir::BinaryOp::Equal ? equal : !equal}}, range);
+                    }
+                case hir::BinaryOp::Less:
+                case hir::BinaryOp::LessEqual:
+                case hir::BinaryOp::Greater:
+                case hir::BinaryOp::GreaterEqual:
+                    {
+                        std::partial_ordering order = std::partial_ordering::unordered;
+                        if (numeric) {
+                            order = number(lhs) <=> number(rhs);
+                        } else if (lhs.meta() == rhs.meta()) {
+                            order = lhs.value.view().compare(rhs.value.view());
+                        } else {
+                            return type_error();
+                        }
+                        if (order == std::partial_ordering::unordered) { return type_error(); }
+                        const bool result = op == hir::BinaryOp::Less        ? order < 0
+                                            : op == hir::BinaryOp::LessEqual ? order <= 0
+                                            : op == hir::BinaryOp::Greater   ? order > 0
+                                                                             : order >= 0;
                         return make_const(hgraph::Value{hgraph::Bool{result}}, range);
+                    }
+                case hir::BinaryOp::And:
+                case hir::BinaryOp::Or:
+                    if (lhs.meta() == types_.bool_type && rhs.meta() == types_.bool_type) {
+                        const bool left  = lhs.value.view().checked_as<hgraph::Bool>();
+                        const bool right = rhs.value.view().checked_as<hgraph::Bool>();
+                        return make_const(hgraph::Value{hgraph::Bool{op == hir::BinaryOp::And ? left && right : left || right}},
+                                          range);
                     }
                     return type_error();
             }
-            backend(range, "unsupported binary operator");
+            return type_error();
         }
 
-        /// Gives a literal harness sequence its element schema (the callee's
-        /// parameter schema or the other side of a comparison).
-        void Compiler::resolve_sequence(Slot &slot, const hgraph::ValueTypeMetaData *elem_meta, Frame &frame)
-        {
+        Slot Compiler::eval_const_expr(gir::ConstExprId id, Frame &frame) {
+            if (!id.valid() || id.value >= module_.const_exprs.size()) { backend({}, "invalid constant expression ID"); }
+            const gir::ConstExpr &expression = module_.const_exprs[id.value];
+            if (expression.literal) { return constant(*expression.literal, expression.range); }
+            switch (expression.kind) {
+                case gir::ConstExprKind::Parameter:
+                    {
+                        const auto found = frame.bindings.find(expression.parameter_binding.value);
+                        if (!expression.parameter_binding.valid() || found == frame.bindings.end()) {
+                            backend(expression.range, "constant parameter '" + expression.parameter + "' is not bound");
+                        }
+                        return found->second;
+                    }
+                case gir::ConstExprKind::Unary:
+                    return fold_unary(expression.unary, eval_const_expr(expression.lhs, frame), expression.range);
+                case gir::ConstExprKind::Binary:
+                    return fold_binary(expression.binary, eval_const_expr(expression.lhs, frame),
+                                       eval_const_expr(expression.rhs, frame), expression.range);
+                case gir::ConstExprKind::Index:
+                    {
+                        const Slot target = eval_const_expr(expression.lhs, frame);
+                        const Slot index  = eval_const_expr(expression.rhs, frame);
+                        if (!target.is_const() || index.meta() != types_.int_type) {
+                            backend(expression.range, "a compile-time index needs a tuple/list and i64");
+                        }
+                        const auto position = index.value.view().checked_as<hgraph::Int>();
+                        if (position < 0) { fail(Category::Type, expression.range, "index out of range"); }
+                        if (target.value.view().is_tuple()) {
+                            const auto input = target.value.view().as_tuple();
+                            if (static_cast<std::size_t>(position) >= input.size()) {
+                                fail(Category::Type, expression.range, "tuple index out of range");
+                            }
+                            return make_const(hgraph::Value{input.at(static_cast<std::size_t>(position))}, expression.range);
+                        }
+                        if (target.value.view().is_list()) {
+                            const auto input = target.value.view().as_list();
+                            if (static_cast<std::size_t>(position) >= input.size()) {
+                                fail(Category::Type, expression.range, "list index out of range");
+                            }
+                            return make_const(hgraph::Value{input.at(static_cast<std::size_t>(position))}, expression.range);
+                        }
+                        backend(expression.range, "a compile-time index needs a tuple or list");
+                    }
+                case gir::ConstExprKind::Field:
+                    {
+                        const Slot target = eval_const_expr(expression.lhs, frame);
+                        if (!target.is_const() || !target.value.view().is_bundle()) {
+                            backend(expression.range, "compile-time field access needs a struct value");
+                        }
+                        const auto field = target.value.view().as_bundle().field(expression.member);
+                        return field.valid() ? make_const(hgraph::Value{field}, expression.range)
+                                             : make_marker(Slot::Kind::Null, expression.range);
+                    }
+                case gir::ConstExprKind::Tuple:
+                    {
+                        std::vector<hgraph::Value>                     values;
+                        std::vector<const hgraph::ValueTypeMetaData *> metadata;
+                        for (gir::ConstExprId item : expression.items) {
+                            Slot slot = eval_const_expr(item, frame);
+                            if (!slot.is_const()) { backend(expression.range, "a tuple element is a constant"); }
+                            metadata.push_back(slot.meta());
+                            values.push_back(std::move(slot.value));
+                        }
+                        const auto   *meta = registry_.tuple(metadata);
+                        hgraph::Value result{hgraph::ValuePlanFactory::instance().type_for(meta)};
+                        auto          output = result.as_tuple().begin_mutation();
+                        for (std::size_t index = 0; index < values.size(); ++index) {
+                            output.at(index).copy_from(values[index].view());
+                        }
+                        return make_const(std::move(result), expression.range);
+                    }
+                case gir::ConstExprKind::Sequence:
+                    {
+                        std::vector<hgraph::Value> values;
+                        for (const gir::ConstElement &element : expression.elements) {
+                            if (element.key.valid()) { backend(expression.range, "a keyed compile-time sequence is unsupported"); }
+                            Slot item = eval_const_expr(element.value, frame);
+                            if (!item.is_const()) { backend(expression.range, "a list element is a constant"); }
+                            values.push_back(std::move(item.value));
+                        }
+                        if (values.empty()) { fail(Category::Type, expression.range, "an empty list has no element type"); }
+                        const auto         *meta = registry_.list(values.front().schema());
+                        hgraph::ListBuilder output{hgraph::ValuePlanFactory::instance().type_for(meta->element_type), *meta};
+                        for (const hgraph::Value &item : values) {
+                            output.push_back(convert(item, meta->element_type, expression.range, "a list element").view());
+                        }
+                        return make_const(output.build(), expression.range);
+                    }
+                case gir::ConstExprKind::Construct:
+                    {
+                        std::vector<std::pair<std::string, Slot>> supplied;
+                        supplied.reserve(expression.arguments.size());
+                        for (const gir::ConstArgument &argument : expression.arguments) {
+                            supplied.emplace_back(argument.name, eval_const_expr(argument.value, frame));
+                        }
+                        return assemble_construct(expression.constructed_type, std::move(supplied), expression.delta,
+                                                  expression.range, frame);
+                    }
+                case gir::ConstExprKind::Literal: break;
+            }
+            backend(expression.range, "constant expression was not folded before hgraph IR lowering");
+        }
+
+        void Compiler::resolve_sequence(Slot &slot, const hgraph::ValueTypeMetaData *element, Frame &frame) {
             if (slot.resolved) { return; }
-            const auto &literal = std::get<ast::SequenceLiteral>(module_.expr(slot.literal).node);
-            for (const ast::SequenceElement &element : literal.elements)
-            {
-                if (element.key != ast::no_node)
-                {
-                    fail(Category::Test, module_.expr(element.key).range,
+            const gir::Value &literal = value(slot.expression);
+            const auto       *source  = std::get_if<gir::Sequence>(&literal.node);
+            if (source == nullptr) { backend(literal.range, "invalid harness sequence"); }
+            for (const gir::SequenceElement &entry : source->elements) {
+                if (entry.key.valid()) {
+                    fail(Category::Test, value(entry.key).range,
                          "timed sequences are not supported by the first pass; write one value per cycle");
                 }
-                const ast::Expr &value = module_.expr(element.value);
-                if (std::holds_alternative<ast::Placeholder>(value.node))
-                {
+                Slot item = eval_value(entry.value, frame);
+                if (item.kind == Slot::Kind::Placeholder) {
                     slot.elements.emplace_back(std::nullopt);
                     continue;
                 }
-                const Slot item = eval_expr(element.value, frame);
-                if (!item.is_const())
-                {
-                    fail(Category::Type, value.range, "a harness sequence element is a constant");
+                if (!item.is_const()) {
+                    fail(Category::Type, value(entry.value).range, "a harness sequence element is a constant");
                 }
-                slot.elements.emplace_back(convert(item.value, elem_meta, value.range, "the sequence element"));
+                slot.elements.emplace_back(convert(item.value, element, item.range, "the sequence element"));
             }
-            slot.elem_meta = elem_meta;
-            slot.resolved  = true;
+            slot.element_meta = element;
+            slot.resolved     = true;
         }
 
-        /// A constant of the value type `meta` from a constant (converted) or,
-        /// for a list type inside a test, from a sequence literal, whose
-        /// elements are then list elements rather than cycles.
-        Slot Compiler::constant_of(const Slot &slot, const hgraph::ValueTypeMetaData *meta, Frame &frame,
-                                   const std::string &what)
-        {
-            if (slot.kind == Slot::Kind::Sequence && meta->try_value_kind() == hgraph::ValueTypeKind::List)
-            {
+        Slot Compiler::constant_of(const Slot &slot, const hgraph::ValueTypeMetaData *meta, Frame &frame, std::string_view role) {
+            if (slot.kind == Slot::Kind::Sequence && meta->try_value_kind() == hgraph::ValueTypeKind::List) {
                 Slot sequence = slot;
                 resolve_sequence(sequence, meta->element_type, frame);
-                hgraph::ListBuilder builder{hgraph::ValuePlanFactory::instance().type_for(meta->element_type), *meta};
-                for (const std::optional<hgraph::Value> &element : sequence.elements)
-                {
-                    if (!element) { fail(Category::Type, slot.range, what + " is a list; '_' is not a list element"); }
-                    builder.push_back(element->view());
+                hgraph::ListBuilder output{hgraph::ValuePlanFactory::instance().type_for(meta->element_type), *meta};
+                for (const auto &item : sequence.elements) {
+                    if (!item) { fail(Category::Type, slot.range, std::string{role} + " is a list; '_' is not a list element"); }
+                    output.push_back(item->view());
                 }
-                return make_const(builder.build(), slot.range);
+                return make_const(output.build(), slot.range);
             }
-            if (!slot.is_const()) { fail(Category::Type, slot.range, what + " is const; a constant is required"); }
-            return make_const(convert(slot.value, meta, slot.range, what), slot.range);
+            if (!slot.is_const()) { fail(Category::Type, slot.range, std::string{role} + " is const; a constant is required"); }
+            return make_const(convert(slot.value, meta, slot.range, role), slot.range);
         }
 
-        Slot Compiler::compare_sequences(const Slot &lhs, const Slot &rhs, bool negate, SourceRange range,
-                                         Frame &frame)
-        {
+        Slot Compiler::compare_sequences(const Slot &lhs, const Slot &rhs, bool negate, SourceRange range, Frame &frame) {
             Slot left  = lhs;
             Slot right = rhs;
-            if (!left.resolved && !right.resolved)
-            {
+            if (!left.resolved && !right.resolved) {
                 backend(range, "comparing two literal sequences is not supported; one side comes from eval");
             }
-            if (!left.resolved) { resolve_sequence(left, right.elem_meta, frame); }
-            if (!right.resolved) { resolve_sequence(right, left.elem_meta, frame); }
+            if (!left.resolved) { resolve_sequence(left, right.element_meta, frame); }
+            if (!right.resolved) { resolve_sequence(right, left.element_meta, frame); }
             bool equal = left.elements.size() == right.elements.size();
-            compare_detail_.clear();
-            if (!equal)
-            {
-                compare_detail_ = "expected " + std::to_string(right.elements.size()) + " cycles, observed " +
-                                  std::to_string(left.elements.size()) + ": " + describe_sequence(left.elements);
+            comparison_detail_.clear();
+            if (!equal) {
+                comparison_detail_ = "expected " + std::to_string(right.elements.size()) + " cycles, observed " +
+                                     std::to_string(left.elements.size()) + ": " + describe_sequence(left.elements);
             }
-            for (std::size_t i = 0; equal && i < left.elements.size(); ++i)
-            {
-                const auto &a = left.elements[i];
-                const auto &b = right.elements[i];
-                const bool same = a.has_value() == b.has_value() &&
-                                  (!a.has_value() || a->view().equals(b->view()));
-                if (!same)
-                {
-                    equal           = false;
-                    compare_detail_ = "cycle " + std::to_string(i) + ": expected " +
-                                      (b.has_value() ? describe_value(*b) : std::string{"_"}) + ", observed " +
-                                      (a.has_value() ? describe_value(*a) : std::string{"_"}) + " in " +
-                                      describe_sequence(left.elements);
+            for (std::size_t index = 0; equal && index < left.elements.size(); ++index) {
+                const auto &observed = left.elements[index];
+                const auto &expected = right.elements[index];
+                const bool  same =
+                    observed.has_value() == expected.has_value() && (!observed || observed->view().equals(expected->view()));
+                if (!same) {
+                    equal              = false;
+                    comparison_detail_ = "cycle " + std::to_string(index) + ": expected " +
+                                         (expected ? describe_value(*expected) : "_") + ", observed " +
+                                         (observed ? describe_value(*observed) : "_") + " in " + describe_sequence(left.elements);
                 }
             }
             return make_const(hgraph::Value{hgraph::Bool{negate ? !equal : equal}}, range);
         }
 
-        // ------------------------------------------------------------ wiring
-
-        Slot Compiler::wire(std::string_view name, std::vector<hgraph::WiringArg> args, SourceRange range,
-                            std::optional<bool> output_required, const hgraph::TSValueTypeMetaData *expected)
-        {
-            hgraph::Wiring &w = wiring(range);
-            try
-            {
+        Slot Compiler::wire(std::string_view name, std::vector<hgraph::WiringArg> arguments, SourceRange range,
+                            std::optional<bool> output_required, const hgraph::TSValueTypeMetaData *expected) {
+            try {
                 hgraph::OperatorWireResult result = hgraph::wire_operator(
-                    w, name, std::span<const hgraph::WiringArg>{args.data(), args.size()}, output_required, expected);
-                if (!result.has_output)
-                {
-                    Slot slot;
-                    slot.range = range;
-                    return slot;
-                }
-                return make_port(result.output.erased(), range);
-            }
-            catch (const hgraph::OperatorResolutionError &error)
-            {
+                    wiring(range), name, std::span<const hgraph::WiringArg>{arguments}, output_required, expected);
+                return result.has_output ? make_port(result.output.erased(), range) : Slot{};
+            } catch (const hgraph::OperatorResolutionError &error) {
                 fail(Category::Operator, range, std::string{name} + ": " + error.what());
-            }
-            catch (const std::exception &error)
-            {
-                backend(range, std::string{name} + ": " + error.what());
-            }
+            } catch (const std::exception &error) { backend(range, std::string{name} + ": " + error.what()); }
         }
 
-        hgraph::WiringArg Compiler::argument_of(const Slot &slot, std::string name)
-        {
-            switch (slot.kind)
-            {
-                case Slot::Kind::Const: return scalar_arg(slot.value, std::move(name));
-                case Slot::Kind::Port: return ts_arg(slot.port, std::move(name));
-                case Slot::Kind::Null: backend(slot.range, "null needs an optional field context");
-                case Slot::Kind::Delta: backend(slot.range, "a structured delta is not an ordinary operator value");
-                case Slot::Kind::Struct:
-                case Slot::Kind::Function:
-                case Slot::Kind::Operator:
-                case Slot::Kind::Intrinsic:
-                    backend(slot.range, "passing a function to an operator is not supported by the first pass");
-                case Slot::Kind::Sequence: backend(slot.range, "a harness sequence is only valid in eval");
-                case Slot::Kind::Void: break;
+        hgraph::WiringArg Compiler::argument_of(const Slot &slot, std::string name) {
+            if (slot.is_const()) { return scalar_arg(slot.value, std::move(name)); }
+            if (slot.is_port()) { return time_series_arg(slot.port, std::move(name)); }
+            if (slot.kind == Slot::Kind::Null) { backend(slot.range, "null needs an optional field context"); }
+            if (slot.kind == Slot::Kind::Delta) { backend(slot.range, "a structured delta is not an ordinary operator value"); }
+            if (slot.kind == Slot::Kind::Sequence) { backend(slot.range, "a harness sequence is only valid in eval"); }
+            if (slot.kind == Slot::Kind::Function || slot.kind == Slot::Kind::Operator || slot.kind == Slot::Kind::Intrinsic ||
+                slot.kind == Slot::Kind::Struct) {
+                backend(slot.range, "passing a callable to an operator is not supported by the first pass");
             }
             backend(slot.range, "this expression produces no value");
         }
 
-        Slot Compiler::wire_constant(const Slot &slot, const hgraph::TSValueTypeMetaData *schema)
-        {
-            return wire("const", {scalar_arg(slot.value, "value")}, slot.range, true, schema);
+        Slot Compiler::wire_constant(const Slot &slot, const hgraph::TSValueTypeMetaData *target) {
+            return wire("const", {scalar_arg(slot.value, "value")}, slot.range, true, target);
         }
 
-        Slot Compiler::wire_binary(ast::BinaryOp op, const Slot &lhs, const Slot &rhs, SourceRange range)
-        {
-            using ast::BinaryOp;
-            const char *name = nullptr;
-            switch (op)
-            {
-                case BinaryOp::Add: name = "add_"; break;
-                case BinaryOp::Sub: name = "sub_"; break;
-                case BinaryOp::Mul: name = "mul_"; break;
-                case BinaryOp::Div: name = "div_"; break;
-                case BinaryOp::Rem: name = "mod_"; break;
-                case BinaryOp::Equal: name = "eq_"; break;
-                case BinaryOp::NotEqual: name = "ne_"; break;
-                case BinaryOp::Less: name = "lt_"; break;
-                case BinaryOp::LessEqual: name = "le_"; break;
-                case BinaryOp::Greater: name = "gt_"; break;
-                case BinaryOp::GreaterEqual: name = "ge_"; break;
-                case BinaryOp::And: name = "and_"; break;
-                case BinaryOp::Or: name = "or_"; break;
-            }
-            return wire(name, {argument_of(lhs, {}), argument_of(rhs, {})}, range);
-        }
-
-        // -------------------------------------------------------- evaluation
-
-        Slot Compiler::eval_literal(const ast::TemporalLiteral &node, SourceRange range)
-        {
-            using syntax::TemporalKind;
-            const syntax::TemporalValue &value = node.value;
-            switch (value.kind)
-            {
-                case TemporalKind::Date:
-                    return make_const(hgraph::Value{hgraph::Date{std::chrono::sys_days{std::chrono::days{value.micros}}}},
-                                      range);
-                case TemporalKind::Time: return make_const(hgraph::Value{hgraph::Time{value.micros}}, range);
-                case TemporalKind::DateTime:
-                    return make_const(hgraph::Value{hgraph::DateTime{std::chrono::microseconds{value.micros}}}, range);
-                case TemporalKind::Duration:
-                    return make_const(hgraph::Value{hgraph::TimeDelta{value.micros}}, range);
-                case TemporalKind::CivilDateTime:
-                case TemporalKind::ZonedDateTime:
-                case TemporalKind::ZonedTime:
-                case TemporalKind::TimeZone: break;
-            }
-            backend(range, "zoned and civil literals are not supported by the first pass");
-        }
-
-        Slot Compiler::eval_tuple(const ast::TupleLiteral &node, SourceRange range, Frame &frame)
-        {
-            std::vector<hgraph::Value>                   values;
-            std::vector<const hgraph::ValueTypeMetaData *> metas;
-            values.reserve(node.elements.size());
-            metas.reserve(node.elements.size());
-            for (ast::ExprId element : node.elements)
-            {
-                if (std::holds_alternative<ast::Placeholder>(module_.expr(element).node))
-                {
-                    backend(module_.expr(element).range,
-                            "'_' inside a tuple is not supported by the first pass (whole-value ticks only)");
+        Slot Compiler::wire_binary(const gir::Value &expression, hir::BinaryOp op, const Slot &lhs, const Slot &rhs) {
+            std::string name = expression.operation.registry_name;
+            if (name.empty()) {
+                switch (op) {
+                    case hir::BinaryOp::Add: name = "add_"; break;
+                    case hir::BinaryOp::Sub: name = "sub_"; break;
+                    case hir::BinaryOp::Mul: name = "mul_"; break;
+                    case hir::BinaryOp::Div: name = "div_"; break;
+                    case hir::BinaryOp::Rem: name = "mod_"; break;
+                    case hir::BinaryOp::Equal: name = "eq_"; break;
+                    case hir::BinaryOp::NotEqual: name = "ne_"; break;
+                    case hir::BinaryOp::Less: name = "lt_"; break;
+                    case hir::BinaryOp::LessEqual: name = "le_"; break;
+                    case hir::BinaryOp::Greater: name = "gt_"; break;
+                    case hir::BinaryOp::GreaterEqual: name = "ge_"; break;
+                    case hir::BinaryOp::And: name = "and_"; break;
+                    case hir::BinaryOp::Or: name = "or_"; break;
                 }
-                Slot item = eval_expr(element, frame);
-                if (!item.is_const())
-                {
-                    backend(module_.expr(element).range,
-                            "a tuple of time-series values is not supported by the first pass");
+            }
+            return wire(name, {argument_of(lhs, {}), argument_of(rhs, {})}, expression.range);
+        }
+
+        Slot Compiler::eval_reference(const gir::Reference &reference, SourceRange range, Frame &frame) {
+            Slot result;
+            result.range = range;
+            switch (reference.kind) {
+                case gir::ReferenceKind::Binding:
+                    {
+                        const auto found = frame.bindings.find(reference.binding.value);
+                        if (!reference.binding.valid() || found == frame.bindings.end()) {
+                            const std::string name = reference.binding.valid() ? binding(reference.binding).name : "value";
+                            backend(range, "'" + name + "' is not bound in this activation");
+                        }
+                        result       = found->second;
+                        result.range = range;
+                        return result;
+                    }
+                case gir::ReferenceKind::Callable:
+                    result.kind     = Slot::Kind::Function;
+                    result.callable = reference.callable;
+                    result.name     = reference.identity;
+                    return result;
+                case gir::ReferenceKind::Operator:
+                    result.kind = Slot::Kind::Operator;
+                    result.name = reference.registry_name.empty() ? reference.identity : reference.registry_name;
+                    return result;
+                case gir::ReferenceKind::Struct:
+                    result.kind = Slot::Kind::Struct;
+                    result.name = reference.identity;
+                    return result;
+                case gir::ReferenceKind::Intrinsic:
+                    result.kind = Slot::Kind::Intrinsic;
+                    result.name = reference.registry_name.empty() ? reference.identity : reference.registry_name;
+                    return result;
+            }
+            backend(range, "invalid hgraph IR reference");
+        }
+
+        Slot Compiler::eval_tuple(const gir::Tuple &tuple, SourceRange range, Frame &frame) {
+            std::vector<hgraph::Value>                     values;
+            std::vector<const hgraph::ValueTypeMetaData *> metadata;
+            for (gir::ValueId element : tuple.elements) {
+                Slot item = eval_value(element, frame);
+                if (item.kind == Slot::Kind::Placeholder) {
+                    backend(item.range, "'_' inside a tuple is not supported by the first pass (whole-value ticks only)");
                 }
-                metas.push_back(item.meta());
+                if (!item.is_const()) { backend(item.range, "a tuple of time-series values is not supported by the first pass"); }
+                metadata.push_back(item.meta());
                 values.push_back(std::move(item.value));
             }
-            const auto   *meta = registry_.tuple(metas);
+            const auto   *meta = registry_.tuple(metadata);
             hgraph::Value result{hgraph::ValuePlanFactory::instance().type_for(meta)};
-            auto          tuple = result.as_tuple().begin_mutation();
-            for (std::size_t i = 0; i < values.size(); ++i) { tuple.at(i).copy_from(values[i].view()); }
+            auto          output = result.as_tuple().begin_mutation();
+            for (std::size_t index = 0; index < values.size(); ++index) { output.at(index).copy_from(values[index].view()); }
             return make_const(std::move(result), range);
         }
 
-        /// A sequence literal outside a test is a constant list; inside a test
-        /// it stays a harness sequence until it meets a parameter schema.
-        Slot Compiler::eval_list(const ast::SequenceLiteral &node, SourceRange range, Frame &frame)
-        {
-            if (frame.in_test)
-            {
-                Slot slot;
-                slot.kind  = Slot::Kind::Sequence;
-                slot.range = range;
-                // The literal id is recovered by the caller (eval_expr).
-                return slot;
+        Slot Compiler::eval_sequence(gir::ValueId id, const gir::Sequence &sequence, SourceRange range, Frame &frame) {
+            if (frame.in_test) {
+                Slot result;
+                result.kind       = Slot::Kind::Sequence;
+                result.expression = id;
+                result.range      = range;
+                return result;
             }
             std::vector<hgraph::Value> values;
-            for (const ast::SequenceElement &element : node.elements)
-            {
-                if (element.key != ast::no_node)
-                {
-                    fail(Category::Type, module_.expr(element.key).range, "a keyed sequence is only valid in a test");
+            for (const gir::SequenceElement &element : sequence.elements) {
+                if (element.key.valid()) {
+                    fail(Category::Type, value(element.key).range, "a keyed sequence is only valid in a test");
                 }
-                Slot item = eval_expr(element.value, frame);
-                if (!item.is_const())
-                {
-                    backend(module_.expr(element.value).range,
-                            "a list of time-series values is not supported by the first pass");
-                }
+                Slot item = eval_value(element.value, frame);
+                if (!item.is_const()) { backend(item.range, "a list of time-series values is not supported by the first pass"); }
                 values.push_back(std::move(item.value));
             }
             if (values.empty()) { fail(Category::Type, range, "an empty list has no element type"); }
-            const auto         *element_meta = values.front().schema();
-            const auto         *list_meta    = registry_.list(element_meta);
-            hgraph::ListBuilder builder{hgraph::ValuePlanFactory::instance().type_for(element_meta), *list_meta};
-            for (const hgraph::Value &value : values)
-            {
-                builder.push_back(convert(value, element_meta, range, "a list element").view());
+            const auto         *meta = registry_.list(values.front().schema());
+            hgraph::ListBuilder output{hgraph::ValuePlanFactory::instance().type_for(meta->element_type), *meta};
+            for (const hgraph::Value &item : values) {
+                output.push_back(convert(item, meta->element_type, range, "a list element").view());
             }
-            return make_const(builder.build(), range);
+            return make_const(output.build(), range);
         }
 
-        Slot Compiler::eval_construct(ast::DeclId decl, ast::TypeId type, const std::vector<ast::Argument> &arguments, bool delta,
-                                      SourceRange range, Frame &frame)
-        {
-            AppliedStruct applied = type == ast::no_node ? apply_plain_struct(decl, range) : apply_struct(type, frame);
-            try
-            {
-                const auto &structure = std::get<ast::StructDecl>(module_.decl(applied.decl).node);
-                if (structure.abstract)
-                {
-                    fail(Category::Type, range, "abstract struct '" + std::string{structure.name.text} + "' is not constructible");
-                }
-                const hgraph::ValueTypeMetaData *meta   = struct_value_meta(applied, frame);
-                std::vector<RuntimeStructField>  fields = struct_fields(applied, frame, true);
-                std::vector<std::optional<Slot>> supplied(fields.size());
-                for (const ast::Argument &argument : arguments)
-                {
-                    if (argument.name.empty())
-                    {
-                        fail(Category::Type, module_.expr(argument.value).range, "struct construction uses named arguments");
-                    }
-                    const auto found = std::find_if(fields.begin(), fields.end(), [&](const RuntimeStructField &field) {
-                        return field.name == argument.name.text;
-                    });
-                    if (found == fields.end())
-                    {
-                        fail(Category::Name, argument.name.range,
-                             "struct '" + std::string{structure.name.text} + "' has no field named '" +
-                                 std::string{argument.name.text} + "'");
-                    }
-                    const auto index = static_cast<std::size_t>(found - fields.begin());
-                    if (supplied[index].has_value())
-                    {
-                        fail(Category::Name, argument.name.range, "field '" + std::string{argument.name.text} + "' is given twice");
-                    }
-                    supplied[index] = eval_expr(argument.value, frame);
-                }
-
-                for (std::size_t i = 0; i < fields.size(); ++i)
-                {
-                    RuntimeStructField &field = fields[i];
-                    std::optional<Slot> value = supplied[i];
-                    if (!value && !delta && field.has_default) { value = field.default_value; }
-                    if (!value)
-                    {
-                        if (delta || field.optional) { continue; }
-                        fail(Category::Type, range,
-                             "struct '" + std::string{structure.name.text} + "' needs field '" + field.name + "'");
-                    }
-                    if (value->kind == Slot::Kind::Null)
-                    {
-                        if (!field.optional)
-                        {
-                            fail(Category::Type, value->range, "required field '" + field.name + "' cannot be null");
-                        }
-                        if (delta)
-                        {
-                            backend(value->range, "clearing an optional struct field needs the "
-                                                  "distinct public hgraph clear-delta operation");
-                        }
-                        continue;
-                    }
-                    if (value->kind != Slot::Kind::Const && value->kind != Slot::Kind::Delta)
-                    {
-                        if (value->kind != Slot::Kind::Port)
-                        {
-                            fail(Category::Type, value->range, "field '" + field.name + "' needs a value");
-                        }
-                    }
-                    if (value->kind == Slot::Kind::Delta && !delta)
-                    {
-                        fail(Category::Type, value->range, "a sparse delta cannot initialise complete field '" + field.name + "'");
-                    }
-                }
-
-                const bool temporal = std::any_of(supplied.begin(), supplied.end(), [](const std::optional<Slot> &value) {
-                    return value && value->kind == Slot::Kind::Port;
-                });
-                if (temporal)
-                {
-                    if (delta)
-                    {
-                        backend(range, "a temporal structured delta is only available in a "
-                                       "runtime function");
-                    }
-                    const hgraph::TSValueTypeMetaData *schema = struct_schema(applied, frame);
-                    std::vector<hgraph::WiringPortRef> children;
-                    children.reserve(fields.size());
-                    for (std::size_t i = 0; i < fields.size(); ++i)
-                    {
-                        RuntimeStructField &field = fields[i];
-                        std::optional<Slot> value = supplied[i];
-                        if (!value && field.has_default) { value = field.default_value; }
-                        if (!value || value->kind == Slot::Kind::Null)
-                        {
-                            children.push_back(hgraph::WiringPortRef::null_source(field.schema));
-                            continue;
-                        }
-                        if (value->kind == Slot::Kind::Const)
-                        {
-                            Slot converted = make_const(
-                                convert(value->value, field.value_meta, value->range, "field '" + field.name + "'"), value->range);
-                            children.push_back(wire_constant(converted, field.schema).port);
-                            continue;
-                        }
-                        if (value->kind != Slot::Kind::Port)
-                        {
-                            fail(Category::Type, value->range, "field '" + field.name + "' needs a temporal or scalar value");
-                        }
-                        if (value->port.schema != field.schema)
-                        {
-                            fail(Category::Type, value->range,
-                                 "field '" + field.name + "' expects " + std::string{field.schema->name()} + ", got " +
-                                     std::string{value->port.schema->name()});
-                        }
-                        children.push_back(value->port);
-                    }
-                    Slot result = make_port(hgraph::WiringPortRef::structural_source(schema, std::move(children)), range);
-                    restore_types(applied.mark);
-                    return result;
-                }
-
-                hgraph::BundleBuilder builder{hgraph::ValuePlanFactory::instance().type_for(meta)};
-                for (std::size_t i = 0; i < fields.size(); ++i)
-                {
-                    RuntimeStructField &field = fields[i];
-                    std::optional<Slot> value = supplied[i];
-                    if (!value && !delta && field.has_default) { value = field.default_value; }
-                    if (!value || value->kind == Slot::Kind::Null) { continue; }
-                    builder.set(i, convert(value->value, field.value_meta, value->range, "field '" + field.name + "'").view());
-                }
-                Slot result = make_const(builder.build(), range);
-                if (delta) { result.kind = Slot::Kind::Delta; }
-                restore_types(applied.mark);
-                return result;
+        Slot Compiler::assemble_construct(gir::TypeId type, std::vector<std::pair<std::string, Slot>> supplied_values, bool delta,
+                                          SourceRange range, Frame &frame) {
+            const gir::StructContract &contract = structure(type);
+            if (contract.abstract) {
+                fail(Category::Type, range, "abstract struct '" + local_name(contract.identity) + "' is not constructible");
             }
-            catch (...)
-            {
-                restore_types(applied.mark);
-                throw;
+            const hgraph::ValueTypeMetaData *meta = value_meta(type);
+            if (meta->try_value_kind() != hgraph::ValueTypeKind::Bundle || meta->field_count != contract.fields.size()) {
+                backend(range, "struct metadata does not match '" + contract.identity + "'");
             }
-        }
-
-        Slot Compiler::eval_name(ast::ExprId id, Frame &frame)
-        {
-            const semantics::Binding &binding = resolved_.binding(id);
-            const SourceRange         range   = module_.expr(id).range;
-            switch (binding.kind)
-            {
-                case BindingKind::Local:
-                {
-                    const auto found = frame.locals.find(binding.stmt);
-                    if (found == frame.locals.end())
-                    {
-                        backend(range, "'" + slice(range) + "' is not bound in this activation");
-                    }
-                    Slot slot  = found->second;
-                    slot.range = range;
-                    return slot;
+            std::vector<std::optional<Slot>> supplied(contract.fields.size());
+            for (auto &[name, slot] : supplied_values) {
+                if (name.empty()) { fail(Category::Type, slot.range, "struct construction uses named arguments"); }
+                const auto found = std::find_if(contract.fields.begin(), contract.fields.end(),
+                                                [&](const gir::StructField &field) { return field.name == name; });
+                if (found == contract.fields.end()) {
+                    fail(Category::Name, slot.range,
+                         "struct '" + local_name(contract.identity) + "' has no field named '" + name + "'");
                 }
-                case BindingKind::Parameter:
-                {
-                    if (binding.decl != frame.fn || binding.index >= frame.params.size())
-                    {
-                        backend(range, "'" + slice(range) + "' is not a parameter of this activation");
-                    }
-                    Slot slot  = frame.params[binding.index];
-                    slot.range = range;
-                    return slot;
-                }
-                case BindingKind::Generic:
-                    backend(range, "generic parameters are not supported by the first pass");
-                case BindingKind::Struct:
-                {
-                    Slot slot;
-                    slot.kind  = Slot::Kind::Struct;
-                    slot.fn    = binding.decl;
-                    slot.range = range;
-                    return slot;
-                }
-                case BindingKind::Function:
-                {
-                    Slot slot;
-                    slot.kind  = Slot::Kind::Function;
-                    slot.fn    = binding.decl;
-                    slot.range = range;
-                    return slot;
-                }
-                case BindingKind::Operator:
-                {
-                    Slot slot;
-                    slot.kind  = Slot::Kind::Operator;
-                    slot.name  = binding.registry_name;
-                    slot.range = range;
-                    return slot;
-                }
-                case BindingKind::LocalOperator:
-                {
-                    const auto &op = std::get<ast::OperatorDecl>(module_.decl(binding.decl).node);
-                    Slot        slot;
-                    slot.kind  = Slot::Kind::Operator;
-                    slot.name  = resolved_.module_path + "." + std::string{op.name.text};
-                    slot.range = range;
-                    return slot;
-                }
-                case BindingKind::Intrinsic:
-                {
-                    Slot slot;
-                    slot.kind  = Slot::Kind::Intrinsic;
-                    slot.name  = binding.registry_name;
-                    slot.range = range;
-                    return slot;
-                }
-                case BindingKind::Test:
-                case BindingKind::Unbound: break;
+                const std::size_t index = static_cast<std::size_t>(found - contract.fields.begin());
+                if (supplied[index]) { fail(Category::Name, slot.range, "field '" + name + "' is given twice"); }
+                supplied[index] = std::move(slot);
             }
-            backend(range, "'" + slice(range) + "' has no value");
-        }
 
-        Slot Compiler::eval_if(const ast::If &node, Frame &frame)
-        {
-            const Slot condition = eval_expr(node.condition, frame);
-            if (condition.is_port())
-            {
-                backend(module_.expr(node.condition).range,
-                        "'if' over a time-series condition is not supported by the first pass; use if_then_else");
-            }
-            if (!is_bool(condition))
-            {
-                fail(Category::Type, module_.expr(node.condition).range, "an 'if' condition is a bool");
-            }
-            if (as_bool(condition)) { return exec_block(node.then_block, frame); }
-            if (node.otherwise == ast::no_node) { return Slot{}; }
-            return eval_expr(node.otherwise, frame);
-        }
-
-        Slot Compiler::eval_expr(ast::ExprId id, Frame &frame)
-        {
-            const ast::Expr &expr = module_.expr(id);
-            return std::visit(
-                [&](const auto &node) -> Slot {
-                    using T = std::decay_t<decltype(node)>;
-                    if constexpr (std::is_same_v<T, ast::IntLiteral>)
-                    {
-                        return make_const(hgraph::Value{hgraph::Int{node.value}}, expr.range);
-                    }
-                    else if constexpr (std::is_same_v<T, ast::FloatLiteral>)
-                    {
-                        return make_const(hgraph::Value{hgraph::Float{node.value}}, expr.range);
-                    }
-                    else if constexpr (std::is_same_v<T, ast::StringLiteral>)
-                    {
-                        return make_const(hgraph::Value{hgraph::Str{node.value}}, expr.range);
-                    }
-                    else if constexpr (std::is_same_v<T, ast::BoolLiteral>)
-                    {
-                        return make_const(hgraph::Value{hgraph::Bool{node.value}}, expr.range);
-                    }
-                    else if constexpr (std::is_same_v<T, ast::NullLiteral>) { return make_null(expr.range); }
-                    else if constexpr (std::is_same_v<T, ast::TemporalLiteral>) { return eval_literal(node, expr.range); }
-                    else if constexpr (std::is_same_v<T, ast::Placeholder>)
-                    {
-                        fail(Category::Type, expr.range, "'_' is only valid in a harness sequence");
-                    }
-                    else if constexpr (std::is_same_v<T, ast::NameRef> || std::is_same_v<T, ast::QualifiedRef>)
-                    {
-                        return eval_name(id, frame);
-                    }
-                    else if constexpr (std::is_same_v<T, ast::Unary>)
-                    {
-                        const Slot operand = eval_expr(node.operand, frame);
-                        if (operand.is_const()) { return fold_unary(node.op, operand, expr.range); }
-                        if (!operand.is_port()) { backend(expr.range, "this operand has no value"); }
-                        return wire(node.op == ast::UnaryOp::Negate ? "neg_" : "not_", {argument_of(operand, {})},
-                                    expr.range);
-                    }
-                    else if constexpr (std::is_same_v<T, ast::Binary>)
-                    {
-                        const Slot lhs = eval_expr(node.lhs, frame);
-                        const Slot rhs = eval_expr(node.rhs, frame);
-                        if (lhs.kind == Slot::Kind::Sequence || rhs.kind == Slot::Kind::Sequence)
-                        {
-                            if ((node.op != ast::BinaryOp::Equal && node.op != ast::BinaryOp::NotEqual) ||
-                                lhs.kind != rhs.kind)
-                            {
-                                fail(Category::Type, expr.range, "a harness sequence only compares with '==' or '!='");
-                            }
-                            return compare_sequences(lhs, rhs, node.op == ast::BinaryOp::NotEqual, expr.range, frame);
-                        }
-                        if (lhs.is_const() && rhs.is_const()) { return fold_binary(node.op, lhs, rhs, expr.range); }
-                        return wire_binary(node.op, lhs, rhs, expr.range);
-                    }
-                    else if constexpr (std::is_same_v<T, ast::Call>) { return eval_call(node, expr.range, frame); }
-                    else if constexpr (std::is_same_v<T, ast::Index>)
-                    {
-                        const Slot target = eval_expr(node.target, frame);
-                        const Slot index  = eval_expr(node.index, frame);
-                        if (target.is_port())
-                        {
-                            return wire("getitem_", {argument_of(target, {}), argument_of(index, {})}, expr.range);
-                        }
-                        if (target.is_const() && target.value.view().is_tuple() && is_int(index))
-                        {
-                            const auto tuple = target.value.view().as_tuple();
-                            const auto i     = as_int(index);
-                            if (i < 0 || static_cast<std::size_t>(i) >= tuple.size())
-                            {
-                                fail(Category::Type, expr.range, "tuple index out of range");
-                            }
-                            return make_const(hgraph::Value{tuple.at(static_cast<std::size_t>(i))}, expr.range);
-                        }
-                        if (target.is_const() && target.value.view().is_list() && is_int(index))
-                        {
-                            const auto list = target.value.view().as_list();
-                            const auto i    = as_int(index);
-                            if (i < 0 || static_cast<std::size_t>(i) >= list.size())
-                            {
-                                fail(Category::Type, expr.range, "list index out of range");
-                            }
-                            return make_const(hgraph::Value{list.at(static_cast<std::size_t>(i))}, expr.range);
-                        }
-                        backend(expr.range, "indexing is supported on time-series values and constant tuples and lists");
-                    }
-                    else if constexpr (std::is_same_v<T, ast::Field>)
-                    {
-                        const Slot target = eval_expr(node.target, frame);
-                        if (target.is_port())
-                        {
-                            return wire("getattr_",
-                                        {argument_of(target, {}), scalar_arg(hgraph::Value{hgraph::Str{node.field.text}})},
-                                        expr.range);
-                        }
-                        if ((target.kind == Slot::Kind::Const || target.kind == Slot::Kind::Delta) &&
-                            target.value.view().is_bundle())
-                        {
-                            const auto field = target.value.view().as_bundle().field(node.field.text);
-                            if (!field.valid()) { return make_null(expr.range); }
-                            return make_const(hgraph::Value{field}, expr.range);
-                        }
-                        backend(expr.range, "field access needs a temporal or structured value");
-                    }
-                    else if constexpr (std::is_same_v<T, ast::SequenceLiteral>)
-                    {
-                        Slot slot = eval_list(node, expr.range, frame);
-                        if (slot.kind == Slot::Kind::Sequence) { slot.literal = id; }
-                        return slot;
-                    }
-                    else if constexpr (std::is_same_v<T, ast::TupleLiteral>) { return eval_tuple(node, expr.range, frame); }
-                    else if constexpr (std::is_same_v<T, ast::AnonymousFn>)
-                    {
-                        backend(expr.range, "anonymous functions are not supported by the first pass");
-                    }
-                    else if constexpr (std::is_same_v<T, ast::If>) { return eval_if(node, frame); }
-                    else if constexpr (std::is_same_v<T, ast::BlockExpr>) { return exec_block(node.block, frame); }
-                    else if constexpr (std::is_same_v<T, ast::Eval>) { return eval_eval(node, expr.range, frame); }
-                    else if constexpr (std::is_same_v<T, ast::Construct>)
-                    {
-                        const semantics::Binding &binding = resolved_.type_binding(node.type);
-                        return eval_construct(binding.decl, node.type, node.arguments, node.delta, expr.range, frame);
-                    }
-                    else
-                    {
-                        static_assert(sizeof(T) == 0, "unhandled expression node");
-                    }
-                },
-                expr.node);
-        }
-
-        // ------------------------------------------------------------- calls
-
-        Slot Compiler::eval_call(const ast::Call &call, SourceRange range, Frame &frame)
-        {
-            const Slot callee = eval_expr(call.callee, frame);
-            switch (callee.kind)
-            {
-                case Slot::Kind::Operator:
-                {
-                    std::vector<hgraph::WiringArg> args;
-                    args.reserve(call.arguments.size());
-                    for (const ast::Argument &argument : call.arguments)
-                    {
-                        args.push_back(argument_of(eval_expr(argument.value, frame), std::string{argument.name.text}));
-                    }
-                    return wire(callee.name, std::move(args), range);
+            std::vector<std::optional<Slot>> effective = supplied;
+            for (std::size_t index = 0; index < contract.fields.size(); ++index) {
+                const gir::StructField &field = contract.fields[index];
+                if (!effective[index] && !delta && field.default_value.valid()) {
+                    effective[index] = eval_const_expr(field.default_value, frame);
                 }
-                case Slot::Kind::Struct: return eval_construct(callee.fn, ast::no_node, call.arguments, false, range, frame);
-                case Slot::Kind::Function: return call_function(callee.fn, call.arguments, range, frame);
-                case Slot::Kind::Intrinsic: return eval_intrinsic(callee, call, range, frame);
-                case Slot::Kind::Const:
-                case Slot::Kind::Null:
-                case Slot::Kind::Delta:
-                case Slot::Kind::Port:
-                case Slot::Kind::Sequence:
-                case Slot::Kind::Void: break;
-            }
-            fail(Category::Type, module_.expr(call.callee).range, "'" + slice(module_.expr(call.callee).range) +
-                                                                      "' is not callable");
-        }
-
-        /// The composition-phase meaning of the prelude intrinsics (developer
-        /// guide, "Interim kernel table", last paragraph).
-        Slot Compiler::eval_intrinsic(const Slot &callee, const ast::Call &call, SourceRange range, Frame &frame)
-        {
-            const std::string &name = callee.name;
-            if (name == "valid" || name == "modified" || name == "all_valid")
-            {
-                if (call.arguments.empty())
-                {
-                    fail(Category::Type, range, "'" + name + "' takes at least one time-series argument");
+                if (!effective[index]) {
+                    if (delta || field.optional) { continue; }
+                    fail(Category::Type, range, "struct '" + local_name(contract.identity) + "' needs field '" + field.name + "'");
                 }
-                const char *op   = name == "modified" ? "modified" : "valid";
-                const char *fold = name == "modified" ? "or_" : "and_";
-                std::optional<Slot> result;
-                for (const ast::Argument &argument : call.arguments)
-                {
-                    const Slot value = eval_expr(argument.value, frame);
-                    if (!value.is_port())
-                    {
-                        fail(Category::Type, module_.expr(argument.value).range,
-                             "'" + name + "' takes time-series arguments");
+                Slot &item = *effective[index];
+                if (item.kind == Slot::Kind::Null) {
+                    if (!field.optional) { fail(Category::Type, item.range, "required field '" + field.name + "' cannot be null"); }
+                    if (delta) {
+                        backend(item.range,
+                                "clearing an optional struct field needs the distinct public hgraph clear-delta operation");
                     }
-                    Slot flag = wire(op, {ts_arg(value.port)}, range);
-                    result    = result ? wire(fold, {ts_arg(result->port), ts_arg(flag.port)}, range) : flag;
-                }
-                return *result;
-            }
-            if (name == "last_modified" || name == "key_set")
-            {
-                if (call.arguments.size() != 1)
-                {
-                    fail(Category::Type, range, "'" + name + "' takes one time-series argument");
-                }
-                const Slot value = eval_expr(call.arguments[0].value, frame);
-                if (!value.is_port())
-                {
-                    fail(Category::Type, module_.expr(call.arguments[0].value).range,
-                         "'" + name + "' takes a time-series argument");
-                }
-                return wire(name == "last_modified" ? "last_modified_time" : "keys_", {ts_arg(value.port)}, range);
-            }
-            backend(range, "'" + name + "' is a runtime traversal; it is not available in a composition body of the "
-                           "first pass");
-        }
-
-        /// Positional then named arguments, then defaults: one expression per
-        /// parameter (syntax guide, "Calls").
-        std::vector<ast::ExprId> Compiler::bind_arguments(const ast::FunctionDecl &fn,
-                                                          const std::vector<ast::Argument> &arguments,
-                                                          SourceRange range)
-        {
-            const auto              &params = fn.signature.parameters;
-            std::vector<ast::ExprId> bound(params.size(), ast::no_node);
-            std::size_t              next = 0;
-            for (const ast::Argument &argument : arguments)
-            {
-                const SourceRange where = module_.expr(argument.value).range;
-                if (argument.name.empty())
-                {
-                    if (next >= params.size())
-                    {
-                        fail(Category::Type, where,
-                             "'" + std::string{fn.name.text} + "' takes " + std::to_string(params.size()) + " arguments");
-                    }
-                    if (bound[next] != ast::no_node)
-                    {
-                        fail(Category::Type, where, "positional argument after a named one");
-                    }
-                    bound[next++] = argument.value;
                     continue;
                 }
-                const auto found = std::find_if(params.begin(), params.end(), [&](const ast::Parameter &param) {
-                    return std::string{param.name.text} == std::string{argument.name.text};
-                });
-                if (found == params.end())
-                {
-                    fail(Category::Name, argument.name.range,
-                         "'" + std::string{fn.name.text} + "' has no parameter named '" + std::string{argument.name.text} + "'");
+                if (!item.is_const() && !item.is_port() && item.kind != Slot::Kind::Delta) {
+                    fail(Category::Type, item.range, "field '" + field.name + "' needs a value");
                 }
-                const auto index = static_cast<std::size_t>(found - params.begin());
-                if (bound[index] != ast::no_node)
-                {
-                    fail(Category::Name, argument.name.range, "'" + std::string{argument.name.text} + "' is given twice");
-                }
-                bound[index] = argument.value;
-                next         = std::max(next, index + 1);
-            }
-            for (std::size_t i = 0; i < params.size(); ++i)
-            {
-                if (bound[i] == ast::no_node && params[i].default_value == ast::no_node)
-                {
-                    fail(Category::Type, range, "'" + std::string{fn.name.text} + "' needs an argument for '" +
-                                                    std::string{params[i].name.text} + "'");
+                if (item.kind == Slot::Kind::Delta && !delta) {
+                    fail(Category::Type, item.range, "a sparse delta cannot initialise complete field '" + field.name + "'");
                 }
             }
-            return bound;
+
+            const bool temporal =
+                std::any_of(effective.begin(), effective.end(), [](const auto &item) { return item && item->is_port(); });
+            if (temporal) {
+                if (delta) { backend(range, "a temporal structured delta is only available in a runtime function"); }
+                const hgraph::TSValueTypeMetaData *target = schema(type);
+                if (target->kind != hgraph::TSTypeKind::TSB || target->field_count() != contract.fields.size()) {
+                    backend(range, "temporal struct metadata does not match '" + contract.identity + "'");
+                }
+                std::vector<hgraph::WiringPortRef> children;
+                for (std::size_t index = 0; index < contract.fields.size(); ++index) {
+                    const auto *field_schema = target->fields()[index].type;
+                    if (!effective[index] || effective[index]->kind == Slot::Kind::Null) {
+                        children.push_back(hgraph::WiringPortRef::null_source(field_schema));
+                    } else if (effective[index]->is_const()) {
+                        Slot converted = make_const(convert(effective[index]->value, meta->fields[index].type,
+                                                            effective[index]->range, "field '" + contract.fields[index].name + "'"),
+                                                    effective[index]->range);
+                        children.push_back(wire_constant(converted, field_schema).port);
+                    } else if (effective[index]->is_port() && effective[index]->port.schema == field_schema) {
+                        children.push_back(effective[index]->port);
+                    } else {
+                        fail(Category::Type, effective[index]->range,
+                             "field '" + contract.fields[index].name + "' expects " + std::string{field_schema->name()});
+                    }
+                }
+                return make_port(hgraph::WiringPortRef::structural_source(target, std::move(children)), range);
+            }
+
+            hgraph::BundleBuilder output{hgraph::ValuePlanFactory::instance().type_for(meta)};
+            for (std::size_t index = 0; index < contract.fields.size(); ++index) {
+                if (!effective[index] || effective[index]->kind == Slot::Kind::Null) { continue; }
+                if (!effective[index]->is_const()) {
+                    fail(Category::Type, effective[index]->range,
+                         "field '" + contract.fields[index].name + "' needs a scalar value");
+                }
+                output.set(index, convert(effective[index]->value, meta->fields[index].type, effective[index]->range,
+                                          "field '" + contract.fields[index].name + "'")
+                                      .view());
+            }
+            Slot result = make_const(output.build(), range);
+            if (delta) { result.kind = Slot::Kind::Delta; }
+            return result;
         }
 
-        /// Places one argument value in the callee frame: constants convert to
-        /// a `const` parameter's type or wire `const` at a temporal
-        /// parameter's schema; ports must match the schema exactly.
-        Slot Compiler::bind_parameter(const ast::Parameter &param, const Slot &arg, Frame &callee, SourceRange range)
-        {
-            if (param.is_const)
-            {
-                const auto *meta = value_meta_for_type(param.type, callee);
-                Slot        slot = constant_of(arg, meta, callee, "parameter '" + std::string{param.name.text} + "'");
-                slot.range       = range;
-                return slot;
+        Slot Compiler::eval_construct(gir::TypeId type, const std::vector<gir::Argument> &arguments, bool delta, SourceRange range,
+                                      Frame &frame) {
+            std::vector<std::pair<std::string, Slot>> supplied;
+            supplied.reserve(arguments.size());
+            for (const gir::Argument &argument : arguments) {
+                supplied.emplace_back(argument.name, eval_value(argument.value, frame));
             }
-            const auto *schema = schema_for_type(param.type, callee);
-            if (arg.is_const()) { return wire_constant(make_const(convert(arg.value, schema->value_schema, arg.range,
-                                                                            "parameter '" + std::string{param.name.text} + "'"),
-                                                                    arg.range),
-                                                         schema); }
-            if (!arg.is_port())
-            {
-                fail(Category::Type, arg.range, "parameter '" + std::string{param.name.text} + "' takes a time-series value");
-            }
-            if (arg.port.schema != schema)
-            {
-                fail(Category::Type, arg.range,
-                     "parameter '" + std::string{param.name.text} + "' expects " + std::string{schema->name()} + ", got " +
-                         std::string{arg.port.schema == nullptr ? "an untyped port" : arg.port.schema->name()});
-            }
-            return make_port(arg.port, range);
+            return assemble_construct(type, std::move(supplied), delta, range, frame);
         }
 
-        Slot Compiler::call_function(ast::DeclId decl, const std::vector<ast::Argument> &arguments, SourceRange range,
-                                     Frame &frame)
-        {
-            const ast::FunctionDecl &fn = function(decl);
-            if (fn.visibility == ast::FunctionVisibility::Impl)
-            {
+        std::vector<std::optional<gir::ValueId>>
+        Compiler::bind_arguments(const gir::Callable &target, const std::vector<gir::Argument> &arguments, SourceRange range) {
+            std::vector<std::optional<gir::ValueId>> result(target.parameters.size());
+            std::size_t                              next = 0;
+            for (const gir::Argument &argument : arguments) {
+                if (argument.name.empty()) {
+                    if (next >= result.size()) {
+                        fail(Category::Type, argument.range,
+                             "'" + local_name(target.identity) + "' takes " + std::to_string(result.size()) + " arguments");
+                    }
+                    if (result[next]) { fail(Category::Type, argument.range, "positional argument after a named one"); }
+                    result[next++] = argument.value;
+                    continue;
+                }
+                const auto found = std::find_if(target.parameters.begin(), target.parameters.end(),
+                                                [&](const gir::Parameter &parameter) { return parameter.name == argument.name; });
+                if (found == target.parameters.end()) {
+                    fail(Category::Name, argument.range,
+                         "'" + local_name(target.identity) + "' has no parameter named '" + argument.name + "'");
+                }
+                const std::size_t index = static_cast<std::size_t>(found - target.parameters.begin());
+                if (result[index]) { fail(Category::Name, argument.range, "'" + argument.name + "' is given twice"); }
+                result[index] = argument.value;
+                next          = std::max(next, index + 1U);
+            }
+            for (std::size_t index = 0; index < target.parameters.size(); ++index) {
+                if (!result[index] && !target.parameters[index].default_value.valid()) {
+                    fail(Category::Type, range,
+                         "'" + local_name(target.identity) + "' needs an argument for '" + target.parameters[index].name + "'");
+                }
+            }
+            return result;
+        }
+
+        Slot Compiler::bind_parameter(const gir::Parameter &parameter, const Slot &argument, Frame &frame, SourceRange range) {
+            if (parameter.is_const) {
+                Slot result  = constant_of(argument, value_meta(parameter.type), frame, "parameter '" + parameter.name + "'");
+                result.range = range;
+                return result;
+            }
+            const auto *target = schema(parameter.type);
+            if (argument.is_const()) {
+                return wire_constant(
+                    make_const(convert(argument.value, target->value_schema, argument.range, "parameter '" + parameter.name + "'"),
+                               argument.range),
+                    target);
+            }
+            if (!argument.is_port()) {
+                fail(Category::Type, argument.range, "parameter '" + parameter.name + "' takes a time-series value");
+            }
+            if (argument.port.schema != target) {
+                fail(Category::Type, argument.range,
+                     "parameter '" + parameter.name + "' expects " + std::string{target->name()} + ", got " +
+                         std::string{argument.port.schema == nullptr ? "an untyped port" : argument.port.schema->name()});
+            }
+            return make_port(argument.port, range);
+        }
+
+        Slot Compiler::wire_function(gir::CallableId id, Frame &frame, SourceRange range) {
+            const gir::Callable           &target = callable(id);
+            std::vector<hgraph::WiringArg> arguments;
+            for (const gir::Parameter &parameter : target.parameters) {
+                arguments.push_back(argument_of(frame.bindings.at(parameter.binding.value), parameter.name));
+            }
+            return wire(target.identity, std::move(arguments), range);
+        }
+
+        Slot Compiler::invoke(gir::CallableId id, Frame &frame) {
+            const gir::Callable &target = callable(id);
+            if (target.concise_body.valid()) { return eval_value(target.concise_body, frame); }
+            Slot result = exec_block(target.block_body, frame);
+            return frame.returned ? *frame.returned : result;
+        }
+
+        Slot Compiler::call_function(gir::CallableId id, const std::vector<gir::Argument> &arguments, SourceRange range,
+                                     Frame &caller) {
+            const gir::Callable &target = callable(id);
+            if (target.visibility == gir::CallableVisibility::Implementation) {
                 backend(range, "an impl fn is reached through its operator, not called directly");
             }
-            if (!fn.generics.empty()) { backend(range, "generic functions are not supported by the first pass"); }
-            const std::vector<ast::ExprId> bound = bind_arguments(fn, arguments, range);
-            Frame                          callee;
-            callee.fn = decl;
-            callee.params.resize(bound.size());
-            const auto &params = fn.signature.parameters;
-            // Const parameters first: temporal parameter types may name them.
-            for (std::size_t pass = 0; pass < 2; ++pass)
-            {
-                for (std::size_t i = 0; i < params.size(); ++i)
-                {
-                    if (params[i].is_const != (pass == 0)) { continue; }
-                    Slot arg = bound[i] != ast::no_node ? eval_expr(bound[i], frame)
-                                                        : eval_expr(params[i].default_value, callee);
-                    callee.params[i] = bind_parameter(params[i], arg, callee, arg.range);
+            if (!target.generics.empty()) { backend(range, "generic functions are not supported by the first pass"); }
+            const auto bound = bind_arguments(target, arguments, range);
+            Frame      callee;
+            callee.callable = id;
+            for (std::size_t pass = 0; pass < 2; ++pass) {
+                for (std::size_t index = 0; index < target.parameters.size(); ++index) {
+                    const gir::Parameter &parameter = target.parameters[index];
+                    if (parameter.is_const != (pass == 0)) { continue; }
+                    Slot argument =
+                        bound[index] ? eval_value(*bound[index], caller) : eval_const_expr(parameter.default_value, callee);
+                    callee.bindings[parameter.binding.value] = bind_parameter(parameter, argument, callee, argument.range);
                 }
             }
-            Slot result = resolved_.kind(decl) == semantics::FunctionKind::Runtime ? wire_function(decl, callee, range)
-                                                                                   : invoke(decl, callee);
+            Slot result  = target.kind == gir::CallableKind::RuntimeNode ? wire_function(id, callee, range) : invoke(id, callee);
             result.range = range;
             return result;
         }
 
-        Slot Compiler::wire_function(ast::DeclId decl, Frame &callee, SourceRange range)
-        {
-            const ast::FunctionDecl       &fn = function(decl);
-            std::vector<hgraph::WiringArg> arguments;
-            arguments.reserve(fn.signature.parameters.size());
-            for (std::size_t i = 0; i < fn.signature.parameters.size(); ++i)
-            {
-                arguments.push_back(argument_of(callee.params[i], std::string{fn.signature.parameters[i].name.text}));
+        Slot Compiler::eval_intrinsic(std::string_view name, const std::vector<gir::Argument> &arguments, SourceRange range,
+                                      Frame &frame) {
+            if (name == "valid" || name == "modified" || name == "all_valid") {
+                if (arguments.empty()) {
+                    fail(Category::Type, range, "'" + std::string{name} + "' takes at least one time-series argument");
+                }
+                const char         *operation = name == "modified" ? "modified" : "valid";
+                const char         *fold      = name == "modified" ? "or_" : "and_";
+                std::optional<Slot> result;
+                for (const gir::Argument &argument : arguments) {
+                    Slot item = eval_value(argument.value, frame);
+                    if (!item.is_port()) {
+                        fail(Category::Type, item.range, "'" + std::string{name} + "' takes time-series arguments");
+                    }
+                    Slot flag = wire(operation, {time_series_arg(item.port)}, range);
+                    result    = result ? wire(fold, {time_series_arg(result->port), time_series_arg(flag.port)}, range) : flag;
+                }
+                return *result;
             }
-            return wire(resolved_.module_path + "." + std::string{fn.name.text}, std::move(arguments), range);
+            if (name == "last_modified" || name == "last_modified_time" || name == "key_set") {
+                if (arguments.size() != 1U) {
+                    fail(Category::Type, range, "'" + std::string{name} + "' takes one time-series argument");
+                }
+                Slot item = eval_value(arguments.front().value, frame);
+                if (!item.is_port()) {
+                    fail(Category::Type, item.range, "'" + std::string{name} + "' takes a time-series argument");
+                }
+                return wire(name == "key_set" ? "keys_" : "last_modified_time", {time_series_arg(item.port)}, range);
+            }
+            backend(range, "'" + std::string{name} +
+                               "' is a runtime traversal; it is not available in a composition body of the first pass");
         }
 
-        Slot Compiler::invoke(ast::DeclId decl, Frame &callee)
-        {
-            const ast::FunctionDecl &fn = function(decl);
-            if (fn.concise_body != ast::no_node) { return eval_expr(fn.concise_body, callee); }
-            Slot result = exec_block(fn.block_body, callee);
-            if (callee.returned) { return *callee.returned; }
-            return result;
+        Slot Compiler::eval_call(const gir::Value &expression, const gir::Call &call, Frame &frame) {
+            if (expression.operation.kind == gir::OperationKind::Constructor) {
+                return eval_construct(expression.type, call.arguments, false, expression.range, frame);
+            }
+            Slot callee = eval_value(call.callee, frame);
+            switch (callee.kind) {
+                case Slot::Kind::Function: return call_function(callee.callable, call.arguments, expression.range, frame);
+                case Slot::Kind::Operator:
+                    {
+                        std::string name =
+                            expression.operation.registry_name.empty() ? callee.name : expression.operation.registry_name;
+                        std::vector<hgraph::WiringArg> arguments;
+                        for (const gir::Argument &argument : call.arguments) {
+                            arguments.push_back(argument_of(eval_value(argument.value, frame), argument.name));
+                        }
+                        return wire(name, std::move(arguments), expression.range);
+                    }
+                case Slot::Kind::Intrinsic: return eval_intrinsic(callee.name, call.arguments, expression.range, frame);
+                case Slot::Kind::Struct: return eval_construct(expression.type, call.arguments, false, expression.range, frame);
+                default: break;
+            }
+            fail(Category::Type, value(call.callee).range, "'" + slice(value(call.callee).range) + "' is not callable");
         }
 
-        // -------------------------------------------------------- statements
+        Slot Compiler::eval_value(gir::ValueId id, Frame &frame) {
+            const gir::Value &expression = value(id);
+            if (expression.constant) { return constant(*expression.constant, expression.range); }
+            return std::visit(
+                [&](const auto &node) -> Slot {
+                    using T = std::decay_t<decltype(node)>;
+                    if constexpr (std::is_same_v<T, gir::Literal>) {
+                        return constant(node.value, expression.range);
+                    } else if constexpr (std::is_same_v<T, gir::Reference>) {
+                        return eval_reference(node, expression.range, frame);
+                    } else if constexpr (std::is_same_v<T, gir::Unary>) {
+                        Slot operand = eval_value(node.operand, frame);
+                        if (operand.is_const()) { return fold_unary(node.op, operand, expression.range); }
+                        const std::string name = expression.operation.registry_name.empty()
+                                                     ? (node.op == hir::UnaryOp::Negate ? "neg_" : "not_")
+                                                     : expression.operation.registry_name;
+                        return wire(name, {argument_of(operand, {})}, expression.range);
+                    } else if constexpr (std::is_same_v<T, gir::Binary>) {
+                        Slot lhs = eval_value(node.lhs, frame);
+                        Slot rhs = eval_value(node.rhs, frame);
+                        if (lhs.kind == Slot::Kind::Sequence || rhs.kind == Slot::Kind::Sequence) {
+                            if ((node.op != hir::BinaryOp::Equal && node.op != hir::BinaryOp::NotEqual) || lhs.kind != rhs.kind) {
+                                fail(Category::Type, expression.range, "a harness sequence only compares with '==' or '!='");
+                            }
+                            return compare_sequences(lhs, rhs, node.op == hir::BinaryOp::NotEqual, expression.range, frame);
+                        }
+                        if (lhs.is_const() && rhs.is_const()) { return fold_binary(node.op, lhs, rhs, expression.range); }
+                        return wire_binary(expression, node.op, lhs, rhs);
+                    } else if constexpr (std::is_same_v<T, gir::Call>) {
+                        return eval_call(expression, node, frame);
+                    } else if constexpr (std::is_same_v<T, gir::Index>) {
+                        Slot target = eval_value(node.target, frame);
+                        Slot index  = eval_value(node.index, frame);
+                        if (target.is_port()) {
+                            const std::string name =
+                                expression.operation.registry_name.empty() ? "getitem_" : expression.operation.registry_name;
+                            return wire(name, {argument_of(target, {}), argument_of(index, {})}, expression.range);
+                        }
+                        if (target.is_const() && index.is_const() && index.meta() == types_.int_type) {
+                            const auto position = index.value.view().checked_as<hgraph::Int>();
+                            if (position < 0) { fail(Category::Type, expression.range, "index out of range"); }
+                            if (target.value.view().is_tuple()) {
+                                const auto input = target.value.view().as_tuple();
+                                if (static_cast<std::size_t>(position) >= input.size()) {
+                                    fail(Category::Type, expression.range, "tuple index out of range");
+                                }
+                                return make_const(hgraph::Value{input.at(static_cast<std::size_t>(position))}, expression.range);
+                            }
+                            if (target.value.view().is_list()) {
+                                const auto input = target.value.view().as_list();
+                                if (static_cast<std::size_t>(position) >= input.size()) {
+                                    fail(Category::Type, expression.range, "list index out of range");
+                                }
+                                return make_const(hgraph::Value{input.at(static_cast<std::size_t>(position))}, expression.range);
+                            }
+                        }
+                        backend(expression.range, "indexing is supported on time-series values and constant tuples and lists");
+                    } else if constexpr (std::is_same_v<T, gir::Field>) {
+                        Slot target = eval_value(node.target, frame);
+                        if (target.is_port()) {
+                            const std::string name =
+                                expression.operation.registry_name.empty() ? "getattr_" : expression.operation.registry_name;
+                            return wire(name, {argument_of(target, {}), scalar_arg(hgraph::Value{node.name})}, expression.range);
+                        }
+                        if ((target.is_const() || target.kind == Slot::Kind::Delta) && target.value.view().is_bundle()) {
+                            const auto field = target.value.view().as_bundle().field(node.name);
+                            return field.valid() ? make_const(hgraph::Value{field}, expression.range)
+                                                 : make_marker(Slot::Kind::Null, expression.range);
+                        }
+                        backend(expression.range, "field access needs a temporal or structured value");
+                    } else if constexpr (std::is_same_v<T, gir::Sequence>) {
+                        return eval_sequence(id, node, expression.range, frame);
+                    } else if constexpr (std::is_same_v<T, gir::Tuple>) {
+                        return eval_tuple(node, expression.range, frame);
+                    } else if constexpr (std::is_same_v<T, gir::Lambda>) {
+                        backend(expression.range, "anonymous functions are not supported by the first pass");
+                    } else if constexpr (std::is_same_v<T, gir::Conditional>) {
+                        Slot condition = eval_value(node.condition, frame);
+                        if (condition.is_port()) {
+                            backend(value(node.condition).range,
+                                    "'if' over a time-series condition is not supported by the first pass; use if_then_else");
+                        }
+                        if (!condition.is_const() || condition.meta() != types_.bool_type) {
+                            fail(Category::Type, value(node.condition).range, "an 'if' condition is a bool");
+                        }
+                        if (condition.value.view().checked_as<hgraph::Bool>()) { return exec_block(node.then_block, frame); }
+                        return node.otherwise.valid() ? eval_value(node.otherwise, frame) : Slot{};
+                    } else if constexpr (std::is_same_v<T, gir::BlockValue>) {
+                        return exec_block(node.block, frame);
+                    } else if constexpr (std::is_same_v<T, gir::HarnessEval>) {
+                        return eval_harness(node, expression.range, frame);
+                    } else if constexpr (std::is_same_v<T, gir::Construct>) {
+                        return eval_construct(node.type, node.arguments, node.delta, expression.range, frame);
+                    }
+                },
+                expression.node);
+        }
 
-        Slot Compiler::exec_block(ast::BlockId id, Frame &frame)
-        {
-            const ast::Block &block = module_.block(id);
-            Slot              result;
-            for (std::size_t i = 0; i < block.statements.size(); ++i)
-            {
+        Slot Compiler::exec_block(gir::BlockId id, Frame &frame) {
+            if (!id.valid() || id.value >= module_.blocks.size()) { backend({}, "invalid hgraph IR block ID"); }
+            const gir::Block &block = module_.blocks[id.value];
+            for (gir::StatementId statement : block.statements) {
                 if (frame.returned) { break; }
-                const bool is_tail = block.tail != ast::no_node && i + 1 == block.statements.size();
-                if (is_tail) { result = eval_expr(block.tail, frame); }
-                else { exec_stmt(block.statements[i], frame); }
+                exec_statement(statement, frame);
             }
-            return result;
+            return !frame.returned && block.tail.valid() ? eval_value(block.tail, frame) : Slot{};
         }
 
-        void Compiler::exec_stmt(ast::StmtId id, Frame &frame)
-        {
-            const ast::Stmt &stmt = module_.stmt(id);
+        void Compiler::exec_statement(gir::StatementId id, Frame &frame) {
+            if (!id.valid() || id.value >= module_.statements.size()) { backend({}, "invalid hgraph IR statement ID"); }
+            const gir::Statement &statement = module_.statements[id.value];
             std::visit(
                 [&](const auto &node) {
                     using T = std::decay_t<decltype(node)>;
-                    if constexpr (std::is_same_v<T, ast::LocalDecl>)
-                    {
-                        Slot value = eval_expr(node.init, frame);
-                        if (node.type != ast::no_node)
-                        {
-                            // A constant keeps its value shape; it meets a
-                            // schema only at a temporal parameter.
-                            if (value.is_const() || value.kind == Slot::Kind::Sequence)
-                            {
-                                value = constant_of(value, value_meta_for_type(node.type, frame), frame,
-                                                    "'" + std::string{node.name.text} + "'");
-                            }
-                            else if (value.is_port())
-                            {
-                                const auto *schema = schema_for_type(node.type, frame);
-                                if (value.port.schema != schema)
-                                {
-                                    fail(Category::Type, value.range,
-                                         "'" + std::string{node.name.text} + "' is declared " + std::string{schema->name()} +
-                                             " but the initialiser is " + std::string{value.port.schema->name()});
+                    if constexpr (std::is_same_v<T, gir::LocalBinding>) {
+                        Slot initial = eval_value(node.init, frame);
+                        if (node.type.valid() && node.type.value < module_.types.size()) {
+                            const hir::TypeKind kind = module_.types[node.type.value].kind;
+                            if ((initial.is_const() || initial.kind == Slot::Kind::Sequence) &&
+                                kind != hir::TypeKind::HarnessSequence && kind != hir::TypeKind::Deferred) {
+                                initial =
+                                    constant_of(initial, value_meta(node.type), frame, "'" + binding(node.binding).name + "'");
+                            } else if (initial.is_port()) {
+                                const auto *target = schema(node.type);
+                                if (initial.port.schema != target) {
+                                    fail(Category::Type, initial.range,
+                                         "'" + binding(node.binding).name + "' is declared " + std::string{target->name()} +
+                                             " but the initialiser is " + std::string{initial.port.schema->name()});
                                 }
                             }
                         }
-                        frame.locals[id] = std::move(value);
-                    }
-                    else if constexpr (std::is_same_v<T, ast::AssignStmt>)
-                    {
-                        const ast::Expr &place = module_.expr(node.place);
-                        if (!std::holds_alternative<ast::NameRef>(place.node) ||
-                            resolved_.binding(node.place).kind != BindingKind::Local)
-                        {
+                        frame.bindings[node.binding.value] = std::move(initial);
+                    } else if constexpr (std::is_same_v<T, gir::Assignment>) {
+                        const gir::Value &place     = value(node.place);
+                        const auto       *reference = std::get_if<gir::Reference>(&place.node);
+                        if (reference == nullptr || reference->kind != gir::ReferenceKind::Binding) {
                             backend(place.range, "assignment targets a local in the first pass");
                         }
-                        const ast::StmtId target = resolved_.binding(node.place).stmt;
-                        const auto       &decl   = module_.stmt(target);
-                        if (const auto *local = std::get_if<ast::LocalDecl>(&decl.node);
-                            local == nullptr || !local->mutable_)
-                        {
-                            fail(Category::Type, place.range, "'" + slice(place.range) + "' is not a 'var'");
+                        const gir::Binding &target = binding(reference->binding);
+                        if (target.kind != gir::BindingKind::LocalVar) {
+                            fail(Category::Type, place.range, "'" + target.name + "' is not a 'var'");
                         }
-                        const Slot &current = frame.locals.at(target);
-                        Slot        value   = eval_expr(node.value, frame);
-                        if (node.op != ast::AssignOp::Assign)
-                        {
-                            const ast::BinaryOp op = node.op == ast::AssignOp::Add   ? ast::BinaryOp::Add
-                                                     : node.op == ast::AssignOp::Sub ? ast::BinaryOp::Sub
-                                                     : node.op == ast::AssignOp::Mul ? ast::BinaryOp::Mul
-                                                                                     : ast::BinaryOp::Div;
-                            value = current.is_const() && value.is_const() ? fold_binary(op, current, value, stmt.range)
-                                                                           : wire_binary(op, current, value, stmt.range);
+                        const Slot current = frame.bindings.at(reference->binding.value);
+                        Slot       next    = eval_value(node.value, frame);
+                        if (node.op != gir::AssignOp::Assign) {
+                            const hir::BinaryOp op = node.op == gir::AssignOp::Add   ? hir::BinaryOp::Add
+                                                     : node.op == gir::AssignOp::Sub ? hir::BinaryOp::Sub
+                                                     : node.op == gir::AssignOp::Mul ? hir::BinaryOp::Mul
+                                                                                     : hir::BinaryOp::Div;
+                            next = current.is_const() && next.is_const() ? fold_binary(op, current, next, statement.range)
+                                                                         : wire_binary(value(node.value), op, current, next);
                         }
-                        if (current.kind != value.kind)
-                        {
-                            fail(Category::Type, stmt.range,
-                                 "assignment to '" + slice(place.range) + "' changes its inferred type");
+                        if (current.kind != next.kind) {
+                            fail(Category::Type, statement.range, "assignment to '" + target.name + "' changes its inferred type");
                         }
-                        if (current.is_const())
-                        {
-                            value = make_const(convert(value.value, current.meta(), value.range,
-                                                       "assignment to '" + slice(place.range) + "'"),
-                                               value.range);
+                        if (current.is_const()) {
+                            next = make_const(
+                                convert(next.value, current.meta(), next.range, "assignment to '" + target.name + "'"), next.range);
+                        } else if (current.is_port() && current.port.schema != next.port.schema) {
+                            fail(Category::Type, next.range,
+                                 "assignment to '" + target.name + "' expects " + std::string{current.port.schema->name()} +
+                                     ", got " + std::string{next.port.schema->name()});
                         }
-                        else if (current.is_port() && current.port.schema != value.port.schema)
-                        {
-                            fail(Category::Type, value.range,
-                                 "assignment to '" + slice(place.range) + "' expects " +
-                                     std::string{current.port.schema->name()} + ", got " + std::string{value.port.schema->name()});
+                        frame.bindings[reference->binding.value] = std::move(next);
+                    } else if constexpr (std::is_same_v<T, gir::Return>) {
+                        frame.returned = node.value.valid() ? eval_value(node.value, frame) : Slot{};
+                    } else if constexpr (std::is_same_v<T, gir::Assert>) {
+                        Slot condition = eval_value(node.condition, frame);
+                        if (!condition.is_const() || condition.meta() != types_.bool_type) {
+                            fail(Category::Type, value(node.condition).range, "'assert' takes a bool");
                         }
-                        frame.locals[target] = std::move(value);
-                    }
-                    else if constexpr (std::is_same_v<T, ast::ReturnStmt>)
-                    {
-                        frame.returned = node.value == ast::no_node ? Slot{} : eval_expr(node.value, frame);
-                    }
-                    else if constexpr (std::is_same_v<T, ast::AssertStmt>)
-                    {
-                        const Slot condition = eval_expr(node.condition, frame);
-                        if (!is_bool(condition))
-                        {
-                            fail(Category::Type, module_.expr(node.condition).range, "'assert' takes a bool");
-                        }
-                        if (!as_bool(condition))
-                        {
-                            std::string message = "assert failed: " + slice(module_.expr(node.condition).range);
-                            if (!compare_detail_.empty()) { message += "\n" + compare_detail_; }
+                        if (!condition.value.view().checked_as<hgraph::Bool>()) {
+                            std::string message = "assert failed: " + slice(value(node.condition).range);
+                            if (!comparison_detail_.empty()) { message += "\n" + comparison_detail_; }
                             throw TestFailure{std::move(message)};
                         }
-                    }
-                    else if constexpr (std::is_same_v<T, ast::ExprStmt>) { (void)eval_expr(node.expr, frame); }
-                    else
-                    {
-                        backend(stmt.range, "runtime statements are not evaluated by the first pass");
+                    } else if constexpr (std::is_same_v<T, gir::Evaluate>) {
+                        (void)eval_value(node.value, frame);
+                    } else {
+                        backend(statement.range, "runtime statements are not evaluated by the first pass");
                     }
                 },
-                stmt.node);
+                statement.node);
         }
 
-        // -------------------------------------------------------------- eval
-
-        /// `eval(fn, sequences...)`: one replay node per temporal parameter,
-        /// the function's body wired between them and a record node, one
-        /// simulation run, and the recorded deltas as a dense sequence
-        /// (developer guide, "First pass"; syntax guide, "Tests").
-        Slot Compiler::eval_eval(const ast::Eval &eval, SourceRange range, Frame &frame)
-        {
-            const Slot callee = eval_expr(eval.callee, frame);
-            if (callee.kind == Slot::Kind::Operator || callee.kind == Slot::Kind::Intrinsic)
-            {
-                backend(module_.expr(eval.callee).range,
-                        "eval takes a module function; wrap the operator in a fn to evaluate it");
+        Slot Compiler::eval_harness(const gir::HarnessEval &eval, SourceRange range, Frame &caller) {
+            Slot callee_slot = eval_value(eval.callee, caller);
+            if (callee_slot.kind == Slot::Kind::Operator || callee_slot.kind == Slot::Kind::Intrinsic) {
+                backend(value(eval.callee).range, "eval takes a module function; wrap the operator in a fn to evaluate it");
             }
-            if (callee.kind != Slot::Kind::Function)
-            {
-                fail(Category::Type, module_.expr(eval.callee).range, "eval takes a function");
+            if (callee_slot.kind != Slot::Kind::Function) {
+                fail(Category::Type, value(eval.callee).range, "eval takes a function");
             }
-            const ast::FunctionDecl &fn = function(callee.fn);
-            if (!fn.generics.empty()) { backend(range, "generic functions are not supported by the first pass"); }
-            const std::vector<ast::ExprId> bound = bind_arguments(fn, eval.arguments, range);
-            const auto                    &params = fn.signature.parameters;
+            const gir::Callable &target = callable(callee_slot.callable);
+            if (!target.generics.empty()) { backend(range, "generic functions are not supported by the first pass"); }
+            const auto bound = bind_arguments(target, eval.arguments, range);
 
-            hgraph::Wiring w;
+            hgraph::Wiring local_wiring;
             hgraph::record_replay::set_config(
-                w.global_state(),
+                local_wiring.global_state(),
                 hgraph::record_replay::RecordReplayConfig{.backend = std::string{hgraph::record_replay::TESTING}});
-            hgraph::Wiring *const outer = wiring_;
-            wiring_                     = &w;
-            struct Restore
-            {
-                hgraph::Wiring *&slot;
-                hgraph::Wiring  *previous;
-                ~Restore() { slot = previous; }
-            } restore{wiring_, outer};
+            hgraph::Wiring *previous = wiring_;
+            wiring_                  = &local_wiring;
+            auto restore_wiring      = hgraph::make_scope_exit([&]() noexcept { wiring_ = previous; });
 
-            Frame callee_frame;
-            callee_frame.fn = callee.fn;
-            callee_frame.params.resize(params.size());
+            Frame callee;
+            callee.callable = callee_slot.callable;
             std::vector<std::vector<std::optional<hgraph::Value>>> inputs;
-            std::vector<std::string>                                keys;
-            std::size_t                                             cycles = 0;
-            for (std::size_t pass = 0; pass < 2; ++pass)
-            {
-                for (std::size_t i = 0; i < params.size(); ++i)
-                {
-                    const ast::Parameter &param = params[i];
-                    if (param.is_const != (pass == 0)) { continue; }
-                    if (param.is_const)
-                    {
-                        Slot arg = bound[i] != ast::no_node ? eval_expr(bound[i], frame)
-                                                            : eval_expr(param.default_value, callee_frame);
-                        callee_frame.params[i] = bind_parameter(param, arg, callee_frame, arg.range);
+            std::vector<std::string>                               keys;
+            std::size_t                                            cycles = 0;
+            for (std::size_t pass = 0; pass < 2; ++pass) {
+                for (std::size_t index = 0; index < target.parameters.size(); ++index) {
+                    const gir::Parameter &parameter = target.parameters[index];
+                    if (parameter.is_const != (pass == 0)) { continue; }
+                    if (parameter.is_const) {
+                        Slot argument =
+                            bound[index] ? eval_value(*bound[index], caller) : eval_const_expr(parameter.default_value, callee);
+                        callee.bindings[parameter.binding.value] = bind_parameter(parameter, argument, callee, argument.range);
                         continue;
                     }
-                    const auto *schema = schema_for_type(param.type, callee_frame);
-                    if (schema->kind != hgraph::TSTypeKind::TS)
-                    {
-                        backend(module_.type(param.type).range,
-                                "eval drives ts parameters in the first pass; '" + std::string{param.name.text} + "' is " +
-                                    std::string{schema->name()});
+                    const auto *parameter_schema = schema(parameter.type);
+                    if (parameter_schema->kind != hgraph::TSTypeKind::TS) {
+                        backend(binding(parameter.binding).range, "eval drives ts parameters in the first pass; '" +
+                                                                      parameter.name + "' is " +
+                                                                      std::string{parameter_schema->name()});
                     }
-                    std::string key = "hgl::in::" + std::string{param.name.text};
-                    if (bound[i] == ast::no_node)
-                    {
-                        // A default for a temporal parameter: a constant, present every cycle.
-                        Slot value = eval_expr(param.default_value, callee_frame);
-                        if (!value.is_const())
-                        {
-                            fail(Category::Type, value.range, "a temporal parameter's default is a constant");
+                    const std::string key = "hgl::in::" + parameter.name;
+                    if (bound[index]) {
+                        Slot sequence = eval_value(*bound[index], caller);
+                        if (sequence.kind != Slot::Kind::Sequence) {
+                            fail(Category::Type, sequence.range, "eval drives '" + parameter.name + "' with a harness sequence");
                         }
-                        inputs.push_back({convert(value.value, schema->value_schema, value.range,
-                                                  "parameter '" + std::string{param.name.text} + "'")});
-                    }
-                    else
-                    {
-                        Slot sequence = eval_expr(bound[i], frame);
-                        if (sequence.kind != Slot::Kind::Sequence)
-                        {
-                            fail(Category::Type, module_.expr(bound[i]).range,
-                                 "eval drives '" + std::string{param.name.text} + "' with a harness sequence");
-                        }
-                        resolve_sequence(sequence, schema->value_schema, frame);
+                        resolve_sequence(sequence, parameter_schema->value_schema, caller);
                         inputs.push_back(std::move(sequence.elements));
+                    } else {
+                        Slot item = eval_const_expr(parameter.default_value, callee);
+                        if (!item.is_const()) { fail(Category::Type, item.range, "a temporal parameter's default is a constant"); }
+                        inputs.push_back({convert(item.value, parameter_schema->value_schema, item.range,
+                                                  "parameter '" + parameter.name + "'")});
                     }
                     cycles = std::max(cycles, inputs.back().size());
                     keys.push_back(key);
-                    callee_frame.params[i] =
-                        wire("replay", {scalar_arg(hgraph::Value{hgraph::Str{key}}, "key")}, range, true, schema);
+                    callee.bindings[parameter.binding.value] =
+                        wire("replay", {scalar_arg(hgraph::Value{key}, "key")}, range, true, parameter_schema);
                 }
             }
 
-            Slot result = resolved_.kind(callee.fn) == semantics::FunctionKind::Runtime
-                              ? wire_function(callee.fn, callee_frame, range)
-                              : invoke(callee.fn, callee_frame);
+            Slot result = target.kind == gir::CallableKind::RuntimeNode ? wire_function(callee_slot.callable, callee, range)
+                                                                        : invoke(callee_slot.callable, callee);
             if (result.is_const()) { result = wire_constant(result, registry_.ts(result.meta())); }
-            const hgraph::TSValueTypeMetaData *out_schema = nullptr;
-            if (result.is_port())
-            {
-                out_schema = result.port.schema;
-                (void)wire("record", {ts_arg(result.port), scalar_arg(hgraph::Value{hgraph::Str{"hgl::out"}}, "key")},
+            const hgraph::TSValueTypeMetaData *output_schema = nullptr;
+            if (result.is_port()) {
+                output_schema = result.port.schema;
+                (void)wire("record", {time_series_arg(result.port), scalar_arg(hgraph::Value{std::string{"hgl::out"}}, "key")},
                            range, false);
-            }
-            else if (result.kind != Slot::Kind::Void)
-            {
-                backend(range, "'" + std::string{fn.name.text} + "' does not produce a time-series value");
+            } else if (result.kind != Slot::Kind::Void) {
+                backend(range, "'" + local_name(target.identity) + "' does not produce a time-series value");
             }
 
             std::vector<std::optional<hgraph::Value>> observed;
-            try
-            {
-                hgraph::GraphBuilder graph = std::move(w).finish();
-                for (std::size_t i = 0; i < keys.size(); ++i)
-                {
-                    hgraph::testing::set_replay_deltas(graph.global_state(), keys[i], inputs[i]);
+            try {
+                hgraph::GraphBuilder graph = std::move(local_wiring).finish();
+                for (std::size_t index = 0; index < keys.size(); ++index) {
+                    hgraph::testing::set_replay_deltas(graph.global_state(), keys[index], inputs[index]);
                 }
                 hgraph::GraphExecutorBuilder builder;
                 builder.graph_builder(std::move(graph)).start_time(hgraph::MIN_ST).end_time(hgraph::MAX_ET);
                 hgraph::GraphExecutorValue executor = builder.make_executor();
                 auto                       view     = executor.view();
                 view.run();
-                if (out_schema != nullptr)
-                {
+                if (output_schema != nullptr) {
                     observed = hgraph::testing::get_recorded_deltas(view.graph().global_state(), "hgl::out");
                 }
+            } catch (const std::exception &error) {
+                throw TestFailure{"eval of '" + local_name(target.identity) + "' failed: " + error.what()};
             }
-            catch (const std::exception &error)
-            {
-                throw TestFailure{"eval of '" + std::string{fn.name.text} + "' failed: " + error.what()};
-            }
-            wiring_ = outer;
             while (observed.size() < cycles) { observed.emplace_back(std::nullopt); }
-
             Slot sequence;
-            sequence.kind      = Slot::Kind::Sequence;
-            sequence.resolved  = true;
-            sequence.elements  = std::move(observed);
-            sequence.elem_meta = out_schema != nullptr ? out_schema->delta_value_schema : nullptr;
-            sequence.range     = range;
+            sequence.kind         = Slot::Kind::Sequence;
+            sequence.resolved     = true;
+            sequence.elements     = std::move(observed);
+            sequence.element_meta = output_schema != nullptr ? output_schema->delta_value_schema : nullptr;
+            sequence.range        = range;
             return sequence;
         }
 
-        std::string Compiler::describe(const Slot &slot)
-        {
-            switch (slot.kind)
-            {
+        std::string Compiler::describe(const Slot &slot) {
+            switch (slot.kind) {
                 case Slot::Kind::Const: return describe_value(slot.value);
                 case Slot::Kind::Null: return "null";
+                case Slot::Kind::Placeholder: return "_";
                 case Slot::Kind::Delta: return "delta " + describe_value(slot.value);
                 case Slot::Kind::Port: return std::string{slot.port.schema->name()};
-                case Slot::Kind::Struct:
-                    return "struct " + std::string{std::get<ast::StructDecl>(module_.decl(slot.fn).node).name.text};
-                case Slot::Kind::Function: return "fn " + std::string{function(slot.fn).name.text};
+                case Slot::Kind::Struct: return "struct " + local_name(slot.name);
+                case Slot::Kind::Function: return "fn " + local_name(callable(slot.callable).identity);
                 case Slot::Kind::Operator: return "operator " + slot.name;
                 case Slot::Kind::Intrinsic: return "intrinsic " + slot.name;
-                case Slot::Kind::Sequence:
-                    return slot.resolved ? describe_sequence(slot.elements) : slice(slot.range);
-                case Slot::Kind::Void: break;
+                case Slot::Kind::Sequence: return slot.resolved ? describe_sequence(slot.elements) : slice(slot.range);
+                case Slot::Kind::Void: return {};
             }
             return {};
         }
 
-        // ------------------------------------------------------------- tests
-
-        std::vector<TestResult> Compiler::run_tests(const TestOptions &options)
-        {
+        std::vector<TestResult> Compiler::run_tests(const TestOptions &options) {
             std::vector<TestResult> results;
-            for (ast::DeclId id : resolved_.tests)
-            {
-                const auto &test = std::get<ast::TestDecl>(module_.decl(id).node);
-                if (!options.names.empty() &&
-                    std::find(options.names.begin(), options.names.end(), std::string{test.name.text}) == options.names.end())
-                {
+            for (const gir::TestPlan &test : module_.tests) {
+                const std::string name = local_name(test.identity);
+                if (!options.names.empty() && std::find(options.names.begin(), options.names.end(), name) == options.names.end()) {
                     continue;
                 }
                 TestResult result;
-                result.name = std::string{test.name.text};
+                result.name = name;
                 Frame frame;
                 frame.in_test = true;
-                compare_detail_.clear();
+                comparison_detail_.clear();
                 const std::size_t before = diagnostics_.size();
-                try
-                {
-                    Slot tail     = exec_block(test.block, frame);
+                try {
+                    Slot tail     = exec_block(test.body, frame);
                     result.passed = true;
                     if (options.describe_tail && tail.kind != Slot::Kind::Void) { result.tail = describe(tail); }
-                }
-                catch (const TestFailure &failure)
-                {
-                    result.message = failure.message;
-                }
-                catch (const Abort &)
-                {
+                } catch (const TestFailure &failure) { result.message = failure.message; } catch (const Abort &) {
                     result.message = "diagnostics reported";
-                }
-                catch (const std::exception &error)
-                {
-                    result.message = std::string{"error: "} + error.what();
-                }
+                } catch (const std::exception &error) { result.message = std::string{"error: "} + error.what(); }
                 if (diagnostics_.size() != before) { result.passed = false; }
                 results.push_back(std::move(result));
             }
             return results;
         }
 
-        // ---------------------------------------------------------- programs
-
-        /// A `--set name=<constant expression>` value, parsed and folded as
-        /// HGL in a scratch unit then converted to the parameter's type.
-        std::optional<hgraph::Value> Compiler::setting_value(const Setting &setting, const ast::Parameter &param,
-                                                             Frame &frame, SourceRange range)
-        {
-            const syntax::SourceFile scratch{"--set " + setting.name, "module hgl.cli\nfn __set() => " + setting.text + "\n"};
-            syntax::DiagnosticSink   scratch_diagnostics;
-            const ast::Module        scratch_module = syntax::parse(scratch, scratch_diagnostics);
-            semantics::ResolvedModule scratch_resolved;
-            if (!scratch_diagnostics.has_errors())
-            {
-                scratch_resolved = semantics::resolve(scratch, scratch_module, has_operator, scratch_diagnostics);
-            }
-            std::optional<hgraph::Value> value;
-            if (!scratch_diagnostics.has_errors())
-            {
-                Compiler scratch_compiler{scratch, scratch_module, scratch_resolved, scratch_diagnostics};
-                Frame    scratch_frame;
-                try
-                {
-                    const ast::DeclId fn = scratch_resolved.functions.at(0);
-                    scratch_frame.fn     = fn;
-                    const Slot slot = scratch_compiler.invoke(fn, scratch_frame);
-                    if (!slot.is_const())
-                    {
-                        scratch_diagnostics.report(Category::Type, slot.range, "a --set value is a constant expression");
-                    }
-                    else { value = slot.value; }
-                }
-                catch (const Abort &)
-                {
-                }
-            }
-            if (scratch_diagnostics.has_errors())
-            {
-                fail(Category::Type, range,
-                     "--set " + setting.name + ": invalid value\n" + scratch_diagnostics.render(scratch));
-            }
-            return convert(*value, value_meta_for_type(param.type, frame), range, "'" + std::string{param.name.text} + "'");
+        std::optional<hgraph::Value> Compiler::evaluate_constant(gir::ValueId id) {
+            try {
+                Frame frame;
+                Slot  result = eval_value(id, frame);
+                if (!result.is_const()) { fail(Category::Type, result.range, "a --set value is a constant expression"); }
+                return result.value;
+            } catch (const Abort &) { return std::nullopt; }
         }
 
-        bool Compiler::run_program(const RunOptions &options, std::ostream &out)
-        {
-            // The entry: the named export, or the only export with no temporal parameters.
-            std::vector<ast::DeclId> candidates;
-            for (ast::DeclId id : resolved_.functions)
-            {
-                const ast::FunctionDecl &fn = function(id);
-                if (fn.visibility != ast::FunctionVisibility::Export) { continue; }
-                if (!options.entry.empty())
-                {
-                    if (std::string{fn.name.text} == options.entry) { candidates.push_back(id); }
+        bool Compiler::run_program(const RunOptions &options, std::ostream &out) {
+            std::vector<gir::CallableId> candidates;
+            for (std::uint32_t index = 0; index < module_.callables.size(); ++index) {
+                const gir::Callable &target = module_.callables[index];
+                if (target.visibility != gir::CallableVisibility::Export) { continue; }
+                if (!options.entry.empty()) {
+                    if (local_name(target.identity) == options.entry) { candidates.push_back(gir::CallableId{index}); }
                     continue;
                 }
-                const bool all_const = std::all_of(fn.signature.parameters.begin(), fn.signature.parameters.end(),
-                                                   [](const ast::Parameter &param) { return param.is_const; });
-                if (all_const) { candidates.push_back(id); }
+                if (std::all_of(target.parameters.begin(), target.parameters.end(),
+                                [](const gir::Parameter &parameter) { return parameter.is_const; })) {
+                    candidates.push_back(gir::CallableId{index});
+                }
             }
-            const SourceRange whole{0, 0};
-            try
-            {
-                if (candidates.empty())
-                {
-                    backend(whole, options.entry.empty()
-                                       ? std::string{"no entry: an entry is an export fn with only const parameters"}
-                                       : "no export fn named '" + options.entry + "'");
+            const SourceRange whole{};
+            try {
+                if (candidates.empty()) {
+                    backend(whole, options.entry.empty() ? "no entry: an entry is an export fn with only const parameters"
+                                                         : "no export fn named '" + options.entry + "'");
                 }
-                if (candidates.size() > 1)
-                {
-                    backend(whole, "several entries; choose one with --entry");
-                }
-                const ast::DeclId        entry = candidates.front();
-                const ast::FunctionDecl &fn    = function(entry);
-                for (const Setting &setting : options.settings)
-                {
-                    const auto &params = fn.signature.parameters;
-                    if (std::none_of(params.begin(), params.end(),
-                                     [&](const ast::Parameter &param) { return std::string{param.name.text} == setting.name; }))
-                    {
-                        fail(Category::Name, whole, "--set " + setting.name + ": '" + std::string{fn.name.text} +
-                                                        "' has no parameter named '" + setting.name + "'");
+                if (candidates.size() > 1U) { backend(whole, "several entries; choose one with --entry"); }
+                const gir::CallableId entry  = candidates.front();
+                const gir::Callable  &target = callable(entry);
+                for (const Setting &setting : options.settings) {
+                    if (std::none_of(target.parameters.begin(), target.parameters.end(),
+                                     [&](const gir::Parameter &parameter) { return parameter.name == setting.name; })) {
+                        fail(Category::Name, whole,
+                             "--set " + setting.name + ": '" + local_name(target.identity) + "' has no parameter named '" +
+                                 setting.name + "'");
                     }
                 }
 
-                hgraph::Wiring w;
-                wiring_ = &w;
+                hgraph::Wiring graph_wiring;
+                wiring_            = &graph_wiring;
+                auto  clear_wiring = hgraph::make_scope_exit([&]() noexcept { wiring_ = nullptr; });
                 Frame frame;
-                frame.fn = entry;
-                frame.params.resize(fn.signature.parameters.size());
-                for (std::size_t i = 0; i < fn.signature.parameters.size(); ++i)
-                {
-                    const ast::Parameter &param = fn.signature.parameters[i];
-                    const SourceRange     range = param.name.range;
-                    if (!param.is_const)
-                    {
-                        backend(range, "entry parameter '" + std::string{param.name.text} + "' is not const; nothing drives it");
+                frame.callable = entry;
+                for (const gir::Parameter &parameter : target.parameters) {
+                    if (!parameter.is_const) {
+                        backend(binding(parameter.binding).range,
+                                "entry parameter '" + parameter.name + "' is not const; nothing drives it");
                     }
                     const auto setting = std::find_if(options.settings.begin(), options.settings.end(),
-                                                      [&](const Setting &s) { return s.name == std::string{param.name.text}; });
-                    if (setting != options.settings.end())
-                    {
-                        frame.params[i] = make_const(*setting_value(*setting, param, frame, range), range);
+                                                      [&](const Setting &item) { return item.name == parameter.name; });
+                    Slot       value_slot;
+                    if (setting != options.settings.end()) {
+                        value_slot = make_const(setting->value, binding(parameter.binding).range);
+                    } else if (parameter.default_value.valid()) {
+                        value_slot = eval_const_expr(parameter.default_value, frame);
+                    } else {
+                        fail(Category::Type, binding(parameter.binding).range,
+                             "'" + parameter.name + "' has no default; pass --set " + parameter.name + "=<value>");
                     }
-                    else if (param.default_value != ast::no_node)
-                    {
-                        Slot value      = eval_expr(param.default_value, frame);
-                        frame.params[i] = bind_parameter(param, value, frame, range);
-                    }
-                    else
-                    {
-                        fail(Category::Type, range, "'" + std::string{param.name.text} + "' has no default; pass --set " +
-                                                        std::string{param.name.text} + "=<value>");
-                    }
+                    frame.bindings[parameter.binding.value] =
+                        bind_parameter(parameter, value_slot, frame, binding(parameter.binding).range);
                 }
-                Slot result = resolved_.kind(entry) == semantics::FunctionKind::Runtime
-                                  ? wire_function(entry, frame, module_.decl(entry).range)
-                                  : invoke(entry, frame);
+                Slot result = target.kind == gir::CallableKind::RuntimeNode ? wire_function(entry, frame, target.range)
+                                                                            : invoke(entry, frame);
                 if (result.is_const()) { result = wire_constant(result, registry_.ts(result.meta())); }
-                if (!result.is_port())
-                {
-                    backend(module_.decl(entry).range, "'" + std::string{fn.name.text} + "' produces no time-series value to run");
+                if (!result.is_port()) {
+                    backend(target.range, "'" + local_name(target.identity) + "' produces no time-series value to run");
                 }
-                (void)wire("hgl.print_tick", {ts_arg(result.port)}, module_.decl(entry).range, false);
-                wiring_ = nullptr;
+                (void)wire("hgl.print_tick", {time_series_arg(result.port)}, target.range, false);
 
-                hgraph::GraphBuilder         graph = std::move(w).finish();
+                hgraph::GraphBuilder         graph = std::move(graph_wiring).finish();
                 hgraph::GraphExecutorBuilder builder;
                 builder.graph_builder(std::move(graph));
-                const bool realtime = options.mode == RunMode::RealTime;
-                builder.mode(realtime ? hgraph::GraphExecutorMode::RealTime : hgraph::GraphExecutorMode::Simulation);
+                const bool real_time = options.mode == RunMode::RealTime;
+                builder.mode(real_time ? hgraph::GraphExecutorMode::RealTime : hgraph::GraphExecutorMode::Simulation);
                 hgraph::DateTime start = hgraph::MIN_ST;
-                if (options.start) { start = *options.start; }
-                else if (realtime)
-                {
+                if (options.start) {
+                    start = *options.start;
+                } else if (real_time) {
                     start = std::chrono::time_point_cast<std::chrono::microseconds>(hgraph::engine_clock::now());
                 }
                 builder.start_time(start);
-                if (options.end) { builder.end_time(*options.end); }
-                else if (options.end_after) { builder.end_time(start + *options.end_after); }
-                else { builder.end_time(hgraph::MAX_ET); }
-                std::ostream *const previous = sink_stream;
-                sink_stream                  = &out;
-                struct RestoreSink
-                {
-                    std::ostream *saved;
-                    ~RestoreSink() { sink_stream = saved; }
-                } restore_sink{previous};
-                hgraph::GraphExecutorValue executor = builder.make_executor();
-                auto                       view     = executor.view();
-                view.run();
+                if (options.end) {
+                    builder.end_time(*options.end);
+                } else if (options.end_after) {
+                    builder.end_time(start + *options.end_after);
+                } else {
+                    builder.end_time(hgraph::MAX_ET);
+                }
+
+                std::ostream *previous                  = sink_stream;
+                sink_stream                             = &out;
+                auto                       restore_sink = hgraph::make_scope_exit([&]() noexcept { sink_stream = previous; });
+                hgraph::GraphExecutorValue executor     = builder.make_executor();
+                executor.view().run();
                 return true;
-            }
-            catch (const Abort &)
-            {
-                wiring_ = nullptr;
-                return false;
-            }
-            catch (const std::exception &error)
-            {
-                wiring_ = nullptr;
+            } catch (const Abort &) { return false; } catch (const std::exception &error) {
                 diagnostics_.report(Category::Backend, whole, std::string{"run failed: "} + error.what());
                 return false;
             }
         }
     }  // namespace
 
-    // ------------------------------------------------------------ public API
-
-    void ensure_session()
-    {
+    void ensure_session() {
         static const bool installed = [] {
             (void)standard_types();
             hgraph::stdlib::register_standard_operators();
@@ -2311,43 +1573,40 @@ namespace hgl::wiring
             hgraph::analytics::register_analytics_operators();
 #endif
             auto &registry = hgraph::OperatorRegistry::instance();
-            registry.register_installer("hgl.wiring",
-                                        [] { hgraph::register_overload<print_tick, print_tick_impl>(); });
+            registry.register_installer("hgl.wiring", [] { hgraph::register_overload<print_tick, print_tick_impl>(); });
             registry.run_installers();
             return true;
         }();
         (void)installed;
     }
 
-    bool has_operator(std::string_view name)
-    {
+    bool has_operator(std::string_view name) {
         ensure_session();
         return !hgraph::OperatorRegistry::instance().overload_signatures(name).empty();
     }
 
-    std::vector<TestResult> run_tests(const syntax::SourceFile &file, const ast::Module &module,
-                                      const semantics::ResolvedModule &resolved, const TestOptions &options,
-                                      syntax::DiagnosticSink &diagnostics)
-    {
+    std::vector<TestResult> run_tests(const syntax::SourceFile &file, const gir::Module &module, const TestOptions &options,
+                                      syntax::DiagnosticSink &diagnostics) {
         ensure_session();
-        Compiler compiler{file, module, resolved, diagnostics};
-        return compiler.run_tests(options);
+        return Compiler{file, module, diagnostics}.run_tests(options);
     }
 
-    bool run_program(const syntax::SourceFile &file, const ast::Module &module,
-                     const semantics::ResolvedModule &resolved, const RunOptions &options,
-                     syntax::DiagnosticSink &diagnostics, std::ostream &out)
-    {
+    bool run_program(const syntax::SourceFile &file, const gir::Module &module, const RunOptions &options,
+                     syntax::DiagnosticSink &diagnostics, std::ostream &out) {
         ensure_session();
-        Compiler compiler{file, module, resolved, diagnostics};
-        return compiler.run_program(options, out);
+        return Compiler{file, module, diagnostics}.run_program(options, out);
     }
 
-    std::string format_time(hgraph::DateTime when)
-    {
+    std::optional<hgraph::Value> evaluate_constant(const syntax::SourceFile &file, const gir::Module &module, gir::ValueId value,
+                                                   syntax::DiagnosticSink &diagnostics) {
+        ensure_session();
+        return Compiler{file, module, diagnostics}.evaluate_constant(value);
+    }
+
+    std::string format_time(hgraph::DateTime when) {
         syntax::TemporalValue value;
-        value.kind   = syntax::TemporalKind::DateTime;
-        value.micros = when.time_since_epoch().count();
+        value.kind           = syntax::TemporalKind::DateTime;
+        value.micros         = when.time_since_epoch().count();
         std::string spelling = syntax::canonical_spelling(value);
         if (!spelling.empty() && spelling.front() == '@') { spelling.erase(0, 1); }
         return spelling;

--- a/language/src/wiring/backend.cpp
+++ b/language/src/wiring/backend.cpp
@@ -271,6 +271,13 @@ namespace hgl::wiring
 
             [[nodiscard]] const gir::StructContract &structure(gir::TypeId type) {
                 if (!type.valid() || type.value >= module_.types.size()) { backend({}, "invalid hgraph IR type ID"); }
+                while (module_.types[type.value].kind == hir::TypeKind::Atomic) {
+                    if (module_.types[type.value].children.size() != 1U) {
+                        backend(module_.types[type.value].range, "an atomic struct type needs one child");
+                    }
+                    type = module_.types[type.value].children.front();
+                    if (!type.valid() || type.value >= module_.types.size()) { backend({}, "invalid atomic child type ID"); }
+                }
                 const std::string &identity = module_.types[type.value].nominal_identity;
                 const auto         found = std::find_if(module_.structures.begin(), module_.structures.end(),
                                                         [&](const gir::StructContract &item) { return item.identity == identity; });
@@ -862,7 +869,10 @@ namespace hgl::wiring
                 values.push_back(std::move(item.value));
             }
             if (values.empty()) { fail(Category::Type, range, "an empty list has no element type"); }
-            const auto         *meta = registry_.list(values.front().schema());
+            const auto *meta = value_meta(value(id).type);
+            if (meta->try_value_kind() != hgraph::ValueTypeKind::List) {
+                backend(range, "a list expression has non-list metadata");
+            }
             hgraph::ListBuilder output{hgraph::ValuePlanFactory::instance().type_for(meta->element_type), *meta};
             for (const hgraph::Value &item : values) {
                 output.push_back(convert(item, meta->element_type, range, "a list element").view());
@@ -952,7 +962,7 @@ namespace hgl::wiring
             hgraph::BundleBuilder output{hgraph::ValuePlanFactory::instance().type_for(meta)};
             for (std::size_t index = 0; index < contract.fields.size(); ++index) {
                 if (!effective[index] || effective[index]->kind == Slot::Kind::Null) { continue; }
-                if (!effective[index]->is_const()) {
+                if (!effective[index]->is_const() && !(delta && effective[index]->kind == Slot::Kind::Delta)) {
                     fail(Category::Type, effective[index]->range,
                          "field '" + contract.fields[index].name + "' needs a scalar value");
                 }

--- a/language/src/wiring/backend.cpp
+++ b/language/src/wiring/backend.cpp
@@ -322,7 +322,8 @@ namespace hgl::wiring
                                                  const hgraph::TSValueTypeMetaData *expected        = nullptr);
             [[nodiscard]] hgraph::WiringArg argument_of(const Slot &slot, std::string name);
             [[nodiscard]] Slot              wire_constant(const Slot &slot, const hgraph::TSValueTypeMetaData *target);
-            [[nodiscard]] Slot wire_binary(const gir::Value &expression, hir::BinaryOp op, const Slot &lhs, const Slot &rhs);
+            [[nodiscard]] Slot              wire_binary(hir::BinaryOp op, const Slot &lhs, const Slot &rhs, SourceRange range,
+                                                        std::string_view registry_name = {});
 
             [[nodiscard]] Slot eval_value(gir::ValueId id, Frame &frame);
             [[nodiscard]] Slot eval_reference(const gir::Reference &reference, SourceRange range, Frame &frame);
@@ -774,8 +775,9 @@ namespace hgl::wiring
             return wire("const", {scalar_arg(slot.value, "value")}, slot.range, true, target);
         }
 
-        Slot Compiler::wire_binary(const gir::Value &expression, hir::BinaryOp op, const Slot &lhs, const Slot &rhs) {
-            std::string name = expression.operation.registry_name;
+        Slot Compiler::wire_binary(hir::BinaryOp op, const Slot &lhs, const Slot &rhs, SourceRange range,
+                                   std::string_view registry_name) {
+            std::string name{registry_name};
             if (name.empty()) {
                 switch (op) {
                     case hir::BinaryOp::Add: name = "add_"; break;
@@ -793,7 +795,7 @@ namespace hgl::wiring
                     case hir::BinaryOp::Or: name = "or_"; break;
                 }
             }
-            return wire(name, {argument_of(lhs, {}), argument_of(rhs, {})}, expression.range);
+            return wire(name, {argument_of(lhs, {}), argument_of(rhs, {})}, range);
         }
 
         Slot Compiler::eval_reference(const gir::Reference &reference, SourceRange range, Frame &frame) {
@@ -1167,7 +1169,7 @@ namespace hgl::wiring
                             return compare_sequences(lhs, rhs, node.op == hir::BinaryOp::NotEqual, expression.range, frame);
                         }
                         if (lhs.is_const() && rhs.is_const()) { return fold_binary(node.op, lhs, rhs, expression.range); }
-                        return wire_binary(expression, node.op, lhs, rhs);
+                        return wire_binary(node.op, lhs, rhs, expression.range, expression.operation.registry_name);
                     } else if constexpr (std::is_same_v<T, gir::Call>) {
                         return eval_call(expression, node, frame);
                     } else if constexpr (std::is_same_v<T, gir::Index>) {
@@ -1290,7 +1292,7 @@ namespace hgl::wiring
                                                      : node.op == gir::AssignOp::Mul ? hir::BinaryOp::Mul
                                                                                      : hir::BinaryOp::Div;
                             next = current.is_const() && next.is_const() ? fold_binary(op, current, next, statement.range)
-                                                                         : wire_binary(value(node.value), op, current, next);
+                                                                         : wire_binary(op, current, next, statement.range);
                         }
                         if (current.kind != next.kind) {
                             fail(Category::Type, statement.range, "assignment to '" + target.name + "' changes its inferred type");

--- a/language/src/wiring/backend.cpp
+++ b/language/src/wiring/backend.cpp
@@ -779,6 +779,11 @@ namespace hgl::wiring
         Slot Compiler::convert_port(const Slot &slot, const hgraph::TSValueTypeMetaData *target) {
             if (!slot.is_port()) { fail(Category::Type, slot.range, "a time-series conversion needs a port"); }
             if (slot.port.schema == target) { return slot; }
+            const bool fixed_list_refines_dynamic =
+                slot.port.schema != nullptr && target != nullptr && slot.port.schema->kind == hgraph::TSTypeKind::TSL &&
+                target->kind == hgraph::TSTypeKind::TSL && slot.port.schema->fixed_size() != 0 && target->fixed_size() == 0 &&
+                slot.port.schema->element_ts() == target->element_ts();
+            if (fixed_list_refines_dynamic) { return slot; }
             return wire("convert", {argument_of(slot, "ts")}, slot.range, true, target);
         }
 
@@ -1150,7 +1155,9 @@ namespace hgl::wiring
                             arguments.push_back(argument_of(eval_value(argument.value, frame), argument.name));
                         }
                         const hgraph::TSValueTypeMetaData *expected =
-                            expression.phase == hir::Phase::Wiring ? schema(expression.type) : nullptr;
+                            expression.phase == hir::Phase::Wiring && expression.value_kind != hir::ValueKind::Void
+                                ? schema(expression.type)
+                                : nullptr;
                         return wire(name, std::move(arguments), expression.range, std::nullopt, expected);
                     }
                 case Slot::Kind::Intrinsic: return eval_intrinsic(callee.name, call.arguments, expression.range, frame);

--- a/language/src/wiring/backend.cpp
+++ b/language/src/wiring/backend.cpp
@@ -16,6 +16,7 @@
 #include <hgraph/types/record_replay.h>
 #include <hgraph/types/static_node.h>
 #include <hgraph/types/static_schema.h>
+#include <hgraph/types/temporal.h>
 #include <hgraph/types/value/value.h>
 #include <hgraph/types/value/value_builder.h>
 #include <hgraph/types/value/value_view.h>
@@ -30,6 +31,7 @@
 #include <compare>
 #include <exception>
 #include <iostream>
+#include <limits>
 #include <optional>
 #include <span>
 #include <sstream>
@@ -193,6 +195,33 @@ namespace hgl::wiring
                 case hir::BinaryOp::Or: return "||";
             }
             return "?";
+        }
+
+        [[nodiscard]] std::optional<hgraph::Int> checked_integer_add(hgraph::Int lhs, hgraph::Int rhs) noexcept {
+            constexpr auto min = std::numeric_limits<hgraph::Int>::min();
+            constexpr auto max = std::numeric_limits<hgraph::Int>::max();
+            if ((rhs > 0 && lhs > max - rhs) || (rhs < 0 && lhs < min - rhs)) { return std::nullopt; }
+            return lhs + rhs;
+        }
+
+        [[nodiscard]] std::optional<hgraph::Int> checked_integer_subtract(hgraph::Int lhs, hgraph::Int rhs) noexcept {
+            constexpr auto min = std::numeric_limits<hgraph::Int>::min();
+            constexpr auto max = std::numeric_limits<hgraph::Int>::max();
+            if ((rhs > 0 && lhs < min + rhs) || (rhs < 0 && lhs > max + rhs)) { return std::nullopt; }
+            return lhs - rhs;
+        }
+
+        [[nodiscard]] std::optional<hgraph::Int> checked_integer_multiply(hgraph::Int lhs, hgraph::Int rhs) noexcept {
+            constexpr auto min = std::numeric_limits<hgraph::Int>::min();
+            constexpr auto max = std::numeric_limits<hgraph::Int>::max();
+            if (lhs == 0 || rhs == 0) { return 0; }
+            if ((lhs == -1 && rhs == min) || (rhs == -1 && lhs == min)) { return std::nullopt; }
+            if (lhs > 0) {
+                if ((rhs > 0 && lhs > max / rhs) || (rhs < 0 && rhs < min / lhs)) { return std::nullopt; }
+            } else if ((rhs > 0 && lhs < min / rhs) || (rhs < 0 && lhs < max / rhs)) {
+                return std::nullopt;
+            }
+            return lhs * rhs;
         }
 
         std::string describe_view(const hgraph::ValueView &view) {
@@ -427,13 +456,22 @@ namespace hgl::wiring
         Slot Compiler::fold_unary(hir::UnaryOp op, const Slot &operand, SourceRange range) {
             if (op == hir::UnaryOp::Negate) {
                 if (operand.meta() == types_.int_type) {
-                    return make_const(hgraph::Value{hgraph::Int{-operand.value.view().checked_as<hgraph::Int>()}}, range);
+                    const hgraph::Int value = operand.value.view().checked_as<hgraph::Int>();
+                    if (value == std::numeric_limits<hgraph::Int>::min()) {
+                        fail(Category::Type, range, "overflow in an integer constant expression");
+                    }
+                    return make_const(hgraph::Value{hgraph::Int{-value}}, range);
                 }
                 if (operand.meta() == types_.float_type) {
                     return make_const(hgraph::Value{hgraph::Float{-operand.value.view().checked_as<hgraph::Float>()}}, range);
                 }
                 if (operand.meta() == types_.timedelta_type) {
-                    return make_const(hgraph::Value{-operand.value.view().checked_as<hgraph::TimeDelta>()}, range);
+                    try {
+                        return make_const(
+                            hgraph::Value{hgraph::checked_negate(operand.value.view().checked_as<hgraph::TimeDelta>())}, range);
+                    } catch (const std::overflow_error &) {
+                        fail(Category::Type, range, "overflow in a temporal constant expression");
+                    }
                 }
                 fail(Category::Type, range, "unary '-' needs a number, got " + std::string{operand.meta()->name()});
             }
@@ -458,12 +496,20 @@ namespace hgl::wiring
                      "'" + binary_spelling(op) + "' is not defined for " + std::string{lhs.meta()->name()} + " and " +
                          std::string{rhs.meta()->name()});
             };
+            const auto integer = [&](std::optional<hgraph::Int> value) -> Slot {
+                if (!value) { fail(Category::Type, range, "overflow in an integer constant expression"); }
+                return make_const(hgraph::Value{*value}, range);
+            };
+            const auto temporal = [&](auto operation) -> Slot {
+                try {
+                    return make_const(hgraph::Value{operation()}, range);
+                } catch (const std::overflow_error &) { fail(Category::Type, range, "overflow in a temporal constant expression"); }
+            };
             switch (op) {
                 case hir::BinaryOp::Add:
                     if (lhs_int && rhs_int) {
-                        return make_const(hgraph::Value{hgraph::Int{lhs.value.view().checked_as<hgraph::Int>() +
-                                                                    rhs.value.view().checked_as<hgraph::Int>()}},
-                                          range);
+                        return integer(checked_integer_add(lhs.value.view().checked_as<hgraph::Int>(),
+                                                           rhs.value.view().checked_as<hgraph::Int>()));
                     }
                     if (numeric) { return make_const(hgraph::Value{number(lhs) + number(rhs)}, range); }
                     if (lhs.meta() == types_.str_type && rhs.meta() == types_.str_type) {
@@ -472,50 +518,54 @@ namespace hgl::wiring
                             range);
                     }
                     if (lhs.meta() == types_.timedelta_type && rhs.meta() == types_.timedelta_type) {
-                        return make_const(hgraph::Value{lhs.value.view().checked_as<hgraph::TimeDelta>() +
-                                                        rhs.value.view().checked_as<hgraph::TimeDelta>()},
-                                          range);
+                        return temporal([&] {
+                            return hgraph::checked_add(lhs.value.view().checked_as<hgraph::TimeDelta>(),
+                                                       rhs.value.view().checked_as<hgraph::TimeDelta>());
+                        });
                     }
                     if (lhs.meta() == types_.datetime_type && rhs.meta() == types_.timedelta_type) {
-                        return make_const(hgraph::Value{lhs.value.view().checked_as<hgraph::DateTime>() +
-                                                        rhs.value.view().checked_as<hgraph::TimeDelta>()},
-                                          range);
+                        return temporal([&] {
+                            return hgraph::checked_add(lhs.value.view().checked_as<hgraph::DateTime>(),
+                                                       rhs.value.view().checked_as<hgraph::TimeDelta>());
+                        });
                     }
                     return type_error();
                 case hir::BinaryOp::Sub:
                     if (lhs_int && rhs_int) {
-                        return make_const(hgraph::Value{hgraph::Int{lhs.value.view().checked_as<hgraph::Int>() -
-                                                                    rhs.value.view().checked_as<hgraph::Int>()}},
-                                          range);
+                        return integer(checked_integer_subtract(lhs.value.view().checked_as<hgraph::Int>(),
+                                                                rhs.value.view().checked_as<hgraph::Int>()));
                     }
                     if (numeric) { return make_const(hgraph::Value{number(lhs) - number(rhs)}, range); }
                     if (lhs.meta() == types_.timedelta_type && rhs.meta() == types_.timedelta_type) {
-                        return make_const(hgraph::Value{lhs.value.view().checked_as<hgraph::TimeDelta>() -
-                                                        rhs.value.view().checked_as<hgraph::TimeDelta>()},
-                                          range);
+                        return temporal([&] {
+                            return hgraph::checked_subtract(lhs.value.view().checked_as<hgraph::TimeDelta>(),
+                                                            rhs.value.view().checked_as<hgraph::TimeDelta>());
+                        });
                     }
                     if (lhs.meta() == types_.datetime_type && rhs.meta() == types_.timedelta_type) {
-                        return make_const(hgraph::Value{lhs.value.view().checked_as<hgraph::DateTime>() -
-                                                        rhs.value.view().checked_as<hgraph::TimeDelta>()},
-                                          range);
+                        return temporal([&] {
+                            return hgraph::checked_subtract(lhs.value.view().checked_as<hgraph::DateTime>(),
+                                                            rhs.value.view().checked_as<hgraph::TimeDelta>());
+                        });
                     }
                     if (lhs.meta() == types_.datetime_type && rhs.meta() == types_.datetime_type) {
-                        return make_const(hgraph::Value{lhs.value.view().checked_as<hgraph::DateTime>() -
-                                                        rhs.value.view().checked_as<hgraph::DateTime>()},
-                                          range);
+                        return temporal([&] {
+                            return hgraph::checked_subtract(lhs.value.view().checked_as<hgraph::DateTime>(),
+                                                            rhs.value.view().checked_as<hgraph::DateTime>());
+                        });
                     }
                     return type_error();
                 case hir::BinaryOp::Mul:
                     if (lhs_int && rhs_int) {
-                        return make_const(hgraph::Value{hgraph::Int{lhs.value.view().checked_as<hgraph::Int>() *
-                                                                    rhs.value.view().checked_as<hgraph::Int>()}},
-                                          range);
+                        return integer(checked_integer_multiply(lhs.value.view().checked_as<hgraph::Int>(),
+                                                                rhs.value.view().checked_as<hgraph::Int>()));
                     }
                     if (numeric) { return make_const(hgraph::Value{number(lhs) * number(rhs)}, range); }
                     if (lhs.meta() == types_.timedelta_type && rhs_int) {
-                        return make_const(hgraph::Value{lhs.value.view().checked_as<hgraph::TimeDelta>() *
-                                                        rhs.value.view().checked_as<hgraph::Int>()},
-                                          range);
+                        return temporal([&] {
+                            return hgraph::checked_multiply(lhs.value.view().checked_as<hgraph::TimeDelta>(),
+                                                            rhs.value.view().checked_as<hgraph::Int>());
+                        });
                     }
                     return type_error();
                 case hir::BinaryOp::Div:
@@ -528,14 +578,20 @@ namespace hgl::wiring
                     if (lhs_int && rhs_int) {
                         const auto divisor = rhs.value.view().checked_as<hgraph::Int>();
                         if (divisor == 0) { fail(Category::Type, range, "division by zero"); }
-                        return make_const(hgraph::Value{hgraph::Int{lhs.value.view().checked_as<hgraph::Int>() % divisor}}, range);
+                        const auto dividend = lhs.value.view().checked_as<hgraph::Int>();
+                        return make_const(
+                            hgraph::Value{hgraph::Int{
+                                dividend == std::numeric_limits<hgraph::Int>::min() && divisor == -1 ? 0 : dividend % divisor}},
+                            range);
                     }
                     return type_error();
                 case hir::BinaryOp::Equal:
                 case hir::BinaryOp::NotEqual:
                     {
                         bool equal = false;
-                        if (numeric) {
+                        if (lhs_int && rhs_int) {
+                            equal = lhs.value.view().checked_as<hgraph::Int>() == rhs.value.view().checked_as<hgraph::Int>();
+                        } else if (numeric) {
                             equal = number(lhs) == number(rhs);
                         } else if (lhs.meta() == rhs.meta()) {
                             equal = lhs.value.view().equals(rhs.value.view());
@@ -550,7 +606,9 @@ namespace hgl::wiring
                 case hir::BinaryOp::GreaterEqual:
                     {
                         std::partial_ordering order = std::partial_ordering::unordered;
-                        if (numeric) {
+                        if (lhs_int && rhs_int) {
+                            order = lhs.value.view().checked_as<hgraph::Int>() <=> rhs.value.view().checked_as<hgraph::Int>();
+                        } else if (numeric) {
                             order = number(lhs) <=> number(rhs);
                         } else if (lhs.meta() == rhs.meta()) {
                             order = lhs.value.view().compare(rhs.value.view());
@@ -1407,6 +1465,14 @@ namespace hgl::wiring
                         wire("replay", {scalar_arg(hgraph::Value{key}, "key")}, range, true, parameter_schema);
                 }
             }
+            if (cycles == 0) { backend(range, "eval requires at least one time-series harness input to bound execution"); }
+            hgraph::DateTime harness_end;
+            try {
+                if (cycles > static_cast<std::size_t>(std::numeric_limits<std::int64_t>::max())) {
+                    throw std::overflow_error{"harness cycle count"};
+                }
+                harness_end = hgraph::checked_add(hgraph::MIN_ST, hgraph::TimeDelta{static_cast<std::int64_t>(cycles)});
+            } catch (const std::overflow_error &) { backend(range, "eval harness is too long to schedule safely"); }
 
             Slot result = target.kind == gir::CallableKind::RuntimeNode ? wire_function(callee_slot.callable, callee, range)
                                                                         : invoke(callee_slot.callable, callee);
@@ -1427,7 +1493,7 @@ namespace hgl::wiring
                     hgraph::testing::set_replay_deltas(graph.global_state(), keys[index], inputs[index]);
                 }
                 hgraph::GraphExecutorBuilder builder;
-                builder.graph_builder(std::move(graph)).start_time(hgraph::MIN_ST).end_time(hgraph::MAX_ET);
+                builder.graph_builder(std::move(graph)).start_time(hgraph::MIN_ST).end_time(harness_end);
                 hgraph::GraphExecutorValue executor = builder.make_executor();
                 auto                       view     = executor.view();
                 view.run();

--- a/language/src/wiring/backend.cpp
+++ b/language/src/wiring/backend.cpp
@@ -322,6 +322,7 @@ namespace hgl::wiring
                                                  const hgraph::TSValueTypeMetaData *expected        = nullptr);
             [[nodiscard]] hgraph::WiringArg argument_of(const Slot &slot, std::string name);
             [[nodiscard]] Slot              wire_constant(const Slot &slot, const hgraph::TSValueTypeMetaData *target);
+            [[nodiscard]] Slot              convert_port(const Slot &slot, const hgraph::TSValueTypeMetaData *target);
             [[nodiscard]] Slot              wire_binary(hir::BinaryOp op, const Slot &lhs, const Slot &rhs, SourceRange range,
                                                         std::string_view registry_name = {});
 
@@ -775,6 +776,12 @@ namespace hgl::wiring
             return wire("const", {scalar_arg(slot.value, "value")}, slot.range, true, target);
         }
 
+        Slot Compiler::convert_port(const Slot &slot, const hgraph::TSValueTypeMetaData *target) {
+            if (!slot.is_port()) { fail(Category::Type, slot.range, "a time-series conversion needs a port"); }
+            if (slot.port.schema == target) { return slot; }
+            return wire("convert", {argument_of(slot, "ts")}, slot.range, true, target);
+        }
+
         Slot Compiler::wire_binary(hir::BinaryOp op, const Slot &lhs, const Slot &rhs, SourceRange range,
                                    std::string_view registry_name) {
             std::string name{registry_name};
@@ -1037,12 +1044,9 @@ namespace hgl::wiring
             if (!argument.is_port()) {
                 fail(Category::Type, argument.range, "parameter '" + parameter.name + "' takes a time-series value");
             }
-            if (argument.port.schema != target) {
-                fail(Category::Type, argument.range,
-                     "parameter '" + parameter.name + "' expects " + std::string{target->name()} + ", got " +
-                         std::string{argument.port.schema == nullptr ? "an untyped port" : argument.port.schema->name()});
-            }
-            return make_port(argument.port, range);
+            Slot result  = convert_port(argument, target);
+            result.range = range;
+            return result;
         }
 
         Slot Compiler::wire_function(gir::CallableId id, Frame &frame, SourceRange range) {
@@ -1056,9 +1060,21 @@ namespace hgl::wiring
 
         Slot Compiler::invoke(gir::CallableId id, Frame &frame) {
             const gir::Callable &target = callable(id);
-            if (target.concise_body.valid()) { return eval_value(target.concise_body, frame); }
-            Slot result = exec_block(target.block_body, frame);
-            return frame.returned ? *frame.returned : result;
+            Slot                 result =
+                target.concise_body.valid() ? eval_value(target.concise_body, frame) : exec_block(target.block_body, frame);
+            if (frame.returned) { result = *frame.returned; }
+            if (result.is_const()) {
+                const hgraph::ValueTypeMetaData *expected = value_meta(target.result);
+                if (expected != nullptr) {
+                    result = make_const(
+                        convert(result.value, expected, result.range, "function '" + local_name(target.identity) + "' result"),
+                        result.range);
+                }
+            } else if (result.is_port()) {
+                const hgraph::TSValueTypeMetaData *expected = schema(target.result);
+                result                                      = convert_port(result, expected);
+            }
+            return result;
         }
 
         Slot Compiler::call_function(gir::CallableId id, const std::vector<gir::Argument> &arguments, SourceRange range,
@@ -1133,7 +1149,9 @@ namespace hgl::wiring
                         for (const gir::Argument &argument : call.arguments) {
                             arguments.push_back(argument_of(eval_value(argument.value, frame), argument.name));
                         }
-                        return wire(name, std::move(arguments), expression.range);
+                        const hgraph::TSValueTypeMetaData *expected =
+                            expression.phase == hir::Phase::Wiring ? schema(expression.type) : nullptr;
+                        return wire(name, std::move(arguments), expression.range, std::nullopt, expected);
                     }
                 case Slot::Kind::Intrinsic: return eval_intrinsic(callee.name, call.arguments, expression.range, frame);
                 case Slot::Kind::Struct: return eval_construct(expression.type, call.arguments, false, expression.range, frame);
@@ -1266,11 +1284,7 @@ namespace hgl::wiring
                                     constant_of(initial, value_meta(node.type), frame, "'" + binding(node.binding).name + "'");
                             } else if (initial.is_port()) {
                                 const auto *target = schema(node.type);
-                                if (initial.port.schema != target) {
-                                    fail(Category::Type, initial.range,
-                                         "'" + binding(node.binding).name + "' is declared " + std::string{target->name()} +
-                                             " but the initialiser is " + std::string{initial.port.schema->name()});
-                                }
+                                initial            = convert_port(initial, target);
                             }
                         }
                         frame.bindings[node.binding.value] = std::move(initial);
@@ -1300,10 +1314,8 @@ namespace hgl::wiring
                         if (current.is_const()) {
                             next = make_const(
                                 convert(next.value, current.meta(), next.range, "assignment to '" + target.name + "'"), next.range);
-                        } else if (current.is_port() && current.port.schema != next.port.schema) {
-                            fail(Category::Type, next.range,
-                                 "assignment to '" + target.name + "' expects " + std::string{current.port.schema->name()} +
-                                     ", got " + std::string{next.port.schema->name()});
+                        } else if (current.is_port()) {
+                            next = convert_port(next, current.port.schema);
                         }
                         frame.bindings[reference->binding.value] = std::move(next);
                     } else if constexpr (std::is_same_v<T, gir::Return>) {

--- a/language/src/wiring/backend.h
+++ b/language/src/wiring/backend.h
@@ -1,11 +1,11 @@
 #ifndef HGL_WIRING_BACKEND_H
 #define HGL_WIRING_BACKEND_H
 
-#include "semantics/resolve.h"
-#include "syntax/ast.h"
+#include "hgraph_ir/ir.h"
 #include "syntax/diagnostic.h"
 #include "syntax/source.h"
 
+#include <hgraph/types/value/value.h>
 #include <hgraph/util/date_time.h>
 
 #include <cstdint>
@@ -17,14 +17,12 @@
 #include <vector>
 
 /// The direct-wiring backend, first pass (developer guide, "Direct-wiring
-/// backend" / "First pass"): walks a resolved module and wires composition
+/// backend" / "First pass"): walks execution-facing hgraph IR and wires composition
 /// functions straight into hgraph through `wire_operator`, runs `test`
 /// bodies with the record/replay harness, and runs an entry with the
 /// tool's own `hgl.print_tick` sink.
 namespace hgl::wiring
 {
-    namespace ast = syntax::ast;
-
     /// Bootstrap hgraph once per process: standard types, standard
     /// operators, the analytics image when the tool links it, and the
     /// backend's own installer. Safe to call repeatedly.
@@ -54,39 +52,44 @@ namespace hgl::wiring
 
     /// Run the module's tests. A test whose walk reports a diagnostic fails
     /// and the diagnostic is left in `diagnostics`.
-    [[nodiscard]] std::vector<TestResult> run_tests(const syntax::SourceFile &file, const ast::Module &module,
-                                                    const semantics::ResolvedModule &resolved,
+    [[nodiscard]] std::vector<TestResult> run_tests(const syntax::SourceFile &file, const hgraph_ir::Module &module,
                                                     const TestOptions &options, syntax::DiagnosticSink &diagnostics);
 
-    enum class RunMode : std::uint8_t
-    {
+    enum class RunMode : std::uint8_t {
         Simulation,
         RealTime,
     };
 
-    /// One `--set name=text`; `text` is an HGL constant expression.
+    /// One front-end-checked `--set name=value`. Text parsing and constant
+    /// evaluation remain driver concerns rather than leaking syntax into the
+    /// execution backend.
     struct Setting
     {
-        std::string name;
-        std::string text;
+        std::string   name;
+        hgraph::Value value;
     };
 
     struct RunOptions
     {
-        std::string                     entry{};  ///< empty = the module's only entry
-        RunMode                         mode{RunMode::Simulation};
-        std::optional<hgraph::DateTime> start{};
-        std::optional<hgraph::DateTime> end{};
+        std::string                      entry{};  ///< empty = the module's only entry
+        RunMode                          mode{RunMode::Simulation};
+        std::optional<hgraph::DateTime>  start{};
+        std::optional<hgraph::DateTime>  end{};
         std::optional<hgraph::TimeDelta> end_after{};  ///< `--end <duration>`
-        std::vector<Setting>            settings{};
+        std::vector<Setting>             settings{};
     };
 
     /// Wire and run an entry (syntax guide, "Running a module"). Each tick
     /// of the entry's result is written to `out` as `time value`. Returns
     /// false when a diagnostic was reported.
-    [[nodiscard]] bool run_program(const syntax::SourceFile &file, const ast::Module &module,
-                                   const semantics::ResolvedModule &resolved, const RunOptions &options,
+    [[nodiscard]] bool run_program(const syntax::SourceFile &file, const hgraph_ir::Module &module, const RunOptions &options,
                                    syntax::DiagnosticSink &diagnostics, std::ostream &out);
+
+    /// Evaluate one typed hgraph-IR value as a scalar constant. The driver
+    /// uses this for the tail of an isolated `--set` test block compiled
+    /// through the ordinary frontend.
+    [[nodiscard]] std::optional<hgraph::Value> evaluate_constant(const syntax::SourceFile &file, const hgraph_ir::Module &module,
+                                                                 hgraph_ir::ValueId value, syntax::DiagnosticSink &diagnostics);
 
     /// The canonical `datetime` spelling without its `@` (the `time` column
     /// of `hgl run` output).

--- a/language/src/wiring/operator_types.cpp
+++ b/language/src/wiring/operator_types.cpp
@@ -50,6 +50,10 @@ namespace hgl::wiring
                     std::optional<hgraph::WiringArg> lowered = lower_argument(argument);
                     if (!lowered) {
                         selection.deferred = true;
+                        if (!selection.result.valid() && unknown_constant_) {
+                            selection.result =
+                                type_for_schema(hgraph::OperatorRegistry::instance().fixed_output_schema(query.identity));
+                        }
                         return selection;
                     }
                     arguments.push_back(std::move(*lowered));
@@ -275,6 +279,15 @@ namespace hgl::wiring
 
             [[nodiscard]] hir::TypeId type_for_schema(const hgraph::TSValueTypeMetaData *target) {
                 if (target == nullptr) { return {}; }
+                // Wiring returns a REF for source-style operators such as
+                // schedule. HGL's surface type denotes the referenced signal,
+                // so recover that canonical type rather than making callers
+                // model the runtime's transport wrapper.
+                while (target != nullptr && target->kind == hgraph::TSTypeKind::REF) { target = target->referenced_ts(); }
+                if (target != nullptr && target->kind == hgraph::TSTypeKind::SIGNAL && target->value_schema != nullptr) {
+                    target = registry_.ts(target->value_schema);
+                }
+                if (target == nullptr) { return {}; }
                 if (const auto found = schema_ids_.find(target); found != schema_ids_.end()) { return found->second; }
 
                 // HIR owns its type arena, so the adapter may only return an
@@ -324,10 +337,18 @@ namespace hgl::wiring
                 result.name = argument.name;
                 if (argument.value_kind == hir::ValueKind::Constant) {
                     std::optional<hgraph::Value> constant_value = constant(argument);
-                    if (!constant_value) { return std::nullopt; }
-                    result.kind         = hgraph::WiringArg::Kind::Scalar;
-                    result.scalar_value = std::move(*constant_value);
-                    result.scalar_meta  = result.scalar_value.schema();
+                    result.kind                                 = hgraph::WiringArg::Kind::Scalar;
+                    if (constant_value) {
+                        result.scalar_value = std::move(*constant_value);
+                        result.scalar_meta  = result.scalar_value.schema();
+                    } else {
+                        // A value-sensitive overload cannot be selected until
+                        // activation binds the const parameter. Do not invent
+                        // a representative value: the caller can still use a
+                        // declared result or the family's common fixed output.
+                        unknown_constant_ = true;
+                        return std::nullopt;
+                    }
                     value_ids_.emplace(result.scalar_meta, canonical(argument.type));
                     return result;
                 }
@@ -368,6 +389,7 @@ namespace hgl::wiring
             std::unordered_map<std::uint32_t, const hgraph::TSValueTypeMetaData *> schemas_{};
             std::unordered_map<const hgraph::ValueTypeMetaData *, hir::TypeId>     value_ids_{};
             std::unordered_map<const hgraph::TSValueTypeMetaData *, hir::TypeId>   schema_ids_{};
+            bool                                                                   unknown_constant_{false};
         };
     }  // namespace
 

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -292,6 +292,29 @@ fn generic<const N: i64>(values: list<f64, N + 1>) -> f64 => 1.0
     REQUIRE(complete(lowered));
 }
 
+TEST_CASE("typed HIR diagnoses temporal constant overflow", "[ir][typed][const][temporal]") {
+    Lowered lowered{R"(
+module checks.temporal_overflow
+
+fn overflow() -> duration => 106751991d4h54s775ms807us + 1us
+)"};
+    require_clean(lowered);
+    CHECK_FALSE(complete(lowered));
+    CHECK(lowered.diagnostics.render(lowered.file).find("overflow in a temporal constant expression") != std::string::npos);
+}
+
+TEST_CASE("typed HIR does not implicitly widen time-series collection elements", "[ir][typed][types][collection]") {
+    Lowered lowered{R"(
+module checks.collection_widening
+
+fn widen(xs: list<i64>) -> list<f64> => xs
+)"};
+    require_clean(lowered);
+    CHECK_FALSE(complete(lowered));
+    CHECK(lowered.diagnostics.render(lowered.file)
+              .find("function result requires an implicit conversion inside a time-series collection") != std::string::npos);
+}
+
 TEST_CASE("typed HIR preserves fixed list sizes during assignment", "[ir][typed][types][list]") {
     Lowered valid{R"(
 module checks.fixed_list_assignment

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -303,6 +303,50 @@ fn overflow() -> duration => 106751991d4h54s775ms807us + 1us
     CHECK(lowered.diagnostics.render(lowered.file).find("overflow in a temporal constant expression") != std::string::npos);
 }
 
+TEST_CASE("typed HIR folds integer constants without floating-point loss", "[ir][typed][const][integer]") {
+    Lowered lowered{R"(
+module checks.integer_constants
+
+fn exact() -> i64 => 9007199254740993 + 0
+fn ordered() -> bool => 9007199254740993 > 9007199254740992
+fn distinct() -> bool => 9007199254740993 != 9007199254740992
+)"};
+    require_clean(lowered);
+    REQUIRE(complete(lowered));
+
+    bool exact    = false;
+    bool ordered  = false;
+    bool distinct = false;
+    for (const hir::Expr &expression : lowered.hir.exprs) {
+        const auto *binary = std::get_if<hir::Binary>(&expression.node);
+        if (binary == nullptr || !expression.constant) { continue; }
+        if (binary->op == hir::BinaryOp::Add) {
+            const auto *value = std::get_if<std::int64_t>(&*expression.constant);
+            exact             = value != nullptr && *value == 9'007'199'254'740'993;
+        } else if (binary->op == hir::BinaryOp::Greater) {
+            const auto *value = std::get_if<bool>(&*expression.constant);
+            ordered           = value != nullptr && *value;
+        } else if (binary->op == hir::BinaryOp::NotEqual) {
+            const auto *value = std::get_if<bool>(&*expression.constant);
+            distinct          = value != nullptr && *value;
+        }
+    }
+    CHECK(exact);
+    CHECK(ordered);
+    CHECK(distinct);
+}
+
+TEST_CASE("typed HIR diagnoses integer constant overflow", "[ir][typed][const][integer]") {
+    Lowered lowered{R"(
+module checks.integer_overflow
+
+fn overflow() -> i64 => 9223372036854775807 + 1
+)"};
+    require_clean(lowered);
+    CHECK_FALSE(complete(lowered));
+    CHECK(lowered.diagnostics.render(lowered.file).find("overflow in an integer constant expression") != std::string::npos);
+}
+
 TEST_CASE("typed HIR does not implicitly widen time-series collection elements", "[ir][typed][types][collection]") {
     Lowered lowered{R"(
 module checks.collection_widening

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -292,6 +292,38 @@ fn generic<const N: i64>(values: list<f64, N + 1>) -> f64 => 1.0
     REQUIRE(complete(lowered));
 }
 
+TEST_CASE("typed HIR preserves fixed list sizes during assignment", "[ir][typed][types][list]") {
+    Lowered valid{R"(
+module checks.fixed_list_assignment
+
+fn pair() -> list<f64, 2> => [1.0, 2.0]
+fn dynamic() -> list<f64> => pair()
+)"};
+    require_clean(valid);
+    REQUIRE(complete(valid));
+
+    Lowered wrong_literal{R"(
+module checks.fixed_list_literal
+
+fn triple() -> list<f64, 3> => [1.0, 2.0]
+)"};
+    require_clean(wrong_literal);
+    CHECK_FALSE(complete(wrong_literal));
+    CHECK(wrong_literal.diagnostics.render(wrong_literal.file).find("list literal has 2 elements, expected 3") !=
+          std::string::npos);
+
+    Lowered wrong_result{R"(
+module checks.fixed_list_result
+
+fn pair() -> list<f64, 2> => [1.0, 2.0]
+fn triple() -> list<f64, 3> => pair()
+)"};
+    require_clean(wrong_result);
+    CHECK_FALSE(complete(wrong_result));
+    CHECK(wrong_result.diagnostics.render(wrong_result.file).find("function result has type list, expected list") !=
+          std::string::npos);
+}
+
 TEST_CASE("typed HIR selects a source operator implementation", "[ir][typed][operators]") {
     Lowered lowered{R"(
 module checks.operators

--- a/language/tests/wiring/backend_tests.cpp
+++ b/language/tests/wiring/backend_tests.cpp
@@ -217,6 +217,7 @@ test generic_value {
 
 test generic_atomic {
     assert eval(same_box, value: [Box<f64>(value: 1.5), _]) == [Box<f64>(value: 1.5), _]
+    assert eval(same_box, value: [Box(value: 2.5), _]) == [Box<f64>(value: 2.5), _]
 }
 )"};
     for (const TestResult &result : unit.tests()) {
@@ -270,6 +271,35 @@ test sparse {
     CHECK(result.tail.starts_with("delta "));
     CHECK(result.tail.find("1.5") != std::string::npos);
     CHECK(result.tail.find("XNAS") == std::string::npos);
+}
+
+TEST_CASE("a structured delta preserves nested sparse deltas", "[wiring]") {
+    Unit unit{R"(
+module suite.nested_struct_deltas
+
+struct Quote {
+    bid: f64
+    ask: f64
+}
+
+struct Book {
+    best: Quote
+    depth: i64
+}
+
+test nested_sparse {
+    delta<Book>(best: delta<Quote>(bid: 100.5))
+}
+)"};
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+    TestOptions options;
+    options.describe_tail   = true;
+    const TestResult result = only(run_tests(unit.file, unit.graph_ir, options, unit.diagnostics));
+    INFO(result.message);
+    CHECK(result.passed);
+    CHECK(result.tail.starts_with("delta "));
+    CHECK(result.tail.find("100.5") != std::string::npos);
 }
 
 TEST_CASE("unavailable structural operations are explicit diagnostics", "[wiring]") {

--- a/language/tests/wiring/backend_tests.cpp
+++ b/language/tests/wiring/backend_tests.cpp
@@ -1,6 +1,10 @@
+#include "hgraph_ir/lower.h"
+#include "ir/lower.h"
+#include "ir/type_check.h"
 #include "semantics/resolve.h"
 #include "syntax/parser.h"
 #include "wiring/backend.h"
+#include "wiring/operator_types.h"
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -22,45 +26,45 @@ namespace
     // backend (developer guide, "Direct-wiring backend", "First pass").
     struct Unit
     {
-        SourceFile     file;
-        DiagnosticSink diagnostics;
-        ast::Module    module;
-        ResolvedModule resolved;
+        SourceFile             file;
+        DiagnosticSink         diagnostics;
+        ast::Module            module;
+        ResolvedModule         resolved;
+        hgl::ir::hir::Module   hir;
+        hgl::hgraph_ir::Module graph_ir;
 
         explicit Unit(std::string text)
             : file{"test.hgl", std::move(text)}, module{parse(file, diagnostics)},
-              resolved{resolve(file, module, has_operator, diagnostics)}
-        {
+              resolved{resolve(file, module, has_operator, diagnostics)} {
+            if (!diagnostics.has_errors()) { hir = hgl::ir::lower_to_hir(module, resolved, diagnostics); }
+            if (!diagnostics.has_errors() && hgl::ir::complete_hir(hir, resolve_operator_types, diagnostics)) {
+                graph_ir = hgl::hgraph_ir::lower(hir, diagnostics);
+            }
         }
 
-        [[nodiscard]] std::vector<TestResult> tests(std::vector<std::string> names = {})
-        {
+        [[nodiscard]] std::vector<TestResult> tests(std::vector<std::string> names = {}) {
             INFO(diagnostics.render(file));
             REQUIRE_FALSE(diagnostics.has_errors());
             TestOptions options;
             options.names = std::move(names);
-            return run_tests(file, module, resolved, options, diagnostics);
+            return run_tests(file, graph_ir, options, diagnostics);
         }
 
-        [[nodiscard]] bool has(Category category, std::string_view fragment) const
-        {
-            return std::any_of(diagnostics.diagnostics().begin(), diagnostics.diagnostics().end(),
-                               [&](const Diagnostic &d) {
-                                   return d.category == category && d.message.find(fragment) != std::string::npos;
-                               });
+        [[nodiscard]] bool has(Category category, std::string_view fragment) const {
+            return std::any_of(diagnostics.diagnostics().begin(), diagnostics.diagnostics().end(), [&](const Diagnostic &d) {
+                return d.category == category && d.message.find(fragment) != std::string::npos;
+            });
         }
     };
 
-    TestResult only(std::vector<TestResult> results)
-    {
+    TestResult only(std::vector<TestResult> results) {
         REQUIRE(results.size() == 1);
         return std::move(results.front());
     }
 }  // namespace
 
-TEST_CASE("constant expressions fold in a test body", "[wiring]")
-{
-    Unit unit{R"(
+TEST_CASE("constant expressions fold in a test body", "[wiring]") {
+    Unit             unit{R"(
 module t
 
 fn third(const xs: list<i64>) -> i64 => xs[2]
@@ -87,10 +91,8 @@ test folding {
     CHECK(result.passed);
 }
 
-TEST_CASE("var assignment retains the initializer's static type", "[wiring]")
-{
-    SECTION("an inferred i64 cannot be narrowed")
-    {
+TEST_CASE("var assignment retains the initializer's static type", "[wiring]") {
+    SECTION("an inferred i64 cannot be narrowed") {
         Unit unit{R"(
 module t
 test narrowing {
@@ -99,13 +101,11 @@ test narrowing {
     assert y == 2
 }
 )"};
-        const TestResult result = only(unit.tests());
-        CHECK_FALSE(result.passed);
-        CHECK(unit.has(Category::Type, "assignment to 'y' expects int, got float"));
+        CHECK(unit.diagnostics.has_errors());
+        CHECK(unit.has(Category::Type, "assignment has type f64, expected i64"));
     }
-    SECTION("compound division cannot change i64 to f64")
-    {
-        Unit unit{R"(
+    SECTION("compound division cannot change i64 to f64") {
+        Unit             unit{R"(
 module t
 test narrowing {
     var y = 4
@@ -117,9 +117,8 @@ test narrowing {
         CHECK_FALSE(result.passed);
         CHECK(unit.has(Category::Type, "assignment to 'y' expects int, got float"));
     }
-    SECTION("i64 widens into an f64 var")
-    {
-        Unit unit{R"(
+    SECTION("i64 widens into an f64 var") {
+        Unit             unit{R"(
 module t
 test widening {
     var y = 1.0
@@ -133,8 +132,7 @@ test widening {
     }
 }
 
-TEST_CASE("eval drives a composition through the harness", "[wiring]")
-{
+TEST_CASE("eval drives a composition through the harness", "[wiring]") {
     Unit unit{R"(
 module t
 
@@ -155,15 +153,13 @@ test defaults_apply {
     assert eval(scale, x: [1.0, _]) == [2.0, _]
 }
 )"};
-    for (const TestResult &result : unit.tests())
-    {
+    for (const TestResult &result : unit.tests()) {
         INFO(result.name << ": " << result.message);
         CHECK(result.passed);
     }
 }
 
-TEST_CASE("nominal struct values apply defaults and inheritance", "[wiring]")
-{
+TEST_CASE("nominal struct values apply defaults and inheritance", "[wiring]") {
     Unit             unit{R"(
 module suite.struct_values
 
@@ -185,6 +181,10 @@ struct Quote {
     note: str = null
 }
 
+struct Snapshot {
+    quote: Quote = Quote(bid: 1.0, ask: 2.0)
+}
+
 test values {
     let q = Quote(bid: 1.0, ask: 2.0)
     let f = Future(symbol: "ES", expiry: @2026-12-18)
@@ -193,6 +193,7 @@ test values {
     assert q.venue == "XNAS"
     assert f.symbol == "ES"
     assert f.venue == "XEUR"
+    assert Snapshot().quote.ask == 2.0
 }
 )"};
     const TestResult result = only(unit.tests());
@@ -200,8 +201,7 @@ test values {
     CHECK(result.passed);
 }
 
-TEST_CASE("type-generic struct specializations retain nominal values", "[wiring]")
-{
+TEST_CASE("type-generic struct specializations retain nominal values", "[wiring]") {
     Unit unit{R"(
 module suite.generic_structs
 
@@ -219,15 +219,13 @@ test generic_atomic {
     assert eval(same_box, value: [Box<f64>(value: 1.5), _]) == [Box<f64>(value: 1.5), _]
 }
 )"};
-    for (const TestResult &result : unit.tests())
-    {
+    for (const TestResult &result : unit.tests()) {
         INFO(result.name << ": " << result.message);
         CHECK(result.passed);
     }
 }
 
-TEST_CASE("temporal struct construction wires a structural bundle", "[wiring]")
-{
+TEST_CASE("temporal struct construction wires a structural bundle", "[wiring]") {
     Unit             unit{R"(
 module suite.temporal_structs
 
@@ -248,8 +246,7 @@ test fieldwise {
     CHECK(result.passed);
 }
 
-TEST_CASE("a structured delta is sparse and does not apply defaults", "[wiring]")
-{
+TEST_CASE("a structured delta is sparse and does not apply defaults", "[wiring]") {
     Unit unit{R"(
 module suite.struct_deltas
 
@@ -267,7 +264,7 @@ test sparse {
     REQUIRE_FALSE(unit.diagnostics.has_errors());
     TestOptions options;
     options.describe_tail   = true;
-    const TestResult result = only(run_tests(unit.file, unit.module, unit.resolved, options, unit.diagnostics));
+    const TestResult result = only(run_tests(unit.file, unit.graph_ir, options, unit.diagnostics));
     INFO(result.message);
     CHECK(result.passed);
     CHECK(result.tail.starts_with("delta "));
@@ -275,10 +272,8 @@ test sparse {
     CHECK(result.tail.find("XNAS") == std::string::npos);
 }
 
-TEST_CASE("unavailable structural operations are explicit diagnostics", "[wiring]")
-{
-    SECTION("an optional clear needs a distinct native delta operation")
-    {
+TEST_CASE("unavailable structural operations are explicit diagnostics", "[wiring]") {
+    SECTION("an optional clear needs a distinct native delta operation") {
         Unit             unit{R"(
 module suite.struct_clear
 struct Quote { note: str = null }
@@ -289,8 +284,7 @@ test clear { delta<Quote>(note: null) }
         CHECK(unit.has(Category::Backend, "distinct public hgraph clear-delta operation"));
     }
 
-    SECTION("const generic identity needs native metadata")
-    {
+    SECTION("const generic identity needs native metadata") {
         Unit             unit{R"(
 module suite.const_generic_structs
 struct Vector<T, const size: i64> { values: list<T, size> }
@@ -303,9 +297,8 @@ test value { Vector<f64, 2>(values: [1.0, 2.0]) }
     }
 }
 
-TEST_CASE("a failing assert reports the observed sequence", "[wiring]")
-{
-    Unit unit{R"(
+TEST_CASE("a failing assert reports the observed sequence", "[wiring]") {
+    Unit                          unit{R"(
 module t
 
 fn midpoint(tob: atomic<tuple<f64, f64>>) -> f64 => (tob[0] + tob[1]) / 2.0
@@ -333,8 +326,7 @@ test plain {
     CHECK(results[2].message == "assert failed: 1 == 2");
 }
 
-TEST_CASE("selected tests run and describe their tail", "[wiring]")
-{
+TEST_CASE("selected tests run and describe their tail", "[wiring]") {
     Unit unit{R"(
 module t
 
@@ -349,22 +341,21 @@ test three { eval(same, tob: [(1.0, 2.0), _]) }
     INFO(unit.diagnostics.render(unit.file));
     REQUIRE_FALSE(unit.diagnostics.has_errors());
     TestOptions options;
-    options.names         = {"two"};
-    options.describe_tail = true;
-    const TestResult result = only(run_tests(unit.file, unit.module, unit.resolved, options, unit.diagnostics));
+    options.names           = {"two"};
+    options.describe_tail   = true;
+    const TestResult result = only(run_tests(unit.file, unit.graph_ir, options, unit.diagnostics));
     CHECK(result.name == "two");
     CHECK(result.passed);
     CHECK(result.tail == "[1.5, 2.5]");
 
-    options.names = {"three"};
-    const TestResult tuples = only(run_tests(unit.file, unit.module, unit.resolved, options, unit.diagnostics));
+    options.names           = {"three"};
+    const TestResult tuples = only(run_tests(unit.file, unit.graph_ir, options, unit.diagnostics));
     CHECK(tuples.passed);
     CHECK(tuples.tail == "[(1.0, 2.0), _]");
 }
 
-TEST_CASE("first-pass limits are diagnostics, not crashes", "[wiring]")
-{
-    Unit unit{R"(
+TEST_CASE("first-pass limits are diagnostics, not crashes", "[wiring]") {
+    Unit                          unit{R"(
 module t
 
 fn midpoint(tob: atomic<tuple<f64, f64>>) -> f64 => (tob[0] + tob[1]) / 2.0
@@ -372,7 +363,7 @@ fn midpoint(tob: atomic<tuple<f64, f64>>) -> f64 => (tob[0] + tob[1]) / 2.0
 fn counter(x: f64) -> f64 {
     state total: f64 = 0.0
     inject out
-    when x { total += x }
+    when modified(x) { total += x }
     out = total
 }
 
@@ -384,20 +375,23 @@ test runtime {
     assert eval(counter, x: [1.0]) == [1.0]
 }
 
-test wrong_type {
-    assert eval(midpoint, tob: ["a"]) == [1.5]
-}
 )"};
     const std::vector<TestResult> results = unit.tests();
-    REQUIRE(results.size() == 3);
+    REQUIRE(results.size() == 2);
     for (const TestResult &result : results) { CHECK_FALSE(result.passed); }
     CHECK(unit.has(Category::Test, "timed sequences are not supported by the first pass"));
     CHECK(unit.has(Category::Operator, "t.counter"));
-    CHECK(unit.has(Category::Type, "the sequence element expects Tuple[float,float], got str"));
+
+    Unit wrong_type{R"(
+module t
+fn midpoint(tob: atomic<tuple<f64, f64>>) -> f64 => (tob[0] + tob[1]) / 2.0
+test wrong_type { assert eval(midpoint, tob: ["a"]) == [1.5] }
+)"};
+    CHECK(wrong_type.diagnostics.has_errors());
+    CHECK(wrong_type.has(Category::Type, "sequence elements have incompatible types"));
 }
 
-TEST_CASE("run_program prints one line per tick", "[wiring]")
-{
+TEST_CASE("run_program prints one line per tick", "[wiring]") {
     Unit unit{R"(
 module t
 
@@ -410,40 +404,36 @@ export fn other(x: f64) -> f64 => x
     INFO(unit.diagnostics.render(unit.file));
     REQUIRE_FALSE(unit.diagnostics.has_errors());
 
-    SECTION("the entry with only const parameters runs")
-    {
+    SECTION("the entry with only const parameters runs") {
         RunOptions options;
         options.start     = hgraph::DateTime{std::chrono::microseconds{1'700'000'000'000'000}};
         options.end_after = hgraph::TimeDelta{std::chrono::seconds{3}};
-        options.settings.push_back(Setting{"every", "1500ms"});
+        options.settings.push_back(Setting{"every", hgraph::Value{hgraph::TimeDelta{std::chrono::milliseconds{1500}}}});
         std::ostringstream out;
-        const bool ok = run_program(unit.file, unit.module, unit.resolved, options, unit.diagnostics, out);
+        const bool         ok = run_program(unit.file, unit.graph_ir, options, unit.diagnostics, out);
         INFO(unit.diagnostics.render(unit.file));
         CHECK(ok);
         CHECK(out.str() == "2023-11-14T22:13:21.5Z 2023-11-14 22:13:21.500000\n");
     }
 
-    SECTION("an entry with temporal parameters cannot run")
-    {
+    SECTION("an entry with temporal parameters cannot run") {
         RunOptions options;
         options.entry = "other";
         std::ostringstream out;
-        CHECK_FALSE(run_program(unit.file, unit.module, unit.resolved, options, unit.diagnostics, out));
+        CHECK_FALSE(run_program(unit.file, unit.graph_ir, options, unit.diagnostics, out));
         CHECK(unit.has(Category::Backend, "entry parameter 'x' is not const"));
     }
 
-    SECTION("settings are checked against the parameter type")
-    {
+    SECTION("settings are checked against the parameter type") {
         RunOptions options;
-        options.settings.push_back(Setting{"every", "3"});
+        options.settings.push_back(Setting{"every", hgraph::Value{hgraph::Int{3}}});
         std::ostringstream out;
-        CHECK_FALSE(run_program(unit.file, unit.module, unit.resolved, options, unit.diagnostics, out));
+        CHECK_FALSE(run_program(unit.file, unit.graph_ir, options, unit.diagnostics, out));
         CHECK(unit.has(Category::Type, "'every' expects timedelta, got int"));
     }
 }
 
-TEST_CASE("format_time spells the canonical datetime without the sigil", "[wiring]")
-{
+TEST_CASE("format_time spells the canonical datetime without the sigil", "[wiring]") {
     CHECK(format_time(hgraph::DateTime{std::chrono::microseconds{1'700'000'000'000'000}}) == "2023-11-14T22:13:20Z");
     CHECK(format_time(hgraph::DateTime{std::chrono::microseconds{1'700'000'000'500'000}}) == "2023-11-14T22:13:20.5Z");
 }

--- a/language/tests/wiring/backend_tests.cpp
+++ b/language/tests/wiring/backend_tests.cpp
@@ -77,7 +77,9 @@ test folding {
     assert b == 7.0
     assert 7 / 2 == 3.5
     assert 7 % 3 == 1
+    assert 1 == 1.0
     assert "ab" + "c" == "abc"
+    assert @2026-09-03T10:30+01[Europe/London] == @2026-09-03T09:30Z[UTC]
     assert (1, 2.0)[1] == 2.0
     let xs: list<i64> = [10, 20, 30]
     assert xs[2] == 30
@@ -364,9 +366,16 @@ fn midpoint(tob: atomic<tuple<f64, f64>>) -> f64 => (tob[0] + tob[1]) / 2.0
 
 fn same(tob: atomic<tuple<f64, f64>>) -> atomic<tuple<f64, f64>> => tob
 
+fn compound(a: f64, b: f64) -> f64 {
+    var y = a
+    y += b * 2.0
+    y
+}
+
 test one { assert 1 == 1 }
 test two { eval(midpoint, tob: [(1.0, 2.0), (2.0, 3.0)]) }
 test three { eval(same, tob: [(1.0, 2.0), _]) }
+test four { assert eval(compound, a: [1.0], b: [3.0]) == [7.0] }
 )"};
     INFO(unit.diagnostics.render(unit.file));
     REQUIRE_FALSE(unit.diagnostics.has_errors());

--- a/language/tests/wiring/backend_tests.cpp
+++ b/language/tests/wiring/backend_tests.cpp
@@ -111,6 +111,39 @@ test folding {
     CHECK(result.passed);
 }
 
+TEST_CASE("folded integer constants retain full i64 precision", "[wiring][constants][integer]") {
+    Unit unit{R"(
+module t
+
+test exact {
+    9007199254740993 + 0
+}
+)"};
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+    TestOptions options;
+    options.describe_tail   = true;
+    const TestResult result = only(run_tests(unit.file, unit.graph_ir, options, unit.diagnostics));
+    INFO(result.message);
+    CHECK(result.passed);
+    CHECK(result.tail == "9007199254740993");
+}
+
+TEST_CASE("activated constant arithmetic diagnoses overflow", "[wiring][constants][overflow]") {
+    Unit             unit{R"(
+module t
+
+fn add_one(const value: duration) -> duration => value + 1us
+
+test overflow {
+    add_one(106751991d4h54s775ms807us)
+}
+)"};
+    const TestResult result = only(unit.tests());
+    CHECK_FALSE(result.passed);
+    CHECK(unit.has(Category::Type, "overflow in a temporal constant expression"));
+}
+
 TEST_CASE("var assignment retains the initializer's static type", "[wiring]") {
     SECTION("an inferred i64 cannot be narrowed") {
         Unit unit{R"(
@@ -234,6 +267,41 @@ test defaults_apply {
         INFO(result.name << ": " << result.message);
         CHECK(result.passed);
     }
+}
+
+TEST_CASE("eval rejects a const-only harness with no execution bound", "[wiring][harness]") {
+    Unit             unit{R"(
+module t
+
+use hgraph.std::{schedule}
+
+fn heartbeat(const every: duration) -> datetime => last_modified(schedule(every))
+
+test const_only {
+    eval(heartbeat, every: 1us)
+}
+)"};
+    const TestResult result = only(unit.tests());
+    CHECK_FALSE(result.passed);
+    CHECK(unit.has(Category::Backend, "at least one time-series harness input to bound execution"));
+}
+
+TEST_CASE("eval bounds scheduled work by the longest harness input", "[wiring][harness]") {
+    Unit             unit{R"(
+module t
+
+use hgraph.std::{schedule}
+
+fn heartbeat(trigger: f64, const every: duration) -> datetime => last_modified(schedule(every))
+
+test bounded {
+    eval(heartbeat, trigger: [1.0, 2.0], every: 1us)
+}
+)"};
+    const TestResult result = only(unit.tests());
+    INFO(unit.diagnostics.render(unit.file));
+    INFO(result.message);
+    CHECK(result.passed);
 }
 
 TEST_CASE("nominal struct values apply defaults and inheritance", "[wiring]") {

--- a/language/tests/wiring/backend_tests.cpp
+++ b/language/tests/wiring/backend_tests.cpp
@@ -6,6 +6,9 @@
 #include "wiring/backend.h"
 #include "wiring/operator_types.h"
 
+#include <hgraph/lib/std/operators/collection.h>
+#include <hgraph/types/operator_dispatch.h>
+
 #include <catch2/catch_test_macros.hpp>
 
 #include <algorithm>
@@ -22,6 +25,21 @@ using namespace hgl::wiring;
 
 namespace
 {
+    struct fixed_pair_operator
+        : hgraph::Operator<"hgl_fixed_pair", hgraph::In<"a", hgraph::TS<hgraph::Float>>, hgraph::In<"b", hgraph::TS<hgraph::Float>>,
+                           hgraph::Out<hgraph::TSL<hgraph::TS<hgraph::Float>, 2>>>
+    {};
+
+    struct fixed_pair_graph
+    {
+        static constexpr auto name = "hgl_fixed_pair_graph";
+
+        static auto compose(hgraph::Wiring &w, hgraph::Port<hgraph::TS<hgraph::Float>> a,
+                            hgraph::Port<hgraph::TS<hgraph::Float>> b) {
+            return hgraph::stdlib::to_tsl(w, a, b);
+        }
+    };
+
     // A unit through the frontend against the live registry, ready for the
     // backend (developer guide, "Direct-wiring backend", "First pass").
     struct Unit
@@ -142,6 +160,47 @@ fn widen(x: i64) -> f64 => x
 
 test widening {
     assert eval(widen, x: [1, 2]) == [1.0, 2.0]
+}
+)"};
+    const TestResult result = only(unit.tests());
+    INFO(unit.diagnostics.render(unit.file));
+    INFO(result.message);
+    CHECK(result.passed);
+}
+
+TEST_CASE("composition boundaries preserve compatible fixed list ports", "[wiring][types][list]") {
+    ensure_session();
+    hgraph::register_graph_overload<fixed_pair_operator, fixed_pair_graph>();
+    Unit             unit{R"(
+module t
+
+use hgraph.std::{hgl_fixed_pair}
+
+fn fixed(a: f64, b: f64) -> list<f64, 2> => hgl_fixed_pair(a, b)
+fn values(a: f64, b: f64) -> list<f64> => fixed(a, b)
+
+test widening {
+    eval(values, a: [1.0], b: [2.0])
+}
+)"};
+    const TestResult result = only(unit.tests());
+    INFO(unit.diagnostics.render(unit.file));
+    INFO(result.message);
+    CHECK(result.passed);
+}
+
+TEST_CASE("outputless operators wire without a result schema", "[wiring][operators][sink]") {
+    Unit             unit{R"(
+module t
+
+use hgraph.std::{null_sink}
+
+fn discard(value: f64) {
+    null_sink(value)
+}
+
+test sink {
+    eval(discard, value: [1.0])
 }
 )"};
     const TestResult result = only(unit.tests());

--- a/language/tests/wiring/backend_tests.cpp
+++ b/language/tests/wiring/backend_tests.cpp
@@ -134,6 +134,22 @@ test widening {
     }
 }
 
+TEST_CASE("composition results preserve their runtime schema", "[wiring][types]") {
+    Unit             unit{R"(
+module t
+
+fn widen(x: i64) -> f64 => x
+
+test widening {
+    assert eval(widen, x: [1, 2]) == [1.0, 2.0]
+}
+)"};
+    const TestResult result = only(unit.tests());
+    INFO(unit.diagnostics.render(unit.file));
+    INFO(result.message);
+    CHECK(result.passed);
+}
+
 TEST_CASE("eval drives a composition through the harness", "[wiring]") {
     Unit unit{R"(
 module t

--- a/language/tests/wiring/operator_types_tests.cpp
+++ b/language/tests/wiring/operator_types_tests.cpp
@@ -76,6 +76,29 @@ fn scaled_average(window: rolling<f64, 20>) -> f64 => mean(window) * 2.0
     CHECK(found);
 }
 
+TEST_CASE("type-only const parameters still permit fixed native output inference", "[ir][operator-types]") {
+    Unit unit{R"(
+module checks.const_parameter_output
+use hgraph.std::{schedule}
+
+fn heartbeat(const every: duration) -> datetime => last_modified(schedule(every))
+)"};
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+    REQUIRE(unit.complete());
+
+    bool found = false;
+    for (const hgl::ir::hir::Expr &expression : unit.hir.exprs) {
+        if (expression.operation.identity != "hgraph.std.schedule") { continue; }
+        found = true;
+        REQUIRE(expression.type.valid());
+        CHECK(unit.hir.type(expression.type).scalar == hgl::ir::hir::ScalarType::Bool);
+        CHECK(expression.operation.deferred);
+        CHECK(expression.operation.candidate_label.empty());
+    }
+    CHECK(found);
+}
+
 TEST_CASE("higher-order operator typing remains explicit and deferred", "[ir][operator-types]") {
     Unit unit{R"(
 module checks.higher_order_types

--- a/src/hgraph/types/operator_dispatch.cpp
+++ b/src/hgraph/types/operator_dispatch.cpp
@@ -1296,6 +1296,25 @@ namespace hgraph
         return false;
     }
 
+    const TSValueTypeMetaData *OperatorRegistry::fixed_output_schema(std::string_view name) const
+    {
+        const auto found = overloads_.find(std::string{name});
+        if (found == overloads_.end() || found->second.empty()) { return nullptr; }
+
+        const TSValueTypeMetaData *shared = nullptr;
+        for (const OperatorImpl &impl : found->second)
+        {
+            if (!impl.has_output) { continue; }
+            if (ts_pattern_has_var(impl.output)) { return nullptr; }
+            ResolutionMap              empty;
+            const TSValueTypeMetaData *meta = ts_pattern_resolve(impl.output, empty);
+            if (meta == nullptr) { return nullptr; }
+            if (shared == nullptr) { shared = meta; }
+            else if (shared != meta) { return nullptr; }
+        }
+        return shared;
+    }
+
     OperatorRegistry::CarrierParameters OperatorRegistry::carrier_parameters(std::string_view name) const
     {
         CarrierParameters result;

--- a/tests/cpp/test_operators.cpp
+++ b/tests/cpp/test_operators.cpp
@@ -1165,6 +1165,17 @@ TEST_CASE("operators: overload signature inspection preserves the complete publi
     CHECK(OperatorRegistry::instance().overload_signatures("not_registered").empty());
 }
 
+TEST_CASE("operators: fixed output inspection does not perform overload resolution")
+{
+    stdlib::register_standard_operators();
+    register_overload<route_shape_, route_shape_any>();
+
+    CHECK(OperatorRegistry::instance().fixed_output_schema("schedule") == ts_type<TS<Bool>>());
+    CHECK(OperatorRegistry::instance().fixed_output_schema("mean") == nullptr);
+    CHECK(OperatorRegistry::instance().fixed_output_schema("route_shape") == nullptr);
+    CHECK(OperatorRegistry::instance().fixed_output_schema("not_registered") == nullptr);
+}
+
 TEST_CASE("operators: graph implementations can be registered as overloads")
 {
     register_graph_overload<double_, double_graph>();


### PR DESCRIPTION
## Summary
- move the scripted test, run, and REPL evaluator from the resolved AST to execution-facing hgraph IR
- evaluate `--set` expressions through the ordinary frontend and pass owned checked values to the backend
- add type-only fixed-output inspection for native operator families without invoking overload defaults, resolvers, or predicates
- preserve constant struct construction, temporal folding, numeric and instant equality, and contextual collection conversion in typed HIR
- materialize direct scalar widening as native conversion nodes while rejecting unsupported implicit widening inside time-series collections
- preserve fixed TSL refinements at unsized list boundaries and wire outputless operators without requesting a result schema
- update the language architecture and tool documentation to describe the remaining C++ backend adapter

## Validation
- complete HGL language suite on macOS: 30/30 passed
- complete HGL language suite on a private Linux validation host: 30/30 passed
- fresh native suite: 1,712/1,712 passed
- stable-ABI wheel built with Python 3.12 and tested with Python 3.14: 3,228 passed, 10 skipped