### PR TITLE
Implement explicit HGL reference types

### DIFF
--- a/language/README.md
+++ b/language/README.md
@@ -37,6 +37,8 @@ overloads. Every checked-in example now reaches generated C++: nominal and
 generic structs, sparse deltas, generic operators, fixed and duration windows,
 concise `map` functions, collection traversal and predicates, logger injection,
 scalar recordable state, prior and keyed output access, and lifecycle blocks.
+Explicit `ref<T>` contracts and guarded fixed-list reference routing also reach
+native schema materialization, descriptors, generated C++, and behavior tests.
 Source operators become transparent aliases of `hgraph::Operator` contracts,
 not generated subclasses. `hgl_add_module()`
 builds such modules — together with hand-written C++ — into a library and,
@@ -47,7 +49,8 @@ fixtures compile and execute generated graph and runtime-node modules.
 Portable runtime-module loading, multi-registry module transactions,
 typed `const` arguments in native generic Bundle identity, multiple-parent
 field order, explicit optional-field clearing,
-general runtime calls and non-scalar state, timed harness sequences, and TOML
+general runtime calls and non-scalar state, wiring-time reference access,
+collection-reference propagation, SIGNAL spelling, timed harness sequences, and TOML
 run configuration remain staged work
 ([roadmap](docs/design/roadmap.md)).
 

--- a/language/docs/README.md
+++ b/language/docs/README.md
@@ -47,12 +47,12 @@ out so examples do not imply an implemented compatibility promise.
 9. [Distribution and deployment](design/distribution.md) — release train,
    package channels (Homebrew first), the relocatable native context, and
    what a host needs to run an HGL program.
-6. [Type extensions](design/type-extensions.md) — agreed atomic treatment of
+10. [Type extensions](design/type-extensions.md) — agreed atomic treatment of
    imported types, `ref<T>`, reference-transparent type compatibility, opaque
    node access, wiring-time dereferencing, and input-only SIGNAL observation.
-7. [Conditional control flow](design/control-flow.md) — wiring-time selection,
+11. [Conditional control flow](design/control-flow.md) — wiring-time selection,
    switch-style temporal conditions in graph functions, and node conditionals.
-8. [Iteration](design/iteration.md) — phase-dependent `for`, wiring-time values
+12. [Iteration](design/iteration.md) — phase-dependent `for`, wiring-time values
    and fixed child connections, independent dynamic graph loops, runtime
    traversal, and deferred map/reduce accumulation.
 

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -173,6 +173,8 @@ planning is implemented.
 - [x] migrate direct wiring from `ResolvedModule` to hgraph IR, including
   canonical type materialization, lexical activation bindings, composition
   expansion, harness evaluation, entry execution, and driver-prepared settings.
+- [x] preserve explicit reference schemas and reference-transparent
+  compatibility through HIR, hgraph IR, and native type materialization.
 
 Acceptance: direct-wiring behavior and diagnostics remain equivalent, and the
 wiring target no longer includes syntax AST headers.
@@ -216,6 +218,8 @@ wiring target no longer includes syntax AST headers.
 - [x] retain deterministic formatting, source maps, public-SDK code, and readable
   output;
 - [x] remove the compatibility path by which a backend walks `ResolvedModule`.
+- [x] emit explicit reference contracts and guarded fixed-list reference
+  routing with selector-aware activation and validity analysis.
 
 Acceptance: both backends consume the same hgraph IR, existing generated tests
 and installed consumers pass, and architecture tests reject backend-to-syntax
@@ -256,7 +260,7 @@ remain rejected.
 Acceptance is behavioral parity, generated-code inspection, installed-SDK
 coverage, and performance evidence against the implementation removed.
 
-## Prototype checkpoint (2026-09-05)
+## Prototype checkpoint (2026-09-06)
 
 The prototype deliberately permits incompatible AST and implementation
 changes while these slices are being exercised. The current tree implements
@@ -269,12 +273,15 @@ The generated C++ backend lowers every checked-in example: ordered activation,
 aggregate scalar recordable state, direct, prior-value, and keyed TSD output,
 logger injection, lifecycle hooks over state and `const` configuration,
 nominal/generic structs and sparse deltas, generic operators, fixed and duration
-windows, concise `map` functions, and borrowed runtime collection iteration.
+windows, concise `map` functions, borrowed runtime collection iteration, and
+guarded selection and forwarding of fixed-list reference elements.
 Generated headers and sources are mandatory `clang-format` output and public
 operator contracts are transparent aliases rather than derived marker classes.
 
 The implementation fails closed where the public or language contract is not
-settled: multiple-parent field order, constructor inference, typed `const`
+settled: wiring-time dereference through a reference, collection-reference
+propagation, nested reference normalization, SIGNAL spelling, multiple-parent
+field order, constructor inference, typed `const`
 generic Bundle metadata, explicit optional-field clearing, consumption of
 temporal deltas, general callable substitution, portable scripted loading, and
 runtime calls. Slice numbering
@@ -330,7 +337,7 @@ Deliverables:
 - `bool`, `i64`, `f64`, `str`, `date`, `time`, `datetime`, `duration`,
   `civil_datetime`, `timezone`, `zoned_datetime`, `zoned_time`, tuple, sized
   and unbounded list, set, map, and `atomic<T>` types, plus tick-count and
-  duration `rolling<T, max_size[, min_size]>`;
+  duration `rolling<T, max_size[, min_size]>` and explicit `ref<T>` boundaries;
 - `@` temporal literals with RFC 9557 zone annotations and unit-suffixed
   duration literals, validated and normalized in the lexer;
 - type and `const` generic declarations, nominal operator identities, and
@@ -387,6 +394,8 @@ Deliverables:
   state, approved injectables, lifecycle hooks, ordered activation, and output;
 - public-view lowering for metadata and collection iteration, including native
   delta ranges and heterogeneous TSB expansion;
+- explicit reference schemas and guarded fixed-list reference selection in
+  generated runtime nodes;
 - hgraph kernel module descriptor;
 - source and imported nominal operator resolution through the hgraph resolver;
 - transparent contract aliases and explicit registration for source-defined operator

--- a/language/docs/design/type-extensions.md
+++ b/language/docs/design/type-extensions.md
@@ -1,8 +1,11 @@
 # Imported values, reference types, and SIGNAL inputs
 
-Status: agreed source semantics, 2026-09-05; compiler implementation is outside
-this change. The collection-reference mapping noted below still needs
-clarification. This record introduces no native declaration syntax.
+Status: agreed source semantics, 2026-09-05; explicit `ref<T>` parsing, type
+checking, metadata, descriptors, and generated reference-routing nodes are
+implemented. Wiring-time access through a reference and imported native types
+remain compiler work. The collection-reference mapping noted below and SIGNAL
+spelling still need clarification. This record introduces no native declaration
+syntax.
 
 ## Imported types are atomic values
 
@@ -136,6 +139,11 @@ This permits graph composition to select fields or collection elements through
 reference-backed sources while preserving the node-level access restriction.
 Reference binding and adaptation belong to the existing hgraph runtime.
 
+This is not implemented in composition bodies yet. The compiler currently
+rejects field or index access through `ref<T>` in every phase rather than
+silently reading a value. Simple reference forwarding and normal hgraph
+endpoint adaptation are supported.
+
 ## SIGNAL inputs
 
 SIGNAL is an input-only observation contract. It accepts a time-series input
@@ -175,10 +183,15 @@ Whether that outer REF is intentional, and the rule that would add it, are
 awaiting clarification. Do not infer a general reference-propagation rule or
 silently remove the outer REF from this example.
 
+The current compiler therefore rejects `map<K, ref<V>>`. It also rejects a
+nested `ref<ref<T>>` boundary instead of relying on native REF normalization;
+that is a fail-closed implementation boundary, not an additional source-level
+decision.
+
 ## Scope of this agreement
 
 This record does not settle SIGNAL spelling, native declaration syntax,
 reference construction or mutation operations, or additional restrictions on
-reference placement. Those remain separate discussion items. No changes to
-the parser, compiler backends, native runtime, or executable examples accompany
-this record.
+reference placement. Those remain separate discussion items. Implemented
+reference forms are exercised by `examples/reference-routing.hgl`; unresolved
+forms continue to fail closed.

--- a/language/docs/developer-guide/README.md
+++ b/language/docs/developer-guide/README.md
@@ -16,6 +16,10 @@ for hgraph, not a second runtime.
 > types, substitutions, constraints, calls, phases, effects, and capabilities.
 > It validates constrained generic structs in every type position and leaves a
 > failed module explicitly `Resolved` rather than claiming `Typed` completion.
+> Explicit `ref<T>` is preserved through canonical HIR and hgraph IR, native
+> schema materialization, module descriptors, operator resolution, and C++
+> signatures. Runtime checking keeps the referenced payload opaque and proves
+> guarded fixed-list reference selectors before code generation.
 > `src/hgraph_ir/` lowers typed HIR into independently owned canonical types,
 > compile-time expressions, nominal contracts, callable interfaces, bindings,
 > values, semantic operations, structured control flow, and test plans. An
@@ -35,7 +39,8 @@ for hgraph, not a second runtime.
 > at a quiescent boundary, and restores the old revision if activation fails.
 > Imported operator-contract conformance, arbitrary residual `const` predicates, `const`
 > generic native metadata, multiple-parent linearization, explicit optional-field
-> clearing, multi-registry module transactions, and the remaining runtime and
+> clearing, wiring-time dereference through `ref<T>`, imported native types,
+> multi-registry module transactions, and the remaining runtime and
 > generated-C++ type support remain to be implemented.
 
 ## Guide map

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -126,6 +126,14 @@ the capabilities admitted by each function. A failed pass leaves
 `Module::completion` as `Resolved`; `hgl check` succeeds only after the module
 is `Typed`.
 
+Reference types remain explicit canonical shapes. Assignability compares their
+underlying types recursively without erasing the endpoint representation. In a
+runtime function, unary and binary value operations, Boolean tests, field
+access, and indexing through a top-level `ref<T>` are type errors; metadata
+intrinsics and forwarding remain available. The unresolved
+`map<K, ref<V>>` mapping and nested reference boundaries fail during type
+formation.
+
 Native candidate selection crosses the narrow `OperatorResolver` port. The
 hgraph adapter constructs schema-only `WiringArg` values and calls
 `OperatorRegistry::resolve`, so argument normalization, `TypePattern`
@@ -264,7 +272,8 @@ HIR-owned. `hgraph_language_backend_architecture` scans the execution backend
 sources and rejects syntax AST/parser or resolver dependencies.
 
 `src/wiring/type_bridge` is the first direct-backend migration boundary. It
-materializes hgraph-IR scalar, tuple, list, set, map, window, atomic, and applied
+materializes hgraph-IR scalar, tuple, list, set, map, window, atomic, reference,
+and applied
 nominal-struct types as canonical public hgraph metadata. Generic struct fields
 and parents are resolved from the graph-IR contract and its applied arguments;
 the bridge never looks up a syntax type or semantic binding. It also translates
@@ -1294,10 +1303,11 @@ device. The TOML run configuration is not in the first pass.
 ## C++ backend, first pass
 
 Status: implemented for the composition and runtime forms exercised by every
-checked-in example as of 2026-09-05. This includes nominal and generic structs,
+checked-in example as of 2026-09-06. This includes nominal and generic structs,
 generic operator implementations, fixed and duration windows, sparse struct
 deltas, concise `map` functions, scalar and collection runtime inputs, borrowed
-collection traversal, `out`, `logger`, state, and lifecycle hooks. File-based
+collection traversal, explicit reference schemas, guarded fixed-list reference
+routing, `out`, `logger`, state, and lifecycle hooks. File-based
 `test` and `run` compile/load supported runtime modules on Unix; portable native
 loading and the remaining language-depth items are still staged. Declaration
 and module planning now come from hgraph IR, as do callable/operator interfaces,
@@ -1440,13 +1450,14 @@ comment; output is deterministic (basenames, no timestamps).
 
 The first pass still fails closed, before writing either file, on: generated
 runtime sources, runtime calls, non-scalar state, output kinds other than the
-implemented scalar, nominal-struct, and map forms, injectables other than
+implemented scalar, nominal-struct, map, and reference forms, injectables other than
 `out` and `logger`, lifecycle access to temporal inputs or output, optional
 field clearing in a sparse delta, generic constructor inference and typed
 `const` generic struct metadata, tuple and list literals and other compound
 constants, `if` or a block used as a value, zoned and civil temporal literals,
-an `impl fn` of an imported operator, and a missing module declaration. Each is
-a diagnostic naming the construct.
+an `impl fn` of an imported operator, wiring-time access through a reference,
+unresolved collection-reference mappings, and a missing module declaration.
+Each is a diagnostic naming the construct.
 
 `hgl_add_module()` (`cmake/HglLanguage.cmake`, installed with `hgl`) runs
 `emit-cpp` as an `add_custom_command` per `.hgl` source, compiles the pairs

--- a/language/docs/user-guide/types-and-expressions.md
+++ b/language/docs/user-guide/types-and-expressions.md
@@ -113,9 +113,12 @@ are accessed by position, lists are sized and traversed.
 
 ## Imported values and references
 
-Status: agreed source semantics; implementation is separate from this design
-update. See [Type extensions](../design/type-extensions.md) for the complete
-agreement and the collection-reference mapping still under discussion.
+Status: partially implemented. Explicit `ref<T>` signatures, transparent
+underlying-type compatibility, opaque node access, forwarding, and fixed-list
+reference selection are available. Wiring-time access through a reference and
+imported native types remain compiler work. See
+[Type extensions](../design/type-extensions.md) for the complete agreement and
+the collection-reference mapping still under discussion.
 
 Imported C++ and Python types are scalar values, like `i64`, `f64`, and `str`.
 They are atomic leaves in a temporal signature, require no `atomic` annotation,
@@ -152,6 +155,11 @@ require the selecting node to copy and forward each value. A dynamic selector
 must nevertheless guard a readable index and selected entry, and observe both
 index changes and selected-reference rebinding. See the
 [routing example](../design/type-extensions.md#selecting-and-forwarding-a-reference).
+
+The executable form is in
+[`examples/reference-routing.hgl`](../../examples/reference-routing.hgl). The
+compiler rejects `map<K, ref<V>>` until its outer-reference rule is settled,
+and rejects nested `ref<ref<T>>` rather than normalizing it implicitly.
 
 ## SIGNAL inputs
 

--- a/language/examples/reference-routing.hgl
+++ b/language/examples/reference-routing.hgl
@@ -1,0 +1,14 @@
+module examples.reference_routing
+
+export fn forward(value: ref<f64>) -> ref<f64> {
+    when modified(value) && valid(value) {
+        return value
+    }
+}
+
+export fn route3<T>(index: i64, values: list<ref<T>, 3>) -> ref<T> {
+    when valid(index) && index >= 0 && index < 3 && valid(values[index]) &&
+         (modified(index) || modified(values[index])) {
+        return values[index]
+    }
+}

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -54,6 +54,7 @@ namespace hgl::codegen
                 Map,
                 Rolling,
                 Atomic,
+                Reference,
                 Generic,
                 Struct,
             };
@@ -515,9 +516,15 @@ namespace hgl::codegen
             void                                     emit_runtime_function(gir::CallableId id, Writer &out);
             [[nodiscard]] RuntimeInfo                runtime_info(gir::CallableId id);
             [[nodiscard]] std::optional<std::size_t> runtime_parameter(gir::ValueId id, gir::CallableId callable_id);
+            [[nodiscard]] std::optional<std::size_t> runtime_root_parameter(gir::ValueId id, gir::CallableId callable_id);
+            [[nodiscard]] std::optional<std::string> runtime_scalar_key(gir::ValueId id, gir::CallableId callable_id);
+            [[nodiscard]] std::optional<std::int64_t> runtime_integer_literal(gir::ValueId id,
+                                                                              gir::CallableId callable_id);
+            [[nodiscard]] std::optional<std::string> runtime_selector_key(gir::ValueId id, gir::CallableId callable_id);
             void collect_runtime_activation(gir::ValueId id, gir::CallableId callable_id, RuntimeInfo &info);
-            using RuntimeValidSet = std::unordered_set<std::size_t>;
+            using RuntimeValidSet = std::unordered_set<std::string>;
             void check_runtime_expr(gir::ValueId id, gir::CallableId callable_id, const RuntimeValidSet &valid);
+            void check_runtime_selector(gir::ValueId id, gir::CallableId callable_id, const RuntimeValidSet &valid);
             [[nodiscard]] RuntimeValidSet runtime_true_valid(gir::ValueId id, gir::CallableId callable_id,
                                                              const RuntimeValidSet &valid);
             void check_runtime_block(gir::BlockId id, gir::CallableId callable_id, const RuntimeValidSet &valid,
@@ -944,6 +951,14 @@ namespace hgl::codegen
                         result.children.push_back(planned_type(type.children.front(), range, bindings));
                         return result;
                     }
+                case TypeKind::Reference:
+                    {
+                        if (type.children.size() != 1U) { backend(range, "hgraph IR ref type requires one target type"); }
+                        HType result;
+                        result.kind = HType::Kind::Reference;
+                        result.children.push_back(planned_type(type.children.front(), range, bindings));
+                        return result;
+                    }
                 case TypeKind::Void:
                 case TypeKind::Iterator:
                 case TypeKind::Callable:
@@ -1144,6 +1159,7 @@ namespace hgl::codegen
                 case HType::Kind::List: unsupported(range, "a list value type");
                 case HType::Kind::Rolling: backend(range, "'rolling' has no value type; it is a time-series window");
                 case HType::Kind::Atomic: return value_type(type.children[0], range);
+                case HType::Kind::Reference: backend(range, "'ref' has no scalar value type");
                 case HType::Kind::Generic: return type.cpp_type;
                 case HType::Kind::Struct: return "typename " + type.cpp_type + "::value_type";
                 case HType::Kind::Unknown: break;
@@ -1170,6 +1186,7 @@ namespace hgl::codegen
                     }
                     return "hgraph::TSW<" + value_type(type.children[0], range) + ", " + type.size + ", " + type.min_size + ">";
                 case HType::Kind::Struct: return "typename " + type.cpp_type + "::time_series";
+                case HType::Kind::Reference: return "hgraph::REF<" + schema(type.children[0], range) + ">";
                 case HType::Kind::Generic: return "hgraph::TS<" + value_type(type, range) + ">";
                 case HType::Kind::Unknown: break;
             }
@@ -1659,6 +1676,18 @@ namespace hgl::codegen
                     } else if constexpr (std::is_same_v<T, gir::Index>) {
                         const Value target = eval_planned_expr(node.target, frame);
                         const Value index  = eval_planned_expr(node.index, frame);
+                        if (frame.runtime) {
+                            if (!target.is_runtime() || target.selector.empty() || target.type.kind != HType::Kind::List ||
+                                target.type.children.size() != 1U || target.type.children.front().kind != HType::Kind::Reference) {
+                                backend(expression.range,
+                                        "runtime indexing currently selects reference elements from a list input");
+                            }
+                            if ((!index.is_const() && !index.is_runtime()) || !index.type.is(hir::ScalarType::I64)) {
+                                fail(Category::Type, index.range, "a runtime list index is an i64 value");
+                            }
+                            const std::string selector = target.selector + "[static_cast<std::size_t>(" + index.code + ")]";
+                            return make_runtime(selector + ".value()", target.type.children.front(), expression.range, selector);
+                        }
                         if (!target.is_port()) { unsupported(expression.range, "indexing a constant"); }
                         const std::string marker = planned_operator_marker(
                             expression.operation.identity,
@@ -2606,6 +2635,66 @@ namespace hgl::codegen
             return std::nullopt;
         }
 
+        std::optional<std::size_t> Emitter::runtime_root_parameter(gir::ValueId id, gir::CallableId decl) {
+            if (const std::optional<std::size_t> parameter = runtime_parameter(id, decl)) { return parameter; }
+            const gir::Value &expression = planned_value(id, callable(decl).range);
+            if (const auto *index = std::get_if<gir::Index>(&expression.node)) {
+                return runtime_root_parameter(index->target, decl);
+            }
+            if (const auto *field = std::get_if<gir::Field>(&expression.node)) {
+                return runtime_root_parameter(field->target, decl);
+            }
+            return std::nullopt;
+        }
+
+        std::optional<std::string> Emitter::runtime_scalar_key(gir::ValueId id, gir::CallableId decl) {
+            const gir::Value &expression = planned_value(id, callable(decl).range);
+            if (const auto *reference = std::get_if<gir::Reference>(&expression.node);
+                reference != nullptr && reference->kind == gir::ReferenceKind::Binding) {
+                return "binding:" + std::to_string(reference->binding.value);
+            }
+            if (const auto *literal = std::get_if<gir::Literal>(&expression.node)) {
+                if (const auto *integer = std::get_if<std::int64_t>(&literal->value)) {
+                    return "integer:" + std::to_string(*integer);
+                }
+            }
+            return std::nullopt;
+        }
+
+        std::optional<std::int64_t> Emitter::runtime_integer_literal(gir::ValueId id, gir::CallableId decl) {
+            const gir::Value &expression = planned_value(id, callable(decl).range);
+            const auto       *literal    = std::get_if<gir::Literal>(&expression.node);
+            return literal == nullptr ? std::nullopt
+                                      : std::visit(
+                                            [](const auto &value) -> std::optional<std::int64_t> {
+                                                using T = std::decay_t<decltype(value)>;
+                                                if constexpr (std::is_same_v<T, std::int64_t>) { return value; }
+                                                return std::nullopt;
+                                            },
+                                            literal->value);
+        }
+
+        std::optional<std::string> Emitter::runtime_selector_key(gir::ValueId id, gir::CallableId decl) {
+            const gir::Value &expression = planned_value(id, callable(decl).range);
+            if (const std::optional<std::size_t> parameter = runtime_parameter(id, decl)) {
+                return "parameter:" + std::to_string(*parameter);
+            }
+            if (const auto *index = std::get_if<gir::Index>(&expression.node)) {
+                const std::optional<std::string> target = runtime_selector_key(index->target, decl);
+                if (!target) { return std::nullopt; }
+                if (const std::optional<std::string> subscript = runtime_scalar_key(index->index, decl)) {
+                    return *target + "[" + *subscript + "]";
+                }
+                return std::nullopt;
+            }
+            if (const auto *field = std::get_if<gir::Field>(&expression.node)) {
+                if (const std::optional<std::string> target = runtime_selector_key(field->target, decl)) {
+                    return *target + "." + field->name;
+                }
+            }
+            return std::nullopt;
+        }
+
         void Emitter::collect_runtime_activation(gir::ValueId id, gir::CallableId decl, RuntimeInfo &info) {
             const gir::Value &expression = planned_value(id, callable(decl).range);
             std::visit(
@@ -2617,10 +2706,10 @@ namespace hgl::codegen
                         if (reference != nullptr && reference->kind == gir::ReferenceKind::Intrinsic &&
                             reference->registry_name == "modified") {
                             for (const gir::Argument &argument : node.arguments) {
-                                const std::optional<std::size_t> parameter = runtime_parameter(argument.value, decl);
+                                const std::optional<std::size_t> parameter = runtime_root_parameter(argument.value, decl);
                                 if (!parameter) {
-                                    backend(argument.range, "the first runtime-node slice requires 'modified' arguments to be "
-                                                            "temporal parameters");
+                                    backend(argument.range,
+                                            "a generated runtime node requires 'modified' arguments to select a temporal input");
                                 }
                                 info.active_parameters.insert(*parameter);
                             }
@@ -2655,7 +2744,8 @@ namespace hgl::codegen
                     if constexpr (std::is_same_v<T, gir::Reference>) {
                         if (node.kind != gir::ReferenceKind::Binding) { return; }
                         const std::optional<std::size_t> parameter = runtime_parameter(id, decl);
-                        if (parameter && !valid.contains(*parameter)) {
+                        const std::optional<std::string> key       = runtime_selector_key(id, decl);
+                        if (parameter && (!key || !valid.contains(*key))) {
                             const gir::Binding &binding = planned_binding(node.binding, expression.range);
                             fail(Category::Type, expression.range,
                                  "temporal input '" + binding.name + "' may be invalid here; guard the read with valid(" +
@@ -2678,13 +2768,20 @@ namespace hgl::codegen
                         if (name == "valid" || name == "all_valid" || name == "modified" || name == "last_modified" ||
                             name == "last_modified_time") {
                             // Metadata intrinsics inspect endpoint selectors; they do not read payloads.
+                            for (const gir::Argument &argument : node.arguments) {
+                                check_runtime_selector(argument.value, decl, valid);
+                            }
                             return;
                         }
                         check_runtime_expr(node.callee, decl, valid);
                         for (const gir::Argument &argument : node.arguments) { check_runtime_expr(argument.value, decl, valid); }
                     } else if constexpr (std::is_same_v<T, gir::Index>) {
-                        check_runtime_expr(node.target, decl, valid);
-                        check_runtime_expr(node.index, decl, valid);
+                        check_runtime_selector(id, decl, valid);
+                        const std::optional<std::string> key = runtime_selector_key(id, decl);
+                        if (!key || !valid.contains(*key)) {
+                            fail(Category::Type, expression.range,
+                                 "selected temporal input may be invalid here; guard the read with valid(...)");
+                        }
                     } else if constexpr (std::is_same_v<T, gir::Field>) {
                         check_runtime_expr(node.target, decl, valid);
                     } else if constexpr (std::is_same_v<T, gir::Sequence>) {
@@ -2712,6 +2809,34 @@ namespace hgl::codegen
                 expression.node);
         }
 
+        void Emitter::check_runtime_selector(gir::ValueId id, gir::CallableId decl, const RuntimeValidSet &valid) {
+            const gir::Value &expression = planned_value(id, callable(decl).range);
+            if (const auto *index = std::get_if<gir::Index>(&expression.node)) {
+                check_runtime_selector(index->target, decl, valid);
+                check_runtime_expr(index->index, decl, valid);
+                const HType target = planned_type(planned_value(index->target, expression.range).type, expression.range);
+                if (target.kind != HType::Kind::List || target.size.empty()) {
+                    backend(expression.range, "safe runtime indexing currently requires a fixed-size list input");
+                }
+                const std::int64_t size = std::stoll(target.size);
+                if (const std::optional<std::int64_t> literal = runtime_integer_literal(index->index, decl)) {
+                    if (*literal < 0 || *literal >= size) {
+                        fail(Category::Type, planned_value(index->index, expression.range).range,
+                             "a fixed-list index is outside its valid range");
+                    }
+                    return;
+                }
+                const std::optional<std::string> subscript = runtime_scalar_key(index->index, decl);
+                if (!subscript || !valid.contains("nonnegative:" + *subscript) ||
+                    !valid.contains("below:" + *subscript + ":" + target.size)) {
+                    fail(Category::Type, planned_value(index->index, expression.range).range,
+                         "a dynamic fixed-list index must be guarded by 'index >= 0 && index < size'");
+                }
+            } else if (const auto *field = std::get_if<gir::Field>(&expression.node)) {
+                check_runtime_selector(field->target, decl, valid);
+            }
+        }
+
         Emitter::RuntimeValidSet Emitter::runtime_true_valid(gir::ValueId id, gir::CallableId decl, const RuntimeValidSet &valid) {
             check_runtime_expr(id, decl, valid);
             RuntimeValidSet   result     = valid;
@@ -2725,8 +2850,8 @@ namespace hgl::codegen
                                                                                       : std::string_view{reference->registry_name};
                 if (name == "valid" || name == "all_valid") {
                     for (const gir::Argument &argument : call->arguments) {
-                        if (const std::optional<std::size_t> parameter = runtime_parameter(argument.value, decl)) {
-                            result.insert(*parameter);
+                        if (const std::optional<std::string> key = runtime_selector_key(argument.value, decl)) {
+                            result.insert(*key);
                         }
                     }
                 }
@@ -2742,10 +2867,21 @@ namespace hgl::codegen
                 const RuntimeValidSet lhs = runtime_true_valid(binary->lhs, decl, valid);
                 const RuntimeValidSet rhs = runtime_true_valid(binary->rhs, decl, valid);
                 RuntimeValidSet       intersection;
-                for (const std::size_t index : lhs) {
-                    if (rhs.contains(index)) { intersection.insert(index); }
+                for (const std::string &selector : lhs) {
+                    if (rhs.contains(selector)) { intersection.insert(selector); }
                 }
                 return intersection;
+            }
+            if (binary->op == ir::hir::BinaryOp::GreaterEqual) {
+                const std::optional<std::string> index = runtime_scalar_key(binary->lhs, decl);
+                const std::optional<std::int64_t> bound = runtime_integer_literal(binary->rhs, decl);
+                if (index && bound == 0) { result.insert("nonnegative:" + *index); }
+            } else if (binary->op == ir::hir::BinaryOp::Less) {
+                const std::optional<std::string> index = runtime_scalar_key(binary->lhs, decl);
+                const std::optional<std::int64_t> bound = runtime_integer_literal(binary->rhs, decl);
+                if (index && bound && *bound > 0) {
+                    result.insert("below:" + *index + ":" + std::to_string(*bound));
+                }
             }
             return result;
         }
@@ -2795,9 +2931,10 @@ namespace hgl::codegen
             }
             if (has_planned_result(planned.result, planned.range)) {
                 const HType result = planned_type(planned.result, planned.range);
-                if (result.kind != HType::Kind::Scalar && result.kind != HType::Kind::Struct && result.kind != HType::Kind::Map) {
+                if (result.kind != HType::Kind::Scalar && result.kind != HType::Kind::Struct && result.kind != HType::Kind::Map &&
+                    result.kind != HType::Kind::Reference) {
                     backend(graph_type(planned.result, planned.range).range,
-                            "the runtime-node slice supports scalar, struct, and map outputs");
+                            "the runtime-node slice supports scalar, struct, map, and ref outputs");
                 }
             }
 
@@ -2809,9 +2946,9 @@ namespace hgl::codegen
                 if (binding.kind != expected) { backend(binding.range, "hgraph IR runtime parameter has the wrong binding kind"); }
                 const HType type = planned_type(parameter.type, planned.range);
                 if (type.kind != HType::Kind::Scalar && type.kind != HType::Kind::Map && type.kind != HType::Kind::Set &&
-                    type.kind != HType::Kind::List) {
+                    type.kind != HType::Kind::List && type.kind != HType::Kind::Reference) {
                     backend(graph_type(parameter.type, planned.range).range,
-                            "the runtime-node slice supports scalar and collection parameters");
+                            "the runtime-node slice supports scalar, collection, and ref parameters");
                 }
                 if (!parameter.is_const) { ++temporal_count; }
             }
@@ -2906,7 +3043,11 @@ namespace hgl::codegen
                 }
             }
             RuntimeValidSet valid;
-            if (!info.has_when) { valid = info.active_parameters; }
+            if (!info.has_when) {
+                for (const std::size_t parameter : info.active_parameters) {
+                    valid.insert("parameter:" + std::to_string(parameter));
+                }
+            }
             for (gir::StatementId id : body.statements) {
                 const gir::Statement &statement = planned_statement(id, body.range);
                 if (std::holds_alternative<gir::StateBinding>(statement.node) ||
@@ -3592,6 +3733,7 @@ namespace hgl::codegen
             header.line("#include <hgraph/types/static_schema.h>");
             header.line();
             header.line("#include <chrono>");
+            header.line("#include <cstddef>");
             header.line("#include <cstdint>");
             header.line("#include <limits>");
             header.line("#include <stdexcept>");

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -518,8 +518,8 @@ namespace hgl::codegen
             [[nodiscard]] std::optional<std::size_t> runtime_parameter(gir::ValueId id, gir::CallableId callable_id);
             [[nodiscard]] std::optional<std::size_t> runtime_root_parameter(gir::ValueId id, gir::CallableId callable_id);
             [[nodiscard]] std::optional<std::string> runtime_scalar_key(gir::ValueId id, gir::CallableId callable_id);
-            [[nodiscard]] std::optional<std::int64_t> runtime_integer_literal(gir::ValueId id,
-                                                                              gir::CallableId callable_id);
+            [[nodiscard]] std::optional<std::int64_t> runtime_integer_constant(gir::ValueId id,
+                                                                               gir::CallableId callable_id);
             [[nodiscard]] std::optional<std::string> runtime_selector_key(gir::ValueId id, gir::CallableId callable_id);
             void collect_runtime_activation(gir::ValueId id, gir::CallableId callable_id, RuntimeInfo &info);
             using RuntimeValidSet = std::unordered_set<std::string>;
@@ -2661,17 +2661,16 @@ namespace hgl::codegen
             return std::nullopt;
         }
 
-        std::optional<std::int64_t> Emitter::runtime_integer_literal(gir::ValueId id, gir::CallableId decl) {
+        std::optional<std::int64_t> Emitter::runtime_integer_constant(gir::ValueId id, gir::CallableId decl) {
             const gir::Value &expression = planned_value(id, callable(decl).range);
-            const auto       *literal    = std::get_if<gir::Literal>(&expression.node);
-            return literal == nullptr ? std::nullopt
-                                      : std::visit(
-                                            [](const auto &value) -> std::optional<std::int64_t> {
-                                                using T = std::decay_t<decltype(value)>;
-                                                if constexpr (std::is_same_v<T, std::int64_t>) { return value; }
-                                                return std::nullopt;
-                                            },
-                                            literal->value);
+            if (!expression.constant) { return std::nullopt; }
+            return std::visit(
+                [](const auto &value) -> std::optional<std::int64_t> {
+                    using T = std::decay_t<decltype(value)>;
+                    if constexpr (std::is_same_v<T, std::int64_t>) { return value; }
+                    return std::nullopt;
+                },
+                *expression.constant);
         }
 
         std::optional<std::string> Emitter::runtime_selector_key(gir::ValueId id, gir::CallableId decl) {
@@ -2819,7 +2818,7 @@ namespace hgl::codegen
                     backend(expression.range, "safe runtime indexing currently requires a fixed-size list input");
                 }
                 const std::int64_t size = std::stoll(target.size);
-                if (const std::optional<std::int64_t> literal = runtime_integer_literal(index->index, decl)) {
+                if (const std::optional<std::int64_t> literal = runtime_integer_constant(index->index, decl)) {
                     if (*literal < 0 || *literal >= size) {
                         fail(Category::Type, planned_value(index->index, expression.range).range,
                              "a fixed-list index is outside its valid range");
@@ -2874,11 +2873,11 @@ namespace hgl::codegen
             }
             if (binary->op == ir::hir::BinaryOp::GreaterEqual) {
                 const std::optional<std::string> index = runtime_scalar_key(binary->lhs, decl);
-                const std::optional<std::int64_t> bound = runtime_integer_literal(binary->rhs, decl);
+                const std::optional<std::int64_t> bound = runtime_integer_constant(binary->rhs, decl);
                 if (index && bound == 0) { result.insert("nonnegative:" + *index); }
             } else if (binary->op == ir::hir::BinaryOp::Less) {
                 const std::optional<std::string> index = runtime_scalar_key(binary->lhs, decl);
-                const std::optional<std::int64_t> bound = runtime_integer_literal(binary->rhs, decl);
+                const std::optional<std::int64_t> bound = runtime_integer_constant(binary->rhs, decl);
                 if (index && bound && *bound > 0) {
                     result.insert("below:" + *index + ":" + std::to_string(*bound));
                 }

--- a/language/src/descriptor/module_descriptor.cpp
+++ b/language/src/descriptor/module_descriptor.cpp
@@ -40,6 +40,7 @@ namespace hgl::descriptor
                 case TypeKind::Map: return TypeCategory::Map;
                 case TypeKind::Rolling: return TypeCategory::Rolling;
                 case TypeKind::Atomic: return TypeCategory::Atomic;
+                case TypeKind::Reference: return TypeCategory::Reference;
                 case TypeKind::Iterator: return TypeCategory::Iterator;
                 case TypeKind::Callable: return TypeCategory::Callable;
                 case TypeKind::Capability: return TypeCategory::Capability;

--- a/language/src/descriptor/module_descriptor.h
+++ b/language/src/descriptor/module_descriptor.h
@@ -38,6 +38,7 @@ namespace hgl::descriptor
         Map,
         Rolling,
         Atomic,
+        Reference,
         Iterator,
         Callable,
         Capability,

--- a/language/src/descriptor/module_descriptor_json.cpp
+++ b/language/src/descriptor/module_descriptor_json.cpp
@@ -46,6 +46,7 @@ namespace hgl::descriptor
                 case TypeCategory::Map: return "map";
                 case TypeCategory::Rolling: return "rolling";
                 case TypeCategory::Atomic: return "atomic";
+                case TypeCategory::Reference: return "ref";
                 case TypeCategory::Iterator: return "iterator";
                 case TypeCategory::Callable: return "callable";
                 case TypeCategory::Capability: return "capability";

--- a/language/src/descriptor/module_descriptor_reader.cpp
+++ b/language/src/descriptor/module_descriptor_reader.cpp
@@ -498,6 +498,7 @@ namespace hgl::descriptor
                                      {"map", TypeCategory::Map},
                                      {"rolling", TypeCategory::Rolling},
                                      {"atomic", TypeCategory::Atomic},
+                                     {"ref", TypeCategory::Reference},
                                      {"iterator", TypeCategory::Iterator},
                                      {"callable", TypeCategory::Callable},
                                      {"capability", TypeCategory::Capability},

--- a/language/src/descriptor/module_descriptor_reader.cpp
+++ b/language/src/descriptor/module_descriptor_reader.cpp
@@ -915,6 +915,7 @@ namespace hgl::descriptor
                     case TypeCategory::Set:
                     case TypeCategory::Rolling:
                     case TypeCategory::Atomic:
+                    case TypeCategory::Reference:
                     case TypeCategory::HarnessSequence: required_children = 1U; break;
                     case TypeCategory::Map: required_children = 2U; break;
                     case TypeCategory::Void:

--- a/language/src/hgraph_ir/printer.cpp
+++ b/language/src/hgraph_ir/printer.cpp
@@ -24,6 +24,7 @@ namespace hgl::hgraph_ir
                 case hir::TypeKind::Map: return "map";
                 case hir::TypeKind::Rolling: return "rolling";
                 case hir::TypeKind::Atomic: return "atomic";
+                case hir::TypeKind::Reference: return "ref";
                 case hir::TypeKind::Iterator: return "iterator";
                 case hir::TypeKind::Callable: return "callable";
                 case hir::TypeKind::Capability: return "capability";

--- a/language/src/ir/canonical_types.cpp
+++ b/language/src/ir/canonical_types.cpp
@@ -240,6 +240,8 @@ namespace hgl::ir::detail
         }
         if (to.kind == TypeKind::Atomic && !to.children.empty()) { return assignable(to.children.front(), actual); }
         if (from.kind == TypeKind::Atomic && !from.children.empty()) { return assignable(expected, from.children.front()); }
+        if (to.kind == TypeKind::Reference && !to.children.empty()) { return assignable(to.children.front(), actual); }
+        if (from.kind == TypeKind::Reference && !from.children.empty()) { return assignable(expected, from.children.front()); }
         const bool sequence_pair = (to.kind == TypeKind::List || to.kind == TypeKind::HarnessSequence) &&
                                    (from.kind == TypeKind::List || from.kind == TypeKind::HarnessSequence);
         if (to.kind == TypeKind::List && from.kind == TypeKind::List && to.size.valid()) {
@@ -272,6 +274,7 @@ namespace hgl::ir::detail
             case TypeKind::Map: return "map";
             case TypeKind::Rolling: return "rolling";
             case TypeKind::Atomic: return "atomic";
+            case TypeKind::Reference: return "ref";
             case TypeKind::Iterator: return "iterator";
             case TypeKind::Callable: return "fn";
             case TypeKind::Capability: return "capability";

--- a/language/src/ir/canonical_types.cpp
+++ b/language/src/ir/canonical_types.cpp
@@ -259,6 +259,41 @@ namespace hgl::ir::detail
         return false;
     }
 
+    bool CanonicalTypes::same_ignoring_references(TypeId lhs, TypeId rhs) const noexcept {
+        lhs = canonical(lhs);
+        rhs = canonical(rhs);
+        while (lhs.valid() && module_.type(lhs).kind == TypeKind::Reference && module_.type(lhs).children.size() == 1U) {
+            lhs = canonical(module_.type(lhs).children.front());
+        }
+        while (rhs.valid() && module_.type(rhs).kind == TypeKind::Reference && module_.type(rhs).children.size() == 1U) {
+            rhs = canonical(module_.type(rhs).children.front());
+        }
+        if (same(lhs, rhs)) { return true; }
+        if (!lhs.valid() || !rhs.valid()) { return false; }
+        const Type &left  = module_.type(lhs);
+        const Type &right = module_.type(rhs);
+        if (left.kind != right.kind || left.scalar != right.scalar || left.symbol != right.symbol ||
+            left.children.size() != right.children.size() || left.arguments.size() != right.arguments.size() ||
+            left.unbounded != right.unbounded || !same_value(left.size, right.size) ||
+            !same_value(left.min_size, right.min_size)) {
+            return false;
+        }
+        for (std::size_t index = 0; index < left.children.size(); ++index) {
+            if (!same_ignoring_references(left.children[index], right.children[index])) { return false; }
+        }
+        for (std::size_t index = 0; index < left.arguments.size(); ++index) {
+            const TypeArgument &a = left.arguments[index];
+            const TypeArgument &b = right.arguments[index];
+            if (a.kind != b.kind) { return false; }
+            if (a.kind == TypeArgumentKind::Type) {
+                if (!same_ignoring_references(a.type, b.type)) { return false; }
+            } else if (!same_value(a.value, b.value)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     bool CanonicalTypes::same_value(ExprId lhs, ExprId rhs) const { return value_key(lhs) == value_key(rhs); }
 
     std::string CanonicalTypes::name(TypeId id) const {

--- a/language/src/ir/canonical_types.h
+++ b/language/src/ir/canonical_types.h
@@ -30,6 +30,7 @@ namespace hgl::ir::detail
         [[nodiscard]] bool        numeric(hir::TypeId id) const noexcept;
         [[nodiscard]] bool        boolean(hir::TypeId id) const noexcept;
         [[nodiscard]] bool        assignable(hir::TypeId expected, hir::TypeId actual) const noexcept;
+        [[nodiscard]] bool        same_ignoring_references(hir::TypeId lhs, hir::TypeId rhs) const noexcept;
         [[nodiscard]] bool        same_value(hir::ExprId lhs, hir::ExprId rhs) const;
         [[nodiscard]] std::string name(hir::TypeId id) const;
 

--- a/language/src/ir/generic_substitution.cpp
+++ b/language/src/ir/generic_substitution.cpp
@@ -60,6 +60,12 @@ namespace hgl::ir::detail
         if (lhs.kind == TypeKind::Symbol && lhs.symbol.valid() && module_.symbol(lhs.symbol).kind == SymbolKind::TypeParameter) {
             return bind_type(lhs.symbol, actual);
         }
+        if (lhs.kind == TypeKind::Reference && rhs.kind != TypeKind::Reference && lhs.children.size() == 1U) {
+            return unify(lhs.children.front(), actual);
+        }
+        if (rhs.kind == TypeKind::Reference && lhs.kind != TypeKind::Reference && rhs.children.size() == 1U) {
+            return unify(pattern, rhs.children.front());
+        }
         if (lhs.kind != rhs.kind || lhs.scalar != rhs.scalar || lhs.symbol != rhs.symbol ||
             lhs.children.size() != rhs.children.size() || lhs.arguments.size() != rhs.arguments.size() ||
             lhs.unbounded != rhs.unbounded) {

--- a/language/src/ir/hir.h
+++ b/language/src/ir/hir.h
@@ -107,6 +107,7 @@ namespace hgl::ir::hir
         Map,
         Rolling,
         Atomic,
+        Reference,
         Iterator,
         Callable,
         Capability,

--- a/language/src/ir/hir_printer.cpp
+++ b/language/src/ir/hir_printer.cpp
@@ -66,6 +66,7 @@ namespace hgl::ir
                 case TypeKind::Map: return "map";
                 case TypeKind::Rolling: return "rolling";
                 case TypeKind::Atomic: return "atomic";
+                case TypeKind::Reference: return "ref";
                 case TypeKind::Iterator: return "iterator";
                 case TypeKind::Callable: return "callable";
                 case TypeKind::Capability: return "capability";

--- a/language/src/ir/lower.cpp
+++ b/language/src/ir/lower.cpp
@@ -55,6 +55,7 @@ namespace hgl::ir
                 case TypeKind::Map: return hir::TypeKind::Map;
                 case TypeKind::Rolling: return hir::TypeKind::Rolling;
                 case TypeKind::Atomic: return hir::TypeKind::Atomic;
+                case TypeKind::Reference: return hir::TypeKind::Reference;
             }
             std::unreachable();
         }

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -137,6 +137,27 @@ namespace hgl::ir
 
             [[nodiscard]] std::string type_name(TypeId id) const { return canonical_types_.name(id); }
 
+            [[nodiscard]] bool invalid_reference_shape(TypeId id) const {
+                id = canonical(id);
+                if (!id.valid()) { return false; }
+                const Type &value = type(id);
+                if (value.kind == TypeKind::Reference && value.children.size() == 1U) {
+                    const TypeId child = canonical(value.children.front());
+                    if (child.valid() && type(child).kind == TypeKind::Reference) { return true; }
+                }
+                if (value.kind == TypeKind::Map && value.children.size() == 2U) {
+                    const TypeId mapped = canonical(value.children[1]);
+                    if (mapped.valid() && type(mapped).kind == TypeKind::Reference) { return true; }
+                }
+                for (TypeId child : value.children) {
+                    if (invalid_reference_shape(child)) { return true; }
+                }
+                for (const TypeArgument &argument : value.arguments) {
+                    if (argument.kind == TypeArgumentKind::Type && invalid_reference_shape(argument.type)) { return true; }
+                }
+                return false;
+            }
+
             [[nodiscard]] std::string operator_identity(SymbolId id) const {
                 if (!id.valid()) { return {}; }
                 const Symbol &symbol = module_.symbol(id);
@@ -382,6 +403,7 @@ namespace hgl::ir
                 while (actual.valid() && type(actual).kind == TypeKind::Atomic && !type(actual).children.empty()) {
                     actual = type(actual).children.front();
                 }
+                if (canonical_types_.same_ignoring_references(expected, actual)) { return false; }
                 if (same(expected, actual) || !expected.valid() || !actual.valid()) { return false; }
                 const Type &to            = type(expected);
                 const Type &from          = type(actual);
@@ -1817,6 +1839,10 @@ namespace hgl::ir
                     }
                     if (std::holds_alternative<Call>(expression.node) && expression.operation.kind == OperationKind::None) {
                         diagnostics_.report(syntax::Category::Type, expression.range, "call has no semantic target");
+                    }
+                    if (expression.type.valid() && invalid_reference_shape(expression.type)) {
+                        diagnostics_.report(syntax::Category::Type, expression.range,
+                                            "generic substitution produces an unsupported reference shape");
                     }
                 }
             }

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -123,6 +123,10 @@ namespace hgl::ir
             [[nodiscard]] bool   same(TypeId lhs, TypeId rhs) const noexcept { return canonical_types_.same(lhs, rhs); }
             [[nodiscard]] bool   numeric(TypeId id) const noexcept { return canonical_types_.numeric(id); }
             [[nodiscard]] bool   boolean(TypeId id) const noexcept { return canonical_types_.boolean(id); }
+            [[nodiscard]] bool   reference(TypeId id) const noexcept {
+                id = canonical(id);
+                return id.valid() && type(id).kind == TypeKind::Reference;
+            }
             [[nodiscard]] bool   assignable(TypeId expected, TypeId actual) const noexcept {
                 return canonical_types_.assignable(expected, actual);
             }
@@ -563,6 +567,9 @@ namespace hgl::ir
 
             void check_unary(Expr &expression, const Unary &node) {
                 Expr &operand        = check_expr(node.operand);
+                if (runtime_owner(expression.owner) && reference(operand.type)) {
+                    type_error(operand.range, "node evaluation cannot read through ref<T>");
+                }
                 expression.effects   = operand.effects;
                 expression.phase     = operand.phase;
                 expression.operation = Operation{.kind     = OperationKind::NominalOperator,
@@ -795,6 +802,9 @@ namespace hgl::ir
             void check_binary(Expr &expression, const Binary &node, TypeId expected) {
                 Expr &lhs = check_expr(node.lhs);
                 Expr &rhs = check_expr(node.rhs, lhs.type.valid() ? lhs.type : expected);
+                if (runtime_owner(expression.owner) && (reference(lhs.type) || reference(rhs.type))) {
+                    type_error(expression.range, "node evaluation cannot read through ref<T>");
+                }
                 if (!lhs.type.valid() && rhs.type.valid()) { contextualize(lhs, rhs.type); }
                 expression.phase     = join_phase(lhs.phase, rhs.phase);
                 expression.effects   = lhs.effects | rhs.effects;
@@ -1181,6 +1191,10 @@ namespace hgl::ir
             void check_index(Expr &expression, const Index &node) {
                 Expr  &target  = check_expr(node.target);
                 Expr  &index   = check_expr(node.index);
+                if (runtime_owner(expression.owner) && reference(target.type)) {
+                    type_error(target.range, "node evaluation cannot index through ref<T>");
+                    return;
+                }
                 TypeId base_id = unwrap_atomic(target.type);
                 if (!base_id.valid()) { return; }
                 const Type &base = type(base_id);
@@ -1220,6 +1234,10 @@ namespace hgl::ir
                     expression.operation  = Operation{.kind     = OperationKind::Capability,
                                                       .target   = reference->symbol,
                                                       .identity = module_.symbol(reference->symbol).name + "." + node.name};
+                    return;
+                }
+                if (runtime_owner(expression.owner) && reference(target.type)) {
+                    type_error(target.range, "node evaluation cannot access fields through ref<T>");
                     return;
                 }
                 const TypeId base_id = unwrap_atomic(target.type);
@@ -1359,6 +1377,9 @@ namespace hgl::ir
                     if (const FunctionDecl *fn = function(expression.owner)) { expected = fn->signature.result; }
                 }
                 Expr &condition = check_expr(node.condition, scalar(ScalarType::Bool));
+                if (runtime_owner(expression.owner) && reference(condition.type)) {
+                    type_error(condition.range, "node evaluation cannot test a value through ref<T>");
+                }
                 require_assignable(scalar(ScalarType::Bool), condition, "if condition");
                 check_block(node.then_block, expected);
                 expression.effects      = condition.effects | module_.block(node.then_block).effects;

--- a/language/src/semantics/resolve.cpp
+++ b/language/src/semantics/resolve.cpp
@@ -596,10 +596,10 @@ namespace hgl::semantics
                                "const generic '" + std::string{parameter.name.text} + "' takes a value argument");
                     } else {
                         const ast::TypeKind kind = module_.type(argument.type).kind;
-                        if (kind == ast::TypeKind::Atomic || kind == ast::TypeKind::Rolling) {
+                        if (kind == ast::TypeKind::Atomic || kind == ast::TypeKind::Rolling || kind == ast::TypeKind::Reference) {
                             report(Category::Type, argument.range,
                                    "generic struct type arguments are canonical value types; put "
-                                   "'atomic' or 'rolling' in the field declaration");
+                                   "the temporal shape in the field declaration");
                         }
                     }
                     return;
@@ -639,10 +639,22 @@ namespace hgl::semantics
 
             void resolve_type(ast::TypeId id, Context &context) {
                 const ast::Type &type = module_.type(id);
-                if (type.value_position && (type.kind == ast::TypeKind::Atomic || type.kind == ast::TypeKind::Rolling)) {
+                if (type.value_position && (type.kind == ast::TypeKind::Atomic || type.kind == ast::TypeKind::Rolling ||
+                                            type.kind == ast::TypeKind::Reference)) {
+                    const std::string_view spelling = type.kind == ast::TypeKind::Atomic    ? "atomic"
+                                                      : type.kind == ast::TypeKind::Rolling ? "rolling"
+                                                                                            : "ref";
                     report(Category::Type, type.range,
-                           std::string{"'"} + (type.kind == ast::TypeKind::Atomic ? "atomic" : "rolling") +
-                               "' is a temporal shape, not a canonical value type");
+                           "'" + std::string{spelling} + "' is a temporal shape, not a canonical value type");
+                }
+                if (type.kind == ast::TypeKind::Reference && type.children.size() == 1U &&
+                    module_.type(type.children.front()).kind == ast::TypeKind::Reference) {
+                    report(Category::Type, type.range, "nested 'ref' boundaries are not supported");
+                }
+                if (type.kind == ast::TypeKind::Map && type.children.size() == 2U &&
+                    module_.type(type.children[1]).kind == ast::TypeKind::Reference) {
+                    report(Category::Type, type.range,
+                           "map values wrapped in 'ref' require the collection-reference mapping to be resolved");
                 }
                 if (type.kind == ast::TypeKind::Named) {
                     if (!type.qualifier.empty()) {

--- a/language/src/syntax/ast.h
+++ b/language/src/syntax/ast.h
@@ -67,6 +67,7 @@ namespace hgl::syntax::ast
         Map,      ///< `children[0]` key, `children[1]` value
         Rolling,  ///< `children[0]`, `size` max, `min_size` (no_node = omitted)
         Atomic,   ///< `children[0]`
+        Reference,  ///< `ref<children[0]>`
     };
 
     /// One argument of an applied nominal type. A bare identifier is kept

--- a/language/src/syntax/ast_printer.cpp
+++ b/language/src/syntax/ast_printer.cpp
@@ -54,6 +54,7 @@ namespace hgl::syntax
                 case ast::TypeKind::Map: return "map";
                 case ast::TypeKind::Rolling: return "rolling";
                 case ast::TypeKind::Atomic: return "atomic";
+                case ast::TypeKind::Reference: return "ref";
             }
             return "?";
         }

--- a/language/src/syntax/ast_projection.cpp
+++ b/language/src/syntax/ast_projection.cpp
@@ -298,6 +298,10 @@ namespace hgl::syntax
                         type.kind = ast::TypeKind::Atomic;
                         type.children.push_back(project_type(only_child(id, SyntaxKind::Type), true));
                         break;
+                    case SyntaxKind::RefType:
+                        type.kind = ast::TypeKind::Reference;
+                        type.children.push_back(project_type(only_child(id, SyntaxKind::Type), value_position));
+                        break;
                     default: malformed("expected a type production");
                 }
                 return module_.add(std::move(type));
@@ -883,6 +887,7 @@ namespace hgl::syntax
                         case SyntaxKind::MapType:
                         case SyntaxKind::RollingType:
                         case SyntaxKind::AtomicType:
+                        case SyntaxKind::RefType:
                             {
                                 const ast::TypeId type = project_type(value, true);
                                 return module_.add(ast::Constraint{module_.type(type).range, ast::ConstraintType{type}});

--- a/language/src/syntax/syntax_tree.cpp
+++ b/language/src/syntax/syntax_tree.cpp
@@ -26,6 +26,7 @@ namespace hgl::syntax
             KindName{SyntaxKind::MapType, "map_type"},
             KindName{SyntaxKind::RollingType, "rolling_type"},
             KindName{SyntaxKind::AtomicType, "atomic_type"},
+            KindName{SyntaxKind::RefType, "ref_type"},
             KindName{SyntaxKind::Type, "type"},
             KindName{SyntaxKind::SizeExpression, "size_expression"},
             KindName{SyntaxKind::ContinuedOperator, "continued_operator"},

--- a/language/src/syntax/syntax_tree.h
+++ b/language/src/syntax/syntax_tree.h
@@ -34,6 +34,7 @@ namespace hgl::syntax
         MapType,
         RollingType,
         AtomicType,
+        RefType,
         Type,
         SizeExpression,
         ContinuedOperator,

--- a/language/src/syntax/token_grammar.cpp
+++ b/language/src/syntax/token_grammar.cpp
@@ -26,6 +26,7 @@ namespace hgl::syntax
             Set,
             Map,
             Rolling,
+            Ref,
             Unbounded,
             Delta,
             AppliedConstructor,
@@ -42,7 +43,8 @@ namespace hgl::syntax
         inline constexpr auto contextual_name = contextual<ContextToken::In> / contextual<ContextToken::Atomic> /
                                                 contextual<ContextToken::Tuple> / contextual<ContextToken::List> /
                                                 contextual<ContextToken::Set> / contextual<ContextToken::Map> /
-                                                contextual<ContextToken::Rolling> / contextual<ContextToken::Unbounded> /
+                                                contextual<ContextToken::Rolling> / contextual<ContextToken::Ref> /
+                                                contextual<ContextToken::Unbounded> /
                                                 contextual<ContextToken::Delta> / contextual<ContextToken::AppliedConstructor>;
         inline constexpr auto reserved_name =
             token_choice<TokenKind::KwModule, TokenKind::KwUse, TokenKind::KwAs, TokenKind::KwExport, TokenKind::KwAbstract,
@@ -162,16 +164,24 @@ namespace hgl::syntax
                                              dsl::recurse<type> + dsl::p<newlines> + token<TokenKind::Greater>;
         };
 
+        struct ref_type
+        {
+            static constexpr auto rule = dsl::peek(contextual<ContextToken::Ref> + token<TokenKind::Less>) >>
+                                         contextual<ContextToken::Ref> + token<TokenKind::Less> + dsl::p<newlines> +
+                                             dsl::recurse<type> + dsl::p<newlines> + token<TokenKind::Greater>;
+        };
+
         struct type
         {
             static constexpr auto rule = scalar_type | dsl::p<tuple_type> | dsl::p<list_type> | dsl::p<set_type> |
-                                         dsl::p<map_type> | dsl::p<rolling_type> | dsl::p<atomic_type> | dsl::p<named_type>;
+                                         dsl::p<map_type> | dsl::p<rolling_type> | dsl::p<atomic_type> | dsl::p<ref_type> |
+                                         dsl::p<named_type>;
         };
 
         struct generic_argument
         {
             static constexpr auto rule = scalar_type | dsl::p<tuple_type> | dsl::p<list_type> | dsl::p<set_type> |
-                                         dsl::p<map_type> | dsl::p<rolling_type> | dsl::p<atomic_type> |
+                                         dsl::p<map_type> | dsl::p<rolling_type> | dsl::p<atomic_type> | dsl::p<ref_type> |
                                          dsl::peek(ordinary_name + (token<TokenKind::Less> / token<TokenKind::ColonColon>)) >>
                                              dsl::p<named_type> |
                                          dsl::peek(expression_start) >> dsl::recurse<size_expression>;
@@ -528,7 +538,7 @@ namespace hgl::syntax
                                                 token<TokenKind::KwNull> / token<TokenKind::Minus>;
             static constexpr auto rule =
                 dsl::p<constraint_set> | scalar_type | dsl::p<tuple_type> | dsl::p<list_type> | dsl::p<set_type> |
-                dsl::p<map_type> | dsl::p<rolling_type> | dsl::p<atomic_type> | dsl::p<constraint_call> |
+                dsl::p<map_type> | dsl::p<rolling_type> | dsl::p<atomic_type> | dsl::p<ref_type> | dsl::p<constraint_call> |
                 dsl::peek(ordinary_name + (token<TokenKind::Less> / token<TokenKind::ColonColon>)) >> dsl::p<named_type> |
                 dsl::peek(value_start) >> dsl::recurse<size_expression> | dsl::p<name>;
         };
@@ -707,6 +717,7 @@ namespace hgl::syntax
                 if (token.text == "set") { return static_cast<std::uint8_t>(grammar::ContextToken::Set); }
                 if (token.text == "map") { return static_cast<std::uint8_t>(grammar::ContextToken::Map); }
                 if (token.text == "rolling") { return static_cast<std::uint8_t>(grammar::ContextToken::Rolling); }
+                if (token.text == "ref") { return static_cast<std::uint8_t>(grammar::ContextToken::Ref); }
                 if (token.text == "unbounded") { return static_cast<std::uint8_t>(grammar::ContextToken::Unbounded); }
             }
             return static_cast<std::uint8_t>(token.kind);

--- a/language/src/wiring/operator_types.cpp
+++ b/language/src/wiring/operator_types.cpp
@@ -73,8 +73,12 @@ namespace hgl::wiring
                         expected != nullptr && !signatures.empty() && std::ranges::all_of(signatures, [](const auto &signature) {
                             return signature.output_pattern && signature.output_pattern->starts_with("REF[");
                         });
-                    const hgraph::TSValueTypeMetaData *dispatch_expected = reference_output ? registry_.ref(expected) : expected;
-                    const hgraph::ResolvedOperatorCall resolved          = hgraph::OperatorRegistry::instance().resolve(
+                    const hir::TypeId expected_id = canonical(query.expected_result);
+                    const bool        explicit_reference =
+                        expected_id.valid() && module_.type(expected_id).kind == hir::TypeKind::Reference;
+                    const hgraph::TSValueTypeMetaData *dispatch_expected =
+                        reference_output && !explicit_reference ? registry_.ref(expected) : expected;
+                    const hgraph::ResolvedOperatorCall resolved = hgraph::OperatorRegistry::instance().resolve(
                         query.identity, arguments, dispatch_expected == nullptr ? std::nullopt : std::optional<bool>{true},
                         dispatch_expected);
                     selection.candidate_label = resolved.impl->label;
@@ -187,6 +191,7 @@ namespace hgl::wiring
                     case hir::TypeKind::Atomic:
                         if (!type.children.empty()) { result = value(type.children.front()); }
                         break;
+                    case hir::TypeKind::Reference: break;
                     case hir::TypeKind::Symbol:
                     case hir::TypeKind::Rolling:
                     case hir::TypeKind::Void:
@@ -262,6 +267,11 @@ namespace hgl::wiring
                             if (const auto *meta = value(type.children.front())) { result = registry_.ts(meta); }
                         }
                         break;
+                    case hir::TypeKind::Reference:
+                        if (!type.children.empty()) {
+                            if (const auto *target = schema(type.children.front())) { result = registry_.ref(target); }
+                        }
+                        break;
                     case hir::TypeKind::Symbol:
                     case hir::TypeKind::Tuple:
                     case hir::TypeKind::Void:
@@ -280,10 +290,18 @@ namespace hgl::wiring
 
             [[nodiscard]] hir::TypeId type_for_schema(const hgraph::TSValueTypeMetaData *target) {
                 if (target == nullptr) { return {}; }
+                if (target->kind == hgraph::TSTypeKind::REF) {
+                    if (const auto found = schema_ids_.find(target); found != schema_ids_.end()) { return found->second; }
+                    const std::size_t count = module_.types.size();
+                    for (std::uint32_t index = 0; index < count; ++index) {
+                        const hir::TypeId candidate{index};
+                        if (schema(candidate) == target) { return canonical(candidate); }
+                    }
+                }
                 // Wiring returns a REF for source-style operators such as
                 // schedule. HGL's surface type denotes the referenced signal,
-                // so recover that canonical type rather than making callers
-                // model the runtime's transport wrapper.
+                // so recover that canonical type when source did not explicitly
+                // declare a ref<T> result.
                 while (target != nullptr && target->kind == hgraph::TSTypeKind::REF) { target = target->referenced_ts(); }
                 if (target != nullptr && target->kind == hgraph::TSTypeKind::SIGNAL && target->value_schema != nullptr) {
                     target = registry_.ts(target->value_schema);

--- a/language/src/wiring/type_bridge.cpp
+++ b/language/src/wiring/type_bridge.cpp
@@ -294,6 +294,9 @@ namespace hgl::wiring
             case hir::TypeKind::Atomic:
                 if (!type.children.empty()) { return value(type.children.front(), bindings); }
                 return nullptr;
+            case hir::TypeKind::Reference:
+                report(type.range, "'ref' has no value type; it is an opaque time-series reference");
+                return nullptr;
             case hir::TypeKind::Rolling:
                 report(type.range, "'rolling' has no value type; it is a time-series window");
                 return nullptr;
@@ -411,6 +414,13 @@ namespace hgl::wiring
                 if (!type.children.empty()) {
                     if (const hgraph::ValueTypeMetaData *meta = value(type.children.front(), bindings)) {
                         return registry_.ts(meta);
+                    }
+                }
+                return nullptr;
+            case hir::TypeKind::Reference:
+                if (!type.children.empty()) {
+                    if (const hgraph::TSValueTypeMetaData *target = schema(type.children.front(), bindings)) {
+                        return registry_.ref(target);
                     }
                 }
                 return nullptr;

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -212,10 +212,13 @@ hgl_add_module(hgl_collection_fixture STATIC HGL ../examples/collection-views.hg
 hgl_apply_warnings(hgl_collection_fixture)
 hgl_add_module(hgl_stateful_fixture STATIC HGL ../examples/stateful-node.hgl)
 hgl_apply_warnings(hgl_stateful_fixture)
+hgl_add_module(hgl_reference_fixture STATIC HGL ../examples/reference-routing.hgl)
+hgl_apply_warnings(hgl_reference_fixture)
 
 set(_hgl_generated_test_sources
     codegen/generated_tests.cpp
     codegen/generated_runtime_tests.cpp
+    codegen/generated_reference_tests.cpp
     codegen/generated_structural_tests.cpp
     codegen/generated_generic_tests.cpp
 )
@@ -225,6 +228,7 @@ set(_hgl_generated_test_libraries
     hgl_generic_fixture
     hgl_collection_fixture
     hgl_stateful_fixture
+    hgl_reference_fixture
 )
 if(TARGET hgraph::analytics)
     # These two examples intentionally exercise an imported extension. Keep

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -1312,6 +1312,18 @@ export fn wrong(index: i64, values: list<ref<f64>, 3>) -> ref<f64> {
         CHECK_FALSE(unit.emit());
         CHECK(unit.has(Category::Type, "a dynamic fixed-list index must be guarded"));
     }
+
+    SECTION("a folded constant proves the upper bound") {
+        Unit unit{R"(
+module t
+export fn select(index: i64, values: list<ref<f64>, 3>) -> ref<f64> {
+    when modified(index, values) && valid(index) && index >= 0 && index < 1 + 2 && valid(values[index]) {
+        return values[index]
+    }
+}
+)"};
+        CHECK(unit.emit());
+    }
 }
 
 TEST_CASE("emit-cpp escapes C++ keywords and its own names", "[codegen]") {

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -1254,6 +1254,66 @@ export fn logged(value: f64) -> f64 {
     CHECK(contains(emitted->header, "logger.log(2, hgraph::Str{\"value\"});"));
 }
 
+TEST_CASE("emit-cpp preserves explicit reference schemas", "[codegen][ref]") {
+    Unit       unit{R"(
+module t
+
+export fn forward(value: ref<f64>) -> ref<f64> {
+    when modified(value) && valid(value) {
+        return value
+    }
+}
+)"};
+    const auto emitted = unit.emit();
+    REQUIRE(emitted);
+
+    CHECK(contains(emitted->descriptor, "\"kind\": \"ref\""));
+    CHECK(contains(emitted->header, "hgraph::In<\"value\", hgraph::REF<hgraph::TS<hgraph::Float>>"));
+    CHECK(contains(emitted->header, "hgraph::Out<hgraph::REF<hgraph::TS<hgraph::Float>>>"));
+    CHECK(contains(emitted->header, "hgl_output.set(value.value());"));
+}
+
+TEST_CASE("emit-cpp proves selected reference validity by selector", "[codegen][ref][validity]") {
+    SECTION("a different selected child is not covered") {
+        Unit unit{R"(
+module t
+export fn wrong(values: list<ref<f64>, 3>) -> ref<f64> {
+    when modified(values) && valid(values[0]) {
+        return values[1]
+    }
+}
+)"};
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Type, "selected temporal input may be invalid here"));
+    }
+
+    SECTION("a selector index must itself be valid") {
+        Unit unit{R"(
+module t
+export fn wrong(index: i64, values: list<ref<f64>, 3>) -> ref<f64> {
+    when modified(values) && valid(values[index]) {
+        return values[index]
+    }
+}
+)"};
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Type, "temporal input 'index' may be invalid here"));
+    }
+
+    SECTION("a dynamic selector index must be range guarded") {
+        Unit unit{R"(
+module t
+export fn wrong(index: i64, values: list<ref<f64>, 3>) -> ref<f64> {
+    when modified(index, values) && valid(index) && valid(values[index]) {
+        return values[index]
+    }
+}
+)"};
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Type, "a dynamic fixed-list index must be guarded"));
+    }
+}
+
 TEST_CASE("emit-cpp escapes C++ keywords and its own names", "[codegen]") {
     Unit       unit{R"(
 module t.new

--- a/language/tests/codegen/generated_reference_tests.cpp
+++ b/language/tests/codegen/generated_reference_tests.cpp
@@ -1,0 +1,40 @@
+#include <reference-routing.h>
+
+#include "wiring/backend.h"
+
+#include <hgraph/lib/testing/check_output.h>
+#include <hgraph/lib/testing/eval_node.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace hgraph;
+using namespace hgraph::testing;
+namespace reference_routing = examples::reference_routing;
+
+namespace
+{
+    struct RouteFirst
+    {
+        static Port<TS<Float>>
+        compose(Wiring &w, Port<TS<Float>> first, Port<TS<Float>> second, Port<TS<Float>> third) {
+            auto index = wire<stdlib::const_, TS<Int>>(w, Int{0});
+            auto values = stdlib::to_tsl<TSL<TS<Float>, 3>>(w, first, second, third);
+            return wire<reference_routing::operators::route3>(w, index, values).as<TS<Float>>();
+        }
+    };
+}  // namespace
+
+TEST_CASE("generated reference operators retain their public schema", "[codegen][generated][ref]") {
+    hgl::wiring::ensure_session();
+    (void)reference_routing::register_operators();
+
+    CHECK(hgl::wiring::has_operator("examples.reference_routing.forward"));
+}
+
+TEST_CASE("generated reference routing follows the selected source", "[codegen][generated][ref]") {
+    hgl::wiring::ensure_session();
+    (void)reference_routing::register_operators();
+
+    CHECK(eval_node<RouteFirst>(values<Float>(1.0, 2.0), values<Float>(10.0, 20.0), values<Float>(100.0, 200.0)) ==
+          values<Float>(1.0, 2.0));
+}

--- a/language/tests/descriptor/module_descriptor_reader_tests.cpp
+++ b/language/tests/descriptor/module_descriptor_reader_tests.cpp
@@ -239,6 +239,13 @@ TEST_CASE("module descriptor reader rejects malformed schema records", "[descrip
                     "type requires exactly 2 children");
     }
 
+    SECTION("reference type has the wrong child count") {
+        source.types.front().category = descriptor::TypeCategory::Reference;
+        source.types.front().scalar_name.clear();
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.schema.types[0].children",
+                    "type requires exactly 1 child");
+    }
+
     SECTION("leaf type has children") {
         source.types.push_back(source.types.front());
         source.types.front().children = {1U};

--- a/language/tests/descriptor/module_descriptor_reader_tests.cpp
+++ b/language/tests/descriptor/module_descriptor_reader_tests.cpp
@@ -31,6 +31,7 @@ namespace
                 .binding_identity = "checks.reader.map::T",
                 .arguments = {{descriptor::TypeArgumentCategory::Type, 0U}, {descriptor::TypeArgumentCategory::Constant, 0U}}},
             descriptor::TypeRecord{.category = descriptor::TypeCategory::Rolling, .children = {1U}, .size = 0U},
+            descriptor::TypeRecord{.category = descriptor::TypeCategory::Reference, .children = {0U}},
         };
 
         descriptor::ConstantExpressionRecord integer;

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -991,6 +991,62 @@ fn total(value: f64) -> f64 {
     CHECK(hir::has_effect(fn->effects, hir::Effect::UseCapability));
 }
 
+TEST_CASE("typed HIR keeps node reference inputs opaque", "[ir][typed][ref]") {
+    const auto rejects = [](std::string source, std::string_view message) {
+        Lowered lowered{std::move(source)};
+        require_clean(lowered);
+        CHECK_FALSE(complete(lowered));
+        INFO(lowered.diagnostics.render(lowered.file));
+        CHECK(lowered.diagnostics.render(lowered.file).find(message) != std::string::npos);
+    };
+
+    rejects(R"(
+module checks.reference_arithmetic
+fn invalid(value: ref<f64>) -> f64 {
+    when modified(value) {
+        return value + 1.0
+    }
+}
+)",
+            "node evaluation cannot read through ref<T>");
+
+    rejects(R"(
+module checks.reference_index
+fn invalid(value: ref<list<f64, 3>>) -> f64 {
+    when modified(value) {
+        return value[0]
+    }
+}
+)",
+            "node evaluation cannot index through ref<T>");
+
+    rejects(R"(
+module checks.reference_field
+struct Quote {
+    price: f64
+}
+fn invalid(value: ref<Quote>) -> f64 {
+    when modified(value) {
+        return value.price
+    }
+}
+)",
+            "node evaluation cannot access fields through ref<T>");
+
+    rejects(R"(
+module checks.reference_condition
+fn invalid(value: ref<bool>) -> bool {
+    when modified(value) {
+        if value {
+            return true
+        }
+        return false
+    }
+}
+)",
+            "node evaluation cannot test a value through ref<T>");
+}
+
 TEST_CASE("typed HIR validates an explicit lambda against collection context", "[ir][typed][lambdas]") {
     Lowered lowered{R"(
 module checks.lambda_context

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -555,6 +555,32 @@ fn wrong() -> f64 {
     CHECK(lowered.hir.completion == hir::Completion::Resolved);
 }
 
+TEST_CASE("typed HIR unifies structured generics through reference boundaries", "[ir][typed][generics][ref]") {
+    Lowered lowered{R"(
+module checks.reference_substitution
+
+fn route3<T>(values: list<ref<T>, 3>, const index: i64) -> ref<T> => values[index]
+fn select_plain(values: list<f64, 3>) -> ref<f64> => route3(values, 0)
+)"};
+    require_clean(lowered);
+    CHECK(complete(lowered));
+    INFO(lowered.diagnostics.render(lowered.file));
+    CHECK_FALSE(lowered.diagnostics.has_errors());
+}
+
+TEST_CASE("typed HIR rejects nested references formed by generic substitution", "[ir][typed][generics][ref]") {
+    Lowered lowered{R"(
+module checks.nested_reference_substitution
+
+fn wrap<T>(value: T) -> ref<T> => value
+fn invalid(value: ref<f64>) -> ref<f64> => wrap(value)
+)"};
+    require_clean(lowered);
+    CHECK_FALSE(complete(lowered));
+    CHECK(lowered.diagnostics.render(lowered.file).find("generic substitution produces an unsupported reference shape") !=
+          std::string::npos);
+}
+
 TEST_CASE("typed HIR admits and rejects closed callable requirements", "[ir][typed][constraints]") {
     Lowered lowered{R"(
 module checks.constraints

--- a/language/tests/semantics/resolve_tests.cpp
+++ b/language/tests/semantics/resolve_tests.cpp
@@ -123,6 +123,34 @@ TEST_CASE("only the kernel modules link in the first pass", "[semantics]") {
     CHECK(resolved.has(Category::Module, "hgraph.std does not export 'nothing_like_this'"));
 }
 
+TEST_CASE("reference types are temporal shapes with value-position restrictions", "[semantics][ref]") {
+    const Resolved valid = resolve_clean(R"(
+module checks.references
+
+fn forward(value: ref<f64>) -> ref<f64> => value
+fn select(values: list<ref<f64>, 3>, const index: i64) -> ref<f64> => values[index]
+)");
+    CHECK_FALSE(valid.diagnostics.has_errors());
+
+    const Resolved key{R"(
+module checks.reference_key
+fn invalid(value: map<ref<i64>, str>) => value
+)"};
+    CHECK(key.has(Category::Type, "'ref' is a temporal shape, not a canonical value type"));
+
+    const Resolved mapped{R"(
+module checks.reference_value
+fn invalid(value: map<i64, ref<str>>) => value
+)"};
+    CHECK(mapped.has(Category::Type, "map values wrapped in 'ref' require the collection-reference mapping to be resolved"));
+
+    const Resolved nested{R"(
+module checks.nested_reference
+fn invalid(value: ref<ref<i64>>) => value
+)"};
+    CHECK(nested.has(Category::Type, "nested 'ref' boundaries are not supported"));
+}
+
 TEST_CASE("names resolve through the scope chain", "[semantics]") {
     const Resolved resolved = resolve_clean(R"(
 module t
@@ -349,6 +377,13 @@ struct Box<T> { value: T }
 fn bad(x: Box<atomic<f64>>) => x
 )"};
     CHECK(temporal_argument.has(Category::Type, "generic struct type arguments are canonical value types"));
+
+    const Resolved reference_argument{R"(
+module t
+struct Box<T> { value: T }
+fn bad(x: Box<ref<f64>>) => x
+)"};
+    CHECK(reference_argument.has(Category::Type, "generic struct type arguments are canonical value types"));
 }
 
 TEST_CASE("requires clauses bind reflection and nominal operators", "[semantics]") {

--- a/language/tests/syntax/parser_tests.cpp
+++ b/language/tests/syntax/parser_tests.cpp
@@ -351,6 +351,14 @@ TEST_CASE("container types", "[parser]") {
                                                    "  Type tuple (value)\n"
                                                    "    Type scalar f64 (value)\n"
                                                    "    Type scalar f64 (value)\n");
+    REQUIRE(type_dump("ref<map<str, f64>>") == "Type ref\n"
+                                               "  Type map\n"
+                                               "    Type scalar str (value)\n"
+                                               "    Type scalar f64\n");
+    REQUIRE(type_dump("list<ref<f64>, 3>") == "Type list\n"
+                                              "  Type ref\n"
+                                              "    Type scalar f64\n"
+                                              "  size: IntLiteral 3\n");
     REQUIRE(type_dump("map<str, list<f64, 2>>") == "Type map\n"
                                                    "  Type scalar str (value)\n"
                                                    "  Type list\n"
@@ -360,6 +368,7 @@ TEST_CASE("container types", "[parser]") {
 
 TEST_CASE("container names are ordinary names without a generic list", "[parser]") {
     REQUIRE(type_dump("rolling") == "Type named rolling\n");
+    REQUIRE(type_dump("ref") == "Type named ref\n");
     REQUIRE(expr_dump("list(1, 2)") == "Call\n"
                                        "  callee: NameRef list\n"
                                        "  Argument\n"

--- a/language/tests/wiring/operator_types_tests.cpp
+++ b/language/tests/wiring/operator_types_tests.cpp
@@ -112,6 +112,28 @@ fn heartbeat(const every: duration) -> datetime => last_modified(schedule(every)
     CHECK(found);
 }
 
+TEST_CASE("native operator typing preserves an explicit reference result", "[ir][operator-types][ref]") {
+    Unit unit{R"(
+module checks.reference_result
+use hgraph.std::{downcast_ref}
+
+fn keep(value: ref<f64>) -> ref<f64> => downcast_ref(value)
+)"};
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+    REQUIRE(unit.complete());
+
+    bool found = false;
+    for (const hgl::ir::hir::Expr &expression : unit.hir.exprs) {
+        if (expression.operation.identity != "hgraph.std.downcast_ref") { continue; }
+        found = true;
+        REQUIRE(expression.type.valid());
+        CHECK(unit.hir.type(expression.type).kind == hgl::ir::hir::TypeKind::Reference);
+        CHECK_FALSE(expression.operation.deferred);
+    }
+    CHECK(found);
+}
+
 TEST_CASE("higher-order operator typing remains explicit and deferred", "[ir][operator-types]") {
     Unit unit{R"(
 module checks.higher_order_types

--- a/language/tests/wiring/type_bridge_tests.cpp
+++ b/language/tests/wiring/type_bridge_tests.cpp
@@ -87,6 +87,8 @@ fn forms(
     series_list: list<f64, 3>,
     series_set: set<str>,
     series_map: map<str, f64>,
+    reference: ref<map<str, f64>>,
+    reference_list: list<ref<f64>, 3>,
     tick_window: rolling<f64, 20, 5>,
     duration_window: rolling<f64, 2s, 1s>,
     wrapped: atomic<Wrapper<i64>>,
@@ -122,6 +124,9 @@ fn forms(
     CHECK(bridge.schema(unit.parameter("forms", "series_list")) == registry.tsl(registry.ts(types.float_type), 3));
     CHECK(bridge.schema(unit.parameter("forms", "series_set")) == registry.tss(types.str_type));
     CHECK(bridge.schema(unit.parameter("forms", "series_map")) == registry.tsd(types.str_type, registry.ts(types.float_type)));
+    CHECK(bridge.schema(unit.parameter("forms", "reference")) ==
+          registry.ref(registry.tsd(types.str_type, registry.ts(types.float_type))));
+    CHECK(bridge.schema(unit.parameter("forms", "reference_list")) == registry.tsl(registry.ref(registry.ts(types.float_type)), 3));
     CHECK(bridge.schema(unit.parameter("forms", "tick_window")) == registry.tsw(types.float_type, 20, 5));
     CHECK(bridge.schema(unit.parameter("forms", "duration_window")) ==
           registry.tsw_duration(types.float_type, hgraph::TimeDelta{2'000'000}, hgraph::TimeDelta{1'000'000}));
@@ -148,8 +153,8 @@ fn forms(
     CHECK(box_contract->generics.front().binding != wrapper_contract->generics.front().binding);
 
     const hgl::hgraph_ir::Callable    &forms = unit.callable("forms");
-    const std::optional<hgraph::Value> count = bridge.literal(forms.parameters[9].default_value);
-    const std::optional<hgraph::Value> delay = bridge.literal(forms.parameters[10].default_value);
+    const std::optional<hgraph::Value> count = bridge.literal(forms.parameters[11].default_value);
+    const std::optional<hgraph::Value> delay = bridge.literal(forms.parameters[12].default_value);
     REQUIRE(count);
     REQUIRE(delay);
     CHECK(count->view().checked_as<hgraph::Int>() == 3);


### PR DESCRIPTION
## Summary
- preserve explicit `ref<T>` boundaries through parsing, typed HIR, hgraph IR, descriptors, and native schema materialization
- generate readable C++ for opaque reference forwarding and guarded fixed-list reference routing
- enforce selector-specific validity and fail closed on unresolved nested, map-propagated, dynamic-list, and wiring-time reference semantics

## Validation
- HGL suite: 36/36
- native C++ suite: 1716/1716
- Python 3.14 non-WIP suite from a Python 3.12 stable-ABI wheel: 3241 passed, 10 skipped
- strict Sphinx HTML build
