### PR TITLE
Language: validate executable provider plans

### DIFF
--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -136,9 +136,10 @@ target_link_libraries(hgl_ir PUBLIC hgl::semantics)
 hgl_apply_warnings(hgl_ir)
 
 # The execution-facing semantic IR (src/hgraph_ir). It owns canonical
-# contracts and structured callable/test bodies; provider planning advances
-# those bodies to an executable plan before either backend migrates here.
+# contracts and structured callable/test bodies. Both backends consume Bodies;
+# provider planning separately validates eligible modules as Executable.
 add_library(hgl_graph_ir STATIC
+    src/hgraph_ir/complete.cpp
     src/hgraph_ir/lower.cpp
     src/hgraph_ir/printer.cpp
 )

--- a/language/docs/design/compiler-architecture.md
+++ b/language/docs/design/compiler-architecture.md
@@ -135,13 +135,17 @@ result, including the selected keyed provider's stable identity. Registry
 implementation pointers and provider leases do not enter HIR. Hgraph IR keeps
 that copied identity on the nominal call and collects a sorted, deduplicated
 external-provider requirement inventory from concrete native selections. It
-does not infer provider provenance from a diagnostic candidate label. Checking
-that inventory against the locked target and retaining provider leases belongs
-to execution-plan completion.
+does not infer provider provenance from a diagnostic candidate label.
+`hgraph_ir::complete_execution` checks that inventory against an explicit,
+closed provider universe supplied by the package target, records the normalized
+universe, and only then advances an eligible module to `Executable`. Native
+provider handles and leases remain registry and wiring-plan concerns; they are
+not stored in either IR.
 Calls depending on a wiring-time scalar value or on callable erasure retain a
-typed nominal call marked `deferred`; the hgraph-IR pass resolves them at the
-first point where those inputs exist. Multiple source `impl fn` candidates are
-also left to the same hgraph ranking contract.
+typed nominal call marked `deferred`; execution completion rejects them until a
+later operator-planning pass resolves them at the first point where those
+inputs exist. Multiple source `impl fn` candidates are also left to the same
+hgraph ranking contract.
 
 Generic unification and application live in `src/ir/generic_substitution`.
 Constraint inference and admission live in `src/ir/constraint_solver`; that
@@ -184,7 +188,8 @@ It distinguishes:
 - activation, validity admission, and residual guards;
 - borrowed collection traversal;
 - terminating returns and explicit output mutation;
-- provider identities and leases required by imported native code.
+- keyed provider requirements and the locked provider universe selected for an
+  executable module.
 
 Both execution backends consume this representation. Neither backend may
 include syntax AST headers or redo name lookup, type inference, function
@@ -195,7 +200,12 @@ and compiler diagnosis. The interface checkpoint owns all type, constant,
 constraint, struct, operator, and callable references in hgraph-IR arenas. The
 body checkpoint owns bindings, values, semantic operations, substitutions,
 statements, blocks, and test plans, with no HIR IDs remaining. Execution-plan
-lowering may not recover either contracts or bodies from HIR declarations.
+completion validates every non-folded nominal operation: it must name a valid
+source implementation or a keyed native provider in the locked universe, and
+it must not remain deferred. The pass also checks that the deterministic
+requirement inventory still agrees with the operations before storing the
+provider plan. It may not recover either contracts or bodies from HIR
+declarations.
 
 ### Backends
 

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -155,15 +155,21 @@ backend consumes that form and resolves against the active in-process registry;
 schema-only native selection now copies its keyed provider identity through HIR
 and hgraph IR without retaining a registry object. Hgraph IR also collects the
 concrete keyed providers selected by non-deferred native operator calls into a
-deterministic requirement inventory. Locked-target validation and provider
-lease planning are the following slices.
+deterministic requirement inventory. An explicit execution-completion pass now
+normalizes the package target's closed provider universe, rejects deferred or
+unkeyed external operations and missing providers, verifies the inventory, and
+advances successful modules to `Executable`. It stores only provider keys;
+native provider handles and leases remain owned by hgraph registry resolution
+and wiring plans. The driver does not invoke this pass until deferred operator
+planning is implemented.
 
 - [x] lower composition and runtime semantics into one explicit hgraph IR;
 - [x] represent state, injectables, lifecycle, activation, validity, traversal,
   output, and semantic operator identities;
 - [x] implement `hgl check --dump-hgraph-ir`;
 - [x] attach concrete keyed-provider requirements;
-- [ ] validate the locked provider universe and advance to `Executable`;
+- [x] validate the locked provider universe and advance eligible modules to
+  `Executable`;
 - [x] migrate direct wiring from `ResolvedModule` to hgraph IR, including
   canonical type materialization, lexical activation bindings, composition
   expansion, harness evaluation, entry execution, and driver-prepared settings.

--- a/language/docs/developer-guide/README.md
+++ b/language/docs/developer-guide/README.md
@@ -18,9 +18,11 @@ for hgraph, not a second runtime.
 > failed module explicitly `Resolved` rather than claiming `Typed` completion.
 > `src/hgraph_ir/` lowers typed HIR into independently owned canonical types,
 > compile-time expressions, nominal contracts, callable interfaces, bindings,
-> values, semantic operations, structured control flow, and test plans. The
-> module is explicitly at the `Bodies` checkpoint; provider planning and
-> backend migration are the next stacked changes.
+> values, semantic operations, structured control flow, and test plans. An
+> explicit completion pass validates concrete operations against a closed
+> keyed-provider universe and advances eligible modules from `Bodies` to
+> `Executable`; the driver remains on `Bodies` until deferred operator
+> planning is available.
 > `src/wiring/` executes the composition subset for `test`, `run`, and the
 > REPL, including scalar and atomic struct values, type-only generic
 > specializations, and field-wise temporal struct composition. `src/codegen/`

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -207,9 +207,23 @@ scope even when parent parameters have different names. `hgl check
 --dump-hgraph-ir` prints that representation. The
 result is marked `Bodies`. No HIR symbol, expression, statement, block, or
 declaration ID remains in it. The direct evaluator can consume this form and
-perform in-process registry resolution while it wires. Locked provider
-selection and native execution planning are still required before a portable
-module may be marked `Executable`.
+perform in-process registry resolution while it wires.
+
+`src/hgraph_ir/complete` is the explicit `Bodies` to `Executable` boundary. Its
+`ProviderPlan` input is the complete keyed-provider universe selected by the
+locked package target, not the set of imported names. The pass sorts and
+deduplicates that universe, then requires every non-folded nominal operation to
+have either a valid source `impl fn` candidate or a keyed native provider in
+the universe. Deferred calls, unkeyed external registrations, missing
+providers, invalid source-candidate handles, and an inconsistent requirement
+inventory fail closed and leave the module at `Bodies`. On success the module
+owns the normalized data-only provider plan and is marked `Executable`.
+Provider handles, candidate pointers, and leases never enter hgraph IR; native
+wiring resolution retains the actual provider lease. Candidate fingerprints
+and validating that loaded native descriptors match a package lock remain part
+of the native-interface stage. The driver continues to consume `Bodies` until
+the earlier operator-planning pass can eliminate the intentionally deferred
+calls in real programs.
 
 The direct-wiring and Stage E C++ backends now consume only hgraph IR. They use
 graph-IR module paths, callable identities, visibility and classification,

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -145,9 +145,12 @@ initialization, injectables, lifecycle operations, activation and validity
 guards, collection traversal, output effects, and test harnesses. They
 deliberately contain no C++ spellings or direct-wiring runtime objects. They
 also lock the deterministic keyed-provider requirement inventory produced by
-concrete native operator selections. The remaining executable-plan checkpoint
-validates those requirements against the locked target and plans provider
-leases.
+concrete native operator selections. Execution-completion tests independently
+prove normalization of a closed provider universe, successful advancement to
+`Executable`, and fail-closed diagnostics for missing, empty, deferred,
+unkeyed, stale, or invalid provider/candidate data. Those tests use data-only
+keys: provider-handle activation, candidate fingerprints, and lease retention
+remain native registry and installed-SDK coverage.
 
 `hgraph_language_backend_architecture` inspects every execution-backend source
 and recursively follows internal includes before rejecting syntax AST/parser or

--- a/language/src/hgraph_ir/complete.cpp
+++ b/language/src/hgraph_ir/complete.cpp
@@ -53,17 +53,18 @@ namespace hgl::hgraph_ir
                     const Operation &operation = value.operation;
                     if (operation.kind != OperationKind::NominalOperator) { continue; }
 
+                    // Constant-folded language operators do not execute and
+                    // therefore need neither a source candidate nor a native
+                    // provider at runtime. Folding also makes any pre-fold
+                    // deferred marker irrelevant to the executable plan.
+                    if (value.constant) { continue; }
+
                     const std::string name = operation_name(operation);
                     if (operation.deferred) {
                         diagnostics_.report(syntax::Category::Operator, value.range,
                                             "operator '" + name + "' remains deferred and cannot enter an executable plan");
                         continue;
                     }
-
-                    // Constant-folded language operators do not execute and
-                    // therefore need neither a source candidate nor a native
-                    // provider at runtime.
-                    if (value.constant) { continue; }
 
                     if (operation.candidate.valid()) {
                         if (operation.candidate.value >= module_.callables.size()) {
@@ -75,8 +76,7 @@ namespace hgl::hgraph_ir
                         if (candidate.visibility != CallableVisibility::Implementation ||
                             candidate.operator_identity != operation.identity) {
                             diagnostics_.report(syntax::Category::Build, value.range,
-                                                "operator '" + name +
-                                                    "' refers to a callable that is not its implementation");
+                                                "operator '" + name + "' refers to a callable that is not its implementation");
                         }
                         continue;
                     }

--- a/language/src/hgraph_ir/complete.cpp
+++ b/language/src/hgraph_ir/complete.cpp
@@ -1,0 +1,117 @@
+#include "hgraph_ir/complete.h"
+
+#include <algorithm>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace hgl::hgraph_ir
+{
+    namespace
+    {
+        [[nodiscard]] std::string operation_name(const Operation &operation) {
+            if (!operation.identity.empty()) { return operation.identity; }
+            if (!operation.registry_name.empty()) { return operation.registry_name; }
+            return "<unnamed>";
+        }
+
+        class ExecutionCompleter
+        {
+          public:
+            ExecutionCompleter(Module &module, ProviderPlan providers, syntax::DiagnosticSink &diagnostics)
+                : module_{module}, providers_{std::move(providers)}, diagnostics_{diagnostics} {}
+
+            [[nodiscard]] bool run() {
+                if (module_.completion != Completion::Bodies) {
+                    diagnostics_.report(syntax::Category::Build, {}, "execution completion requires hgraph IR bodies");
+                    return false;
+                }
+
+                normalize_provider_universe();
+                validate_operations();
+                validate_requirement_inventory();
+                if (diagnostics_.has_errors()) { return false; }
+
+                module_.provider_plan = std::move(providers_);
+                module_.completion    = Completion::Executable;
+                return true;
+            }
+
+          private:
+            void normalize_provider_universe() {
+                auto &universe = providers_.universe;
+                if (std::ranges::any_of(universe, [](const std::string &key) { return key.empty(); })) {
+                    diagnostics_.report(syntax::Category::Build, {}, "the locked provider universe contains an empty provider key");
+                }
+                std::ranges::sort(universe);
+                universe.erase(std::unique(universe.begin(), universe.end()), universe.end());
+            }
+
+            void validate_operations() {
+                for (const Value &value : module_.values) {
+                    const Operation &operation = value.operation;
+                    if (operation.kind != OperationKind::NominalOperator) { continue; }
+
+                    const std::string name = operation_name(operation);
+                    if (operation.deferred) {
+                        diagnostics_.report(syntax::Category::Operator, value.range,
+                                            "operator '" + name + "' remains deferred and cannot enter an executable plan");
+                        continue;
+                    }
+
+                    // Constant-folded language operators do not execute and
+                    // therefore need neither a source candidate nor a native
+                    // provider at runtime.
+                    if (value.constant) { continue; }
+
+                    if (operation.candidate.valid()) {
+                        if (operation.candidate.value >= module_.callables.size()) {
+                            diagnostics_.report(syntax::Category::Build, value.range,
+                                                "operator '" + name + "' refers to an invalid source implementation");
+                            continue;
+                        }
+                        const Callable &candidate = module_.callables[operation.candidate.value];
+                        if (candidate.visibility != CallableVisibility::Implementation ||
+                            candidate.operator_identity != operation.identity) {
+                            diagnostics_.report(syntax::Category::Build, value.range,
+                                                "operator '" + name +
+                                                    "' refers to a callable that is not its implementation");
+                        }
+                        continue;
+                    }
+
+                    if (operation.provider_key.empty()) {
+                        diagnostics_.report(syntax::Category::Operator, value.range,
+                                            "operator '" + name + "' has no keyed provider identity for executable planning");
+                        continue;
+                    }
+
+                    requirements_.insert(operation.provider_key);
+                    if (!std::ranges::binary_search(providers_.universe, operation.provider_key)) {
+                        diagnostics_.report(syntax::Category::Build, value.range,
+                                            "operator '" + name + "' requires provider '" + operation.provider_key +
+                                                "', which is absent from the locked provider universe");
+                    }
+                }
+            }
+
+            void validate_requirement_inventory() {
+                const std::vector<std::string> actual{requirements_.begin(), requirements_.end()};
+                if (module_.provider_requirements != actual) {
+                    diagnostics_.report(syntax::Category::Build, {},
+                                        "the hgraph IR provider requirement inventory is inconsistent with its operations");
+                }
+            }
+
+            Module                 &module_;
+            ProviderPlan            providers_;
+            syntax::DiagnosticSink &diagnostics_;
+            std::set<std::string>   requirements_{};
+        };
+    }  // namespace
+
+    bool complete_execution(Module &module, ProviderPlan providers, syntax::DiagnosticSink &diagnostics) {
+        return ExecutionCompleter{module, std::move(providers), diagnostics}.run();
+    }
+}  // namespace hgl::hgraph_ir

--- a/language/src/hgraph_ir/complete.h
+++ b/language/src/hgraph_ir/complete.h
@@ -1,0 +1,16 @@
+#ifndef HGL_HGRAPH_IR_COMPLETE_H
+#define HGL_HGRAPH_IR_COMPLETE_H
+
+#include "hgraph_ir/ir.h"
+#include "syntax/diagnostic.h"
+
+namespace hgl::hgraph_ir
+{
+    /// Validate that every executable nominal operation has a concrete source
+    /// implementation or a keyed native provider in the locked package target.
+    /// On success the normalized provider plan is retained and the module
+    /// advances from Bodies to Executable.
+    [[nodiscard]] bool complete_execution(Module &module, ProviderPlan providers, syntax::DiagnosticSink &diagnostics);
+}  // namespace hgl::hgraph_ir
+
+#endif  // HGL_HGRAPH_IR_COMPLETE_H

--- a/language/src/hgraph_ir/ir.h
+++ b/language/src/hgraph_ir/ir.h
@@ -512,6 +512,17 @@ namespace hgl::hgraph_ir
         Executable,
     };
 
+    /// The closed keyed-provider universe selected by the package target.
+    /// Keys are normalized into lexical order by execution completion. This
+    /// is data-only planning: native handles and provider leases remain owned
+    /// by the hgraph registry and wiring plan.
+    struct ProviderPlan
+    {
+        std::vector<std::string> universe{};
+
+        friend bool operator==(const ProviderPlan &, const ProviderPlan &) = default;
+    };
+
     struct Module
     {
         std::string                   path{};
@@ -531,6 +542,9 @@ namespace hgl::hgraph_ir
         /// sorted for deterministic execution planning. Deferred calls and
         /// source-defined candidates do not contribute an external provider.
         std::vector<std::string> provider_requirements{};
+        /// Present only after the requirements above have been validated
+        /// against an explicit closed provider universe.
+        std::optional<ProviderPlan> provider_plan{};
         /// Execution-facing declarations in original source order. Each
         /// referenced record owns the source range used for diagnostics and
         /// generated-code source mapping.

--- a/language/src/hgraph_ir/printer.cpp
+++ b/language/src/hgraph_ir/printer.cpp
@@ -363,6 +363,14 @@ namespace hgl::hgraph_ir
             out << std::quoted(module.provider_requirements[index]);
         }
         out << "]\n";
+        if (module.provider_plan) {
+            out << "provider-universe [";
+            for (std::size_t index = 0; index < module.provider_plan->universe.size(); ++index) {
+                if (index != 0) { out << ", "; }
+                out << std::quoted(module.provider_plan->universe[index]);
+            }
+            out << "]\n";
+        }
         out << "constant-expressions\n";
         for (std::size_t index = 0; index < module.const_exprs.size(); ++index) {
             const ConstExpr &expression = module.const_exprs[index];

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -111,7 +111,10 @@ hgl_apply_warnings(hgl_ir_tests)
 add_test(NAME hgraph_language_ir COMMAND hgl_ir_tests)
 
 # The hgraph-IR boundary owns self-contained canonical contracts and bodies.
-add_executable(hgl_graph_ir_tests hgraph_ir/lower_tests.cpp)
+add_executable(hgl_graph_ir_tests
+    hgraph_ir/complete_tests.cpp
+    hgraph_ir/lower_tests.cpp
+)
 target_compile_features(hgl_graph_ir_tests PRIVATE cxx_std_23)
 target_link_libraries(hgl_graph_ir_tests PRIVATE hgl::graph_ir Catch2::Catch2WithMain)
 target_compile_definitions(hgl_graph_ir_tests PRIVATE HGL_EXAMPLES_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../examples")

--- a/language/tests/hgraph_ir/complete_tests.cpp
+++ b/language/tests/hgraph_ir/complete_tests.cpp
@@ -87,6 +87,7 @@ TEST_CASE("execution completion accepts source implementations and folded consta
 
     hgl::hgraph_ir::Value folded = native_call("add", {});
     folded.constant              = hgl::ir::hir::Constant{std::int64_t{3}};
+    folded.operation.deferred    = true;
     module.values.push_back(std::move(folded));
 
     hgl::syntax::DiagnosticSink diagnostics;

--- a/language/tests/hgraph_ir/complete_tests.cpp
+++ b/language/tests/hgraph_ir/complete_tests.cpp
@@ -1,0 +1,150 @@
+#include "hgraph_ir/complete.h"
+#include "hgraph_ir/printer.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace
+{
+    hgl::hgraph_ir::Value native_call(std::string name, std::string provider, std::uint32_t begin = 0) {
+        hgl::hgraph_ir::Value value;
+        value.range                  = {begin, begin + 1};
+        value.operation.kind         = hgl::hgraph_ir::OperationKind::NominalOperator;
+        value.operation.identity     = std::move(name);
+        value.operation.provider_key = std::move(provider);
+        value.operation.deferred     = false;
+        return value;
+    }
+}  // namespace
+
+TEST_CASE("execution completion locks a normalized provider universe", "[hgraph-ir][providers][completion]") {
+    hgl::hgraph_ir::Module module;
+    module.path                  = "checks.executable";
+    module.completion            = hgl::hgraph_ir::Completion::Bodies;
+    module.provider_requirements = {"provider.alpha", "provider.zeta"};
+    module.values.push_back(native_call("mean", "provider.zeta"));
+    module.values.push_back(native_call("total", "provider.alpha"));
+    module.values.push_back(native_call("mean", "provider.zeta"));
+
+    hgl::syntax::DiagnosticSink diagnostics;
+    CHECK(hgl::hgraph_ir::complete_execution(
+        module, hgl::hgraph_ir::ProviderPlan{{"provider.zeta", "provider.unused", "provider.alpha", "provider.alpha"}},
+        diagnostics));
+    CHECK_FALSE(diagnostics.has_errors());
+    CHECK(module.completion == hgl::hgraph_ir::Completion::Executable);
+    REQUIRE(module.provider_plan);
+    CHECK(module.provider_plan->universe == std::vector<std::string>{"provider.alpha", "provider.unused", "provider.zeta"});
+    CHECK(hgl::hgraph_ir::print(module).find("provider-universe [\"provider.alpha\", \"provider.unused\", \"provider.zeta\"]") !=
+          std::string::npos);
+}
+
+TEST_CASE("execution completion rejects providers outside the locked universe", "[hgraph-ir][providers][completion]") {
+    hgl::hgraph_ir::Module module;
+    module.completion            = hgl::hgraph_ir::Completion::Bodies;
+    module.provider_requirements = {"provider.alpha"};
+    module.values.push_back(native_call("total", "provider.alpha", 12));
+
+    hgl::syntax::DiagnosticSink diagnostics;
+    CHECK_FALSE(hgl::hgraph_ir::complete_execution(module, hgl::hgraph_ir::ProviderPlan{{"provider.zeta"}}, diagnostics));
+    REQUIRE(diagnostics.size() == 1);
+    CHECK(diagnostics.diagnostics().front().category == hgl::syntax::Category::Build);
+    CHECK(diagnostics.diagnostics().front().range.begin == 12);
+    CHECK(diagnostics.diagnostics().front().message.find("provider.alpha") != std::string::npos);
+    CHECK(module.completion == hgl::hgraph_ir::Completion::Bodies);
+    CHECK_FALSE(module.provider_plan);
+}
+
+TEST_CASE("execution completion rejects deferred and unkeyed operator calls", "[hgraph-ir][providers][completion]") {
+    hgl::hgraph_ir::Module module;
+    module.completion = hgl::hgraph_ir::Completion::Bodies;
+    module.values.push_back(native_call("map", {}));
+    module.values.push_back(native_call("add", "provider.alpha"));
+    module.values.back().operation.deferred = true;
+
+    hgl::syntax::DiagnosticSink diagnostics;
+    CHECK_FALSE(hgl::hgraph_ir::complete_execution(module, {}, diagnostics));
+    REQUIRE(diagnostics.size() == 2);
+    CHECK(diagnostics.diagnostics()[0].category == hgl::syntax::Category::Operator);
+    CHECK(diagnostics.diagnostics()[0].message.find("no keyed provider") != std::string::npos);
+    CHECK(diagnostics.diagnostics()[1].category == hgl::syntax::Category::Operator);
+    CHECK(diagnostics.diagnostics()[1].message.find("remains deferred") != std::string::npos);
+}
+
+TEST_CASE("execution completion accepts source implementations and folded constants", "[hgraph-ir][providers][completion]") {
+    hgl::hgraph_ir::Module module;
+    module.completion = hgl::hgraph_ir::Completion::Bodies;
+    module.callables.emplace_back();
+    module.callables.back().visibility        = hgl::hgraph_ir::CallableVisibility::Implementation;
+    module.callables.back().operator_identity = "checks.local.choose";
+
+    hgl::hgraph_ir::Value source = native_call("checks.local.choose", {});
+    source.operation.candidate   = hgl::hgraph_ir::CallableId{0};
+    module.values.push_back(std::move(source));
+
+    hgl::hgraph_ir::Value folded = native_call("add", {});
+    folded.constant              = hgl::ir::hir::Constant{std::int64_t{3}};
+    module.values.push_back(std::move(folded));
+
+    hgl::syntax::DiagnosticSink diagnostics;
+    CHECK(hgl::hgraph_ir::complete_execution(module, {}, diagnostics));
+    CHECK_FALSE(diagnostics.has_errors());
+    CHECK(module.completion == hgl::hgraph_ir::Completion::Executable);
+}
+
+TEST_CASE("execution completion validates its input and requirement inventory", "[hgraph-ir][providers][completion]") {
+    SECTION("requires bodies") {
+        hgl::hgraph_ir::Module      module;
+        hgl::syntax::DiagnosticSink diagnostics;
+        CHECK_FALSE(hgl::hgraph_ir::complete_execution(module, {}, diagnostics));
+        REQUIRE(diagnostics.size() == 1);
+        CHECK(diagnostics.diagnostics().front().message == "execution completion requires hgraph IR bodies");
+    }
+
+    SECTION("rejects empty provider keys") {
+        hgl::hgraph_ir::Module module;
+        module.completion = hgl::hgraph_ir::Completion::Bodies;
+        hgl::syntax::DiagnosticSink diagnostics;
+        CHECK_FALSE(hgl::hgraph_ir::complete_execution(module, hgl::hgraph_ir::ProviderPlan{{""}}, diagnostics));
+        REQUIRE(diagnostics.size() == 1);
+        CHECK(diagnostics.diagnostics().front().message.find("empty provider key") != std::string::npos);
+    }
+
+    SECTION("rejects a stale inventory") {
+        hgl::hgraph_ir::Module module;
+        module.completion            = hgl::hgraph_ir::Completion::Bodies;
+        module.provider_requirements = {"provider.stale"};
+        hgl::syntax::DiagnosticSink diagnostics;
+        CHECK_FALSE(hgl::hgraph_ir::complete_execution(module, {}, diagnostics));
+        REQUIRE(diagnostics.size() == 1);
+        CHECK(diagnostics.diagnostics().front().message.find("inventory is inconsistent") != std::string::npos);
+    }
+
+    SECTION("rejects an invalid source implementation") {
+        hgl::hgraph_ir::Module module;
+        module.completion            = hgl::hgraph_ir::Completion::Bodies;
+        hgl::hgraph_ir::Value source = native_call("checks.local.choose", {});
+        source.operation.candidate   = hgl::hgraph_ir::CallableId{4};
+        module.values.push_back(std::move(source));
+        hgl::syntax::DiagnosticSink diagnostics;
+        CHECK_FALSE(hgl::hgraph_ir::complete_execution(module, {}, diagnostics));
+        REQUIRE(diagnostics.size() == 1);
+        CHECK(diagnostics.diagnostics().front().message.find("invalid source implementation") != std::string::npos);
+    }
+
+    SECTION("rejects an unrelated source callable") {
+        hgl::hgraph_ir::Module module;
+        module.completion = hgl::hgraph_ir::Completion::Bodies;
+        module.callables.emplace_back();
+        hgl::hgraph_ir::Value source = native_call("checks.local.choose", {});
+        source.operation.candidate   = hgl::hgraph_ir::CallableId{0};
+        module.values.push_back(std::move(source));
+        hgl::syntax::DiagnosticSink diagnostics;
+        CHECK_FALSE(hgl::hgraph_ir::complete_execution(module, {}, diagnostics));
+        REQUIRE(diagnostics.size() == 1);
+        CHECK(diagnostics.diagnostics().front().message.find("not its implementation") != std::string::npos);
+    }
+}

--- a/language/tests/hgraph_ir/lower_tests.cpp
+++ b/language/tests/hgraph_ir/lower_tests.cpp
@@ -1,3 +1,4 @@
+#include "hgraph_ir/complete.h"
 #include "hgraph_ir/lower.h"
 #include "hgraph_ir/printer.h"
 #include "ir/lower.h"
@@ -249,6 +250,33 @@ fn combine(values: rolling<f64, 20>) -> f64 => mean(values) + total(values) + me
     CHECK(lowered.graph->provider_requirements == std::vector<std::string>{"provider.alpha", "provider.zeta"});
     const std::string printed = hgl::hgraph_ir::print(*lowered.graph);
     CHECK(printed.find("provider-requirements [\"provider.alpha\", \"provider.zeta\"]") != std::string::npos);
+}
+
+TEST_CASE("lowered hgraph IR completes against its locked provider universe", "[hgraph-ir][providers][completion]") {
+    const hgl::ir::OperatorResolver operators = [](const hir::Module &, const hgl::ir::OperatorQuery &query) {
+        return hgl::ir::OperatorSelection{
+            .candidate_label = "selected " + query.identity,
+            .provider_key    = "provider.analytics",
+            .result          = query.expected_result,
+        };
+    };
+    Lowered lowered{R"(
+module checks.provider_completion
+use hgraph.std::{mean}
+
+fn average(values: rolling<f64, 20>) -> f64 => mean(values)
+)",
+                    operators};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE_FALSE(lowered.diagnostics.has_errors());
+    REQUIRE(lowered.graph);
+
+    CHECK(hgl::hgraph_ir::complete_execution(
+        *lowered.graph, hgl::hgraph_ir::ProviderPlan{{"provider.analytics", "provider.unused"}}, lowered.diagnostics));
+    INFO(lowered.diagnostics.render(lowered.file));
+    CHECK_FALSE(lowered.diagnostics.has_errors());
+    CHECK(lowered.graph->completion == hgl::hgraph_ir::Completion::Executable);
+    CHECK(lowered.graph->provider_plan == hgl::hgraph_ir::ProviderPlan{{"provider.analytics", "provider.unused"}});
 }
 
 TEST_CASE("hgraph IR bodies preserve lifecycle and capability calls once", "[hgraph-ir][bodies][lifecycle]") {


### PR DESCRIPTION
## Summary

- add an explicit hgraph-IR `Bodies` to `Executable` completion pass
- validate concrete operator calls against a normalized closed keyed-provider universe
- reject deferred, unkeyed, missing-provider, stale-inventory, and invalid source-candidate plans without mutating completion
- retain only the data-only provider plan in hgraph IR; native handles and leases stay in registry/wiring ownership
- split provider-completion coverage into its own Catch2 translation unit and update the architecture, roadmap, and developer guide

This is stacked on #716. The driver intentionally remains on `Bodies` until deferred operator planning is implemented; candidate fingerprints and loaded-descriptor consistency remain Stage F work.

## Validation

- `cmake --build cmake-build-hgl-lexy --target hgl_graph_ir_tests -j 8`
- `cmake-build-hgl-lexy/language/tests/hgl_graph_ir_tests --reporter compact` (336 assertions, 23 test cases)
- `ctest --test-dir cmake-build-hgl-lexy -R '^hgraph_language_' --parallel 8 --output-on-failure` (32/32)
- `cmake --preset cpp --fresh`
- `cmake --build --preset cpp --target clean`
- `cmake --build --preset cpp --parallel`
- `ctest --preset cpp --parallel 2 --output-on-failure` (1,716/1,716)
- Python 3.12 stable-ABI wheel installed into a fresh Python 3.14 environment; `python/tests -q -m 'not wip'` (3,241 passed, 10 skipped)
- `python -m sphinx -W --keep-going -b html docs/source <temp>`
