### PR TITLE
HGL: check typed local assignment paths

### DIFF
--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -123,6 +123,7 @@ hgl_apply_warnings(hgl_semantics)
 add_library(hgl_ir STATIC
     src/ir/canonical_types.cpp
     src/ir/constraint_solver.cpp
+    src/ir/definite_assignment.cpp
     src/ir/generic_substitution.cpp
     src/ir/hir.cpp
     src/ir/hir_printer.cpp

--- a/language/docs/design/control-flow.md
+++ b/language/docs/design/control-flow.md
@@ -1,8 +1,10 @@
 # Conditional control flow
 
-Status: agreed conditional strategy, 2026-09-05; compiler implementation is
-separate. This record uses the existing `if`/`else` syntax. It does not settle
-the other control-flow constructs or introduce new keywords.
+Status: agreed conditional strategy, 2026-09-05. The compiler accepts typed
+uninitialized `var` declarations and checks definite assignment; temporal
+child-graph lowering remains separate work. This record uses the existing
+`if`/`else` syntax. It does not settle the other control-flow constructs or
+introduce new keywords.
 
 ## The three conditional contexts
 
@@ -89,9 +91,11 @@ fn use_conditional_result(condition: bool, x: i64, y: i64) -> i64 {
 }
 ```
 
-This example includes the agreed typed declaration without an initializer,
-`var r: i64`. It is design syntax awaiting compiler support, not an executable
-example for the current language test corpus.
+The compiler accepts the typed declaration without an initializer,
+`var r: i64`. It does not supply a value or connection: a later read is valid
+only after definite-assignment analysis proves that every reaching path has
+assigned it. This complete example remains outside the executable corpus until
+temporal conditional lowering is implemented.
 
 An escaping variable must be declared before the conditional in an enclosing
 scope. Its branch-assigned binding is needed outside the conditional. A
@@ -242,7 +246,8 @@ variables, check each one independently before constructing the result bundle.
 
 The negative design-corpus example is
 [conditional-unassigned-result.hgl](../../stdlib/examples/invalid/conditional-unassigned-result.hgl).
-It records the required rejection, not an implemented compiler test.
+The compiler now implements this path-sensitive rejection; the file remains in
+the design corpus rather than the positive runnable examples.
 
 ## Expression results and escaping assignments
 
@@ -523,9 +528,8 @@ or `mesh` is introduced by these conditional agreements.
 
 At this change's baseline, both language backends reject a composition `if`
 whose condition is a temporal port and direct authors to `if_then_else`.
-The parser already accepts the conditional syntax. The new agreement changes
-the target semantics; this documentation change does not remove that compiler
-restriction. The parser also currently requires local declarations to have
-initializers; supporting `var r: i64` is part of the newly agreed design. The
-standard-library design corpus is kept outside the executable example glob
-until the relevant compiler support exists.
+The parser already accepts the conditional syntax. Typed uninitialized `var`
+declarations and path-sensitive definite assignment are now implemented; they
+do not remove the temporal-backend restriction. The standard-library design
+corpus is kept outside the executable example glob until the remaining
+compiler support exists.

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -730,7 +730,12 @@ language feature from `<U>`.
 HIR. `var` admits assignment but does not allocate node state. In composition
 code a local may hold a scalar or port handle; in runtime code it holds a
 canonical scalar or borrowed view. Only `state` lowers through a recordable
-state selector.
+state selector. A `var` without an initializer must carry an explicit type.
+HIR completion tracks assignment as a forward data-flow fact, intersects facts
+from conditional paths that both reach the continuation, and excludes a path
+terminated by `return`. Reading the binding before every reaching path assigns
+it is a type error. The declaration itself creates neither a scalar default nor
+a time-series endpoint.
 
 ## Composition lowering
 

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -911,23 +911,24 @@ Mutation statements are restricted to declared `state` variables, injected
 the previous value and therefore follows the same validity rules as an explicit
 read followed by assignment.
 
-`let` and `var` are lexical declarations and both require an initializer in the
-first slice. In a `CompositionFn`, their initializer may produce a scalar or a
-port handle; assigning a `var` only changes that local handle. In a `RuntimeFn`,
-they hold canonical scalar values local to the executing block. Runtime `var`
-storage is recreated on every block execution and is never added to the
-function's recordable state. A value that crosses evaluations must use `state`.
+`let` and `var` are lexical declarations. `let` requires an initializer. A
+`var` may omit it only when it has an explicit type. In a `CompositionFn`, an
+initializer may produce a scalar or a port handle; assigning a `var` only
+changes that local handle. In a `RuntimeFn`, locals hold canonical scalar values
+local to the executing block. Runtime `var` storage is recreated on every block
+execution and is never added to the function's recordable state. A value that
+crosses evaluations must use `state`.
 
 The agreed
 [conditional-result design](../design/control-flow.md#results-used-after-the-conditional)
-extends this baseline with typed, uninitialized declarations such as
+uses typed, uninitialized declarations such as
 `var r: i64`. The declaration introduces the enclosing variable; branch
 assignments supply its output connection, and lowering remaps the binding
 after the switch. Count any used expression result alongside the escaping
 bindings: one result is returned directly; several are returned through a
-compiler-generated bundle. The grammar above still
-describes the current initializer-required implementation. No default value
-or runtime state cell is implied by the new declaration form.
+compiler-generated bundle. The grammar and semantic passes implement the
+declaration and definite-assignment portions. No default value or runtime state
+cell is implied; switch-result remapping remains backend work.
 
 For each escaping result, lowering preserves the resolved declared temporal
 schema as the common branch-output slot. A branch that forwards an incoming
@@ -938,7 +939,7 @@ explicitly `ref<T>`, the reference remains part of the output schema and is not
 dereferenced. Corresponding branch-output fields must match recursively before
 they reach the native switch.
 
-The target design also requires definite-assignment analysis for escaping
+The compiler performs path-sensitive definite-assignment analysis for escaping
 variables. At a use, every path reaching it must supply a binding, either by
 assignment or by forwarding an existing incoming binding. Otherwise reject
 the use at compile time; do not synthesize a never-ticking source to fill the

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -371,9 +371,10 @@ scheduling, and change tracking rather than from removing a graph wrapper.
 
 ## Conditional control flow
 
-Status: the temporal-condition strategy below is agreed design. The current
-compiler still rejects a temporal condition in a composition `if`; implementing
-that strategy is separate work. The existing syntax needs no new keyword.
+Status: the temporal-condition strategy below is agreed design. The compiler
+accepts typed uninitialized `var` declarations and checks definite assignment,
+but still rejects a temporal condition in a composition `if`; implementing that
+lowering is separate work. The existing syntax needs no new keyword.
 
 `if` has three context-dependent meanings:
 
@@ -411,8 +412,9 @@ Each branch returns its binding for `r`, and the enclosing `r` is remapped to
 the switch output. The multiplication is composed outside the switch. For
 multiple escaping variables, the branches return a common bundle whose fields
 are remapped to those variables. Branch-local declarations do not escape.
-The typed declaration without an initializer is also agreed design awaiting
-compiler support. Both branches assign `r` here.
+The typed declaration without an initializer is compiler-supported. It creates
+no default value or connection; both branches must assign `r` before the later
+read.
 
 If `r` already has a binding before the conditional, a branch that leaves it
 unchanged forwards that incoming binding, including the implicit false branch

--- a/language/docs/user-guide/types-and-expressions.md
+++ b/language/docs/user-guide/types-and-expressions.md
@@ -679,14 +679,14 @@ hold evaluation-local scalar values and are recreated whenever the containing
 block executes. Use `state`, not `var`, for a value that must survive into a
 later evaluation.
 
-The current compiler requires an initializer. The agreed
-[conditional-result design](../design/control-flow.md#results-used-after-the-conditional)
-also permits a typed declaration such as `var r: i64` before an `if`, with
-both branches assigning `r` and later statements using its remapped switch
-output. This form is not implemented yet, supplies no implicit initial value,
-and does not make an unassigned variable readable.
+An initializer may be omitted only from a typed mutable declaration such as
+`var r: i64`. The form supplies no implicit initial value and does not make an
+unassigned variable readable. It supports the agreed
+[conditional-result design](../design/control-flow.md#results-used-after-the-conditional),
+where both branches assign `r` before later statements use its remapped switch
+output. Temporal switch remapping remains separate backend work.
 
-In this design, using an escaping variable without a binding on every path
+Using an escaping variable without a binding on every path
 reaching that use is a compile-time error. An existing incoming binding can
 be forwarded by an unassigned branch; without one, the relevant path must
 assign the variable. This is

--- a/language/examples/runtime-choice.hgl
+++ b/language/examples/runtime-choice.hgl
@@ -24,6 +24,17 @@ fn selected_price(
     return if_then_else(use_adjusted, adjusted, raw)
 }
 
+// A typed var may defer its first binding when every reaching path assigns it.
+fn selected_offset(value: i64, const positive: bool = true) -> i64 {
+    var result: i64
+    if positive {
+        result = value + 1
+    } else {
+        result = value - 1
+    }
+    result
+}
+
 // `when` classifies the function as one generated runtime node.
 fn add_when_ready(a: f64, b: f64) -> f64 {
     when modified(a, b) && valid(a) {

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -2169,11 +2169,27 @@ namespace hgl::codegen
                         if (binding.kind != gir::BindingKind::LocalLet && binding.kind != gir::BindingKind::LocalVar) {
                             backend(statement.range, "hgraph IR local statement refers to a non-local binding");
                         }
+                        const HType       declared = planned_type(node.type, statement.range);
+                        const std::string base     = cpp_name(binding.name);
+                        std::string       local    = base;
+                        int              &suffix   = local_counts_[base];
+                        while (local_names_.contains(local)) { local = base + "_" + std::to_string(++suffix); }
+                        local_names_.insert(local);
+                        if (!node.init.valid()) {
+                            if (binding.kind != gir::BindingKind::LocalVar) {
+                                backend(binding.range, "only a 'var' may omit its initializer");
+                            }
+                            out.line("hgraph::Port<" + schema(declared, binding.range) + "> " + local + ";");
+                            Value value = make_port(local, declared, binding.range);
+                            if (!frame.planned_bindings.emplace(node.binding.value, std::move(value)).second) {
+                                backend(binding.range, "hgraph IR block repeats a local binding");
+                            }
+                            return;
+                        }
                         Value value = eval_planned_expr(node.init, frame);
                         if (value.kind != Value::Kind::Const && value.kind != Value::Kind::Port) {
                             unsupported(statement.range, "binding a function or operator to a local");
                         }
-                        const HType declared = planned_type(node.type, statement.range);
                         if (value.is_const()) {
                             value.code = as_const(value, declared, value.range, "'" + binding.name + "'");
                         } else {
@@ -2181,11 +2197,6 @@ namespace hgl::codegen
                         }
                         value.type = declared;
 
-                        const std::string base   = cpp_name(binding.name);
-                        std::string       local  = base;
-                        int              &suffix = local_counts_[base];
-                        while (local_names_.contains(local)) { local = base + "_" + std::to_string(++suffix); }
-                        local_names_.insert(local);
                         out.line((binding.kind == gir::BindingKind::LocalVar ? "auto " : "const auto ") + local + " = " +
                                  value.code + ";");
                         value.code = local;
@@ -2365,19 +2376,32 @@ namespace hgl::codegen
                         if (binding.kind != gir::BindingKind::LocalLet && binding.kind != gir::BindingKind::LocalVar) {
                             backend(statement.range, "hgraph IR local statement refers to a non-local binding");
                         }
+                        const HType       declared = planned_type(node.type, statement.range);
+                        const std::string base     = cpp_name(binding.name);
+                        std::string       local    = base;
+                        int              &suffix   = local_counts_[base];
+                        while (local_names_.contains(local)) { local = base + "_" + std::to_string(++suffix); }
+                        local_names_.insert(local);
+                        if (!node.init.valid()) {
+                            if (binding.kind != gir::BindingKind::LocalVar) {
+                                backend(binding.range, "only a 'var' may omit its initializer");
+                            }
+                            if (declared.kind != HType::Kind::Scalar) {
+                                backend(binding.range, "an uninitialized runtime local currently requires a scalar type");
+                            }
+                            out.line(value_type(declared, binding.range) + " " + local + ";");
+                            Value value = make_runtime(local, declared, binding.range);
+                            if (!frame.planned_bindings.emplace(node.binding.value, std::move(value)).second) {
+                                backend(binding.range, "hgraph IR block repeats a local binding");
+                            }
+                            return;
+                        }
                         Value value = eval_planned_expr(node.init, frame);
                         if (!value.is_const() && !value.is_runtime()) {
                             fail(Category::Type, statement.range, "a runtime local needs a scalar value");
                         }
-                        const HType declared = planned_type(node.type, statement.range);
-                        value.code           = as_runtime(value, declared, value.range, "'" + binding.name + "'");
-                        value.type           = declared;
-
-                        const std::string base   = cpp_name(binding.name);
-                        std::string       local  = base;
-                        int              &suffix = local_counts_[base];
-                        while (local_names_.contains(local)) { local = base + "_" + std::to_string(++suffix); }
-                        local_names_.insert(local);
+                        value.code = as_runtime(value, declared, value.range, "'" + binding.name + "'");
+                        value.type = declared;
                         out.line((binding.kind == gir::BindingKind::LocalVar ? "auto " : "const auto ") + local + " = " +
                                  value.code + ";");
                         value.code = local;
@@ -2892,7 +2916,7 @@ namespace hgl::codegen
                 [&](const auto &node) {
                     using T = std::decay_t<decltype(node)>;
                     if constexpr (std::is_same_v<T, gir::LocalBinding>) {
-                        check_runtime_expr(node.init, decl, valid);
+                        if (node.init.valid()) { check_runtime_expr(node.init, decl, valid); }
                     } else if constexpr (std::is_same_v<T, gir::Activation>) {
                         if (!allow_when) { backend(statement.range, "a 'when' block must be at function top level"); }
                         const RuntimeValidSet body_valid = runtime_true_valid(node.condition, decl, valid);
@@ -3507,7 +3531,7 @@ namespace hgl::codegen
                     [&](const auto &node) {
                         using T = std::decay_t<decltype(node)>;
                         if constexpr (std::is_same_v<T, gir::LocalBinding> || std::is_same_v<T, gir::StateBinding>) {
-                            collect_calls(node.init, calls, statement.range);
+                            if (node.init.valid()) { collect_calls(node.init, calls, statement.range); }
                         } else if constexpr (std::is_same_v<T, gir::Lifecycle>) {
                             collect_calls(node.block, calls, statement.range);
                         } else if constexpr (std::is_same_v<T, gir::Activation>) {

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -2227,7 +2227,8 @@ namespace hgl::codegen
                             value = current.is_const() && value.is_const() ? fold_binary(op, current, value, statement.range)
                                                                            : wire_binary(op, current, value, statement.range);
                         }
-                        if (current.kind != value.kind) {
+                        const bool promotes_constant_to_port = current.is_port() && value.is_const();
+                        if (current.kind != value.kind && !promotes_constant_to_port) {
                             fail(Category::Type, statement.range, "assignment to '" + binding.name + "' changes its inferred type");
                         }
                         if (current.is_const()) {
@@ -2237,6 +2238,7 @@ namespace hgl::codegen
                             if (current.type.kind != HType::Kind::Unknown) {
                                 value.code = as_port(value, current.type, value.range);
                             }
+                            value.kind = Value::Kind::Port;
                             value.type = current.type;
                         }
                         out.line(current.code + " = " + value.code + ";");

--- a/language/src/ir/definite_assignment.cpp
+++ b/language/src/ir/definite_assignment.cpp
@@ -1,0 +1,187 @@
+#include "ir/definite_assignment.h"
+
+#include <cstdint>
+#include <type_traits>
+#include <unordered_set>
+
+namespace hgl::ir
+{
+    namespace
+    {
+        using namespace hir;
+
+        struct Flow
+        {
+            std::unordered_set<std::uint32_t> assigned{};
+            bool                              reaches{true};
+        };
+
+        class Analyzer
+        {
+          public:
+            Analyzer(const Module &module, syntax::DiagnosticSink &diagnostics) : module_{module}, diagnostics_{diagnostics} {}
+
+            void run() {
+                for (const Stmt &statement : module_.stmts) {
+                    if (const auto *local = std::get_if<LocalDecl>(&statement.node);
+                        local != nullptr && !local->init.valid() && local->symbol.valid()) {
+                        uninitialized_.insert(local->symbol.value);
+                    }
+                }
+                if (uninitialized_.empty()) { return; }
+
+                for (DeclarationId declaration : module_.source_order) {
+                    const Declaration &item = module_.declaration(declaration);
+                    if (const auto *fn = std::get_if<FunctionDecl>(&item.node)) {
+                        Flow flow;
+                        if (fn->concise_body.valid()) { expression(fn->concise_body, flow); }
+                        if (fn->block_body.valid()) { block(fn->block_body, flow); }
+                    } else if (const auto *test = std::get_if<TestDecl>(&item.node)) {
+                        Flow flow;
+                        block(test->block, flow);
+                    }
+                }
+            }
+
+          private:
+            [[nodiscard]] SymbolId place_root(ExprId id) const noexcept {
+                if (!id.valid()) { return {}; }
+                const Expr &value = module_.expr(id);
+                if (const auto *reference = std::get_if<SymbolRef>(&value.node)) { return reference->symbol; }
+                if (const auto *index = std::get_if<Index>(&value.node)) { return place_root(index->target); }
+                if (const auto *field = std::get_if<Field>(&value.node)) { return place_root(field->target); }
+                return {};
+            }
+
+            void reference(SymbolId symbol, syntax::SourceRange range, const Flow &flow) {
+                if (symbol.valid() && uninitialized_.contains(symbol.value) && !flow.assigned.contains(symbol.value)) {
+                    diagnostics_.report(syntax::Category::Type, range,
+                                        "'" + module_.symbol(symbol).name + "' may be used before it is assigned");
+                }
+            }
+
+            static void merge(Flow &target, const Flow &then_flow, const Flow &else_flow) {
+                if (!then_flow.reaches) {
+                    target = else_flow;
+                    return;
+                }
+                if (!else_flow.reaches) {
+                    target = then_flow;
+                    return;
+                }
+                target.reaches = true;
+                target.assigned.clear();
+                for (const std::uint32_t symbol : then_flow.assigned) {
+                    if (else_flow.assigned.contains(symbol)) { target.assigned.insert(symbol); }
+                }
+            }
+
+            void expression(ExprId id, Flow &flow) {
+                if (!id.valid() || !flow.reaches) { return; }
+                const Expr &value = module_.expr(id);
+                std::visit(
+                    [&](const auto &node) {
+                        using T = std::decay_t<decltype(node)>;
+                        if constexpr (std::is_same_v<T, SymbolRef>) {
+                            reference(node.symbol, value.range, flow);
+                        } else if constexpr (std::is_same_v<T, Unary>) {
+                            expression(node.operand, flow);
+                        } else if constexpr (std::is_same_v<T, Binary>) {
+                            expression(node.lhs, flow);
+                            expression(node.rhs, flow);
+                        } else if constexpr (std::is_same_v<T, Call>) {
+                            expression(node.callee, flow);
+                            for (const Argument &argument : node.arguments) { expression(argument.value, flow); }
+                        } else if constexpr (std::is_same_v<T, Index>) {
+                            expression(node.target, flow);
+                            expression(node.index, flow);
+                        } else if constexpr (std::is_same_v<T, Field>) {
+                            expression(node.target, flow);
+                        } else if constexpr (std::is_same_v<T, Sequence>) {
+                            for (const SequenceElement &element : node.elements) {
+                                expression(element.key, flow);
+                                expression(element.value, flow);
+                            }
+                        } else if constexpr (std::is_same_v<T, Tuple>) {
+                            for (ExprId element : node.elements) { expression(element, flow); }
+                        } else if constexpr (std::is_same_v<T, Lambda>) {
+                            expression(node.body, flow);
+                        } else if constexpr (std::is_same_v<T, If>) {
+                            expression(node.condition, flow);
+                            Flow then_flow = flow;
+                            block(node.then_block, then_flow);
+                            Flow else_flow = flow;
+                            if (node.otherwise.valid()) { expression(node.otherwise, else_flow); }
+                            merge(flow, then_flow, else_flow);
+                        } else if constexpr (std::is_same_v<T, BlockExpr>) {
+                            block(node.block, flow);
+                        } else if constexpr (std::is_same_v<T, Eval>) {
+                            expression(node.callee, flow);
+                            for (const Argument &argument : node.arguments) { expression(argument.value, flow); }
+                        } else if constexpr (std::is_same_v<T, Construct>) {
+                            for (const Argument &argument : node.arguments) { expression(argument.value, flow); }
+                        }
+                    },
+                    value.node);
+            }
+
+            void statement(StmtId id, Flow &flow) {
+                if (!id.valid() || !flow.reaches) { return; }
+                const Stmt &value = module_.stmt(id);
+                std::visit(
+                    [&](const auto &node) {
+                        using T = std::decay_t<decltype(node)>;
+                        if constexpr (std::is_same_v<T, LocalDecl>) {
+                            if (node.init.valid()) {
+                                expression(node.init, flow);
+                                flow.assigned.insert(node.symbol.value);
+                            } else {
+                                flow.assigned.erase(node.symbol.value);
+                            }
+                        } else if constexpr (std::is_same_v<T, StateDecl>) {
+                            expression(node.init, flow);
+                        } else if constexpr (std::is_same_v<T, LifecycleBlock>) {
+                            Flow nested = flow;
+                            block(node.block, nested);
+                        } else if constexpr (std::is_same_v<T, WhenStmt>) {
+                            expression(node.condition, flow);
+                            Flow nested = flow;
+                            block(node.block, nested);
+                        } else if constexpr (std::is_same_v<T, ForStmt>) {
+                            expression(node.iterable, flow);
+                            Flow nested = flow;
+                            block(node.block, nested);
+                        } else if constexpr (std::is_same_v<T, AssignStmt>) {
+                            const SymbolId root = place_root(node.place);
+                            const bool     direct_initialization =
+                                node.op == AssignOp::Assign && std::holds_alternative<SymbolRef>(module_.expr(node.place).node);
+                            if (!direct_initialization) { expression(node.place, flow); }
+                            expression(node.value, flow);
+                            if (root.valid()) { flow.assigned.insert(root.value); }
+                        } else if constexpr (std::is_same_v<T, ReturnStmt>) {
+                            expression(node.value, flow);
+                            flow.reaches = false;
+                        } else if constexpr (std::is_same_v<T, AssertStmt>) {
+                            expression(node.condition, flow);
+                        } else if constexpr (std::is_same_v<T, ExprStmt>) {
+                            expression(node.expr, flow);
+                        }
+                    },
+                    value.node);
+            }
+
+            void block(BlockId id, Flow &flow) {
+                if (!id.valid() || !flow.reaches) { return; }
+                for (StmtId item : module_.block(id).statements) { statement(item, flow); }
+            }
+
+            const Module                     &module_;
+            syntax::DiagnosticSink           &diagnostics_;
+            std::unordered_set<std::uint32_t> uninitialized_{};
+        };
+    }  // namespace
+
+    void check_definite_assignment(const hir::Module &module, syntax::DiagnosticSink &diagnostics) {
+        Analyzer{module, diagnostics}.run();
+    }
+}  // namespace hgl::ir

--- a/language/src/ir/definite_assignment.h
+++ b/language/src/ir/definite_assignment.h
@@ -1,0 +1,15 @@
+#ifndef HGL_IR_DEFINITE_ASSIGNMENT_H
+#define HGL_IR_DEFINITE_ASSIGNMENT_H
+
+#include "ir/hir.h"
+#include "syntax/diagnostic.h"
+
+namespace hgl::ir
+{
+    /// Check that every typed local without an initializer has been assigned
+    /// on each path which reaches a read. This is a control-flow fact, not a
+    /// type-inference or runtime-validity rule.
+    void check_definite_assignment(const hir::Module &module, syntax::DiagnosticSink &diagnostics);
+}  // namespace hgl::ir
+
+#endif

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -2,6 +2,7 @@
 
 #include "ir/canonical_types.h"
 #include "ir/constraint_solver.h"
+#include "ir/definite_assignment.h"
 #include "ir/generic_substitution.h"
 #include "syntax/temporal.h"
 
@@ -104,6 +105,7 @@ namespace hgl::ir
                 canonical_types_.initialize();
                 void_type_ = canonical_types_.void_type();
                 for (DeclarationId declaration : module_.source_order) { check_declaration(declaration); }
+                ir::check_definite_assignment(module_, diagnostics_);
                 validate_completion();
                 if (diagnostics_.has_errors()) { return false; }
                 module_.completion = Completion::Typed;
@@ -1718,13 +1720,22 @@ namespace hgl::ir
                     [&](auto &node) {
                         using T = std::decay_t<decltype(node)>;
                         if constexpr (std::is_same_v<T, LocalDecl>) {
-                            Expr &init = check_expr(node.init, node.type);
-                            if (!node.type.valid()) { node.type = init.type; }
-                            require_assignable(node.type, init, "local initializer");
-                            Symbol &symbol                   = module_.symbols[node.symbol.value];
-                            symbol.type                      = node.type;
-                            symbol_phase_[node.symbol.value] = init.phase;
-                            statement.effects                = init.effects;
+                            Symbol &symbol = module_.symbols[node.symbol.value];
+                            if (node.init.valid()) {
+                                Expr &init = check_expr(node.init, node.type);
+                                if (!node.type.valid()) { node.type = init.type; }
+                                require_assignable(node.type, init, "local initializer");
+                                symbol.type                      = node.type;
+                                symbol_phase_[node.symbol.value] = init.phase;
+                                statement.effects                = init.effects;
+                            } else {
+                                if (!node.type.valid()) {
+                                    type_error(statement.range, "an uninitialized 'var' requires an explicit type");
+                                }
+                                symbol.type                      = canonical(node.type);
+                                symbol_phase_[node.symbol.value] = runtime_owner(statement.owner) ? Phase::Runtime : Phase::Wiring;
+                                statement.effects                = Effect::None;
+                            }
                         } else if constexpr (std::is_same_v<T, StateDecl>) {
                             Expr &init = check_expr(node.init, node.type);
                             if (!node.type.valid()) { node.type = init.type; }

--- a/language/src/semantics/resolve.cpp
+++ b/language/src/semantics/resolve.cpp
@@ -378,7 +378,14 @@ namespace hgl::semantics
                         using T = std::decay_t<decltype(node)>;
                         if constexpr (std::is_same_v<T, ast::LocalDecl>) {
                             if (node.type != ast::no_node) { resolve_type(node.type, context); }
-                            resolve_expr(node.init, context);
+                            if (node.init != ast::no_node) {
+                                resolve_expr(node.init, context);
+                            } else {
+                                if (!node.mutable_) { report(Category::Type, stmt.range, "'let' requires an initializer"); }
+                                if (node.type == ast::no_node) {
+                                    report(Category::Type, stmt.range, "an uninitialized 'var' requires an explicit type");
+                                }
+                            }
                             Binding binding;
                             binding.kind = BindingKind::Local;
                             binding.stmt = id;

--- a/language/src/syntax/ast_printer.cpp
+++ b/language/src/syntax/ast_printer.cpp
@@ -500,7 +500,7 @@ namespace hgl::syntax
             {
                 line(depth, "LocalDecl", range, (s.mutable_ ? "var " : "let ") + std::string{s.name.text});
                 if (s.type != ast::no_node) { type(depth + 1, s.type, "type"); }
-                expr(depth + 1, s.init, "init");
+                if (s.init != ast::no_node) { expr(depth + 1, s.init, "init"); }
             }
             void stmt_node(int depth, SourceRange range, const ast::StateDecl &s, ast::ExprId)
             {

--- a/language/src/syntax/ast_projection.cpp
+++ b/language/src/syntax/ast_projection.cpp
@@ -650,7 +650,9 @@ namespace hgl::syntax
                             if (const auto type = find_child(statement, SyntaxKind::Type)) {
                                 result.type = project_type(*type, false);
                             }
-                            result.init = project_expression(only_child(statement, SyntaxKind::Expression));
+                            if (const auto init = find_child(statement, SyntaxKind::Expression)) {
+                                result.init = project_expression(*init);
+                            }
                             return module_.add(ast::Stmt{range, std::move(result)});
                         }
                     case SyntaxKind::StateDecl:

--- a/language/src/syntax/token_grammar.cpp
+++ b/language/src/syntax/token_grammar.cpp
@@ -395,7 +395,7 @@ namespace hgl::syntax
         {
             static constexpr auto rule = token_choice<TokenKind::KwLet, TokenKind::KwVar> >>
                                          dsl::p<name> + dsl::if_(token<TokenKind::Colon> >> dsl::p<newlines> + dsl::p<type>) +
-                                             token<TokenKind::Assign> + dsl::p<newlines> + dsl::recurse<expression>;
+                                             dsl::if_(token<TokenKind::Assign> >> dsl::p<newlines> + dsl::recurse<expression>);
         };
 
         struct state_decl

--- a/language/src/wiring/backend.cpp
+++ b/language/src/wiring/backend.cpp
@@ -1340,6 +1340,12 @@ namespace hgl::wiring
                 [&](const auto &node) {
                     using T = std::decay_t<decltype(node)>;
                     if constexpr (std::is_same_v<T, gir::LocalBinding>) {
+                        if (!node.init.valid()) {
+                            // A typed declaration reserves the lexical binding;
+                            // the first plain assignment supplies its value.
+                            frame.bindings.erase(node.binding.value);
+                            return;
+                        }
                         Slot initial = eval_value(node.init, frame);
                         if (node.type.valid() && node.type.value < module_.types.size()) {
                             const hir::TypeKind kind = module_.types[node.type.value].kind;
@@ -1363,8 +1369,22 @@ namespace hgl::wiring
                         if (target.kind != gir::BindingKind::LocalVar) {
                             fail(Category::Type, place.range, "'" + target.name + "' is not a 'var'");
                         }
-                        const Slot current = frame.bindings.at(reference->binding.value);
-                        Slot       next    = eval_value(node.value, frame);
+                        const auto current_it = frame.bindings.find(reference->binding.value);
+                        Slot       next       = eval_value(node.value, frame);
+                        if (current_it == frame.bindings.end()) {
+                            if (node.op != gir::AssignOp::Assign) {
+                                backend(statement.range,
+                                        "compound assignment requires '" + target.name + "' to have a prior value");
+                            }
+                            if (next.is_const() || next.kind == Slot::Kind::Sequence) {
+                                next = constant_of(next, value_meta(target.type), frame, "assignment to '" + target.name + "'");
+                            } else if (next.is_port()) {
+                                next = convert_port(next, schema(target.type));
+                            }
+                            frame.bindings[reference->binding.value] = std::move(next);
+                            return;
+                        }
+                        const Slot current = current_it->second;
                         if (node.op != gir::AssignOp::Assign) {
                             const hir::BinaryOp op = node.op == gir::AssignOp::Add   ? hir::BinaryOp::Add
                                                      : node.op == gir::AssignOp::Sub ? hir::BinaryOp::Sub

--- a/language/stdlib/README.md
+++ b/language/stdlib/README.md
@@ -37,8 +37,9 @@ compiler support.
 [conditional-unassigned-result.hgl](examples/invalid/conditional-unassigned-result.hgl)
 is intentionally invalid: the escaping variable has no incoming binding and
 is assigned only on the true path before it is used. It records the agreed
-compile-time definite-assignment error, without prescribing diagnostic wording
-or claiming that the compiler implements that check yet.
+compile-time definite-assignment error. The compiler now implements this
+path-sensitive check, although the temporal conditional itself still awaits
+backend lowering.
 
 ## Iteration
 
@@ -59,8 +60,8 @@ unsupported, not added here as a supported loop contract.
 
 ## Compiler status
 
-These design examples depend on features requiring compiler work, including
-temporal graph conditionals, graph-phase iteration, and typed declarations
-without initializers. They are design inputs, not runnable tests, and are
-deliberately outside `language/examples/`, whose `.hgl` files are checked by
-CTest. No runtime or compiler implementation is added here.
+These design examples still depend on compiler work, including temporal graph
+conditionals and graph-phase iteration. Typed declarations without initializers
+and their definite-assignment checks are implemented. The files remain design
+inputs, not runnable tests, and are deliberately outside `language/examples/`,
+whose `.hgl` files are checked by CTest.

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -527,6 +527,33 @@ export fn selected(const condition: bool, value: i64) -> i64 {
     CHECK(contains(emitted->source, "return result;"));
 }
 
+TEST_CASE("emit-cpp promotes the first constant assignment to a typed composition var", "[codegen][locals][control-flow]") {
+    Unit unit{R"(
+module planned_constant_assignment
+
+export fn selected(const condition: bool) -> i64 {
+    var result: i64
+    if condition {
+        result = 1
+    } else {
+        result = 2
+    }
+    result
+}
+)"};
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+
+    const auto emitted = unit.emit();
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE(emitted);
+    CHECK(contains(emitted->source, "hgraph::Port<hgraph::TS<hgraph::Int>> result;"));
+    CHECK(contains(emitted->source,
+                   "result = hgraph::wire<hgraph::stdlib::const_, hgraph::TS<hgraph::Int>>(w, hgraph::Int{1});"));
+    CHECK(contains(emitted->source,
+                   "result = hgraph::wire<hgraph::stdlib::const_, hgraph::TS<hgraph::Int>>(w, hgraph::Int{2});"));
+    CHECK(contains(emitted->source, "return result;"));
+}
+
 TEST_CASE("emit-cpp uses inferred hgraph IR state types", "[codegen][hgraph-ir][locals][runtime]") {
     Unit unit{R"(
 module inferred_state

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -502,6 +502,31 @@ export fn adjusted(value: f64) -> f64 {
     }
 }
 
+TEST_CASE("emit-cpp declares a typed var before conditional assignment", "[codegen][locals][control-flow]") {
+    Unit unit{R"(
+module planned_conditional_assignment
+
+export fn selected(const condition: bool, value: i64) -> i64 {
+    var result: i64
+    if condition {
+        result = value
+    } else {
+        result = value + 1
+    }
+    result
+}
+)"};
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+
+    const auto emitted = unit.emit();
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE(emitted);
+    CHECK(contains(emitted->source, "hgraph::Port<hgraph::TS<hgraph::Int>> result;"));
+    CHECK(contains(emitted->source, "if (condition.value())"));
+    CHECK(contains(emitted->source, "result = value;"));
+    CHECK(contains(emitted->source, "return result;"));
+}
+
 TEST_CASE("emit-cpp uses inferred hgraph IR state types", "[codegen][hgraph-ir][locals][runtime]") {
     Unit unit{R"(
 module inferred_state

--- a/language/tests/codegen/generated_runtime_tests.cpp
+++ b/language/tests/codegen/generated_runtime_tests.cpp
@@ -53,6 +53,13 @@ TEST_CASE("a generated composition can wire a generated operator implementation"
                  values<Float>(2.0, 3.0));
 }
 
+TEST_CASE("generated runtime control flow definitely assigns typed locals", "[codegen][runtime][locals]")
+{
+    session();
+    CHECK_OUTPUT(eval_node<runtime::operators::absolute_local>(values<Float>(-2.0, 3.0)),
+                 values<Float>(2.0, 3.0));
+}
+
 TEST_CASE("generated runtime predicates use modified-or and valid-and semantics", "[codegen][runtime]")
 {
     session();

--- a/language/tests/codegen/runtime.hgl
+++ b/language/tests/codegen/runtime.hgl
@@ -17,6 +17,18 @@ impl fn absolute(value: f64) -> f64 {
 
 export fn absolute_graph(value: f64) -> f64 => absolute(value)
 
+export fn absolute_local(value: f64) -> f64 {
+    when modified(value) && valid(value) {
+        var result: f64
+        if value < 0.0 {
+            result = -value
+        } else {
+            result = value
+        }
+        return result
+    }
+}
+
 export fn add_when_ready(a: f64, b: f64) -> f64 {
     when modified(a, b) && valid(a, b) {
         return a + b

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -225,6 +225,78 @@ fn wrong() -> str {
     CHECK(lowered.hir.completion == hir::Completion::Resolved);
 }
 
+TEST_CASE("typed HIR checks definite assignment across conditional paths", "[ir][typed][locals][control-flow]") {
+    SECTION("both reaching branches assign the variable") {
+        Lowered lowered{R"(
+module checks.assigned
+
+fn choose(condition: bool, value: i64) -> i64 {
+    var result: i64
+    if condition {
+        result = value
+    } else {
+        result = value + 1
+    }
+    result
+}
+)"};
+        require_clean(lowered);
+        INFO(lowered.diagnostics.render(lowered.file));
+        CHECK(complete(lowered));
+    }
+
+    SECTION("a reaching unassigned path is rejected") {
+        Lowered lowered{R"(
+module checks.unassigned
+
+fn choose(condition: bool, value: i64) -> i64 {
+    var result: i64
+    if condition {
+        result = value
+    }
+    result
+}
+)"};
+        require_clean(lowered);
+        CHECK_FALSE(complete(lowered));
+        CHECK(lowered.diagnostics.render(lowered.file).find("'result' may be used before it is assigned") != std::string::npos);
+    }
+
+    SECTION("a branch that returns does not reach the later use") {
+        Lowered lowered{R"(
+module checks.returned
+
+fn choose(condition: bool, value: i64) -> i64 {
+    var result: i64
+    if condition {
+        return value
+    } else {
+        result = value + 1
+    }
+    result
+}
+)"};
+        require_clean(lowered);
+        INFO(lowered.diagnostics.render(lowered.file));
+        CHECK(complete(lowered));
+    }
+
+    SECTION("compound assignment reads the prior value") {
+        Lowered lowered{R"(
+module checks.compound
+
+fn invalid(value: i64) -> i64 {
+    var result: i64
+    result += value
+    result
+}
+)"};
+        require_clean(lowered);
+        CHECK_FALSE(complete(lowered));
+        CHECK(lowered.diagnostics.render(lowered.file).find("'result' may be used before it is assigned") != std::string::npos);
+    }
+}
+
 TEST_CASE("typed HIR enforces const arguments at exact calls", "[ir][typed][calls][phase]") {
     Lowered lowered{R"(
 module checks.const_call

--- a/language/tests/semantics/resolve_tests.cpp
+++ b/language/tests/semantics/resolve_tests.cpp
@@ -445,6 +445,28 @@ fn abstract_value() => Base(id: 1)
     CHECK(invalid.has(Category::Type, "abstract struct 'Base' is not constructible"));
 }
 
+TEST_CASE("only typed var declarations may omit an initializer", "[semantics][locals]") {
+    const Resolved valid = resolve_clean(R"(
+module t
+fn choose(condition: bool, value: i64) -> i64 {
+    var result: i64
+    if condition {
+        result = value
+    } else {
+        result = value + 1
+    }
+    result
+}
+)");
+    CHECK_FALSE(valid.diagnostics.has_errors());
+
+    const Resolved immutable{"module t\nfn invalid() {\n    let value: i64\n}\n"};
+    CHECK(immutable.has(Category::Type, "'let' requires an initializer"));
+
+    const Resolved inferred{"module t\nfn invalid() {\n    var value\n}\n"};
+    CHECK(inferred.has(Category::Type, "an uninitialized 'var' requires an explicit type"));
+}
+
 TEST_CASE("every guide example resolves", "[semantics]") {
     // The examples exercise generics, inject, impl fn, and the intrinsics;
     // the resolver must accept them all (the backend limits what runs).

--- a/language/tests/syntax/parser_tests.cpp
+++ b/language/tests/syntax/parser_tests.cpp
@@ -749,16 +749,18 @@ TEST_CASE("expression ranges span the whole expression", "[parser]") {
 TEST_CASE("let and var declarations", "[parser]") {
     REQUIRE(body_dump("    let a = 1\n"
                       "    var b: f64 = 2.0\n"
+                      "    var c: i64\n"
                       "    a") == "Block\n"
                                   "  LocalDecl let a\n"
                                   "    init: IntLiteral 1\n"
                                   "  LocalDecl var b\n"
                                   "    type: Type scalar f64\n"
                                   "    init: FloatLiteral 2.0\n"
+                                  "  LocalDecl var c\n"
+                                  "    type: Type scalar i64\n"
                                   "  ExprStmt tail\n"
                                   "    NameRef a\n");
-    REQUIRE(Parsed{"module t\nfn f() {\n    let a\n}\n"}.messages() ==
-            std::vector<std::string>{"expected '=' and an initializer, found newline"});
+    REQUIRE(Parsed{"module t\nfn f() {\n    let a\n}\n"}.messages().empty());
 }
 
 TEST_CASE("state declarations use value types", "[parser]") {

--- a/language/tests/wiring/backend_tests.cpp
+++ b/language/tests/wiring/backend_tests.cpp
@@ -185,6 +185,26 @@ test widening {
     }
 }
 
+TEST_CASE("a typed var can receive its first value after declaration", "[wiring][locals][control-flow]") {
+    Unit             unit{R"(
+module t
+
+test assigned {
+    var result: i64
+    if true {
+        result = 4
+    } else {
+        result = 5
+    }
+    assert result == 4
+}
+)"};
+    const TestResult result = only(unit.tests());
+    INFO(unit.diagnostics.render(unit.file));
+    INFO(result.message);
+    CHECK(result.passed);
+}
+
 TEST_CASE("composition results preserve their runtime schema", "[wiring][types]") {
     Unit             unit{R"(
 module t


### PR DESCRIPTION
## Summary

- permit typed mutable locals to omit their initializer while keeping let and inferred var strict
- add a dedicated path-sensitive definite-assignment pass with return-aware branch merging
- support the declaration form in direct evaluation and generated composition/runtime-node code
- update the accepted conditional design and exercise native generated fixtures

## Validation

- all 36 HGL CTest tests pass
- generated composition and runtime-node fixtures compile with warnings as errors
- direct evaluator, parser, resolver, HIR, codegen, and generated runtime regression tests pass

Stacked on #725.