### PR TITLE
refactor(language): plan local bindings from hgraph IR

### DIFF
--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -188,9 +188,9 @@ endfunction()
 
 # The C++ backend (src/codegen): emits a header/source pair of public hgraph
 # authoring code per module (developer guide, "C++ backend, first pass").
-# Hgraph IR owns module and callable/operator interfaces, struct layouts, and
-# construction defaults while a temporary syntax adapter prints bodies and
-# local annotations.
+# Hgraph IR owns module and callable/operator interfaces, struct layouts,
+# construction defaults, and local/state binding types while a temporary
+# syntax adapter prints executable bodies and discovers dependencies.
 add_library(hgl_codegen STATIC
     src/codegen/cpp_emitter.cpp
 )

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -179,8 +179,10 @@ wiring target no longer includes syntax AST headers.
   and effective field layouts from hgraph IR;
 - [x] migrate construction defaults from the temporary
   syntax/`ResolvedModule` adapter to hgraph IR;
-- [ ] migrate local annotations, bodies, and dependency emission from the
-  temporary syntax/`ResolvedModule` adapter to hgraph IR;
+- [x] migrate local `let`/`var` and state binding types from the temporary
+  syntax/`ResolvedModule` adapter to hgraph IR;
+- [ ] migrate executable bodies, expression-level type syntax, and dependency
+  emission from the temporary syntax/`ResolvedModule` adapter to hgraph IR;
 - remove duplicate name, type, generic, phase, and classification logic from
   the emitter;
 - retain deterministic formatting, source maps, public-SDK code, and readable
@@ -189,9 +191,10 @@ wiring target no longer includes syntax AST headers.
 
 Acceptance: both backends consume the same hgraph IR, existing generated tests
 and installed consumers pass, and architecture tests reject backend-to-syntax
-dependencies. The declaration, interface, callable-default, and struct-layout
-and construction-default checkpoints are complete, but Stage E remains in
-progress until the body adapter and its syntax dependency are gone.
+dependencies. The declaration, interface, callable-default, struct-layout,
+construction-default, and local-binding-type checkpoints are complete, but
+Stage E remains in progress until the body adapter and its syntax dependency
+are gone.
 
 ### F. Constrained native interface
 

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -202,8 +202,8 @@ perform in-process registry resolution while it wires. Locked provider
 selection and native execution planning are still required before a portable
 module may be marked `Executable`.
 
-The direct-wiring backend now consumes only hgraph IR. The first Stage E C++
-checkpoint also takes hgraph IR as its primary input. It uses graph-IR module
+The direct-wiring backend now consumes only hgraph IR. The Stage E C++
+checkpoints also take hgraph IR as their primary input. They use graph-IR module
 paths, callable identities, visibility and classification, nominal operator
 bindings, exports, and registration plans. A declaration range maps each
 planned callable, local operator, or struct back to exactly one source
@@ -218,14 +218,18 @@ nested struct construction, without reading the source default expression;
 lexical `BindingId` overrides give a struct template's own type parameters their
 local readable C++ names without changing the canonical generic type used by
 operator interfaces. Const-generic structs remain rejected until hgraph has
-typed constant Bundle metadata. The range mapping is the explicitly temporary
-adapter through which the existing printer still reads syntax bodies, local
-annotations, and expression dependencies from the AST and `ResolvedModule`.
+typed constant Bundle metadata. The same range mapping now pairs graph-IR local
+and state statements with their temporary syntax bodies. Resolved binding
+names, mutability, and types come from `LocalBinding`, `StateBinding`, and their
+`BindingId` records; inferred state types therefore no longer need a
+backend-only explicit-annotation restriction. The explicitly temporary adapter
+still supplies executable bodies, expression-level type syntax, and expression
+dependencies from the AST and `ResolvedModule`.
 
 This seam keeps the generated package readable while preventing declaration
 policy from drifting between execution paths. The next Stage E checkpoints
-move local-annotation handling, then body/dependency emission, to hgraph IR.
-Only after those moves may `codegen` drop its syntax and resolver dependencies.
+move body and dependency emission to hgraph IR. Only after those moves may
+`codegen` drop its syntax and resolver dependencies.
 
 `src/wiring/type_bridge` is the first direct-backend migration boundary. It
 materializes hgraph-IR scalar, tuple, list, set, map, window, atomic, and applied
@@ -1227,10 +1231,10 @@ deltas, concise `map` functions, scalar and collection runtime inputs, borrowed
 collection traversal, `out`, `logger`, state, and lifecycle hooks. File-based
 `test` and `run` compile/load supported runtime modules on Unix; portable native
 loading and the remaining language-depth items are still staged. Declaration
-and module planning now come from hgraph IR, as do callable/operator interfaces
-and nominal struct layouts. Struct construction defaults also come from the
-graph-IR constant-expression arena. Body-local types and dependency discovery
-remain behind the temporary AST adapter.
+and module planning now come from hgraph IR, as do callable/operator interfaces,
+nominal struct layouts, construction defaults, and local/state binding types.
+Executable expression lowering and dependency discovery remain behind the
+temporary AST adapter.
 
 `hgl emit-cpp <file.hgl>` writes one header/source pair named after the
 source — `prices.hgl` becomes `prices.h` and `prices.cpp` — beside the
@@ -1253,10 +1257,11 @@ callable set, visibility, composition/runtime classification, canonical
 callable and operator identities, export surface, registry bindings, and all
 callable/operator parameter and result types. Supported callable parameter
 defaults and omitted local-call arguments also use the graph-IR compile-time
-expression arena. The adapter uses retained source ranges only to locate the
-legacy syntax body and local annotations that must still be printed; it cannot
-silently add or omit a planned declaration. Struct layout and omitted-field
-defaults come from hgraph IR.
+expression arena. Local and state statements use the graph-IR binding name,
+kind, and resolved type; retained source ranges pair those statements with the
+legacy executable body that must still be printed. The adapter cannot silently
+add or omit a planned declaration or body binding. Struct layout and
+omitted-field defaults come from hgraph IR.
 
 - **Operator contracts.** `namespace operators` holds one transparent alias to
   `hgraph::Operator<"module.name",

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -40,8 +40,9 @@ namespace hgl::codegen
         // ------------------------------------------------------------ types
 
         /// A normalized type used by the temporary C++ body printer. Public
-        /// interface instances come from hgraph IR; local annotations still
-        /// arrive through the syntax compatibility adapter.
+        /// interface instances and body-local binding types come from hgraph
+        /// IR; expression-level type syntax still arrives through the syntax
+        /// compatibility adapter.
         struct HType
         {
             enum class Kind : std::uint8_t {
@@ -363,6 +364,8 @@ namespace hgl::codegen
                 return std::get<ast::StructDecl>(module_.decl(decl).node);
             }
             void                                       bind_hgraph_declarations();
+            [[nodiscard]] const gir::Statement        &planned_statement(ast::StmtId id);
+            [[nodiscard]] const gir::Binding          &planned_binding(gir::BindingId id, SourceRange fallback);
             [[nodiscard]] const gir::Callable         &callable(ast::DeclId decl) const { return *callables_.at(decl); }
             [[nodiscard]] const gir::OperatorContract &operator_decl(ast::DeclId decl) const { return *operators_.at(decl); }
             [[nodiscard]] const gir::StructContract &struct_contract(ast::DeclId decl) const { return *structures_.at(decl); }
@@ -486,6 +489,7 @@ namespace hgl::codegen
             std::unordered_map<ast::DeclId, const gir::Callable *>         callables_{};
             std::unordered_map<ast::DeclId, const gir::OperatorContract *> operators_{};
             std::unordered_map<ast::DeclId, const gir::StructContract *>   structures_{};
+            std::unordered_map<ast::StmtId, const gir::Statement *>        body_statements_{};
             bool                             uses_analytics_{false};
             /// Locals declared in the current function, for unique C++ names.
             std::unordered_map<std::string, int> local_counts_{};
@@ -518,6 +522,21 @@ namespace hgl::codegen
                 backend(item.range, "hgraph IR implementation '" + item.identity + "' has no canonical numeric identity");
             }
             return name + "_impl_" + item.identity.substr(marker + 1U);
+        }
+
+        const gir::Statement &Emitter::planned_statement(ast::StmtId id) {
+            const auto found = body_statements_.find(id);
+            if (found == body_statements_.end()) {
+                backend(module_.stmt(id).range, "the hgraph IR has no planned body binding for this syntax statement");
+            }
+            return *found->second;
+        }
+
+        const gir::Binding &Emitter::planned_binding(gir::BindingId id, SourceRange fallback) {
+            if (!id.valid() || id.value >= graph_.bindings.size()) {
+                backend(fallback, "hgraph IR contains an invalid body binding ID");
+            }
+            return graph_.bindings[id.value];
         }
 
         void Emitter::bind_hgraph_declarations() {
@@ -630,6 +649,41 @@ namespace hgl::codegen
             }
             if (structures_.size() != resolved_.structs.size()) {
                 backend(SourceRange{}, "the hgraph IR and syntax construction adapter disagree on the module's structs");
+            }
+
+            std::size_t planned_body_bindings = 0;
+            for (const gir::Statement &item : graph_.statements) {
+                const bool is_local = std::holds_alternative<gir::LocalBinding>(item.node);
+                const bool is_state = std::holds_alternative<gir::StateBinding>(item.node);
+                if (!is_local && !is_state) { continue; }
+                ++planned_body_bindings;
+
+                ast::StmtId match = ast::no_node;
+                for (ast::StmtId id = 0; id < module_.stmts.size(); ++id) {
+                    const ast::Stmt &source = module_.stmt(id);
+                    if (source.range != item.range) { continue; }
+                    const bool source_is_local = std::holds_alternative<ast::LocalDecl>(source.node);
+                    const bool source_is_state = std::holds_alternative<ast::StateDecl>(source.node);
+                    if ((is_local && !source_is_local) || (is_state && !source_is_state)) { continue; }
+                    if (match != ast::no_node) {
+                        backend(item.range, "hgraph IR body-binding range matches more than one syntax statement");
+                    }
+                    match = id;
+                }
+                if (match == ast::no_node) { backend(item.range, "an hgraph IR body binding has no syntax body adapter"); }
+                if (!body_statements_.emplace(match, &item).second) {
+                    backend(item.range, "more than one hgraph IR body binding maps to the same syntax statement");
+                }
+            }
+
+            std::size_t syntax_body_bindings = 0;
+            for (const ast::Stmt &item : module_.stmts) {
+                if (std::holds_alternative<ast::LocalDecl>(item.node) || std::holds_alternative<ast::StateDecl>(item.node)) {
+                    ++syntax_body_bindings;
+                }
+            }
+            if (body_statements_.size() != syntax_body_bindings || planned_body_bindings != syntax_body_bindings) {
+                backend(SourceRange{}, "the hgraph IR and syntax body adapter disagree on local and state bindings");
             }
         }
 
@@ -2420,32 +2474,31 @@ namespace hgl::codegen
                     if constexpr (std::is_same_v<T, ast::LocalDecl>)
                     {
                         Value value = eval_expr(node.init, frame);
-                        if (node.type != ast::no_node)
-                        {
-                            const HType declared = type_of(node.type, frame);
-                            if (value.is_const())
-                            {
-                                value.code = as_const(value, declared, value.range, "'" + std::string{node.name.text} + "'");
-                                value.type = declared;
-                            }
-                            else if (value.is_port())
-                            {
-                                value.code = as_port(value, declared, value.range);
-                                value.type = declared;
-                            }
-                        }
                         if (value.kind != Value::Kind::Const && value.kind != Value::Kind::Port)
                         {
                             unsupported(stmt.range, "binding a function or operator to a local");
                         }
+                        const auto         &binding  = std::get<gir::LocalBinding>(planned_statement(id).node);
+                        const gir::Binding &name     = planned_binding(binding.binding, stmt.range);
+                        const HType         declared = planned_type(binding.type, stmt.range);
+                        if (value.is_const()) {
+                            value.code = as_const(value, declared, value.range, "'" + name.name + "'");
+                        } else {
+                            value.code = as_port(value, declared, value.range);
+                        }
+                        value.type = declared;
                         // A unique C++ local per declaration: HGL lets a
                         // later `let` shadow an earlier one in a block.
-                        const std::string base = cpp_name(node.name.text);
+                        const std::string base   = cpp_name(name.name);
                         std::string       local = base;
                         int              &suffix = local_counts_[base];
                         while (local_names_.contains(local)) { local = base + "_" + std::to_string(++suffix); }
                         local_names_.insert(local);
-                        out.line((node.mutable_ ? "auto " : "const auto ") + local + " = " + value.code + ";");
+                        if (name.kind != gir::BindingKind::LocalLet && name.kind != gir::BindingKind::LocalVar) {
+                            backend(stmt.range, "hgraph IR local statement refers to a non-local binding");
+                        }
+                        out.line((name.kind == gir::BindingKind::LocalVar ? "auto " : "const auto ") + local + " = " + value.code +
+                                 ";");
                         value.code       = local;
                         frame.locals[id] = std::move(value);
                     }
@@ -2650,13 +2703,15 @@ namespace hgl::codegen
                         {
                             fail(Category::Type, stmt.range, "a runtime local needs a scalar value");
                         }
-                        if (node.type != ast::no_node)
-                        {
-                            const HType declared = type_of(node.type, frame);
-                            value.code           = as_runtime(value, declared, value.range, "'" + std::string{node.name.text} + "'");
-                            value.type           = declared;
+                        const auto         &binding = std::get<gir::LocalBinding>(planned_statement(id).node);
+                        const gir::Binding &name    = planned_binding(binding.binding, stmt.range);
+                        if (name.kind != gir::BindingKind::LocalLet && name.kind != gir::BindingKind::LocalVar) {
+                            backend(stmt.range, "hgraph IR local statement refers to a non-local binding");
                         }
-                        const std::string base   = cpp_name(node.name.text);
+                        const HType declared     = planned_type(binding.type, stmt.range);
+                        value.code               = as_runtime(value, declared, value.range, "'" + name.name + "'");
+                        value.type               = declared;
+                        const std::string base   = cpp_name(name.name);
                         std::string       local  = base;
                         int              &suffix = local_counts_[base];
                         while (local_names_.contains(local))
@@ -2664,7 +2719,8 @@ namespace hgl::codegen
                             local = base + "_" + std::to_string(++suffix);
                         }
                         local_names_.insert(local);
-                        out.line((node.mutable_ ? "auto " : "const auto ") + local + " = " + value.code + ";");
+                        out.line((name.kind == gir::BindingKind::LocalVar ? "auto " : "const auto ") + local + " = " + value.code +
+                                 ";");
                         value.code = local;
                         value.selector.clear();
                         value.kind       = Value::Kind::Runtime;
@@ -3210,22 +3266,23 @@ namespace hgl::codegen
                         using T = std::decay_t<decltype(node)>;
                         if constexpr (std::is_same_v<T, ast::StateDecl>)
                         {
-                            if (node.type == ast::no_node)
-                            {
-                                backend(node.name.range, "a generated runtime state declaration "
-                                                         "needs an explicit scalar type");
+                            const auto         &binding = std::get<gir::StateBinding>(planned_statement(id).node);
+                            const gir::Binding &name    = planned_binding(binding.binding, stmt.range);
+                            if (name.kind != gir::BindingKind::State) {
+                                backend(stmt.range, "hgraph IR state statement refers to a non-state binding");
                             }
-                            const HType type = type_of(node.type, frame);
+                            const HType type = planned_type(binding.type, stmt.range);
                             if (type.kind != HType::Kind::Scalar)
                             {
-                                backend(module_.type(node.type).range, "the first runtime-node slice supports scalar state fields");
+                                backend(graph_type(binding.type, stmt.range).range,
+                                        "the first runtime-node slice supports scalar state fields");
                             }
                             if (node.init == ast::no_node)
                             {
                                 backend(node.name.range, "a generated runtime state field needs an initializer");
                             }
-                            info.states.push_back(RuntimeState{
-                                .id = id, .name = std::string{node.name.text}, .type = type, .init = node.init, .range = node.name.range});
+                            info.states.push_back(
+                                RuntimeState{.id = id, .name = name.name, .type = type, .init = node.init, .range = name.range});
                         }
                         else if constexpr (std::is_same_v<T, ast::InjectDecl>)
                         {

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -366,6 +366,7 @@ namespace hgl::codegen
             void                                       bind_hgraph_declarations();
             [[nodiscard]] const gir::Statement        &planned_statement(ast::StmtId id);
             [[nodiscard]] const gir::Binding          &planned_binding(gir::BindingId id, SourceRange fallback);
+            [[nodiscard]] bool                         planned_local_mutable(ast::StmtId id, SourceRange fallback);
             [[nodiscard]] const gir::Callable         &callable(ast::DeclId decl) const { return *callables_.at(decl); }
             [[nodiscard]] const gir::OperatorContract &operator_decl(ast::DeclId decl) const { return *operators_.at(decl); }
             [[nodiscard]] const gir::StructContract &struct_contract(ast::DeclId decl) const { return *structures_.at(decl); }
@@ -537,6 +538,15 @@ namespace hgl::codegen
                 backend(fallback, "hgraph IR contains an invalid body binding ID");
             }
             return graph_.bindings[id.value];
+        }
+
+        bool Emitter::planned_local_mutable(ast::StmtId id, SourceRange fallback) {
+            const auto *local = std::get_if<gir::LocalBinding>(&planned_statement(id).node);
+            if (local == nullptr) { backend(fallback, "hgraph IR assignment target is not a local binding"); }
+            const gir::Binding &binding = planned_binding(local->binding, fallback);
+            if (binding.kind == gir::BindingKind::LocalVar) { return true; }
+            if (binding.kind == gir::BindingKind::LocalLet) { return false; }
+            backend(fallback, "hgraph IR local statement refers to a non-local binding");
         }
 
         void Emitter::bind_hgraph_declarations() {
@@ -2511,9 +2521,7 @@ namespace hgl::codegen
                             backend(place.range, "assignment targets a local in the first pass");
                         }
                         const ast::StmtId target = resolved_.binding(node.place).stmt;
-                        if (const auto *local = std::get_if<ast::LocalDecl>(&module_.stmt(target).node);
-                            local == nullptr || !local->mutable_)
-                        {
+                        if (!planned_local_mutable(target, place.range)) {
                             fail(Category::Type, place.range, "'" + slice(place.range) + "' is not a 'var'");
                         }
                         Value        value   = eval_expr(node.value, frame);
@@ -2762,9 +2770,8 @@ namespace hgl::codegen
                         if (local != frame.locals.end())
                         {
                             current = local->second;
-                            if (const auto *decl = std::get_if<ast::LocalDecl>(&module_.stmt(target).node);
-                                decl != nullptr && !decl->mutable_)
-                            {
+                            if (std::holds_alternative<ast::LocalDecl>(module_.stmt(target).node) &&
+                                !planned_local_mutable(target, place.range)) {
                                 fail(Category::Type, place.range, "'" + slice(place.range) + "' is not a 'var'");
                             }
                             selector_assignment = std::holds_alternative<ast::StateDecl>(module_.stmt(target).node);

--- a/language/src/codegen/cpp_emitter.h
+++ b/language/src/codegen/cpp_emitter.h
@@ -15,10 +15,11 @@
 /// one header/source pair of public hgraph authoring code per module. It is
 /// planned from hgraph IR and prints names and types without linking the hgraph
 /// runtime, so what it emits is checked by the native compiler that builds the
-/// package. A temporary syntax adapter still supplies bodies and local
-/// annotations during the Stage E migration. Tests run generated graphs beside
-/// `hgl test` and exercise generated runtime nodes directly through hgraph's
-/// public harness.
+/// package. Body-local let, var, and state binding types also come from hgraph
+/// IR. A temporary syntax adapter still supplies executable bodies,
+/// expression-level type syntax, and dependency discovery during the Stage E
+/// migration. Tests run generated graphs beside `hgl test` and exercise
+/// generated runtime nodes directly through hgraph's public harness.
 namespace hgl::codegen
 {
     namespace ast = syntax::ast;

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -460,6 +460,47 @@ export fn adjusted(value: f64) -> f64 {
     CHECK_FALSE(contains(emitted->source, "static_cast<hgraph::Float>(hgraph::Int{1})"));
 }
 
+TEST_CASE("emit-cpp validates local assignment mutability from hgraph IR", "[codegen][hgraph-ir][locals]") {
+    Unit unit{R"(
+module planned_local_assignment
+
+export fn adjusted(value: f64) -> f64 {
+    var amount = 1.0
+    amount = 2.0
+    value + amount
+}
+)"};
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+
+    const auto statement = std::find_if(unit.graph.statements.begin(), unit.graph.statements.end(), [](const auto &candidate) {
+        return std::holds_alternative<hgl::hgraph_ir::LocalBinding>(candidate.node);
+    });
+    REQUIRE(statement != unit.graph.statements.end());
+    const auto &local = std::get<hgl::hgraph_ir::LocalBinding>(statement->node);
+    REQUIRE(local.binding.valid());
+    REQUIRE(local.binding.value < unit.graph.bindings.size());
+
+    SECTION("a planned let rejects assignment") {
+        unit.graph.bindings[local.binding.value].kind = hgl::hgraph_ir::BindingKind::LocalLet;
+
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Type, "'amount' is not a 'var'"));
+    }
+
+    SECTION("a planned var ignores stale syntax mutability") {
+        const auto declaration = std::find_if(unit.module.stmts.begin(), unit.module.stmts.end(), [](auto &candidate) {
+            return std::holds_alternative<ast::LocalDecl>(candidate.node);
+        });
+        REQUIRE(declaration != unit.module.stmts.end());
+        std::get<ast::LocalDecl>(declaration->node).mutable_ = false;
+
+        const auto emitted = unit.emit();
+        REQUIRE(emitted);
+        CHECK(contains(emitted->source, "auto amount = hgraph::Float{1.0};"));
+        CHECK(contains(emitted->source, "amount = hgraph::Float{2.0};"));
+    }
+}
+
 TEST_CASE("emit-cpp uses inferred hgraph IR state types", "[codegen][hgraph-ir][locals][runtime]") {
     Unit unit{R"(
 module inferred_state

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -241,6 +241,14 @@ TEST_CASE("emit-cpp rejects a mismatched syntax compatibility adapter", "[codege
         CHECK_FALSE(unit.emit());
         CHECK(unit.has(Category::Backend, "syntax construction adapter's declaration shape"));
     }
+    SECTION("a missing body binding") {
+        Unit unit{"module t\nexport fn value(x: f64) -> f64 {\n    let y = 1.0\n    x + y\n}\n"};
+        REQUIRE(unit.graph.completion == hgl::hgraph_ir::Completion::Bodies);
+        unit.graph.statements.clear();
+
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Backend, "syntax body adapter disagree on local and state bindings"));
+    }
 }
 
 TEST_CASE("emit-cpp plans struct identity and layout from hgraph IR", "[codegen][hgraph-ir][structs]") {
@@ -414,6 +422,62 @@ export fn make_outer() -> Outer<f64> => Outer<f64>()
     CHECK(contains(emitted->source, "typename Leaf<hgraph::Float>::time_series"));
     CHECK(contains(emitted->source, "typename Middle<hgraph::Float>::time_series"));
     CHECK_FALSE(contains(emitted->source, "ScalarVar<\"U\">"));
+}
+
+TEST_CASE("emit-cpp plans body-local bindings from hgraph IR", "[codegen][hgraph-ir][locals]") {
+    Unit unit{R"(
+module planned_locals
+
+export fn adjusted(value: f64) -> f64 {
+    let amount: f64 = 1
+    value + amount
+}
+)"};
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+    REQUIRE(unit.graph.completion == hgl::hgraph_ir::Completion::Bodies);
+
+    const auto statement = std::find_if(unit.graph.statements.begin(), unit.graph.statements.end(), [](const auto &candidate) {
+        return std::holds_alternative<hgl::hgraph_ir::LocalBinding>(candidate.node);
+    });
+    REQUIRE(statement != unit.graph.statements.end());
+    auto &local = std::get<hgl::hgraph_ir::LocalBinding>(statement->node);
+    REQUIRE(local.binding.valid());
+    REQUIRE(local.binding.value < unit.graph.bindings.size());
+
+    const hgl::hgraph_ir::TypeId integer{static_cast<std::uint32_t>(unit.graph.types.size())};
+    unit.graph.types.push_back(
+        {.kind = hgl::ir::hir::TypeKind::Scalar, .scalar = hgl::ir::hir::ScalarType::I64, .range = statement->range});
+    local.type    = integer;
+    auto &binding = unit.graph.bindings[local.binding.value];
+    binding.name  = "planned_amount";
+    binding.kind  = hgl::hgraph_ir::BindingKind::LocalVar;
+    binding.type  = integer;
+
+    const auto emitted = unit.emit();
+    REQUIRE(emitted);
+    CHECK(contains(emitted->source, "auto planned_amount = hgraph::Int{1};"));
+    CHECK_FALSE(contains(emitted->source, "const auto amount"));
+    CHECK_FALSE(contains(emitted->source, "static_cast<hgraph::Float>(hgraph::Int{1})"));
+}
+
+TEST_CASE("emit-cpp uses inferred hgraph IR state types", "[codegen][hgraph-ir][locals][runtime]") {
+    Unit unit{R"(
+module inferred_state
+
+export fn total(value: f64) -> f64 {
+    state sum = 0.0
+    when modified(value) && valid(value) {
+        sum += value
+        return sum
+    }
+}
+)"};
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+
+    const auto emitted = unit.emit();
+    REQUIRE(emitted);
+    CHECK(contains(emitted->header, "hgraph::Field<\"sum\", hgraph::TS<hgraph::Float>>"));
+    CHECK(contains(emitted->header, "hgraph::Float{0.0}"));
 }
 
 TEST_CASE("emit-cpp renders defaults and omitted arguments from hgraph IR", "[codegen][hgraph-ir][defaults]") {
@@ -797,18 +861,6 @@ export fn sampled(x: f64) -> f64 {
 )"};
         CHECK_FALSE(unit.emit());
         CHECK(unit.has(Category::Backend, "calls in a runtime function are not supported by emit-cpp yet"));
-    }
-    SECTION("runtime state without an explicit type")
-    {
-        Unit unit{R"(
-module t
-export fn total(x: f64) -> f64 {
-    state sum = 0.0
-    when modified(x) { return x }
-}
-)"};
-        CHECK_FALSE(unit.emit());
-        CHECK(unit.has(Category::Backend, "runtime state declaration needs an explicit scalar type"));
     }
     SECTION("a temporal input in a lifecycle block")
     {

--- a/language/tests/codegen/runtime.hgl
+++ b/language/tests/codegen/runtime.hgl
@@ -84,7 +84,7 @@ export fn lifecycle_value(value: f64) -> f64 {
 }
 
 export fn configured_total(value: f64, const initial: f64 = 10.0) -> f64 {
-    state total: f64 = initial
+    state total = initial
 
     when modified(value) && valid(value) {
         total += value


### PR DESCRIPTION
## Summary
- pair local and state body statements with their HGraph IR plans and fail closed on adapter drift
- render local names, let/var mutability, and resolved local/state types from HGraph IR
- validate assignments against HGraph IR mutability rather than the syntax adapter
- allow inferred state types now that codegen consumes the resolved plan
- narrow the remaining Stage E compatibility seam to executable bodies, expression-level type syntax, and dependency discovery

## Validation
- codegen suite: 29 cases / 274 assertions
- generated suite: 27 cases / 57 assertions
- language suite: 30/30
- fresh native acceptance: 1,716/1,716
- Python 3.12 ABI3 wheel installed into fresh Python 3.14: 3,240 passed, 10 skipped
- private Linux GCC 14 warnings-as-errors: final-head codegen/generated 2/2; full language 29/29 before the focused review fixes

Stacked on #704.