### PR TITLE
Move the Python-retained value entry onto the bridge behind a registered provider

### DIFF
--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -254,7 +254,9 @@ three physical representations:
   value.
 
 The declared schema does not change. The value factory owns the representation
-policy and may conservatively decline either Python-aware request. The first
+policy and may conservatively decline either Python-aware request; the Python
+half of that policy is the bridge's registered ``PythonStorageProvider``
+(below, "Python-object semantics"). The first
 implementation retains standard scalar strings/bytes, Python-owned named
 Bundles, fixed tuples, and dynamic lists or variadic tuples whose elements are
 recursively retainable. It declines Python-aware storage for cheap
@@ -517,9 +519,15 @@ Value and reference crossings
   Python-owned Bundle entry, the retained-value entry and the bridge's
   ``PyObj`` hash all delegate to them; the ``python-object-hash-units``
   ratchet pins ``PyObject_Hash`` to that one translation unit. The retained
-  entry itself still lives in ``types/metadata/value_plan_factory.cpp``;
-  moving it behind a bridge-registered provider is the remaining layering
-  step for that file.
+  entry lives on the bridge (``src/hgraph/python/impl/retained_value.cpp``,
+  ``include/hgraph/python/retained_value.h``) and reaches the plan factory
+  only through the ``ValuePlanFactory::PythonStorageProvider`` table it
+  registers at module initialisation: which schemas may retain, whether an
+  inline cache pays, the retained and Python-owned-Bundle bindings, the
+  holder's plan and the reset hook, as plain function pointers. The factory
+  carries no Python type and no build-time conditional for that policy, and
+  with no provider registered every Python-aware request downgrades to
+  ``Native``.
 
 Per-tick application is registry-free (ruling 2026-08-15)
 ---------------------------------------------------------

--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -522,7 +522,10 @@ Value and reference crossings
   entry lives on the bridge (``src/hgraph/python/impl/retained_value.cpp``,
   ``include/hgraph/python/retained_value.h``) and reaches the plan factory
   only through the ``ValuePlanFactory::PythonStorageProvider`` table it
-  registers at module initialisation: which schemas may retain, whether an
+  registers when the unit is loaded (it is compiled in exactly when Python
+  user nodes are enabled, so a standalone ``HGRAPH_ENABLE_PYTHON_USER_NODES``
+  build without the ``_hgraph`` module has the policy too; the module
+  initializer registers it again, idempotently): which schemas may retain, whether an
   inline cache pays, the retained and Python-owned-Bundle bindings, the
   holder's plan and the reset hook, as plain function pointers. The factory
   carries no Python type and no build-time conditional for that policy, and

--- a/include/hgraph/python/retained_value.h
+++ b/include/hgraph/python/retained_value.h
@@ -1,0 +1,30 @@
+#ifndef HGRAPH_PYTHON_RETAINED_VALUE_H
+#define HGRAPH_PYTHON_RETAINED_VALUE_H
+
+#include <hgraph/python/bridge_state.h>
+#include <hgraph/types/metadata/type_meta_data.h>
+
+namespace hgraph::python_bridge
+{
+    /**
+     * Python-aware value storage (``python_bridge.rst``, "Consumer-selected
+     * Python value storage"): the retained-value entry -- the ops table for a
+     * ``PyObject`` retained as the value itself behind a supported schema --
+     * and the policy that says which schemas may retain. It lives on the
+     * bridge and reaches the plan factory only through the
+     * ``PythonStorageProvider`` table it registers (``register_python_storage_provider``,
+     * called once at module initialisation): the type layer sees Python only
+     * through registered ops tables, never through a conditional of its own.
+     */
+    HGRAPH_EXPORT void register_python_storage_provider() noexcept;
+
+    /**
+     * Validate and, where the canonical Python read shape requires it,
+     * normalize an object before it is retained in Python-aware storage
+     * (a list returned for ``TS[tuple[T, ...]]`` is retained as a tuple).
+     */
+    [[nodiscard]] HGRAPH_EXPORT nb::object prepare_python_storage_value(const ValueTypeMetaData *schema,
+                                                                         nb::handle source);
+}  // namespace hgraph::python_bridge
+
+#endif  // HGRAPH_PYTHON_RETAINED_VALUE_H

--- a/include/hgraph/python/retained_value.h
+++ b/include/hgraph/python/retained_value.h
@@ -12,9 +12,13 @@ namespace hgraph::python_bridge
      * ``PyObject`` retained as the value itself behind a supported schema --
      * and the policy that says which schemas may retain. It lives on the
      * bridge and reaches the plan factory only through the
-     * ``PythonStorageProvider`` table it registers (``register_python_storage_provider``,
-     * called once at module initialisation): the type layer sees Python only
-     * through registered ops tables, never through a conditional of its own.
+     * ``PythonStorageProvider`` table it registers: the unit registers the
+     * table when it is loaded (it is compiled in exactly when Python user
+     * nodes are enabled, with or without the ``_hgraph`` module, so a
+     * standalone Python-user-node build has the policy too), and the module
+     * initializer calls ``register_python_storage_provider`` again,
+     * idempotently. The type layer sees Python only through registered ops
+     * tables, never through a conditional of its own.
      */
     HGRAPH_EXPORT void register_python_storage_provider() noexcept;
 

--- a/include/hgraph/types/metadata/value_plan_factory.h
+++ b/include/hgraph/types/metadata/value_plan_factory.h
@@ -154,15 +154,35 @@ namespace hgraph
             ValueTypeRef native_binding,
             ValueStorageVariant requested);
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
         /**
-         * Validate and, where the canonical Python read shape requires it,
-         * normalize an object before it is retained in Python-aware storage.
+         * The Python half of the storage policy, as a table of plain function
+         * pointers the language bridge registers once at initialisation
+         * (``python_bridge::register_python_storage_provider``). The factory
+         * sees Python only through this table -- no Python type and no
+         * build-time conditional of its own -- and with no provider registered
+         * every Python-aware request downgrades to ``Native``.
          */
-        [[nodiscard]] nb::object prepare_python_storage_value(
-            const ValueTypeMetaData *schema,
-            nb::handle source) const;
-#endif
+        struct PythonStorageProvider
+        {
+            /** Whether ``schema`` may retain a Python object as its value. */
+            bool (*retained_supported)(const ValueTypeMetaData *schema) noexcept{nullptr};
+            /** Whether a native binding gains from an inline retained-object cache. */
+            bool (*cache_beneficial)(ValueTypeRef native_binding) noexcept{nullptr};
+            /** The Python-owned Bundle binding for a Bundle schema, or empty. */
+            ValueTypeRef (*bundle_storage_binding)(ValueTypeRef native_binding){nullptr};
+            /** Whether ``schema`` is a Python-owned Bundle schema (which never
+                takes the retained-object entry: its own binding is the
+                direct representation). */
+            bool (*python_bundle_schema)(const ValueTypeMetaData *schema) noexcept{nullptr};
+            /** The retained-value binding for a supported schema (interned). */
+            ValueTypeRef (*retained_binding_for)(const ValueTypeMetaData *schema){nullptr};
+            /** The storage plan of the retained-object holder (the cache field). */
+            const MemoryUtils::StoragePlan *(*python_holder_plan)(){nullptr};
+            /** Reset hook: drop the retained-binding index with the registries. */
+            void (*clear_retained_bindings)() noexcept{nullptr};
+        };
+        static void set_python_storage_provider(const PythonStorageProvider *provider) noexcept;
+        [[nodiscard]] static const PythonStorageProvider *python_storage_provider() noexcept;
 
         /**
          * Build a graph-realized Tuple/Bundle binding from explicit field

--- a/python/module.cpp
+++ b/python/module.cpp
@@ -7,6 +7,7 @@
  * C++-owned; this file is the compatibility/binding surface.
  */
 #include "module_internal.h"
+#include <hgraph/python/retained_value.h>
 #include "py_bindings.h"
 #include "py_wiring.h"
 
@@ -114,6 +115,9 @@ NB_MODULE(_hgraph, m)
     stdlib::register_standard_operators();
     python_bridge::py_infer_value_slot() =
         reinterpret_cast<python_bridge::PyInferValueFn>(&python_bridge::py_to_value);
+    // The retained-value storage policy reaches the plan factory only through
+    // this table (python_bridge.rst, "Consumer-selected Python value storage").
+    python_bridge::register_python_storage_provider();
     // The enum slots read the meta -> python-Enum-class registry (an
     // immortal map; lazily constructed by its accessor, cleared with the
     // registries).

--- a/python/tests/test_architecture_ratchets.py
+++ b/python/tests/test_architecture_ratchets.py
@@ -178,7 +178,7 @@ RATCHETS: tuple[Ratchet, ...] = (
     ),
     Ratchet(
         id="type-layer-python-conditionals",
-        baseline=165,
+        baseline=160,
         roots=("src/hgraph/types", "include/hgraph/types"),
         suffixes=(".cpp", ".h"),
         pattern=r"HGRAPH_ENABLE_PYTHON_USER_NODES",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,6 +97,7 @@ if(HGRAPH_BUILD_PYTHON_BINDINGS OR HGRAPH_ENABLE_PYTHON_USER_NODES)
     list(APPEND HGRAPH_RUNTIME_SOURCES
         hgraph/python/bridge_state.cpp
         hgraph/python/impl/object_semantics.cpp
+        hgraph/python/impl/retained_value.cpp
         hgraph/python/impl/ts_data_conversion.cpp
     )
 endif()

--- a/src/hgraph/python/impl/retained_value.cpp
+++ b/src/hgraph/python/impl/retained_value.cpp
@@ -436,6 +436,21 @@ namespace hgraph::python_bridge
         ValuePlanFactory::set_python_storage_provider(&provider_table());
     }
 
+    namespace
+    {
+        // Linking this unit is what makes the policy active: it is compiled in
+        // exactly when Python user nodes are enabled, with or without the
+        // ``_hgraph`` module's initializer (the ``python-user-nodes`` preset
+        // embeds the bridge without the module), so it registers itself at
+        // load and the module's explicit registration is idempotent. Both
+        // targets are function-local statics, so there is no ordering to get
+        // wrong.
+        [[maybe_unused]] const bool provider_registered_at_load = [] {
+            register_python_storage_provider();
+            return true;
+        }();
+    }  // namespace
+
     nb::object prepare_python_storage_value(const ValueTypeMetaData *schema, nb::handle source)
     {
         if (!retained_python_supported(schema))

--- a/src/hgraph/python/impl/retained_value.cpp
+++ b/src/hgraph/python/impl/retained_value.cpp
@@ -1,0 +1,447 @@
+#include <hgraph/python/retained_value.h>
+
+#include <hgraph/python/object_semantics.h>
+#include <hgraph/types/metadata/type_registry.h>
+#include <hgraph/types/metadata/value_plan_factory.h>
+#include <hgraph/types/primitive_types.h>
+#include <hgraph/types/static_schema.h>
+#include <hgraph/types/utils/intern_table.h>
+#include <hgraph/types/utils/memory_utils.h>
+#include <hgraph/types/value/value.h>
+#include <hgraph/types/value/value_ops.h>
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// The Python-retained value entry (moved here from
+// types/metadata/value_plan_factory.cpp: the remaining layering step named in
+// python_bridge.rst). The plan factory calls into this unit only through the
+// PythonStorageProvider table registered below.
+namespace hgraph::python_bridge
+{
+    namespace
+    {
+        [[nodiscard]] const PyBundleClassInfo *retained_bundle_info(const ValueTypeMetaData *schema)
+        {
+            const auto &registry = bundle_class_info_registry();
+            const auto  found    = registry.find(schema);
+            return found != registry.end() ? &found->second : nullptr;
+        }
+
+        [[nodiscard]] bool
+        retained_python_supported(const ValueTypeMetaData *schema) noexcept {
+          if (schema == nullptr) {
+            return false;
+          }
+          if (python_bridge::is_python_bundle_schema(schema)) {
+            return true;
+          }
+          switch (schema->value_kind()) {
+          case ValueTypeKind::Atomic:
+            return schema == scalar_descriptor<Bool>::value_meta() ||
+                   schema == scalar_descriptor<Int>::value_meta() ||
+                   schema == scalar_descriptor<Float>::value_meta() ||
+                   schema == scalar_descriptor<Str>::value_meta() ||
+                   schema == scalar_descriptor<Bytes>::value_meta();
+          case ValueTypeKind::Tuple:
+            for (std::size_t index = 0; index < schema->field_count; ++index) {
+              if (!retained_python_supported(schema->fields[index].type)) {
+                return false;
+              }
+            }
+            return true;
+          case ValueTypeKind::List:
+            return schema->fixed_size == 0 &&
+                   !schema->has(ValueTypeFlags::ShapedArray) &&
+                   retained_python_supported(schema->element_type);
+          case ValueTypeKind::Bundle:
+            return retained_bundle_info(schema) != nullptr;
+          case ValueTypeKind::Set:
+          case ValueTypeKind::Map:
+          case ValueTypeKind::CyclicBuffer:
+          case ValueTypeKind::Queue:
+          case ValueTypeKind::Any:
+            return false;
+          }
+          return false;
+        }
+
+        [[nodiscard]] bool
+        python_cache_beneficial(ValueTypeRef native_binding) noexcept {
+          const auto *schema = native_binding.schema();
+          return retained_python_supported(schema) &&
+                 !python_bridge::is_python_bundle_binding(native_binding) &&
+                 schema != scalar_descriptor<Bool>::value_meta() &&
+                 schema != scalar_descriptor<Int>::value_meta() &&
+                 schema != scalar_descriptor<Float>::value_meta();
+        }
+
+        [[nodiscard]] ValueTypeRef
+        python_bundle_storage_binding(ValueTypeRef source_binding) {
+          if (python_bridge::is_python_bundle_binding(source_binding)) {
+            return source_binding;
+          }
+          const auto *schema = source_binding.schema();
+          if (!python_bridge::is_python_bundle_schema(schema)) {
+            return {};
+          }
+          const auto *ops = try_value_ops<IndexedValueOps>(source_binding);
+          if (ops == nullptr || ops->element_binding == nullptr) {
+            return {};
+          }
+          std::vector<ValueTypeRef> fields;
+          fields.reserve(schema->field_count);
+          for (std::size_t index = 0; index < schema->field_count; ++index) {
+            const auto field = ops->element_binding(ops->context, nullptr, index);
+            if (!field) {
+              return {};
+            }
+            fields.push_back(field);
+          }
+          return python_bridge::python_bundle_binding_for(schema, fields);
+        }
+
+        [[noreturn]] void invalid_retained_python_value(const ValueTypeMetaData &schema,
+                                                        std::string_view reason) {
+          throw nb::type_error(("Python value for '" + std::string{schema.name()} +
+                                "' " + std::string{reason})
+                                   .c_str());
+        }
+
+        [[nodiscard]] nb::object
+        prepare_retained_python_value(const ValueTypeMetaData *schema,
+                                      nb::handle source) {
+          if (schema == nullptr || !source.is_valid() || source.is_none()) {
+            throw nb::type_error(
+                "retained Python output storage requires a typed non-None value");
+          }
+          if (schema->value_kind() == ValueTypeKind::Bundle) {
+            const auto *info = retained_bundle_info(schema);
+            if (info == nullptr || !info->type.is_valid()) {
+              invalid_retained_python_value(*schema, "has no registered Python class");
+            }
+            if (nb::isinstance(source, info->type)) {
+              return nb::borrow<nb::object>(source);
+            }
+            // Dict and other accepted bridge inputs must retain the declared Python
+            // read shape, not the raw source object.
+            const auto binding = ValuePlanFactory::instance().type_for(schema);
+            Value normalized{binding};
+            binding.ops_ref().from_python(
+                binding, const_cast<void *>(normalized.view().data()), source);
+            return binding.ops_ref().to_python(normalized.view().data());
+          }
+
+          if (schema->value_kind() == ValueTypeKind::Atomic) {
+            if (schema == scalar_descriptor<Bool>::value_meta()) {
+              if (!PyBool_Check(source.ptr())) {
+                invalid_retained_python_value(*schema, "requires bool");
+              }
+              return nb::borrow<nb::object>(source);
+            }
+            if (schema == scalar_descriptor<Int>::value_meta()) {
+              if (PyLong_CheckExact(source.ptr())) {
+                static_cast<void>(PyLong_AsLongLong(source.ptr()));
+                if (PyErr_Occurred() != nullptr) {
+                  throw nb::python_error();
+                }
+                return nb::borrow<nb::object>(source);
+              }
+              if (PyUnicode_Check(source.ptr()) || PyBytes_Check(source.ptr())) {
+                invalid_retained_python_value(*schema, "requires an integer");
+              }
+              nb::object normalized = nb::steal(PyNumber_Long(source.ptr()));
+              if (!normalized.is_valid()) {
+                throw nb::python_error();
+              }
+              static_cast<void>(PyLong_AsLongLong(normalized.ptr()));
+              if (PyErr_Occurred() != nullptr) {
+                throw nb::python_error();
+              }
+              return normalized;
+            }
+            if (schema == scalar_descriptor<Float>::value_meta()) {
+              if (PyFloat_CheckExact(source.ptr())) {
+                return nb::borrow<nb::object>(source);
+              }
+              if (PyUnicode_Check(source.ptr()) || PyBytes_Check(source.ptr())) {
+                invalid_retained_python_value(*schema, "requires a number");
+              }
+              nb::object normalized = nb::steal(PyNumber_Float(source.ptr()));
+              if (!normalized.is_valid()) {
+                throw nb::python_error();
+              }
+              return normalized;
+            }
+            if (schema == scalar_descriptor<Str>::value_meta()) {
+              if (!PyUnicode_Check(source.ptr())) {
+                invalid_retained_python_value(*schema, "requires str");
+              }
+              return PyUnicode_CheckExact(source.ptr())
+                         ? nb::borrow<nb::object>(source)
+                         : nb::steal(PyUnicode_FromObject(source.ptr()));
+            }
+            if (schema == scalar_descriptor<Bytes>::value_meta()) {
+              if (!PyBytes_Check(source.ptr())) {
+                invalid_retained_python_value(*schema, "requires bytes");
+              }
+              if (PyBytes_CheckExact(source.ptr())) {
+                return nb::borrow<nb::object>(source);
+              }
+              char *buffer = nullptr;
+              Py_ssize_t length = 0;
+              if (PyBytes_AsStringAndSize(source.ptr(), &buffer, &length) != 0) {
+                throw nb::python_error();
+              }
+              return nb::steal(PyBytes_FromStringAndSize(buffer, length));
+            }
+            invalid_retained_python_value(*schema, "has no Python-only storage policy");
+          }
+
+          if (schema->value_kind() == ValueTypeKind::Tuple) {
+            if (PySequence_Check(source.ptr()) == 0) {
+              invalid_retained_python_value(*schema, "expects a Python list or tuple");
+            }
+            const Py_ssize_t count = PySequence_Size(source.ptr());
+            if (count < 0) {
+              throw nb::python_error();
+            }
+            const auto field_count = static_cast<Py_ssize_t>(schema->field_count);
+            if (count < field_count) {
+              invalid_retained_python_value(
+                  *schema, "does not provide every declared tuple field");
+            }
+            bool exact = PyTuple_CheckExact(source.ptr()) && count == field_count;
+            nb::tuple normalized = nb::steal<nb::tuple>(PyTuple_New(field_count));
+            if (!normalized.is_valid()) {
+              throw nb::python_error();
+            }
+            for (Py_ssize_t index = 0; index < field_count; ++index) {
+              nb::object item = nb::steal(PySequence_GetItem(source.ptr(), index));
+              if (!item.is_valid()) {
+                throw nb::python_error();
+              }
+              nb::object prepared =
+                  item.is_none()
+                      ? nb::none()
+                      : prepare_retained_python_value(
+                            schema->fields[static_cast<std::size_t>(index)].type, item);
+              exact = exact && prepared.is(item);
+              if (PyTuple_SetItem(normalized.ptr(), index, prepared.release().ptr()) !=
+                  0) {
+                throw nb::python_error();
+              }
+            }
+            return exact ? nb::borrow<nb::object>(source)
+                         : nb::object{std::move(normalized)};
+          }
+
+          if (schema->value_kind() == ValueTypeKind::List && schema->fixed_size == 0) {
+            const bool sequence = PyList_Check(source.ptr()) ||
+                                  PyTuple_Check(source.ptr()) ||
+                                  nb::hasattr(source, "__array_interface__");
+            if (!sequence) {
+              invalid_retained_python_value(*schema, "expects a Python list or tuple");
+            }
+            nb::object source_object = nb::borrow<nb::object>(source);
+            nb::list prepared_items;
+            bool unchanged = schema->has(ValueTypeFlags::VariadicTuple)
+                                 ? PyTuple_CheckExact(source.ptr())
+                                 : PyList_CheckExact(source.ptr());
+            for (nb::handle item : nb::iter(source_object)) {
+              if (item.is_none()) {
+                invalid_retained_python_value(*schema, "does not allow None elements");
+              }
+              nb::object prepared =
+                  prepare_retained_python_value(schema->element_type, item);
+              unchanged = unchanged && prepared.is(item);
+              prepared_items.append(std::move(prepared));
+            }
+            if (unchanged) {
+              return source_object;
+            }
+            return schema->has(ValueTypeFlags::VariadicTuple)
+                       ? nb::object{nb::tuple(prepared_items)}
+                       : nb::object{std::move(prepared_items)};
+          }
+
+          invalid_retained_python_value(*schema, "has no Python-only storage policy");
+        }
+
+        struct PythonRetainedBindingEntry {
+          const ValueTypeMetaData *schema{nullptr};
+          ValueOps ops{};
+          ValueTypeRef binding{};
+
+          explicit PythonRetainedBindingEntry(const ValueTypeMetaData *value_schema)
+              : schema(value_schema) {
+            if (!retained_python_supported(schema) ||
+                python_bridge::is_python_bundle_schema(schema)) {
+              throw std::invalid_argument(
+                  "Python-retained binding requires a supported non-native schema");
+            }
+            ops.kind = ValueOpsKind::Base;
+            ops.context = this;
+            ops.allows_mutation = false;
+            ops.hash_impl = schema->is_hashable() ? &hash : nullptr;
+            ops.equals_impl = schema->is_equatable() ? &equals : nullptr;
+            ops.compare_impl = schema->is_comparable() ? &compare : nullptr;
+            ops.to_string_impl = &to_string;
+            ops.to_python_impl = &to_python;
+            ops.from_python_impl = &from_python;
+            ops.accepts_source_impl = &accepts_source;
+            ops.copy_assign_from_impl = &copy_assign_from;
+            ops.move_assign_from_impl = &move_assign_from;
+            ops.format_string_impl = &to_string;
+            binding = intern_value_type(
+                *schema, MemoryUtils::plan_for<python_bridge::PythonValueHolder>(),
+                ops);
+          }
+
+          [[nodiscard]] static const PythonRetainedBindingEntry &
+          entry(const void *context) noexcept {
+            return *static_cast<const PythonRetainedBindingEntry *>(context);
+          }
+
+          [[nodiscard]] static python_bridge::PythonValueHolder &value(void *memory) {
+            if (memory == nullptr) {
+              throw std::logic_error(
+                  "Python-retained value operation requires live memory");
+            }
+            return *static_cast<python_bridge::PythonValueHolder *>(memory);
+          }
+
+          [[nodiscard]] static const python_bridge::PythonValueHolder &
+          value(const void *memory) {
+            if (memory == nullptr) {
+              throw std::logic_error(
+                  "Python-retained value operation requires live memory");
+            }
+            return *static_cast<const python_bridge::PythonValueHolder *>(memory);
+          }
+
+          // Value semantics come from the bridge's one set of Python-object
+          // primitives (python_bridge::object_*); this entry owns only the holder.
+          static std::size_t hash(const void *, const void *memory) {
+            const auto &stored = value(memory);
+            if (stored.object == nullptr) {
+              throw std::logic_error("cannot hash an empty Python-retained value");
+            }
+            return python_bridge::object_hash(stored.object);
+          }
+
+          static bool equals(const void *, const void *lhs, const void *rhs) {
+            return python_bridge::object_equals(value(lhs).object, value(rhs).object);
+          }
+
+          static std::partial_ordering compare(const void *, const void *lhs,
+                                               const void *rhs) noexcept {
+            return python_bridge::object_compare(value(lhs).object, value(rhs).object);
+          }
+
+          static std::string to_string(const void *, const void *memory) {
+            const auto &stored = value(memory);
+            if (stored.object == nullptr) {
+              return "<empty Python-retained value>";
+            }
+            return python_bridge::object_str(stored.object);
+          }
+
+          static nb::object to_python(const void *, const void *memory) {
+            return value(memory).get();
+          }
+
+          static void from_python(const void *context, const ValueTypeRef &,
+                                  void *memory, nb::handle source) {
+            const auto &self = entry(context);
+            value(memory).set(prepare_retained_python_value(self.schema, source));
+          }
+
+          static bool accepts_source(const void *context, ValueTypeRef binding,
+                                     ValueTypeRef source) noexcept {
+            const auto &self = entry(context);
+            return binding == self.binding && source && source.schema() == self.schema;
+          }
+
+          static void copy_assign_from(const void *context, ValueTypeRef, void *dst,
+                                       ValueTypeRef source, const void *src) {
+            const auto &self = entry(context);
+            if (source == self.binding) {
+              value(dst) = value(src);
+              return;
+            }
+            nb::gil_scoped_acquire gil;
+            value(dst).set(prepare_retained_python_value(
+                self.schema, source.ops_ref().to_python(src)));
+          }
+
+          static void move_assign_from(const void *context, ValueTypeRef binding,
+                                       void *dst, ValueTypeRef source, void *src) {
+            const auto &self = entry(context);
+            if (source == self.binding) {
+              value(dst) = std::move(value(src));
+              return;
+            }
+            copy_assign_from(context, binding, dst, source, src);
+          }
+        };
+
+        // Entries are address-published AND immortal: python Values can outlive a
+        // registry reset, so a reset drops only the key index (clear_index) while
+        // every entry stays alive. The table itself is leaked for the same reason.
+        [[nodiscard]] InternTable<const ValueTypeMetaData *,
+                                  std::unique_ptr<PythonRetainedBindingEntry>> &
+        python_retained_bindings() noexcept {
+          static auto *bindings =
+              new InternTable<const ValueTypeMetaData *,
+                              std::unique_ptr<PythonRetainedBindingEntry>>{};
+          return *bindings;
+        }
+
+        [[nodiscard]] ValueTypeRef
+        python_retained_binding_for(const ValueTypeMetaData *schema) {
+          // intern_serialized: the entry ctor interns a TypeRecord pointing at
+          // itself, so a racing loser must never be constructed and destroyed.
+          return python_retained_bindings()
+              .intern_serialized(
+                  schema,
+                  [&] { return std::make_unique<PythonRetainedBindingEntry>(schema); })
+              ->binding;
+        }
+
+        void clear_python_retained_bindings() noexcept {
+          python_retained_bindings().clear_index();
+        }
+
+        const ValuePlanFactory::PythonStorageProvider &provider_table()
+        {
+            static const ValuePlanFactory::PythonStorageProvider table{
+                .retained_supported     = &retained_python_supported,
+                .cache_beneficial       = &python_cache_beneficial,
+                .bundle_storage_binding = &python_bundle_storage_binding,
+                .python_bundle_schema   = &is_python_bundle_schema,
+                .retained_binding_for   = &python_retained_binding_for,
+                .python_holder_plan     = [] { return &MemoryUtils::plan_for<PythonValueHolder>(); },
+                .clear_retained_bindings = &clear_python_retained_bindings,
+            };
+            return table;
+        }
+    }  // namespace
+
+    void register_python_storage_provider() noexcept
+    {
+        ValuePlanFactory::set_python_storage_provider(&provider_table());
+    }
+
+    nb::object prepare_python_storage_value(const ValueTypeMetaData *schema, nb::handle source)
+    {
+        if (!retained_python_supported(schema))
+        {
+            throw std::logic_error("ValuePlanFactory has no retained-Python policy for this schema");
+        }
+        return prepare_retained_python_value(schema, source);
+    }
+}  // namespace hgraph::python_bridge

--- a/src/hgraph/types/metadata/ts_data_atomic_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_atomic_ops.cpp
@@ -6,6 +6,7 @@
 
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
 #include <hgraph/python/bridge_state.h>
+#include <hgraph/python/retained_value.h>
 #include <hgraph/python/ts_data_conversion.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
 #endif
@@ -365,7 +366,7 @@ namespace hgraph::ts_data_plan_factory_detail
                           ValueStorageVariant::NativeWithPythonCache)
             {
                 nb::object retained =
-                    ValuePlanFactory::instance().prepare_python_storage_value(
+                    python_bridge::prepare_python_storage_value(
                         layout->value_binding.schema(), source);
                 layout->value_binding.ops_ref().from_python(
                     layout->value_binding,

--- a/src/hgraph/types/metadata/value_plan_factory.cpp
+++ b/src/hgraph/types/metadata/value_plan_factory.cpp
@@ -2466,392 +2466,6 @@ void clear_structured_indexed_ops() noexcept {
   realized_fixed_list_cache().clear();
 }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-[[nodiscard]] bool
-retained_python_supported(const ValueTypeMetaData *schema) noexcept {
-  if (schema == nullptr) {
-    return false;
-  }
-  if (python_bridge::is_python_bundle_schema(schema)) {
-    return true;
-  }
-  switch (schema->value_kind()) {
-  case ValueTypeKind::Atomic:
-    return schema == scalar_descriptor<Bool>::value_meta() ||
-           schema == scalar_descriptor<Int>::value_meta() ||
-           schema == scalar_descriptor<Float>::value_meta() ||
-           schema == scalar_descriptor<Str>::value_meta() ||
-           schema == scalar_descriptor<Bytes>::value_meta();
-  case ValueTypeKind::Tuple:
-    for (std::size_t index = 0; index < schema->field_count; ++index) {
-      if (!retained_python_supported(schema->fields[index].type)) {
-        return false;
-      }
-    }
-    return true;
-  case ValueTypeKind::List:
-    return schema->fixed_size == 0 &&
-           !schema->has(ValueTypeFlags::ShapedArray) &&
-           retained_python_supported(schema->element_type);
-  case ValueTypeKind::Bundle:
-    return python_bundle_info(schema) != nullptr;
-  case ValueTypeKind::Set:
-  case ValueTypeKind::Map:
-  case ValueTypeKind::CyclicBuffer:
-  case ValueTypeKind::Queue:
-  case ValueTypeKind::Any:
-    return false;
-  }
-  return false;
-}
-
-[[nodiscard]] bool
-python_cache_beneficial(ValueTypeRef native_binding) noexcept {
-  const auto *schema = native_binding.schema();
-  return retained_python_supported(schema) &&
-         !python_bridge::is_python_bundle_binding(native_binding) &&
-         schema != scalar_descriptor<Bool>::value_meta() &&
-         schema != scalar_descriptor<Int>::value_meta() &&
-         schema != scalar_descriptor<Float>::value_meta();
-}
-
-[[nodiscard]] ValueTypeRef
-python_bundle_storage_binding(ValueTypeRef source_binding) {
-  if (python_bridge::is_python_bundle_binding(source_binding)) {
-    return source_binding;
-  }
-  const auto *schema = source_binding.schema();
-  if (!python_bridge::is_python_bundle_schema(schema)) {
-    return {};
-  }
-  const auto *ops = try_value_ops<IndexedValueOps>(source_binding);
-  if (ops == nullptr || ops->element_binding == nullptr) {
-    return {};
-  }
-  std::vector<ValueTypeRef> fields;
-  fields.reserve(schema->field_count);
-  for (std::size_t index = 0; index < schema->field_count; ++index) {
-    const auto field = ops->element_binding(ops->context, nullptr, index);
-    if (!field) {
-      return {};
-    }
-    fields.push_back(field);
-  }
-  return python_bridge::python_bundle_binding_for(schema, fields);
-}
-
-[[noreturn]] void invalid_retained_python_value(const ValueTypeMetaData &schema,
-                                                std::string_view reason) {
-  throw nb::type_error(("Python value for '" + std::string{schema.name()} +
-                        "' " + std::string{reason})
-                           .c_str());
-}
-
-[[nodiscard]] nb::object
-prepare_retained_python_value(const ValueTypeMetaData *schema,
-                              nb::handle source) {
-  if (schema == nullptr || !source.is_valid() || source.is_none()) {
-    throw nb::type_error(
-        "retained Python output storage requires a typed non-None value");
-  }
-  if (schema->value_kind() == ValueTypeKind::Bundle) {
-    const auto *info = python_bundle_info(schema);
-    if (info == nullptr || !info->type.is_valid()) {
-      invalid_retained_python_value(*schema, "has no registered Python class");
-    }
-    if (nb::isinstance(source, info->type)) {
-      return nb::borrow<nb::object>(source);
-    }
-    // Dict and other accepted bridge inputs must retain the declared Python
-    // read shape, not the raw source object.
-    const auto binding = ValuePlanFactory::instance().type_for(schema);
-    Value normalized{binding};
-    binding.ops_ref().from_python(
-        binding, const_cast<void *>(normalized.view().data()), source);
-    return binding.ops_ref().to_python(normalized.view().data());
-  }
-
-  if (schema->value_kind() == ValueTypeKind::Atomic) {
-    if (schema == scalar_descriptor<Bool>::value_meta()) {
-      if (!PyBool_Check(source.ptr())) {
-        invalid_retained_python_value(*schema, "requires bool");
-      }
-      return nb::borrow<nb::object>(source);
-    }
-    if (schema == scalar_descriptor<Int>::value_meta()) {
-      if (PyLong_CheckExact(source.ptr())) {
-        static_cast<void>(PyLong_AsLongLong(source.ptr()));
-        if (PyErr_Occurred() != nullptr) {
-          throw nb::python_error();
-        }
-        return nb::borrow<nb::object>(source);
-      }
-      if (PyUnicode_Check(source.ptr()) || PyBytes_Check(source.ptr())) {
-        invalid_retained_python_value(*schema, "requires an integer");
-      }
-      nb::object normalized = nb::steal(PyNumber_Long(source.ptr()));
-      if (!normalized.is_valid()) {
-        throw nb::python_error();
-      }
-      static_cast<void>(PyLong_AsLongLong(normalized.ptr()));
-      if (PyErr_Occurred() != nullptr) {
-        throw nb::python_error();
-      }
-      return normalized;
-    }
-    if (schema == scalar_descriptor<Float>::value_meta()) {
-      if (PyFloat_CheckExact(source.ptr())) {
-        return nb::borrow<nb::object>(source);
-      }
-      if (PyUnicode_Check(source.ptr()) || PyBytes_Check(source.ptr())) {
-        invalid_retained_python_value(*schema, "requires a number");
-      }
-      nb::object normalized = nb::steal(PyNumber_Float(source.ptr()));
-      if (!normalized.is_valid()) {
-        throw nb::python_error();
-      }
-      return normalized;
-    }
-    if (schema == scalar_descriptor<Str>::value_meta()) {
-      if (!PyUnicode_Check(source.ptr())) {
-        invalid_retained_python_value(*schema, "requires str");
-      }
-      return PyUnicode_CheckExact(source.ptr())
-                 ? nb::borrow<nb::object>(source)
-                 : nb::steal(PyUnicode_FromObject(source.ptr()));
-    }
-    if (schema == scalar_descriptor<Bytes>::value_meta()) {
-      if (!PyBytes_Check(source.ptr())) {
-        invalid_retained_python_value(*schema, "requires bytes");
-      }
-      if (PyBytes_CheckExact(source.ptr())) {
-        return nb::borrow<nb::object>(source);
-      }
-      char *buffer = nullptr;
-      Py_ssize_t length = 0;
-      if (PyBytes_AsStringAndSize(source.ptr(), &buffer, &length) != 0) {
-        throw nb::python_error();
-      }
-      return nb::steal(PyBytes_FromStringAndSize(buffer, length));
-    }
-    invalid_retained_python_value(*schema, "has no Python-only storage policy");
-  }
-
-  if (schema->value_kind() == ValueTypeKind::Tuple) {
-    if (PySequence_Check(source.ptr()) == 0) {
-      invalid_retained_python_value(*schema, "expects a Python list or tuple");
-    }
-    const Py_ssize_t count = PySequence_Size(source.ptr());
-    if (count < 0) {
-      throw nb::python_error();
-    }
-    const auto field_count = static_cast<Py_ssize_t>(schema->field_count);
-    if (count < field_count) {
-      invalid_retained_python_value(
-          *schema, "does not provide every declared tuple field");
-    }
-    bool exact = PyTuple_CheckExact(source.ptr()) && count == field_count;
-    nb::tuple normalized = nb::steal<nb::tuple>(PyTuple_New(field_count));
-    if (!normalized.is_valid()) {
-      throw nb::python_error();
-    }
-    for (Py_ssize_t index = 0; index < field_count; ++index) {
-      nb::object item = nb::steal(PySequence_GetItem(source.ptr(), index));
-      if (!item.is_valid()) {
-        throw nb::python_error();
-      }
-      nb::object prepared =
-          item.is_none()
-              ? nb::none()
-              : prepare_retained_python_value(
-                    schema->fields[static_cast<std::size_t>(index)].type, item);
-      exact = exact && prepared.is(item);
-      if (PyTuple_SetItem(normalized.ptr(), index, prepared.release().ptr()) !=
-          0) {
-        throw nb::python_error();
-      }
-    }
-    return exact ? nb::borrow<nb::object>(source)
-                 : nb::object{std::move(normalized)};
-  }
-
-  if (schema->value_kind() == ValueTypeKind::List && schema->fixed_size == 0) {
-    const bool sequence = PyList_Check(source.ptr()) ||
-                          PyTuple_Check(source.ptr()) ||
-                          nb::hasattr(source, "__array_interface__");
-    if (!sequence) {
-      invalid_retained_python_value(*schema, "expects a Python list or tuple");
-    }
-    nb::object source_object = nb::borrow<nb::object>(source);
-    nb::list prepared_items;
-    bool unchanged = schema->has(ValueTypeFlags::VariadicTuple)
-                         ? PyTuple_CheckExact(source.ptr())
-                         : PyList_CheckExact(source.ptr());
-    for (nb::handle item : nb::iter(source_object)) {
-      if (item.is_none()) {
-        invalid_retained_python_value(*schema, "does not allow None elements");
-      }
-      nb::object prepared =
-          prepare_retained_python_value(schema->element_type, item);
-      unchanged = unchanged && prepared.is(item);
-      prepared_items.append(std::move(prepared));
-    }
-    if (unchanged) {
-      return source_object;
-    }
-    return schema->has(ValueTypeFlags::VariadicTuple)
-               ? nb::object{nb::tuple(prepared_items)}
-               : nb::object{std::move(prepared_items)};
-  }
-
-  invalid_retained_python_value(*schema, "has no Python-only storage policy");
-}
-
-struct PythonRetainedBindingEntry {
-  const ValueTypeMetaData *schema{nullptr};
-  ValueOps ops{};
-  ValueTypeRef binding{};
-
-  explicit PythonRetainedBindingEntry(const ValueTypeMetaData *value_schema)
-      : schema(value_schema) {
-    if (!retained_python_supported(schema) ||
-        python_bridge::is_python_bundle_schema(schema)) {
-      throw std::invalid_argument(
-          "Python-retained binding requires a supported non-native schema");
-    }
-    ops.kind = ValueOpsKind::Base;
-    ops.context = this;
-    ops.allows_mutation = false;
-    ops.hash_impl = schema->is_hashable() ? &hash : nullptr;
-    ops.equals_impl = schema->is_equatable() ? &equals : nullptr;
-    ops.compare_impl = schema->is_comparable() ? &compare : nullptr;
-    ops.to_string_impl = &to_string;
-    ops.to_python_impl = &to_python;
-    ops.from_python_impl = &from_python;
-    ops.accepts_source_impl = &accepts_source;
-    ops.copy_assign_from_impl = &copy_assign_from;
-    ops.move_assign_from_impl = &move_assign_from;
-    ops.format_string_impl = &to_string;
-    binding = intern_value_type(
-        *schema, MemoryUtils::plan_for<python_bridge::PythonValueHolder>(),
-        ops);
-  }
-
-  [[nodiscard]] static const PythonRetainedBindingEntry &
-  entry(const void *context) noexcept {
-    return *static_cast<const PythonRetainedBindingEntry *>(context);
-  }
-
-  [[nodiscard]] static python_bridge::PythonValueHolder &value(void *memory) {
-    if (memory == nullptr) {
-      throw std::logic_error(
-          "Python-retained value operation requires live memory");
-    }
-    return *static_cast<python_bridge::PythonValueHolder *>(memory);
-  }
-
-  [[nodiscard]] static const python_bridge::PythonValueHolder &
-  value(const void *memory) {
-    if (memory == nullptr) {
-      throw std::logic_error(
-          "Python-retained value operation requires live memory");
-    }
-    return *static_cast<const python_bridge::PythonValueHolder *>(memory);
-  }
-
-  // Value semantics come from the bridge's one set of Python-object
-  // primitives (python_bridge::object_*); this entry owns only the holder.
-  static std::size_t hash(const void *, const void *memory) {
-    const auto &stored = value(memory);
-    if (stored.object == nullptr) {
-      throw std::logic_error("cannot hash an empty Python-retained value");
-    }
-    return python_bridge::object_hash(stored.object);
-  }
-
-  static bool equals(const void *, const void *lhs, const void *rhs) {
-    return python_bridge::object_equals(value(lhs).object, value(rhs).object);
-  }
-
-  static std::partial_ordering compare(const void *, const void *lhs,
-                                       const void *rhs) noexcept {
-    return python_bridge::object_compare(value(lhs).object, value(rhs).object);
-  }
-
-  static std::string to_string(const void *, const void *memory) {
-    const auto &stored = value(memory);
-    if (stored.object == nullptr) {
-      return "<empty Python-retained value>";
-    }
-    return python_bridge::object_str(stored.object);
-  }
-
-  static nb::object to_python(const void *, const void *memory) {
-    return value(memory).get();
-  }
-
-  static void from_python(const void *context, const ValueTypeRef &,
-                          void *memory, nb::handle source) {
-    const auto &self = entry(context);
-    value(memory).set(prepare_retained_python_value(self.schema, source));
-  }
-
-  static bool accepts_source(const void *context, ValueTypeRef binding,
-                             ValueTypeRef source) noexcept {
-    const auto &self = entry(context);
-    return binding == self.binding && source && source.schema() == self.schema;
-  }
-
-  static void copy_assign_from(const void *context, ValueTypeRef, void *dst,
-                               ValueTypeRef source, const void *src) {
-    const auto &self = entry(context);
-    if (source == self.binding) {
-      value(dst) = value(src);
-      return;
-    }
-    nb::gil_scoped_acquire gil;
-    value(dst).set(prepare_retained_python_value(
-        self.schema, source.ops_ref().to_python(src)));
-  }
-
-  static void move_assign_from(const void *context, ValueTypeRef binding,
-                               void *dst, ValueTypeRef source, void *src) {
-    const auto &self = entry(context);
-    if (source == self.binding) {
-      value(dst) = std::move(value(src));
-      return;
-    }
-    copy_assign_from(context, binding, dst, source, src);
-  }
-};
-
-// Entries are address-published AND immortal: python Values can outlive a
-// registry reset, so a reset drops only the key index (clear_index) while
-// every entry stays alive. The table itself is leaked for the same reason.
-[[nodiscard]] InternTable<const ValueTypeMetaData *,
-                          std::unique_ptr<PythonRetainedBindingEntry>> &
-python_retained_bindings() noexcept {
-  static auto *bindings =
-      new InternTable<const ValueTypeMetaData *,
-                      std::unique_ptr<PythonRetainedBindingEntry>>{};
-  return *bindings;
-}
-
-[[nodiscard]] ValueTypeRef
-python_retained_binding_for(const ValueTypeMetaData *schema) {
-  // intern_serialized: the entry ctor interns a TypeRecord pointing at
-  // itself, so a racing loser must never be constructed and destroyed.
-  return python_retained_bindings()
-      .intern_serialized(
-          schema,
-          [&] { return std::make_unique<PythonRetainedBindingEntry>(schema); })
-      ->binding;
-}
-
-void clear_python_retained_bindings() noexcept {
-  python_retained_bindings().clear_index();
-}
-#endif
 } // namespace
 
 ValuePlanFactory &ValuePlanFactory::instance() {
@@ -3015,17 +2629,16 @@ ValuePlanFactory::storage_for(ValueTypeRef native_binding,
       .value_binding = native_binding,
       .storage_plan = native_binding.plan(),
   };
-#if !HGRAPH_ENABLE_PYTHON_USER_NODES
-  static_cast<void>(requested);
-  return native;
-#else
-  if (requested == ValueStorageVariant::Native) {
+  // The Python half of the policy is the bridge's registered provider; with
+  // none registered, every Python-aware request downgrades to Native.
+  const PythonStorageProvider *provider = python_storage_provider();
+  if (requested == ValueStorageVariant::Native || provider == nullptr) {
     return native;
   }
   const auto *schema = native_binding.schema();
   if (requested == ValueStorageVariant::PythonOnly) {
     if (const auto python_binding =
-            python_bundle_storage_binding(native_binding);
+            provider->bundle_storage_binding(native_binding);
         python_binding) {
       return ValueStorageSelection{
           .effective = ValueStorageVariant::PythonOnly,
@@ -3033,11 +2646,11 @@ ValuePlanFactory::storage_for(ValueTypeRef native_binding,
           .storage_plan = python_binding.plan(),
       };
     }
-    if (!python_cache_beneficial(native_binding) ||
-        python_bridge::is_python_bundle_schema(schema)) {
+    if (!provider->cache_beneficial(native_binding) ||
+        provider->python_bundle_schema(schema)) {
       return native;
     }
-    const auto retained = python_retained_binding_for(schema);
+    const auto retained = provider->retained_binding_for(schema);
     return ValueStorageSelection{
         .effective = ValueStorageVariant::PythonOnly,
         .value_binding = retained,
@@ -3046,14 +2659,13 @@ ValuePlanFactory::storage_for(ValueTypeRef native_binding,
         .python_value_offset = 0,
     };
   }
-  if (!python_cache_beneficial(native_binding)) {
+  if (!provider->cache_beneficial(native_binding)) {
     return native;
   }
   auto builder = MemoryUtils::named_tuple();
   builder.reserve(2);
   builder.add_field("native", native_binding.checked_plan());
-  builder.add_field("python",
-                    MemoryUtils::plan_for<python_bridge::PythonValueHolder>());
+  builder.add_field("python", *provider->python_holder_plan());
   const auto &plan = builder.build();
   return ValueStorageSelection{
       .effective = ValueStorageVariant::NativeWithPythonCache,
@@ -3062,20 +2674,24 @@ ValuePlanFactory::storage_for(ValueTypeRef native_binding,
       .value_offset = plan.component("native").offset,
       .python_value_offset = plan.component("python").offset,
   };
-#endif
 }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-nb::object
-ValuePlanFactory::prepare_python_storage_value(const ValueTypeMetaData *schema,
-                                               nb::handle source) const {
-  if (!retained_python_supported(schema)) {
-    throw std::logic_error(
-        "ValuePlanFactory has no retained-Python policy for this schema");
-  }
-  return prepare_retained_python_value(schema, source);
+namespace {
+const ValuePlanFactory::PythonStorageProvider *&python_storage_provider_slot() noexcept {
+  static const ValuePlanFactory::PythonStorageProvider *provider = nullptr;
+  return provider;
 }
-#endif
+} // namespace
+
+void ValuePlanFactory::set_python_storage_provider(
+    const PythonStorageProvider *provider) noexcept {
+  python_storage_provider_slot() = provider;
+}
+
+const ValuePlanFactory::PythonStorageProvider *
+ValuePlanFactory::python_storage_provider() noexcept {
+  return python_storage_provider_slot();
+}
 
 ValueTypeRef
 ValuePlanFactory::find_type(const ValueTypeMetaData *schema) const {
@@ -3167,9 +2783,9 @@ void ValuePlanFactory::reset() noexcept {
   type_cache_.clear();
   clear_structured_indexed_ops();
   clear_value_debug_descriptors();
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-  clear_python_retained_bindings();
-#endif
+  if (const PythonStorageProvider *provider = python_storage_provider()) {
+    provider->clear_retained_bindings();
+  }
 }
 
 const MemoryUtils::StoragePlan *


### PR DESCRIPTION
## Summary

The layering step `python_bridge.rst` still named as outstanding for `value_plan_factory.cpp`: the Python-retained value entry (the ops table for a `PyObject` retained as the value itself, plus the policy that says which schemas may retain, whether an inline cache pays, and how a Python-owned Bundle binds) moves out of the type layer onto the bridge.

- **New bridge unit** `src/hgraph/python/impl/retained_value.cpp` with `include/hgraph/python/retained_value.h`; the block moved verbatim, namespaced.
- **Provider table.** `ValuePlanFactory::PythonStorageProvider` is a struct of plain function pointers (retained-supported, cache-beneficial, Python-owned-Bundle binding and check, retained binding, holder plan, reset hook). The module registers it once at initialisation (`register_python_storage_provider`, beside the existing infer-value slot). `storage_for` and `reset` go through the table; the factory carries no Python type and no build-time conditional for that policy.
- **Default build unchanged in behaviour.** With no provider registered every Python-aware storage request downgrades to `Native`, so the Python-free build compiles the same policy code rather than a conditional variant.
- `prepare_python_storage_value` is a bridge function now; its one type-layer caller (`ts_data_atomic_ops.cpp`) calls it there.
- Ratchet `type-layer-python-conditionals` 165 → 160; `python_bridge.rst` updated in the same change.

The remaining conditionals in the plan factory are the container ops' `to_python`/`from_python` implementations (composite, array, owned, shared), a different family ("No kind-switches in conversion"), and are out of scope here.

## Test plan

- [x] C++ `hgraph_unit_tests` on the default (Python-free) build: 1696 cases green on a fresh binary.
- [x] Python core + five extension suites + `python/tests/adaptors`: 3594 passed, 10 skipped (`test_python_value_storage.py` covers the three storage variants).
- [x] Installed-SDK consumer checks (Python extension, native executable, Fabric SDK): pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
