### PR TITLE
Parity: carrier templates for the RFC 0033 fix shapes

### DIFF
--- a/docs/source/developer_guide/parity_matrix.rst
+++ b/docs/source/developer_guide/parity_matrix.rst
@@ -581,6 +581,17 @@ Types and scalars
    * - ``TSL``
      - Full
      - Fixed and dynamic.
+   * - Type arguments (``type[...]``, RFC 0033)
+     - Full, two accepted deviations
+     - Matched, deferred, materialised and ranked by the registry; the parity
+       templates ``type_argument_*`` replay the four fix shapes identically
+       against 0.5. Accepted deviations found by them: ``const(1, TS[float])``
+       converts the value at the selected type here, where 0.5 raises
+       ``TypeError`` at runtime (additive); a ``type[SCALAR]`` carrier resolved
+       from ``TS[frozenset[int]]`` reads back as ``frozenset[int]`` here (the
+       reverse binding hands back what was written) where 0.5 spells it
+       ``collections.abc.Set[int]`` -- the same parameterised generic, which
+       is what the template compares.
    * - ``Frame[Rows, Metadata]``
      - Full for typed value transport and metadata-aware table transforms
      - Metadata is encoded field by field in Arrow schema metadata: supported

--- a/docs/source/developer_guide/parity_testing.rst
+++ b/docs/source/developer_guide/parity_testing.rst
@@ -329,6 +329,21 @@ and extending as new regressions are identified:
   ``debug_``, and both ordinary graph evaluation and Arrow's standalone
   ``eval_`` runner.  Its first seed found that ``eval_`` closed the graph before
   client-defined concrete leaves were registered.
+- ``type_argument_positional``, ``type_argument_default_order``,
+  ``type_argument_size_pin`` and ``type_argument_collection`` cover the four
+  type-argument fix shapes the 2026-09 fix-series retrospective catalogued
+  and RFC 0033 moved into the registry: the type as the positional argument
+  after the value (``const(value, TS[float])``, ``nothing(TS[int])``), a
+  bare graph subscript filling the ``DEFAULT`` variable ahead of an
+  ``AUTO_RESOLVE`` one declared first, a ``type[SIZE]`` resolved from a
+  ``TSL`` input or pinned by ``g[Size[n]]`` reaching the body as the
+  ``Size`` object, and a ``type[SCALAR]`` carrier resolved from a
+  ``TS[tuple[int, ...]]`` / ``TS[frozenset[int]]`` input reading back as the
+  parameterised generic.  Each is written in its released 0.5 spelling and
+  makes the materialised type observable on every tick, so a wrong carrier
+  form diverges rather than merely wiring.  The ``coverage-type-argument-*``
+  corpus recipes pin them; they are corpus-only (no generator strategy),
+  like the other public-contract templates.
 
 When a new compatibility issue is fixed, extend this list: either an
 existing template's generated space must provably contain the issue's

--- a/docs/source/rfc/rfc_0033_type_carrier_resolution.rst
+++ b/docs/source/rfc/rfc_0033_type_carrier_resolution.rst
@@ -924,9 +924,13 @@ Ratchets (``python/tests/test_architecture_ratchets.py``)
 
 Parity
    The ``tools/parity`` nightly shards run on each PR's wheel; the campaign
-   catalogue gains carrier templates for the fix shapes the retrospective
+   catalogue gained carrier templates for the fix shapes the retrospective
    catalogued (positional ``tp``, ``DEFAULT`` before ``AUTO_RESOLVE``, size
-   pins, collection carriers).
+   pins, collection carriers): ``type_argument_positional``,
+   ``type_argument_default_order``, ``type_argument_size_pin`` and
+   ``type_argument_collection`` with the ``coverage-type-argument-*``
+   corpus recipes, each replayed identically against the 0.5 reference
+   (``parity_testing.rst``).
 
 Documentation, in the same change as the code (CLAUDE.md section 2)
    ``operators.rst`` gains a "Type arguments" section (the ``TypeArg``

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -269,6 +269,59 @@ def test_realtime_default_start_recipe_requires_one_boolean_probe():
         validate_recipe(Recipe.from_dict(raw))
 
 
+def _type_argument_recipe(template, inputs, parameters):
+    return Recipe.from_dict(
+        {
+            "schema_version": 1,
+            "id": f"test-{template.replace('_', '-')}",
+            "description": "test",
+            "template": template,
+            "inputs": inputs,
+            "parameters": parameters,
+            "features": ["compatibility:release-0.5"],
+        }
+    )
+
+
+def test_type_argument_templates_reject_unbounded_parameters():
+    # RFC 0033 fix shapes: each template accepts exactly its bounded space.
+    validate_recipe(_type_argument_recipe(
+        "type_argument_positional", {"value": [1, None, 2.5]}, {"mode": "nothing", "offset": 2}))
+    with pytest.raises(RecipeError, match="mode must be one of"):
+        validate_recipe(_type_argument_recipe(
+            "type_argument_positional", {"value": [1]}, {"mode": "replay"}))
+    with pytest.raises(RecipeError, match="offset must be an integer"):
+        validate_recipe(_type_argument_recipe(
+            "type_argument_positional", {"value": [1]}, {"offset": 1000}))
+    with pytest.raises(RecipeError, match="value ticks must be numbers"):
+        validate_recipe(_type_argument_recipe(
+            "type_argument_positional", {"value": ["x"]}, {}))
+
+    validate_recipe(_type_argument_recipe(
+        "type_argument_default_order", {"value": [1, None]}, {"pinned": "str", "inferred": "float"}))
+    with pytest.raises(RecipeError, match="pinned must be one of"):
+        validate_recipe(_type_argument_recipe(
+            "type_argument_default_order", {"value": [1]}, {"pinned": "complex"}))
+
+    validate_recipe(_type_argument_recipe(
+        "type_argument_size_pin", {"values": [[1, 2], None]}, {"mode": "subscript", "size": 2}))
+    with pytest.raises(RecipeError, match="integer lists of the declared size"):
+        validate_recipe(_type_argument_recipe(
+            "type_argument_size_pin", {"values": [[1, 2, 3]]}, {"size": 2}))
+    with pytest.raises(RecipeError, match="size must be an integer in"):
+        validate_recipe(_type_argument_recipe(
+            "type_argument_size_pin", {"values": [[1]]}, {"size": 9}))
+
+    validate_recipe(_type_argument_recipe(
+        "type_argument_collection", {"values": [[1, 2], None, []]}, {"collection": "frozenset"}))
+    with pytest.raises(RecipeError, match="collection must be one of"):
+        validate_recipe(_type_argument_recipe(
+            "type_argument_collection", {"values": [[1]]}, {"collection": "list"}))
+    with pytest.raises(RecipeError, match="requires inputs"):
+        validate_recipe(_type_argument_recipe(
+            "type_argument_collection", {"value": [[1]]}, {}))
+
+
 def test_value_consumer_reference_recipe_rejects_parameters():
     raw = {
         "schema_version": 1,

--- a/python/tests/test_parity_harness.py
+++ b/python/tests/test_parity_harness.py
@@ -283,43 +283,36 @@ def _type_argument_recipe(template, inputs, parameters):
     )
 
 
-def test_type_argument_templates_reject_unbounded_parameters():
+_TYPE_ARGUMENT_ACCEPTED = [
     # RFC 0033 fix shapes: each template accepts exactly its bounded space.
-    validate_recipe(_type_argument_recipe(
-        "type_argument_positional", {"value": [1, None, 2.5]}, {"mode": "nothing", "offset": 2}))
-    with pytest.raises(RecipeError, match="mode must be one of"):
-        validate_recipe(_type_argument_recipe(
-            "type_argument_positional", {"value": [1]}, {"mode": "replay"}))
-    with pytest.raises(RecipeError, match="offset must be an integer"):
-        validate_recipe(_type_argument_recipe(
-            "type_argument_positional", {"value": [1]}, {"offset": 1000}))
-    with pytest.raises(RecipeError, match="value ticks must be numbers"):
-        validate_recipe(_type_argument_recipe(
-            "type_argument_positional", {"value": ["x"]}, {}))
+    ("type_argument_positional", {"value": [1, None, 2.5]}, {"mode": "nothing", "offset": 2}),
+    ("type_argument_default_order", {"value": [1, None]}, {"pinned": "str", "inferred": "float"}),
+    ("type_argument_size_pin", {"values": [[1, 2], None]}, {"mode": "subscript", "size": 2}),
+    ("type_argument_collection", {"values": [[1, 2], None, []]}, {"collection": "frozenset"}),
+]
 
-    validate_recipe(_type_argument_recipe(
-        "type_argument_default_order", {"value": [1, None]}, {"pinned": "str", "inferred": "float"}))
-    with pytest.raises(RecipeError, match="pinned must be one of"):
-        validate_recipe(_type_argument_recipe(
-            "type_argument_default_order", {"value": [1]}, {"pinned": "complex"}))
+_TYPE_ARGUMENT_REJECTED = [
+    ("type_argument_positional", {"value": [1]}, {"mode": "replay"}, "mode must be one of"),
+    ("type_argument_positional", {"value": [1]}, {"offset": 1000}, "offset must be an integer"),
+    ("type_argument_positional", {"value": ["x"]}, {}, "value ticks must be numbers"),
+    ("type_argument_default_order", {"value": [1]}, {"pinned": "complex"}, "pinned must be one of"),
+    ("type_argument_size_pin", {"values": [[1, 2, 3]]}, {"size": 2}, "integer lists of the declared size"),
+    ("type_argument_size_pin", {"values": [[1]]}, {"size": 9}, "size must be an integer in"),
+    ("type_argument_collection", {"values": [[1]]}, {"collection": "list"}, "collection must be one of"),
+    ("type_argument_collection", {"value": [[1]]}, {}, "requires inputs"),
+]
 
-    validate_recipe(_type_argument_recipe(
-        "type_argument_size_pin", {"values": [[1, 2], None]}, {"mode": "subscript", "size": 2}))
-    with pytest.raises(RecipeError, match="integer lists of the declared size"):
-        validate_recipe(_type_argument_recipe(
-            "type_argument_size_pin", {"values": [[1, 2, 3]]}, {"size": 2}))
-    with pytest.raises(RecipeError, match="size must be an integer in"):
-        validate_recipe(_type_argument_recipe(
-            "type_argument_size_pin", {"values": [[1]]}, {"size": 9}))
 
-    validate_recipe(_type_argument_recipe(
-        "type_argument_collection", {"values": [[1, 2], None, []]}, {"collection": "frozenset"}))
-    with pytest.raises(RecipeError, match="collection must be one of"):
-        validate_recipe(_type_argument_recipe(
-            "type_argument_collection", {"values": [[1]]}, {"collection": "list"}))
-    with pytest.raises(RecipeError, match="requires inputs"):
-        validate_recipe(_type_argument_recipe(
-            "type_argument_collection", {"value": [[1]]}, {}))
+@pytest.mark.parametrize("template,inputs,parameters", _TYPE_ARGUMENT_ACCEPTED)
+def test_type_argument_templates_accept_bounded_parameters(template, inputs, parameters):
+    validate_recipe(_type_argument_recipe(template, inputs, parameters))
+
+
+@pytest.mark.parametrize("template,inputs,parameters,message", _TYPE_ARGUMENT_REJECTED)
+def test_type_argument_templates_reject_unbounded_parameters(template, inputs, parameters, message):
+    recipe = _type_argument_recipe(template, inputs, parameters)
+    with pytest.raises(RecipeError, match=message):
+        validate_recipe(recipe)
 
 
 def test_value_consumer_reference_recipe_rejects_parameters():

--- a/tools/parity/catalog.py
+++ b/tools/parity/catalog.py
@@ -2932,6 +2932,226 @@ def _json_operator_contract(hg, recipe):
     }
 
 
+# ---------------------------------------------------------------------------
+# Type arguments (RFC 0033): the four fix shapes the 2026-09 fix-series
+# retrospective catalogued -- a positional ``tp``, ``DEFAULT`` before
+# ``AUTO_RESOLVE``, a size pin, a collection carrier -- each in its released
+# 0.5 spelling, so the reference and the candidate resolve the same call.
+# ---------------------------------------------------------------------------
+
+_TYPE_ARGUMENT_POSITIONAL_MODES = ("const", "nothing")
+
+
+def _validate_type_argument_positional(recipe):
+    if set(recipe.parameters) - {"mode", "offset"}:
+        raise RecipeError(
+            "type_argument_positional accepts only the mode and offset parameters"
+        )
+    mode = recipe.parameters.get("mode", "const")
+    if mode not in _TYPE_ARGUMENT_POSITIONAL_MODES:
+        raise RecipeError(
+            "type_argument_positional mode must be one of "
+            + ", ".join(_TYPE_ARGUMENT_POSITIONAL_MODES)
+        )
+    offset = recipe.parameters.get("offset", 1)
+    if not isinstance(offset, int) or isinstance(offset, bool) or not -100 <= offset <= 100:
+        raise RecipeError("type_argument_positional offset must be an integer in [-100, 100]")
+    for tick in recipe.inputs["value"]:
+        if tick is None:
+            continue
+        if not isinstance(tick, (int, float)) or isinstance(tick, bool):
+            raise RecipeError("type_argument_positional value ticks must be numbers")
+
+
+def _type_argument_positional(hg, recipe):
+    from hgraph.test import eval_node
+
+    mode = recipe.parameters.get("mode", "const")
+    offset = recipe.parameters.get("offset", 1)
+    inputs = decoded_inputs(hg, recipe)
+
+    if mode == "const":
+        # ``const(value, tp)``: the type is the positional argument after the
+        # value (the 0.5 signature ``const(value, tp=..., delay=...)``). The
+        # offset is passed as a float: the candidate converts an int at the
+        # selected output, released 0.5 raises at runtime (parity_matrix.rst),
+        # and this recipe is about the positional carrier, not that.
+        @hg.graph
+        def parity_graph(value: hg.TS[float]) -> hg.TS[float]:
+            return value + hg.const(float(offset), hg.TS[float])
+
+        return eval_node(
+            parity_graph,
+            [None if tick is None else float(tick) for tick in inputs["value"]],
+        )
+
+    # ``nothing(tp)``: the type IS the argument; a never-valid source under a
+    # default makes the stream observable tick by tick.
+    @hg.graph
+    def parity_graph(value: hg.TS[int]) -> hg.TS[int]:
+        return hg.default(hg.nothing(hg.TS[int]), value + offset)
+
+    return eval_node(
+        parity_graph,
+        [None if tick is None else int(tick) for tick in inputs["value"]],
+    )
+
+
+def _validate_type_argument_default_order(recipe):
+    if set(recipe.parameters) - {"pinned", "inferred"}:
+        raise RecipeError(
+            "type_argument_default_order accepts only the pinned and inferred parameters"
+        )
+    for name in ("pinned", "inferred"):
+        chosen = recipe.parameters.get(name, "int")
+        if chosen not in _SCALAR_TYPES:
+            raise RecipeError(
+                f"type_argument_default_order {name} must be one of {sorted(_SCALAR_TYPES)}"
+            )
+    for tick in recipe.inputs["value"]:
+        if tick is not None and (not isinstance(tick, int) or isinstance(tick, bool)):
+            raise RecipeError("type_argument_default_order value ticks must be integers")
+
+
+def _type_argument_default_order(hg, recipe):
+    from typing import TypeVar
+
+    from hgraph.test import eval_node
+
+    pinned = _SCALAR_TYPES[recipe.parameters.get("pinned", "int")]
+    inferred = _SCALAR_TYPES[recipe.parameters.get("inferred", "int")]
+    inputs = decoded_inputs(hg, recipe)
+    OTHER = TypeVar("OTHER")
+
+    # A bare subscript fills the DEFAULT variable, not the AUTO_RESOLVE one
+    # that appears first; the explicit keyword fills the other. The body
+    # reports which type landed where.
+    @hg.graph
+    def parity_graph(
+        value: hg.TS[int],
+        other: type[OTHER] = hg.AUTO_RESOLVE,
+        schema: type[hg.SCALAR] = hg.DEFAULT[hg.SCALAR],
+    ) -> hg.TS[str]:
+        label = f"{schema.__name__}/{other.__name__}:{{}}"
+        return hg.format_(label, value)
+
+    @hg.graph
+    def outer(value: hg.TS[int]) -> hg.TS[str]:
+        return parity_graph[pinned](value, other=inferred)
+
+    return eval_node(outer, inputs["value"])
+
+
+_TYPE_ARGUMENT_SIZE_MODES = ("auto", "subscript")
+
+
+def _validate_type_argument_size_pin(recipe):
+    if set(recipe.parameters) - {"mode", "size"}:
+        raise RecipeError("type_argument_size_pin accepts only the mode and size parameters")
+    mode = recipe.parameters.get("mode", "auto")
+    if mode not in _TYPE_ARGUMENT_SIZE_MODES:
+        raise RecipeError(
+            "type_argument_size_pin mode must be one of " + ", ".join(_TYPE_ARGUMENT_SIZE_MODES)
+        )
+    size = recipe.parameters.get("size", 2)
+    if not isinstance(size, int) or isinstance(size, bool) or not 1 <= size <= 4:
+        raise RecipeError("type_argument_size_pin size must be an integer in [1, 4]")
+    for tick in recipe.inputs["values"]:
+        if tick is None:
+            continue
+        if (
+            not isinstance(tick, list)
+            or len(tick) != size
+            or not all(isinstance(item, int) and not isinstance(item, bool) for item in tick)
+        ):
+            raise RecipeError(
+                "type_argument_size_pin values ticks must be integer lists of the declared size"
+            )
+
+
+def _type_argument_size_pin(hg, recipe):
+    from hgraph.test import eval_node
+
+    mode = recipe.parameters.get("mode", "auto")
+    size = recipe.parameters.get("size", 2)
+    inputs = decoded_inputs(hg, recipe)
+    ticks = [None if tick is None else tuple(tick) for tick in inputs["values"]]
+
+    # ``type[SIZE]`` materialises as the Size object (``.SIZE``) whether it was
+    # resolved from the TSL input or pinned by ``g[Size[n]]``; the body adds
+    # the declared size to the element sum so both paths are observable.
+    @hg.graph
+    def parity_graph(
+        values: hg.TSL[hg.TS[int], hg.SIZE], _sz: type[hg.SIZE] = hg.AUTO_RESOLVE
+    ) -> hg.TS[int]:
+        return hg.sum_(values) + hg.const(_sz.SIZE)
+
+    tsl_type = hg.TSL[hg.TS[int], hg.Size[size]]
+    if mode == "subscript":
+        return eval_node(
+            parity_graph[hg.Size[size]], ticks, resolution_dict={"values": tsl_type}
+        )
+    return eval_node(parity_graph, ticks, resolution_dict={"values": tsl_type})
+
+
+_TYPE_ARGUMENT_COLLECTIONS = ("tuple", "frozenset")
+
+
+def _validate_type_argument_collection(recipe):
+    if set(recipe.parameters) - {"collection"}:
+        raise RecipeError("type_argument_collection accepts only the collection parameter")
+    collection = recipe.parameters.get("collection", "tuple")
+    if collection not in _TYPE_ARGUMENT_COLLECTIONS:
+        raise RecipeError(
+            "type_argument_collection collection must be one of "
+            + ", ".join(_TYPE_ARGUMENT_COLLECTIONS)
+        )
+    for tick in recipe.inputs["values"]:
+        if tick is None:
+            continue
+        if not isinstance(tick, list) or not all(
+            isinstance(item, int) and not isinstance(item, bool) for item in tick
+        ):
+            raise RecipeError("type_argument_collection values ticks must be integer lists")
+
+
+def _collection_carrier_matches(tp, origins, args):
+    """Structural comparison of a materialised collection carrier: released
+    0.5 spells a frozenset carrier ``collections.abc.Set[int]`` and the
+    candidate ``frozenset[int]`` (an accepted spelling deviation,
+    ``parity_matrix.rst``); both are the same parameterised generic."""
+    import typing
+
+    return typing.get_origin(tp) in origins and typing.get_args(tp) == args
+
+
+def _type_argument_collection(hg, recipe):
+    import collections.abc
+
+    from hgraph.test import eval_node
+
+    collection = recipe.parameters.get("collection", "tuple")
+    inputs = decoded_inputs(hg, recipe)
+    if collection == "tuple":
+        annotation, convert = hg.TS[tuple[int, ...]], tuple
+        origins, args = (tuple,), (int, Ellipsis)
+    else:
+        annotation, convert = hg.TS[frozenset[int]], frozenset
+        origins, args = (frozenset, collections.abc.Set), (int,)
+    ticks = [None if tick is None else convert(tick) for tick in inputs["values"]]
+
+    # A collection type argument resolved from the wired input materialises
+    # as the parameterised generic the input was declared with, not a bare
+    # ``tuple`` or ``frozenset``; the body adds the element count when the
+    # carrier reads back as that generic, so a wrong form is visible on every
+    # tick.
+    @hg.graph
+    def parity_graph(values: hg.TS[hg.SCALAR], tp: type[hg.SCALAR] = hg.AUTO_RESOLVE) -> hg.TS[int]:
+        return hg.len_(values) + hg.const(1 if _collection_carrier_matches(tp, origins, args) else -1000)
+
+    return eval_node(parity_graph, ticks, resolution_dict={"values": annotation})
+
+
 CATALOG = {
     "scalar_expression": TemplateSpec(
         name="scalar_expression",
@@ -3528,6 +3748,55 @@ CATALOG = {
         operators=("record", "replay"),
         execute=_data_frame_recording,
     ),
+    "type_argument_positional": TemplateSpec(
+        name="type_argument_positional",
+        required_inputs=("value",),
+        features=(
+            "shape:TS",
+            "type-argument:positional",
+            "syntax:positional-target",
+            "compatibility:release-0.5",
+            "api:public-signature",
+        ),
+        operators=("const", "nothing", "default", "add_"),
+        execute=_type_argument_positional,
+    ),
+    "type_argument_default_order": TemplateSpec(
+        name="type_argument_default_order",
+        required_inputs=("value",),
+        features=(
+            "shape:TS",
+            "type-argument:default-before-auto-resolve",
+            "syntax:bare-subscript",
+            "compatibility:release-0.5",
+        ),
+        operators=("format_",),
+        execute=_type_argument_default_order,
+    ),
+    "type_argument_size_pin": TemplateSpec(
+        name="type_argument_size_pin",
+        required_inputs=("values",),
+        features=(
+            "shape:TSL",
+            "type-argument:size",
+            "syntax:bare-subscript",
+            "compatibility:release-0.5",
+        ),
+        operators=("sum_", "const", "add_"),
+        execute=_type_argument_size_pin,
+    ),
+    "type_argument_collection": TemplateSpec(
+        name="type_argument_collection",
+        required_inputs=("values",),
+        features=(
+            "shape:TS",
+            "type-argument:collection",
+            "type:collection",
+            "compatibility:release-0.5",
+        ),
+        operators=("len_", "const", "add_"),
+        execute=_type_argument_collection,
+    ),
 }
 
 
@@ -3604,6 +3873,14 @@ def validate_recipe(recipe):
         _validate_structural_map_projection(recipe)
     elif recipe.template == "arrow_typed_projection":
         _validate_arrow_typed_projection(recipe)
+    elif recipe.template == "type_argument_positional":
+        _validate_type_argument_positional(recipe)
+    elif recipe.template == "type_argument_default_order":
+        _validate_type_argument_default_order(recipe)
+    elif recipe.template == "type_argument_size_pin":
+        _validate_type_argument_size_pin(recipe)
+    elif recipe.template == "type_argument_collection":
+        _validate_type_argument_collection(recipe)
     elif recipe.template == "feedback_accumulate":
         initial = recipe.parameters.get("initial", 0)
         if not isinstance(initial, int) or isinstance(initial, bool):

--- a/tools/parity/corpus/coverage-type-argument-collection-frozenset.json
+++ b/tools/parity/corpus/coverage-type-argument-collection-frozenset.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "coverage-type-argument-collection-frozenset",
+  "description": "RFC 0033 fix shape: a type[SCALAR] carrier resolved from TS[frozenset[int]] reads back as frozenset[int].",
+  "template": "type_argument_collection",
+  "inputs": {
+    "values": [
+      [
+        1,
+        2,
+        2
+      ],
+      null,
+      [
+        3
+      ],
+      [],
+      [
+        4,
+        5,
+        6
+      ]
+    ]
+  },
+  "parameters": {
+    "collection": "frozenset"
+  },
+  "features": [
+    "shape:TS",
+    "type-argument:collection",
+    "type:collection",
+    "compatibility:release-0.5"
+  ]
+}

--- a/tools/parity/corpus/coverage-type-argument-collection-tuple.json
+++ b/tools/parity/corpus/coverage-type-argument-collection-tuple.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "id": "coverage-type-argument-collection-tuple",
+  "description": "RFC 0033 fix shape: a type[SCALAR] carrier resolved from TS[tuple[int, ...]] reads back as the parameterised generic tuple[int, ...].",
+  "template": "type_argument_collection",
+  "inputs": {
+    "values": [
+      [
+        1,
+        2,
+        3
+      ],
+      null,
+      [],
+      [
+        4
+      ],
+      [
+        5,
+        6
+      ]
+    ]
+  },
+  "parameters": {
+    "collection": "tuple"
+  },
+  "features": [
+    "shape:TS",
+    "type-argument:collection",
+    "type:collection",
+    "compatibility:release-0.5"
+  ]
+}

--- a/tools/parity/corpus/coverage-type-argument-default-before-auto-resolve.json
+++ b/tools/parity/corpus/coverage-type-argument-default-before-auto-resolve.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "id": "coverage-type-argument-default-before-auto-resolve",
+  "description": "RFC 0033 fix shape: a bare graph subscript fills the DEFAULT variable even though an AUTO_RESOLVE type argument is declared first; the keyword fills the other.",
+  "template": "type_argument_default_order",
+  "inputs": {
+    "value": [
+      1,
+      null,
+      2,
+      3,
+      null,
+      5
+    ]
+  },
+  "parameters": {
+    "pinned": "str",
+    "inferred": "float"
+  },
+  "features": [
+    "shape:TS",
+    "type-argument:default-before-auto-resolve",
+    "syntax:bare-subscript",
+    "compatibility:release-0.5"
+  ]
+}

--- a/tools/parity/corpus/coverage-type-argument-positional-const.json
+++ b/tools/parity/corpus/coverage-type-argument-positional-const.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "id": "coverage-type-argument-positional-const",
+  "description": "RFC 0033 fix shape: const(value, TS[float]) with the type as the positional argument after the value; an integer offset converts at the selected output.",
+  "template": "type_argument_positional",
+  "inputs": {
+    "value": [
+      1.5,
+      null,
+      -2.0,
+      4.25,
+      null,
+      0.0
+    ]
+  },
+  "parameters": {
+    "mode": "const",
+    "offset": 3
+  },
+  "features": [
+    "shape:TS",
+    "type-argument:positional",
+    "syntax:positional-target",
+    "compatibility:release-0.5",
+    "api:public-signature"
+  ]
+}

--- a/tools/parity/corpus/coverage-type-argument-positional-nothing.json
+++ b/tools/parity/corpus/coverage-type-argument-positional-nothing.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "id": "coverage-type-argument-positional-nothing",
+  "description": "RFC 0033 fix shape: nothing(TS[int]) takes its type positionally; under default() the never-valid source passes each tick through.",
+  "template": "type_argument_positional",
+  "inputs": {
+    "value": [
+      1,
+      2,
+      null,
+      5,
+      null,
+      8,
+      13
+    ]
+  },
+  "parameters": {
+    "mode": "nothing",
+    "offset": -1
+  },
+  "features": [
+    "shape:TS",
+    "type-argument:positional",
+    "syntax:positional-target",
+    "compatibility:release-0.5",
+    "api:public-signature"
+  ]
+}

--- a/tools/parity/corpus/coverage-type-argument-size-auto.json
+++ b/tools/parity/corpus/coverage-type-argument-size-auto.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": 1,
+  "id": "coverage-type-argument-size-auto",
+  "description": "RFC 0033 fix shape: type[SIZE] resolved from a TSL input materialises as the Size object with .SIZE.",
+  "template": "type_argument_size_pin",
+  "inputs": {
+    "values": [
+      [
+        1,
+        2,
+        3
+      ],
+      null,
+      [
+        4,
+        5,
+        6
+      ],
+      [
+        0,
+        0,
+        1
+      ]
+    ]
+  },
+  "parameters": {
+    "mode": "auto",
+    "size": 3
+  },
+  "features": [
+    "shape:TSL",
+    "type-argument:size",
+    "syntax:bare-subscript",
+    "compatibility:release-0.5"
+  ]
+}

--- a/tools/parity/corpus/coverage-type-argument-size-subscript.json
+++ b/tools/parity/corpus/coverage-type-argument-size-subscript.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "id": "coverage-type-argument-size-subscript",
+  "description": "RFC 0033 fix shape: a Size pinned by subscript, g[Size[2]], reaches the body as the same Size object as the auto-resolved form.",
+  "template": "type_argument_size_pin",
+  "inputs": {
+    "values": [
+      [
+        1,
+        2
+      ],
+      [
+        3,
+        4
+      ],
+      null,
+      [
+        5,
+        6
+      ]
+    ]
+  },
+  "parameters": {
+    "mode": "subscript",
+    "size": 2
+  },
+  "features": [
+    "shape:TSL",
+    "type-argument:size",
+    "syntax:bare-subscript",
+    "compatibility:release-0.5"
+  ]
+}


### PR DESCRIPTION
## Summary

RFC 0033's last open commitment: the parity catalogue gains templates for the four type-argument fix shapes the 2026-09 fix-series retrospective catalogued, each written in its released 0.5 spelling and each making the materialised type observable on every tick, so a wrong carrier form diverges rather than merely wiring.

| Template | Shape |
|---|---|
| `type_argument_positional` | the type as the positional argument after the value: `const(value, TS[float])`, `nothing(TS[int])` under `default()` |
| `type_argument_default_order` | a bare graph subscript fills the `DEFAULT` variable ahead of an `AUTO_RESOLVE` one declared first |
| `type_argument_size_pin` | `type[SIZE]` resolved from a `TSL` input or pinned by `g[Size[n]]` reaches the body as the `Size` object |
| `type_argument_collection` | a `type[SCALAR]` carrier resolved from `TS[tuple[int, ...]]` / `TS[frozenset[int]]` reads back as the parameterised generic |

Seven `coverage-type-argument-*` corpus recipes pin them (corpus-only, like the other public-contract templates). Every one replays identically against the local 0.5 reference environment.

Two reference differences surfaced on the way and are recorded as accepted deviations in `parity_matrix.rst`:

- 0.5 raises `TypeError` at runtime for `const(3, TS[float])`; the candidate converts the value at the selected type. The recipe passes a float, since its subject is the positional carrier.
- 0.5 spells a frozenset carrier `collections.abc.Set[int]`; the candidate hands back `frozenset[int]` (the reverse binding returns what was written). The template compares the generic structurally.

Validators bound every parameter; controller tests cover them; `parity_testing.rst` lists the templates; the RFC's Parity paragraph records the commitment as met.

## Test plan

- [x] `python -m tools.parity validate`: 101 recipes.
- [x] `python -m tools.parity replay` of all seven recipes: reference and candidate both `ok`, difference `null`.
- [x] `test_parity_harness.py` + `test_all_valid_parity.py`: 62 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
