### PR TITLE
Preserve operator provider provenance in HGL IR

### DIFF
--- a/include/hgraph/types/operator_dispatch.h
+++ b/include/hgraph/types/operator_dispatch.h
@@ -475,7 +475,7 @@ namespace hgraph
             Empty for historical process-lifetime registrations. The view is
             valid under the same registry-lifetime contract as ``impl`` and
             does not retain or expose the provider generation. */
-        [[nodiscard]] std::string_view provider_key() const noexcept;
+        [[nodiscard]] HGRAPH_EXPORT std::string_view provider_key() const noexcept;
     };
 
     /** Thrown when an operator call has no matching overload, or an ambiguous one. */

--- a/include/hgraph/types/operator_dispatch.h
+++ b/include/hgraph/types/operator_dispatch.h
@@ -470,6 +470,12 @@ namespace hgraph
         ResolutionMap       map{};
         std::vector<WiringArg> args{};
         std::vector<std::pair<std::string, WiringPortRef>> kwargs{};
+
+        /** Stable key of the keyed installer which contributed ``impl``.
+            Empty for historical process-lifetime registrations. The view is
+            valid under the same registry-lifetime contract as ``impl`` and
+            does not retain or expose the provider generation. */
+        [[nodiscard]] std::string_view provider_key() const noexcept;
     };
 
     /** Thrown when an operator call has no matching overload, or an ambiguous one. */

--- a/language/docs/design/compiler-architecture.md
+++ b/language/docs/design/compiler-architecture.md
@@ -131,7 +131,11 @@ contracts. It does not maintain a language-local overload matcher with subtly
 different ranking.
 
 The adapter performs a schema-only resolution probe and copies data out of the
-result. Registry implementation pointers and provider leases do not enter HIR.
+result, including the selected keyed provider's stable identity. Registry
+implementation pointers and provider leases do not enter HIR. Hgraph IR keeps
+that copied identity on the nominal call while concrete requirement planning
+remains incomplete; it does not infer provider provenance from a diagnostic
+candidate label.
 Calls depending on a wiring-time scalar value or on callable erasure retain a
 typed nominal call marked `deferred`; the hgraph-IR pass resolves them at the
 first point where those inputs exist. Multiple source `impl fn` candidates are

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -152,7 +152,9 @@ plans. It explicitly represents state, injectables, lifecycle, ordered
 activation, traversal, assignment, returns, output and capability access, and
 test evaluation. The module is now `Bodies`, not `Executable`. The direct
 backend consumes that form and resolves against the active in-process registry;
-concrete locked provider planning is the following slice.
+schema-only native selection now copies its keyed provider identity through HIR
+and hgraph IR without retaining a registry object. Concrete requirement
+planning and locked-provider validation are the following slices.
 
 - [x] lower composition and runtime semantics into one explicit hgraph IR;
 - [x] represent state, injectables, lifecycle, activation, validity, traversal,

--- a/language/src/hgraph_ir/ir.h
+++ b/language/src/hgraph_ir/ir.h
@@ -301,6 +301,7 @@ namespace hgl::hgraph_ir
         std::string               registry_name{};
         std::string               candidate_identity{};
         std::string               candidate_label{};
+        std::string               provider_key{};
         std::vector<Substitution> substitutions{};
         bool                      deferred{false};
     };

--- a/language/src/hgraph_ir/lower.cpp
+++ b/language/src/hgraph_ir/lower.cpp
@@ -639,6 +639,7 @@ namespace hgl::hgraph_ir
                 target.capability      = binding(source.target);
                 target.identity        = source.identity;
                 target.candidate_label = source.candidate_label;
+                target.provider_key    = source.provider_key;
                 target.deferred        = source.deferred;
                 if (source.target.valid()) {
                     const hir::Symbol &symbol = source_.symbol(source.target);

--- a/language/src/hgraph_ir/printer.cpp
+++ b/language/src/hgraph_ir/printer.cpp
@@ -246,6 +246,7 @@ namespace hgl::hgraph_ir
             }
             if (!operation.candidate_identity.empty()) { out << " candidate-identity=" << operation.candidate_identity; }
             if (!operation.candidate_label.empty()) { out << " candidate-label=" << std::quoted(operation.candidate_label); }
+            if (!operation.provider_key.empty()) { out << " provider=" << std::quoted(operation.provider_key); }
             if (operation.capability.valid()) {
                 out << " capability=";
                 print_binding_id(out, operation.capability);

--- a/language/src/ir/hir.h
+++ b/language/src/ir/hir.h
@@ -224,7 +224,8 @@ namespace hgl::ir::hir
 
     /// Semantic identity assigned to an expression operation. Operator
     /// implementations are named by stable symbols/strings and copied
-    /// candidate labels; no registry pointer or wiring object enters HIR.
+    /// candidate/provider identities; no registry pointer or wiring object
+    /// enters HIR.
     struct Operation
     {
         OperationKind             kind{OperationKind::None};
@@ -232,6 +233,7 @@ namespace hgl::ir::hir
         SymbolId                  candidate{};
         std::string               identity{};
         std::string               candidate_label{};
+        std::string               provider_key{};
         std::vector<Substitution> substitutions{};
         bool                      deferred{false};
     };

--- a/language/src/ir/hir_printer.cpp
+++ b/language/src/ir/hir_printer.cpp
@@ -352,6 +352,7 @@ namespace hgl::ir
                         if (!operation.candidate_label.empty()) {
                             out_ << " candidate-label=" << std::quoted(operation.candidate_label);
                         }
+                        if (!operation.provider_key.empty()) { out_ << " provider=" << std::quoted(operation.provider_key); }
                         if (!operation.substitutions.empty()) {
                             out_ << " substitutions=[";
                             for (std::size_t substitution = 0; substitution < operation.substitutions.size(); ++substitution) {

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -1131,6 +1131,7 @@ namespace hgl::ir
                                                  .target          = target,
                                                  .identity        = operator_identity(target),
                                                  .candidate_label = std::move(selection.candidate_label),
+                                                 .provider_key    = std::move(selection.provider_key),
                                                  .substitutions   = std::move(selection.substitutions),
                                                  .deferred        = selection.deferred};
             }

--- a/language/src/ir/type_check.h
+++ b/language/src/ir/type_check.h
@@ -30,9 +30,10 @@ namespace hgl::ir
 
     struct OperatorSelection
     {
-        /// The native candidate's copied diagnostic label. No candidate
-        /// pointer or provider lease may cross into HIR.
+        /// The native candidate's copied diagnostic label and keyed provider
+        /// identity. No candidate pointer or provider lease may cross into HIR.
         std::string                    candidate_label{};
+        std::string                    provider_key{};
         hir::TypeId                    result{};
         std::vector<hir::Substitution> substitutions{};
         bool                           deferred{false};

--- a/language/src/wiring/operator_types.cpp
+++ b/language/src/wiring/operator_types.cpp
@@ -79,6 +79,7 @@ namespace hgl::wiring
                         dispatch_expected);
                     selection.candidate_label = resolved.impl->label;
                     if (selection.candidate_label.empty()) { selection.candidate_label = resolved.impl->name; }
+                    selection.provider_key = resolved.provider_key();
                     if (resolved.impl->has_output) {
                         const hgraph::TSValueTypeMetaData *output = hgraph::ts_pattern_resolve(resolved.impl->output, resolved.map);
                         if (output != nullptr) {

--- a/language/tests/wiring/operator_types_tests.cpp
+++ b/language/tests/wiring/operator_types_tests.cpp
@@ -1,3 +1,4 @@
+#include "hgraph_ir/lower.h"
 #include "ir/lower.h"
 #include "ir/type_check.h"
 #include "semantics/resolve.h"
@@ -48,10 +49,20 @@ fn average(window: rolling<f64, 20>) -> f64 => mean(window)
         if (expression.operation.identity != "hgraph.std.mean") { continue; }
         found = true;
         CHECK_FALSE(expression.operation.candidate_label.empty());
+        CHECK(expression.operation.provider_key == "hgraph.stdlib");
         CHECK_FALSE(expression.operation.deferred);
         CHECK_FALSE(expression.operation.substitutions.empty());
     }
     CHECK(found);
+
+    const hgl::hgraph_ir::Module graph         = hgl::hgraph_ir::lower(unit.hir, unit.diagnostics);
+    bool                         lowered_found = false;
+    for (const hgl::hgraph_ir::Value &value : graph.values) {
+        if (value.operation.identity != "hgraph.std.mean") { continue; }
+        lowered_found = true;
+        CHECK(value.operation.provider_key == "hgraph.stdlib");
+    }
+    CHECK(lowered_found);
 }
 
 TEST_CASE("native operator typing recovers an inferred result for nested calls", "[ir][operator-types]") {

--- a/src/hgraph/types/operator_dispatch.cpp
+++ b/src/hgraph/types/operator_dispatch.cpp
@@ -1033,6 +1033,11 @@ namespace hgraph
         return state_ != nullptr ? state_->live_leases.load(std::memory_order_acquire) : 0;
     }
 
+    std::string_view ResolvedOperatorCall::provider_key() const noexcept
+    {
+        return impl != nullptr && impl->provider != nullptr ? std::string_view{impl->provider->key} : std::string_view{};
+    }
+
     void OperatorRegistry::register_overload(OperatorImpl impl)
     {
         impl.provider = active_provider_;

--- a/tests/cpp/test_operator_installers.cpp
+++ b/tests/cpp/test_operator_installers.cpp
@@ -255,6 +255,9 @@ TEST_CASE("installers: provider removal erases only its candidates and reset int
     CHECK(provider_probe_count() == 1);
     CHECK_FALSE(registry.remove_provider(provider));
 
+    const ResolvedOperatorCall direct = registry.resolve("provider_lifecycle_probe", {}, true);
+    CHECK(direct.provider_key().empty());
+
     // The direct candidate is reset, while removed installer intent is not
     // replayed. Reusing the key creates a new generation which the stale
     // handle cannot remove.
@@ -369,6 +372,10 @@ TEST_CASE("installers: provider leases follow graph plan and runtime lifetimes")
     OperatorProviderHandle provider =
         registry.register_installer("test.leased-provider", &install_leased_provider_probe);
     registry.run_installers();
+
+    const ResolvedOperatorCall selected = registry.resolve("leased_provider_probe", {}, true);
+    CHECK(selected.provider_key() == "test.leased-provider");
+    CHECK(provider.live_leases() == 0);
 
     GraphBuilder graph_builder;
     {


### PR DESCRIPTION
## Summary
- expose the selected keyed installer through a source-compatible, shared-library-exported `ResolvedOperatorCall::provider_key()` accessor
- copy provider identity through native operator selection, typed HIR, and HGraph IR without retaining registry pointers or leases
- document the provenance boundary and keep concrete provider-requirement planning as the next slice

## Validation
- 1,716/1,716 fresh native C++ tests
- stable-ABI wheel built with Python 3.12; 3,240 passed and 10 skipped on Python 3.14
- 32/32 HGL integration tests
- focused provider lifecycle and operator/HGraph IR tests