### PR TITLE
Refactor HGL struct codegen onto HGraph IR

### DIFF
--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -175,9 +175,10 @@ wiring target no longer includes syntax AST headers.
   selector signatures from hgraph IR;
 - [x] render supported callable parameter defaults and omitted local-call
   arguments from hgraph IR;
-- [ ] migrate struct layouts and construction defaults, local annotations,
-  bodies, and dependency emission from the temporary syntax/`ResolvedModule`
-  adapter to hgraph IR;
+- [x] emit nominal struct identity, abstractness, generic parameters, parents,
+  and effective field layouts from hgraph IR;
+- [ ] migrate construction defaults, local annotations, bodies, and dependency
+  emission from the temporary syntax/`ResolvedModule` adapter to hgraph IR;
 - remove duplicate name, type, generic, phase, and classification logic from
   the emitter;
 - retain deterministic formatting, source maps, public-SDK code, and readable
@@ -186,9 +187,9 @@ wiring target no longer includes syntax AST headers.
 
 Acceptance: both backends consume the same hgraph IR, existing generated tests
 and installed consumers pass, and architecture tests reject backend-to-syntax
-dependencies. The declaration, interface, and callable-default checkpoints are
-complete, but Stage E remains in progress until the body adapter and its syntax
-dependency are gone.
+dependencies. The declaration, interface, callable-default, and struct-layout
+checkpoints are complete, but Stage E remains in progress until the body
+adapter and its syntax dependency are gone.
 
 ### F. Constrained native interface
 

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -206,19 +206,25 @@ The direct-wiring backend now consumes only hgraph IR. The first Stage E C++
 checkpoint also takes hgraph IR as its primary input. It uses graph-IR module
 paths, callable identities, visibility and classification, nominal operator
 bindings, exports, and registration plans. A declaration range maps each
-planned callable or local operator back to exactly one source declaration; a
-missing, duplicate, or extra mapping is a backend diagnostic. Callable and
-operator parameter/result names, roles, canonical types, rolling-window shapes,
-generated selector signatures, and supported callable parameter defaults now
-come from hgraph IR. The range mapping is the explicitly temporary adapter
-through which the existing printer still reads syntax bodies, local
-annotations, struct layouts and construction defaults, and expression
-dependencies from the AST and `ResolvedModule`.
+planned callable, local operator, or struct back to exactly one source
+declaration; a missing, duplicate, extra, or incompatible adapter shape is a
+backend diagnostic. Callable and operator parameter/result names, roles,
+canonical types, rolling-window shapes, generated selector signatures, and
+supported callable parameter defaults now come from hgraph IR. Nominal struct
+identity, abstractness, type-generic parameters, applied parents, and effective
+value/time-series fields are likewise printed directly from `StructContract`;
+lexical `BindingId` overrides give a struct template's own type parameters their
+local readable C++ names without changing the canonical generic type used by
+operator interfaces. Const-generic structs remain rejected until hgraph has
+typed constant Bundle metadata. The range mapping is the explicitly temporary
+adapter through which the existing printer still reads syntax bodies, local
+annotations, struct construction defaults, and expression dependencies from
+the AST and `ResolvedModule`.
 
 This seam keeps the generated package readable while preventing declaration
 policy from drifting between execution paths. The next Stage E checkpoints
-move struct layout and construction-default printing and then body/dependency
-emission to hgraph IR.
+move struct construction-default and local-annotation handling, then
+body/dependency emission, to hgraph IR.
 Only after those moves may `codegen` drop its syntax and resolver dependencies.
 
 `src/wiring/type_bridge` is the first direct-backend migration boundary. It
@@ -1221,8 +1227,8 @@ deltas, concise `map` functions, scalar and collection runtime inputs, borrowed
 collection traversal, `out`, `logger`, state, and lifecycle hooks. File-based
 `test` and `run` compile/load supported runtime modules on Unix; portable native
 loading and the remaining language-depth items are still staged. Declaration
-and module planning now come from hgraph IR, as does callable/operator interface
-printing. Body-local types, struct layouts and construction defaults, and
+and module planning now come from hgraph IR, as do callable/operator interfaces
+and nominal struct layouts. Body-local types, struct construction defaults, and
 dependency discovery remain behind the temporary AST adapter; callable
 parameter defaults do not.
 

--- a/language/examples/structural-types.hgl
+++ b/language/examples/structural-types.hgl
@@ -30,6 +30,13 @@ export struct LabeledValue<U>: ValueBox<U> {
     label: str
 }
 
+export abstract struct Pair<A, B> {
+    first: A
+    second: B
+}
+
+export struct Swap<X, Y>: Pair<Y, X> {}
+
 export abstract struct Instrument {
     symbol: str
     venue: str = null
@@ -45,6 +52,9 @@ fn make_quote(bid: f64, ask: f64) -> Quote =>
 
 fn boxed_midpoint(value: f64) -> atomic<Box<f64>> =>
     Box<f64>(value: value)
+
+export fn make_swapped(first: f64, second: i64) -> Swap<i64, f64> =>
+    Swap<i64, f64>(first: first, second: second)
 
 fn bid_delta(value: f64) -> Quote {
     when modified(value) && valid(value) {

--- a/language/examples/structural-types.hgl
+++ b/language/examples/structural-types.hgl
@@ -22,6 +22,14 @@ requires T in {i64, f64}
     upper: T
 }
 
+export abstract struct ValueBox<T> {
+    value: T
+}
+
+export struct LabeledValue<U>: ValueBox<U> {
+    label: str
+}
+
 export abstract struct Instrument {
     symbol: str
     venue: str = null

--- a/language/src/README.md
+++ b/language/src/README.md
@@ -16,13 +16,13 @@ them.
 | `driver/` | commands, native build/cache/load, REPL orchestration | assemble inputs and invoke passes |
 
 During migration, `ResolvedModule` and the syntax AST remain a compatibility
-boundary only for C++ bodies, local annotations, struct layouts and construction
-defaults, and dependency discovery. Module identity, callable visibility and
+boundary only for C++ bodies, local annotations, struct construction defaults,
+and dependency discovery. Module identity, callable visibility and
 classification, operator binding, exports, registration planning,
-callable/operator interfaces, and supported callable parameter defaults already
-come from hgraph IR. New language semantics belong in HIR construction, not in
-either backend. The remaining adapter is named here and must be removed as Stage
-E advances.
+callable/operator interfaces, supported callable parameter defaults, and
+nominal struct declarations and field layouts already come from hgraph IR. New
+language semantics belong in HIR construction, not in either backend. The
+remaining adapter is named here and must be removed as Stage E advances.
 
 Every new pass documents:
 

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -364,6 +364,7 @@ namespace hgl::codegen
             void                                       bind_hgraph_declarations();
             [[nodiscard]] const gir::Callable         &callable(ast::DeclId decl) const { return *callables_.at(decl); }
             [[nodiscard]] const gir::OperatorContract &operator_decl(ast::DeclId decl) const { return *operators_.at(decl); }
+            [[nodiscard]] const gir::StructContract &struct_contract(ast::DeclId decl) const { return *structures_.at(decl); }
             [[nodiscard]] static std::string_view      local_identity(std::string_view identity) noexcept;
             [[nodiscard]] std::string_view             callable_name(ast::DeclId decl) const;
             [[nodiscard]] std::string                  callable_cpp_name(ast::DeclId decl);
@@ -1865,26 +1866,50 @@ namespace hgl::codegen
 
         Value Emitter::eval_construct(ast::DeclId decl, ast::TypeId type_id, const std::vector<ast::Argument> &arguments,
                                       bool delta, SourceRange range, Frame &frame) {
-            const ast::StructDecl       &item = structure(decl);
-            const semantics::StructInfo &info = resolved_.structure(decl);
+            const semantics::StructInfo &info     = resolved_.structure(decl);
+            const gir::StructContract   &contract = struct_contract(decl);
             HType                        type;
             if (type_id != ast::no_node) {
                 type = type_of(type_id, frame);
             } else {
-                if (!item.generics.empty()) {
-                    backend(range, "generic struct '" + std::string{item.name.text} + "' needs explicit type arguments");
+                if (!contract.generics.empty()) {
+                    backend(range, "generic struct '" + std::string{local_identity(contract.identity)} +
+                                       "' needs explicit type arguments");
                 }
                 type.kind             = HType::Kind::Struct;
                 type.declaration      = decl;
-                type.nominal_identity = resolved_.module_path + "." + std::string{item.name.text};
-                type.cpp_type         = cpp_name(item.name.text);
+                type.nominal_identity = contract.identity;
+                type.cpp_type         = cpp_name(local_identity(contract.identity));
             }
 
-            Frame       struct_frame  = frame;
+            PlannedTypeBindings planned_generics;
             std::size_t type_argument = 0;
-            for (std::size_t generic = 0; generic < item.generics.size(); ++generic) {
-                if (item.generics[generic].is_const) { continue; }
-                if (type_argument < type.children.size()) { struct_frame.generic_types[generic] = type.children[type_argument++]; }
+            for (const gir::GenericParameter &generic : contract.generics) {
+                if (generic.is_const) { continue; }
+                if (!generic.binding.valid() || generic.binding.value >= graph_.bindings.size()) {
+                    backend(contract.range, "hgraph IR struct '" + contract.identity + "' has an invalid generic binding");
+                }
+                if (graph_.bindings[generic.binding.value].kind != gir::BindingKind::TypeParameter) {
+                    backend(contract.range, "hgraph IR struct '" + contract.identity + "' has a mismatched type binding");
+                }
+                if (type_argument >= type.children.size()) {
+                    backend(range, "constructed type '" + contract.identity + "' is missing a generic type argument");
+                }
+                if (!planned_generics.emplace(generic.binding.value, type.children[type_argument++]).second) {
+                    backend(contract.range, "hgraph IR struct '" + contract.identity + "' repeats a generic binding");
+                }
+            }
+            if (type_argument != type.children.size()) {
+                backend(range, "constructed type '" + contract.identity + "' has too many generic type arguments");
+            }
+            if (type_id != ast::no_node) {
+                type.declaration      = decl;
+                type.nominal_identity = contract.identity;
+                type.cpp_type         = cpp_name(local_identity(contract.identity));
+                std::vector<std::string> type_arguments;
+                type_arguments.reserve(type.children.size());
+                for (const HType &argument : type.children) { type_arguments.push_back(value_type(argument, range)); }
+                if (!type_arguments.empty()) { type.cpp_type += "<" + join(type_arguments, ", ") + ">"; }
             }
 
             const auto argument_for = [&](std::string_view field) -> ast::ExprId {
@@ -1896,16 +1921,18 @@ namespace hgl::codegen
 
             std::vector<std::string>                   temporal_fields;
             std::vector<std::pair<std::size_t, Value>> delta_fields;
-            for (std::size_t index = 0; index < info.fields.size(); ++index) {
-                const semantics::StructField &field    = info.fields[index];
-                ast::ExprId                   value_id = argument_for(field.name);
-                if (value_id == ast::no_node && !delta) { value_id = field.default_value; }
-                const HType field_type = type_of(field.type, struct_frame);
+            for (std::size_t index = 0; index < contract.fields.size(); ++index) {
+                const semantics::StructField &source_field = info.fields[index];
+                const gir::StructField       &field        = contract.fields[index];
+                ast::ExprId                   value_id      = argument_for(source_field.name);
+                if (value_id == ast::no_node && !delta) { value_id = source_field.default_value; }
+                const HType       field_type  = planned_type(field.type, field.range, &planned_generics);
+                const SourceRange field_range = graph_type(field.type, field.range).range;
 
                 if (value_id == ast::no_node) {
                     if (delta) { continue; }
                     temporal_fields.push_back("hgraph::wire<hgraph::stdlib::nothing, " +
-                                              schema(field_type, module_.type(field.type).range) + ">(w)");
+                                              schema(field_type, field_range) + ">(w)");
                     continue;
                 }
                 if (std::holds_alternative<ast::NullLiteral>(module_.expr(value_id).node)) {
@@ -1914,7 +1941,7 @@ namespace hgl::codegen
                                                               "operation");
                     }
                     temporal_fields.push_back("hgraph::wire<hgraph::stdlib::nothing, " +
-                                              schema(field_type, module_.type(field.type).range) + ">(w)");
+                                              schema(field_type, field_range) + ">(w)");
                     continue;
                 }
 

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -379,8 +379,10 @@ namespace hgl::codegen
             }
 
             // -- types
-            [[nodiscard]] HType       type_of(ast::TypeId id, Frame &frame);
-            [[nodiscard]] HType                       planned_type(gir::TypeId id, SourceRange fallback = {});
+            [[nodiscard]] HType type_of(ast::TypeId id, Frame &frame);
+            using PlannedTypeBindings = std::unordered_map<std::uint32_t, HType>;
+            [[nodiscard]] HType planned_type(gir::TypeId id, SourceRange fallback = {},
+                                             const PlannedTypeBindings *bindings = nullptr);
             [[nodiscard]] const gir::Type            &graph_type(gir::TypeId id, SourceRange fallback);
             [[nodiscard]] const gir::ConstExpr       &graph_constant(gir::ConstExprId id, SourceRange fallback);
             [[nodiscard]] std::optional<std::int64_t> planned_integer(gir::ConstExprId id, SourceRange fallback);
@@ -439,7 +441,7 @@ namespace hgl::codegen
                 OutOfLine,
             };
             void emit_function(ast::DeclId decl, Writer &out, Form form);
-            void                      emit_struct(ast::DeclId decl, Writer &out);
+            void emit_struct(const gir::StructContract &item, Writer &out);
             void emit_runtime_function(ast::DeclId decl, Writer &out);
             void emit_if(const ast::If &branch, Frame &frame, Writer &out);
             [[nodiscard]] RuntimeInfo runtime_info(ast::DeclId decl);
@@ -473,6 +475,7 @@ namespace hgl::codegen
             std::vector<ast::DeclId>                                       operator_declarations_{};
             std::unordered_map<ast::DeclId, const gir::Callable *>         callables_{};
             std::unordered_map<ast::DeclId, const gir::OperatorContract *> operators_{};
+            std::unordered_map<ast::DeclId, const gir::StructContract *>   structures_{};
             bool                             uses_analytics_{false};
             /// Locals declared in the current function, for unique C++ names.
             std::unordered_map<std::string, int> local_counts_{};
@@ -573,6 +576,51 @@ namespace hgl::codegen
             }
             if (operator_declarations_.size() != resolved_.operators.size()) {
                 backend(SourceRange{}, "the hgraph IR and syntax signature adapter disagree on the module's operators");
+            }
+
+            const auto structure_for_range = [&](SourceRange range) {
+                ast::DeclId match = ast::no_node;
+                for (const ast::DeclId id : resolved_.structs) {
+                    if (module_.decl(id).range != range) { continue; }
+                    if (match != ast::no_node) {
+                        backend(range, "hgraph IR struct range matches more than one syntax declaration");
+                    }
+                    match = id;
+                }
+                return match;
+            };
+            for (const gir::StructContract &item : graph_.structures) {
+                const ast::DeclId id = structure_for_range(item.range);
+                if (id == ast::no_node) {
+                    backend(item.range, "hgraph IR struct '" + item.identity + "' has no syntax construction adapter");
+                }
+                const ast::StructDecl       &source = structure(id);
+                const semantics::StructInfo &info   = resolved_.structure(id);
+                if (item.generics.size() != source.generics.size() || item.parents.size() != source.parents.size() ||
+                    item.fields.size() != info.fields.size()) {
+                    backend(item.range,
+                            "hgraph IR struct '" + item.identity +
+                                "' disagrees with the syntax construction adapter's declaration shape");
+                }
+                for (std::size_t index = 0; index < item.generics.size(); ++index) {
+                    if (item.generics[index].is_const != source.generics[index].is_const) {
+                        backend(item.range, "hgraph IR struct '" + item.identity +
+                                                "' disagrees with the syntax construction adapter's generic roles");
+                    }
+                }
+                for (std::size_t index = 0; index < item.fields.size(); ++index) {
+                    if (item.fields[index].optional != info.fields[index].optional ||
+                        item.fields[index].default_value.valid() != (info.fields[index].default_value != ast::no_node)) {
+                        backend(item.range, "hgraph IR struct '" + item.identity +
+                                                "' disagrees with the syntax construction adapter's field defaults");
+                    }
+                }
+                if (!structures_.emplace(id, &item).second) {
+                    backend(item.range, "more than one hgraph IR struct maps to the same syntax declaration");
+                }
+            }
+            if (structures_.size() != resolved_.structs.size()) {
+                backend(SourceRange{}, "the hgraph IR and syntax construction adapter disagree on the module's structs");
             }
         }
 
@@ -679,7 +727,7 @@ namespace hgl::codegen
             backend(range, "hgraph IR contains an incomplete constant expression");
         }
 
-        HType Emitter::planned_type(gir::TypeId id, SourceRange fallback) {
+        HType Emitter::planned_type(gir::TypeId id, SourceRange fallback, const PlannedTypeBindings *bindings) {
             const gir::Type  &type  = graph_type(id, fallback);
             const SourceRange range = type.range.end > type.range.begin ? type.range : fallback;
             using TypeKind          = ir::hir::TypeKind;
@@ -706,6 +754,11 @@ namespace hgl::codegen
                 case TypeKind::Symbol:
                     {
                         if (type.binding.valid()) {
+                            if (bindings != nullptr) {
+                                if (const auto found = bindings->find(type.binding.value); found != bindings->end()) {
+                                    return found->second;
+                                }
+                            }
                             if (type.binding.value >= graph_.bindings.size()) {
                                 backend(range, "hgraph IR type refers to an invalid generic binding");
                             }
@@ -732,7 +785,7 @@ namespace hgl::codegen
                         arguments.reserve(type.arguments.size());
                         for (const gir::TypeArgument &argument : type.arguments) {
                             if (argument.type) {
-                                HType child = planned_type(*argument.type, range);
+                                HType child = planned_type(*argument.type, range, bindings);
                                 arguments.push_back(value_type(child, range));
                                 result.children.push_back(std::move(child));
                             } else if (argument.value) {
@@ -750,7 +803,9 @@ namespace hgl::codegen
                     {
                         HType result;
                         result.kind = HType::Kind::Tuple;
-                        for (gir::TypeId child : type.children) { result.children.push_back(planned_type(child, range)); }
+                        for (gir::TypeId child : type.children) {
+                            result.children.push_back(planned_type(child, range, bindings));
+                        }
                         return result;
                     }
                 case TypeKind::List:
@@ -758,7 +813,7 @@ namespace hgl::codegen
                         if (type.children.size() != 1U) { backend(range, "hgraph IR list type requires one element type"); }
                         HType result;
                         result.kind = HType::Kind::List;
-                        result.children.push_back(planned_type(type.children.front(), range));
+                        result.children.push_back(planned_type(type.children.front(), range, bindings));
                         if (type.size.valid()) {
                             const std::optional<std::int64_t> size = planned_integer(type.size, range);
                             if (!size || *size <= 0) {
@@ -773,7 +828,7 @@ namespace hgl::codegen
                         if (type.children.size() != 1U) { backend(range, "hgraph IR set type requires one element type"); }
                         HType result;
                         result.kind = HType::Kind::Set;
-                        result.children.push_back(planned_type(type.children.front(), range));
+                        result.children.push_back(planned_type(type.children.front(), range, bindings));
                         return result;
                     }
                 case TypeKind::Map:
@@ -781,8 +836,8 @@ namespace hgl::codegen
                         if (type.children.size() != 2U) { backend(range, "hgraph IR map type requires key and value types"); }
                         HType result;
                         result.kind = HType::Kind::Map;
-                        result.children.push_back(planned_type(type.children[0], range));
-                        result.children.push_back(planned_type(type.children[1], range));
+                        result.children.push_back(planned_type(type.children[0], range, bindings));
+                        result.children.push_back(planned_type(type.children[1], range, bindings));
                         return result;
                     }
                 case TypeKind::Rolling:
@@ -790,7 +845,7 @@ namespace hgl::codegen
                         if (type.children.size() != 1U) { backend(range, "hgraph IR rolling type requires one element type"); }
                         HType result;
                         result.kind = HType::Kind::Rolling;
-                        result.children.push_back(planned_type(type.children.front(), range));
+                        result.children.push_back(planned_type(type.children.front(), range, bindings));
                         if (!type.size.valid()) { return result; }
                         const gir::ConstExpr &maximum = graph_constant(type.size, range);
                         if (maximum.kind != gir::ConstExprKind::Literal || !maximum.literal) {
@@ -836,7 +891,7 @@ namespace hgl::codegen
                         if (type.children.size() != 1U) { backend(range, "hgraph IR atomic type requires one value type"); }
                         HType result;
                         result.kind = HType::Kind::Atomic;
-                        result.children.push_back(planned_type(type.children.front(), range));
+                        result.children.push_back(planned_type(type.children.front(), range, bindings));
                         return result;
                     }
                 case TypeKind::Void:
@@ -3254,58 +3309,67 @@ namespace hgl::codegen
             return "hgraph::Operator<" + join(selectors, ", ") + ">";
         }
 
-        void Emitter::emit_struct(ast::DeclId decl, Writer &out) {
-            const ast::StructDecl       &item = structure(decl);
-            const semantics::StructInfo &info = resolved_.structure(decl);
-            for (const ast::GenericParameter &parameter : item.generics)
-            {
-                if (parameter.is_const)
-                {
-                    backend(parameter.name.range,
-                            "const generic struct arguments require typed constant Bundle metadata in hgraph");
-                }
-            }
-            Frame                        frame;
-            frame.fn = decl;
-
+        void Emitter::emit_struct(const gir::StructContract &item, Writer &out) {
             std::vector<std::string> template_parameters;
             std::vector<std::string> type_arguments;
+            PlannedTypeBindings      generic_types;
             for (std::size_t index = 0; index < item.generics.size(); ++index) {
-                const ast::GenericParameter &parameter = item.generics[index];
-                const std::string            name      = cpp_name(parameter.name.text);
-                if (parameter.is_const) {
-                    template_parameters.push_back("std::int64_t " + name);
-                    continue;
+                const gir::GenericParameter &parameter = item.generics[index];
+                if (!parameter.binding.valid() || parameter.binding.value >= graph_.bindings.size()) {
+                    backend(item.range, "hgraph IR struct '" + item.identity + "' has an invalid generic binding");
                 }
+                const gir::Binding &binding = graph_.bindings[parameter.binding.value];
+                if (parameter.is_const) {
+                    if (binding.kind != gir::BindingKind::ConstParameter) {
+                        backend(binding.range, "hgraph IR struct '" + item.identity + "' has a mismatched const binding");
+                    }
+                    backend(binding.range, "const generic struct arguments require typed constant Bundle metadata in hgraph");
+                }
+                if (binding.kind != gir::BindingKind::TypeParameter) {
+                    backend(binding.range, "hgraph IR struct '" + item.identity + "' has a mismatched type binding");
+                }
+                const std::string name = cpp_name(parameter.name);
                 template_parameters.push_back("typename " + name);
                 HType type;
-                type.kind                  = HType::Kind::Generic;
-                type.cpp_type              = name;
-                frame.generic_types[index] = type;
+                type.kind     = HType::Kind::Generic;
+                type.cpp_type = name;
+                if (!generic_types.emplace(parameter.binding.value, type).second) {
+                    backend(binding.range, "hgraph IR struct '" + item.identity + "' repeats a generic binding");
+                }
                 type_arguments.push_back(name);
             }
 
-            out.line("// " + where(module_.decl(decl).range));
+            const std::size_t identity_separator = item.identity.find_last_of('.');
+            if (identity_separator == std::string::npos || identity_separator == 0U ||
+                identity_separator + 1U == item.identity.size()) {
+                backend(item.range, "hgraph IR struct '" + item.identity + "' has no module-qualified identity");
+            }
+            const std::string identity_module = item.identity.substr(0, identity_separator);
+            const std::string identity_name   = item.identity.substr(identity_separator + 1U);
+
+            out.line("// " + where(item.range));
             if (!template_parameters.empty()) { out.line("template <" + join(template_parameters, ", ") + ">"); }
-            out.open("struct " + cpp_name(item.name.text));
+            out.open("struct " + cpp_name(identity_name));
 
             std::vector<std::string> parents;
-            for (const ast::TypeId parent : item.parents) {
-                const HType type = type_of(parent, frame);
-                parents.push_back(value_type(type, module_.type(parent).range));
+            for (const gir::TypeId parent : item.parents) {
+                const gir::Type &planned = graph_type(parent, item.range);
+                const HType      type    = planned_type(parent, item.range, &generic_types);
+                parents.push_back(value_type(type, planned.range));
             }
 
             std::vector<std::string> value_fields;
             std::vector<std::string> temporal_fields;
-            for (const semantics::StructField &field : info.fields) {
-                const HType type = type_of(field.type, frame);
+            for (const gir::StructField &field : item.fields) {
+                const gir::Type &planned = graph_type(field.type, field.range);
+                const HType      type    = planned_type(field.type, field.range, &generic_types);
                 value_fields.push_back("hgraph::Field<" + quote(field.name) + ", " +
-                                       value_type(type, module_.type(field.type).range) + ">");
+                                       value_type(type, planned.range) + ">");
                 temporal_fields.push_back("hgraph::Field<" + quote(field.name) + ", " +
-                                          schema(type, module_.type(field.type).range) + ">");
+                                          schema(type, planned.range) + ">");
             }
 
-            std::vector<std::string> bundle_parts{quote(module_name_), quote(item.name.text), item.abstract ? "true" : "false",
+            std::vector<std::string> bundle_parts{quote(identity_module), quote(identity_name), item.abstract ? "true" : "false",
                                                   "hgraph::BundleParents<" + join(parents, ", ") + ">",
                                                   "hgraph::BundleArguments<" + join(type_arguments, ", ") + ">"};
             bundle_parts.insert(bundle_parts.end(), value_fields.begin(), value_fields.end());
@@ -3697,7 +3761,7 @@ namespace hgl::codegen
             header.line("namespace " + namespace_);
             header.line("{");
             header.indent();
-            for (const ast::DeclId id : resolved_.structs) { emit_struct(id, header); }
+            for (const gir::StructContract &item : graph_.structures) { emit_struct(item, header); }
             if (!operator_declarations_.empty() || !exports.empty()) {
                 header.line("/// Operator contracts for the module's public callables.");
                 header.open("namespace operators");

--- a/language/src/ir/constraint_solver.cpp
+++ b/language/src/ir/constraint_solver.cpp
@@ -241,6 +241,12 @@ namespace hgl::ir::detail
 
         for (TypeId parent : decl.parents) { append_fields(substitution.apply(parent), fields); }
         for (const StructField &field : decl.fields) {
+            // StructDecl owns the effective field list, including inherited
+            // fields in their declaring generic scope. Parents above already
+            // contribute those fields after applying this child application;
+            // visiting the flattened copy again would overwrite the
+            // substituted type with the parent's unbound generic.
+            if (field.origin != symbol.owner) { continue; }
             const auto   existing = std::ranges::find(fields, field.name, &EffectiveField::name);
             const TypeId resolved = substitution.apply(field.type);
             if (existing == fields.end()) {

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -1434,12 +1434,6 @@ namespace hgl::ir
                 }
             }
 
-            [[nodiscard]] TypeId apply_struct_field_type(TypeId field, TypeId applied) {
-                detail::GenericSubstitution bindings{module_, canonical_types_};
-                bind_struct_arguments(applied, bindings);
-                return bindings.apply(field);
-            }
-
             [[nodiscard]] TypeId infer_struct_application(TypeId applied, const StructDecl &structure,
                                                           const std::vector<Argument> &arguments, syntax::SourceRange range) {
                 const TypeId unwrapped = unwrap_atomic(applied);
@@ -1462,8 +1456,13 @@ namespace hgl::ir
                     if (!field) { continue; }
                     const Expr &source = module_.expr(argument.value);
                     if (source.constant && std::holds_alternative<NullValue>(*source.constant)) { continue; }
+                    const std::optional<TypeId> expected = constraint_solver_.field_type({}, unwrapped, field->name);
+                    if (!expected) {
+                        type_error(argument.range, "cannot resolve effective type for struct field '" + field->name + "'");
+                        continue;
+                    }
                     Expr &value = check_expr(argument.value);
-                    (void)bindings.unify(field->type, value.type);
+                    (void)bindings.unify(*expected, value.type);
                 }
 
                 Type inferred = nominal;
@@ -1531,14 +1530,18 @@ namespace hgl::ir
                         if (found != structure->fields.end()) { field = &*found; }
                     }
                     if (!field) { continue; }
-                    const TypeId expected = apply_struct_field_type(field->type, unwrapped);
-                    Expr        &value    = check_expr(argument.value, expected);
+                    const std::optional<TypeId> expected = constraint_solver_.field_type({}, unwrapped, field->name);
+                    if (!expected) {
+                        type_error(argument.range, "cannot resolve effective type for struct field '" + field->name + "'");
+                        continue;
+                    }
+                    Expr &value = check_expr(argument.value, *expected);
                     if (value.constant && std::holds_alternative<NullValue>(*value.constant)) {
                         if (!delta && !field->optional) {
                             type_error(value.range, "null is only valid for an optional field or sparse delta");
                         }
                     } else {
-                        require_assignable(expected, value, "constructor field");
+                        require_assignable(*expected, value, "constructor field");
                     }
                     expression.effects |= value.effects;
                 }

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -225,6 +225,62 @@ TEST_CASE("emit-cpp rejects a mismatched syntax compatibility adapter", "[codege
         CHECK_FALSE(unit.emit());
         CHECK(unit.has(Category::Backend, "syntax body adapter's default shape"));
     }
+    SECTION("a missing struct") {
+        Unit unit{"module t\nexport struct Value { amount: f64 }\n"};
+        REQUIRE(unit.graph.completion == hgl::hgraph_ir::Completion::Bodies);
+        unit.graph.structures.clear();
+
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Backend, "syntax construction adapter disagree"));
+    }
+    SECTION("a changed struct field count") {
+        Unit unit{"module t\nexport struct Value { amount: f64 }\n"};
+        REQUIRE(unit.graph.completion == hgl::hgraph_ir::Completion::Bodies);
+        unit.graph.structures.front().fields.clear();
+
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Backend, "syntax construction adapter's declaration shape"));
+    }
+}
+
+TEST_CASE("emit-cpp plans struct identity and layout from hgraph IR", "[codegen][hgraph-ir][structs]") {
+    Unit unit{R"(
+module old
+
+export abstract struct Shape<T> {
+    value: T
+    label: str = null
+}
+)"};
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+    REQUIRE(unit.graph.completion == hgl::hgraph_ir::Completion::Bodies);
+    REQUIRE(unit.graph.structures.size() == 1);
+
+    auto &structure             = unit.graph.structures.front();
+    structure.identity          = "planned.module.Record";
+    structure.abstract          = false;
+    structure.generics[0].name = "Item";
+    structure.fields[0].name    = "amount";
+    structure.fields[1].name    = "count";
+    const hgl::hgraph_ir::TypeId integer{static_cast<std::uint32_t>(unit.graph.types.size())};
+    unit.graph.types.push_back({.kind   = hgl::ir::hir::TypeKind::Scalar,
+                                .scalar = hgl::ir::hir::ScalarType::I64,
+                                .range  = structure.fields[1].range});
+    structure.fields[1].type = integer;
+    unit.graph.path           = "planned.module";
+
+    const auto emitted = unit.emit();
+    REQUIRE(emitted);
+    CHECK(emitted->module_name == "planned.module");
+    CHECK(contains(emitted->header, "namespace planned::module"));
+    CHECK(contains(emitted->header, "template <typename Item>\n    struct Record"));
+    CHECK(contains(emitted->header, "hgraph::NominalBundle<\"planned.module\", \"Record\", false"));
+    CHECK(contains(emitted->header, "hgraph::Field<\"amount\", Item>"));
+    CHECK(contains(emitted->header, "hgraph::Field<\"count\", hgraph::Int>"));
+    CHECK(contains(emitted->header, "hgraph::Field<\"amount\", hgraph::TS<Item>>"));
+    CHECK_FALSE(contains(emitted->header, "struct Shape"));
+    CHECK_FALSE(contains(emitted->header, "hgraph::Field<\"value\""));
+    CHECK_FALSE(contains(emitted->header, "hgraph::Field<\"label\""));
 }
 
 TEST_CASE("emit-cpp renders defaults and omitted arguments from hgraph IR", "[codegen][hgraph-ir][defaults]") {

--- a/language/tests/codegen/generated_structural_tests.cpp
+++ b/language/tests/codegen/generated_structural_tests.cpp
@@ -25,6 +25,8 @@ TEST_CASE("generated structural types preserve nominal metadata", "[codegen][gen
     const auto *instrument = scalar_descriptor<structural::Instrument::value_type>::value_meta();
     const auto *future     = scalar_descriptor<structural::Future::value_type>::value_meta();
     const auto *box        = scalar_descriptor<structural::Box<Float>::value_type>::value_meta();
+    const auto *value_box  = scalar_descriptor<structural::ValueBox<Float>::value_type>::value_meta();
+    const auto *labeled    = scalar_descriptor<structural::LabeledValue<Float>::value_type>::value_meta();
 
     REQUIRE(instrument->name() == "examples.structural_types::Instrument");
     REQUIRE(instrument->is_abstract_bundle());
@@ -32,6 +34,8 @@ TEST_CASE("generated structural types preserve nominal metadata", "[codegen][gen
     REQUIRE(box->name() == "examples.structural_types::Box[float]");
     REQUIRE(box->bundle_generic_arguments() ==
             std::vector<const ValueTypeMetaData *>{TypeRegistry::instance().value_type("float")});
+    REQUIRE(value_box->is_abstract_bundle());
+    REQUIRE(labeled->bundle_hierarchy->parents == std::vector<const ValueTypeMetaData *>{value_box});
     REQUIRE(schema_descriptor<structural::Box<Float>::time_series>::ts_meta()->value_schema == box);
 }
 

--- a/language/tests/codegen/generated_structural_tests.cpp
+++ b/language/tests/codegen/generated_structural_tests.cpp
@@ -19,6 +19,9 @@ namespace
 {
     using BidDelta =
         Operator<"examples.structural_types.bid_delta", In<"value", TS<Float>>, Out<typename structural::Quote::time_series>>;
+    using MakeSwapped =
+        Operator<"examples.structural_types.make_swapped", In<"first", TS<Float>>, In<"second", TS<Int>>,
+                 Out<typename structural::Swap<Int, Float>::time_series>>;
 }
 
 TEST_CASE("generated structural types preserve nominal metadata", "[codegen][generated][struct]") {
@@ -27,6 +30,8 @@ TEST_CASE("generated structural types preserve nominal metadata", "[codegen][gen
     const auto *box        = scalar_descriptor<structural::Box<Float>::value_type>::value_meta();
     const auto *value_box  = scalar_descriptor<structural::ValueBox<Float>::value_type>::value_meta();
     const auto *labeled    = scalar_descriptor<structural::LabeledValue<Float>::value_type>::value_meta();
+    const auto *pair       = scalar_descriptor<structural::Pair<Float, Int>::value_type>::value_meta();
+    const auto *swapped    = scalar_descriptor<structural::Swap<Int, Float>::value_type>::value_meta();
 
     REQUIRE(instrument->name() == "examples.structural_types::Instrument");
     REQUIRE(instrument->is_abstract_bundle());
@@ -36,7 +41,17 @@ TEST_CASE("generated structural types preserve nominal metadata", "[codegen][gen
             std::vector<const ValueTypeMetaData *>{TypeRegistry::instance().value_type("float")});
     REQUIRE(value_box->is_abstract_bundle());
     REQUIRE(labeled->bundle_hierarchy->parents == std::vector<const ValueTypeMetaData *>{value_box});
+    REQUIRE(pair->is_abstract_bundle());
+    REQUIRE(swapped->bundle_hierarchy->parents == std::vector<const ValueTypeMetaData *>{pair});
     REQUIRE(schema_descriptor<structural::Box<Float>::time_series>::ts_meta()->value_schema == box);
+}
+
+TEST_CASE("generated structural construction uses substituted inherited fields", "[codegen][generated][struct]") {
+    hgl::wiring::ensure_session();
+    structural::register_operators();
+
+    CHECK_OUTPUT(eval_node<MakeSwapped>(values<Float>(1.25), values<Int>(7)),
+                 values<Value>(tsb_delta<typename structural::Swap<Int, Float>::time_series>(Float{1.25}, Int{7})));
 }
 
 TEST_CASE("generated structural deltas remain sparse", "[codegen][generated][struct]") {

--- a/language/tests/hgraph_ir/lower_tests.cpp
+++ b/language/tests/hgraph_ir/lower_tests.cpp
@@ -428,6 +428,13 @@ abstract struct Samples<T, const N: i64> {
 }
 
 struct Renamed<U, const M: i64>: Samples<U, M> {}
+
+abstract struct Pair<A, B> {
+    first: A
+    second: B
+}
+
+struct Swap<X, Y>: Pair<Y, X> {}
 )"};
     INFO(lowered.diagnostics.render(lowered.file));
     REQUIRE_FALSE(lowered.diagnostics.has_errors());
@@ -444,6 +451,14 @@ struct Renamed<U, const M: i64>: Samples<U, M> {}
     const hgl::hgraph_ir::ConstExpr &size = lowered.graph->const_exprs[history.size.value];
     CHECK(size.kind == hgl::hgraph_ir::ConstExprKind::Parameter);
     CHECK(size.parameter == "M");
+
+    const hgl::hgraph_ir::StructContract *swap = structure(*lowered.graph, "checks.inherited_arguments.Swap");
+    REQUIRE(swap != nullptr);
+    REQUIRE(swap->fields.size() == 2);
+    const hgl::hgraph_ir::Type &first  = lowered.graph->types[swap->fields[0].type.value];
+    const hgl::hgraph_ir::Type &second = lowered.graph->types[swap->fields[1].type.value];
+    CHECK(first.nominal_identity == "Y");
+    CHECK(second.nominal_identity == "X");
 }
 
 TEST_CASE("hgraph IR preserves operator and implementation requirements", "[hgraph-ir][constraints][operators]") {

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -275,7 +275,37 @@ struct Box<T> {
     value: T
 }
 
+abstract struct Pair<A, B> {
+    first: A
+    second: B
+}
+
+struct Swap<X, Y>: Pair<Y, X> {}
+
 fn unwrap(box: Box<f64>) -> f64 => box.value
+
+fn swapped(first: f64, second: i64) -> Swap<i64, f64> =>
+    Swap<i64, f64>(first: first, second: second)
+)"};
+    require_clean(lowered);
+    REQUIRE(complete(lowered));
+}
+
+TEST_CASE("typed HIR infers remapped inherited generic struct fields", "[ir][typed][structs][generics]") {
+    Lowered lowered{R"(
+module checks.remapped_constructor
+
+abstract struct Pair<A, B> {
+    first: A
+    second: B
+}
+
+struct Swap<X, Y>: Pair<Y, X> {}
+
+fn swapped(first: f64, second: i64) -> Swap<i64, f64> {
+    let value = Swap(first: first, second: second)
+    value
+}
 )"};
     require_clean(lowered);
     REQUIRE(complete(lowered));


### PR DESCRIPTION
## Summary
- emit nominal struct identity, abstractness, type generics, parents, and effective fields from HGraph IR
- bind struct contracts to the temporary syntax construction adapter by exact range and fail closed on shape drift
- type construction and delta fields from the substituted HGraph IR contract, including remapped generic parents
- correct the typed-HIR effective-field walk so flattened inherited fields cannot overwrite parent substitutions
- exercise Pair<A, B> / Swap<X, Y>: Pair<Y, X> through typed HIR, HGraph IR, generated C++ metadata, and runtime output
- document the narrower remaining AST seam

## Validation
- focused codegen suite: 21 cases / 210 assertions
- full stacked language suite on the current merged main: 30/30 passed
- fresh native acceptance suite: 1,716/1,716 passed
- Python 3.12 ABI3 wheel installed into fresh Python 3.14: 3,240 passed, 10 skipped

Stacked on #700 and rebased onto the current merged main.