### PR TITLE
docs(language): track syntax expansion and stdlib design corpus

### DIFF
--- a/docs/source/developer_guide/nested_graphs.rst
+++ b/docs/source/developer_guide/nested_graphs.rst
@@ -603,7 +603,10 @@ ts…)``).
   order (optionally preceded by the key) and keyword args **per branch by
   the branch's own parameter names** (``NamedPort`` / ``In<"name">`` —
   branches may declare the same names in different orders, like Python).
-  Deferred: all-sink switches.
+- A switch whose branches are all sinks has no output endpoint or output
+  resolver. It still owns and switches the active child graph with the same
+  sampled-input and lifecycle rules. This outputless path is covered alongside
+  value-producing switches in ``tests/cpp/test_switch.cpp``.
 
 Tests: ``tests/cpp/test_switch.cpp``.
 

--- a/language/docs/README.md
+++ b/language/docs/README.md
@@ -36,8 +36,25 @@ out so examples do not imply an implemented compatibility promise.
 5. [Distribution and deployment](design/distribution.md) — release train,
    package channels (Homebrew first), the relocatable native context, and
    what a host needs to run an HGL program.
+6. [Type extensions](design/type-extensions.md) — agreed atomic treatment of
+   imported types, `ref<T>`, reference-transparent type compatibility, opaque
+   node access, wiring-time dereferencing, and input-only SIGNAL observation.
+7. [Conditional control flow](design/control-flow.md) — wiring-time selection,
+   switch-style temporal conditions in graph functions, and node conditionals.
+8. [Iteration](design/iteration.md) — phase-dependent `for`, wiring-time values
+   and fixed child connections, independent dynamic graph loops, runtime
+   traversal, and deferred map/reduce accumulation.
 
 An accepted change should update the relevant guide and its owning design
 record together. The user guide is the source of truth for observable language
 behavior; the developer guide is the source of truth for implementation
 constraints.
+
+## Standard-library design corpus
+
+The [standard-library folder](../stdlib/README.md) collects agreed HGL examples
+to drive core-library coverage and expose missing language features. It starts
+with conditional-result, fixed-list, and independent dynamic-map iteration
+examples; a complete component catalogue remains to be developed. These design
+examples are separate from the compiler's runnable example corpus and are not
+a claim of implemented support.

--- a/language/docs/design/architecture.md
+++ b/language/docs/design/architecture.md
@@ -79,9 +79,12 @@ backend phases:
 | Compute or sink | Evaluation | Read admitted runtime inputs, update declared state, produce the contracted tick or side effect | Add topology, resolve overloads, acquire arbitrary external resources |
 | Imported adaptor or service | Native C++ | Own callbacks, threads, queues, protocols, and resources through hgraph lifecycle contracts | Expose unrestricted native execution to language source |
 
-The current provisional rule classifies an ordinary body as composition. A
-`state` or `inject` declaration, a `start`, `when`, or `stop` block, or runtime
-collection iteration classifies the complete function as runtime evaluation.
+The current provisional implementation classifies an ordinary body as
+composition. A `state` or `inject` declaration, a `start`, `when`, or `stop`
+block, or any collection iteration classifies the complete function as runtime
+evaluation. The target model instead lets iteration follow the phase selected
+by the containing body; iterator-only runtime functions therefore need a
+still-unresolved disambiguation rule before that classifier migration.
 Composition bodies flatten through hgraph wiring, while runtime bodies lower
 to typed static C++ hooks whose instance data uses hgraph selectors and plans.
 

--- a/language/docs/design/control-flow.md
+++ b/language/docs/design/control-flow.md
@@ -192,16 +192,19 @@ Deduplicating a captured source must not discard these per-branch contracts.
 The same forwarding rule applies independently to each escaping field when
 multiple results are bundled. A branch can supply a newly computed binding
 for one field and forward another field's incoming binding by reference.
-It does not imply an outer reference over the whole bundle, nor may it leave a
-`REF` wrapper on that field of the branch output. Lowering chooses the escaped
-binding's declared, non-`REF` temporal schema as the common output schema for
-each result slot. A forwarding branch retains its `REF` capture, then explicitly
-dereferences that connection at the branch-output boundary before packing the
-field; a computed branch already supplies the same ordinary temporal schema.
-The two branch bundles consequently have identical schemas at every field, not
-merely compatible root types. If the public native API cannot express that
-per-field reference adaptation, HGL must reject the conditional until the
-native support exists rather than send mismatched bundles to `switch_`.
+It does not imply an outer reference over the whole bundle. Lowering preserves
+the escaped binding's resolved declared temporal schema as the common output
+schema for each result slot. For an ordinary `T` result, a forwarding branch
+retains its `ref<T>` capture and explicitly dereferences that connection at the
+branch-output boundary before packing the field; a computed branch already
+supplies the same ordinary temporal schema. For an explicitly declared
+`ref<T>` result, the result slot remains `ref<T>` and a forwarding capture is
+packed without dereferencing it. Every branch must produce that same declared
+schema; a branch that cannot produce the required reference binding is rejected.
+The branch bundles consequently have identical schemas at every field, not
+merely compatible root types. If the public native API cannot express the
+required per-field reference adaptation, HGL must reject the conditional until
+the native support exists rather than send mismatched bundles to `switch_`.
 
 The corresponding design-corpus source is
 [conditional-results.hgl](../../stdlib/examples/conditional-results.hgl).

--- a/language/docs/design/control-flow.md
+++ b/language/docs/design/control-flow.md
@@ -1,0 +1,515 @@
+# Conditional control flow
+
+Status: agreed conditional strategy, 2026-09-05; compiler implementation is
+separate. This record uses the existing `if`/`else` syntax. It does not settle
+the other control-flow constructs or introduce new keywords.
+
+## The three conditional contexts
+
+| Context | Meaning of `if` |
+| --- | --- |
+| Graph composition with a wiring-time Boolean condition | Choose which branch to wire. |
+| Graph composition with a temporal Boolean condition | Wire a native switch with branch callables selected by the condition. |
+| Node evaluation, including a `when` handler | Execute an ordinary conditional using current readable values. |
+
+A temporal condition in a graph function uses the switch strategy, following
+the approach of the Arrow API. It does not classify the containing function
+as a runtime node. Graph composition still runs during wiring; the native
+switch owns the runtime selection and execution of its child graph.
+
+## Temporal condition in graph composition
+
+The following uses existing syntax with the newly agreed temporal-condition
+semantics. It is a design example, not a currently executable compiler test:
+
+```hgl
+fn choose(condition: bool, value: f64) -> f64 {
+    if condition {
+        value + 1.0
+    } else {
+        value - 1.0
+    }
+}
+```
+
+The condition becomes the Boolean selector of a switch. Each branch's
+composition becomes a child callable, with the required inputs connected
+through the native child-graph boundary. The branches are not evaluated as
+two eager outer argument expressions before selecting their results.
+
+The runtime behavior is the existing native switch contract:
+
+- Only the selected child graph runs.
+- A changed condition stops the previous child and starts the selected child.
+- Returning to a previously selected branch creates a fresh child instance;
+  the switch does not keep inactive branch state suspended for later resumption.
+- Under the native default policy, an unchanged Boolean value does not rebuild
+  the child merely because the condition ticks again.
+- Output compatibility, binding, and sampling follow the native switch rules.
+
+The lifetime boundary covers computations composed inside the branch. A source
+or computation wired outside the conditional and supplied to a branch remains
+outside that lifetime boundary. Selecting a branch does not stop its external
+producers.
+
+The existing `if_then_else` library operator continues to describe selection
+between already-wired outputs. It is distinct from the agreed temporal `if`
+strategy, which controls child-graph execution.
+
+## Omitted else
+
+A value-producing temporal `if` without an `else` uses a typed, never-ticking
+false branch, matching the Arrow approach. This is now an agreed HGL rule.
+The false branch has the required result schema but produces no output tick;
+it does not manufacture a default scalar value.
+
+An assignment to an already-bound enclosing variable has a different false
+branch: it forwards the incoming binding, as described below. That case does
+not replace the existing connection with a never-ticking source.
+
+A conditional early return is also distinct: its non-returning path continues
+through the remaining function body, as described under
+[Early returns](#early-returns-and-continuations).
+
+## Results used after the conditional
+
+A temporal conditional can supply bindings used by later statements; it is
+not limited to a tail expression returned directly from the function:
+
+```hgl
+fn use_conditional_result(condition: bool, x: i64, y: i64) -> i64 {
+    var r: i64
+    if condition {
+        r = x + 1
+    } else {
+        r = y - 1
+    }
+
+    return r * 2
+}
+```
+
+This example includes the agreed typed declaration without an initializer,
+`var r: i64`. It is design syntax awaiting compiler support, not an executable
+example for the current language test corpus.
+
+An escaping variable must be declared before the conditional in an enclosing
+scope. Its branch-assigned binding is needed outside the conditional. A
+variable declared inside a branch remains branch-local; naming it does not
+make it visible after the conditional.
+
+When the only result is one escaping variable, each generated branch callable
+returns that variable's final binding directly. Here the true branch takes
+`x` and returns `x + 1`; the false branch takes `y` and returns `y - 1`. The switch returns the
+selected `i64` time-series connection, and the enclosing `r` is remapped to
+that output. The multiplication by two is composed once outside the switch
+and consumes this connection.
+
+These are graph lexical bindings. Assignments inside the branch determine its
+output connection; they do not create a persistent runtime variable shared
+between the parent and child graphs. The uninitialized `r` is not an input
+capture: neither branch reads an incoming binding for it.
+
+### Multiple escaping variables
+
+When multiple variables escape, each generated branch returns a bundle. The
+switch produces that bundle, and its fields are remapped to the corresponding
+enclosing variables:
+
+```hgl
+fn use_conditional_results(condition: bool, x: i64, y: i64) -> i64 {
+    var r: i64
+    var adjustment: i64
+    if condition {
+        r = x + 1
+        adjustment = x
+    } else {
+        r = y - 1
+        adjustment = y
+    }
+
+    return r * 2 + adjustment
+}
+```
+
+| Escaping binding | True branch output | False branch output | Enclosing binding after the switch |
+| --- | --- | --- | --- |
+| `r` | `x + 1` | `y - 1` | The switch output's `r` field. |
+| `adjustment` | `x` | `y` | The switch output's `adjustment` field. |
+
+The bundle is a compiler-generated branch-output interface. The author does
+not need to declare a bundle type, construct a bundle literal, or write a
+remapping operation. The fields remain time-series connections with native
+bundle/switch semantics; this does not introduce a scalar tuple snapshot or
+an additional simultaneous-tick guarantee.
+
+Both examples assign every escaping variable in both branches. An existing
+incoming binding also allows a branch to leave an escaping variable unchanged.
+
+### Forwarding an existing binding
+
+If an escaping variable already has a binding before the conditional, a branch
+that does not assign it forwards that incoming binding. This also supplies the
+implicit false branch when there is no `else`:
+
+```hgl
+fn use_existing_conditional_result(condition: bool, x: i64) -> i64 {
+    var r: i64 = x
+    if condition {
+        r = r + 1
+    }
+
+    return r * 2
+}
+```
+
+The true branch processes the incoming `r` and returns the connection for
+`r + 1`. It may consume an ordinary `i64` temporal input. The implicit false
+branch only returns the incoming `r`, so its generated input/output contract
+uses `ref<i64>` to forward the connection without observing or copying its
+value ticks. Downstream consumers continue to receive ticks from the selected
+source through that connection.
+
+The incoming binding is `x` for both branches. Lowering resolves that binding
+before remapping the enclosing `r` to the switch output; `r = r + 1` does not
+create feedback from that output. When false is selected, the result follows
+`x`, not a value remembered from a previous execution of the true branch.
+
+Capture access is determined per branch. A pure forwarding branch takes the
+incoming time series by reference. Where analysis establishes that the input
+will be processed, an ordinary temporal input is sufficient; reference
+capture is not required solely to avoid pass-through copying. Merely finding
+a use on one path is not proof that the input is processed on every path.
+
+This is the compiler specifying the intent of a generated component, not a
+change to the author's `var r: i64` declaration or a general rule for rewriting
+user-declared types. Explicit reference access restrictions still apply.
+Branch signatures can differ in REF qualification while remaining compatible
+in underlying type. Their native boundary bindings must preserve the
+forwarding connection and adapt it for value-consuming downstream nodes.
+Deduplicating a captured source must not discard these per-branch contracts.
+
+The same forwarding rule applies independently to each escaping field when
+multiple results are bundled. A branch can supply a newly computed binding
+for one field and forward another field's incoming binding by reference.
+It does not imply an outer reference over the whole bundle.
+
+The corresponding design-corpus source is
+[conditional-results.hgl](../../stdlib/examples/conditional-results.hgl).
+
+### Definite assignment
+
+An escaping variable must have a binding on every path reaching its use. It
+must either have an incoming binding before the conditional or be assigned
+on every path reaching that use. A type annotation alone does not supply a
+connection. Using a variable without definite assignment is a compile-time
+error.
+
+The following is intentionally invalid under the agreed design:
+
+```hgl
+fn unassigned_conditional_result(condition: bool, x: i64) -> i64 {
+    var r: i64
+    if condition {
+        r = x + 1
+    }
+
+    return r * 2
+}
+```
+
+On the false path, `r` has neither an assignment nor an incoming binding to
+forward. Its later use must be rejected; lowering must not silently create
+a typed never-ticking source for it. That fallback remains specific to the
+agreed value-producing `if` expression without `else`.
+
+Definite assignment checks the existence of a binding, not the runtime
+validity of its time series. A bound source can be invalid or have produced
+no tick without making its variable unassigned. For multiple escaping
+variables, check each one independently before constructing the result bundle.
+
+The negative design-corpus example is
+[conditional-unassigned-result.hgl](../../stdlib/examples/invalid/conditional-unassigned-result.hgl).
+It records the required rejection, not an implemented compiler test.
+
+## Expression results and escaping assignments
+
+A conditional may supply an expression result and also assign variables that
+escape to the enclosing scope:
+
+```hgl
+fn choose(condition: bool, x: i64, y: i64) -> i64 {
+    var r: i64
+
+    let result = if condition {
+        r = x + 1
+        x * 2
+    } else {
+        r = y - 1
+        y * 3
+    }
+
+    return result + r
+}
+```
+
+The final expression of each branch supplies the value of the `if`
+expression. Assignments to the predeclared `r` supply a separate escaping
+binding. Count the used expression result alongside the escaping variables
+when determining the generated switch output.
+
+Here both branches return a common compiler-generated bundle with two
+time-series connections:
+
+| Result | True branch | False branch | Receiver after the switch |
+| --- | --- | --- | --- |
+| Expression result | `x * 2` | `y * 3` | The initializer for `result`. |
+| Escaping binding | `x + 1` | `y - 1` | The remapped enclosing `r`. |
+
+The expression-result field is a compiler detail; it needs no source-level
+field name or bundle declaration. `result` receives the value of the complete
+`if` expression and is not an escaping variable. Only `r` needs the declaration
+before the conditional, because it is assigned inside the branches and used
+outside them.
+
+The true branch captures `x`, the false branch captures `y`, and the switch
+receives `condition`, `x`, and `y`. The final addition is composed outside the
+switch after the two results have been remapped. Both results retain native
+time-series bundle semantics, not scalar snapshot semantics.
+
+The common output rule counts the used expression result, if any, plus the
+escaping variables:
+
+- Zero results: an outputless switch, preserving any conditional sink wiring.
+- One result: return that connection directly.
+- Multiple results: return a generated bundle and remap its fields to the
+  expression consumer and enclosing variables as appropriate.
+
+The existing definite-assignment and REF-forwarding rules continue to apply
+to escaping variables. Combining the results adds no new source syntax and
+does not expose branch-local declarations to the enclosing scope.
+
+See [conditional-mixed-results.hgl](../../stdlib/examples/conditional-mixed-results.hgl)
+for this agreed design example. Compiler support remains separate work.
+
+## Early returns and continuations
+
+An explicit `return` inside a temporal branch returns from the enclosing HGL
+function, not merely from the branch lambda generated during lowering. A path
+that returns skips the remaining function body. The non-returning path's
+continuation therefore belongs inside that path's switch branch:
+
+```hgl
+fn choose(condition: bool, x: i64, y: i64) -> i64 {
+    if condition {
+        return x + 1
+    }
+
+    let r = y - 1
+    return r * 2
+}
+```
+
+The generated true branch captures `x` and returns `x + 1`. The generated
+false branch captures `y`, composes `r = y - 1`, and returns `r * 2`. Both
+branches supply the enclosing function's `i64` result. The outer switch
+receives `condition`, `x`, and `y` and provides that selected result.
+The local `r` belongs to the false continuation; it is not an escaping
+variable that must be declared before the original `if`.
+
+This is not the never-ticking false branch of a value-producing `if`
+expression without `else`: the source contains a continuation that supplies
+the false path's result. Its inputs must be included when computing the
+generated branch signature.
+
+The lifetime consequences follow the native switch contract:
+
+- The continuation is active only while its branch is selected. It must not
+  remain independently active outside the switch.
+- Stateful nodes and sinks composed in the continuation belong to that child
+  graph and follow its stop/start and fresh-instance behavior.
+- Computations composed before the `if` remain outside the child boundary.
+  Capturing one does not move its producer into the continuation.
+- A later condition change can select either branch. An early return does
+  not permanently stop the graph or prevent future branch selection.
+
+Graph composition still occurs at wiring time; the native switch owns runtime
+branch activation. The return determines which path supplies the function's
+output, rather than making the graph function execute on each tick.
+
+Definite assignment considers only paths reaching the relevant use. A path
+that returns earlier does not have to assign a variable used only in the
+continuation, because that path never reaches the use. This does not permit
+a read before assignment on a path that does reach it.
+
+See [conditional-early-return.hgl](../../stdlib/examples/conditional-early-return.hgl)
+for the design-corpus example. These semantics are agreed; compiler lowering
+remains separate work.
+
+## Outputless conditionals
+
+A temporal conditional with no result or escaping variable uses the native
+outputless switch path. It describes conditional sink wiring:
+
+```hgl
+fn observe(enabled: bool, value: f64) {
+    if enabled {
+        debug_print("enabled", value)
+    }
+
+    debug_print("always", value)
+}
+```
+
+`debug_print` takes the label first and the time series second, matching the
+[native operator contract](../../../include/hgraph/lib/std/operators/io.h).
+
+When enabled, the `"enabled"` sink is wired in through the switch-selected
+branch. The `"always"` sink is always wired in the enclosing graph, outside
+the switch. When the false branch is selected, the conditional contributes no
+sink; it does not affect the unconditional sink's connection.
+
+The graph function describes these connections at wiring time. The sink nodes
+perform printing during execution; the graph body does not become a per-tick
+printing function. The switch owns the conditional child and its lifecycle
+under the previously agreed native rules.
+
+The true branch takes `value` as a temporal input, with `"enabled"` as its
+fixed label. The selector is `enabled`. The false path has no conditional
+work. This switch has no output: no returned time-series connection, bundle,
+dummy value, or SIGNAL output is required. There are no escaping bindings to
+remap. Native sink-switch behavior is covered in
+[test_switch.cpp](../../../tests/cpp/test_switch.cpp).
+
+Whether a conditional needs an output depends on its result and escaping
+variables, not on the enclosing function's return annotation. An outputless
+function can still compose a value-producing conditional and connect its
+result to a sink.
+
+The [conditional-sinks.hgl](../../stdlib/examples/conditional-sinks.hgl)
+design example records this wiring model. HGL compiler support remains
+separate work.
+
+## Branch signatures
+
+Lowering must compute the branch lambdas and their complete input signatures
+in order to construct a valid switch signature. The branch bodies can refer
+to different enclosing inputs, so the condition and the result type alone
+are insufficient to describe the generated switch.
+
+This requires identifying the external dependencies of each branch, retaining
+their resolved types and wiring-time versus temporal roles, and describing how
+the branch's inputs bind to the enclosing switch. The agreed REF boundaries
+and SIGNAL input restrictions remain part of the relevant input contracts;
+type compatibility must not erase those access semantics.
+
+First determine the source return targets and the continuations reached by
+each path. A generated lambda must not accidentally become the target of an
+enclosing-function `return`. Capture analysis includes the continuation when
+it belongs to that branch, not just the statements textually inside the
+original `if` block.
+
+The agreed derivation then has both input and output sides:
+
+1. Resolve names by lexical binding and identify each branch's external
+   dependencies, including dependencies used by nested expressions. Branch
+   locals are not captures. An assignment target alone is not an incoming
+   dependency; reading or forwarding its pre-conditional binding is. Include
+   an implicit forwarding dependency when a branch leaves an already-bound
+   escaping variable unchanged.
+2. Separate wiring-time scalar captures from temporal input captures. Scalar
+   captures specialize branch composition; they are not live switch input
+   slots. Preserve resolved input types, REF boundaries, and SIGNAL contracts.
+   Use reference capture for a generated pure forwarding branch; an ordinary
+   temporal input is sufficient where processing is assured.
+3. Form the shared temporal input slots from both branches, deduplicating by
+   source identity, and map each branch's required inputs to those slots. Add
+   the condition as the switch selector. A condition used inside a branch is
+   also an explicit dependency of that branch; selecting it alone does not
+   imply that the branch reads it.
+4. Identify the used expression result and the predeclared variables whose
+   branch-assigned bindings escape. Check definite assignment for their uses;
+   reject a used variable when a path supplies neither an assignment nor an
+   incoming binding. Count the expression result alongside the escaping
+   variables: zero results require no output, one is returned directly, and
+   several use a common generated bundle. Resolve output compatibility while
+   preserving the declared reference/access contracts.
+5. For branches that rejoin, supply the expression result to its consumer and
+   remap the enclosing variables from the switch output or its bundle fields,
+   then continue composing the statements after the conditional. Both result
+   forms may be present together. For an early-return conditional such as the
+   example above, the non-returning branch includes the remaining function
+   body and both branches supply the function's result.
+
+For the single-result example, the true branch has temporal input `x` and
+output `r: i64`; the false branch has temporal input `y` and the same output
+contract. The outer switch receives `condition`, `x`, and `y`. Neither `r`
+nor the literal constants are incoming temporal slots. For the two-result
+example, the input mapping is unchanged and the common output is a bundle
+with `r: i64` and `adjustment: i64` fields.
+
+An input used only by the inactive branch must not prevent the selected
+branch from running merely because that unused input is invalid. Likewise,
+capturing an already-wired outer computation does not move its lifetime into
+the conditional.
+
+The existing native machinery distinguishes explicit callable arguments from
+captured outer ports. In
+[higher_order_impl.h](../../../include/hgraph/lib/std/operators/impl/higher_order_impl.h),
+`compile_switch_branch` adds `CompiledSubGraph::captured_inputs` to shared outer
+slots, deduplicates by source identity, and remaps child boundary inputs onto
+those slots. The switch's complete temporal input schema is its selector plus
+the resulting outer slots.
+
+Explicit call arguments have a different constraint:
+`bind_wired_fn_args` in
+[wired_fn.h](../../../include/hgraph/types/wired_fn.h) validates each branch's
+arity and parameter names. It does not silently discard arguments that one
+branch does not accept. A language lowering must therefore provide consistent
+explicit branch signatures or use the native capture-boundary mapping; it
+cannot pass a union of arguments to differently shaped lambdas and assume the
+binder filters them.
+
+These lambdas and their boundary signatures are generated internally. This
+agreement does not require new source-level closure syntax or implement
+compiler lowering.
+
+If the conditional exports no result or escaping variable, its generated
+branch signatures are outputless. Preserve their sink wiring through the
+native outputless switch; the absence of a result is not a reason to discard
+the conditional's work or manufacture an output.
+
+## Arrow precedent and native ownership
+
+[Arrow control flow](../../../python/hgraph/arrow/_control_flow.py) constructs
+true and false branch callables in `_IfThenOtherwise.__call__`, then calls
+`hg.switch_`. The
+[Arrow tests](../../../python/tests/ported/arrow/test_arrow.py) exercise
+`if_then(...).otherwise(...)` and `if_(...).then(...).otherwise(...)`.
+
+The lifetime contract is owned by the native switch, documented in
+[Nested graphs](../../../docs/source/developer_guide/nested_graphs.rst)
+and tested through public wiring in
+[test_switch.cpp](../../../tests/cpp/test_switch.cpp). HGL should reuse that
+contract rather than implement branch execution independently.
+
+## Scope and next topics
+
+The examples above establish predeclared escaping bindings, forwarding existing
+bindings, definite assignment, early-return continuations, outputless
+conditional wiring, mixed expression/assignment results, and subsequent
+composition. [Iteration](iteration.md) records the subsequent agreement about
+`for` in graph composition and node evaluation.
+No new syntax or lifetime policy for `for`, explicit `switch`, `map`, `reduce`,
+or `mesh` is introduced by these conditional agreements.
+
+## Implementation status
+
+At this change's baseline, both language backends reject a composition `if`
+whose condition is a temporal port and direct authors to `if_then_else`.
+The parser already accepts the conditional syntax. The new agreement changes
+the target semantics; this documentation change does not remove that compiler
+restriction. The parser also currently requires local declarations to have
+initializers; supporting `var r: i64` is part of the newly agreed design. The
+standard-library design corpus is kept outside the executable example glob
+until the relevant compiler support exists.

--- a/language/docs/design/control-flow.md
+++ b/language/docs/design/control-flow.md
@@ -184,15 +184,24 @@ a use on one path is not proof that the input is processed on every path.
 This is the compiler specifying the intent of a generated component, not a
 change to the author's `var r: i64` declaration or a general rule for rewriting
 user-declared types. Explicit reference access restrictions still apply.
-Branch signatures can differ in REF qualification while remaining compatible
-in underlying type. Their native boundary bindings must preserve the
+Branch input signatures can differ in REF qualification while remaining
+compatible in underlying type. Their native input bindings must preserve the
 forwarding connection and adapt it for value-consuming downstream nodes.
 Deduplicating a captured source must not discard these per-branch contracts.
 
 The same forwarding rule applies independently to each escaping field when
 multiple results are bundled. A branch can supply a newly computed binding
 for one field and forward another field's incoming binding by reference.
-It does not imply an outer reference over the whole bundle.
+It does not imply an outer reference over the whole bundle, nor may it leave a
+`REF` wrapper on that field of the branch output. Lowering chooses the escaped
+binding's declared, non-`REF` temporal schema as the common output schema for
+each result slot. A forwarding branch retains its `REF` capture, then explicitly
+dereferences that connection at the branch-output boundary before packing the
+field; a computed branch already supplies the same ordinary temporal schema.
+The two branch bundles consequently have identical schemas at every field, not
+merely compatible root types. If the public native API cannot express that
+per-field reference adaptation, HGL must reject the conditional until the
+native support exists rather than send mismatched bundles to `switch_`.
 
 The corresponding design-corpus source is
 [conditional-results.hgl](../../stdlib/examples/conditional-results.hgl).
@@ -432,8 +441,11 @@ The agreed derivation then has both input and output sides:
    reject a used variable when a path supplies neither an assignment nor an
    incoming binding. Count the expression result alongside the escaping
    variables: zero results require no output, one is returned directly, and
-   several use a common generated bundle. Resolve output compatibility while
-   preserving the declared reference/access contracts.
+   several use a common generated bundle. For every result slot, select the
+   declared non-`REF` temporal schema as the common output schema and insert an
+   explicit dereference at a forwarding branch's output boundary. Preserve
+   REF qualification on the branch input capture, but never emit branch result
+   bundles that differ only because one field still carries that wrapper.
 5. For branches that rejoin, supply the expression result to its consumer and
    remap the enclosing variables from the switch output or its bundle fields,
    then continue composing the statements after the conditional. Both result

--- a/language/docs/design/control-flow.md
+++ b/language/docs/design/control-flow.md
@@ -444,11 +444,12 @@ The agreed derivation then has both input and output sides:
    reject a used variable when a path supplies neither an assignment nor an
    incoming binding. Count the expression result alongside the escaping
    variables: zero results require no output, one is returned directly, and
-   several use a common generated bundle. For every result slot, select the
-   declared non-`REF` temporal schema as the common output schema and insert an
-   explicit dereference at a forwarding branch's output boundary. Preserve
-   REF qualification on the branch input capture, but never emit branch result
-   bundles that differ only because one field still carries that wrapper.
+   several use a common generated bundle. For every result slot, preserve its
+   resolved declared temporal schema as the common output schema. When that
+   schema is non-`REF`, insert an explicit dereference at a forwarding branch's
+   output boundary; when it is explicitly `ref<T>`, preserve the reference in
+   the result. Never emit branch result bundles whose corresponding fields have
+   different schemas.
 5. For branches that rejoin, supply the expression result to its consumer and
    remap the enclosing variables from the switch output or its bundle fields,
    then continue composing the statements after the conditional. Both result

--- a/language/docs/design/iteration.md
+++ b/language/docs/design/iteration.md
@@ -1,0 +1,179 @@
+# Iteration in graph composition and node evaluation
+
+Status: phase-dependent iteration and the independent-body boundary for
+dynamic graph loops agreed, 2026-09-05; compiler implementation is separate.
+Map/reduce lowering of loop-carried accumulators is a documented future
+extension, explicitly unsupported in the initial graph-loop implementation.
+
+## Iteration follows the containing phase
+
+The existing `for ... in ... { ... }` syntax and the `keys`, `values`, and
+`items` operations follow the containing function's phase. Their presence
+alone does not classify a function as a runtime node. Node-only constructs
+such as `when` establish runtime evaluation; a body without node-only
+constructs describes graph composition.
+
+| Context | Iteration receives | Body does |
+| --- | --- | --- |
+| Graph, over a supported wiring-time iterable | Scalar values known during wiring. | Composes nodes using those values. |
+| Graph, over a fixed temporal structure | Child time-series connections. | Composes nodes connected to each child. |
+| Graph, over a dynamic map or list, with independent iterations | Per-member time-series connections in a generated child graph. | Describes one child graph per key or index through native mapping. |
+| Node evaluation | Current child views or scalar elements. | Processes values within that evaluation. |
+
+The iterator must be meaningful in that phase. This agreement does not make
+runtime payloads available during wiring or make runtime-only borrowed views
+persist across evaluations. It also does not supply an iteration protocol for
+every imported atomic type; native operations remain a separate topic.
+
+## Fixed temporal structure at wiring time
+
+```hgl
+fn observe(samples: list<f64, 3>) {
+    for sample in values(samples) {
+        debug_print("sample", sample)
+    }
+}
+```
+
+The list's three positions are known while wiring. The loop wires three sinks,
+one connected to each child. `sample` is a time-series connection, not its
+current payload. No sample value needs to exist during wiring. Source value
+ticks subsequently reach those sinks through their fixed connections; they do
+not cause the graph function to iterate again.
+
+The source is recorded in
+[fixed-list-iteration.hgl](../../stdlib/examples/fixed-list-iteration.hgl)
+as a design example, outside the executable compiler example corpus.
+
+## Node-time traversal
+
+Inside a node's evaluation, including a `when` handler, a loop traverses the
+current child views or scalar elements. Ordinary readable child expressions
+observe their payloads; `valid`, `modified`, and `last_modified` retain their
+endpoint-metadata meaning. The loop does not wire new nodes.
+
+The existing runtime traversal and predicate rules remain in
+[Collection views and iteration](../user-guide/types-and-expressions.md#collection-views-and-iteration).
+In particular, runtime iterators are evaluation-local borrowed views, predicate
+filters are pure, and the supported `modified`, `added`, and `removed` ranges
+follow the collection's native delta semantics. None of those rules grants
+node code access below an explicit REF boundary.
+
+## Dynamic structures: independent bodies first
+
+Maps and non-fixed-size lists do not provide a fixed set of child connections
+that a graph loop can enumerate during wiring. For independent bodies, the
+initial design lowers the loop through the native map machinery: one child
+graph per map key or dynamic-list index, with membership controlling child
+lifetime. The graph function does not traverse current payloads on each tick.
+
+```hgl
+fn observe(book: map<str, f64>, offset: f64) {
+    for value in values(book) {
+        debug_print("adjusted", value + offset)
+    }
+}
+```
+
+The generated child accepts the current member's time-series connection and
+the shared `offset` connection. Lexical capture analysis separates wiring-time
+scalars from temporal inputs, preserving their types and REF access boundaries,
+as with generated conditional branches. Here the body is outputless, so the
+lowering uses a sink map. The source is recorded in
+[dynamic-map-iteration.hgl](../../stdlib/examples/dynamic-map-iteration.hgl)
+as a design example, not a runnable compiler test.
+
+Map keys determine child identity. Dynamic lists use index identity, not the
+identity of a stored value. Updating an existing member does not recreate its
+child; membership removal or list truncation stops the affected children using
+the native lifetime protocol. Surviving children retain their own node state.
+The native ownership, binding, and scheduling contracts remain authoritative;
+see [Nested graphs](../../../docs/source/developer_guide/nested_graphs.rst) and
+the public-wiring coverage in [test_map.cpp](../../../tests/cpp/test_map.cpp).
+
+Independent bodies may capture surrounding inputs and compose stateful nodes
+or sinks within each child. Independence does not mean that every node must be
+stateless or pure. It means that one iteration cannot depend on a binding
+assigned by another iteration. No sequential side-effect order between children
+is promised. In the initial dynamic-loop subset, assignments to enclosing
+variables and loop-result construction are unsupported; local bindings within
+an individual body remain available.
+
+## Deferred option: map plus reduce
+
+A dynamic graph loop with independent contributions and a loop-carried
+accumulator can potentially lower to a map followed by a reduction. This is an
+intended extension, not support in the initial implementation. For example,
+the following records a candidate shape that is initially unsupported:
+
+```hgl
+fn total(samples: map<str, f64>, factor: f64) -> f64 {
+    var result: f64 = 0.0
+    for value in values(samples) {
+        result = result + value * factor
+    }
+    return result
+}
+```
+
+The independent contribution is `value * factor`; `result` carries the
+combination between iterations. Recognizing this dependency pattern is not by
+itself permission to reassociate or reorder the selected addition operation.
+In particular, floating-point addition is not exactly associative.
+
+The collection determines the future reduction strategy:
+
+- **Map:** reduction should be supported without imposing an order. HGL has no
+  sorted-map contract, so a loop must not imply key-sorted or insertion-order
+  folding. The resolved combiner must permit the reduction's regrouping and
+  reordering; the compiler cannot infer that permission from an operator's
+  spelling alone.
+- **List:** indices provide an order. Where that order affects the result,
+  use the native linear, ordered-left-fold option of `reduce`. An associative
+  tree reduction is only an option when the operation's contract permits it.
+  The native selector is `is_associative=false`; this is a reference to the
+  runtime API, not a newly agreed HGL call or policy syntax.
+
+The future analysis must resolve input and combiner types, identify captures,
+and check that each mapped contribution is independent of the accumulator.
+Observing intermediate accumulator bindings, including through sinks, can
+require prefix or recurrence semantics rather than one final reduction. Such
+patterns are not covered by this map-plus-reduce option.
+
+The result would describe the current collection, not accumulate all ticks
+over time. Membership changes must remove obsolete contributions. Validity,
+tick behaviour, and mapped-child state and effects are part of the contract,
+not merely the final scalar result. Their exact reduction rules must be agreed
+before this extension is enabled.
+
+The incoming accumulator binding must also be preserved. Native associative
+`reduce` uses `zero` for an empty collection, combines it with a singleton, and
+does not include it for two or more live values. It is therefore not a general
+loop initializer: changing `result` above to start at `10.0` cannot simply
+become `zero=10.0`. Ordered reduction provides a true initial accumulator.
+See the [native reduce contract](../../../include/hgraph/lib/std/operators/higher_order.h),
+[ordered dynamic-list tests](../../../tests/cpp/test_reduce.cpp), and
+[zero-semantics tests](../../../python/tests/test_reduce_zero_semantics.py).
+
+Initially, the compiler should diagnose a dynamic graph loop requiring a
+loop-carried reduction as unsupported. It must not silently choose a reduction
+order or change the containing graph into a runtime node. This restriction
+does not prohibit ordinary evaluation-time accumulation inside a node, and
+does not remove the existing native map or reduce APIs.
+
+## Remaining decisions
+
+Loop result construction, the precise recognition and operator contracts for
+deferred reductions, other cross-iteration dependencies, graph-phase
+predicates, and loop exits remain to be worked through. No new source spelling
+for explicit `map`, `reduce`, or their policies is introduced here.
+
+## Implementation status
+
+Earlier language documentation treated collection iterators as inherently
+runtime-only and as function-classification triggers. The agreed target now
+makes iteration phase-dependent, with an initial independent-body subset for
+dynamic graph loops and deferred map/reduce accumulation. This documentation
+change does not implement graph iteration, its unsupported-pattern diagnostics,
+or the compiler's classifier change. The graph examples are design inputs,
+not passing compiler tests.

--- a/language/docs/design/iteration.md
+++ b/language/docs/design/iteration.md
@@ -165,8 +165,13 @@ does not remove the existing native map or reduce APIs.
 
 Loop result construction, the precise recognition and operator contracts for
 deferred reductions, other cross-iteration dependencies, graph-phase
-predicates, and loop exits remain to be worked through. No new source spelling
-for explicit `map`, `reduce`, or their policies is introduced here.
+predicates, and loop exits remain to be worked through. So does the
+disambiguation of a function whose only phase-sensitive operation is runtime
+collection traversal: once iteration follows its containing phase, such a body
+contains no existing construct that selects runtime evaluation. Whether this
+needs an explicit phase marker or another rule is deliberately unresolved. No
+new source spelling for that distinction, explicit `map`, `reduce`, or their
+policies is introduced here.
 
 ## Implementation status
 

--- a/language/docs/design/language-model.md
+++ b/language/docs/design/language-model.md
@@ -511,11 +511,23 @@ any of these constructs makes the complete body a runtime function:
 - a `state` declaration;
 - an `inject` declaration;
 - a `start`, `when`, or `stop` block.
-- a runtime `keys`, `values`, or `items` iterator.
+
+Under the agreed [iteration model](iteration.md), `for`, `keys`, `values`, and
+`items` follow the containing phase and do not themselves force runtime
+classification. This updates the earlier iterator-only classification rule;
+compiler implementation is separate.
 
 Mixing wiring-only and runtime-only constructs is an error. Classification is
 based on the resolved source body, not on the implementation kind selected for
 a called operator.
+
+A graph `if` with a temporal Boolean condition uses native switch-style child
+execution, following the Arrow API. It remains graph composition: the graph
+wires the conditional once and the native switch manages branch execution.
+A wiring-time Boolean still selects which branch to wire, and a conditional
+inside node evaluation remains ordinary runtime control flow. See
+[Conditional control flow](control-flow.md) for this agreed strategy and its
+implementation status.
 
 A runtime function may declare persistent state, approved injected
 capabilities, lifecycle behavior, and ordered activation handlers:
@@ -656,8 +668,15 @@ The collection surface separates a materialized temporal view from borrowed
 runtime iteration. `key_set(tsd)` is available in both phases: composition
 produces the live TSS key projection, while runtime evaluation exposes the
 current borrowed set view. The calls `keys(value)`, `values(value)`, and
-`items(value)` produce evaluation-local iterators and therefore make their
-containing function a runtime function.
+`items(value)` follow the containing phase. In node evaluation they produce
+evaluation-local iterators. In graph composition, iteration over a supported
+wiring-time iterable visits scalar values, and iteration over a fixed temporal
+structure visits child connections. The calls do not themselves make a
+function a runtime node. Dynamic graph loops initially admit independent bodies
+lowered through per-key or per-index mapping. Loop-carried reductions are
+deferred, with unordered map reduction and linear list reduction documented as
+future options. See [Iteration](iteration.md) for the agreement and separate
+compiler implementation status.
 
 `values` is the common value-only spelling for TSB, TSD, TSL, and TSS; there is
 no `elements` alias. `items` yields `(field, value)` for TSB, `(key, value)` for

--- a/language/docs/design/type-extensions.md
+++ b/language/docs/design/type-extensions.md
@@ -1,0 +1,176 @@
+# Imported values, reference types, and SIGNAL inputs
+
+Status: agreed source semantics, 2026-09-05; compiler implementation is outside
+this change. The collection-reference mapping noted below still needs
+clarification. This record introduces no native declaration syntax.
+
+## Imported types are atomic values
+
+Imported C++ and Python types are not time-series types. They participate as
+scalar value types, like `i64`, `f64`, and `str`:
+
+- An ordinary temporal parameter carries complete imported values on one
+  atomic endpoint.
+- A `const` parameter carries a wiring-time scalar value.
+- An explicit `atomic` annotation is not required.
+- An imported type remains an atomic leaf inside an HGL list, map, or struct.
+- Native fields do not cause recursive temporalization or acquire independent
+  tick histories merely because the type has been imported.
+
+HGL-declared structs retain their existing structural temporalization. An
+imported structured object does not acquire that behavior. Importing a type
+preserves its native value identity and supported operations; it does not
+import a time-series shape. The declaration mechanism for exposing those types
+and operations remains to be discussed.
+
+## Reference spelling and type compatibility
+
+The agreed spelling is `ref<T>`, wrapping an existing HGL type. The user or
+component designer specifies REF to declare what the component intends to
+access or pass through. Use it only where the component intends to forward a
+time series without observing or interacting with its values. It is not a
+default annotation for every connection or a general inferred rewrite of
+user-declared types.
+
+For compiler-generated conditional branch callables, the compiler specifies
+that component's access intent: a branch which only forwards an enclosing
+variable's incoming binding takes it by reference. An ordinary temporal input
+is sufficient when the branch is known to process it. This narrowly scoped
+capture rule leaves the author's variable declaration unchanged; see
+[Forwarding an existing binding](control-flow.md#forwarding-an-existing-binding).
+
+For example:
+
+```text
+ref<map<i64, str>> -> REF[TSD[int, TS[str]]]
+```
+
+Reference wrappers do not participate in underlying type compatibility:
+
+```text
+ref<map<i64, str>> ~ map<i64, str>
+```
+
+The same compatibility principle applies within a type's structure. The
+underlying types must still match. Compatibility does not erase the reference
+from its endpoint representation or grant a node access through it.
+
+Type formation is checked separately. A map key cannot be a reference:
+
+```text
+map<ref<i64>, str> -> error
+```
+
+Ignoring REF for compatibility does not make an invalid type formation legal.
+
+## Node access and ticks
+
+Inside node evaluation, including a `when` handler, a reference is an opaque
+value. Code cannot inspect the values of the schema below the reference:
+field access, collection indexing, and traversal through that reference are
+not value-reading operations available to the node.
+
+The reference ticks only when its binding changes. A value tick on the
+referenced endpoint does not itself tick the reference. A binding change is
+observable even when the old and new targets currently hold equal values.
+
+REF-transparent type compatibility and opaque node access are distinct rules.
+An ordinary non-reference input can consume a reference producer through
+normal hgraph binding adaptation. A reference-typed node input retains the
+opaque reference view; it does not implicitly dereference itself during
+evaluation.
+
+## Selecting and forwarding a reference
+
+The routing example from the discussion illustrates the intended use. This
+is a signature/body fragment; its enclosing generic declaration is omitted:
+
+```text
+route(r: i64, l: list<ref<T>, S>) -> ref<T> {
+    when modified(r) {
+        return l[r]
+    }
+}
+```
+
+The node observes the index `r`. The list itself is accessible, and indexing
+it obtains one opaque `ref<T>` element. This does not cross that element's
+reference boundary or read a value of `T`. The node returns the selected
+reference, establishing the connection through which consumers observe the
+selected time series.
+
+After that connection is established, value ticks from the selected target
+do not require this routing node to evaluate, copy the value, or emit it
+again. Reference inputs observe binding changes, rather than value ticks
+behind those bindings. The example's explicit handler condition remains
+`modified(r)`; reference tick semantics do not silently add another handler
+condition.
+
+The position of the boundary determines which operations are available:
+
+| Node input | Permitted access in evaluation |
+| --- | --- |
+| `list<ref<T>, S>` | Access the list and select an opaque reference element. |
+| `ref<list<T, S>>` | Handle the opaque reference; do not index the list beneath it. |
+
+An ordinary list of temporal values instead requires a value-forwarding node
+to observe and copy each selected value tick that it forwards. REF expresses
+that this component is responsible for selecting the connection, without
+processing the values subsequently carried by it.
+
+## Wiring-time access
+
+During wiring, code may access elements beneath a reference layer. Such access
+causes dereferencing to obtain the element of interest. The result of wiring
+is a connection to that element, not a read of its current runtime value.
+
+This permits graph composition to select fields or collection elements through
+reference-backed sources while preserving the node-level access restriction.
+Reference binding and adaptation belong to the existing hgraph runtime.
+
+## SIGNAL inputs
+
+SIGNAL is an input-only observation contract. It accepts a time-series input
+without exposing the input's value or structure. Its only observation
+operations are:
+
+- `modified`: whether the input was modified in the current evaluation cycle;
+- `valid`: whether the input is valid;
+- `last_modified`: the input's last modification time.
+
+Value access is unavailable, including any value or delta payload that an
+underlying native representation may technically expose. The intended source
+contract does not permit arithmetic, Boolean value tests, field access,
+indexing, or traversal of the connected data through a SIGNAL input.
+
+There is no SIGNAL output in the language contract. There is consequently no
+signal-emission operation or literal to design. Native implementation details
+must not broaden this source contract.
+
+SIGNAL is primarily meaningful inside a node, where those observation
+operations can control evaluation. Graph functions may also accept SIGNAL
+inputs and pass them to components with compatible inputs. This does not make
+the graph body execute on ticks or expose a runtime value during wiring.
+
+The semantics above are agreed; the HGL type spelling remains to be confirmed.
+
+## Collection-reference mapping to clarify
+
+The second mapping supplied during the discussion was:
+
+```text
+map<i64, ref<str>> -> REF[TSD[int, REF[TS[str]]]]
+```
+
+This includes an outer REF without an explicit outer `ref` in the source.
+Whether that outer REF is intentional, and the rule that would add it, are
+awaiting clarification. Do not infer a general reference-propagation rule or
+silently remove the outer REF from this example.
+
+## Scope of this agreement
+
+This record does not settle SIGNAL spelling, native declaration syntax,
+reference construction or mutation operations, or additional restrictions on
+reference placement. Those remain separate discussion items. No changes to
+the parser, compiler backends, native runtime, or executable examples accompany
+this record.

--- a/language/docs/design/type-extensions.md
+++ b/language/docs/design/type-extensions.md
@@ -87,24 +87,26 @@ is a signature/body fragment; its enclosing generic declaration is omitted:
 
 ```text
 route(r: i64, l: list<ref<T>, S>) -> ref<T> {
-    when modified(r) {
+    when valid(r) and valid(l[r]) and (modified(r) or modified(l[r])) {
         return l[r]
     }
 }
 ```
 
-The node observes the index `r`. The list itself is accessible, and indexing
-it obtains one opaque `ref<T>` element. This does not cross that element's
-reference boundary or read a value of `T`. The node returns the selected
-reference, establishing the connection through which consumers observe the
-selected time series.
+The first guard establishes that the index can be read. Short-circuit order
+then makes the selected entry available to its own validity and modification
+checks. The list itself is accessible, and indexing it obtains one opaque
+`ref<T>` element. This does not cross that element's reference boundary or read
+a value of `T`. The node returns the selected reference, establishing the
+connection through which consumers observe the selected time series.
 
 After that connection is established, value ticks from the selected target
 do not require this routing node to evaluate, copy the value, or emit it
-again. Reference inputs observe binding changes, rather than value ticks
-behind those bindings. The example's explicit handler condition remains
-`modified(r)`; reference tick semantics do not silently add another handler
-condition.
+again. The explicit handler observes both routing changes and reference-binding
+changes: `modified(r)` selects a different entry, while `modified(l[r])`
+republishes a selected entry that retargets without changing the index.
+Reference inputs observe those binding changes, rather than value ticks behind
+the bindings; the compiler does not silently add either activation condition.
 
 The position of the boundary determines which operations are available:
 

--- a/language/docs/design/type-extensions.md
+++ b/language/docs/design/type-extensions.md
@@ -87,18 +87,19 @@ is a signature/body fragment; its enclosing generic declaration is omitted:
 
 ```text
 route(r: i64, l: list<ref<T>, S>) -> ref<T> {
-    when valid(r) and valid(l[r]) and (modified(r) or modified(l[r])) {
+    when valid(r) && r >= 0 && r < S && valid(l[r]) && (modified(r) || modified(l[r])) {
         return l[r]
     }
 }
 ```
 
-The first guard establishes that the index can be read. Short-circuit order
-then makes the selected entry available to its own validity and modification
-checks. The list itself is accessible, and indexing it obtains one opaque
-`ref<T>` element. This does not cross that element's reference boundary or read
-a value of `T`. The node returns the selected reference, establishing the
-connection through which consumers observe the selected time series.
+The first guard establishes that the index can be read, and the next two prove
+that it is in the fixed list's half-open range `[0, S)`. Short-circuit order
+therefore makes the selected entry available safely to its own validity and
+modification checks. The list itself is accessible, and indexing it obtains one
+opaque `ref<T>` element. This does not cross that element's reference boundary
+or read a value of `T`. The node returns the selected reference, establishing
+the connection through which consumers observe the selected time series.
 
 After that connection is established, value ticks from the selected target
 do not require this routing node to evaluate, copy the value, or emit it

--- a/language/docs/design/type-extensions.md
+++ b/language/docs/design/type-extensions.md
@@ -82,24 +82,29 @@ evaluation.
 
 ## Selecting and forwarding a reference
 
-The routing example from the discussion illustrates the intended use. This
-is a signature/body fragment; its enclosing generic declaration is omitted:
+The routing example from the discussion illustrates the intended use. It is
+deliberately fixed-size so that every bound in the guard is numeric:
 
 ```text
-route(r: i64, l: list<ref<T>, S>) -> ref<T> {
-    when valid(r) && r >= 0 && r < S && valid(l[r]) && (modified(r) || modified(l[r])) {
+fn route3<T>(r: i64, l: list<ref<T>, 3>) -> ref<T> {
+    when valid(r) && r >= 0 && r < 3 && valid(l[r]) && (modified(r) || modified(l[r])) {
         return l[r]
     }
 }
 ```
 
 The first guard establishes that the index can be read, and the next two prove
-that it is in the fixed list's half-open range `[0, S)`. Short-circuit order
+that it is in the fixed list's half-open range `[0, 3)`. Short-circuit order
 therefore makes the selected entry available safely to its own validity and
 modification checks. The list itself is accessible, and indexing it obtains one
 opaque `ref<T>` element. This does not cross that element's reference boundary
 or read a value of `T`. The node returns the selected reference, establishing
 the connection through which consumers observe the selected time series.
+
+A `const` list-size generic may also bind `unbounded`, whose sentinel is not a
+numeric upper bound. The language has not yet decided the dynamic-list size and
+safe-indexing surface, so this example does not generalise the comparison to
+`list<ref<T>, S>` or invent a constraint that excludes `unbounded`.
 
 After that connection is established, value ticks from the selected target
 do not require this routing node to evaluate, copy the value, or emit it

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -981,8 +981,10 @@ walk:
   generic function is a `backend` diagnostic naming it;
 - the prelude intrinsics take the meaning of "Interim kernel table";
 - `if` selects a branch when its condition is a constant `bool`; a port
-  condition is a `backend` diagnostic until the guide decides whether it
-  lowers to `if_then_else`; the branch value is the arm's tail expression;
+  condition remains a `backend` diagnostic in the current prototype. The
+  agreed target is native switch-style child-graph execution, not eager wiring
+  of both outputs through `if_then_else`; the branch value is the arm's tail
+  expression;
 - a block body runs its statements in order: `let` and `var` bind locals
   (a declared type converts a constant or checks a port's schema), `=` and
   the compound assignments rebind a `var`, `return` ends the activation,

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -242,6 +242,7 @@ type            = scalar_type
                 | set_type
                 | map_type
                 | rolling_type
+                | ref_type
                 | named_type
                 | "atomic", "<", value_type, ">";
 value_type      = scalar_type
@@ -268,6 +269,7 @@ map_type        = "map", "<", value_type, ",", type, ">";
 rolling_type    = "rolling", "<", value_type, ",",
                   const_expression,
                   [ ",", const_expression ], ">";
+ref_type        = "ref", "<", type, ">";
 value_tuple_type = "tuple", "<", value_type,
                    { ",", value_type }, ">";
 value_list_type = "list", "<", value_type, ">";
@@ -294,10 +296,20 @@ temporalized:
 map<str, atomic<tuple<f64, f64>>>
 ```
 
-`value_type` excludes `atomic` and `rolling` and is used for `const` parameters
-and atomic payloads. `type` allows atomic boundaries recursively inside
-structural values. `rolling` is already a temporal endpoint shape and therefore
-cannot appear under `atomic` or in a `const` parameter.
+`value_type` excludes `atomic`, `rolling`, and `ref` and is used for `const`
+parameters, atomic payloads, map keys, set elements, and rolling values. `type` allows
+atomic and reference boundaries recursively inside structural values. `rolling`
+is already a temporal endpoint shape and therefore cannot appear under `atomic`
+or in a `const` parameter.
+
+`ref<T>` is a temporal reference boundary, not a named scalar type. It is
+therefore legal only in positions described by the full `type` production,
+including temporal parameters, results, and collection values. It is rejected
+where the grammar requires `value_type`: a `const` annotation, an atomic
+payload, a map or set key, or a rolling value. `ref` is a contextual type
+keyword when directly followed by `<`; otherwise normal name resolution
+applies. Reference access and compatibility rules are recorded in
+[Imported values, reference types, and SIGNAL inputs](../design/type-extensions.md).
 
 A rolling window is sized by tick count or by duration. The size arguments
 are constant expressions, and their type selects the kind: `i64` sizes

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -917,6 +917,13 @@ compiler-generated bundle. The grammar above still
 describes the current initializer-required implementation. No default value
 or runtime state cell is implied by the new declaration form.
 
+For each escaping result, lowering uses the declared non-`REF` temporal schema
+as the common branch-output slot. A branch that forwards an incoming binding
+still captures it through `REF`, but explicitly dereferences it before returning
+the slot or packing its field into a generated multi-result bundle. REF is not
+allowed to leak into only one branch's output schema; branch bundles must match
+recursively before they reach the native switch.
+
 The target design also requires definite-assignment analysis for escaping
 variables. At a use, every path reaching it must supply a binding, either by
 assignment or by forwarding an existing incoming binding. Otherwise reject

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -1313,7 +1313,11 @@ The implemented provisional classifier currently applies these rules:
 
 The target classifier will instead let iteration inherit its containing phase;
 `for` will not by itself distinguish composition from runtime behavior. That
-change is an explicit compiler migration rather than current behavior.
+change is an explicit compiler migration rather than current behavior. It also
+leaves iterator-only runtime functions ambiguous because they contain no
+existing node-only construct. The language must resolve that boundary before
+the classifier migration, but this document does not invent an explicit phase
+marker or another disambiguation rule.
 
 Classification is based on resolved source syntax. It must not be guessed
 from which imported overload happens to win, inferred from generated C++, or
@@ -1340,8 +1344,10 @@ and phase checking derive one safe node policy across the complete body:
 - handler-specific activation, validity, and other predicates remain ordered
   runtime conditions.
 
-A runtime function with no `when` uses hgraph's default policy: every ordinary
-temporal input is active and required-valid.
+A function classified as runtime by another node-only construct but containing
+no `when` uses hgraph's default policy: every ordinary temporal input is active
+and required-valid. This does not by itself classify an otherwise ordinary or
+iterator-only body as runtime.
 
 ## Runtime state, injectables, and lifecycle
 

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -727,7 +727,7 @@ requires U is struct
 
 In this example the first two predicates establish that field lookup is valid,
 and the equality resolves or checks `V`. `fields` is deliberately distinct
-from the runtime collection iterator `keys`; constraint reflection operates on
+from collection traversal with `keys`; constraint reflection operates on
 the canonical source type and does not expose its expanded hgraph schema.
 
 An operator requirement is resolved against the nominal operator selected by
@@ -906,6 +906,24 @@ they hold canonical scalar values local to the executing block. Runtime `var`
 storage is recreated on every block execution and is never added to the
 function's recordable state. A value that crosses evaluations must use `state`.
 
+The agreed
+[conditional-result design](../design/control-flow.md#results-used-after-the-conditional)
+extends this baseline with typed, uninitialized declarations such as
+`var r: i64`. The declaration introduces the enclosing variable; branch
+assignments supply its output connection, and lowering remaps the binding
+after the switch. Count any used expression result alongside the escaping
+bindings: one result is returned directly; several are returned through a
+compiler-generated bundle. The grammar above still
+describes the current initializer-required implementation. No default value
+or runtime state cell is implied by the new declaration form.
+
+The target design also requires definite-assignment analysis for escaping
+variables. At a use, every path reaching it must supply a binding, either by
+assignment or by forwarding an existing incoming binding. Otherwise reject
+the use at compile time; do not synthesize a never-ticking source to fill the
+gap. This is static binding analysis, not runtime time-series validity
+checking. See [Definite assignment](../design/control-flow.md#definite-assignment).
+
 The statement and expression productions are:
 
 ```ebnf
@@ -953,10 +971,38 @@ The final statement of a block is its tail expression when it is an
 expression. `if` is a primary expression, so it is an operand only when
 parenthesized (`(if c { 1 } else { 2 }) + 1`); as a statement its value is
 discarded. A bare `{ ... }` in expression position is a block expression.
-Which conditions a composition body may branch on is a
-classification question (the open item on temporal conditions), not a
-grammar one: the parser accepts `if` uniformly and the classifier
-diagnoses the cases the current slice does not lower.
+The parser accepts `if` uniformly. Its meaning depends on context: a
+wiring-time Boolean chooses composition, a temporal Boolean in composition
+uses the agreed native switch strategy, and a runtime-node condition is an
+ordinary current-value conditional. See
+[Conditional control flow](../design/control-flow.md). The temporal composition
+case remains unimplemented in the current backends; their rejection is an
+implementation limit rather than an unresolved choice of strategy.
+
+Under the agreed temporal composition design, `return` targets the enclosing
+HGL function, not a compiler-generated branch lambda. Lowering must identify
+early-return paths and place the remaining function body in the non-returning
+path's continuation before deriving branch captures and result signatures.
+The continuation's computations share that branch's lifetime. Definite
+assignment considers only paths reaching a use, excluding paths that return
+before it. See [Early returns](../design/control-flow.md#early-returns-and-continuations).
+This is a target lowering requirement, not implemented backend behavior.
+
+An outputless temporal conditional uses the native sink-switch path without a
+synthetic output. Sinks inside the branch are wired through the switch; sinks
+outside it remain unconditionally wired. The graph body still describes
+wiring, and the sink nodes perform runtime effects. Result and escape analysis
+determines whether a switch is outputless, independently of the enclosing
+function's return annotation. See
+[Outputless conditionals](../design/control-flow.md#outputless-conditionals).
+
+Expression results and escaping assignments may coexist in one conditional.
+Include both in the generated branch output signature and remap each to its
+consumer. The binding receiving the whole expression result is not an
+escaping variable; only the variables assigned inside the branches require
+prior declarations. This uses the existing expression and assignment syntax;
+no source-level bundle declaration or reserved result-field name is needed.
+See [Mixed results](../design/control-flow.md#expression-results-and-escaping-assignments).
 
 Expression precedence is:
 
@@ -1173,8 +1219,8 @@ registered live TSS projection and has temporal source type `set<K>`. In a
 `RuntimeFn` it produces an evaluation-local borrowed set view over the current
 TSD key set.
 
-`keys`, `values`, and `items` produce runtime-only iterator types. They accept
-the collection followed by an optional predicate:
+In runtime evaluation, `keys`, `values`, and `items` produce evaluation-local
+iterator types. They accept the collection followed by an optional predicate:
 
 ```ebnf
 collection_iterator
@@ -1183,11 +1229,19 @@ collection_iterator
 ```
 
 The calls are parsed as ordinary call expressions. The grammar above records
-their checked intrinsic shapes rather than adding special parser nodes. A
-runtime collection iterator is a node-only construct and therefore classifies
-its containing function as `RuntimeFn`. The iterator must be consumed directly
-by `for`; it is neither a canonical value nor a temporal port and cannot escape
-the current evaluation.
+their checked intrinsic shapes rather than adding special parser nodes.
+Under the agreed phase-dependent design, these calls no longer force the
+containing function to be a `RuntimeFn`. This section describes their runtime
+interpretation: the iterator must be consumed directly by `for`; it is neither
+a canonical value nor a temporal port and cannot escape the current
+evaluation. In graph composition, a supported wiring-time iterable provides
+scalar values and a fixed temporal structure provides child connections.
+Independent dynamic graph-loop bodies lower through per-key or per-index
+mapping. The initial dynamic subset rejects assignments to enclosing variables
+and loop-carried reductions; it must not silently change the function's phase.
+Unordered map reduction and ordered, linear list reduction are deferred
+options, not initial lowering support. See [Iteration](../design/iteration.md)
+for the target design and its separate compiler implementation work.
 
 Traversal and built-in delta-predicate support is:
 
@@ -1243,9 +1297,10 @@ determine whether its body describes:
 The current provisional classifier applies these rules:
 
 1. A body containing no node-only construct becomes `CompositionFn`.
-2. The presence of `state`, `inject`, `start`, `when`, `stop`, or a runtime
-   collection iterator makes the complete function a `RuntimeFn`, even when
-   nested syntax is later rejected by phase checking.
+2. The presence of `state`, `inject`, `start`, `when`, or `stop` makes the
+   complete function a `RuntimeFn`, even when nested syntax is later rejected
+   by phase checking. Iteration follows the containing phase and is not itself
+   a runtime-classification trigger under the newly agreed target design.
 3. A body that mixes wiring-only and runtime-only constructs is rejected.
 
 Classification is based on resolved source syntax. It must not be guessed

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -1294,14 +1294,19 @@ determine whether its body describes:
 - runtime compute or sink behavior;
 - or another explicitly admitted hgraph implementation kind.
 
-The current provisional classifier applies these rules:
+The implemented provisional classifier currently applies these rules:
 
-1. A body containing no node-only construct becomes `CompositionFn`.
+1. A body containing no node-only construct and no iteration becomes
+   `CompositionFn`.
 2. The presence of `state`, `inject`, `start`, `when`, or `stop` makes the
    complete function a `RuntimeFn`, even when nested syntax is later rejected
-   by phase checking. Iteration follows the containing phase and is not itself
-   a runtime-classification trigger under the newly agreed target design.
+   by phase checking. The current compiler also treats every `for` statement as
+   a runtime-classification trigger.
 3. A body that mixes wiring-only and runtime-only constructs is rejected.
+
+The target classifier will instead let iteration inherit its containing phase;
+`for` will not by itself distinguish composition from runtime behavior. That
+change is an explicit compiler migration rather than current behavior.
 
 Classification is based on resolved source syntax. It must not be guessed
 from which imported overload happens to win, inferred from generated C++, or

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -929,12 +929,14 @@ compiler-generated bundle. The grammar above still
 describes the current initializer-required implementation. No default value
 or runtime state cell is implied by the new declaration form.
 
-For each escaping result, lowering uses the declared non-`REF` temporal schema
-as the common branch-output slot. A branch that forwards an incoming binding
-still captures it through `REF`, but explicitly dereferences it before returning
-the slot or packing its field into a generated multi-result bundle. REF is not
-allowed to leak into only one branch's output schema; branch bundles must match
-recursively before they reach the native switch.
+For each escaping result, lowering preserves the resolved declared temporal
+schema as the common branch-output slot. A branch that forwards an incoming
+binding still captures it through `REF`. If the result slot is declared as an
+ordinary `T`, lowering explicitly dereferences that capture before returning the
+slot or packing its field into a generated multi-result bundle. If the result is
+explicitly `ref<T>`, the reference remains part of the output schema and is not
+dereferenced. Corresponding branch-output fields must match recursively before
+they reach the native switch.
 
 The target design also requires definite-assignment analysis for escaping
 variables. At a use, every path reaching it must supply a binding, either by

--- a/language/docs/user-guide/README.md
+++ b/language/docs/user-guide/README.md
@@ -69,8 +69,13 @@ persistent values use `state`.
 The current design classifies a function from the constructs used in its body:
 
 - an ordinary expression body describes wiring composition;
-- `state`, `inject`, `start`, `when`, `stop`, or runtime collection traversal
-  makes the complete function a runtime implementation compiled as one node.
+- `state`, `inject`, `start`, `when`, or `stop` makes the complete function a
+  runtime implementation compiled as one node.
+
+The agreed [iteration model](../design/iteration.md) makes `for`, `keys`,
+`values`, and `items` follow the containing phase; they do not alone force a
+runtime function. Graph-phase iteration and the classification update remain
+separate compiler work.
 
 Runtime functions use ordinary `return` to produce an output tick. They may
 request direct output access alongside other runtime capabilities:

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -415,9 +415,10 @@ when it is known to process the input, an ordinary temporal input is sufficient.
 This determines the generated branch's contract without changing the author's
 declaration. It forwards the pre-conditional connection, not remembered state
 from a previously selected branch. For a bundled multi-result switch, each
-forwarded field is dereferenced at the branch-output boundary to the escaped
-variable's ordinary temporal schema. REF remains an input-capture property;
-both branch output bundles have the same non-REF field schemas.
+forwarded field uses the escaped variable's declared temporal schema. An
+ordinary `T` result is dereferenced at the branch-output boundary; an explicitly
+declared `ref<T>` result preserves the reference. Both branch output bundles
+have the same field schemas.
 
 Every escaping variable must have a binding on every path reaching its use:
 either a prior binding to forward or an assignment on that path. Otherwise

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -414,7 +414,10 @@ when `else` is omitted. A pure forwarding branch takes the binding by reference;
 when it is known to process the input, an ordinary temporal input is sufficient.
 This determines the generated branch's contract without changing the author's
 declaration. It forwards the pre-conditional connection, not remembered state
-from a previously selected branch.
+from a previously selected branch. For a bundled multi-result switch, each
+forwarded field is dereferenced at the branch-output boundary to the escaped
+variable's ordinary temporal schema. REF remains an input-capture property;
+both branch output bundles have the same non-REF field schemas.
 
 Every escaping variable must have a binding on every path reaching its use:
 either a prior binding to forward or an assignment on that path. Otherwise

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -633,9 +633,13 @@ children accumulate into one output delta; repeated writes to the same child
 use the last value. `inject out` is invalid on an outputless function and `out`
 is initially restricted to evaluation code rather than `start` or `stop`.
 
-A runtime function without `when` uses hgraph's ordinary policy: any temporal
-input can activate it and all ordinary inputs must be valid. `when` is needed
-only to customize activation, validity, or ordered conditional handling.
+Once some other node-only construct classifies a function as runtime, omitting
+`when` uses hgraph's ordinary policy: any temporal input can activate it and
+all ordinary inputs must be valid. `when` is then needed only to customize
+activation, validity, or ordered conditional handling. A function whose only
+runtime operation is collection traversal cannot yet select this phase without
+also using an existing node-only construct. The explicit phase-disambiguation
+syntax, if any, remains to be designed.
 
 The exact conditional-expression spelling, structural metadata aggregation,
 ephemeral cache syntax, and calls between runtime functions remain provisional.

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -299,7 +299,7 @@ An outputless function omits the return arrow:
 
 ```hgl
 fn observe(price: f64, const label: str = "price") {
-    debug_print(price, label)
+    debug_print(label, price)
 }
 ```
 
@@ -323,8 +323,8 @@ The body runs while hgraph is wired. Its operators and calls compose existing
 contracts. The function itself flattens into the resulting primitive nodes and
 does not remain as a runtime evaluation object.
 
-A function containing `state`, `inject`, `start`, `when`, `stop`, or a runtime
-collection iterator describes runtime evaluation and is compiled as one node:
+A function containing `state`, `inject`, `start`, `when`, or `stop` describes
+runtime evaluation and is compiled as one node:
 
 ```hgl
 fn add_when_ready(a: f64, b: f64) -> f64 {
@@ -347,10 +347,121 @@ Use `if valid(value) { ... }` inside a handler when only part of that handler
 needs a value. Validity guards follow normal left-to-right short-circuit order,
 so place `valid(value)` before reading `value` in the same `&&` condition.
 
+Under the agreed [iteration model](../design/iteration.md), `for` and collection
+traversal follow the containing phase rather than forcing runtime
+classification. In a graph, a supported wiring-time iterable provides scalar
+values and a fixed temporal structure provides child connections. Independent
+bodies over dynamic maps or lists lower through per-key or per-index mapping.
+Loop-carried reductions are initially unsupported: unordered map reduction
+and the linear reduction option for ordered lists are documented future
+extensions. In a node, traversal visits the current child views or scalar
+elements. This is the target design; graph iteration and the classifier change
+are separate compiler work.
+
 This can deliberately fuse work that would otherwise become several
 primitive nodes and intermediate endpoints. Graph composition still flattens;
 the possible saving comes from eliminating intermediate nodes, bindings,
 scheduling, and change tracking rather than from removing a graph wrapper.
+
+## Conditional control flow
+
+Status: the temporal-condition strategy below is agreed design. The current
+compiler still rejects a temporal condition in a composition `if`; implementing
+that strategy is separate work. The existing syntax needs no new keyword.
+
+`if` has three context-dependent meanings:
+
+| Context | Behavior |
+| --- | --- |
+| Graph function, wiring-time Boolean condition | Wire the selected branch once. |
+| Graph function, temporal Boolean condition | Use native switch-style child-graph execution, as in the Arrow API. |
+| Node evaluation, including `when` | Execute the selected branch using current readable values. |
+
+For a temporal condition in a graph, only the selected child graph runs. A
+change of condition stops the old child and starts the new one under native
+switch lifecycle rules. The surrounding graph still composes at wiring time.
+Computations wired outside the branches retain their own lifetimes.
+
+This differs from calling `if_then_else` on already-wired outputs, whose
+upstream computations remain independently active. A value-producing temporal
+`if` without `else` uses a typed, never-ticking false branch, matching Arrow.
+Lowering computes each branch lambda's input captures and output signature.
+An escaping variable must be declared before the conditional. For example:
+
+```hgl
+fn use_conditional_result(condition: bool, x: i64, y: i64) -> i64 {
+    var r: i64
+    if condition {
+        r = x + 1
+    } else {
+        r = y - 1
+    }
+
+    return r * 2
+}
+```
+
+Each branch returns its binding for `r`, and the enclosing `r` is remapped to
+the switch output. The multiplication is composed outside the switch. For
+multiple escaping variables, the branches return a common bundle whose fields
+are remapped to those variables. Branch-local declarations do not escape.
+The typed declaration without an initializer is also agreed design awaiting
+compiler support. Both branches assign `r` here.
+
+If `r` already has a binding before the conditional, a branch that leaves it
+unchanged forwards that incoming binding, including the implicit false branch
+when `else` is omitted. A pure forwarding branch takes the binding by reference;
+when it is known to process the input, an ordinary temporal input is sufficient.
+This determines the generated branch's contract without changing the author's
+declaration. It forwards the pre-conditional connection, not remembered state
+from a previously selected branch.
+
+Every escaping variable must have a binding on every path reaching its use:
+either a prior binding to forward or an assignment on that path. Otherwise
+its use is a compile-time definite-assignment error. A type annotation alone
+is insufficient, and an unassigned branch does not receive an automatic
+never-ticking source. This checks whether a connection exists, not whether
+its time series currently has a valid value.
+
+An explicit `return` inside a temporal branch returns from the enclosing HGL
+function. If one path returns early, the remaining function body becomes the
+other path's continuation inside its switch branch. Nodes and sinks composed
+there share that branch's lifetime; computations composed before the `if`
+remain outside. This does not permanently stop graph execution: later
+condition changes can still select either branch.
+
+Capture analysis includes the continuation's dependencies. Definite assignment
+checks only paths that reach a use; an earlier-returning path need not assign
+a variable used solely in the continuation. See the
+[early-return example](../design/control-flow.md#early-returns-and-continuations).
+
+An outputless temporal conditional wires its sinks through the switch. In
+`if enabled { debug_print("enabled", value) }`, the `"enabled"` sink is wired
+through the selected branch when enabled. A subsequent
+`debug_print("always", value)` outside that conditional is always wired into
+the enclosing graph. The graph body describes the wiring; the sink nodes
+perform the printing. With no `else`, the false path contributes no conditional
+sink. The conditional has no output or escaping binding to remap.
+
+Whether the switch needs an output depends on the conditional's results and
+escaping variables, not on whether the enclosing function is outputless. See
+[Outputless conditionals](../design/control-flow.md#outputless-conditionals).
+
+A conditional can supply an expression result while also assigning escaping
+variables. The final expression in each branch supplies the expression result;
+assignments supply the escaping bindings. Count them together: zero results
+need no output, one is returned directly, and multiple results use a generated
+bundle. Its fields are remapped to the expression consumer and enclosing
+variables. A binding initialized from the complete `if` expression is not
+itself an escaping variable and needs no prior declaration. See the
+[mixed-result example](../design/control-flow.md#expression-results-and-escaping-assignments).
+
+See
+[Conditional control flow](../design/control-flow.md) for the agreed strategy,
+single- and multiple-result examples, capture/signature derivation, Arrow
+precedent, forwarding of existing bindings, definite-assignment and early-return
+examples, outputless conditional wiring, and mixed expression/assignment
+results.
 
 ## State
 

--- a/language/docs/user-guide/types-and-expressions.md
+++ b/language/docs/user-guide/types-and-expressions.md
@@ -148,7 +148,9 @@ A node may index `list<ref<T>, S>` to select and return an opaque reference:
 the list is outside the reference boundary. It cannot index through
 `ref<list<T, S>>`, where the list is below that boundary. Returning a selected
 reference establishes a connection; subsequent target value ticks do not
-require the selecting node to copy and forward each value. See the
+require the selecting node to copy and forward each value. A dynamic selector
+must nevertheless guard a readable index and selected entry, and observe both
+index changes and selected-reference rebinding. See the
 [routing example](../design/type-extensions.md#selecting-and-forwarding-a-reference).
 
 ## SIGNAL inputs

--- a/language/docs/user-guide/types-and-expressions.md
+++ b/language/docs/user-guide/types-and-expressions.md
@@ -104,12 +104,68 @@ shapes recursively:
 | `map<str, f64>` | Keyed temporal map from `str` to temporal `f64` |
 | `rolling<f64, 20, 5>` | Rolling window of at most 20 `f64` values, valid from 5 values |
 | `rolling<f64, 5m>` | Rolling window of the last five minutes of `f64` values |
-| a structured value type | Structural bundle whose fields are temporal |
+| an HGL-declared structured value type | Structural bundle whose fields are temporal |
 
 A structural tuple is hgraph's un-named bundle with positional fields, so its
 children may have different types and `pair[0]` is positional field access. A
 homogeneous `tuple<f64, f64>` is still a tuple, not a two-element list: tuples
 are accessed by position, lists are sized and traversed.
+
+## Imported values and references
+
+Status: agreed source semantics; implementation is separate from this design
+update. See [Type extensions](../design/type-extensions.md) for the complete
+agreement and the collection-reference mapping still under discussion.
+
+Imported C++ and Python types are scalar values, like `i64`, `f64`, and `str`.
+They are atomic leaves in a temporal signature, require no `atomic` annotation,
+and remain scalar values in `const` positions. Native fields do not recursively
+become time series. This differs from an HGL-declared struct, whose temporal
+form is a bundle of fields.
+
+`ref<T>` describes a reference to the temporal shape of `T`. For example,
+`ref<map<i64, str>>` corresponds to `REF[TSD[int, TS[str]]]`. Reference wrappers
+are ignored when checking underlying type compatibility, including within
+structures, but their representation and access semantics are preserved.
+Invalid placements remain invalid: `map<ref<i64>, str>` is an error because
+map keys cannot be references.
+
+The user or component designer specifies `ref` to express an intention to
+pass through a time series without observing or interacting with its values.
+It is not the default form of a connection or a general automatic rewrite of
+the author's type declarations. For generated conditional branches, the
+compiler uses a reference input when that branch only forwards an incoming
+binding; an ordinary temporal input is sufficient when processing is assured.
+See [forwarding an existing binding](../design/control-flow.md#forwarding-an-existing-binding).
+
+Inside a node, a reference is opaque and ticks only when its binding changes.
+Code in a `when` handler cannot read fields, index elements, or traverse values
+below a reference layer. During wiring, access below that layer is allowed and
+causes dereferencing to obtain the element's connection. It does not read a
+runtime value while wiring.
+
+A node may index `list<ref<T>, S>` to select and return an opaque reference:
+the list is outside the reference boundary. It cannot index through
+`ref<list<T, S>>`, where the list is below that boundary. Returning a selected
+reference establishes a connection; subsequent target value ticks do not
+require the selecting node to copy and forward each value. See the
+[routing example](../design/type-extensions.md#selecting-and-forwarding-a-reference).
+
+## SIGNAL inputs
+
+Status: agreed input semantics; HGL spelling and compiler implementation remain
+separate discussion and implementation work. See
+[SIGNAL inputs](../design/type-extensions.md#signal-inputs).
+
+SIGNAL accepts a time-series input and exposes only `modified`, `valid`, and
+`last_modified`. It has no accessible value or delta payload, regardless of
+what the native representation may store internally. It cannot be used to
+read fields, index data, perform arithmetic, or test a Boolean payload.
+
+SIGNAL is input-only: there is no SIGNAL result or signal-emission syntax.
+Its observation operations are primarily useful in nodes. Graph functions may
+also accept SIGNAL inputs and pass them to other components; the graph itself
+still executes only during wiring.
 
 ## List sizes
 
@@ -604,7 +660,21 @@ hold evaluation-local scalar values and are recreated whenever the containing
 block executes. Use `state`, not `var`, for a value that must survive into a
 later evaluation.
 
-An initializer is required in the first language slice. `let` cannot be
+The current compiler requires an initializer. The agreed
+[conditional-result design](../design/control-flow.md#results-used-after-the-conditional)
+also permits a typed declaration such as `var r: i64` before an `if`, with
+both branches assigning `r` and later statements using its remapped switch
+output. This form is not implemented yet, supplies no implicit initial value,
+and does not make an unassigned variable readable.
+
+In this design, using an escaping variable without a binding on every path
+reaching that use is a compile-time error. An existing incoming binding can
+be forwarded by an unassigned branch; without one, the relevant path must
+assign the variable. This is
+[definite assignment](../design/control-flow.md#definite-assignment), separate
+from the runtime validity of the connected time series.
+
+`let` cannot be
 assigned again. A `var` may use ordinary and compound assignment, but its type
 is fixed by its annotation or, when unannotated, by its initializer. The normal
 `i64`-to-`f64` widening is allowed when the fixed type is `f64`; assigning an
@@ -686,6 +756,18 @@ tick or delta.
 
 ## Collection views and iteration
 
+Status: phase-dependent iteration is agreed design; graph iteration and its
+classification changes are separate compiler work. `for`, `keys`, `values`,
+and `items` follow the containing phase rather than themselves forcing a
+runtime node. A graph loop over a supported wiring-time iterable receives
+scalar values; over a fixed temporal structure it receives child connections.
+For dynamic maps and lists, independent bodies lower through native mapping,
+with one child graph per key or index. Loop-carried reductions are initially
+unsupported; future map reductions are unordered, while lists may require the
+linear reduction option to preserve index order. See
+[Iteration](../design/iteration.md) for examples, restrictions, and the
+deferred reduction option.
+
 `key_set(value)` exposes the keys of a temporal map as `set<K>`. It works in
 both function phases: a composition function receives the live set-valued
 time-series projection, while a runtime function receives the current borrowed
@@ -754,10 +836,13 @@ Iterator predicates are pure filters. They may read admitted values and
 capture surrounding bindings, but they cannot mutate a `var`, `state`, or
 `out`, and cannot invoke an effect such as logging.
 
-These iterators are evaluation-local borrowed views. They may be consumed by a
-`for` loop but cannot be returned, stored in state, assigned to output, or kept
-for a later evaluation. Collection traversal is not available during graph
-composition; use graph operations such as `key_set` and `map` there instead.
+These runtime iterators are evaluation-local borrowed views. They may be
+consumed by a `for` loop but cannot be returned, stored in state, assigned to
+output, or kept for a later evaluation. Graph-phase iteration instead visits
+wiring-time values or fixed child connections, or describes independently
+mapped child graphs for dynamic collections; it does not read these runtime
+borrowed views. Graph-phase predicate behavior remains a separate design
+decision, and dynamic-loop reductions are deferred.
 
 ## Open scalar edge cases
 

--- a/language/stdlib/README.md
+++ b/language/stdlib/README.md
@@ -1,0 +1,66 @@
+# HGL standard-library design corpus
+
+This folder will describe the core hgraph node and graph library in HGL as the
+required language contracts are agreed. It starts with worked examples that
+exercise those contracts; these example functions are not new public library
+components. The component inventory and HGL declarations remain to be added.
+
+Only agreed syntax belongs in the corpus. Open questions should be recorded
+in the owning design document, without filling gaps with speculative
+declarations or native-binding syntax.
+
+## Conditional results
+
+[conditional-results.hgl](examples/conditional-results.hgl) covers one and
+multiple predeclared variables assigned by temporal `if` branches and used by
+later statements. It also covers forwarding an initialized variable by
+reference through a branch that leaves it unchanged. The
+[conditional control-flow design](../docs/design/control-flow.md) explains
+branch captures, output signatures, bundle remapping, and remaining decisions.
+
+[conditional-mixed-results.hgl](examples/conditional-mixed-results.hgl) combines
+an `if` expression result with an escaping assignment. They share one generated
+bundle output, then remap to the expression's receiving binding and the
+predeclared variable. This remains a design example awaiting compiler support.
+
+[conditional-early-return.hgl](examples/conditional-early-return.hgl) covers an
+early return from one temporal branch. The remaining function body becomes
+the other branch's continuation, including its input captures and child-graph
+lifetime. It remains a design example awaiting compiler support.
+
+[conditional-sinks.hgl](examples/conditional-sinks.hgl) covers an outputless
+conditional: `debug_print("enabled", value)` is wired through the switch,
+while `debug_print("always", value)` is always wired outside it. The label
+precedes the time-series argument. This remains a design example awaiting
+compiler support.
+
+[conditional-unassigned-result.hgl](examples/invalid/conditional-unassigned-result.hgl)
+is intentionally invalid: the escaping variable has no incoming binding and
+is assigned only on the true path before it is used. It records the agreed
+compile-time definite-assignment error, without prescribing diagnostic wording
+or claiming that the compiler implements that check yet.
+
+## Iteration
+
+[fixed-list-iteration.hgl](examples/fixed-list-iteration.hgl) uses a graph-phase
+`for` to wire one sink per fixed-list child connection. It records the agreed
+[phase-dependent iteration model](../docs/design/iteration.md).
+
+[dynamic-map-iteration.hgl](examples/dynamic-map-iteration.hgl) covers an
+independent dynamic graph-loop body: one sink child graph per map key, with a
+shared temporal capture. The initial dynamic-loop design excludes assignments
+to enclosing variables and loop-carried reductions.
+
+The [deferred map/reduce option](../docs/design/iteration.md#deferred-option-map-plus-reduce)
+records future unordered map reductions and the linear reduction option for
+lists when index order matters. Neither reduction lowering is initially
+supported by graph `for`; the example in that section is deliberately marked
+unsupported, not added here as a supported loop contract.
+
+## Compiler status
+
+These design examples depend on features requiring compiler work, including
+temporal graph conditionals, graph-phase iteration, and typed declarations
+without initializers. They are design inputs, not runnable tests, and are
+deliberately outside `language/examples/`, whose `.hgl` files are checked by
+CTest. No runtime or compiler implementation is added here.

--- a/language/stdlib/examples/conditional-early-return.hgl
+++ b/language/stdlib/examples/conditional-early-return.hgl
@@ -1,0 +1,12 @@
+// Agreed design example; temporal early-return lowering is not implemented yet.
+// The remaining function body belongs to the false branch's continuation.
+// See language/docs/design/control-flow.md.
+
+fn choose(condition: bool, x: i64, y: i64) -> i64 {
+    if condition {
+        return x + 1
+    }
+
+    let r = y - 1
+    return r * 2
+}

--- a/language/stdlib/examples/conditional-mixed-results.hgl
+++ b/language/stdlib/examples/conditional-mixed-results.hgl
@@ -1,0 +1,17 @@
+// Agreed design example; temporal conditional lowering is not implemented yet.
+// The expression result and escaping r share a generated bundle output.
+// See language/docs/design/control-flow.md.
+
+fn choose(condition: bool, x: i64, y: i64) -> i64 {
+    var r: i64
+
+    let result = if condition {
+        r = x + 1
+        x * 2
+    } else {
+        r = y - 1
+        y * 3
+    }
+
+    return result + r
+}

--- a/language/stdlib/examples/conditional-results.hgl
+++ b/language/stdlib/examples/conditional-results.hgl
@@ -1,0 +1,36 @@
+// Agreed design examples; not yet supported by the compiler.
+// See language/docs/design/control-flow.md.
+
+fn use_conditional_result(condition: bool, x: i64, y: i64) -> i64 {
+    var r: i64
+    if condition {
+        r = x + 1
+    } else {
+        r = y - 1
+    }
+
+    return r * 2
+}
+
+fn use_conditional_results(condition: bool, x: i64, y: i64) -> i64 {
+    var r: i64
+    var adjustment: i64
+    if condition {
+        r = x + 1
+        adjustment = x
+    } else {
+        r = y - 1
+        adjustment = y
+    }
+
+    return r * 2 + adjustment
+}
+
+fn use_existing_conditional_result(condition: bool, x: i64) -> i64 {
+    var r: i64 = x
+    if condition {
+        r = r + 1
+    }
+
+    return r * 2
+}

--- a/language/stdlib/examples/conditional-sinks.hgl
+++ b/language/stdlib/examples/conditional-sinks.hgl
@@ -1,0 +1,11 @@
+// Agreed design example; temporal conditional lowering is not implemented yet.
+// The enabled sink is wired through the switch; the always sink is outside it.
+// See language/docs/design/control-flow.md.
+
+fn observe(enabled: bool, value: f64) {
+    if enabled {
+        debug_print("enabled", value)
+    }
+
+    debug_print("always", value)
+}

--- a/language/stdlib/examples/dynamic-map-iteration.hgl
+++ b/language/stdlib/examples/dynamic-map-iteration.hgl
@@ -1,0 +1,9 @@
+// Agreed design example; dynamic graph-phase iteration is not implemented yet.
+// Independent bodies lower to one sink child graph per key, with shared captures.
+// Loop-carried reductions are deferred; see language/docs/design/iteration.md.
+
+fn observe(book: map<str, f64>, offset: f64) {
+    for value in values(book) {
+        debug_print("adjusted", value + offset)
+    }
+}

--- a/language/stdlib/examples/fixed-list-iteration.hgl
+++ b/language/stdlib/examples/fixed-list-iteration.hgl
@@ -1,0 +1,9 @@
+// Agreed design example; graph-phase iteration is not implemented yet.
+// Wiring visits three child connections and composes one sink for each.
+// See language/docs/design/iteration.md.
+
+fn observe(samples: list<f64, 3>) {
+    for sample in values(samples) {
+        debug_print("sample", sample)
+    }
+}

--- a/language/stdlib/examples/invalid/conditional-unassigned-result.hgl
+++ b/language/stdlib/examples/invalid/conditional-unassigned-result.hgl
@@ -1,0 +1,13 @@
+// Intentionally invalid under the agreed design; not an executable test yet.
+// Expected: a compile-time definite-assignment error at the later use of r.
+// The false path has no assignment and no incoming binding to forward.
+// See language/docs/design/control-flow.md.
+
+fn unassigned_conditional_result(condition: bool, x: i64) -> i64 {
+    var r: i64
+    if condition {
+        r = x + 1
+    }
+
+    return r * 2
+}


### PR DESCRIPTION
## Purpose

Progress checkpoint for the ongoing HGL syntax expansion and standard-library design work. This PR records agreed semantics and keeps unresolved decisions visible so the discussion can continue against a reviewable change.

This is documentation and design-corpus work only. It does not change the compiler, native runtime, or Python implementation.

## Recorded in this checkpoint

- [x] Imported C++ and Python types are atomic scalar values, distinct from HGL structural temporalization.
- [x] Explicit `ref<T>` access intent, reference-transparent type compatibility, opaque node access, binding ticks, and wiring-time dereferencing.
- [x] Input-only SIGNAL observation through `modified`, `valid`, and `last_modified`; type spelling remains open.
- [x] Temporal graph `if` uses native switch-style child graphs, including capture signatures, escaping bindings, definite assignment, REF forwarding, early-return continuations, mixed results, and conditional sinks.
- [x] Phase-dependent `for`: wiring-time values, fixed child connections, node-time traversal, and an initial independent-body subset for dynamic graph loops.
- [x] Document deferred map-plus-reduce lowering: unordered reductions for maps and linear list reduction where index order matters. Loop-carried reductions are initially unsupported.
- [x] Create `language/stdlib/` with nine worked functions across seven design-fixture files, including one intentional definite-assignment failure.

## Remaining design work

- [ ] Review remaining core type coverage and confirm SIGNAL spelling.
- [ ] Clarify the recorded nested collection/reference mapping before deriving any outer-REF propagation rule.
- [ ] Agree native type/function declarations and work through C++ and Python platform-function examples.
- [ ] Work through the complete explicit `switch`, `map`, `reduce`, and `mesh` surfaces.
- [ ] Resolve graph-loop result construction, predicates, exits, and the recognition/contracts needed for future reductions.
- [ ] Build out the core standard-library component inventory and HGL descriptions, using coverage gaps to prioritize language features.

Compiler implementation is tracked separately. These checkboxes describe design progress, not shipped compiler support.

## Review entry points

- `language/docs/design/type-extensions.md`
- `language/docs/design/control-flow.md`
- `language/docs/design/iteration.md`
- `language/stdlib/README.md`

The relevant user/developer guides and documentation index are updated alongside the design records. The new `.hgl` fixtures stay outside `language/examples/`, which is the executable compiler-example corpus.

## Validation

- `git diff --check` and `git diff --cached --check` passed.
- Read-only documentation audit passed for all 17 changed files: relative links and Markdown anchors, code fences, whitespace, private-path checks, and `debug_print` argument order.
- All nine functions in the seven corpus files exactly match their owning design records.
- Verified that deferred reduction examples are not included as supported corpus contracts and that executable compiler examples are unchanged.
- Full native/Python suites were not run: this is documentation/design-fixture-only work under the repository documentation-only validation policy.
- No claim that these new design fixtures pass the current HGL compiler.