### PR TITLE
Language: validate module descriptors without native loading

### DIFF
--- a/.github/workflows/language.yml
+++ b/.github/workflows/language.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Build hgl and its suites
         run: >-
           cmake --build build-language --parallel ${{ matrix.parallel }} --target
-          hgl hgl_syntax_tests hgl_semantics_tests hgl_ir_tests hgl_graph_ir_tests hgl_descriptor_tests
+          hgl hgl_syntax_tests hgl_semantics_tests hgl_ir_tests hgl_graph_ir_tests hgl_descriptor_tests hgl_descriptor_reader_tests
           hgl_wiring_tests hgl_wiring_type_tests
           hgl_operator_type_tests hgl_native_module_tests hgl_codegen_tests hgl_codegen_fixture
           hgl_generated_tests

--- a/language/CHANGELOG.md
+++ b/language/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Add strict reading and descriptor-only `hgl check` for versioned JSON module
+  descriptors, including compatible unknown-member handling and diagnostics for
+  duplicate keys, malformed records, unsupported versions, and dangling schema
+  references. Descriptor validation remains independent of native loading and
+  operator-registry state.
 - Compile every checked-in language example through `hgl_add_module()`, adding
   generated support for nominal and generic structs, sparse structural deltas,
   generic operator implementations, fixed and duration windows, concise graph

--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -163,6 +163,17 @@ target_include_directories(hgl_descriptor PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src
 target_link_libraries(hgl_descriptor PUBLIC hgl::graph_ir)
 hgl_apply_warnings(hgl_descriptor)
 
+# Descriptor consumption is a separate boundary: the model/writer remains
+# independent of JSON parsing while check/import tooling opts into simdjson.
+add_library(hgl_descriptor_reader STATIC
+    src/descriptor/module_descriptor_reader.cpp
+)
+add_library(hgl::descriptor_reader ALIAS hgl_descriptor_reader)
+target_compile_features(hgl_descriptor_reader PUBLIC cxx_std_23)
+target_include_directories(hgl_descriptor_reader PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_link_libraries(hgl_descriptor_reader PUBLIC hgl::descriptor PRIVATE simdjson::simdjson)
+hgl_apply_warnings(hgl_descriptor_reader)
+
 # Canonical hgraph metadata materialization for execution backends. Keeping
 # this bridge separate prevents hgraph runtime types from entering hgraph IR.
 add_library(hgl_wiring_types STATIC
@@ -227,7 +238,7 @@ add_library(hgl_driver STATIC
 add_library(hgl::driver ALIAS hgl_driver)
 target_compile_features(hgl_driver PUBLIC cxx_std_23)
 target_include_directories(hgl_driver PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
-target_link_libraries(hgl_driver PUBLIC hgl::graph_ir hgl::wiring hgl::codegen hgraph::core)
+target_link_libraries(hgl_driver PUBLIC hgl::graph_ir hgl::wiring hgl::codegen hgl::descriptor_reader hgraph::core)
 if(UNIX)
     target_link_libraries(hgl_driver PRIVATE ${CMAKE_DL_LIBS})
 endif()

--- a/language/README.md
+++ b/language/README.md
@@ -15,9 +15,11 @@ and `hgl_add_module()` expose the same route to package builds. The shared
 subset builds the same graph; the parity tests hold the two paths to it.
 
 The project is an intentionally changeable prototype in its first executable
-slice. `hgl check` lexes, parses, and resolves a module and reports diagnostics
-(`--dump-tokens`, `--dump-ast`, `--dump-hir`, and `--dump-hgraph-ir` show its
-successive views). The hgraph-IR dump now owns callable and test bodies as well
+slice. `hgl check` lexes, parses, and resolves an HGL module and reports
+diagnostics (`--dump-tokens`, `--dump-ast`, `--dump-hir`, and
+`--dump-hgraph-ir` show its successive views). It also validates one generated
+`.hgl-module.json` descriptor without loading native code; dependency closure
+remains staged. The hgraph-IR dump now owns callable and test bodies as well
 as their interfaces. Direct test, REPL, and run evaluation consumes that IR;
 only C++ generation still has its temporary resolved-AST adapter. That frontend now
 models nominal and generic structs, abstract-only inheritance, defaults and

--- a/language/docs/design/decisions/0004-json-module-descriptors.md
+++ b/language/docs/design/decisions/0004-json-module-descriptors.md
@@ -1,6 +1,7 @@
 # ADR 0004: Module descriptors use canonical versioned JSON
 
-Status: accepted; writer implemented, reader and native ABI metadata pending
+Status: accepted; writer, strict reader, and descriptor-only validation implemented;
+native ABI metadata pending
 
 ## Context
 
@@ -65,14 +66,17 @@ install or aggregate it deliberately.
 ## Consequences
 
 - Descriptors are human-readable and tool-neutral.
+- `hgl check <file>.hgl-module.json` validates the envelope, schema record
+  shapes, and every descriptor-local reference without loading native code.
 - Serialization is a backend over HGraph IR, independent of parsing, C++
   formatting, registry access, and dynamic loading.
 - Scripted compilation and AOT generation retain the identical descriptor
   bytes with their other build artifacts.
 - The file now contains structured HGL signatures, struct layouts, defaults,
-  generic bindings, and constraints. Descriptor reading, dependency closure,
-  phase/effect/ownership policy, lifecycle ABI, and fingerprints remain
-  explicit Stage F work before descriptor-only checking is complete.
+  generic bindings, and constraints. The reader ignores compatible unknown
+  members but rejects duplicate keys, malformed records, unsupported versions,
+  and dangling references. Dependency closure, phase/effect/ownership policy,
+  lifecycle ABI, and fingerprints remain explicit Stage F work.
 
 ## Alternatives
 

--- a/language/docs/design/native-interface.md
+++ b/language/docs/design/native-interface.md
@@ -1,6 +1,7 @@
 # Native interface
 
-Status: accepted boundary; HGL interface schema implemented, native metadata and ABI remain
+Status: accepted boundary; HGL interface schema and descriptor-only validation
+implemented, native metadata and ABI remain
 
 ## Purpose
 
@@ -55,7 +56,8 @@ The serialized representation is the canonical, versioned JSON selected in
 [ADR 0004](decisions/0004-json-module-descriptors.md). The current compiler
 emits its envelope, public/provider inventories, structured HGL signatures,
 struct layouts, defaults, canonical types and constraints, and generated build
-metadata. Descriptor reading and dependency closure,
+metadata. `hgl check` reads and validates one such descriptor without loading a
+library or consulting a registry. Transitive dependency closure,
 phase/effect/ownership policy, lifecycle ABI, and fingerprints remain to be
 added. The native-package authoring API is not yet chosen. No HGL declaration
 syntax is implied by this list.

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -230,6 +230,8 @@ HGraph IR; unsupported language-depth items remain explicit roadmap work.
 - [x] choose and version a reviewable descriptor representation;
 - [x] emit structured public/provider signatures, struct layouts, defaults,
   canonical types, and generic constraints;
+- [x] read and validate one descriptor without loading native code or consulting
+  the operator registry;
 - choose and version the lifecycle ABI;
 - provide a native-package authoring API which emits descriptors and normalized
   wrappers;

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -1026,9 +1026,19 @@ binding identity. Defaults and const-generic bounds remain expression trees,
 not strings to be reparsed. Tagged textual i64/f64 payloads retain the full i64
 range and non-finite HGL floats while keeping the output valid JSON.
 
-This is still not descriptor-only checking: a reader and locked dependency
-closure, effect/ownership policy, lifecycle entry points, and fingerprints are
-the following Stage F slices.
+The data-only `hgl_descriptor_reader` target parses version 1 with `simdjson`
+and validates every descriptor-local reference and category-specific record
+shape. Keeping that dependency separate means the descriptor model and
+canonical writer remain parser-free. The reader rejects duplicate object
+members, malformed required values, unsupported versions, record-ID mismatch,
+and dangling references while ignoring unknown members in a supported version.
+`hgl check <file>.hgl-module.json` uses this path and does not load native code
+or consult the registry.
+
+Locked transitive dependency closure, effect/ownership policy, lifecycle entry
+points, and fingerprints are the following Stage F slices. Validating one file
+does not yet prove that its declared provider requirements are present or
+mutually compatible.
 
 A descriptor separates its importable interface from its provider inventory.
 The interface contains automatically public nominal operators, explicitly

--- a/language/docs/user-guide/modules-and-tools.md
+++ b/language/docs/user-guide/modules-and-tools.md
@@ -301,9 +301,21 @@ than embedding source text that another tool would need to parse:
 The `type`, `result`, `default`, and `requires` numbers refer to records in the
 same file's `schema` object. They have no identity outside that one descriptor.
 
-Descriptor loading, transitive dependency locking, native ownership/effect
-declarations, lifecycle entry points, and fingerprints are not implemented yet,
-so this checkpoint does not provide descriptor-only `hgl check`.
+Validate a descriptor without loading its native library:
+
+```sh
+hgl check build/generated/prices.hgl-module.json
+```
+
+This checks the versioned envelope, required field types, record shapes, and
+all descriptor-local schema references. Object order and whitespace do not
+matter; duplicate keys and unsupported versions are errors, while unknown
+members are ignored for forward-compatible additions. Syntax and IR dump flags
+apply only to HGL source and are rejected for descriptors.
+
+This command validates one descriptor. It does not yet locate or lock its
+transitive provider requirements. Native ownership/effect declarations,
+lifecycle entry points, and fingerprints are also not implemented yet.
 
 A package is a CMake project. `hgl_add_module()`, installed with `hgl` in
 `lib/cmake/hgl/HglLanguage.cmake`, runs `emit-cpp` at build time and compiles

--- a/language/src/descriptor/module_descriptor_reader.cpp
+++ b/language/src/descriptor/module_descriptor_reader.cpp
@@ -1,0 +1,1019 @@
+#include "descriptor/module_descriptor_reader.h"
+
+#include "syntax/temporal.h"
+
+#include <simdjson.h>
+
+#include <algorithm>
+#include <charconv>
+#include <cmath>
+#include <cstdint>
+#include <initializer_list>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace hgl::descriptor
+{
+    namespace
+    {
+        using Element = simdjson::dom::element;
+
+        struct ObjectFields
+        {
+            std::vector<std::pair<std::string, Element>> values{};
+
+            [[nodiscard]] const Element *find(std::string_view name) const noexcept {
+                const auto found = std::ranges::find(values, name, &std::pair<std::string, Element>::first);
+                return found == values.end() ? nullptr : &found->second;
+            }
+        };
+
+        [[nodiscard]] std::string member_path(std::string_view path, std::string_view name) {
+            std::string result{path};
+            result += '.';
+            result += name;
+            return result;
+        }
+
+        [[nodiscard]] std::string index_path(std::string_view path, std::size_t index) {
+            std::string result{path};
+            result += '[';
+            result += std::to_string(index);
+            result += ']';
+            return result;
+        }
+
+        [[nodiscard]] std::optional<ReadError> find_duplicate_member(Element value, std::string_view path) {
+            if (value.is_object()) {
+                simdjson::dom::object object_value;
+                if (value.get(object_value)) { return ReadError{std::string{path}, "expected object"}; }
+                std::vector<std::string> names;
+                for (const simdjson::dom::key_value_pair field : object_value) {
+                    const std::string name{field.key};
+                    const std::string field_path = member_path(path, name);
+                    if (std::ranges::find(names, name) != names.end()) { return ReadError{field_path, "duplicate member"}; }
+                    names.push_back(name);
+                    if (std::optional<ReadError> nested = find_duplicate_member(field.value, field_path)) { return nested; }
+                }
+            } else if (value.is_array()) {
+                simdjson::dom::array array;
+                if (value.get(array)) { return ReadError{std::string{path}, "expected array"}; }
+                std::size_t index = 0;
+                for (Element item : array) {
+                    if (std::optional<ReadError> nested = find_duplicate_member(item, index_path(path, index))) { return nested; }
+                    ++index;
+                }
+            }
+            return std::nullopt;
+        }
+
+        class Decoder
+        {
+          public:
+            [[nodiscard]] ReadResult run(Element root) {
+                ModuleDescriptor descriptor;
+                ObjectFields     document;
+                if (!object(root, "$", document)) { return failure(); }
+
+                std::string format;
+                if (!required_string(document, "format", "$", format)) { return failure(); }
+                if (format != "hgl.module") {
+                    fail("$.format", "expected 'hgl.module'");
+                    return failure();
+                }
+                if (!required_u32(document, "format_version", "$", descriptor.format_version)) { return failure(); }
+                if (descriptor.format_version != module_descriptor_format_version) {
+                    fail("$.format_version", "unsupported descriptor format version " + std::to_string(descriptor.format_version));
+                    return failure();
+                }
+
+                const Element *module = required(document, "module", "$");
+                if (module == nullptr || !read_module(*module, descriptor)) { return failure(); }
+                const Element *interface = required(document, "interface", "$");
+                if (interface == nullptr || !read_interface(*interface, descriptor.interface)) { return failure(); }
+                const Element *provider = required(document, "provider", "$");
+                if (provider == nullptr || !read_provider(*provider, descriptor)) { return failure(); }
+                const Element *schema = required(document, "schema", "$");
+                if (schema == nullptr || !read_schema(*schema, descriptor)) { return failure(); }
+                const Element *build = required(document, "build", "$");
+                if (build == nullptr || !read_build(*build, descriptor.build)) { return failure(); }
+
+                if (std::optional<ReadError> invalid = validate(descriptor)) {
+                    error_ = std::move(invalid);
+                    return failure();
+                }
+                return ReadResult{.value = std::move(descriptor)};
+            }
+
+          private:
+            [[nodiscard]] ReadResult failure() { return ReadResult{.error = std::move(error_)}; }
+
+            bool fail(std::string path, std::string message) {
+                if (!error_) { error_ = ReadError{std::move(path), std::move(message)}; }
+                return false;
+            }
+
+            bool object(Element value, std::string_view path, ObjectFields &out) {
+                simdjson::dom::object object_value;
+                if (value.get(object_value)) { return fail(std::string{path}, "expected object"); }
+                for (const simdjson::dom::key_value_pair field : object_value) {
+                    const std::string key{field.key};
+                    if (out.find(key) != nullptr) { return fail(member_path(path, key), "duplicate member"); }
+                    out.values.emplace_back(key, field.value);
+                }
+                return true;
+            }
+
+            [[nodiscard]] const Element *required(const ObjectFields &fields, std::string_view name, std::string_view path) {
+                const Element *value = fields.find(name);
+                if (value == nullptr) { fail(member_path(path, name), "missing required member"); }
+                return value;
+            }
+
+            bool string(Element value, std::string_view path, std::string &out) {
+                std::string_view text;
+                if (value.get(text)) { return fail(std::string{path}, "expected string"); }
+                out.assign(text);
+                return true;
+            }
+
+            bool boolean(Element value, std::string_view path, bool &out) {
+                if (value.get(out)) { return fail(std::string{path}, "expected boolean"); }
+                return true;
+            }
+
+            bool u32(Element value, std::string_view path, std::uint32_t &out) {
+                std::uint64_t number{};
+                if (value.get(number) || number > std::numeric_limits<std::uint32_t>::max()) {
+                    return fail(std::string{path}, "expected unsigned 32-bit integer");
+                }
+                out = static_cast<std::uint32_t>(number);
+                return true;
+            }
+
+            bool reference(Element value, std::string_view path, SchemaId &out) {
+                if (value.is_null()) {
+                    out = no_schema_id;
+                    return true;
+                }
+                return u32(value, path, out);
+            }
+
+            bool required_string(const ObjectFields &fields, std::string_view name, std::string_view path, std::string &out) {
+                const Element *value = required(fields, name, path);
+                return value != nullptr && string(*value, member_path(path, name), out);
+            }
+
+            bool optional_string(const ObjectFields &fields, std::string_view name, std::string_view path, std::string &out) {
+                const Element *value = fields.find(name);
+                return value == nullptr || string(*value, member_path(path, name), out);
+            }
+
+            bool required_bool(const ObjectFields &fields, std::string_view name, std::string_view path, bool &out) {
+                const Element *value = required(fields, name, path);
+                return value != nullptr && boolean(*value, member_path(path, name), out);
+            }
+
+            bool optional_bool(const ObjectFields &fields, std::string_view name, std::string_view path, bool &out) {
+                const Element *value = fields.find(name);
+                return value == nullptr || boolean(*value, member_path(path, name), out);
+            }
+
+            bool required_u32(const ObjectFields &fields, std::string_view name, std::string_view path, std::uint32_t &out) {
+                const Element *value = required(fields, name, path);
+                return value != nullptr && u32(*value, member_path(path, name), out);
+            }
+
+            bool required_reference(const ObjectFields &fields, std::string_view name, std::string_view path, SchemaId &out) {
+                const Element *value = required(fields, name, path);
+                return value != nullptr && reference(*value, member_path(path, name), out);
+            }
+
+            bool optional_reference(const ObjectFields &fields, std::string_view name, std::string_view path, SchemaId &out) {
+                const Element *value = fields.find(name);
+                return value == nullptr || reference(*value, member_path(path, name), out);
+            }
+
+            template <typename Enum>
+            bool enum_value(Element value, std::string_view path, std::initializer_list<std::pair<std::string_view, Enum>> choices,
+                            Enum &out) {
+                std::string text;
+                if (!string(value, path, text)) { return false; }
+                for (const auto &[name, choice] : choices) {
+                    if (text == name) {
+                        out = choice;
+                        return true;
+                    }
+                }
+                return fail(std::string{path}, "unknown value '" + text + "'");
+            }
+
+            bool string_array(Element value, std::string_view path, std::vector<std::string> &out) {
+                simdjson::dom::array array;
+                if (value.get(array)) { return fail(std::string{path}, "expected array"); }
+                std::size_t index = 0;
+                for (Element item : array) {
+                    std::string decoded;
+                    if (!string(item, index_path(path, index), decoded)) { return false; }
+                    out.push_back(std::move(decoded));
+                    ++index;
+                }
+                return true;
+            }
+
+            bool reference_array(Element value, std::string_view path, std::vector<SchemaId> &out) {
+                simdjson::dom::array array;
+                if (value.get(array)) { return fail(std::string{path}, "expected array"); }
+                std::size_t index = 0;
+                for (Element item : array) {
+                    SchemaId decoded{};
+                    if (!reference(item, index_path(path, index), decoded)) { return false; }
+                    out.push_back(decoded);
+                    ++index;
+                }
+                return true;
+            }
+
+            bool required_string_array(const ObjectFields &fields, std::string_view name, std::string_view path,
+                                       std::vector<std::string> &out) {
+                const Element *value = required(fields, name, path);
+                return value != nullptr && string_array(*value, member_path(path, name), out);
+            }
+
+            bool read_module(Element value, ModuleDescriptor &out) {
+                ObjectFields fields;
+                return object(value, "$.module", fields) && required_string(fields, "identity", "$.module", out.module_identity) &&
+                       required_string(fields, "language_version", "$.module", out.language_version);
+            }
+
+            bool read_generic_parameters(Element value, std::string_view path, std::vector<GenericParameter> &out) {
+                simdjson::dom::array array;
+                if (value.get(array)) { return fail(std::string{path}, "expected array"); }
+                std::size_t index = 0;
+                for (Element item : array) {
+                    const std::string item_path = index_path(path, index);
+                    ObjectFields      fields;
+                    GenericParameter  parameter;
+                    std::string       kind;
+                    if (!object(item, item_path, fields) || !required_string(fields, "name", item_path, parameter.name) ||
+                        !required_string(fields, "kind", item_path, kind) ||
+                        !required_string(fields, "binding", item_path, parameter.binding_identity) ||
+                        !required_reference(fields, "type", item_path, parameter.type)) {
+                        return false;
+                    }
+                    if (kind == "const") {
+                        parameter.is_const = true;
+                    } else if (kind != "type") {
+                        return fail(member_path(item_path, "kind"), "unknown value '" + kind + "'");
+                    }
+                    out.push_back(std::move(parameter));
+                    ++index;
+                }
+                return true;
+            }
+
+            bool read_parameters(Element value, std::string_view path, std::vector<Parameter> &out) {
+                simdjson::dom::array array;
+                if (value.get(array)) { return fail(std::string{path}, "expected array"); }
+                std::size_t index = 0;
+                for (Element item : array) {
+                    const std::string item_path = index_path(path, index);
+                    ObjectFields      fields;
+                    Parameter         parameter;
+                    std::string       kind;
+                    if (!object(item, item_path, fields) || !required_string(fields, "name", item_path, parameter.name) ||
+                        !required_string(fields, "kind", item_path, kind) ||
+                        !required_string(fields, "binding", item_path, parameter.binding_identity) ||
+                        !required_reference(fields, "type", item_path, parameter.type) ||
+                        !required_reference(fields, "default", item_path, parameter.default_value)) {
+                        return false;
+                    }
+                    if (kind == "const") {
+                        parameter.is_const = true;
+                    } else if (kind != "signal") {
+                        return fail(member_path(item_path, "kind"), "unknown value '" + kind + "'");
+                    }
+                    out.push_back(std::move(parameter));
+                    ++index;
+                }
+                return true;
+            }
+
+            bool read_signature(Element value, std::string_view path, Signature &out) {
+                ObjectFields fields;
+                if (!object(value, path, fields)) { return false; }
+                const Element *generics   = required(fields, "generic_parameters", path);
+                const Element *parameters = required(fields, "parameters", path);
+                return generics != nullptr && parameters != nullptr &&
+                       read_generic_parameters(*generics, member_path(path, "generic_parameters"), out.generics) &&
+                       read_parameters(*parameters, member_path(path, "parameters"), out.parameters) &&
+                       required_reference(fields, "result", path, out.result) &&
+                       required_reference(fields, "requires", path, out.requirements);
+            }
+
+            bool read_fields(Element value, std::string_view path, std::vector<StructField> &out) {
+                simdjson::dom::array array;
+                if (value.get(array)) { return fail(std::string{path}, "expected array"); }
+                std::size_t index = 0;
+                for (Element item : array) {
+                    const std::string item_path = index_path(path, index);
+                    ObjectFields      fields;
+                    StructField       field;
+                    if (!object(item, item_path, fields) || !required_string(fields, "name", item_path, field.name) ||
+                        !required_reference(fields, "type", item_path, field.type) ||
+                        !required_bool(fields, "optional", item_path, field.optional) ||
+                        !required_reference(fields, "default", item_path, field.default_value) ||
+                        !required_string(fields, "origin", item_path, field.origin_identity)) {
+                        return false;
+                    }
+                    out.push_back(std::move(field));
+                    ++index;
+                }
+                return true;
+            }
+
+            bool read_interface(Element value, std::vector<InterfaceDeclaration> &out) {
+                simdjson::dom::array array;
+                if (value.get(array)) { return fail("$.interface", "expected array"); }
+                std::size_t index = 0;
+                for (Element item : array) {
+                    const std::string    item_path = index_path("$.interface", index);
+                    ObjectFields         fields;
+                    InterfaceDeclaration declaration;
+                    const Element       *category{};
+                    if (!object(item, item_path, fields) || (category = required(fields, "category", item_path)) == nullptr ||
+                        !enum_value(*category, member_path(item_path, "category"),
+                                    {{"structure", DeclarationCategory::Structure},
+                                     {"operator", DeclarationCategory::Operator},
+                                     {"function", DeclarationCategory::Function}},
+                                    declaration.category) ||
+                        !required_string(fields, "identity", item_path, declaration.identity) ||
+                        !optional_string(fields, "registry_name", item_path, declaration.registry_name)) {
+                        return false;
+                    }
+                    if (const Element *execution = fields.find("execution")) {
+                        if (!enum_value(*execution, member_path(item_path, "execution"),
+                                        {{"none", ExecutionKind::None},
+                                         {"composition", ExecutionKind::Composition},
+                                         {"runtime-node", ExecutionKind::RuntimeNode}},
+                                        declaration.execution)) {
+                            return false;
+                        }
+                    }
+                    if (declaration.category == DeclarationCategory::Structure) {
+                        const Element *generics = required(fields, "generic_parameters", item_path);
+                        const Element *parents  = required(fields, "parents", item_path);
+                        const Element *members  = required(fields, "fields", item_path);
+                        if (generics == nullptr || parents == nullptr || members == nullptr ||
+                            !required_bool(fields, "abstract", item_path, declaration.abstract) ||
+                            !read_generic_parameters(*generics, member_path(item_path, "generic_parameters"),
+                                                     declaration.signature.generics) ||
+                            !reference_array(*parents, member_path(item_path, "parents"), declaration.parents) ||
+                            !required_reference(fields, "requires", item_path, declaration.signature.requirements) ||
+                            !read_fields(*members, member_path(item_path, "fields"), declaration.fields)) {
+                            return false;
+                        }
+                    } else {
+                        const Element *signature = required(fields, "signature", item_path);
+                        if (signature == nullptr ||
+                            !read_signature(*signature, member_path(item_path, "signature"), declaration.signature)) {
+                            return false;
+                        }
+                    }
+                    out.push_back(std::move(declaration));
+                    ++index;
+                }
+                return true;
+            }
+
+            bool read_implementations(Element value, std::string_view path, std::vector<Implementation> &out) {
+                simdjson::dom::array array;
+                if (value.get(array)) { return fail(std::string{path}, "expected array"); }
+                std::size_t index = 0;
+                for (Element item : array) {
+                    const std::string item_path = index_path(path, index);
+                    ObjectFields      fields;
+                    Implementation    implementation;
+                    const Element    *execution{};
+                    const Element    *signature{};
+                    if (!object(item, item_path, fields) ||
+                        !required_string(fields, "identity", item_path, implementation.identity) ||
+                        !required_string(fields, "operator", item_path, implementation.operator_identity) ||
+                        !required_string(fields, "registry_name", item_path, implementation.operator_registry_name) ||
+                        (execution = required(fields, "execution", item_path)) == nullptr ||
+                        !enum_value(*execution, member_path(item_path, "execution"),
+                                    {{"none", ExecutionKind::None},
+                                     {"composition", ExecutionKind::Composition},
+                                     {"runtime-node", ExecutionKind::RuntimeNode}},
+                                    implementation.execution) ||
+                        (signature = required(fields, "signature", item_path)) == nullptr ||
+                        !read_signature(*signature, member_path(item_path, "signature"), implementation.signature)) {
+                        return false;
+                    }
+                    out.push_back(std::move(implementation));
+                    ++index;
+                }
+                return true;
+            }
+
+            bool read_provider(Element value, ModuleDescriptor &out) {
+                ObjectFields fields;
+                if (!object(value, "$.provider", fields) ||
+                    !required_string(fields, "identity", "$.provider", out.provider_identity)) {
+                    return false;
+                }
+                const Element *implementations = required(fields, "implementations", "$.provider");
+                const Element *requirements    = required(fields, "requires", "$.provider");
+                return implementations != nullptr && requirements != nullptr &&
+                       read_implementations(*implementations, "$.provider.implementations", out.implementations) &&
+                       string_array(*requirements, "$.provider.requires", out.provider_requirements);
+            }
+
+            bool read_type_arguments(Element value, std::string_view path, std::vector<TypeArgument> &out) {
+                simdjson::dom::array array;
+                if (value.get(array)) { return fail(std::string{path}, "expected array"); }
+                std::size_t index = 0;
+                for (Element item : array) {
+                    const std::string item_path = index_path(path, index);
+                    ObjectFields      fields;
+                    TypeArgument      argument;
+                    const Element    *kind{};
+                    if (!object(item, item_path, fields) || (kind = required(fields, "kind", item_path)) == nullptr ||
+                        !enum_value(*kind, member_path(item_path, "kind"),
+                                    {{"type", TypeArgumentCategory::Type}, {"constant", TypeArgumentCategory::Constant}},
+                                    argument.category) ||
+                        !required_reference(fields, "reference", item_path, argument.reference)) {
+                        return false;
+                    }
+                    out.push_back(argument);
+                    ++index;
+                }
+                return true;
+            }
+
+            bool read_types(Element value, std::vector<TypeRecord> &out) {
+                simdjson::dom::array array;
+                if (value.get(array)) { return fail("$.schema.types", "expected array"); }
+                std::size_t index = 0;
+                for (Element item : array) {
+                    const std::string item_path = index_path("$.schema.types", index);
+                    ObjectFields      fields;
+                    TypeRecord        record;
+                    std::uint32_t     id{};
+                    const Element    *kind{};
+                    if (!object(item, item_path, fields) || !required_u32(fields, "id", item_path, id) ||
+                        static_cast<std::size_t>(id) != index || (kind = required(fields, "kind", item_path)) == nullptr ||
+                        !enum_value(*kind, member_path(item_path, "kind"),
+                                    {{"void", TypeCategory::Void},
+                                     {"scalar", TypeCategory::Scalar},
+                                     {"symbol", TypeCategory::Symbol},
+                                     {"tuple", TypeCategory::Tuple},
+                                     {"list", TypeCategory::List},
+                                     {"set", TypeCategory::Set},
+                                     {"map", TypeCategory::Map},
+                                     {"rolling", TypeCategory::Rolling},
+                                     {"atomic", TypeCategory::Atomic},
+                                     {"iterator", TypeCategory::Iterator},
+                                     {"callable", TypeCategory::Callable},
+                                     {"capability", TypeCategory::Capability},
+                                     {"harness-sequence", TypeCategory::HarnessSequence},
+                                     {"deferred", TypeCategory::Deferred}},
+                                    record.category) ||
+                        !optional_string(fields, "name", item_path, record.scalar_name) ||
+                        !optional_string(fields, "identity", item_path, record.nominal_identity) ||
+                        !optional_string(fields, "binding", item_path, record.binding_identity) ||
+                        !optional_reference(fields, "size", item_path, record.size) ||
+                        !optional_reference(fields, "min_size", item_path, record.min_size) ||
+                        !optional_bool(fields, "unbounded", item_path, record.unbounded)) {
+                        if (!error_ && static_cast<std::size_t>(id) != index) {
+                            fail(member_path(item_path, "id"), "record id does not match array index");
+                        }
+                        return false;
+                    }
+                    if (const Element *children = fields.find("children")) {
+                        if (!reference_array(*children, member_path(item_path, "children"), record.children)) { return false; }
+                    }
+                    if (const Element *arguments = fields.find("arguments")) {
+                        if (!read_type_arguments(*arguments, member_path(item_path, "arguments"), record.arguments)) {
+                            return false;
+                        }
+                    }
+                    out.push_back(std::move(record));
+                    ++index;
+                }
+                return true;
+            }
+
+            bool read_literal(Element value, std::string_view path, ir::hir::Constant &out) {
+                ObjectFields fields;
+                std::string  kind;
+                if (!object(value, path, fields) || !required_string(fields, "kind", path, kind)) { return false; }
+                const Element *payload = fields.find("value");
+                if (kind == "null") {
+                    out = ir::hir::NullValue{};
+                    return true;
+                }
+                if (kind == "placeholder") {
+                    out = ir::hir::PlaceholderValue{};
+                    return true;
+                }
+                if (payload == nullptr) { return fail(member_path(path, "value"), "missing required member"); }
+                if (kind == "bool") {
+                    bool decoded{};
+                    if (!boolean(*payload, member_path(path, "value"), decoded)) { return false; }
+                    out = decoded;
+                    return true;
+                }
+                std::string text;
+                if (!string(*payload, member_path(path, "value"), text)) { return false; }
+                if (kind == "str") {
+                    out = std::move(text);
+                    return true;
+                }
+                if (kind == "i64") {
+                    std::int64_t decoded{};
+                    const auto [end, error] = std::from_chars(text.data(), text.data() + text.size(), decoded);
+                    if (error != std::errc{} || end != text.data() + text.size()) {
+                        return fail(member_path(path, "value"), "invalid i64 literal");
+                    }
+                    out = decoded;
+                    return true;
+                }
+                if (kind == "f64") {
+                    double decoded{};
+                    if (text == "nan") {
+                        decoded = std::numeric_limits<double>::quiet_NaN();
+                    } else if (text == "inf") {
+                        decoded = std::numeric_limits<double>::infinity();
+                    } else if (text == "-inf") {
+                        decoded = -std::numeric_limits<double>::infinity();
+                    } else {
+                        const auto [end, error] =
+                            std::from_chars(text.data(), text.data() + text.size(), decoded, std::chars_format::general);
+                        if (error != std::errc{} || end != text.data() + text.size() || !std::isfinite(decoded)) {
+                            return fail(member_path(path, "value"), "invalid f64 literal");
+                        }
+                    }
+                    out = decoded;
+                    return true;
+                }
+                syntax::TemporalParseResult temporal = syntax::parse_temporal_literal(text);
+                if (!temporal.value || syntax::temporal_kind_name(temporal.value->kind) != kind) {
+                    return fail(member_path(path, "kind"), "unknown or mismatched literal kind '" + kind + "'");
+                }
+                out = std::move(*temporal.value);
+                return true;
+            }
+
+            bool read_constant_elements(Element value, std::string_view path, std::vector<ConstantElement> &out) {
+                simdjson::dom::array array;
+                if (value.get(array)) { return fail(std::string{path}, "expected array"); }
+                std::size_t index = 0;
+                for (Element item : array) {
+                    const std::string item_path = index_path(path, index);
+                    ObjectFields      fields;
+                    ConstantElement   element;
+                    if (!object(item, item_path, fields) || !optional_reference(fields, "key", item_path, element.key) ||
+                        !required_reference(fields, "value", item_path, element.value)) {
+                        return false;
+                    }
+                    out.push_back(element);
+                    ++index;
+                }
+                return true;
+            }
+
+            bool read_constant_arguments(Element value, std::string_view path, std::vector<ConstantArgument> &out) {
+                simdjson::dom::array array;
+                if (value.get(array)) { return fail(std::string{path}, "expected array"); }
+                std::size_t index = 0;
+                for (Element item : array) {
+                    const std::string item_path = index_path(path, index);
+                    ObjectFields      fields;
+                    ConstantArgument  argument;
+                    if (!object(item, item_path, fields) || !required_string(fields, "name", item_path, argument.name) ||
+                        !required_reference(fields, "value", item_path, argument.value)) {
+                        return false;
+                    }
+                    out.push_back(std::move(argument));
+                    ++index;
+                }
+                return true;
+            }
+
+            bool read_constants(Element value, std::vector<ConstantExpressionRecord> &out) {
+                simdjson::dom::array array;
+                if (value.get(array)) { return fail("$.schema.constant_expressions", "expected array"); }
+                std::size_t index = 0;
+                for (Element item : array) {
+                    const std::string        item_path = index_path("$.schema.constant_expressions", index);
+                    ObjectFields             fields;
+                    ConstantExpressionRecord record;
+                    std::uint32_t            id{};
+                    const Element           *kind{};
+                    if (!object(item, item_path, fields) || !required_u32(fields, "id", item_path, id) ||
+                        static_cast<std::size_t>(id) != index || (kind = required(fields, "kind", item_path)) == nullptr ||
+                        !enum_value(*kind, member_path(item_path, "kind"),
+                                    {{"literal", ConstantExpressionCategory::Literal},
+                                     {"parameter", ConstantExpressionCategory::Parameter},
+                                     {"unary", ConstantExpressionCategory::Unary},
+                                     {"binary", ConstantExpressionCategory::Binary},
+                                     {"index", ConstantExpressionCategory::Index},
+                                     {"field", ConstantExpressionCategory::Field},
+                                     {"sequence", ConstantExpressionCategory::Sequence},
+                                     {"tuple", ConstantExpressionCategory::Tuple},
+                                     {"construct", ConstantExpressionCategory::Construct}},
+                                    record.category) ||
+                        !optional_string(fields, "parameter", item_path, record.parameter_identity) ||
+                        !optional_string(fields, "operator", item_path, record.operator_spelling) ||
+                        !optional_reference(fields, "lhs", item_path, record.lhs) ||
+                        !optional_reference(fields, "rhs", item_path, record.rhs) ||
+                        !optional_string(fields, "member", item_path, record.member) ||
+                        !optional_reference(fields, "type", item_path, record.constructed_type) ||
+                        !optional_bool(fields, "delta", item_path, record.delta)) {
+                        if (!error_ && static_cast<std::size_t>(id) != index) {
+                            fail(member_path(item_path, "id"), "record id does not match array index");
+                        }
+                        return false;
+                    }
+                    if (const Element *literal = fields.find("literal")) {
+                        ir::hir::Constant decoded;
+                        if (!read_literal(*literal, member_path(item_path, "literal"), decoded)) { return false; }
+                        record.literal = std::move(decoded);
+                    }
+                    if (const Element *elements = fields.find("elements")) {
+                        if (!read_constant_elements(*elements, member_path(item_path, "elements"), record.elements)) {
+                            return false;
+                        }
+                    }
+                    if (const Element *items = fields.find("items")) {
+                        if (!reference_array(*items, member_path(item_path, "items"), record.items)) { return false; }
+                    }
+                    if (const Element *arguments = fields.find("arguments")) {
+                        if (!read_constant_arguments(*arguments, member_path(item_path, "arguments"), record.arguments)) {
+                            return false;
+                        }
+                    }
+                    out.push_back(std::move(record));
+                    ++index;
+                }
+                return true;
+            }
+
+            bool read_constraints(Element value, std::vector<ConstraintRecord> &out) {
+                simdjson::dom::array array;
+                if (value.get(array)) { return fail("$.schema.constraints", "expected array"); }
+                std::size_t index = 0;
+                for (Element item : array) {
+                    const std::string item_path = index_path("$.schema.constraints", index);
+                    ObjectFields      fields;
+                    ConstraintRecord  record;
+                    std::uint32_t     id{};
+                    const Element    *kind{};
+                    if (!object(item, item_path, fields) || !required_u32(fields, "id", item_path, id) ||
+                        static_cast<std::size_t>(id) != index || (kind = required(fields, "kind", item_path)) == nullptr ||
+                        !enum_value(*kind, member_path(item_path, "kind"),
+                                    {{"symbol", ConstraintCategory::Symbol},
+                                     {"type", ConstraintCategory::Type},
+                                     {"value", ConstraintCategory::Value},
+                                     {"set", ConstraintCategory::Set},
+                                     {"call", ConstraintCategory::Call},
+                                     {"operator", ConstraintCategory::Operator},
+                                     {"relation", ConstraintCategory::Relation},
+                                     {"not", ConstraintCategory::Not},
+                                     {"logic", ConstraintCategory::Logic}},
+                                    record.category) ||
+                        !optional_string(fields, "identity", item_path, record.identity) ||
+                        !optional_string(fields, "registry_name", item_path, record.registry_name) ||
+                        !optional_string(fields, "operator", item_path, record.operator_spelling) ||
+                        !optional_string(fields, "category", item_path, record.relation_category) ||
+                        !optional_reference(fields, "type", item_path, record.type) ||
+                        !optional_reference(fields, "value", item_path, record.value) ||
+                        !optional_reference(fields, "lhs", item_path, record.lhs) ||
+                        !optional_reference(fields, "rhs", item_path, record.rhs) ||
+                        !optional_reference(fields, "operand", item_path, record.operand) ||
+                        !optional_reference(fields, "result", item_path, record.result)) {
+                        if (!error_ && static_cast<std::size_t>(id) != index) {
+                            fail(member_path(item_path, "id"), "record id does not match array index");
+                        }
+                        return false;
+                    }
+                    if (const Element *elements = fields.find("elements")) {
+                        if (!reference_array(*elements, member_path(item_path, "elements"), record.elements)) { return false; }
+                    }
+                    if (const Element *arguments = fields.find("arguments")) {
+                        if (!reference_array(*arguments, member_path(item_path, "arguments"), record.arguments)) { return false; }
+                    }
+                    out.push_back(std::move(record));
+                    ++index;
+                }
+                return true;
+            }
+
+            bool read_schema(Element value, ModuleDescriptor &out) {
+                ObjectFields fields;
+                if (!object(value, "$.schema", fields)) { return false; }
+                const Element *types       = required(fields, "types", "$.schema");
+                const Element *constants   = required(fields, "constant_expressions", "$.schema");
+                const Element *constraints = required(fields, "constraints", "$.schema");
+                return types != nullptr && constants != nullptr && constraints != nullptr && read_types(*types, out.types) &&
+                       read_constants(*constants, out.constant_expressions) && read_constraints(*constraints, out.constraints);
+            }
+
+            bool read_build(Element value, BuildMetadata &out) {
+                ObjectFields fields;
+                if (!object(value, "$.build", fields) ||
+                    !required_string_array(fields, "public_headers", "$.build", out.public_headers) ||
+                    !required_string_array(fields, "cmake_packages", "$.build", out.cmake_packages) ||
+                    !required_string_array(fields, "imported_targets", "$.build", out.imported_targets)) {
+                    return false;
+                }
+                const Element *registration = required(fields, "registration", "$.build");
+                if (registration == nullptr) { return false; }
+                ObjectFields registration_fields;
+                std::string  kind;
+                if (!object(*registration, "$.build.registration", registration_fields) ||
+                    !required_string(registration_fields, "kind", "$.build.registration", kind) ||
+                    !required_string(registration_fields, "symbol", "$.build.registration", out.registration_symbol)) {
+                    return false;
+                }
+                return kind == "cpp" || fail("$.build.registration.kind", "unknown value '" + kind + "'");
+            }
+
+            std::optional<ReadError> error_{};
+        };
+
+        class Validator
+        {
+          public:
+            explicit Validator(const ModuleDescriptor &descriptor) : descriptor_{descriptor} {}
+
+            [[nodiscard]] std::optional<ReadError> run() {
+                if (descriptor_.format_version != module_descriptor_format_version) {
+                    return ReadError{"$.format_version",
+                                     "unsupported descriptor format version " + std::to_string(descriptor_.format_version)};
+                }
+                if (descriptor_.module_identity.empty()) {
+                    return ReadError{"$.module.identity", "module identity must not be empty"};
+                }
+                if (descriptor_.provider_identity.empty()) {
+                    return ReadError{"$.provider.identity", "provider identity must not be empty"};
+                }
+                for (std::size_t index = 0; index < descriptor_.types.size(); ++index) {
+                    if (!type_record(descriptor_.types[index], index_path("$.schema.types", index))) { return error_; }
+                }
+                for (std::size_t index = 0; index < descriptor_.constant_expressions.size(); ++index) {
+                    if (!constant_record(descriptor_.constant_expressions[index],
+                                         index_path("$.schema.constant_expressions", index))) {
+                        return error_;
+                    }
+                }
+                for (std::size_t index = 0; index < descriptor_.constraints.size(); ++index) {
+                    if (!constraint_record(descriptor_.constraints[index], index_path("$.schema.constraints", index))) {
+                        return error_;
+                    }
+                }
+                for (std::size_t index = 0; index < descriptor_.interface.size(); ++index) {
+                    const InterfaceDeclaration &declaration = descriptor_.interface[index];
+                    const std::string           path        = index_path("$.interface", index);
+                    if (!unique_identity(declaration.identity, path, interface_identities_)) { return error_; }
+                    if (declaration.category == DeclarationCategory::Structure) {
+                        if (!generic_parameters(declaration.signature.generics, member_path(path, "generic_parameters")) ||
+                            !constraint_ref(declaration.signature.requirements, member_path(path, "requires"), true)) {
+                            return error_;
+                        }
+                    } else if (!signature(declaration.signature, member_path(path, "signature"))) {
+                        return error_;
+                    }
+                    for (std::size_t parent = 0; parent < declaration.parents.size(); ++parent) {
+                        if (!type_ref(declaration.parents[parent], index_path(member_path(path, "parents"), parent))) {
+                            return error_;
+                        }
+                    }
+                    for (std::size_t field = 0; field < declaration.fields.size(); ++field) {
+                        const StructField &member     = declaration.fields[field];
+                        const std::string  field_path = index_path(member_path(path, "fields"), field);
+                        if (!type_ref(member.type, member_path(field_path, "type")) ||
+                            !constant_ref(member.default_value, member_path(field_path, "default"), true)) {
+                            return error_;
+                        }
+                    }
+                }
+                for (std::size_t index = 0; index < descriptor_.implementations.size(); ++index) {
+                    const Implementation &implementation = descriptor_.implementations[index];
+                    const std::string     path           = index_path("$.provider.implementations", index);
+                    if (!unique_identity(implementation.identity, path, implementation_identities_) ||
+                        !signature(implementation.signature, member_path(path, "signature"))) {
+                        return error_;
+                    }
+                }
+                return std::nullopt;
+            }
+
+          private:
+            bool fail(std::string path, std::string message) {
+                error_ = ReadError{std::move(path), std::move(message)};
+                return false;
+            }
+
+            bool unique_identity(const std::string &identity, std::string_view path, std::vector<std::string> &seen) {
+                if (identity.empty()) { return fail(member_path(path, "identity"), "identity must not be empty"); }
+                if (std::ranges::find(seen, identity) != seen.end()) {
+                    return fail(member_path(path, "identity"), "duplicate declaration identity '" + identity + "'");
+                }
+                seen.push_back(identity);
+                return true;
+            }
+
+            bool arena_ref(SchemaId id, std::size_t size, std::string_view arena, std::string_view path, bool optional = false) {
+                if (id == no_schema_id) {
+                    return optional || fail(std::string{path}, "missing required " + std::string{arena} + " reference");
+                }
+                if (id >= size) {
+                    return fail(std::string{path}, "dangling " + std::string{arena} + " reference " + std::to_string(id));
+                }
+                return true;
+            }
+
+            bool type_ref(SchemaId id, std::string_view path, bool optional = false) {
+                return arena_ref(id, descriptor_.types.size(), "type", path, optional);
+            }
+
+            bool constant_ref(SchemaId id, std::string_view path, bool optional = false) {
+                return arena_ref(id, descriptor_.constant_expressions.size(), "constant-expression", path, optional);
+            }
+
+            bool constraint_ref(SchemaId id, std::string_view path, bool optional = false) {
+                return arena_ref(id, descriptor_.constraints.size(), "constraint", path, optional);
+            }
+
+            bool generic_parameters(const std::vector<GenericParameter> &parameters, std::string_view path) {
+                for (std::size_t index = 0; index < parameters.size(); ++index) {
+                    const GenericParameter &parameter = parameters[index];
+                    if (!type_ref(parameter.type, member_path(index_path(path, index), "type"), !parameter.is_const)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            bool signature(const Signature &value, std::string_view path) {
+                if (!generic_parameters(value.generics, member_path(path, "generic_parameters"))) { return false; }
+                for (std::size_t index = 0; index < value.parameters.size(); ++index) {
+                    const Parameter  &parameter      = value.parameters[index];
+                    const std::string parameter_path = index_path(member_path(path, "parameters"), index);
+                    if (!type_ref(parameter.type, member_path(parameter_path, "type")) ||
+                        !constant_ref(parameter.default_value, member_path(parameter_path, "default"), true)) {
+                        return false;
+                    }
+                }
+                return type_ref(value.result, member_path(path, "result"), true) &&
+                       constraint_ref(value.requirements, member_path(path, "requires"), true);
+            }
+
+            bool type_record(const TypeRecord &record, std::string_view path) {
+                if (record.category == TypeCategory::Scalar && record.scalar_name.empty()) {
+                    return fail(member_path(path, "name"), "scalar type is missing its name");
+                }
+                if (record.category == TypeCategory::Symbol && record.nominal_identity.empty()) {
+                    return fail(member_path(path, "identity"), "symbol type is missing its identity");
+                }
+                for (std::size_t index = 0; index < record.children.size(); ++index) {
+                    if (!type_ref(record.children[index], index_path(member_path(path, "children"), index))) { return false; }
+                }
+                for (std::size_t index = 0; index < record.arguments.size(); ++index) {
+                    const TypeArgument &argument      = record.arguments[index];
+                    const std::string   argument_path = member_path(index_path(member_path(path, "arguments"), index), "reference");
+                    if (argument.category == TypeArgumentCategory::Type) {
+                        if (!type_ref(argument.reference, argument_path)) { return false; }
+                    } else if (!constant_ref(argument.reference, argument_path)) {
+                        return false;
+                    }
+                }
+                return constant_ref(record.size, member_path(path, "size"), true) &&
+                       constant_ref(record.min_size, member_path(path, "min_size"), true);
+            }
+
+            bool constant_record(const ConstantExpressionRecord &record, std::string_view path) {
+                switch (record.category) {
+                    case ConstantExpressionCategory::Literal:
+                        if (!record.literal) { return fail(member_path(path, "literal"), "missing literal payload"); }
+                        break;
+                    case ConstantExpressionCategory::Parameter:
+                        if (record.parameter_identity.empty()) {
+                            return fail(member_path(path, "parameter"), "missing parameter identity");
+                        }
+                        break;
+                    case ConstantExpressionCategory::Unary:
+                        if (record.operator_spelling.empty()) {
+                            return fail(member_path(path, "operator"), "unary expression is missing its operator");
+                        }
+                        if (!constant_ref(record.lhs, member_path(path, "lhs"))) { return false; }
+                        break;
+                    case ConstantExpressionCategory::Binary:
+                        if (record.operator_spelling.empty()) {
+                            return fail(member_path(path, "operator"), "binary expression is missing its operator");
+                        }
+                        if (!constant_ref(record.lhs, member_path(path, "lhs")) ||
+                            !constant_ref(record.rhs, member_path(path, "rhs"))) {
+                            return false;
+                        }
+                        break;
+                    case ConstantExpressionCategory::Index:
+                        if (!constant_ref(record.lhs, member_path(path, "lhs")) ||
+                            !constant_ref(record.rhs, member_path(path, "rhs"))) {
+                            return false;
+                        }
+                        break;
+                    case ConstantExpressionCategory::Field:
+                        if (record.member.empty()) {
+                            return fail(member_path(path, "member"), "field expression is missing its member");
+                        }
+                        if (!constant_ref(record.lhs, member_path(path, "lhs"))) { return false; }
+                        break;
+                    case ConstantExpressionCategory::Sequence:
+                    case ConstantExpressionCategory::Tuple: break;
+                    case ConstantExpressionCategory::Construct:
+                        if (!type_ref(record.constructed_type, member_path(path, "type"))) { return false; }
+                        break;
+                }
+                for (std::size_t index = 0; index < record.elements.size(); ++index) {
+                    const ConstantElement &element      = record.elements[index];
+                    const std::string      element_path = index_path(member_path(path, "elements"), index);
+                    if (!constant_ref(element.key, member_path(element_path, "key"), true) ||
+                        !constant_ref(element.value, member_path(element_path, "value"))) {
+                        return false;
+                    }
+                }
+                for (std::size_t index = 0; index < record.items.size(); ++index) {
+                    if (!constant_ref(record.items[index], index_path(member_path(path, "items"), index))) { return false; }
+                }
+                for (std::size_t index = 0; index < record.arguments.size(); ++index) {
+                    if (!constant_ref(record.arguments[index].value,
+                                      member_path(index_path(member_path(path, "arguments"), index), "value"))) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            bool constraint_record(const ConstraintRecord &record, std::string_view path) {
+                switch (record.category) {
+                    case ConstraintCategory::Symbol:
+                        return !record.identity.empty() ||
+                               fail(member_path(path, "identity"), "constraint symbol is missing its identity");
+                    case ConstraintCategory::Type: return type_ref(record.type, member_path(path, "type"));
+                    case ConstraintCategory::Value: return constant_ref(record.value, member_path(path, "value"));
+                    case ConstraintCategory::Set: return constraint_refs(record.elements, member_path(path, "elements"));
+                    case ConstraintCategory::Call:
+                        return (!record.identity.empty() ||
+                                fail(member_path(path, "identity"), "constraint call is missing its identity")) &&
+                               constraint_refs(record.arguments, member_path(path, "arguments"));
+                    case ConstraintCategory::Operator:
+                        return (!record.identity.empty() ||
+                                fail(member_path(path, "identity"), "operator requirement is missing its identity")) &&
+                               constraint_refs(record.arguments, member_path(path, "arguments")) &&
+                               type_ref(record.result, member_path(path, "result"), true);
+                    case ConstraintCategory::Relation:
+                    case ConstraintCategory::Logic:
+                        return (!record.operator_spelling.empty() ||
+                                fail(member_path(path, "operator"), "constraint expression is missing its operator")) &&
+                               constraint_ref(record.lhs, member_path(path, "lhs")) &&
+                               constraint_ref(record.rhs, member_path(path, "rhs"));
+                    case ConstraintCategory::Not: return constraint_ref(record.operand, member_path(path, "operand"));
+                }
+                std::unreachable();
+            }
+
+            bool constraint_refs(const std::vector<SchemaId> &values, std::string_view path) {
+                for (std::size_t index = 0; index < values.size(); ++index) {
+                    if (!constraint_ref(values[index], index_path(path, index))) { return false; }
+                }
+                return true;
+            }
+
+            const ModuleDescriptor  &descriptor_;
+            std::optional<ReadError> error_{};
+            std::vector<std::string> interface_identities_{};
+            std::vector<std::string> implementation_identities_{};
+        };
+    }  // namespace
+
+    ReadResult read_json(std::string_view json) {
+        simdjson::dom::parser   parser;
+        simdjson::padded_string padded{json};
+        Element                 root;
+        if (const simdjson::error_code error = parser.parse(padded).get(root)) {
+            return ReadResult{.error = ReadError{"$", "invalid JSON: " + std::string{simdjson::error_message(error)}}};
+        }
+        if (std::optional<ReadError> duplicate = find_duplicate_member(root, "$")) {
+            return ReadResult{.error = std::move(duplicate)};
+        }
+        return Decoder{}.run(root);
+    }
+
+    std::optional<ReadError> validate(const ModuleDescriptor &descriptor) { return Validator{descriptor}.run(); }
+}  // namespace hgl::descriptor

--- a/language/src/descriptor/module_descriptor_reader.cpp
+++ b/language/src/descriptor/module_descriptor_reader.cpp
@@ -46,6 +46,28 @@ namespace hgl::descriptor
             return result;
         }
 
+        [[nodiscard]] bool known_scalar_name(std::string_view name) noexcept {
+            using ir::hir::ScalarType;
+            for (std::uint8_t value = static_cast<std::uint8_t>(ScalarType::Bool);
+                 value <= static_cast<std::uint8_t>(ScalarType::TimeZone); ++value) {
+                if (ir::hir::scalar_type_name(static_cast<ScalarType>(value)) == name) { return true; }
+            }
+            return false;
+        }
+
+        [[nodiscard]] bool known_unary_operator(std::string_view spelling) noexcept {
+            return spelling == "-" || spelling == "!";
+        }
+
+        [[nodiscard]] bool known_binary_operator(std::string_view spelling) noexcept {
+            using ir::hir::BinaryOp;
+            for (std::uint8_t value = static_cast<std::uint8_t>(BinaryOp::Mul);
+                 value <= static_cast<std::uint8_t>(BinaryOp::Or); ++value) {
+                if (ir::hir::binary_op_spelling(static_cast<BinaryOp>(value)) == spelling) { return true; }
+            }
+            return false;
+        }
+
         [[nodiscard]] std::optional<ReadError> find_duplicate_member(Element value, std::string_view path) {
             if (value.is_object()) {
                 simdjson::dom::object object_value;
@@ -875,11 +897,38 @@ namespace hgl::descriptor
             }
 
             bool type_record(const TypeRecord &record, std::string_view path) {
-                if (record.category == TypeCategory::Scalar && record.scalar_name.empty()) {
-                    return fail(member_path(path, "name"), "scalar type is missing its name");
+                if (record.category == TypeCategory::Scalar) {
+                    if (record.scalar_name.empty()) {
+                        return fail(member_path(path, "name"), "scalar type is missing its name");
+                    }
+                    if (!known_scalar_name(record.scalar_name)) {
+                        return fail(member_path(path, "name"), "unknown scalar type '" + record.scalar_name + "'");
+                    }
                 }
                 if (record.category == TypeCategory::Symbol && record.nominal_identity.empty()) {
                     return fail(member_path(path, "identity"), "symbol type is missing its identity");
+                }
+                std::optional<std::size_t> required_children;
+                switch (record.category) {
+                    case TypeCategory::List:
+                    case TypeCategory::Set:
+                    case TypeCategory::Rolling:
+                    case TypeCategory::Atomic:
+                    case TypeCategory::HarnessSequence: required_children = 1U; break;
+                    case TypeCategory::Map: required_children = 2U; break;
+                    case TypeCategory::Void:
+                    case TypeCategory::Scalar:
+                    case TypeCategory::Symbol:
+                    case TypeCategory::Capability:
+                    case TypeCategory::Deferred: required_children = 0U; break;
+                    case TypeCategory::Tuple:
+                    case TypeCategory::Iterator:
+                    case TypeCategory::Callable: break;
+                }
+                if (required_children && record.children.size() != *required_children) {
+                    return fail(member_path(path, "children"),
+                                "type requires exactly " + std::to_string(*required_children) + " child" +
+                                    (*required_children == 1U ? "" : "ren"));
                 }
                 for (std::size_t index = 0; index < record.children.size(); ++index) {
                     if (!type_ref(record.children[index], index_path(member_path(path, "children"), index))) { return false; }
@@ -908,14 +957,20 @@ namespace hgl::descriptor
                         }
                         break;
                     case ConstantExpressionCategory::Unary:
-                        if (record.operator_spelling.empty()) {
-                            return fail(member_path(path, "operator"), "unary expression is missing its operator");
+                        if (!known_unary_operator(record.operator_spelling)) {
+                            return fail(member_path(path, "operator"),
+                                        record.operator_spelling.empty() ? "unary expression is missing its operator"
+                                                                         : "unknown unary operator '" +
+                                                                               record.operator_spelling + "'");
                         }
                         if (!constant_ref(record.lhs, member_path(path, "lhs"))) { return false; }
                         break;
                     case ConstantExpressionCategory::Binary:
-                        if (record.operator_spelling.empty()) {
-                            return fail(member_path(path, "operator"), "binary expression is missing its operator");
+                        if (!known_binary_operator(record.operator_spelling)) {
+                            return fail(member_path(path, "operator"),
+                                        record.operator_spelling.empty() ? "binary expression is missing its operator"
+                                                                         : "unknown binary operator '" +
+                                                                               record.operator_spelling + "'");
                         }
                         if (!constant_ref(record.lhs, member_path(path, "lhs")) ||
                             !constant_ref(record.rhs, member_path(path, "rhs"))) {

--- a/language/src/descriptor/module_descriptor_reader.h
+++ b/language/src/descriptor/module_descriptor_reader.h
@@ -1,0 +1,39 @@
+#ifndef HGL_DESCRIPTOR_MODULE_DESCRIPTOR_READER_H
+#define HGL_DESCRIPTOR_MODULE_DESCRIPTOR_READER_H
+
+#include "descriptor/module_descriptor.h"
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace hgl::descriptor
+{
+    struct ReadError
+    {
+        std::string path{};
+        std::string message{};
+
+        friend bool operator==(const ReadError &, const ReadError &) = default;
+    };
+
+    struct ReadResult
+    {
+        std::optional<ModuleDescriptor> value{};
+        std::optional<ReadError>        error{};
+
+        [[nodiscard]] explicit operator bool() const noexcept { return value.has_value(); }
+    };
+
+    /// Parse and validate one versioned HGL module descriptor without loading
+    /// native code or consulting a registry. Unknown object members are
+    /// ignored within a supported format version; duplicate members, invalid
+    /// enums and dangling schema references are rejected.
+    [[nodiscard]] ReadResult read_json(std::string_view json);
+
+    /// Validate a descriptor assembled by another producer. This applies the
+    /// same semantic integrity rules as read_json after JSON decoding.
+    [[nodiscard]] std::optional<ReadError> validate(const ModuleDescriptor &descriptor);
+}  // namespace hgl::descriptor
+
+#endif  // HGL_DESCRIPTOR_MODULE_DESCRIPTOR_READER_H

--- a/language/src/driver/driver.cpp
+++ b/language/src/driver/driver.cpp
@@ -1,6 +1,7 @@
 #include "driver/driver.h"
 
 #include "codegen/cpp_emitter.h"
+#include "descriptor/module_descriptor_reader.h"
 #include "driver/cpp_formatter.h"
 #include "driver/line_reader.h"
 #include "driver/native_module.h"
@@ -55,7 +56,7 @@ namespace hgl::driver
                          "  hgl --help\n"
                          "  hgl --version\n\n"
                          "Commands:\n"
-                         "  check     parse, resolve and type-check a module and report diagnostics\n"
+                         "  check     validate an HGL source module or .hgl-module.json descriptor\n"
                          "  test      run the module's test declarations\n"
                          "  run       bind an entry to a mode, clock and parameters, then execute it\n"
                          "  emit-cpp  write the module as a C++ header/source pair and versioned JSON\n"
@@ -214,6 +215,23 @@ namespace hgl::driver
             if (!text) {
                 std::cerr << "hgl: cannot read '" << *path << "'\n";
                 return exit_usage;
+            }
+
+            if (path->ends_with(".hgl-module.json")) {
+                if (want_tokens || want_ast || want_hir || want_hgraph_ir) {
+                    return usage_error("descriptor check does not support syntax or IR dump options");
+                }
+                const descriptor::ReadResult result = descriptor::read_json(*text);
+                if (!result) {
+                    if (!result.error) {
+                        std::cerr << *path << ": descriptor reader returned neither a value nor an error\n";
+                        return exit_diagnostics;
+                    }
+                    const descriptor::ReadError &error = *result.error;
+                    std::cerr << *path << ':' << error.path << ": descriptor: " << error.message << '\n';
+                    return exit_diagnostics;
+                }
+                return exit_ok;
             }
 
             Unit unit{*path, std::move(*text)};

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -60,6 +60,15 @@ set_tests_properties(hgraph_language_dump_hgraph_ir PROPERTIES
     PASS_REGULAR_EXPRESSION "HGRAPH-IR bodies module examples.stateful_node"
 )
 
+add_test(
+    NAME hgraph_language_check_descriptor
+    COMMAND ${CMAKE_COMMAND}
+        -DHGL=$<TARGET_FILE:hgl>
+        -DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/../examples/midpoint.hgl
+        -DOUT=${CMAKE_CURRENT_BINARY_DIR}/descriptor-check
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/driver/check_descriptor.cmake
+)
+
 # Catch2 for the frontend unit tests: reuse the repository's target when the
 # language is built as part of hgraph, else find or fetch it.
 if(NOT TARGET Catch2::Catch2WithMain)
@@ -130,6 +139,15 @@ target_link_libraries(hgl_descriptor_tests PRIVATE hgl::descriptor Catch2::Catch
 hgl_apply_warnings(hgl_descriptor_tests)
 
 add_test(NAME hgraph_language_descriptor COMMAND hgl_descriptor_tests)
+
+# Descriptor decoding has a JSON dependency and a deliberately adversarial
+# input corpus, so keep it out of the compact writer/snapshot test TU.
+add_executable(hgl_descriptor_reader_tests descriptor/module_descriptor_reader_tests.cpp)
+target_compile_features(hgl_descriptor_reader_tests PRIVATE cxx_std_23)
+target_link_libraries(hgl_descriptor_reader_tests PRIVATE hgl::descriptor_reader Catch2::Catch2WithMain)
+hgl_apply_warnings(hgl_descriptor_reader_tests)
+
+add_test(NAME hgraph_language_descriptor_reader COMMAND hgl_descriptor_reader_tests)
 
 # The direct-wiring backend against the live registry: folding, eval, the
 # failure detail, run_program (developer guide, "First pass").

--- a/language/tests/descriptor/module_descriptor_reader_tests.cpp
+++ b/language/tests/descriptor/module_descriptor_reader_tests.cpp
@@ -224,6 +224,47 @@ TEST_CASE("module descriptor reader rejects malformed schema records", "[descrip
         check_error(descriptor::read_json(descriptor::to_json(source)), "$.schema.types[0].name",
                     "scalar type is missing its name");
     }
+
+    SECTION("unknown scalar name") {
+        source.types.front().scalar_name = "mystery";
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.schema.types[0].name",
+                    "unknown scalar type 'mystery'");
+    }
+
+    SECTION("fixed-shape type has the wrong child count") {
+        source.types.front().category = descriptor::TypeCategory::Map;
+        source.types.front().scalar_name.clear();
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.schema.types[0].children",
+                    "type requires exactly 2 children");
+    }
+
+    SECTION("leaf type has children") {
+        source.types.push_back(source.types.front());
+        source.types.front().children = {1U};
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.schema.types[0].children",
+                    "type requires exactly 0 children");
+    }
+}
+
+TEST_CASE("module descriptor reader rejects unknown constant operators", "[descriptor][reader]") {
+    descriptor::ModuleDescriptor source = minimal_descriptor();
+    source.constant_expressions = {
+        descriptor::ConstantExpressionRecord{.literal = hgl::ir::hir::Constant{std::int64_t{1}}},
+        descriptor::ConstantExpressionRecord{
+            .category = descriptor::ConstantExpressionCategory::Unary, .operator_spelling = "bogus", .lhs = 0U},
+    };
+
+    check_error(descriptor::read_json(descriptor::to_json(source)), "$.schema.constant_expressions[1].operator",
+                "unknown unary operator 'bogus'");
+
+    source.constant_expressions[1] = descriptor::ConstantExpressionRecord{
+        .category = descriptor::ConstantExpressionCategory::Binary,
+        .operator_spelling = "bogus",
+        .lhs = 0U,
+        .rhs = 0U,
+    };
+    check_error(descriptor::read_json(descriptor::to_json(source)), "$.schema.constant_expressions[1].operator",
+                "unknown binary operator 'bogus'");
 }
 
 TEST_CASE("module descriptor validation rejects incomplete semantic records", "[descriptor][reader]") {

--- a/language/tests/descriptor/module_descriptor_reader_tests.cpp
+++ b/language/tests/descriptor/module_descriptor_reader_tests.cpp
@@ -1,0 +1,237 @@
+#include "descriptor/module_descriptor_reader.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace descriptor = hgl::descriptor;
+
+namespace
+{
+    descriptor::ModuleDescriptor minimal_descriptor() {
+        descriptor::ModuleDescriptor result;
+        result.module_identity   = "checks.reader";
+        result.language_version  = "0.1-test";
+        result.provider_identity = "checks.reader";
+        return result;
+    }
+
+    descriptor::ModuleDescriptor rich_descriptor() {
+        descriptor::ModuleDescriptor result = minimal_descriptor();
+
+        result.types = {
+            descriptor::TypeRecord{.category = descriptor::TypeCategory::Scalar, .scalar_name = "i64"},
+            descriptor::TypeRecord{
+                .category         = descriptor::TypeCategory::Symbol,
+                .nominal_identity = "T",
+                .binding_identity = "checks.reader.map::T",
+                .arguments = {{descriptor::TypeArgumentCategory::Type, 0U}, {descriptor::TypeArgumentCategory::Constant, 0U}}},
+            descriptor::TypeRecord{.category = descriptor::TypeCategory::Rolling, .children = {1U}, .size = 0U},
+        };
+
+        descriptor::ConstantExpressionRecord integer;
+        integer.literal = hgl::ir::hir::Constant{std::numeric_limits<std::int64_t>::max()};
+        descriptor::ConstantExpressionRecord floating;
+        floating.literal = hgl::ir::hir::Constant{std::numeric_limits<double>::infinity()};
+        descriptor::ConstantExpressionRecord text;
+        text.literal                = hgl::ir::hir::Constant{std::string{"reader\nvalue"}};
+        result.constant_expressions = {
+            std::move(integer),
+            std::move(floating),
+            std::move(text),
+            descriptor::ConstantExpressionRecord{
+                .category = descriptor::ConstantExpressionCategory::Unary, .operator_spelling = "-", .lhs = 0U},
+            descriptor::ConstantExpressionRecord{
+                .category = descriptor::ConstantExpressionCategory::Binary, .operator_spelling = "+", .lhs = 0U, .rhs = 0U},
+            descriptor::ConstantExpressionRecord{.category = descriptor::ConstantExpressionCategory::Sequence,
+                                                 .elements = {{descriptor::no_schema_id, 0U}, {0U, 1U}}},
+            descriptor::ConstantExpressionRecord{.category = descriptor::ConstantExpressionCategory::Index, .lhs = 5U, .rhs = 0U},
+            descriptor::ConstantExpressionRecord{
+                .category = descriptor::ConstantExpressionCategory::Field, .lhs = 5U, .member = "value"},
+            descriptor::ConstantExpressionRecord{.category = descriptor::ConstantExpressionCategory::Tuple, .items = {0U, 1U, 2U}},
+            descriptor::ConstantExpressionRecord{.category         = descriptor::ConstantExpressionCategory::Construct,
+                                                 .constructed_type = 0U,
+                                                 .arguments        = {{"value", 0U}},
+                                                 .delta            = true},
+            descriptor::ConstantExpressionRecord{.category           = descriptor::ConstantExpressionCategory::Parameter,
+                                                 .parameter_identity = "checks.reader.map::max_size"},
+        };
+
+        result.constraints = {
+            descriptor::ConstraintRecord{.category = descriptor::ConstraintCategory::Symbol, .identity = "T"},
+            descriptor::ConstraintRecord{.category = descriptor::ConstraintCategory::Type, .type = 0U},
+            descriptor::ConstraintRecord{.category = descriptor::ConstraintCategory::Value, .value = 0U},
+            descriptor::ConstraintRecord{.category = descriptor::ConstraintCategory::Set, .elements = {1U}},
+            descriptor::ConstraintRecord{.category = descriptor::ConstraintCategory::Call, .identity = "schema", .arguments = {0U}},
+            descriptor::ConstraintRecord{.category      = descriptor::ConstraintCategory::Operator,
+                                         .identity      = "hgraph.std.add",
+                                         .registry_name = "add_",
+                                         .result        = 0U,
+                                         .arguments     = {0U}},
+            descriptor::ConstraintRecord{.category          = descriptor::ConstraintCategory::Relation,
+                                         .operator_spelling = "in",
+                                         .relation_category = "admission",
+                                         .lhs               = 0U,
+                                         .rhs               = 3U},
+            descriptor::ConstraintRecord{.category = descriptor::ConstraintCategory::Not, .operand = 6U},
+            descriptor::ConstraintRecord{
+                .category = descriptor::ConstraintCategory::Logic, .operator_spelling = "and", .lhs = 7U, .rhs = 2U},
+        };
+
+        descriptor::InterfaceDeclaration structure;
+        structure.category               = descriptor::DeclarationCategory::Structure;
+        structure.identity               = "checks.reader.Record";
+        structure.abstract               = true;
+        structure.signature.generics     = {{"T", "checks.reader.Record::T", false, descriptor::no_schema_id}};
+        structure.signature.requirements = 6U;
+        structure.parents                = {1U};
+        structure.fields                 = {{"value", 0U, 0U, "checks.reader.Record", true}};
+
+        descriptor::InterfaceDeclaration operation;
+        operation.category               = descriptor::DeclarationCategory::Operator;
+        operation.identity               = "checks.reader.map";
+        operation.registry_name          = "checks.reader.map";
+        operation.signature.generics     = {{"T", "checks.reader.map::T", false, descriptor::no_schema_id},
+                                            {"max_size", "checks.reader.map::max_size", true, 0U}};
+        operation.signature.parameters   = {{"window", "checks.reader.map::window", false, 2U, 0U}};
+        operation.signature.result       = 0U;
+        operation.signature.requirements = 8U;
+
+        descriptor::InterfaceDeclaration function;
+        function.category             = descriptor::DeclarationCategory::Function;
+        function.identity             = "checks.reader.public_value";
+        function.execution            = descriptor::ExecutionKind::Composition;
+        function.signature.parameters = {{"value", "checks.reader.public_value::value", false, 0U, descriptor::no_schema_id}};
+        function.signature.result     = 0U;
+        result.interface              = {std::move(structure), std::move(operation), std::move(function)};
+
+        descriptor::Implementation implementation;
+        implementation.identity               = "checks.reader.map#1";
+        implementation.operator_identity      = "checks.reader.map";
+        implementation.operator_registry_name = "checks.reader.map";
+        implementation.execution              = descriptor::ExecutionKind::RuntimeNode;
+        implementation.signature.parameters   = {{"window", "checks.reader.map#1::window", false, 2U, 0U}};
+        implementation.signature.result       = 0U;
+        result.implementations                = {std::move(implementation)};
+
+        result.provider_requirements     = {"hgraph.std"};
+        result.build.public_headers      = {"checks_reader.h"};
+        result.build.cmake_packages      = {"hgraph"};
+        result.build.imported_targets    = {"hgraph::core"};
+        result.build.registration_symbol = "checks::reader::register_operators";
+        return result;
+    }
+
+    void replace_once(std::string &text, std::string_view from, std::string_view to) {
+        const std::size_t offset = text.find(from);
+        REQUIRE(offset != std::string::npos);
+        text.replace(offset, from.size(), to);
+    }
+
+    void check_error(const descriptor::ReadResult &result, std::string_view path, std::string_view message) {
+        REQUIRE_FALSE(result);
+        REQUIRE(result.error);
+        CHECK(result.error->path == path);
+        CHECK(result.error->message == message);
+    }
+}  // namespace
+
+TEST_CASE("module descriptor reader round-trips the complete version-one model", "[descriptor][reader]") {
+    const descriptor::ModuleDescriptor expected = rich_descriptor();
+    const descriptor::ReadResult       result   = descriptor::read_json(descriptor::to_json(expected));
+
+    REQUIRE(result);
+    REQUIRE(result.value);
+    CHECK(*result.value == expected);
+    CHECK_FALSE(result.error);
+}
+
+TEST_CASE("module descriptor reader accepts compatible unknown members", "[descriptor][reader]") {
+    std::string json = descriptor::to_json(minimal_descriptor());
+    replace_once(json, "  \"format\":", "  \"future_top_level\": {\"value\": true},\n  \"format\":");
+    replace_once(json, "    \"identity\": \"checks.reader\",",
+                 "    \"identity\": \"checks.reader\",\n    \"future_module_member\": [1, 2, 3],");
+
+    const descriptor::ReadResult result = descriptor::read_json(json);
+    REQUIRE(result);
+    CHECK(result.value == minimal_descriptor());
+}
+
+TEST_CASE("module descriptor reader rejects malformed envelopes", "[descriptor][reader]") {
+    SECTION("invalid JSON") {
+        const descriptor::ReadResult result = descriptor::read_json("{");
+        REQUIRE_FALSE(result);
+        REQUIRE(result.error);
+        CHECK(result.error->path == "$");
+        CHECK(result.error->message.starts_with("invalid JSON:"));
+    }
+
+    SECTION("duplicate members") {
+        std::string json = descriptor::to_json(minimal_descriptor());
+        replace_once(json, "  \"format\": \"hgl.module\",", "  \"format\": \"hgl.module\",\n  \"format\": \"hgl.module\",");
+        check_error(descriptor::read_json(json), "$.format", "duplicate member");
+    }
+
+    SECTION("duplicate members inside compatible unknown values") {
+        std::string json = descriptor::to_json(minimal_descriptor());
+        replace_once(json, "  \"format\":", "  \"future\": {\"nested\": {\"value\": 1, \"value\": 2}},\n  \"format\":");
+        check_error(descriptor::read_json(json), "$.future.nested.value", "duplicate member");
+    }
+
+    SECTION("wrong format") {
+        std::string json = descriptor::to_json(minimal_descriptor());
+        replace_once(json, "\"format\": \"hgl.module\"", "\"format\": \"other.module\"");
+        check_error(descriptor::read_json(json), "$.format", "expected 'hgl.module'");
+    }
+
+    SECTION("unsupported version") {
+        std::string json = descriptor::to_json(minimal_descriptor());
+        replace_once(json, "\"format_version\": 1", "\"format_version\": 2");
+        check_error(descriptor::read_json(json), "$.format_version", "unsupported descriptor format version 2");
+    }
+}
+
+TEST_CASE("module descriptor reader rejects malformed schema records", "[descriptor][reader]") {
+    descriptor::ModuleDescriptor source = minimal_descriptor();
+    source.types = {descriptor::TypeRecord{.category = descriptor::TypeCategory::Scalar, .scalar_name = "i64"}};
+
+    SECTION("unknown record kind") {
+        std::string json = descriptor::to_json(source);
+        replace_once(json, "\"kind\": \"scalar\"", "\"kind\": \"mystery\"");
+        check_error(descriptor::read_json(json), "$.schema.types[0].kind", "unknown value 'mystery'");
+    }
+
+    SECTION("record id does not match its position") {
+        std::string json = descriptor::to_json(source);
+        replace_once(json, "\"id\": 0", "\"id\": 1");
+        check_error(descriptor::read_json(json), "$.schema.types[0].id", "record id does not match array index");
+    }
+
+    SECTION("dangling reference") {
+        source.types.front().category = descriptor::TypeCategory::Tuple;
+        source.types.front().scalar_name.clear();
+        source.types.front().children = {4U};
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.schema.types[0].children[0]",
+                    "dangling type reference 4");
+    }
+
+    SECTION("missing category payload") {
+        source.types.front().scalar_name.clear();
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.schema.types[0].name",
+                    "scalar type is missing its name");
+    }
+}
+
+TEST_CASE("module descriptor validation rejects incomplete semantic records", "[descriptor][reader]") {
+    descriptor::ModuleDescriptor source = minimal_descriptor();
+    source.constant_expressions.emplace_back();
+
+    const std::optional<descriptor::ReadError> error = descriptor::validate(source);
+    REQUIRE(error);
+    CHECK(error->path == "$.schema.constant_expressions[0].literal");
+    CHECK(error->message == "missing literal payload");
+}

--- a/language/tests/driver/check_descriptor.cmake
+++ b/language/tests/driver/check_descriptor.cmake
@@ -1,0 +1,49 @@
+if(NOT DEFINED HGL OR NOT DEFINED SOURCE OR NOT DEFINED OUT)
+    message(FATAL_ERROR "HGL, SOURCE, and OUT are required")
+endif()
+
+file(MAKE_DIRECTORY "${OUT}")
+execute_process(
+    COMMAND "${HGL}" emit-cpp "${SOURCE}" --out-dir "${OUT}"
+    RESULT_VARIABLE emit_result
+    OUTPUT_VARIABLE emit_output
+    ERROR_VARIABLE emit_error
+)
+if(NOT emit_result EQUAL 0)
+    message(FATAL_ERROR "emit-cpp failed (${emit_result})\n${emit_output}${emit_error}")
+endif()
+
+set(descriptor "${OUT}/midpoint.hgl-module.json")
+execute_process(
+    COMMAND "${HGL}" check "${descriptor}"
+    RESULT_VARIABLE check_result
+    OUTPUT_VARIABLE check_output
+    ERROR_VARIABLE check_error
+)
+if(NOT check_result EQUAL 0)
+    message(FATAL_ERROR "descriptor check failed (${check_result})\n${check_output}${check_error}")
+endif()
+
+execute_process(
+    COMMAND "${HGL}" check "${descriptor}" --dump-hir
+    RESULT_VARIABLE dump_result
+    OUTPUT_VARIABLE dump_output
+    ERROR_VARIABLE dump_error
+)
+if(NOT dump_result EQUAL 2 OR NOT dump_error MATCHES "descriptor check does not support syntax or IR dump options")
+    message(FATAL_ERROR "descriptor dump options did not fail as usage (${dump_result})\n${dump_output}${dump_error}")
+endif()
+
+file(READ "${descriptor}" invalid_json)
+string(REPLACE [["format_version": 1]] [["format_version": 99]] invalid_json "${invalid_json}")
+set(invalid_descriptor "${OUT}/invalid.hgl-module.json")
+file(WRITE "${invalid_descriptor}" "${invalid_json}")
+execute_process(
+    COMMAND "${HGL}" check "${invalid_descriptor}"
+    RESULT_VARIABLE invalid_result
+    OUTPUT_VARIABLE invalid_output
+    ERROR_VARIABLE invalid_error
+)
+if(NOT invalid_result EQUAL 1 OR NOT invalid_error MATCHES [[\$.format_version: descriptor: unsupported descriptor format version 99]])
+    message(FATAL_ERROR "invalid descriptor diagnostic mismatch (${invalid_result})\n${invalid_output}${invalid_error}")
+endif()


### PR DESCRIPTION
## Summary

- add a strict version-1 JSON module-descriptor reader behind a separate simdjson-linked target
- validate record shapes, duplicate keys, supported enums, identities, and descriptor-local arena references without loading native code or consulting the registry
- teach `hgl check` to validate `.hgl-module.json` files and document the remaining dependency/lifecycle boundary

## Validation

- `cmake --build build-language-review --target hgl hgl_descriptor_reader_tests --parallel`
- `ctest --test-dir build-language-review --output-on-failure -R "hgraph_language_(descriptor_reader|check_descriptor)"`
- complete HGL CTest suite: 35/35 passed
- fresh native acceptance preset: 1716/1716 passed
- Python 3.14 non-WIP compatibility suite from a Python 3.12 ABI3 wheel: 3241 passed, 10 skipped
- `.venv/bin/python -m sphinx -W --keep-going -b html docs/source docs/_build/hgl-descriptor-reader`

## Boundaries

This is descriptor-local validation only. Dependency closure, native loading/lifecycle, ownership/effect metadata, and fingerprints remain explicit Stage F work.