### PR TITLE
refactor(language): emit composition blocks from hgraph IR

### DIFF
--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -190,8 +190,8 @@ endfunction()
 # authoring code per module (developer guide, "C++ backend, first pass").
 # Hgraph IR owns module and callable/operator interfaces, struct layouts,
 # construction defaults, local/state binding types, dependency order, and
-# concise composition bodies while a temporary syntax adapter prints
-# block/runtime bodies.
+# composition bodies while a temporary syntax adapter prints runtime-node
+# bodies.
 add_library(hgl_codegen STATIC
     src/codegen/cpp_emitter.cpp
 )

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -185,7 +185,9 @@ wiring target no longer includes syntax AST headers.
   reachable hgraph-IR body operations;
 - [x] migrate concise composition bodies, including concise anonymous `map`
   functions, from the temporary syntax/`ResolvedModule` adapter to hgraph IR;
-- [ ] migrate block and runtime bodies plus expression-level type syntax from
+- [x] migrate composition block bodies from the temporary
+  syntax/`ResolvedModule` adapter to hgraph IR;
+- [ ] migrate runtime-node bodies plus expression-level type syntax from
   the temporary syntax/`ResolvedModule` adapter to hgraph IR;
 - remove duplicate name, type, generic, phase, and classification logic from
   the emitter;
@@ -197,8 +199,9 @@ Acceptance: both backends consume the same hgraph IR, existing generated tests
 and installed consumers pass, and architecture tests reject backend-to-syntax
 dependencies. The declaration, interface, callable-default, struct-layout,
 construction-default, local-binding-type, dependency-order, and concise-body
-checkpoints are complete, but Stage E remains in progress until block/runtime
-body emission and expression-level type syntax no longer use the adapter.
+checkpoints are complete, as is composition block-body emission. Stage E
+remains in progress until runtime-node body emission and expression-level type
+syntax no longer use the adapter.
 
 ### F. Constrained native interface
 

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -218,24 +218,23 @@ nested struct construction, without reading the source default expression;
 lexical `BindingId` overrides give a struct template's own type parameters their
 local readable C++ names without changing the canonical generic type used by
 operator interfaces. Const-generic structs remain rejected until hgraph has
-typed constant Bundle metadata. The same range mapping now pairs graph-IR local
-and state statements with their temporary syntax bodies. Resolved binding
-names, mutability, and types come from `LocalBinding`, `StateBinding`, and their
-`BindingId` records; inferred state types therefore no longer need a
-backend-only explicit-annotation restriction. The explicitly temporary adapter
-no longer supplies concise composition bodies. Those bodies now walk graph-IR
-values and resolved operations directly; lexical parameter and
-anonymous-function references use graph-IR `BindingId` values, and concise
-`map` helpers are printed from graph-IR lambda bodies. Internal callable
-dependencies are likewise discovered by walking reachable hgraph-IR values,
-statements, and blocks, and exact local-call operations determine definition
-order and recursion diagnostics. The adapter remains only for block/runtime
-body emission and expression-level type syntax from the AST and
-`ResolvedModule`.
+typed constant Bundle metadata. Composition block statements now come directly
+from graph-IR blocks. Their local declarations, assignments, explicit returns,
+scalar wiring-time conditionals, and tail expressions use graph-IR values,
+resolved operations, and `BindingId` references. Concise composition bodies
+and concise `map` helpers use that same path. Runtime state bindings already
+take their names, mutability, and types from `StateBinding` and its `BindingId`,
+so inferred state types no longer need a backend-only explicit-annotation
+restriction, but the runtime statement printer still uses retained syntax body
+structure. Internal callable dependencies are likewise discovered by walking
+reachable hgraph-IR values, statements, and blocks, and exact local-call
+operations determine definition order and recursion diagnostics. The adapter
+remains only for runtime-node body emission and expression-level type syntax
+from the AST and `ResolvedModule`.
 
 This seam keeps the generated package readable while preventing declaration
 policy from drifting between execution paths. The next Stage E checkpoints
-move block/runtime body emission and expression-level type syntax to hgraph IR.
+move runtime-node body emission and expression-level type syntax to hgraph IR.
 Only after that move may `codegen` drop its syntax and resolver dependencies.
 
 `src/wiring/type_bridge` is the first direct-backend migration boundary. It
@@ -1242,8 +1241,9 @@ and module planning now come from hgraph IR, as do callable/operator interfaces,
 nominal struct layouts, construction defaults, and local/state binding types.
 Internal callable dependency ordering also walks the hgraph-IR body graph.
 Concise composition expressions and concise `map` functions are emitted from
-those graph-IR values and bindings. Block/runtime body emission and
-expression-level type syntax remain behind the temporary AST adapter.
+those graph-IR values and bindings. Composition blocks also emit directly from
+graph-IR statements and blocks. Runtime-node body emission and expression-level
+type syntax remain behind the temporary AST adapter.
 
 `hgl emit-cpp <file.hgl>` writes one header/source pair named after the
 source — `prices.hgl` becomes `prices.h` and `prices.cpp` — beside the
@@ -1266,14 +1266,13 @@ callable set, visibility, composition/runtime classification, canonical
 callable and operator identities, export surface, registry bindings, and all
 callable/operator parameter and result types. Supported callable parameter
 defaults and omitted local-call arguments also use the graph-IR compile-time
-expression arena. Local and state statements use the graph-IR binding name,
-kind, and resolved type; retained source ranges pair those statements with the
-legacy executable body that must still be printed. The adapter cannot silently
-add or omit a planned declaration or body binding. Struct layout and
-omitted-field defaults come from hgraph IR. A concise composition callable is
-the exception to that remaining body seam: its result expression, resolved
-operations, exact function targets, and lexical bindings are read directly
-from hgraph IR. Only block/runtime bodies still use the retained syntax body.
+expression arena. Composition blocks use graph-IR statements, values, exact
+function targets, and lexical bindings throughout. Runtime local and state
+statements already use graph-IR binding names, kinds, and resolved types, while
+retained source ranges pair those bindings with the runtime syntax body that
+must still be printed. The adapter cannot silently add or omit a planned
+declaration or body binding. Struct layout and omitted-field defaults come from
+hgraph IR. Only runtime-node bodies still use the retained syntax body.
 
 - **Operator contracts.** `namespace operators` holds one transparent alias to
   `hgraph::Operator<"module.name",

--- a/language/docs/user-guide/modules-and-tools.md
+++ b/language/docs/user-guide/modules-and-tools.md
@@ -312,17 +312,17 @@ The target architecture gives `test`, `run`, `emit-cpp`, and the REPL one
 checked semantic IR and one hgraph runtime. The direct evaluator now consumes
 hgraph IR. C++ generation uses the same IR for module, callable, operator,
 export, registration, type, signature, internal dependency planning, and
-concise composition bodies (including concise functions passed to `map`). A
-temporary source adapter still prints block and runtime bodies. A program made
-only of composition functions is wired onto the runtime directly, in process.
-A file-based `test` or `run` containing supported runtime functions goes
-through generated C++, as does an ahead-of-time package. The REPL selects the
-same two routes from the accepted session:
+composition bodies, whether concise or block-shaped (including concise
+functions passed to `map`). A temporary source adapter still prints runtime
+node bodies. A program made only of composition functions is wired onto the
+runtime directly, in process. A file-based `test` or `run` containing supported
+runtime functions goes through generated C++, as does an ahead-of-time package.
+The REPL selects the same two routes from the accepted session:
 
 ```text
 source -> typed HIR -> hgraph IR -> direct wiring -> hgraph runtime
                               \-> C++ backend -> native -> hgraph runtime
-                                  (temporary block/runtime body adapter)
+                                  (temporary runtime-body adapter)
 ```
 
 Parity tests require both paths to build the same graph across their shared

--- a/language/src/README.md
+++ b/language/src/README.md
@@ -12,17 +12,18 @@ them.
 | `ir/` | source-ranged HIR, canonical types, substitutions, constraint solving, phase/effect completion | resolved frontend state to typed HIR |
 | `hgraph_ir/` | canonical execution-facing types, compile-time expressions, constraints, struct contracts, operator and callable interfaces | typed HIR to executable composition and runtime-node plans |
 | `wiring/` | direct walk over hgraph IR | hgraph IR to public erased wiring calls |
-| `codegen/` | hgraph-IR declaration/interface/dependency planning and concise-body emission plus a temporary AST block/runtime body adapter | hgraph IR to formatted C++ and build artifacts |
+| `codegen/` | hgraph-IR declaration/interface/dependency planning and composition-body emission plus a temporary AST runtime-body adapter | hgraph IR to formatted C++ and build artifacts |
 | `driver/` | commands, native build/cache/load, REPL orchestration | assemble inputs and invoke passes |
 
 During migration, `ResolvedModule` and the syntax AST remain a compatibility
-boundary only for C++ block/runtime bodies and expression-level type syntax.
+boundary only for C++ runtime-node bodies and expression-level type syntax.
 Module identity, callable visibility and classification, operator binding,
 exports, registration planning, callable/operator interfaces, supported
 callable parameter defaults, nominal struct declarations and field layouts,
 local/state binding types, construction defaults, and internal dependency order
 already come from hgraph IR. Concise composition bodies and concise anonymous
-functions also walk graph-IR values, operations, and lexical bindings directly.
+functions also walk graph-IR values, operations, and lexical bindings directly;
+composition block bodies additionally consume graph-IR statements and blocks.
 New language semantics belong in HIR construction, not in either backend. The
 remaining adapter is named here and must be removed as Stage E advances.
 

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -468,14 +468,15 @@ namespace hgl::codegen
                                                                   SourceRange range);
 
             // -- statements
-            void emit_block(ast::BlockId id, Frame &frame, Writer &out, bool function_body);
-            void emit_stmt(ast::StmtId id, Frame &frame, Writer &out);
+            void emit_planned_block(gir::BlockId id, Frame &frame, Writer &out, bool function_body, SourceRange fallback);
+            void emit_planned_statement(gir::StatementId id, Frame &frame, Writer &out, SourceRange fallback);
+            void emit_planned_if(const gir::Conditional &branch, SourceRange range, Frame &frame, Writer &out);
             void emit_return(const Value &value, Frame &frame, Writer &out, SourceRange range);
             void emit_runtime_stmt(ast::StmtId id, Frame &frame, Writer &out);
             void emit_runtime_block(ast::BlockId id, Frame &frame, Writer &out);
             void emit_runtime_if(const ast::If &branch, Frame &frame, Writer &out);
-            [[nodiscard]] bool expression_terminates(ast::ExprId id) const;
-            [[nodiscard]] bool block_terminates(ast::BlockId id) const;
+            [[nodiscard]] bool        planned_expression_terminates(gir::ValueId id, SourceRange fallback);
+            [[nodiscard]] bool        planned_block_terminates(gir::BlockId id, SourceRange fallback);
             [[nodiscard]] std::string as_runtime(const Value &value, const HType &target, SourceRange range, const std::string &what);
 
             // -- declarations
@@ -496,8 +497,7 @@ namespace hgl::codegen
             };
             void emit_function(ast::DeclId decl, Writer &out, Form form);
             void emit_struct(const gir::StructContract &item, Writer &out);
-            void emit_runtime_function(ast::DeclId decl, Writer &out);
-            void emit_if(const ast::If &branch, Frame &frame, Writer &out);
+            void                      emit_runtime_function(ast::DeclId decl, Writer &out);
             [[nodiscard]] RuntimeInfo runtime_info(ast::DeclId decl);
             void collect_runtime_activation(ast::ExprId id, ast::DeclId decl, RuntimeInfo &info);
             using RuntimeValidSet = std::unordered_set<std::size_t>;
@@ -2960,10 +2960,11 @@ namespace hgl::codegen
 
         void Emitter::emit_return(const Value &value, Frame &frame, Writer &out, SourceRange range)
         {
-            const ast::FunctionDecl &fn      = function(frame.fn);
-            const gir::Callable     &planned = callable(frame.fn);
+            const gir::Callable &planned = callable(frame.fn);
             if (!has_planned_result(planned.result, planned.range)) {
-                if (value.kind != Value::Kind::Void) { fail(Category::Type, range, "'" + std::string{fn.name.text} + "' has no result"); }
+                if (value.kind != Value::Kind::Void) {
+                    fail(Category::Type, range, "'" + std::string{local_identity(planned.identity)} + "' has no result");
+                }
                 if (!value.code.empty()) { out.line(value.code + ";"); }
                 out.line("return;");
                 return;
@@ -2972,192 +2973,164 @@ namespace hgl::codegen
             out.line("return " + as_port(value, result, range) + ";");
         }
 
-        void Emitter::emit_stmt(ast::StmtId id, Frame &frame, Writer &out)
-        {
-            const ast::Stmt &stmt = module_.stmt(id);
+        void Emitter::emit_planned_statement(gir::StatementId id, Frame &frame, Writer &out, SourceRange fallback) {
+            const gir::Statement &statement = planned_statement(id, fallback);
             std::visit(
                 [&](const auto &node) {
                     using T = std::decay_t<decltype(node)>;
-                    if constexpr (std::is_same_v<T, ast::LocalDecl>)
-                    {
-                        Value value = eval_expr(node.init, frame);
-                        if (value.kind != Value::Kind::Const && value.kind != Value::Kind::Port)
-                        {
-                            unsupported(stmt.range, "binding a function or operator to a local");
+                    if constexpr (std::is_same_v<T, gir::LocalBinding>) {
+                        const gir::Binding &binding = planned_binding(node.binding, statement.range);
+                        if (binding.kind != gir::BindingKind::LocalLet && binding.kind != gir::BindingKind::LocalVar) {
+                            backend(statement.range, "hgraph IR local statement refers to a non-local binding");
                         }
-                        const auto         &binding  = std::get<gir::LocalBinding>(planned_statement(id).node);
-                        const gir::Binding &name     = planned_binding(binding.binding, stmt.range);
-                        const HType         declared = planned_type(binding.type, stmt.range);
+                        Value value = eval_planned_expr(node.init, frame);
+                        if (value.kind != Value::Kind::Const && value.kind != Value::Kind::Port) {
+                            unsupported(statement.range, "binding a function or operator to a local");
+                        }
+                        const HType declared = planned_type(node.type, statement.range);
                         if (value.is_const()) {
-                            value.code = as_const(value, declared, value.range, "'" + name.name + "'");
+                            value.code = as_const(value, declared, value.range, "'" + binding.name + "'");
                         } else {
                             value.code = as_port(value, declared, value.range);
                         }
                         value.type = declared;
-                        // A unique C++ local per declaration: HGL lets a
-                        // later `let` shadow an earlier one in a block.
-                        const std::string base   = cpp_name(name.name);
-                        std::string       local = base;
+
+                        const std::string base   = cpp_name(binding.name);
+                        std::string       local  = base;
                         int              &suffix = local_counts_[base];
                         while (local_names_.contains(local)) { local = base + "_" + std::to_string(++suffix); }
                         local_names_.insert(local);
-                        if (name.kind != gir::BindingKind::LocalLet && name.kind != gir::BindingKind::LocalVar) {
-                            backend(stmt.range, "hgraph IR local statement refers to a non-local binding");
+                        out.line((binding.kind == gir::BindingKind::LocalVar ? "auto " : "const auto ") + local + " = " +
+                                 value.code + ";");
+                        value.code = local;
+                        if (!frame.planned_bindings.emplace(node.binding.value, std::move(value)).second) {
+                            backend(binding.range, "hgraph IR block repeats a local binding");
                         }
-                        out.line((name.kind == gir::BindingKind::LocalVar ? "auto " : "const auto ") + local + " = " + value.code +
-                                 ";");
-                        value.code       = local;
-                        frame.locals[id] = std::move(value);
-                    }
-                    else if constexpr (std::is_same_v<T, ast::AssignStmt>)
-                    {
-                        const ast::Expr &place = module_.expr(node.place);
-                        if (!std::holds_alternative<ast::NameRef>(place.node) ||
-                            resolved_.binding(node.place).kind != BindingKind::Local)
-                        {
+                    } else if constexpr (std::is_same_v<T, gir::Assignment>) {
+                        const gir::Value &place     = planned_value(node.place, statement.range);
+                        const auto       *reference = std::get_if<gir::Reference>(&place.node);
+                        if (reference == nullptr || reference->kind != gir::ReferenceKind::Binding) {
                             backend(place.range, "assignment targets a local in the first pass");
                         }
-                        const ast::StmtId target = resolved_.binding(node.place).stmt;
-                        if (!planned_local_mutable(target, place.range)) {
-                            fail(Category::Type, place.range, "'" + slice(place.range) + "' is not a 'var'");
+                        const gir::Binding &binding = planned_binding(reference->binding, place.range);
+                        if (binding.kind != gir::BindingKind::LocalVar) {
+                            fail(Category::Type, place.range, "'" + binding.name + "' is not a 'var'");
                         }
-                        Value        value   = eval_expr(node.value, frame);
-                        const Value &current = frame.locals.at(target);
-                        if (node.op != ast::AssignOp::Assign)
-                        {
-                            const ast::BinaryOp op = node.op == ast::AssignOp::Add   ? ast::BinaryOp::Add
-                                                     : node.op == ast::AssignOp::Sub ? ast::BinaryOp::Sub
-                                                     : node.op == ast::AssignOp::Mul ? ast::BinaryOp::Mul
+                        const auto current_it = frame.planned_bindings.find(reference->binding.value);
+                        if (current_it == frame.planned_bindings.end()) {
+                            backend(place.range, "'" + binding.name + "' is not bound in this function");
+                        }
+                        const Value current = current_it->second;
+                        Value       value   = eval_planned_expr(node.value, frame);
+                        if (node.op != gir::AssignOp::Assign) {
+                            const ast::BinaryOp op = node.op == gir::AssignOp::Add   ? ast::BinaryOp::Add
+                                                     : node.op == gir::AssignOp::Sub ? ast::BinaryOp::Sub
+                                                     : node.op == gir::AssignOp::Mul ? ast::BinaryOp::Mul
                                                                                      : ast::BinaryOp::Div;
-                            value = current.is_const() && value.is_const() ? fold_binary(op, current, value, stmt.range)
-                                                                           : wire_binary(op, current, value, stmt.range);
+                            value = current.is_const() && value.is_const() ? fold_binary(op, current, value, statement.range)
+                                                                           : wire_binary(op, current, value, statement.range);
                         }
-                        if (current.kind != value.kind)
-                        {
-                            fail(Category::Type, stmt.range,
-                                 "assignment to '" + slice(place.range) + "' changes its inferred type");
+                        if (current.kind != value.kind) {
+                            fail(Category::Type, statement.range, "assignment to '" + binding.name + "' changes its inferred type");
                         }
-                        if (current.is_const())
-                        {
-                            value.code = as_const(value, current.type, value.range,
-                                                  "assignment to '" + slice(place.range) + "'");
+                        if (current.is_const()) {
+                            value.code = as_const(value, current.type, value.range, "assignment to '" + binding.name + "'");
                             value.type = current.type;
-                        }
-                        else if (current.is_port())
-                        {
-                            // `auto` fixes the C++ port type at the declaration.
-                            // Retain that static HGL type after every rebind and
-                            // narrow an erased operator result at this boundary.
-                            if (current.type.kind != HType::Kind::Unknown)
-                            {
+                        } else if (current.is_port()) {
+                            if (current.type.kind != HType::Kind::Unknown) {
                                 value.code = as_port(value, current.type, value.range);
                             }
                             value.type = current.type;
                         }
                         out.line(current.code + " = " + value.code + ";");
-                        Value updated       = value;
-                        updated.code        = current.code;
-                        frame.locals[target] = std::move(updated);
-                    }
-                    else if constexpr (std::is_same_v<T, ast::ReturnStmt>)
-                    {
+                        value.code                                       = current.code;
+                        frame.planned_bindings[reference->binding.value] = std::move(value);
+                    } else if constexpr (std::is_same_v<T, gir::Return>) {
                         Value value;
-                        if (node.value != ast::no_node) { value = eval_expr(node.value, frame); }
-                        emit_return(value, frame, out, stmt.range);
-                    }
-                    else if constexpr (std::is_same_v<T, ast::AssertStmt>)
-                    {
-                        fail(Category::Type, stmt.range, "'assert' is only valid in a test");
-                    }
-                    else if constexpr (std::is_same_v<T, ast::ExprStmt>)
-                    {
-                        const ast::Expr &expr = module_.expr(node.expr);
-                        if (const auto *branch = std::get_if<ast::If>(&expr.node))
-                        {
-                            emit_if(*branch, frame, out);
+                        if (node.value.valid()) { value = eval_planned_expr(node.value, frame); }
+                        emit_return(value, frame, out, statement.range);
+                    } else if constexpr (std::is_same_v<T, gir::Assert>) {
+                        fail(Category::Type, statement.range, "'assert' is only valid in a test");
+                    } else if constexpr (std::is_same_v<T, gir::Evaluate>) {
+                        const gir::Value &expression = planned_value(node.value, statement.range);
+                        if (const auto *branch = std::get_if<gir::Conditional>(&expression.node)) {
+                            emit_planned_if(*branch, expression.range, frame, out);
                             return;
                         }
-                        const Value value = eval_expr(node.expr, frame);
-                        if (value.kind == Value::Kind::Void) { out.line(value.code + ";"); }
-                        else { out.line("(void)" + value.code + ";"); }
-                    }
-                    else
-                    {
-                        backend(stmt.range, "runtime statements are not evaluated by the first pass");
+                        const Value value = eval_planned_expr(node.value, frame);
+                        if (value.kind == Value::Kind::Void) {
+                            out.line(value.code + ";");
+                        } else {
+                            out.line("(void)" + value.code + ";");
+                        }
+                    } else {
+                        backend(statement.range, "runtime statements are not evaluated by the first pass");
                     }
                 },
-                stmt.node);
+                statement.node);
         }
 
-        /// A wiring-time `if`: its condition is a constant, so it is a C++
-        /// `if`; an `else if` chain recurses.
-        void Emitter::emit_if(const ast::If &branch, Frame &frame, Writer &out)
-        {
-            const Value condition = eval_expr(branch.condition, frame);
-            if (condition.is_port())
-            {
-                backend(module_.expr(branch.condition).range,
+        void Emitter::emit_planned_if(const gir::Conditional &branch, SourceRange range, Frame &frame, Writer &out) {
+            const gir::Value &condition_expression = planned_value(branch.condition, range);
+            const Value       condition            = eval_planned_expr(branch.condition, frame);
+            if (condition.is_port()) {
+                backend(condition_expression.range,
                         "'if' over a time-series condition is not supported by the first pass; use if_then_else");
             }
-            if (!condition.is_const() || !condition.type.is(ast::ScalarType::Bool))
-            {
-                fail(Category::Type, module_.expr(branch.condition).range, "an 'if' condition is a bool");
+            if (!condition.is_const() || !condition.type.is(ast::ScalarType::Bool)) {
+                fail(Category::Type, condition_expression.range, "an 'if' condition is a bool");
             }
             out.open("if (" + condition.code + ")");
-            emit_block(branch.then_block, frame, out, false);
+            emit_planned_block(branch.then_block, frame, out, false, range);
             out.close();
-            if (branch.otherwise == ast::no_node) { return; }
-            const ast::Expr &otherwise = module_.expr(branch.otherwise);
+            if (!branch.otherwise.valid()) { return; }
+
+            const gir::Value &otherwise = planned_value(branch.otherwise, range);
             out.open("else");
-            if (const auto *block = std::get_if<ast::BlockExpr>(&otherwise.node)) { emit_block(block->block, frame, out, false); }
-            else if (const auto *chained = std::get_if<ast::If>(&otherwise.node)) { emit_if(*chained, frame, out); }
-            else { unsupported(otherwise.range, "this 'else' form"); }
+            if (const auto *block = std::get_if<gir::BlockValue>(&otherwise.node)) {
+                emit_planned_block(block->block, frame, out, false, otherwise.range);
+            } else if (const auto *chained = std::get_if<gir::Conditional>(&otherwise.node)) {
+                emit_planned_if(*chained, otherwise.range, frame, out);
+            } else {
+                unsupported(otherwise.range, "this 'else' form");
+            }
             out.close();
         }
 
-        void Emitter::emit_block(ast::BlockId id, Frame &frame, Writer &out, bool function_body)
-        {
-            const ast::Block &block = module_.block(id);
-            for (std::size_t i = 0; i < block.statements.size(); ++i)
-            {
-                const bool is_tail = block.tail != ast::no_node && i + 1 == block.statements.size();
-                if (is_tail && function_body)
-                {
-                    const Value value = eval_expr(block.tail, frame);
-                    emit_return(value, frame, out, module_.expr(block.tail).range);
-                    return;
-                }
-                emit_stmt(block.statements[i], frame, out);
+        void Emitter::emit_planned_block(gir::BlockId id, Frame &frame, Writer &out, bool function_body, SourceRange fallback) {
+            const gir::Block &block = planned_block(id, fallback);
+            for (gir::StatementId statement : block.statements) { emit_planned_statement(statement, frame, out, block.range); }
+            if (function_body && block.tail.valid()) {
+                const gir::Value &tail  = planned_value(block.tail, block.range);
+                const Value       value = eval_planned_expr(block.tail, frame);
+                emit_return(value, frame, out, tail.range);
+                return;
             }
-            if (function_body && function(frame.fn).signature.result != ast::no_node && block.tail == ast::no_node &&
-                !block_terminates(id))
-            {
-                // Every path must return: a body that ends after a `return`
-                // inside `if` still needs a terminating statement for C++.
-                out.line("throw std::logic_error(\"" + std::string{function(frame.fn).name.text} +
+            if (function_body && has_planned_result(callable(frame.fn).result, callable(frame.fn).range) &&
+                !planned_block_terminates(id, fallback)) {
+                out.line("throw std::logic_error(\"" + std::string{local_identity(callable(frame.fn).identity)} +
                          ": reached the end of the body without a result\");");
             }
         }
 
-        bool Emitter::expression_terminates(ast::ExprId id) const
-        {
-            const ast::Expr &expr = module_.expr(id);
-            if (const auto *block = std::get_if<ast::BlockExpr>(&expr.node)) { return block_terminates(block->block); }
-            const auto *branch = std::get_if<ast::If>(&expr.node);
-            return branch != nullptr && block_terminates(branch->then_block) && branch->otherwise != ast::no_node &&
-                   expression_terminates(branch->otherwise);
+        bool Emitter::planned_expression_terminates(gir::ValueId id, SourceRange fallback) {
+            const gir::Value &expression = planned_value(id, fallback);
+            if (const auto *block = std::get_if<gir::BlockValue>(&expression.node)) {
+                return planned_block_terminates(block->block, expression.range);
+            }
+            const auto *branch = std::get_if<gir::Conditional>(&expression.node);
+            return branch != nullptr && planned_block_terminates(branch->then_block, expression.range) &&
+                   branch->otherwise.valid() && planned_expression_terminates(branch->otherwise, expression.range);
         }
 
-        bool Emitter::block_terminates(ast::BlockId id) const
-        {
-            const ast::Block &block = module_.block(id);
-            if (block.tail != ast::no_node) { return true; }
+        bool Emitter::planned_block_terminates(gir::BlockId id, SourceRange fallback) {
+            const gir::Block &block = planned_block(id, fallback);
+            if (block.tail.valid()) { return true; }
             if (block.statements.empty()) { return false; }
-            const ast::StmtNode &last = module_.stmt(block.statements.back()).node;
-            if (std::holds_alternative<ast::ReturnStmt>(last)) { return true; }
-            if (const auto *expression = std::get_if<ast::ExprStmt>(&last))
-            {
-                return expression_terminates(expression->expr);
+            const gir::Statement &last = planned_statement(block.statements.back(), block.range);
+            if (std::holds_alternative<gir::Return>(last.node)) { return true; }
+            if (const auto *expression = std::get_if<gir::Evaluate>(&last.node)) {
+                return planned_expression_terminates(expression->value, last.range);
             }
             return false;
         }
@@ -4169,7 +4142,6 @@ namespace hgl::codegen
                 emit_runtime_function(decl, out);
                 return;
             }
-            const ast::FunctionDecl &fn      = function(decl);
             const gir::Callable     &planned = callable(decl);
             Frame                    frame;
             frame.fn = decl;
@@ -4233,7 +4205,7 @@ namespace hgl::codegen
                 const Value       value = eval_planned_expr(planned.concise_body, frame);
                 emit_return(value, frame, out, body.range);
             } else {
-                emit_block(fn.block_body, frame, out, true);
+                emit_planned_block(planned.block_body, frame, out, true, planned.range);
             }
             out.close();
             if (form == Form::InlineStruct) { out.close(";"); }

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -3100,10 +3100,21 @@ namespace hgl::codegen
         void Emitter::emit_planned_block(gir::BlockId id, Frame &frame, Writer &out, bool function_body, SourceRange fallback) {
             const gir::Block &block = planned_block(id, fallback);
             for (gir::StatementId statement : block.statements) { emit_planned_statement(statement, frame, out, block.range); }
-            if (function_body && block.tail.valid()) {
-                const gir::Value &tail  = planned_value(block.tail, block.range);
-                const Value       value = eval_planned_expr(block.tail, frame);
-                emit_return(value, frame, out, tail.range);
+            if (block.tail.valid()) {
+                const gir::Value &tail = planned_value(block.tail, block.range);
+                if (function_body) {
+                    const Value value = eval_planned_expr(block.tail, frame);
+                    emit_return(value, frame, out, tail.range);
+                } else if (const auto *branch = std::get_if<gir::Conditional>(&tail.node)) {
+                    emit_planned_if(*branch, tail.range, frame, out);
+                } else {
+                    const Value value = eval_planned_expr(block.tail, frame);
+                    if (value.kind == Value::Kind::Void) {
+                        out.line(value.code + ";");
+                    } else {
+                        out.line("(void)" + value.code + ";");
+                    }
+                }
                 return;
             }
             if (function_body && has_planned_result(callable(frame.fn).result, callable(frame.fn).range) &&

--- a/language/src/codegen/cpp_emitter.h
+++ b/language/src/codegen/cpp_emitter.h
@@ -17,10 +17,10 @@
 /// runtime, so what it emits is checked by the native compiler that builds the
 /// package. Body-local let, var, and state binding types also come from hgraph
 /// IR. Internal callable dependencies are read from reachable hgraph-IR body
-/// operations. Concise composition bodies and their anonymous functions are
-/// emitted from those values and lexical bindings. A temporary syntax adapter
-/// still supplies block/runtime bodies and expression-level type syntax during
-/// the Stage E migration. Tests run
+/// operations. Composition bodies and their anonymous functions are emitted
+/// from graph-IR values, statements, blocks, and lexical bindings. A temporary
+/// syntax adapter still supplies runtime-node bodies and expression-level type
+/// syntax during the Stage E migration. Tests run
 /// generated graphs beside `hgl test` and exercise generated runtime nodes
 /// directly through hgraph's public harness.
 namespace hgl::codegen

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -911,6 +911,69 @@ export fn combine(a: f64, b: f64) -> f64 => a + b
     }
 }
 
+TEST_CASE("emit-cpp renders composition blocks from hgraph IR", "[codegen][hgraph-ir][blocks]") {
+    Unit unit{R"(
+module planned_block
+
+export fn adjusted(value: f64, const enabled: bool = true) -> f64 {
+    var amount = 1.0
+    amount += 2.0
+    if enabled {
+        return value + amount
+    }
+    value
+}
+)"};
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+    REQUIRE(unit.graph.callables.size() == 1U);
+    const hgl::hgraph_ir::BlockId body_id = unit.graph.callables.front().block_body;
+    REQUIRE(body_id.valid());
+    REQUIRE(body_id.value < unit.graph.blocks.size());
+
+    const auto local_statement =
+        std::find_if(unit.graph.statements.begin(), unit.graph.statements.end(),
+                     [](const auto &statement) { return std::holds_alternative<hgl::hgraph_ir::LocalBinding>(statement.node); });
+    REQUIRE(local_statement != unit.graph.statements.end());
+    const auto &local = std::get<hgl::hgraph_ir::LocalBinding>(local_statement->node);
+    REQUIRE(local.init.valid());
+    REQUIRE(local.init.value < unit.graph.values.size());
+
+    const auto return_statement =
+        std::find_if(unit.graph.statements.begin(), unit.graph.statements.end(),
+                     [](const auto &statement) { return std::holds_alternative<hgl::hgraph_ir::Return>(statement.node); });
+    REQUIRE(return_statement != unit.graph.statements.end());
+    const auto &returned = std::get<hgl::hgraph_ir::Return>(return_statement->node);
+    REQUIRE(returned.value.valid());
+    REQUIRE(returned.value.value < unit.graph.values.size());
+
+    SECTION("planned local initializers and return operations are authoritative") {
+        auto &init    = unit.graph.values[local.init.value];
+        init.node     = hgl::hgraph_ir::Literal{3.0};
+        init.constant = 3.0;
+
+        auto &result                                     = unit.graph.values[returned.value.value];
+        std::get<hgl::hgraph_ir::Binary>(result.node).op = hgl::ir::hir::BinaryOp::Mul;
+        result.operation.identity                        = "mul_";
+        result.operation.registry_name                   = "mul_";
+
+        const auto emitted = unit.emit();
+        REQUIRE(emitted);
+        CHECK(contains(emitted->source, "auto amount = hgraph::Float{3.0};"));
+        CHECK_FALSE(contains(emitted->source, "auto amount = hgraph::Float{1.0};"));
+        CHECK(contains(emitted->source, "hgraph::wire<hgraph::stdlib::mul_>(w, value, amount)"));
+        CHECK_FALSE(contains(emitted->source, "hgraph::wire<hgraph::stdlib::add_>(w, value, amount)"));
+    }
+
+    SECTION("an invalid planned statement fails closed") {
+        auto &body = unit.graph.blocks[body_id.value];
+        REQUIRE_FALSE(body.statements.empty());
+        body.statements.front() = hgl::hgraph_ir::StatementId{static_cast<std::uint32_t>(unit.graph.statements.size())};
+
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Backend, "hgraph IR contains an invalid body statement ID"));
+    }
+}
+
 TEST_CASE("emit-cpp lowers scalar runtime functions to static nodes", "[codegen][runtime]")
 {
     Unit unit{R"(

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -921,6 +921,9 @@ export fn adjusted(value: f64, const enabled: bool = true) -> f64 {
     if enabled {
         return value + amount
     }
+    if enabled {
+        value - amount
+    }
     value
 }
 )"};
@@ -962,6 +965,7 @@ export fn adjusted(value: f64, const enabled: bool = true) -> f64 {
         CHECK_FALSE(contains(emitted->source, "auto amount = hgraph::Float{1.0};"));
         CHECK(contains(emitted->source, "hgraph::wire<hgraph::stdlib::mul_>(w, value, amount)"));
         CHECK_FALSE(contains(emitted->source, "hgraph::wire<hgraph::stdlib::add_>(w, value, amount)"));
+        CHECK(contains(emitted->source, "(void)hgraph::wire<hgraph::stdlib::sub_>(w, value, amount)"));
     }
 
     SECTION("an invalid planned statement fails closed") {


### PR DESCRIPTION
## Summary

- emit composition block statements, conditionals, assignments, returns, and tail expressions from hgraph IR
- key local values by graph-IR binding identity and reject malformed planned body edges
- remove the now-dead composition AST body printer while retaining the explicitly temporary runtime-node body adapter
- update the Stage E roadmap and compiler/user documentation

Stacked on #707.

## Validation

- `cmake --preset cpp --fresh`
- `cmake --build --preset cpp --target clean`
- `cmake --build --preset cpp --parallel`
- `ctest --preset cpp --parallel 2 --output-on-failure` (1716/1716)
- codegen tests (367 assertions in 32 cases)
- generated HGL tests on macOS (57 assertions in 27 cases)
- HGL integration tests (30/30)
- Python 3.12 ABI3 wheel installed into a fresh Python 3.14 environment; `pytest python/tests -q -m "not wip"` (3240 passed, 10 skipped)
- private Linux GCC 14 warnings-as-errors build; codegen tests (367 assertions in 32 cases) and generated HGL tests (54 assertions in 24 cases)
