### PR TITLE
feat(language): inventory selected operator providers

### DIFF
--- a/language/docs/design/compiler-architecture.md
+++ b/language/docs/design/compiler-architecture.md
@@ -133,9 +133,11 @@ different ranking.
 The adapter performs a schema-only resolution probe and copies data out of the
 result, including the selected keyed provider's stable identity. Registry
 implementation pointers and provider leases do not enter HIR. Hgraph IR keeps
-that copied identity on the nominal call while concrete requirement planning
-remains incomplete; it does not infer provider provenance from a diagnostic
-candidate label.
+that copied identity on the nominal call and collects a sorted, deduplicated
+external-provider requirement inventory from concrete native selections. It
+does not infer provider provenance from a diagnostic candidate label. Checking
+that inventory against the locked target and retaining provider leases belongs
+to execution-plan completion.
 Calls depending on a wiring-time scalar value or on callable erasure retain a
 typed nominal call marked `deferred`; the hgraph-IR pass resolves them at the
 first point where those inputs exist. Multiple source `impl fn` candidates are

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -153,14 +153,17 @@ activation, traversal, assignment, returns, output and capability access, and
 test evaluation. The module is now `Bodies`, not `Executable`. The direct
 backend consumes that form and resolves against the active in-process registry;
 schema-only native selection now copies its keyed provider identity through HIR
-and hgraph IR without retaining a registry object. Concrete requirement
-planning and locked-provider validation are the following slices.
+and hgraph IR without retaining a registry object. Hgraph IR also collects the
+concrete keyed providers selected by non-deferred native operator calls into a
+deterministic requirement inventory. Locked-target validation and provider
+lease planning are the following slices.
 
 - [x] lower composition and runtime semantics into one explicit hgraph IR;
 - [x] represent state, injectables, lifecycle, activation, validity, traversal,
   output, and semantic operator identities;
 - [x] implement `hgl check --dump-hgraph-ir`;
-- [ ] attach concrete provider requirements and advance to `Executable`;
+- [x] attach concrete keyed-provider requirements;
+- [ ] validate the locked provider universe and advance to `Executable`;
 - [x] migrate direct wiring from `ResolvedModule` to hgraph IR, including
   canonical type materialization, lexical activation bindings, composition
   expansion, harness evaluation, entry execution, and driver-prepared settings.

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -195,6 +195,10 @@ the module retains those handles in source order while module and import
 declarations remain frontend-only. Each referenced contract or plan owns its
 source range, so a backend can preserve declaration order and source mapping
 without retaining an HIR declaration ID.
+Concrete native operator selections also contribute their copied keyed
+provider identities to a sorted, deduplicated requirement inventory. Deferred
+calls and source-defined implementation candidates remain explicit operations
+and do not create external-provider requirements.
 Effective fields retain their defining struct identity, while every constraint
 reference uses hgraph-IR type, constant-expression, and requirement IDs rather
 than semantic symbols. Inherited field types and defaults are substituted

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -143,8 +143,11 @@ prove that incomplete or contradictory types never reach hgraph IR.
 Hgraph-IR snapshots now cover composition calls, runtime state and
 initialization, injectables, lifecycle operations, activation and validity
 guards, collection traversal, output effects, and test harnesses. They
-deliberately contain no C++ spellings or direct-wiring runtime objects. The
-remaining executable-plan checkpoint adds concrete provider requirements.
+deliberately contain no C++ spellings or direct-wiring runtime objects. They
+also lock the deterministic keyed-provider requirement inventory produced by
+concrete native operator selections. The remaining executable-plan checkpoint
+validates those requirements against the locked target and plans provider
+leases.
 
 `hgraph_language_backend_architecture` inspects every execution-backend source
 and recursively follows internal includes before rejecting syntax AST/parser or

--- a/language/src/hgraph_ir/ir.h
+++ b/language/src/hgraph_ir/ir.h
@@ -527,6 +527,10 @@ namespace hgl::hgraph_ir
         std::vector<Statement>        statements{};
         std::vector<Block>            blocks{};
         std::vector<TestPlan>         tests{};
+        /// Stable keyed providers selected by concrete native operator calls,
+        /// sorted for deterministic execution planning. Deferred calls and
+        /// source-defined candidates do not contribute an external provider.
+        std::vector<std::string> provider_requirements{};
         /// Execution-facing declarations in original source order. Each
         /// referenced record owns the source range used for diagnostics and
         /// generated-code source mapping.

--- a/language/src/hgraph_ir/lower.cpp
+++ b/language/src/hgraph_ir/lower.cpp
@@ -1,6 +1,7 @@
 #include "hgraph_ir/lower.h"
 
 #include <cstddef>
+#include <set>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -34,6 +35,7 @@ namespace hgl::hgraph_ir
                 lower_operators();
                 lower_callables();
                 lower_tests();
+                collect_provider_requirements();
                 lower_source_order();
                 if (!diagnostics_.has_errors()) { result_.completion = Completion::Bodies; }
                 return std::move(result_);
@@ -668,6 +670,19 @@ namespace hgl::hgraph_ir
                     });
                 }
                 return target;
+            }
+
+            void collect_provider_requirements() {
+                std::set<std::string> requirements;
+                for (const Value &value : result_.values) {
+                    const Operation &operation = value.operation;
+                    if (operation.kind != OperationKind::NominalOperator || operation.candidate.valid() || operation.deferred ||
+                        operation.provider_key.empty()) {
+                        continue;
+                    }
+                    requirements.insert(operation.provider_key);
+                }
+                result_.provider_requirements.assign(requirements.begin(), requirements.end());
             }
 
             [[nodiscard]] std::vector<Argument> lower_arguments(const std::vector<hir::Argument> &source) {

--- a/language/src/hgraph_ir/lower.h
+++ b/language/src/hgraph_ir/lower.h
@@ -7,8 +7,9 @@
 namespace hgl::hgraph_ir
 {
     /// Lower typed HIR into self-contained hgraph contracts and bodies. The
-    /// Bodies checkpoint owns all references and control flow but intentionally
-    /// precedes overload-provider and native execution planning.
+    /// Bodies checkpoint owns all references, control flow, and concrete keyed
+    /// provider requirements selected by native operator calls. It intentionally
+    /// precedes locked-target validation and native execution planning.
     [[nodiscard]] Module lower(const ir::hir::Module &source, syntax::DiagnosticSink &diagnostics);
 }  // namespace hgl::hgraph_ir
 

--- a/language/src/hgraph_ir/printer.cpp
+++ b/language/src/hgraph_ir/printer.cpp
@@ -357,6 +357,12 @@ namespace hgl::hgraph_ir
             print_declaration_ref(out, module.source_order[index]);
         }
         out << "]\n";
+        out << "provider-requirements [";
+        for (std::size_t index = 0; index < module.provider_requirements.size(); ++index) {
+            if (index != 0) { out << ", "; }
+            out << std::quoted(module.provider_requirements[index]);
+        }
+        out << "]\n";
         out << "constant-expressions\n";
         for (std::size_t index = 0; index < module.const_exprs.size(); ++index) {
             const ConstExpr &expression = module.const_exprs[index];

--- a/language/tests/hgraph_ir/lower_tests.cpp
+++ b/language/tests/hgraph_ir/lower_tests.cpp
@@ -27,18 +27,23 @@ namespace
         hgl::syntax::DiagnosticSink           diagnostics{};
         std::optional<hgl::hgraph_ir::Module> graph{};
 
-        explicit Lowered(std::string text, std::string path = "test.hgl") : file{std::move(path), std::move(text)} {
+        explicit Lowered(std::string text, std::string path = "test.hgl")
+            : Lowered{std::move(text),
+                      [](const hir::Module &, const hgl::ir::OperatorQuery &query) {
+                          hgl::ir::OperatorSelection selected;
+                          selected.result   = query.expected_result;
+                          selected.deferred = true;
+                          return selected;
+                      },
+                      std::move(path)} {}
+
+        Lowered(std::string text, hgl::ir::OperatorResolver operators, std::string path = "test.hgl")
+            : file{std::move(path), std::move(text)} {
             hgl::syntax::ast::Module ast = hgl::syntax::parse(file, diagnostics);
             if (diagnostics.has_errors()) { return; }
             hgl::semantics::ResolvedModule resolved = hgl::semantics::resolve(file, ast, has_operator, diagnostics);
             if (diagnostics.has_errors()) { return; }
-            hir::Module                     language  = hgl::ir::lower_to_hir(ast, resolved, diagnostics);
-            const hgl::ir::OperatorResolver operators = [](const hir::Module &, const hgl::ir::OperatorQuery &query) {
-                hgl::ir::OperatorSelection selected;
-                selected.result   = query.expected_result;
-                selected.deferred = true;
-                return selected;
-            };
+            hir::Module language = hgl::ir::lower_to_hir(ast, resolved, diagnostics);
             if (!hgl::ir::complete_hir(language, operators, diagnostics)) { return; }
             graph = hgl::hgraph_ir::lower(language, diagnostics);
         }
@@ -217,6 +222,35 @@ fn adjusted(value: f64) -> f64 => double(value) - 1.0
     CHECK(add->operation.deferred);
 }
 
+TEST_CASE("hgraph IR inventories concrete keyed operator providers deterministically", "[hgraph-ir][providers]") {
+    const hgl::ir::OperatorResolver operators = [](const hir::Module &module, const hgl::ir::OperatorQuery &query) {
+        hgl::ir::OperatorSelection selected;
+        selected.result = query.expected_result;
+        if (!selected.result.valid()) {
+            const hir::Type &argument = module.type(query.arguments.front().type);
+            selected.result           = argument.children.front();
+        }
+        selected.candidate_label = "selected " + query.identity;
+        selected.provider_key    = query.identity == "total" ? "provider.alpha" : "provider.zeta";
+        return selected;
+    };
+    Lowered lowered{R"(
+module checks.providers
+use hgraph.std::{mean, total}
+
+fn combine(values: rolling<f64, 20>) -> f64 => mean(values) + total(values) + mean(values)
+)",
+                    operators};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE_FALSE(lowered.diagnostics.has_errors());
+    REQUIRE(lowered.graph);
+
+    CHECK(lowered.graph->completion == hgl::hgraph_ir::Completion::Bodies);
+    CHECK(lowered.graph->provider_requirements == std::vector<std::string>{"provider.alpha", "provider.zeta"});
+    const std::string printed = hgl::hgraph_ir::print(*lowered.graph);
+    CHECK(printed.find("provider-requirements [\"provider.alpha\", \"provider.zeta\"]") != std::string::npos);
+}
+
 TEST_CASE("hgraph IR bodies preserve lifecycle and capability calls once", "[hgraph-ir][bodies][lifecycle]") {
     Lowered lowered{R"(
 module checks.lifecycle
@@ -334,6 +368,7 @@ fn selected(value: f64) -> f64 => choose(value)
                                            [](const hgl::hgraph_ir::Value &value) { return value.operation.candidate.valid(); });
     REQUIRE(call != lowered.graph->values.end());
     CHECK(call->operation.candidate_identity == implementation.identity);
+    CHECK(lowered.graph->provider_requirements.empty());
 }
 
 TEST_CASE("hgraph IR prints constant-only operation substitutions", "[hgraph-ir][operators][printer]") {

--- a/language/tests/wiring/operator_types_tests.cpp
+++ b/language/tests/wiring/operator_types_tests.cpp
@@ -9,6 +9,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <string>
+#include <vector>
 
 namespace
 {
@@ -55,8 +56,9 @@ fn average(window: rolling<f64, 20>) -> f64 => mean(window)
     }
     CHECK(found);
 
-    const hgl::hgraph_ir::Module graph         = hgl::hgraph_ir::lower(unit.hir, unit.diagnostics);
-    bool                         lowered_found = false;
+    const hgl::hgraph_ir::Module graph = hgl::hgraph_ir::lower(unit.hir, unit.diagnostics);
+    CHECK(graph.provider_requirements == std::vector<std::string>{"hgraph.stdlib"});
+    bool lowered_found = false;
     for (const hgl::hgraph_ir::Value &value : graph.values) {
         if (value.operation.identity != "hgraph.std.mean") { continue; }
         lowered_found = true;


### PR DESCRIPTION
## Summary

- collect copied keyed provider identities from concrete, non-deferred native operator selections into HGraph IR
- keep the requirement inventory sorted and deduplicated while excluding source-defined implementation candidates
- expose the inventory in `--dump-hgraph-ir` and align the compiler architecture, roadmap, and validation guide

This is the first PR in the new post-#715 stack. Locked-target validation and the transition from `Bodies` to `Executable` remain the next isolated slice.

## Validation

- `ctest --test-dir cmake-build-hgl-parser-release -R '^hgraph_language_' --parallel 2 --output-on-failure` (32/32)
- fresh native configure, clean build, and `ctest --preset cpp --parallel 2 --output-on-failure` (1,716/1,716)
- stable-ABI wheel built with Python 3.12, installed into a fresh Python 3.14 environment, then `pytest python/tests -q -m "not wip"` (3,241 passed, 10 skipped)
- `python -m sphinx -W --keep-going -b html docs/source <temporary-directory>`
