### PR TITLE
feat(language): lower temporal if results

### DIFF
--- a/language/CHANGELOG.md
+++ b/language/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Lower explicit two-branch temporal `if` expressions through native
+  `switch_` in both the direct and generated-C++ backends. A shared HGraph-IR
+  pass computes branch captures and escaping effects; generated branches are
+  readable graph structs, and scripted/AOT parity covers branch changes.
 - Add strict reading and descriptor-only `hgl check` for versioned JSON module
   descriptors, including compatible unknown-member handling and diagnostics for
   duplicate keys, malformed records, unsupported versions, and dangling schema

--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -141,6 +141,7 @@ hgl_apply_warnings(hgl_ir)
 # provider planning separately validates eligible modules as Executable.
 add_library(hgl_graph_ir STATIC
     src/hgraph_ir/complete.cpp
+    src/hgraph_ir/control_flow.cpp
     src/hgraph_ir/lower.cpp
     src/hgraph_ir/printer.cpp
 )

--- a/language/docs/design/control-flow.md
+++ b/language/docs/design/control-flow.md
@@ -1,8 +1,10 @@
 # Conditional control flow
 
-Status: agreed conditional strategy, 2026-09-05. The compiler accepts typed
-uninitialized `var` declarations and checks definite assignment; temporal
-child-graph lowering remains separate work. This record uses the existing
+Status: agreed conditional strategy, 2026-09-05; partially implemented. Both
+backends lower an explicit two-branch temporal `if` whose result is the tail
+value of each branch through the native switch. Escaping assignments, scalar
+branch captures, omitted `else`, early-return continuations, mixed/multiple
+results, and outputless branches remain staged. This record uses the existing
 `if`/`else` syntax. It does not settle the other control-flow constructs or
 introduce new keywords.
 
@@ -21,8 +23,7 @@ switch owns the runtime selection and execution of its child graph.
 
 ## Temporal condition in graph composition
 
-The following uses existing syntax with the newly agreed temporal-condition
-semantics. It is a design example, not a currently executable compiler test:
+The following uses existing syntax and is supported by both execution paths:
 
 ```hgl
 fn choose(condition: bool, value: f64) -> f64 {
@@ -492,8 +493,12 @@ cannot pass a union of arguments to differently shaped lambdas and assume the
 binder filters them.
 
 These lambdas and their boundary signatures are generated internally. This
-agreement does not require new source-level closure syntax or implement
-compiler lowering.
+agreement does not require new source-level closure syntax. The initial
+implementation gives both generated branches one consistent explicit temporal
+signature formed from the stable first-use union. Unused branch parameters are
+marked in generated C++, and hgraph's switch boundary binds the same slots to
+both branches. Scalar specialization and the more selective native
+capture-boundary form remain later work.
 
 If the conditional exports no result or escaping variable, its generated
 branch signatures are outputless. Preserve their sink wiring through the
@@ -526,10 +531,16 @@ or `mesh` is introduced by these conditional agreements.
 
 ## Implementation status
 
-At this change's baseline, both language backends reject a composition `if`
-whose condition is a temporal port and direct authors to `if_then_else`.
-The parser already accepts the conditional syntax. Typed uninitialized `var`
-declarations and path-sensitive definite assignment are now implemented; they
-do not remove the temporal-backend restriction. The standard-library design
-corpus is kept outside the executable example glob until the remaining
-compiler support exists.
+Both language backends now accept the smallest value-producing form: a
+temporal Boolean condition, an explicit block `else`, no scalar captures,
+escaping assignments, or branch `return`, and one compatible tail value from
+each branch. HGraph IR performs capture/effect analysis once; the direct path
+builds context-backed branch callables, while `emit-cpp` writes ordinary named
+graph structs and a native `switch_` call. Scripted and generated behavior are
+covered by the same parity fixture.
+
+The parser, typed uninitialized `var`, and path-sensitive definite assignment
+support are broader than this first backend slice. The remaining
+standard-library conditional corpus stays outside the executable example glob
+until escaping results, continuations, omitted branches, and sink switching are
+implemented.

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -1249,11 +1249,13 @@ walk:
   function is a `backend` diagnostic naming it; a runtime function is wired by
   its module-qualified identity after the driver loads its provider;
 - the prelude intrinsics take the meaning of "Interim kernel table";
-- `if` selects a branch when its condition is a constant `bool`; a port
-  condition remains a `backend` diagnostic in the current prototype. The
-  agreed target is native switch-style child-graph execution, not eager wiring
-  of both outputs through `if_then_else`; the branch value is the arm's tail
-  expression;
+- `if` selects a branch directly when its condition is a constant `bool`. For
+  a temporal Boolean, the initial value-result slice analyzes lexical captures
+  in HGraph IR and lowers an explicit pair of tail-valued block branches to the
+  native `switch_`. The direct backend uses context-backed `WiredFn` branches;
+  generated C++ uses readable local graph structs with one consistent union
+  signature. Scalar captures, escaping assignments, branch returns, omitted
+  `else`, multiple results, and sinks fail closed for later slices;
 - a block body runs its statements in order: `let` and `var` bind locals
   (a declared type converts a constant or checks a port's schema), `=` and
   the compound assignments rebind a `var`, `return` ends the activation,

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -371,10 +371,11 @@ scheduling, and change tracking rather than from removing a graph wrapper.
 
 ## Conditional control flow
 
-Status: the temporal-condition strategy below is agreed design. The compiler
-accepts typed uninitialized `var` declarations and checks definite assignment,
-but still rejects a temporal condition in a composition `if`; implementing that
-lowering is separate work. The existing syntax needs no new keyword.
+Status: partially implemented. A temporal condition with an explicit `else`
+and one tail value per branch runs in both scripted and compiled modes. The
+current slice rejects scalar branch captures, escaping assignments, omitted
+`else`, early branch returns, mixed/multiple results, and outputless branches.
+The existing syntax needs no new keyword.
 
 `if` has three context-dependent meanings:
 
@@ -393,6 +394,7 @@ This differs from calling `if_then_else` on already-wired outputs, whose
 upstream computations remain independently active. A value-producing temporal
 `if` without `else` uses a typed, never-ticking false branch, matching Arrow.
 Lowering computes each branch lambda's input captures and output signature.
+The omitted-`else` rule is agreed but not yet implemented.
 An escaping variable must be declared before the conditional. For example:
 
 ```hgl

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -1,6 +1,7 @@
 #include "codegen/cpp_emitter.h"
 
 #include "descriptor/module_descriptor.h"
+#include "hgraph_ir/control_flow.h"
 
 #include <algorithm>
 #include <cmath>
@@ -463,6 +464,12 @@ namespace hgl::codegen
 
             // -- expressions
             [[nodiscard]] Value eval_planned_expr(gir::ValueId id, Frame &frame);
+            [[nodiscard]] Value lower_planned_conditional(gir::ValueId id, const gir::Conditional &branch, SourceRange range,
+                                                          Frame &frame);
+            void emit_planned_conditional_branch(std::string_view name, const gir::ConditionalBranchPlan &branch,
+                                                 const gir::ConditionalPlan                       &plan,
+                                                 const std::vector<std::pair<std::string, HType>> &parameters, Frame &outer,
+                                                 SourceRange range);
             [[nodiscard]] Value eval_planned_reference(const gir::Reference &reference, SourceRange range, Frame &frame);
             [[nodiscard]] Value eval_planned_call(const gir::Value &expression, const gir::Call &call, Frame &frame);
             [[nodiscard]] Value eval_planned_construct(gir::TypeId type, const std::vector<gir::Argument> &arguments, bool delta,
@@ -511,16 +518,15 @@ namespace hgl::codegen
                 InlineStruct,
                 OutOfLine,
             };
-            void                                     emit_function(gir::CallableId id, Writer &out, Form form);
-            void                                     emit_struct(const gir::StructContract &item, Writer &out);
-            void                                     emit_runtime_function(gir::CallableId id, Writer &out);
-            [[nodiscard]] RuntimeInfo                runtime_info(gir::CallableId id);
-            [[nodiscard]] std::optional<std::size_t> runtime_parameter(gir::ValueId id, gir::CallableId callable_id);
-            [[nodiscard]] std::optional<std::size_t> runtime_root_parameter(gir::ValueId id, gir::CallableId callable_id);
-            [[nodiscard]] std::optional<std::string> runtime_scalar_key(gir::ValueId id, gir::CallableId callable_id);
-            [[nodiscard]] std::optional<std::int64_t> runtime_integer_constant(gir::ValueId id,
-                                                                               gir::CallableId callable_id);
-            [[nodiscard]] std::optional<std::string> runtime_selector_key(gir::ValueId id, gir::CallableId callable_id);
+            void                                      emit_function(gir::CallableId id, Writer &out, Form form);
+            void                                      emit_struct(const gir::StructContract &item, Writer &out);
+            void                                      emit_runtime_function(gir::CallableId id, Writer &out);
+            [[nodiscard]] RuntimeInfo                 runtime_info(gir::CallableId id);
+            [[nodiscard]] std::optional<std::size_t>  runtime_parameter(gir::ValueId id, gir::CallableId callable_id);
+            [[nodiscard]] std::optional<std::size_t>  runtime_root_parameter(gir::ValueId id, gir::CallableId callable_id);
+            [[nodiscard]] std::optional<std::string>  runtime_scalar_key(gir::ValueId id, gir::CallableId callable_id);
+            [[nodiscard]] std::optional<std::int64_t> runtime_integer_constant(gir::ValueId id, gir::CallableId callable_id);
+            [[nodiscard]] std::optional<std::string>  runtime_selector_key(gir::ValueId id, gir::CallableId callable_id);
             void collect_runtime_activation(gir::ValueId id, gir::CallableId callable_id, RuntimeInfo &info);
             using RuntimeValidSet = std::unordered_set<std::string>;
             void check_runtime_expr(gir::ValueId id, gir::CallableId callable_id, const RuntimeValidSet &valid);
@@ -565,6 +571,8 @@ namespace hgl::codegen
             std::unordered_set<std::string>      local_names_{};
             Writer                               generated_helpers_{};
             std::size_t                          anonymous_function_index_{0};
+            Writer                              *current_body_{nullptr};
+            std::size_t                          conditional_index_{0};
         };
 
         std::string_view Emitter::local_identity(std::string_view identity) noexcept {
@@ -1637,6 +1645,111 @@ namespace hgl::codegen
             backend(range, "hgraph IR contains an unsupported reference");
         }
 
+        void Emitter::emit_planned_conditional_branch(std::string_view name, const gir::ConditionalBranchPlan &branch,
+                                                      const gir::ConditionalPlan                       &plan,
+                                                      const std::vector<std::pair<std::string, HType>> &parameters, Frame &outer,
+                                                      SourceRange range) {
+            if (current_body_ == nullptr) { backend(range, "a generated conditional branch has no enclosing function body"); }
+
+            const auto saved_counts = local_counts_;
+            const auto saved_names  = local_names_;
+            local_counts_.clear();
+            local_names_.clear();
+            local_names_.insert("w");
+
+            Frame nested;
+            nested.fn = outer.fn;
+            std::vector<std::string> signature{"[[maybe_unused]] hgraph::Wiring &w"};
+            for (std::size_t index = 0; index < plan.captures.size(); ++index) {
+                const gir::ConditionalCapture &capture = plan.captures[index];
+                const gir::Binding            &binding = planned_binding(capture.binding, range);
+                const auto &[cpp, type]                = parameters[index];
+                local_names_.insert(cpp);
+                signature.push_back("[[maybe_unused]] hgraph::Port<" + schema(type, binding.range) + "> " + cpp);
+                if (!nested.planned_bindings.emplace(capture.binding.value, make_port(cpp, type, binding.range)).second) {
+                    backend(binding.range, "a generated conditional branch repeats a capture binding");
+                }
+            }
+
+            const HType result = planned_type(plan.result, range);
+            current_body_->line("// " + where(planned_block(branch.block, range).range));
+            current_body_->open("struct " + std::string{name});
+            current_body_->line("static hgraph::Port<" + schema(result, range) + "> compose(" + join(signature, ", ") + ")");
+            current_body_->open("");
+            const gir::Block &body = planned_block(branch.block, range);
+            for (gir::StatementId statement : body.statements) {
+                emit_planned_statement(statement, nested, *current_body_, body.range);
+            }
+            if (!body.tail.valid()) { backend(body.range, "a value-producing time-series 'if' branch must end with a value"); }
+            const gir::Value &tail  = planned_value(body.tail, body.range);
+            const Value       value = eval_planned_expr(body.tail, nested);
+            current_body_->line("return " + as_port(value, result, tail.range) + ";");
+            current_body_->close();
+            current_body_->close(";");
+
+            local_counts_ = saved_counts;
+            local_names_  = saved_names;
+        }
+
+        Value Emitter::lower_planned_conditional(gir::ValueId id, const gir::Conditional &, SourceRange range, Frame &frame) {
+            const gir::ConditionalPlan plan = gir::analyze_temporal_conditional(graph_, id);
+            if (!plan.when_false) {
+                backend(range, "a value-producing time-series 'if' needs an explicit block 'else' in this compiler stage");
+            }
+            if (!plan.when_true.assigned_outer.empty() || !plan.when_false->assigned_outer.empty()) {
+                backend(range, "assignment escaping a time-series 'if' is not supported in this compiler stage");
+            }
+            if (plan.when_true.returns || plan.when_false->returns) {
+                backend(range, "return from a time-series 'if' branch is not supported in this compiler stage");
+            }
+
+            std::vector<std::pair<std::string, HType>> parameters;
+            std::vector<std::string>                   arguments;
+            std::unordered_set<std::string>            parameter_names{"w"};
+            std::unordered_map<std::string, int>       parameter_counts;
+            parameters.reserve(plan.captures.size());
+            arguments.reserve(plan.captures.size() + 2U);
+            for (const gir::ConditionalCapture &capture : plan.captures) {
+                const gir::Binding &binding = planned_binding(capture.binding, range);
+                if (capture.phase != hir::Phase::Wiring) {
+                    backend(binding.range,
+                            "capturing scalar configuration in a time-series 'if' branch is not supported in this compiler stage");
+                }
+                const auto outer = frame.planned_bindings.find(capture.binding.value);
+                if (outer == frame.planned_bindings.end() || !outer->second.is_port()) {
+                    backend(binding.range, "a temporal conditional capture is not bound to a time-series port");
+                }
+                const std::string base   = cpp_name(binding.name);
+                std::string       name   = base;
+                int              &suffix = parameter_counts[base];
+                while (parameter_names.contains(name)) { name = base + "_" + std::to_string(++suffix); }
+                parameter_names.insert(name);
+                parameters.emplace_back(std::move(name), planned_type(capture.type, binding.range));
+                arguments.push_back(outer->second.code);
+            }
+
+            const Value condition = eval_planned_expr(plan.condition, frame);
+            if (!condition.is_port()) {
+                backend(planned_value(plan.condition, range).range, "a temporal conditional needs a port");
+            }
+
+            const std::size_t index       = ++conditional_index_;
+            const std::string base        = "hgl_" + callable_cpp_name(frame.fn) + "_if_" + std::to_string(index);
+            const std::string then_branch = base + "_then";
+            const std::string else_branch = base + "_else";
+            emit_planned_conditional_branch(then_branch, plan.when_true, plan, parameters, frame, range);
+            emit_planned_conditional_branch(else_branch, *plan.when_false, plan, parameters, frame, range);
+
+            std::vector<std::string> switch_arguments{
+                condition.code, "hgraph::stdlib::switch_cases({{hgraph::Value{hgraph::Bool{true}}, hgraph::fn<" + then_branch +
+                                    ">()}, {hgraph::Value{hgraph::Bool{false}}, hgraph::fn<" + else_branch + ">()}})"};
+            switch_arguments.insert(switch_arguments.end(), arguments.begin(), arguments.end());
+            const HType result = planned_type(plan.result, range);
+            Value       value  = wire("hgraph::stdlib::switch_", switch_arguments, range, result);
+            value.code += ".as<" + schema(result, range) + ">()";
+            return value;
+        }
+
         Value Emitter::eval_planned_expr(gir::ValueId id, Frame &frame) {
             const gir::Value &expression = planned_value(id, {});
             if (expression.constant) { return planned_literal(*expression.constant, expression.range); }
@@ -1718,6 +1831,9 @@ namespace hgl::codegen
                     } else if constexpr (std::is_same_v<T, gir::Lambda>) {
                         backend(expression.range, "anonymous functions are not supported by the first pass");
                     } else if constexpr (std::is_same_v<T, gir::Conditional>) {
+                        if (expression.phase == hir::Phase::Wiring) {
+                            return lower_planned_conditional(id, node, expression.range, frame);
+                        }
                         unsupported(expression.range, "'if' used as a value");
                     } else if constexpr (std::is_same_v<T, gir::BlockValue>) {
                         unsupported(expression.range, "a block used as a value");
@@ -2898,15 +3014,13 @@ namespace hgl::codegen
                 return intersection;
             }
             if (binary->op == ir::hir::BinaryOp::GreaterEqual) {
-                const std::optional<std::string> index = runtime_scalar_key(binary->lhs, decl);
+                const std::optional<std::string>  index = runtime_scalar_key(binary->lhs, decl);
                 const std::optional<std::int64_t> bound = runtime_integer_constant(binary->rhs, decl);
                 if (index && bound == 0) { result.insert("nonnegative:" + *index); }
             } else if (binary->op == ir::hir::BinaryOp::Less) {
-                const std::optional<std::string> index = runtime_scalar_key(binary->lhs, decl);
+                const std::optional<std::string>  index = runtime_scalar_key(binary->lhs, decl);
                 const std::optional<std::int64_t> bound = runtime_integer_constant(binary->rhs, decl);
-                if (index && bound && *bound > 0) {
-                    result.insert("below:" + *index + ":" + std::to_string(*bound));
-                }
+                if (index && bound && *bound > 0) { result.insert("below:" + *index + ":" + std::to_string(*bound)); }
             }
             return result;
         }
@@ -3436,6 +3550,7 @@ namespace hgl::codegen
                 }
             }
             out.open("");
+            current_body_ = &out;
             if (planned.concise_body.valid() == planned.block_body.valid()) {
                 backend(planned.range, "hgraph IR callable '" + std::string{callable_name(decl)} +
                                            "' must have exactly one concise or block body");
@@ -3447,6 +3562,7 @@ namespace hgl::codegen
             } else {
                 emit_planned_block(planned.block_body, frame, out, true, planned.range);
             }
+            current_body_ = nullptr;
             out.close();
             if (form == Form::InlineStruct) { out.close(";"); }
             out.line();

--- a/language/src/hgraph_ir/control_flow.cpp
+++ b/language/src/hgraph_ir/control_flow.cpp
@@ -1,0 +1,265 @@
+#include "hgraph_ir/control_flow.h"
+
+#include <algorithm>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+namespace hgl::hgraph_ir
+{
+    namespace
+    {
+        template <typename T> [[nodiscard]] bool contains(const std::vector<T> &values, T value) {
+            return std::ranges::find(values, value) != values.end();
+        }
+
+        class BranchAnalyzer
+        {
+          public:
+            BranchAnalyzer(const Module &module, BlockId block) : module_{module} {
+                plan_.block = block;
+                collect_locals(block);
+                scan_block(block);
+            }
+
+            [[nodiscard]] ConditionalBranchPlan take() && { return std::move(plan_); }
+
+          private:
+            [[nodiscard]] const Value     &value(ValueId id) const { return module_.values.at(id.value); }
+            [[nodiscard]] const Statement &statement(StatementId id) const { return module_.statements.at(id.value); }
+            [[nodiscard]] const Block     &block(BlockId id) const { return module_.blocks.at(id.value); }
+
+            void add_local(BindingId binding) {
+                if (binding.valid() && !contains(locals_, binding)) { locals_.push_back(binding); }
+            }
+
+            void collect_value_locals(ValueId id) {
+                if (!id.valid()) { return; }
+                const Value &expression = value(id);
+                std::visit(
+                    [&](const auto &node) {
+                        using T = std::decay_t<decltype(node)>;
+                        if constexpr (std::is_same_v<T, Unary>) {
+                            collect_value_locals(node.operand);
+                        } else if constexpr (std::is_same_v<T, Binary>) {
+                            collect_value_locals(node.lhs);
+                            collect_value_locals(node.rhs);
+                        } else if constexpr (std::is_same_v<T, Call> || std::is_same_v<T, HarnessEval>) {
+                            collect_value_locals(node.callee);
+                            for (const Argument &argument : node.arguments) { collect_value_locals(argument.value); }
+                        } else if constexpr (std::is_same_v<T, Index>) {
+                            collect_value_locals(node.target);
+                            collect_value_locals(node.index);
+                        } else if constexpr (std::is_same_v<T, Field>) {
+                            collect_value_locals(node.target);
+                        } else if constexpr (std::is_same_v<T, Sequence>) {
+                            for (const SequenceElement &element : node.elements) {
+                                collect_value_locals(element.key);
+                                collect_value_locals(element.value);
+                            }
+                        } else if constexpr (std::is_same_v<T, Tuple>) {
+                            for (ValueId element : node.elements) { collect_value_locals(element); }
+                        } else if constexpr (std::is_same_v<T, Lambda>) {
+                            for (BindingId parameter : node.parameters) { add_local(parameter); }
+                            collect_value_locals(node.body);
+                        } else if constexpr (std::is_same_v<T, Conditional>) {
+                            collect_locals(node.then_block);
+                            collect_value_locals(node.otherwise);
+                        } else if constexpr (std::is_same_v<T, BlockValue>) {
+                            collect_locals(node.block);
+                        } else if constexpr (std::is_same_v<T, Construct>) {
+                            for (const Argument &argument : node.arguments) { collect_value_locals(argument.value); }
+                        }
+                    },
+                    expression.node);
+            }
+
+            void collect_locals(BlockId id) {
+                if (!id.valid()) { return; }
+                const Block &body = block(id);
+                for (StatementId statement_id : body.statements) {
+                    const Statement &item = statement(statement_id);
+                    std::visit(
+                        [&](const auto &node) {
+                            using T = std::decay_t<decltype(node)>;
+                            if constexpr (std::is_same_v<T, LocalBinding> || std::is_same_v<T, StateBinding>) {
+                                add_local(node.binding);
+                                collect_value_locals(node.init);
+                            } else if constexpr (std::is_same_v<T, Inject>) {
+                                for (BindingId binding : node.bindings) { add_local(binding); }
+                            } else if constexpr (std::is_same_v<T, Lifecycle>) {
+                                collect_locals(node.block);
+                            } else if constexpr (std::is_same_v<T, Activation>) {
+                                collect_value_locals(node.condition);
+                                collect_locals(node.block);
+                            } else if constexpr (std::is_same_v<T, Traversal>) {
+                                for (BindingId binding : node.bindings) { add_local(binding); }
+                                collect_value_locals(node.iterable);
+                                collect_locals(node.block);
+                            } else if constexpr (std::is_same_v<T, Assignment>) {
+                                collect_value_locals(node.place);
+                                collect_value_locals(node.value);
+                            } else if constexpr (std::is_same_v<T, Return>) {
+                                collect_value_locals(node.value);
+                            } else if constexpr (std::is_same_v<T, Assert>) {
+                                collect_value_locals(node.condition);
+                            } else if constexpr (std::is_same_v<T, Evaluate>) {
+                                collect_value_locals(node.value);
+                            }
+                        },
+                        item.node);
+                }
+                collect_value_locals(body.tail);
+            }
+
+            void capture(const Value &expression, BindingId binding) {
+                if (!binding.valid() || contains(locals_, binding)) { return; }
+                const auto existing = std::ranges::find_if(
+                    plan_.captures, [&](const ConditionalCapture &candidate) { return candidate.binding == binding; });
+                if (existing == plan_.captures.end()) {
+                    const TypeId type =
+                        binding.value < module_.bindings.size() ? module_.bindings[binding.value].type : expression.type;
+                    plan_.captures.push_back(ConditionalCapture{binding, type, expression.phase});
+                }
+            }
+
+            void scan_value(ValueId id) {
+                if (!id.valid()) { return; }
+                const Value &expression = value(id);
+                std::visit(
+                    [&](const auto &node) {
+                        using T = std::decay_t<decltype(node)>;
+                        if constexpr (std::is_same_v<T, Reference>) {
+                            if (node.kind == ReferenceKind::Binding) { capture(expression, node.binding); }
+                        } else if constexpr (std::is_same_v<T, Unary>) {
+                            scan_value(node.operand);
+                        } else if constexpr (std::is_same_v<T, Binary>) {
+                            scan_value(node.lhs);
+                            scan_value(node.rhs);
+                        } else if constexpr (std::is_same_v<T, Call>) {
+                            scan_value(node.callee);
+                            for (const Argument &argument : node.arguments) { scan_value(argument.value); }
+                        } else if constexpr (std::is_same_v<T, Index>) {
+                            scan_value(node.target);
+                            scan_value(node.index);
+                        } else if constexpr (std::is_same_v<T, Field>) {
+                            scan_value(node.target);
+                        } else if constexpr (std::is_same_v<T, Sequence>) {
+                            for (const SequenceElement &element : node.elements) {
+                                scan_value(element.key);
+                                scan_value(element.value);
+                            }
+                        } else if constexpr (std::is_same_v<T, Tuple>) {
+                            for (ValueId element : node.elements) { scan_value(element); }
+                        } else if constexpr (std::is_same_v<T, Lambda>) {
+                            scan_value(node.body);
+                        } else if constexpr (std::is_same_v<T, Conditional>) {
+                            scan_value(node.condition);
+                            scan_block(node.then_block);
+                            scan_value(node.otherwise);
+                        } else if constexpr (std::is_same_v<T, BlockValue>) {
+                            scan_block(node.block);
+                        } else if constexpr (std::is_same_v<T, HarnessEval>) {
+                            scan_value(node.callee);
+                            for (const Argument &argument : node.arguments) { scan_value(argument.value); }
+                        } else if constexpr (std::is_same_v<T, Construct>) {
+                            for (const Argument &argument : node.arguments) { scan_value(argument.value); }
+                        }
+                    },
+                    expression.node);
+            }
+
+            [[nodiscard]] BindingId direct_assignment_target(ValueId id) const {
+                if (!id.valid()) { return {}; }
+                const auto *reference = std::get_if<Reference>(&value(id).node);
+                return reference != nullptr && reference->kind == ReferenceKind::Binding ? reference->binding : BindingId{};
+            }
+
+            [[nodiscard]] BindingId place_root(ValueId id) const {
+                if (!id.valid()) { return {}; }
+                const Value &place = value(id);
+                if (const auto *reference = std::get_if<Reference>(&place.node)) {
+                    return reference->kind == ReferenceKind::Binding ? reference->binding : BindingId{};
+                }
+                if (const auto *index = std::get_if<Index>(&place.node)) { return place_root(index->target); }
+                if (const auto *field = std::get_if<Field>(&place.node)) { return place_root(field->target); }
+                return {};
+            }
+
+            void scan_block(BlockId id) {
+                if (!id.valid()) { return; }
+                const Block &body = block(id);
+                for (StatementId statement_id : body.statements) {
+                    const Statement &item = statement(statement_id);
+                    std::visit(
+                        [&](const auto &node) {
+                            using T = std::decay_t<decltype(node)>;
+                            if constexpr (std::is_same_v<T, LocalBinding> || std::is_same_v<T, StateBinding>) {
+                                scan_value(node.init);
+                            } else if constexpr (std::is_same_v<T, Lifecycle>) {
+                                scan_block(node.block);
+                            } else if constexpr (std::is_same_v<T, Activation>) {
+                                scan_value(node.condition);
+                                scan_block(node.block);
+                            } else if constexpr (std::is_same_v<T, Traversal>) {
+                                scan_value(node.iterable);
+                                scan_block(node.block);
+                            } else if constexpr (std::is_same_v<T, Assignment>) {
+                                const BindingId target = place_root(node.place);
+                                if (target.valid() && !contains(locals_, target) && !contains(plan_.assigned_outer, target)) {
+                                    plan_.assigned_outer.push_back(target);
+                                }
+                                if (node.op != AssignOp::Assign || direct_assignment_target(node.place) != target) {
+                                    scan_value(node.place);
+                                }
+                                scan_value(node.value);
+                            } else if constexpr (std::is_same_v<T, Return>) {
+                                plan_.returns = true;
+                                scan_value(node.value);
+                            } else if constexpr (std::is_same_v<T, Assert>) {
+                                scan_value(node.condition);
+                            } else if constexpr (std::is_same_v<T, Evaluate>) {
+                                scan_value(node.value);
+                            }
+                        },
+                        item.node);
+                }
+                scan_value(body.tail);
+            }
+
+            const Module          &module_;
+            ConditionalBranchPlan  plan_{};
+            std::vector<BindingId> locals_{};
+        };
+
+        void append_capture(std::vector<ConditionalCapture> &captures, const ConditionalCapture &capture) {
+            const bool exists = std::ranges::any_of(
+                captures, [&](const ConditionalCapture &candidate) { return candidate.binding == capture.binding; });
+            if (!exists) { captures.push_back(capture); }
+        }
+    }  // namespace
+
+    ConditionalPlan analyze_temporal_conditional(const Module &module, ValueId value_id) {
+        ConditionalPlan plan;
+        plan.value = value_id;
+        if (!value_id.valid() || value_id.value >= module.values.size()) { return plan; }
+
+        const Value &value  = module.values[value_id.value];
+        const auto  *branch = std::get_if<Conditional>(&value.node);
+        if (branch == nullptr) { return plan; }
+
+        plan.condition = branch->condition;
+        plan.result    = value.type;
+        plan.when_true = BranchAnalyzer{module, branch->then_block}.take();
+        for (const ConditionalCapture &capture : plan.when_true.captures) { append_capture(plan.captures, capture); }
+
+        if (branch->otherwise.valid() && branch->otherwise.value < module.values.size()) {
+            const Value &otherwise = module.values[branch->otherwise.value];
+            if (const auto *block = std::get_if<BlockValue>(&otherwise.node)) {
+                plan.when_false = BranchAnalyzer{module, block->block}.take();
+                for (const ConditionalCapture &capture : plan.when_false->captures) { append_capture(plan.captures, capture); }
+            }
+        }
+        return plan;
+    }
+}  // namespace hgl::hgraph_ir

--- a/language/src/hgraph_ir/control_flow.h
+++ b/language/src/hgraph_ir/control_flow.h
@@ -1,0 +1,48 @@
+#ifndef HGL_HGRAPH_IR_CONTROL_FLOW_H
+#define HGL_HGRAPH_IR_CONTROL_FLOW_H
+
+#include "hgraph_ir/ir.h"
+
+#include <optional>
+#include <vector>
+
+namespace hgl::hgraph_ir
+{
+    /// An outer lexical binding read by a nested conditional branch. The
+    /// phase is retained at the use site so execution backends can distinguish
+    /// temporal boundary inputs from scalar configuration captures.
+    struct ConditionalCapture
+    {
+        BindingId      binding{};
+        TypeId         type{};
+        ir::hir::Phase phase{ir::hir::Phase::Unknown};
+    };
+
+    struct ConditionalBranchPlan
+    {
+        BlockId                         block{};
+        std::vector<ConditionalCapture> captures{};
+        std::vector<BindingId>          assigned_outer{};
+        bool                            returns{false};
+    };
+
+    /// Backend-independent plan for one graph-phase conditional. Captures are
+    /// the stable first-use union of the two branch signatures.
+    struct ConditionalPlan
+    {
+        ValueId                              value{};
+        ValueId                              condition{};
+        TypeId                               result{};
+        ConditionalBranchPlan                when_true{};
+        std::optional<ConditionalBranchPlan> when_false{};
+        std::vector<ConditionalCapture>      captures{};
+    };
+
+    /// Analyze an HGraph-IR Conditional value. The input module is already
+    /// structurally valid; a non-conditional value or non-block else arm is
+    /// represented as an incomplete plan for the backends to diagnose against
+    /// the original source range.
+    [[nodiscard]] ConditionalPlan analyze_temporal_conditional(const Module &module, ValueId value);
+}  // namespace hgl::hgraph_ir
+
+#endif  // HGL_HGRAPH_IR_CONTROL_FLOW_H

--- a/language/src/wiring/backend.cpp
+++ b/language/src/wiring/backend.cpp
@@ -360,8 +360,7 @@ namespace hgl::wiring
                                                         std::string_view registry_name = {});
 
             [[nodiscard]] Slot eval_value(gir::ValueId id, Frame &frame);
-            [[nodiscard]] Slot eval_temporal_conditional(gir::ValueId id, const gir::Conditional &branch, SourceRange range,
-                                                         Frame &frame);
+            [[nodiscard]] Slot eval_temporal_conditional(gir::ValueId id, const Slot &condition, SourceRange range, Frame &frame);
             [[nodiscard]] Slot eval_reference(const gir::Reference &reference, SourceRange range, Frame &frame);
             [[nodiscard]] Slot eval_call(const gir::Value &expression, const gir::Call &call, Frame &frame);
             [[nodiscard]] Slot eval_intrinsic(std::string_view name, const std::vector<gir::Argument> &arguments, SourceRange range,
@@ -1318,7 +1317,7 @@ namespace hgl::wiring
             return result.port;
         }
 
-        Slot Compiler::eval_temporal_conditional(gir::ValueId id, const gir::Conditional &, SourceRange range, Frame &frame) {
+        Slot Compiler::eval_temporal_conditional(gir::ValueId id, const Slot &condition, SourceRange range, Frame &frame) {
             const gir::ConditionalPlan plan = gir::analyze_temporal_conditional(module_, id);
             if (!plan.when_false) {
                 backend(range, "a value-producing time-series 'if' needs an explicit block 'else' in this compiler stage");
@@ -1336,7 +1335,6 @@ namespace hgl::wiring
                 }
             }
 
-            Slot condition = eval_value(plan.condition, frame);
             if (!condition.is_port()) {
                 backend(value(plan.condition).range, "a temporal conditional needs a time-series condition");
             }
@@ -1428,7 +1426,7 @@ namespace hgl::wiring
                         backend(expression.range, "anonymous functions are not supported by the first pass");
                     } else if constexpr (std::is_same_v<T, gir::Conditional>) {
                         Slot condition = eval_value(node.condition, frame);
-                        if (condition.is_port()) { return eval_temporal_conditional(id, node, expression.range, frame); }
+                        if (condition.is_port()) { return eval_temporal_conditional(id, condition, expression.range, frame); }
                         if (!condition.is_const() || condition.meta() != types_.bool_type) {
                             fail(Category::Type, value(node.condition).range, "an 'if' condition is a bool");
                         }

--- a/language/src/wiring/backend.cpp
+++ b/language/src/wiring/backend.cpp
@@ -1,8 +1,10 @@
 #include "wiring/backend.h"
 
+#include "hgraph_ir/control_flow.h"
 #include "syntax/temporal.h"
 #include "wiring/type_bridge.h"
 
+#include <hgraph/lib/std/operators/higher_order.h>
 #include <hgraph/lib/std/operators/registration.h>
 #include <hgraph/lib/std/standard_types.h>
 #include <hgraph/lib/testing/record_replay.h>
@@ -20,6 +22,7 @@
 #include <hgraph/types/value/value.h>
 #include <hgraph/types/value/value_builder.h>
 #include <hgraph/types/value/value_view.h>
+#include <hgraph/types/wired_fn.h>
 #include <hgraph/util/scope.h>
 
 #if defined(HGL_HAVE_ANALYTICS)
@@ -32,6 +35,7 @@
 #include <exception>
 #include <iostream>
 #include <limits>
+#include <memory>
 #include <optional>
 #include <span>
 #include <sstream>
@@ -356,6 +360,8 @@ namespace hgl::wiring
                                                         std::string_view registry_name = {});
 
             [[nodiscard]] Slot eval_value(gir::ValueId id, Frame &frame);
+            [[nodiscard]] Slot eval_temporal_conditional(gir::ValueId id, const gir::Conditional &branch, SourceRange range,
+                                                         Frame &frame);
             [[nodiscard]] Slot eval_reference(const gir::Reference &reference, SourceRange range, Frame &frame);
             [[nodiscard]] Slot eval_call(const gir::Value &expression, const gir::Call &call, Frame &frame);
             [[nodiscard]] Slot eval_intrinsic(std::string_view name, const std::vector<gir::Argument> &arguments, SourceRange range,
@@ -379,14 +385,31 @@ namespace hgl::wiring
                                                      SourceRange range);
             [[nodiscard]] std::string describe(const Slot &slot);
 
-            const syntax::SourceFile                      &file_;
-            const gir::Module                             &module_;
-            syntax::DiagnosticSink                        &diagnostics_;
-            TypeBridge                                     bridge_;
-            hgraph::TypeRegistry                          &registry_;
-            const hgraph::stdlib::RegisteredStandardTypes &types_{standard_types()};
-            hgraph::Wiring                                *wiring_{nullptr};
-            std::string                                    comparison_detail_{};
+            struct ConditionalBranchContext
+            {
+                Compiler    *compiler{nullptr};
+                Frame        frame{};
+                gir::BlockId block{};
+                gir::TypeId  result{};
+                SourceRange  range{};
+                std::string  label{};
+            };
+
+            [[nodiscard]] hgraph::WiredFn              conditional_branch(Frame &frame, gir::BlockId block, gir::TypeId result,
+                                                                          SourceRange range, std::string label);
+            [[nodiscard]] static hgraph::WiringPortRef wire_conditional_branch(const void *context, hgraph::Wiring &w,
+                                                                               std::span<const hgraph::WiringPortRef> arguments);
+            [[nodiscard]] static const hgraph::WiredFnOps &conditional_branch_ops();
+
+            const syntax::SourceFile                              &file_;
+            const gir::Module                                     &module_;
+            syntax::DiagnosticSink                                &diagnostics_;
+            TypeBridge                                             bridge_;
+            hgraph::TypeRegistry                                  &registry_;
+            const hgraph::stdlib::RegisteredStandardTypes         &types_{standard_types()};
+            hgraph::Wiring                                        *wiring_{nullptr};
+            std::string                                            comparison_detail_{};
+            std::vector<std::unique_ptr<ConditionalBranchContext>> conditional_branches_{};
         };
 
         Slot Compiler::constant(const hir::Constant &source, SourceRange range) {
@@ -1225,6 +1248,108 @@ namespace hgl::wiring
             fail(Category::Type, value(call.callee).range, "'" + slice(value(call.callee).range) + "' is not callable");
         }
 
+        const hgraph::WiredFnOps &Compiler::conditional_branch_ops() {
+            static constexpr hgraph::WiredFnOps ops{
+                &Compiler::wire_conditional_branch,
+                nullptr,
+                nullptr,
+                [](const void *) { return std::span<const std::string_view>{}; },
+                [](const void *, std::size_t) -> const hgraph::TSValueTypeMetaData * { return nullptr; },
+                nullptr,
+                [](const void *context) {
+                    const auto &branch = *static_cast<const ConditionalBranchContext *>(context);
+                    return branch.compiler->schema(branch.result);
+                },
+                nullptr,
+                nullptr,
+                [](const void *context) -> std::string_view {
+                    return static_cast<const ConditionalBranchContext *>(context)->label;
+                },
+            };
+            return ops;
+        }
+
+        hgraph::WiredFn Compiler::conditional_branch(Frame &frame, gir::BlockId block, gir::TypeId result, SourceRange range,
+                                                     std::string label) {
+            auto context      = std::make_unique<ConditionalBranchContext>();
+            context->compiler = this;
+            context->frame    = frame;
+            context->frame.returned.reset();
+            context->block                         = block;
+            context->result                        = result;
+            context->range                         = range;
+            context->label                         = std::move(label);
+            const ConditionalBranchContext *stored = context.get();
+            conditional_branches_.push_back(std::move(context));
+            return hgraph::WiredFn{
+                .ops        = &conditional_branch_ops(),
+                .context    = stored,
+                .identity   = &typeid(ConditionalBranchContext),
+                .arity      = 0,
+                .has_output = true,
+            };
+        }
+
+        hgraph::WiringPortRef Compiler::wire_conditional_branch(const void *opaque, hgraph::Wiring &child,
+                                                                std::span<const hgraph::WiringPortRef> arguments) {
+            const auto &context = *static_cast<const ConditionalBranchContext *>(opaque);
+            if (!arguments.empty()) { throw std::invalid_argument("an HGL conditional branch takes no explicit arguments"); }
+
+            Compiler       &compiler = *context.compiler;
+            hgraph::Wiring *previous = compiler.wiring_;
+            compiler.wiring_         = &child;
+            auto restore_wiring      = hgraph::make_scope_exit([&]() noexcept { compiler.wiring_ = previous; });
+
+            Frame frame  = context.frame;
+            Slot  result = compiler.exec_block(context.block, frame);
+            if (frame.returned) { result = *frame.returned; }
+
+            const hgraph::TSValueTypeMetaData *expected = compiler.schema(context.result);
+            if (result.is_const()) {
+                result = compiler.wire_constant(
+                    make_const(compiler.convert(result.value, expected->value_schema, result.range, "conditional branch result"),
+                               result.range),
+                    expected);
+            } else if (result.is_port()) {
+                result = compiler.convert_port(result, expected);
+            } else {
+                compiler.backend(context.range, "a time-series conditional branch must produce a value");
+            }
+            return result.port;
+        }
+
+        Slot Compiler::eval_temporal_conditional(gir::ValueId id, const gir::Conditional &, SourceRange range, Frame &frame) {
+            const gir::ConditionalPlan plan = gir::analyze_temporal_conditional(module_, id);
+            if (!plan.when_false) {
+                backend(range, "a value-producing time-series 'if' needs an explicit block 'else' in this compiler stage");
+            }
+            if (!plan.when_true.assigned_outer.empty() || !plan.when_false->assigned_outer.empty()) {
+                backend(range, "assignment escaping a time-series 'if' is not supported in this compiler stage");
+            }
+            if (plan.when_true.returns || plan.when_false->returns) {
+                backend(range, "return from a time-series 'if' branch is not supported in this compiler stage");
+            }
+            for (const gir::ConditionalCapture &capture : plan.captures) {
+                if (capture.phase != hir::Phase::Wiring) {
+                    backend(binding(capture.binding).range,
+                            "capturing scalar configuration in a time-series 'if' branch is not supported in this compiler stage");
+                }
+            }
+
+            Slot condition = eval_value(plan.condition, frame);
+            if (!condition.is_port()) {
+                backend(value(plan.condition).range, "a temporal conditional needs a time-series condition");
+            }
+
+            hgraph::stdlib::SwitchCases cases = hgraph::stdlib::switch_cases(
+                {{hgraph::Value{hgraph::Bool{true}},
+                  conditional_branch(frame, plan.when_true.block, plan.result, range, "hgl conditional then")},
+                 {hgraph::Value{hgraph::Bool{false}},
+                  conditional_branch(frame, plan.when_false->block, plan.result, range, "hgl conditional else")}});
+            return wire("switch_", {time_series_arg(condition.port, "key"), scalar_arg(hgraph::Value{std::move(cases)}, "cases")},
+                        range, true, schema(plan.result));
+        }
+
         Slot Compiler::eval_value(gir::ValueId id, Frame &frame) {
             const gir::Value &expression = value(id);
             if (expression.constant) { return constant(*expression.constant, expression.range); }
@@ -1303,10 +1428,7 @@ namespace hgl::wiring
                         backend(expression.range, "anonymous functions are not supported by the first pass");
                     } else if constexpr (std::is_same_v<T, gir::Conditional>) {
                         Slot condition = eval_value(node.condition, frame);
-                        if (condition.is_port()) {
-                            backend(value(node.condition).range,
-                                    "'if' over a time-series condition is not supported by the first pass; use if_then_else");
-                        }
+                        if (condition.is_port()) { return eval_temporal_conditional(id, node, expression.range, frame); }
                         if (!condition.is_const() || condition.meta() != types_.bool_type) {
                             fail(Category::Type, value(node.condition).range, "an 'if' condition is a bool");
                         }

--- a/language/stdlib/README.md
+++ b/language/stdlib/README.md
@@ -60,8 +60,11 @@ unsupported, not added here as a supported loop contract.
 
 ## Compiler status
 
-These design examples still depend on compiler work, including temporal graph
-conditionals and graph-phase iteration. Typed declarations without initializers
-and their definite-assignment checks are implemented. The files remain design
-inputs, not runnable tests, and are deliberately outside `language/examples/`,
-whose `.hgl` files are checked by CTest.
+The smallest temporal graph conditional—an explicit two-branch expression with
+one tail value and temporal captures—is implemented in both backends and the
+backend-parity fixture. These corpus examples still depend on the broader
+escaping-result, continuation, sink, and graph-phase iteration work. Typed
+declarations without initializers and their definite-assignment checks are
+implemented. The files remain design inputs, not runnable tests, and are
+deliberately outside `language/examples/`, whose `.hgl` files are checked by
+CTest.

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -122,6 +122,7 @@ add_test(NAME hgraph_language_ir COMMAND hgl_ir_tests)
 # The hgraph-IR boundary owns self-contained canonical contracts and bodies.
 add_executable(hgl_graph_ir_tests
     hgraph_ir/complete_tests.cpp
+    hgraph_ir/control_flow_tests.cpp
     hgraph_ir/lower_tests.cpp
 )
 target_compile_features(hgl_graph_ir_tests PRIVATE cxx_std_23)
@@ -264,7 +265,7 @@ add_test(
     COMMAND $<TARGET_FILE:hgl> test ${CMAKE_CURRENT_SOURCE_DIR}/codegen/parity.hgl
 )
 set_tests_properties(hgraph_language_test_parity PROPERTIES
-    PASS_REGULAR_EXPRESSION "6 tests, 0 failed"
+    PASS_REGULAR_EXPRESSION "7 tests, 0 failed"
 )
 
 if(UNIX)

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -101,7 +101,7 @@ TEST_CASE("emit-cpp names the pair after the module and exports its functions", 
 
     CHECK(emitted->namespace_name == "hgl::codegen::parity");
     CHECK(emitted->module_name == "hgl.codegen.parity");
-    CHECK(emitted->exports == std::vector<std::string>{"plus", "scaled_sum", "above", "maybe_double", "offset_by"});
+    CHECK(emitted->exports == std::vector<std::string>{"plus", "scaled_sum", "above", "maybe_double", "offset_by", "choose"});
     CHECK(contains(emitted->descriptor, "\"format\": \"hgl.module\""));
     CHECK(contains(emitted->descriptor, "\"identity\": \"hgl.codegen.parity\""));
     CHECK(contains(emitted->descriptor, "\"signature\": {"));
@@ -527,6 +527,32 @@ export fn selected(const condition: bool, value: i64) -> i64 {
     CHECK(contains(emitted->source, "return result;"));
 }
 
+TEST_CASE("emit-cpp lowers a temporal if to readable switch branch graphs", "[codegen][control-flow][conditional]") {
+    Unit unit{R"(
+module planned_temporal_conditional
+
+export fn selected(condition: bool, x: i64, y: i64) -> i64 {
+    if condition {
+        let adjusted = x + 1
+        adjusted
+    } else {
+        y - 1
+    }
+}
+)"};
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+
+    const auto emitted = unit.emit();
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE(emitted);
+    CHECK(contains(emitted->source, "struct hgl_selected_if_1_then"));
+    CHECK(contains(emitted->source, "struct hgl_selected_if_1_else"));
+    CHECK(contains(emitted->source, "static hgraph::Port<hgraph::TS<hgraph::Int>> compose("));
+    CHECK(contains(emitted->source, "hgraph::stdlib::switch_cases("));
+    CHECK(contains(emitted->source, "hgraph::fn<hgl_selected_if_1_then>()"));
+    CHECK_FALSE(contains(emitted->source, "if_then_else"));
+}
+
 TEST_CASE("emit-cpp promotes the first constant assignment to a typed composition var", "[codegen][locals][control-flow]") {
     Unit unit{R"(
 module planned_constant_assignment
@@ -547,10 +573,8 @@ export fn selected(const condition: bool) -> i64 {
     INFO(unit.diagnostics.render(unit.file));
     REQUIRE(emitted);
     CHECK(contains(emitted->source, "hgraph::Port<hgraph::TS<hgraph::Int>> result;"));
-    CHECK(contains(emitted->source,
-                   "result = hgraph::wire<hgraph::stdlib::const_, hgraph::TS<hgraph::Int>>(w, hgraph::Int{1});"));
-    CHECK(contains(emitted->source,
-                   "result = hgraph::wire<hgraph::stdlib::const_, hgraph::TS<hgraph::Int>>(w, hgraph::Int{2});"));
+    CHECK(contains(emitted->source, "result = hgraph::wire<hgraph::stdlib::const_, hgraph::TS<hgraph::Int>>(w, hgraph::Int{1});"));
+    CHECK(contains(emitted->source, "result = hgraph::wire<hgraph::stdlib::const_, hgraph::TS<hgraph::Int>>(w, hgraph::Int{2});"));
     CHECK(contains(emitted->source, "return result;"));
 }
 
@@ -671,7 +695,8 @@ TEST_CASE("emit-cpp writes a Python wrapper over the registered names", "[codege
     REQUIRE(emitted);
     CHECK(contains(emitted->python, "from . import _parity as _hgl_native"));
     CHECK(contains(emitted->python, "\"plus\": _hgl_operator_function(\"hgl.codegen.parity.plus\")"));
-    CHECK(contains(emitted->python, "__all__ = [\"plus\", \"scaled_sum\", \"above\", \"maybe_double\", \"offset_by\"]"));
+    CHECK(
+        contains(emitted->python, "__all__ = [\"plus\", \"scaled_sum\", \"above\", \"maybe_double\", \"offset_by\", \"choose\"]"));
 }
 
 TEST_CASE("emit-cpp gives Python keyword exports a usable spelling", "[codegen]") {

--- a/language/tests/codegen/generated_tests.cpp
+++ b/language/tests/codegen/generated_tests.cpp
@@ -20,21 +20,18 @@ namespace parity = hgl::codegen::parity;
 
 namespace
 {
-    void session()
-    {
+    void session() {
         hgl::wiring::ensure_session();
         parity::register_operators();
     }
 }  // namespace
 
-TEST_CASE("generated plus records the ticks hgl test asserts", "[codegen][generated]")
-{
+TEST_CASE("generated plus records the ticks hgl test asserts", "[codegen][generated]") {
     session();
     CHECK(eval_node<parity::plus>(values<Float>(1.0, 2.0), values<Float>(10.0, 20.0)) == values<Float>(11.0, 22.0));
 }
 
-TEST_CASE("generated compositions wire helpers, constants and kernels", "[codegen][generated]")
-{
+TEST_CASE("generated compositions wire helpers, constants and kernels", "[codegen][generated]") {
     session();
     CHECK(eval_node<parity::scaled_sum>(values<Float>(1.0), values<Float>(2.0), Float{3.0}) == values<Float>(9.0));
     CHECK(eval_node<parity::above>(values<Float>(1.0, 3.0), Float{2.0}) == values<Bool>(false, true));
@@ -43,11 +40,17 @@ TEST_CASE("generated compositions wire helpers, constants and kernels", "[codege
     CHECK(eval_node<parity::offset_by>(values<Float>(1.0, 2.5), Int{3}) == values<Float>(7.0, 8.5));
 }
 
-TEST_CASE("generated exports are registered by module-qualified name with their defaults", "[codegen][generated]")
-{
+TEST_CASE("generated temporal conditionals match scripted switch behavior", "[codegen][generated][conditional]") {
+    session();
+    CHECK(eval_node<parity::choose>(values<Bool>(true, true, false), values<Int>(1, 2, 3), values<Int>(10, 20, 30)) ==
+          values<Int>(2, 3, 29));
+}
+
+TEST_CASE("generated exports are registered by module-qualified name with their defaults", "[codegen][generated]") {
     session();
     CHECK(hgl::wiring::has_operator("hgl.codegen.parity.plus"));
     CHECK(hgl::wiring::has_operator("hgl.codegen.parity.scaled_sum"));
+    CHECK(hgl::wiring::has_operator("hgl.codegen.parity.choose"));
     // Through the registry the const default applies, as it would from Python.
     CHECK_OUTPUT(eval_node<parity::operators::scaled_sum>(values<Float>(1.0), values<Float>(2.0)), values<Float>(6.0));
     CHECK_OUTPUT(eval_node<parity::operators::maybe_double>(values<Float>(1.5)), values<Float>(3.0));

--- a/language/tests/codegen/parity.hgl
+++ b/language/tests/codegen/parity.hgl
@@ -39,6 +39,15 @@ export fn offset_by(x: f64, const delta: i64 = -9223372036854775807 - 1) -> f64 
     x + shift
 }
 
+export fn choose(condition: bool, x: i64, y: i64) -> i64 {
+    if condition {
+        let adjusted = x + 1
+        adjusted
+    } else {
+        y - 1
+    }
+}
+
 test plus_ticks {
     assert eval(plus, a: [1.0, 2.0], b: [10.0, 20.0]) == [11.0, 22.0]
 }
@@ -62,4 +71,8 @@ test maybe_double_ticks {
 
 test offset_by_ticks {
     assert eval(offset_by, x: [1.0, 2.5], delta: 3) == [7.0, 8.5]
+}
+
+test choose_ticks {
+    assert eval(choose, condition: [true, true, false], x: [1, 2, 3], y: [10, 20, 30]) == [2, 3, 29]
 }

--- a/language/tests/hgraph_ir/control_flow_tests.cpp
+++ b/language/tests/hgraph_ir/control_flow_tests.cpp
@@ -1,0 +1,104 @@
+#include "hgraph_ir/control_flow.h"
+#include "hgraph_ir/lower.h"
+#include "ir/lower.h"
+#include "ir/type_check.h"
+#include "semantics/resolve.h"
+#include "syntax/parser.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace
+{
+    namespace gir = hgl::hgraph_ir;
+    namespace hir = hgl::ir::hir;
+
+    struct Lowered
+    {
+        hgl::syntax::SourceFile     file{"control_flow.hgl", {}};
+        hgl::syntax::DiagnosticSink diagnostics{};
+        std::optional<gir::Module>  graph{};
+
+        explicit Lowered(std::string source) : file{"control_flow.hgl", std::move(source)} {
+            const hgl::syntax::ast::Module ast = hgl::syntax::parse(file, diagnostics);
+            if (diagnostics.has_errors()) { return; }
+            const auto resolved = hgl::semantics::resolve(file, ast, [](std::string_view) { return true; }, diagnostics);
+            if (diagnostics.has_errors()) { return; }
+            hir::Module module    = hgl::ir::lower_to_hir(ast, resolved, diagnostics);
+            const auto  operators = [](const hir::Module &, const hgl::ir::OperatorQuery &query) {
+                hgl::ir::OperatorSelection selection;
+                selection.result   = query.expected_result;
+                selection.deferred = true;
+                return selection;
+            };
+            if (!hgl::ir::complete_hir(module, operators, diagnostics)) { return; }
+            graph = gir::lower(module, diagnostics);
+        }
+    };
+
+    gir::ValueId conditional_value(const gir::Module &module) {
+        for (std::uint32_t index = 0; index < module.values.size(); ++index) {
+            if (std::holds_alternative<gir::Conditional>(module.values[index].node)) { return gir::ValueId{index}; }
+        }
+        return {};
+    }
+}  // namespace
+
+TEST_CASE("temporal conditional analysis produces a stable union capture signature", "[hgraph-ir][control-flow]") {
+    Lowered lowered{R"(
+module checks.temporal_capture
+
+fn choose(condition: bool, x: i64, y: i64, const scale: i64) -> i64 {
+    if condition {
+        let local = x + scale
+        local
+    } else {
+        y + x
+    }
+}
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE(lowered.graph);
+
+    const gir::ConditionalPlan plan = gir::analyze_temporal_conditional(*lowered.graph, conditional_value(*lowered.graph));
+    REQUIRE(plan.when_false);
+    REQUIRE(plan.captures.size() == 3);
+    CHECK(lowered.graph->bindings[plan.captures[0].binding.value].name == "x");
+    CHECK(plan.captures[0].phase == hir::Phase::Wiring);
+    CHECK(lowered.graph->bindings[plan.captures[1].binding.value].name == "scale");
+    CHECK(plan.captures[1].phase == hir::Phase::Constant);
+    CHECK(lowered.graph->bindings[plan.captures[2].binding.value].name == "y");
+    CHECK(plan.captures[2].phase == hir::Phase::Wiring);
+    CHECK(plan.when_true.captures.size() == 2);
+    CHECK(plan.when_false->captures.size() == 2);
+}
+
+TEST_CASE("temporal conditional analysis records escaping assignment and return", "[hgraph-ir][control-flow]") {
+    Lowered lowered{R"(
+module checks.temporal_escape
+
+fn choose(condition: bool, value: i64) -> i64 {
+    var result: i64
+    if condition {
+        result = value
+        return result
+    } else {
+        result = value + 1
+    }
+    result
+}
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE(lowered.graph);
+
+    const gir::ConditionalPlan plan = gir::analyze_temporal_conditional(*lowered.graph, conditional_value(*lowered.graph));
+    REQUIRE(plan.when_false);
+    REQUIRE(plan.when_true.assigned_outer.size() == 1);
+    REQUIRE(plan.when_false->assigned_outer.size() == 1);
+    CHECK(plan.when_true.assigned_outer.front() == plan.when_false->assigned_outer.front());
+    CHECK(plan.when_true.returns);
+    CHECK_FALSE(plan.when_false->returns);
+}

--- a/language/tests/wiring/backend_tests.cpp
+++ b/language/tests/wiring/backend_tests.cpp
@@ -7,6 +7,7 @@
 #include "wiring/operator_types.h"
 
 #include <hgraph/lib/std/operators/collection.h>
+#include <hgraph/lib/std/operators/logical.h>
 #include <hgraph/types/operator_dispatch.h>
 
 #include <catch2/catch_test_macros.hpp>
@@ -37,6 +38,23 @@ namespace
         static auto compose(hgraph::Wiring &w, hgraph::Port<hgraph::TS<hgraph::Float>> a,
                             hgraph::Port<hgraph::TS<hgraph::Float>> b) {
             return hgraph::stdlib::to_tsl(w, a, b);
+        }
+    };
+
+    struct observed_condition_operator
+        : hgraph::Operator<"hgl_observed_condition", hgraph::In<"condition", hgraph::TS<hgraph::Bool>>,
+                           hgraph::Out<hgraph::TS<hgraph::Bool>>>
+    {};
+
+    struct observed_condition_graph
+    {
+        static constexpr auto name = "hgl_observed_condition_graph";
+        static inline int     compose_calls{0};
+
+        static auto compose(hgraph::Wiring &w, hgraph::Port<hgraph::TS<hgraph::Bool>> condition) {
+            ++compose_calls;
+            auto negated = hgraph::wire<hgraph::stdlib::not_>(w, condition).as<hgraph::TS<hgraph::Bool>>();
+            return hgraph::wire<hgraph::stdlib::not_>(w, negated).as<hgraph::TS<hgraph::Bool>>();
         }
     };
 
@@ -241,6 +259,34 @@ test choose_ticks {
     INFO(unit.diagnostics.render(unit.file));
     INFO(result.message);
     CHECK(result.passed);
+}
+
+TEST_CASE("a temporal if evaluates its condition composition once", "[wiring][control-flow][conditional]") {
+    ensure_session();
+    hgraph::register_graph_overload<observed_condition_operator, observed_condition_graph>();
+    observed_condition_graph::compose_calls = 0;
+    Unit             unit{R"(
+module t
+
+use hgraph.std::{hgl_observed_condition}
+
+fn choose(condition: bool, x: i64, y: i64) -> i64 {
+    if hgl_observed_condition(condition) {
+        x + 0
+    } else {
+        y + 0
+    }
+}
+
+test choose_once {
+    eval(choose, condition: [true], x: [1], y: [2])
+}
+)"};
+    const TestResult result = only(unit.tests());
+    INFO(unit.diagnostics.render(unit.file));
+    INFO(result.message);
+    CHECK(result.passed);
+    CHECK(observed_condition_graph::compose_calls == 1);
 }
 
 TEST_CASE("composition boundaries preserve compatible fixed list ports", "[wiring][types][list]") {

--- a/language/tests/wiring/backend_tests.cpp
+++ b/language/tests/wiring/backend_tests.cpp
@@ -221,6 +221,28 @@ test widening {
     CHECK(result.passed);
 }
 
+TEST_CASE("a temporal if wires value-producing branches through switch", "[wiring][control-flow][conditional]") {
+    Unit             unit{R"(
+module t
+
+fn choose(condition: bool, x: i64, y: i64) -> i64 {
+    if condition {
+        x + 1
+    } else {
+        y - 1
+    }
+}
+
+test choose_ticks {
+    assert eval(choose, condition: [true, true, false], x: [1, 2, 3], y: [10, 20, 30]) == [2, 3, 29]
+}
+)"};
+    const TestResult result = only(unit.tests());
+    INFO(unit.diagnostics.render(unit.file));
+    INFO(result.message);
+    CHECK(result.passed);
+}
+
 TEST_CASE("composition boundaries preserve compatible fixed list ports", "[wiring][types][list]") {
     ensure_session();
     hgraph::register_graph_overload<fixed_pair_operator, fixed_pair_graph>();


### PR DESCRIPTION
## Summary
- add backend-independent HGraph-IR analysis for temporal conditional captures, escaping assignments, and branch returns
- lower explicit two-branch tail-valued temporal `if` expressions through native `switch_` in both the direct and generated-C++ backends
- emit readable function-scoped branch graph structs and cover scripted/generated parity across a branch change
- update the user, developer, and design status to distinguish this initial slice from remaining escaping, continuation, scalar-capture, omitted-else, and sink work

## Validation
- `ctest --test-dir build-language-review --output-on-failure -R "^hgraph_language_" --parallel 4` (36/36 passed)
- generated parity fixture compiles warning-free through `hgl_add_module()` and clang-format
