### PR TITLE
refactor(language): render defaults from hgraph IR

### DIFF
--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -189,7 +189,8 @@ endfunction()
 # The C++ backend (src/codegen): emits a header/source pair of public hgraph
 # authoring code per module (developer guide, "C++ backend, first pass").
 # Hgraph IR owns module and callable/operator interfaces while a temporary
-# syntax adapter prints bodies, local annotations, defaults, and struct layouts.
+# syntax adapter prints bodies, local annotations, struct layouts, and their
+# construction defaults.
 add_library(hgl_codegen STATIC
     src/codegen/cpp_emitter.cpp
 )

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -173,9 +173,11 @@ wiring target no longer includes syntax AST headers.
   planning;
 - [x] render callable and operator parameter/result types, names, roles, and
   selector signatures from hgraph IR;
-- [ ] migrate struct layouts, defaults, local annotations, bodies, and
-  dependency emission from the temporary syntax/`ResolvedModule` adapter to
-  hgraph IR;
+- [x] render supported callable parameter defaults and omitted local-call
+  arguments from hgraph IR;
+- [ ] migrate struct layouts and construction defaults, local annotations,
+  bodies, and dependency emission from the temporary syntax/`ResolvedModule`
+  adapter to hgraph IR;
 - remove duplicate name, type, generic, phase, and classification logic from
   the emitter;
 - retain deterministic formatting, source maps, public-SDK code, and readable
@@ -184,9 +186,9 @@ wiring target no longer includes syntax AST headers.
 
 Acceptance: both backends consume the same hgraph IR, existing generated tests
 and installed consumers pass, and architecture tests reject backend-to-syntax
-dependencies. The declaration and interface checkpoints are complete, but
-Stage E remains in progress until the body adapter and its syntax dependency
-are gone.
+dependencies. The declaration, interface, and callable-default checkpoints are
+complete, but Stage E remains in progress until the body adapter and its syntax
+dependency are gone.
 
 ### F. Constrained native interface
 

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -209,14 +209,16 @@ bindings, exports, and registration plans. A declaration range maps each
 planned callable or local operator back to exactly one source declaration; a
 missing, duplicate, or extra mapping is a backend diagnostic. Callable and
 operator parameter/result names, roles, canonical types, rolling-window shapes,
-and generated selector signatures now come from hgraph IR. The range mapping is
-the explicitly temporary adapter through which the existing printer still
-reads syntax bodies, local annotations, default expressions, struct layouts,
-and expression dependencies from the AST and `ResolvedModule`.
+generated selector signatures, and supported callable parameter defaults now
+come from hgraph IR. The range mapping is the explicitly temporary adapter
+through which the existing printer still reads syntax bodies, local
+annotations, struct layouts and construction defaults, and expression
+dependencies from the AST and `ResolvedModule`.
 
 This seam keeps the generated package readable while preventing declaration
 policy from drifting between execution paths. The next Stage E checkpoints
-move struct/default printing and then body/dependency emission to hgraph IR.
+move struct layout and construction-default printing and then body/dependency
+emission to hgraph IR.
 Only after those moves may `codegen` drop its syntax and resolver dependencies.
 
 `src/wiring/type_bridge` is the first direct-backend migration boundary. It
@@ -1220,8 +1222,9 @@ collection traversal, `out`, `logger`, state, and lifecycle hooks. File-based
 `test` and `run` compile/load supported runtime modules on Unix; portable native
 loading and the remaining language-depth items are still staged. Declaration
 and module planning now come from hgraph IR, as does callable/operator interface
-printing. Body-local types, defaults, struct layouts, and dependency discovery
-remain behind the temporary AST adapter.
+printing. Body-local types, struct layouts and construction defaults, and
+dependency discovery remain behind the temporary AST adapter; callable
+parameter defaults do not.
 
 `hgl emit-cpp <file.hgl>` writes one header/source pair named after the
 source — `prices.hgl` becomes `prices.h` and `prices.cpp` — beside the
@@ -1242,10 +1245,12 @@ What is emitted, in this order:
 Before emission, hgraph IR determines the module namespace, source-order
 callable set, visibility, composition/runtime classification, canonical
 callable and operator identities, export surface, registry bindings, and all
-callable/operator parameter and result types. The adapter uses retained source
-ranges only to locate the legacy syntax body, defaults, local annotations, and
-struct layout that must still be printed; it cannot silently add or omit a
-planned declaration.
+callable/operator parameter and result types. Supported callable parameter
+defaults and omitted local-call arguments also use the graph-IR compile-time
+expression arena. The adapter uses retained source ranges only to locate the
+legacy syntax body, local annotations, and struct layout and construction
+defaults that must still be printed; it cannot silently add or omit a planned
+declaration.
 
 - **Operator contracts.** `namespace operators` holds one transparent alias to
   `hgraph::Operator<"module.name",
@@ -1262,8 +1267,10 @@ planned declaration.
   in the header and defined out of line in the source; module-internal
   functions and `impl fn` candidates are whole structs in an anonymous
   namespace of the source, in dependency order (a recursive helper is a
-  diagnostic). `const` parameter defaults become `static auto defaults()`
-  so the registry applies them when the function is called by name.
+  diagnostic). Supported `const` parameter defaults are rendered from hgraph IR
+  into `static auto defaults()` so the registry applies them when the function
+  is called by name. Omitted calls inside another generated function use the
+  same graph-IR default rather than re-reading its syntax expression.
 - **Structural types.** An exported source struct becomes a readable C++
   declaration with `value_type` and `time_series` aliases. `NominalBundle`
   preserves module-qualified identity, abstract parents, and concrete generic

--- a/language/src/README.md
+++ b/language/src/README.md
@@ -16,12 +16,13 @@ them.
 | `driver/` | commands, native build/cache/load, REPL orchestration | assemble inputs and invoke passes |
 
 During migration, `ResolvedModule` and the syntax AST remain a compatibility
-boundary only for C++ bodies, local annotations, default-expression printing,
-struct layouts, and dependency discovery. Module identity, callable visibility
-and classification, operator binding, exports, registration planning, and
-callable/operator interface types and parameter roles already come from hgraph
-IR. New language semantics belong in HIR construction, not in either backend.
-The remaining adapter is named here and must be removed as Stage E advances.
+boundary only for C++ bodies, local annotations, struct layouts and construction
+defaults, and dependency discovery. Module identity, callable visibility and
+classification, operator binding, exports, registration planning,
+callable/operator interfaces, and supported callable parameter defaults already
+come from hgraph IR. New language semantics belong in HIR construction, not in
+either backend. The remaining adapter is named here and must be removed as Stage
+E advances.
 
 Every new pass documents:
 

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -1073,7 +1073,9 @@ namespace hgl::codegen
         }
 
         std::optional<Value> temporal_constant(syntax::TemporalValue literal, SourceRange range) {
-            const std::string micros = std::to_string(literal.micros);
+            const std::string micros = literal.micros == std::numeric_limits<std::int64_t>::min()
+                                           ? "std::numeric_limits<hgraph::TimeDelta::rep>::min()"
+                                           : std::to_string(literal.micros);
             switch (literal.kind) {
                 case syntax::TemporalKind::Date:
                     return make_const("hgraph::Date{std::chrono::sys_days{std::chrono::days{" + micros + "}}}",

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -647,22 +647,24 @@ namespace hgl::codegen
                     }
                 case gir::ConstExprKind::Binary:
                     {
-                        ast::BinaryOp op;
-                        switch (expression.binary) {
-                            case ir::hir::BinaryOp::Mul: op = ast::BinaryOp::Mul; break;
-                            case ir::hir::BinaryOp::Div: op = ast::BinaryOp::Div; break;
-                            case ir::hir::BinaryOp::Rem: op = ast::BinaryOp::Rem; break;
-                            case ir::hir::BinaryOp::Add: op = ast::BinaryOp::Add; break;
-                            case ir::hir::BinaryOp::Sub: op = ast::BinaryOp::Sub; break;
-                            case ir::hir::BinaryOp::Less: op = ast::BinaryOp::Less; break;
-                            case ir::hir::BinaryOp::LessEqual: op = ast::BinaryOp::LessEqual; break;
-                            case ir::hir::BinaryOp::Greater: op = ast::BinaryOp::Greater; break;
-                            case ir::hir::BinaryOp::GreaterEqual: op = ast::BinaryOp::GreaterEqual; break;
-                            case ir::hir::BinaryOp::Equal: op = ast::BinaryOp::Equal; break;
-                            case ir::hir::BinaryOp::NotEqual: op = ast::BinaryOp::NotEqual; break;
-                            case ir::hir::BinaryOp::And: op = ast::BinaryOp::And; break;
-                            case ir::hir::BinaryOp::Or: op = ast::BinaryOp::Or; break;
-                        }
+                        const ast::BinaryOp op = [&] {
+                            switch (expression.binary) {
+                                case ir::hir::BinaryOp::Mul: return ast::BinaryOp::Mul;
+                                case ir::hir::BinaryOp::Div: return ast::BinaryOp::Div;
+                                case ir::hir::BinaryOp::Rem: return ast::BinaryOp::Rem;
+                                case ir::hir::BinaryOp::Add: return ast::BinaryOp::Add;
+                                case ir::hir::BinaryOp::Sub: return ast::BinaryOp::Sub;
+                                case ir::hir::BinaryOp::Less: return ast::BinaryOp::Less;
+                                case ir::hir::BinaryOp::LessEqual: return ast::BinaryOp::LessEqual;
+                                case ir::hir::BinaryOp::Greater: return ast::BinaryOp::Greater;
+                                case ir::hir::BinaryOp::GreaterEqual: return ast::BinaryOp::GreaterEqual;
+                                case ir::hir::BinaryOp::Equal: return ast::BinaryOp::Equal;
+                                case ir::hir::BinaryOp::NotEqual: return ast::BinaryOp::NotEqual;
+                                case ir::hir::BinaryOp::And: return ast::BinaryOp::And;
+                                case ir::hir::BinaryOp::Or: return ast::BinaryOp::Or;
+                            }
+                            std::unreachable();
+                        }();
                         return fold_binary(op, planned_constant(expression.lhs, range), planned_constant(expression.rhs, range),
                                            range);
                     }

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -176,6 +176,9 @@ namespace hgl::codegen
             bool                            has_when{false};
         };
 
+        Value                       make_const(std::string code, HType type, SourceRange range,
+                                               std::variant<std::monostate, std::int64_t, double> number = {});
+        std::optional<Value>        temporal_constant(syntax::TemporalValue literal, SourceRange range);
         std::optional<double>       numeric_value(const Value &value);
         std::optional<std::int64_t> integer_value(const Value &value);
 
@@ -373,6 +376,7 @@ namespace hgl::codegen
             [[nodiscard]] const gir::ConstExpr       &graph_constant(gir::ConstExprId id, SourceRange fallback);
             [[nodiscard]] std::optional<std::int64_t> planned_integer(gir::ConstExprId id, SourceRange fallback);
             [[nodiscard]] bool                        has_planned_result(gir::TypeId id, SourceRange fallback);
+            [[nodiscard]] Value                       planned_constant(gir::ConstExprId id, SourceRange fallback = {});
             [[nodiscard]] std::string value_type(const HType &type, SourceRange range);
             [[nodiscard]] std::string schema(const HType &type, SourceRange range);
             [[nodiscard]] std::string size_text(ast::ExprId id, Frame &frame, std::string_view what);
@@ -395,8 +399,8 @@ namespace hgl::codegen
             [[nodiscard]] std::string argument_code(const Value &value);
             [[nodiscard]] std::string as_port(const Value &value, const HType &temporal, SourceRange range);
             [[nodiscard]] std::string as_const(const Value &value, const HType &target, SourceRange range, const std::string &what);
-            [[nodiscard]] std::vector<ast::ExprId> bind_arguments(const ast::FunctionDecl &fn,
-                                                                  const std::vector<ast::Argument> &arguments, SourceRange range);
+            [[nodiscard]] std::vector<ast::ExprId> bind_arguments(ast::DeclId decl, const std::vector<ast::Argument> &arguments,
+                                                                  SourceRange range);
 
             // -- statements
             void emit_block(ast::BlockId id, Frame &frame, Writer &out, bool function_body);
@@ -442,7 +446,7 @@ namespace hgl::codegen
                                                         bool include_inputs, bool include_output);
             void prepare_runtime_frame(ast::DeclId decl, const RuntimeInfo &info, Frame &frame, Writer &out, bool include_inputs,
                                        bool include_output);
-            void emit_runtime_defaults(ast::DeclId decl, Writer &out);
+            void emit_defaults(const gir::Callable &callable, Writer &out);
             [[nodiscard]] std::vector<ast::DeclId> ordered_internal_functions();
             void collect_calls(ast::ExprId id, std::set<ast::DeclId> &calls);
             void collect_calls_block(ast::BlockId id, std::set<ast::DeclId> &calls);
@@ -522,6 +526,10 @@ namespace hgl::codegen
                         backend(item.range, "hgraph IR callable '" + item.identity +
                                                 "' disagrees with the syntax body adapter's parameter roles");
                     }
+                    if (item.parameters[index].default_value.valid() != (source.parameters[index].default_value != ast::no_node)) {
+                        backend(item.range, "hgraph IR callable '" + item.identity +
+                                                "' disagrees with the syntax body adapter's default shape");
+                    }
                 }
                 if (!callables_.emplace(id, &item).second) {
                     backend(item.range, "more than one hgraph IR callable maps to the same syntax declaration");
@@ -591,6 +599,74 @@ namespace hgl::codegen
             if (expression.kind != gir::ConstExprKind::Literal || !expression.literal) { return std::nullopt; }
             if (const auto *value = std::get_if<std::int64_t>(&*expression.literal)) { return *value; }
             return std::nullopt;
+        }
+
+        Value Emitter::planned_constant(gir::ConstExprId id, SourceRange fallback) {
+            const gir::ConstExpr &expression = graph_constant(id, fallback);
+            const SourceRange     range      = expression.range.end > expression.range.begin ? expression.range : fallback;
+            if (expression.literal) {
+                return std::visit(
+                    [&](const auto &literal) -> Value {
+                        using T = std::decay_t<decltype(literal)>;
+                        if constexpr (std::is_same_v<T, ir::hir::NullValue>) {
+                            unsupported(range, "'null' in a parameter default");
+                        } else if constexpr (std::is_same_v<T, ir::hir::PlaceholderValue>) {
+                            fail(Category::Type, range, "'_' is only valid in a harness sequence");
+                        } else if constexpr (std::is_same_v<T, bool>) {
+                            return make_const(literal ? "true" : "false", scalar_type(ast::ScalarType::Bool), range);
+                        } else if constexpr (std::is_same_v<T, std::int64_t>) {
+                            return make_const("hgraph::Int{" + std::to_string(literal) + "}", scalar_type(ast::ScalarType::I64),
+                                              range, literal);
+                        } else if constexpr (std::is_same_v<T, double>) {
+                            return make_const("hgraph::Float{" + float_literal(literal) + "}", scalar_type(ast::ScalarType::F64),
+                                              range, literal);
+                        } else if constexpr (std::is_same_v<T, std::string>) {
+                            return make_const("hgraph::Str{" + quote(literal) + "}", scalar_type(ast::ScalarType::Str), range);
+                        } else if constexpr (std::is_same_v<T, syntax::TemporalValue>) {
+                            if (std::optional<Value> value = temporal_constant(literal, range)) { return std::move(*value); }
+                            backend(range, "zoned and civil literals are not supported by the first pass");
+                        }
+                    },
+                    *expression.literal);
+            }
+
+            switch (expression.kind) {
+                case gir::ConstExprKind::Unary:
+                    {
+                        const ast::UnaryOp op =
+                            expression.unary == ir::hir::UnaryOp::Negate ? ast::UnaryOp::Negate : ast::UnaryOp::Not;
+                        return fold_unary(op, planned_constant(expression.lhs, range), range);
+                    }
+                case gir::ConstExprKind::Binary:
+                    {
+                        ast::BinaryOp op;
+                        switch (expression.binary) {
+                            case ir::hir::BinaryOp::Mul: op = ast::BinaryOp::Mul; break;
+                            case ir::hir::BinaryOp::Div: op = ast::BinaryOp::Div; break;
+                            case ir::hir::BinaryOp::Rem: op = ast::BinaryOp::Rem; break;
+                            case ir::hir::BinaryOp::Add: op = ast::BinaryOp::Add; break;
+                            case ir::hir::BinaryOp::Sub: op = ast::BinaryOp::Sub; break;
+                            case ir::hir::BinaryOp::Less: op = ast::BinaryOp::Less; break;
+                            case ir::hir::BinaryOp::LessEqual: op = ast::BinaryOp::LessEqual; break;
+                            case ir::hir::BinaryOp::Greater: op = ast::BinaryOp::Greater; break;
+                            case ir::hir::BinaryOp::GreaterEqual: op = ast::BinaryOp::GreaterEqual; break;
+                            case ir::hir::BinaryOp::Equal: op = ast::BinaryOp::Equal; break;
+                            case ir::hir::BinaryOp::NotEqual: op = ast::BinaryOp::NotEqual; break;
+                            case ir::hir::BinaryOp::And: op = ast::BinaryOp::And; break;
+                            case ir::hir::BinaryOp::Or: op = ast::BinaryOp::Or; break;
+                        }
+                        return fold_binary(op, planned_constant(expression.lhs, range), planned_constant(expression.rhs, range),
+                                           range);
+                    }
+                case gir::ConstExprKind::Parameter: unsupported(range, "a generic parameter in a parameter default");
+                case gir::ConstExprKind::Index: unsupported(range, "an indexed parameter default");
+                case gir::ConstExprKind::Field: unsupported(range, "a field-read parameter default");
+                case gir::ConstExprKind::Sequence: unsupported(range, "a list or map parameter default");
+                case gir::ConstExprKind::Tuple: unsupported(range, "a tuple parameter default");
+                case gir::ConstExprKind::Construct: unsupported(range, "a struct parameter default");
+                case gir::ConstExprKind::Literal: break;
+            }
+            backend(range, "hgraph IR contains an incomplete constant expression");
         }
 
         HType Emitter::planned_type(gir::TypeId id, SourceRange fallback) {
@@ -978,8 +1054,7 @@ namespace hgl::codegen
         // ------------------------------------------------------------ values
 
         Value make_const(std::string code, HType type, SourceRange range,
-                         std::variant<std::monostate, std::int64_t, double> number = {})
-        {
+                         std::variant<std::monostate, std::int64_t, double> number) {
             Value value;
             value.kind  = Value::Kind::Const;
             value.code  = std::move(code);
@@ -987,6 +1062,27 @@ namespace hgl::codegen
             value.range = range;
             value.number = std::move(number);
             return value;
+        }
+
+        std::optional<Value> temporal_constant(syntax::TemporalValue literal, SourceRange range) {
+            const std::string micros = std::to_string(literal.micros);
+            switch (literal.kind) {
+                case syntax::TemporalKind::Date:
+                    return make_const("hgraph::Date{std::chrono::sys_days{std::chrono::days{" + micros + "}}}",
+                                      scalar_type(ast::ScalarType::Date), range);
+                case syntax::TemporalKind::Time:
+                    return make_const("hgraph::Time{" + micros + "}", scalar_type(ast::ScalarType::Time), range);
+                case syntax::TemporalKind::DateTime:
+                    return make_const("hgraph::DateTime{std::chrono::microseconds{" + micros + "}}",
+                                      scalar_type(ast::ScalarType::DateTime), range);
+                case syntax::TemporalKind::Duration:
+                    return make_const("hgraph::TimeDelta{" + micros + "}", scalar_type(ast::ScalarType::Duration), range);
+                case syntax::TemporalKind::CivilDateTime:
+                case syntax::TemporalKind::ZonedDateTime:
+                case syntax::TemporalKind::ZonedTime:
+                case syntax::TemporalKind::TimeZone: return std::nullopt;
+            }
+            return std::nullopt;
         }
 
         std::optional<double> numeric_value(const Value &value)
@@ -1499,26 +1595,7 @@ namespace hgl::codegen
                     else if constexpr (std::is_same_v<T, ast::NullLiteral>) { unsupported(expr.range, "'null'"); }
                     else if constexpr (std::is_same_v<T, ast::TemporalLiteral>)
                     {
-                        using syntax::TemporalKind;
-                        const std::string micros = std::to_string(node.value.micros);
-                        switch (node.value.kind)
-                        {
-                            case TemporalKind::Date:
-                                return make_const("hgraph::Date{std::chrono::sys_days{std::chrono::days{" + micros + "}}}",
-                                                  scalar_type(ast::ScalarType::Date), expr.range);
-                            case TemporalKind::Time:
-                                return make_const("hgraph::Time{" + micros + "}", scalar_type(ast::ScalarType::Time), expr.range);
-                            case TemporalKind::DateTime:
-                                return make_const("hgraph::DateTime{std::chrono::microseconds{" + micros + "}}",
-                                                  scalar_type(ast::ScalarType::DateTime), expr.range);
-                            case TemporalKind::Duration:
-                                return make_const("hgraph::TimeDelta{" + micros + "}", scalar_type(ast::ScalarType::Duration),
-                                                  expr.range);
-                            case TemporalKind::CivilDateTime:
-                            case TemporalKind::ZonedDateTime:
-                            case TemporalKind::ZonedTime:
-                            case TemporalKind::TimeZone: break;
-                        }
+                        if (std::optional<Value> value = temporal_constant(node.value, expr.range)) { return std::move(*value); }
                         backend(expr.range, "zoned and civil literals are not supported by the first pass");
                     }
                     else if constexpr (std::is_same_v<T, ast::Placeholder>)
@@ -1963,10 +2040,10 @@ namespace hgl::codegen
                                "' is a runtime traversal; it is not available in a composition body of the first pass");
         }
 
-        std::vector<ast::ExprId> Emitter::bind_arguments(const ast::FunctionDecl &fn, const std::vector<ast::Argument> &arguments,
-                                                         SourceRange range)
-        {
-            const auto              &params = fn.signature.parameters;
+        std::vector<ast::ExprId> Emitter::bind_arguments(ast::DeclId decl, const std::vector<ast::Argument> &arguments,
+                                                         SourceRange range) {
+            const gir::Callable     &fn     = callable(decl);
+            const auto              &params = fn.parameters;
             std::vector<ast::ExprId> bound(params.size(), ast::no_node);
             std::size_t              next = 0;
             for (const ast::Argument &argument : arguments)
@@ -1976,18 +2053,20 @@ namespace hgl::codegen
                 {
                     if (next >= params.size())
                     {
-                        fail(Category::Type, at, "'" + std::string{fn.name.text} + "' takes " + std::to_string(params.size()) + " arguments");
+                        fail(Category::Type, at,
+                             "'" + std::string{callable_name(decl)} + "' takes " + std::to_string(params.size()) + " arguments");
                     }
                     if (bound[next] != ast::no_node) { fail(Category::Type, at, "positional argument after a named one"); }
                     bound[next++] = argument.value;
                     continue;
                 }
                 const auto found = std::find_if(params.begin(), params.end(),
-                                                [&](const ast::Parameter &param) { return param.name.text == argument.name.text; });
+                                                [&](const gir::Parameter &param) { return param.name == argument.name.text; });
                 if (found == params.end())
                 {
                     fail(Category::Name, argument.name.range,
-                         "'" + std::string{fn.name.text} + "' has no parameter named '" + std::string{argument.name.text} + "'");
+                         "'" + std::string{callable_name(decl)} + "' has no parameter named '" + std::string{argument.name.text} +
+                             "'");
                 }
                 const auto index = static_cast<std::size_t>(found - params.begin());
                 if (bound[index] != ast::no_node)
@@ -1999,10 +2078,9 @@ namespace hgl::codegen
             }
             for (std::size_t i = 0; i < params.size(); ++i)
             {
-                if (bound[i] == ast::no_node && params[i].default_value == ast::no_node)
-                {
+                if (bound[i] == ast::no_node && !params[i].default_value.valid()) {
                     fail(Category::Type, range,
-                         "'" + std::string{fn.name.text} + "' needs an argument for '" + std::string{params[i].name.text} + "'");
+                         "'" + std::string{callable_name(decl)} + "' needs an argument for '" + params[i].name + "'");
                 }
             }
             return bound;
@@ -2015,21 +2093,17 @@ namespace hgl::codegen
         Value Emitter::call_function(ast::DeclId decl, const std::vector<ast::Argument> &arguments, SourceRange range, Frame &frame)
         {
             check_supported(decl);
-            const ast::FunctionDecl       &fn    = function(decl);
             const gir::Callable           &planned = callable(decl);
-            const std::vector<ast::ExprId> bound = bind_arguments(fn, arguments, range);
-            const auto                    &params = fn.signature.parameters;
-            Frame                          callee;
-            callee.fn = decl;
-            std::vector<std::string> args(params.size());
-            for (std::size_t i = 0; i < params.size(); ++i)
-            {
-                const ast::Parameter &param = params[i];
-                Value arg = bound[i] != ast::no_node ? eval_expr(bound[i], frame) : eval_expr(param.default_value, callee);
-                const HType           type  = planned_type(planned.parameters[i].type, planned.range);
+            const std::vector<ast::ExprId> bound   = bind_arguments(decl, arguments, range);
+            std::vector<std::string>       args(planned.parameters.size());
+            for (std::size_t i = 0; i < planned.parameters.size(); ++i) {
+                const gir::Parameter &param = planned.parameters[i];
+                Value                 arg =
+                    bound[i] != ast::no_node ? eval_expr(bound[i], frame) : planned_constant(param.default_value, planned.range);
+                const HType type = planned_type(param.type, planned.range);
                 if (param.is_const)
                 {
-                    args[i] = as_const(arg, type, arg.range, "parameter '" + planned.parameters[i].name + "'");
+                    args[i] = as_const(arg, type, arg.range, "parameter '" + param.name + "'");
                 }
                 else { args[i] = as_port(arg, type, arg.range); }
             }
@@ -3043,28 +3117,16 @@ namespace hgl::codegen
             }
         }
 
-        void Emitter::emit_runtime_defaults(ast::DeclId decl, Writer &out)
-        {
-            const ast::FunctionDecl &fn = function(decl);
-            const gir::Callable     &planned = callable(decl);
+        void Emitter::emit_defaults(const gir::Callable &planned, Writer &out) {
             std::vector<std::string> defaults;
-            for (std::size_t index = 0; index < fn.signature.parameters.size(); ++index) {
-                const ast::Parameter &param = fn.signature.parameters[index];
-                if (!param.is_const || param.default_value == ast::no_node)
-                {
-                    continue;
-                }
-                Frame scratch;
-                scratch.fn        = decl;
-                const Value value = eval_expr(param.default_value, scratch);
-                const HType type  = planned_type(planned.parameters[index].type, planned.range);
-                defaults.push_back("hgraph::arg<" + quote(planned.parameters[index].name) + ">(" +
-                                   as_const(value, type, value.range, "default of '" + std::string{param.name.text} + "'") + ")");
+            for (const gir::Parameter &param : planned.parameters) {
+                if (!param.is_const || !param.default_value.valid()) { continue; }
+                const Value value = planned_constant(param.default_value, planned.range);
+                const HType type  = planned_type(param.type, planned.range);
+                defaults.push_back("hgraph::arg<" + quote(param.name) + ">(" +
+                                   as_const(value, type, value.range, "default of '" + param.name + "'") + ")");
             }
-            if (!defaults.empty())
-            {
-                out.line("static auto defaults() { return std::tuple{" + join(defaults, ", ") + "}; }");
-            }
+            if (!defaults.empty()) { out.line("static auto defaults() { return std::tuple{" + join(defaults, ", ") + "}; }"); }
         }
 
         void Emitter::emit_runtime_function(ast::DeclId decl, Writer &out)
@@ -3077,7 +3139,7 @@ namespace hgl::codegen
             out.line("// " + where(module_.decl(decl).range));
             out.open("struct " + callable_cpp_name(decl));
             out.line("[[maybe_unused]] static constexpr auto name = " + quote(callable(decl).identity) + ";");
-            emit_runtime_defaults(decl, out);
+            emit_defaults(callable(decl), out);
             if (!info.states.empty())
             {
                 std::vector<std::string> fields;
@@ -3272,22 +3334,7 @@ namespace hgl::codegen
                 out.line("[[maybe_unused]] static constexpr auto name = " + quote(callable(decl).identity) + ";");
                 // Defaults of const parameters travel with the graph so the
                 // registry can apply them when the function is called by name.
-                std::vector<std::string> defaults;
-                for (std::size_t index = 0; index < fn.signature.parameters.size(); ++index) {
-                    const ast::Parameter &param = fn.signature.parameters[index];
-                    if (!param.is_const || param.default_value == ast::no_node) { continue; }
-                    Frame scratch;
-                    scratch.fn        = decl;
-                    const Value value = eval_expr(param.default_value, scratch);
-                    const HType type  = planned_type(callable(decl).parameters[index].type, callable(decl).range);
-                    defaults.push_back("hgraph::arg<" + quote(callable(decl).parameters[index].name) + ">(" +
-                                       as_const(value, type, value.range, "default of '" + std::string{param.name.text} + "'") +
-                                       ")");
-                }
-                if (!defaults.empty())
-                {
-                    out.line("static auto defaults() { return std::tuple{" + join(defaults, ", ") + "}; }");
-                }
+                emit_defaults(callable(decl), out);
                 out.line("static " + result_type(decl) + " compose(" + signature(decl, form != Form::Declaration) +
                          (form == Form::Declaration ? ");" : ")"));
                 if (form == Form::Declaration)

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -1,6 +1,7 @@
 #include "codegen/cpp_emitter.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <cstdio>
 #include <functional>
@@ -267,8 +268,16 @@ namespace hgl::codegen
             return out + "\"";
         }
 
-        std::string float_literal(double value)
-        {
+        std::string integer_literal(std::int64_t value) {
+            if (value == std::numeric_limits<std::int64_t>::min()) { return "std::numeric_limits<hgraph::Int>::min()"; }
+            return "hgraph::Int{" + std::to_string(value) + "}";
+        }
+
+        std::string float_literal(double value) {
+            if (std::isnan(value)) { return "std::numeric_limits<hgraph::Float>::quiet_NaN()"; }
+            if (std::isinf(value)) {
+                return std::string{std::signbit(value) ? "-" : ""} + "std::numeric_limits<hgraph::Float>::infinity()";
+            }
             char buffer[64];
             std::snprintf(buffer, sizeof buffer, "%.17g", value);
             std::string text{buffer};
@@ -615,8 +624,7 @@ namespace hgl::codegen
                         } else if constexpr (std::is_same_v<T, bool>) {
                             return make_const(literal ? "true" : "false", scalar_type(ast::ScalarType::Bool), range);
                         } else if constexpr (std::is_same_v<T, std::int64_t>) {
-                            return make_const("hgraph::Int{" + std::to_string(literal) + "}", scalar_type(ast::ScalarType::I64),
-                                              range, literal);
+                            return make_const(integer_literal(literal), scalar_type(ast::ScalarType::I64), range, literal);
                         } else if constexpr (std::is_same_v<T, double>) {
                             return make_const("hgraph::Float{" + float_literal(literal) + "}", scalar_type(ast::ScalarType::F64),
                                               range, literal);
@@ -1576,8 +1584,8 @@ namespace hgl::codegen
                     using T = std::decay_t<decltype(node)>;
                     if constexpr (std::is_same_v<T, ast::IntLiteral>)
                     {
-                        return make_const("hgraph::Int{" + std::to_string(node.value) + "}", scalar_type(ast::ScalarType::I64),
-                                          expr.range, static_cast<std::int64_t>(node.value));
+                        return make_const(integer_literal(node.value), scalar_type(ast::ScalarType::I64), expr.range,
+                                          static_cast<std::int64_t>(node.value));
                     }
                     else if constexpr (std::is_same_v<T, ast::FloatLiteral>)
                     {
@@ -3678,6 +3686,7 @@ namespace hgl::codegen
             header.line();
             header.line("#include <chrono>");
             header.line("#include <cstdint>");
+            header.line("#include <limits>");
             header.line("#include <stdexcept>");
             header.line("#include <tuple>");
             header.line();

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -121,6 +121,7 @@ TEST_CASE("emit-cpp names the pair after the module and exports its functions", 
     CHECK(contains(emitted->header, "static auto defaults() { return std::tuple{hgraph::arg<\"k\">(hgraph::Float{2.0})}; }"));
     CHECK(contains(emitted->header, "std::numeric_limits<hgraph::Float>::infinity()"));
     CHECK(contains(emitted->header, "std::numeric_limits<hgraph::Int>::min()"));
+    CHECK(contains(emitted->source, "std::numeric_limits<hgraph::TimeDelta::rep>::min()"));
     CHECK(contains(emitted->header, "hgraph::OperatorProviderHandle register_operators();"));
     CHECK_FALSE(contains(emitted->header, "struct scale\n"));  // module-internal (scaled_sum is exported)
 

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -119,6 +119,8 @@ TEST_CASE("emit-cpp names the pair after the module and exports its functions", 
                                     "hgraph::Port<hgraph::TS<hgraph::Float>>, hgraph::Port<hgraph::TS<hgraph::Float>>);"));
     CHECK(contains(emitted->header, "hgraph::Scalar<\"k\", hgraph::Float>"));
     CHECK(contains(emitted->header, "static auto defaults() { return std::tuple{hgraph::arg<\"k\">(hgraph::Float{2.0})}; }"));
+    CHECK(contains(emitted->header, "std::numeric_limits<hgraph::Float>::infinity()"));
+    CHECK(contains(emitted->header, "std::numeric_limits<hgraph::Int>::min()"));
     CHECK(contains(emitted->header, "hgraph::OperatorProviderHandle register_operators();"));
     CHECK_FALSE(contains(emitted->header, "struct scale\n"));  // module-internal (scaled_sum is exported)
 

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -214,6 +214,39 @@ TEST_CASE("emit-cpp rejects a mismatched syntax compatibility adapter", "[codege
         CHECK_FALSE(unit.emit());
         CHECK(unit.has(Category::Backend, "syntax body adapter's parameter roles"));
     }
+    SECTION("a changed default shape") {
+        Unit unit{"module t\nexport fn value(x: f64, const factor: f64 = 2.0) -> f64 => x * factor\n"};
+        REQUIRE(unit.graph.completion == hgl::hgraph_ir::Completion::Bodies);
+        unit.graph.callables.front().parameters.back().default_value = {};
+
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Backend, "syntax body adapter's default shape"));
+    }
+}
+
+TEST_CASE("emit-cpp renders defaults and omitted arguments from hgraph IR", "[codegen][hgraph-ir][defaults]") {
+    Unit unit{R"(
+module planned_defaults
+
+fn scaled(value: f64, const factor: f64 = 2.0) -> f64 => value * factor
+export fn result(value: f64) -> f64 => scaled(value)
+)"};
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+    REQUIRE(unit.graph.completion == hgl::hgraph_ir::Completion::Bodies);
+    const auto scaled = std::find_if(unit.graph.callables.begin(), unit.graph.callables.end(),
+                                     [](const auto &callable) { return callable.identity == "planned_defaults.scaled"; });
+    REQUIRE(scaled != unit.graph.callables.end());
+    REQUIRE(scaled->parameters.size() == 2);
+    const hgl::hgraph_ir::ConstExprId default_value = scaled->parameters.back().default_value;
+    REQUIRE(default_value.valid());
+    REQUIRE(default_value.value < unit.graph.const_exprs.size());
+    unit.graph.const_exprs[default_value.value].literal = std::int64_t{7};
+
+    const auto emitted = unit.emit();
+    REQUIRE(emitted);
+    CHECK(contains(emitted->source, "hgraph::arg<\"factor\">(static_cast<hgraph::Float>(hgraph::Int{7}))"));
+    CHECK(contains(emitted->source, "hgraph::wire<scaled>(w, value, static_cast<hgraph::Float>(hgraph::Int{7}))"));
+    CHECK_FALSE(contains(emitted->source, "hgraph::Float{2.0}"));
 }
 
 TEST_CASE("emit-cpp gives operator implementations distinct readable C++ names", "[codegen][hgraph-ir][operators]") {

--- a/language/tests/codegen/parity.hgl
+++ b/language/tests/codegen/parity.hgl
@@ -14,7 +14,7 @@ export fn plus(a: f64, b: f64) -> f64 => a + b
 export fn scaled_sum(a: f64, b: f64, const k: f64 = 2.0) -> f64 =>
     scale(plus(a, b), k)
 
-export fn above(x: f64, const threshold: f64) -> bool =>
+export fn above(x: f64, const threshold: f64 = 1e308 * 1e308) -> bool =>
     x > threshold
 
 export fn maybe_double(x: f64, const enabled: bool = true) -> f64 {
@@ -24,7 +24,7 @@ export fn maybe_double(x: f64, const enabled: bool = true) -> f64 {
     x
 }
 
-export fn offset_by(x: f64, const delta: i64) -> f64 {
+export fn offset_by(x: f64, const delta: i64 = -9223372036854775807 - 1) -> f64 {
     let shift = delta * 2
     x + shift
 }

--- a/language/tests/codegen/parity.hgl
+++ b/language/tests/codegen/parity.hgl
@@ -9,6 +9,16 @@ module hgl.codegen.parity
 
 fn scale(x: f64, const k: f64) -> f64 => x * k
 
+fn duration_default(
+    x: f64,
+    const delay: duration = 0us - 9223372036854775807us - 1us,
+) -> f64 {
+    if delay < 0us {
+        return x + 0.0
+    }
+    x + 0.0
+}
+
 export fn plus(a: f64, b: f64) -> f64 => a + b
 
 export fn scaled_sum(a: f64, b: f64, const k: f64 = 2.0) -> f64 =>


### PR DESCRIPTION
## Summary
- render supported callable parameter defaults from the HGraph IR constant-expression arena
- use the same planned defaults when generated functions omit local-call arguments
- render minimum integers, non-finite floats, and minimum durations with portable C++ spellings
- fail closed when the temporary AST body adapter disagrees about default presence and document the narrower remaining seam
- make binary-expression lowering exhaustive so GCC cannot observe an uninitialized planned operator

## Validation
- complete generated-fixture build, including compiling numeric and temporal edge defaults
- focused codegen suite: 20 cases / 190 assertions
- full stacked language suite on the current merged main: 30/30 passed
- fresh native acceptance suite at the stack tip: 1,716/1,716 passed
- Python 3.12 ABI3 wheel installed into fresh Python 3.14 at the stack tip: 3,240 passed, 10 skipped

Stacked on #699 and rebased onto the current merged main.