### PR TITLE
fix(language): stage lexy for offline Conan builds

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -39,9 +39,11 @@ from conan.tools.system.package_manager import (
 
 MINIMUM_RELEASE_VERSION = (0, 8, 0)
 
-# The REPL line editor is the one dependency without a Conan (or Homebrew)
-# package. It is fetched in source() so the CMake configure stays offline;
-# keep the pin in step with language/CMakeLists.txt.
+# The language-only FetchContent dependencies are staged in source() so the
+# CMake configure stays offline. Keep these pins in step with
+# language/CMakeLists.txt and the Homebrew formula.
+LEXY_URL = "https://github.com/foonathan/lexy/archive/refs/tags/v2025.05.0.tar.gz"
+LEXY_SHA256 = "ae867846b890b7564d633cf28d39dfc4938fe7c54515126f720c1762de5eab30"
 ISOCLINE_URL = "https://github.com/daanx/isocline/archive/refs/tags/v1.1.0.tar.gz"
 ISOCLINE_SHA256 = "1e5f0efa2b719c3e1d292f501e5329e141a039deefc801099f8bbb9a50255531"
 
@@ -154,6 +156,8 @@ class HgraphConan(ConanFile):
         cmake_layout(self)
 
     def source(self):
+        get(self, LEXY_URL, sha256=LEXY_SHA256, strip_root=True,
+            destination="lexy")
         get(self, ISOCLINE_URL, sha256=ISOCLINE_SHA256, strip_root=True,
             destination="isocline")
 
@@ -175,6 +179,8 @@ class HgraphConan(ConanFile):
         tc.cache_variables["HGRAPH_ENABLE_COMPILER_CACHE"] = False
         tc.cache_variables["HGRAPH_BUILD_LANGUAGE"] = bool(self.options.language)
         if self.options.language:
+            tc.cache_variables["FETCHCONTENT_SOURCE_DIR_LEXY"] = os.path.join(
+                self.source_folder, "lexy")
             tc.cache_variables["FETCHCONTENT_SOURCE_DIR_ISOCLINE"] = os.path.join(
                 self.source_folder, "isocline")
         tc.generate()

--- a/docs/source/rfc/rfc_0032_native_distribution.rst
+++ b/docs/source/rfc/rfc_0032_native_distribution.rst
@@ -274,8 +274,9 @@ Channels
 ``boost`` (Boost.Math, header-only, for the analytics kernels), ``cmake``
 and ``ninja`` at build time; ``apache-arrow``, ``fmt``,
 ``howard-hinnant-date``, ``simdjson``, ``spdlog`` at run time; ``gcc`` on
-Linux. isocline is a ``resource`` staged into the build directory and
-handed to CMake with ``FETCHCONTENT_SOURCE_DIR_ISOCLINE`` under
+Linux. lexy and isocline are ``resource`` archives staged into the build
+directory and handed to CMake with ``FETCHCONTENT_SOURCE_DIR_LEXY`` and
+``FETCHCONTENT_SOURCE_DIR_ISOCLINE`` under
 ``FETCHCONTENT_FULLY_DISCONNECTED=ON`` (the Homebrew sandbox has no
 network). No formula options. ``packaging/smoke`` is installed as
 ``share/hgraph/smoke``; the ``test do`` block runs ``hgl test`` on its

--- a/language/README.md
+++ b/language/README.md
@@ -59,19 +59,20 @@ cmake --build --preset cpp --target hgl
 ctest --preset cpp -R hgraph_language
 ```
 
-`HGL_ENABLE_LINE_EDITING=OFF` drops the REPL's line editor (isocline, MIT,
-fetched at configure time) and its network fetch; the REPL then reads plain
-lines. `clang-format` is required because formatted C++ is part of every
-`emit-cpp`, scripted, and AOT generation path. Set
+`HGL_ENABLE_LINE_EDITING=OFF` drops the REPL's line editor (isocline, MIT)
+and its fetch; the REPL then reads plain lines. The declarative parser uses
+lexy in every language build. `clang-format` is required because formatted C++
+is part of every `emit-cpp`, scripted, and AOT generation path. Set
 `HGL_CLANG_FORMAT_EXECUTABLE` while configuring to select it and
 `HGL_CLANG_FORMAT` while running `hgl` to override it. Generated code uses the
 repository's `.clang-format` policy, embedded in `hgl` so output does not vary
-with the caller's working directory. A build with no network keeps the editor
-by handing CMake an
-unpacked isocline v1.1.0 source tree:
-`-DFETCHCONTENT_SOURCE_DIR_ISOCLINE=/path/to/isocline
+with the caller's working directory. A build with no network hands CMake
+unpacked lexy v2025.05.0 and isocline v1.1.0 source trees:
+`-DFETCHCONTENT_SOURCE_DIR_LEXY=/path/to/lexy
+-DFETCHCONTENT_SOURCE_DIR_ISOCLINE=/path/to/isocline
 -DFETCHCONTENT_FULLY_DISCONNECTED=ON` (this is what the Homebrew formula in
-`packaging/homebrew/` does). CI builds the toolchain on Linux and macOS
+`packaging/homebrew/` and the language-enabled Conan recipe do). CI builds the
+toolchain on Linux and macOS
 (`.github/workflows/language.yml`); `.github/workflows/packaging.yml`
 builds it the way the package channels do.
 

--- a/language/docs/design/distribution.md
+++ b/language/docs/design/distribution.md
@@ -138,8 +138,10 @@ flags, neither of which the language has yet.
 `simdjson`, `howard-hinnant-date` (built as the tz library over the
 system database, matching the Conan configuration), and `boost` at build
 time only (the analytics kernels use header-only Boost.Math, floor 1.90).
-Isocline is not, and Homebrew's build sandbox has no network, so the
-REPL's line editor is a formula resource handed to FetchContent.
+Lexy and isocline are not, and Homebrew's build sandbox has no network, so the
+declarative parser and REPL line editor are formula resources handed to
+FetchContent. The language-enabled Conan recipe stages the same pinned source
+archives before its offline CMake configure.
 
 The formula itself is kept in this repository as
 `packaging/homebrew/Formula/hgraph.rb`, next to the tap templates that

--- a/python/tests/test_packaging.py
+++ b/python/tests/test_packaging.py
@@ -77,6 +77,20 @@ def test_conan_language_declares_its_formatter_and_current_generated_namespace()
     assert "smoke::ops::twice" not in consumer
 
 
+def test_conan_language_stages_fetchcontent_dependencies_for_offline_configure():
+    conan = (ROOT / "conanfile.py").read_text()
+
+    for dependency, version in {
+        "LEXY": "v2025.05.0",
+        "ISOCLINE": "v1.1.0",
+    }.items():
+        assert f'{dependency}_URL = ' in conan
+        assert version in conan
+        assert f'{dependency}_SHA256 = ' in conan
+        assert f'destination="{dependency.lower()}"' in conan
+        assert f'"FETCHCONTENT_SOURCE_DIR_{dependency}"' in conan
+
+
 def test_nanobind_build_and_sdk_headers_use_one_exact_runtime_abi():
     project = load_project()
 


### PR DESCRIPTION
## Summary
- stage the pinned lexy source archive alongside isocline during Conan source preparation
- pass both unpacked sources to CMake for language-enabled offline configure
- add a packaging contract test and align the offline-build documentation

## Validation
- 1,716/1,716 fresh native C++ tests
- stable-ABI wheel built with Python 3.12; 3,241 passed and 10 skipped on Python 3.14
- 32/32 HGL integration tests
- Sphinx HTML build with warnings as errors
- `conan source` downloaded and verified both pinned archive checksums