### PR TITLE
refactor(language): construct defaults from hgraph IR

### DIFF
--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -188,9 +188,9 @@ endfunction()
 
 # The C++ backend (src/codegen): emits a header/source pair of public hgraph
 # authoring code per module (developer guide, "C++ backend, first pass").
-# Hgraph IR owns module and callable/operator interfaces while a temporary
-# syntax adapter prints bodies, local annotations, struct layouts, and their
-# construction defaults.
+# Hgraph IR owns module and callable/operator interfaces, struct layouts, and
+# construction defaults while a temporary syntax adapter prints bodies and
+# local annotations.
 add_library(hgl_codegen STATIC
     src/codegen/cpp_emitter.cpp
 )

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -177,8 +177,10 @@ wiring target no longer includes syntax AST headers.
   arguments from hgraph IR;
 - [x] emit nominal struct identity, abstractness, generic parameters, parents,
   and effective field layouts from hgraph IR;
-- [ ] migrate construction defaults, local annotations, bodies, and dependency
-  emission from the temporary syntax/`ResolvedModule` adapter to hgraph IR;
+- [x] migrate construction defaults from the temporary
+  syntax/`ResolvedModule` adapter to hgraph IR;
+- [ ] migrate local annotations, bodies, and dependency emission from the
+  temporary syntax/`ResolvedModule` adapter to hgraph IR;
 - remove duplicate name, type, generic, phase, and classification logic from
   the emitter;
 - retain deterministic formatting, source maps, public-SDK code, and readable
@@ -188,8 +190,8 @@ wiring target no longer includes syntax AST headers.
 Acceptance: both backends consume the same hgraph IR, existing generated tests
 and installed consumers pass, and architecture tests reject backend-to-syntax
 dependencies. The declaration, interface, callable-default, and struct-layout
-checkpoints are complete, but Stage E remains in progress until the body
-adapter and its syntax dependency are gone.
+and construction-default checkpoints are complete, but Stage E remains in
+progress until the body adapter and its syntax dependency are gone.
 
 ### F. Constrained native interface
 

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -212,19 +212,19 @@ backend diagnostic. Callable and operator parameter/result names, roles,
 canonical types, rolling-window shapes, generated selector signatures, and
 supported callable parameter defaults now come from hgraph IR. Nominal struct
 identity, abstractness, type-generic parameters, applied parents, and effective
-value/time-series fields are likewise printed directly from `StructContract`;
+value/time-series fields are likewise printed directly from `StructContract`.
+Omitted fields now consume their substituted graph-IR defaults, including
+nested struct construction, without reading the source default expression;
 lexical `BindingId` overrides give a struct template's own type parameters their
 local readable C++ names without changing the canonical generic type used by
 operator interfaces. Const-generic structs remain rejected until hgraph has
 typed constant Bundle metadata. The range mapping is the explicitly temporary
 adapter through which the existing printer still reads syntax bodies, local
-annotations, struct construction defaults, and expression dependencies from
-the AST and `ResolvedModule`.
+annotations, and expression dependencies from the AST and `ResolvedModule`.
 
 This seam keeps the generated package readable while preventing declaration
 policy from drifting between execution paths. The next Stage E checkpoints
-move struct construction-default and local-annotation handling, then
-body/dependency emission, to hgraph IR.
+move local-annotation handling, then body/dependency emission, to hgraph IR.
 Only after those moves may `codegen` drop its syntax and resolver dependencies.
 
 `src/wiring/type_bridge` is the first direct-backend migration boundary. It
@@ -1228,9 +1228,9 @@ collection traversal, `out`, `logger`, state, and lifecycle hooks. File-based
 `test` and `run` compile/load supported runtime modules on Unix; portable native
 loading and the remaining language-depth items are still staged. Declaration
 and module planning now come from hgraph IR, as do callable/operator interfaces
-and nominal struct layouts. Body-local types, struct construction defaults, and
-dependency discovery remain behind the temporary AST adapter; callable
-parameter defaults do not.
+and nominal struct layouts. Struct construction defaults also come from the
+graph-IR constant-expression arena. Body-local types and dependency discovery
+remain behind the temporary AST adapter.
 
 `hgl emit-cpp <file.hgl>` writes one header/source pair named after the
 source — `prices.hgl` becomes `prices.h` and `prices.cpp` — beside the
@@ -1254,9 +1254,9 @@ callable and operator identities, export surface, registry bindings, and all
 callable/operator parameter and result types. Supported callable parameter
 defaults and omitted local-call arguments also use the graph-IR compile-time
 expression arena. The adapter uses retained source ranges only to locate the
-legacy syntax body, local annotations, and struct layout and construction
-defaults that must still be printed; it cannot silently add or omit a planned
-declaration.
+legacy syntax body and local annotations that must still be printed; it cannot
+silently add or omit a planned declaration. Struct layout and omitted-field
+defaults come from hgraph IR.
 
 - **Operator contracts.** `namespace operators` holds one transparent alias to
   `hgraph::Operator<"module.name",

--- a/language/examples/structural-types.hgl
+++ b/language/examples/structural-types.hgl
@@ -47,7 +47,7 @@ export struct Future: Instrument {
     expiry: date
 }
 
-fn make_quote(bid: f64, ask: f64) -> Quote =>
+export fn make_quote(bid: f64, ask: f64) -> Quote =>
     Quote(bid: bid, ask: ask)
 
 fn boxed_midpoint(value: f64) -> atomic<Box<f64>> =>

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -179,6 +179,7 @@ namespace hgl::codegen
 
         Value                       make_const(std::string code, HType type, SourceRange range,
                                                std::variant<std::monostate, std::int64_t, double> number = {});
+        Value                       make_port(std::string code, HType type, SourceRange range);
         std::optional<Value>        temporal_constant(syntax::TemporalValue literal, SourceRange range);
         std::optional<double>       numeric_value(const Value &value);
         std::optional<std::int64_t> integer_value(const Value &value);
@@ -384,11 +385,19 @@ namespace hgl::codegen
             using PlannedTypeBindings = std::unordered_map<std::uint32_t, HType>;
             [[nodiscard]] HType planned_type(gir::TypeId id, SourceRange fallback = {},
                                              const PlannedTypeBindings *bindings = nullptr);
+            [[nodiscard]] const gir::StructContract &planned_structure(std::string_view identity, SourceRange fallback);
+            [[nodiscard]] PlannedTypeBindings        planned_struct_bindings(const gir::StructContract &contract, const HType &type,
+                                                                             SourceRange fallback);
             [[nodiscard]] const gir::Type            &graph_type(gir::TypeId id, SourceRange fallback);
             [[nodiscard]] const gir::ConstExpr       &graph_constant(gir::ConstExprId id, SourceRange fallback);
             [[nodiscard]] std::optional<std::int64_t> planned_integer(gir::ConstExprId id, SourceRange fallback);
             [[nodiscard]] bool                        has_planned_result(gir::TypeId id, SourceRange fallback);
             [[nodiscard]] Value                       planned_constant(gir::ConstExprId id, SourceRange fallback = {});
+            [[nodiscard]] bool                        planned_null(gir::ConstExprId id, SourceRange fallback);
+            [[nodiscard]] Value                       planned_field_value(gir::ConstExprId id, SourceRange fallback,
+                                                                          const PlannedTypeBindings *bindings = nullptr);
+            [[nodiscard]] Value                       planned_construct(const gir::ConstExpr &expression, SourceRange fallback,
+                                                                        const PlannedTypeBindings *bindings);
             [[nodiscard]] std::string value_type(const HType &type, SourceRange range);
             [[nodiscard]] std::string schema(const HType &type, SourceRange range);
             [[nodiscard]] std::string size_text(ast::ExprId id, Frame &frame, std::string_view what);
@@ -610,10 +619,9 @@ namespace hgl::codegen
                     }
                 }
                 for (std::size_t index = 0; index < item.fields.size(); ++index) {
-                    if (item.fields[index].optional != info.fields[index].optional ||
-                        item.fields[index].default_value.valid() != (info.fields[index].default_value != ast::no_node)) {
+                    if (item.fields[index].optional != info.fields[index].optional) {
                         backend(item.range, "hgraph IR struct '" + item.identity +
-                                                "' disagrees with the syntax construction adapter's field defaults");
+                                                "' disagrees with the syntax construction adapter's field optionality");
                     }
                 }
                 if (!structures_.emplace(id, &item).second) {
@@ -667,7 +675,7 @@ namespace hgl::codegen
                     [&](const auto &literal) -> Value {
                         using T = std::decay_t<decltype(literal)>;
                         if constexpr (std::is_same_v<T, ir::hir::NullValue>) {
-                            unsupported(range, "'null' in a parameter default");
+                            unsupported(range, "'null' in a generated constant expression");
                         } else if constexpr (std::is_same_v<T, ir::hir::PlaceholderValue>) {
                             fail(Category::Type, range, "'_' is only valid in a harness sequence");
                         } else if constexpr (std::is_same_v<T, bool>) {
@@ -717,15 +725,21 @@ namespace hgl::codegen
                         return fold_binary(op, planned_constant(expression.lhs, range), planned_constant(expression.rhs, range),
                                            range);
                     }
-                case gir::ConstExprKind::Parameter: unsupported(range, "a generic parameter in a parameter default");
-                case gir::ConstExprKind::Index: unsupported(range, "an indexed parameter default");
-                case gir::ConstExprKind::Field: unsupported(range, "a field-read parameter default");
-                case gir::ConstExprKind::Sequence: unsupported(range, "a list or map parameter default");
-                case gir::ConstExprKind::Tuple: unsupported(range, "a tuple parameter default");
-                case gir::ConstExprKind::Construct: unsupported(range, "a struct parameter default");
+                case gir::ConstExprKind::Parameter: unsupported(range, "a generic parameter in a generated constant expression");
+                case gir::ConstExprKind::Index: unsupported(range, "an indexed generated constant expression");
+                case gir::ConstExprKind::Field: unsupported(range, "a field-read generated constant expression");
+                case gir::ConstExprKind::Sequence: unsupported(range, "a generated list or map constant");
+                case gir::ConstExprKind::Tuple: unsupported(range, "a generated tuple constant");
+                case gir::ConstExprKind::Construct: unsupported(range, "a generated struct constant");
                 case gir::ConstExprKind::Literal: break;
             }
             backend(range, "hgraph IR contains an incomplete constant expression");
+        }
+
+        bool Emitter::planned_null(gir::ConstExprId id, SourceRange fallback) {
+            const gir::ConstExpr &expression = graph_constant(id, fallback);
+            return expression.kind == gir::ConstExprKind::Literal && expression.literal &&
+                   std::holds_alternative<ir::hir::NullValue>(*expression.literal);
         }
 
         HType Emitter::planned_type(gir::TypeId id, SourceRange fallback, const PlannedTypeBindings *bindings) {
@@ -903,6 +917,113 @@ namespace hgl::codegen
                 case TypeKind::Deferred: break;
             }
             backend(range, "unsupported hgraph IR interface type");
+        }
+
+        const gir::StructContract &Emitter::planned_structure(std::string_view identity, SourceRange fallback) {
+            const auto found = std::find_if(graph_.structures.begin(), graph_.structures.end(),
+                                            [&](const auto &candidate) { return candidate.identity == identity; });
+            if (found == graph_.structures.end()) {
+                backend(fallback, "unknown hgraph IR nominal type '" + std::string{identity} + "'");
+            }
+            return *found;
+        }
+
+        Emitter::PlannedTypeBindings Emitter::planned_struct_bindings(const gir::StructContract &contract, const HType &type,
+                                                                      SourceRange fallback) {
+            PlannedTypeBindings result;
+            std::size_t         type_argument = 0;
+            for (const gir::GenericParameter &generic : contract.generics) {
+                if (generic.is_const) { continue; }
+                if (!generic.binding.valid() || generic.binding.value >= graph_.bindings.size()) {
+                    backend(contract.range, "hgraph IR struct '" + contract.identity + "' has an invalid generic binding");
+                }
+                if (graph_.bindings[generic.binding.value].kind != gir::BindingKind::TypeParameter) {
+                    backend(contract.range, "hgraph IR struct '" + contract.identity + "' has a mismatched type binding");
+                }
+                if (type_argument >= type.children.size()) {
+                    backend(fallback, "constructed type '" + contract.identity + "' is missing a generic type argument");
+                }
+                if (!result.emplace(generic.binding.value, type.children[type_argument++]).second) {
+                    backend(contract.range, "hgraph IR struct '" + contract.identity + "' repeats a generic binding");
+                }
+            }
+            if (type_argument != type.children.size()) {
+                backend(fallback, "constructed type '" + contract.identity + "' has too many generic type arguments");
+            }
+            return result;
+        }
+
+        Value Emitter::planned_field_value(gir::ConstExprId id, SourceRange fallback, const PlannedTypeBindings *bindings) {
+            const gir::ConstExpr &expression = graph_constant(id, fallback);
+            if (expression.kind == gir::ConstExprKind::Construct) { return planned_construct(expression, fallback, bindings); }
+            return planned_constant(id, fallback);
+        }
+
+        Value Emitter::planned_construct(const gir::ConstExpr &expression, SourceRange fallback,
+                                         const PlannedTypeBindings *bindings) {
+            const SourceRange range = expression.range.end > expression.range.begin ? expression.range : fallback;
+            if (expression.delta) { unsupported(range, "a sparse delta in a struct field default"); }
+
+            HType type = planned_type(expression.constructed_type, range, bindings);
+            if (type.kind != HType::Kind::Struct) { backend(range, "a constructed hgraph IR default does not name a struct type"); }
+            const gir::StructContract &contract = planned_structure(type.nominal_identity, range);
+            if (contract.abstract) {
+                fail(Category::Type, range,
+                     "abstract struct '" + std::string{local_identity(contract.identity)} + "' is not constructible");
+            }
+            const PlannedTypeBindings generics = planned_struct_bindings(contract, type, range);
+
+            std::unordered_map<std::string_view, gir::ConstExprId> supplied;
+            supplied.reserve(expression.arguments.size());
+            for (const gir::ConstArgument &argument : expression.arguments) {
+                const auto field = std::find_if(contract.fields.begin(), contract.fields.end(),
+                                                [&](const auto &candidate) { return candidate.name == argument.name; });
+                if (field == contract.fields.end()) {
+                    backend(range, "struct '" + std::string{local_identity(contract.identity)} + "' has no field named '" +
+                                       argument.name + "'");
+                }
+                if (!supplied.emplace(argument.name, argument.value).second) {
+                    backend(range, "field '" + argument.name + "' is given twice");
+                }
+            }
+
+            std::vector<std::string> temporal_fields;
+            temporal_fields.reserve(contract.fields.size());
+            for (const gir::StructField &field : contract.fields) {
+                gir::ConstExprId value;
+                if (const auto found = supplied.find(field.name); found != supplied.end()) {
+                    value = found->second;
+                } else {
+                    value = field.default_value;
+                }
+                const HType       field_type  = planned_type(field.type, field.range, &generics);
+                const SourceRange field_range = graph_type(field.type, field.range).range;
+                if (!value.valid()) {
+                    if (!field.optional) {
+                        backend(range,
+                                "struct '" + std::string{local_identity(contract.identity)} + "' needs field '" + field.name + "'");
+                    }
+                    temporal_fields.push_back("hgraph::wire<hgraph::stdlib::nothing, " + schema(field_type, field_range) + ">(w)");
+                    continue;
+                }
+                if (planned_null(value, field.range)) {
+                    if (!field.optional) {
+                        fail(Category::Type, graph_constant(value, field.range).range,
+                             "required field '" + field.name + "' cannot be null");
+                    }
+                    temporal_fields.push_back("hgraph::wire<hgraph::stdlib::nothing, " + schema(field_type, field_range) + ">(w)");
+                    continue;
+                }
+                Value item = planned_field_value(value, field.range, &generics);
+                temporal_fields.push_back(as_port(item, field_type, item.range));
+            }
+
+            Value result = make_port("hgraph::stdlib::to_tsb<" + schema(type, range) + ">(w" +
+                                         (temporal_fields.empty() ? std::string{} : ", " + join(temporal_fields, ", ")) + ")",
+                                     type, range);
+            result.atomic_code =
+                "hgraph::wire<hgraph::stdlib::combine_cs, hgraph::TS<" + value_type(type, range) + ">>(w, " + result.code + ")";
+            return result;
         }
 
         std::string Emitter::size_text(ast::ExprId id, Frame &frame, std::string_view what)
@@ -1866,7 +1987,6 @@ namespace hgl::codegen
 
         Value Emitter::eval_construct(ast::DeclId decl, ast::TypeId type_id, const std::vector<ast::Argument> &arguments,
                                       bool delta, SourceRange range, Frame &frame) {
-            const semantics::StructInfo &info     = resolved_.structure(decl);
             const gir::StructContract   &contract = struct_contract(decl);
             HType                        type;
             if (type_id != ast::no_node) {
@@ -1882,26 +2002,7 @@ namespace hgl::codegen
                 type.cpp_type         = cpp_name(local_identity(contract.identity));
             }
 
-            PlannedTypeBindings planned_generics;
-            std::size_t type_argument = 0;
-            for (const gir::GenericParameter &generic : contract.generics) {
-                if (generic.is_const) { continue; }
-                if (!generic.binding.valid() || generic.binding.value >= graph_.bindings.size()) {
-                    backend(contract.range, "hgraph IR struct '" + contract.identity + "' has an invalid generic binding");
-                }
-                if (graph_.bindings[generic.binding.value].kind != gir::BindingKind::TypeParameter) {
-                    backend(contract.range, "hgraph IR struct '" + contract.identity + "' has a mismatched type binding");
-                }
-                if (type_argument >= type.children.size()) {
-                    backend(range, "constructed type '" + contract.identity + "' is missing a generic type argument");
-                }
-                if (!planned_generics.emplace(generic.binding.value, type.children[type_argument++]).second) {
-                    backend(contract.range, "hgraph IR struct '" + contract.identity + "' repeats a generic binding");
-                }
-            }
-            if (type_argument != type.children.size()) {
-                backend(range, "constructed type '" + contract.identity + "' has too many generic type arguments");
-            }
+            const PlannedTypeBindings planned_generics = planned_struct_bindings(contract, type, range);
             if (type_id != ast::no_node) {
                 type.declaration      = decl;
                 type.nominal_identity = contract.identity;
@@ -1922,15 +2023,31 @@ namespace hgl::codegen
             std::vector<std::string>                   temporal_fields;
             std::vector<std::pair<std::size_t, Value>> delta_fields;
             for (std::size_t index = 0; index < contract.fields.size(); ++index) {
-                const semantics::StructField &source_field = info.fields[index];
-                const gir::StructField       &field        = contract.fields[index];
-                ast::ExprId                   value_id      = argument_for(source_field.name);
-                if (value_id == ast::no_node && !delta) { value_id = source_field.default_value; }
+                const gir::StructField &field       = contract.fields[index];
+                ast::ExprId             value_id    = argument_for(field.name);
                 const HType       field_type  = planned_type(field.type, field.range, &planned_generics);
                 const SourceRange field_range = graph_type(field.type, field.range).range;
 
                 if (value_id == ast::no_node) {
                     if (delta) { continue; }
+                    if (field.default_value.valid()) {
+                        if (planned_null(field.default_value, field.range)) {
+                            if (!field.optional) {
+                                fail(Category::Type, graph_constant(field.default_value, field.range).range,
+                                     "required field '" + field.name + "' cannot be null");
+                            }
+                            temporal_fields.push_back("hgraph::wire<hgraph::stdlib::nothing, " + schema(field_type, field_range) +
+                                                      ">(w)");
+                            continue;
+                        }
+                        Value value = planned_field_value(field.default_value, field.range, &planned_generics);
+                        temporal_fields.push_back(as_port(value, field_type, value.range));
+                        continue;
+                    }
+                    if (!field.optional) {
+                        backend(range,
+                                "struct '" + std::string{local_identity(contract.identity)} + "' needs field '" + field.name + "'");
+                    }
                     temporal_fields.push_back("hgraph::wire<hgraph::stdlib::nothing, " +
                                               schema(field_type, field_range) + ">(w)");
                     continue;

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -955,8 +955,70 @@ namespace hgl::codegen
 
         Value Emitter::planned_field_value(gir::ConstExprId id, SourceRange fallback, const PlannedTypeBindings *bindings) {
             const gir::ConstExpr &expression = graph_constant(id, fallback);
-            if (expression.kind == gir::ConstExprKind::Construct) { return planned_construct(expression, fallback, bindings); }
-            return planned_constant(id, fallback);
+            const SourceRange     range      = expression.range.end > expression.range.begin ? expression.range : fallback;
+            switch (expression.kind) {
+                case gir::ConstExprKind::Unary:
+                    {
+                        const Value        operand = planned_field_value(expression.lhs, range, bindings);
+                        const ast::UnaryOp op =
+                            expression.unary == ir::hir::UnaryOp::Negate ? ast::UnaryOp::Negate : ast::UnaryOp::Not;
+                        if (operand.is_const() || operand.is_runtime()) { return fold_unary(op, operand, range); }
+                        if (!operand.is_port()) { backend(range, "this operand has no value"); }
+                        return wire(op == ast::UnaryOp::Negate ? "hgraph::stdlib::neg_" : "hgraph::stdlib::not_", {operand.code},
+                                    range);
+                    }
+                case gir::ConstExprKind::Binary:
+                    {
+                        const Value         lhs = planned_field_value(expression.lhs, range, bindings);
+                        const Value         rhs = planned_field_value(expression.rhs, range, bindings);
+                        const ast::BinaryOp op  = [&] {
+                            switch (expression.binary) {
+                                case ir::hir::BinaryOp::Mul: return ast::BinaryOp::Mul;
+                                case ir::hir::BinaryOp::Div: return ast::BinaryOp::Div;
+                                case ir::hir::BinaryOp::Rem: return ast::BinaryOp::Rem;
+                                case ir::hir::BinaryOp::Add: return ast::BinaryOp::Add;
+                                case ir::hir::BinaryOp::Sub: return ast::BinaryOp::Sub;
+                                case ir::hir::BinaryOp::Less: return ast::BinaryOp::Less;
+                                case ir::hir::BinaryOp::LessEqual: return ast::BinaryOp::LessEqual;
+                                case ir::hir::BinaryOp::Greater: return ast::BinaryOp::Greater;
+                                case ir::hir::BinaryOp::GreaterEqual: return ast::BinaryOp::GreaterEqual;
+                                case ir::hir::BinaryOp::Equal: return ast::BinaryOp::Equal;
+                                case ir::hir::BinaryOp::NotEqual: return ast::BinaryOp::NotEqual;
+                                case ir::hir::BinaryOp::And: return ast::BinaryOp::And;
+                                case ir::hir::BinaryOp::Or: return ast::BinaryOp::Or;
+                            }
+                            std::unreachable();
+                        }();
+                        if ((lhs.is_const() || lhs.is_runtime()) && (rhs.is_const() || rhs.is_runtime())) {
+                            return fold_binary(op, lhs, rhs, range);
+                        }
+                        return wire_binary(op, lhs, rhs, range);
+                    }
+                case gir::ConstExprKind::Index:
+                    {
+                        const Value target = planned_field_value(expression.lhs, range, bindings);
+                        const Value index  = planned_field_value(expression.rhs, range, bindings);
+                        if (target.is_port()) {
+                            return wire("hgraph::stdlib::getitem_", {target.code, argument_code(index)}, range);
+                        }
+                        unsupported(range, "indexing a constant");
+                    }
+                case gir::ConstExprKind::Field:
+                    {
+                        const Value target = planned_field_value(expression.lhs, range, bindings);
+                        if (target.is_port()) {
+                            return wire("hgraph::stdlib::getattr_", {target.code, "hgraph::Str{" + quote(expression.member) + "}"},
+                                        range);
+                        }
+                        unsupported(range, "field access on a constant");
+                    }
+                case gir::ConstExprKind::Construct: return planned_construct(expression, fallback, bindings);
+                case gir::ConstExprKind::Literal:
+                case gir::ConstExprKind::Parameter:
+                case gir::ConstExprKind::Sequence:
+                case gir::ConstExprKind::Tuple: return planned_constant(id, fallback);
+            }
+            std::unreachable();
         }
 
         Value Emitter::planned_construct(const gir::ConstExpr &expression, SourceRange fallback,
@@ -965,13 +1027,21 @@ namespace hgl::codegen
             if (expression.delta) { unsupported(range, "a sparse delta in a struct field default"); }
 
             HType type = planned_type(expression.constructed_type, range, bindings);
+            if (type.kind == HType::Kind::Atomic) {
+                if (type.children.size() != 1U) { backend(range, "an atomic constructed type requires one value type"); }
+                HType inner = std::move(type.children.front());
+                type        = std::move(inner);
+            }
             if (type.kind != HType::Kind::Struct) { backend(range, "a constructed hgraph IR default does not name a struct type"); }
             const gir::StructContract &contract = planned_structure(type.nominal_identity, range);
             if (contract.abstract) {
                 fail(Category::Type, range,
                      "abstract struct '" + std::string{local_identity(contract.identity)} + "' is not constructible");
             }
-            const PlannedTypeBindings generics = planned_struct_bindings(contract, type, range);
+            PlannedTypeBindings generics = bindings != nullptr ? *bindings : PlannedTypeBindings{};
+            for (auto &&[binding, value] : planned_struct_bindings(contract, type, range)) {
+                generics.insert_or_assign(binding, std::move(value));
+            }
 
             std::unordered_map<std::string_view, gir::ConstExprId> supplied;
             supplied.reserve(expression.arguments.size());

--- a/language/src/codegen/cpp_emitter.h
+++ b/language/src/codegen/cpp_emitter.h
@@ -15,8 +15,8 @@
 /// one header/source pair of public hgraph authoring code per module. It is
 /// planned from hgraph IR and prints names and types without linking the hgraph
 /// runtime, so what it emits is checked by the native compiler that builds the
-/// package. A temporary syntax adapter still supplies bodies, types, and
-/// signatures during the Stage E migration. Tests run generated graphs beside
+/// package. A temporary syntax adapter still supplies bodies and local
+/// annotations during the Stage E migration. Tests run generated graphs beside
 /// `hgl test` and exercise generated runtime nodes directly through hgraph's
 /// public harness.
 namespace hgl::codegen

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -345,6 +345,77 @@ export fn make_outer() -> Outer => Outer()
     CHECK(contains(emitted->source, "hgraph::stdlib::to_tsb<typename Outer::time_series>"));
 }
 
+TEST_CASE("emit-cpp constructs atomic hgraph IR struct defaults", "[codegen][hgraph-ir][structs][defaults]") {
+    Unit unit{R"(
+module atomic_struct_defaults
+
+struct Inner {
+    amount: f64
+}
+
+struct Outer {
+    inner: atomic<Inner> = Inner(amount: 1.0)
+}
+
+export fn make_outer() -> Outer => Outer()
+)"};
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+
+    const auto emitted = unit.emit();
+    REQUIRE(emitted);
+    CHECK(contains(emitted->source, "hgraph::stdlib::to_tsb<typename Inner::time_series>"));
+    CHECK(contains(emitted->source, "hgraph::stdlib::combine_cs, hgraph::TS<typename Inner::value_type>"));
+}
+
+TEST_CASE("emit-cpp projects nested hgraph IR struct defaults", "[codegen][hgraph-ir][structs][defaults]") {
+    Unit unit{R"(
+module projected_struct_defaults
+
+struct Inner {
+    amount: f64
+}
+
+struct Outer {
+    amount: f64 = Inner(amount: 1.0).amount
+}
+
+export fn make_outer() -> Outer => Outer()
+)"};
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+
+    const auto emitted = unit.emit();
+    REQUIRE(emitted);
+    CHECK(contains(emitted->source, "hgraph::wire<hgraph::stdlib::getattr_>"));
+    CHECK(contains(emitted->source, "hgraph::Str{\"amount\"}"));
+}
+
+TEST_CASE("emit-cpp preserves outer bindings in nested hgraph IR struct defaults", "[codegen][hgraph-ir][structs][defaults]") {
+    Unit unit{R"(
+module generic_struct_defaults
+
+struct Leaf<U> {
+    marker: i64 = 1
+}
+
+struct Middle<U> {
+    leaf: Leaf<U>
+}
+
+struct Outer<U> {
+    middle: Middle<U> = Middle<U>(leaf: Leaf<U>())
+}
+
+export fn make_outer() -> Outer<f64> => Outer<f64>()
+)"};
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+
+    const auto emitted = unit.emit();
+    REQUIRE(emitted);
+    CHECK(contains(emitted->source, "typename Leaf<hgraph::Float>::time_series"));
+    CHECK(contains(emitted->source, "typename Middle<hgraph::Float>::time_series"));
+    CHECK_FALSE(contains(emitted->source, "ScalarVar<\"U\">"));
+}
+
 TEST_CASE("emit-cpp renders defaults and omitted arguments from hgraph IR", "[codegen][hgraph-ir][defaults]") {
     Unit unit{R"(
 module planned_defaults

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -283,6 +283,68 @@ export abstract struct Shape<T> {
     CHECK_FALSE(contains(emitted->header, "hgraph::Field<\"label\""));
 }
 
+TEST_CASE("emit-cpp constructs omitted struct fields from hgraph IR defaults", "[codegen][hgraph-ir][structs][defaults]") {
+    Unit unit{R"(
+module planned_struct_defaults
+
+struct Record {
+    amount: f64
+    label: str = "source"
+}
+
+export fn make_record(amount: f64) -> Record => Record(amount: amount)
+)"};
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+    REQUIRE(unit.graph.completion == hgl::hgraph_ir::Completion::Bodies);
+    REQUIRE(unit.graph.structures.size() == 1);
+    REQUIRE(unit.graph.structures.front().fields.size() == 2);
+
+    hgl::hgraph_ir::StructField &label = unit.graph.structures.front().fields[1];
+    REQUIRE(label.default_value.valid());
+    REQUIRE(label.default_value.value < unit.graph.const_exprs.size());
+
+    SECTION("the planned value is authoritative") {
+        unit.graph.const_exprs[label.default_value.value].literal = std::string{"planned"};
+
+        const auto emitted = unit.emit();
+        REQUIRE(emitted);
+        CHECK(contains(emitted->source, "hgraph::Str{\"planned\"}"));
+        CHECK_FALSE(contains(emitted->source, "hgraph::Str{\"source\"}"));
+    }
+
+    SECTION("the planned presence is authoritative") {
+        label.default_value = {};
+
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Backend, "struct 'Record' needs field 'label'"));
+    }
+}
+
+TEST_CASE("emit-cpp constructs nested hgraph IR struct defaults", "[codegen][hgraph-ir][structs][defaults]") {
+    Unit unit{R"(
+module nested_struct_defaults
+
+struct Inner {
+    amount: f64
+    label: str = "inner"
+}
+
+struct Outer {
+    inner: Inner = Inner(amount: 1.0)
+}
+
+export fn make_outer() -> Outer => Outer()
+)"};
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+
+    const auto emitted = unit.emit();
+    REQUIRE(emitted);
+    CHECK(contains(emitted->source, "hgraph::Float{1.0}"));
+    CHECK(contains(emitted->source, "hgraph::Str{\"inner\"}"));
+    CHECK(contains(emitted->source, "hgraph::stdlib::to_tsb<typename Inner::time_series>"));
+    CHECK(contains(emitted->source, "hgraph::stdlib::to_tsb<typename Outer::time_series>"));
+}
+
 TEST_CASE("emit-cpp renders defaults and omitted arguments from hgraph IR", "[codegen][hgraph-ir][defaults]") {
     Unit unit{R"(
 module planned_defaults

--- a/language/tests/codegen/generated_structural_tests.cpp
+++ b/language/tests/codegen/generated_structural_tests.cpp
@@ -22,6 +22,8 @@ namespace
     using MakeSwapped =
         Operator<"examples.structural_types.make_swapped", In<"first", TS<Float>>, In<"second", TS<Int>>,
                  Out<typename structural::Swap<Int, Float>::time_series>>;
+    using MakeQuote = Operator<"examples.structural_types.make_quote", In<"bid", TS<Float>>, In<"ask", TS<Float>>,
+                               Out<typename structural::Quote::time_series>>;
 }
 
 TEST_CASE("generated structural types preserve nominal metadata", "[codegen][generated][struct]") {
@@ -52,6 +54,15 @@ TEST_CASE("generated structural construction uses substituted inherited fields",
 
     CHECK_OUTPUT(eval_node<MakeSwapped>(values<Float>(1.25), values<Int>(7)),
                  values<Value>(tsb_delta<typename structural::Swap<Int, Float>::time_series>(Float{1.25}, Int{7})));
+}
+
+TEST_CASE("generated structural construction applies hgraph IR defaults", "[codegen][generated][struct]") {
+    hgl::wiring::ensure_session();
+    structural::register_operators();
+
+    CHECK_OUTPUT(
+        eval_node<MakeQuote>(values<Float>(1.25), values<Float>(1.5)),
+        values<Value>(tsb_delta<typename structural::Quote::time_series>(Float{1.25}, Float{1.5}, Str{"USD"}, std::nullopt)));
 }
 
 TEST_CASE("generated structural deltas remain sparse", "[codegen][generated][struct]") {


### PR DESCRIPTION
## Summary
- make HGraph IR field-default value and presence authoritative for omitted struct construction
- lower nested struct defaults from substituted HGraph IR contracts
- fail closed for a required omitted field once its planned default is absent
- execute the generated Quote default path and document the narrower remaining AST body seam

## Validation
- focused codegen defaults: 2 cases / 23 assertions
- complete codegen suite: 23 cases / 233 assertions
- generated suite: 27 cases / 57 assertions
- language suite: 30/30
- fresh native acceptance: 1,716/1,716
- Python 3.12 ABI3 wheel installed into fresh Python 3.14: 3,240 passed, 10 skipped
- private Linux GCC 14 warnings-as-errors language build: 30/30

Stacked on #703.