### PR TITLE
refactor(language): plan C++ modules from hgraph IR

### DIFF
--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -188,14 +188,15 @@ endfunction()
 
 # The C++ backend (src/codegen): emits a header/source pair of public hgraph
 # authoring code per module (developer guide, "C++ backend, first pass").
-# hgraph-free like the resolver: it prints types and names.
+# Hgraph IR owns module and callable/operator planning while a temporary
+# syntax adapter prints bodies, types, and signatures.
 add_library(hgl_codegen STATIC
     src/codegen/cpp_emitter.cpp
 )
 add_library(hgl::codegen ALIAS hgl_codegen)
 target_compile_features(hgl_codegen PUBLIC cxx_std_23)
 target_include_directories(hgl_codegen PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
-target_link_libraries(hgl_codegen PUBLIC hgl::semantics)
+target_link_libraries(hgl_codegen PUBLIC hgl::graph_ir)
 hgl_apply_warnings(hgl_codegen)
 
 # The command driver (src/driver): check, test, run, repl, emit-cpp and the dumps.

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -168,7 +168,11 @@ wiring target no longer includes syntax AST headers.
 
 ### E. C++ backend migration
 
-- migrate C++ generation to hgraph IR;
+- [x] make hgraph IR authoritative for module paths, callable identity,
+  visibility and classification, operator identity, exports, and registration
+  planning;
+- [ ] migrate type, signature, body, and dependency emission from the temporary
+  syntax/`ResolvedModule` adapter to hgraph IR;
 - remove duplicate name, type, generic, phase, and classification logic from
   the emitter;
 - retain deterministic formatting, source maps, public-SDK code, and readable
@@ -177,7 +181,8 @@ wiring target no longer includes syntax AST headers.
 
 Acceptance: both backends consume the same hgraph IR, existing generated tests
 and installed consumers pass, and architecture tests reject backend-to-syntax
-dependencies.
+dependencies. The first checkpoint is complete, but Stage E remains in progress
+until the body adapter and its syntax dependency are gone.
 
 ### F. Constrained native interface
 

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -46,7 +46,8 @@ src/
   hgraph_ir/    execution-facing types, callable interfaces, and plans
   wiring/       direct-wiring backend: IR walk over hgraph's erased dispatch,
                 harness sequences, test runner
-  codegen/cpp/  generated C++ and source maps
+  codegen/      hgraph-IR declaration planning, temporary AST body printer,
+                generated C++ and source maps
   driver/       check, test, emit-cpp, build, run
   repl/         session assembly over the driver
 ```
@@ -201,9 +202,20 @@ perform in-process registry resolution while it wires. Locked provider
 selection and native execution planning are still required before a portable
 module may be marked `Executable`.
 
-The direct-wiring backend now consumes only hgraph IR. The C++ backend still
-walks `ResolvedModule` beside typed HIR during migration; that remaining adapter
-is explicitly temporary.
+The direct-wiring backend now consumes only hgraph IR. The first Stage E C++
+checkpoint also takes hgraph IR as its primary input. It uses graph-IR module
+paths, callable identities, visibility and classification, nominal operator
+bindings, exports, and registration plans. A declaration range maps each
+planned callable or local operator back to exactly one source declaration; a
+missing, duplicate, or extra mapping is a backend diagnostic. That mapping is
+the explicitly temporary adapter through which the existing printer still
+reads syntax bodies, types, signatures, struct layouts, and expression
+dependencies from the AST and `ResolvedModule`.
+
+This seam keeps the generated package readable while preventing declaration
+policy from drifting between execution paths. The next Stage E checkpoints
+move type/signature printing and then body/dependency emission to hgraph IR.
+Only after those moves may `codegen` drop its syntax and resolver dependencies.
 
 `src/wiring/type_bridge` is the first direct-backend migration boundary. It
 materializes hgraph-IR scalar, tuple, list, set, map, window, atomic, and applied
@@ -1204,7 +1216,9 @@ generic operator implementations, fixed and duration windows, sparse struct
 deltas, concise `map` functions, scalar and collection runtime inputs, borrowed
 collection traversal, `out`, `logger`, state, and lifecycle hooks. File-based
 `test` and `run` compile/load supported runtime modules on Unix; portable native
-loading and the remaining language-depth items are still staged.
+loading and the remaining language-depth items are still staged. Declaration
+and module planning now comes from hgraph IR; the body/type/signature printer is
+the remaining temporary AST adapter.
 
 `hgl emit-cpp <file.hgl>` writes one header/source pair named after the
 source — `prices.hgl` becomes `prices.h` and `prices.cpp` — beside the
@@ -1221,6 +1235,13 @@ compilation diagnostic, not a best-effort warning; `HGL_CLANG_FORMAT`
 overrides the executable selected when `hgl` was built.
 
 What is emitted, in this order:
+
+Before emission, hgraph IR determines the module namespace, source-order
+callable set, visibility, composition/runtime classification, canonical
+callable and operator identities, export surface, and registry bindings. The
+adapter uses retained source ranges only to locate the legacy syntax body or
+signature that must still be printed; it cannot silently add or omit a planned
+declaration.
 
 - **Operator contracts.** `namespace operators` holds one transparent alias to
   `hgraph::Operator<"module.name",

--- a/language/docs/user-guide/modules-and-tools.md
+++ b/language/docs/user-guide/modules-and-tools.md
@@ -310,15 +310,18 @@ civil literals.
 
 The target architecture gives `test`, `run`, `emit-cpp`, and the REPL one
 checked semantic IR and one hgraph runtime. The direct evaluator now consumes
-hgraph IR; C++ generation retains the remaining temporary `ResolvedModule`
-adapter. A program made only of composition functions is wired onto the runtime
-directly, in process. A file-based `test` or `run` containing supported
-runtime functions goes through generated C++, as does an ahead-of-time package.
-The REPL selects the same two routes from the accepted session:
+hgraph IR. C++ generation uses the same IR for module, callable, operator,
+export, and registration planning, while a temporary source adapter still
+prints function bodies, types, and signatures. A program made only of
+composition functions is wired onto the runtime directly, in process. A
+file-based `test` or `run` containing supported runtime functions goes through
+generated C++, as does an ahead-of-time package. The REPL selects the same two
+routes from the accepted session:
 
 ```text
-source -> typed HIR -> hgraph IR -> direct wiring          -> hgraph runtime
-                    \-> temporary AST adapter -> C++ -> native -> hgraph runtime
+source -> typed HIR -> hgraph IR -> direct wiring -> hgraph runtime
+                              \-> C++ backend -> native -> hgraph runtime
+                                  (temporary AST body/type/signature adapter)
 ```
 
 Parity tests require both paths to build the same graph across their shared

--- a/language/src/README.md
+++ b/language/src/README.md
@@ -11,13 +11,16 @@ them.
 | `semantics/` | name binding, nominal hierarchy, generic argument roles, function classification | syntax plus descriptors to resolved names and shapes |
 | `ir/` | source-ranged HIR, canonical types, substitutions, constraint solving, phase/effect completion | resolved frontend state to typed HIR |
 | `hgraph_ir/` | canonical execution-facing types, compile-time expressions, constraints, struct contracts, operator and callable interfaces | typed HIR to executable composition and runtime-node plans |
-| `wiring/` | direct walk over `ResolvedModule` | hgraph IR to public erased wiring calls |
-| `codegen/` | direct walk over `ResolvedModule` | hgraph IR to formatted C++ and build artifacts |
+| `wiring/` | direct walk over hgraph IR | hgraph IR to public erased wiring calls |
+| `codegen/` | hgraph-IR declaration planning plus a temporary AST body adapter | hgraph IR to formatted C++ and build artifacts |
 | `driver/` | commands, native build/cache/load, REPL orchestration | assemble inputs and invoke passes |
 
-During migration, `ResolvedModule` is a compatibility boundary only. New
-language semantics belong in HIR construction, not in either backend. Temporary
-adapters must be named and removed when both backends consume hgraph IR.
+During migration, `ResolvedModule` and the syntax AST remain a compatibility
+boundary only for C++ body, type, and signature printing. Module identity,
+callable visibility and classification, operator binding, exports, and
+registration planning already come from hgraph IR. New language semantics
+belong in HIR construction, not in either backend. The remaining adapter is
+named here and must be removed as Stage E advances.
 
 Every new pass documents:
 

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -1235,11 +1235,11 @@ namespace hgl::codegen
                     return value;
                 }
                 case BindingKind::LocalOperator: {
-                    const auto &op = std::get<ast::OperatorDecl>(module_.decl(binding.decl).node);
-                    Value       value;
+                    const gir::OperatorContract &op = operator_decl(binding.decl);
+                    Value                        value;
                     value.kind  = Value::Kind::LocalOperator;
                     value.decl  = binding.decl;
-                    value.name  = "operators::" + cpp_name(op.name.text);
+                    value.name  = "operators::" + cpp_name(local_identity(op.identity));
                     value.range = range;
                     return value;
                 }

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -24,6 +24,8 @@
 // native compiler and hgraph registry check each emitted package.
 namespace hgl::codegen
 {
+    namespace gir = hgraph_ir;
+
     namespace
     {
         using semantics::BindingKind;
@@ -316,11 +318,9 @@ namespace hgl::codegen
         class Emitter
         {
           public:
-            Emitter(const syntax::SourceFile &file, const ast::Module &module, const semantics::ResolvedModule &resolved,
-                    const EmitOptions &options, syntax::DiagnosticSink &diagnostics)
-                : file_{file}, module_{module}, resolved_{resolved}, options_{options}, diagnostics_{diagnostics}
-            {
-            }
+            Emitter(const syntax::SourceFile &file, const gir::Module &graph, const ast::Module &module,
+                    const semantics::ResolvedModule &resolved, const EmitOptions &options, syntax::DiagnosticSink &diagnostics)
+                : file_{file}, graph_{graph}, module_{module}, resolved_{resolved}, options_{options}, diagnostics_{diagnostics} {}
 
             [[nodiscard]] EmittedModule emit();
 
@@ -346,6 +346,15 @@ namespace hgl::codegen
             }
             [[nodiscard]] const ast::StructDecl &structure(ast::DeclId decl) const {
                 return std::get<ast::StructDecl>(module_.decl(decl).node);
+            }
+            void                                       bind_hgraph_declarations();
+            [[nodiscard]] const gir::Callable         &callable(ast::DeclId decl) const { return *callables_.at(decl); }
+            [[nodiscard]] const gir::OperatorContract &operator_decl(ast::DeclId decl) const { return *operators_.at(decl); }
+            [[nodiscard]] static std::string_view      local_identity(std::string_view identity) noexcept;
+            [[nodiscard]] std::string_view             callable_name(ast::DeclId decl) const;
+            [[nodiscard]] std::string                  callable_cpp_name(ast::DeclId decl);
+            [[nodiscard]] static std::string           operator_registry_name(const gir::OperatorContract &op) {
+                return op.registry_name.empty() ? op.identity : op.registry_name;
             }
             [[nodiscard]] const ast::GenericParameter &generic_parameter(ast::DeclId decl, std::size_t index) const;
             [[nodiscard]] std::string                  slice(SourceRange range) const { return std::string{file_.slice(range)}; }
@@ -431,6 +440,7 @@ namespace hgl::codegen
             void collect_calls_block(ast::BlockId id, std::set<ast::DeclId> &calls);
 
             const syntax::SourceFile        &file_;
+            const gir::Module                                             &graph_;
             const ast::Module               &module_;
             const semantics::ResolvedModule &resolved_;
             const EmitOptions               &options_;
@@ -438,6 +448,10 @@ namespace hgl::codegen
             std::string                      basename_{};
             std::string                      namespace_{};
             std::string                      module_name_{};
+            std::vector<ast::DeclId>                                       callable_declarations_{};
+            std::vector<ast::DeclId>                                       operator_declarations_{};
+            std::unordered_map<ast::DeclId, const gir::Callable *>         callables_{};
+            std::unordered_map<ast::DeclId, const gir::OperatorContract *> operators_{};
             bool                             uses_analytics_{false};
             /// Locals declared in the current function, for unique C++ names.
             std::unordered_map<std::string, int> local_counts_{};
@@ -445,6 +459,85 @@ namespace hgl::codegen
             Writer                               generated_helpers_{};
             std::size_t                          anonymous_function_index_{0};
         };
+
+        std::string_view Emitter::local_identity(std::string_view identity) noexcept {
+            const std::size_t separator = identity.find_last_of('.');
+            return separator == std::string_view::npos ? identity : identity.substr(separator + 1);
+        }
+
+        std::string_view Emitter::callable_name(ast::DeclId decl) const {
+            const gir::Callable &item = callable(decl);
+            if (item.visibility == gir::CallableVisibility::Implementation && !item.operator_identity.empty()) {
+                return local_identity(item.operator_identity);
+            }
+            return local_identity(item.identity);
+        }
+
+        std::string Emitter::callable_cpp_name(ast::DeclId decl) {
+            const gir::Callable &item = callable(decl);
+            std::string          name = cpp_name(callable_name(decl));
+            if (item.visibility != gir::CallableVisibility::Implementation) { return name; }
+
+            const std::size_t marker = item.identity.find_last_of('#');
+            if (marker == std::string::npos || marker + 1U == item.identity.size() ||
+                item.identity.find_first_not_of("0123456789", marker + 1U) != std::string::npos) {
+                backend(item.range, "hgraph IR implementation '" + item.identity + "' has no canonical numeric identity");
+            }
+            return name + "_impl_" + item.identity.substr(marker + 1U);
+        }
+
+        void Emitter::bind_hgraph_declarations() {
+            const auto function_for_range = [&](SourceRange range) {
+                ast::DeclId match = ast::no_node;
+                for (const ast::DeclId id : resolved_.functions) {
+                    if (module_.decl(id).range != range) { continue; }
+                    if (match != ast::no_node) {
+                        backend(range, "hgraph IR callable range matches more than one syntax declaration");
+                    }
+                    match = id;
+                }
+                return match;
+            };
+            for (const gir::Callable &item : graph_.callables) {
+                const ast::DeclId id = function_for_range(item.range);
+                if (id == ast::no_node) {
+                    backend(item.range, "hgraph IR callable '" + item.identity + "' has no syntax body adapter");
+                }
+                if (!callables_.emplace(id, &item).second) {
+                    backend(item.range, "more than one hgraph IR callable maps to the same syntax declaration");
+                }
+                callable_declarations_.push_back(id);
+            }
+            if (callable_declarations_.size() != resolved_.functions.size()) {
+                backend(SourceRange{}, "the hgraph IR and syntax body adapter disagree on the module's callables");
+            }
+
+            const auto operator_for_range = [&](SourceRange range) {
+                ast::DeclId match = ast::no_node;
+                for (const ast::DeclId id : resolved_.operators) {
+                    if (module_.decl(id).range != range) { continue; }
+                    if (match != ast::no_node) {
+                        backend(range, "hgraph IR operator range matches more than one syntax declaration");
+                    }
+                    match = id;
+                }
+                return match;
+            };
+            for (const gir::OperatorContract &item : graph_.operators) {
+                if (item.imported) { continue; }
+                const ast::DeclId id = operator_for_range(item.range);
+                if (id == ast::no_node) {
+                    backend(item.range, "hgraph IR operator '" + item.identity + "' has no syntax signature adapter");
+                }
+                if (!operators_.emplace(id, &item).second) {
+                    backend(item.range, "more than one hgraph IR operator maps to the same syntax declaration");
+                }
+                operator_declarations_.push_back(id);
+            }
+            if (operator_declarations_.size() != resolved_.operators.size()) {
+                backend(SourceRange{}, "the hgraph IR and syntax signature adapter disagree on the module's operators");
+            }
+        }
 
         // ------------------------------------------------------------ types
 
@@ -1724,7 +1817,7 @@ namespace hgl::codegen
             }
             HType result;
             if (fn.signature.result != ast::no_node) { result = type_of(fn.signature.result, callee); }
-            Value value = wire(cpp_name(fn.name.text), args, range, result);
+            Value value = wire(callable_cpp_name(decl), args, range, result);
             if (fn.signature.result == ast::no_node) { value.kind = Value::Kind::Void; }
             return value;
         }
@@ -2626,10 +2719,7 @@ namespace hgl::codegen
         }
 
         void Emitter::check_supported(ast::DeclId decl) {
-            if (resolved_.kind(decl) == semantics::FunctionKind::Runtime)
-            {
-                static_cast<void>(runtime_info(decl));
-            }
+            if (callable(decl).kind == gir::CallableKind::RuntimeNode) { static_cast<void>(runtime_info(decl)); }
         }
 
         std::string Emitter::runtime_signature(ast::DeclId decl, const RuntimeInfo &info, Frame &frame, bool with_names,
@@ -2766,9 +2856,8 @@ namespace hgl::codegen
             frame.fn      = decl;
             frame.runtime = true;
             out.line("// " + where(module_.decl(decl).range));
-            out.open("struct " + cpp_name(fn.name.text));
-            out.line("[[maybe_unused]] static constexpr auto name = " +
-                     quote(module_name_ + "." + std::string{fn.name.text}) + ";");
+            out.open("struct " + callable_cpp_name(decl));
+            out.line("[[maybe_unused]] static constexpr auto name = " + quote(callable(decl).identity) + ";");
             emit_runtime_defaults(decl, out);
             if (!info.states.empty())
             {
@@ -2777,7 +2866,7 @@ namespace hgl::codegen
                 {
                     fields.push_back("hgraph::Field<" + quote(state.name) + ", " + schema(state.type, state.range) + ">");
                 }
-                out.line("using recordable_state = hgraph::TSB<" + quote(module_name_ + "." + std::string{fn.name.text} + ".state") + ", " +
+                out.line("using recordable_state = hgraph::TSB<" + quote(callable(decl).identity + ".state") + ", " +
                          join(fields, ", ") + ">;");
             }
 
@@ -2952,8 +3041,7 @@ namespace hgl::codegen
         void Emitter::emit_function(ast::DeclId decl, Writer &out, Form form)
         {
             check_supported(decl);
-            if (resolved_.kind(decl) == semantics::FunctionKind::Runtime)
-            {
+            if (callable(decl).kind == gir::CallableKind::RuntimeNode) {
                 if (form != Form::InlineStruct)
                 {
                     backend(module_.decl(decl).range, "a generated runtime node must be "
@@ -2965,7 +3053,7 @@ namespace hgl::codegen
             const ast::FunctionDecl &fn = function(decl);
             Frame                    frame;
             frame.fn = decl;
-            const std::string name = cpp_name(fn.name.text);
+            const std::string name = callable_cpp_name(decl);
 
             out.line("// " + where(module_.decl(decl).range));
             if (form == Form::OutOfLine)
@@ -2975,8 +3063,7 @@ namespace hgl::codegen
             else
             {
                 out.open("struct " + name);
-                out.line("[[maybe_unused]] static constexpr auto name = " +
-                         quote(module_name_ + "." + std::string{fn.name.text}) + ";");
+                out.line("[[maybe_unused]] static constexpr auto name = " + quote(callable(decl).identity) + ";");
                 // Defaults of const parameters travel with the graph so the
                 // registry can apply them when the function is called by name.
                 std::vector<std::string> defaults;
@@ -3128,9 +3215,8 @@ namespace hgl::codegen
         std::vector<ast::DeclId> Emitter::ordered_internal_functions()
         {
             std::vector<ast::DeclId> internal;
-            for (const ast::DeclId id : resolved_.functions)
-            {
-                if (function(id).visibility == ast::FunctionVisibility::Internal) { internal.push_back(id); }
+            for (const ast::DeclId id : callable_declarations_) {
+                if (callable(id).visibility == gir::CallableVisibility::Internal) { internal.push_back(id); }
             }
             std::map<ast::DeclId, std::set<ast::DeclId>> deps;
             for (const ast::DeclId id : internal)
@@ -3158,7 +3244,7 @@ namespace hgl::codegen
                 if (visiting.contains(id))
                 {
                     backend(module_.decl(id).range,
-                            "'" + std::string{function(id).name.text} + "' is recursive; recursive functions are not supported");
+                            "'" + std::string{callable_name(id)} + "' is recursive; recursive functions are not supported");
                 }
                 visiting.insert(id);
                 for (const ast::DeclId dep : deps[id]) { visit(dep); }
@@ -3174,8 +3260,9 @@ namespace hgl::codegen
 
         EmittedModule Emitter::emit()
         {
+            bind_hgraph_declarations();
             EmittedModule result;
-            result.module_name = resolved_.module_path;
+            result.module_name = graph_.path;
             if (result.module_name.empty()) { fail(Category::Module, SourceRange{0, 0}, "emit-cpp needs a module declaration"); }
             {
                 std::string ns;
@@ -3202,12 +3289,11 @@ namespace hgl::codegen
             std::vector<ast::DeclId> exports;
             std::vector<ast::DeclId> impls;
             std::map<std::string, std::string> cpp_functions;
-            for (const ast::DeclId id : resolved_.functions)
-            {
+            for (const ast::DeclId id : callable_declarations_) {
                 check_supported(id);
                 const ast::FunctionDecl &fn = function(id);
-                const std::string        source_name{fn.name.text};
-                const std::string        generated_name = cpp_name(source_name);
+                const std::string        source_name{callable_name(id)};
+                const std::string        generated_name = callable_cpp_name(id);
                 if (const auto [found, inserted] = cpp_functions.emplace(generated_name, source_name);
                     !inserted && found->second != source_name)
                 {
@@ -3226,8 +3312,8 @@ namespace hgl::codegen
                                                       "' as '" + generated_parameter + "'");
                     }
                 }
-                if (fn.visibility == ast::FunctionVisibility::Export) { exports.push_back(id); }
-                if (fn.visibility == ast::FunctionVisibility::Impl) { impls.push_back(id); }
+                if (callable(id).visibility == gir::CallableVisibility::Export) { exports.push_back(id); }
+                if (callable(id).visibility == gir::CallableVisibility::Implementation) { impls.push_back(id); }
             }
             const std::vector<ast::DeclId> internal = ordered_internal_functions();
 
@@ -3239,9 +3325,7 @@ namespace hgl::codegen
             for (const ast::DeclId id : impls) { emit_function(id, private_functions, Form::InlineStruct); }
             Writer public_functions;
             for (const ast::DeclId id : exports) {
-                if (resolved_.kind(id) == semantics::FunctionKind::Composition) {
-                    emit_function(id, public_functions, Form::OutOfLine);
-                }
+                if (callable(id).kind == gir::CallableKind::Composition) { emit_function(id, public_functions, Form::OutOfLine); }
             }
 
             Writer body;
@@ -3251,7 +3335,7 @@ namespace hgl::codegen
                 body.indent();
                 body.open("namespace");
                 const bool has_internal_runtime = std::any_of(internal.begin(), internal.end(), [&](ast::DeclId id) {
-                    return resolved_.kind(id) == semantics::FunctionKind::Runtime;
+                    return callable(id).kind == gir::CallableKind::RuntimeNode;
                 });
                 if (has_internal_runtime)
                 {
@@ -3259,11 +3343,10 @@ namespace hgl::codegen
                 }
                 for (const ast::DeclId id : internal)
                 {
-                    if (resolved_.kind(id) != semantics::FunctionKind::Runtime) { continue; }
+                    if (callable(id).kind != gir::CallableKind::RuntimeNode) { continue; }
                     Frame frame;
                     frame.fn = id;
-                    body.line("using " + cpp_name(function(id).name.text) + " = " +
-                              operator_contract(id, result.module_name + "." + std::string{function(id).name.text}, frame) + ";");
+                    body.line("using " + callable_cpp_name(id) + " = " + operator_contract(id, callable(id).identity, frame) + ";");
                 }
                 if (has_internal_runtime)
                 {
@@ -3287,38 +3370,32 @@ namespace hgl::codegen
             body.open("auto provider = registry.register_installer(" + quote(result.module_name) + ", []");
             for (const ast::DeclId id : exports)
             {
-                const std::string name = cpp_name(function(id).name.text);
-                const std::string registration = resolved_.kind(id) == semantics::FunctionKind::Runtime
+                const std::string name         = callable_cpp_name(id);
+                const std::string registration = callable(id).kind == gir::CallableKind::RuntimeNode
                                                      ? "hgraph::register_overload"
                                                      : "hgraph::register_graph_overload";
                 body.line(registration + "<operators::" + name + ", " + name + ">();");
             }
             for (const ast::DeclId id : internal)
             {
-                if (resolved_.kind(id) != semantics::FunctionKind::Runtime) { continue; }
-                const std::string name = cpp_name(function(id).name.text);
+                if (callable(id).kind != gir::CallableKind::RuntimeNode) { continue; }
+                const std::string name = callable_cpp_name(id);
                 body.line("hgraph::register_overload<operator_contracts::" + name + ", " + name + ">();");
             }
             for (const ast::DeclId id : impls)
             {
-                const ast::FunctionDecl &fn = function(id);
-                bool                     bound = false;
-                for (const ast::DeclId op_id : resolved_.operators)
-                {
-                    if (std::get<ast::OperatorDecl>(module_.decl(op_id).node).name.text == fn.name.text)
-                    {
-                        bound = true;
-                        break;
-                    }
-                }
-                if (!bound)
-                {
+                const gir::Callable &implementation = callable(id);
+                const auto contract = std::find_if(graph_.operators.begin(), graph_.operators.end(), [&](const auto &candidate) {
+                    return candidate.identity == implementation.operator_identity;
+                });
+                if (contract == graph_.operators.end() || contract->imported) {
                     unsupported(module_.decl(id).range, "an impl fn of an imported operator");
                 }
-                const std::string registration = resolved_.kind(id) == semantics::FunctionKind::Runtime
+                const std::string registration = implementation.kind == gir::CallableKind::RuntimeNode
                                                      ? "hgraph::register_overload"
                                                      : "hgraph::register_graph_overload";
-                body.line(registration + "<operators::" + cpp_name(fn.name.text) + ", " + cpp_name(fn.name.text) + ">();");
+                body.line(registration + "<operators::" + cpp_name(local_identity(contract->identity)) + ", " +
+                          callable_cpp_name(id) + ">();");
             }
             body.close(");");
             body.open("auto rollback = hgraph::make_scope_exit<true>([&]");
@@ -3353,26 +3430,23 @@ namespace hgl::codegen
             header.line("{");
             header.indent();
             for (const ast::DeclId id : resolved_.structs) { emit_struct(id, header); }
-            if (!resolved_.operators.empty() || !exports.empty())
-            {
+            if (!operator_declarations_.empty() || !exports.empty()) {
                 header.line("/// Operator contracts for the module's public callables.");
                 header.open("namespace operators");
-                for (const ast::DeclId id : resolved_.operators)
-                {
-                    const auto &op = std::get<ast::OperatorDecl>(module_.decl(id).node);
-                    Frame       frame;
+                for (const ast::DeclId id : operator_declarations_) {
+                    const gir::OperatorContract &op = operator_decl(id);
+                    Frame                        frame;
                     header.line("// " + where(module_.decl(id).range));
-                    header.line("using " + cpp_name(op.name.text) + " = " +
-                                operator_contract(id, result.module_name + "." + std::string{op.name.text}, frame) + ";");
+                    header.line("using " + cpp_name(local_identity(op.identity)) + " = " +
+                                operator_contract(id, operator_registry_name(op), frame) + ";");
                 }
                 for (const ast::DeclId id : exports)
                 {
-                    const ast::FunctionDecl &fn = function(id);
-                    Frame                    frame;
+                    Frame frame;
                     frame.fn = id;
                     header.line("// " + where(module_.decl(id).range));
-                    header.line("using " + cpp_name(fn.name.text) + " = " +
-                                operator_contract(id, result.module_name + "." + std::string{fn.name.text}, frame) + ";");
+                    header.line("using " + callable_cpp_name(id) + " = " + operator_contract(id, callable(id).identity, frame) +
+                                ";");
                 }
                 header.close("  // namespace operators");
                 header.line();
@@ -3380,8 +3454,8 @@ namespace hgl::codegen
             for (const ast::DeclId id : exports)
             {
                 emit_function(id, header,
-                              resolved_.kind(id) == semantics::FunctionKind::Runtime ? Form::InlineStruct : Form::Declaration);
-                result.exports.push_back(std::string{function(id).name.text});
+                              callable(id).kind == gir::CallableKind::RuntimeNode ? Form::InlineStruct : Form::Declaration);
+                result.exports.push_back(std::string{callable_name(id)});
             }
             header.line("/// Register the module's operators and implementations with the hgraph");
             header.line("/// registry and return the exact removable provider generation.");
@@ -3424,7 +3498,7 @@ namespace hgl::codegen
                         backend(module_.decl(exports[i]).range,
                                 "Python export '" + name + "' collides with '" + found->second + "' as '" + alias + "'");
                     }
-                    py += "    " + quote(alias) + ": _hgl_operator_function(" + quote(result.module_name + "." + name) + "),\n";
+                    py += "    " + quote(alias) + ": _hgl_operator_function(" + quote(callable(exports[i]).identity) + "),\n";
                     names.push_back(quote(alias));
                 }
                 py += "})\n\n__all__ = [" + join(names, ", ") + "]\n";
@@ -3434,11 +3508,10 @@ namespace hgl::codegen
         }
     }  // namespace
 
-    std::optional<EmittedModule> emit_cpp(const syntax::SourceFile &file, const ast::Module &module,
+    std::optional<EmittedModule> emit_cpp(const syntax::SourceFile &file, const hgraph_ir::Module &graph, const ast::Module &module,
                                           const semantics::ResolvedModule &resolved, const EmitOptions &options,
-                                          syntax::DiagnosticSink &diagnostics)
-    {
-        Emitter emitter{file, module, resolved, options, diagnostics};
+                                          syntax::DiagnosticSink &diagnostics) {
+        Emitter emitter{file, graph, module, resolved, options, diagnostics};
         try
         {
             return emitter.emit();

--- a/language/src/codegen/cpp_emitter.h
+++ b/language/src/codegen/cpp_emitter.h
@@ -1,6 +1,7 @@
 #ifndef HGL_CODEGEN_CPP_EMITTER_H
 #define HGL_CODEGEN_CPP_EMITTER_H
 
+#include "hgraph_ir/ir.h"
 #include "semantics/resolve.h"
 #include "syntax/ast.h"
 #include "syntax/diagnostic.h"
@@ -12,10 +13,12 @@
 
 /// The C++ backend, first pass (developer guide, "C++ backend, first pass"):
 /// one header/source pair of public hgraph authoring code per module. It is
-/// hgraph-free like the resolver — it prints names and types — so what it
-/// emits is checked by the native compiler that builds the package. Tests run
-/// generated graphs beside `hgl test` and exercise generated runtime nodes
-/// directly through hgraph's public harness.
+/// planned from hgraph IR and prints names and types without linking the hgraph
+/// runtime, so what it emits is checked by the native compiler that builds the
+/// package. A temporary syntax adapter still supplies bodies, types, and
+/// signatures during the Stage E migration. Tests run generated graphs beside
+/// `hgl test` and exercise generated runtime nodes directly through hgraph's
+/// public harness.
 namespace hgl::codegen
 {
     namespace ast = syntax::ast;
@@ -49,8 +52,8 @@ namespace hgl::codegen
     /// Emit the module. Returns nullopt after reporting a diagnostic; every
     /// construct outside the first pass is reported as a `backend`
     /// diagnostic that names the construct.
-    [[nodiscard]] std::optional<EmittedModule> emit_cpp(const syntax::SourceFile &file, const ast::Module &module,
-                                                        const semantics::ResolvedModule &resolved,
+    [[nodiscard]] std::optional<EmittedModule> emit_cpp(const syntax::SourceFile &file, const hgraph_ir::Module &graph,
+                                                        const ast::Module &module, const semantics::ResolvedModule &resolved,
                                                         const EmitOptions &options, syntax::DiagnosticSink &diagnostics);
 }  // namespace hgl::codegen
 

--- a/language/src/driver/driver.cpp
+++ b/language/src/driver/driver.cpp
@@ -140,20 +140,24 @@ namespace hgl::driver
         }
 
         bool needs_native_module(const Unit &unit) {
-            return std::any_of(unit.resolved.functions.begin(), unit.resolved.functions.end(), [&](syntax::ast::DeclId id) {
-                const auto &fn = std::get<syntax::ast::FunctionDecl>(unit.module.decl(id).node);
-                return unit.resolved.kind(id) == semantics::FunctionKind::Runtime ||
-                       fn.visibility == syntax::ast::FunctionVisibility::Impl;
-            });
+            return unit.hgraph && std::any_of(unit.hgraph->callables.begin(), unit.hgraph->callables.end(), [](const auto &item) {
+                       return item.kind == hgraph_ir::CallableKind::RuntimeNode ||
+                              item.visibility == hgraph_ir::CallableVisibility::Implementation;
+                   });
         }
 
         std::optional<codegen::EmittedModule> emit_native_module(Unit &unit, std::string_view language_version) {
             wiring::ensure_session();
+            if (!unit.hgraph) {
+                unit.diagnostics.report(syntax::Category::Backend, syntax::SourceRange{},
+                                        "C++ generation requires completed hgraph IR");
+                return std::nullopt;
+            }
             codegen::EmitOptions options;
             options.header_name  = "module.h";
             options.tool_version = std::string{language_version};
             std::optional<codegen::EmittedModule> emitted =
-                codegen::emit_cpp(unit.file, unit.module, unit.resolved, options, unit.diagnostics);
+                codegen::emit_cpp(unit.file, *unit.hgraph, unit.module, unit.resolved, options, unit.diagnostics);
             if (emitted) {
                 std::string error;
                 if (!format_cpp(*emitted, error)) {
@@ -445,6 +449,12 @@ namespace hgl::driver
                 std::cerr << unit->diagnostics.render(unit->file);
                 return exit_diagnostics;
             }
+            if (!unit->hgraph) {
+                unit->diagnostics.report(syntax::Category::Backend, syntax::SourceRange{},
+                                         "C++ generation requires completed hgraph IR");
+                std::cerr << unit->diagnostics.render(unit->file);
+                return exit_diagnostics;
+            }
 
             // The pair is named after the source: prices.hgl -> prices.h, prices.cpp.
             const std::filesystem::path source{*path};
@@ -463,7 +473,7 @@ namespace hgl::driver
             options.tool_version         = std::string{tool_version};
             options.python_native_module = python_native;
             std::optional<codegen::EmittedModule> emitted =
-                codegen::emit_cpp(unit->file, unit->module, unit->resolved, options, unit->diagnostics);
+                codegen::emit_cpp(unit->file, *unit->hgraph, unit->module, unit->resolved, options, unit->diagnostics);
             if (!emitted) {
                 std::cerr << unit->diagnostics.render(unit->file);
                 return exit_diagnostics;

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -1,4 +1,7 @@
 #include "codegen/cpp_emitter.h"
+#include "hgraph_ir/lower.h"
+#include "ir/lower.h"
+#include "ir/type_check.h"
 #include "semantics/resolve.h"
 #include "syntax/parser.h"
 
@@ -32,11 +35,81 @@ namespace
         DiagnosticSink diagnostics;
         ast::Module    module;
         ResolvedModule resolved;
+        hgl::ir::hir::Module   hir;
+        hgl::hgraph_ir::Module graph;
+
+        [[nodiscard]] hgl::hgraph_ir::Module declaration_plan() const {
+            hgl::hgraph_ir::Module plan;
+            plan.path = resolved.module_path;
+            for (const ast::DeclId id : resolved.operators) {
+                const auto &op = std::get<ast::OperatorDecl>(module.decl(id).node);
+                plan.operators.push_back(
+                    {.identity = resolved.module_path + "." + std::string{op.name.text}, .range = module.decl(id).range});
+            }
+            for (const ast::DeclId id : resolved.functions) {
+                const auto              &fn = std::get<ast::FunctionDecl>(module.decl(id).node);
+                hgl::hgraph_ir::Callable callable;
+                callable.identity = resolved.module_path + "." + std::string{fn.name.text};
+                callable.range    = module.decl(id).range;
+                switch (fn.visibility) {
+                    case ast::FunctionVisibility::Internal:
+                        callable.visibility = hgl::hgraph_ir::CallableVisibility::Internal;
+                        break;
+                    case ast::FunctionVisibility::Export: callable.visibility = hgl::hgraph_ir::CallableVisibility::Export; break;
+                    case ast::FunctionVisibility::Impl:
+                        {
+                            callable.visibility = hgl::hgraph_ir::CallableVisibility::Implementation;
+                            callable.identity += "#" + std::to_string(id);
+                            const Binding &binding          = resolved.implementation_binding(id);
+                            callable.operator_identity      = binding.operator_identity;
+                            callable.operator_registry_name = binding.registry_name;
+                            if (binding.kind == BindingKind::LocalOperator) {
+                                const auto &op             = std::get<ast::OperatorDecl>(module.decl(binding.decl).node);
+                                callable.operator_identity = resolved.module_path + "." + std::string{op.name.text};
+                            } else if (!callable.operator_identity.empty() &&
+                                       std::none_of(plan.operators.begin(), plan.operators.end(), [&](const auto &candidate) {
+                                           return candidate.identity == callable.operator_identity;
+                                       })) {
+                                plan.operators.push_back({.identity      = callable.operator_identity,
+                                                          .registry_name = callable.operator_registry_name,
+                                                          .imported      = true,
+                                                          .range         = module.decl(id).range});
+                            }
+                            break;
+                        }
+                }
+                callable.kind = resolved.kind(id) == FunctionKind::Runtime ? hgl::hgraph_ir::CallableKind::RuntimeNode
+                                                                           : hgl::hgraph_ir::CallableKind::Composition;
+                plan.callables.push_back(std::move(callable));
+            }
+            return plan;
+        }
 
         explicit Unit(std::string text, std::string path = "unit.hgl")
-            : file{std::move(path), std::move(text)}, module{parse(file, diagnostics)},
-              resolved{resolve(file, module, kernel_has, diagnostics)}
-        {
+            : file{std::move(path), std::move(text)}, module{parse(file, diagnostics)} {
+            resolved = resolve(file, module, kernel_has, diagnostics);
+            if (diagnostics.has_errors()) { return; }
+            hir                                       = hgl::ir::lower_to_hir(module, resolved, diagnostics);
+            const hgl::ir::OperatorResolver operators = [](const hgl::ir::hir::Module &, const hgl::ir::OperatorQuery &query) {
+                hgl::ir::OperatorSelection selected;
+                selected.result = query.expected_result;
+                if (!selected.result.valid() && !query.arguments.empty()) { selected.result = query.arguments.front().type; }
+                selected.deferred = true;
+                return selected;
+            };
+            hgl::ir::hir::Module        typed = hir;
+            hgl::syntax::DiagnosticSink graph_diagnostics;
+            if (hgl::ir::complete_hir(typed, operators, graph_diagnostics)) {
+                hgl::hgraph_ir::Module lowered = hgl::hgraph_ir::lower(typed, graph_diagnostics);
+                if (!graph_diagnostics.has_errors()) {
+                    graph = std::move(lowered);
+                    return;
+                }
+            }
+            // Backend-negative tests deliberately stop before typed HIR. They
+            // still need the declaration plan that production obtains from
+            // hgraph IR so the legacy body adapter can report its own error.
+            graph = declaration_plan();
         }
 
         [[nodiscard]] std::optional<EmittedModule> emit(EmitOptions options = {})
@@ -45,7 +118,7 @@ namespace
             REQUIRE_FALSE(diagnostics.has_errors());
             if (options.header_name.empty()) { options.header_name = "unit.h"; }
             if (options.tool_version.empty()) { options.tool_version = "test"; }
-            return emit_cpp(file, module, resolved, options, diagnostics);
+            return emit_cpp(file, graph, module, resolved, options, diagnostics);
         }
 
         [[nodiscard]] bool has(Category category, std::string_view fragment) const
@@ -121,6 +194,62 @@ TEST_CASE("emit-cpp names the pair after the module and exports its functions", 
     REQUIRE(second);
     CHECK(second->header == emitted->header);
     CHECK(second->source == emitted->source);
+}
+
+TEST_CASE("emit-cpp plans module and callable identity from hgraph IR", "[codegen][hgraph-ir]") {
+    Unit unit{R"(
+module old
+
+fn hidden(value: f64) -> f64 => value
+)"};
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+    REQUIRE(unit.graph.completion == hgl::hgraph_ir::Completion::Bodies);
+    REQUIRE(unit.graph.callables.size() == 1);
+    unit.graph.path                         = "planned.module";
+    unit.graph.callables.front().identity   = "planned.module.exposed";
+    unit.graph.callables.front().visibility = hgl::hgraph_ir::CallableVisibility::Export;
+
+    const auto emitted = unit.emit();
+    REQUIRE(emitted);
+    CHECK(emitted->module_name == "planned.module");
+    CHECK(emitted->namespace_name == "planned::module");
+    CHECK(emitted->exports == std::vector<std::string>{"exposed"});
+    CHECK(contains(emitted->header, "namespace planned::module"));
+    CHECK(contains(emitted->header, "struct exposed"));
+    CHECK(contains(emitted->header, "static constexpr auto name = \"planned.module.exposed\""));
+    CHECK(contains(emitted->source, "register_graph_overload<operators::exposed, exposed>()"));
+}
+
+TEST_CASE("emit-cpp rejects a mismatched syntax compatibility adapter", "[codegen][hgraph-ir]") {
+    Unit unit{"module t\nexport fn value(x: f64) -> f64 => x\n"};
+    REQUIRE(unit.graph.completion == hgl::hgraph_ir::Completion::Bodies);
+    unit.graph.callables.clear();
+
+    CHECK_FALSE(unit.emit());
+    CHECK(unit.has(Category::Backend, "syntax body adapter disagree"));
+}
+
+TEST_CASE("emit-cpp gives operator implementations distinct readable C++ names", "[codegen][hgraph-ir][operators]") {
+    Unit unit{R"(
+module overloads
+
+operator choose<T>(value: T) -> T
+impl fn choose(value: f64) -> f64 => value
+impl fn choose(value: i64) -> i64 => value
+)"};
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+    REQUIRE(unit.graph.completion == hgl::hgraph_ir::Completion::Bodies);
+    REQUIRE(unit.graph.callables.size() == 2);
+
+    const auto emitted = unit.emit();
+    REQUIRE(emitted);
+    for (const auto &implementation : unit.graph.callables) {
+        const std::size_t marker = implementation.identity.find_last_of('#');
+        REQUIRE(marker != std::string::npos);
+        const std::string concrete = "choose_impl_" + implementation.identity.substr(marker + 1U);
+        CHECK(contains(emitted->source, "struct " + concrete));
+        CHECK(contains(emitted->source, "register_graph_overload<operators::choose, " + concrete + ">()"));
+    }
 }
 
 TEST_CASE("emit-cpp writes a Python wrapper over the registered names", "[codegen]")

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -252,6 +252,33 @@ impl fn choose(value: i64) -> i64 => value
     }
 }
 
+TEST_CASE("emit-cpp uses the hgraph IR identity for local operator calls", "[codegen][hgraph-ir][operators]") {
+    Unit unit{R"(
+module renamed_ops
+
+operator choose<T>(value: T) -> T
+impl fn choose(value: f64) -> f64 => value
+export fn selected(value: f64) -> f64 => choose(value)
+)"};
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+    REQUIRE(unit.graph.completion == hgl::hgraph_ir::Completion::Bodies);
+    REQUIRE(unit.graph.operators.size() == 1);
+
+    unit.graph.operators.front().identity = "renamed_ops.pick";
+    for (auto &callable : unit.graph.callables) {
+        if (callable.visibility == hgl::hgraph_ir::CallableVisibility::Implementation) {
+            callable.operator_identity = unit.graph.operators.front().identity;
+        }
+    }
+
+    const auto emitted = unit.emit();
+    REQUIRE(emitted);
+    CHECK(contains(emitted->header, "using pick = hgraph::Operator<"));
+    CHECK(contains(emitted->source, "hgraph::wire<operators::pick>(w, value)"));
+    CHECK(contains(emitted->source, "register_graph_overload<operators::pick, pick_impl_"));
+    CHECK_FALSE(contains(emitted->source, "operators::choose"));
+}
+
 TEST_CASE("emit-cpp writes a Python wrapper over the registered names", "[codegen]")
 {
     Unit unit{read_file(std::string{HGL_CODEGEN_DIR} + "/parity.hgl"), "parity.hgl"};


### PR DESCRIPTION
## Summary

- make hgraph IR authoritative for module paths, callable identity, visibility/classification, operator identity, exports, and registration planning in the C++ backend
- retain a fail-closed source-range adapter only for the syntax bodies, types, signatures, struct layouts, and dependency collection that Stage E has not migrated yet
- select native-module generation from hgraph IR in the driver and give multiple implementations readable, unique concrete C++ names
- document the completed Stage E checkpoint and the remaining migration boundary

## Validation

- generated codegen tests: 18 cases, 181 assertions
- all 30 language tests, including compiled generated fixtures
- complete native suite: 1,734 tests passed
- stable-ABI wheel built with Python 3.12 and installed/tested with Python 3.14: 3,228 passed, 10 skipped
- full 41-commit stack rebased onto current main; `git range-diff` reports every prior HGL patch unchanged