### PR TITLE
language: retain source declaration order in HGraph IR

### DIFF
--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -195,8 +195,11 @@ wiring target no longer includes syntax AST headers.
   type/expression/call evaluator;
 - [x] remove duplicate expression, type, generic, phase, and classification
   logic from the emitter;
-- [ ] replace source-range-to-declaration association with hgraph-IR source
-  order and source-map handles;
+- [x] retain typed hgraph-IR handles for structs, operators, callables, and
+  tests in one source-order sequence, with source ranges owned by the
+  referenced records;
+- [ ] replace the emitter's source-range-to-declaration association with those
+  hgraph-IR source-order and source-map handles;
 - retain deterministic formatting, source maps, public-SDK code, and readable
   output;
 - remove the compatibility path by which a backend walks `ResolvedModule`.

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -190,6 +190,11 @@ flow is explicit: state and local declarations, injectables, lifecycle blocks,
 ordered activations, collection traversal, assignment, return, assertion, and
 expression evaluation have distinct variants. Tail expressions are removed
 from the executable statement list so they cannot be evaluated twice.
+`DeclarationRef` provides typed struct, operator, callable, and test handles;
+the module retains those handles in source order while module and import
+declarations remain frontend-only. Each referenced contract or plan owns its
+source range, so a backend can preserve declaration order and source mapping
+without retaining an HIR declaration ID.
 Effective fields retain their defining struct identity, while every constraint
 reference uses hgraph-IR type, constant-expression, and requirement IDs rather
 than semantic symbols. Inherited field types and defaults are substituted
@@ -236,9 +241,11 @@ obsolete AST type/expression/call evaluator has been removed.
 `codegen` still retains one non-semantic frontend seam. It associates each
 planned declaration range with a source declaration ID to preserve source
 order, source comments, diagnostics, and current emission grouping, and rejects
-missing, duplicate, extra, or incompatible association shapes. The next Stage
-E checkpoint moves those ordering and source-map handles into hgraph IR so
-`codegen` can drop its syntax and resolver dependencies completely.
+missing, duplicate, extra, or incompatible association shapes. Hgraph IR now
+owns the typed declaration handles, their source-order sequence, and the source
+ranges on referenced records. The next Stage E checkpoint consumes those
+handles in `codegen` so it can drop its syntax and resolver dependencies
+completely.
 
 `src/wiring/type_bridge` is the first direct-backend migration boundary. It
 materializes hgraph-IR scalar, tuple, list, set, map, window, atomic, and applied
@@ -1265,10 +1272,11 @@ overrides the executable selected when `hgl` was built.
 
 What is emitted, in this order:
 
-Before emission, hgraph IR determines the module namespace, source-order
-callable set, visibility, composition/runtime classification, canonical
-callable and operator identities, export surface, registry bindings, and all
-callable/operator parameter and result types. Supported callable parameter
+Before emission, hgraph IR determines the module namespace, typed source-order
+declaration sequence, callable set, visibility, composition/runtime
+classification, canonical callable and operator identities, export surface,
+registry bindings, and all callable/operator parameter and result types.
+Supported callable parameter
 defaults and omitted local-call arguments also use the graph-IR compile-time
 expression arena. Composition and runtime blocks use graph-IR statements,
 values, exact function targets, lifecycle plans, capabilities, and lexical

--- a/language/src/README.md
+++ b/language/src/README.md
@@ -10,14 +10,16 @@ them.
 | `syntax/` | source buffers, diagnostics, temporal literals, lexer, parser, arena AST | source text to source-accurate syntax |
 | `semantics/` | name binding, nominal hierarchy, generic argument roles, function classification | syntax plus descriptors to resolved names and shapes |
 | `ir/` | source-ranged HIR, canonical types, substitutions, constraint solving, phase/effect completion | resolved frontend state to typed HIR |
-| `hgraph_ir/` | canonical execution-facing types, compile-time expressions, constraints, struct contracts, operator and callable interfaces | typed HIR to executable composition and runtime-node plans |
+| `hgraph_ir/` | canonical execution-facing types, compile-time expressions, constraints, typed source-order declaration handles, struct contracts, operator and callable interfaces | typed HIR to executable composition and runtime-node plans |
 | `wiring/` | direct walk over hgraph IR | hgraph IR to public erased wiring calls |
 | `codegen/` | hgraph-IR declaration, interface, dependency, composition-body, and runtime-body emission plus temporary source-declaration association | hgraph IR to formatted C++ and build artifacts |
 | `driver/` | commands, native build/cache/load, REPL orchestration | assemble inputs and invoke passes |
 
-During migration, `ResolvedModule` and the syntax AST remain only to associate
-planned declarations with source declaration IDs and ranges for diagnostics,
-source order, and source maps. The backend no longer walks syntax types,
+Hgraph IR now retains typed struct, operator, callable, and test handles in
+source order; each referenced record owns its source range. During migration,
+`ResolvedModule` and the syntax AST remain only because `codegen` still
+associates those planned records with source declaration IDs for its current
+grouping and source comments. The backend no longer walks syntax types,
 expressions, statements, or blocks.
 Module identity, callable visibility and classification, operator binding,
 exports, registration planning, callable/operator interfaces, supported

--- a/language/src/hgraph_ir/ir.h
+++ b/language/src/hgraph_ir/ir.h
@@ -21,7 +21,10 @@ namespace hgl::hgraph_ir
     };
 
     using TypeId       = Id<struct TypeTag>;
+    using StructId     = Id<struct StructTag>;
+    using OperatorId   = Id<struct OperatorTag>;
     using CallableId   = Id<struct CallableTag>;
+    using TestId       = Id<struct TestTag>;
     using ConstExprId  = Id<struct ConstExprTag>;
     using ConstraintId = Id<struct ConstraintTag>;
     using BindingId    = Id<struct BindingTag>;
@@ -497,6 +500,11 @@ namespace hgl::hgraph_ir
         syntax::SourceRange range{};
     };
 
+    /// A stable, typed handle to a source declaration retained by hgraph IR.
+    /// Module and import declarations do not produce execution-facing records
+    /// and are therefore absent from this variant.
+    using DeclarationRef = std::variant<StructId, OperatorId, CallableId, TestId>;
+
     enum class Completion : std::uint8_t {
         Interfaces,
         Bodies,
@@ -518,6 +526,18 @@ namespace hgl::hgraph_ir
         std::vector<Statement>        statements{};
         std::vector<Block>            blocks{};
         std::vector<TestPlan>         tests{};
+        /// Execution-facing declarations in original source order. Each
+        /// referenced record owns the source range used for diagnostics and
+        /// generated-code source mapping.
+        std::vector<DeclarationRef> source_order{};
+
+        [[nodiscard]] syntax::SourceRange declaration_range(StructId id) const noexcept { return structures[id.value].range; }
+        [[nodiscard]] syntax::SourceRange declaration_range(OperatorId id) const noexcept { return operators[id.value].range; }
+        [[nodiscard]] syntax::SourceRange declaration_range(CallableId id) const noexcept { return callables[id.value].range; }
+        [[nodiscard]] syntax::SourceRange declaration_range(TestId id) const noexcept { return tests[id.value].range; }
+        [[nodiscard]] syntax::SourceRange declaration_range(const DeclarationRef &declaration) const noexcept {
+            return std::visit([this](auto id) { return declaration_range(id); }, declaration);
+        }
     };
 }  // namespace hgl::hgraph_ir
 

--- a/language/src/hgraph_ir/lower.cpp
+++ b/language/src/hgraph_ir/lower.cpp
@@ -34,6 +34,7 @@ namespace hgl::hgraph_ir
                 lower_operators();
                 lower_callables();
                 lower_tests();
+                lower_source_order();
                 if (!diagnostics_.has_errors()) { result_.completion = Completion::Bodies; }
                 return std::move(result_);
             }
@@ -493,6 +494,8 @@ namespace hgl::hgraph_ir
                     if (source == nullptr || !declaration.symbol.valid()) { continue; }
 
                     StructContract target;
+                    const StructId id{static_cast<std::uint32_t>(result_.structures.size())};
+                    declarations_.emplace(declaration.id.value, id);
                     target.identity     = symbol_identity(declaration.symbol);
                     target.exported     = source->exported;
                     target.abstract     = source->abstract;
@@ -553,6 +556,8 @@ namespace hgl::hgraph_ir
                     const auto *source = std::get_if<hir::OperatorDecl>(&declaration.node);
                     if (source == nullptr || !declaration.symbol.valid()) { continue; }
                     OperatorContract target;
+                    const OperatorId id{static_cast<std::uint32_t>(result_.operators.size())};
+                    declarations_.emplace(declaration.id.value, id);
                     target.identity = symbol_identity(declaration.symbol);
                     target.range    = declaration.range;
                     lower_signature(source->generics, source->signature, target.generics, target.parameters, target.result);
@@ -833,6 +838,7 @@ namespace hgl::hgraph_ir
                     if (source == nullptr || !declaration.symbol.valid()) { continue; }
                     const CallableId id{static_cast<std::uint32_t>(result_.callables.size())};
                     callables_.emplace(declaration.symbol.value, id);
+                    declarations_.emplace(declaration.id.value, id);
                     Callable target;
                     target.visibility = lower_visibility(source->visibility);
                     target.identity   = declaration_identity(declaration.id);
@@ -867,22 +873,42 @@ namespace hgl::hgraph_ir
                 for (const hir::Declaration &declaration : source_.declarations) {
                     const auto *source = std::get_if<hir::TestDecl>(&declaration.node);
                     if (source == nullptr || !declaration.symbol.valid()) { continue; }
+                    const TestId id{static_cast<std::uint32_t>(result_.tests.size())};
+                    declarations_.emplace(declaration.id.value, id);
                     result_.tests.push_back(
                         TestPlan{declaration_identity(declaration.id), lower_block(source->block), declaration.range});
                 }
             }
 
-            const hir::Module                              &source_;
-            syntax::DiagnosticSink                         &diagnostics_;
-            Module                                          result_{};
-            std::unordered_map<std::uint32_t, TypeId>       types_{};
-            std::unordered_map<std::uint32_t, ConstExprId>  const_exprs_{};
-            std::unordered_map<std::uint32_t, ConstraintId> constraints_{};
-            std::unordered_map<std::uint32_t, BindingId>    bindings_{};
-            std::unordered_map<std::uint32_t, CallableId>   callables_{};
-            std::unordered_map<std::uint32_t, ValueId>      values_{};
-            std::unordered_map<std::uint32_t, StatementId>  statements_{};
-            std::unordered_map<std::uint32_t, BlockId>      blocks_{};
+            void lower_source_order() {
+                for (hir::DeclarationId source_id : source_.source_order) {
+                    const auto found = declarations_.find(source_id.value);
+                    if (found != declarations_.end()) {
+                        result_.source_order.push_back(found->second);
+                        continue;
+                    }
+
+                    const hir::Declaration &declaration = source_.declaration(source_id);
+                    if (std::holds_alternative<hir::ModuleDecl>(declaration.node) ||
+                        std::holds_alternative<hir::UseDecl>(declaration.node)) {
+                        continue;
+                    }
+                    diagnostics_.report(syntax::Category::Type, declaration.range, "typed HIR declaration has no hgraph IR handle");
+                }
+            }
+
+            const hir::Module                                &source_;
+            syntax::DiagnosticSink                           &diagnostics_;
+            Module                                            result_{};
+            std::unordered_map<std::uint32_t, TypeId>         types_{};
+            std::unordered_map<std::uint32_t, ConstExprId>    const_exprs_{};
+            std::unordered_map<std::uint32_t, ConstraintId>   constraints_{};
+            std::unordered_map<std::uint32_t, BindingId>      bindings_{};
+            std::unordered_map<std::uint32_t, CallableId>     callables_{};
+            std::unordered_map<std::uint32_t, ValueId>        values_{};
+            std::unordered_map<std::uint32_t, StatementId>    statements_{};
+            std::unordered_map<std::uint32_t, BlockId>        blocks_{};
+            std::unordered_map<std::uint32_t, DeclarationRef> declarations_{};
         };
     }  // namespace
 

--- a/language/src/hgraph_ir/printer.cpp
+++ b/language/src/hgraph_ir/printer.cpp
@@ -118,6 +118,24 @@ namespace hgl::hgraph_ir
             }
         }
 
+        void print_declaration_ref(std::ostream &out, const DeclarationRef &declaration) {
+            std::visit(
+                [&](auto id) {
+                    using T = decltype(id);
+                    if constexpr (std::is_same_v<T, StructId>) {
+                        out << "struct:s";
+                    } else if constexpr (std::is_same_v<T, OperatorId>) {
+                        out << "operator:o";
+                    } else if constexpr (std::is_same_v<T, CallableId>) {
+                        out << "callable:f";
+                    } else {
+                        out << "test:x";
+                    }
+                    out << id.value;
+                },
+                declaration);
+        }
+
         void print_range(std::ostream &out, syntax::SourceRange range) { out << " [" << range.begin << ".." << range.end << ')'; }
 
         template <typename IdType> void print_ids(std::ostream &out, char prefix, const std::vector<IdType> &ids) {
@@ -332,6 +350,12 @@ namespace hgl::hgraph_ir
         std::ostringstream                out;
         static constexpr std::string_view completion_names[]{"interfaces", "bodies", "executable"};
         out << "HGRAPH-IR " << completion_names[static_cast<std::size_t>(module.completion)] << " module " << module.path << '\n';
+        out << "source-order [";
+        for (std::size_t index = 0; index < module.source_order.size(); ++index) {
+            if (index != 0) { out << ", "; }
+            print_declaration_ref(out, module.source_order[index]);
+        }
+        out << "]\n";
         out << "constant-expressions\n";
         for (std::size_t index = 0; index < module.const_exprs.size(); ++index) {
             const ConstExpr &expression = module.const_exprs[index];

--- a/language/tests/hgraph_ir/lower_tests.cpp
+++ b/language/tests/hgraph_ir/lower_tests.cpp
@@ -107,6 +107,46 @@ fn map_values(values: map<str, f64>) -> map<str, f64> =>
     CHECK(op.registry_name == "map_");
 }
 
+TEST_CASE("hgraph IR retains typed declaration handles in source order", "[hgraph-ir][declarations]") {
+    Lowered lowered{R"(
+module checks.source_order
+
+struct Box {
+    value: f64
+}
+
+fn first(value: f64) -> f64 => value
+
+operator scale(value: f64) -> f64
+
+impl fn scale(value: f64) -> f64 => value
+
+fn last(value: f64) -> f64 => first(value)
+
+test last_ticks {
+    assert eval(last, value: [1.0]) == [1.0]
+}
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE_FALSE(lowered.diagnostics.has_errors());
+    REQUIRE(lowered.graph);
+
+    const auto &order = lowered.graph->source_order;
+    REQUIRE(order.size() == 6);
+    CHECK(std::get<hgl::hgraph_ir::StructId>(order[0]).value == 0);
+    CHECK(std::get<hgl::hgraph_ir::CallableId>(order[1]).value == 0);
+    CHECK(std::get<hgl::hgraph_ir::OperatorId>(order[2]).value == 0);
+    CHECK(std::get<hgl::hgraph_ir::CallableId>(order[3]).value == 1);
+    CHECK(std::get<hgl::hgraph_ir::CallableId>(order[4]).value == 2);
+    CHECK(std::get<hgl::hgraph_ir::TestId>(order[5]).value == 0);
+    CHECK(lowered.file.slice(lowered.graph->declaration_range(order[0])).starts_with("struct Box"));
+    CHECK(lowered.file.slice(lowered.graph->declaration_range(order[2])).starts_with("operator scale"));
+    CHECK(lowered.file.slice(lowered.graph->declaration_range(order[5])).starts_with("test last_ticks"));
+
+    const std::string dump = hgl::hgraph_ir::print(*lowered.graph);
+    CHECK(dump.find("source-order [struct:s0, callable:f0, operator:o0, callable:f1, callable:f2, test:x0]") != std::string::npos);
+}
+
 TEST_CASE("hgraph IR classifies runtime nodes and copies capabilities", "[hgraph-ir][runtime]") {
     Lowered lowered{R"(
 module checks.runtime


### PR DESCRIPTION
## Summary

- add typed HGraph IR handles for source structs, operators, callables, and tests
- retain those execution-facing declarations in original source order with direct source-range lookup
- expose the order in the HGraph IR dump and document the remaining codegen migration boundary

## Validation

- all 30 HGL integration tests
- fresh native C++ suite: 1,716/1,716
- ABI3 wheel built with Python 3.12 and tested with Python 3.14: 3,240 passed, 10 skipped
- private Linux GCC 14 warnings-as-errors: HGraph IR 287 assertions / 16 cases; codegen 409 / 33; generated code 57 / 27
- clang-format and diff checks

Stacked on #710.