### PR TITLE
refactor(language): render C++ interfaces from hgraph IR

### DIFF
--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -188,8 +188,8 @@ endfunction()
 
 # The C++ backend (src/codegen): emits a header/source pair of public hgraph
 # authoring code per module (developer guide, "C++ backend, first pass").
-# Hgraph IR owns module and callable/operator planning while a temporary
-# syntax adapter prints bodies, types, and signatures.
+# Hgraph IR owns module and callable/operator interfaces while a temporary
+# syntax adapter prints bodies, local annotations, defaults, and struct layouts.
 add_library(hgl_codegen STATIC
     src/codegen/cpp_emitter.cpp
 )

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -171,8 +171,11 @@ wiring target no longer includes syntax AST headers.
 - [x] make hgraph IR authoritative for module paths, callable identity,
   visibility and classification, operator identity, exports, and registration
   planning;
-- [ ] migrate type, signature, body, and dependency emission from the temporary
-  syntax/`ResolvedModule` adapter to hgraph IR;
+- [x] render callable and operator parameter/result types, names, roles, and
+  selector signatures from hgraph IR;
+- [ ] migrate struct layouts, defaults, local annotations, bodies, and
+  dependency emission from the temporary syntax/`ResolvedModule` adapter to
+  hgraph IR;
 - remove duplicate name, type, generic, phase, and classification logic from
   the emitter;
 - retain deterministic formatting, source maps, public-SDK code, and readable
@@ -181,8 +184,9 @@ wiring target no longer includes syntax AST headers.
 
 Acceptance: both backends consume the same hgraph IR, existing generated tests
 and installed consumers pass, and architecture tests reject backend-to-syntax
-dependencies. The first checkpoint is complete, but Stage E remains in progress
-until the body adapter and its syntax dependency are gone.
+dependencies. The declaration and interface checkpoints are complete, but
+Stage E remains in progress until the body adapter and its syntax dependency
+are gone.
 
 ### F. Constrained native interface
 

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -207,14 +207,16 @@ checkpoint also takes hgraph IR as its primary input. It uses graph-IR module
 paths, callable identities, visibility and classification, nominal operator
 bindings, exports, and registration plans. A declaration range maps each
 planned callable or local operator back to exactly one source declaration; a
-missing, duplicate, or extra mapping is a backend diagnostic. That mapping is
+missing, duplicate, or extra mapping is a backend diagnostic. Callable and
+operator parameter/result names, roles, canonical types, rolling-window shapes,
+and generated selector signatures now come from hgraph IR. The range mapping is
 the explicitly temporary adapter through which the existing printer still
-reads syntax bodies, types, signatures, struct layouts, and expression
-dependencies from the AST and `ResolvedModule`.
+reads syntax bodies, local annotations, default expressions, struct layouts,
+and expression dependencies from the AST and `ResolvedModule`.
 
 This seam keeps the generated package readable while preventing declaration
 policy from drifting between execution paths. The next Stage E checkpoints
-move type/signature printing and then body/dependency emission to hgraph IR.
+move struct/default printing and then body/dependency emission to hgraph IR.
 Only after those moves may `codegen` drop its syntax and resolver dependencies.
 
 `src/wiring/type_bridge` is the first direct-backend migration boundary. It
@@ -1217,8 +1219,9 @@ deltas, concise `map` functions, scalar and collection runtime inputs, borrowed
 collection traversal, `out`, `logger`, state, and lifecycle hooks. File-based
 `test` and `run` compile/load supported runtime modules on Unix; portable native
 loading and the remaining language-depth items are still staged. Declaration
-and module planning now comes from hgraph IR; the body/type/signature printer is
-the remaining temporary AST adapter.
+and module planning now come from hgraph IR, as does callable/operator interface
+printing. Body-local types, defaults, struct layouts, and dependency discovery
+remain behind the temporary AST adapter.
 
 `hgl emit-cpp <file.hgl>` writes one header/source pair named after the
 source — `prices.hgl` becomes `prices.h` and `prices.cpp` — beside the
@@ -1238,10 +1241,11 @@ What is emitted, in this order:
 
 Before emission, hgraph IR determines the module namespace, source-order
 callable set, visibility, composition/runtime classification, canonical
-callable and operator identities, export surface, and registry bindings. The
-adapter uses retained source ranges only to locate the legacy syntax body or
-signature that must still be printed; it cannot silently add or omit a planned
-declaration.
+callable and operator identities, export surface, registry bindings, and all
+callable/operator parameter and result types. The adapter uses retained source
+ranges only to locate the legacy syntax body, defaults, local annotations, and
+struct layout that must still be printed; it cannot silently add or omit a
+planned declaration.
 
 - **Operator contracts.** `namespace operators` holds one transparent alias to
   `hgraph::Operator<"module.name",

--- a/language/src/README.md
+++ b/language/src/README.md
@@ -12,15 +12,16 @@ them.
 | `ir/` | source-ranged HIR, canonical types, substitutions, constraint solving, phase/effect completion | resolved frontend state to typed HIR |
 | `hgraph_ir/` | canonical execution-facing types, compile-time expressions, constraints, struct contracts, operator and callable interfaces | typed HIR to executable composition and runtime-node plans |
 | `wiring/` | direct walk over hgraph IR | hgraph IR to public erased wiring calls |
-| `codegen/` | hgraph-IR declaration planning plus a temporary AST body adapter | hgraph IR to formatted C++ and build artifacts |
+| `codegen/` | hgraph-IR declaration/interface planning plus a temporary AST body adapter | hgraph IR to formatted C++ and build artifacts |
 | `driver/` | commands, native build/cache/load, REPL orchestration | assemble inputs and invoke passes |
 
 During migration, `ResolvedModule` and the syntax AST remain a compatibility
-boundary only for C++ body, type, and signature printing. Module identity,
-callable visibility and classification, operator binding, exports, and
-registration planning already come from hgraph IR. New language semantics
-belong in HIR construction, not in either backend. The remaining adapter is
-named here and must be removed as Stage E advances.
+boundary only for C++ bodies, local annotations, default-expression printing,
+struct layouts, and dependency discovery. Module identity, callable visibility
+and classification, operator binding, exports, registration planning, and
+callable/operator interface types and parameter roles already come from hgraph
+IR. New language semantics belong in HIR construction, not in either backend.
+The remaining adapter is named here and must be removed as Stage E advances.
 
 Every new pass documents:
 

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -38,8 +38,9 @@ namespace hgl::codegen
 
         // ------------------------------------------------------------ types
 
-        /// An HGL type as the emitter reasons about it (the AST shape after
-        /// constant size expressions are printed).
+        /// A normalized type used by the temporary C++ body printer. Public
+        /// interface instances come from hgraph IR; local annotations still
+        /// arrive through the syntax compatibility adapter.
         struct HType
         {
             enum class Kind : std::uint8_t {
@@ -62,6 +63,7 @@ namespace hgl::codegen
             std::string        min_size{};  ///< rolling minimum, as C++ text
             bool               duration_window{false};
             ast::DeclId        declaration{ast::no_node};
+            std::string        nominal_identity{};
             std::string        cpp_type{};
 
             [[nodiscard]] bool is(ast::ScalarType s) const noexcept { return kind == Kind::Scalar && scalar == s; }
@@ -80,7 +82,7 @@ namespace hgl::codegen
         {
             if (a.kind != b.kind || a.children.size() != b.children.size()) { return false; }
             if (a.kind == HType::Kind::Scalar && a.scalar != b.scalar) { return false; }
-            if (a.declaration != b.declaration || a.cpp_type != b.cpp_type) { return false; }
+            if (a.nominal_identity != b.nominal_identity || a.cpp_type != b.cpp_type) { return false; }
             if (a.size != b.size || a.min_size != b.min_size || a.duration_window != b.duration_window) { return false; }
             for (std::size_t i = 0; i < a.children.size(); ++i)
             {
@@ -366,6 +368,11 @@ namespace hgl::codegen
 
             // -- types
             [[nodiscard]] HType       type_of(ast::TypeId id, Frame &frame);
+            [[nodiscard]] HType                       planned_type(gir::TypeId id, SourceRange fallback = {});
+            [[nodiscard]] const gir::Type            &graph_type(gir::TypeId id, SourceRange fallback);
+            [[nodiscard]] const gir::ConstExpr       &graph_constant(gir::ConstExprId id, SourceRange fallback);
+            [[nodiscard]] std::optional<std::int64_t> planned_integer(gir::ConstExprId id, SourceRange fallback);
+            [[nodiscard]] bool                        has_planned_result(gir::TypeId id, SourceRange fallback);
             [[nodiscard]] std::string value_type(const HType &type, SourceRange range);
             [[nodiscard]] std::string schema(const HType &type, SourceRange range);
             [[nodiscard]] std::string size_text(ast::ExprId id, Frame &frame, std::string_view what);
@@ -404,9 +411,10 @@ namespace hgl::codegen
 
             // -- declarations
             void check_supported(ast::DeclId decl);
-            [[nodiscard]] std::string signature(ast::DeclId decl, Frame &frame, bool with_names);
-            [[nodiscard]] std::string result_type(ast::DeclId decl, Frame &frame);
-            [[nodiscard]] std::string operator_contract(ast::DeclId decl, std::string_view registry_name, Frame &frame);
+            [[nodiscard]] std::string signature(ast::DeclId decl, bool with_names);
+            [[nodiscard]] std::string result_type(ast::DeclId decl);
+            [[nodiscard]] std::string operator_contract(const std::vector<gir::Parameter> &parameters, gir::TypeId result,
+                                                        std::string_view registry_name);
             /// How a function is written: its struct declaration (header), the
             /// whole struct inline (module-internal helpers and operator
             /// implementations), or the out-of-line `compose` definition of a
@@ -430,7 +438,7 @@ namespace hgl::codegen
             void check_runtime_block(ast::BlockId id, ast::DeclId decl, const RuntimeValidSet &valid,
                                      bool allow_when = false);
             void check_runtime_stmt(ast::StmtId id, ast::DeclId decl, const RuntimeValidSet &valid, bool allow_when);
-            [[nodiscard]] std::string runtime_signature(ast::DeclId decl, const RuntimeInfo &info, Frame &frame, bool with_names,
+            [[nodiscard]] std::string runtime_signature(ast::DeclId decl, const RuntimeInfo &info, bool with_names,
                                                         bool include_inputs, bool include_output);
             void prepare_runtime_frame(ast::DeclId decl, const RuntimeInfo &info, Frame &frame, Writer &out, bool include_inputs,
                                        bool include_output);
@@ -503,6 +511,18 @@ namespace hgl::codegen
                 if (id == ast::no_node) {
                     backend(item.range, "hgraph IR callable '" + item.identity + "' has no syntax body adapter");
                 }
+                const ast::Signature &source = function(id).signature;
+                if (item.parameters.size() != source.parameters.size() ||
+                    has_planned_result(item.result, item.range) != (source.result != ast::no_node)) {
+                    backend(item.range,
+                            "hgraph IR callable '" + item.identity + "' disagrees with the syntax body adapter's signature shape");
+                }
+                for (std::size_t index = 0; index < item.parameters.size(); ++index) {
+                    if (item.parameters[index].is_const != source.parameters[index].is_const) {
+                        backend(item.range, "hgraph IR callable '" + item.identity +
+                                                "' disagrees with the syntax body adapter's parameter roles");
+                    }
+                }
                 if (!callables_.emplace(id, &item).second) {
                     backend(item.range, "more than one hgraph IR callable maps to the same syntax declaration");
                 }
@@ -548,6 +568,201 @@ namespace hgl::codegen
             return std::get<ast::StructDecl>(node).generics.at(index);
         }
 
+        const gir::Type &Emitter::graph_type(gir::TypeId id, SourceRange fallback) {
+            if (!id.valid() || id.value >= graph_.types.size()) { backend(fallback, "hgraph IR contains an invalid type ID"); }
+            return graph_.types[id.value];
+        }
+
+        const gir::ConstExpr &Emitter::graph_constant(gir::ConstExprId id, SourceRange fallback) {
+            if (!id.valid() || id.value >= graph_.const_exprs.size()) {
+                backend(fallback, "hgraph IR contains an invalid constant-expression ID");
+            }
+            return graph_.const_exprs[id.value];
+        }
+
+        bool Emitter::has_planned_result(gir::TypeId id, SourceRange fallback) {
+            if (!id.valid()) { return false; }
+            if (id.value >= graph_.types.size()) { backend(fallback, "hgraph IR contains an invalid result type ID"); }
+            return graph_.types[id.value].kind != ir::hir::TypeKind::Void;
+        }
+
+        std::optional<std::int64_t> Emitter::planned_integer(gir::ConstExprId id, SourceRange fallback) {
+            const gir::ConstExpr &expression = graph_constant(id, fallback);
+            if (expression.kind != gir::ConstExprKind::Literal || !expression.literal) { return std::nullopt; }
+            if (const auto *value = std::get_if<std::int64_t>(&*expression.literal)) { return *value; }
+            return std::nullopt;
+        }
+
+        HType Emitter::planned_type(gir::TypeId id, SourceRange fallback) {
+            const gir::Type  &type  = graph_type(id, fallback);
+            const SourceRange range = type.range.end > type.range.begin ? type.range : fallback;
+            using TypeKind          = ir::hir::TypeKind;
+            switch (type.kind) {
+                case TypeKind::Scalar:
+                    {
+                        using ScalarType = ir::hir::ScalarType;
+                        switch (type.scalar) {
+                            case ScalarType::Bool: return scalar_type(ast::ScalarType::Bool);
+                            case ScalarType::I64: return scalar_type(ast::ScalarType::I64);
+                            case ScalarType::F64: return scalar_type(ast::ScalarType::F64);
+                            case ScalarType::Str: return scalar_type(ast::ScalarType::Str);
+                            case ScalarType::Date: return scalar_type(ast::ScalarType::Date);
+                            case ScalarType::Time: return scalar_type(ast::ScalarType::Time);
+                            case ScalarType::DateTime: return scalar_type(ast::ScalarType::DateTime);
+                            case ScalarType::Duration: return scalar_type(ast::ScalarType::Duration);
+                            case ScalarType::CivilDateTime: return scalar_type(ast::ScalarType::CivilDateTime);
+                            case ScalarType::ZonedDateTime: return scalar_type(ast::ScalarType::ZonedDateTime);
+                            case ScalarType::ZonedTime: return scalar_type(ast::ScalarType::ZonedTime);
+                            case ScalarType::TimeZone: return scalar_type(ast::ScalarType::TimeZone);
+                        }
+                        break;
+                    }
+                case TypeKind::Symbol:
+                    {
+                        if (type.binding.valid()) {
+                            if (type.binding.value >= graph_.bindings.size()) {
+                                backend(range, "hgraph IR type refers to an invalid generic binding");
+                            }
+                            const gir::Binding &binding = graph_.bindings[type.binding.value];
+                            if (binding.kind != gir::BindingKind::TypeParameter) {
+                                backend(range, "a non-type generic cannot be used as a value type");
+                            }
+                            HType result;
+                            result.kind     = HType::Kind::Generic;
+                            result.cpp_type = "hgraph::ScalarVar<" + quote(binding.name) + ">";
+                            return result;
+                        }
+                        const auto contract =
+                            std::find_if(graph_.structures.begin(), graph_.structures.end(),
+                                         [&](const auto &candidate) { return candidate.identity == type.nominal_identity; });
+                        if (contract == graph_.structures.end()) {
+                            backend(range, "unknown hgraph IR nominal type '" + type.nominal_identity + "'");
+                        }
+                        HType result;
+                        result.kind             = HType::Kind::Struct;
+                        result.nominal_identity = type.nominal_identity;
+                        result.cpp_type         = cpp_name(local_identity(type.nominal_identity));
+                        std::vector<std::string> arguments;
+                        arguments.reserve(type.arguments.size());
+                        for (const gir::TypeArgument &argument : type.arguments) {
+                            if (argument.type) {
+                                HType child = planned_type(*argument.type, range);
+                                arguments.push_back(value_type(child, range));
+                                result.children.push_back(std::move(child));
+                            } else if (argument.value) {
+                                const std::optional<std::int64_t> value = planned_integer(*argument.value, range);
+                                if (!value) { backend(range, "a generated const struct argument must be an i64 literal"); }
+                                arguments.push_back(std::to_string(*value));
+                            } else {
+                                backend(range, "an unresolved hgraph IR struct type argument");
+                            }
+                        }
+                        if (!arguments.empty()) { result.cpp_type += "<" + join(arguments, ", ") + ">"; }
+                        return result;
+                    }
+                case TypeKind::Tuple:
+                    {
+                        HType result;
+                        result.kind = HType::Kind::Tuple;
+                        for (gir::TypeId child : type.children) { result.children.push_back(planned_type(child, range)); }
+                        return result;
+                    }
+                case TypeKind::List:
+                    {
+                        if (type.children.size() != 1U) { backend(range, "hgraph IR list type requires one element type"); }
+                        HType result;
+                        result.kind = HType::Kind::List;
+                        result.children.push_back(planned_type(type.children.front(), range));
+                        if (type.size.valid()) {
+                            const std::optional<std::int64_t> size = planned_integer(type.size, range);
+                            if (!size || *size <= 0) {
+                                fail(Category::Type, range, "a fixed list size must be a positive i64 literal");
+                            }
+                            result.size = std::to_string(*size);
+                        }
+                        return result;
+                    }
+                case TypeKind::Set:
+                    {
+                        if (type.children.size() != 1U) { backend(range, "hgraph IR set type requires one element type"); }
+                        HType result;
+                        result.kind = HType::Kind::Set;
+                        result.children.push_back(planned_type(type.children.front(), range));
+                        return result;
+                    }
+                case TypeKind::Map:
+                    {
+                        if (type.children.size() != 2U) { backend(range, "hgraph IR map type requires key and value types"); }
+                        HType result;
+                        result.kind = HType::Kind::Map;
+                        result.children.push_back(planned_type(type.children[0], range));
+                        result.children.push_back(planned_type(type.children[1], range));
+                        return result;
+                    }
+                case TypeKind::Rolling:
+                    {
+                        if (type.children.size() != 1U) { backend(range, "hgraph IR rolling type requires one element type"); }
+                        HType result;
+                        result.kind = HType::Kind::Rolling;
+                        result.children.push_back(planned_type(type.children.front(), range));
+                        if (!type.size.valid()) { return result; }
+                        const gir::ConstExpr &maximum = graph_constant(type.size, range);
+                        if (maximum.kind != gir::ConstExprKind::Literal || !maximum.literal) {
+                            // A symbolic size is a type relationship, not a C++
+                            // non-type template parameter on the operator marker.
+                            return result;
+                        }
+                        if (const auto *size = std::get_if<std::int64_t>(&*maximum.literal)) {
+                            if (*size <= 0) {
+                                fail(Category::Type, range, "a rolling size is a positive i64 constant or a duration");
+                            }
+                            result.size                               = std::to_string(*size);
+                            const std::optional<std::int64_t> minimum = planned_integer(type.min_size, range);
+                            if (!minimum || *minimum < 0 || *minimum > *size) {
+                                fail(Category::Type, range,
+                                     "rolling sizes require a positive maximum and a non-negative minimum no larger than it");
+                            }
+                            result.min_size = std::to_string(*minimum);
+                            return result;
+                        }
+                        if (const auto *size = std::get_if<syntax::TemporalValue>(&*maximum.literal);
+                            size != nullptr && size->kind == syntax::TemporalKind::Duration) {
+                            const gir::ConstExpr &minimum = graph_constant(type.min_size, range);
+                            const auto           *minimum_value =
+                                minimum.literal ? std::get_if<syntax::TemporalValue>(&*minimum.literal) : nullptr;
+                            if (minimum.kind != gir::ConstExprKind::Literal || minimum_value == nullptr ||
+                                minimum_value->kind != syntax::TemporalKind::Duration) {
+                                fail(Category::Type, range, "a duration rolling minimum must be a duration literal");
+                            }
+                            if (size->micros <= 0 || minimum_value->micros < 0 || minimum_value->micros > size->micros) {
+                                fail(Category::Type, range,
+                                     "rolling durations require a positive maximum and a non-negative minimum no larger than it");
+                            }
+                            result.duration_window = true;
+                            result.size            = std::to_string(size->micros);
+                            result.min_size        = std::to_string(minimum_value->micros);
+                            return result;
+                        }
+                        fail(Category::Type, range, "a rolling size is a positive i64 constant or a duration");
+                    }
+                case TypeKind::Atomic:
+                    {
+                        if (type.children.size() != 1U) { backend(range, "hgraph IR atomic type requires one value type"); }
+                        HType result;
+                        result.kind = HType::Kind::Atomic;
+                        result.children.push_back(planned_type(type.children.front(), range));
+                        return result;
+                    }
+                case TypeKind::Void:
+                case TypeKind::Iterator:
+                case TypeKind::Callable:
+                case TypeKind::Capability:
+                case TypeKind::HarnessSequence:
+                case TypeKind::Deferred: break;
+            }
+            backend(range, "unsupported hgraph IR interface type");
+        }
+
         std::string Emitter::size_text(ast::ExprId id, Frame &frame, std::string_view what)
         {
             const Value value = eval_expr(id, frame);
@@ -581,9 +796,10 @@ namespace hgl::codegen
                     if (binding.kind == BindingKind::Struct) {
                         const ast::StructDecl &decl = structure(binding.decl);
                         HType                  result;
-                        result.kind        = HType::Kind::Struct;
-                        result.declaration = binding.decl;
-                        result.cpp_type    = cpp_name(decl.name.text);
+                        result.kind             = HType::Kind::Struct;
+                        result.declaration      = binding.decl;
+                        result.nominal_identity = resolved_.module_path + "." + std::string{decl.name.text};
+                        result.cpp_type         = cpp_name(decl.name.text);
 
                         std::vector<std::string> arguments;
                         arguments.reserve(type.arguments.size());
@@ -1514,9 +1730,10 @@ namespace hgl::codegen
                 if (!item.generics.empty()) {
                     backend(range, "generic struct '" + std::string{item.name.text} + "' needs explicit type arguments");
                 }
-                type.kind        = HType::Kind::Struct;
-                type.declaration = decl;
-                type.cpp_type    = cpp_name(item.name.text);
+                type.kind             = HType::Kind::Struct;
+                type.declaration      = decl;
+                type.nominal_identity = resolved_.module_path + "." + std::string{item.name.text};
+                type.cpp_type         = cpp_name(item.name.text);
             }
 
             Frame       struct_frame  = frame;
@@ -1799,6 +2016,7 @@ namespace hgl::codegen
         {
             check_supported(decl);
             const ast::FunctionDecl       &fn    = function(decl);
+            const gir::Callable           &planned = callable(decl);
             const std::vector<ast::ExprId> bound = bind_arguments(fn, arguments, range);
             const auto                    &params = fn.signature.parameters;
             Frame                          callee;
@@ -1808,17 +2026,17 @@ namespace hgl::codegen
             {
                 const ast::Parameter &param = params[i];
                 Value arg = bound[i] != ast::no_node ? eval_expr(bound[i], frame) : eval_expr(param.default_value, callee);
-                const HType type = type_of(param.type, callee);
+                const HType           type  = planned_type(planned.parameters[i].type, planned.range);
                 if (param.is_const)
                 {
-                    args[i] = as_const(arg, type, arg.range, "parameter '" + std::string{param.name.text} + "'");
+                    args[i] = as_const(arg, type, arg.range, "parameter '" + planned.parameters[i].name + "'");
                 }
                 else { args[i] = as_port(arg, type, arg.range); }
             }
             HType result;
-            if (fn.signature.result != ast::no_node) { result = type_of(fn.signature.result, callee); }
+            if (has_planned_result(planned.result, planned.range)) { result = planned_type(planned.result, planned.range); }
             Value value = wire(callable_cpp_name(decl), args, range, result);
-            if (fn.signature.result == ast::no_node) { value.kind = Value::Kind::Void; }
+            if (!has_planned_result(planned.result, planned.range)) { value.kind = Value::Kind::Void; }
             return value;
         }
 
@@ -1826,15 +2044,15 @@ namespace hgl::codegen
 
         void Emitter::emit_return(const Value &value, Frame &frame, Writer &out, SourceRange range)
         {
-            const ast::FunctionDecl &fn = function(frame.fn);
-            if (fn.signature.result == ast::no_node)
-            {
+            const ast::FunctionDecl &fn      = function(frame.fn);
+            const gir::Callable     &planned = callable(frame.fn);
+            if (!has_planned_result(planned.result, planned.range)) {
                 if (value.kind != Value::Kind::Void) { fail(Category::Type, range, "'" + std::string{fn.name.text} + "' has no result"); }
                 if (!value.code.empty()) { out.line(value.code + ";"); }
                 out.line("return;");
                 return;
             }
-            const HType result = type_of(fn.signature.result, frame);
+            const HType result = planned_type(planned.result, planned.range);
             out.line("return " + as_port(value, result, range) + ";");
         }
 
@@ -2103,11 +2321,11 @@ namespace hgl::codegen
                         const ast::Expr &place = module_.expr(node.place);
                         if (const auto *index = std::get_if<ast::Index>(&place.node);
                             index != nullptr && slice(module_.expr(index->target).range) == "out") {
-                            const ast::FunctionDecl &fn = function(frame.fn);
-                            if (!frame.output_available || fn.signature.result == ast::no_node) {
+                            const gir::Callable &planned = callable(frame.fn);
+                            if (!frame.output_available || !has_planned_result(planned.result, planned.range)) {
                                 fail(Category::Phase, place.range, "'out' is not available in this lifecycle block");
                             }
-                            const HType result = type_of(fn.signature.result, frame);
+                            const HType result = planned_type(planned.result, planned.range);
                             if (result.kind != HType::Kind::Map || result.children.size() != 2) {
                                 backend(place.range, "indexed output assignment currently requires a map result");
                             }
@@ -2186,12 +2404,12 @@ namespace hgl::codegen
                         }
                         if (node.value != ast::no_node)
                         {
-                            const ast::FunctionDecl &fn = function(frame.fn);
-                            if (fn.signature.result == ast::no_node)
-                            {
+                            const ast::FunctionDecl &fn      = function(frame.fn);
+                            const gir::Callable     &planned = callable(frame.fn);
+                            if (!has_planned_result(planned.result, planned.range)) {
                                 fail(Category::Type, stmt.range, "'" + std::string{fn.name.text} + "' has no result");
                             }
-                            const HType result = type_of(fn.signature.result, frame);
+                            const HType result = planned_type(planned.result, planned.range);
                             const Value value  = eval_expr(node.value, frame);
                             if (value.structured_delta) {
                                 if (result.kind != HType::Kind::Struct || !same_type(value.type, result)) {
@@ -2593,6 +2811,7 @@ namespace hgl::codegen
         RuntimeInfo Emitter::runtime_info(ast::DeclId decl)
         {
             const ast::FunctionDecl &fn = function(decl);
+            const gir::Callable     &planned = callable(decl);
             RuntimeInfo              info;
             Frame                    frame;
             frame.fn      = decl;
@@ -2602,21 +2821,21 @@ namespace hgl::codegen
             {
                 backend(module_.decl(decl).range, "a runtime function needs a block body");
             }
-            if (fn.signature.result != ast::no_node) {
-                const HType result = type_of(fn.signature.result, frame);
+            if (has_planned_result(planned.result, planned.range)) {
+                const HType result = planned_type(planned.result, planned.range);
                 if (result.kind != HType::Kind::Scalar && result.kind != HType::Kind::Struct && result.kind != HType::Kind::Map) {
-                    backend(module_.type(fn.signature.result).range,
+                    backend(graph_type(planned.result, planned.range).range,
                             "the runtime-node slice supports scalar, struct, and map outputs");
                 }
             }
 
             std::size_t temporal_count = 0;
-            for (const ast::Parameter &param : fn.signature.parameters)
-            {
-                const HType type = type_of(param.type, frame);
+            for (const gir::Parameter &param : planned.parameters) {
+                const HType type = planned_type(param.type, planned.range);
                 if (type.kind != HType::Kind::Scalar && type.kind != HType::Kind::Map && type.kind != HType::Kind::Set &&
                     type.kind != HType::Kind::List) {
-                    backend(module_.type(param.type).range, "the runtime-node slice supports scalar and collection parameters");
+                    backend(graph_type(param.type, planned.range).range,
+                            "the runtime-node slice supports scalar and collection parameters");
                 }
                 if (!param.is_const)
                 {
@@ -2722,26 +2941,23 @@ namespace hgl::codegen
             if (callable(decl).kind == gir::CallableKind::RuntimeNode) { static_cast<void>(runtime_info(decl)); }
         }
 
-        std::string Emitter::runtime_signature(ast::DeclId decl, const RuntimeInfo &info, Frame &frame, bool with_names,
-                                               bool include_inputs, bool include_output)
-        {
-            const ast::FunctionDecl &fn = function(decl);
+        std::string Emitter::runtime_signature(ast::DeclId decl, const RuntimeInfo &info, bool with_names, bool include_inputs,
+                                               bool include_output) {
+            const gir::Callable     &fn = callable(decl);
             std::vector<std::string> params;
-            for (std::size_t i = 0; i < fn.signature.parameters.size(); ++i)
-            {
-                const ast::Parameter &param  = fn.signature.parameters[i];
-                const HType           type   = type_of(param.type, frame);
-                const std::string     name   = with_names ? " " + cpp_name(param.name.text) : "";
+            for (std::size_t i = 0; i < fn.parameters.size(); ++i) {
+                const gir::Parameter &param  = fn.parameters[i];
+                const HType           type   = planned_type(param.type, fn.range);
+                const SourceRange     range  = graph_type(param.type, fn.range).range;
+                const std::string     name   = with_names ? " " + cpp_name(param.name) : "";
                 const std::string     unused = with_names ? "[[maybe_unused]] " : "";
                 if (param.is_const)
                 {
-                    params.push_back(unused + "hgraph::Scalar<" + quote(param.name.text) + ", " +
-                                     value_type(type, module_.type(param.type).range) + ">" + name);
+                    params.push_back(unused + "hgraph::Scalar<" + quote(param.name) + ", " + value_type(type, range) + ">" + name);
                     continue;
                 }
                 if (!include_inputs) { continue; }
-                std::string selector =
-                    unused + "hgraph::In<" + quote(param.name.text) + ", " + schema(type, module_.type(param.type).range);
+                std::string selector = unused + "hgraph::In<" + quote(param.name) + ", " + schema(type, range);
                 if (!info.active_parameters.contains(i))
                 {
                     selector += ", hgraph::InputActivity::Passive";
@@ -2762,9 +2978,9 @@ namespace hgl::codegen
                 params.push_back(std::string{with_names ? "[[maybe_unused]] " : ""} + "hgraph::LoggerView" +
                                  std::string{with_names ? " logger" : ""});
             }
-            if (include_output && fn.signature.result != ast::no_node) {
+            if (include_output && has_planned_result(fn.result, fn.range)) {
                 params.push_back(std::string{with_names ? "[[maybe_unused]] " : ""} + "hgraph::Out<" +
-                                 schema(type_of(fn.signature.result, frame), module_.type(fn.signature.result).range) + ">" +
+                                 schema(planned_type(fn.result, fn.range), graph_type(fn.result, fn.range).range) + ">" +
                                  std::string{with_names ? " hgl_output" : ""});
             }
             return join(params, ", ");
@@ -2774,6 +2990,7 @@ namespace hgl::codegen
                                             bool include_output)
         {
             const ast::FunctionDecl &fn    = function(decl);
+            const gir::Callable     &planned = callable(decl);
             frame.fn                       = decl;
             frame.runtime                  = true;
             frame.runtime_inputs_available = include_inputs;
@@ -2790,8 +3007,8 @@ namespace hgl::codegen
             for (std::size_t i = 0; i < fn.signature.parameters.size(); ++i)
             {
                 const ast::Parameter &param = fn.signature.parameters[i];
-                const HType           type  = type_of(param.type, frame);
-                const std::string     name  = cpp_name(param.name.text);
+                const HType           type  = planned_type(planned.parameters[i].type, planned.range);
+                const std::string     name  = cpp_name(planned.parameters[i].name);
                 local_names_.insert(name);
                 frame.params[i] = param.is_const ? make_const(name + ".value()", type, param.name.range)
                                                  : make_runtime(name + ".value()", type, param.name.range, name);
@@ -2812,10 +3029,11 @@ namespace hgl::codegen
             }
             if (include_output && info.inject_out)
             {
-                const HType result = type_of(fn.signature.result, frame);
-                frame.injects.emplace("out", make_runtime("hgl_output.value().checked_as<" +
-                                                              value_type(result, module_.type(fn.signature.result).range) + ">()",
-                                                          result, fn.name.range, "hgl_output"));
+                const HType result = planned_type(planned.result, planned.range);
+                frame.injects.emplace("out",
+                                      make_runtime("hgl_output.value().checked_as<" +
+                                                       value_type(result, graph_type(planned.result, planned.range).range) + ">()",
+                                                   result, fn.name.range, "hgl_output"));
             }
             if (info.inject_logger) {
                 Value logger;
@@ -2828,9 +3046,10 @@ namespace hgl::codegen
         void Emitter::emit_runtime_defaults(ast::DeclId decl, Writer &out)
         {
             const ast::FunctionDecl &fn = function(decl);
+            const gir::Callable     &planned = callable(decl);
             std::vector<std::string> defaults;
-            for (const ast::Parameter &param : fn.signature.parameters)
-            {
+            for (std::size_t index = 0; index < fn.signature.parameters.size(); ++index) {
+                const ast::Parameter &param = fn.signature.parameters[index];
                 if (!param.is_const || param.default_value == ast::no_node)
                 {
                     continue;
@@ -2838,8 +3057,8 @@ namespace hgl::codegen
                 Frame scratch;
                 scratch.fn        = decl;
                 const Value value = eval_expr(param.default_value, scratch);
-                const HType type  = type_of(param.type, scratch);
-                defaults.push_back("hgraph::arg<" + quote(param.name.text) + ">(" +
+                const HType type  = planned_type(planned.parameters[index].type, planned.range);
+                defaults.push_back("hgraph::arg<" + quote(planned.parameters[index].name) + ">(" +
                                    as_const(value, type, value.range, "default of '" + std::string{param.name.text} + "'") + ")");
             }
             if (!defaults.empty())
@@ -2872,7 +3091,7 @@ namespace hgl::codegen
 
             if (!info.states.empty() || !info.start_blocks.empty())
             {
-                out.line("static void start(" + runtime_signature(decl, info, frame, true, false, false) + ")");
+                out.line("static void start(" + runtime_signature(decl, info, true, false, false) + ")");
                 out.open("");
                 prepare_runtime_frame(decl, info, frame, out, false, false);
                 for (const RuntimeState &state : info.states)
@@ -2889,8 +3108,8 @@ namespace hgl::codegen
                 out.close();
             }
 
-            const bool has_output = fn.signature.result != ast::no_node;
-            out.line("static void eval(" + runtime_signature(decl, info, frame, true, true, has_output) + ")");
+            const bool has_output = has_planned_result(callable(decl).result, callable(decl).range);
+            out.line("static void eval(" + runtime_signature(decl, info, true, true, has_output) + ")");
             out.open("");
             prepare_runtime_frame(decl, info, frame, out, true, has_output);
             for (const ast::StmtId id : module_.block(fn.block_body).statements)
@@ -2907,7 +3126,7 @@ namespace hgl::codegen
 
             if (!info.stop_blocks.empty())
             {
-                out.line("static void stop(" + runtime_signature(decl, info, frame, true, false, false) + ")");
+                out.line("static void stop(" + runtime_signature(decl, info, true, false, false) + ")");
                 out.open("");
                 prepare_runtime_frame(decl, info, frame, out, false, false);
                 emit_runtime_block(std::get<ast::LifecycleBlock>(module_.stmt(info.stop_blocks.front()).node).block, frame, out);
@@ -2917,59 +3136,46 @@ namespace hgl::codegen
             out.line();
         }
 
-        std::string Emitter::signature(ast::DeclId decl, Frame &frame, bool with_names)
-        {
-            const ast::FunctionDecl &fn = function(decl);
+        std::string Emitter::signature(ast::DeclId decl, bool with_names) {
+            const gir::Callable     &fn = callable(decl);
             std::vector<std::string> params{with_names ? "hgraph::Wiring &w" : "hgraph::Wiring &"};
-            for (const ast::Parameter &param : fn.signature.parameters)
-            {
-                const HType type = type_of(param.type, frame);
-                const std::string name = with_names ? " " + cpp_name(param.name.text) : "";
+            for (const gir::Parameter &param : fn.parameters) {
+                const HType       type  = planned_type(param.type, fn.range);
+                const SourceRange range = graph_type(param.type, fn.range).range;
+                const std::string name  = with_names ? " " + cpp_name(param.name) : "";
                 if (param.is_const)
                 {
-                    params.push_back("hgraph::Scalar<" + quote(param.name.text) + ", " + value_type(type, module_.type(param.type).range) +
-                                     ">" + name);
+                    params.push_back("hgraph::Scalar<" + quote(param.name) + ", " + value_type(type, range) + ">" + name);
+                } else {
+                    params.push_back("hgraph::Port<" + schema(type, range) + ">" + name);
                 }
-                else { params.push_back("hgraph::Port<" + schema(type, module_.type(param.type).range) + ">" + name); }
             }
             return join(params, ", ");
         }
 
-        std::string Emitter::result_type(ast::DeclId decl, Frame &frame)
-        {
-            const ast::FunctionDecl &fn = function(decl);
-            if (fn.signature.result == ast::no_node) { return "void"; }
-            return "hgraph::Port<" + schema(type_of(fn.signature.result, frame), module_.type(fn.signature.result).range) + ">";
+        std::string Emitter::result_type(ast::DeclId decl) {
+            const gir::Callable &fn = callable(decl);
+            if (!has_planned_result(fn.result, fn.range)) { return "void"; }
+            return "hgraph::Port<" + schema(planned_type(fn.result, fn.range), graph_type(fn.result, fn.range).range) + ">";
         }
 
         /// The operator contract for a public callable: its parameters as
         /// `In`/`Scalar` selectors and its result as `Out`.
-        std::string Emitter::operator_contract(ast::DeclId decl, std::string_view registry_name, Frame &frame) {
-            const ast::DeclNode                 &node   = module_.decl(decl).node;
-            const ast::Signature                *sig    = nullptr;
-            if (const auto *fn = std::get_if<ast::FunctionDecl>(&node))
-            {
-                sig = &fn->signature;
-            }
-            else
-            {
-                const auto &op = std::get<ast::OperatorDecl>(node);
-                sig            = &op.signature;
-            }
+        std::string Emitter::operator_contract(const std::vector<gir::Parameter> &parameters, gir::TypeId result,
+                                               std::string_view registry_name) {
             std::vector<std::string> selectors{quote(registry_name)};
-            for (const ast::Parameter &param : sig->parameters)
-            {
-                const HType       type  = type_of(param.type, frame);
-                const SourceRange range = module_.type(param.type).range;
+            for (const gir::Parameter &param : parameters) {
+                const HType       type  = planned_type(param.type);
+                const SourceRange range = graph_type(param.type, {}).range;
                 if (param.is_const)
                 {
-                    selectors.push_back("hgraph::Scalar<" + quote(param.name.text) + ", " + value_type(type, range) + ">");
+                    selectors.push_back("hgraph::Scalar<" + quote(param.name) + ", " + value_type(type, range) + ">");
+                } else {
+                    selectors.push_back("hgraph::In<" + quote(param.name) + ", " + schema(type, range) + ">");
                 }
-                else { selectors.push_back("hgraph::In<" + quote(param.name.text) + ", " + schema(type, range) + ">"); }
             }
-            if (sig->result != ast::no_node)
-            {
-                selectors.push_back("hgraph::Out<" + schema(type_of(sig->result, frame), module_.type(sig->result).range) + ">");
+            if (has_planned_result(result, {})) {
+                selectors.push_back("hgraph::Out<" + schema(planned_type(result), graph_type(result, {}).range) + ">");
             }
             return "hgraph::Operator<" + join(selectors, ", ") + ">";
         }
@@ -3058,7 +3264,7 @@ namespace hgl::codegen
             out.line("// " + where(module_.decl(decl).range));
             if (form == Form::OutOfLine)
             {
-                out.line(result_type(decl, frame) + " " + name + "::compose(" + signature(decl, frame, true) + ")");
+                out.line(result_type(decl) + " " + name + "::compose(" + signature(decl, true) + ")");
             }
             else
             {
@@ -3067,21 +3273,22 @@ namespace hgl::codegen
                 // Defaults of const parameters travel with the graph so the
                 // registry can apply them when the function is called by name.
                 std::vector<std::string> defaults;
-                for (const ast::Parameter &param : fn.signature.parameters)
-                {
+                for (std::size_t index = 0; index < fn.signature.parameters.size(); ++index) {
+                    const ast::Parameter &param = fn.signature.parameters[index];
                     if (!param.is_const || param.default_value == ast::no_node) { continue; }
                     Frame scratch;
                     scratch.fn        = decl;
                     const Value value = eval_expr(param.default_value, scratch);
-                    const HType type  = type_of(param.type, scratch);
-                    defaults.push_back("hgraph::arg<" + quote(param.name.text) + ">(" +
-                                       as_const(value, type, value.range, "default of '" + std::string{param.name.text} + "'") + ")");
+                    const HType type  = planned_type(callable(decl).parameters[index].type, callable(decl).range);
+                    defaults.push_back("hgraph::arg<" + quote(callable(decl).parameters[index].name) + ">(" +
+                                       as_const(value, type, value.range, "default of '" + std::string{param.name.text} + "'") +
+                                       ")");
                 }
                 if (!defaults.empty())
                 {
                     out.line("static auto defaults() { return std::tuple{" + join(defaults, ", ") + "}; }");
                 }
-                out.line("static " + result_type(decl, frame) + " compose(" + signature(decl, frame, form != Form::Declaration) +
+                out.line("static " + result_type(decl) + " compose(" + signature(decl, form != Form::Declaration) +
                          (form == Form::Declaration ? ");" : ")"));
                 if (form == Form::Declaration)
                 {
@@ -3099,13 +3306,15 @@ namespace hgl::codegen
             for (std::size_t i = 0; i < fn.signature.parameters.size(); ++i)
             {
                 const ast::Parameter &param = fn.signature.parameters[i];
-                const HType           type  = type_of(param.type, frame);
-                local_names_.insert(cpp_name(param.name.text));
+                const HType           type  = planned_type(callable(decl).parameters[i].type, callable(decl).range);
+                const std::string     name  = cpp_name(callable(decl).parameters[i].name);
+                local_names_.insert(name);
                 if (param.is_const)
                 {
-                    frame.params[i] = make_const(cpp_name(param.name.text) + ".value()", type, param.name.range);
+                    frame.params[i] = make_const(name + ".value()", type, param.name.range);
+                } else {
+                    frame.params[i] = make_port(name, type, param.name.range);
                 }
-                else { frame.params[i] = make_port(cpp_name(param.name.text), type, param.name.range); }
             }
             out.open("");
             if (fn.concise_body != ast::no_node)
@@ -3291,25 +3500,24 @@ namespace hgl::codegen
             std::map<std::string, std::string> cpp_functions;
             for (const ast::DeclId id : callable_declarations_) {
                 check_supported(id);
-                const ast::FunctionDecl &fn = function(id);
+                const gir::Callable     &fn = callable(id);
                 const std::string        source_name{callable_name(id)};
                 const std::string        generated_name = callable_cpp_name(id);
                 if (const auto [found, inserted] = cpp_functions.emplace(generated_name, source_name);
                     !inserted && found->second != source_name)
                 {
-                    backend(fn.name.range, "C++ function '" + source_name + "' collides with '" + found->second +
-                                               "' as '" + generated_name + "'");
+                    backend(fn.range,
+                            "C++ function '" + source_name + "' collides with '" + found->second + "' as '" + generated_name + "'");
                 }
                 std::map<std::string, std::string> cpp_parameters;
-                for (const ast::Parameter &param : fn.signature.parameters)
-                {
-                    const std::string parameter_name{param.name.text};
+                for (const gir::Parameter &param : fn.parameters) {
+                    const std::string parameter_name{param.name};
                     const std::string generated_parameter = cpp_name(parameter_name);
                     if (const auto [found, inserted] = cpp_parameters.emplace(generated_parameter, parameter_name);
                         !inserted && found->second != parameter_name)
                     {
-                        backend(param.name.range, "C++ parameter '" + parameter_name + "' collides with '" + found->second +
-                                                      "' as '" + generated_parameter + "'");
+                        backend(graph_type(param.type, fn.range).range, "C++ parameter '" + parameter_name + "' collides with '" +
+                                                                            found->second + "' as '" + generated_parameter + "'");
                     }
                 }
                 if (callable(id).visibility == gir::CallableVisibility::Export) { exports.push_back(id); }
@@ -3344,9 +3552,9 @@ namespace hgl::codegen
                 for (const ast::DeclId id : internal)
                 {
                     if (callable(id).kind != gir::CallableKind::RuntimeNode) { continue; }
-                    Frame frame;
-                    frame.fn = id;
-                    body.line("using " + callable_cpp_name(id) + " = " + operator_contract(id, callable(id).identity, frame) + ";");
+                    const gir::Callable &item = callable(id);
+                    body.line("using " + callable_cpp_name(id) + " = " +
+                              operator_contract(item.parameters, item.result, item.identity) + ";");
                 }
                 if (has_internal_runtime)
                 {
@@ -3435,18 +3643,16 @@ namespace hgl::codegen
                 header.open("namespace operators");
                 for (const ast::DeclId id : operator_declarations_) {
                     const gir::OperatorContract &op = operator_decl(id);
-                    Frame                        frame;
                     header.line("// " + where(module_.decl(id).range));
                     header.line("using " + cpp_name(local_identity(op.identity)) + " = " +
-                                operator_contract(id, operator_registry_name(op), frame) + ";");
+                                operator_contract(op.parameters, op.result, operator_registry_name(op)) + ";");
                 }
                 for (const ast::DeclId id : exports)
                 {
-                    Frame frame;
-                    frame.fn = id;
+                    const gir::Callable &item = callable(id);
                     header.line("// " + where(module_.decl(id).range));
-                    header.line("using " + callable_cpp_name(id) + " = " + operator_contract(id, callable(id).identity, frame) +
-                                ";");
+                    header.line("using " + callable_cpp_name(id) + " = " +
+                                operator_contract(item.parameters, item.result, item.identity) + ";");
                 }
                 header.close("  // namespace operators");
                 header.line();

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -8,6 +8,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <algorithm>
+#include <cstdint>
 #include <fstream>
 #include <iterator>
 #include <string>
@@ -38,53 +39,6 @@ namespace
         hgl::ir::hir::Module   hir;
         hgl::hgraph_ir::Module graph;
 
-        [[nodiscard]] hgl::hgraph_ir::Module declaration_plan() const {
-            hgl::hgraph_ir::Module plan;
-            plan.path = resolved.module_path;
-            for (const ast::DeclId id : resolved.operators) {
-                const auto &op = std::get<ast::OperatorDecl>(module.decl(id).node);
-                plan.operators.push_back(
-                    {.identity = resolved.module_path + "." + std::string{op.name.text}, .range = module.decl(id).range});
-            }
-            for (const ast::DeclId id : resolved.functions) {
-                const auto              &fn = std::get<ast::FunctionDecl>(module.decl(id).node);
-                hgl::hgraph_ir::Callable callable;
-                callable.identity = resolved.module_path + "." + std::string{fn.name.text};
-                callable.range    = module.decl(id).range;
-                switch (fn.visibility) {
-                    case ast::FunctionVisibility::Internal:
-                        callable.visibility = hgl::hgraph_ir::CallableVisibility::Internal;
-                        break;
-                    case ast::FunctionVisibility::Export: callable.visibility = hgl::hgraph_ir::CallableVisibility::Export; break;
-                    case ast::FunctionVisibility::Impl:
-                        {
-                            callable.visibility = hgl::hgraph_ir::CallableVisibility::Implementation;
-                            callable.identity += "#" + std::to_string(id);
-                            const Binding &binding          = resolved.implementation_binding(id);
-                            callable.operator_identity      = binding.operator_identity;
-                            callable.operator_registry_name = binding.registry_name;
-                            if (binding.kind == BindingKind::LocalOperator) {
-                                const auto &op             = std::get<ast::OperatorDecl>(module.decl(binding.decl).node);
-                                callable.operator_identity = resolved.module_path + "." + std::string{op.name.text};
-                            } else if (!callable.operator_identity.empty() &&
-                                       std::none_of(plan.operators.begin(), plan.operators.end(), [&](const auto &candidate) {
-                                           return candidate.identity == callable.operator_identity;
-                                       })) {
-                                plan.operators.push_back({.identity      = callable.operator_identity,
-                                                          .registry_name = callable.operator_registry_name,
-                                                          .imported      = true,
-                                                          .range         = module.decl(id).range});
-                            }
-                            break;
-                        }
-                }
-                callable.kind = resolved.kind(id) == FunctionKind::Runtime ? hgl::hgraph_ir::CallableKind::RuntimeNode
-                                                                           : hgl::hgraph_ir::CallableKind::Composition;
-                plan.callables.push_back(std::move(callable));
-            }
-            return plan;
-        }
-
         explicit Unit(std::string text, std::string path = "unit.hgl")
             : file{std::move(path), std::move(text)}, module{parse(file, diagnostics)} {
             resolved = resolve(file, module, kernel_has, diagnostics);
@@ -106,16 +60,16 @@ namespace
                     return;
                 }
             }
-            // Backend-negative tests deliberately stop before typed HIR. They
-            // still need the declaration plan that production obtains from
-            // hgraph IR so the legacy body adapter can report its own error.
-            graph = declaration_plan();
+            for (const Diagnostic &diagnostic : graph_diagnostics.diagnostics()) {
+                Diagnostic &copy = diagnostics.report(diagnostic.category, diagnostic.range, diagnostic.message);
+                copy.notes       = diagnostic.notes;
+            }
         }
 
         [[nodiscard]] std::optional<EmittedModule> emit(EmitOptions options = {})
         {
             INFO(diagnostics.render(file));
-            REQUIRE_FALSE(diagnostics.has_errors());
+            if (diagnostics.has_errors()) { return std::nullopt; }
             if (options.header_name.empty()) { options.header_name = "unit.h"; }
             if (options.tool_version.empty()) { options.tool_version = "test"; }
             return emit_cpp(file, graph, module, resolved, options, diagnostics);
@@ -123,10 +77,12 @@ namespace
 
         [[nodiscard]] bool has(Category category, std::string_view fragment) const
         {
-            return std::any_of(diagnostics.diagnostics().begin(), diagnostics.diagnostics().end(),
-                               [&](const Diagnostic &d) {
-                                   return d.category == category && d.message.find(fragment) != std::string::npos;
-                               });
+            const bool found =
+                std::any_of(diagnostics.diagnostics().begin(), diagnostics.diagnostics().end(), [&](const Diagnostic &d) {
+                    return d.category == category && d.message.find(fragment) != std::string::npos;
+                });
+            if (!found) { WARN(diagnostics.render(file)); }
+            return found;
         }
     };
 
@@ -208,6 +164,13 @@ fn hidden(value: f64) -> f64 => value
     unit.graph.path                         = "planned.module";
     unit.graph.callables.front().identity   = "planned.module.exposed";
     unit.graph.callables.front().visibility = hgl::hgraph_ir::CallableVisibility::Export;
+    const hgl::hgraph_ir::TypeId integer{static_cast<std::uint32_t>(unit.graph.types.size())};
+    unit.graph.types.push_back({.kind   = hgl::ir::hir::TypeKind::Scalar,
+                                .scalar = hgl::ir::hir::ScalarType::I64,
+                                .range  = unit.graph.callables.front().range});
+    unit.graph.callables.front().parameters.front().name = "amount";
+    unit.graph.callables.front().parameters.front().type = integer;
+    unit.graph.callables.front().result                  = integer;
 
     const auto emitted = unit.emit();
     REQUIRE(emitted);
@@ -217,16 +180,40 @@ fn hidden(value: f64) -> f64 => value
     CHECK(contains(emitted->header, "namespace planned::module"));
     CHECK(contains(emitted->header, "struct exposed"));
     CHECK(contains(emitted->header, "static constexpr auto name = \"planned.module.exposed\""));
+    CHECK(contains(emitted->header, "hgraph::In<\"amount\", hgraph::TS<hgraph::Int>>"));
+    CHECK(contains(emitted->header, "hgraph::Out<hgraph::TS<hgraph::Int>>"));
+    CHECK(contains(emitted->source, "hgraph::Port<hgraph::TS<hgraph::Int>> amount"));
+    CHECK(contains(emitted->source, "hgraph::Port<hgraph::TS<hgraph::Int>> exposed::compose"));
+    CHECK(contains(emitted->source, "return amount;"));
+    CHECK_FALSE(contains(emitted->header, "hgraph::TS<hgraph::Float>"));
     CHECK(contains(emitted->source, "register_graph_overload<operators::exposed, exposed>()"));
 }
 
 TEST_CASE("emit-cpp rejects a mismatched syntax compatibility adapter", "[codegen][hgraph-ir]") {
-    Unit unit{"module t\nexport fn value(x: f64) -> f64 => x\n"};
-    REQUIRE(unit.graph.completion == hgl::hgraph_ir::Completion::Bodies);
-    unit.graph.callables.clear();
+    SECTION("a missing callable") {
+        Unit unit{"module t\nexport fn value(x: f64) -> f64 => x\n"};
+        REQUIRE(unit.graph.completion == hgl::hgraph_ir::Completion::Bodies);
+        unit.graph.callables.clear();
 
-    CHECK_FALSE(unit.emit());
-    CHECK(unit.has(Category::Backend, "syntax body adapter disagree"));
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Backend, "syntax body adapter disagree"));
+    }
+    SECTION("a changed parameter count") {
+        Unit unit{"module t\nexport fn value(x: f64) -> f64 => x\n"};
+        REQUIRE(unit.graph.completion == hgl::hgraph_ir::Completion::Bodies);
+        unit.graph.callables.front().parameters.push_back(unit.graph.callables.front().parameters.front());
+
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Backend, "syntax body adapter's signature shape"));
+    }
+    SECTION("a changed parameter role") {
+        Unit unit{"module t\nexport fn value(x: f64) -> f64 => x\n"};
+        REQUIRE(unit.graph.completion == hgl::hgraph_ir::Completion::Bodies);
+        unit.graph.callables.front().parameters.front().is_const = true;
+
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Backend, "syntax body adapter's parameter roles"));
+    }
 }
 
 TEST_CASE("emit-cpp gives operator implementations distinct readable C++ names", "[codegen][hgraph-ir][operators]") {
@@ -264,7 +251,8 @@ export fn selected(value: f64) -> f64 => choose(value)
     REQUIRE(unit.graph.completion == hgl::hgraph_ir::Completion::Bodies);
     REQUIRE(unit.graph.operators.size() == 1);
 
-    unit.graph.operators.front().identity = "renamed_ops.pick";
+    unit.graph.operators.front().identity                = "renamed_ops.pick";
+    unit.graph.operators.front().parameters.front().name = "item";
     for (auto &callable : unit.graph.callables) {
         if (callable.visibility == hgl::hgraph_ir::CallableVisibility::Implementation) {
             callable.operator_identity = unit.graph.operators.front().identity;
@@ -274,6 +262,7 @@ export fn selected(value: f64) -> f64 => choose(value)
     const auto emitted = unit.emit();
     REQUIRE(emitted);
     CHECK(contains(emitted->header, "using pick = hgraph::Operator<"));
+    CHECK(contains(emitted->header, "hgraph::In<\"item\","));
     CHECK(contains(emitted->source, "hgraph::wire<operators::pick>(w, value)"));
     CHECK(contains(emitted->source, "register_graph_overload<operators::pick, pick_impl_"));
     CHECK_FALSE(contains(emitted->source, "operators::choose"));
@@ -372,7 +361,7 @@ export fn f(x: f64) -> f64 {
 }
 )"};
         CHECK_FALSE(unit.emit());
-        CHECK(unit.has(Category::Type, "assignment to 'y' expects hgraph::Int, got hgraph::Float"));
+        CHECK(unit.has(Category::Type, "assignment has type f64, expected i64"));
     }
     SECTION("compound division cannot change an inferred i64 to f64")
     {
@@ -421,7 +410,7 @@ module t
 export fn f(x: f64) -> f64 => x + 1 % 0
 )"};
         CHECK_FALSE(unit.emit());
-        CHECK(unit.has(Category::Type, "division by zero"));
+        CHECK(unit.has(Category::Type, "remainder by zero"));
     }
 }
 
@@ -548,9 +537,9 @@ export fn positive(value: f64) -> f64 {
     {
         Unit unit{R"(
 module t
-export fn sampled(value: f64) -> f64 {
+export fn sampled(value: f64) {
     if valid(value) {
-        when modified(value) { return value }
+        when modified(value) { let sampled = value }
     }
 }
 )"};
@@ -613,7 +602,7 @@ export fn seeded(x: f64) -> f64 {
     {
         Unit unit{R"(
 module t
-export fn recent(window: rolling<f64, 0>) -> f64 => window
+export fn recent(window: rolling<f64, 0>) -> f64 => 1.0
 )"};
         CHECK_FALSE(unit.emit());
         CHECK(unit.has(Category::Type, "a rolling size is a positive i64 constant or a duration"));
@@ -622,10 +611,26 @@ export fn recent(window: rolling<f64, 0>) -> f64 => window
     {
         Unit unit{R"(
 module t
-export fn recent(window: rolling<f64, -1>) -> f64 => window
+export fn recent(window: rolling<f64, -1>) -> f64 => 1.0
 )"};
         CHECK_FALSE(unit.emit());
         CHECK(unit.has(Category::Type, "a rolling size is a positive i64 constant or a duration"));
+    }
+    SECTION("a rolling minimum larger than its maximum") {
+        Unit unit{R"(
+module t
+export fn recent(window: rolling<f64, 5, 6>) -> f64 => 1.0
+)"};
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Type, "minimum no larger than it"));
+    }
+    SECTION("a zero fixed list size") {
+        Unit unit{R"(
+module t
+export fn recent(values: list<f64, 0>) -> f64 => 1.0
+)"};
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Type, "a fixed list size must be a positive i64 literal"));
     }
     SECTION("a missing module declaration")
     {


### PR DESCRIPTION
## Summary
- make HGraph IR authoritative for generated callable and operator interface names, roles, types, and selectors
- fail closed when the temporary syntax body adapter disagrees with planned callable shape
- validate planned list and rolling bounds and document the narrower remaining AST compatibility seam

## Validation
- complete generated-fixture build
- language suite: 30/30 passed

Stacked on #697.