### PR TITLE
refactor(language): plan dependencies from hgraph IR

### DIFF
--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -189,8 +189,8 @@ endfunction()
 # The C++ backend (src/codegen): emits a header/source pair of public hgraph
 # authoring code per module (developer guide, "C++ backend, first pass").
 # Hgraph IR owns module and callable/operator interfaces, struct layouts,
-# construction defaults, and local/state binding types while a temporary
-# syntax adapter prints executable bodies and discovers dependencies.
+# construction defaults, local/state binding types, and dependency order while
+# a temporary syntax adapter prints executable bodies.
 add_library(hgl_codegen STATIC
     src/codegen/cpp_emitter.cpp
 )

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -181,8 +181,10 @@ wiring target no longer includes syntax AST headers.
   syntax/`ResolvedModule` adapter to hgraph IR;
 - [x] migrate local `let`/`var` and state binding types from the temporary
   syntax/`ResolvedModule` adapter to hgraph IR;
-- [ ] migrate executable bodies, expression-level type syntax, and dependency
-  emission from the temporary syntax/`ResolvedModule` adapter to hgraph IR;
+- [x] derive internal callable dependency order and recursion diagnostics from
+  reachable hgraph-IR body operations;
+- [ ] migrate executable bodies and expression-level type syntax from the
+  temporary syntax/`ResolvedModule` adapter to hgraph IR;
 - remove duplicate name, type, generic, phase, and classification logic from
   the emitter;
 - retain deterministic formatting, source maps, public-SDK code, and readable
@@ -192,9 +194,9 @@ wiring target no longer includes syntax AST headers.
 Acceptance: both backends consume the same hgraph IR, existing generated tests
 and installed consumers pass, and architecture tests reject backend-to-syntax
 dependencies. The declaration, interface, callable-default, struct-layout,
-construction-default, and local-binding-type checkpoints are complete, but
-Stage E remains in progress until the body adapter and its syntax dependency
-are gone.
+construction-default, local-binding-type, and dependency-order checkpoints are
+complete, but Stage E remains in progress until the body adapter and its syntax
+dependency are gone.
 
 ### F. Constrained native interface
 

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -46,8 +46,8 @@ src/
   hgraph_ir/    execution-facing types, callable interfaces, and plans
   wiring/       direct-wiring backend: IR walk over hgraph's erased dispatch,
                 harness sequences, test runner
-  codegen/      hgraph-IR declaration planning, temporary AST body printer,
-                generated C++ and source maps
+  codegen/      hgraph-IR declaration and dependency planning, temporary AST
+                body printer, generated C++ and source maps
   driver/       check, test, emit-cpp, build, run
   repl/         session assembly over the driver
 ```
@@ -223,13 +223,15 @@ and state statements with their temporary syntax bodies. Resolved binding
 names, mutability, and types come from `LocalBinding`, `StateBinding`, and their
 `BindingId` records; inferred state types therefore no longer need a
 backend-only explicit-annotation restriction. The explicitly temporary adapter
-still supplies executable bodies, expression-level type syntax, and expression
-dependencies from the AST and `ResolvedModule`.
+still supplies executable bodies and expression-level type syntax from the AST
+and `ResolvedModule`. Internal callable dependencies are discovered by walking
+reachable hgraph-IR values, statements, and blocks, and exact local-call
+operations determine definition order and recursion diagnostics.
 
 This seam keeps the generated package readable while preventing declaration
 policy from drifting between execution paths. The next Stage E checkpoints
-move body and dependency emission to hgraph IR. Only after those moves may
-`codegen` drop its syntax and resolver dependencies.
+move body emission to hgraph IR. Only after that move may `codegen` drop its
+syntax and resolver dependencies.
 
 `src/wiring/type_bridge` is the first direct-backend migration boundary. It
 materializes hgraph-IR scalar, tuple, list, set, map, window, atomic, and applied
@@ -1233,8 +1235,9 @@ collection traversal, `out`, `logger`, state, and lifecycle hooks. File-based
 loading and the remaining language-depth items are still staged. Declaration
 and module planning now come from hgraph IR, as do callable/operator interfaces,
 nominal struct layouts, construction defaults, and local/state binding types.
-Executable expression lowering and dependency discovery remain behind the
-temporary AST adapter.
+Internal callable dependency ordering also walks the hgraph-IR body graph.
+Executable expression lowering and expression-level type syntax remain behind
+the temporary AST adapter.
 
 `hgl emit-cpp <file.hgl>` writes one header/source pair named after the
 source — `prices.hgl` becomes `prices.h` and `prices.cpp` — beside the

--- a/language/docs/user-guide/modules-and-tools.md
+++ b/language/docs/user-guide/modules-and-tools.md
@@ -311,9 +311,9 @@ civil literals.
 The target architecture gives `test`, `run`, `emit-cpp`, and the REPL one
 checked semantic IR and one hgraph runtime. The direct evaluator now consumes
 hgraph IR. C++ generation uses the same IR for module, callable, operator,
-export, and registration planning, while a temporary source adapter still
-prints function bodies, types, and signatures. A program made only of
-composition functions is wired onto the runtime directly, in process. A
+export, registration, type, signature, and internal dependency planning, while
+a temporary source adapter still prints executable bodies. A program made only
+of composition functions is wired onto the runtime directly, in process. A
 file-based `test` or `run` containing supported runtime functions goes through
 generated C++, as does an ahead-of-time package. The REPL selects the same two
 routes from the accepted session:
@@ -321,7 +321,7 @@ routes from the accepted session:
 ```text
 source -> typed HIR -> hgraph IR -> direct wiring -> hgraph runtime
                               \-> C++ backend -> native -> hgraph runtime
-                                  (temporary AST body/type/signature adapter)
+                                  (temporary AST executable-body adapter)
 ```
 
 Parity tests require both paths to build the same graph across their shared

--- a/language/src/README.md
+++ b/language/src/README.md
@@ -12,17 +12,18 @@ them.
 | `ir/` | source-ranged HIR, canonical types, substitutions, constraint solving, phase/effect completion | resolved frontend state to typed HIR |
 | `hgraph_ir/` | canonical execution-facing types, compile-time expressions, constraints, struct contracts, operator and callable interfaces | typed HIR to executable composition and runtime-node plans |
 | `wiring/` | direct walk over hgraph IR | hgraph IR to public erased wiring calls |
-| `codegen/` | hgraph-IR declaration/interface planning plus a temporary AST body adapter | hgraph IR to formatted C++ and build artifacts |
+| `codegen/` | hgraph-IR declaration/interface/dependency planning plus a temporary AST body adapter | hgraph IR to formatted C++ and build artifacts |
 | `driver/` | commands, native build/cache/load, REPL orchestration | assemble inputs and invoke passes |
 
 During migration, `ResolvedModule` and the syntax AST remain a compatibility
-boundary only for C++ bodies, local annotations, struct construction defaults,
-and dependency discovery. Module identity, callable visibility and
-classification, operator binding, exports, registration planning,
-callable/operator interfaces, supported callable parameter defaults, and
-nominal struct declarations and field layouts already come from hgraph IR. New
-language semantics belong in HIR construction, not in either backend. The
-remaining adapter is named here and must be removed as Stage E advances.
+boundary only for C++ executable bodies and expression-level type syntax.
+Module identity, callable visibility and classification, operator binding,
+exports, registration planning, callable/operator interfaces, supported
+callable parameter defaults, nominal struct declarations and field layouts,
+local/state binding types, construction defaults, and internal dependency order
+already come from hgraph IR. New language semantics belong in HIR construction,
+not in either backend. The remaining adapter is named here and must be removed
+as Stage E advances.
 
 Every new pass documents:
 

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -3772,7 +3772,6 @@ namespace hgl::codegen
         }
 
         void Emitter::collect_calls(gir::ValueId id, PlannedCalls &calls, SourceRange fallback) {
-            if (!id.valid()) { return; }
             const gir::Value &value = planned_value(id, fallback);
             if (!calls.values.insert(id.value).second) { return; }
             if (value.operation.kind == gir::OperationKind::ExactFunction) {
@@ -3801,7 +3800,7 @@ namespace hgl::codegen
                         collect_calls(node.target, calls, value.range);
                     } else if constexpr (std::is_same_v<T, gir::Sequence>) {
                         for (const gir::SequenceElement &element : node.elements) {
-                            collect_calls(element.key, calls, value.range);
+                            if (element.key.valid()) { collect_calls(element.key, calls, value.range); }
                             collect_calls(element.value, calls, value.range);
                         }
                     } else if constexpr (std::is_same_v<T, gir::Tuple>) {
@@ -3811,7 +3810,7 @@ namespace hgl::codegen
                     } else if constexpr (std::is_same_v<T, gir::Conditional>) {
                         collect_calls(node.condition, calls, value.range);
                         collect_calls(node.then_block, calls, value.range);
-                        collect_calls(node.otherwise, calls, value.range);
+                        if (node.otherwise.valid()) { collect_calls(node.otherwise, calls, value.range); }
                     } else if constexpr (std::is_same_v<T, gir::BlockValue>) {
                         collect_calls(node.block, calls, value.range);
                     } else if constexpr (std::is_same_v<T, gir::Construct>) {
@@ -3824,7 +3823,6 @@ namespace hgl::codegen
         }
 
         void Emitter::collect_calls(gir::BlockId id, PlannedCalls &calls, SourceRange fallback) {
-            if (!id.valid()) { return; }
             const gir::Block &block = planned_block(id, fallback);
             if (!calls.blocks.insert(id.value).second) { return; }
             for (gir::StatementId statement_id : block.statements) {
@@ -3846,7 +3844,7 @@ namespace hgl::codegen
                             collect_calls(node.place, calls, statement.range);
                             collect_calls(node.value, calls, statement.range);
                         } else if constexpr (std::is_same_v<T, gir::Return>) {
-                            collect_calls(node.value, calls, statement.range);
+                            if (node.value.valid()) { collect_calls(node.value, calls, statement.range); }
                         } else if constexpr (std::is_same_v<T, gir::Assert>) {
                             collect_calls(node.condition, calls, statement.range);
                         } else if constexpr (std::is_same_v<T, gir::Evaluate>) {
@@ -3855,7 +3853,7 @@ namespace hgl::codegen
                     },
                     statement.node);
             }
-            collect_calls(block.tail, calls, block.range);
+            if (block.tail.valid()) { collect_calls(block.tail, calls, block.range); }
         }
 
         /// Internal functions in dependency order: C++ needs a helper defined
@@ -3871,8 +3869,15 @@ namespace hgl::codegen
             {
                 const gir::Callable &fn = callable(id);
                 PlannedCalls         calls;
-                collect_calls(fn.concise_body, calls, fn.range);
-                collect_calls(fn.block_body, calls, fn.range);
+                if (fn.concise_body.valid() == fn.block_body.valid()) {
+                    backend(fn.range, "hgraph IR callable '" + std::string{callable_name(id)} +
+                                          "' must have exactly one concise or block body");
+                }
+                if (fn.concise_body.valid()) {
+                    collect_calls(fn.concise_body, calls, fn.range);
+                } else {
+                    collect_calls(fn.block_body, calls, fn.range);
+                }
                 std::set<ast::DeclId> filtered;
                 for (const std::uint32_t call_id : calls.calls) {
                     const ast::DeclId call = syntax_callable(gir::CallableId{call_id}, fn.range);

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -3775,7 +3775,10 @@ namespace hgl::codegen
             if (!id.valid()) { return; }
             const gir::Value &value = planned_value(id, fallback);
             if (!calls.values.insert(id.value).second) { return; }
-            if (value.operation.kind == gir::OperationKind::ExactFunction && value.operation.callable.valid()) {
+            if (value.operation.kind == gir::OperationKind::ExactFunction) {
+                if (!value.operation.callable.valid()) {
+                    backend(value.range, "hgraph IR contains an invalid callable dependency ID");
+                }
                 calls.calls.insert(value.operation.callable.value);
             }
             std::visit(

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -473,8 +473,18 @@ namespace hgl::codegen
                                        bool include_output);
             void emit_defaults(const gir::Callable &callable, Writer &out);
             [[nodiscard]] std::vector<ast::DeclId> ordered_internal_functions();
-            void collect_calls(ast::ExprId id, std::set<ast::DeclId> &calls);
-            void collect_calls_block(ast::BlockId id, std::set<ast::DeclId> &calls);
+            struct PlannedCalls
+            {
+                std::set<std::uint32_t> calls{};
+                std::set<std::uint32_t> values{};
+                std::set<std::uint32_t> blocks{};
+            };
+            void                                collect_calls(gir::ValueId id, PlannedCalls &calls, SourceRange fallback = {});
+            void                                collect_calls(gir::BlockId id, PlannedCalls &calls, SourceRange fallback = {});
+            [[nodiscard]] const gir::Value     &planned_value(gir::ValueId id, SourceRange fallback);
+            [[nodiscard]] const gir::Statement &planned_statement(gir::StatementId id, SourceRange fallback);
+            [[nodiscard]] const gir::Block     &planned_block(gir::BlockId id, SourceRange fallback);
+            [[nodiscard]] ast::DeclId           syntax_callable(gir::CallableId id, SourceRange fallback);
 
             const syntax::SourceFile        &file_;
             const gir::Module                                             &graph_;
@@ -3729,95 +3739,120 @@ namespace hgl::codegen
             out.line();
         }
 
-        void Emitter::collect_calls_block(ast::BlockId id, std::set<ast::DeclId> &calls)
-        {
-            for (const ast::StmtId stmt_id : module_.block(id).statements)
-            {
-                std::visit(
-                    [&](const auto &node) {
-                        using T = std::decay_t<decltype(node)>;
-                        if constexpr (std::is_same_v<T, ast::LocalDecl> || std::is_same_v<T, ast::StateDecl>)
-                        {
-                            if (node.init != ast::no_node) { collect_calls(node.init, calls); }
-                        }
-                        else if constexpr (std::is_same_v<T, ast::AssignStmt>) { collect_calls(node.value, calls); }
-                        else if constexpr (std::is_same_v<T, ast::ReturnStmt>)
-                        {
-                            if (node.value != ast::no_node) { collect_calls(node.value, calls); }
-                        }
-                        else if constexpr (std::is_same_v<T, ast::AssertStmt>) { collect_calls(node.condition, calls); }
-                        else if constexpr (std::is_same_v<T, ast::ExprStmt>) { collect_calls(node.expr, calls); }
-                        else if constexpr (std::is_same_v<T, ast::WhenStmt>)
-                        {
-                            collect_calls(node.condition, calls);
-                            collect_calls_block(node.block, calls);
-                        }
-                        else if constexpr (std::is_same_v<T, ast::ForStmt>)
-                        {
-                            collect_calls(node.iterable, calls);
-                            collect_calls_block(node.block, calls);
-                        }
-                        else if constexpr (std::is_same_v<T, ast::LifecycleBlock>) { collect_calls_block(node.block, calls); }
-                    },
-                    module_.stmt(stmt_id).node);
+        const gir::Value &Emitter::planned_value(gir::ValueId id, SourceRange fallback) {
+            if (!id.valid() || id.value >= graph_.values.size()) {
+                backend(fallback, "hgraph IR contains an invalid body value ID");
             }
+            return graph_.values[id.value];
         }
 
-        void Emitter::collect_calls(ast::ExprId id, std::set<ast::DeclId> &calls)
-        {
-            const ast::Expr &expr = module_.expr(id);
+        const gir::Statement &Emitter::planned_statement(gir::StatementId id, SourceRange fallback) {
+            if (!id.valid() || id.value >= graph_.statements.size()) {
+                backend(fallback, "hgraph IR contains an invalid body statement ID");
+            }
+            return graph_.statements[id.value];
+        }
+
+        const gir::Block &Emitter::planned_block(gir::BlockId id, SourceRange fallback) {
+            if (!id.valid() || id.value >= graph_.blocks.size()) {
+                backend(fallback, "hgraph IR contains an invalid body block ID");
+            }
+            return graph_.blocks[id.value];
+        }
+
+        ast::DeclId Emitter::syntax_callable(gir::CallableId id, SourceRange fallback) {
+            if (!id.valid() || id.value >= graph_.callables.size()) {
+                backend(fallback, "hgraph IR contains an invalid callable dependency ID");
+            }
+            const gir::Callable *planned = &graph_.callables[id.value];
+            const auto           found   = std::find_if(callables_.begin(), callables_.end(),
+                                                        [&](const auto &candidate) { return candidate.second == planned; });
+            if (found == callables_.end()) { backend(fallback, "hgraph IR callable dependency has no syntax body adapter"); }
+            return found->first;
+        }
+
+        void Emitter::collect_calls(gir::ValueId id, PlannedCalls &calls, SourceRange fallback) {
+            if (!id.valid()) { return; }
+            const gir::Value &value = planned_value(id, fallback);
+            if (!calls.values.insert(id.value).second) { return; }
+            if (value.operation.kind == gir::OperationKind::ExactFunction && value.operation.callable.valid()) {
+                calls.calls.insert(value.operation.callable.value);
+            }
             std::visit(
                 [&](const auto &node) {
                     using T = std::decay_t<decltype(node)>;
-                    if constexpr (std::is_same_v<T, ast::NameRef> || std::is_same_v<T, ast::QualifiedRef>)
-                    {
-                        const semantics::Binding &binding = resolved_.binding(id);
-                        if (binding.kind == BindingKind::Function) { calls.insert(binding.decl); }
-                    }
-                    else if constexpr (std::is_same_v<T, ast::Unary>) { collect_calls(node.operand, calls); }
-                    else if constexpr (std::is_same_v<T, ast::Binary>)
-                    {
-                        collect_calls(node.lhs, calls);
-                        collect_calls(node.rhs, calls);
-                    }
-                    else if constexpr (std::is_same_v<T, ast::Call>)
-                    {
-                        collect_calls(node.callee, calls);
-                        for (const ast::Argument &argument : node.arguments) { collect_calls(argument.value, calls); }
-                    }
-                    else if constexpr (std::is_same_v<T, ast::Index>)
-                    {
-                        collect_calls(node.target, calls);
-                        collect_calls(node.index, calls);
-                    }
-                    else if constexpr (std::is_same_v<T, ast::Field>) { collect_calls(node.target, calls); }
-                    else if constexpr (std::is_same_v<T, ast::SequenceLiteral>)
-                    {
-                        for (const ast::SequenceElement &element : node.elements) { collect_calls(element.value, calls); }
-                    }
-                    else if constexpr (std::is_same_v<T, ast::TupleLiteral>)
-                    {
-                        for (const ast::ExprId element : node.elements) { collect_calls(element, calls); }
-                    }
-                    else if constexpr (std::is_same_v<T, ast::AnonymousFn>) { collect_calls(node.body, calls); }
-                    else if constexpr (std::is_same_v<T, ast::If>)
-                    {
-                        collect_calls(node.condition, calls);
-                        collect_calls_block(node.then_block, calls);
-                        if (node.otherwise != ast::no_node) { collect_calls(node.otherwise, calls); }
-                    }
-                    else if constexpr (std::is_same_v<T, ast::BlockExpr>) { collect_calls_block(node.block, calls); }
-                    else if constexpr (std::is_same_v<T, ast::Eval>)
-                    {
-                        collect_calls(node.callee, calls);
-                        for (const ast::Argument &argument : node.arguments) { collect_calls(argument.value, calls); }
-                    }
-                    else if constexpr (std::is_same_v<T, ast::Construct>)
-                    {
-                        for (const ast::Argument &argument : node.arguments) { collect_calls(argument.value, calls); }
+                    if constexpr (std::is_same_v<T, gir::Unary>) {
+                        collect_calls(node.operand, calls, value.range);
+                    } else if constexpr (std::is_same_v<T, gir::Binary>) {
+                        collect_calls(node.lhs, calls, value.range);
+                        collect_calls(node.rhs, calls, value.range);
+                    } else if constexpr (std::is_same_v<T, gir::Call> || std::is_same_v<T, gir::HarnessEval>) {
+                        collect_calls(node.callee, calls, value.range);
+                        for (const gir::Argument &argument : node.arguments) {
+                            collect_calls(argument.value, calls, argument.range);
+                        }
+                    } else if constexpr (std::is_same_v<T, gir::Index>) {
+                        collect_calls(node.target, calls, value.range);
+                        collect_calls(node.index, calls, value.range);
+                    } else if constexpr (std::is_same_v<T, gir::Field>) {
+                        collect_calls(node.target, calls, value.range);
+                    } else if constexpr (std::is_same_v<T, gir::Sequence>) {
+                        for (const gir::SequenceElement &element : node.elements) {
+                            collect_calls(element.key, calls, value.range);
+                            collect_calls(element.value, calls, value.range);
+                        }
+                    } else if constexpr (std::is_same_v<T, gir::Tuple>) {
+                        for (gir::ValueId element : node.elements) { collect_calls(element, calls, value.range); }
+                    } else if constexpr (std::is_same_v<T, gir::Lambda>) {
+                        collect_calls(node.body, calls, value.range);
+                    } else if constexpr (std::is_same_v<T, gir::Conditional>) {
+                        collect_calls(node.condition, calls, value.range);
+                        collect_calls(node.then_block, calls, value.range);
+                        collect_calls(node.otherwise, calls, value.range);
+                    } else if constexpr (std::is_same_v<T, gir::BlockValue>) {
+                        collect_calls(node.block, calls, value.range);
+                    } else if constexpr (std::is_same_v<T, gir::Construct>) {
+                        for (const gir::Argument &argument : node.arguments) {
+                            collect_calls(argument.value, calls, argument.range);
+                        }
                     }
                 },
-                expr.node);
+                value.node);
+        }
+
+        void Emitter::collect_calls(gir::BlockId id, PlannedCalls &calls, SourceRange fallback) {
+            if (!id.valid()) { return; }
+            const gir::Block &block = planned_block(id, fallback);
+            if (!calls.blocks.insert(id.value).second) { return; }
+            for (gir::StatementId statement_id : block.statements) {
+                const gir::Statement &statement = planned_statement(statement_id, block.range);
+                std::visit(
+                    [&](const auto &node) {
+                        using T = std::decay_t<decltype(node)>;
+                        if constexpr (std::is_same_v<T, gir::LocalBinding> || std::is_same_v<T, gir::StateBinding>) {
+                            collect_calls(node.init, calls, statement.range);
+                        } else if constexpr (std::is_same_v<T, gir::Lifecycle>) {
+                            collect_calls(node.block, calls, statement.range);
+                        } else if constexpr (std::is_same_v<T, gir::Activation>) {
+                            collect_calls(node.condition, calls, statement.range);
+                            collect_calls(node.block, calls, statement.range);
+                        } else if constexpr (std::is_same_v<T, gir::Traversal>) {
+                            collect_calls(node.iterable, calls, statement.range);
+                            collect_calls(node.block, calls, statement.range);
+                        } else if constexpr (std::is_same_v<T, gir::Assignment>) {
+                            collect_calls(node.place, calls, statement.range);
+                            collect_calls(node.value, calls, statement.range);
+                        } else if constexpr (std::is_same_v<T, gir::Return>) {
+                            collect_calls(node.value, calls, statement.range);
+                        } else if constexpr (std::is_same_v<T, gir::Assert>) {
+                            collect_calls(node.condition, calls, statement.range);
+                        } else if constexpr (std::is_same_v<T, gir::Evaluate>) {
+                            collect_calls(node.value, calls, statement.range);
+                        }
+                    },
+                    statement.node);
+            }
+            collect_calls(block.tail, calls, block.range);
         }
 
         /// Internal functions in dependency order: C++ needs a helper defined
@@ -3831,17 +3866,13 @@ namespace hgl::codegen
             std::map<ast::DeclId, std::set<ast::DeclId>> deps;
             for (const ast::DeclId id : internal)
             {
-                const ast::FunctionDecl &fn = function(id);
-                std::set<ast::DeclId>    calls;
-                if (fn.concise_body != ast::no_node) { collect_calls(fn.concise_body, calls); }
-                if (fn.block_body != ast::no_node) { collect_calls_block(fn.block_body, calls); }
-                for (const ast::Parameter &param : fn.signature.parameters)
-                {
-                    if (param.default_value != ast::no_node) { collect_calls(param.default_value, calls); }
-                }
+                const gir::Callable &fn = callable(id);
+                PlannedCalls         calls;
+                collect_calls(fn.concise_body, calls, fn.range);
+                collect_calls(fn.block_body, calls, fn.range);
                 std::set<ast::DeclId> filtered;
-                for (const ast::DeclId call : calls)
-                {
+                for (const std::uint32_t call_id : calls.calls) {
+                    const ast::DeclId call = syntax_callable(gir::CallableId{call_id}, fn.range);
                     if (std::find(internal.begin(), internal.end(), call) != internal.end()) { filtered.insert(call); }
                 }
                 deps[id] = std::move(filtered);
@@ -3853,7 +3884,7 @@ namespace hgl::codegen
                 if (done.contains(id)) { return; }
                 if (visiting.contains(id))
                 {
-                    backend(module_.decl(id).range,
+                    backend(callable(id).range,
                             "'" + std::string{callable_name(id)} + "' is recursive; recursive functions are not supported");
                 }
                 visiting.insert(id);

--- a/language/src/codegen/cpp_emitter.h
+++ b/language/src/codegen/cpp_emitter.h
@@ -16,10 +16,11 @@
 /// planned from hgraph IR and prints names and types without linking the hgraph
 /// runtime, so what it emits is checked by the native compiler that builds the
 /// package. Body-local let, var, and state binding types also come from hgraph
-/// IR. A temporary syntax adapter still supplies executable bodies,
-/// expression-level type syntax, and dependency discovery during the Stage E
-/// migration. Tests run generated graphs beside `hgl test` and exercise
-/// generated runtime nodes directly through hgraph's public harness.
+/// IR. Internal callable dependencies are read from reachable hgraph-IR body
+/// operations. A temporary syntax adapter still supplies executable bodies and
+/// expression-level type syntax during the Stage E migration. Tests run
+/// generated graphs beside `hgl test` and exercise generated runtime nodes
+/// directly through hgraph's public harness.
 namespace hgl::codegen
 {
     namespace ast = syntax::ast;

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -823,6 +823,13 @@ export fn result(value: f64) -> f64 => first(value)
         CHECK_FALSE(unit.emit());
         CHECK(unit.has(Category::Backend, "hgraph IR contains an invalid callable dependency ID"));
     }
+
+    SECTION("a missing planned dependency fails closed") {
+        dependency->operation.callable = {};
+
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Backend, "hgraph IR contains an invalid callable dependency ID"));
+    }
 }
 
 TEST_CASE("emit-cpp lowers scalar runtime functions to static nodes", "[codegen][runtime]")

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -795,6 +795,7 @@ export fn result(value: f64) -> f64 => first(value)
         REQUIRE(found != unit.graph.callables.end());
         return hgl::hgraph_ir::CallableId{static_cast<std::uint32_t>(std::distance(unit.graph.callables.begin(), found))};
     };
+    const hgl::hgraph_ir::CallableId first  = callable_id("planned_dependencies.first");
     const hgl::hgraph_ir::CallableId second = callable_id("planned_dependencies.second");
     const hgl::hgraph_ir::CallableId third  = callable_id("planned_dependencies.third");
     const auto dependency = std::find_if(unit.graph.values.begin(), unit.graph.values.end(), [&](const auto &candidate) {
@@ -829,6 +830,28 @@ export fn result(value: f64) -> f64 => first(value)
 
         CHECK_FALSE(unit.emit());
         CHECK(unit.has(Category::Backend, "hgraph IR contains an invalid callable dependency ID"));
+    }
+
+    SECTION("a missing callable body fails closed") {
+        unit.graph.callables[first.value].concise_body = {};
+
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Backend, "'first' must have exactly one concise or block body"));
+    }
+
+    SECTION("a missing required value edge fails closed") {
+        std::get<hgl::hgraph_ir::Call>(dependency->node).callee = {};
+
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Backend, "hgraph IR contains an invalid body value ID"));
+    }
+
+    SECTION("a missing required block edge fails closed") {
+        dependency->operation = {};
+        dependency->node      = hgl::hgraph_ir::BlockValue{};
+
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Backend, "hgraph IR contains an invalid body block ID"));
     }
 }
 

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -777,6 +777,54 @@ fn plus_one(y: f64) -> f64 => y + 1.0
     CHECK(emitted->source.find("struct plus_one") < emitted->source.find("fixed::compose"));
 }
 
+TEST_CASE("emit-cpp orders internal dependencies from hgraph IR", "[codegen][hgraph-ir][dependencies]") {
+    Unit unit{R"(
+module planned_dependencies
+
+fn second(value: f64) -> f64 => value
+fn first(value: f64) -> f64 => second(value)
+fn third(value: f64) -> f64 => value
+
+export fn result(value: f64) -> f64 => first(value)
+)"};
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+
+    const auto callable_id = [&](std::string_view identity) {
+        const auto found = std::find_if(unit.graph.callables.begin(), unit.graph.callables.end(),
+                                        [&](const auto &candidate) { return candidate.identity == identity; });
+        REQUIRE(found != unit.graph.callables.end());
+        return hgl::hgraph_ir::CallableId{static_cast<std::uint32_t>(std::distance(unit.graph.callables.begin(), found))};
+    };
+    const hgl::hgraph_ir::CallableId second = callable_id("planned_dependencies.second");
+    const hgl::hgraph_ir::CallableId third  = callable_id("planned_dependencies.third");
+    const auto dependency = std::find_if(unit.graph.values.begin(), unit.graph.values.end(), [&](const auto &candidate) {
+        return candidate.operation.kind == hgl::hgraph_ir::OperationKind::ExactFunction && candidate.operation.callable == second;
+    });
+    REQUIRE(dependency != unit.graph.values.end());
+
+    SECTION("the planned dependency is authoritative") {
+        dependency->operation.callable = third;
+
+        const auto emitted = unit.emit();
+        REQUIRE(emitted);
+        const std::size_t second_pos = emitted->source.find("struct second");
+        const std::size_t third_pos  = emitted->source.find("struct third");
+        const std::size_t first_pos  = emitted->source.find("struct first");
+        REQUIRE(second_pos != std::string::npos);
+        REQUIRE(third_pos != std::string::npos);
+        REQUIRE(first_pos != std::string::npos);
+        CHECK(second_pos < third_pos);
+        CHECK(third_pos < first_pos);
+    }
+
+    SECTION("an invalid planned dependency fails closed") {
+        dependency->operation.callable = hgl::hgraph_ir::CallableId{static_cast<std::uint32_t>(unit.graph.callables.size())};
+
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Backend, "hgraph IR contains an invalid callable dependency ID"));
+    }
+}
+
 TEST_CASE("emit-cpp lowers scalar runtime functions to static nodes", "[codegen][runtime]")
 {
     Unit unit{R"(


### PR DESCRIPTION
## Summary

- discover internal callable dependencies from reachable HGraph IR values, statements, blocks, and exact-call operations
- order internal definitions and diagnose recursion without walking AST/resolver annotations
- require exactly one callable body and fail closed on missing or out-of-range required body edges and callable IDs
- skip only semantically optional body edges explicitly
- narrow the remaining Stage E compatibility seam to executable bodies and expression-level type syntax

## Validation

- dependency regression: 1 case / 46 assertions
- codegen suite: 30 cases / 320 assertions
- generated suite: 27 cases / 57 assertions on macOS
- complete language suite: 30/30
- fresh native acceptance: 1,716/1,716
- Python 3.12 ABI3 wheel installed into fresh Python 3.14: 3,240 passed, 10 skipped
- private Linux GCC 14 warnings-as-errors: codegen 30 cases / 320 assertions; generated 24 cases / 54 assertions

Stacked on #705.