### PR TITLE
Retire the runtime thread-locals: a Wiring binds its seed state

### DIFF
--- a/docs/source/developer_guide/architecture.rst
+++ b/docs/source/developer_guide/architecture.rst
@@ -21,17 +21,24 @@ wiring seed, and each root graph instance receives its own copy exactly as it
 does on the unseeded path.  Nested graphs continue to resolve the root graph's
 state and never own a separate copy.
 
-``GlobalContext`` is optional pre-wiring shorthand.  It selects one seed per
-thread and rejects nesting; new top-level wiring/builders copy that seed, while
-the context itself is not retained by the graph or runner.  C++ callers read the
-completed owned copy from the executor's root ``GraphView`` as before; automatic
-copy-back is a language-bridge concern.
+``GlobalContext`` is optional C++ authoring shorthand.  It selects one seed in
+one process-wide slot (the build is single-threaded; there is no thread-local
+anywhere in the runtime, ruling 2026-09-05) and rejects nesting.  A top-level
+``Wiring`` constructed while it is active *binds* the selected state at
+construction (``Wiring::seed_state``) and reads and writes it through that
+binding; a context that exits early detaches every wiring it seeded, so reads
+fall back to the wiring's own store and the build fails loudly rather than
+dereferencing a dead state.  The context itself is not retained by the graph or
+runner.  C++ callers read the completed owned copy from the executor's root
+``GraphView`` as before; automatic copy-back is a language-bridge concern.
 
-Language bridges may begin that lifecycle earlier without changing the C++
-model.  The Python bridge keeps a seed in thread-local Python state, copies it
-into each top-level ``Wiring``, and copies the root graph's final state back only
-after the runner finishes.  The graph never borrows the Python seed and there is
-no alternate external-state path in ``GraphBuilder`` or the runtime.
+Language bridges do not use the context.  The Python bridge keeps a seed in
+thread-local *Python* state, hands it to each top-level ``Wiring`` directly
+(``Wiring(GlobalState &)``), and copies the root graph's final state back only
+after the runner finishes; a child wiring reads the root's seed through its own
+binding.  That explicit binding is what lets distinct runs proceed on distinct
+threads.  The graph never borrows the Python seed and there is no alternate
+external-state path in ``GraphBuilder`` or the runtime.
 
 Clock And Execution Mode
 ------------------------

--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -332,7 +332,10 @@ registration are process-wide. The lock remains held through
 ``Wiring::finish()`` and service materialization, where C++ can re-enter Python
 wiring, and is released as soon as the native executor has been constructed.
 The executor run therefore does not hold the wiring lock: distinct native
-executors can progress concurrently on different threads.
+executors can progress concurrently on different threads. Nothing in that
+path is a C++ thread-local (``runtime-thread-locals`` is at zero): the seed
+state is bound to the ``Wiring`` explicitly, and the wiring-time realization
+policy is read from that binding (``Wiring::realization_options``).
 
 C++ re-enters Python wiring through the *borrowed wiring* pattern: when the C++
 side calls back into a Python graph function (graph-fn wrapper) or a Python

--- a/docs/source/developer_guide/python_integration.rst
+++ b/docs/source/developer_guide/python_integration.rst
@@ -498,8 +498,10 @@ Recorded divergences / gaps (the morning-summary list):
 - **Global run state** preserves the C++ ownership model.  Python keeps one
   ``GlobalState`` seed per thread.  ``GlobalContext`` selects that seed for an
   outer wiring/run scope and rejects nesting; ``with GlobalState()`` is
-  compatibility shorthand.  A top-level Python ``Wiring`` copies from the
-  selected seed, the C++ builder and root graph then use their normal owned-copy
+  compatibility shorthand.  A top-level Python ``Wiring`` binds the selected
+  seed directly (``Wiring(GlobalState &)``; the C++ ``GlobalContext`` and its
+  process-wide slot are never involved, so runs on different threads do not
+  contend), the C++ builder and root graph then use their normal owned-copy
   lifecycle, and the bridge replaces the Python seed with the root graph's final
   state after execution.  Runtime access is explicit: a graph or node declares
   the ``GlobalState`` injectable, and each callback receives a guarded projection

--- a/include/hgraph/lib/std/lower.h
+++ b/include/hgraph/lib/std/lower.h
@@ -73,13 +73,15 @@ namespace hgraph::stdlib
       private:
         friend HGRAPH_EXPORT LowerExecution prepare_lower(const WiredFn &, std::span<const Frame>, LowerOptions);
 
-        explicit LowerExecution(GraphExecutorValue executor, bool has_output, GlobalState *seed = nullptr);
+        explicit LowerExecution(GraphExecutorValue executor, bool has_output, GlobalSeed seed = {});
 
         GraphExecutorValue executor_{};
         std::optional<Frame> result_{};
         bool has_output_{false};
-        /** The seed the lowered wiring was bound to; results copy back into it. */
-        GlobalState *seed_{nullptr};
+        /** The seed binding the lowered wiring held; results copy back into
+            the seed while it is still attached (a context that exited, or a
+            bridge that released, detaches it). */
+        GlobalSeed seed_{};
         bool ran_{false};
     };
 

--- a/include/hgraph/lib/std/lower.h
+++ b/include/hgraph/lib/std/lower.h
@@ -38,6 +38,10 @@ namespace hgraph::stdlib
         /** Install ``phase_runner`` only when the finished graph or a nested
             child plan opts into it. */
         bool phase_runner_requires_graph_opt_in{false};
+        /** Borrowed live seed for the lowered wiring (a bridge's state);
+            results copy back into it at run end. Null: the wiring binds the
+            active C++ ``GlobalContext`` seed, if any. */
+        GlobalState *global_state{nullptr};
     };
 
     /**
@@ -69,11 +73,13 @@ namespace hgraph::stdlib
       private:
         friend HGRAPH_EXPORT LowerExecution prepare_lower(const WiredFn &, std::span<const Frame>, LowerOptions);
 
-        explicit LowerExecution(GraphExecutorValue executor, bool has_output);
+        explicit LowerExecution(GraphExecutorValue executor, bool has_output, GlobalState *seed = nullptr);
 
         GraphExecutorValue executor_{};
         std::optional<Frame> result_{};
         bool has_output_{false};
+        /** The seed the lowered wiring was bound to; results copy back into it. */
+        GlobalState *seed_{nullptr};
         bool ran_{false};
     };
 

--- a/include/hgraph/runtime/global_state.h
+++ b/include/hgraph/runtime/global_state.h
@@ -6,6 +6,7 @@
 
 #include <string>
 #include <string_view>
+#include <memory>
 #include <vector>
 
 namespace hgraph
@@ -108,24 +109,45 @@ namespace hgraph
     };
 
     /**
+     * A detachable binding to a LIVE seed state. Every holder -- a top-level
+     * wiring, the child wirings it spawns, a prepared ``lower`` execution --
+     * reads the seed through the shared binding; the owner (a
+     * ``GlobalContext`` when it exits, or the top-level wiring an explicit
+     * seed was handed to when it releases) DETACHES it, after which every
+     * holder sees no seed and nothing can dereference a dead state. No
+     * holder ever copies the raw pointer out.
+     */
+    class HGRAPH_CLASS_EXPORT GlobalSeedBinding
+    {
+      public:
+        explicit GlobalSeedBinding(GlobalState *state) noexcept : state_(state) {}
+        [[nodiscard]] GlobalState *state() const noexcept { return state_; }
+        void detach() noexcept { state_ = nullptr; }
+
+      private:
+        GlobalState *state_{nullptr};
+    };
+    using GlobalSeed = std::shared_ptr<GlobalSeedBinding>;
+
+    /**
      * C++ authoring shorthand that selects the LIVE global state for the
-     * top-level wirings constructed while it is active (lifecycle ruling
-     * 2026-07-27; no-thread-locals ruling 2026-09-05). The build is
-     * single-threaded, so the active context is one process-wide slot, like
-     * the wiring-time context stack on the operator registry -- never a
-     * thread-local. A ``Wiring`` binds the selected state at construction
-     * (``Wiring::seed_state``) and reads and writes it through that binding
-     * for the duration of the wiring; nothing copies it. The wiring end
-     * (graph build) FIXES the seed: the state is copied then, as it stands,
-     * into the graph as its initial state; the run works on that isolation
-     * copy (global to the runtime graph and all nested graphs) and results
-     * copy back at run end. The selected state must span the wiring
-     * process: a context that exits early DETACHES every wiring it seeded
-     * (the wiring falls back to its own store and its build fails loudly)
-     * rather than leaving a dangling binding. Language bridges do not use
-     * the context: they hand the state to ``Wiring(GlobalState &)``
-     * directly, which is what lets distinct runs proceed on distinct
-     * threads.
+     * wirings constructed while it is active (lifecycle ruling 2026-07-27;
+     * no-thread-locals ruling 2026-09-05). The build is single-threaded, so
+     * the active context is one process-wide slot, like the wiring-time
+     * context stack on the operator registry -- never a thread-local. A
+     * ``Wiring`` takes the context's ``GlobalSeed`` at construction and
+     * reads and writes the state through that binding for the duration of
+     * the wiring; nothing copies it. The wiring end (graph build) FIXES the
+     * seed: the state is copied then, as it stands, into the graph as its
+     * initial state; the run works on that isolation copy (global to the
+     * runtime graph and all nested graphs) and results copy back at run
+     * end. The selected state must span the wiring process: a context that
+     * exits early detaches the binding it handed out, so every wiring and
+     * child seeded from it falls back to its own store and a top-level
+     * build fails loudly rather than dereferencing a dead state. Language
+     * bridges do not use the context: they hand the state to
+     * ``Wiring(GlobalState &)`` directly, which is what lets distinct runs
+     * proceed on distinct threads.
      */
     class HGRAPH_CLASS_EXPORT GlobalContext
     {
@@ -140,22 +162,19 @@ namespace hgraph
         ~GlobalContext();
 
         [[nodiscard]] GlobalState &state() const noexcept { return *state_; }
-        /** The active context, or null: consulted once, when a top-level
-            ``Wiring`` is constructed, and by C++ test harnesses. */
+        /** The binding this context hands to the wirings constructed under it. */
+        [[nodiscard]] const GlobalSeed &seed() const noexcept { return seed_; }
+        /** The active context, or null: consulted once, when a ``Wiring`` is
+            constructed, and by C++ test harnesses. */
         [[nodiscard]] static GlobalContext *active() noexcept;
         [[nodiscard]] static GlobalState *active_state() noexcept;
-
-        /** A wiring seeded from this context registers the slot holding its
-            binding; the context nulls every registered slot when it exits. */
-        void bind_seed(GlobalState **slot);
-        void unbind_seed(GlobalState **slot) noexcept;
 
       private:
         void activate();
 
-        GlobalState                owned_state_{};
-        GlobalState               *state_{nullptr};
-        std::vector<GlobalState **> seeded_{};
+        GlobalState  owned_state_{};
+        GlobalState *state_{nullptr};
+        GlobalSeed   seed_{};
     };
 }  // namespace hgraph
 

--- a/include/hgraph/runtime/global_state.h
+++ b/include/hgraph/runtime/global_state.h
@@ -6,6 +6,7 @@
 
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace hgraph
 {
@@ -107,17 +108,24 @@ namespace hgraph
     };
 
     /**
-     * Selects the LIVE global state on the current thread (lifecycle ruling
-     * 2026-07-27). A top-level Wiring created inside the context reads and
-     * writes the selected state THROUGH the context for the duration of the
-     * wiring — nothing copies it and nothing retains a pointer to it. The
-     * wiring end (graph build) FIXES the seed: the state is copied then, as
-     * it stands, into the graph as its initial state; the run works on that
-     * isolation copy (global to the runtime graph and all nested graphs)
-     * and results copy back at run end, after which no reference to the
-     * selected state is held anywhere. The selected state must span the
-     * wiring process — a wiring whose context exited early fails its build
-     * loudly rather than dereferencing a dead state.
+     * C++ authoring shorthand that selects the LIVE global state for the
+     * top-level wirings constructed while it is active (lifecycle ruling
+     * 2026-07-27; no-thread-locals ruling 2026-09-05). The build is
+     * single-threaded, so the active context is one process-wide slot, like
+     * the wiring-time context stack on the operator registry -- never a
+     * thread-local. A ``Wiring`` binds the selected state at construction
+     * (``Wiring::seed_state``) and reads and writes it through that binding
+     * for the duration of the wiring; nothing copies it. The wiring end
+     * (graph build) FIXES the seed: the state is copied then, as it stands,
+     * into the graph as its initial state; the run works on that isolation
+     * copy (global to the runtime graph and all nested graphs) and results
+     * copy back at run end. The selected state must span the wiring
+     * process: a context that exits early DETACHES every wiring it seeded
+     * (the wiring falls back to its own store and its build fails loudly)
+     * rather than leaving a dangling binding. Language bridges do not use
+     * the context: they hand the state to ``Wiring(GlobalState &)``
+     * directly, which is what lets distinct runs proceed on distinct
+     * threads.
      */
     class HGRAPH_CLASS_EXPORT GlobalContext
     {
@@ -132,13 +140,22 @@ namespace hgraph
         ~GlobalContext();
 
         [[nodiscard]] GlobalState &state() const noexcept { return *state_; }
+        /** The active context, or null: consulted once, when a top-level
+            ``Wiring`` is constructed, and by C++ test harnesses. */
+        [[nodiscard]] static GlobalContext *active() noexcept;
         [[nodiscard]] static GlobalState *active_state() noexcept;
+
+        /** A wiring seeded from this context registers the slot holding its
+            binding; the context nulls every registered slot when it exits. */
+        void bind_seed(GlobalState **slot);
+        void unbind_seed(GlobalState **slot) noexcept;
 
       private:
         void activate();
 
-        GlobalState  owned_state_{};
-        GlobalState *state_{nullptr};
+        GlobalState                owned_state_{};
+        GlobalState               *state_{nullptr};
+        std::vector<GlobalState **> seeded_{};
     };
 }  // namespace hgraph
 

--- a/include/hgraph/types/graph_wiring.h
+++ b/include/hgraph/types/graph_wiring.h
@@ -858,6 +858,12 @@ namespace hgraph
       public:
         explicit Wiring(WiringKind kind = WiringKind::TopLevel,
                         WiringOptions options = {});
+        /** A top-level wiring bound to an explicitly selected live seed (the
+            bridge's state): reads and writes go to ``seed`` for the duration
+            of the wiring, the build fixes a copy. Never combined with an
+            active ``GlobalContext``. The seed must outlive the wiring's
+            build; ``release_seed`` drops the binding early. */
+        explicit Wiring(GlobalState &seed, WiringOptions options = {});
         ~Wiring();
         Wiring(const Wiring &)            = delete;
         Wiring &operator=(const Wiring &) = delete;
@@ -1139,8 +1145,16 @@ namespace hgraph
          * ``GraphBuilder`` (and thence onto each graph it builds).
          */
         [[nodiscard]] GlobalStateView global_state() noexcept;
-        /** State visible to operator resolution; sub-graphs read the active root seed. */
+        /** State visible to operator resolution; a child wiring reads the root's seed. */
         [[nodiscard]] GlobalStateView operator_state() noexcept;
+        /** The bound live seed, or null for a stateless wiring (and after a
+            C++ context exited or ``release_seed``). */
+        [[nodiscard]] GlobalState *seed_state() const noexcept;
+        /** Drop the seed binding; reads fall back to the internal store. */
+        void release_seed() noexcept;
+        /** Representation policy for values built while wiring: the enclosing
+            realization snapshot's, else the bound seed's configuration. */
+        [[nodiscard]] TypeRealizationOptions realization_options() const;
         /**
          * Wiring-time logger for graph composition diagnostics. The returned
          * view has no node context; runtime value logging belongs in a node or
@@ -3187,7 +3201,7 @@ namespace hgraph
                 Value scalars;
                 if constexpr (signature::scalar_count() > 0)
                 {
-                    const auto binding = value_type_for_wiring(signature::scalar_schema(map));
+                    const auto binding = value_type_for_wiring(signature::scalar_schema(map), w.realization_options());
                     BundleBuilder bundle{binding};
                     [&]<std::size_t... I>(std::index_sequence<I...>) {
                         (
@@ -3320,7 +3334,7 @@ namespace hgraph
                 Value scalars;
                 if constexpr (signature::scalar_count() > 0)
                 {
-                    const auto binding = value_type_for_wiring(signature::scalar_schema());
+                    const auto binding = value_type_for_wiring(signature::scalar_schema(), w.realization_options());
                     scalars             = Value{binding};
                     auto mutation       = scalars.as_bundle().begin_mutation();
                     [&]<std::size_t... I>(std::index_sequence<I...>) {

--- a/include/hgraph/types/graph_wiring.h
+++ b/include/hgraph/types/graph_wiring.h
@@ -1150,7 +1150,12 @@ namespace hgraph
         /** The bound live seed, or null for a stateless wiring (and after a
             C++ context exited or ``release_seed``). */
         [[nodiscard]] GlobalState *seed_state() const noexcept;
-        /** Drop the seed binding; reads fall back to the internal store. */
+        /** The shared, detachable binding itself, for a holder that must
+            outlive this wiring without copying the raw pointer out (a
+            prepared ``lower`` execution). Empty for a stateless wiring. */
+        [[nodiscard]] GlobalSeed seed() const noexcept;
+        /** Drop the seed binding; reads fall back to the internal store. An
+            explicitly seeded wiring detaches the binding for every holder. */
         void release_seed() noexcept;
         /** Representation policy for values built while wiring: the enclosing
             realization snapshot's, else the bound seed's configuration. */

--- a/include/hgraph/types/metadata/type_realization.h
+++ b/include/hgraph/types/metadata/type_realization.h
@@ -129,9 +129,12 @@ namespace hgraph
     value_type_for_active_realization(const ValueTypeMetaData *schema);
 
     /** Resolve storage for a wiring-time value. Reuse an enclosing graph's
-        closed-union snapshot, or capture the current registered hierarchy. */
+        closed-union snapshot, or capture the current registered hierarchy
+        under ``options`` (the wiring's ``realization_options()``: its bound
+        seed's configuration -- never an ambient state). */
     [[nodiscard]] HGRAPH_EXPORT ValueTypeRef
-    value_type_for_wiring(const ValueTypeMetaData *schema);
+    value_type_for_wiring(const ValueTypeMetaData *schema,
+                          const TypeRealizationOptions &options = {});
 
     /** Test-only registry teardown hook; call after TypeRecordRegistry reset. */
     HGRAPH_EXPORT void clear_type_realization_snapshots() noexcept;

--- a/include/hgraph/types/operator_dispatch.h
+++ b/include/hgraph/types/operator_dispatch.h
@@ -1153,14 +1153,15 @@ namespace hgraph
 
         // Assemble the resolved scalar-configuration bundle from the erased scalar args.
         template <typename Impl>
-        [[nodiscard]] Value assemble_scalars(const ResolutionMap &map, std::span<const WiringArg> args)
+        [[nodiscard]] Value assemble_scalars(const ResolutionMap &map, std::span<const WiringArg> args,
+                                             const TypeRealizationOptions &options)
         {
             using sig = StaticNodeSignature<Impl>;
             if constexpr (sig::scalar_count() == 0) { return Value{}; }
             else
             {
                 using wire_params   = typename sig::wire_param_types;
-                const auto binding = value_type_for_wiring(sig::scalar_schema(map));
+                const auto binding = value_type_for_wiring(sig::scalar_schema(map), options);
                 BundleBuilder bundle{binding};
                 [&]<std::size_t... I>(std::index_sequence<I...>) {
                     (
@@ -1229,7 +1230,7 @@ namespace hgraph
             map.bind_ts("S", target_schema);
 
             const auto binding = value_type_for_wiring(
-                StaticNodeSignature<operator_auto_const>::scalar_schema(map));
+                StaticNodeSignature<operator_auto_const>::scalar_schema(map), w.realization_options());
             BundleBuilder bundle{binding};
             bundle.set("value", lifted_value->view());
 
@@ -1907,7 +1908,7 @@ namespace hgraph
             NodeBuilder builder;
             builder.template implementation<Impl>(map);
             w.apply_pending_node_label(operator_name, builder);
-            Value scalars = operator_dispatch_detail::assemble_scalars<Impl>(map, args);
+            Value scalars = operator_dispatch_detail::assemble_scalars<Impl>(map, args, w.realization_options());
             std::vector<WiringPortRef> inputs = operator_dispatch_detail::collect_node_inputs<Impl>(w, map, args);
             builder.input_endpoint(graph_wiring_detail::input_endpoint_for_sources(
                 builder.type().schema() != nullptr ? builder.type().schema()->input_schema : nullptr,

--- a/python/py_wiring.cpp
+++ b/python/py_wiring.cpp
@@ -1523,8 +1523,8 @@ namespace hgraph::python_bridge
                 frames.push_back(converted.view().checked_as<Frame>());
             }
 
-            GlobalContext context{state};
             stdlib::LowerOptions options;
+            options.global_state     = &state;
             options.date_column      = date_column;
             options.as_of_column     = as_of_column;
             options.no_as_of_support = no_as_of_support;

--- a/python/py_wiring.h
+++ b/python/py_wiring.h
@@ -89,7 +89,6 @@ namespace hgraph::python_bridge
         // Owned by default; a BORROWED PyWiring (python graph callables run
         // against a Wiring the C++ side owns - e.g. a sub-graph compile)
         // aliases without ownership and cannot be run/finished.
-        std::unique_ptr<GlobalContext> seed_context{};
         std::vector<nb::object>        borrowed_wiring_observers{};
         std::vector<nb::object>        lifecycle_observers{};
         std::unique_ptr<WiringTracer> wiring_tracer{};
@@ -120,11 +119,11 @@ namespace hgraph::python_bridge
             }
         }
 
+        // The Python seed is handed to the Wiring directly (no C++
+        // GlobalContext, no thread-local): distinct runs on distinct threads
+        // each bind their own state.
         explicit PyWiring(GlobalState &state, bool is_realtime = false)
-            : seed_context(std::make_unique<GlobalContext>(state)),
-              owned(std::make_unique<Wiring>(
-                  WiringKind::TopLevel,
-                  WiringOptions{.is_realtime = is_realtime})),
+            : owned(std::make_unique<Wiring>(state, WiringOptions{.is_realtime = is_realtime})),
               raw(owned.get()),
               python_state(&state)
         {
@@ -607,7 +606,12 @@ namespace hgraph::python_bridge
             fb.bound = true;
         }
 
-        void release_seed_context() noexcept { seed_context.reset(); }
+        /** The executor has been constructed: the wiring no longer needs the
+            Python seed (the build fixed its copy), so drop the binding. */
+        void release_seed_context() noexcept
+        {
+            if (raw != nullptr) { raw->release_seed(); }
+        }
 
       private:
         void ensure_open() const

--- a/python/tests/test_architecture_ratchets.py
+++ b/python/tests/test_architecture_ratchets.py
@@ -199,7 +199,7 @@ RATCHETS: tuple[Ratchet, ...] = (
     # --- Rulings (family 8) ---
     Ratchet(
         id="runtime-thread-locals",
-        baseline=2,
+        baseline=0,
         roots=("src/hgraph/runtime", "include/hgraph/runtime"),
         suffixes=(".cpp", ".h"),
         pattern=r"\bthread_local\b",

--- a/src/hgraph/lib/std/lower.cpp
+++ b/src/hgraph/lib/std/lower.cpp
@@ -414,8 +414,8 @@ namespace hgraph::stdlib
     LowerExecution::LowerExecution(LowerExecution &&) noexcept = default;
     LowerExecution &LowerExecution::operator=(LowerExecution &&) noexcept = default;
 
-    LowerExecution::LowerExecution(GraphExecutorValue executor, bool has_output, GlobalState *seed)
-        : executor_(std::move(executor)), has_output_(has_output), seed_(seed)
+    LowerExecution::LowerExecution(GraphExecutorValue executor, bool has_output, GlobalSeed seed)
+        : executor_(std::move(executor)), has_output_(has_output), seed_(std::move(seed))
     {
     }
 
@@ -442,7 +442,10 @@ namespace hgraph::stdlib
             result_ = stored.checked_as<Frame>();
             graph_state.erase(lower_detail::RESULT_KEY);
         }
-        if (seed_ != nullptr) { seed_->view().copy_from(graph_state); }
+        if (GlobalState *seed = seed_ ? seed_->state() : nullptr; seed != nullptr)
+        {
+            seed->view().copy_from(graph_state);
+        }
         ran_ = true;
     }
 
@@ -474,7 +477,7 @@ namespace hgraph::stdlib
         // The lowered wiring binds the caller's seed (a bridge's state), else
         // the active C++ authoring context's; results copy back into it.
         Wiring wiring = options.global_state != nullptr ? Wiring{*options.global_state} : Wiring{};
-        GlobalState *seed = wiring.seed_state();
+        GlobalSeed seed = wiring.seed();
         const DateTime invocation_as_of = options.as_of.value_or(lower_detail::current_time());
         std::vector<WiringPortRef> ports;
         ports.reserve(inputs.size());

--- a/src/hgraph/lib/std/lower.cpp
+++ b/src/hgraph/lib/std/lower.cpp
@@ -414,8 +414,8 @@ namespace hgraph::stdlib
     LowerExecution::LowerExecution(LowerExecution &&) noexcept = default;
     LowerExecution &LowerExecution::operator=(LowerExecution &&) noexcept = default;
 
-    LowerExecution::LowerExecution(GraphExecutorValue executor, bool has_output)
-        : executor_(std::move(executor)), has_output_(has_output)
+    LowerExecution::LowerExecution(GraphExecutorValue executor, bool has_output, GlobalState *seed)
+        : executor_(std::move(executor)), has_output_(has_output), seed_(seed)
     {
     }
 
@@ -442,10 +442,7 @@ namespace hgraph::stdlib
             result_ = stored.checked_as<Frame>();
             graph_state.erase(lower_detail::RESULT_KEY);
         }
-        if (GlobalState *state = GlobalContext::active_state())
-        {
-            state->view().copy_from(graph_state);
-        }
+        if (seed_ != nullptr) { seed_->view().copy_from(graph_state); }
         ran_ = true;
     }
 
@@ -474,7 +471,10 @@ namespace hgraph::stdlib
     {
         lower_detail::validate(function, inputs, options);
 
-        Wiring wiring;
+        // The lowered wiring binds the caller's seed (a bridge's state), else
+        // the active C++ authoring context's; results copy back into it.
+        Wiring wiring = options.global_state != nullptr ? Wiring{*options.global_state} : Wiring{};
+        GlobalState *seed = wiring.seed_state();
         const DateTime invocation_as_of = options.as_of.value_or(lower_detail::current_time());
         std::vector<WiringPortRef> ports;
         ports.reserve(inputs.size());
@@ -513,7 +513,7 @@ namespace hgraph::stdlib
         {
             builder.add_lifecycle_observer(options.observer);
         }
-        return LowerExecution{builder.make_executor(), has_output};
+        return LowerExecution{builder.make_executor(), has_output, seed};
     }
 
     std::optional<Frame> lower(const WiredFn &function, std::span<const Frame> inputs, LowerOptions options)

--- a/src/hgraph/runtime/global_state.cpp
+++ b/src/hgraph/runtime/global_state.cpp
@@ -5,29 +5,44 @@
 #include <hgraph/types/value/any_ops.h>
 #include <hgraph/types/value/mutable_container_ops.h>
 
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
 #include <string>
 
 namespace hgraph
 {
     namespace
     {
-        thread_local GlobalContext *active_global_context = nullptr;
+        // The active C++ authoring context: one process-wide slot, never a
+        // thread-local (the build is single-threaded; bridges hand the state
+        // to the Wiring directly and never touch this).
+        GlobalContext *active_global_context = nullptr;
 
-        // Canonical binding for the GlobalState backing: a mutable Map<string, Any>.
+        // Canonical binding for the GlobalState backing: a mutable Map<string,
+        // Any>. Generation-checked cache shared by every thread (no
+        // thread-local: ruling 2026-09-05): readers take one acquire load and
+        // stay off the registry mutexes; a stale generation (a test-only
+        // registry reset) resolves again under the registry and publishes a
+        // fresh immutable record. The record a reset retires is left to the
+        // process rather than freed under a concurrent reader -- a few bytes
+        // per test-only reset.
+        struct CachedBinding
+        {
+            std::uint64_t generation{0};
+            ValueTypeRef  binding{};
+        };
+
         ValueTypeRef global_state_binding()
         {
-            struct CachedBinding
-            {
-                std::uint64_t generation{0};
-                ValueTypeRef  binding{};
-            };
-            thread_local CachedBinding cached{};
+            static std::atomic<const CachedBinding *> cache{nullptr};
 
-            auto &registry = TypeRegistry::instance();
+            auto               &registry   = TypeRegistry::instance();
             const std::uint64_t generation = registry.reset_generation();
-            if (cached.binding.bound() && cached.generation == generation)
+            if (const CachedBinding *cached = cache.load(std::memory_order_acquire);
+                cached != nullptr && cached->generation == generation && cached->binding.bound())
             {
-                return cached.binding;
+                return cached->binding;
             }
 
             const auto *str_meta = registry.register_scalar<std::string>("str");
@@ -35,7 +50,16 @@ namespace hgraph
             const auto *schema   = registry.mutable_map(str_meta, any_meta);
             auto binding = ValuePlanFactory::instance().type_for(schema);
             if (!binding) { throw std::logic_error("GlobalState: no binding for Map<string, Any>"); }
-            cached = CachedBinding{generation, binding};
+            auto *fresh = new CachedBinding{generation, binding};
+            const CachedBinding *expected = cache.load(std::memory_order_acquire);
+            while (!cache.compare_exchange_weak(expected, fresh, std::memory_order_acq_rel, std::memory_order_acquire))
+            {
+                if (expected != nullptr && expected->generation == generation)
+                {
+                    delete fresh;   // a concurrent refresh published the same interned binding
+                    return expected->binding;
+                }
+            }
             return binding;
         }
     }  // namespace
@@ -104,6 +128,10 @@ namespace hgraph
 
     GlobalContext::~GlobalContext()
     {
+        // Detach every wiring this context seeded: the binding must not
+        // outlive the selected state.
+        for (GlobalState **slot : seeded_) { *slot = nullptr; }
+        seeded_.clear();
         if (active_global_context == this) { active_global_context = nullptr; }
     }
 
@@ -116,8 +144,21 @@ namespace hgraph
         active_global_context = this;
     }
 
+    GlobalContext *GlobalContext::active() noexcept { return active_global_context; }
+
     GlobalState *GlobalContext::active_state() noexcept
     {
         return active_global_context != nullptr ? &active_global_context->state() : nullptr;
+    }
+
+    void GlobalContext::bind_seed(GlobalState **slot)
+    {
+        *slot = state_;
+        seeded_.push_back(slot);
+    }
+
+    void GlobalContext::unbind_seed(GlobalState **slot) noexcept
+    {
+        std::erase(seeded_, slot);
     }
 }  // namespace hgraph

--- a/src/hgraph/runtime/global_state.cpp
+++ b/src/hgraph/runtime/global_state.cpp
@@ -128,10 +128,9 @@ namespace hgraph
 
     GlobalContext::~GlobalContext()
     {
-        // Detach every wiring this context seeded: the binding must not
-        // outlive the selected state.
-        for (GlobalState **slot : seeded_) { *slot = nullptr; }
-        seeded_.clear();
+        // Detach the binding handed to every wiring, child and prepared
+        // execution seeded from this context: none may outlive the state.
+        if (seed_) { seed_->detach(); }
         if (active_global_context == this) { active_global_context = nullptr; }
     }
 
@@ -141,6 +140,7 @@ namespace hgraph
         {
             throw std::logic_error("GlobalContext does not support nested activation");
         }
+        seed_                 = std::make_shared<GlobalSeedBinding>(state_);
         active_global_context = this;
     }
 
@@ -151,14 +151,5 @@ namespace hgraph
         return active_global_context != nullptr ? &active_global_context->state() : nullptr;
     }
 
-    void GlobalContext::bind_seed(GlobalState **slot)
-    {
-        *slot = state_;
-        seeded_.push_back(slot);
-    }
 
-    void GlobalContext::unbind_seed(GlobalState **slot) noexcept
-    {
-        std::erase(seeded_, slot);
-    }
 }  // namespace hgraph

--- a/src/hgraph/types/graph_wiring.cpp
+++ b/src/hgraph/types/graph_wiring.cpp
@@ -1155,18 +1155,50 @@ struct Wiring::Impl {
       : observers(std::move(observer_registry)),
         wiring_path(std::move(observer_path)), kind(wiring_kind),
         is_realtime(options.is_realtime) {
-    if (kind == WiringKind::TopLevel) {
-      // The LIVE selected state, not a copy (ruling 2026-07-27): setters
-      // invoked during wiring (set_record_replay_model, set_as_of, ...)
-      // write into the selected GlobalState, and wiring-time reads must see
-      // the same store — a construction-time copy silently ignored them.
-      // NOTHING is retained: reads resolve through the active context per
-      // call, the seed is FIXED by copy at wiring end (graph build), and
-      // the selected state must span the wiring process (finish fails
-      // loudly if it exited early). Only whether this wiring was live-
-      // seeded is remembered.
-      live_seeded = GlobalContext::active_state() != nullptr;
+    // The LIVE selected state, not a copy (ruling 2026-07-27): setters
+    // invoked during wiring (set_record_replay_model, set_as_of, ...)
+    // write into the selected GlobalState, and wiring-time reads must see
+    // the same store — a construction-time copy silently ignored them.
+    // A wiring BINDS the state selected by the active C++ authoring context
+    // at construction (no per-call ambient read, no thread-local: ruling
+    // 2026-09-05); the context nulls the binding if it exits before the
+    // wiring is done, so reads fall back to the internal store and a
+    // top-level build fails loudly. A directly constructed sub-graph wiring
+    // reads the same seed for operator resolution and realization policy;
+    // child_wiring() rebinds a child to its parent's seed. A bridge seeds
+    // through Wiring(GlobalState &) instead and never touches the context.
+    if (GlobalContext *context = GlobalContext::active()) {
+      seed_context = context;
+      context->bind_seed(&seed_state);
+      live_seeded = kind == WiringKind::TopLevel;
     }
+  }
+
+  ~Impl() {
+    if (seed_context != nullptr) {
+      seed_context->unbind_seed(&seed_state);
+    }
+  }
+
+  /** Bind an explicitly selected seed (a bridge's state, a parent wiring's
+      seed for a child), replacing any context binding. */
+  void bind_seed(GlobalState *seed) noexcept {
+    if (seed_context != nullptr) {
+      seed_context->unbind_seed(&seed_state);
+      seed_context = nullptr;
+    }
+    seed_state = seed;
+    live_seeded = kind == WiringKind::TopLevel && seed != nullptr;
+  }
+
+  /** Drop the seed binding: the finished build fixed its copy, or the bridge
+      released the state. */
+  void release_seed() noexcept {
+    if (seed_context != nullptr) {
+      seed_context->unbind_seed(&seed_state);
+      seed_context = nullptr;
+    }
+    seed_state = nullptr;
   }
 
   struct ServiceImplementationScopeState {
@@ -1231,7 +1263,9 @@ struct Wiring::Impl {
   std::vector<ServiceImplementationScopeState> implementation_scopes{};
   bool building_services{false};
   std::string service_materialization_path{};
-  GlobalState global_state{};  // stateless-wiring fallback (no live context)
+  GlobalState global_state{};  // stateless-wiring fallback (no seed bound)
+  GlobalState *seed_state{nullptr};      // the bound live seed, if any
+  GlobalContext *seed_context{nullptr};  // the C++ context that bound it, if any
   bool live_seeded{false};
   std::vector<std::shared_ptr<void>> extension_state{};
   std::unordered_map<std::type_index, std::shared_ptr<void>> keyed_extension_state{};
@@ -1246,6 +1280,14 @@ struct Wiring::Impl {
 
 Wiring::Wiring(WiringKind kind, WiringOptions options)
     : impl_(std::make_unique<Impl>(kind, options)) {}
+Wiring::Wiring(GlobalState &seed, WiringOptions options)
+    : impl_(std::make_unique<Impl>(WiringKind::TopLevel, options)) {
+  if (impl_->seed_context != nullptr) {
+    throw std::logic_error(
+        "Wiring: an explicit GlobalState seed cannot be combined with an active GlobalContext");
+  }
+  impl_->bind_seed(&seed);
+}
 Wiring::Wiring(WiringKind kind,
                WiringOptions options,
                std::shared_ptr<WiringObserverRegistry> observers,
@@ -1325,9 +1367,26 @@ bool Wiring::has_wiring_observers() const noexcept {
 }
 
 Wiring Wiring::child_wiring() const {
-  return Wiring{WiringKind::SubGraph,
-                WiringOptions{.is_realtime = impl_->is_realtime},
-                impl_->observers, impl_->wiring_path};
+  Wiring child{WiringKind::SubGraph,
+               WiringOptions{.is_realtime = impl_->is_realtime},
+               impl_->observers, impl_->wiring_path};
+  // A child reads the root's seed for operator resolution (record/replay
+  // configuration and the like) through its own binding, not an ambient.
+  child.impl_->bind_seed(impl_->seed_state);
+  return child;
+}
+
+GlobalState *Wiring::seed_state() const noexcept { return impl_->seed_state; }
+
+void Wiring::release_seed() noexcept { impl_->release_seed(); }
+
+TypeRealizationOptions Wiring::realization_options() const {
+  if (const TypeRealizationSnapshot *active = active_type_realization()) {
+    return active->options();
+  }
+  return impl_->seed_state != nullptr
+             ? type_realization_options(impl_->seed_state->view())
+             : TypeRealizationOptions{};
 }
 
 std::vector<std::string> Wiring::current_wiring_path() const {
@@ -2500,22 +2559,17 @@ Wiring::activate_error_capture(const WiringInstance *node,
 }
 
 GlobalStateView Wiring::global_state() noexcept {
-  // Resolved LIVE through the wiring context on every call — never a
-  // retained pointer (which would dangle when a short-lived GlobalContext
-  // exits before the wiring is done).
-  if (impl_->kind == WiringKind::TopLevel && impl_->live_seeded) {
-    if (GlobalState *state = GlobalContext::active_state()) {
-      return state->view();
-    }
+  // The bound live seed while it is bound (a C++ context that exits early
+  // nulls the binding, so nothing dangles); the internal store otherwise.
+  if (impl_->kind == WiringKind::TopLevel && impl_->seed_state != nullptr) {
+    return impl_->seed_state->view();
   }
   return impl_->global_state.view();
 }
 
 GlobalStateView Wiring::operator_state() noexcept {
-  if (impl_->kind == WiringKind::SubGraph) {
-    if (GlobalState *state = GlobalContext::active_state()) {
-      return state->view();
-    }
+  if (impl_->kind == WiringKind::SubGraph && impl_->seed_state != nullptr) {
+    return impl_->seed_state->view();
   }
   return global_state();
 }
@@ -2568,7 +2622,7 @@ GraphBuilder Wiring::finish_top_level(bool consume_state) {
   finalize_extensions();
   apply_service_rank_dependencies(); // add_rank_dependency de-dupes: idempotent
   GlobalState *live = impl_->kind == WiringKind::TopLevel && impl_->live_seeded
-                          ? GlobalContext::active_state()
+                          ? impl_->seed_state
                           : nullptr;
   if (impl_->live_seeded && live == nullptr) {
     throw std::logic_error(
@@ -2650,15 +2704,8 @@ CompiledSubGraph Wiring::finish_subgraph(
   }
 
   apply_service_rank_dependencies();
-  const TypeRealizationSnapshot *active_realization =
-      active_type_realization();
-  GlobalState *active_state = GlobalContext::active_state();
   const TypeRealizationOptions realization_options =
-      active_realization != nullptr
-          ? active_realization->options()
-          : active_state != nullptr
-                ? type_realization_options(active_state->view())
-                : TypeRealizationOptions{};
+      this->realization_options();
   const auto realization = TypeRealizationSnapshot::capture(
       TypeRegistry::instance(), realization_options);
   TypeRealizationScope realization_scope{realization.get()};

--- a/src/hgraph/types/graph_wiring.cpp
+++ b/src/hgraph/types/graph_wiring.cpp
@@ -1168,37 +1168,33 @@ struct Wiring::Impl {
     // child_wiring() rebinds a child to its parent's seed. A bridge seeds
     // through Wiring(GlobalState &) instead and never touches the context.
     if (GlobalContext *context = GlobalContext::active()) {
-      seed_context = context;
-      context->bind_seed(&seed_state);
+      seed = context->seed();
       live_seeded = kind == WiringKind::TopLevel;
     }
   }
 
-  ~Impl() {
-    if (seed_context != nullptr) {
-      seed_context->unbind_seed(&seed_state);
-    }
+  [[nodiscard]] GlobalState *seed_state() const noexcept {
+    return seed ? seed->state() : nullptr;
   }
 
-  /** Bind an explicitly selected seed (a bridge's state, a parent wiring's
-      seed for a child), replacing any context binding. */
-  void bind_seed(GlobalState *seed) noexcept {
-    if (seed_context != nullptr) {
-      seed_context->unbind_seed(&seed_state);
-      seed_context = nullptr;
-    }
-    seed_state = seed;
-    live_seeded = kind == WiringKind::TopLevel && seed != nullptr;
+  /** Own an explicitly selected seed (a bridge's state): this wiring detaches
+      the binding for every holder when it releases. */
+  void own_seed(GlobalState &state) {
+    seed = std::make_shared<GlobalSeedBinding>(&state);
+    owns_seed = true;
+    live_seeded = kind == WiringKind::TopLevel;
   }
 
   /** Drop the seed binding: the finished build fixed its copy, or the bridge
-      released the state. */
+      released the state. An owned binding is detached for every holder
+      (children, prepared executions); a context's binding is left to the
+      context. */
   void release_seed() noexcept {
-    if (seed_context != nullptr) {
-      seed_context->unbind_seed(&seed_state);
-      seed_context = nullptr;
+    if (owns_seed && seed) {
+      seed->detach();
     }
-    seed_state = nullptr;
+    seed.reset();
+    owns_seed = false;
   }
 
   struct ServiceImplementationScopeState {
@@ -1264,8 +1260,8 @@ struct Wiring::Impl {
   bool building_services{false};
   std::string service_materialization_path{};
   GlobalState global_state{};  // stateless-wiring fallback (no seed bound)
-  GlobalState *seed_state{nullptr};      // the bound live seed, if any
-  GlobalContext *seed_context{nullptr};  // the C++ context that bound it, if any
+  GlobalSeed seed{};            // the shared, detachable binding to the live seed, if any
+  bool owns_seed{false};        // an explicit seed: this wiring detaches it on release
   bool live_seeded{false};
   std::vector<std::shared_ptr<void>> extension_state{};
   std::unordered_map<std::type_index, std::shared_ptr<void>> keyed_extension_state{};
@@ -1282,11 +1278,11 @@ Wiring::Wiring(WiringKind kind, WiringOptions options)
     : impl_(std::make_unique<Impl>(kind, options)) {}
 Wiring::Wiring(GlobalState &seed, WiringOptions options)
     : impl_(std::make_unique<Impl>(WiringKind::TopLevel, options)) {
-  if (impl_->seed_context != nullptr) {
+  if (impl_->seed) {
     throw std::logic_error(
         "Wiring: an explicit GlobalState seed cannot be combined with an active GlobalContext");
   }
-  impl_->bind_seed(&seed);
+  impl_->own_seed(seed);
 }
 Wiring::Wiring(WiringKind kind,
                WiringOptions options,
@@ -1371,12 +1367,16 @@ Wiring Wiring::child_wiring() const {
                WiringOptions{.is_realtime = impl_->is_realtime},
                impl_->observers, impl_->wiring_path};
   // A child reads the root's seed for operator resolution (record/replay
-  // configuration and the like) through its own binding, not an ambient.
-  child.impl_->bind_seed(impl_->seed_state);
+  // configuration and the like) through the SAME shared binding, so the
+  // owner's detach reaches it too; it never copies the raw pointer out.
+  child.impl_->seed = impl_->seed;
+  child.impl_->owns_seed = false;
   return child;
 }
 
-GlobalState *Wiring::seed_state() const noexcept { return impl_->seed_state; }
+GlobalState *Wiring::seed_state() const noexcept { return impl_->seed_state(); }
+
+GlobalSeed Wiring::seed() const noexcept { return impl_->seed; }
 
 void Wiring::release_seed() noexcept { impl_->release_seed(); }
 
@@ -1384,9 +1384,9 @@ TypeRealizationOptions Wiring::realization_options() const {
   if (const TypeRealizationSnapshot *active = active_type_realization()) {
     return active->options();
   }
-  return impl_->seed_state != nullptr
-             ? type_realization_options(impl_->seed_state->view())
-             : TypeRealizationOptions{};
+  GlobalState *seed = impl_->seed_state();
+  return seed != nullptr ? type_realization_options(seed->view())
+                         : TypeRealizationOptions{};
 }
 
 std::vector<std::string> Wiring::current_wiring_path() const {
@@ -2561,15 +2561,17 @@ Wiring::activate_error_capture(const WiringInstance *node,
 GlobalStateView Wiring::global_state() noexcept {
   // The bound live seed while it is bound (a C++ context that exits early
   // nulls the binding, so nothing dangles); the internal store otherwise.
-  if (impl_->kind == WiringKind::TopLevel && impl_->seed_state != nullptr) {
-    return impl_->seed_state->view();
+  if (GlobalState *seed = impl_->seed_state();
+      impl_->kind == WiringKind::TopLevel && seed != nullptr) {
+    return seed->view();
   }
   return impl_->global_state.view();
 }
 
 GlobalStateView Wiring::operator_state() noexcept {
-  if (impl_->kind == WiringKind::SubGraph && impl_->seed_state != nullptr) {
-    return impl_->seed_state->view();
+  if (GlobalState *seed = impl_->seed_state();
+      impl_->kind == WiringKind::SubGraph && seed != nullptr) {
+    return seed->view();
   }
   return global_state();
 }
@@ -2622,7 +2624,7 @@ GraphBuilder Wiring::finish_top_level(bool consume_state) {
   finalize_extensions();
   apply_service_rank_dependencies(); // add_rank_dependency de-dupes: idempotent
   GlobalState *live = impl_->kind == WiringKind::TopLevel && impl_->live_seeded
-                          ? impl_->seed_state
+                          ? impl_->seed_state()
                           : nullptr;
   if (impl_->live_seeded && live == nullptr) {
     throw std::logic_error(

--- a/src/hgraph/types/metadata/type_realization.cpp
+++ b/src/hgraph/types/metadata/type_realization.cpp
@@ -1468,14 +1468,11 @@ value_type_for_active_realization(const ValueTypeMetaData *schema) {
                                  : active_snapshot->type_for(schema);
 }
 
-ValueTypeRef value_type_for_wiring(const ValueTypeMetaData *schema) {
+ValueTypeRef value_type_for_wiring(const ValueTypeMetaData *schema,
+                                   const TypeRealizationOptions &options) {
   if (active_snapshot != nullptr) {
     return active_snapshot->type_for(schema);
   }
-  GlobalState *state = GlobalContext::active_state();
-  const TypeRealizationOptions options =
-      state != nullptr ? type_realization_options(state->view())
-                       : TypeRealizationOptions{};
   return TypeRealizationSnapshot::capture(TypeRegistry::instance(), options)
       ->type_for(schema);
 }

--- a/tests/cpp/test_global_state.cpp
+++ b/tests/cpp/test_global_state.cpp
@@ -339,3 +339,50 @@ TEST_CASE("global context: the selected state must span the wiring process")
     CounterGraph::compose(wiring);
     CHECK_THROWS_AS(std::move(wiring).finish(), std::logic_error);
 }
+
+TEST_CASE("global state: a wiring binds an explicit seed without a context")
+{
+    // The bridge's path (no-thread-locals ruling 2026-09-05): the seed is
+    // handed to the Wiring, read and written live through the binding, and
+    // fixed by copy at the build; two such wirings coexist with distinct
+    // seeds, which is what lets distinct runs proceed on distinct threads.
+    GlobalState first;
+    GlobalState second;
+    first.view().set("who", Value{std::string{"first"}});
+    second.view().set("who", Value{std::string{"second"}});
+    CHECK(GlobalContext::active() == nullptr);
+
+    Wiring wiring_a{first};
+    Wiring wiring_b{second};
+    CHECK(wiring_a.seed_state() == &first);
+    CHECK(wiring_b.seed_state() == &second);
+    CHECK(wiring_a.global_state().get_as<std::string>("who") == "first");
+    CHECK(wiring_b.global_state().get_as<std::string>("who") == "second");
+
+    wiring_a.global_state().set("written", Value{std::int32_t{1}});
+    CHECK(first.view().contains("written"));          // live: written through the binding
+    CHECK_FALSE(second.view().contains("written"));
+
+    CounterGraph::compose(wiring_a);
+    GraphBuilder builder = std::move(wiring_a).finish();
+    CHECK(builder.global_state().get_as<std::string>("who") == "first");
+    builder.global_state().set("builder_only", Value{std::int32_t{9}});
+    CHECK_FALSE(first.view().contains("builder_only"));   // the build fixed a copy
+
+    // An explicit seed is never combined with an active context.
+    GlobalContext context;
+    CHECK_THROWS_AS(Wiring{second}, std::logic_error);
+}
+
+TEST_CASE("global state: a child wiring reads its root's seed through its own binding")
+{
+    GlobalState seed;
+    seed.view().set("root", Value{std::int32_t{3}});
+    Wiring root{seed};
+    Wiring child = root.child_wiring();
+    CHECK(child.seed_state() == &seed);
+    CHECK(child.operator_state().get_as<std::int32_t>("root") == 3);
+    root.release_seed();
+    CHECK(root.seed_state() == nullptr);
+    CHECK_FALSE(root.global_state().contains("root"));
+}

--- a/tests/cpp/test_global_state.cpp
+++ b/tests/cpp/test_global_state.cpp
@@ -9,6 +9,7 @@
 #include <hgraph/lib/testing/mock_runtime.h>
 #include <hgraph/runtime/runtime.h>
 #include <hgraph/types/graph_wiring.h>
+#include <hgraph/types/subgraph_wiring.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/static_node.h>
@@ -374,7 +375,7 @@ TEST_CASE("global state: a wiring binds an explicit seed without a context")
     CHECK_THROWS_AS(Wiring{second}, std::logic_error);
 }
 
-TEST_CASE("global state: a child wiring reads its root's seed through its own binding")
+TEST_CASE("global state: a child wiring shares its root's seed binding, and its detach")
 {
     GlobalState seed;
     seed.view().set("root", Value{std::int32_t{3}});
@@ -382,7 +383,30 @@ TEST_CASE("global state: a child wiring reads its root's seed through its own bi
     Wiring child = root.child_wiring();
     CHECK(child.seed_state() == &seed);
     CHECK(child.operator_state().get_as<std::int32_t>("root") == 3);
+    // The owner's release detaches the binding for every holder: the child
+    // never copied the raw pointer out.
     root.release_seed();
     CHECK(root.seed_state() == nullptr);
+    CHECK(child.seed_state() == nullptr);
     CHECK_FALSE(root.global_state().contains("root"));
+    CHECK_FALSE(child.operator_state().contains("root"));
+}
+
+TEST_CASE("global state: a child wiring that outlives its context is detached with it")
+{
+    // Review finding on the binding: a child created under a context must
+    // not keep a raw copy of the context-owned state.
+    Wiring child;
+    {
+        GlobalContext context;
+        context.state().view().set("root", Value{std::int32_t{5}});
+        Wiring root;
+        child = root.child_wiring();
+        CHECK(child.seed_state() == &context.state());
+        CHECK(child.operator_state().get_as<std::int32_t>("root") == 5);
+    }
+    CHECK(child.seed_state() == nullptr);
+    CHECK_FALSE(child.operator_state().contains("root"));
+    CompiledSubGraph compiled = std::move(child).finish_subgraph(std::nullopt, {});
+    CHECK_FALSE(compiled.graph_builder.global_state().contains("root"));
 }

--- a/tests/cpp/test_lower.cpp
+++ b/tests/cpp/test_lower.cpp
@@ -268,6 +268,28 @@ TEST_CASE("lower can retain one fixed as-of column and keeps private state priva
     CHECK_FALSE(context.state().view().contains("__hgraph.lower.result__"));
 }
 
+TEST_CASE("lower: a prepared execution run after its context exited copies nothing back")
+{
+    // Review finding on the seed binding: prepare/run may be split across the
+    // context's lifetime; the execution holds the shared binding, which the
+    // context detaches on exit, so the deferred run never writes through a
+    // dead state and still produces its result.
+    stdlib::register_standard_operators();
+    const std::array inputs{
+        input_frame({{MIN_ST, Int{1}}}),
+        input_frame({{MIN_ST, Int{2}}}),
+    };
+    stdlib::LowerExecution execution;
+    {
+        GlobalContext context;
+        context.state().view().set("seed", Value{Int{7}});
+        execution = stdlib::prepare_lower(fn<AddGraph>(), inputs, {});
+    }
+    execution.run();
+    REQUIRE(execution.ran());
+    CHECK(execution.result().has_value());
+}
+
 TEST_CASE("lower supports sink graphs and validates frame arity")
 {
     stdlib::register_standard_operators();


### PR DESCRIPTION
## Summary

The two `thread_local`s in the runtime are gone (`runtime-thread-locals` 2 → 0). Both lived in `global_state.cpp`: the active `GlobalContext` slot and the per-thread cache of the `GlobalState` binding. The standing ruling is that per-graph state binds to the running graph, never the thread, and this PR makes the wiring layer follow it.

- **A `Wiring` binds its seed.** `Wiring(GlobalState &)` binds an explicitly selected live state at construction; reads and writes go through that binding (`seed_state()`, `release_seed()`), a child wiring rebinds to its parent's seed, and the build fixes a copy exactly as before. Wiring-time realization policy is read from the binding (`Wiring::realization_options()`), and `value_type_for_wiring(schema, options)` takes it explicitly rather than reading an ambient state.
- **`GlobalContext` is C++ authoring shorthand only.** One process-wide slot (the build is single-threaded, like the wiring-time context stack on the operator registry), consulted once when a wiring is constructed. On exit it detaches every wiring it seeded, so reads fall back to the internal store and a top-level build fails loudly, as the existing test pins, without a dangling binding.
- **The Python bridge never creates a C++ `GlobalContext`.** It hands the seed to the `Wiring` directly, which is what lets distinct runs proceed on distinct threads (the `run_graph_on_thread` suite covers it). The lowered execution copies back into the seed it was bound to (`LowerOptions::global_state`).
- **The binding cache is shared, not per thread.** One generation-checked atomic record: readers take an acquire load and stay off the registry mutexes (`test_registry_snapshot` pins that a `GraphBuilder`'s default `GlobalState` costs no registry lock); a test-only registry reset publishes a fresh record.

The type-layer thread-locals the developer guide sanctions (realization snapshot scopes, the `scalar_binding<T>` and JSON generation-checked caches, the record/replay scope stack) are unchanged and outside the ratchet's roots.

New C++ cases pin the explicit binding, two seeds coexisting without a context, child rebinding and release. Docs: `architecture.rst`, `python_integration.rst`, `python_bridge.rst`, `global_state.h`.

## Test plan

- [x] C++ `hgraph_unit_tests`: 1694 cases green on a fresh binary.
- [x] Python core + five extension suites + `python/tests/adaptors` (threaded runs included): 3594 passed, 10 skipped.
- [x] Installed-SDK consumer checks (Python extension, native executable, Fabric SDK): pass.
- [x] Ratchet `runtime-thread-locals` at 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
