### PR TITLE
Type layer: opaque Python slots and the PythonOps provider (RFC 0035, PR 1 of 5)

### DIFF
--- a/docs/source/developer_guide/data_structures/plans_and_ops/ops_catalogue.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/ops_catalogue.rst
@@ -136,10 +136,10 @@ constant when the ops struct layout changes.
      - Value
      - Declared in
    * - ``VALUE_OPS_ABI_VERSION``
-     - 6
+     - 7
      - ``include/hgraph/types/value/value_ops.h``
    * - ``TS_DATA_OPS_ABI_VERSION``
-     - 10
+     - 13
      - ``include/hgraph/types/time_series/ts_type_ref.h``
    * - ``NODE_OPS_ABI_VERSION``
      - 5

--- a/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
@@ -136,7 +136,14 @@ The implementation uses the following names consistently:
     ``Output`` roles. Data and Output select mutable role-specific ops; an
     owned Input selects the corresponding physical plan under a read-only
     role, while peered positions select target-link storage and ops.
-    ``TS_DATA_OPS_ABI_VERSION`` is 10. ABI 10 removes the never-dispatched
+    ``TS_DATA_OPS_ABI_VERSION`` is 13. ABI 13 (RFC 0035) makes the Python
+    slots unconditional -- typed on the opaque ``PyRef`` / ``PyNewRef`` and
+    present in a Python-disabled build too, with ``PythonTSDataOps`` now a
+    type-layer struct whose default is the throwing table -- so a table
+    built with Python off has the same layout as one built with Python on;
+    ``VALUE_OPS_ABI_VERSION`` moves to 7 for the same reason. ABI 11 and 12 made the
+    keyed and window TSData projections representation-safe.
+    ABI 10 removes the never-dispatched
     ``reset_delta`` hook (slot deltas roll lazily inside the storages), adds
     the explicit ``is_target_link`` and ``is_input_binding`` discriminators
     (replacing ownership-ops pointer-identity comparisons), and gives the
@@ -476,7 +483,7 @@ TargetLink projection into producer-owned storage. The ownership table reports
 TargetLink trie/observer storage at the owning endpoint and traverses only
 owned children. This projection is private lifecycle infrastructure; it adds no
 storage-layout cost, and its ops-table ABI contribution is tracked by
-``TS_DATA_OPS_ABI_VERSION``, currently 10.
+``TS_DATA_OPS_ABI_VERSION``, currently 13.
 
 Fixed to-REF alternatives are the exception to the general legacy-alternative
 rule. Their allocation is owned through the canonical Data-role record. At the

--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -505,9 +505,50 @@ Value and reference crossings
   source is wired under the hood) — a Python node seeing ``None`` for an
   unwired input is contract, not a lost value.
 - **No kind-switches in conversion**: Value ↔ Python conversion binds onto the
-  per-type *ops tables* (``python_conversion_traits`` hooks), never a switch
-  over value kinds in the bridge (ruling 2026-07-07). If a new value kind
-  needs conversion, extend its ops, not ``value_conversion.cpp``.
+  per-type *ops tables*, never a switch over value kinds in the bridge
+  (ruling 2026-07-07). If a new value kind needs conversion, extend its ops,
+  not ``value_conversion.cpp``.
+- **The type layer converts through the registered ``PythonOps`` table**
+  (RFC 0035, 2026-09-06): the Python slots of ``ValueOps``, ``TSDataOps`` and
+  the TS input shape ops are typed on the opaque ``PyRef`` / ``PyNewRef``
+  of ``include/hgraph/types/python_object.h`` (a forward-declared
+  ``struct _object``: borrowed in, one new reference out) and hold
+  Python-free *forwarders* from ``include/hgraph/types/python_ops.h``. A
+  forwarder reads the provider the bridge registered
+  (``python_bridge::register_python_ops``, at unit load and again from the
+  module initializer) when the slot is called and passes the arguments to
+  its family's entry unchanged; scalars resolve ``typeid(T)`` through
+  ``scalars.conversion_for`` on their first conversion and cache the hit
+  (the bridge keys that registry by the mangled type name, because the
+  forwarder and the registration live in different libraries and two
+  libraries' ``type_info`` objects need not compare equal on macOS).
+  Nothing reads the table when a table is constructed, so there is no
+  ordering rule between constructing a type's ops and registering its
+  conversion (the module registers the stdlib enums after
+  ``register_standard_operators()`` has used them; an extension may register
+  its scalars after its operators). A missing provider or entry throws
+  ``no Python conversion is registered for ...`` where the compiled-in thunks
+  used to throw *not available*. The former ``ValueOps::to_python``,
+  ``ValueView::to_python`` / ``from_python`` / ``assign_from_python``,
+  ``Value::to_python``, ``TSDataView::value_to_python`` /
+  ``delta_value_to_python``, ``TSDataMutationView::from_python`` and
+  ``TSInputView::value_to_python`` / ``delta_value_to_python`` are the free
+  functions of ``include/hgraph/python/conversion.h``, which is also the one
+  place that converts between the opaque references and nanobind
+  (``borrow`` / ``give`` / ``take``) and holds the ``*_slot<&fn>`` adapters
+  a family's conversion body uses until it moves to a bridge unit.
+  ``python_conversion_traits<T>`` -- the scalar customisation point -- and
+  ``register_python_scalar_conversion<T>()`` live in
+  ``include/hgraph/python/native_scalar_registration.h``;
+  ``register_native_scalar_type<T>`` registers the conversion before the
+  schema, and the core scalars' specialisations (``Time``, ``Bytes``, the
+  temporal types, the ``Frame`` / ``Series`` / ``TimeSeriesReference`` /
+  ``ValueCallable`` / ``WiredFn`` hook pairs the module installs) are in
+  ``include/hgraph/python/scalar_conversions.h``. The
+  ``type-layer-python-conditionals`` and ``type-layer-nanobind`` ratchets
+  measure what is left: the conversion bodies still beside their storage
+  (``*_slot<&fn>`` adapted) move to ``src/hgraph/python/impl/`` family by
+  family per the RFC's implementation plan.
 - **One set of Python-object value primitives** (2026-09-05):
   ``python_bridge::object_hash`` / ``object_equals`` / ``object_compare`` /
   ``object_str`` -- the contract in ``include/hgraph/python/object_semantics.h``,

--- a/docs/source/developer_guide/testing.rst
+++ b/docs/source/developer_guide/testing.rst
@@ -214,8 +214,12 @@ Each entry names the layer that owns the rule:
 * a second or third ancestry walker beside ``TypeRegistry::value_is_a``;
 * operators recomputing ``value_type_for_active_realization`` instead of
   reading the binding from their bound views;
-* Python-object hashing in more than one translation unit, and
-  ``HGRAPH_ENABLE_PYTHON_USER_NODES`` conditionals inside the type layer;
+* Python-object hashing in more than one translation unit,
+  ``HGRAPH_ENABLE_PYTHON_USER_NODES`` conditionals inside the type layer,
+  and ``nanobind`` spelled inside the type layer (RFC 0035: the type layer
+  names Python only through the opaque references of ``python_object.h``
+  and the ``PythonOps`` provider; both counts fall to zero family by
+  family);
 * ``thread_local`` in the runtime;
 * a bare ``catch (...)`` outside ``util/scope.h`` and the three documented
   translation boundaries -- an exception boundary without a name (see

--- a/docs/source/rfc/rfc_0035_python_free_type_layer.rst
+++ b/docs/source/rfc/rfc_0035_python_free_type_layer.rst
@@ -620,7 +620,28 @@ Five PRs, each green on the full gate, each lowering the ratchet:
 Implementation status
 ---------------------
 
-Proposed; no implementation has merged.
+Proposed. PR 1 (``hardening/python-ops-slots``) implements the slots, the
+opaque reference, the ``PythonOps`` provider and its forwarders, the bridge
+``conversion.h`` wrappers, the scalar / enum / ``Any`` conversions through
+the provider and the relocated trait specialisations; the remaining
+conversion bodies are adapted to the opaque slots with ``*_slot<&fn>``
+adapters where they stand. ``type-layer-python-conditionals`` 160 → 120
+(the three extra mentions over the plan's 118 are the transitional guarded
+``conversion.h`` includes of the two container-ops headers, gone with PR 2);
+``type-layer-nanobind`` introduced at 525 and ratcheted from there rather
+than at the end, so the count can only fall. Implementation experience
+recorded: every Python-aware unit must see nanobind's ``std::string``
+caster (``conversion.h`` and ``bridge_state.h`` include it) -- the type
+layer's ``value_ops.h`` used to supply it to everyone, and a unit that
+instantiates the generic caster instead can win the link for the whole
+library, after which every ``str`` crossing fails with a bad cast. And the
+scalar registry is keyed by the mangled type *name*, not ``std::type_index``:
+the forwarder that looks a type up is instantiated in whichever library
+first used the type (``hgraph_stdlib`` for ``CmpResult``, an extension's
+native library for its scalars) while the registration comes from the
+Python module, and on macOS two libraries' ``type_info`` objects for one
+type compare unequal unless the RTTI is marked non-unique; 27 ported
+operator tests failed that way before the change.
 
 References
 ----------

--- a/extensions/fabric/src/python_module.cpp
+++ b/extensions/fabric/src/python_module.cpp
@@ -6,6 +6,7 @@
 #include <hgraph/fabric/resolution.h>
 #include <hgraph/fabric/service.h>
 #include <hgraph/fabric/value_builders.h>
+#include <hgraph/python/scalar_conversions.h>
 
 #include <hgraph/persistence/value_store.h>
 

--- a/extensions/kafka/include/hgraph/kafka/types.h
+++ b/extensions/kafka/include/hgraph/kafka/types.h
@@ -308,6 +308,8 @@ namespace hgraph::static_schema_detail
 }  // namespace hgraph::static_schema_detail
 
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
+#include <hgraph/python/native_scalar_registration.h>
+
 namespace hgraph
 {
     #define HGRAPH_KAFKA_PYTHON_ENUM_CONVERSION(EnumType)                                                                          \

--- a/extensions/persistence/include/hgraph/persistence/recording_options.h
+++ b/extensions/persistence/include/hgraph/persistence/recording_options.h
@@ -90,6 +90,7 @@ namespace hgraph
 
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
 #include <hgraph/python/bridge_state.h>
+#include <hgraph/python/native_scalar_registration.h>
 
 namespace hgraph
 {

--- a/extensions/web/include/hgraph/web/types.h
+++ b/extensions/web/include/hgraph/web/types.h
@@ -304,6 +304,8 @@ namespace hgraph::static_schema_detail
 }  // namespace hgraph::static_schema_detail
 
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
+#include <hgraph/python/native_scalar_registration.h>
+
 namespace hgraph
 {
     #define HGRAPH_WEB_PYTHON_ENUM_CONVERSION(EnumType)                                                                            \

--- a/include/hgraph/lib/std/operators/arithmetic.h
+++ b/include/hgraph/lib/std/operators/arithmetic.h
@@ -248,6 +248,7 @@ namespace hgraph::stdlib
 
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
 #include <hgraph/python/bridge_state.h>
+#include <hgraph/python/native_scalar_registration.h>
 
 namespace hgraph
 {

--- a/include/hgraph/lib/std/operators/comparison.h
+++ b/include/hgraph/lib/std/operators/comparison.h
@@ -168,6 +168,7 @@ namespace hgraph::stdlib
 
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
 #include <hgraph/python/bridge_state.h>
+#include <hgraph/python/native_scalar_registration.h>
 
 namespace hgraph
 {

--- a/include/hgraph/lib/std/operators/table.h
+++ b/include/hgraph/lib/std/operators/table.h
@@ -74,6 +74,7 @@ namespace hgraph::static_schema_detail
 
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
 #include <hgraph/python/bridge_state.h>
+#include <hgraph/python/native_scalar_registration.h>
 
 namespace hgraph
 {

--- a/include/hgraph/python/bridge_state.h
+++ b/include/hgraph/python/bridge_state.h
@@ -7,6 +7,7 @@
 #include <hgraph/hgraph_export.h>
 
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>  // one std::string caster for every unit (see conversion.h)
 
 #include <utility>
 #include <span>

--- a/include/hgraph/python/conversion.h
+++ b/include/hgraph/python/conversion.h
@@ -1,0 +1,135 @@
+#ifndef HGRAPH_PYTHON_CONVERSION_H
+#define HGRAPH_PYTHON_CONVERSION_H
+
+#include <hgraph/config.h>
+
+#if HGRAPH_ENABLE_PYTHON_USER_NODES
+
+#include <hgraph/hgraph_export.h>
+#include <hgraph/types/python_object.h>
+#include <hgraph/types/time_series/ts_data/base_view.h>
+#include <hgraph/types/time_series/ts_input/base_view.h>
+#include <hgraph/types/value/value.h>
+#include <hgraph/types/value/value_ops.h>
+#include <hgraph/types/value/value_view.h>
+#include <hgraph/util/date_time.h>
+
+#include <nanobind/nanobind.h>
+// Every Python-aware unit must see the same std::string caster: an inline
+// instantiation without it (the generic bound-class caster) can win the link
+// for the whole library and every str crossing then fails with a bad cast.
+#include <nanobind/stl/string.h>
+
+/**
+ * Value / TSData / TSInput <-> Python through the type-erased slots (RFC
+ * 0035). The type layer's slots are typed on the opaque ``PyRef`` /
+ * ``PyNewRef``; this header is the one place that converts between them
+ * and nanobind, and it carries the former ``ValueOps::to_python``,
+ * ``ValueView::to_python``, ``TSDataView::value_to_python`` ... members as
+ * free functions so the type layer needs no Python member at all.
+ */
+namespace hgraph
+{
+    // The alias the type layer's guarded conversion bodies used from
+    // value_ops.h; it moves out with them, family by family.
+    namespace nb = nanobind;
+}
+
+namespace hgraph::python_bridge
+{
+    namespace nb = nanobind;
+
+    // -- opaque reference helpers ------------------------------------------
+    [[nodiscard]] inline PyRef borrow(nb::handle source) noexcept { return PyRef{source.ptr()}; }
+    [[nodiscard]] inline nb::handle handle_of(PyRef source) noexcept { return nb::handle{source.ptr}; }
+    /** Hand a new reference across a slot boundary. */
+    [[nodiscard]] inline PyNewRef give(nb::object object) noexcept { return PyNewRef{object.release().ptr()}; }
+    /** Receive a new reference from a slot; a null result is a broken slot. */
+    [[nodiscard]] HGRAPH_EXPORT nb::object take(PyNewRef result);
+
+    // -- slot adapters ---------------------------------------------------------
+    // Wrap a nanobind-typed implementation as an opaque slot so a family's
+    // conversion body keeps its ``nb::object`` / ``nb::handle`` signature
+    // while it still lives beside its storage (the bodies move to bridge
+    // units family by family; see the RFC's implementation plan).
+    template <auto Fn>
+    PyNewRef to_python_slot(const void *context, const void *memory)
+    {
+        return give(Fn(context, memory));
+    }
+    template <auto Fn>
+    void from_python_slot(const void *context, const ValueTypeRef &binding, void *memory, PyRef source)
+    {
+        Fn(context, binding, memory, handle_of(source));
+    }
+    template <auto Fn>
+    PyNewRef to_python_buffer_slot(const void *context, const ValueTypeRef &binding, const ValueArraySource &source)
+    {
+        return give(Fn(context, binding, source));
+    }
+    template <auto Fn>
+    bool ts_from_python_slot(const void *context, void *memory, PyRef source, DateTime modified_time)
+    {
+        return Fn(context, memory, handle_of(source), modified_time);
+    }
+    template <auto Fn>
+    PyNewRef ts_delta_to_python_slot(const void *context, const void *memory, DateTime evaluation_time)
+    {
+        return give(Fn(context, memory, evaluation_time));
+    }
+
+    // -- value conversions -----------------------------------------------------
+    /** The binding's ``to_python`` slot over ``memory``; throws when the type has none. */
+    [[nodiscard]] HGRAPH_EXPORT nb::object to_python(const ValueOps &ops, const void *memory);
+    [[nodiscard]] inline nb::object to_python(const ValueTypeRef &binding, const void *memory)
+    {
+        return to_python(binding.ops_ref(), memory);
+    }
+    HGRAPH_EXPORT void from_python(const ValueOps &ops, const ValueTypeRef &binding, void *memory, nb::handle source);
+    inline void from_python(const ValueTypeRef &binding, void *memory, nb::handle source)
+    {
+        from_python(binding.ops_ref(), binding, memory, source);
+    }
+    [[nodiscard]] HGRAPH_EXPORT bool can_to_python_buffer(const ValueOps &ops, const ValueTypeRef &binding) noexcept;
+    [[nodiscard]] HGRAPH_EXPORT nb::object to_python_buffer(const ValueOps &ops, const ValueTypeRef &binding,
+                                                            const ValueArraySource &source);
+
+    /** ``ValueView::to_python``: requires a non-empty view. */
+    [[nodiscard]] HGRAPH_EXPORT nb::object to_python(const ValueView &view);
+    /** ``ValueView::from_python``: a mutation-protocol write into a non-empty view; ``None`` is refused. */
+    HGRAPH_EXPORT void from_python(const ValueView &view, nb::handle source);
+    /**
+     * ``ValueView::assign_from_python``: a LIFECYCLE-level write like
+     * ``copy_assign`` -- it requires writable storage but not the mutation
+     * protocol, so compact (immutable-API) containers construct through it.
+     */
+    HGRAPH_EXPORT void assign_from_python(const ValueView &view, nb::handle source);
+    /** ``Value::to_python``: ``None`` for an empty value. */
+    [[nodiscard]] HGRAPH_EXPORT nb::object to_python(const Value &value);
+    /** ``Value::from_python``: ``None`` resets; otherwise a schema-bound replacement. */
+    HGRAPH_EXPORT void from_python(Value &value, nb::handle source);
+
+    // -- time-series conversions ----------------------------------------------
+    /**
+     * Export the current value through the live representation's erased
+     * TSDataOps. Structural implementations recurse through child TSDataOps
+     * and produce the complete public Python shape; callers never switch on
+     * TSTypeKind and rebuild it.
+     */
+    [[nodiscard]] HGRAPH_EXPORT nb::object value_to_python(const TSDataView &view);
+    /** Export the delta for ``evaluation_time`` the same way; ``None`` when unchanged. */
+    [[nodiscard]] HGRAPH_EXPORT nb::object delta_value_to_python(const TSDataView &view, DateTime evaluation_time);
+    /** Apply a Python object through the binding's erased conversion; true when newly modified. */
+    [[nodiscard]] HGRAPH_EXPORT bool from_python(TSDataMutationView &view, nb::handle source);
+    [[nodiscard]] inline bool from_python(TSDataMutationView &&view, nb::handle source)
+    {
+        return from_python(view, source);
+    }
+    /** Export an input's current value through the resolved endpoint's erased TSDataOps. */
+    [[nodiscard]] HGRAPH_EXPORT nb::object value_to_python(const TSInputView &view);
+    /** Export an input's delta, preserving the sampled-rebind semantics TSInputView owns. */
+    [[nodiscard]] HGRAPH_EXPORT nb::object delta_value_to_python(const TSInputView &view);
+}  // namespace hgraph::python_bridge
+
+#endif  // HGRAPH_ENABLE_PYTHON_USER_NODES
+#endif  // HGRAPH_PYTHON_CONVERSION_H

--- a/include/hgraph/python/conversion.h
+++ b/include/hgraph/python/conversion.h
@@ -8,7 +8,9 @@
 #include <hgraph/hgraph_export.h>
 #include <hgraph/types/python_object.h>
 #include <hgraph/types/time_series/ts_data/base_view.h>
+#include <hgraph/types/time_series/ts_data/ops.h>
 #include <hgraph/types/time_series/ts_input/base_view.h>
+#include <hgraph/types/time_series/ts_output.h>
 #include <hgraph/types/value/value.h>
 #include <hgraph/types/value/value_ops.h>
 #include <hgraph/types/value/value_view.h>
@@ -76,6 +78,21 @@ namespace hgraph::python_bridge
     PyNewRef ts_delta_to_python_slot(const void *context, const void *memory, DateTime evaluation_time)
     {
         return give(Fn(context, memory, evaluation_time));
+    }
+    template <auto Fn>
+    bool ts_requires_authored_slot(TSRoleTypeRef type, PyRef source)
+    {
+        return Fn(type, handle_of(source));
+    }
+    template <auto Fn>
+    Value ts_delta_from_python_slot(TSRoleTypeRef type, PyRef source, bool authored)
+    {
+        return Fn(type, handle_of(source), authored);
+    }
+    template <auto Fn>
+    void ts_apply_result_slot(const TSOutputView &output, PyRef result)
+    {
+        Fn(output, handle_of(result));
     }
 
     // -- value conversions -----------------------------------------------------

--- a/include/hgraph/python/native_scalar_registration.h
+++ b/include/hgraph/python/native_scalar_registration.h
@@ -6,14 +6,275 @@
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
 
 #include <hgraph/hgraph_export.h>
+#include <hgraph/python/chrono.h>
+#include <hgraph/python/conversion.h>
+#include <hgraph/types/metadata/value_type_meta_data.h>
+#include <hgraph/types/python_object.h>
+#include <hgraph/types/python_ops.h>
 #include <hgraph/types/static_schema.h>
+#include <hgraph/util/date_time.h>
 
 #include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/string.h>
 
+#include <algorithm>
+#include <cstring>
+#include <memory>
+#include <stdexcept>
 #include <string_view>
+#include <type_traits>
+#include <typeindex>
+#include <typeinfo>
+
+namespace hgraph
+{
+    /**
+     * Python-conversion customization point for scalar types the generic
+     * nanobind cast cannot handle (RFC 0003, RFC 0035). Specialise it for
+     * ``T`` and register the type with ``register_python_scalar_conversion<T>``
+     * (which ``register_native_scalar_type<T>`` does for you); the scalar's
+     * ops table resolves to the registration on the type's first conversion,
+     * so the specialisation only has to be visible where it is registered.
+     * Provide:
+     *   static nb::object to_python(const T &);
+     *   static T          from_python(nb::handle);
+     */
+    template <typename T>
+    struct python_conversion_traits;
+}  // namespace hgraph
 
 namespace hgraph::python_bridge
 {
+    namespace nb = nanobind;
+
+    namespace scalar_detail
+    {
+        template <typename T>
+        constexpr bool python_scalar_castable =
+            std::is_arithmetic_v<T> || std::is_same_v<T, std::string> || std::is_same_v<T, Date> ||
+            std::is_same_v<T, DateTime> || std::is_same_v<T, TimeDelta>;
+
+        template <typename T>
+        concept has_python_conversion_traits = requires(const T &value, nb::handle source) {
+            { python_conversion_traits<T>::to_python(value) } -> std::same_as<nb::object>;
+            { python_conversion_traits<T>::from_python(source) } -> std::same_as<T>;
+        };
+
+        template <typename T>
+        PyNewRef to_python_thunk(const void *, const void *memory)
+        {
+            if constexpr (python_scalar_castable<T>)
+            {
+                return give(nb::cast(*static_cast<const T *>(memory)));
+            }
+            else if constexpr (has_python_conversion_traits<T>)
+            {
+                return give(python_conversion_traits<T>::to_python(*static_cast<const T *>(memory)));
+            }
+            else
+            {
+                throw std::logic_error("ValueOps::to_python is not available for this scalar type");
+            }
+        }
+
+        template <typename T>
+        void from_python_thunk(const void *, const ValueTypeRef &, void *memory, PyRef source_ref)
+        {
+            const nb::handle source = handle_of(source_ref);
+            if constexpr (python_scalar_castable<T>)
+            {
+                if constexpr (std::is_arithmetic_v<T>)
+                {
+                    // Pythonic strictness: numeric scalars never convert from
+                    // strings (PyNumber coercion would accept "1"); numeric
+                    // cross-conversions stay permitted.
+                    if (nb::isinstance<nb::str>(source) || nb::isinstance<nb::bytes>(source))
+                    {
+                        throw nb::type_error("cannot convert a python string to a numeric scalar");
+                    }
+                }
+                *static_cast<T *>(memory) = nb::cast<T>(source);
+            }
+            else if constexpr (has_python_conversion_traits<T>)
+            {
+                *static_cast<T *>(memory) = python_conversion_traits<T>::from_python(source);
+            }
+            else
+            {
+                throw std::logic_error("ValueOps::from_python is not available for this scalar type");
+            }
+        }
+
+        template <typename T>
+        struct python_buffer_traits
+        {
+            using storage_type = T;
+
+            static storage_type convert(const void *memory) { return *static_cast<const T *>(memory); }
+
+            [[nodiscard]] static constexpr const char *numpy_view_dtype() noexcept { return nullptr; }
+        };
+
+        template <>
+        struct python_buffer_traits<DateTime>
+        {
+            using storage_type = std::int64_t;
+
+            static storage_type convert(const void *memory)
+            {
+                return static_cast<storage_type>(static_cast<const DateTime *>(memory)->time_since_epoch().count());
+            }
+
+            [[nodiscard]] static constexpr const char *numpy_view_dtype() noexcept { return "datetime64[us]"; }
+        };
+
+        template <>
+        struct python_buffer_traits<TimeDelta>
+        {
+            using storage_type = std::int64_t;
+
+            static storage_type convert(const void *memory)
+            {
+                return static_cast<storage_type>(static_cast<const TimeDelta *>(memory)->count());
+            }
+
+            [[nodiscard]] static constexpr const char *numpy_view_dtype() noexcept { return "timedelta64[us]"; }
+        };
+
+        template <>
+        struct python_buffer_traits<Date>
+        {
+            using storage_type = std::int64_t;
+
+            static storage_type convert(const void *memory)
+            {
+                const auto days =
+                    std::chrono::sys_days{*static_cast<const Date *>(memory)}.time_since_epoch().count();
+                return static_cast<storage_type>(days);
+            }
+
+            [[nodiscard]] static constexpr const char *numpy_view_dtype() noexcept { return "datetime64[D]"; }
+        };
+
+        template <typename Storage>
+        void copy_value_array_span(Storage *&dst, ValueArraySpan span)
+        {
+            if (span.size == 0) { return; }
+            if (span.data == nullptr) { throw std::logic_error("ValueOps::to_python_buffer span has null data"); }
+
+            if (span.stride == sizeof(Storage))
+            {
+                std::memcpy(dst, span.data, span.size * sizeof(Storage));
+                dst += span.size;
+                return;
+            }
+
+            const auto *src = static_cast<const std::byte *>(span.data);
+            for (std::size_t index = 0; index < span.size; ++index)
+            {
+                std::memcpy(dst + index, src + index * span.stride, sizeof(Storage));
+            }
+            dst += span.size;
+        }
+
+        template <typename Storage>
+        void delete_python_buffer(void *memory) noexcept
+        {
+            delete[] static_cast<Storage *>(memory);
+        }
+
+        template <typename T>
+        PyNewRef to_python_buffer_thunk(const void *, const ValueTypeRef &, const ValueArraySource &source)
+        {
+            if constexpr (detail::buffer_compatible_type<T>)
+            {
+                using traits       = python_buffer_traits<T>;
+                using storage_type = typename traits::storage_type;
+
+                auto          owner = std::make_unique<storage_type[]>(std::max<std::size_t>(source.size, 1));
+                storage_type *data  = owner.get();
+
+                constexpr bool direct_copy =
+                    std::is_same_v<std::remove_cv_t<T>, storage_type> && std::is_trivially_copyable_v<storage_type>;
+                if constexpr (direct_copy)
+                {
+                    if (source.first.size + source.second.size == source.size)
+                    {
+                        storage_type *dst = data;
+                        copy_value_array_span<storage_type>(dst, source.first);
+                        copy_value_array_span<storage_type>(dst, source.second);
+                    }
+                    else
+                    {
+                        if (source.element_at == nullptr)
+                        {
+                            throw std::logic_error("ValueOps::to_python_buffer requires an element accessor");
+                        }
+                        for (std::size_t index = 0; index < source.size; ++index)
+                        {
+                            data[index] = traits::convert(source.element_at(source.owner, index));
+                        }
+                    }
+                }
+                else
+                {
+                    if (source.element_at == nullptr)
+                    {
+                        throw std::logic_error("ValueOps::to_python_buffer requires an element accessor");
+                    }
+                    for (std::size_t index = 0; index < source.size; ++index)
+                    {
+                        data[index] = traits::convert(source.element_at(source.owner, index));
+                    }
+                }
+
+                storage_type *owned = owner.release();
+                nb::capsule   owner_capsule{owned, &delete_python_buffer<storage_type>};
+                nb::ndarray<nb::numpy, const storage_type, nb::ndim<1>> array{owned, {source.size}, owner_capsule};
+                nb::object result = array.cast();
+                if constexpr (traits::numpy_view_dtype() != nullptr)
+                {
+                    return give(result.attr("view")(nb::str{traits::numpy_view_dtype()}));
+                }
+                return give(std::move(result));
+            }
+            else
+            {
+                throw std::logic_error("ValueOps::to_python_buffer is not available for this scalar type");
+            }
+        }
+    }  // namespace scalar_detail
+
+    /** The registered slot table for ``T``: one function-local static per type. */
+    template <typename T>
+    [[nodiscard]] const PythonScalarSlots &python_scalar_slots_for() noexcept
+    {
+        static const PythonScalarSlots slots{
+            .to_python        = &scalar_detail::to_python_thunk<T>,
+            .from_python      = &scalar_detail::from_python_thunk<T>,
+            .to_python_buffer = &scalar_detail::to_python_buffer_thunk<T>,
+        };
+        return slots;
+    }
+
+    /**
+     * Register the Python conversion for the C++ scalar type ``type``. The
+     * scalar's ops table (``ops_for<T>``) resolves to it on the type's first
+     * conversion (RFC 0035, "Scalars"); registering the same table again is
+     * a no-op and registering a different table for a type replaces it.
+     */
+    HGRAPH_EXPORT void register_python_scalar_conversion(const std::type_info &type, const PythonScalarSlots *slots);
+
+    template <typename T>
+    void register_python_scalar_conversion()
+    {
+        register_python_scalar_conversion(typeid(T), &python_scalar_slots_for<T>());
+    }
+
+    /** The provider table the bridge registers (idempotent; also at unit load). */
+    HGRAPH_EXPORT void register_python_ops() noexcept;
+
     /**
      * Associate a Python class with a native atomic scalar schema.
      *
@@ -61,11 +322,12 @@ namespace hgraph::python_bridge
 
     /**
      * Register ``T`` through its ``scalar_descriptor`` and associate it with
-     * the supplied Python class.
+     * the supplied Python class. Registers ``T``'s Python conversion first.
      */
     template <typename T>
     const ValueTypeMetaData *register_native_scalar_type(nanobind::handle python_type)
     {
+        register_python_scalar_conversion<T>();
         const auto *native_value_type = scalar_descriptor<T>::value_meta();
         register_native_scalar_type(python_type, native_value_type);
         return native_value_type;
@@ -73,13 +335,14 @@ namespace hgraph::python_bridge
 
     /**
      * Register ``T`` under an explicit native schema name and associate it
-     * with the supplied Python class.
+     * with the supplied Python class. Registers ``T``'s Python conversion first.
      */
     template <typename T>
     const ValueTypeMetaData *register_native_scalar_type(
         nanobind::handle python_type,
         std::string_view native_name)
     {
+        register_python_scalar_conversion<T>();
         const auto *native_value_type =
             TypeRegistry::instance().register_scalar<T>(native_name);
         register_native_scalar_type(python_type, native_value_type);

--- a/include/hgraph/python/scalar_conversions.h
+++ b/include/hgraph/python/scalar_conversions.h
@@ -1,0 +1,142 @@
+#ifndef HGRAPH_PYTHON_SCALAR_CONVERSIONS_H
+#define HGRAPH_PYTHON_SCALAR_CONVERSIONS_H
+
+#include <hgraph/config.h>
+
+#if HGRAPH_ENABLE_PYTHON_USER_NODES
+
+#include <hgraph/hgraph_export.h>
+#include <hgraph/python/native_scalar_registration.h>
+#include <hgraph/types/frame.h>
+#include <hgraph/types/primitive_types.h>
+#include <hgraph/types/series.h>
+#include <hgraph/types/temporal.h>
+#include <hgraph/types/time_series_reference.h>
+#include <hgraph/types/value_callable.h>
+#include <hgraph/types/wired_fn.h>
+
+#include <nanobind/nanobind.h>
+
+#include <cstdint>
+
+/**
+ * The core scalars' ``python_conversion_traits`` (RFC 0035): the
+ * specialisations that lived beside their types in the type layer, now on
+ * the bridge, plus the hook pairs the module installs for the types whose
+ * Python glue needs pyarrow or the DSL. ``register_python_ops`` registers
+ * every one of them at load.
+ */
+namespace hgraph
+{
+    template <>
+    struct python_conversion_traits<Time>
+    {
+        static nanobind::object to_python(const Time &value)
+        {
+            const auto micro   = value.microseconds;
+            const auto seconds = micro / 1'000'000;
+            return nanobind::module_::import_("datetime")
+                .attr("time")(static_cast<int>(seconds / 3600), static_cast<int>((seconds / 60) % 60),
+                              static_cast<int>(seconds % 60), static_cast<int>(micro % 1'000'000));
+        }
+
+        static Time from_python(nanobind::handle source)
+        {
+            if (nanobind::hasattr(source, "tzinfo") && !source.attr("tzinfo").is_none())
+            {
+                throw nanobind::type_error("timezone-aware time values require a zoned time scalar");
+            }
+            if (nanobind::hasattr(source, "utcoffset"))
+            {
+                nanobind::object offset = source.attr("utcoffset")();
+                if (!offset.is_none())
+                {
+                    throw nanobind::type_error("timezone-aware time values require a zoned time scalar");
+                }
+            }
+            const auto hours   = nanobind::cast<std::int64_t>(source.attr("hour"));
+            const auto minutes = nanobind::cast<std::int64_t>(source.attr("minute"));
+            const auto seconds = nanobind::cast<std::int64_t>(source.attr("second"));
+            const auto micro   = nanobind::cast<std::int64_t>(source.attr("microsecond"));
+            return Time{((hours * 60 + minutes) * 60 + seconds) * 1'000'000 + micro};
+        }
+    };
+
+    template <>
+    struct python_conversion_traits<Bytes>
+    {
+        static nanobind::object to_python(const Bytes &value)
+        {
+            return nanobind::steal(
+                PyBytes_FromStringAndSize(value.data.data(), static_cast<Py_ssize_t>(value.data.size())));
+        }
+
+        static Bytes from_python(nanobind::handle source)
+        {
+            char      *buffer = nullptr;
+            Py_ssize_t length = 0;
+            if (PyBytes_AsStringAndSize(source.ptr(), &buffer, &length) != 0) { throw nanobind::python_error(); }
+            return Bytes{std::string{buffer, static_cast<std::size_t>(length)}};
+        }
+    };
+
+    /** The temporal scalars bind through nanobind's registered classes. */
+    template <typename T>
+    struct temporal_native_python_conversion
+    {
+        static nanobind::object to_python(const T &value) { return nanobind::cast(value); }
+        static T from_python(nanobind::handle source) { return nanobind::cast<T>(source); }
+    };
+
+    template <> struct python_conversion_traits<Period> : temporal_native_python_conversion<Period> {};
+    template <> struct python_conversion_traits<CivilDateTime> : temporal_native_python_conversion<CivilDateTime> {};
+    template <> struct python_conversion_traits<ZoneId> : temporal_native_python_conversion<ZoneId> {};
+    template <> struct python_conversion_traits<ZonedDateTime> : temporal_native_python_conversion<ZonedDateTime> {};
+    template <> struct python_conversion_traits<InstantRange> : temporal_native_python_conversion<InstantRange> {};
+    template <> struct python_conversion_traits<CivilDateRange> : temporal_native_python_conversion<CivilDateRange> {};
+    template <> struct python_conversion_traits<InstantRangeSet> : temporal_native_python_conversion<InstantRangeSet> {};
+    template <> struct python_conversion_traits<CivilDateRangeSet> : temporal_native_python_conversion<CivilDateRangeSet> {};
+    template <> struct python_conversion_traits<MonthEndPolicy> : temporal_native_python_conversion<MonthEndPolicy> {};
+    template <> struct python_conversion_traits<AmbiguousTimePolicy> : temporal_native_python_conversion<AmbiguousTimePolicy> {};
+    template <> struct python_conversion_traits<NonexistentTimePolicy> : temporal_native_python_conversion<NonexistentTimePolicy> {};
+    template <> struct python_conversion_traits<Boundary> : temporal_native_python_conversion<Boundary> {};
+
+/** A hook pair the module installs at import: the Python glue for these
+    types needs pyarrow (Frame, Series) or the DSL's wrappers (the
+    reference token, WiredFn, ValueCallable). Conversion before the hooks
+    are installed throws a *hook not installed* error. */
+#define HGRAPH_DECLARE_PYTHON_CONVERSION_HOOKS(Type)                                                           \
+    template <>                                                                                                \
+    struct python_conversion_traits<Type>                                                                      \
+    {                                                                                                          \
+        using ToPythonHook   = nanobind::object (*)(const Type &);                                             \
+        using FromPythonHook = Type (*)(nanobind::handle);                                                     \
+                                                                                                               \
+        [[nodiscard]] HGRAPH_EXPORT static ToPythonHook   &to_python_hook() noexcept;                          \
+        [[nodiscard]] HGRAPH_EXPORT static FromPythonHook &from_python_hook() noexcept;                        \
+        HGRAPH_EXPORT static nanobind::object to_python(const Type &value);                                    \
+        HGRAPH_EXPORT static Type             from_python(nanobind::handle source);                            \
+    }
+
+    HGRAPH_DECLARE_PYTHON_CONVERSION_HOOKS(Frame);
+    HGRAPH_DECLARE_PYTHON_CONVERSION_HOOKS(Series);
+    HGRAPH_DECLARE_PYTHON_CONVERSION_HOOKS(TimeSeriesReference);
+    HGRAPH_DECLARE_PYTHON_CONVERSION_HOOKS(ValueCallable);
+    HGRAPH_DECLARE_PYTHON_CONVERSION_HOOKS(WiredFn);
+
+#undef HGRAPH_DECLARE_PYTHON_CONVERSION_HOOKS
+}  // namespace hgraph
+
+namespace hgraph::python_bridge
+{
+    /** Python-enum conversion hooks: installed by the python module (which
+        owns the meta -> python-Enum-class registry); the provider's enum
+        entries call through these slots. */
+    using EnumToPythonFn   = nanobind::object (*)(const ValueTypeMetaData *meta, long long value);
+    using EnumFromPythonFn = long long (*)(const ValueTypeMetaData *meta, nanobind::handle source);
+    [[nodiscard]] HGRAPH_EXPORT EnumToPythonFn &enum_to_python_slot() noexcept;
+    [[nodiscard]] HGRAPH_EXPORT EnumFromPythonFn &enum_from_python_slot() noexcept;
+}  // namespace hgraph::python_bridge
+
+#endif  // HGRAPH_ENABLE_PYTHON_USER_NODES
+#endif  // HGRAPH_PYTHON_SCALAR_CONVERSIONS_H

--- a/include/hgraph/python/ts_data_conversion.h
+++ b/include/hgraph/python/ts_data_conversion.h
@@ -6,6 +6,7 @@
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
 
 #include <hgraph/hgraph_export.h>
+#include <hgraph/types/time_series/ts_data/ops.h>
 #include <hgraph/types/time_series/ts_type_ref.h>
 
 #include <nanobind/nanobind.h>
@@ -15,45 +16,14 @@ namespace hgraph
     class TSOutputView;
     class Value;
     struct TSValueTypeMetaData;
-    struct TSDataOps;
 
     namespace python_bridge
     {
         namespace nb = nanobind;
 
-        /**
-         * Python-authoring policy attached to one realized TSData strategy.
-         *
-         * ``from_python_impl`` on ``TSDataOps`` imports a replacement/current
-         * value into live storage.  These operations are deliberately
-         * separate: an authored delta and a Python compute-node result have
-         * collection-specific semantics (for example TSS set-vs-frozenset and
-         * strict TSD removals) that are not replacement assignment.
-         *
-         * Concrete TSData factories select this passive table once.  Python
-         * bridge callers dispatch through it and must not reconstruct a TS
-         * shape by switching on ``TSTypeKind``.
-         */
-        struct PythonTSDataOps
-        {
-            /** True when this authored value (including nested children) needs
-                the wider authored-delta schema. */
-            bool (*requires_authored_delta_impl)(TSRoleTypeRef type, nb::handle source);
-
-            /** Build the delta in the schema selected by the preceding query. */
-            Value (*delta_from_python_impl)(TSRoleTypeRef type, nb::handle source,
-                                            bool authored);
-            void (*apply_result_impl)(const TSOutputView &output, nb::handle result);
-        };
-
-        /** Canonical throwing table for representations without Python authoring support. */
-        [[nodiscard]] HGRAPH_EXPORT const PythonTSDataOps &missing_python_ts_data_ops() noexcept;
-
-        /** The authoring table a TSData strategy selected, or the throwing
-            table when it selected none (RFC 0035: the type layer's default is
-            null; the null branch lives here, once, not in the callers). */
-        [[nodiscard]] HGRAPH_EXPORT const PythonTSDataOps &python_ts_data_ops(const TSDataOps &ops) noexcept;
-
+        /** The table is ``hgraph::PythonTSDataOps`` (``ts_data/ops.h``); the
+            bridge defines the per-family instances and the canonical throwing
+            default is the type layer's ``ts_data_detail::missing_python_ts_data_ops``. */
         /** Strategy tables installed by the corresponding TSData factories. */
         [[nodiscard]] HGRAPH_EXPORT const PythonTSDataOps &atomic_python_ts_data_ops() noexcept;
         [[nodiscard]] HGRAPH_EXPORT const PythonTSDataOps &ref_python_ts_data_ops() noexcept;

--- a/include/hgraph/python/ts_data_conversion.h
+++ b/include/hgraph/python/ts_data_conversion.h
@@ -15,6 +15,7 @@ namespace hgraph
     class TSOutputView;
     class Value;
     struct TSValueTypeMetaData;
+    struct TSDataOps;
 
     namespace python_bridge
     {
@@ -47,6 +48,11 @@ namespace hgraph
 
         /** Canonical throwing table for representations without Python authoring support. */
         [[nodiscard]] HGRAPH_EXPORT const PythonTSDataOps &missing_python_ts_data_ops() noexcept;
+
+        /** The authoring table a TSData strategy selected, or the throwing
+            table when it selected none (RFC 0035: the type layer's default is
+            null; the null branch lives here, once, not in the callers). */
+        [[nodiscard]] HGRAPH_EXPORT const PythonTSDataOps &python_ts_data_ops(const TSDataOps &ops) noexcept;
 
         /** Strategy tables installed by the corresponding TSData factories. */
         [[nodiscard]] HGRAPH_EXPORT const PythonTSDataOps &atomic_python_ts_data_ops() noexcept;

--- a/include/hgraph/types/frame.h
+++ b/include/hgraph/types/frame.h
@@ -108,27 +108,4 @@ struct std::hash<hgraph::Frame>
     }
 };
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-#include <hgraph/types/value/value_ops.h>
-
-#include <nanobind/nanobind.h>
-
-namespace hgraph
-{
-    /** Frame <-> pyarrow binds onto the type-erased ops (module installs the
-        hooks; core dispatches uniformly - no kind-switch). */
-    template <>
-    struct python_conversion_traits<Frame>
-    {
-        using ToPythonHook   = nanobind::object (*)(const Frame &);
-        using FromPythonHook = Frame (*)(nanobind::handle);
-
-        [[nodiscard]] HGRAPH_EXPORT static ToPythonHook &to_python_hook() noexcept;
-        [[nodiscard]] HGRAPH_EXPORT static FromPythonHook &from_python_hook() noexcept;
-        HGRAPH_EXPORT static nanobind::object to_python(const Frame &value);
-        HGRAPH_EXPORT static Frame from_python(nanobind::handle source);
-    };
-}  // namespace hgraph
-#endif  // HGRAPH_ENABLE_PYTHON_USER_NODES
-
 #endif  // HGRAPH_TYPES_FRAME_H

--- a/include/hgraph/types/python_object.h
+++ b/include/hgraph/types/python_object.h
@@ -1,0 +1,34 @@
+#ifndef HGRAPH_TYPES_PYTHON_OBJECT_H
+#define HGRAPH_TYPES_PYTHON_OBJECT_H
+
+/**
+ * The opaque CPython reference the type layer can name without a Python
+ * header (RFC 0035).
+ *
+ * ``struct _object`` is CPython's ``PyObject`` tag; declaring it here is
+ * compatible with ``<Python.h>`` (which completes it) and with the limited
+ * API. The two wrappers make ownership visible at every ops-table slot:
+ * a ``PyRef`` is borrowed for the duration of the call, a ``PyNewRef`` is
+ * one new reference the receiver owns. Only bridge code
+ * (``include/hgraph/python/conversion.h``) converts between them and the
+ * binding library's handle types; the type layer stores and forwards them
+ * and never dereferences one.
+ */
+struct _object;
+
+namespace hgraph
+{
+    /** A borrowed reference: the caller keeps ownership for the call. */
+    struct PyRef
+    {
+        ::_object *ptr{nullptr};
+    };
+
+    /** A new reference: the receiver owns exactly one reference. */
+    struct PyNewRef
+    {
+        ::_object *ptr{nullptr};
+    };
+}  // namespace hgraph
+
+#endif  // HGRAPH_TYPES_PYTHON_OBJECT_H

--- a/include/hgraph/types/python_ops.h
+++ b/include/hgraph/types/python_ops.h
@@ -1,0 +1,158 @@
+#ifndef HGRAPH_TYPES_PYTHON_OPS_H
+#define HGRAPH_TYPES_PYTHON_OPS_H
+
+#include <hgraph/hgraph_export.h>
+#include <hgraph/types/python_object.h>
+
+#include <atomic>
+#include <typeinfo>
+
+/**
+ * The provider table through which the type layer reaches every Python
+ * conversion (RFC 0035, "PythonOps -- the provider table").
+ *
+ * The type layer owns the table's shape and the forwarders its ops-table
+ * slots hold; the bridge (``src/hgraph/python/impl/python_ops.cpp``) fills
+ * one table and registers it at load, and again, idempotently, from the
+ * ``_hgraph`` module initializer. A forwarder reads the registered table
+ * when its slot is called and passes the slot's arguments to the matching
+ * entry unchanged; with no table, or a null entry, it throws the
+ * *no Python conversion is registered* error at the moment the old
+ * compiled-in thunks threw *not available*. Nothing reads the table at
+ * table-construction time, so registration has no ordering rule beyond
+ * "before the first conversion".
+ */
+namespace hgraph
+{
+    class ValueTypeRef;
+    struct ValueArraySource;
+
+    /** The three value-ops slots of one C++ scalar type, as the bridge
+        registers them (``register_python_scalar_conversion<T>``). */
+    struct PythonScalarSlots
+    {
+        PyNewRef (*to_python)(const void *context, const void *memory){nullptr};
+        void (*from_python)(const void *context, const ValueTypeRef &binding, void *memory, PyRef source){nullptr};
+        PyNewRef (*to_python_buffer)(const void *context, const ValueTypeRef &binding,
+                                     const ValueArraySource &source){nullptr};
+    };
+
+    struct PythonOps
+    {
+        struct Scalars
+        {
+            /** The slots registered for a C++ scalar type, or nullptr when
+                the bridge has none for it. Called by ``T``'s scalar forwarders
+                on their first conversion; a non-null result is cached. */
+            const PythonScalarSlots *(*conversion_for)(const std::type_info &type){nullptr};
+        } scalars;
+
+        /** Enum ops: ``context`` is the enum's ``ValueTypeMetaData``. */
+        struct Enums
+        {
+            static constexpr const char *name = "enum";
+            PyNewRef (*to_python)(const void *context, const void *memory){nullptr};
+            void (*from_python)(const void *context, const ValueTypeRef &binding, void *memory, PyRef source){nullptr};
+        } enums;
+
+        /** ``Any`` and the nominal JSON ``Any``: ``memory`` is the boxed ``Value``. */
+        struct Any
+        {
+            static constexpr const char *name = "Any";
+            PyNewRef (*to_python)(const void *context, const void *memory){nullptr};
+            void (*from_python)(const void *context, const ValueTypeRef &binding, void *memory, PyRef source){nullptr};
+            PyNewRef (*json_to_python)(const void *context, const void *memory){nullptr};
+            void (*json_from_python)(const void *context, const ValueTypeRef &binding, void *memory, PyRef source){nullptr};
+        } any;
+    };
+
+    /** Register (or replace) the provider. May be called at any time before
+        the first conversion; the bridge unit calls it at load. */
+    HGRAPH_EXPORT void set_python_ops(const PythonOps *ops) noexcept;
+    [[nodiscard]] HGRAPH_EXPORT const PythonOps *python_ops() noexcept;
+
+    namespace python_ops_detail
+    {
+        /** The registered table, or throw the *no Python conversion is
+            registered* error naming ``what``. */
+        [[nodiscard]] HGRAPH_EXPORT const PythonOps &require_python_ops(const char *what);
+        [[noreturn]] HGRAPH_EXPORT void throw_unregistered(const char *what);
+        [[noreturn]] HGRAPH_EXPORT void throw_unregistered_scalar(const std::type_info &type);
+        [[nodiscard]] HGRAPH_EXPORT const PythonScalarSlots *scalar_slots(const std::type_info &type) noexcept;
+
+        /**
+         * The forwarder a slot holds for a provider entry: 
+         * ``forwarder<&PythonOps::Any::to_python>::call`` reads the table,
+         * takes ``python_ops()->any.to_python`` and calls it with the slot's
+         * arguments unchanged. The section is deduced from the member
+         * pointer and located in the table by ``section_of``; its ``name``
+         * is what the error names.
+         */
+        template <typename Section>
+        [[nodiscard]] const Section &section_of(const PythonOps &ops) noexcept;
+
+        template <>
+        [[nodiscard]] inline const PythonOps::Enums &section_of<PythonOps::Enums>(const PythonOps &ops) noexcept
+        {
+            return ops.enums;
+        }
+        template <>
+        [[nodiscard]] inline const PythonOps::Any &section_of<PythonOps::Any>(const PythonOps &ops) noexcept
+        {
+            return ops.any;
+        }
+
+        template <auto Member>
+        struct forwarder;
+
+        template <typename Section, typename Result, typename... Args, Result (*Section::*Member)(Args...)>
+        struct forwarder<Member>
+        {
+            static Result call(Args... args)
+            {
+                const auto entry = section_of<Section>(require_python_ops(Section::name)).*Member;
+                if (entry == nullptr) { throw_unregistered(Section::name); }
+                return entry(args...);
+            }
+        };
+
+        /** Scalar forwarders: resolved by ``typeid(T)`` on first use and
+            cached once found (a null result is retried by the next call, so
+            a conversion registered later is picked up). */
+        template <typename T>
+        [[nodiscard]] const PythonScalarSlots &scalar_slots_for()
+        {
+            static const PythonScalarSlots *slots = nullptr;
+            if (slots == nullptr) { slots = scalar_slots(typeid(T)); }
+            if (slots == nullptr) { throw_unregistered_scalar(typeid(T)); }
+            return *slots;
+        }
+
+        template <typename T>
+        PyNewRef scalar_to_python(const void *context, const void *memory)
+        {
+            const auto &slots = scalar_slots_for<T>();
+            if (slots.to_python == nullptr) { throw_unregistered_scalar(typeid(T)); }
+            return slots.to_python(context, memory);
+        }
+
+        template <typename T>
+        void scalar_from_python(const void *context, const ValueTypeRef &binding, void *memory, PyRef source)
+        {
+            const auto &slots = scalar_slots_for<T>();
+            if (slots.from_python == nullptr) { throw_unregistered_scalar(typeid(T)); }
+            slots.from_python(context, binding, memory, source);
+        }
+
+        template <typename T>
+        PyNewRef scalar_to_python_buffer(const void *context, const ValueTypeRef &binding,
+                                         const ValueArraySource &source)
+        {
+            const auto &slots = scalar_slots_for<T>();
+            if (slots.to_python_buffer == nullptr) { throw_unregistered_scalar(typeid(T)); }
+            return slots.to_python_buffer(context, binding, source);
+        }
+    }  // namespace python_ops_detail
+}  // namespace hgraph
+
+#endif  // HGRAPH_TYPES_PYTHON_OPS_H

--- a/include/hgraph/types/series.h
+++ b/include/hgraph/types/series.h
@@ -67,32 +67,4 @@ struct std::hash<hgraph::Series>
     }
 };
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-#include <hgraph/types/value/value_ops.h>
-
-#include <nanobind/nanobind.h>
-
-namespace hgraph
-{
-    /**
-     * Series <-> pyarrow conversion binds onto the TYPE-ERASED ops (the
-     * python_conversion_traits hook the scalar ops thunk already dispatches
-     * through - no kind-switch in value_to_py). The arrow glue lives module-
-     * side (pyarrow import + C Data Interface), so the module INSTALLS the
-     * hooks at init; core dispatches through them uniformly.
-     */
-    template <>
-    struct python_conversion_traits<Series>
-    {
-        using ToPythonHook   = nanobind::object (*)(const Series &);
-        using FromPythonHook = Series (*)(nanobind::handle);
-
-        [[nodiscard]] HGRAPH_EXPORT static ToPythonHook &to_python_hook() noexcept;
-        [[nodiscard]] HGRAPH_EXPORT static FromPythonHook &from_python_hook() noexcept;
-        HGRAPH_EXPORT static nanobind::object to_python(const Series &value);
-        HGRAPH_EXPORT static Series from_python(nanobind::handle source);
-    };
-}  // namespace hgraph
-#endif  // HGRAPH_ENABLE_PYTHON_USER_NODES
-
 #endif  // HGRAPH_TYPES_SERIES_H

--- a/include/hgraph/types/temporal.h
+++ b/include/hgraph/types/temporal.h
@@ -1192,43 +1192,4 @@ namespace hgraph
 #undef HGRAPH_DECLARE_TEMPORAL_SCALAR_BINDING
 }  // namespace hgraph
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-#include <hgraph/types/value/value_ops.h>
-
-namespace hgraph
-{
-    template <typename T>
-    struct temporal_native_python_conversion
-    {
-        static nb::object to_python(const T &value) { return nb::cast(value); }
-        static T from_python(nb::handle source) { return nb::cast<T>(source); }
-    };
-
-    template <> struct python_conversion_traits<Period>
-        : temporal_native_python_conversion<Period> {};
-    template <> struct python_conversion_traits<CivilDateTime>
-        : temporal_native_python_conversion<CivilDateTime> {};
-    template <> struct python_conversion_traits<ZoneId>
-        : temporal_native_python_conversion<ZoneId> {};
-    template <> struct python_conversion_traits<ZonedDateTime>
-        : temporal_native_python_conversion<ZonedDateTime> {};
-    template <> struct python_conversion_traits<InstantRange>
-        : temporal_native_python_conversion<InstantRange> {};
-    template <> struct python_conversion_traits<CivilDateRange>
-        : temporal_native_python_conversion<CivilDateRange> {};
-    template <> struct python_conversion_traits<InstantRangeSet>
-        : temporal_native_python_conversion<InstantRangeSet> {};
-    template <> struct python_conversion_traits<CivilDateRangeSet>
-        : temporal_native_python_conversion<CivilDateRangeSet> {};
-    template <> struct python_conversion_traits<MonthEndPolicy>
-        : temporal_native_python_conversion<MonthEndPolicy> {};
-    template <> struct python_conversion_traits<AmbiguousTimePolicy>
-        : temporal_native_python_conversion<AmbiguousTimePolicy> {};
-    template <> struct python_conversion_traits<NonexistentTimePolicy>
-        : temporal_native_python_conversion<NonexistentTimePolicy> {};
-    template <> struct python_conversion_traits<Boundary>
-        : temporal_native_python_conversion<Boundary> {};
-}  // namespace hgraph
-#endif
-
 #endif  // HGRAPH_TYPES_TEMPORAL_H

--- a/include/hgraph/types/time_series/ts_data/base_view.h
+++ b/include/hgraph/types/time_series/ts_data/base_view.h
@@ -240,26 +240,6 @@ namespace hgraph
         /** Delta value for ``evaluation_time``, or a typed null view when unchanged. */
         [[nodiscard]] ValueView delta_value(DateTime evaluation_time) const;
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-        /**
-         * Export the current value through this live representation's
-         * type-erased TSDataOps table.
-         *
-         * Structural implementations must recursively invoke child TSDataOps
-         * and produce the complete public Python shape. Callers must not
-         * switch on TSTypeKind and reconstruct that shape themselves.
-         */
-        [[nodiscard]] nb::object value_to_python() const;
-
-        /**
-         * Export the delta for ``evaluation_time`` through this live
-         * representation's type-erased TSDataOps table.
-         *
-         * As with value_to_python(), recursive shape conversion belongs to
-         * the concrete TSData strategy, not its Python-facing caller.
-         */
-        [[nodiscard]] nb::object delta_value_to_python(DateTime evaluation_time) const;
-#endif
 
         /** Last evaluation time that modified this TSData node, or ``MIN_DT`` if never valid. */
         [[nodiscard]] DateTime last_modified_time() const;
@@ -417,6 +397,15 @@ namespace hgraph
          */
         void mark_modified();
 
+        /**
+         * Record a modification an erased write op reported as NEW at this
+         * scope's mutation time and notify the parent. Throws when the
+         * tracking record already held that time: the op and the record
+         * disagree. The bridge commits ``from_python_impl`` results through
+         * this (RFC 0035); typed writes use ``mark_modified``.
+         */
+        void record_reported_modification();
+
         /** Copy a value-layer view into this TSData node using the binding's type-erased copy op. */
         [[nodiscard]] bool copy_value_from(const ValueView &source);
 
@@ -435,10 +424,6 @@ namespace hgraph
          */
         [[nodiscard]] bool invalidate();
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-        /** Apply a Python object through the TSData binding's type-erased conversion op. */
-        [[nodiscard]] bool from_python(nb::handle source);
-#endif
 
       private:
         friend class TSWDataMutationView;

--- a/include/hgraph/types/time_series/ts_data/ops.h
+++ b/include/hgraph/types/time_series/ts_data/ops.h
@@ -28,13 +28,33 @@ namespace hgraph
         struct TSDataOwnershipOps;
     }
 
-    namespace python_bridge
+    class TSOutputView;
+
+    /**
+     * Python-authoring policy attached to one realized TSData strategy (RFC
+     * 0035: opaque references, so the table is the type layer's while every
+     * entry is the bridge's).
+     *
+     * ``from_python_impl`` on ``TSDataOps`` imports a replacement/current
+     * value into live storage. These operations are deliberately separate:
+     * an authored delta and a Python compute-node result have
+     * collection-specific semantics (for example TSS set-vs-frozenset and
+     * strict TSD removals) that are not replacement assignment.
+     *
+     * Concrete TSData factories select this passive table once. Python
+     * bridge callers dispatch through it and must not reconstruct a TS
+     * shape by switching on ``TSTypeKind``. The default is the canonical
+     * throwing table, never null, so callers dispatch without null branching.
+     */
+    struct PythonTSDataOps
     {
-        /** The bridge's Python-authoring table for one TSData family (RFC
-            0035): named here so a factory can record which one its family
-            uses; only the bridge defines or dereferences it. */
-        struct PythonTSDataOps;
-    }
+        /** True when this authored value (including nested children) needs
+            the wider authored-delta schema. */
+        bool (*requires_authored_delta_impl)(TSRoleTypeRef type, PyRef source);
+        /** Build the delta in the schema selected by the preceding query. */
+        Value (*delta_from_python_impl)(TSRoleTypeRef type, PyRef source, bool authored);
+        void (*apply_result_impl)(const TSOutputView &output, PyRef result);
+    };
 
     namespace ts_data_detail
     {
@@ -69,6 +89,8 @@ namespace hgraph
         [[nodiscard]] HGRAPH_EXPORT Value missing_capture_delta(const TSInputView &);
         [[nodiscard]] HGRAPH_EXPORT bool missing_delta_has_effect(const TSOutputView &, const ValueView &);
         HGRAPH_EXPORT void missing_apply_delta(const TSOutputView &, const ValueView &);
+        /** Canonical throwing Python-authoring table for representations without Python authoring support. */
+        [[nodiscard]] HGRAPH_EXPORT const PythonTSDataOps &missing_python_ts_data_ops() noexcept;
         [[nodiscard]] HGRAPH_EXPORT bool missing_from_python(const void *, void *, PyRef, DateTime);
         [[nodiscard]] HGRAPH_EXPORT PyNewRef missing_to_python(const void *, const void *);
         [[nodiscard]] HGRAPH_EXPORT PyNewRef missing_delta_to_python(const void *, const void *, DateTime);
@@ -284,11 +306,9 @@ namespace hgraph
             void *memory,
             std::size_t index) = &ts_data_detail::missing_mutable_indexed_element_memory;
         bool indexed_child_growth{false};
-        // Python authoring is a separately selected erased policy: the
-        // bridge's table for this family, or null when the family has none
-        // (the bridge substitutes its throwing table, so Python-side dispatch
-        // has no kind/null branching of its own).
-        const python_bridge::PythonTSDataOps *python_ops{nullptr};
+        // Python authoring is a separately selected erased policy. It must
+        // remain non-null so callers dispatch without kind/null branching.
+        const PythonTSDataOps *python_ops{&ts_data_detail::missing_python_ts_data_ops()};
         // Required for every representation that can reach a Python-authored
         // node. Structural strategies recurse through each child's TSDataOps;
         // Python facades must never reconstruct shapes by switching on kind.

--- a/include/hgraph/types/time_series/ts_data/ops.h
+++ b/include/hgraph/types/time_series/ts_data/ops.h
@@ -7,6 +7,7 @@
 #include <hgraph/types/time_series/ts_data/types.h>
 #include <hgraph/types/utils/slot_observer.h>
 #include <hgraph/types/value/value_range.h>
+#include <hgraph/types/python_object.h>
 #include <hgraph/types/value/value_view.h>
 #include <cstddef>
 #include <stdexcept>
@@ -27,13 +28,13 @@ namespace hgraph
         struct TSDataOwnershipOps;
     }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
     namespace python_bridge
     {
+        /** The bridge's Python-authoring table for one TSData family (RFC
+            0035): named here so a factory can record which one its family
+            uses; only the bridge defines or dereferences it. */
         struct PythonTSDataOps;
-        [[nodiscard]] HGRAPH_EXPORT const PythonTSDataOps &missing_python_ts_data_ops() noexcept;
     }
-#endif
 
     namespace ts_data_detail
     {
@@ -68,11 +69,9 @@ namespace hgraph
         [[nodiscard]] HGRAPH_EXPORT Value missing_capture_delta(const TSInputView &);
         [[nodiscard]] HGRAPH_EXPORT bool missing_delta_has_effect(const TSOutputView &, const ValueView &);
         HGRAPH_EXPORT void missing_apply_delta(const TSOutputView &, const ValueView &);
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-        [[nodiscard]] HGRAPH_EXPORT bool missing_from_python(const void *, void *, nb::handle, DateTime);
-        [[nodiscard]] HGRAPH_EXPORT nb::object missing_to_python(const void *, const void *);
-        [[nodiscard]] HGRAPH_EXPORT nb::object missing_delta_to_python(const void *, const void *, DateTime);
-#endif
+        [[nodiscard]] HGRAPH_EXPORT bool missing_from_python(const void *, void *, PyRef, DateTime);
+        [[nodiscard]] HGRAPH_EXPORT PyNewRef missing_to_python(const void *, const void *);
+        [[nodiscard]] HGRAPH_EXPORT PyNewRef missing_delta_to_python(const void *, const void *, DateTime);
         [[nodiscard]] HGRAPH_EXPORT std::size_t missing_indexed_size(const void *, const void *);
         [[nodiscard]] HGRAPH_EXPORT TSRoleTypeRef missing_indexed_element_binding(
             const void *, const void *, std::size_t);
@@ -285,22 +284,23 @@ namespace hgraph
             void *memory,
             std::size_t index) = &ts_data_detail::missing_mutable_indexed_element_memory;
         bool indexed_child_growth{false};
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-        // Python authoring is a separately selected erased policy.  It must
-        // remain non-null so callers dispatch without kind/null branching.
-        const python_bridge::PythonTSDataOps *python_ops{
-            &python_bridge::missing_python_ts_data_ops()};
+        // Python authoring is a separately selected erased policy: the
+        // bridge's table for this family, or null when the family has none
+        // (the bridge substitutes its throwing table, so Python-side dispatch
+        // has no kind/null branching of its own).
+        const python_bridge::PythonTSDataOps *python_ops{nullptr};
         // Required for every representation that can reach a Python-authored
         // node. Structural strategies recurse through each child's TSDataOps;
         // Python facades must never reconstruct shapes by switching on kind.
-        bool (*from_python_impl)(const void *context, void *memory, nb::handle source,
+        // Opaque references (RFC 0035): the type layer forwards them, the
+        // bridge converts them; the defaults throw the missing-op error.
+        bool (*from_python_impl)(const void *context, void *memory, PyRef source,
                                  DateTime modified_time) = &ts_data_detail::missing_from_python;
-        nb::object (*to_python_impl)(const void *context,
-                                     const void *memory) = &ts_data_detail::missing_to_python;
-        nb::object (*delta_to_python_impl)(const void *context,
-                                           const void *memory,
-                                           DateTime evaluation_time) = &ts_data_detail::missing_delta_to_python;
-#endif
+        PyNewRef (*to_python_impl)(const void *context,
+                                   const void *memory) = &ts_data_detail::missing_to_python;
+        PyNewRef (*delta_to_python_impl)(const void *context,
+                                         const void *memory,
+                                         DateTime evaluation_time) = &ts_data_detail::missing_delta_to_python;
     };
 
     struct TSSDataOps : TSDataOps

--- a/include/hgraph/types/time_series/ts_input/base_view.h
+++ b/include/hgraph/types/time_series/ts_input/base_view.h
@@ -130,23 +130,13 @@ namespace hgraph
 
         [[nodiscard]] ValueView delta_value() const;
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
         /**
-         * Export the current input value through the resolved endpoint's
-         * type-erased TSDataOps.
-         *
-         * Python facades must call this operation rather than inspect
-         * TSTypeKind and rebuild structural values themselves. Concrete
-         * storage/input strategies own recursive child conversion.
+         * True when this cycle's delta is a sampled target rebind: the
+         * modification sits on the input link, not on the already-valid
+         * target, so the input's delta is the target's CURRENT value. The
+         * bridge's delta export asks this before the data delta (RFC 0035).
          */
-        [[nodiscard]] nb::object value_to_python() const;
-
-        /**
-         * Export this input's current delta through type-erased TSDataOps,
-         * preserving sampled-rebind semantics owned by TSInputView.
-         */
-        [[nodiscard]] nb::object delta_value_to_python() const;
-#endif
+        [[nodiscard]] bool delta_is_sampled_rebind() const noexcept;
 
         /** Dynamic storage owned by this view's complete input endpoint. */
         [[nodiscard]] DynamicStorageMetrics dynamic_storage_metrics() const noexcept;

--- a/include/hgraph/types/time_series/ts_input/detail.h
+++ b/include/hgraph/types/time_series/ts_input/detail.h
@@ -88,12 +88,11 @@ namespace hgraph::detail
                                                            DateTime transition_time);
         /** Convert a non-peered input projection of this shape to a reference token. */
         using reference_fn = TimeSeriesReference (*)(const TSInputView &view);
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-        using to_python_fn = nb::object (*)(const void *context, const void *memory);
-        using delta_to_python_fn = nb::object (*)(const void *context,
-                                                  const void *memory,
-                                                  DateTime evaluation_time);
-#endif
+        /** Opaque Python references (RFC 0035); the bridge converts. */
+        using to_python_fn = PyNewRef (*)(const void *context, const void *memory);
+        using delta_to_python_fn = PyNewRef (*)(const void *context,
+                                                const void *memory,
+                                                DateTime evaluation_time);
 
         const char      *name{nullptr};
         bool             supports_input_projection{false};
@@ -108,10 +107,8 @@ namespace hgraph::detail
         structural_observation_fn structural_observation{nullptr};
         has_published_structural_state_fn has_published_structural_state{nullptr};
         reference_fn     reference{nullptr};
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
         to_python_fn       to_python{nullptr};
         delta_to_python_fn delta_to_python{nullptr};
-#endif
     };
 
     struct TSInputSchedulingNotifier final : Notifiable

--- a/include/hgraph/types/time_series/ts_type_ref.h
+++ b/include/hgraph/types/time_series/ts_type_ref.h
@@ -15,7 +15,7 @@ namespace hgraph
     struct TSDataOps;
     struct TSParentLink;
 
-    inline constexpr std::uint16_t TS_DATA_OPS_ABI_VERSION = 12;
+    inline constexpr std::uint16_t TS_DATA_OPS_ABI_VERSION = 13;
 
     class HGRAPH_CLASS_EXPORT TSRoleTypeRef
     {

--- a/include/hgraph/types/time_series_reference.h
+++ b/include/hgraph/types/time_series_reference.h
@@ -213,31 +213,4 @@ namespace std
     };
 }  // namespace std
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-#include <hgraph/types/value/value_ops.h>
-
-#include <nanobind/nanobind.h>
-
-namespace hgraph
-{
-    /**
-     * TimeSeriesReference <-> Python conversion binds onto the atomic value
-     * ops. The Python module owns the opaque wrapper and installs these hooks
-     * during module initialization; the C++ runtime remains Python-free when
-     * user-node support is disabled.
-     */
-    template <>
-    struct python_conversion_traits<TimeSeriesReference>
-    {
-        using ToPythonHook   = nanobind::object (*)(const TimeSeriesReference &);
-        using FromPythonHook = TimeSeriesReference (*)(nanobind::handle);
-
-        [[nodiscard]] HGRAPH_EXPORT static ToPythonHook &to_python_hook() noexcept;
-        [[nodiscard]] HGRAPH_EXPORT static FromPythonHook &from_python_hook() noexcept;
-        HGRAPH_EXPORT static nanobind::object to_python(const TimeSeriesReference &value);
-        HGRAPH_EXPORT static TimeSeriesReference from_python(nanobind::handle source);
-    };
-}  // namespace hgraph
-#endif  // HGRAPH_ENABLE_PYTHON_USER_NODES
-
 #endif  // HGRAPH_CPP_ROOT_TIME_SERIES_REFERENCE_H

--- a/include/hgraph/types/value/compact_container_ops.h
+++ b/include/hgraph/types/value/compact_container_ops.h
@@ -7,6 +7,10 @@
 #include <hgraph/types/value/container_ops.h>
 #include <hgraph/types/value/specialized_views.h>
 #include <hgraph/types/value/value_ops.h>
+
+#if HGRAPH_ENABLE_PYTHON_USER_NODES
+#include <hgraph/python/conversion.h>
+#endif
 #include <hgraph/types/value/value_range.h>
 #include <hgraph/types/value/value_view.h>
 
@@ -160,8 +164,8 @@ namespace hgraph
                                                     ValueArraySource        source)
         {
             const auto &ops = element_binding.ops_ref();
-            return ops.can_to_python_buffer(element_binding)
-                       ? ops.to_python_buffer(element_binding, source)
+            return python_bridge::can_to_python_buffer(ops, element_binding)
+                       ? python_bridge::to_python_buffer(ops, element_binding, source)
                        : nb::object{};
         }
 
@@ -214,7 +218,7 @@ namespace hgraph
             for (std::size_t i = 0; i < storage->size(); ++i)
             {
                 // UNSET holes read back as None.
-                result.append(storage->element_set(i) ? ops.to_python(storage->element_at(i)) : nb::none());
+                result.append(storage->element_set(i) ? python_bridge::to_python(ops, storage->element_at(i)) : nb::none());
             }
             return result;
         }
@@ -364,7 +368,7 @@ namespace hgraph
             nb::list result;
             for (std::size_t i = 0; i < storage->size(); ++i)
             {
-                result.append(ops.to_python(storage->element_at(i)));
+                result.append(python_bridge::to_python(ops, storage->element_at(i)));
             }
             return result;
         }
@@ -488,7 +492,7 @@ namespace hgraph
             nb::list result;
             for (std::size_t i = 0; i < storage->size(); ++i)
             {
-                result.append(ops.to_python(storage->element_at(i)));
+                result.append(python_bridge::to_python(ops, storage->element_at(i)));
             }
             return result;
         }
@@ -573,7 +577,7 @@ namespace hgraph
             nb::list items;
             for (std::size_t i = 0; i < storage->size(); ++i)
             {
-                items.append(ops.to_python(storage->element_at(i)));
+                items.append(python_bridge::to_python(ops, storage->element_at(i)));
             }
             // A compact Set is the value-layer realization of Python's
             // immutable frozenset scalar. This concrete ValueOps strategy must
@@ -708,8 +712,8 @@ namespace hgraph
             for (std::size_t i = 0; i < storage->size(); ++i)
             {
                 // UNSET values (None-valued entries) read back as None.
-                result[key_ops.to_python(storage->key_at(i))] =
-                    storage->value_set(i) ? value_ops.to_python(storage->value_at_index(i)) : nb::none();
+                result[python_bridge::to_python(key_ops, storage->key_at(i))] =
+                    storage->value_set(i) ? python_bridge::to_python(value_ops, storage->value_at_index(i)) : nb::none();
             }
             return result;
         }
@@ -989,7 +993,7 @@ namespace hgraph
             nb::set result;
             for (std::size_t i = 0; i < storage->size(); ++i)
             {
-                result.add(ops.to_python(storage->key_at(i)));
+                result.add(python_bridge::to_python(ops, storage->key_at(i)));
             }
             return result;
         }
@@ -1083,10 +1087,10 @@ namespace hgraph
                   &container_ops_detail::list_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                   ,
-                  ShapedArray ? &container_ops_detail::list_to_python_array
-                              : VariadicTuple ? &container_ops_detail::list_to_python_tuple
-                                              : &container_ops_detail::list_to_python,
-                  &container_ops_detail::list_from_python
+                  ShapedArray ? &python_bridge::to_python_slot<&container_ops_detail::list_to_python_array>
+                              : VariadicTuple ? &python_bridge::to_python_slot<&container_ops_detail::list_to_python_tuple>
+                                              : &python_bridge::to_python_slot<&container_ops_detail::list_to_python>,
+                  &python_bridge::from_python_slot<&container_ops_detail::list_from_python>
 #endif
                  },
                  // IndexedValueOps:
@@ -1131,8 +1135,8 @@ namespace hgraph
               &container_ops_detail::set_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
               ,
-              &container_ops_detail::set_to_python,
-              &container_ops_detail::set_from_python
+              &python_bridge::to_python_slot<&container_ops_detail::set_to_python>,
+              &python_bridge::from_python_slot<&container_ops_detail::set_from_python>
 #endif
              },
              &container_ops_detail::set_size,
@@ -1174,8 +1178,8 @@ namespace hgraph
               &container_ops_detail::map_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
               ,
-              &container_ops_detail::map_to_python,
-              &container_ops_detail::map_from_python
+              &python_bridge::to_python_slot<&container_ops_detail::map_to_python>,
+              &python_bridge::from_python_slot<&container_ops_detail::map_from_python>
 #endif
              },
              &container_ops_detail::map_size,
@@ -1231,8 +1235,8 @@ namespace hgraph
               &container_ops_detail::cyclic_buffer_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
               ,
-              &container_ops_detail::cyclic_buffer_to_python,
-              &container_ops_detail::cyclic_buffer_from_python
+              &python_bridge::to_python_slot<&container_ops_detail::cyclic_buffer_to_python>,
+              &python_bridge::from_python_slot<&container_ops_detail::cyclic_buffer_from_python>
 #endif
              },
              &container_ops_detail::cyclic_buffer_size,
@@ -1270,8 +1274,8 @@ namespace hgraph
               &container_ops_detail::queue_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
               ,
-              &container_ops_detail::queue_to_python,
-              &container_ops_detail::queue_from_python
+              &python_bridge::to_python_slot<&container_ops_detail::queue_to_python>,
+              &python_bridge::from_python_slot<&container_ops_detail::queue_from_python>
 #endif
              },
              &container_ops_detail::queue_size,
@@ -1313,7 +1317,7 @@ namespace hgraph
               &container_ops_detail::map_key_adapter_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
               ,
-              &container_ops_detail::map_key_adapter_to_python,
+              &python_bridge::to_python_slot<&container_ops_detail::map_key_adapter_to_python>,
               // Read-only projection: null = unsupported, the one idiom for
               // the fact (the wrapper throws); a bespoke throwing thunk was
               // a second idiom for the same statement.

--- a/include/hgraph/types/value/mutable_container_ops.h
+++ b/include/hgraph/types/value/mutable_container_ops.h
@@ -9,6 +9,10 @@
 #include <hgraph/types/value/container_ops.h>
 #include <hgraph/types/value/value_ops.h>
 
+#if HGRAPH_ENABLE_PYTHON_USER_NODES
+#include <hgraph/python/conversion.h>
+#endif
+
 #include <sul/dynamic_bitset.hpp>
 
 #include <algorithm>
@@ -431,7 +435,7 @@ namespace hgraph
             for (std::size_t i = 0; i < storage->size(); ++i)
             {
                 // UNSET elements (holes) read back as None.
-                result.append(storage->element_set(i) ? ops.to_python(storage->element_at(i)) : nb::none());
+                result.append(storage->element_set(i) ? python_bridge::to_python(ops, storage->element_at(i)) : nb::none());
             }
             return result;
         }
@@ -542,7 +546,7 @@ namespace hgraph
                &list_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                ,
-               &mutable_container_detail::mutable_list_to_python,
+               &python_bridge::to_python_slot<&mutable_container_detail::mutable_list_to_python>,
                nullptr
 #endif
               },
@@ -964,7 +968,7 @@ namespace hgraph
             for (std::size_t slot = 0; slot < s->slot_capacity(); ++slot)
             {
                 if (!s->slot_live(slot)) { continue; }
-                result[kops.to_python(s->key_at(slot))] = vops.to_python(s->value_at_slot(slot));
+                result[python_bridge::to_python(kops, s->key_at(slot))] = python_bridge::to_python(vops, s->value_at_slot(slot));
             }
             return result;
         }
@@ -1186,7 +1190,7 @@ namespace hgraph
                &map_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                ,
-               &mutable_map_to_python,
+               &python_bridge::to_python_slot<&mutable_map_to_python>,
                nullptr
 #endif
               },
@@ -1440,7 +1444,7 @@ namespace hgraph
                 for (std::size_t slot = 0; slot < s->slot_capacity(); ++slot)
                 {
                     if (!s->slot_live(slot)) { continue; }
-                    items.append(eops.to_python(s->key_at(slot)));
+                    items.append(python_bridge::to_python(eops, s->key_at(slot)));
                 }
             }
             return nb::steal(PyFrozenSet_New(items.ptr()));
@@ -1540,7 +1544,7 @@ namespace hgraph
                &set_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                ,
-               &mutable_set_to_python,
+               &python_bridge::to_python_slot<&mutable_set_to_python>,
                nullptr
 #endif
               },

--- a/include/hgraph/types/value/value.h
+++ b/include/hgraph/types/value/value.h
@@ -386,11 +386,6 @@ namespace hgraph
             return result;
         }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-        [[nodiscard]] nb::object to_python() const;
-        void from_python(nb::handle source);
-#endif
-
       private:
         friend class value_impl::GraphLocalValueAccess;
         storage_type storage_{};

--- a/include/hgraph/types/value/value_ops.h
+++ b/include/hgraph/types/value/value_ops.h
@@ -44,7 +44,7 @@ namespace hgraph
     };
 
     static_assert(sizeof(ValueOpsKind) == 1);
-    inline constexpr std::uint16_t VALUE_OPS_ABI_VERSION = 6;
+    inline constexpr std::uint16_t VALUE_OPS_ABI_VERSION = 7;
 
     struct ValueOps;
     using ValueArrayElementAt = const void *(*)(const void *owner, std::size_t index);

--- a/include/hgraph/types/value/value_ops.h
+++ b/include/hgraph/types/value/value_ops.h
@@ -24,14 +24,7 @@
 #include <type_traits>
 #include <typeinfo>
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-#include <hgraph/python/chrono.h>
-#include <nanobind/ndarray.h>
-#include <nanobind/nanobind.h>
-#include <nanobind/stl/string.h>
-
-namespace nb = nanobind;
-#endif
+#include <hgraph/types/python_ops.h>
 
 namespace hgraph
 {
@@ -54,7 +47,6 @@ namespace hgraph
     inline constexpr std::uint16_t VALUE_OPS_ABI_VERSION = 6;
 
     struct ValueOps;
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
     using ValueArrayElementAt = const void *(*)(const void *owner, std::size_t index);
 
     /**
@@ -82,7 +74,6 @@ namespace hgraph
         ValueArraySpan         first{};
         ValueArraySpan         second{};
     };
-#endif
 
     /**
      * Runtime behaviour vtable for value-layer types.
@@ -122,13 +113,13 @@ namespace hgraph
         std::partial_ordering (*compare_impl)(const void *context, const void *lhs,
                                               const void *rhs) noexcept = nullptr;
         std::string (*to_string_impl)(const void *context, const void *memory) = nullptr;
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-        nb::object (*to_python_impl)(const void *context, const void *memory) = nullptr;
+        // Python conversion (RFC 0035): opaque references, filled with the
+        // type layer's forwarders into the registered ``PythonOps`` table.
+        PyNewRef (*to_python_impl)(const void *context, const void *memory) = nullptr;
         void (*from_python_impl)(const void *context, const ValueTypeRef &binding, void *memory,
-                                 nb::handle source) = nullptr;
-        nb::object (*to_python_buffer_impl)(const void *context, const ValueTypeRef &binding,
-                                            const ValueArraySource &source) = nullptr;
-#endif
+                                 PyRef source) = nullptr;
+        PyNewRef (*to_python_buffer_impl)(const void *context, const ValueTypeRef &binding,
+                                          const ValueArraySource &source) = nullptr;
         void (*copy_construct_view_impl)(const void *context, const ValueTypeRef &binding, void *dst,
                                          const void *memory) = nullptr;
         void (*copy_assign_view_impl)(const void *context, const ValueTypeRef &binding, void *dst,
@@ -198,45 +189,6 @@ namespace hgraph
                        : to_string(memory);
         }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-        [[nodiscard]] nb::object to_python(const void *memory) const
-        {
-            if (to_python_impl == nullptr)
-            {
-                throw std::logic_error("ValueOps::to_python is not available for this value type");
-            }
-            return to_python_impl(context, memory);
-        }
-
-        void from_python(const ValueTypeRef &binding, void *memory, nb::handle source) const
-        {
-            if (from_python_impl == nullptr)
-            {
-                throw std::logic_error("ValueOps::from_python is not available for this value type");
-            }
-            from_python_impl(context, binding, memory, source);
-        }
-
-        [[nodiscard]] bool can_to_python_buffer(const ValueTypeRef &binding) const noexcept
-        {
-            return binding.schema() != nullptr && binding.schema()->is_buffer_compatible() &&
-                   to_python_buffer_impl != nullptr;
-        }
-
-        [[nodiscard]] nb::object to_python_buffer(const ValueTypeRef &binding,
-                                                  const ValueArraySource &source) const
-        {
-            if (!can_to_python_buffer(binding))
-            {
-                throw std::logic_error("ValueOps::to_python_buffer is not available for this value type");
-            }
-            if (source.element_at == nullptr && source.first.size + source.second.size != source.size)
-            {
-                throw std::logic_error("ValueOps::to_python_buffer requires an element accessor or complete spans");
-            }
-            return to_python_buffer_impl(context, binding, source);
-        }
-#endif
 
         [[nodiscard]] ValueTypeRef owning_type(ValueTypeRef view_type) const
         {
@@ -551,288 +503,6 @@ namespace hgraph
 
     }  // namespace value_ops_detail
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-    /**
-     * Python-conversion customization point for scalar types the generic
-     * nanobind cast cannot handle (the type-erasure rule: conversion binds
-     * onto the type's OPS at registration - specializations must be visible
-     * wherever ``register_scalar<T>`` / ``ops_for<T>`` first instantiates).
-     * Provide:
-     *   static nb::object to_python(const T &);
-     *   static T          from_python(nb::handle);
-     */
-    template <typename T>
-    struct python_conversion_traits;
-
-    template <>
-    struct python_conversion_traits<Time>
-    {
-        static nb::object to_python(const Time &value)
-        {
-            const auto  micro   = value.microseconds;
-            const auto  seconds = micro / 1'000'000;
-            return nb::module_::import_("datetime")
-                .attr("time")(static_cast<int>(seconds / 3600), static_cast<int>((seconds / 60) % 60),
-                              static_cast<int>(seconds % 60), static_cast<int>(micro % 1'000'000));
-        }
-
-        static Time from_python(nb::handle source)
-        {
-            if (nb::hasattr(source, "tzinfo") &&
-                !source.attr("tzinfo").is_none())
-            {
-                throw nb::type_error(
-                    "timezone-aware time values require a zoned time scalar");
-            }
-            if (nb::hasattr(source, "utcoffset"))
-            {
-                nb::object offset = source.attr("utcoffset")();
-                if (!offset.is_none())
-                {
-                    throw nb::type_error(
-                        "timezone-aware time values require a zoned time scalar");
-                }
-            }
-            const auto hours   = nb::cast<std::int64_t>(source.attr("hour"));
-            const auto minutes = nb::cast<std::int64_t>(source.attr("minute"));
-            const auto seconds = nb::cast<std::int64_t>(source.attr("second"));
-            const auto micro   = nb::cast<std::int64_t>(source.attr("microsecond"));
-            return Time{((hours * 60 + minutes) * 60 + seconds) * 1'000'000 + micro};
-        }
-    };
-
-    template <>
-    struct python_conversion_traits<Bytes>
-    {
-        static nb::object to_python(const Bytes &value)
-        {
-            return nb::steal(PyBytes_FromStringAndSize(value.data.data(),
-                                                       static_cast<Py_ssize_t>(value.data.size())));
-        }
-
-        static Bytes from_python(nb::handle source)
-        {
-            char       *buffer = nullptr;
-            Py_ssize_t  length = 0;
-            if (PyBytes_AsStringAndSize(source.ptr(), &buffer, &length) != 0)
-            {
-                throw nb::python_error();
-            }
-            return Bytes{std::string{buffer, static_cast<std::size_t>(length)}};
-        }
-    };
-
-#endif  // HGRAPH_ENABLE_PYTHON_USER_NODES
-
-    namespace value_ops_detail
-    {
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-        template <typename T>
-        constexpr bool python_scalar_castable =
-            std::is_arithmetic_v<T> || std::is_same_v<T, std::string> || std::is_same_v<T, Date> ||
-            std::is_same_v<T, DateTime> || std::is_same_v<T, TimeDelta>;
-
-        template <typename T>
-        concept has_python_conversion_traits = requires(const T &value, nb::handle source) {
-            { python_conversion_traits<T>::to_python(value) } -> std::same_as<nb::object>;
-            { python_conversion_traits<T>::from_python(source) } -> std::same_as<T>;
-        };
-
-        template <typename T>
-        nb::object to_python_thunk(const void *, const void *memory)
-        {
-            if constexpr (python_scalar_castable<T>)
-            {
-                return nb::cast(*static_cast<const T *>(memory));
-            }
-            else if constexpr (has_python_conversion_traits<T>)
-            {
-                return python_conversion_traits<T>::to_python(*static_cast<const T *>(memory));
-            }
-            else
-            {
-                throw std::logic_error("ValueOps::to_python is not available for this scalar type");
-            }
-        }
-
-        template <typename T>
-        void from_python_thunk(const void *, const ValueTypeRef &, void *memory, nb::handle source)
-        {
-            if constexpr (python_scalar_castable<T>)
-            {
-                if constexpr (std::is_arithmetic_v<T>)
-                {
-                    // Pythonic strictness: numeric scalars never convert from
-                    // strings (PyNumber coercion would accept "1"); numeric
-                    // cross-conversions stay permitted.
-                    if (nb::isinstance<nb::str>(source) || nb::isinstance<nb::bytes>(source))
-                    {
-                        throw nb::type_error("cannot convert a python string to a numeric scalar");
-                    }
-                }
-                *static_cast<T *>(memory) = nb::cast<T>(source);
-            }
-            else if constexpr (has_python_conversion_traits<T>)
-            {
-                *static_cast<T *>(memory) = python_conversion_traits<T>::from_python(source);
-            }
-            else
-            {
-                throw std::logic_error("ValueOps::from_python is not available for this scalar type");
-            }
-        }
-
-        template <typename T>
-        struct python_buffer_traits
-        {
-            using storage_type = T;
-
-            static storage_type convert(const void *memory)
-            {
-                return *static_cast<const T *>(memory);
-            }
-
-            [[nodiscard]] static constexpr const char *numpy_view_dtype() noexcept { return nullptr; }
-        };
-
-        template <>
-        struct python_buffer_traits<DateTime>
-        {
-            using storage_type = std::int64_t;
-
-            static storage_type convert(const void *memory)
-            {
-                return static_cast<storage_type>(
-                    static_cast<const DateTime *>(memory)->time_since_epoch().count());
-            }
-
-            [[nodiscard]] static constexpr const char *numpy_view_dtype() noexcept { return "datetime64[us]"; }
-        };
-
-        template <>
-        struct python_buffer_traits<TimeDelta>
-        {
-            using storage_type = std::int64_t;
-
-            static storage_type convert(const void *memory)
-            {
-                return static_cast<storage_type>(static_cast<const TimeDelta *>(memory)->count());
-            }
-
-            [[nodiscard]] static constexpr const char *numpy_view_dtype() noexcept { return "timedelta64[us]"; }
-        };
-
-        template <>
-        struct python_buffer_traits<Date>
-        {
-            using storage_type = std::int64_t;
-
-            static storage_type convert(const void *memory)
-            {
-                const auto days = std::chrono::sys_days{*static_cast<const Date *>(memory)}
-                                      .time_since_epoch()
-                                      .count();
-                return static_cast<storage_type>(days);
-            }
-
-            [[nodiscard]] static constexpr const char *numpy_view_dtype() noexcept { return "datetime64[D]"; }
-        };
-
-        template <typename Storage>
-        void copy_value_array_span(Storage *&dst, ValueArraySpan span)
-        {
-            if (span.size == 0) { return; }
-            if (span.data == nullptr)
-            {
-                throw std::logic_error("ValueOps::to_python_buffer span has null data");
-            }
-
-            if (span.stride == sizeof(Storage))
-            {
-                std::memcpy(dst, span.data, span.size * sizeof(Storage));
-                dst += span.size;
-                return;
-            }
-
-            const auto *src = static_cast<const std::byte *>(span.data);
-            for (std::size_t index = 0; index < span.size; ++index)
-            {
-                std::memcpy(dst + index, src + index * span.stride, sizeof(Storage));
-            }
-            dst += span.size;
-        }
-
-        template <typename Storage>
-        void delete_python_buffer(void *memory) noexcept
-        {
-            delete[] static_cast<Storage *>(memory);
-        }
-
-        template <typename T>
-        nb::object to_python_buffer_thunk(const void *,
-                                          const ValueTypeRef &,
-                                          const ValueArraySource &source)
-        {
-            if constexpr (detail::buffer_compatible_type<T>)
-            {
-                using traits      = python_buffer_traits<T>;
-                using storage_type = typename traits::storage_type;
-
-                auto          owner = std::make_unique<storage_type[]>(std::max<std::size_t>(source.size, 1));
-                storage_type *data  = owner.get();
-
-                constexpr bool direct_copy =
-                    std::is_same_v<std::remove_cv_t<T>, storage_type> && std::is_trivially_copyable_v<storage_type>;
-                if constexpr (direct_copy)
-                {
-                    if (source.first.size + source.second.size == source.size)
-                    {
-                        storage_type *dst = data;
-                        copy_value_array_span<storage_type>(dst, source.first);
-                        copy_value_array_span<storage_type>(dst, source.second);
-                    }
-                    else
-                    {
-                        if (source.element_at == nullptr)
-                        {
-                            throw std::logic_error("ValueOps::to_python_buffer requires an element accessor");
-                        }
-                        for (std::size_t index = 0; index < source.size; ++index)
-                        {
-                            data[index] = traits::convert(source.element_at(source.owner, index));
-                        }
-                    }
-                }
-                else
-                {
-                    if (source.element_at == nullptr)
-                    {
-                        throw std::logic_error("ValueOps::to_python_buffer requires an element accessor");
-                    }
-                    for (std::size_t index = 0; index < source.size; ++index)
-                    {
-                        data[index] = traits::convert(source.element_at(source.owner, index));
-                    }
-                }
-
-                storage_type *owned = owner.release();
-                nb::capsule   owner_capsule{owned, &delete_python_buffer<storage_type>};
-                nb::ndarray<nb::numpy, const storage_type, nb::ndim<1>> array{owned, {source.size}, owner_capsule};
-                nb::object result = array.cast();
-                if constexpr (traits::numpy_view_dtype() != nullptr)
-                {
-                    return result.attr("view")(nb::str{traits::numpy_view_dtype()});
-                }
-                return result;
-            }
-            else
-            {
-                throw std::logic_error("ValueOps::to_python_buffer is not available for this scalar type");
-            }
-        }
-#endif
-    }  // namespace value_ops_detail
-
     /**
      * Synthesise the canonical ``ValueOps`` for a C++ type ``T``.
      *
@@ -852,25 +522,14 @@ namespace hgraph
             .equals_impl = value_ops_detail::equals_impl_for<T>(),
             .compare_impl = value_ops_detail::compare_impl_for<T>(),
             .to_string_impl = &value_ops_detail::to_string_thunk<T>,
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-            .to_python_impl = &value_ops_detail::to_python_thunk<T>,
-            .from_python_impl = &value_ops_detail::from_python_thunk<T>,
-            .to_python_buffer_impl = &value_ops_detail::to_python_buffer_thunk<T>,
-#endif
+            .to_python_impl = &python_ops_detail::scalar_to_python<T>,
+            .from_python_impl = &python_ops_detail::scalar_from_python<T>,
+            .to_python_buffer_impl = &python_ops_detail::scalar_to_python_buffer<T>,
             .format_string_impl = &value_ops_detail::format_string_thunk<T>,
             .dynamic_storage_metrics_impl = &value_ops_detail::dynamic_storage_metrics_thunk<T>,
         };
         return ops;
     }
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-    /** Python-enum conversion hooks: installed by the python module (which
-        owns the meta -> python-Enum-class registry); the core enum ops call
-        through these slots. */
-    using EnumToPythonFn   = nanobind::object (*)(const ValueTypeMetaData *meta, long long value);
-    using EnumFromPythonFn = long long (*)(const ValueTypeMetaData *meta, nanobind::handle source);
-    HGRAPH_EXPORT EnumToPythonFn &enum_to_python_slot() noexcept;
-    HGRAPH_EXPORT EnumFromPythonFn &enum_from_python_slot() noexcept;
-#endif
 }  // namespace hgraph
 
 #endif  // HGRAPH_CPP_ROOT_VALUE_OPS_H

--- a/include/hgraph/types/value/value_view.h
+++ b/include/hgraph/types/value/value_view.h
@@ -177,25 +177,6 @@ namespace hgraph
             return ValueView{pointer_.begin_mutation_trusted(), TrustedPointer{}};
         }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-        /**
-         * Assign this view's storage FROM a python object through the
-         * binding's ``from_python`` op (the type-erased conversion entry).
-         * A LIFECYCLE-level write like ``copy_assign``: it requires writable
-         * storage but not the mutation protocol - compact (immutable-API)
-         * containers construct through it too.
-         */
-        void assign_from_python(nanobind::handle source) const
-        {
-            if (!valid()) { throw std::logic_error("ValueView::assign_from_python on invalid view"); }
-            if (!writable_payload())
-            {
-                throw std::logic_error("ValueView::assign_from_python requires writable storage");
-            }
-            const auto bound = type();
-            bound.ops_ref().from_python(bound, const_cast<void *>(data()), source);
-        }
-#endif
 
         // -- kind queries --
         [[nodiscard]] bool is_atomic() const noexcept
@@ -407,11 +388,6 @@ namespace hgraph
             return valid() ? type().ops_ref().dynamic_storage_metrics(data())
                            : DynamicStorageMetrics{};
         }
-
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-        [[nodiscard]] nb::object to_python() const;
-        void from_python(nb::handle source);
-#endif
 
       private:
         friend struct detail::ValueVisitorAccess;

--- a/include/hgraph/types/value_callable.h
+++ b/include/hgraph/types/value_callable.h
@@ -139,20 +139,6 @@ namespace hgraph
         }
     };
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-    template <>
-    struct python_conversion_traits<ValueCallable>
-    {
-        using ToPythonHook   = nanobind::object (*)(const ValueCallable &);
-        using FromPythonHook = ValueCallable (*)(nanobind::handle);
-
-        [[nodiscard]] HGRAPH_EXPORT static ToPythonHook &to_python_hook() noexcept;
-        [[nodiscard]] HGRAPH_EXPORT static FromPythonHook &from_python_hook() noexcept;
-        HGRAPH_EXPORT static nanobind::object to_python(const ValueCallable &value);
-        HGRAPH_EXPORT static ValueCallable from_python(nanobind::handle source);
-    };
-#endif
-
     namespace static_schema_detail
     {
         template <>

--- a/include/hgraph/types/wired_fn.h
+++ b/include/hgraph/types/wired_fn.h
@@ -412,23 +412,6 @@ namespace hgraph
         }
     };
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-    /** Python conversion is installed by the optional bridge. Keeping the
-        hook on the scalar's ops preserves ordinary type-erased conversion
-        for requirements/resolvers without adding a WiredFn case there. */
-    template <>
-    struct python_conversion_traits<WiredFn>
-    {
-        using ToPythonHook   = nanobind::object (*)(const WiredFn &);
-        using FromPythonHook = WiredFn (*)(nanobind::handle);
-
-        [[nodiscard]] HGRAPH_EXPORT static ToPythonHook &to_python_hook() noexcept;
-        [[nodiscard]] HGRAPH_EXPORT static FromPythonHook &from_python_hook() noexcept;
-        HGRAPH_EXPORT static nanobind::object to_python(const WiredFn &value);
-        HGRAPH_EXPORT static WiredFn from_python(nanobind::handle source);
-    };
-#endif
-
     template <typename T>
     struct WiredFnArgBinding
     {

--- a/python/module.cpp
+++ b/python/module.cpp
@@ -118,10 +118,18 @@ NB_MODULE(_hgraph, m)
     // The retained-value storage policy reaches the plan factory only through
     // this table (python_bridge.rst, "Consumer-selected Python value storage").
     python_bridge::register_python_storage_provider();
+    // The Python conversions the type layer resolves through the registered
+    // provider (RFC 0035): the runtime's own scalars register at load; the
+    // module adds the types declared above the runtime library.
+    python_bridge::register_python_ops();
+    python_bridge::register_python_scalar_conversion<python_bridge::PyObj>();
+    python_bridge::register_python_scalar_conversion<stdlib::DivideByZero>();
+    python_bridge::register_python_scalar_conversion<stdlib::CmpResult>();
+    python_bridge::register_python_scalar_conversion<stdlib::ToTableMode>();
     // The enum slots read the meta -> python-Enum-class registry (an
     // immortal map; lazily constructed by its accessor, cleared with the
     // registries).
-    enum_to_python_slot() = [](const ValueTypeMetaData *meta, long long value) -> nb::object {
+    python_bridge::enum_to_python_slot() = [](const ValueTypeMetaData *meta, long long value) -> nb::object {
         auto &registry = python_bridge::enum_to_python_registry();
         if (const auto type = registry.find(meta); type != registry.end())
         {
@@ -134,7 +142,7 @@ NB_MODULE(_hgraph, m)
                                (meta->header.label ? meta->header.label : "?") +
                                "' has no registered python member");
     };
-    enum_from_python_slot() = [](const ValueTypeMetaData *meta, nb::handle source) -> long long {
+    python_bridge::enum_from_python_slot() = [](const ValueTypeMetaData *meta, nb::handle source) -> long long {
         const std::string name = nb::cast<std::string>(source.attr("name"));
         auto &registry = python_bridge::enum_from_python_registry();
         if (const auto type = registry.find(meta); type != registry.end())

--- a/python/module_internal.h
+++ b/python/module_internal.h
@@ -4,6 +4,7 @@
 #include <hgraph/lib/std/operators/comparison.h>
 #include <hgraph/lib/std/operators/control.h>
 #include <hgraph/python/bridge_state.h>
+#include <hgraph/python/scalar_conversions.h>
 #include <hgraph/python/chrono.h>
 #include <hgraph/types/frame.h>
 #include <hgraph/types/series.h>

--- a/python/py_nodes.cpp
+++ b/python/py_nodes.cpp
@@ -1567,7 +1567,7 @@ struct type_py_node {
     translate_python_error([&] {
       // Projected structures may use non-owning ValueOps; the input's TSData
       // conversion contract is the authoritative Python value surface.
-      nb::object value = ts.base().value_to_python();
+      nb::object value = python_bridge::value_to_python(ts.base());
       out.set(Value{PyObj{nb::borrow(value.type())}});
     });
   }
@@ -1596,7 +1596,7 @@ struct downcast_python_opaque_node {
     translate_python_error([&] {
       const auto &erased = static_cast<const TSOutputView &>(out);
       nb::object target = python_type_for_opaque(erased.schema()->value_schema);
-      nb::object value = ts.base().value_to_python();
+      nb::object value = python_bridge::value_to_python(ts.base());
       if (target.is_none() || !nb::isinstance(value, target)) {
         throw nb::type_error(
             "downcast_: opaque Python value does not match the requested type");

--- a/python/py_runtime.h
+++ b/python/py_runtime.h
@@ -53,7 +53,7 @@ namespace hgraph::python_bridge
                 return static_cast<const TSWDataView *>(owner)->time_value_at(index).data();
             },
         };
-        return binding.ops_ref().to_python_buffer(binding, source);
+        return python_bridge::to_python_buffer(binding.ops_ref(), binding, source);
     }
 
     /**
@@ -545,7 +545,7 @@ namespace hgraph::python_bridge
             auto view = checked();
             // Do not add TSTypeKind branches here. Every output storage
             // representation owns Python shaping through its TSDataOps table.
-            return !view.valid() ? nb::none() : view.data_view().value_to_python();
+            return !view.valid() ? nb::none() : python_bridge::value_to_python(view.data_view());
         }
 
         void set_value(nb::object value) const
@@ -566,7 +566,7 @@ namespace hgraph::python_bridge
         [[nodiscard]] nb::object delta_value() const
         {
             auto view = checked();
-            nb::object delta = view.data_view().delta_value_to_python(now);
+            nb::object delta = python_bridge::delta_value_to_python(view.data_view(), now);
             nb::object &shape = delta_shaper_slot();
             return shape.is_valid() ? shape(delta) : delta;
         }
@@ -1508,7 +1508,7 @@ namespace hgraph::python_bridge
                     return nb::cast(PyRecordableState{child.handle(), now, lease});
                 }
             }
-            return view.valid() ? view.data_view().value_to_python() : nb::none();
+            return view.valid() ? python_bridge::value_to_python(view.data_view()) : nb::none();
         }
 
         void set_value(nb::handle value) const
@@ -1682,7 +1682,7 @@ namespace hgraph::python_bridge
         {
             if (key_set_projection)
             {
-                return projected_dict().data_view().key_set().base().value_to_python();
+                return python_bridge::value_to_python(projected_dict().data_view().key_set().base());
             }
             if (python_value_ops != nullptr)
             {
@@ -1691,8 +1691,8 @@ namespace hgraph::python_bridge
                 // its common ``ts.value`` read avoids both a schema lookup and
                 // a duplicate has-current-value dispatch.
                 require_alive();
-                return python_value_ops->to_python_impl(
-                    python_value_ops->context, evaluation_data.data());
+                return python_bridge::take(python_value_ops->to_python_impl(
+                    python_value_ops->context, evaluation_data.data()));
             }
             const auto &v = checked();
             const auto *schema = v.schema();
@@ -1705,15 +1705,15 @@ namespace hgraph::python_bridge
             }
             // Structural shape is entirely a TSDataOps concern. The facade
             // has one erased operation regardless of TSD/TSL/TSB nesting.
-            return v.value_to_python();
+            return python_bridge::value_to_python(v);
         }
 
         [[nodiscard]] nb::object delta_value() const
         {
             if (key_set_projection)
             {
-                nb::object canonical = projected_dict().data_view().key_set().base()
-                                           .delta_value_to_python(checked().evaluation_time());
+                nb::object canonical = python_bridge::delta_value_to_python(
+                    projected_dict().data_view().key_set().base(), checked().evaluation_time());
                 nb::object &shape = delta_shaper_slot();
                 return shape.is_valid() ? shape(canonical) : std::move(canonical);
             }
@@ -1734,7 +1734,7 @@ namespace hgraph::python_bridge
             // earlier cycle.
             // As with value(), representation-specific delta recursion is an
             // erased TSData operation owned below the Python facade.
-            nb::object delta = ts.delta_value_to_python();
+            nb::object delta = python_bridge::delta_value_to_python(ts);
             nb::object &shape = delta_shaper_slot();
             return shape.is_valid() ? shape(delta) : delta;
         }

--- a/python/tests/test_architecture_ratchets.py
+++ b/python/tests/test_architecture_ratchets.py
@@ -178,12 +178,24 @@ RATCHETS: tuple[Ratchet, ...] = (
     ),
     Ratchet(
         id="type-layer-python-conditionals",
-        baseline=160,
+        baseline=120,
         roots=("src/hgraph/types", "include/hgraph/types"),
         suffixes=(".cpp", ".h"),
         pattern=r"HGRAPH_ENABLE_PYTHON_USER_NODES",
         owner="the type layer sees Python only through registered ops tables "
-        "(python_bridge.rst, 'No kind-switches in conversion')",
+        "(python_bridge.rst, 'No kind-switches in conversion'); RFC 0035 "
+        "takes this to zero family by family",
+    ),
+    Ratchet(
+        id="type-layer-nanobind",
+        baseline=525,
+        roots=("src/hgraph/types", "include/hgraph/types"),
+        suffixes=(".cpp", ".h"),
+        pattern=r"nanobind|\bnb::",
+        owner="the type layer names Python only through the opaque PyRef / "
+        "PyNewRef of python_object.h and the PythonOps provider of "
+        "python_ops.h (RFC 0035); conversion bodies that still spell "
+        "nanobind move to src/hgraph/python/impl/ with their family",
     ),
     # --- One lifecycle path per Python node kind (family 7) ---
     Ratchet(

--- a/python/value_conversion.cpp
+++ b/python/value_conversion.cpp
@@ -208,7 +208,7 @@ namespace hgraph::python_bridge
             switch (source.schema()->value_kind())
             {
                 case ValueTypeKind::Atomic:
-                    return source.binding().ops_ref().to_python(source.data());
+                    return python_bridge::to_python(source.binding(), source.data());
                 case ValueTypeKind::List: {
                     nb::list result;
                     for (const ValueView item : source.as_list())
@@ -550,12 +550,12 @@ namespace hgraph::python_bridge
                 {
                     Value value{ValuePlanFactory::instance().type_for(
                         registry.list(elements.front().schema(), 0, true))};
-                    value.view().assign_from_python(object);
+                    python_bridge::assign_from_python(value.view(), object);
                     return value;
                 }
                 Value value{ValuePlanFactory::instance().type_for(
                     registry.tuple(schemas))};
-                value.view().assign_from_python(object);
+                python_bridge::assign_from_python(value.view(), object);
                 return value;
             }
             if (nb::isinstance<nb::list>(object))
@@ -864,7 +864,7 @@ namespace hgraph::python_bridge
         // Python conversion dispatches through the type-erased ops. Types
         // requiring module-owned wrappers install python_conversion_traits
         // hooks during module initialization.
-        return view.binding().ops_ref().to_python(view.data());
+        return python_bridge::to_python(view.binding(), view.data());
     }
 
     [[nodiscard]] const ValueTypeMetaData *python_bundle_source_schema(
@@ -966,7 +966,7 @@ namespace hgraph::python_bridge
         if (!type) { throw nb::type_error("schema has no canonical type"); }
         TypeRealizationScope realization_scope{snapshot};
         Value result{type};
-        result.view().assign_from_python(object);
+        python_bridge::assign_from_python(result.view(), object);
         if (frame_target)
         {
             const auto frame = result.view().checked_as<Frame>();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,7 @@ set(HGRAPH_RUNTIME_SOURCES
     hgraph/types/metadata/type_realization.cpp
     hgraph/types/metadata/type_registry.cpp
     hgraph/types/metadata/value_plan_factory.cpp
+    hgraph/types/python_ops.cpp
     hgraph/types/primitive_types.cpp
     hgraph/types/time_series/endpoint_owner.cpp
     hgraph/types/time_series/endpoint_schema.cpp
@@ -96,7 +97,9 @@ set(HGRAPH_RUNTIME_SOURCES
 if(HGRAPH_BUILD_PYTHON_BINDINGS OR HGRAPH_ENABLE_PYTHON_USER_NODES)
     list(APPEND HGRAPH_RUNTIME_SOURCES
         hgraph/python/bridge_state.cpp
+        hgraph/python/impl/conversion.cpp
         hgraph/python/impl/object_semantics.cpp
+        hgraph/python/impl/python_ops.cpp
         hgraph/python/impl/retained_value.cpp
         hgraph/python/impl/ts_data_conversion.cpp
     )

--- a/src/hgraph/python/bridge_state.cpp
+++ b/src/hgraph/python/bridge_state.cpp
@@ -1,6 +1,8 @@
 #include <hgraph/python/bridge_state.h>
 #include <hgraph/util/scope.h>
+#include <hgraph/python/conversion.h>
 #include <hgraph/python/native_scalar_registration.h>
+#include <hgraph/python/scalar_conversions.h>
 #include <hgraph/python/object_semantics.h>
 
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
@@ -216,8 +218,8 @@ struct PythonBundleBindingEntry {
     // fields are ordered.
     ops.compare_impl = nullptr;
     ops.to_string_impl = &to_string;
-    ops.to_python_impl = &to_python;
-    ops.from_python_impl = &from_python;
+    ops.to_python_impl = &python_bridge::to_python_slot<&to_python>;
+    ops.from_python_impl = &python_bridge::from_python_slot<&from_python>;
     ops.accepts_source_impl = &accepts_source;
     ops.copy_assign_from_impl = &copy_assign_from;
     ops.move_assign_from_impl = &move_assign_from;
@@ -359,7 +361,7 @@ struct PythonBundleBindingEntry {
 
     if (is_python_bundle_schema(concrete.schema()) &&
         concrete.plan() == &MemoryUtils::plan_for<PythonBundleValue>()) {
-      nb::object object = concrete.ops_ref().to_python(concrete_memory);
+      nb::object object = python_bridge::to_python(concrete, concrete_memory);
       if (nb::isinstance(object, self.class_info().type)) {
         return object;
       }
@@ -395,10 +397,8 @@ struct PythonBundleBindingEntry {
             "' cannot be constructed because required field '" +
             std::string{self.schema->fields[index].name} + "' is unset");
       }
-      nb::object field_value =
-          indexed->element_binding(indexed->context, concrete_memory, index)
-              .ops_ref()
-              .to_python(field_memory);
+      nb::object field_value = python_bridge::to_python(
+          indexed->element_binding(indexed->context, concrete_memory, index), field_memory);
       arguments[info.field_names[index]] = std::move(field_value);
     }
 
@@ -546,7 +546,7 @@ struct PythonBundleBindingEntry {
     if (!fields[index].binding()) {
       fields[index] = Value{self.field_bindings[index]};
     }
-    annotate_on_exception([&] { fields[index].view().assign_from_python(attribute); }, [&] {
+    annotate_on_exception([&] { python_bridge::assign_from_python(fields[index].view(), attribute); }, [&] {
       const auto *declared = self.schema->fields[index].type;
       nb::object actual_type = nb::steal(PyObject_Type(attribute.ptr()));
       std::string actual =

--- a/src/hgraph/python/impl/conversion.cpp
+++ b/src/hgraph/python/impl/conversion.cpp
@@ -1,0 +1,159 @@
+#include <hgraph/python/conversion.h>
+
+#include <hgraph/types/metadata/value_type_meta_data.h>
+#include <hgraph/types/time_series/ts_data/ops.h>
+#include <hgraph/types/metadata/ts_value_type_meta_data.h>
+
+#include <stdexcept>
+
+namespace hgraph::python_bridge
+{
+    nb::object take(PyNewRef result)
+    {
+        if (result.ptr == nullptr)
+        {
+            throw std::logic_error("a Python conversion slot returned no object and no error");
+        }
+        return nb::steal(nb::handle{result.ptr});
+    }
+
+    nb::object to_python(const ValueOps &ops, const void *memory)
+    {
+        if (ops.to_python_impl == nullptr)
+        {
+            throw std::logic_error("ValueOps::to_python is not available for this value type");
+        }
+        return take(ops.to_python_impl(ops.context, memory));
+    }
+
+    void from_python(const ValueOps &ops, const ValueTypeRef &binding, void *memory, nb::handle source)
+    {
+        if (ops.from_python_impl == nullptr)
+        {
+            throw std::logic_error("ValueOps::from_python is not available for this value type");
+        }
+        ops.from_python_impl(ops.context, binding, memory, borrow(source));
+    }
+
+    bool can_to_python_buffer(const ValueOps &ops, const ValueTypeRef &binding) noexcept
+    {
+        return binding.schema() != nullptr && binding.schema()->is_buffer_compatible() &&
+               ops.to_python_buffer_impl != nullptr;
+    }
+
+    nb::object to_python_buffer(const ValueOps &ops, const ValueTypeRef &binding, const ValueArraySource &source)
+    {
+        if (!can_to_python_buffer(ops, binding))
+        {
+            throw std::logic_error("ValueOps::to_python_buffer is not available for this value type");
+        }
+        if (source.element_at == nullptr && source.first.size + source.second.size != source.size)
+        {
+            throw std::logic_error("ValueOps::to_python_buffer requires an element accessor or complete spans");
+        }
+        return take(ops.to_python_buffer_impl(ops.context, binding, source));
+    }
+
+    nb::object to_python(const ValueView &view)
+    {
+        if (!view.valid()) { throw std::runtime_error("ValueView::to_python requires a non-empty view"); }
+        return to_python(view.binding(), view.data());
+    }
+
+    void from_python(const ValueView &view, nb::handle source)
+    {
+        if (!view.valid()) { throw std::runtime_error("ValueView::from_python requires a non-empty view"); }
+        if (source.is_none())
+        {
+            throw std::invalid_argument("ValueView::from_python cannot reset a view from None");
+        }
+        const auto bound = view.binding();
+        from_python(bound, view.mutable_data(), source);
+    }
+
+    void assign_from_python(const ValueView &view, nb::handle source)
+    {
+        if (!view.valid()) { throw std::logic_error("ValueView::assign_from_python on invalid view"); }
+        if (!view.writable_payload())
+        {
+            throw std::logic_error("ValueView::assign_from_python requires writable storage");
+        }
+        const auto bound = view.type();
+        from_python(bound, const_cast<void *>(view.data()), source);
+    }
+
+    nb::object to_python(const Value &value)
+    {
+        if (!value.has_value()) { return nb::none(); }
+        return to_python(value.view());
+    }
+
+    void from_python(Value &value, nb::handle source)
+    {
+        if (source.is_none())
+        {
+            value.reset();
+            return;
+        }
+        if (!value.binding()) { throw std::logic_error("Value::from_python requires a schema-bound Value"); }
+        const auto bound = value.binding();
+        Value      replacement{bound};
+        from_python(bound, const_cast<void *>(replacement.view().data()), source);
+        value = std::move(replacement);
+    }
+
+    nb::object value_to_python(const TSDataView &view)
+    {
+        const auto &table = view.ops();
+        if (!table.has_current_value_impl(table.context, view.data())) { return nb::none(); }
+        return take(table.to_python_impl(table.context, view.data()));
+    }
+
+    nb::object delta_value_to_python(const TSDataView &view, DateTime evaluation_time)
+    {
+        const auto &table = view.ops();
+        if (evaluation_time == MIN_DT ||
+            table.tracking_impl(table.context, view.data())->last_modified_time != evaluation_time)
+        {
+            return nb::none();
+        }
+        return take(table.delta_to_python_impl(table.context, view.data(), evaluation_time));
+    }
+
+    bool from_python(TSDataMutationView &view, nb::handle source)
+    {
+        if (source.is_none()) { return false; }
+        const auto &table          = view.ops();
+        const bool  newly_modified = table.from_python_impl(table.context, view.mutable_data(), borrow(source),
+                                                            view.current_mutation_time());
+        if (newly_modified) { view.record_reported_modification(); }
+        return newly_modified;
+    }
+
+    nb::object value_to_python(const TSInputView &view)
+    {
+        const auto &data = view.data_view();
+        return data.valid() ? value_to_python(data) : nb::none();
+    }
+
+    nb::object delta_value_to_python(const TSInputView &view)
+    {
+        const auto &data = view.data_view();
+        if (!data.valid()) { return nb::none(); }
+
+        // Sampled target rebinds carry the modification on the input link,
+        // not on the already-valid target. In that case the input delta is
+        // the target's current value, exported by the target TSData strategy.
+        if (view.delta_is_sampled_rebind()) { return value_to_python(data); }
+
+        nb::object delta = delta_value_to_python(data, view.evaluation_time());
+        if (!delta.is_none()) { return delta; }
+
+        const auto *view_schema = view.schema();
+        if (view_schema != nullptr && view_schema->kind == TSTypeKind::TS && view.modified())
+        {
+            return value_to_python(data);
+        }
+        return nb::none();
+    }
+}  // namespace hgraph::python_bridge

--- a/src/hgraph/python/impl/python_ops.cpp
+++ b/src/hgraph/python/impl/python_ops.cpp
@@ -1,0 +1,247 @@
+#include <hgraph/python/scalar_conversions.h>
+
+#include <hgraph/python/bridge_state.h>
+#include <hgraph/python/conversion.h>
+#include <hgraph/python/native_scalar_registration.h>
+#include <hgraph/types/metadata/type_registry.h>
+#include <hgraph/types/metadata/value_type_meta_data.h>
+#include <hgraph/types/primitive_types.h>
+#include <hgraph/types/python_ops.h>
+#include <hgraph/types/value/value.h>
+
+#include <ankerl/unordered_dense.h>
+
+#include <cstdint>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+
+/**
+ * The bridge's ``PythonOps`` table (RFC 0035): the scalar registry the
+ * scalar forwarders resolve through, the enum and ``Any`` entries, and the
+ * registration that makes the table active. This unit is compiled in
+ * exactly when Python user nodes are enabled, with or without the
+ * ``_hgraph`` module, so it registers at load; the module initializer
+ * calls ``register_python_ops`` again, idempotently.
+ */
+namespace hgraph::python_bridge
+{
+    namespace
+    {
+        // -- scalars ---------------------------------------------------------
+        // Registration runs at import (extension module initializers) and
+        // the lookup once per scalar type on its first conversion; both hold
+        // the GIL, the mutex keeps the table safe regardless. It is a plain
+        // mutex, not the counted type-system mutex: the one lookup per type
+        // is not a registry access the evaluation snapshot should count.
+        //
+        // Keyed by the mangled type NAME, not std::type_index: the forwarder
+        // that looks a type up is instantiated in whichever library first
+        // used the type (hgraph_stdlib for its enums, an extension's native
+        // library for its scalars) while the registration comes from the
+        // Python module, and on macOS two libraries' type_info objects for
+        // one type compare unequal unless the RTTI is marked non-unique.
+        // The name is identical everywhere.
+        std::mutex &scalar_registry_mutex()
+        {
+            static std::mutex mutex;
+            return mutex;
+        }
+
+        ankerl::unordered_dense::map<std::string, const PythonScalarSlots *> &scalar_registry()
+        {
+            static auto *registry = new ankerl::unordered_dense::map<std::string, const PythonScalarSlots *>{};
+            return *registry;
+        }
+
+        const PythonScalarSlots *scalar_conversion_for(const std::type_info &type)
+        {
+            const std::lock_guard lock{scalar_registry_mutex()};
+            const auto           &registry = scalar_registry();
+            const auto            found    = registry.find(std::string{type.name()});
+            return found == registry.end() ? nullptr : found->second;
+        }
+
+        // -- enums -----------------------------------------------------------
+        PyNewRef enum_to_python(const void *context, const void *memory)
+        {
+            const auto *meta = static_cast<const ValueTypeMetaData *>(context);
+            if (enum_to_python_slot() == nullptr)
+            {
+                throw std::logic_error("enum python conversion requires the python module's enum registry");
+            }
+            return give(enum_to_python_slot()(meta, *static_cast<const Int *>(memory)));
+        }
+
+        void enum_from_python(const void *context, const ValueTypeRef &, void *memory, PyRef source)
+        {
+            const auto *meta = static_cast<const ValueTypeMetaData *>(context);
+            if (enum_from_python_slot() == nullptr)
+            {
+                throw std::logic_error("enum python conversion requires the python module's enum registry");
+            }
+            *static_cast<Int *>(memory) = enum_from_python_slot()(meta, handle_of(source));
+        }
+
+        // -- Any -------------------------------------------------------------
+        nb::object any_to_python_object(const Value &value)
+        {
+            if (!value.has_value()) { return nb::none(); }
+            // Type-erased delegation: the BOXED value's own binding converts.
+            return to_python(value.view());
+        }
+
+        PyNewRef any_to_python(const void *, const void *memory)
+        {
+            return give(any_to_python_object(*static_cast<const Value *>(memory)));
+        }
+
+        void any_from_python(const void *, const ValueTypeRef &, void *memory, PyRef source_ref)
+        {
+            const nb::handle source = handle_of(source_ref);
+            Value           &boxed  = *static_cast<Value *>(memory);
+            if (source.is_none())
+            {
+                boxed = Value{};
+                return;
+            }
+            // Schema-free INFERENCE lives in the module (a dispatch on
+            // python types); it installs this hook at import.
+            const auto slot = py_infer_value_slot();
+            if (slot == nullptr)
+            {
+                throw std::logic_error("Any::from_python requires the python module's inference hook");
+            }
+            Value inferred = reinterpret_cast<Value (*)(nb::handle)>(slot)(source);
+            // Schema-free Python inference may itself choose the public Any
+            // type (opaque objects and heterogeneous containers). The storage
+            // here is already the EMBEDDED value of an Any box, so retain its
+            // concrete content rather than creating Any<Any<T>>.
+            if (inferred.view().is_any())
+            {
+                const ValueView contained = inferred.as_any().get();
+                boxed                     = contained.valid() ? Value{contained} : Value{};
+            }
+            else { boxed = std::move(inferred); }
+        }
+
+        PyNewRef json_any_to_python(const void *context, const void *memory)
+        {
+            const Value &inner = *static_cast<const Value *>(memory);
+            if (const auto slot = py_json_to_python_slot()) { return give(slot(inner)); }
+            return any_to_python(context, memory);
+        }
+
+        void json_any_from_python(const void *context, const ValueTypeRef &binding, void *memory, PyRef source_ref)
+        {
+            const auto slot = py_json_from_python_slot();
+            if (slot == nullptr)
+            {
+                any_from_python(context, binding, memory, source_ref);
+                return;
+            }
+
+            Value outer = slot(handle_of(source_ref));
+            if (outer.schema() != TypeRegistry::instance().json())
+            {
+                throw nb::type_error("native JSON conversion returned the wrong schema");
+            }
+            const ValueView inner       = outer.as_any().get();
+            *static_cast<Value *>(memory) = inner.valid() ? Value{inner} : Value{};
+        }
+
+        // -- the table -------------------------------------------------------
+        const PythonOps &provider_table()
+        {
+            static const PythonOps table = [] {
+                PythonOps ops;
+                ops.scalars.conversion_for = &scalar_conversion_for;
+                ops.enums.to_python        = &enum_to_python;
+                ops.enums.from_python      = &enum_from_python;
+                ops.any.to_python          = &any_to_python;
+                ops.any.from_python        = &any_from_python;
+                ops.any.json_to_python     = &json_any_to_python;
+                ops.any.json_from_python   = &json_any_from_python;
+                return ops;
+            }();
+            return table;
+        }
+
+        /** The scalars the runtime library itself knows how to convert. The
+            stdlib enums and the bridge's own object scalar are registered by
+            the module (they are declared above this library). */
+        void register_core_scalar_conversions()
+        {
+            register_python_scalar_conversion<bool>();
+            register_python_scalar_conversion<std::int8_t>();
+            register_python_scalar_conversion<std::int16_t>();
+            register_python_scalar_conversion<std::int32_t>();
+            register_python_scalar_conversion<std::int64_t>();
+            register_python_scalar_conversion<std::uint8_t>();
+            register_python_scalar_conversion<std::uint16_t>();
+            register_python_scalar_conversion<std::uint32_t>();
+            register_python_scalar_conversion<std::uint64_t>();
+            register_python_scalar_conversion<float>();
+            register_python_scalar_conversion<double>();
+            register_python_scalar_conversion<std::string>();
+            register_python_scalar_conversion<Date>();
+            register_python_scalar_conversion<DateTime>();
+            register_python_scalar_conversion<TimeDelta>();
+            register_python_scalar_conversion<Time>();
+            register_python_scalar_conversion<Bytes>();
+            register_python_scalar_conversion<Period>();
+            register_python_scalar_conversion<CivilDateTime>();
+            register_python_scalar_conversion<ZoneId>();
+            register_python_scalar_conversion<ZonedDateTime>();
+            register_python_scalar_conversion<InstantRange>();
+            register_python_scalar_conversion<CivilDateRange>();
+            register_python_scalar_conversion<InstantRangeSet>();
+            register_python_scalar_conversion<CivilDateRangeSet>();
+            register_python_scalar_conversion<MonthEndPolicy>();
+            register_python_scalar_conversion<AmbiguousTimePolicy>();
+            register_python_scalar_conversion<NonexistentTimePolicy>();
+            register_python_scalar_conversion<Boundary>();
+            register_python_scalar_conversion<Frame>();
+            register_python_scalar_conversion<Series>();
+            register_python_scalar_conversion<TimeSeriesReference>();
+            register_python_scalar_conversion<ValueCallable>();
+            register_python_scalar_conversion<WiredFn>();
+        }
+    }  // namespace
+
+    void register_python_scalar_conversion(const std::type_info &type, const PythonScalarSlots *slots)
+    {
+        const std::lock_guard lock{scalar_registry_mutex()};
+        scalar_registry()[std::string{type.name()}] = slots;
+    }
+
+    void register_python_ops() noexcept
+    {
+        register_core_scalar_conversions();
+        set_python_ops(&provider_table());
+    }
+
+    EnumToPythonFn &enum_to_python_slot() noexcept
+    {
+        static EnumToPythonFn slot = nullptr;
+        return slot;
+    }
+
+    EnumFromPythonFn &enum_from_python_slot() noexcept
+    {
+        static EnumFromPythonFn slot = nullptr;
+        return slot;
+    }
+
+    namespace
+    {
+        // Linking this unit is what makes the conversions active (the
+        // ``python-user-nodes`` preset embeds the bridge without the module's
+        // initializer), so it registers itself at load; the module's explicit
+        // registration is idempotent.
+        [[maybe_unused]] const bool python_ops_registered_at_load = [] {
+            register_python_ops();
+            return true;
+        }();
+    }  // namespace
+}  // namespace hgraph::python_bridge

--- a/src/hgraph/python/impl/retained_value.cpp
+++ b/src/hgraph/python/impl/retained_value.cpp
@@ -1,5 +1,6 @@
 #include <hgraph/python/retained_value.h>
 
+#include <hgraph/python/conversion.h>
 #include <hgraph/python/object_semantics.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
@@ -130,9 +131,9 @@ namespace hgraph::python_bridge
             // read shape, not the raw source object.
             const auto binding = ValuePlanFactory::instance().type_for(schema);
             Value normalized{binding};
-            binding.ops_ref().from_python(
+            python_bridge::from_python(binding.ops_ref(), 
                 binding, const_cast<void *>(normalized.view().data()), source);
-            return binding.ops_ref().to_python(normalized.view().data());
+            return python_bridge::to_python(binding, normalized.view().data());
           }
 
           if (schema->value_kind() == ValueTypeKind::Atomic) {
@@ -290,8 +291,8 @@ namespace hgraph::python_bridge
             ops.equals_impl = schema->is_equatable() ? &equals : nullptr;
             ops.compare_impl = schema->is_comparable() ? &compare : nullptr;
             ops.to_string_impl = &to_string;
-            ops.to_python_impl = &to_python;
-            ops.from_python_impl = &from_python;
+            ops.to_python_impl = &python_bridge::to_python_slot<&to_python>;
+            ops.from_python_impl = &python_bridge::from_python_slot<&from_python>;
             ops.accepts_source_impl = &accepts_source;
             ops.copy_assign_from_impl = &copy_assign_from;
             ops.move_assign_from_impl = &move_assign_from;
@@ -375,7 +376,7 @@ namespace hgraph::python_bridge
             }
             nb::gil_scoped_acquire gil;
             value(dst).set(prepare_retained_python_value(
-                self.schema, source.ops_ref().to_python(src)));
+                self.schema, python_bridge::to_python(source, src)));
           }
 
           static void move_assign_from(const void *context, ValueTypeRef binding,

--- a/src/hgraph/python/impl/ts_data_conversion.cpp
+++ b/src/hgraph/python/impl/ts_data_conversion.cpp
@@ -78,7 +78,7 @@ namespace hgraph::python_bridge
         {
             // TSDataOps binds either a concrete strategy or the canonical
             // throwing table. A null check here would weaken that invariant.
-            return *type.ops_ref().python_ops;
+            return python_ts_data_ops(type.ops_ref());
         }
 
         [[nodiscard]] bool requires_authored(TSRoleTypeRef type,
@@ -150,7 +150,7 @@ namespace hgraph::python_bridge
                                       nb::handle result)
         {
             static_cast<void>(
-                output.begin_mutation(output.evaluation_time()).from_python(result));
+                python_bridge::from_python(output.begin_mutation(output.evaluation_time()), result));
         }
 
         void apply_ref_result(const TSOutputView &output, nb::handle result)
@@ -262,7 +262,7 @@ namespace hgraph::python_bridge
             std::vector<Value> to_remove;
             const auto convert = [&](nb::handle item) {
                 Value value{layout.key_binding};
-                value.view().assign_from_python(item);
+                python_bridge::assign_from_python(value.view(), item);
                 return value;
             };
 
@@ -281,7 +281,7 @@ namespace hgraph::python_bridge
                 }
                 for (const auto &key : set_out.values())
                 {
-                    const nb::object obj = key.to_python();
+                    const nb::object obj = python_bridge::to_python(key);
                     const int held = PySet_Contains(result.ptr(), obj.ptr());
                     if (held == -1) { throw nb::python_error(); }
                     if (held == 0) { to_remove.push_back(convert(obj)); }
@@ -497,7 +497,7 @@ namespace hgraph::python_bridge
             for (auto [key, item] : source)
             {
                 if (item.is_none()) { continue; }
-                key_scratch.view().assign_from_python(key);
+                python_bridge::assign_from_python(key_scratch.view(), key);
                 const auto key_view = key_scratch.view();
                 if (strict_sentinel.is_valid() && item.is(strict_sentinel))
                 {
@@ -856,6 +856,11 @@ namespace hgraph::python_bridge
             .apply_result_impl = &missing_apply_result,
         };
         return ops;
+    }
+
+    const PythonTSDataOps &python_ts_data_ops(const TSDataOps &ops) noexcept
+    {
+        return ops.python_ops != nullptr ? *ops.python_ops : missing_python_ts_data_ops();
     }
 
     const PythonTSDataOps &atomic_python_ts_data_ops() noexcept

--- a/src/hgraph/python/impl/ts_data_conversion.cpp
+++ b/src/hgraph/python/impl/ts_data_conversion.cpp
@@ -1,6 +1,7 @@
 #include <hgraph/python/ts_data_conversion.h>
 
 #include <hgraph/python/bridge_state.h>
+#include <hgraph/python/conversion.h>
 #include <hgraph/types/metadata/ts_data_plan_factory.h>
 #include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/value_type_meta_data.h>
@@ -78,14 +79,14 @@ namespace hgraph::python_bridge
         {
             // TSDataOps binds either a concrete strategy or the canonical
             // throwing table. A null check here would weaken that invariant.
-            return python_ts_data_ops(type.ops_ref());
+            return *type.ops_ref().python_ops;
         }
 
         [[nodiscard]] bool requires_authored(TSRoleTypeRef type,
                                              nb::handle source)
         {
             return python_ops_for(type)
-                .requires_authored_delta_impl(type, source);
+                .requires_authored_delta_impl(type, borrow(source));
         }
 
         [[nodiscard]] Value build_delta(TSRoleTypeRef type,
@@ -93,39 +94,13 @@ namespace hgraph::python_bridge
                                         bool authored)
         {
             return python_ops_for(type)
-                .delta_from_python_impl(type, source, authored);
+                .delta_from_python_impl(type, borrow(source), authored);
         }
 
         [[nodiscard]] bool never_requires_authored(TSRoleTypeRef,
                                                    nb::handle)
         {
             return false;
-        }
-
-        [[nodiscard]] bool missing_requires_authored(TSRoleTypeRef,
-                                                     nb::handle)
-        {
-            throw std::logic_error(
-                "time-series representation has no Python authored-delta strategy");
-        }
-
-        [[nodiscard]] Value missing_delta_from_python(TSRoleTypeRef,
-                                                      nb::handle,
-                                                      bool)
-        {
-            throw std::logic_error(
-                "time-series representation has no Python authored-delta strategy");
-        }
-
-        void missing_apply_result(const TSOutputView &output, nb::handle)
-        {
-            const auto type = output.storage_type();
-            const auto implementation =
-                type.record() != nullptr ? type.record()->implementation_name()
-                                         : std::string_view{};
-            throw std::logic_error(
-                "time-series representation '" + std::string{implementation} +
-                "' has no Python result strategy");
         }
 
         [[nodiscard]] Value atomic_delta_from_python(TSRoleTypeRef type,
@@ -519,9 +494,7 @@ namespace hgraph::python_bridge
                 else
                 {
                     auto child = ensure_mutation().at(key_view);
-                    child_ops.apply_result_impl(
-                        TSOutputView{output.output(), child, evaluation_time},
-                        item);
+                    child_ops.apply_result_impl(TSOutputView{output.output(), child, evaluation_time}, borrow(item));
                 }
             }
             // Touch LAST, only when something applied — mirrors
@@ -685,7 +658,7 @@ namespace hgraph::python_bridge
                     if (item.is_none() || (dynamic && is_list_removal(item))) { continue; }
                     const auto index = nb::cast<std::int64_t>(key);
                     child_ops.apply_result_impl(
-                        list_out.at(static_cast<std::size_t>(index)), item);
+                        list_out.at(static_cast<std::size_t>(index)), borrow(item));
                 }
                 return;
             }
@@ -701,7 +674,7 @@ namespace hgraph::python_bridge
             {
                 if (!item.is_none())
                 {
-                    child_ops.apply_result_impl(list_out.at(index), item);
+                    child_ops.apply_result_impl(list_out.at(index), borrow(item));
                 }
                 ++index;
             }
@@ -834,7 +807,7 @@ namespace hgraph::python_bridge
                         "TSB apply result names unknown field '" + name + "'");
                 }
                 python_ops_for(layout.field(index).type)
-                    .apply_result_impl(bundle_out.at(index), item);
+                    .apply_result_impl(bundle_out.at(index), borrow(item));
             }
         }
 
@@ -848,27 +821,12 @@ namespace hgraph::python_bridge
         }
     }  // namespace
 
-    const PythonTSDataOps &missing_python_ts_data_ops() noexcept
-    {
-        static const PythonTSDataOps ops{
-            .requires_authored_delta_impl = &missing_requires_authored,
-            .delta_from_python_impl = &missing_delta_from_python,
-            .apply_result_impl = &missing_apply_result,
-        };
-        return ops;
-    }
-
-    const PythonTSDataOps &python_ts_data_ops(const TSDataOps &ops) noexcept
-    {
-        return ops.python_ops != nullptr ? *ops.python_ops : missing_python_ts_data_ops();
-    }
-
     const PythonTSDataOps &atomic_python_ts_data_ops() noexcept
     {
         static const PythonTSDataOps ops{
-            .requires_authored_delta_impl = &never_requires_authored,
-            .delta_from_python_impl = &atomic_delta_from_python,
-            .apply_result_impl = &apply_replacement_result,
+            .requires_authored_delta_impl = &ts_requires_authored_slot<&never_requires_authored>,
+            .delta_from_python_impl = &ts_delta_from_python_slot<&atomic_delta_from_python>,
+            .apply_result_impl = &ts_apply_result_slot<&apply_replacement_result>,
         };
         return ops;
     }
@@ -876,9 +834,9 @@ namespace hgraph::python_bridge
     const PythonTSDataOps &ref_python_ts_data_ops() noexcept
     {
         static const PythonTSDataOps ops{
-            .requires_authored_delta_impl = &never_requires_authored,
-            .delta_from_python_impl = &atomic_delta_from_python,
-            .apply_result_impl = &apply_ref_result,
+            .requires_authored_delta_impl = &ts_requires_authored_slot<&never_requires_authored>,
+            .delta_from_python_impl = &ts_delta_from_python_slot<&atomic_delta_from_python>,
+            .apply_result_impl = &ts_apply_result_slot<&apply_ref_result>,
         };
         return ops;
     }
@@ -886,9 +844,9 @@ namespace hgraph::python_bridge
     const PythonTSDataOps &set_python_ts_data_ops() noexcept
     {
         static const PythonTSDataOps ops{
-            .requires_authored_delta_impl = &never_requires_authored,
-            .delta_from_python_impl = &set_delta_from_python,
-            .apply_result_impl = &apply_set_result,
+            .requires_authored_delta_impl = &ts_requires_authored_slot<&never_requires_authored>,
+            .delta_from_python_impl = &ts_delta_from_python_slot<&set_delta_from_python>,
+            .apply_result_impl = &ts_apply_result_slot<&apply_set_result>,
         };
         return ops;
     }
@@ -896,9 +854,9 @@ namespace hgraph::python_bridge
     const PythonTSDataOps &dict_python_ts_data_ops() noexcept
     {
         static const PythonTSDataOps ops{
-            .requires_authored_delta_impl = &dict_requires_authored,
-            .delta_from_python_impl = &dict_delta_from_python,
-            .apply_result_impl = &apply_dict_result,
+            .requires_authored_delta_impl = &ts_requires_authored_slot<&dict_requires_authored>,
+            .delta_from_python_impl = &ts_delta_from_python_slot<&dict_delta_from_python>,
+            .apply_result_impl = &ts_apply_result_slot<&apply_dict_result>,
         };
         return ops;
     }
@@ -906,9 +864,9 @@ namespace hgraph::python_bridge
     const PythonTSDataOps &list_python_ts_data_ops() noexcept
     {
         static const PythonTSDataOps ops{
-            .requires_authored_delta_impl = &list_requires_authored,
-            .delta_from_python_impl = &list_delta_from_python,
-            .apply_result_impl = &apply_list_result,
+            .requires_authored_delta_impl = &ts_requires_authored_slot<&list_requires_authored>,
+            .delta_from_python_impl = &ts_delta_from_python_slot<&list_delta_from_python>,
+            .apply_result_impl = &ts_apply_result_slot<&apply_list_result>,
         };
         return ops;
     }
@@ -916,9 +874,9 @@ namespace hgraph::python_bridge
     const PythonTSDataOps &bundle_python_ts_data_ops() noexcept
     {
         static const PythonTSDataOps ops{
-            .requires_authored_delta_impl = &bundle_requires_authored,
-            .delta_from_python_impl = &bundle_delta_from_python,
-            .apply_result_impl = &apply_bundle_result,
+            .requires_authored_delta_impl = &ts_requires_authored_slot<&bundle_requires_authored>,
+            .delta_from_python_impl = &ts_delta_from_python_slot<&bundle_delta_from_python>,
+            .apply_result_impl = &ts_apply_result_slot<&apply_bundle_result>,
         };
         return ops;
     }
@@ -926,9 +884,9 @@ namespace hgraph::python_bridge
     const PythonTSDataOps &window_python_ts_data_ops() noexcept
     {
         static const PythonTSDataOps ops{
-            .requires_authored_delta_impl = &never_requires_authored,
-            .delta_from_python_impl = &window_delta_from_python,
-            .apply_result_impl = &apply_delta_result,
+            .requires_authored_delta_impl = &ts_requires_authored_slot<&never_requires_authored>,
+            .delta_from_python_impl = &ts_delta_from_python_slot<&window_delta_from_python>,
+            .apply_result_impl = &ts_apply_result_slot<&apply_delta_result>,
         };
         return ops;
     }
@@ -969,6 +927,6 @@ namespace hgraph::python_bridge
     {
         if (result.is_none()) { return; }
         python_ops_for(output.storage_type())
-            .apply_result_impl(output, result);
+            .apply_result_impl(output, borrow(result));
     }
 }  // namespace hgraph::python_bridge

--- a/src/hgraph/runtime/mapped_key_source.h
+++ b/src/hgraph/runtime/mapped_key_source.h
@@ -6,6 +6,10 @@
 #include <hgraph/types/time_series/ts_output.h>
 #include <hgraph/types/value/value.h>
 
+#if HGRAPH_ENABLE_PYTHON_USER_NODES
+#include <hgraph/python/conversion.h>
+#endif
+
 #include <memory>
 #include <mutex>
 #include <stdexcept>
@@ -112,33 +116,33 @@ namespace hgraph::runtime_detail
                 .delta_has_effect_impl     = &ts_data_detail::delta_has_effect_atomic,
                 .apply_delta_impl          = &ts_data_detail::missing_apply_delta,
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
-                .from_python_impl          = [](const void *, void *, nb::handle, DateTime) -> bool {
+                .from_python_impl          = [](const void *, void *, PyRef, DateTime) -> bool {
                     throw std::logic_error("mapped key source is read-only");
                 },
-                .to_python_impl            = [](const void *ctx, const void *memory) -> nb::object {
+                .to_python_impl            = [](const void *ctx, const void *memory) -> PyNewRef {
                     const auto *context = static_cast<const Context *>(ctx);
                     const auto *storage = static_cast<const MappedKeySourceStorage *>(memory);
                     if (storage == nullptr || storage->key == nullptr || !storage->key->has_value())
                     {
-                        return nb::none();
+                        return python_bridge::give(nb::none());
                     }
                     // This synthetic TSData strategy must preserve the scalar
                     // ValueOps result unchanged. Representation policy (for
                     // example compact Set -> frozenset) belongs to ValueOps,
                     // never to this source or a Python facade.
-                    return context->layout.value_binding.ops_ref().to_python(
-                        storage->key->view().data());
+                    return python_bridge::give(python_bridge::to_python(context->layout.value_binding,
+                                                                        storage->key->view().data()));
                 },
-                .delta_to_python_impl      = [](const void *ctx, const void *memory, DateTime evaluation_time) -> nb::object {
+                .delta_to_python_impl      = [](const void *ctx, const void *memory, DateTime evaluation_time) -> PyNewRef {
                     const auto *context = static_cast<const Context *>(ctx);
                     const auto *storage = static_cast<const MappedKeySourceStorage *>(memory);
                     if (storage == nullptr || storage->key == nullptr || !storage->key->has_value() ||
                         storage->tracking.last_modified_time != evaluation_time)
                     {
-                        return nb::none();
+                        return python_bridge::give(nb::none());
                     }
-                    return context->layout.delta_binding.ops_ref().to_python(
-                        storage->key->view().data());
+                    return python_bridge::give(python_bridge::to_python(context->layout.delta_binding,
+                                                                        storage->key->view().data()));
                 },
 #endif
             };

--- a/src/hgraph/types/metadata/ts_data_atomic_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_atomic_ops.cpp
@@ -6,6 +6,7 @@
 
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
 #include <hgraph/python/bridge_state.h>
+#include <hgraph/python/conversion.h>
 #include <hgraph/python/retained_value.h>
 #include <hgraph/python/ts_data_conversion.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
@@ -81,31 +82,25 @@ namespace hgraph::ts_data_plan_factory_detail
                                   : &python_bridge::atomic_python_ts_data_ops(),
                 .from_python_impl =
                     value_storage == ValueStorageVariant::PythonOnly
-                        ? &atomic_from_python<
-                              ValueStorageVariant::PythonOnly>
+                        ? &python_bridge::ts_from_python_slot<&atomic_from_python<ValueStorageVariant::PythonOnly>>
                     : value_storage ==
                               ValueStorageVariant::NativeWithPythonCache
-                        ? &atomic_from_python<
-                              ValueStorageVariant::NativeWithPythonCache>
-                        : &atomic_from_python<ValueStorageVariant::Native>,
+                        ? &python_bridge::ts_from_python_slot<&atomic_from_python<ValueStorageVariant::NativeWithPythonCache>>
+                        : &python_bridge::ts_from_python_slot<&atomic_from_python<ValueStorageVariant::Native>>,
                 .to_python_impl =
                     value_storage == ValueStorageVariant::PythonOnly
-                        ? &atomic_to_python<ValueStorageVariant::PythonOnly>
+                        ? &python_bridge::to_python_slot<&atomic_to_python<ValueStorageVariant::PythonOnly>>
                     : value_storage ==
                               ValueStorageVariant::NativeWithPythonCache
-                        ? &atomic_to_python<
-                              ValueStorageVariant::NativeWithPythonCache>
-                        : &atomic_to_python<ValueStorageVariant::Native>,
+                        ? &python_bridge::to_python_slot<&atomic_to_python<ValueStorageVariant::NativeWithPythonCache>>
+                        : &python_bridge::to_python_slot<&atomic_to_python<ValueStorageVariant::Native>>,
                 .delta_to_python_impl =
                     value_storage == ValueStorageVariant::PythonOnly
-                        ? &atomic_delta_to_python<
-                              ValueStorageVariant::PythonOnly>
+                        ? &python_bridge::ts_delta_to_python_slot<&atomic_delta_to_python<ValueStorageVariant::PythonOnly>>
                     : value_storage ==
                               ValueStorageVariant::NativeWithPythonCache
-                        ? &atomic_delta_to_python<
-                              ValueStorageVariant::NativeWithPythonCache>
-                        : &atomic_delta_to_python<
-                              ValueStorageVariant::Native>,
+                        ? &python_bridge::ts_delta_to_python_slot<&atomic_delta_to_python<ValueStorageVariant::NativeWithPythonCache>>
+                        : &python_bridge::ts_delta_to_python_slot<&atomic_delta_to_python<ValueStorageVariant::Native>>,
 #endif
             };
         }
@@ -357,7 +352,7 @@ namespace hgraph::ts_data_plan_factory_detail
             const bool  first_for_time = tracking->last_modified_time != modified_time;
             if constexpr (Storage == ValueStorageVariant::PythonOnly)
             {
-                layout->value_binding.ops_ref().from_python(
+                python_bridge::from_python(layout->value_binding.ops_ref(), 
                     layout->value_binding,
                     atomic_mutable_value_memory(context, memory), source);
                 return first_for_time;
@@ -368,14 +363,14 @@ namespace hgraph::ts_data_plan_factory_detail
                 nb::object retained =
                     python_bridge::prepare_python_storage_value(
                         layout->value_binding.schema(), source);
-                layout->value_binding.ops_ref().from_python(
+                python_bridge::from_python(layout->value_binding.ops_ref(), 
                     layout->value_binding,
                     atomic_mutable_value_memory(context, memory), source);
                 python_value(context, memory)->set(retained);
             }
             else
             {
-                layout->value_binding.ops_ref().from_python(
+                python_bridge::from_python(layout->value_binding.ops_ref(), 
                     layout->value_binding,
                     atomic_mutable_value_memory(context, memory), source);
             }
@@ -391,7 +386,7 @@ namespace hgraph::ts_data_plan_factory_detail
             if constexpr (Storage !=
                           ValueStorageVariant::NativeWithPythonCache)
             {
-                converted = layout->value_binding.ops_ref().to_python(
+                converted = python_bridge::to_python(layout->value_binding, 
                     atomic_value_memory(context, memory));
             }
             else
@@ -403,7 +398,7 @@ namespace hgraph::ts_data_plan_factory_detail
                 }
                 else
                 {
-                    converted = layout->value_binding.ops_ref().to_python(
+                    converted = python_bridge::to_python(layout->value_binding, 
                         atomic_value_memory(context, memory));
                     if (auto *cached =
                             python_value(context, const_cast<void *>(memory));
@@ -428,7 +423,7 @@ namespace hgraph::ts_data_plan_factory_detail
             if constexpr (Storage == ValueStorageVariant::Native)
             {
                 const auto *layout = atomic_layout(context);
-                nb::object converted = layout->delta_binding.ops_ref().to_python(
+                nb::object converted = python_bridge::to_python(layout->delta_binding, 
                     atomic_delta_memory(context, memory));
                 return converted;
             }

--- a/src/hgraph/types/metadata/ts_data_dynamic_list_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_dynamic_list_ops.cpp
@@ -11,6 +11,7 @@
 
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
 #include <hgraph/python/bridge_state.h>
+#include <hgraph/python/conversion.h>
 #include <hgraph/python/ts_data_conversion.h>
 #endif
 
@@ -579,9 +580,9 @@ namespace hgraph::ts_data_plan_factory_detail
                     .indexed_child_growth      = true,
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                     .python_ops               = &python_bridge::list_python_ts_data_ops(),
-                    .from_python_impl          = &dynamic_from_python,
-                    .to_python_impl            = &dynamic_to_python,
-                    .delta_to_python_impl      = &dynamic_delta_to_python,
+                    .from_python_impl          = &python_bridge::ts_from_python_slot<&dynamic_from_python>,
+                    .to_python_impl            = &python_bridge::to_python_slot<&dynamic_to_python>,
+                    .delta_to_python_impl      = &python_bridge::ts_delta_to_python_slot<&dynamic_delta_to_python>,
 #endif
                 };
                 ops.size_impl                   = &dynamic_indexed_size;
@@ -603,7 +604,7 @@ namespace hgraph::ts_data_plan_factory_detail
                      &dynamic_value_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                      ,
-                     &dynamic_value_projection_to_python
+                     &python_bridge::to_python_slot<&dynamic_value_projection_to_python>
 #endif
                     },
                     &dynamic_value_size,
@@ -623,7 +624,7 @@ namespace hgraph::ts_data_plan_factory_detail
                       &dynamic_delta_map_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                       ,
-                      &dynamic_delta_projection_to_python
+                      &python_bridge::to_python_slot<&dynamic_delta_projection_to_python>
 #endif
                      },
                      &dynamic_delta_map_size,
@@ -649,7 +650,7 @@ namespace hgraph::ts_data_plan_factory_detail
                       &dynamic_delta_key_set_compare, &dynamic_delta_key_set_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                       ,
-                      &dynamic_delta_key_set_projection_to_python
+                      &python_bridge::to_python_slot<&dynamic_delta_key_set_projection_to_python>
 #endif
                      },
                      &dynamic_delta_map_size,
@@ -668,7 +669,7 @@ namespace hgraph::ts_data_plan_factory_detail
                       &dynamic_removed_set_compare, &dynamic_removed_set_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                       ,
-                      &dynamic_removed_set_projection_to_python
+                      &python_bridge::to_python_slot<&dynamic_removed_set_projection_to_python>
 #endif
                      },
                      &dynamic_removed_set_size,
@@ -691,7 +692,7 @@ namespace hgraph::ts_data_plan_factory_detail
                      &dynamic_delta_bundle_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                      ,
-                     &dynamic_delta_bundle_to_python
+                     &python_bridge::to_python_slot<&dynamic_delta_bundle_to_python>
 #endif
                     },
                     &dynamic_delta_bundle_size,
@@ -715,21 +716,21 @@ namespace hgraph::ts_data_plan_factory_detail
                 const void *context, const void *memory)
             {
                 const auto *state = ctx(context);
-                return Value{ValueView{state->list_layout.value_binding, memory}}.to_python();
+                return python_bridge::to_python(Value{ValueView{state->list_layout.value_binding, memory}});
             }
 
             [[nodiscard]] static nb::object dynamic_delta_projection_to_python(
                 const void *context, const void *memory)
             {
                 const auto *state = ctx(context);
-                return Value{ValueView{state->list_layout.delta_binding, memory}}.to_python();
+                return python_bridge::to_python(Value{ValueView{state->list_layout.delta_binding, memory}});
             }
 
             [[nodiscard]] static nb::object dynamic_delta_key_set_projection_to_python(
                 const void *context, const void *memory)
             {
                 const auto *state = ctx(context);
-                return Value{ValueView{state->delta_key_set_binding, memory}}.to_python();
+                return python_bridge::to_python(Value{ValueView{state->delta_key_set_binding, memory}});
             }
 
             /** Dynamic TSL Python export is a TSData strategy. It deliberately
@@ -746,7 +747,7 @@ namespace hgraph::ts_data_plan_factory_detail
                 {
                     const auto *child = store.child_memory(index);
                     result.append(ops.has_current_value_impl(ops.context, child)
-                                      ? ops.to_python_impl(ops.context, child)
+                                      ? python_bridge::take(ops.to_python_impl(ops.context, child))
                                       : nb::none());
                 }
                 return nb::tuple(result);
@@ -767,15 +768,15 @@ namespace hgraph::ts_data_plan_factory_detail
                 {
                     const auto index = store.modified_index_at(ordinal);
                     const auto *child = store.child_memory(index);
-                    nb::object value = ops.delta_to_python_impl(
-                        ops.context, child, evaluation_time);
+                    nb::object value = python_bridge::take(ops.delta_to_python_impl(
+                        ops.context, child, evaluation_time));
                     if (!value.is_none()) { modified[nb::int_{index}] = std::move(value); }
                 }
                 // RFC 0031: the canonical {removed, modified} shape, which
                 // hgraph's _simplify_delta rewrites into the friendly
                 // {index: delta, removed_index: REMOVE} form.
                 nb::dict result;
-                result[nb::str{"removed"}] = state->removed_set_binding.ops_ref().to_python(memory);
+                result[nb::str{"removed"}] = python_bridge::to_python(state->removed_set_binding, memory);
                 result[nb::str{"modified"}] = std::move(modified);
                 return result;
             }
@@ -815,7 +816,7 @@ namespace hgraph::ts_data_plan_factory_detail
                 const auto update = [&](std::size_t index, nb::handle item) {
                     target.ensure_size(index + 1, state->element_type, modified_time);
                     void *child = target.child_memory(index);
-                    if (!ops.from_python_impl(ops.context, child, item,
+                    if (!ops.from_python_impl(ops.context, child, python_bridge::borrow(item),
                                               modified_time))
                     {
                         return;
@@ -1776,7 +1777,7 @@ namespace hgraph::ts_data_plan_factory_detail
                 const void *context, const void *memory)
             {
                 const auto *state = ctx(context);
-                return Value{ValueView{state->removed_set_binding, memory}}.to_python();
+                return python_bridge::to_python(Value{ValueView{state->removed_set_binding, memory}});
             }
 #endif
 
@@ -1900,8 +1901,8 @@ namespace hgraph::ts_data_plan_factory_detail
             {
                 const auto *state = ctx(context);
                 nb::dict result;
-                result[nb::str{"removed"}] = state->removed_set_binding.ops_ref().to_python(memory);
-                result[nb::str{"modified"}] = state->modified_map_binding.ops_ref().to_python(memory);
+                result[nb::str{"removed"}] = python_bridge::to_python(state->removed_set_binding, memory);
+                result[nb::str{"modified"}] = python_bridge::to_python(state->modified_map_binding, memory);
                 return result;
             }
 #endif

--- a/src/hgraph/types/metadata/ts_data_fixed_structured_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_fixed_structured_ops.cpp
@@ -11,6 +11,7 @@
 
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
 #include <hgraph/python/bridge_state.h>
+#include <hgraph/python/conversion.h>
 #include <hgraph/python/ts_data_conversion.h>
 #endif
 
@@ -347,9 +348,9 @@ namespace hgraph::ts_data_plan_factory_detail
                 .python_ops = schema->kind == TSTypeKind::TSB
                                   ? &python_bridge::bundle_python_ts_data_ops()
                                   : &python_bridge::list_python_ts_data_ops(),
-                .from_python_impl          = &fixed_from_python,
-                .to_python_impl            = &fixed_to_python,
-                .delta_to_python_impl      = &fixed_delta_to_python,
+                .from_python_impl          = &python_bridge::ts_from_python_slot<&fixed_from_python>,
+                .to_python_impl            = &python_bridge::to_python_slot<&fixed_to_python>,
+                .delta_to_python_impl      = &python_bridge::ts_delta_to_python_slot<&fixed_delta_to_python>,
 #endif
             };
             ops.size_impl                   = &fixed_indexed_size;
@@ -365,7 +366,7 @@ namespace hgraph::ts_data_plan_factory_detail
                  &fixed_value_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                  ,
-                 &fixed_value_to_python
+                 &python_bridge::to_python_slot<&fixed_value_to_python>
 #endif
                 },
                 &fixed_indexed_size,
@@ -385,7 +386,7 @@ namespace hgraph::ts_data_plan_factory_detail
                  &fixed_delta_bundle_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                  ,
-                 &fixed_delta_bundle_to_python
+                 &python_bridge::to_python_slot<&fixed_delta_bundle_to_python>
 #endif
                 },
                 &fixed_indexed_size,
@@ -404,7 +405,7 @@ namespace hgraph::ts_data_plan_factory_detail
                   &fixed_delta_map_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                   ,
-                  &fixed_delta_map_to_python
+                  &python_bridge::to_python_slot<&fixed_delta_map_to_python>
 #endif
                  },
                  &fixed_delta_map_size,
@@ -431,7 +432,7 @@ namespace hgraph::ts_data_plan_factory_detail
                   &fixed_delta_key_set_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                   ,
-                  &fixed_delta_key_set_to_python
+                  &python_bridge::to_python_slot<&fixed_delta_key_set_to_python>
 #endif
                  },
                  &fixed_delta_map_size,
@@ -893,7 +894,7 @@ namespace hgraph::ts_data_plan_factory_detail
             // This is a VALUE projection, not the TSData Python surface.
             // Materialise through the erased owning-type/copy contract so a
             // projected child never needs ad-hoc recursive shape knowledge.
-            return Value{ValueView{state->layout_ptr()->value_binding, memory}}.to_python();
+            return python_bridge::to_python(Value{ValueView{state->layout_ptr()->value_binding, memory}});
         }
 #endif
 
@@ -960,7 +961,7 @@ namespace hgraph::ts_data_plan_factory_detail
         [[nodiscard]] static nb::object fixed_delta_bundle_to_python(const void *context, const void *memory)
         {
             const auto *state = ctx(context);
-            return Value{ValueView{state->layout_ptr()->delta_binding, memory}}.to_python();
+            return python_bridge::to_python(Value{ValueView{state->layout_ptr()->delta_binding, memory}});
         }
 #endif
 
@@ -1260,7 +1261,7 @@ namespace hgraph::ts_data_plan_factory_detail
         [[nodiscard]] static nb::object fixed_delta_map_to_python(const void *context, const void *memory)
         {
             const auto *state = ctx(context);
-            return Value{ValueView{state->layout_ptr()->delta_binding, memory}}.to_python();
+            return python_bridge::to_python(Value{ValueView{state->layout_ptr()->delta_binding, memory}});
         }
 #endif
 
@@ -1599,7 +1600,7 @@ namespace hgraph::ts_data_plan_factory_detail
                     const auto &ops = child_ops(state->element_type(index));
                     const auto *child = child_data(state, memory, index);
                     result[nb::str{name}] = ops.has_current_value_impl(ops.context, child)
-                                                ? ops.to_python_impl(ops.context, child)
+                                                ? python_bridge::take(ops.to_python_impl(ops.context, child))
                                                 : nb::none();
                 }
                 return python_bridge::materialize_tsb_python_value(
@@ -1612,7 +1613,7 @@ namespace hgraph::ts_data_plan_factory_detail
                 const auto &ops = child_ops(state->element_type(index));
                 const auto *child = child_data(state, memory, index);
                 result.append(ops.has_current_value_impl(ops.context, child)
-                                  ? ops.to_python_impl(ops.context, child)
+                                  ? python_bridge::take(ops.to_python_impl(ops.context, child))
                                   : nb::none());
             }
             return nb::tuple(result);
@@ -1630,8 +1631,8 @@ namespace hgraph::ts_data_plan_factory_detail
                 if (!child_modified_for_parent_time(state, memory, index)) { continue; }
                 const auto &ops = child_ops(state->element_type(index));
                 const auto *child = child_data(state, memory, index);
-                nb::object value = ops.delta_to_python_impl(
-                    ops.context, child, evaluation_time);
+                nb::object value = python_bridge::take(ops.delta_to_python_impl(
+                    ops.context, child, evaluation_time));
                 if (value.is_none()) { continue; }
                 if (state->schema->kind == TSTypeKind::TSB)
                 {
@@ -1706,7 +1707,7 @@ namespace hgraph::ts_data_plan_factory_detail
             const auto child = state->element_type(index);
             const auto &ops  = child_ops(child);
             void       *data  = child_data(state, memory, index);
-            if (!ops.from_python_impl(ops.context, data, source, modified_time)) { return false; }
+            if (!ops.from_python_impl(ops.context, data, python_bridge::borrow(source), modified_time)) { return false; }
 
             auto *tracking = ops.mutable_tracking_impl(ops.context, data);
             if (tracking == nullptr) { throw std::logic_error("fixed TSData child has no tracking record"); }

--- a/src/hgraph/types/metadata/ts_data_slot_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_slot_ops.cpp
@@ -18,6 +18,7 @@
 
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
 #include <hgraph/python/ts_data_conversion.h>
+#include <hgraph/python/conversion.h>
 #endif
 
 #include <sul/dynamic_bitset.hpp>
@@ -829,7 +830,7 @@ namespace hgraph::ts_data_plan_factory_detail
         {
             if (source.is_none()) { throw std::invalid_argument(std::string{what} + " requires a non-None value"); }
             Value value{binding};
-            binding.ops_ref().from_python(binding, const_cast<void *>(value.view().data()), source);
+            python_bridge::from_python(binding.ops_ref(), binding, const_cast<void *>(value.view().data()), source);
             return value;
         }
 
@@ -1022,9 +1023,9 @@ namespace hgraph::ts_data_plan_factory_detail
                     .clear_collection_impl     = &ts_data_detail::clear_tss_collection,
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                     .python_ops               = &python_bridge::set_python_ts_data_ops(),
-                    .from_python_impl          = &tss_from_python,
-                    .to_python_impl            = &tss_to_python,
-                    .delta_to_python_impl      = &tss_delta_to_python,
+                    .from_python_impl          = &python_bridge::ts_from_python_slot<&tss_from_python>,
+                    .to_python_impl            = &python_bridge::to_python_slot<&tss_to_python>,
+                    .delta_to_python_impl      = &python_bridge::ts_delta_to_python_slot<&tss_delta_to_python>,
 #endif
                 };
                 set_ops.size_impl                      = &tss_size;
@@ -1067,7 +1068,7 @@ namespace hgraph::ts_data_plan_factory_detail
                      &delta_bundle_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                      ,
-                     &delta_bundle_to_python
+                     &python_bridge::to_python_slot<&delta_bundle_to_python>
 #endif
                     },
                     &delta_bundle_size,
@@ -1102,7 +1103,7 @@ namespace hgraph::ts_data_plan_factory_detail
                       &set_to_string<Surface>
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                       ,
-                      &set_to_python<Surface>
+                      &python_bridge::to_python_slot<&set_to_python<Surface>>
 #endif
                      },
                      &set_size<Surface>,
@@ -1343,7 +1344,7 @@ namespace hgraph::ts_data_plan_factory_detail
             [[nodiscard]] static nb::object tss_to_python(const void *context, const void *memory)
             {
                 const auto *state = ctx(context);
-                return state->set_layout.value_binding.ops_ref().to_python(memory);
+                return python_bridge::to_python(state->set_layout.value_binding, memory);
             }
 
             [[nodiscard]] static nb::object tss_delta_to_python(const void *context,
@@ -1352,7 +1353,7 @@ namespace hgraph::ts_data_plan_factory_detail
             {
                 const auto *state = ctx(context);
                 if (storage<Storage>(memory).tracking().last_modified_time != evaluation_time) { return nb::none(); }
-                return state->set_layout.delta_binding.ops_ref().to_python(memory);
+                return python_bridge::to_python(state->set_layout.delta_binding, memory);
             }
 
             [[nodiscard]] static bool tss_from_python(const void *context,
@@ -1726,7 +1727,7 @@ namespace hgraph::ts_data_plan_factory_detail
                 nb::set     result;
                 for (const auto key : set_make_range<Surface>(context, memory))
                 {
-                    result.add(ops.to_python(key.data()));
+                    result.add(python_bridge::to_python(ops, key.data()));
                 }
                 return result;
             }
@@ -1810,8 +1811,8 @@ namespace hgraph::ts_data_plan_factory_detail
             {
                 const auto *state = ctx(context);
                 nb::dict    result;
-                result[nb::str{"added"}] = state->added_set_binding.ops_ref().to_python(memory);
-                result[nb::str{"removed"}] = state->removed_set_binding.ops_ref().to_python(memory);
+                result[nb::str{"added"}] = python_bridge::to_python(state->added_set_binding, memory);
+                result[nb::str{"removed"}] = python_bridge::to_python(state->removed_set_binding, memory);
                 return result;
             }
 #endif
@@ -1979,9 +1980,9 @@ namespace hgraph::ts_data_plan_factory_detail
                 base_ops.clear_collection_impl = &ts_data_detail::clear_tsd_collection;
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                 base_ops.python_ops = &python_bridge::dict_python_ts_data_ops();
-                base_ops.from_python_impl = &tsd_from_python;
-                base_ops.to_python_impl = &tsd_to_python;
-                base_ops.delta_to_python_impl = &tsd_delta_to_python;
+                base_ops.from_python_impl = &python_bridge::ts_from_python_slot<&tsd_from_python>;
+                base_ops.to_python_impl = &python_bridge::to_python_slot<&tsd_to_python>;
+                base_ops.delta_to_python_impl = &python_bridge::ts_delta_to_python_slot<&tsd_delta_to_python>;
 #endif
 
                 dict_ops.structural_delta_current_impl = &tsd_structural_delta_current;
@@ -2015,7 +2016,7 @@ namespace hgraph::ts_data_plan_factory_detail
                       &map_key_set_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                       ,
-                      &map_key_set_to_python
+                      &python_bridge::to_python_slot<&map_key_set_to_python>
 #endif
                      },
                      &map_live_size,
@@ -2043,7 +2044,7 @@ namespace hgraph::ts_data_plan_factory_detail
                      &dict_delta_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                      ,
-                     &dict_delta_to_python
+                     &python_bridge::to_python_slot<&dict_delta_to_python>
 #endif
                     },
                     &dict_delta_size,
@@ -2143,7 +2144,7 @@ namespace hgraph::ts_data_plan_factory_detail
                       &map_to_string<Surface>
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                       ,
-                      &map_to_python<Surface>
+                      &python_bridge::to_python_slot<&map_to_python<Surface>>
 #endif
                      },
                      &map_size<Surface>,
@@ -2347,8 +2348,8 @@ namespace hgraph::ts_data_plan_factory_detail
                     if (!map_slot_in_surface<SlotMapSurface::Live>(store, slot)) { continue; }
                     const auto *child = store.child_at_slot(slot);
                     if (!child_ops.has_current_value_impl(child_ops.context, child)) { continue; }
-                    result[key_ops.to_python(store.key_at_slot(slot))] =
-                        child_ops.to_python_impl(child_ops.context, child);
+                    result[python_bridge::to_python(key_ops, store.key_at_slot(slot))] =
+                        python_bridge::take(child_ops.to_python_impl(child_ops.context, child));
                 }
                 return result;
             }
@@ -2370,15 +2371,15 @@ namespace hgraph::ts_data_plan_factory_detail
                 {
                     if (!map_slot_in_surface<SlotMapSurface::Modified>(store, slot)) { continue; }
                     const auto *child = store.child_at_slot(slot);
-                    nb::object delta = child_ops.delta_to_python_impl(
-                        child_ops.context, child, evaluation_time);
+                    nb::object delta = python_bridge::take(child_ops.delta_to_python_impl(
+                        child_ops.context, child, evaluation_time));
                     if (!delta.is_none())
                     {
-                        modified[key_ops.to_python(store.key_at_slot(slot))] = std::move(delta);
+                        modified[python_bridge::to_python(key_ops, store.key_at_slot(slot))] = std::move(delta);
                     }
                 }
                 nb::dict result;
-                result[nb::str{"removed"}] = state->removed_set_binding.ops_ref().to_python(memory);
+                result[nb::str{"removed"}] = python_bridge::to_python(state->removed_set_binding, memory);
                 result[nb::str{"modified"}] = std::move(modified);
                 return result;
             }
@@ -2433,7 +2434,7 @@ namespace hgraph::ts_data_plan_factory_detail
 
                             const auto &child_ops    = state->dict_layout.element_type.ops_ref();
                             void       *child_memory = target.child_memory_for_write(result.slot);
-                            if (!child_ops.from_python_impl(child_ops.context, child_memory, value_source,
+                            if (!child_ops.from_python_impl(child_ops.context, child_memory, python_bridge::borrow(value_source),
                                                             modified_time))
                             {
                                 return;
@@ -2472,7 +2473,7 @@ namespace hgraph::ts_data_plan_factory_detail
                     const auto result = target.insert_key(key.view(), modified_time);
                     const auto &child_ops = state->dict_layout.element_type.ops_ref();
                     void       *child_memory = target.child_memory_for_write(result.slot);
-                    if (child_ops.from_python_impl(child_ops.context, child_memory, value_source, modified_time))
+                    if (child_ops.from_python_impl(child_ops.context, child_memory, python_bridge::borrow(value_source), modified_time))
                     {
                         auto *child_tracking = child_ops.mutable_tracking_impl(child_ops.context, child_memory);
                         if (child_tracking == nullptr)
@@ -2994,8 +2995,8 @@ namespace hgraph::ts_data_plan_factory_detail
                 nb::dict result;
                 for (const auto [key, value] : map_kv_range<Surface>(context, memory))
                 {
-                    result[key_ops.to_python(key.data())] =
-                        value.has_value() ? value_ops.to_python(value.data()) : nb::none();
+                    result[python_bridge::to_python(key_ops, key.data())] =
+                        value.has_value() ? python_bridge::to_python(value_ops, value.data()) : nb::none();
                 }
                 return result;
             }
@@ -3109,8 +3110,8 @@ namespace hgraph::ts_data_plan_factory_detail
             {
                 const auto *state = ctxd(context);
                 nb::dict result;
-                result[nb::str{"removed"}] = state->removed_set_binding.ops_ref().to_python(memory);
-                result[nb::str{"modified"}] = state->modified_map_binding.ops_ref().to_python(memory);
+                result[nb::str{"removed"}] = python_bridge::to_python(state->removed_set_binding, memory);
+                result[nb::str{"modified"}] = python_bridge::to_python(state->modified_map_binding, memory);
                 return result;
             }
 #endif

--- a/src/hgraph/types/metadata/ts_data_window_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_window_ops.cpp
@@ -10,6 +10,7 @@
 
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
 #include <hgraph/python/ts_data_conversion.h>
+#include <hgraph/python/conversion.h>
 #endif
 
 #include <fmt/format.h>
@@ -561,7 +562,7 @@ namespace hgraph::ts_data_plan_factory_detail
                 {
                     if ((*it).is_none()) { throw std::invalid_argument("TSW value does not allow None elements"); }
                     Value element{element_binding()};
-                    element_binding().ops_ref().from_python(element_binding(),
+                    python_bridge::from_python(element_binding().ops_ref(), element_binding(),
                                                                 const_cast<void *>(element.view().data()),
                                                                 *it);
                     push(element.view(), modified_time);
@@ -634,7 +635,7 @@ namespace hgraph::ts_data_plan_factory_detail
                 {
                     if ((*it).is_none()) { throw std::invalid_argument("TSW value does not allow None elements"); }
                     Value element{element_binding()};
-                    element_binding().ops_ref().from_python(element_binding(),
+                    python_bridge::from_python(element_binding().ops_ref(), element_binding(),
                                                                 const_cast<void *>(element.view().data()),
                                                                 *it);
                     push(element.view(), modified_time);
@@ -864,9 +865,9 @@ namespace hgraph::ts_data_plan_factory_detail
                     .apply_delta_impl          = &ts_data_detail::apply_delta_tsw,
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                     .python_ops               = &python_bridge::window_python_ts_data_ops(),
-                    .from_python_impl          = &window_from_python,
-                    .to_python_impl            = &window_to_python,
-                    .delta_to_python_impl      = &window_delta_to_python,
+                    .from_python_impl          = &python_bridge::ts_from_python_slot<&window_from_python>,
+                    .to_python_impl            = &python_bridge::to_python_slot<&window_to_python>,
+                    .delta_to_python_impl      = &python_bridge::ts_delta_to_python_slot<&window_delta_to_python>,
 #endif
                 };
                 ops.size_impl        = &window_size;
@@ -906,7 +907,7 @@ namespace hgraph::ts_data_plan_factory_detail
                      &window_value_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                      ,
-                     &window_value_to_python
+                     &python_bridge::to_python_slot<&window_value_to_python>
 #endif
                     },
                     &window_value_size,
@@ -1088,7 +1089,7 @@ namespace hgraph::ts_data_plan_factory_detail
 
             [[nodiscard]] static nb::object window_to_python(const void *context, const void *memory)
             {
-                return ctx(context)->layout->value_binding.ops_ref().to_python(window_value_memory(context, memory));
+                return python_bridge::to_python(ctx(context)->layout->value_binding, window_value_memory(context, memory));
             }
 
             [[nodiscard]] static nb::object window_delta_to_python(const void *context,
@@ -1098,7 +1099,7 @@ namespace hgraph::ts_data_plan_factory_detail
                 if (window_tracking(context, memory)->last_modified_time != evaluation_time) { return nb::none(); }
                 const auto *delta = window_delta_memory(context, memory);
                 if (delta == nullptr) { return nb::none(); }
-                return ctx(context)->layout->delta_binding.ops_ref().to_python(delta);
+                return python_bridge::to_python(ctx(context)->layout->delta_binding, delta);
             }
 
             [[nodiscard]] static bool window_from_python(const void *context,
@@ -1129,7 +1130,7 @@ namespace hgraph::ts_data_plan_factory_detail
 
                 const auto *state = ctx(context);
                 Value       element{state->layout->element_binding};
-                state->layout->element_binding.ops_ref().from_python(
+                python_bridge::from_python(state->layout->element_binding.ops_ref(), 
                     state->layout->element_binding,
                     const_cast<void *>(element.view().data()),
                     source);
@@ -1349,9 +1350,9 @@ namespace hgraph::ts_data_plan_factory_detail
                 const auto &ops   = state->layout->element_binding.ops_ref();
                 const auto binding = state->layout->element_binding;
                 const auto &window = storage<Storage>(memory);
-                if (ops.can_to_python_buffer(binding))
+                if (python_bridge::can_to_python_buffer(ops, binding))
                 {
-                    return ops.to_python_buffer(binding,
+                    return python_bridge::to_python_buffer(ops, binding,
                                                 ValueArraySource{
                                                     .owner      = memory,
                                                     .size       = window.size(),
@@ -1362,7 +1363,7 @@ namespace hgraph::ts_data_plan_factory_detail
                 nb::list result;
                 for (std::size_t index = 0; index < window.size(); ++index)
                 {
-                    result.append(ops.to_python(window.element_at(index)));
+                    result.append(python_bridge::to_python(ops, window.element_at(index)));
                 }
                 return result;
             }

--- a/src/hgraph/types/metadata/type_realization.cpp
+++ b/src/hgraph/types/metadata/type_realization.cpp
@@ -3,6 +3,7 @@
 #include <hgraph/config.h>
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
 #include <hgraph/python/bridge_state.h>
+#include <hgraph/python/conversion.h>
 #endif
 
 #include <hgraph/runtime/global_state.h>
@@ -115,8 +116,8 @@ struct TypeRealizationSnapshot::Impl {
       ops.compare_impl = &compare;
       ops.to_string_impl = &to_string;
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
-      ops.to_python_impl = &to_python;
-      ops.from_python_impl = &from_python;
+      ops.to_python_impl = &python_bridge::to_python_slot<&to_python>;
+      ops.from_python_impl = &python_bridge::from_python_slot<&from_python>;
 #endif
       ops.accepts_source_impl = &accepts_source;
       ops.copy_assign_from_impl = &copy_assign_from;
@@ -578,7 +579,7 @@ struct TypeRealizationSnapshot::Impl {
       if (!active) {
         throw std::logic_error("closed Bundle has an invalid active type");
       }
-      return active.ops_ref().to_python(payload(self, memory));
+      return python_bridge::to_python(active, payload(self, memory));
     }
 
     [[nodiscard]] ValueTypeRef python_source_type(nb::handle source) const {
@@ -747,7 +748,7 @@ struct TypeRealizationSnapshot::Impl {
         set_active_record(memory, requested.record());
         restore.release();
       }
-      requested.ops_ref().from_python(requested, payload(self, memory), source);
+      python_bridge::from_python(requested.ops_ref(), requested, payload(self, memory), source);
     }
 #endif
   };

--- a/src/hgraph/types/metadata/type_registry.cpp
+++ b/src/hgraph/types/metadata/type_registry.cpp
@@ -1,4 +1,5 @@
 #include <hgraph/types/metadata/type_registry.h>
+#include <hgraph/types/python_ops.h>
 
 #include <hgraph/lib/std/standard_types.h>
 #include <hgraph/types/temporal.h>
@@ -582,27 +583,6 @@ namespace hgraph
             return std::to_string(value);
         }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-        nanobind::object enum_to_python(const void *context, const void *memory)
-        {
-            const auto *meta = static_cast<const ValueTypeMetaData *>(context);
-            if (enum_to_python_slot() == nullptr)
-            {
-                throw std::logic_error("enum python conversion requires the python bridge");
-            }
-            return enum_to_python_slot()(meta, *static_cast<const Int *>(memory));
-        }
-
-        void enum_from_python(const void *context, const ValueTypeRef &, void *memory, nanobind::handle source)
-        {
-            const auto *meta = static_cast<const ValueTypeMetaData *>(context);
-            if (enum_from_python_slot() == nullptr)
-            {
-                throw std::logic_error("enum python conversion requires the python bridge");
-            }
-            *static_cast<Int *>(memory) = enum_from_python_slot()(meta, source);
-        }
-#endif
 
         const ValueOps &enum_ops_for(const ValueTypeMetaData *meta)
         {
@@ -610,11 +590,11 @@ namespace hgraph
                 ValueOps ops       = ops_for<Int>();
                 ops.context        = meta;
                 ops.to_string_impl = &enum_to_string;
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-                ops.to_python_impl        = &enum_to_python;
-                ops.from_python_impl      = &enum_from_python;
+                // Python conversion resolves through the registered provider
+                // (RFC 0035): the module owns the enum-class registry.
+                ops.to_python_impl        = &python_ops_detail::forwarder<&PythonOps::Enums::to_python>::call;
+                ops.from_python_impl      = &python_ops_detail::forwarder<&PythonOps::Enums::from_python>::call;
                 ops.to_python_buffer_impl = nullptr;
-#endif
                 return ops;
             });
         }
@@ -622,19 +602,6 @@ namespace hgraph
         void clear_enum_ops() noexcept { enum_ops_store().clear(); }
     }  // namespace
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-    EnumToPythonFn &enum_to_python_slot() noexcept
-    {
-        static EnumToPythonFn slot = nullptr;
-        return slot;
-    }
-
-    EnumFromPythonFn &enum_from_python_slot() noexcept
-    {
-        static EnumFromPythonFn slot = nullptr;
-        return slot;
-    }
-#endif
 
     const ValueTypeMetaData *TypeRegistry::named_enum(std::string_view name) const
     {

--- a/src/hgraph/types/metadata/value_plan_factory.cpp
+++ b/src/hgraph/types/metadata/value_plan_factory.cpp
@@ -4,6 +4,7 @@
 
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
 #include <hgraph/python/bridge_state.h>
+#include <hgraph/python/conversion.h>
 #include <hgraph/python/object_semantics.h>
 #include <hgraph/types/primitive_types.h>
 #include <hgraph/types/static_schema.h>
@@ -625,7 +626,7 @@ void assign_child_from_python(const ValueTypeRef &binding, void *memory,
     throw std::invalid_argument(std::string{what} +
                                 " does not allow None elements");
   }
-  binding.ops_ref().from_python(binding, memory, source);
+  python_bridge::from_python(binding.ops_ref(), binding, memory, source);
 }
 
 [[nodiscard]] const python_bridge::PyBundleClassInfo *
@@ -664,7 +665,7 @@ python_bundle_info(const ValueTypeMetaData *schema) {
         const auto &ops = state->child_bindings[index].ops_ref();
         const auto *child =
             static_cast<const std::byte *>(memory) + state->offsets[index];
-        result[nb::str{name}] = ops.to_python(child);
+        result[nb::str{name}] = python_bridge::to_python(ops, child);
       }
       return result;
     }
@@ -687,7 +688,7 @@ python_bundle_info(const ValueTypeMetaData *schema) {
       }
       nb::handle key = bundle_info->field_names[index];
       const bool set = composite_field_set(state, memory, index);
-      nb::object value = set ? state->child_bindings[index].ops_ref().to_python(
+      nb::object value = set ? python_bridge::to_python(state->child_bindings[index], 
                                    static_cast<const std::byte *>(memory) +
                                    state->offsets[index])
                              : nb::none();
@@ -725,7 +726,7 @@ python_bundle_info(const ValueTypeMetaData *schema) {
     const auto &ops = state->child_bindings[index].ops_ref();
     const auto *child =
         static_cast<const std::byte *>(memory) + state->offsets[index];
-    result.append(ops.to_python(child));
+    result.append(python_bridge::to_python(ops, child));
   }
   return nb::tuple(result);
 }
@@ -1139,7 +1140,7 @@ array_dynamic_storage_metrics(const void *context,
   const auto *state = static_cast<const ArrayIndexedContext *>(context);
   const auto &ops = state->element_binding.ops_ref();
   const auto size = array_indexed_size(context, memory);
-  if (ops.can_to_python_buffer(state->element_binding)) {
+  if (python_bridge::can_to_python_buffer(ops, state->element_binding)) {
     struct ArrayBufferOwner {
       const void *memory{nullptr};
       const ArrayIndexedContext *state{nullptr};
@@ -1153,7 +1154,7 @@ array_dynamic_storage_metrics(const void *context,
              owner_state->state->data_offset +
              index * owner_state->state->stride;
     };
-    return ops.to_python_buffer(
+    return python_bridge::to_python_buffer(ops, 
         state->element_binding,
         ValueArraySource{
             .owner = &owner,
@@ -1173,7 +1174,7 @@ array_dynamic_storage_metrics(const void *context,
   for (std::size_t index = 0; index < size; ++index) {
     const auto *child = static_cast<const std::byte *>(memory) +
                         state->data_offset + index * state->stride;
-    result.append(ops.to_python(child));
+    result.append(python_bridge::to_python(ops, child));
   }
   return result;
 }
@@ -1262,8 +1263,8 @@ struct OwnedValueEntry {
     ops.compare_impl = owned_schema.is_comparable() ? &compare : nullptr;
     ops.to_string_impl = &to_string;
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
-    ops.to_python_impl = &to_python;
-    ops.from_python_impl = &from_python;
+    ops.to_python_impl = &python_bridge::to_python_slot<&to_python>;
+    ops.from_python_impl = &python_bridge::from_python_slot<&from_python>;
 #endif
     ops.accepts_source_impl = &accepts_source;
     ops.copy_assign_from_impl = &copy_assign_from;
@@ -1383,9 +1384,7 @@ struct OwnedValueEntry {
     if (allocation == nullptr) {
       return nb::none();
     }
-    return allocation_type(allocation)
-        .ops_ref()
-        .to_python(owned_payload(*allocation));
+    return python_bridge::to_python(allocation_type(allocation), owned_payload(*allocation));
   }
 
   static void from_python(const void *context, const ValueTypeRef &,
@@ -1404,7 +1403,7 @@ struct OwnedValueEntry {
       auto *replacement = allocate_owned(desired);
       auto cleanup = make_scope_exit(
           [&]() noexcept { destroy_owned_allocation(replacement); });
-      desired.ops_ref().from_python(desired, owned_payload(*replacement),
+      python_bridge::from_python(desired.ops_ref(), desired, owned_payload(*replacement),
                                     source);
       auto *previous = allocation;
       set_owned_allocation(memory, replacement);
@@ -1412,7 +1411,7 @@ struct OwnedValueEntry {
       destroy_owned_allocation(previous);
       return;
     }
-    desired.ops_ref().from_python(desired, owned_payload(*allocation), source);
+    python_bridge::from_python(desired.ops_ref(), desired, owned_payload(*allocation), source);
   }
 #endif
 
@@ -1697,8 +1696,8 @@ struct SharedValueEntry {
     ops.compare_impl = shared_schema.is_comparable() ? &compare : nullptr;
     ops.to_string_impl = &to_string;
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
-    ops.to_python_impl = &to_python;
-    ops.from_python_impl = &from_python;
+    ops.to_python_impl = &python_bridge::to_python_slot<&to_python>;
+    ops.from_python_impl = &python_bridge::from_python_slot<&from_python>;
 #endif
     ops.accepts_source_impl = &accepts_source;
     ops.copy_assign_from_impl = &copy_assign_from;
@@ -1849,7 +1848,7 @@ struct SharedValueEntry {
       return nb::none();
     }
     const auto type = allocation_type(allocation);
-    return type.ops_ref().to_python(payload(allocation));
+    return python_bridge::to_python(type, payload(allocation));
   }
 
   static void from_python(const void *context, const ValueTypeRef &,
@@ -1863,7 +1862,7 @@ struct SharedValueEntry {
 
     const auto desired = target_type(entry(context));
     auto *replacement = construct_allocation(desired, [&](void *payload) {
-      desired.ops_ref().from_python(desired, payload, source);
+      python_bridge::from_python(desired.ops_ref(), desired, payload, source);
     });
     auto *previous = shared_allocation(memory);
     set_shared_allocation(memory, replacement);
@@ -2109,7 +2108,8 @@ struct CompositeIndexedOpsEntry {
          &composite_value_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
          ,
-         &composite_value_to_python, &composite_value_from_python
+         &python_bridge::to_python_slot<&composite_value_to_python>,
+         &python_bridge::from_python_slot<&composite_value_from_python>
 #endif
         },
         &composite_indexed_size,
@@ -2198,9 +2198,9 @@ struct ArrayIndexedOpsEntry {
          &array_value_equals, &array_value_compare, &array_value_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
          ,
-         schema.is_shaped_array() ? &array_value_to_numpy
-                                  : &array_value_to_python,
-         &array_value_from_python
+         schema.is_shaped_array() ? &python_bridge::to_python_slot<&array_value_to_numpy>
+                                  : &python_bridge::to_python_slot<&array_value_to_python>,
+         &python_bridge::from_python_slot<&array_value_from_python>
 #endif
         },
         &array_indexed_size,

--- a/src/hgraph/types/python_ops.cpp
+++ b/src/hgraph/types/python_ops.cpp
@@ -1,0 +1,56 @@
+#include <hgraph/types/python_ops.h>
+
+#include <atomic>
+#include <stdexcept>
+#include <string>
+
+namespace hgraph
+{
+    namespace
+    {
+        std::atomic<const PythonOps *> &python_ops_slot() noexcept
+        {
+            static std::atomic<const PythonOps *> slot{nullptr};
+            return slot;
+        }
+    }  // namespace
+
+    void set_python_ops(const PythonOps *ops) noexcept
+    {
+        python_ops_slot().store(ops, std::memory_order_release);
+    }
+
+    const PythonOps *python_ops() noexcept
+    {
+        return python_ops_slot().load(std::memory_order_acquire);
+    }
+
+    namespace python_ops_detail
+    {
+        const PythonOps &require_python_ops(const char *what)
+        {
+            const auto *ops = python_ops();
+            if (ops == nullptr) { throw_unregistered(what); }
+            return *ops;
+        }
+
+        void throw_unregistered(const char *what)
+        {
+            throw std::logic_error(std::string{"no Python conversion is registered for "} + what +
+                                   " (the Python bridge is not loaded)");
+        }
+
+        void throw_unregistered_scalar(const std::type_info &type)
+        {
+            throw std::logic_error(std::string{"no Python conversion is registered for the scalar type "} +
+                                   type.name());
+        }
+
+        const PythonScalarSlots *scalar_slots(const std::type_info &type) noexcept
+        {
+            const auto *ops = python_ops();
+            if (ops == nullptr || ops->scalars.conversion_for == nullptr) { return nullptr; }
+            return ops->scalars.conversion_for(type);
+        }
+    }  // namespace python_ops_detail
+}  // namespace hgraph

--- a/src/hgraph/types/time_series/ts_data/base_view.cpp
+++ b/src/hgraph/types/time_series/ts_data/base_view.cpp
@@ -150,25 +150,6 @@ ValueView TSDataView::delta_value(DateTime evaluation_time) const {
       .concrete();
 }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-nb::object TSDataView::value_to_python() const {
-  const auto &table = ops();
-  if (!table.has_current_value_impl(table.context, data())) {
-    return nb::none();
-  }
-  return table.to_python_impl(table.context, data());
-}
-
-nb::object TSDataView::delta_value_to_python(DateTime evaluation_time) const {
-  const auto &table = ops();
-  if (evaluation_time == MIN_DT ||
-      table.tracking_impl(table.context, data())->last_modified_time !=
-          evaluation_time) {
-    return nb::none();
-  }
-  return table.delta_to_python_impl(table.context, data(), evaluation_time);
-}
-#endif
 
 DateTime TSDataView::last_modified_time() const {
   return tracking().last_modified_time;
@@ -546,28 +527,17 @@ bool TSDataMutationView::invalidate() {
   return true;
 }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-bool TSDataMutationView::from_python(nb::handle source) {
+
+void TSDataMutationView::record_reported_modification() {
   require_active_mutation();
-  if (source.is_none()) {
-    return false;
-  }
-
   const auto &table = ops();
-  const bool newly_modified = table.from_python_impl(
-      table.context, storage_.data(), source, mutation_time_);
-  if (newly_modified) {
-    auto &state = *table.mutable_tracking_impl(table.context, storage_.data());
-    if (!state.record_modified(mutation_time_)) {
-      throw std::logic_error("TSDataMutationView::from_python reported a new "
-                             "modification that was already recorded");
-    }
-    state.parent.notify_child_modified(mutation_time_);
+  auto &state = *table.mutable_tracking_impl(table.context, storage_.data());
+  if (!state.record_modified(mutation_time_)) {
+    throw std::logic_error("TSDataMutationView: an erased write reported a new "
+                           "modification that was already recorded");
   }
-  return newly_modified;
+  state.parent.notify_child_modified(mutation_time_);
 }
-
-#endif
 
 void TSDataMutationView::validate_mutation_view() const {
   // The one validation per mutation scope (audit 2026-08-16). Everything a

--- a/src/hgraph/types/time_series/ts_data/ops.cpp
+++ b/src/hgraph/types/time_series/ts_data/ops.cpp
@@ -297,6 +297,23 @@ namespace hgraph::ts_data_detail
         missing_ts_data_op("apply delta");
     }
 
+    namespace
+    {
+        bool missing_requires_authored(TSRoleTypeRef, PyRef) { missing_ts_data_op("requires authored delta"); }
+        Value missing_delta_from_python(TSRoleTypeRef, PyRef, bool) { missing_ts_data_op("delta from Python"); }
+        void missing_apply_result(const TSOutputView &, PyRef) { missing_ts_data_op("apply Python result"); }
+    }  // namespace
+
+    const PythonTSDataOps &missing_python_ts_data_ops() noexcept
+    {
+        static const PythonTSDataOps ops{
+            .requires_authored_delta_impl = &missing_requires_authored,
+            .delta_from_python_impl       = &missing_delta_from_python,
+            .apply_result_impl            = &missing_apply_result,
+        };
+        return ops;
+    }
+
     bool missing_from_python(const void *, void *, PyRef, DateTime)
     {
         missing_ts_data_op("from Python");

--- a/src/hgraph/types/time_series/ts_data/ops.cpp
+++ b/src/hgraph/types/time_series/ts_data/ops.cpp
@@ -297,22 +297,20 @@ namespace hgraph::ts_data_detail
         missing_ts_data_op("apply delta");
     }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-    bool missing_from_python(const void *, void *, nb::handle, DateTime)
+    bool missing_from_python(const void *, void *, PyRef, DateTime)
     {
         missing_ts_data_op("from Python");
     }
 
-    nb::object missing_to_python(const void *, const void *)
+    PyNewRef missing_to_python(const void *, const void *)
     {
         missing_ts_data_op("to Python");
     }
 
-    nb::object missing_delta_to_python(const void *, const void *, DateTime)
+    PyNewRef missing_delta_to_python(const void *, const void *, DateTime)
     {
         missing_ts_data_op("delta to Python");
     }
-#endif
 
     std::size_t missing_indexed_size(const void *, const void *)
     {
@@ -501,9 +499,7 @@ namespace hgraph
         ops.mutable_value_memory_impl         = base_defaults.mutable_value_memory_impl;
         ops.mutable_delta_memory_impl         = base_defaults.mutable_delta_memory_impl;
         ops.mutable_indexed_child_memory_impl = base_defaults.mutable_indexed_child_memory_impl;
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
         ops.from_python_impl                  = base_defaults.from_python_impl;
-#endif
         ops.insert_key_impl      = set_defaults.insert_key_impl;
         ops.insert_key_move_impl = set_defaults.insert_key_move_impl;
         ops.remove_key_impl      = set_defaults.remove_key_impl;

--- a/src/hgraph/types/time_series/ts_data/proxy.cpp
+++ b/src/hgraph/types/time_series/ts_data/proxy.cpp
@@ -5,6 +5,7 @@
 
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
 #include <nanobind/nanobind.h>
+#include <hgraph/python/conversion.h>
 #endif
 
 #include <hgraph/types/metadata/type_registry.h>
@@ -193,7 +194,7 @@ namespace hgraph
                      &delta_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                      ,
-                     &delta_projection_to_python
+                     &python_bridge::to_python_slot<&delta_projection_to_python>
 #endif
                     },
                     &delta_size,
@@ -232,8 +233,8 @@ namespace hgraph
                     .delta_has_effect_impl     = &ts_data_detail::delta_has_effect_tss,
                     .apply_delta_impl          = &ts_data_detail::apply_delta_tss,
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
-                    .to_python_impl            = &key_set_to_python,
-                    .delta_to_python_impl      = &key_set_delta_to_python,
+                    .to_python_impl            = &python_bridge::to_python_slot<&key_set_to_python>,
+                    .delta_to_python_impl      = &python_bridge::ts_delta_to_python_slot<&key_set_delta_to_python>,
 #endif
                 };
                 key_set_ts_ops.size_impl                      = &set_size<TSDProxySetSurface::Live>;
@@ -271,8 +272,8 @@ namespace hgraph
                 dict_base.delta_has_effect_impl = &ts_data_detail::delta_has_effect_tsd;
                 dict_base.apply_delta_impl = &ts_data_detail::apply_delta_tsd;
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
-                dict_base.to_python_impl = &dict_to_python;
-                dict_base.delta_to_python_impl = &dict_delta_to_python;
+                dict_base.to_python_impl = &python_bridge::to_python_slot<&dict_to_python>;
+                dict_base.delta_to_python_impl = &python_bridge::ts_delta_to_python_slot<&dict_delta_to_python>;
 #endif
                 dict_ops.structural_delta_current_impl = &structural_delta_current;
                 dict_ops.child_at_slot_impl = &tsd_child_at_slot;
@@ -333,7 +334,7 @@ namespace hgraph
                       &set_compare<Surface>, &set_to_string<Surface>
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                       ,
-                      &set_surface_to_python<Surface>,
+                      &python_bridge::to_python_slot<&set_surface_to_python<Surface>>,
                       nullptr
 #endif
                      },
@@ -358,7 +359,7 @@ namespace hgraph
                       &map_compare<Surface>, &map_to_string<Surface>
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                       ,
-                      &map_surface_to_python<Surface>,
+                      &python_bridge::to_python_slot<&map_surface_to_python<Surface>>,
                       nullptr
 #endif
                      },
@@ -403,7 +404,7 @@ namespace hgraph
                 const void *context, const void *memory)
             {
                 const auto *state = ctx(context);
-                return Value{ValueView{state->layout.delta_binding, memory}}.to_python();
+                return python_bridge::to_python(Value{ValueView{state->layout.delta_binding, memory}});
             }
 
             [[nodiscard]] static nb::object key_set_to_python(
@@ -413,7 +414,7 @@ namespace hgraph
                 nb::set result;
                 for (const auto key : set_range<TSDProxySetSurface::Live>(context, memory))
                 {
-                    result.add(state->layout.key_binding.ops_ref().to_python(key.data()));
+                    result.add(python_bridge::to_python(state->layout.key_binding, key.data()));
                 }
                 return result;
             }
@@ -451,8 +452,8 @@ namespace hgraph
                     const auto key = dict.key_at_slot(slot);
                     const auto *child = proxy.child_at_slot(slot);
                     if (!child_ops.has_current_value_impl(child_ops.context, child)) { continue; }
-                    result[key.binding().ops_ref().to_python(key.data())] =
-                        child_ops.to_python_impl(child_ops.context, child);
+                    result[python_bridge::to_python(key.binding(), key.data())] =
+                        python_bridge::take(child_ops.to_python_impl(child_ops.context, child));
                 }
                 return result;
             }
@@ -474,11 +475,11 @@ namespace hgraph
                     if (!slot_modified(context, memory, slot) || !proxy.has_child(slot)) { continue; }
                     const auto key = dict.key_at_slot(slot);
                     const auto *child = proxy.child_at_slot(slot);
-                    nb::object delta = child_ops.delta_to_python_impl(
-                        child_ops.context, child, evaluation_time);
+                    nb::object delta = python_bridge::take(child_ops.delta_to_python_impl(
+                        child_ops.context, child, evaluation_time));
                     if (!delta.is_none())
                     {
-                        modified[key.binding().ops_ref().to_python(key.data())] = std::move(delta);
+                        modified[python_bridge::to_python(key.binding(), key.data())] = std::move(delta);
                     }
                 }
                 nb::dict result;
@@ -1074,8 +1075,8 @@ namespace hgraph
                     const auto value_type = map_value_binding<Surface>(context, memory);
                     const auto *value_memory = map_value_at_slot<Surface>(context, memory, slot);
                     auto key = dict.key_at_slot(slot);
-                    const auto py_key = key.binding().ops_ref().to_python(key.data());
-                    result[py_key] = value_memory != nullptr ? value_type.ops_ref().to_python(value_memory)
+                    const auto py_key = python_bridge::to_python(key.binding(), key.data());
+                    result[py_key] = value_memory != nullptr ? python_bridge::to_python(value_type, value_memory)
                                                               : nb::none();
                 }
                 return result;
@@ -1091,7 +1092,7 @@ namespace hgraph
                 {
                     if (!slot_in_set_surface<Surface>(context, memory, slot)) { continue; }
                     auto key = dict.key_at_slot(slot);
-                    items.append(key.binding().ops_ref().to_python(key.data()));
+                    items.append(python_bridge::to_python(key.binding(), key.data()));
                 }
                 return nb::steal(PyFrozenSet_New(items.ptr()));
             }

--- a/src/hgraph/types/time_series/ts_input.cpp
+++ b/src/hgraph/types/time_series/ts_input.cpp
@@ -22,6 +22,7 @@
 
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
 #include <hgraph/python/bridge_state.h>
+#include <hgraph/python/conversion.h>
 #endif
 
 #include <algorithm>
@@ -387,8 +388,8 @@ namespace hgraph
             .target_child = &tsl_target_child_at,
             .reference = &input_tsl_reference,
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
-            .to_python = &input_tsl_to_python,
-            .delta_to_python = &input_tsl_delta_to_python,
+            .to_python = &python_bridge::to_python_slot<&input_tsl_to_python>,
+            .delta_to_python = &python_bridge::ts_delta_to_python_slot<&input_tsl_delta_to_python>,
 #endif
         };
 
@@ -414,8 +415,8 @@ namespace hgraph
             .target_child = &tsb_target_child_at,
             .reference = &input_tsb_reference,
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
-            .to_python = &input_tsb_to_python,
-            .delta_to_python = &input_tsb_delta_to_python,
+            .to_python = &python_bridge::to_python_slot<&input_tsb_to_python>,
+            .delta_to_python = &python_bridge::ts_delta_to_python_slot<&input_tsb_delta_to_python>,
 #endif
         };
 
@@ -1853,13 +1854,13 @@ namespace hgraph
         [[nodiscard]] nb::object input_delta_bundle_value_to_python(const void *context, const void *memory)
         {
             const auto *state = static_cast<const InputBindingContext *>(context);
-            return Value{ValueView{state->delta_binding, memory}}.to_python();
+            return python_bridge::to_python(Value{ValueView{state->delta_binding, memory}});
         }
 
         [[nodiscard]] nb::object input_delta_map_value_to_python(const void *context, const void *memory)
         {
             const auto *state = static_cast<const InputBindingContext *>(context);
-            return Value{ValueView{state->delta_binding, memory}}.to_python();
+            return python_bridge::to_python(Value{ValueView{state->delta_binding, memory}});
         }
 
         [[nodiscard]] nb::object input_value_projection_to_python(const void *context,
@@ -1869,7 +1870,7 @@ namespace hgraph
             // Projection storage is materialised exclusively through its
             // erased owning-type and copy hooks. This keeps ValueOps complete
             // without teaching the caller which structural endpoint produced it.
-            return Value{ValueView{state->value_binding, memory}}.to_python();
+            return python_bridge::to_python(Value{ValueView{state->value_binding, memory}});
         }
 
         [[nodiscard]] nb::object input_delta_key_set_to_python(const void *context, const void *memory)
@@ -1892,7 +1893,7 @@ namespace hgraph
             if (!type || memory == nullptr) { return nb::none(); }
             const auto &ops = *type.ops();
             if (!ops.has_current_value_impl(ops.context, memory)) { return nb::none(); }
-            return ops.to_python_impl(ops.context, memory);
+            return python_bridge::take(ops.to_python_impl(ops.context, memory));
         }
 
         [[nodiscard]] nb::object child_delta_to_python(TSRoleTypeRef type,
@@ -1903,7 +1904,7 @@ namespace hgraph
             const auto &ops = *type.ops();
             const auto *tracking = ops.tracking_impl(ops.context, memory);
             if (tracking == nullptr || tracking->last_modified_time != evaluation_time) { return nb::none(); }
-            return ops.delta_to_python_impl(ops.context, memory, evaluation_time);
+            return python_bridge::take(ops.delta_to_python_impl(ops.context, memory, evaluation_time));
         }
 
         [[nodiscard]] nb::object input_tsb_to_python(const void *context, const void *memory)
@@ -1942,7 +1943,7 @@ namespace hgraph
             {
                 throw std::logic_error("TSInput non-peered to_python is not available for this endpoint shape");
             }
-            return endpoint_ops.to_python(context, memory);
+            return python_bridge::take(endpoint_ops.to_python(context, memory));
         }
 
         [[nodiscard]] nb::object input_tsb_delta_to_python(const void *context,
@@ -1989,7 +1990,7 @@ namespace hgraph
             {
                 throw std::logic_error("TSInput non-peered delta_to_python is not available for this endpoint shape");
             }
-            return endpoint_ops.delta_to_python(context, memory, evaluation_time);
+            return python_bridge::take(endpoint_ops.delta_to_python(context, memory, evaluation_time));
         }
 #endif
 
@@ -2180,7 +2181,7 @@ namespace hgraph
                  &input_value_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                  ,
-                 &input_value_projection_to_python
+                 &python_bridge::to_python_slot<&input_value_projection_to_python>
 #endif
                 },
                 &input_indexed_size,
@@ -2212,7 +2213,7 @@ namespace hgraph
                      &input_delta_bundle_compare, &input_delta_bundle_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                      ,
-                     &input_delta_bundle_value_to_python
+                     &python_bridge::to_python_slot<&input_delta_bundle_value_to_python>
 #endif
                     },
                     &input_indexed_size,
@@ -2241,7 +2242,7 @@ namespace hgraph
                       &input_delta_map_compare, &input_delta_map_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                       ,
-                      &input_delta_map_value_to_python
+                      &python_bridge::to_python_slot<&input_delta_map_value_to_python>
 #endif
                      },
                      &input_delta_map_size,
@@ -2267,7 +2268,7 @@ namespace hgraph
                       &input_delta_key_set_compare, &input_delta_key_set_to_string
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                       ,
-                      &input_delta_key_set_to_python
+                      &python_bridge::to_python_slot<&input_delta_key_set_to_python>
 #endif
                      },
                      &input_delta_map_size,
@@ -2316,8 +2317,8 @@ namespace hgraph
                 .indexed_child_memory_impl = &input_element_memory,
                 .mutable_indexed_child_memory_impl = &input_mutable_element_memory,
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
-                .to_python_impl = &input_to_python,
-                .delta_to_python_impl = &input_delta_to_python,
+                .to_python_impl = &python_bridge::to_python_slot<&input_to_python>,
+                .delta_to_python_impl = &python_bridge::ts_delta_to_python_slot<&input_delta_to_python>,
 #endif
             };
             context->ts_data_ops.size_impl = &input_indexed_size;

--- a/src/hgraph/types/time_series/ts_input/base_view.cpp
+++ b/src/hgraph/types/time_series/ts_input/base_view.cpp
@@ -509,41 +509,14 @@ namespace hgraph
         throw std::logic_error("TSInputView::delta_value requires a live input view");
     }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-    nb::object TSInputView::value_to_python() const
+
+    bool TSInputView::delta_is_sampled_rebind() const noexcept
     {
         const auto &data = data_view();
-        return data.valid() ? data.value_to_python() : nb::none();
+        if (!data.valid() || !is_target_position()) { return false; }
+        const auto *link = data_.link_storage();
+        return link != nullptr && link->tracking.last_modified_time > data.last_modified_time();
     }
-
-    nb::object TSInputView::delta_value_to_python() const
-    {
-        const auto &data = data_view();
-        if (!data.valid()) { return nb::none(); }
-
-        // Sampled target rebinds carry the modification on the input link,
-        // not on the already-valid target. In that case the input delta is
-        // the target's current value, exported by the target TSData strategy.
-        if (is_target_position())
-        {
-            const auto *link = data_.link_storage();
-            if (link != nullptr && link->tracking.last_modified_time > data.last_modified_time())
-            {
-                return data.value_to_python();
-            }
-        }
-
-        nb::object delta = data.delta_value_to_python(evaluation_time_);
-        if (!delta.is_none()) { return delta; }
-
-        const auto *view_schema = schema();
-        if (view_schema != nullptr && view_schema->kind == TSTypeKind::TS && modified())
-        {
-            return data.value_to_python();
-        }
-        return nb::none();
-    }
-#endif
 
     DynamicStorageMetrics TSInputView::dynamic_storage_metrics() const noexcept
     {

--- a/src/hgraph/types/time_series/ts_input/target_link_ops.cpp
+++ b/src/hgraph/types/time_series/ts_input/target_link_ops.cpp
@@ -1228,10 +1228,10 @@ namespace hgraph::detail
                 .as_role();
         }
 
-        [[nodiscard]] const python_bridge::PythonTSDataOps &
+        [[nodiscard]] const PythonTSDataOps &
         target_link_python_ops_for(TSRoleTypeRef type)
         {
-            return python_bridge::python_ts_data_ops(type.ops_ref());
+            return *type.ops_ref().python_ops;
         }
 
         [[nodiscard]] bool target_link_requires_authored_delta(
@@ -1239,7 +1239,7 @@ namespace hgraph::detail
         {
             const auto canonical = target_link_canonical_data_type(type);
             return target_link_python_ops_for(canonical)
-                .requires_authored_delta_impl(canonical, source);
+                .requires_authored_delta_impl(canonical, python_bridge::borrow(source));
         }
 
         [[nodiscard]] Value target_link_delta_from_python(
@@ -1247,7 +1247,7 @@ namespace hgraph::detail
         {
             const auto canonical = target_link_canonical_data_type(type);
             return target_link_python_ops_for(canonical)
-                .delta_from_python_impl(canonical, source, authored);
+                .delta_from_python_impl(canonical, python_bridge::borrow(source), authored);
         }
 
         void target_link_apply_python_result(const TSOutputView &output,
@@ -1258,14 +1258,14 @@ namespace hgraph::detail
                 target_link_delta_target(ops.context, output), result);
         }
 
-        [[nodiscard]] const python_bridge::PythonTSDataOps &
+        [[nodiscard]] const PythonTSDataOps &
         target_link_python_ts_data_ops() noexcept
         {
-            static const python_bridge::PythonTSDataOps ops{
+            static const PythonTSDataOps ops{
                 .requires_authored_delta_impl =
-                    &target_link_requires_authored_delta,
-                .delta_from_python_impl = &target_link_delta_from_python,
-                .apply_result_impl = &target_link_apply_python_result,
+                    &python_bridge::ts_requires_authored_slot<&target_link_requires_authored_delta>,
+                .delta_from_python_impl = &python_bridge::ts_delta_from_python_slot<&target_link_delta_from_python>,
+                .apply_result_impl      = &python_bridge::ts_apply_result_slot<&target_link_apply_python_result>,
             };
             return ops;
         }

--- a/src/hgraph/types/time_series/ts_input/target_link_ops.cpp
+++ b/src/hgraph/types/time_series/ts_input/target_link_ops.cpp
@@ -9,6 +9,7 @@
 
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
 #include <hgraph/python/ts_data_conversion.h>
+#include <hgraph/python/conversion.h>
 #include <hgraph/types/metadata/ts_data_plan_factory.h>
 #endif
 
@@ -1137,7 +1138,7 @@ namespace hgraph::detail
         {
             const auto *link = target_link_storage_at(*static_cast<const TSInputTargetLinkContext *>(context), memory);
             const auto  target = link != nullptr ? link->target_view() : TSDataView{};
-            return target.value_to_python();
+            return python_bridge::value_to_python(target);
         }
 
         [[nodiscard]] nb::object target_link_delta_to_python(const void *context,
@@ -1146,7 +1147,7 @@ namespace hgraph::detail
         {
             const auto *link = target_link_storage_at(*static_cast<const TSInputTargetLinkContext *>(context), memory);
             const auto  target = link != nullptr ? link->target_view() : TSDataView{};
-            return target.delta_value_to_python(evaluation_time);
+            return python_bridge::delta_value_to_python(target, evaluation_time);
         }
 #endif
 
@@ -1230,7 +1231,7 @@ namespace hgraph::detail
         [[nodiscard]] const python_bridge::PythonTSDataOps &
         target_link_python_ops_for(TSRoleTypeRef type)
         {
-            return *type.ops_ref().python_ops;
+            return python_bridge::python_ts_data_ops(type.ops_ref());
         }
 
         [[nodiscard]] bool target_link_requires_authored_delta(
@@ -1336,8 +1337,8 @@ namespace hgraph::detail
                 .apply_delta_impl          = &target_link_apply_delta_op,
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
                 .python_ops               = &target_link_python_ts_data_ops(),
-                .to_python_impl            = &target_link_to_python,
-                .delta_to_python_impl      = &target_link_delta_to_python,
+                .to_python_impl            = &python_bridge::to_python_slot<&target_link_to_python>,
+                .delta_to_python_impl      = &python_bridge::ts_delta_to_python_slot<&target_link_delta_to_python>,
 #endif
             };
         }

--- a/src/hgraph/types/value/any_ops.cpp
+++ b/src/hgraph/types/value/any_ops.cpp
@@ -5,11 +5,7 @@
 #include <hgraph/types/utils/memory_utils.h>
 #include <hgraph/types/value/value.h>
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-#include <nanobind/nanobind.h>
-#include <hgraph/python/bridge_state.h>
-namespace hgraph { namespace nb = nanobind; }
-#endif
+#include <hgraph/types/python_ops.h>
 
 #include <compare>
 #include <cstddef>
@@ -67,81 +63,13 @@ namespace hgraph
             return static_cast<const Value *>(memory)->dynamic_storage_metrics();
         }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-        nb::object any_to_python(const void *, const void *memory)
-        {
-            const Value &value = *static_cast<const Value *>(memory);
-            if (!value.has_value()) { return nb::none(); }
-            // Type-erased delegation: the BOXED value's own binding converts.
-            return value.view().binding().ops_ref().to_python(value.view().data());
-        }
-
-        void any_from_python(const void *, const ValueTypeRef &, void *memory, nb::handle source)
-        {
-            Value &boxed = *static_cast<Value *>(memory);
-            if (source.is_none())
-            {
-                boxed = Value{};
-                return;
-            }
-            // Schema-free INFERENCE lives in the module (a dispatch on
-            // python types); it installs this hook at import.
-            const auto slot = python_bridge::py_infer_value_slot();
-            if (slot == nullptr)
-            {
-                throw std::logic_error("Any::from_python requires the python module's inference hook");
-            }
-            Value inferred = reinterpret_cast<Value (*)(nb::handle)>(slot)(source);
-            // Schema-free Python inference may itself choose the public Any
-            // type (opaque objects and heterogeneous containers). The storage
-            // here is already the EMBEDDED value of an Any box, so retain its
-            // concrete content rather than creating Any<Any<T>>.
-            if (inferred.view().is_any())
-            {
-                const ValueView contained = inferred.as_any().get();
-                boxed = contained.valid() ? Value{contained} : Value{};
-            }
-            else { boxed = std::move(inferred); }
-        }
-
-        nb::object json_any_to_python(const void *, const void *memory)
-        {
-            const Value &inner = *static_cast<const Value *>(memory);
-            if (const auto slot = python_bridge::py_json_to_python_slot())
-            {
-                return slot(inner);
-            }
-            return any_to_python(nullptr, memory);
-        }
-
-        void json_any_from_python(const void *, const ValueTypeRef &, void *memory,
-                                  nb::handle source)
-        {
-            const auto slot = python_bridge::py_json_from_python_slot();
-            if (slot == nullptr)
-            {
-                any_from_python(nullptr, ValueTypeRef{}, memory, source);
-                return;
-            }
-
-            Value outer = slot(source);
-            if (outer.schema() != TypeRegistry::instance().json())
-            {
-                throw nb::type_error("native JSON conversion returned the wrong schema");
-            }
-            const ValueView inner = outer.as_any().get();
-            *static_cast<Value *>(memory) = inner.valid() ? Value{inner} : Value{};
-        }
-#endif
 
         const ValueOps &json_any_ops() noexcept
         {
             static const ValueOps ops = [] {
                 ValueOps result = any_ops();
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-                result.to_python_impl = &json_any_to_python;
-                result.from_python_impl = &json_any_from_python;
-#endif
+                result.to_python_impl   = &python_ops_detail::forwarder<&PythonOps::Any::json_to_python>::call;
+                result.from_python_impl = &python_ops_detail::forwarder<&PythonOps::Any::json_from_python>::call;
                 return result;
             }();
             return ops;
@@ -158,11 +86,11 @@ namespace hgraph
             .equals_impl = &any_equals,
             .compare_impl = &any_compare,
             .to_string_impl = &any_to_string,
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-            .to_python_impl = &any_to_python,
-            .from_python_impl = &any_from_python,
+            // Python conversion resolves through the registered provider
+            // (RFC 0035); the bridge unit holds the Any conversions.
+            .to_python_impl = &python_ops_detail::forwarder<&PythonOps::Any::to_python>::call,
+            .from_python_impl = &python_ops_detail::forwarder<&PythonOps::Any::from_python>::call,
             .to_python_buffer_impl = nullptr,
-#endif
             .format_string_impl = &any_format_string,
             .dynamic_storage_metrics_impl = &any_dynamic_storage_metrics,
         };

--- a/src/hgraph/types/value/compact_container_ops.cpp
+++ b/src/hgraph/types/value/compact_container_ops.cpp
@@ -337,7 +337,7 @@ namespace hgraph
             {
                 require_non_none(source, "from_python");
                 Value out{binding};
-                binding.ops_ref().from_python(binding, const_cast<void *>(out.view().data()), source);
+                python_bridge::from_python(binding.ops_ref(), binding, const_cast<void *>(out.view().data()), source);
                 return out;
             }
         }  // namespace

--- a/src/hgraph/types/value/impl/pooled_polymorphic_value_type.cpp
+++ b/src/hgraph/types/value/impl/pooled_polymorphic_value_type.cpp
@@ -106,8 +106,8 @@ struct PooledUnionEntry {
     ops.compare_impl = &compare;
     ops.to_string_impl = &to_string;
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
-    ops.to_python_impl = &to_python;
-    ops.from_python_impl = &from_python;
+    ops.to_python_impl = &python_bridge::to_python_slot<&to_python>;
+    ops.from_python_impl = &python_bridge::from_python_slot<&from_python>;
 #endif
     ops.accepts_source_impl = &accepts_source;
     ops.copy_assign_from_impl = &copy_assign_from;
@@ -525,7 +525,7 @@ struct PooledUnionEntry {
     if (!active) {
       throw std::logic_error("pooled closed Bundle has an invalid active type");
     }
-    return active.ops_ref().to_python(payload(stored_allocation(memory)));
+    return python_bridge::to_python(active, payload(stored_allocation(memory)));
   }
 
   static void from_python(const void *context, const ValueTypeRef &,
@@ -539,7 +539,7 @@ struct PooledUnionEntry {
           "Python value is outside this graph's pooled Bundle snapshot");
     }
     auto *replacement = construct_allocation(target, [&](void *payload) {
-      target.ops_ref().from_python(target, payload, source);
+      python_bridge::from_python(target.ops_ref(), target, payload, source);
     });
     replace_allocation(memory, replacement);
   }

--- a/src/hgraph/types/value/impl/pooled_polymorphic_value_type.h
+++ b/src/hgraph/types/value/impl/pooled_polymorphic_value_type.h
@@ -9,6 +9,7 @@
 
 #if HGRAPH_ENABLE_PYTHON_USER_NODES
 #include <nanobind/nanobind.h>
+#include <hgraph/python/conversion.h>
 
 namespace nb = nanobind;
 #endif

--- a/src/hgraph/types/value/value_view.cpp
+++ b/src/hgraph/types/value/value_view.cpp
@@ -317,49 +317,6 @@ namespace hgraph
         });
     }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-    nb::object ValueView::to_python() const
-    {
-        if (!valid()) { throw std::runtime_error("ValueView::to_python requires a non-empty view"); }
-        return binding().ops_ref().to_python(data());
-    }
-
-    void ValueView::from_python(nb::handle source)
-    {
-        if (!valid()) { throw std::runtime_error("ValueView::from_python requires a non-empty view"); }
-        if (source.is_none())
-        {
-            throw std::invalid_argument("ValueView::from_python cannot reset a view from None");
-        }
-
-        const auto bound = binding();
-        bound.ops_ref().from_python(bound, mutable_data(), source);
-    }
-
-    nb::object Value::to_python() const
-    {
-        if (!has_value()) { return nb::none(); }
-        return view().to_python();
-    }
-
-    void Value::from_python(nb::handle source)
-    {
-        if (source.is_none())
-        {
-            reset();
-            return;
-        }
-        if (!binding())
-        {
-            throw std::logic_error("Value::from_python requires a schema-bound Value");
-        }
-
-        const auto bound = binding();
-        Value replacement{bound};
-        bound.ops_ref().from_python(bound, const_cast<void *>(replacement.view().data()), source);
-        *this = std::move(replacement);
-    }
-#endif
 
     // -- AnyView / MutableAnyView ----------------------------------------------
     // Defined here (not inline) because they reach into the embedded owning

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -291,6 +291,7 @@ hgraph_add_test_objects(hgraph_value_test_objects
     test_type_record.cpp
     test_type_pointer.cpp
     test_tsd_proxy.cpp
+    test_python_ops.cpp
     test_type_registry.cpp
     test_value.cpp
     test_value_builder.cpp

--- a/tests/cpp/test_python_ops.cpp
+++ b/tests/cpp/test_python_ops.cpp
@@ -1,0 +1,104 @@
+// RFC 0035: the type layer's Python slots resolve through the registered
+// PythonOps table via Python-free forwarders. These tests run without any
+// interpreter: the "objects" are sentinel pointers, which is all the type
+// layer ever sees of them.
+#include <hgraph/types/python_ops.h>
+#include <hgraph/types/value/any_ops.h>
+#include <hgraph/types/value/value_ops.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include <cstdint>
+#include <string>
+#include <typeindex>
+
+namespace
+{
+    struct ProviderReset
+    {
+        const hgraph::PythonOps *previous{hgraph::python_ops()};
+        ~ProviderReset() { hgraph::set_python_ops(previous); }
+    };
+
+    ::_object *sentinel(std::uintptr_t tag) { return reinterpret_cast<::_object *>(tag); }
+
+    hgraph::PyNewRef fake_int_to_python(const void *, const void *memory)
+    {
+        return hgraph::PyNewRef{sentinel(0x1000 + static_cast<std::uintptr_t>(*static_cast<const int *>(memory)))};
+    }
+
+    void fake_int_from_python(const void *, const hgraph::ValueTypeRef &, void *memory, hgraph::PyRef source)
+    {
+        *static_cast<int *>(memory) = static_cast<int>(reinterpret_cast<std::uintptr_t>(source.ptr) - 0x1000);
+    }
+
+    const hgraph::PythonScalarSlots &int_slots()
+    {
+        static const hgraph::PythonScalarSlots slots{
+            .to_python = &fake_int_to_python, .from_python = &fake_int_from_python, .to_python_buffer = nullptr};
+        return slots;
+    }
+
+    const hgraph::PythonScalarSlots *conversion_for(const std::type_info &type)
+    {
+        return std::type_index{type} == std::type_index{typeid(int)} ? &int_slots() : nullptr;
+    }
+
+    hgraph::PyNewRef fake_any_to_python(const void *, const void *) { return hgraph::PyNewRef{sentinel(0x2000)}; }
+
+    const hgraph::PythonOps &fake_provider()
+    {
+        static const hgraph::PythonOps ops = [] {
+            hgraph::PythonOps table;
+            table.scalars.conversion_for = &conversion_for;
+            table.any.to_python          = &fake_any_to_python;
+            return table;
+        }();
+        return ops;
+    }
+}  // namespace
+
+TEST_CASE("scalar slots resolve through the registered PythonOps table", "[python_ops][rfc0035]")
+{
+    ProviderReset reset;
+    const auto   &ops = hgraph::ops_for<int>();
+    REQUIRE(ops.to_python_impl != nullptr);
+    REQUIRE(ops.from_python_impl != nullptr);
+
+    hgraph::set_python_ops(&fake_provider());
+    int value = 7;
+    const auto result = ops.to_python_impl(ops.context, &value);
+    CHECK(result.ptr == sentinel(0x1007));
+
+    int written = 0;
+    ops.from_python_impl(ops.context, hgraph::ValueTypeRef{}, &written, hgraph::PyRef{sentinel(0x1003)});
+    CHECK(written == 3);
+}
+
+TEST_CASE("a scalar the provider does not know throws the named error", "[python_ops][rfc0035]")
+{
+    ProviderReset reset;
+    hgraph::set_python_ops(&fake_provider());
+    const auto &ops = hgraph::ops_for<double>();
+    double      value = 1.5;
+    CHECK_THROWS_WITH(ops.to_python_impl(ops.context, &value),
+                      Catch::Matchers::ContainsSubstring("no Python conversion is registered for the scalar type"));
+}
+
+TEST_CASE("family forwarders read the table when called, so registration order is free",
+          "[python_ops][rfc0035]")
+{
+    ProviderReset reset;
+    hgraph::set_python_ops(nullptr);
+    const auto &any = hgraph::any_ops();  // the table exists before any provider
+    CHECK_THROWS_WITH(any.to_python_impl(any.context, nullptr),
+                      Catch::Matchers::ContainsSubstring("no Python conversion is registered for Any"));
+
+    hgraph::set_python_ops(&fake_provider());
+    CHECK(any.to_python_impl(any.context, nullptr).ptr == sentinel(0x2000));
+
+    // An entry the provider left null is reported the same way.
+    CHECK_THROWS_WITH(any.from_python_impl(any.context, hgraph::ValueTypeRef{}, nullptr, hgraph::PyRef{}),
+                      Catch::Matchers::ContainsSubstring("no Python conversion is registered for Any"));
+}

--- a/tests/cpp/test_python_ops.cpp
+++ b/tests/cpp/test_python_ops.cpp
@@ -3,6 +3,7 @@
 // interpreter: the "objects" are sentinel pointers, which is all the type
 // layer ever sees of them.
 #include <hgraph/types/python_ops.h>
+#include <hgraph/types/time_series/ts_data/ops.h>
 #include <hgraph/types/value/any_ops.h>
 #include <hgraph/types/value/value_ops.h>
 
@@ -101,4 +102,15 @@ TEST_CASE("family forwarders read the table when called, so registration order i
     // An entry the provider left null is reported the same way.
     CHECK_THROWS_WITH(any.from_python_impl(any.context, hgraph::ValueTypeRef{}, nullptr, hgraph::PyRef{}),
                       Catch::Matchers::ContainsSubstring("no Python conversion is registered for Any"));
+}
+
+TEST_CASE("a TSData table without a Python-authoring family holds the throwing table, never null",
+          "[python_ops][rfc0035]")
+{
+    const hgraph::TSDataOps ops{};
+    REQUIRE(ops.python_ops != nullptr);
+    CHECK(ops.python_ops == &hgraph::ts_data_detail::missing_python_ts_data_ops());
+    CHECK_THROWS_WITH(ops.python_ops->requires_authored_delta_impl(hgraph::TSRoleTypeRef{}, hgraph::PyRef{}),
+                      Catch::Matchers::ContainsSubstring("requires authored delta"));
+    CHECK_THROWS_WITH(ops.to_python_impl(ops.context, nullptr), Catch::Matchers::ContainsSubstring("to Python"));
 }

--- a/tests/cpp/test_type_erasure_layout.cpp
+++ b/tests/cpp/test_type_erasure_layout.cpp
@@ -80,8 +80,13 @@ TEST_CASE("current type-erasure records retain their baseline layouts")
     static_assert(!HasNoArgumentRemovedValue<TSWDataView>);
     static_assert(HasNoArgumentRemovedValue<TSWInputView>);
     static_assert(sizeof(TSDataView) == sizeof(void *) * 2);
+    // ABI 13 (RFC 0035): the Python slots are unconditional and opaque, so a
+    // table built with Python off has the layout of one built with Python on,
+    // and the authoring table pointer is never null.
+    static_assert(TS_DATA_OPS_ABI_VERSION == 13);
+    static_assert(std::is_same_v<decltype(TSDataOps::to_python_impl), PyNewRef (*)(const void *, const void *)>);
+    static_assert(std::is_same_v<decltype(TSDataOps::python_ops), const PythonTSDataOps *>);
     // ABI 12: keyed and window TSData projections keep binding and memory together.
-    static_assert(TS_DATA_OPS_ABI_VERSION == 12);
     using KeyAtSlotFn = ValueView (*)(const void *, const void *, std::size_t);
     using WindowElementFn = ValueView (*)(const void *, const void *, std::size_t);
     static_assert(std::is_same_v<decltype(TSSDataOps::key_at_slot_impl), KeyAtSlotFn>);
@@ -282,7 +287,11 @@ TEST_CASE("value ops discriminator has a fixed byte ABI at offset zero")
     static_assert(sizeof(ValueOpsKind) == 1);
     static_assert(offsetof(ValueOps, kind) == 0);
     static_assert(std::is_same_v<decltype(VALUE_OPS_ABI_VERSION), const std::uint16_t>);
-    static_assert(VALUE_OPS_ABI_VERSION == 6);
+    // ABI 7 (RFC 0035): the three Python slots are unconditional and opaque.
+    static_assert(VALUE_OPS_ABI_VERSION == 7);
+    static_assert(std::is_same_v<decltype(ValueOps::to_python_impl), PyNewRef (*)(const void *, const void *)>);
+    static_assert(std::is_same_v<decltype(ValueOps::from_python_impl),
+                                 void (*)(const void *, const ValueTypeRef &, void *, PyRef)>);
     static_assert(static_cast<std::uint8_t>(ValueOpsKind::Invalid) == 0);
     static_assert(static_cast<std::uint8_t>(ValueOpsKind::Base) == 1);
     static_assert(static_cast<std::uint8_t>(ValueOpsKind::Indexed) == 2);

--- a/tests/install_consumer/main.cpp
+++ b/tests/install_consumer/main.cpp
@@ -331,8 +331,9 @@ int main()
     static_assert(std::is_trivially_copyable_v<ChildGraphInspectionOps>);
     static_assert(GRAPH_OPS_ABI_VERSION == 8);
     static_assert(EXECUTOR_OPS_ABI_VERSION == 5);
-    // ABI 12: keyed and window TSData projections return binding and memory together.
-    static_assert(TS_DATA_OPS_ABI_VERSION == 12);
+    // ABI 13 (RFC 0035): the Python slots are unconditional and opaque; ABI 12 made the
+    // keyed and window TSData projections return binding and memory together.
+    static_assert(TS_DATA_OPS_ABI_VERSION == 13);
     static_assert(sizeof(PolymorphicValueType) == 2 * sizeof(void *));
     static_assert(std::is_standard_layout_v<PolymorphicValueType>);
     static_assert(!std::is_polymorphic_v<TableTypeOps>);


### PR DESCRIPTION
First implementation step of RFC 0035 (#720); stacked on the RFC branch.

**What changes**

- `include/hgraph/types/python_object.h` (new): `PyRef` / `PyNewRef` over a forward-declared `struct _object` — the only way the type layer names a Python object.
- `include/hgraph/types/python_ops.h` (new) + `src/hgraph/types/python_ops.cpp`: the `PythonOps` provider table (scalars by `typeid`, enums, `Any`), `set_python_ops` / `python_ops()`, and the Python-free **forwarders** the slots hold — they read the registered table when called, so there is no ordering rule between constructing a type's ops and registering its conversion.
- `value_ops.h`, `ts_data/ops.h`, `ts_input/detail.h`: slots unconditional and opaque; no nanobind include anywhere in the type layer's public headers; the `ValueOps` / `ValueView` / `Value` / `TSDataView` / `TSDataMutationView` / `TSInputView` Python members are gone (two Python-free helpers replace what they reached privately: `TSDataMutationView::record_reported_modification`, `TSInputView::delta_is_sampled_rebind`).
- Bridge: `include/hgraph/python/conversion.h` (the former members as free functions, `borrow`/`give`/`take`, and the `*_slot<&fn>` adapters), `native_scalar_registration.h` (now home of `python_conversion_traits<T>` and `register_python_scalar_conversion<T>()`; `register_native_scalar_type<T>` registers the conversion first), `scalar_conversions.h` (Time, Bytes, the temporal types, and the Frame / Series / TimeSeriesReference / ValueCallable / WiredFn hook pairs), `src/hgraph/python/impl/python_ops.cpp` (the table, the scalar registry, enums, Any; registers at load and from the module).
- Every remaining conversion body stays beside its storage, adapted with `*_slot<&fn>`; the six public type-layer headers lose their trait specialisations; stdlib and extension enum traits include the bridge header; the module registers `PyObj` and the stdlib enums.

**Ratchets**: `type-layer-python-conditionals` 160 → 120 (118 planned; +3 are the transitional guarded `conversion.h` includes in the two container-ops headers, gone with PR 2). New `type-layer-nanobind` at 525, ratcheted from here so it can only fall.

**Two lessons** (recorded in the RFC's implementation status and `python_bridge.rst`):
1. `value_ops.h` used to hand nanobind's `std::string` caster to every Python-aware unit. Without it, a unit that instantiates the generic bound-class caster can win the link for the whole library and every `str` crossing fails with `std::bad_cast`. `conversion.h` and `bridge_state.h` now include it.
2. The scalar registry is keyed by the mangled type **name**, not `std::type_index`: the forwarder is instantiated in whichever library first used the type (`hgraph_stdlib` for `CmpResult`) while the registration comes from the module, and on macOS the two libraries' `type_info` objects compare unequal. 27 ported operator tests failed that way before the change.

**Gate** (macOS): native `_hgraph` rebuilt; `uv sync` reinstall of every native member; core + adaptor + extension suites 3608 passed, 10 skipped; core C++ suite 1700 cases incl. the new Python-free `test_python_ops.cpp`; `hgraph_header_compile_check`; the three consumer checks; ratchets; `sphinx -W`. Linux GCC 14 validation running out of band; results will be posted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga