### PR TITLE
Language: describe canonical module interfaces

### DIFF
--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -155,6 +155,7 @@ hgl_apply_warnings(hgl_graph_ir)
 # descriptor-only checking.
 add_library(hgl_descriptor STATIC
     src/descriptor/module_descriptor.cpp
+    src/descriptor/module_descriptor_json.cpp
 )
 add_library(hgl::descriptor ALIAS hgl_descriptor)
 target_compile_features(hgl_descriptor PUBLIC cxx_std_23)

--- a/language/docs/design/decisions/0004-json-module-descriptors.md
+++ b/language/docs/design/decisions/0004-json-module-descriptors.md
@@ -1,6 +1,6 @@
 # ADR 0004: Module descriptors use canonical versioned JSON
 
-Status: accepted; reader and complete interface schema pending
+Status: accepted; writer implemented, reader and native ABI metadata pending
 
 ## Context
 
@@ -9,9 +9,9 @@ authors can review, build tools can transport, and `hgl check` can eventually
 consume without loading executable code. The representation must not depend on
 C++ object layout, compiler ABI, parser internals, or a running hgraph registry.
 
-The first producer is the HGL C++ backend itself. It needs to establish the
-envelope and package inventories before the following slices add complete type,
-constraint, lifecycle, and fingerprint records.
+The first producer is the HGL C++ backend itself. The descriptor must carry
+enough structured source interface data for a later reader to check imports
+without reparsing HGL or loading executable code.
 
 ## Decision
 
@@ -20,17 +20,37 @@ Use UTF-8 JSON with the format identity `hgl.module` and an integer
 
 - module identity and HGL release version;
 - automatically public operators, exported structures, and exported functions;
+- generic and ordinary parameters, results, default values, struct parents and
+  effective fields;
+- canonical type, compile-time-expression, and constraint records reachable
+  from those public declarations and implementation candidates;
 - implementation-to-operator bindings and required provider identities;
 - generated public headers, known CMake packages and imported targets; and
 - the generated C++ registration symbol.
 
 The canonical emitter uses a fixed object-member order, lexically sorts and
-deduplicates set-like arrays, escapes every JSON control character, and writes
-one trailing line feed. A reader must treat object-member order and insignificant
+deduplicates set-like identity and build inventories, preserves semantic operand
+order inside expressions, escapes every JSON control character, and writes one
+trailing line feed. A reader must treat object-member order and insignificant
 whitespace as irrelevant, reject duplicate members and unsupported format
 versions, and ignore unknown members within a supported version. Adding an
 optional member is compatible; changing or removing existing meaning requires a
 new `format_version`.
+
+Declarations and candidates refer into three descriptor-local schema arenas:
+`types`, `constant_expressions`, and `constraints`. Records are assigned by
+visiting exported structures, local operators, exported functions, and provider
+implementations in that order, with each group ordered by stable identity.
+References are unsigned JSON integers and a missing optional reference is
+`null`; record IDs have no meaning outside their descriptor. Generic type and
+const parameters also retain a declaration-scoped binding identity, so repeated
+names from different contracts never alias.
+
+Integer and floating-point literal payloads are tagged strings. This preserves
+the full i64 range and HGL's `inf`, `-inf`, and `nan` values without depending on
+a JSON consumer's numeric range or its handling of non-standard JSON tokens.
+Booleans remain JSON booleans, strings remain strings, and temporal values use
+their canonical HGL spelling together with their temporal kind.
 
 Descriptor fingerprints will be computed over the canonical semantic form, not
 over arbitrary input whitespace. The fingerprint field itself is excluded from
@@ -49,9 +69,10 @@ install or aggregate it deliberately.
   formatting, registry access, and dynamic loading.
 - Scripted compilation and AOT generation retain the identical descriptor
   bytes with their other build artifacts.
-- The initial file is not yet sufficient for descriptor-only type checking;
-  signatures, constraints, ownership/effects, lifecycle ABI, and fingerprints
-  remain explicit Stage F work.
+- The file now contains structured HGL signatures, struct layouts, defaults,
+  generic bindings, and constraints. Descriptor reading, dependency closure,
+  phase/effect/ownership policy, lifecycle ABI, and fingerprints remain
+  explicit Stage F work before descriptor-only checking is complete.
 
 ## Alternatives
 

--- a/language/docs/design/native-interface.md
+++ b/language/docs/design/native-interface.md
@@ -1,6 +1,6 @@
 # Native interface
 
-Status: accepted boundary; JSON envelope implemented, complete schema and ABI remain
+Status: accepted boundary; HGL interface schema implemented, native metadata and ABI remain
 
 ## Purpose
 
@@ -53,10 +53,12 @@ For every exposed native declaration the descriptor records:
 
 The serialized representation is the canonical, versioned JSON selected in
 [ADR 0004](decisions/0004-json-module-descriptors.md). The current compiler
-emits its envelope, public/provider inventories, and generated build metadata;
-complete signatures, constraints, phase/effect/ownership policy, lifecycle ABI,
-and fingerprints remain to be added. The native-package authoring API is not yet
-chosen. No HGL declaration syntax is implied by this list.
+emits its envelope, public/provider inventories, structured HGL signatures,
+struct layouts, defaults, canonical types and constraints, and generated build
+metadata. Descriptor reading and dependency closure,
+phase/effect/ownership policy, lifecycle ABI, and fingerprints remain to be
+added. The native-package authoring API is not yet chosen. No HGL declaration
+syntax is implied by this list.
 
 ## Native declaration categories
 

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -228,6 +228,8 @@ HGraph IR; unsupported language-depth items remain explicit roadmap work.
 ### F. Constrained native interface
 
 - [x] choose and version a reviewable descriptor representation;
+- [x] emit structured public/provider signatures, struct layouts, defaults,
+  canonical types, and generic constraints;
 - choose and version the lifecycle ABI;
 - provide a native-package authoring API which emits descriptors and normalized
   wrappers;

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -1011,11 +1011,23 @@ registry, loader, or C++ formatter dependency. `hgl emit-cpp` writes
 `<stem>.hgl-module.json` beside the generated source, and scripted native builds
 retain the same bytes in their content-addressed artifacts.
 
-Version 1 currently materializes the module/version envelope, public declaration
-identities and categories, implementation/provider inventories, baseline build
-requirements, and the generated registration symbol. This is a staging
-checkpoint, not descriptor-only checking: canonical signature and constraint
-records, effect/ownership policy, lifecycle entry points, and fingerprints are
+Version 1 materializes the module/version envelope, public declarations,
+implementation/provider inventories, baseline build requirements, and the
+generated registration symbol. Public structures, operators, functions, and
+implementation candidates reference structured signatures and three
+descriptor-local arenas for canonical types, compile-time expressions, and
+constraints. Only records reachable from those surfaces are retained; private
+body types do not leak into the package interface.
+
+Record IDs are assigned by a fixed traversal of declarations ordered by stable
+identity and are meaningful only inside that descriptor. A symbol type carries
+both its nominal spelling and, for a generic parameter, its declaration-scoped
+binding identity. Defaults and const-generic bounds remain expression trees,
+not strings to be reparsed. Tagged textual i64/f64 payloads retain the full i64
+range and non-finite HGL floats while keeping the output valid JSON.
+
+This is still not descriptor-only checking: a reader and locked dependency
+closure, effect/ownership policy, lifecycle entry points, and fingerprints are
 the following Stage F slices.
 
 A descriptor separates its importable interface from its provider inventory.

--- a/language/docs/user-guide/modules-and-tools.md
+++ b/language/docs/user-guide/modules-and-tools.md
@@ -258,13 +258,52 @@ generated `operators` namespace contains transparent type aliases rather than
 derived marker classes, so the registry contract visible in the source is the
 exact hgraph `Operator` type.
 
-The JSON sidecar is canonical and versioned. Its first checkpoint records the
-module and language versions, public declaration identities, operator
-implementations and provider requirements, generated header, baseline hgraph
-CMake dependency, and registration symbol. Complete imported signatures,
-constraints, native ownership/effect declarations, lifecycle entry points, and
-fingerprints are not implemented yet, so this checkpoint does not provide
-descriptor-only `hgl check`.
+The JSON sidecar is canonical and versioned. It records the module and language
+versions; public structures, operators, and functions; implementation
+candidates and provider requirements; and the generated build boundary. Its
+structured schema records preserve generic bindings, parameters and results,
+struct inheritance and effective fields, defaults and rolling bounds, nominal
+type applications, and `requires` constraints. Integer and float literal
+payloads are tagged strings so the full i64 range and non-finite floats remain
+valid JSON.
+
+For example, a generic operator points to descriptor-local type records rather
+than embedding source text that another tool would need to parse:
+
+```json
+{
+  "category": "operator",
+  "identity": "examples.windows.summarize",
+  "signature": {
+    "generic_parameters": [
+      {
+        "name": "T",
+        "kind": "type",
+        "binding": "examples.windows.summarize::T",
+        "type": null
+      }
+    ],
+    "parameters": [
+      {
+        "name": "window",
+        "kind": "signal",
+        "binding": "examples.windows.summarize::window",
+        "type": 1,
+        "default": null
+      }
+    ],
+    "result": 2,
+    "requires": null
+  }
+}
+```
+
+The `type`, `result`, `default`, and `requires` numbers refer to records in the
+same file's `schema` object. They have no identity outside that one descriptor.
+
+Descriptor loading, transitive dependency locking, native ownership/effect
+declarations, lifecycle entry points, and fingerprints are not implemented yet,
+so this checkpoint does not provide descriptor-only `hgl check`.
 
 A package is a CMake project. `hgl_add_module()`, installed with `hgl` in
 `lib/cmake/hgl/HglLanguage.cmake`, runs `emit-cpp` at build time and compiles

--- a/language/src/README.md
+++ b/language/src/README.md
@@ -11,7 +11,7 @@ them.
 | `semantics/` | name binding, nominal hierarchy, generic argument roles, function classification | syntax plus descriptors to resolved names and shapes |
 | `ir/` | source-ranged HIR, canonical types, substitutions, constraint solving, phase/effect completion | resolved frontend state to typed HIR |
 | `hgraph_ir/` | canonical execution-facing types, compile-time expressions, constraints, typed source-order declaration handles, struct contracts, operator and callable interfaces | typed HIR to executable composition and runtime-node plans |
-| `descriptor/` | versioned module descriptor model and canonical JSON serialization | hgraph IR to reviewable package metadata |
+| `descriptor/` | versioned module/interface schema, deterministic HGraph-IR snapshot, and canonical JSON serialization | hgraph IR to reviewable package metadata |
 | `wiring/` | direct walk over hgraph IR | hgraph IR to public erased wiring calls |
 | `codegen/` | hgraph-IR declaration, interface, dependency, composition-body, and runtime-body emission | hgraph IR to formatted C++ and build artifacts |
 | `driver/` | commands, native build/cache/load, REPL orchestration | assemble inputs and invoke passes |

--- a/language/src/descriptor/module_descriptor.cpp
+++ b/language/src/descriptor/module_descriptor.cpp
@@ -1,10 +1,9 @@
 #include "descriptor/module_descriptor.h"
 
 #include <algorithm>
-#include <array>
-#include <iomanip>
-#include <sstream>
 #include <string_view>
+#include <type_traits>
+#include <unordered_map>
 #include <utility>
 
 namespace hgl::descriptor
@@ -29,61 +28,241 @@ namespace hgl::descriptor
             return std::string{configured.empty() ? identity : configured};
         }
 
-        [[nodiscard]] std::string_view category_name(DeclarationCategory category) noexcept {
-            switch (category) {
-                case DeclarationCategory::Structure: return "structure";
-                case DeclarationCategory::Operator: return "operator";
-                case DeclarationCategory::Function: return "function";
+        [[nodiscard]] TypeCategory type_category(ir::hir::TypeKind kind) noexcept {
+            using ir::hir::TypeKind;
+            switch (kind) {
+                case TypeKind::Void: return TypeCategory::Void;
+                case TypeKind::Scalar: return TypeCategory::Scalar;
+                case TypeKind::Symbol: return TypeCategory::Symbol;
+                case TypeKind::Tuple: return TypeCategory::Tuple;
+                case TypeKind::List: return TypeCategory::List;
+                case TypeKind::Set: return TypeCategory::Set;
+                case TypeKind::Map: return TypeCategory::Map;
+                case TypeKind::Rolling: return TypeCategory::Rolling;
+                case TypeKind::Atomic: return TypeCategory::Atomic;
+                case TypeKind::Iterator: return TypeCategory::Iterator;
+                case TypeKind::Callable: return TypeCategory::Callable;
+                case TypeKind::Capability: return TypeCategory::Capability;
+                case TypeKind::HarnessSequence: return TypeCategory::HarnessSequence;
+                case TypeKind::Deferred: return TypeCategory::Deferred;
             }
             std::unreachable();
         }
 
-        [[nodiscard]] std::string_view execution_name(ExecutionKind execution) noexcept {
-            switch (execution) {
-                case ExecutionKind::None: return "none";
-                case ExecutionKind::Composition: return "composition";
-                case ExecutionKind::RuntimeNode: return "runtime-node";
+        [[nodiscard]] ConstantExpressionCategory constant_category(hgraph_ir::ConstExprKind kind) noexcept {
+            using hgraph_ir::ConstExprKind;
+            switch (kind) {
+                case ConstExprKind::Literal: return ConstantExpressionCategory::Literal;
+                case ConstExprKind::Parameter: return ConstantExpressionCategory::Parameter;
+                case ConstExprKind::Unary: return ConstantExpressionCategory::Unary;
+                case ConstExprKind::Binary: return ConstantExpressionCategory::Binary;
+                case ConstExprKind::Index: return ConstantExpressionCategory::Index;
+                case ConstExprKind::Field: return ConstantExpressionCategory::Field;
+                case ConstExprKind::Sequence: return ConstantExpressionCategory::Sequence;
+                case ConstExprKind::Tuple: return ConstantExpressionCategory::Tuple;
+                case ConstExprKind::Construct: return ConstantExpressionCategory::Construct;
             }
             std::unreachable();
         }
 
-        void quote_json(std::ostream &out, std::string_view value) {
-            static constexpr std::array<char, 16> hex{'0', '1', '2', '3', '4', '5', '6', '7',
-                                                      '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
-            out << '"';
-            for (const unsigned char character : value) {
-                switch (character) {
-                    case '"': out << "\\\""; break;
-                    case '\\': out << "\\\\"; break;
-                    case '\b': out << "\\b"; break;
-                    case '\f': out << "\\f"; break;
-                    case '\n': out << "\\n"; break;
-                    case '\r': out << "\\r"; break;
-                    case '\t': out << "\\t"; break;
-                    default:
-                        if (character < 0x20U) {
-                            out << "\\u00" << hex[character >> 4U] << hex[character & 0x0fU];
-                        } else {
-                            out << static_cast<char>(character);
-                        }
+        [[nodiscard]] std::string unary_spelling(ir::hir::UnaryOp operation) {
+            return operation == ir::hir::UnaryOp::Negate ? "-" : "!";
+        }
+
+        [[nodiscard]] std::string relation_spelling(hgraph_ir::ConstraintRelationOp operation) {
+            using hgraph_ir::ConstraintRelationOp;
+            switch (operation) {
+                case ConstraintRelationOp::Equal: return "equal";
+                case ConstraintRelationOp::In: return "in";
+                case ConstraintRelationOp::Is: return "is";
+            }
+            std::unreachable();
+        }
+
+        class SchemaBuilder
+        {
+          public:
+            SchemaBuilder(const hgraph_ir::Module &source, ModuleDescriptor &result) : source_{source}, result_{result} {}
+
+            [[nodiscard]] Signature signature(const std::vector<hgraph_ir::GenericParameter> &generics,
+                                              const std::vector<hgraph_ir::Parameter> &parameters, hgraph_ir::TypeId result,
+                                              hgraph_ir::ConstraintId requirements) {
+                Signature snapshot;
+                for (const hgraph_ir::GenericParameter &generic : generics) {
+                    snapshot.generics.push_back(GenericParameter{
+                        .name             = generic.name,
+                        .binding_identity = binding_identity(generic.binding, generic.name),
+                        .is_const         = generic.is_const,
+                        .type             = type(generic.type),
+                    });
                 }
+                for (const hgraph_ir::Parameter &parameter : parameters) {
+                    snapshot.parameters.push_back(Parameter{
+                        .name             = parameter.name,
+                        .binding_identity = binding_identity(parameter.binding, parameter.name),
+                        .is_const         = parameter.is_const,
+                        .type             = type(parameter.type),
+                        .default_value    = constant(parameter.default_value),
+                    });
+                }
+                snapshot.result       = type(result);
+                snapshot.requirements = constraint(requirements);
+                return snapshot;
             }
-            out << '"';
-        }
 
-        void string_array(std::ostream &out, const std::vector<std::string> &values, std::string_view indent) {
-            if (values.empty()) {
-                out << "[]";
-                return;
+            [[nodiscard]] StructField field(const hgraph_ir::StructField &source) {
+                return StructField{
+                    .name            = source.name,
+                    .type            = type(source.type),
+                    .default_value   = constant(source.default_value),
+                    .origin_identity = source.origin_identity,
+                    .optional        = source.optional,
+                };
             }
-            out << "[\n";
-            for (std::size_t index = 0; index < values.size(); ++index) {
-                out << indent << "  ";
-                quote_json(out, values[index]);
-                out << (index + 1U == values.size() ? "\n" : ",\n");
+
+            [[nodiscard]] SchemaId type_reference(hgraph_ir::TypeId source) { return type(source); }
+
+          private:
+            [[nodiscard]] std::string binding_identity(hgraph_ir::BindingId id, std::string_view fallback) const {
+                if (!id.valid()) { return std::string{fallback}; }
+                const hgraph_ir::Binding &binding = source_.bindings.at(id.value);
+                return binding.owner_identity.empty() ? binding.name : binding.owner_identity + "::" + binding.name;
             }
-            out << indent << ']';
-        }
+
+            [[nodiscard]] SchemaId type(hgraph_ir::TypeId source_id) {
+                if (!source_id.valid()) { return no_schema_id; }
+                if (const auto found = types_.find(source_id.value); found != types_.end()) { return found->second; }
+
+                const SchemaId id{static_cast<SchemaId>(result_.types.size())};
+                types_.emplace(source_id.value, id);
+                result_.types.emplace_back();
+
+                const hgraph_ir::Type &source = source_.types.at(source_id.value);
+                TypeRecord             record;
+                record.category         = type_category(source.kind);
+                record.scalar_name      = source.kind == ir::hir::TypeKind::Scalar
+                                              ? std::string{ir::hir::scalar_type_name(source.scalar)}
+                                              : std::string{};
+                record.nominal_identity = source.nominal_identity;
+                if (source.binding.valid()) { record.binding_identity = binding_identity(source.binding, source.nominal_identity); }
+                record.unbounded = source.unbounded;
+                for (hgraph_ir::TypeId child : source.children) { record.children.push_back(type(child)); }
+                for (const hgraph_ir::TypeArgument &argument : source.arguments) {
+                    if (argument.type) {
+                        record.arguments.push_back(TypeArgument{TypeArgumentCategory::Type, type(*argument.type)});
+                    } else if (argument.value) {
+                        record.arguments.push_back(TypeArgument{TypeArgumentCategory::Constant, constant(*argument.value)});
+                    }
+                }
+                record.size       = constant(source.size);
+                record.min_size   = constant(source.min_size);
+                result_.types[id] = std::move(record);
+                return id;
+            }
+
+            [[nodiscard]] SchemaId constant(hgraph_ir::ConstExprId source_id) {
+                if (!source_id.valid()) { return no_schema_id; }
+                if (const auto found = constants_.find(source_id.value); found != constants_.end()) { return found->second; }
+
+                const SchemaId id{static_cast<SchemaId>(result_.constant_expressions.size())};
+                constants_.emplace(source_id.value, id);
+                result_.constant_expressions.emplace_back();
+
+                const hgraph_ir::ConstExpr &source = source_.const_exprs.at(source_id.value);
+                ConstantExpressionRecord    record;
+                record.category           = constant_category(source.kind);
+                record.literal            = source.literal;
+                record.parameter_identity = binding_identity(source.parameter_binding, source.parameter);
+                if (source.kind == hgraph_ir::ConstExprKind::Unary) {
+                    record.operator_spelling = unary_spelling(source.unary);
+                } else if (source.kind == hgraph_ir::ConstExprKind::Binary) {
+                    record.operator_spelling = ir::hir::binary_op_spelling(source.binary);
+                }
+                record.lhs    = constant(source.lhs);
+                record.rhs    = constant(source.rhs);
+                record.member = source.member;
+                for (const hgraph_ir::ConstElement &element : source.elements) {
+                    record.elements.push_back(ConstantElement{constant(element.key), constant(element.value)});
+                }
+                for (hgraph_ir::ConstExprId item : source.items) { record.items.push_back(constant(item)); }
+                record.constructed_type = type(source.constructed_type);
+                for (const hgraph_ir::ConstArgument &argument : source.arguments) {
+                    record.arguments.push_back(ConstantArgument{argument.name, constant(argument.value)});
+                }
+                record.delta                     = source.delta;
+                result_.constant_expressions[id] = std::move(record);
+                return id;
+            }
+
+            [[nodiscard]] SchemaId constraint(hgraph_ir::ConstraintId source_id) {
+                if (!source_id.valid()) { return no_schema_id; }
+                if (const auto found = constraints_.find(source_id.value); found != constraints_.end()) { return found->second; }
+
+                const SchemaId id{static_cast<SchemaId>(result_.constraints.size())};
+                constraints_.emplace(source_id.value, id);
+                result_.constraints.emplace_back();
+
+                const hgraph_ir::Constraint &source = source_.constraints.at(source_id.value);
+                ConstraintRecord             record;
+                std::visit(
+                    [&](const auto &node) {
+                        using T = std::decay_t<decltype(node)>;
+                        if constexpr (std::is_same_v<T, hgraph_ir::ConstraintSymbol>) {
+                            record.category = ConstraintCategory::Symbol;
+                            record.identity = node.identity;
+                        } else if constexpr (std::is_same_v<T, hgraph_ir::ConstraintType>) {
+                            record.category = ConstraintCategory::Type;
+                            record.type     = type(node.type);
+                        } else if constexpr (std::is_same_v<T, hgraph_ir::ConstraintValue>) {
+                            record.category = ConstraintCategory::Value;
+                            record.value    = constant(node.value);
+                        } else if constexpr (std::is_same_v<T, hgraph_ir::ConstraintSet>) {
+                            record.category = ConstraintCategory::Set;
+                            for (hgraph_ir::ConstraintId element : node.elements) {
+                                record.elements.push_back(constraint(element));
+                            }
+                        } else if constexpr (std::is_same_v<T, hgraph_ir::ConstraintCall>) {
+                            record.category = ConstraintCategory::Call;
+                            record.identity = node.function_identity;
+                            for (hgraph_ir::ConstraintId argument : node.arguments) {
+                                record.arguments.push_back(constraint(argument));
+                            }
+                        } else if constexpr (std::is_same_v<T, hgraph_ir::OperatorRequirement>) {
+                            record.category      = ConstraintCategory::Operator;
+                            record.identity      = node.operator_identity;
+                            record.registry_name = registry_name(node.operator_registry_name, node.operator_identity);
+                            for (hgraph_ir::ConstraintId argument : node.arguments) {
+                                record.arguments.push_back(constraint(argument));
+                            }
+                            record.result = type(node.result);
+                        } else if constexpr (std::is_same_v<T, hgraph_ir::ConstraintRelation>) {
+                            record.category          = ConstraintCategory::Relation;
+                            record.operator_spelling = relation_spelling(node.op);
+                            record.lhs               = constraint(node.lhs);
+                            record.rhs               = constraint(node.rhs);
+                            record.relation_category = node.category;
+                        } else if constexpr (std::is_same_v<T, hgraph_ir::ConstraintNot>) {
+                            record.category = ConstraintCategory::Not;
+                            record.operand  = constraint(node.operand);
+                        } else {
+                            record.category          = ConstraintCategory::Logic;
+                            record.operator_spelling = node.op == hgraph_ir::ConstraintLogicOp::And ? "and" : "or";
+                            record.lhs               = constraint(node.lhs);
+                            record.rhs               = constraint(node.rhs);
+                        }
+                    },
+                    source.node);
+                result_.constraints[id] = std::move(record);
+                return id;
+            }
+
+            const hgraph_ir::Module                    &source_;
+            ModuleDescriptor                           &result_;
+            std::unordered_map<std::uint32_t, SchemaId> types_{};
+            std::unordered_map<std::uint32_t, SchemaId> constants_{};
+            std::unordered_map<std::uint32_t, SchemaId> constraints_{};
+        };
+
     }  // namespace
 
     ModuleDescriptor describe_module(const hgraph_ir::Module &module, DescribeOptions options) {
@@ -97,30 +276,68 @@ namespace hgl::descriptor
         result.build.imported_targets    = std::move(options.imported_targets);
         result.build.registration_symbol = std::move(options.registration_symbol);
 
+        SchemaBuilder schema{module, result};
+
+        std::vector<const hgraph_ir::StructContract *> structures;
         for (const hgraph_ir::StructContract &structure : module.structures) {
             if (!structure.exported) { continue; }
-            result.interface.push_back(InterfaceDeclaration{
-                .category = DeclarationCategory::Structure, .identity = structure.identity, .abstract = structure.abstract});
+            structures.push_back(&structure);
         }
+        std::ranges::sort(structures, {}, &hgraph_ir::StructContract::identity);
+        for (const hgraph_ir::StructContract *structure : structures) {
+            InterfaceDeclaration declaration;
+            declaration.category  = DeclarationCategory::Structure;
+            declaration.identity  = structure->identity;
+            declaration.abstract  = structure->abstract;
+            declaration.signature = schema.signature(structure->generics, {}, {}, structure->requirements);
+            for (hgraph_ir::TypeId parent : structure->parents) { declaration.parents.push_back(schema.type_reference(parent)); }
+            for (const hgraph_ir::StructField &field : structure->fields) { declaration.fields.push_back(schema.field(field)); }
+            result.interface.push_back(std::move(declaration));
+        }
+
+        std::vector<const hgraph_ir::OperatorContract *> operators;
         for (const hgraph_ir::OperatorContract &operation : module.operators) {
             if (operation.imported) { continue; }
-            result.interface.push_back(
-                InterfaceDeclaration{.category      = DeclarationCategory::Operator,
-                                     .identity      = operation.identity,
-                                     .registry_name = registry_name(operation.registry_name, operation.identity)});
+            operators.push_back(&operation);
         }
+        std::ranges::sort(operators, {}, &hgraph_ir::OperatorContract::identity);
+        for (const hgraph_ir::OperatorContract *operation : operators) {
+            result.interface.push_back(InterfaceDeclaration{
+                .category      = DeclarationCategory::Operator,
+                .identity      = operation->identity,
+                .registry_name = registry_name(operation->registry_name, operation->identity),
+                .signature =
+                    schema.signature(operation->generics, operation->parameters, operation->result, operation->requirements),
+            });
+        }
+
+        std::vector<const hgraph_ir::Callable *> exports;
+        std::vector<const hgraph_ir::Callable *> implementations;
         for (const hgraph_ir::Callable &callable : module.callables) {
             if (callable.visibility == hgraph_ir::CallableVisibility::Export) {
-                result.interface.push_back(InterfaceDeclaration{.category  = DeclarationCategory::Function,
-                                                                .identity  = callable.identity,
-                                                                .execution = execution_kind(callable.kind)});
+                exports.push_back(&callable);
             } else if (callable.visibility == hgraph_ir::CallableVisibility::Implementation) {
-                result.implementations.push_back(Implementation{
-                    .identity               = callable.identity,
-                    .operator_identity      = callable.operator_identity,
-                    .operator_registry_name = registry_name(callable.operator_registry_name, callable.operator_identity),
-                    .execution              = execution_kind(callable.kind)});
+                implementations.push_back(&callable);
             }
+        }
+        std::ranges::sort(exports, {}, &hgraph_ir::Callable::identity);
+        for (const hgraph_ir::Callable *callable : exports) {
+            result.interface.push_back(InterfaceDeclaration{
+                .category  = DeclarationCategory::Function,
+                .identity  = callable->identity,
+                .execution = execution_kind(callable->kind),
+                .signature = schema.signature(callable->generics, callable->parameters, callable->result, callable->requirements),
+            });
+        }
+        std::ranges::sort(implementations, {}, &hgraph_ir::Callable::identity);
+        for (const hgraph_ir::Callable *callable : implementations) {
+            result.implementations.push_back(Implementation{
+                .identity               = callable->identity,
+                .operator_identity      = callable->operator_identity,
+                .operator_registry_name = registry_name(callable->operator_registry_name, callable->operator_identity),
+                .execution              = execution_kind(callable->kind),
+                .signature = schema.signature(callable->generics, callable->parameters, callable->result, callable->requirements),
+            });
         }
 
         normalize(result.interface, &InterfaceDeclaration::identity);
@@ -132,66 +349,4 @@ namespace hgl::descriptor
         return result;
     }
 
-    std::string to_json(const ModuleDescriptor &descriptor) {
-        std::ostringstream out;
-        out << "{\n"
-            << "  \"format\": \"hgl.module\",\n"
-            << "  \"format_version\": " << descriptor.format_version << ",\n"
-            << "  \"module\": {\n"
-            << "    \"identity\": ";
-        quote_json(out, descriptor.module_identity);
-        out << ",\n    \"language_version\": ";
-        quote_json(out, descriptor.language_version);
-        out << "\n  },\n  \"interface\": [";
-        if (!descriptor.interface.empty()) { out << '\n'; }
-        for (std::size_t index = 0; index < descriptor.interface.size(); ++index) {
-            const InterfaceDeclaration &declaration = descriptor.interface[index];
-            out << "    {\n      \"category\": ";
-            quote_json(out, category_name(declaration.category));
-            out << ",\n      \"identity\": ";
-            quote_json(out, declaration.identity);
-            if (!declaration.registry_name.empty()) {
-                out << ",\n      \"registry_name\": ";
-                quote_json(out, declaration.registry_name);
-            }
-            if (declaration.execution != ExecutionKind::None) {
-                out << ",\n      \"execution\": ";
-                quote_json(out, execution_name(declaration.execution));
-            }
-            if (declaration.category == DeclarationCategory::Structure) {
-                out << ",\n      \"abstract\": " << (declaration.abstract ? "true" : "false");
-            }
-            out << "\n    }" << (index + 1U == descriptor.interface.size() ? "\n" : ",\n");
-        }
-        if (!descriptor.interface.empty()) { out << "  "; }
-        out << "],\n  \"provider\": {\n    \"identity\": ";
-        quote_json(out, descriptor.provider_identity);
-        out << ",\n    \"implementations\": [";
-        if (!descriptor.implementations.empty()) { out << '\n'; }
-        for (std::size_t index = 0; index < descriptor.implementations.size(); ++index) {
-            const Implementation &implementation = descriptor.implementations[index];
-            out << "      {\n        \"identity\": ";
-            quote_json(out, implementation.identity);
-            out << ",\n        \"operator\": ";
-            quote_json(out, implementation.operator_identity);
-            out << ",\n        \"registry_name\": ";
-            quote_json(out, implementation.operator_registry_name);
-            out << ",\n        \"execution\": ";
-            quote_json(out, execution_name(implementation.execution));
-            out << "\n      }" << (index + 1U == descriptor.implementations.size() ? "\n" : ",\n");
-        }
-        if (!descriptor.implementations.empty()) { out << "    "; }
-        out << "],\n    \"requires\": ";
-        string_array(out, descriptor.provider_requirements, "    ");
-        out << "\n  },\n  \"build\": {\n    \"public_headers\": ";
-        string_array(out, descriptor.build.public_headers, "    ");
-        out << ",\n    \"cmake_packages\": ";
-        string_array(out, descriptor.build.cmake_packages, "    ");
-        out << ",\n    \"imported_targets\": ";
-        string_array(out, descriptor.build.imported_targets, "    ");
-        out << ",\n    \"registration\": {\n      \"kind\": \"cpp\",\n      \"symbol\": ";
-        quote_json(out, descriptor.build.registration_symbol);
-        out << "\n    }\n  }\n}\n";
-        return out.str();
-    }
 }  // namespace hgl::descriptor

--- a/language/src/descriptor/module_descriptor.h
+++ b/language/src/descriptor/module_descriptor.h
@@ -4,6 +4,8 @@
 #include "hgraph_ir/ir.h"
 
 #include <cstdint>
+#include <limits>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -23,13 +25,192 @@ namespace hgl::descriptor
         RuntimeNode,
     };
 
+    using SchemaId                         = std::uint32_t;
+    inline constexpr SchemaId no_schema_id = std::numeric_limits<SchemaId>::max();
+
+    enum class TypeCategory : std::uint8_t {
+        Void,
+        Scalar,
+        Symbol,
+        Tuple,
+        List,
+        Set,
+        Map,
+        Rolling,
+        Atomic,
+        Iterator,
+        Callable,
+        Capability,
+        HarnessSequence,
+        Deferred,
+    };
+
+    enum class TypeArgumentCategory : std::uint8_t {
+        Type,
+        Constant,
+    };
+
+    struct TypeArgument
+    {
+        TypeArgumentCategory category{TypeArgumentCategory::Type};
+        SchemaId             reference{no_schema_id};
+
+        friend bool operator==(const TypeArgument &, const TypeArgument &) = default;
+    };
+
+    /// One canonical type reachable from the public interface or provider
+    /// inventory. References index ModuleDescriptor::types; generic symbols
+    /// retain their stable declaration-scoped binding identity.
+    struct TypeRecord
+    {
+        TypeCategory              category{TypeCategory::Deferred};
+        std::string               scalar_name{};
+        std::string               nominal_identity{};
+        std::string               binding_identity{};
+        std::vector<SchemaId>     children{};
+        std::vector<TypeArgument> arguments{};
+        SchemaId                  size{no_schema_id};
+        SchemaId                  min_size{no_schema_id};
+        bool                      unbounded{false};
+
+        friend bool operator==(const TypeRecord &, const TypeRecord &) = default;
+    };
+
+    enum class ConstantExpressionCategory : std::uint8_t {
+        Literal,
+        Parameter,
+        Unary,
+        Binary,
+        Index,
+        Field,
+        Sequence,
+        Tuple,
+        Construct,
+    };
+
+    struct ConstantElement
+    {
+        SchemaId key{no_schema_id};
+        SchemaId value{no_schema_id};
+
+        friend bool operator==(const ConstantElement &, const ConstantElement &) = default;
+    };
+
+    struct ConstantArgument
+    {
+        std::string name{};
+        SchemaId    value{no_schema_id};
+
+        friend bool operator==(const ConstantArgument &, const ConstantArgument &) = default;
+    };
+
+    /// A structured compile-time expression. Literal kinds remain explicit in
+    /// JSON, so an i64, f64, temporal value, null, and placeholder never rely
+    /// on JSON's narrower value model for their type identity.
+    struct ConstantExpressionRecord
+    {
+        ConstantExpressionCategory       category{ConstantExpressionCategory::Literal};
+        std::optional<ir::hir::Constant> literal{};
+        std::string                      parameter_identity{};
+        std::string                      operator_spelling{};
+        SchemaId                         lhs{no_schema_id};
+        SchemaId                         rhs{no_schema_id};
+        std::string                      member{};
+        std::vector<ConstantElement>     elements{};
+        std::vector<SchemaId>            items{};
+        SchemaId                         constructed_type{no_schema_id};
+        std::vector<ConstantArgument>    arguments{};
+        bool                             delta{false};
+
+        friend bool operator==(const ConstantExpressionRecord &, const ConstantExpressionRecord &) = default;
+    };
+
+    enum class ConstraintCategory : std::uint8_t {
+        Symbol,
+        Type,
+        Value,
+        Set,
+        Call,
+        Operator,
+        Relation,
+        Not,
+        Logic,
+    };
+
+    /// A normalized constraint node. Constraint references index
+    /// ModuleDescriptor::constraints; type/value references use their
+    /// corresponding schema arenas.
+    struct ConstraintRecord
+    {
+        ConstraintCategory    category{ConstraintCategory::Symbol};
+        std::string           identity{};
+        std::string           registry_name{};
+        std::string           operator_spelling{};
+        std::string           relation_category{};
+        SchemaId              type{no_schema_id};
+        SchemaId              value{no_schema_id};
+        SchemaId              lhs{no_schema_id};
+        SchemaId              rhs{no_schema_id};
+        SchemaId              operand{no_schema_id};
+        SchemaId              result{no_schema_id};
+        std::vector<SchemaId> elements{};
+        std::vector<SchemaId> arguments{};
+
+        friend bool operator==(const ConstraintRecord &, const ConstraintRecord &) = default;
+    };
+
+    struct GenericParameter
+    {
+        std::string name{};
+        std::string binding_identity{};
+        bool        is_const{false};
+        SchemaId    type{no_schema_id};
+
+        friend bool operator==(const GenericParameter &, const GenericParameter &) = default;
+    };
+
+    struct Parameter
+    {
+        std::string name{};
+        std::string binding_identity{};
+        bool        is_const{false};
+        SchemaId    type{no_schema_id};
+        SchemaId    default_value{no_schema_id};
+
+        friend bool operator==(const Parameter &, const Parameter &) = default;
+    };
+
+    struct Signature
+    {
+        std::vector<GenericParameter> generics{};
+        std::vector<Parameter>        parameters{};
+        SchemaId                      result{no_schema_id};
+        SchemaId                      requirements{no_schema_id};
+
+        friend bool operator==(const Signature &, const Signature &) = default;
+    };
+
+    struct StructField
+    {
+        std::string name{};
+        SchemaId    type{no_schema_id};
+        SchemaId    default_value{no_schema_id};
+        std::string origin_identity{};
+        bool        optional{false};
+
+        friend bool operator==(const StructField &, const StructField &) = default;
+    };
+
     struct InterfaceDeclaration
     {
-        DeclarationCategory category{DeclarationCategory::Function};
-        std::string         identity{};
-        std::string         registry_name{};
-        ExecutionKind       execution{ExecutionKind::None};
-        bool                abstract{false};
+        DeclarationCategory      category{DeclarationCategory::Function};
+        std::string              identity{};
+        std::string              registry_name{};
+        ExecutionKind            execution{ExecutionKind::None};
+        bool                     abstract{false};
+        Signature                signature{};
+        std::vector<SchemaId>    parents{};
+        std::vector<StructField> fields{};
 
         friend bool operator==(const InterfaceDeclaration &, const InterfaceDeclaration &) = default;
     };
@@ -40,6 +221,7 @@ namespace hgl::descriptor
         std::string   operator_identity{};
         std::string   operator_registry_name{};
         ExecutionKind execution{ExecutionKind::Composition};
+        Signature     signature{};
 
         friend bool operator==(const Implementation &, const Implementation &) = default;
     };
@@ -54,20 +236,22 @@ namespace hgl::descriptor
         friend bool operator==(const BuildMetadata &, const BuildMetadata &) = default;
     };
 
-    /// The first data-only descriptor boundary. Interface signatures and
-    /// constraints are intentionally a following schema addition: this
-    /// checkpoint versions the envelope, public/provider inventories, and
-    /// build boundary without claiming descriptor-only type checking.
+    /// A data-only package boundary: public/provider declarations refer to
+    /// structured type, compile-time expression, and constraint arenas. Native
+    /// lifecycle and ownership/effect policy remain separate ABI additions.
     struct ModuleDescriptor
     {
-        std::uint32_t                     format_version{module_descriptor_format_version};
-        std::string                       module_identity{};
-        std::string                       language_version{};
-        std::vector<InterfaceDeclaration> interface{};
-        std::string                       provider_identity{};
-        std::vector<Implementation>       implementations{};
-        std::vector<std::string>          provider_requirements{};
-        BuildMetadata                     build{};
+        std::uint32_t                         format_version{module_descriptor_format_version};
+        std::string                           module_identity{};
+        std::string                           language_version{};
+        std::vector<InterfaceDeclaration>     interface{};
+        std::string                           provider_identity{};
+        std::vector<Implementation>           implementations{};
+        std::vector<std::string>              provider_requirements{};
+        std::vector<TypeRecord>               types{};
+        std::vector<ConstantExpressionRecord> constant_expressions{};
+        std::vector<ConstraintRecord>         constraints{};
+        BuildMetadata                         build{};
 
         friend bool operator==(const ModuleDescriptor &, const ModuleDescriptor &) = default;
     };
@@ -83,8 +267,9 @@ namespace hgl::descriptor
     };
 
     /// Build a normalized module descriptor from the execution-facing IR.
-    /// Set-like inventories are sorted and deduplicated so serialization is
-    /// independent of incidental insertion order.
+    /// Public declarations are visited by stable identity; set-like package
+    /// inventories are sorted and deduplicated. Only schema records reachable
+    /// from the public interface and provider inventory are retained.
     [[nodiscard]] ModuleDescriptor describe_module(const hgraph_ir::Module &module, DescribeOptions options);
 
     /// Serialize canonical, reviewable UTF-8 JSON with a trailing newline.

--- a/language/src/descriptor/module_descriptor_json.cpp
+++ b/language/src/descriptor/module_descriptor_json.cpp
@@ -11,6 +11,7 @@
 #include <sstream>
 #include <string_view>
 #include <type_traits>
+#include <utility>
 
 namespace hgl::descriptor
 {

--- a/language/src/descriptor/module_descriptor_json.cpp
+++ b/language/src/descriptor/module_descriptor_json.cpp
@@ -1,0 +1,528 @@
+#include "descriptor/module_descriptor.h"
+
+#include "syntax/temporal.h"
+
+#include <array>
+#include <cmath>
+#include <iomanip>
+#include <limits>
+#include <locale>
+#include <ostream>
+#include <sstream>
+#include <string_view>
+#include <type_traits>
+
+namespace hgl::descriptor
+{
+    namespace
+    {
+        [[nodiscard]] std::string_view declaration_category_name(DeclarationCategory category) noexcept {
+            switch (category) {
+                case DeclarationCategory::Structure: return "structure";
+                case DeclarationCategory::Operator: return "operator";
+                case DeclarationCategory::Function: return "function";
+            }
+            std::unreachable();
+        }
+
+        [[nodiscard]] std::string_view execution_name(ExecutionKind execution) noexcept {
+            switch (execution) {
+                case ExecutionKind::None: return "none";
+                case ExecutionKind::Composition: return "composition";
+                case ExecutionKind::RuntimeNode: return "runtime-node";
+            }
+            std::unreachable();
+        }
+
+        [[nodiscard]] std::string_view type_category_name(TypeCategory category) noexcept {
+            switch (category) {
+                case TypeCategory::Void: return "void";
+                case TypeCategory::Scalar: return "scalar";
+                case TypeCategory::Symbol: return "symbol";
+                case TypeCategory::Tuple: return "tuple";
+                case TypeCategory::List: return "list";
+                case TypeCategory::Set: return "set";
+                case TypeCategory::Map: return "map";
+                case TypeCategory::Rolling: return "rolling";
+                case TypeCategory::Atomic: return "atomic";
+                case TypeCategory::Iterator: return "iterator";
+                case TypeCategory::Callable: return "callable";
+                case TypeCategory::Capability: return "capability";
+                case TypeCategory::HarnessSequence: return "harness-sequence";
+                case TypeCategory::Deferred: return "deferred";
+            }
+            std::unreachable();
+        }
+
+        [[nodiscard]] std::string_view constant_category_name(ConstantExpressionCategory category) noexcept {
+            switch (category) {
+                case ConstantExpressionCategory::Literal: return "literal";
+                case ConstantExpressionCategory::Parameter: return "parameter";
+                case ConstantExpressionCategory::Unary: return "unary";
+                case ConstantExpressionCategory::Binary: return "binary";
+                case ConstantExpressionCategory::Index: return "index";
+                case ConstantExpressionCategory::Field: return "field";
+                case ConstantExpressionCategory::Sequence: return "sequence";
+                case ConstantExpressionCategory::Tuple: return "tuple";
+                case ConstantExpressionCategory::Construct: return "construct";
+            }
+            std::unreachable();
+        }
+
+        [[nodiscard]] std::string_view constraint_category_name(ConstraintCategory category) noexcept {
+            switch (category) {
+                case ConstraintCategory::Symbol: return "symbol";
+                case ConstraintCategory::Type: return "type";
+                case ConstraintCategory::Value: return "value";
+                case ConstraintCategory::Set: return "set";
+                case ConstraintCategory::Call: return "call";
+                case ConstraintCategory::Operator: return "operator";
+                case ConstraintCategory::Relation: return "relation";
+                case ConstraintCategory::Not: return "not";
+                case ConstraintCategory::Logic: return "logic";
+            }
+            std::unreachable();
+        }
+
+        void quote_json(std::ostream &out, std::string_view value) {
+            static constexpr std::array<char, 16> hex{'0', '1', '2', '3', '4', '5', '6', '7',
+                                                      '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+            out << '"';
+            for (const unsigned char character : value) {
+                switch (character) {
+                    case '"': out << "\\\""; break;
+                    case '\\': out << "\\\\"; break;
+                    case '\b': out << "\\b"; break;
+                    case '\f': out << "\\f"; break;
+                    case '\n': out << "\\n"; break;
+                    case '\r': out << "\\r"; break;
+                    case '\t': out << "\\t"; break;
+                    default:
+                        if (character < 0x20U) {
+                            out << "\\u00" << hex[character >> 4U] << hex[character & 0x0fU];
+                        } else {
+                            out << static_cast<char>(character);
+                        }
+                }
+            }
+            out << '"';
+        }
+
+        void schema_reference(std::ostream &out, SchemaId value) {
+            if (value == no_schema_id) {
+                out << "null";
+            } else {
+                out << value;
+            }
+        }
+
+        void string_array(std::ostream &out, const std::vector<std::string> &values, std::string_view indent) {
+            if (values.empty()) {
+                out << "[]";
+                return;
+            }
+            out << "[\n";
+            for (std::size_t index = 0; index < values.size(); ++index) {
+                out << indent << "  ";
+                quote_json(out, values[index]);
+                out << (index + 1U == values.size() ? "\n" : ",\n");
+            }
+            out << indent << ']';
+        }
+
+        void reference_array(std::ostream &out, const std::vector<SchemaId> &values, std::string_view indent) {
+            if (values.empty()) {
+                out << "[]";
+                return;
+            }
+            out << "[\n";
+            for (std::size_t index = 0; index < values.size(); ++index) {
+                out << indent << "  ";
+                schema_reference(out, values[index]);
+                out << (index + 1U == values.size() ? "\n" : ",\n");
+            }
+            out << indent << ']';
+        }
+
+        [[nodiscard]] std::string floating_spelling(double value) {
+            if (std::isnan(value)) { return "nan"; }
+            if (std::isinf(value)) { return std::signbit(value) ? "-inf" : "inf"; }
+            std::ostringstream out;
+            out.imbue(std::locale::classic());
+            out << std::setprecision(std::numeric_limits<double>::max_digits10) << value;
+            return out.str();
+        }
+
+        void literal(std::ostream &out, const ir::hir::Constant &literal) {
+            out << "{\n";
+            std::visit(
+                [&](const auto &value) {
+                    using T = std::decay_t<decltype(value)>;
+                    if constexpr (std::is_same_v<T, ir::hir::NullValue>) {
+                        out << "            \"kind\": \"null\"\n";
+                    } else if constexpr (std::is_same_v<T, ir::hir::PlaceholderValue>) {
+                        out << "            \"kind\": \"placeholder\"\n";
+                    } else if constexpr (std::is_same_v<T, bool>) {
+                        out << "            \"kind\": \"bool\",\n            \"value\": " << (value ? "true" : "false") << '\n';
+                    } else if constexpr (std::is_same_v<T, std::int64_t>) {
+                        out << "            \"kind\": \"i64\",\n            \"value\": ";
+                        quote_json(out, std::to_string(value));
+                        out << '\n';
+                    } else if constexpr (std::is_same_v<T, double>) {
+                        out << "            \"kind\": \"f64\",\n            \"value\": ";
+                        quote_json(out, floating_spelling(value));
+                        out << '\n';
+                    } else if constexpr (std::is_same_v<T, std::string>) {
+                        out << "            \"kind\": \"str\",\n            \"value\": ";
+                        quote_json(out, value);
+                        out << '\n';
+                    } else {
+                        out << "            \"kind\": ";
+                        quote_json(out, syntax::temporal_kind_name(value.kind));
+                        out << ",\n            \"value\": ";
+                        quote_json(out, syntax::canonical_spelling(value));
+                        out << '\n';
+                    }
+                },
+                literal);
+            out << "          }";
+        }
+
+        void generic_parameters(std::ostream &out, const std::vector<GenericParameter> &parameters, std::string_view indent) {
+            if (parameters.empty()) {
+                out << "[]";
+                return;
+            }
+            out << "[\n";
+            for (std::size_t index = 0; index < parameters.size(); ++index) {
+                const GenericParameter &parameter = parameters[index];
+                out << indent << "  {\n" << indent << "    \"name\": ";
+                quote_json(out, parameter.name);
+                out << ",\n"
+                    << indent << "    \"kind\": \"" << (parameter.is_const ? "const" : "type") << "\",\n"
+                    << indent << "    \"binding\": ";
+                quote_json(out, parameter.binding_identity);
+                out << ",\n" << indent << "    \"type\": ";
+                schema_reference(out, parameter.type);
+                out << "\n" << indent << "  }" << (index + 1U == parameters.size() ? "\n" : ",\n");
+            }
+            out << indent << ']';
+        }
+
+        void parameters(std::ostream &out, const std::vector<Parameter> &parameters, std::string_view indent) {
+            if (parameters.empty()) {
+                out << "[]";
+                return;
+            }
+            out << "[\n";
+            for (std::size_t index = 0; index < parameters.size(); ++index) {
+                const Parameter &parameter = parameters[index];
+                out << indent << "  {\n" << indent << "    \"name\": ";
+                quote_json(out, parameter.name);
+                out << ",\n"
+                    << indent << "    \"kind\": \"" << (parameter.is_const ? "const" : "signal") << "\",\n"
+                    << indent << "    \"binding\": ";
+                quote_json(out, parameter.binding_identity);
+                out << ",\n" << indent << "    \"type\": ";
+                schema_reference(out, parameter.type);
+                out << ",\n" << indent << "    \"default\": ";
+                schema_reference(out, parameter.default_value);
+                out << "\n" << indent << "  }" << (index + 1U == parameters.size() ? "\n" : ",\n");
+            }
+            out << indent << ']';
+        }
+
+        void signature(std::ostream &out, const Signature &signature, std::string_view indent) {
+            out << "{\n" << indent << "  \"generic_parameters\": ";
+            generic_parameters(out, signature.generics, std::string{indent} + "  ");
+            out << ",\n" << indent << "  \"parameters\": ";
+            parameters(out, signature.parameters, std::string{indent} + "  ");
+            out << ",\n" << indent << "  \"result\": ";
+            schema_reference(out, signature.result);
+            out << ",\n" << indent << "  \"requires\": ";
+            schema_reference(out, signature.requirements);
+            out << "\n" << indent << '}';
+        }
+
+        void fields(std::ostream &out, const std::vector<StructField> &fields, std::string_view indent) {
+            if (fields.empty()) {
+                out << "[]";
+                return;
+            }
+            out << "[\n";
+            for (std::size_t index = 0; index < fields.size(); ++index) {
+                const StructField &field = fields[index];
+                out << indent << "  {\n" << indent << "    \"name\": ";
+                quote_json(out, field.name);
+                out << ",\n" << indent << "    \"type\": ";
+                schema_reference(out, field.type);
+                out << ",\n"
+                    << indent << "    \"optional\": " << (field.optional ? "true" : "false") << ",\n"
+                    << indent << "    \"default\": ";
+                schema_reference(out, field.default_value);
+                out << ",\n" << indent << "    \"origin\": ";
+                quote_json(out, field.origin_identity);
+                out << "\n" << indent << "  }" << (index + 1U == fields.size() ? "\n" : ",\n");
+            }
+            out << indent << ']';
+        }
+
+        void type_records(std::ostream &out, const std::vector<TypeRecord> &records) {
+            out << '[';
+            if (!records.empty()) { out << '\n'; }
+            for (std::size_t index = 0; index < records.size(); ++index) {
+                const TypeRecord &record = records[index];
+                out << "      {\n        \"id\": " << index << ",\n        \"kind\": ";
+                quote_json(out, type_category_name(record.category));
+                if (!record.scalar_name.empty()) {
+                    out << ",\n        \"name\": ";
+                    quote_json(out, record.scalar_name);
+                }
+                if (!record.nominal_identity.empty()) {
+                    out << ",\n        \"identity\": ";
+                    quote_json(out, record.nominal_identity);
+                }
+                if (!record.binding_identity.empty()) {
+                    out << ",\n        \"binding\": ";
+                    quote_json(out, record.binding_identity);
+                }
+                if (!record.children.empty()) {
+                    out << ",\n        \"children\": ";
+                    reference_array(out, record.children, "        ");
+                }
+                if (!record.arguments.empty()) {
+                    out << ",\n        \"arguments\": [\n";
+                    for (std::size_t argument_index = 0; argument_index < record.arguments.size(); ++argument_index) {
+                        const TypeArgument &argument = record.arguments[argument_index];
+                        out << "          {\n            \"kind\": \""
+                            << (argument.category == TypeArgumentCategory::Type ? "type" : "constant")
+                            << "\",\n            \"reference\": ";
+                        schema_reference(out, argument.reference);
+                        out << "\n          }" << (argument_index + 1U == record.arguments.size() ? "\n" : ",\n");
+                    }
+                    out << "        ]";
+                }
+                if (record.size != no_schema_id) {
+                    out << ",\n        \"size\": ";
+                    schema_reference(out, record.size);
+                }
+                if (record.min_size != no_schema_id) {
+                    out << ",\n        \"min_size\": ";
+                    schema_reference(out, record.min_size);
+                }
+                if (record.unbounded) { out << ",\n        \"unbounded\": true"; }
+                out << "\n      }" << (index + 1U == records.size() ? "\n" : ",\n");
+            }
+            if (!records.empty()) { out << "    "; }
+            out << ']';
+        }
+
+        void constant_records(std::ostream &out, const std::vector<ConstantExpressionRecord> &records) {
+            out << '[';
+            if (!records.empty()) { out << '\n'; }
+            for (std::size_t index = 0; index < records.size(); ++index) {
+                const ConstantExpressionRecord &record = records[index];
+                out << "      {\n        \"id\": " << index << ",\n        \"kind\": ";
+                quote_json(out, constant_category_name(record.category));
+                if (record.literal) {
+                    out << ",\n        \"literal\": ";
+                    literal(out, *record.literal);
+                }
+                if (!record.parameter_identity.empty()) {
+                    out << ",\n        \"parameter\": ";
+                    quote_json(out, record.parameter_identity);
+                }
+                if (!record.operator_spelling.empty() && (record.category == ConstantExpressionCategory::Unary ||
+                                                          record.category == ConstantExpressionCategory::Binary)) {
+                    out << ",\n        \"operator\": ";
+                    quote_json(out, record.operator_spelling);
+                }
+                if (record.lhs != no_schema_id) {
+                    out << ",\n        \"lhs\": ";
+                    schema_reference(out, record.lhs);
+                }
+                if (record.rhs != no_schema_id) {
+                    out << ",\n        \"rhs\": ";
+                    schema_reference(out, record.rhs);
+                }
+                if (!record.member.empty()) {
+                    out << ",\n        \"member\": ";
+                    quote_json(out, record.member);
+                }
+                if (!record.elements.empty()) {
+                    out << ",\n        \"elements\": [\n";
+                    for (std::size_t element_index = 0; element_index < record.elements.size(); ++element_index) {
+                        const ConstantElement &element = record.elements[element_index];
+                        out << "          {";
+                        if (element.key != no_schema_id) {
+                            out << "\n            \"key\": ";
+                            schema_reference(out, element.key);
+                            out << ",";
+                        }
+                        out << "\n            \"value\": ";
+                        schema_reference(out, element.value);
+                        out << "\n          }" << (element_index + 1U == record.elements.size() ? "\n" : ",\n");
+                    }
+                    out << "        ]";
+                }
+                if (!record.items.empty()) {
+                    out << ",\n        \"items\": ";
+                    reference_array(out, record.items, "        ");
+                }
+                if (record.constructed_type != no_schema_id) {
+                    out << ",\n        \"type\": ";
+                    schema_reference(out, record.constructed_type);
+                }
+                if (!record.arguments.empty()) {
+                    out << ",\n        \"arguments\": [\n";
+                    for (std::size_t argument_index = 0; argument_index < record.arguments.size(); ++argument_index) {
+                        const ConstantArgument &argument = record.arguments[argument_index];
+                        out << "          {\n            \"name\": ";
+                        quote_json(out, argument.name);
+                        out << ",\n            \"value\": ";
+                        schema_reference(out, argument.value);
+                        out << "\n          }" << (argument_index + 1U == record.arguments.size() ? "\n" : ",\n");
+                    }
+                    out << "        ]";
+                }
+                if (record.category == ConstantExpressionCategory::Construct) {
+                    out << ",\n        \"delta\": " << (record.delta ? "true" : "false");
+                }
+                out << "\n      }" << (index + 1U == records.size() ? "\n" : ",\n");
+            }
+            if (!records.empty()) { out << "    "; }
+            out << ']';
+        }
+
+        void constraint_records(std::ostream &out, const std::vector<ConstraintRecord> &records) {
+            out << '[';
+            if (!records.empty()) { out << '\n'; }
+            for (std::size_t index = 0; index < records.size(); ++index) {
+                const ConstraintRecord &record = records[index];
+                out << "      {\n        \"id\": " << index << ",\n        \"kind\": ";
+                quote_json(out, constraint_category_name(record.category));
+                if (!record.identity.empty()) {
+                    out << ",\n        \"identity\": ";
+                    quote_json(out, record.identity);
+                }
+                if (!record.registry_name.empty()) {
+                    out << ",\n        \"registry_name\": ";
+                    quote_json(out, record.registry_name);
+                }
+                if (!record.operator_spelling.empty()) {
+                    out << ",\n        \"operator\": ";
+                    quote_json(out, record.operator_spelling);
+                }
+                if (!record.relation_category.empty()) {
+                    out << ",\n        \"category\": ";
+                    quote_json(out, record.relation_category);
+                }
+                const auto reference = [&](std::string_view name, SchemaId value) {
+                    if (value == no_schema_id) { return; }
+                    out << ",\n        \"" << name << "\": ";
+                    schema_reference(out, value);
+                };
+                reference("type", record.type);
+                reference("value", record.value);
+                reference("lhs", record.lhs);
+                reference("rhs", record.rhs);
+                reference("operand", record.operand);
+                reference("result", record.result);
+                if (!record.elements.empty()) {
+                    out << ",\n        \"elements\": ";
+                    reference_array(out, record.elements, "        ");
+                }
+                if (!record.arguments.empty()) {
+                    out << ",\n        \"arguments\": ";
+                    reference_array(out, record.arguments, "        ");
+                }
+                out << "\n      }" << (index + 1U == records.size() ? "\n" : ",\n");
+            }
+            if (!records.empty()) { out << "    "; }
+            out << ']';
+        }
+    }  // namespace
+
+    std::string to_json(const ModuleDescriptor &descriptor) {
+        std::ostringstream out;
+        out.imbue(std::locale::classic());
+        out << "{\n"
+            << "  \"format\": \"hgl.module\",\n"
+            << "  \"format_version\": " << descriptor.format_version << ",\n"
+            << "  \"module\": {\n"
+            << "    \"identity\": ";
+        quote_json(out, descriptor.module_identity);
+        out << ",\n    \"language_version\": ";
+        quote_json(out, descriptor.language_version);
+        out << "\n  },\n  \"interface\": [";
+        if (!descriptor.interface.empty()) { out << '\n'; }
+        for (std::size_t index = 0; index < descriptor.interface.size(); ++index) {
+            const InterfaceDeclaration &declaration = descriptor.interface[index];
+            out << "    {\n      \"category\": ";
+            quote_json(out, declaration_category_name(declaration.category));
+            out << ",\n      \"identity\": ";
+            quote_json(out, declaration.identity);
+            if (!declaration.registry_name.empty()) {
+                out << ",\n      \"registry_name\": ";
+                quote_json(out, declaration.registry_name);
+            }
+            if (declaration.execution != ExecutionKind::None) {
+                out << ",\n      \"execution\": ";
+                quote_json(out, execution_name(declaration.execution));
+            }
+            if (declaration.category == DeclarationCategory::Structure) {
+                out << ",\n      \"abstract\": " << (declaration.abstract ? "true" : "false")
+                    << ",\n      \"generic_parameters\": ";
+                generic_parameters(out, declaration.signature.generics, "      ");
+                out << ",\n      \"parents\": ";
+                reference_array(out, declaration.parents, "      ");
+                out << ",\n      \"requires\": ";
+                schema_reference(out, declaration.signature.requirements);
+                out << ",\n      \"fields\": ";
+                fields(out, declaration.fields, "      ");
+            } else {
+                out << ",\n      \"signature\": ";
+                signature(out, declaration.signature, "      ");
+            }
+            out << "\n    }" << (index + 1U == descriptor.interface.size() ? "\n" : ",\n");
+        }
+        if (!descriptor.interface.empty()) { out << "  "; }
+        out << "],\n  \"provider\": {\n    \"identity\": ";
+        quote_json(out, descriptor.provider_identity);
+        out << ",\n    \"implementations\": [";
+        if (!descriptor.implementations.empty()) { out << '\n'; }
+        for (std::size_t index = 0; index < descriptor.implementations.size(); ++index) {
+            const Implementation &implementation = descriptor.implementations[index];
+            out << "      {\n        \"identity\": ";
+            quote_json(out, implementation.identity);
+            out << ",\n        \"operator\": ";
+            quote_json(out, implementation.operator_identity);
+            out << ",\n        \"registry_name\": ";
+            quote_json(out, implementation.operator_registry_name);
+            out << ",\n        \"execution\": ";
+            quote_json(out, execution_name(implementation.execution));
+            out << ",\n        \"signature\": ";
+            signature(out, implementation.signature, "        ");
+            out << "\n      }" << (index + 1U == descriptor.implementations.size() ? "\n" : ",\n");
+        }
+        if (!descriptor.implementations.empty()) { out << "    "; }
+        out << "],\n    \"requires\": ";
+        string_array(out, descriptor.provider_requirements, "    ");
+        out << "\n  },\n  \"schema\": {\n    \"types\": ";
+        type_records(out, descriptor.types);
+        out << ",\n    \"constant_expressions\": ";
+        constant_records(out, descriptor.constant_expressions);
+        out << ",\n    \"constraints\": ";
+        constraint_records(out, descriptor.constraints);
+        out << "\n  },\n  \"build\": {\n    \"public_headers\": ";
+        string_array(out, descriptor.build.public_headers, "    ");
+        out << ",\n    \"cmake_packages\": ";
+        string_array(out, descriptor.build.cmake_packages, "    ");
+        out << ",\n    \"imported_targets\": ";
+        string_array(out, descriptor.build.imported_targets, "    ");
+        out << ",\n    \"registration\": {\n      \"kind\": \"cpp\",\n      \"symbol\": ";
+        quote_json(out, descriptor.build.registration_symbol);
+        out << "\n    }\n  }\n}\n";
+        return out.str();
+    }
+}  // namespace hgl::descriptor

--- a/language/tests/cmake/package_test.cmake
+++ b/language/tests/cmake/package_test.cmake
@@ -34,8 +34,17 @@ if(NOT EXISTS "${_descriptor}")
 endif()
 file(READ "${_descriptor}" _descriptor_text)
 if(NOT _descriptor_text MATCHES "\"format\"[ 	]*:[ 	]*\"hgl.module\"" OR
-   NOT _descriptor_text MATCHES "\"identity\"[ 	]*:[ 	]*\"pkg.new\"")
+   NOT _descriptor_text MATCHES "\"identity\"[ 	]*:[ 	]*\"pkg.new\"" OR
+   NOT _descriptor_text MATCHES "\"schema\"[ 	]*:")
     message(FATAL_ERROR "generated package descriptor has the wrong envelope:\n${_descriptor_text}")
+endif()
+execute_process(
+    COMMAND "${PYTHON}" -m json.tool "${_descriptor}"
+    RESULT_VARIABLE _descriptor_json_result
+    OUTPUT_QUIET
+    ERROR_VARIABLE _descriptor_json_error)
+if(NOT _descriptor_json_result EQUAL 0)
+    message(FATAL_ERROR "generated package descriptor is not valid JSON:\n${_descriptor_json_error}")
 endif()
 execute_process(
     COMMAND "${PYTHON}" -m py_compile

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -104,6 +104,9 @@ TEST_CASE("emit-cpp names the pair after the module and exports its functions", 
     CHECK(emitted->exports == std::vector<std::string>{"plus", "scaled_sum", "above", "maybe_double", "offset_by"});
     CHECK(contains(emitted->descriptor, "\"format\": \"hgl.module\""));
     CHECK(contains(emitted->descriptor, "\"identity\": \"hgl.codegen.parity\""));
+    CHECK(contains(emitted->descriptor, "\"signature\": {"));
+    CHECK(contains(emitted->descriptor, "\"schema\": {"));
+    CHECK(contains(emitted->descriptor, "\"kind\": \"scalar\""));
     CHECK(contains(emitted->descriptor, "\"public_headers\": [\n      \"parity.h\""));
     CHECK(contains(emitted->descriptor, "\"symbol\": \"hgl::codegen::parity::register_operators\""));
 

--- a/language/tests/descriptor/module_descriptor_tests.cpp
+++ b/language/tests/descriptor/module_descriptor_tests.cpp
@@ -2,6 +2,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <limits>
 #include <string>
 
 namespace descriptor = hgl::descriptor;
@@ -56,6 +57,92 @@ TEST_CASE("module descriptors normalize public and provider inventories", "[desc
     CHECK(result.build.imported_targets == std::vector<std::string>{"hgraph::core", "zeta::native"});
 }
 
+TEST_CASE("module descriptors retain structured signatures layouts and constraints", "[descriptor][schema]") {
+    gir::Module module;
+    module.path     = "checks.schema";
+    module.bindings = {
+        gir::Binding{.name = "T", .kind = gir::BindingKind::TypeParameter, .owner_identity = "checks.schema.Range"},
+        gir::Binding{.name = "T", .kind = gir::BindingKind::TypeParameter, .owner_identity = "checks.schema.summarize"},
+        gir::Binding{.name = "max_size", .kind = gir::BindingKind::ConstParameter, .owner_identity = "checks.schema.summarize"},
+        gir::Binding{.name = "window", .kind = gir::BindingKind::SignalParameter, .owner_identity = "checks.schema.summarize"},
+    };
+    module.types = {
+        gir::Type{.kind = hgl::ir::hir::TypeKind::Scalar, .scalar = hgl::ir::hir::ScalarType::I64},
+        gir::Type{.kind = hgl::ir::hir::TypeKind::Scalar, .scalar = hgl::ir::hir::ScalarType::F64},
+        gir::Type{.kind = hgl::ir::hir::TypeKind::Symbol, .nominal_identity = "T", .binding = gir::BindingId{0}},
+        gir::Type{.kind = hgl::ir::hir::TypeKind::Symbol, .nominal_identity = "T", .binding = gir::BindingId{1}},
+        gir::Type{.kind = hgl::ir::hir::TypeKind::Rolling, .children = {gir::TypeId{3}}, .size = gir::ConstExprId{0}},
+    };
+    module.const_exprs = {
+        gir::ConstExpr{.kind = gir::ConstExprKind::Parameter, .parameter = "max_size", .parameter_binding = gir::BindingId{2}},
+        gir::ConstExpr{.kind = gir::ConstExprKind::Literal, .literal = hgl::ir::hir::Constant{true}},
+    };
+    module.constraints = {
+        gir::Constraint{.node = gir::ConstraintSymbol{"T"}},
+        gir::Constraint{.node = gir::ConstraintType{gir::TypeId{0}}},
+        gir::Constraint{.node = gir::ConstraintType{gir::TypeId{1}}},
+        gir::Constraint{.node = gir::ConstraintSet{{gir::ConstraintId{1}, gir::ConstraintId{2}}}},
+        gir::Constraint{.node = gir::ConstraintRelation{gir::ConstraintRelationOp::In, gir::ConstraintId{0}, gir::ConstraintId{3}}},
+        gir::Constraint{.node = gir::ConstraintValue{gir::ConstExprId{1}}},
+        gir::Constraint{.node = gir::ConstraintCall{"schema", {gir::ConstraintId{0}}}},
+        gir::Constraint{.node = gir::OperatorRequirement{"checks.schema.add", "add_", {gir::ConstraintId{0}}, gir::TypeId{3}}},
+        gir::Constraint{.node = gir::ConstraintRelation{gir::ConstraintRelationOp::Equal, gir::ConstraintId{6},
+                                                        gir::ConstraintId{7}, "compatibility"}},
+        gir::Constraint{.node = gir::ConstraintNot{gir::ConstraintId{8}}},
+        gir::Constraint{.node = gir::ConstraintLogic{gir::ConstraintLogicOp::And, gir::ConstraintId{9}, gir::ConstraintId{5}}},
+    };
+    module.structures = {
+        gir::StructContract{
+            .identity     = "checks.schema.Range",
+            .exported     = true,
+            .generics     = {gir::GenericParameter{"T", false, {}, gir::BindingId{0}}},
+            .requirements = gir::ConstraintId{4},
+            .fields       = {gir::StructField{.name = "lower", .type = gir::TypeId{2}, .origin_identity = "checks.schema.Range"}},
+        },
+    };
+    module.operators = {
+        gir::OperatorContract{
+            .identity     = "checks.schema.summarize",
+            .generics     = {gir::GenericParameter{"T", false, {}, gir::BindingId{1}},
+                             gir::GenericParameter{"max_size", true, gir::TypeId{0}, gir::BindingId{2}}},
+            .parameters   = {gir::Parameter{"window", false, gir::TypeId{4}, {}, gir::BindingId{3}}},
+            .result       = gir::TypeId{3},
+            .requirements = gir::ConstraintId{10},
+        },
+    };
+
+    const descriptor::ModuleDescriptor result = descriptor::describe_module(module, {});
+
+    REQUIRE(result.interface.size() == 2U);
+    const descriptor::InterfaceDeclaration &range = result.interface[0];
+    CHECK(range.identity == "checks.schema.Range");
+    CHECK(range.signature.requirements == 0U);
+    REQUIRE(range.fields.size() == 1U);
+    CHECK(range.fields.front().origin_identity == "checks.schema.Range");
+
+    const descriptor::InterfaceDeclaration &summarize = result.interface[1];
+    REQUIRE(summarize.signature.generics.size() == 2U);
+    CHECK(summarize.signature.generics[1].binding_identity == "checks.schema.summarize::max_size");
+    REQUIRE(summarize.signature.parameters.size() == 1U);
+    CHECK(summarize.signature.parameters.front().binding_identity == "checks.schema.summarize::window");
+    REQUIRE(result.constant_expressions.size() == 2U);
+    CHECK(result.constant_expressions.front().parameter_identity == "checks.schema.summarize::max_size");
+    REQUIRE(result.constraints.size() == 11U);
+    CHECK(result.constraints.front().operator_spelling == "in");
+    CHECK(result.constraints[2].category == descriptor::ConstraintCategory::Set);
+    CHECK(result.constraints[5].category == descriptor::ConstraintCategory::Logic);
+    CHECK(result.constraints[6].category == descriptor::ConstraintCategory::Not);
+    CHECK(result.constraints[8].category == descriptor::ConstraintCategory::Call);
+    CHECK(result.constraints[9].registry_name == "add_");
+    CHECK(result.constraints[10].category == descriptor::ConstraintCategory::Value);
+
+    const std::string json = descriptor::to_json(result);
+    CHECK(json.find("\"binding\": \"checks.schema.Range::T\"") != std::string::npos);
+    CHECK(json.find("\"kind\": \"rolling\"") != std::string::npos);
+    CHECK(json.find("\"operator\": \"in\"") != std::string::npos);
+    CHECK(json.find("\"category\": \"compatibility\"") != std::string::npos);
+}
+
 TEST_CASE("module descriptor JSON is canonical and reviewable", "[descriptor]") {
     descriptor::ModuleDescriptor module;
     module.module_identity   = "acme.\"prices\"";
@@ -80,7 +167,13 @@ TEST_CASE("module descriptor JSON is canonical and reviewable", "[descriptor]") 
     {
       "category": "operator",
       "identity": "acme.prices.value",
-      "registry_name": "value"
+      "registry_name": "value",
+      "signature": {
+        "generic_parameters": [],
+        "parameters": [],
+        "result": null,
+        "requires": null
+      }
     }
   ],
   "provider": {
@@ -89,6 +182,11 @@ TEST_CASE("module descriptor JSON is canonical and reviewable", "[descriptor]") 
     "requires": [
       "hgraph.stdlib"
     ]
+  },
+  "schema": {
+    "types": [],
+    "constant_expressions": [],
+    "constraints": []
   },
   "build": {
     "public_headers": [
@@ -107,4 +205,98 @@ TEST_CASE("module descriptor JSON is canonical and reviewable", "[descriptor]") 
   }
 }
 )json");
+}
+
+TEST_CASE("module descriptor literals preserve values outside JSON's numeric model", "[descriptor][schema]") {
+    descriptor::ModuleDescriptor module;
+    module.constant_expressions = {
+        descriptor::ConstantExpressionRecord{.literal = hgl::ir::hir::Constant{std::numeric_limits<std::int64_t>::max()}},
+        descriptor::ConstantExpressionRecord{.literal = hgl::ir::hir::Constant{std::numeric_limits<double>::infinity()}},
+        descriptor::ConstantExpressionRecord{.literal = hgl::ir::hir::Constant{-std::numeric_limits<double>::infinity()}},
+    };
+
+    const std::string json = descriptor::to_json(module);
+    CHECK(json.find("\"value\": \"9223372036854775807\"") != std::string::npos);
+    CHECK(json.find("\"value\": \"inf\"") != std::string::npos);
+    CHECK(json.find("\"value\": \"-inf\"") != std::string::npos);
+}
+
+TEST_CASE("module descriptors preserve structured compile-time expressions", "[descriptor][schema]") {
+    gir::Module module;
+    module.path        = "checks.constants";
+    module.types       = {gir::Type{.kind = hgl::ir::hir::TypeKind::Scalar, .scalar = hgl::ir::hir::ScalarType::I64}};
+    module.const_exprs = {
+        gir::ConstExpr{.kind = gir::ConstExprKind::Literal, .literal = hgl::ir::hir::Constant{std::int64_t{1}}},
+        gir::ConstExpr{.kind = gir::ConstExprKind::Literal, .literal = hgl::ir::hir::Constant{std::int64_t{2}}},
+        gir::ConstExpr{.kind = gir::ConstExprKind::Unary, .unary = hgl::ir::hir::UnaryOp::Negate, .lhs = gir::ConstExprId{0}},
+        gir::ConstExpr{.kind   = gir::ConstExprKind::Binary,
+                       .binary = hgl::ir::hir::BinaryOp::Add,
+                       .lhs    = gir::ConstExprId{0},
+                       .rhs    = gir::ConstExprId{1}},
+        gir::ConstExpr{.kind     = gir::ConstExprKind::Sequence,
+                       .elements = {{.value = gir::ConstExprId{0}}, {.key = gir::ConstExprId{0}, .value = gir::ConstExprId{1}}}},
+        gir::ConstExpr{.kind = gir::ConstExprKind::Index, .lhs = gir::ConstExprId{4}, .rhs = gir::ConstExprId{0}},
+        gir::ConstExpr{.kind = gir::ConstExprKind::Field, .lhs = gir::ConstExprId{4}, .member = "value"},
+        gir::ConstExpr{.kind = gir::ConstExprKind::Tuple, .items = {gir::ConstExprId{0}, gir::ConstExprId{1}}},
+        gir::ConstExpr{.kind             = gir::ConstExprKind::Construct,
+                       .constructed_type = gir::TypeId{0},
+                       .arguments        = {{"value", gir::ConstExprId{0}}},
+                       .delta            = true},
+    };
+    module.callables = {
+        gir::Callable{
+            .identity   = "checks.constants.public_defaults",
+            .visibility = gir::CallableVisibility::Export,
+            .parameters = {gir::Parameter{"unary", false, gir::TypeId{0}, gir::ConstExprId{2}},
+                           gir::Parameter{"binary", false, gir::TypeId{0}, gir::ConstExprId{3}},
+                           gir::Parameter{"index", false, gir::TypeId{0}, gir::ConstExprId{5}},
+                           gir::Parameter{"field", false, gir::TypeId{0}, gir::ConstExprId{6}},
+                           gir::Parameter{"tuple", false, gir::TypeId{0}, gir::ConstExprId{7}},
+                           gir::Parameter{"construct", false, gir::TypeId{0}, gir::ConstExprId{8}}},
+            .result     = gir::TypeId{0},
+        },
+    };
+
+    const descriptor::ModuleDescriptor result = descriptor::describe_module(module, {});
+
+    REQUIRE(result.constant_expressions.size() == 9U);
+    CHECK(result.constant_expressions[0].category == descriptor::ConstantExpressionCategory::Unary);
+    CHECK(result.constant_expressions[2].category == descriptor::ConstantExpressionCategory::Binary);
+    CHECK(result.constant_expressions[4].category == descriptor::ConstantExpressionCategory::Index);
+    CHECK(result.constant_expressions[5].category == descriptor::ConstantExpressionCategory::Sequence);
+    CHECK(result.constant_expressions[6].category == descriptor::ConstantExpressionCategory::Field);
+    CHECK(result.constant_expressions[7].category == descriptor::ConstantExpressionCategory::Tuple);
+    CHECK(result.constant_expressions[8].category == descriptor::ConstantExpressionCategory::Construct);
+
+    const std::string json = descriptor::to_json(result);
+    CHECK(json.find("\"member\": \"value\"") != std::string::npos);
+    CHECK(json.find("\"elements\": [") != std::string::npos);
+    CHECK(json.find("\"delta\": true") != std::string::npos);
+}
+
+TEST_CASE("module descriptor schema IDs ignore source arena and declaration order", "[descriptor][schema]") {
+    gir::Module first;
+    first.path  = "checks.order";
+    first.types = {
+        gir::Type{.kind = hgl::ir::hir::TypeKind::Scalar, .scalar = hgl::ir::hir::ScalarType::F64},
+        gir::Type{.kind = hgl::ir::hir::TypeKind::Scalar, .scalar = hgl::ir::hir::ScalarType::I64},
+    };
+    first.callables = {
+        gir::Callable{.identity = "checks.order.zeta", .visibility = gir::CallableVisibility::Export, .result = gir::TypeId{1}},
+        gir::Callable{.identity = "checks.order.alpha", .visibility = gir::CallableVisibility::Export, .result = gir::TypeId{0}},
+    };
+
+    gir::Module second;
+    second.path  = first.path;
+    second.types = {
+        gir::Type{.kind = hgl::ir::hir::TypeKind::Scalar, .scalar = hgl::ir::hir::ScalarType::I64},
+        gir::Type{.kind = hgl::ir::hir::TypeKind::Scalar, .scalar = hgl::ir::hir::ScalarType::F64},
+    };
+    second.callables = {
+        gir::Callable{.identity = "checks.order.alpha", .visibility = gir::CallableVisibility::Export, .result = gir::TypeId{1}},
+        gir::Callable{.identity = "checks.order.zeta", .visibility = gir::CallableVisibility::Export, .result = gir::TypeId{0}},
+    };
+
+    CHECK(descriptor::to_json(descriptor::describe_module(first, {})) ==
+          descriptor::to_json(descriptor::describe_module(second, {})));
 }


### PR DESCRIPTION
## Summary

- emit structured public and provider signatures, struct layouts, defaults, canonical types, and generic constraints in HGL module descriptors
- preserve stable declaration-scoped bindings and deterministic descriptor-local schema references
- split canonical JSON serialization from HGraph IR snapshot construction and encode i64/f64 literal payloads without narrowing or invalid JSON
- document the implemented interface boundary and the remaining descriptor reader, dependency, lifecycle, ownership/effect, and fingerprint work

## Validation

- `ctest --test-dir cmake-build-hgl-lexy --parallel 2 --output-on-failure` (1,749/1,749)
- `cmake --preset cpp --fresh`
- `cmake --build --preset cpp --target clean`
- `cmake --build --preset cpp --parallel`
- `ctest --preset cpp --parallel 2` (1,716/1,716)
- Python 3.12 ABI3 wheel installed under Python 3.14; `pytest python/tests -q -m "not wip"` (3,241 passed, 10 skipped)
- `.venv/bin/sphinx-build -W --keep-going -b html docs/source <temp>`
- clang-format check and `git diff --check`
- all eight HGL example/codegen inputs emitted descriptors accepted by `python3 -m json.tool`

Stacked on #719.