### PR TITLE
feat(language): describe native interface policy

### DIFF
--- a/language/CHANGELOG.md
+++ b/language/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Describe native types and declarations with phase, effect, ownership,
+  borrowed-lifetime, exception, and thread-safety metadata. Seal descriptors
+  with a canonical SHA-256 fingerprint and require the generated native module
+  table to present the exact fingerprint before initialization.
 - Add an installed C-compatible native module lifecycle ABI and move scripted
   image registration ownership behind its opaque, versioned module table.
 - Lower explicit two-branch temporal `if` expressions through native

--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -172,7 +172,7 @@ add_library(hgl_descriptor STATIC
 add_library(hgl::descriptor ALIAS hgl_descriptor)
 target_compile_features(hgl_descriptor PUBLIC cxx_std_23)
 target_include_directories(hgl_descriptor PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
-target_link_libraries(hgl_descriptor PUBLIC hgl::graph_ir)
+target_link_libraries(hgl_descriptor PUBLIC hgl::graph_ir PRIVATE hgraph::core)
 hgl_apply_warnings(hgl_descriptor)
 
 # Descriptor consumption is a separate boundary: the model/writer remains
@@ -183,7 +183,7 @@ add_library(hgl_descriptor_reader STATIC
 add_library(hgl::descriptor_reader ALIAS hgl_descriptor_reader)
 target_compile_features(hgl_descriptor_reader PUBLIC cxx_std_23)
 target_include_directories(hgl_descriptor_reader PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
-target_link_libraries(hgl_descriptor_reader PUBLIC hgl::descriptor PRIVATE simdjson::simdjson)
+target_link_libraries(hgl_descriptor_reader PUBLIC hgl::descriptor PRIVATE hgl::native_interface simdjson::simdjson)
 hgl_apply_warnings(hgl_descriptor_reader)
 
 # Canonical hgraph metadata materialization for execution backends. Keeping

--- a/language/docs/design/decisions/0004-json-module-descriptors.md
+++ b/language/docs/design/decisions/0004-json-module-descriptors.md
@@ -1,7 +1,7 @@
 # ADR 0004: Module descriptors use canonical versioned JSON
 
-Status: accepted; writer, strict reader, descriptor-only validation, and
-lifecycle ABI implemented; native declaration metadata pending
+Status: accepted; writer, strict reader, descriptor-only validation, native
+declaration metadata, canonical fingerprints, and lifecycle ABI implemented
 
 ## Context
 
@@ -53,10 +53,10 @@ a JSON consumer's numeric range or its handling of non-standard JSON tokens.
 Booleans remain JSON booleans, strings remain strings, and temporal values use
 their canonical HGL spelling together with their temporal kind.
 
-Descriptor fingerprints will be computed over the canonical semantic form, not
-over arbitrary input whitespace. The fingerprint field itself is excluded from
-that input. Its algorithm and placement are intentionally left to the
-fingerprint slice.
+Descriptor fingerprints are `sha256:` followed by the lowercase SHA-256 digest
+of the canonical semantic JSON with `module.descriptor_fingerprint` empty.
+Arbitrary input whitespace and object ordering therefore do not affect the
+fingerprint, while every understood semantic field does.
 
 The generated file is named `<stem>.hgl-module.json`. With split C++ output it
 is placed beside the generated source. `hgl_add_module()` exposes the complete
@@ -75,9 +75,10 @@ install or aggregate it deliberately.
 - The file now contains structured HGL signatures, struct layouts, defaults,
   generic bindings, and constraints. The reader ignores compatible unknown
   members but rejects duplicate keys, malformed records, unsupported versions,
-  and dangling references. Dependency closure, phase/effect/ownership policy,
-  and fingerprints remain explicit Stage F work; lifecycle uses the separate
-  installed C ABI.
+  and dangling references. The native section records type associations, exact
+  symbols, phase/effect/ownership/lifetime policy, exception and thread-safety
+  policy; build metadata records runtime images and the separate lifecycle ABI.
+  Locked dependency closure and native package authoring remain Stage F work.
 
 ## Alternatives
 

--- a/language/docs/design/decisions/0004-json-module-descriptors.md
+++ b/language/docs/design/decisions/0004-json-module-descriptors.md
@@ -54,9 +54,11 @@ Booleans remain JSON booleans, strings remain strings, and temporal values use
 their canonical HGL spelling together with their temporal kind.
 
 Descriptor fingerprints are `sha256:` followed by the lowercase SHA-256 digest
-of the canonical semantic JSON with `module.descriptor_fingerprint` empty.
-Arbitrary input whitespace and object ordering therefore do not affect the
-fingerprint, while every understood semantic field does.
+of the canonical version-one semantic model with
+`module.descriptor_fingerprint` empty. Arbitrary input whitespace and object
+ordering therefore do not affect the fingerprint. Compatible unknown version-one
+members are outside that projection; a new field that changes the bindable or
+executable contract requires a descriptor format-version increment.
 
 The generated file is named `<stem>.hgl-module.json`. With split C++ output it
 is placed beside the generated source. `hgl_add_module()` exposes the complete

--- a/language/docs/design/native-interface.md
+++ b/language/docs/design/native-interface.md
@@ -1,7 +1,8 @@
 # Native interface
 
-Status: accepted boundary; HGL interface schema, descriptor-only validation,
-and native module lifecycle ABI implemented; declaration metadata remains
+Status: accepted boundary; descriptor validation, native declaration metadata,
+canonical fingerprints, and the lifecycle ABI implemented; authoring and call
+lowering remain
 
 ## Purpose
 
@@ -57,10 +58,14 @@ The serialized representation is the canonical, versioned JSON selected in
 emits its envelope, public/provider inventories, structured HGL signatures,
 struct layouts, defaults, canonical types and constraints, and generated build
 metadata. `hgl check` reads and validates one such descriptor without loading a
-library or consulting a registry. Transitive dependency closure,
-phase/effect/ownership policy, and verified fingerprints remain to be added.
-The native-package authoring API is not yet chosen. No HGL declaration syntax
-is implied by this list.
+library or consulting a registry. Native declarations now encode exact C++
+symbols, permitted phases, effects, parameter/result ownership and dependent
+lifetimes, exception policy, thread-safety policy, opaque or atomic native type
+associations, runtime images, and lifecycle ABI metadata. The reader enforces
+the initial non-blocking/noexcept evaluation envelope, explicit mutable state,
+borrow rules, and lifecycle consistency. Transitive dependency closure and the
+native-package authoring API remain to be added. No HGL declaration syntax is
+implied by this list.
 
 ## Native declaration categories
 
@@ -193,13 +198,15 @@ all registration state behind the opaque context. Initialization and
 deinitialization are idempotent. The scripted compiler bootstrap implements
 this contract and catches registration/removal failures through hgraph's common
 exception-boundary helper. The host validates the ABI version, table size,
-identity, required callbacks, and presence of a fingerprint field before it
+identity, required callbacks, and exact descriptor fingerprint before it
 retains the image and invokes lifecycle callbacks.
 
-The current generated bootstrap reserves an empty fingerprint until canonical
-descriptor fingerprints are implemented. It therefore proves lifecycle
-ownership and replacement independently of fingerprint agreement; a native
-descriptor will not be considered bindable until that later check succeeds.
+Descriptors are sealed with `sha256:` followed by the lowercase digest of their
+canonical semantic JSON with the fingerprint field empty. Input whitespace and
+object ordering therefore do not affect identity. The generated bootstrap
+embeds that fingerprint, and the loader rejects an image whose module identity
+or fingerprint differs before invoking `init`.
+
 Calls within generated code may still use direct C++ types and functions when
 the descriptor permits them. Logical provider removal and native-image
 unloading are distinct: the first implementation deinitializes registrations

--- a/language/docs/design/native-interface.md
+++ b/language/docs/design/native-interface.md
@@ -202,10 +202,12 @@ identity, required callbacks, and exact descriptor fingerprint before it
 retains the image and invokes lifecycle callbacks.
 
 Descriptors are sealed with `sha256:` followed by the lowercase digest of their
-canonical semantic JSON with the fingerprint field empty. Input whitespace and
-object ordering therefore do not affect identity. The generated bootstrap
-embeds that fingerprint, and the loader rejects an image whose module identity
-or fingerprint differs before invoking `init`.
+canonical version-one semantic model with the fingerprint field empty. Input
+whitespace and object ordering therefore do not affect identity. Compatible
+unknown version-one members remain outside that projection; a security-relevant
+semantic addition requires a format-version increment. The generated bootstrap
+embeds the fingerprint, and the loader rejects an image whose module identity or
+fingerprint differs before invoking `init`.
 
 Calls within generated code may still use direct C++ types and functions when
 the descriptor permits them. Logical provider removal and native-image

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -240,7 +240,8 @@ HGraph IR; unsupported language-depth items remain explicit roadmap work.
   scripted native module activation, replacement, and logical removal;
 - provide a native-package authoring API which emits descriptors and normalized
   wrappers;
-- add phase, effect, ownership, exception, build, and fingerprint metadata;
+- [x] add phase, effect, ownership, dependent-lifetime, exception,
+  thread-safety, build, lifecycle, and canonical fingerprint metadata;
 - support a canonical scalar evaluation function and owned opaque node state;
 - prove descriptor-only checking and identical scripted/AOT behavior.
 

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -1049,10 +1049,24 @@ and dangling references while ignoring unknown members in a supported version.
 `hgl check <file>.hgl-module.json` uses this path and does not load native code
 or consult the registry.
 
-Locked transitive dependency closure, effect/ownership policy, lifecycle entry
-points, and fingerprints are the following Stage F slices. Validating one file
-does not yet prove that its declared provider requirements are present or
-mutually compatible.
+The descriptor's native section shares the same type and signature arenas as
+the HGL interface. It records opaque and atomic native types plus declaration
+phase, effects, ownership and borrowed-lifetime relationships, exception
+policy, and thread-safety policy. The reader enforces the first native safety
+envelope: evaluation declarations cannot block or translate exceptions,
+mutation must name exactly one mutable borrowed argument, shared ownership is
+not part of ABI version 1, borrowed results must name a borrowed argument, and
+lifecycle metadata must match the installed ABI contract.
+
+Every descriptor produced by the compiler is sealed with a SHA-256 fingerprint
+of its canonical JSON form while the fingerprint field is empty. Reordering or
+reformatting JSON does not change that identity. The scripted native table
+embeds the same fingerprint, and the loader compares both module identity and
+the exact fingerprint before initialization.
+
+Locked transitive dependency closure and the public native-package authoring
+API are the following Stage F slices. Validating one file does not yet prove
+that its declared provider requirements are present or mutually compatible.
 
 A descriptor separates its importable interface from its provider inventory.
 The interface contains automatically public nominal operators, explicitly
@@ -1128,9 +1142,9 @@ The scripted bootstrap owns that provider handle behind its ABI context; no
 hgraph C++ object crosses the dynamic boundary. ABI callbacks return explicit
 status and fill a fixed-capacity host-owned error record, and must not allow an
 exception to cross the boundary. The loader validates table version, size,
-identity, fingerprint presence, context, and callbacks before activation. It
-keeps accepted native images resident while separating logical deactivation
-from physical unloading.
+identity, exact descriptor fingerprint, context, and callbacks before
+activation. It keeps accepted native images resident while separating logical
+deactivation from physical unloading.
 
 The public hgraph `OperatorRegistry` now returns an opaque provider handle from
 keyed installer registration, records candidate provenance while the installer
@@ -1538,9 +1552,10 @@ arguments; CMake system, processor and configuration; hgraph version/commit;
 relevant compiler search environment; and the hosting `hgl` executable path
 and digest. The executable digests prevent an image built by a changed tool or
 against one host executable's exported symbols from being reused even when its
-path and reported version remain unchanged. External module descriptor
-fingerprints must join the key when scripted imports of separately built
-providers land.
+path and reported version remain unchanged. The generated module descriptor
+fingerprint is already covered because it is embedded in the registration
+bootstrap. Imported provider descriptor fingerprints must join the key when
+scripted imports of separately built providers land.
 
 A miss compiles in the ordinary artifact directory, copies the generated
 sources, image and diagnostic manifest into a unique staging directory beside

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -1059,10 +1059,12 @@ not part of ABI version 1, borrowed results must name a borrowed argument, and
 lifecycle metadata must match the installed ABI contract.
 
 Every descriptor produced by the compiler is sealed with a SHA-256 fingerprint
-of its canonical JSON form while the fingerprint field is empty. Reordering or
-reformatting JSON does not change that identity. The scripted native table
-embeds the same fingerprint, and the loader compares both module identity and
-the exact fingerprint before initialization.
+of its canonical version-one semantic model while the fingerprint field is
+empty. Reordering or reformatting JSON does not change that identity.
+Compatible unknown version-one members are excluded; new bindable or executable
+semantics require a format-version increment. The scripted native table embeds
+the same fingerprint, and the loader compares both module identity and the
+exact fingerprint before initialization.
 
 Locked transitive dependency closure and the public native-package authoring
 API are the following Stage F slices. Validating one file does not yet prove

--- a/language/docs/user-guide/modules-and-tools.md
+++ b/language/docs/user-guide/modules-and-tools.md
@@ -317,11 +317,17 @@ matter; duplicate keys and unsupported versions are errors, while unknown
 members are ignored for forward-compatible additions. Syntax and IR dump flags
 apply only to HGL source and are rejected for descriptors.
 
-This command validates one descriptor. It does not yet locate or lock its
-transitive provider requirements. Native ownership/effect declarations,
-descriptor fingerprints, and the native-package authoring API are also not
-implemented yet. The versioned lifecycle entry point itself is implemented for
-scripted native images.
+This command validates one descriptor. Native declarations describe where a
+function may run, its effects, value ownership and borrowed lifetimes, exception
+policy, and thread-safety policy. Validation rejects unsafe combinations such
+as blocking or throwing evaluation code, implicit mutation, shared ownership
+in ABI version 1, and borrowed results without a declared input lifetime. It
+also verifies the descriptor's canonical SHA-256 fingerprint and lifecycle ABI
+metadata without loading native code.
+
+Descriptor validation does not yet locate or lock transitive provider
+requirements. The native-package authoring API and lowering imported native
+declarations into HGL calls are the next implementation slices.
 
 A package is a CMake project. `hgl_add_module()`, installed with `hgl` in
 `lib/cmake/hgl/HglLanguage.cmake`, runs `emit-cpp` at build time and compiles

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -3952,13 +3952,15 @@ namespace hgl::codegen
                 result.python = std::move(py);
             }
             descriptor::DescribeOptions descriptor_options;
-            descriptor_options.language_version    = options_.tool_version;
-            descriptor_options.provider_identity   = result.module_name;
-            descriptor_options.public_headers      = {options_.header_name};
-            descriptor_options.cmake_packages      = {"hgraph"};
-            descriptor_options.imported_targets    = {"hgraph::core"};
-            descriptor_options.registration_symbol = namespace_ + "::register_operators";
-            result.descriptor = descriptor::to_json(descriptor::describe_module(graph_, std::move(descriptor_options)));
+            descriptor_options.language_version           = options_.tool_version;
+            descriptor_options.provider_identity          = result.module_name;
+            descriptor_options.public_headers             = {options_.header_name};
+            descriptor_options.cmake_packages             = {"hgraph"};
+            descriptor_options.imported_targets           = {"hgraph::core"};
+            descriptor_options.registration_symbol        = namespace_ + "::register_operators";
+            const descriptor::ModuleDescriptor descriptor = descriptor::describe_module(graph_, std::move(descriptor_options));
+            result.descriptor_fingerprint                 = descriptor.descriptor_fingerprint;
+            result.descriptor                             = descriptor::to_json(descriptor);
             return result;
         }
     }  // namespace

--- a/language/src/codegen/cpp_emitter.h
+++ b/language/src/codegen/cpp_emitter.h
@@ -45,6 +45,9 @@ namespace hgl::codegen
         std::string source{};
         /// Canonical UTF-8 JSON for `<stem>.hgl-module.json`.
         std::string descriptor{};
+        /// Canonical descriptor fingerprint also embedded in a dynamic module
+        /// lifecycle table and checked before activation.
+        std::string descriptor_fingerprint{};
         /// Empty unless `EmitOptions::python_native_module` was set.
         std::string python{};
         /// Exported function names, in declaration order.

--- a/language/src/descriptor/module_descriptor.cpp
+++ b/language/src/descriptor/module_descriptor.cpp
@@ -275,7 +275,9 @@ namespace hgl::descriptor
         result.build.public_headers      = std::move(options.public_headers);
         result.build.cmake_packages      = std::move(options.cmake_packages);
         result.build.imported_targets    = std::move(options.imported_targets);
+        result.build.runtime_images      = std::move(options.runtime_images);
         result.build.registration_symbol = std::move(options.registration_symbol);
+        result.build.lifecycle           = std::move(options.lifecycle);
 
         SchemaBuilder schema{module, result};
 
@@ -347,6 +349,8 @@ namespace hgl::descriptor
         normalize(result.build.public_headers);
         normalize(result.build.cmake_packages);
         normalize(result.build.imported_targets);
+        normalize(result.build.runtime_images);
+        seal(result);
         return result;
     }
 

--- a/language/src/descriptor/module_descriptor.h
+++ b/language/src/descriptor/module_descriptor.h
@@ -227,24 +227,130 @@ namespace hgl::descriptor
         friend bool operator==(const Implementation &, const Implementation &) = default;
     };
 
+    enum class NativeTypeCategory : std::uint8_t {
+        OpaqueState,
+        AtomicValue,
+    };
+
+    /// A reviewed native type associated with a nominal HGL identity. Opaque
+    /// state never crosses a temporal port; an atomic value additionally needs
+    /// the hgraph value/storage operations described by the native interface.
+    struct NativeTypeDeclaration
+    {
+        NativeTypeCategory category{NativeTypeCategory::OpaqueState};
+        std::string        identity{};
+        std::string        cpp_type{};
+        std::string        public_header{};
+
+        friend bool operator==(const NativeTypeDeclaration &, const NativeTypeDeclaration &) = default;
+    };
+
+    enum class NativeDeclarationCategory : std::uint8_t {
+        Function,
+        Constructor,
+        Lifecycle,
+    };
+
+    enum class NativePhase : std::uint8_t {
+        Wiring,
+        Start,
+        Evaluation,
+        Stop,
+    };
+
+    enum class NativeEffect : std::uint8_t {
+        Mutation,
+        InputOutput,
+        Blocking,
+        Allocation,
+    };
+
+    enum class NativeOwnership : std::uint8_t {
+        Value,
+        Owned,
+        Shared,
+        Borrowed,
+    };
+
+    enum class NativeExceptionPolicy : std::uint8_t {
+        NoThrow,
+        Translated,
+    };
+
+    enum class NativeThreadSafety : std::uint8_t {
+        NodeLocal,
+        ThreadSafe,
+        Serialized,
+    };
+
+    struct NativeValuePolicy
+    {
+        NativeOwnership ownership{NativeOwnership::Value};
+        /// Parameter name whose lifetime bounds this borrowed value. Empty for
+        /// value/owned/shared results and for call-confined borrowed arguments.
+        std::string dependent_on{};
+        bool        mutable_value{false};
+
+        friend bool operator==(const NativeValuePolicy &, const NativeValuePolicy &) = default;
+    };
+
+    struct NativeParameterPolicy
+    {
+        std::string       name{};
+        NativeValuePolicy value{};
+
+        friend bool operator==(const NativeParameterPolicy &, const NativeParameterPolicy &) = default;
+    };
+
+    /// One exact native operation. Its HGL signature uses the shared schema
+    /// arenas; the remaining fields make phase, effects, ownership, exception
+    /// handling, and direct C++ lowering explicit.
+    struct NativeDeclaration
+    {
+        NativeDeclarationCategory          category{NativeDeclarationCategory::Function};
+        std::string                        identity{};
+        std::string                        cpp_symbol{};
+        Signature                          signature{};
+        std::vector<NativePhase>           phases{};
+        std::vector<NativeEffect>          effects{};
+        std::vector<NativeParameterPolicy> parameters{};
+        NativeValuePolicy                  result{};
+        NativeExceptionPolicy              exception_policy{NativeExceptionPolicy::NoThrow};
+        NativeThreadSafety                 thread_safety{NativeThreadSafety::NodeLocal};
+
+        friend bool operator==(const NativeDeclaration &, const NativeDeclaration &) = default;
+    };
+
+    struct LifecycleMetadata
+    {
+        std::uint32_t abi_version{0};
+        std::string   query_symbol{};
+
+        friend bool operator==(const LifecycleMetadata &, const LifecycleMetadata &) = default;
+    };
+
     struct BuildMetadata
     {
         std::vector<std::string> public_headers{};
         std::vector<std::string> cmake_packages{};
         std::vector<std::string> imported_targets{};
+        std::vector<std::string> runtime_images{};
         std::string              registration_symbol{};
+        LifecycleMetadata        lifecycle{};
 
         friend bool operator==(const BuildMetadata &, const BuildMetadata &) = default;
     };
 
-    /// A data-only package boundary: public/provider declarations refer to
-    /// structured type, compile-time expression, and constraint arenas. Native
-    /// lifecycle and ownership/effect policy remain separate ABI additions.
+    /// A data-only package boundary: public/provider and exact-native
+    /// declarations refer to structured type, compile-time expression, and
+    /// constraint arenas. The fingerprint is sealed separately so it can be
+    /// computed over the canonical descriptor with that field empty.
     struct ModuleDescriptor
     {
         std::uint32_t                         format_version{module_descriptor_format_version};
         std::string                           module_identity{};
         std::string                           language_version{};
+        std::string                           descriptor_fingerprint{};
         std::vector<InterfaceDeclaration>     interface{};
         std::string                           provider_identity{};
         std::vector<Implementation>           implementations{};
@@ -252,6 +358,8 @@ namespace hgl::descriptor
         std::vector<TypeRecord>               types{};
         std::vector<ConstantExpressionRecord> constant_expressions{};
         std::vector<ConstraintRecord>         constraints{};
+        std::vector<NativeTypeDeclaration>    native_types{};
+        std::vector<NativeDeclaration>        native_declarations{};
         BuildMetadata                         build{};
 
         friend bool operator==(const ModuleDescriptor &, const ModuleDescriptor &) = default;
@@ -264,7 +372,9 @@ namespace hgl::descriptor
         std::vector<std::string> public_headers{};
         std::vector<std::string> cmake_packages{};
         std::vector<std::string> imported_targets{};
+        std::vector<std::string> runtime_images{};
         std::string              registration_symbol{};
+        LifecycleMetadata        lifecycle{};
     };
 
     /// Build a normalized module descriptor from the execution-facing IR.
@@ -276,6 +386,13 @@ namespace hgl::descriptor
     /// Serialize canonical, reviewable UTF-8 JSON with a trailing newline.
     /// Object key order and array order are deterministic.
     [[nodiscard]] std::string to_json(const ModuleDescriptor &descriptor);
+
+    /// Compute the canonical SHA-256 fingerprint with the fingerprint field
+    /// empty, then prefix the lowercase digest with `sha256:`.
+    [[nodiscard]] std::string fingerprint(const ModuleDescriptor &descriptor);
+
+    /// Replace descriptor_fingerprint with fingerprint(descriptor).
+    void seal(ModuleDescriptor &descriptor);
 }  // namespace hgl::descriptor
 
 #endif  // HGL_DESCRIPTOR_MODULE_DESCRIPTOR_H

--- a/language/src/descriptor/module_descriptor.h
+++ b/language/src/descriptor/module_descriptor.h
@@ -387,8 +387,9 @@ namespace hgl::descriptor
     /// Object key order and array order are deterministic.
     [[nodiscard]] std::string to_json(const ModuleDescriptor &descriptor);
 
-    /// Compute the canonical SHA-256 fingerprint with the fingerprint field
-    /// empty, then prefix the lowercase digest with `sha256:`.
+    /// Compute the canonical version-one semantic-model SHA-256 fingerprint
+    /// with the fingerprint field empty, then prefix the lowercase digest with
+    /// `sha256:`. Compatible unknown JSON members are outside this projection.
     [[nodiscard]] std::string fingerprint(const ModuleDescriptor &descriptor);
 
     /// Replace descriptor_fingerprint with fingerprint(descriptor).

--- a/language/src/descriptor/module_descriptor_json.cpp
+++ b/language/src/descriptor/module_descriptor_json.cpp
@@ -2,12 +2,15 @@
 
 #include "syntax/temporal.h"
 
+#include <hgraph/util/sha256.h>
+
 #include <array>
 #include <cmath>
 #include <iomanip>
 #include <limits>
 #include <locale>
 #include <ostream>
+#include <span>
 #include <sstream>
 #include <string_view>
 #include <type_traits>
@@ -31,6 +34,70 @@ namespace hgl::descriptor
                 case ExecutionKind::None: return "none";
                 case ExecutionKind::Composition: return "composition";
                 case ExecutionKind::RuntimeNode: return "runtime-node";
+            }
+            std::unreachable();
+        }
+
+        [[nodiscard]] std::string_view native_type_category_name(NativeTypeCategory category) noexcept {
+            switch (category) {
+                case NativeTypeCategory::OpaqueState: return "opaque-state";
+                case NativeTypeCategory::AtomicValue: return "atomic-value";
+            }
+            std::unreachable();
+        }
+
+        [[nodiscard]] std::string_view native_declaration_category_name(NativeDeclarationCategory category) noexcept {
+            switch (category) {
+                case NativeDeclarationCategory::Function: return "function";
+                case NativeDeclarationCategory::Constructor: return "constructor";
+                case NativeDeclarationCategory::Lifecycle: return "lifecycle";
+            }
+            std::unreachable();
+        }
+
+        [[nodiscard]] std::string_view native_phase_name(NativePhase phase) noexcept {
+            switch (phase) {
+                case NativePhase::Wiring: return "wiring";
+                case NativePhase::Start: return "start";
+                case NativePhase::Evaluation: return "evaluation";
+                case NativePhase::Stop: return "stop";
+            }
+            std::unreachable();
+        }
+
+        [[nodiscard]] std::string_view native_effect_name(NativeEffect effect) noexcept {
+            switch (effect) {
+                case NativeEffect::Mutation: return "mutation";
+                case NativeEffect::InputOutput: return "io";
+                case NativeEffect::Blocking: return "blocking";
+                case NativeEffect::Allocation: return "allocation";
+            }
+            std::unreachable();
+        }
+
+        [[nodiscard]] std::string_view native_ownership_name(NativeOwnership ownership) noexcept {
+            switch (ownership) {
+                case NativeOwnership::Value: return "value";
+                case NativeOwnership::Owned: return "owned";
+                case NativeOwnership::Shared: return "shared";
+                case NativeOwnership::Borrowed: return "borrowed";
+            }
+            std::unreachable();
+        }
+
+        [[nodiscard]] std::string_view native_exception_name(NativeExceptionPolicy policy) noexcept {
+            switch (policy) {
+                case NativeExceptionPolicy::NoThrow: return "noexcept";
+                case NativeExceptionPolicy::Translated: return "translated";
+            }
+            std::unreachable();
+        }
+
+        [[nodiscard]] std::string_view native_thread_safety_name(NativeThreadSafety policy) noexcept {
+            switch (policy) {
+                case NativeThreadSafety::NodeLocal: return "node-local";
+                case NativeThreadSafety::ThreadSafe: return "thread-safe";
+                case NativeThreadSafety::Serialized: return "serialized";
             }
             std::unreachable();
         }
@@ -127,6 +194,21 @@ namespace hgl::descriptor
             for (std::size_t index = 0; index < values.size(); ++index) {
                 out << indent << "  ";
                 quote_json(out, values[index]);
+                out << (index + 1U == values.size() ? "\n" : ",\n");
+            }
+            out << indent << ']';
+        }
+
+        template <typename Enum, typename Name>
+        void enum_array(std::ostream &out, const std::vector<Enum> &values, std::string_view indent, Name name) {
+            if (values.empty()) {
+                out << "[]";
+                return;
+            }
+            out << "[\n";
+            for (std::size_t index = 0; index < values.size(); ++index) {
+                out << indent << "  ";
+                quote_json(out, name(values[index]));
                 out << (index + 1U == values.size() ? "\n" : ",\n");
             }
             out << indent << ']';
@@ -267,6 +349,73 @@ namespace hgl::descriptor
                 out << "\n" << indent << "  }" << (index + 1U == fields.size() ? "\n" : ",\n");
             }
             out << indent << ']';
+        }
+
+        void native_value_policy(std::ostream &out, const NativeValuePolicy &policy, std::string_view indent) {
+            out << "{\n" << indent << "  \"ownership\": ";
+            quote_json(out, native_ownership_name(policy.ownership));
+            out << ",\n" << indent << "  \"dependent_on\": ";
+            if (policy.dependent_on.empty()) {
+                out << "null";
+            } else {
+                quote_json(out, policy.dependent_on);
+            }
+            out << ",\n" << indent << "  \"mutable\": " << (policy.mutable_value ? "true" : "false") << "\n" << indent << '}';
+        }
+
+        void native_section(std::ostream &out, const ModuleDescriptor &descriptor) {
+            out << "  \"native\": {\n    \"types\": [";
+            if (!descriptor.native_types.empty()) { out << '\n'; }
+            for (std::size_t index = 0; index < descriptor.native_types.size(); ++index) {
+                const NativeTypeDeclaration &type = descriptor.native_types[index];
+                out << "      {\n        \"category\": ";
+                quote_json(out, native_type_category_name(type.category));
+                out << ",\n        \"identity\": ";
+                quote_json(out, type.identity);
+                out << ",\n        \"cpp_type\": ";
+                quote_json(out, type.cpp_type);
+                out << ",\n        \"public_header\": ";
+                quote_json(out, type.public_header);
+                out << "\n      }" << (index + 1U == descriptor.native_types.size() ? "\n" : ",\n");
+            }
+            if (!descriptor.native_types.empty()) { out << "    "; }
+            out << "],\n    \"declarations\": [";
+            if (!descriptor.native_declarations.empty()) { out << '\n'; }
+            for (std::size_t index = 0; index < descriptor.native_declarations.size(); ++index) {
+                const NativeDeclaration &declaration = descriptor.native_declarations[index];
+                out << "      {\n        \"category\": ";
+                quote_json(out, native_declaration_category_name(declaration.category));
+                out << ",\n        \"identity\": ";
+                quote_json(out, declaration.identity);
+                out << ",\n        \"cpp_symbol\": ";
+                quote_json(out, declaration.cpp_symbol);
+                out << ",\n        \"signature\": ";
+                signature(out, declaration.signature, "        ");
+                out << ",\n        \"phases\": ";
+                enum_array(out, declaration.phases, "        ", native_phase_name);
+                out << ",\n        \"effects\": ";
+                enum_array(out, declaration.effects, "        ", native_effect_name);
+                out << ",\n        \"parameters\": [";
+                if (!declaration.parameters.empty()) { out << '\n'; }
+                for (std::size_t parameter_index = 0; parameter_index < declaration.parameters.size(); ++parameter_index) {
+                    const NativeParameterPolicy &parameter = declaration.parameters[parameter_index];
+                    out << "          {\n            \"name\": ";
+                    quote_json(out, parameter.name);
+                    out << ",\n            \"value\": ";
+                    native_value_policy(out, parameter.value, "            ");
+                    out << "\n          }" << (parameter_index + 1U == declaration.parameters.size() ? "\n" : ",\n");
+                }
+                if (!declaration.parameters.empty()) { out << "        "; }
+                out << "],\n        \"result\": ";
+                native_value_policy(out, declaration.result, "        ");
+                out << ",\n        \"exception\": ";
+                quote_json(out, native_exception_name(declaration.exception_policy));
+                out << ",\n        \"thread_safety\": ";
+                quote_json(out, native_thread_safety_name(declaration.thread_safety));
+                out << "\n      }" << (index + 1U == descriptor.native_declarations.size() ? "\n" : ",\n");
+            }
+            if (!descriptor.native_declarations.empty()) { out << "    "; }
+            out << "]\n  },\n";
         }
 
         void type_records(std::ostream &out, const std::vector<TypeRecord> &records) {
@@ -456,6 +605,8 @@ namespace hgl::descriptor
         quote_json(out, descriptor.module_identity);
         out << ",\n    \"language_version\": ";
         quote_json(out, descriptor.language_version);
+        out << ",\n    \"descriptor_fingerprint\": ";
+        quote_json(out, descriptor.descriptor_fingerprint);
         out << "\n  },\n  \"interface\": [";
         if (!descriptor.interface.empty()) { out << '\n'; }
         for (std::size_t index = 0; index < descriptor.interface.size(); ++index) {
@@ -516,15 +667,33 @@ namespace hgl::descriptor
         constant_records(out, descriptor.constant_expressions);
         out << ",\n    \"constraints\": ";
         constraint_records(out, descriptor.constraints);
-        out << "\n  },\n  \"build\": {\n    \"public_headers\": ";
+        out << "\n  },\n";
+        native_section(out, descriptor);
+        out << "  \"build\": {\n    \"public_headers\": ";
         string_array(out, descriptor.build.public_headers, "    ");
         out << ",\n    \"cmake_packages\": ";
         string_array(out, descriptor.build.cmake_packages, "    ");
         out << ",\n    \"imported_targets\": ";
         string_array(out, descriptor.build.imported_targets, "    ");
+        out << ",\n    \"runtime_images\": ";
+        string_array(out, descriptor.build.runtime_images, "    ");
         out << ",\n    \"registration\": {\n      \"kind\": \"cpp\",\n      \"symbol\": ";
         quote_json(out, descriptor.build.registration_symbol);
+        out << "\n    },\n    \"lifecycle\": {\n      \"abi_version\": " << descriptor.build.lifecycle.abi_version
+            << ",\n      \"query_symbol\": ";
+        quote_json(out, descriptor.build.lifecycle.query_symbol);
         out << "\n    }\n  }\n}\n";
         return out.str();
     }
+
+    std::string fingerprint(const ModuleDescriptor &descriptor) {
+        ModuleDescriptor canonical = descriptor;
+        canonical.descriptor_fingerprint.clear();
+        const std::string                bytes  = to_json(canonical);
+        const hgraph::util::Sha256Digest digest = hgraph::util::sha256(std::as_bytes(std::span{bytes.data(), bytes.size()}));
+        const std::array<char, 64>       hex    = hgraph::util::sha256_hex(digest);
+        return "sha256:" + std::string{hex.data(), hex.size()};
+    }
+
+    void seal(ModuleDescriptor &descriptor) { descriptor.descriptor_fingerprint = fingerprint(descriptor); }
 }  // namespace hgl::descriptor

--- a/language/src/descriptor/module_descriptor_reader.cpp
+++ b/language/src/descriptor/module_descriptor_reader.cpp
@@ -1114,9 +1114,9 @@ namespace hgl::descriptor
                 return true;
             }
 
-            bool known_parameter(const NativeDeclaration &declaration, std::string_view name) const {
-                return std::ranges::any_of(declaration.parameters,
-                                           [&](const NativeParameterPolicy &parameter) { return parameter.name == name; });
+            const NativeParameterPolicy *find_parameter(const NativeDeclaration &declaration, std::string_view name) const {
+                const auto found = std::ranges::find(declaration.parameters, name, &NativeParameterPolicy::name);
+                return found == declaration.parameters.end() ? nullptr : &*found;
             }
 
             bool native_value_policy(const NativeValuePolicy &policy, std::string_view path, const NativeDeclaration &declaration,
@@ -1128,8 +1128,15 @@ namespace hgl::descriptor
                     if (result && policy.dependent_on.empty()) {
                         return fail(member_path(path, "dependent_on"), "a borrowed native result must name its lifetime parameter");
                     }
-                    if (!policy.dependent_on.empty() && !known_parameter(declaration, policy.dependent_on)) {
-                        return fail(member_path(path, "dependent_on"), "unknown lifetime parameter '" + policy.dependent_on + "'");
+                    if (!policy.dependent_on.empty()) {
+                        const NativeParameterPolicy *source = find_parameter(declaration, policy.dependent_on);
+                        if (source == nullptr) {
+                            return fail(member_path(path, "dependent_on"),
+                                        "unknown lifetime parameter '" + policy.dependent_on + "'");
+                        }
+                        if (source->value.ownership != NativeOwnership::Borrowed) {
+                            return fail(member_path(path, "dependent_on"), "a dependent lifetime must name a borrowed parameter");
+                        }
                     }
                 } else if (!policy.dependent_on.empty()) {
                     return fail(member_path(path, "dependent_on"), "only borrowed native values have a dependent lifetime");
@@ -1143,9 +1150,40 @@ namespace hgl::descriptor
                 return true;
             }
 
+            bool native_value_type(SchemaId id, std::string_view path, bool optional = false) {
+                if (id == no_schema_id) { return optional || fail(std::string{path}, "missing required native value type"); }
+                const TypeRecord &type = descriptor_.types[id];
+                if (type.category == TypeCategory::Scalar) { return true; }
+                if (type.category == TypeCategory::Symbol &&
+                    std::ranges::any_of(descriptor_.native_types, [&](const NativeTypeDeclaration &declaration) {
+                        return declaration.identity == type.nominal_identity;
+                    })) {
+                    return true;
+                }
+                return fail(std::string{path}, "native signature type is outside the initial scalar and declared-native envelope");
+            }
+
+            bool native_signature(const Signature &signature, std::string_view path) {
+                if (!signature.generics.empty()) {
+                    return fail(member_path(path, "generic_parameters"),
+                                "native declarations require one complete exact signature");
+                }
+                if (signature.requirements != no_schema_id) {
+                    return fail(member_path(path, "requires"), "native declarations cannot carry unresolved constraints");
+                }
+                for (std::size_t index = 0; index < signature.parameters.size(); ++index) {
+                    if (!native_value_type(signature.parameters[index].type,
+                                           member_path(index_path(member_path(path, "parameters"), index), "type"))) {
+                        return false;
+                    }
+                }
+                return native_value_type(signature.result, member_path(path, "result"), true);
+            }
+
             bool native_declaration(const NativeDeclaration &declaration, std::string_view path) {
                 if (!unique_identity(declaration.identity, path, native_declaration_identities_) ||
-                    !signature(declaration.signature, member_path(path, "signature"))) {
+                    !signature(declaration.signature, member_path(path, "signature")) ||
+                    !native_signature(declaration.signature, member_path(path, "signature"))) {
                     return false;
                 }
                 if (declaration.cpp_symbol.empty()) {
@@ -1177,7 +1215,7 @@ namespace hgl::descriptor
                 }
                 if (!native_value_policy(declaration.result, member_path(path, "result"), declaration, true)) { return false; }
                 const bool mutates = std::ranges::find(declaration.effects, NativeEffect::Mutation) != declaration.effects.end();
-                if (mutates != (mutable_parameters == 1U)) {
+                if (mutable_parameters != (mutates ? 1U : 0U)) {
                     return fail(member_path(path, "effects"), "mutation requires exactly one explicitly mutable borrowed argument");
                 }
                 const bool evaluation = std::ranges::find(declaration.phases, NativePhase::Evaluation) != declaration.phases.end();

--- a/language/src/descriptor/module_descriptor_reader.cpp
+++ b/language/src/descriptor/module_descriptor_reader.cpp
@@ -1,5 +1,7 @@
 #include "descriptor/module_descriptor_reader.h"
 
+#include <hgl/native_module_abi.h>
+
 #include "syntax/temporal.h"
 
 #include <simdjson.h>
@@ -7,6 +9,7 @@
 #include <algorithm>
 #include <charconv>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <initializer_list>
 #include <limits>
@@ -55,14 +58,12 @@ namespace hgl::descriptor
             return false;
         }
 
-        [[nodiscard]] bool known_unary_operator(std::string_view spelling) noexcept {
-            return spelling == "-" || spelling == "!";
-        }
+        [[nodiscard]] bool known_unary_operator(std::string_view spelling) noexcept { return spelling == "-" || spelling == "!"; }
 
         [[nodiscard]] bool known_binary_operator(std::string_view spelling) noexcept {
             using ir::hir::BinaryOp;
-            for (std::uint8_t value = static_cast<std::uint8_t>(BinaryOp::Mul);
-                 value <= static_cast<std::uint8_t>(BinaryOp::Or); ++value) {
+            for (std::uint8_t value = static_cast<std::uint8_t>(BinaryOp::Mul); value <= static_cast<std::uint8_t>(BinaryOp::Or);
+                 ++value) {
                 if (ir::hir::binary_op_spelling(static_cast<BinaryOp>(value)) == spelling) { return true; }
             }
             return false;
@@ -120,6 +121,9 @@ namespace hgl::descriptor
                 if (provider == nullptr || !read_provider(*provider, descriptor)) { return failure(); }
                 const Element *schema = required(document, "schema", "$");
                 if (schema == nullptr || !read_schema(*schema, descriptor)) { return failure(); }
+                if (const Element *native = document.find("native"); native != nullptr && !read_native(*native, descriptor)) {
+                    return failure();
+                }
                 const Element *build = required(document, "build", "$");
                 if (build == nullptr || !read_build(*build, descriptor.build)) { return failure(); }
 
@@ -194,6 +198,14 @@ namespace hgl::descriptor
                 return value == nullptr || string(*value, member_path(path, name), out);
             }
 
+            bool nullable_string(Element value, std::string_view path, std::string &out) {
+                if (value.is_null()) {
+                    out.clear();
+                    return true;
+                }
+                return string(value, path, out);
+            }
+
             bool required_bool(const ObjectFields &fields, std::string_view name, std::string_view path, bool &out) {
                 const Element *value = required(fields, name, path);
                 return value != nullptr && boolean(*value, member_path(path, name), out);
@@ -233,6 +245,21 @@ namespace hgl::descriptor
                 return fail(std::string{path}, "unknown value '" + text + "'");
             }
 
+            template <typename Enum>
+            bool enum_array(Element value, std::string_view path, std::initializer_list<std::pair<std::string_view, Enum>> choices,
+                            std::vector<Enum> &out) {
+                simdjson::dom::array array;
+                if (value.get(array)) { return fail(std::string{path}, "expected array"); }
+                std::size_t index = 0;
+                for (Element item : array) {
+                    Enum decoded{};
+                    if (!enum_value(item, index_path(path, index), choices, decoded)) { return false; }
+                    out.push_back(decoded);
+                    ++index;
+                }
+                return true;
+            }
+
             bool string_array(Element value, std::string_view path, std::vector<std::string> &out) {
                 simdjson::dom::array array;
                 if (value.get(array)) { return fail(std::string{path}, "expected array"); }
@@ -268,7 +295,8 @@ namespace hgl::descriptor
             bool read_module(Element value, ModuleDescriptor &out) {
                 ObjectFields fields;
                 return object(value, "$.module", fields) && required_string(fields, "identity", "$.module", out.module_identity) &&
-                       required_string(fields, "language_version", "$.module", out.language_version);
+                       required_string(fields, "language_version", "$.module", out.language_version) &&
+                       optional_string(fields, "descriptor_fingerprint", "$.module", out.descriptor_fingerprint);
             }
 
             bool read_generic_parameters(Element value, std::string_view path, std::vector<GenericParameter> &out) {
@@ -746,12 +774,150 @@ namespace hgl::descriptor
                        read_constants(*constants, out.constant_expressions) && read_constraints(*constraints, out.constraints);
             }
 
+            bool read_native_value_policy(Element value, std::string_view path, NativeValuePolicy &out) {
+                ObjectFields   fields;
+                const Element *ownership{};
+                const Element *dependent_on{};
+                return object(value, path, fields) && (ownership = required(fields, "ownership", path)) != nullptr &&
+                       enum_value(*ownership, member_path(path, "ownership"),
+                                  {{"value", NativeOwnership::Value},
+                                   {"owned", NativeOwnership::Owned},
+                                   {"shared", NativeOwnership::Shared},
+                                   {"borrowed", NativeOwnership::Borrowed}},
+                                  out.ownership) &&
+                       (dependent_on = required(fields, "dependent_on", path)) != nullptr &&
+                       nullable_string(*dependent_on, member_path(path, "dependent_on"), out.dependent_on) &&
+                       required_bool(fields, "mutable", path, out.mutable_value);
+            }
+
+            bool read_native_types(Element value, std::vector<NativeTypeDeclaration> &out) {
+                simdjson::dom::array array;
+                if (value.get(array)) { return fail("$.native.types", "expected array"); }
+                std::size_t index = 0;
+                for (Element item : array) {
+                    const std::string     item_path = index_path("$.native.types", index);
+                    ObjectFields          fields;
+                    NativeTypeDeclaration declaration;
+                    const Element        *category{};
+                    if (!object(item, item_path, fields) || (category = required(fields, "category", item_path)) == nullptr ||
+                        !enum_value(
+                            *category, member_path(item_path, "category"),
+                            {{"opaque-state", NativeTypeCategory::OpaqueState}, {"atomic-value", NativeTypeCategory::AtomicValue}},
+                            declaration.category) ||
+                        !required_string(fields, "identity", item_path, declaration.identity) ||
+                        !required_string(fields, "cpp_type", item_path, declaration.cpp_type) ||
+                        !required_string(fields, "public_header", item_path, declaration.public_header)) {
+                        return false;
+                    }
+                    out.push_back(std::move(declaration));
+                    ++index;
+                }
+                return true;
+            }
+
+            bool read_native_parameter_policies(Element value, std::string_view path, std::vector<NativeParameterPolicy> &out) {
+                simdjson::dom::array array;
+                if (value.get(array)) { return fail(std::string{path}, "expected array"); }
+                std::size_t index = 0;
+                for (Element item : array) {
+                    const std::string     item_path = index_path(path, index);
+                    ObjectFields          fields;
+                    NativeParameterPolicy parameter;
+                    const Element        *policy{};
+                    if (!object(item, item_path, fields) || !required_string(fields, "name", item_path, parameter.name) ||
+                        (policy = required(fields, "value", item_path)) == nullptr ||
+                        !read_native_value_policy(*policy, member_path(item_path, "value"), parameter.value)) {
+                        return false;
+                    }
+                    out.push_back(std::move(parameter));
+                    ++index;
+                }
+                return true;
+            }
+
+            bool read_native_declarations(Element value, std::vector<NativeDeclaration> &out) {
+                simdjson::dom::array array;
+                if (value.get(array)) { return fail("$.native.declarations", "expected array"); }
+                std::size_t index = 0;
+                for (Element item : array) {
+                    const std::string item_path = index_path("$.native.declarations", index);
+                    ObjectFields      fields;
+                    NativeDeclaration declaration;
+                    const Element    *category{};
+                    const Element    *signature_value{};
+                    const Element    *phases{};
+                    const Element    *effects{};
+                    const Element    *parameters{};
+                    const Element    *result{};
+                    const Element    *exception{};
+                    const Element    *thread_safety{};
+                    if (!object(item, item_path, fields) || (category = required(fields, "category", item_path)) == nullptr ||
+                        !enum_value(*category, member_path(item_path, "category"),
+                                    {{"function", NativeDeclarationCategory::Function},
+                                     {"constructor", NativeDeclarationCategory::Constructor},
+                                     {"lifecycle", NativeDeclarationCategory::Lifecycle}},
+                                    declaration.category) ||
+                        !required_string(fields, "identity", item_path, declaration.identity) ||
+                        !required_string(fields, "cpp_symbol", item_path, declaration.cpp_symbol) ||
+                        (signature_value = required(fields, "signature", item_path)) == nullptr ||
+                        !read_signature(*signature_value, member_path(item_path, "signature"), declaration.signature) ||
+                        (phases = required(fields, "phases", item_path)) == nullptr ||
+                        !enum_array(*phases, member_path(item_path, "phases"),
+                                    {{"wiring", NativePhase::Wiring},
+                                     {"start", NativePhase::Start},
+                                     {"evaluation", NativePhase::Evaluation},
+                                     {"stop", NativePhase::Stop}},
+                                    declaration.phases) ||
+                        (effects = required(fields, "effects", item_path)) == nullptr ||
+                        !enum_array(*effects, member_path(item_path, "effects"),
+                                    {{"mutation", NativeEffect::Mutation},
+                                     {"io", NativeEffect::InputOutput},
+                                     {"blocking", NativeEffect::Blocking},
+                                     {"allocation", NativeEffect::Allocation}},
+                                    declaration.effects) ||
+                        (parameters = required(fields, "parameters", item_path)) == nullptr ||
+                        !read_native_parameter_policies(*parameters, member_path(item_path, "parameters"),
+                                                        declaration.parameters) ||
+                        (result = required(fields, "result", item_path)) == nullptr ||
+                        !read_native_value_policy(*result, member_path(item_path, "result"), declaration.result) ||
+                        (exception = required(fields, "exception", item_path)) == nullptr ||
+                        !enum_value(
+                            *exception, member_path(item_path, "exception"),
+                            {{"noexcept", NativeExceptionPolicy::NoThrow}, {"translated", NativeExceptionPolicy::Translated}},
+                            declaration.exception_policy) ||
+                        (thread_safety = required(fields, "thread_safety", item_path)) == nullptr ||
+                        !enum_value(*thread_safety, member_path(item_path, "thread_safety"),
+                                    {{"node-local", NativeThreadSafety::NodeLocal},
+                                     {"thread-safe", NativeThreadSafety::ThreadSafe},
+                                     {"serialized", NativeThreadSafety::Serialized}},
+                                    declaration.thread_safety)) {
+                        return false;
+                    }
+                    out.push_back(std::move(declaration));
+                    ++index;
+                }
+                return true;
+            }
+
+            bool read_native(Element value, ModuleDescriptor &out) {
+                ObjectFields fields;
+                if (!object(value, "$.native", fields)) { return false; }
+                const Element *types        = required(fields, "types", "$.native");
+                const Element *declarations = required(fields, "declarations", "$.native");
+                return types != nullptr && declarations != nullptr && read_native_types(*types, out.native_types) &&
+                       read_native_declarations(*declarations, out.native_declarations);
+            }
+
             bool read_build(Element value, BuildMetadata &out) {
                 ObjectFields fields;
                 if (!object(value, "$.build", fields) ||
                     !required_string_array(fields, "public_headers", "$.build", out.public_headers) ||
                     !required_string_array(fields, "cmake_packages", "$.build", out.cmake_packages) ||
                     !required_string_array(fields, "imported_targets", "$.build", out.imported_targets)) {
+                    return false;
+                }
+                if (const Element *runtime_images = fields.find("runtime_images");
+                    runtime_images != nullptr && !string_array(*runtime_images, "$.build.runtime_images", out.runtime_images)) {
                     return false;
                 }
                 const Element *registration = required(fields, "registration", "$.build");
@@ -763,7 +929,16 @@ namespace hgl::descriptor
                     !required_string(registration_fields, "symbol", "$.build.registration", out.registration_symbol)) {
                     return false;
                 }
-                return kind == "cpp" || fail("$.build.registration.kind", "unknown value '" + kind + "'");
+                if (kind != "cpp") { return fail("$.build.registration.kind", "unknown value '" + kind + "'"); }
+                if (const Element *lifecycle = fields.find("lifecycle")) {
+                    ObjectFields lifecycle_fields;
+                    if (!object(*lifecycle, "$.build.lifecycle", lifecycle_fields) ||
+                        !required_u32(lifecycle_fields, "abi_version", "$.build.lifecycle", out.lifecycle.abi_version) ||
+                        !required_string(lifecycle_fields, "query_symbol", "$.build.lifecycle", out.lifecycle.query_symbol)) {
+                        return false;
+                    }
+                }
+                return true;
             }
 
             std::optional<ReadError> error_{};
@@ -781,6 +956,9 @@ namespace hgl::descriptor
                 }
                 if (descriptor_.module_identity.empty()) {
                     return ReadError{"$.module.identity", "module identity must not be empty"};
+                }
+                if (!descriptor_.descriptor_fingerprint.empty() && descriptor_.descriptor_fingerprint != fingerprint(descriptor_)) {
+                    return ReadError{"$.module.descriptor_fingerprint", "descriptor fingerprint does not match canonical contents"};
                 }
                 if (descriptor_.provider_identity.empty()) {
                     return ReadError{"$.provider.identity", "provider identity must not be empty"};
@@ -833,6 +1011,15 @@ namespace hgl::descriptor
                         return error_;
                     }
                 }
+                for (std::size_t index = 0; index < descriptor_.native_types.size(); ++index) {
+                    if (!native_type(descriptor_.native_types[index], index_path("$.native.types", index))) { return error_; }
+                }
+                for (std::size_t index = 0; index < descriptor_.native_declarations.size(); ++index) {
+                    if (!native_declaration(descriptor_.native_declarations[index], index_path("$.native.declarations", index))) {
+                        return error_;
+                    }
+                }
+                if (!lifecycle()) { return error_; }
                 return std::nullopt;
             }
 
@@ -897,11 +1084,136 @@ namespace hgl::descriptor
                        constraint_ref(value.requirements, member_path(path, "requires"), true);
             }
 
+            template <typename Enum>
+            bool unique_enum_values(const std::vector<Enum> &values, std::string_view path, std::string_view role) {
+                for (std::size_t index = 0; index < values.size(); ++index) {
+                    if (std::ranges::find(values.begin(), values.begin() + static_cast<std::ptrdiff_t>(index), values[index]) !=
+                        values.begin() + static_cast<std::ptrdiff_t>(index)) {
+                        return fail(index_path(path, index), "duplicate native " + std::string{role});
+                    }
+                }
+                return true;
+            }
+
+            bool native_type(const NativeTypeDeclaration &type, std::string_view path) {
+                if (!unique_identity(type.identity, path, native_type_identities_)) { return false; }
+                const bool known_identity = std::ranges::any_of(descriptor_.types, [&](const TypeRecord &record) {
+                    return record.category == TypeCategory::Symbol && record.nominal_identity == type.identity;
+                });
+                if (!known_identity) {
+                    return fail(member_path(path, "identity"), "native type does not name a nominal descriptor type");
+                }
+                if (type.cpp_type.empty()) { return fail(member_path(path, "cpp_type"), "C++ type must not be empty"); }
+                if (type.public_header.empty()) {
+                    return fail(member_path(path, "public_header"), "public header must not be empty");
+                }
+                if (std::ranges::find(descriptor_.build.public_headers, type.public_header) ==
+                    descriptor_.build.public_headers.end()) {
+                    return fail(member_path(path, "public_header"), "native type header is not present in build.public_headers");
+                }
+                return true;
+            }
+
+            bool known_parameter(const NativeDeclaration &declaration, std::string_view name) const {
+                return std::ranges::any_of(declaration.parameters,
+                                           [&](const NativeParameterPolicy &parameter) { return parameter.name == name; });
+            }
+
+            bool native_value_policy(const NativeValuePolicy &policy, std::string_view path, const NativeDeclaration &declaration,
+                                     bool result) {
+                if (policy.ownership == NativeOwnership::Shared) {
+                    return fail(member_path(path, "ownership"), "shared native ownership is not supported in this ABI version");
+                }
+                if (policy.ownership == NativeOwnership::Borrowed) {
+                    if (result && policy.dependent_on.empty()) {
+                        return fail(member_path(path, "dependent_on"), "a borrowed native result must name its lifetime parameter");
+                    }
+                    if (!policy.dependent_on.empty() && !known_parameter(declaration, policy.dependent_on)) {
+                        return fail(member_path(path, "dependent_on"), "unknown lifetime parameter '" + policy.dependent_on + "'");
+                    }
+                } else if (!policy.dependent_on.empty()) {
+                    return fail(member_path(path, "dependent_on"), "only borrowed native values have a dependent lifetime");
+                }
+                if (result && policy.mutable_value) {
+                    return fail(member_path(path, "mutable"), "a native result cannot be a mutable argument");
+                }
+                if (policy.mutable_value && policy.ownership != NativeOwnership::Borrowed) {
+                    return fail(member_path(path, "mutable"), "a mutable native argument must be borrowed");
+                }
+                return true;
+            }
+
+            bool native_declaration(const NativeDeclaration &declaration, std::string_view path) {
+                if (!unique_identity(declaration.identity, path, native_declaration_identities_) ||
+                    !signature(declaration.signature, member_path(path, "signature"))) {
+                    return false;
+                }
+                if (declaration.cpp_symbol.empty()) {
+                    return fail(member_path(path, "cpp_symbol"), "C++ symbol must not be empty");
+                }
+                if (declaration.phases.empty()) {
+                    return fail(member_path(path, "phases"), "native declaration needs at least one permitted phase");
+                }
+                if (!unique_enum_values(declaration.phases, member_path(path, "phases"), "phase") ||
+                    !unique_enum_values(declaration.effects, member_path(path, "effects"), "effect")) {
+                    return false;
+                }
+                if (declaration.parameters.size() != declaration.signature.parameters.size()) {
+                    return fail(member_path(path, "parameters"), "native parameter policy count does not match the signature");
+                }
+                std::size_t mutable_parameters = 0;
+                for (std::size_t index = 0; index < declaration.parameters.size(); ++index) {
+                    const NativeParameterPolicy &parameter      = declaration.parameters[index];
+                    const std::string            parameter_path = index_path(member_path(path, "parameters"), index);
+                    if (parameter.name != declaration.signature.parameters[index].name) {
+                        return fail(member_path(parameter_path, "name"),
+                                    "native parameter policy does not match signature parameter '" +
+                                        declaration.signature.parameters[index].name + "'");
+                    }
+                    if (!native_value_policy(parameter.value, member_path(parameter_path, "value"), declaration, false)) {
+                        return false;
+                    }
+                    if (parameter.value.mutable_value) { ++mutable_parameters; }
+                }
+                if (!native_value_policy(declaration.result, member_path(path, "result"), declaration, true)) { return false; }
+                const bool mutates = std::ranges::find(declaration.effects, NativeEffect::Mutation) != declaration.effects.end();
+                if (mutates != (mutable_parameters == 1U)) {
+                    return fail(member_path(path, "effects"), "mutation requires exactly one explicitly mutable borrowed argument");
+                }
+                const bool evaluation = std::ranges::find(declaration.phases, NativePhase::Evaluation) != declaration.phases.end();
+                if (evaluation && declaration.exception_policy != NativeExceptionPolicy::NoThrow) {
+                    return fail(member_path(path, "exception"), "evaluation native functions must be noexcept");
+                }
+                if (evaluation && std::ranges::find(declaration.effects, NativeEffect::Blocking) != declaration.effects.end()) {
+                    return fail(member_path(path, "effects"), "evaluation native functions must be non-blocking");
+                }
+                if (declaration.category == NativeDeclarationCategory::Constructor &&
+                    declaration.result.ownership != NativeOwnership::Owned) {
+                    return fail(member_path(path, "result.ownership"), "a native constructor must return owned state");
+                }
+                return true;
+            }
+
+            bool lifecycle() {
+                const LifecycleMetadata &lifecycle = descriptor_.build.lifecycle;
+                if (lifecycle.abi_version == 0U) {
+                    return lifecycle.query_symbol.empty() ||
+                           fail("$.build.lifecycle.query_symbol", "a descriptor without a lifecycle ABI has no query symbol");
+                }
+                if (lifecycle.abi_version != HGL_NATIVE_MODULE_ABI_V1) {
+                    return fail("$.build.lifecycle.abi_version",
+                                "unsupported native module ABI version " + std::to_string(lifecycle.abi_version));
+                }
+                if (lifecycle.query_symbol != HGL_NATIVE_MODULE_QUERY_SYMBOL_V1) {
+                    return fail("$.build.lifecycle.query_symbol", "query symbol does not match native module ABI version 1");
+                }
+                return !descriptor_.build.runtime_images.empty() ||
+                       fail("$.build.runtime_images", "a native lifecycle requires at least one runtime image");
+            }
+
             bool type_record(const TypeRecord &record, std::string_view path) {
                 if (record.category == TypeCategory::Scalar) {
-                    if (record.scalar_name.empty()) {
-                        return fail(member_path(path, "name"), "scalar type is missing its name");
-                    }
+                    if (record.scalar_name.empty()) { return fail(member_path(path, "name"), "scalar type is missing its name"); }
                     if (!known_scalar_name(record.scalar_name)) {
                         return fail(member_path(path, "name"), "unknown scalar type '" + record.scalar_name + "'");
                     }
@@ -928,9 +1240,8 @@ namespace hgl::descriptor
                     case TypeCategory::Callable: break;
                 }
                 if (required_children && record.children.size() != *required_children) {
-                    return fail(member_path(path, "children"),
-                                "type requires exactly " + std::to_string(*required_children) + " child" +
-                                    (*required_children == 1U ? "" : "ren"));
+                    return fail(member_path(path, "children"), "type requires exactly " + std::to_string(*required_children) +
+                                                                   " child" + (*required_children == 1U ? "" : "ren"));
                 }
                 for (std::size_t index = 0; index < record.children.size(); ++index) {
                     if (!type_ref(record.children[index], index_path(member_path(path, "children"), index))) { return false; }
@@ -961,18 +1272,18 @@ namespace hgl::descriptor
                     case ConstantExpressionCategory::Unary:
                         if (!known_unary_operator(record.operator_spelling)) {
                             return fail(member_path(path, "operator"),
-                                        record.operator_spelling.empty() ? "unary expression is missing its operator"
-                                                                         : "unknown unary operator '" +
-                                                                               record.operator_spelling + "'");
+                                        record.operator_spelling.empty()
+                                            ? "unary expression is missing its operator"
+                                            : "unknown unary operator '" + record.operator_spelling + "'");
                         }
                         if (!constant_ref(record.lhs, member_path(path, "lhs"))) { return false; }
                         break;
                     case ConstantExpressionCategory::Binary:
                         if (!known_binary_operator(record.operator_spelling)) {
                             return fail(member_path(path, "operator"),
-                                        record.operator_spelling.empty() ? "binary expression is missing its operator"
-                                                                         : "unknown binary operator '" +
-                                                                               record.operator_spelling + "'");
+                                        record.operator_spelling.empty()
+                                            ? "binary expression is missing its operator"
+                                            : "unknown binary operator '" + record.operator_spelling + "'");
                         }
                         if (!constant_ref(record.lhs, member_path(path, "lhs")) ||
                             !constant_ref(record.rhs, member_path(path, "rhs"))) {
@@ -1056,6 +1367,8 @@ namespace hgl::descriptor
             std::optional<ReadError> error_{};
             std::vector<std::string> interface_identities_{};
             std::vector<std::string> implementation_identities_{};
+            std::vector<std::string> native_type_identities_{};
+            std::vector<std::string> native_declaration_identities_{};
         };
     }  // namespace
 

--- a/language/src/driver/native_module.cpp
+++ b/language/src/driver/native_module.cpp
@@ -506,34 +506,9 @@ namespace hgl::driver
             return std::nullopt;
         }
 
-        bool validate_native_module_abi(const hgl_native_module_v1 *module, std::string_view expected_identity,
-                                        std::string &error) {
-            if (module == nullptr) {
-                error = "native artifact does not support HGL native module ABI v1";
-                return false;
-            }
-            if (module->abi_version != HGL_NATIVE_MODULE_ABI_V1 || module->struct_size < sizeof(*module)) {
-                error = "native artifact returned an incompatible HGL native module ABI table";
-                return false;
-            }
-            if (module->module_identity == nullptr || std::string_view{module->module_identity} != expected_identity) {
-                error = "native artifact identity does not match descriptor module '" + std::string{expected_identity} + "'";
-                return false;
-            }
-            if (module->descriptor_fingerprint == nullptr) {
-                error = "native artifact returned no descriptor fingerprint";
-                return false;
-            }
-            if (module->context == nullptr || module->init == nullptr || module->deinit == nullptr ||
-                module->is_active == nullptr) {
-                error = "native artifact returned an incomplete HGL native module ABI table";
-                return false;
-            }
-            return true;
-        }
-
         bool load_native_image(const std::filesystem::path &image_path, const std::filesystem::path &retained_directory,
-                               std::string_view expected_identity, const hgl_native_module_v1 *&module_abi, std::string &error) {
+                               std::string_view expected_identity, std::string_view expected_fingerprint,
+                               const hgl_native_module_v1 *&module_abi, std::string &error) {
             void *image = ::dlopen(image_path.c_str(), RTLD_NOW | RTLD_LOCAL);
             if (image == nullptr) {
                 const char *load_error = ::dlerror();
@@ -561,7 +536,7 @@ namespace hgl::driver
                         error = "native artifact module query failed: ";
                         error.append(message);
                     }) ||
-                !validate_native_module_abi(module_abi, expected_identity, error)) {
+                !validate_native_module_abi(module_abi, expected_identity, expected_fingerprint, error)) {
                 error += "; artifacts retained in '" + retained_directory.string() + "'";
                 ::dlclose(image);
                 return false;
@@ -571,6 +546,31 @@ namespace hgl::driver
         }
 #endif
     }  // namespace
+
+    bool validate_native_module_abi(const hgl_native_module_v1 *module, std::string_view expected_identity,
+                                    std::string_view expected_fingerprint, std::string &error) {
+        if (module == nullptr) {
+            error = "native artifact does not support HGL native module ABI v1";
+            return false;
+        }
+        if (module->abi_version != HGL_NATIVE_MODULE_ABI_V1 || module->struct_size < sizeof(*module)) {
+            error = "native artifact returned an incompatible HGL native module ABI table";
+            return false;
+        }
+        if (module->module_identity == nullptr || std::string_view{module->module_identity} != expected_identity) {
+            error = "native artifact identity does not match descriptor module '" + std::string{expected_identity} + "'";
+            return false;
+        }
+        if (module->descriptor_fingerprint == nullptr || std::string_view{module->descriptor_fingerprint} != expected_fingerprint) {
+            error = "native artifact descriptor fingerprint does not match its descriptor";
+            return false;
+        }
+        if (module->context == nullptr || module->init == nullptr || module->deinit == nullptr || module->is_active == nullptr) {
+            error = "native artifact returned an incomplete HGL native module ABI table";
+            return false;
+        }
+        return true;
+    }
 
     static std::optional<NativeModule> compile_native_module(const codegen::EmittedModule &module, std::string_view source_stem,
                                                              std::string &error) {
@@ -667,7 +667,9 @@ namespace hgl::driver
                      "        \""
                   << module.module_name
                   << "\",\n"
-                     "        \"\",\n"
+                     "        \""
+                  << module.descriptor_fingerprint
+                  << "\",\n"
                      "        &module_state,\n"
                      "        init_module,\n"
                      "        deinit_module,\n"
@@ -707,7 +709,10 @@ namespace hgl::driver
             if (complete_cache_entry(entry, key, stem, module.descriptor)) {
                 trace_cache("hit " + key);
                 const hgl_native_module_v1 *module_abi = nullptr;
-                if (!load_native_image(entry / image_name(), entry, module.module_name, module_abi, error)) { return std::nullopt; }
+                if (!load_native_image(entry / image_name(), entry, module.module_name, module.descriptor_fingerprint, module_abi,
+                                       error)) {
+                    return std::nullopt;
+                }
                 return NativeModule{entry, key, true, module_abi};
             }
             trace_cache("miss " + key);
@@ -763,7 +768,7 @@ namespace hgl::driver
             }
         }
         const hgl_native_module_v1 *module_abi = nullptr;
-        if (!load_native_image(load_path, result_directory, module.module_name, module_abi, error)) {
+        if (!load_native_image(load_path, result_directory, module.module_name, module.descriptor_fingerprint, module_abi, error)) {
             if (load_path != image_path) { error += "; build artifacts retained in '" + artifact_directory->string() + "'"; }
             return std::nullopt;
         }

--- a/language/src/driver/native_module.h
+++ b/language/src/driver/native_module.h
@@ -12,6 +12,11 @@
 
 namespace hgl::driver
 {
+    /// Validate the immutable portion of a discovered ABI table before its
+    /// image is retained or any lifecycle callback is invoked.
+    [[nodiscard]] bool validate_native_module_abi(const hgl_native_module_v1 *module, std::string_view expected_identity,
+                                                  std::string_view expected_fingerprint, std::string &error);
+
     /// One loaded generated HGL image and its module-owned lifecycle table.
     /// The image remains resident for process lifetime; this object invokes
     /// logical activation/deactivation transactionally without accepting

--- a/language/tests/descriptor/module_descriptor_reader_tests.cpp
+++ b/language/tests/descriptor/module_descriptor_reader_tests.cpp
@@ -32,6 +32,7 @@ namespace
                 .arguments = {{descriptor::TypeArgumentCategory::Type, 0U}, {descriptor::TypeArgumentCategory::Constant, 0U}}},
             descriptor::TypeRecord{.category = descriptor::TypeCategory::Rolling, .children = {1U}, .size = 0U},
             descriptor::TypeRecord{.category = descriptor::TypeCategory::Reference, .children = {0U}},
+            descriptor::TypeRecord{.category = descriptor::TypeCategory::Symbol, .nominal_identity = "checks.reader.State"},
         };
 
         descriptor::ConstantExpressionRecord integer;
@@ -119,11 +120,45 @@ namespace
         implementation.signature.result       = 0U;
         result.implementations                = {std::move(implementation)};
 
+        result.native_types = {
+            descriptor::NativeTypeDeclaration{.category      = descriptor::NativeTypeCategory::OpaqueState,
+                                              .identity      = "checks.reader.State",
+                                              .cpp_type      = "checks::reader::State",
+                                              .public_header = "checks_reader.h"},
+        };
+        descriptor::NativeDeclaration update;
+        update.identity             = "checks.reader.update";
+        update.cpp_symbol           = "checks::reader::update";
+        update.signature.parameters = {{"state", "checks.reader.update::state", false, 4U, descriptor::no_schema_id},
+                                       {"value", "checks.reader.update::value", false, 0U, descriptor::no_schema_id}};
+        update.signature.result     = 0U;
+        update.phases               = {descriptor::NativePhase::Evaluation};
+        update.effects              = {descriptor::NativeEffect::Mutation};
+        update.parameters           = {
+            {"state", {descriptor::NativeOwnership::Borrowed, {}, true}},
+            {"value", {descriptor::NativeOwnership::Value}},
+        };
+        update.thread_safety = descriptor::NativeThreadSafety::NodeLocal;
+
+        descriptor::NativeDeclaration construct;
+        construct.category         = descriptor::NativeDeclarationCategory::Constructor;
+        construct.identity         = "checks.reader.make_state";
+        construct.cpp_symbol       = "checks::reader::make_state";
+        construct.signature.result = 4U;
+        construct.phases           = {descriptor::NativePhase::Start};
+        construct.effects          = {descriptor::NativeEffect::Allocation};
+        construct.result.ownership = descriptor::NativeOwnership::Owned;
+        construct.exception_policy = descriptor::NativeExceptionPolicy::Translated;
+        result.native_declarations = {std::move(update), std::move(construct)};
+
         result.provider_requirements     = {"hgraph.std"};
         result.build.public_headers      = {"checks_reader.h"};
         result.build.cmake_packages      = {"hgraph"};
         result.build.imported_targets    = {"hgraph::core"};
+        result.build.runtime_images      = {"libchecks_reader.so"};
         result.build.registration_symbol = "checks::reader::register_operators";
+        result.build.lifecycle           = {1U, "hgl_query_native_module_v1"};
+        descriptor::seal(result);
         return result;
     }
 
@@ -160,6 +195,15 @@ TEST_CASE("module descriptor reader accepts compatible unknown members", "[descr
     const descriptor::ReadResult result = descriptor::read_json(json);
     REQUIRE(result);
     CHECK(result.value == minimal_descriptor());
+}
+
+TEST_CASE("module descriptor reader rejects a stale canonical fingerprint", "[descriptor][reader][fingerprint]") {
+    descriptor::ModuleDescriptor source = rich_descriptor();
+    std::string                  json   = descriptor::to_json(source);
+    replace_once(json, "\"identity\": \"checks.reader\"", "\"identity\": \"checks.changed\"");
+
+    check_error(descriptor::read_json(json), "$.module.descriptor_fingerprint",
+                "descriptor fingerprint does not match canonical contents");
 }
 
 TEST_CASE("module descriptor reader rejects malformed envelopes", "[descriptor][reader]") {
@@ -228,8 +272,7 @@ TEST_CASE("module descriptor reader rejects malformed schema records", "[descrip
 
     SECTION("unknown scalar name") {
         source.types.front().scalar_name = "mystery";
-        check_error(descriptor::read_json(descriptor::to_json(source)), "$.schema.types[0].name",
-                    "unknown scalar type 'mystery'");
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.schema.types[0].name", "unknown scalar type 'mystery'");
     }
 
     SECTION("fixed-shape type has the wrong child count") {
@@ -256,7 +299,7 @@ TEST_CASE("module descriptor reader rejects malformed schema records", "[descrip
 
 TEST_CASE("module descriptor reader rejects unknown constant operators", "[descriptor][reader]") {
     descriptor::ModuleDescriptor source = minimal_descriptor();
-    source.constant_expressions = {
+    source.constant_expressions         = {
         descriptor::ConstantExpressionRecord{.literal = hgl::ir::hir::Constant{std::int64_t{1}}},
         descriptor::ConstantExpressionRecord{
             .category = descriptor::ConstantExpressionCategory::Unary, .operator_spelling = "bogus", .lhs = 0U},
@@ -266,10 +309,10 @@ TEST_CASE("module descriptor reader rejects unknown constant operators", "[descr
                 "unknown unary operator 'bogus'");
 
     source.constant_expressions[1] = descriptor::ConstantExpressionRecord{
-        .category = descriptor::ConstantExpressionCategory::Binary,
+        .category          = descriptor::ConstantExpressionCategory::Binary,
         .operator_spelling = "bogus",
-        .lhs = 0U,
-        .rhs = 0U,
+        .lhs               = 0U,
+        .rhs               = 0U,
     };
     check_error(descriptor::read_json(descriptor::to_json(source)), "$.schema.constant_expressions[1].operator",
                 "unknown binary operator 'bogus'");
@@ -283,4 +326,47 @@ TEST_CASE("module descriptor validation rejects incomplete semantic records", "[
     REQUIRE(error);
     CHECK(error->path == "$.schema.constant_expressions[0].literal");
     CHECK(error->message == "missing literal payload");
+}
+
+TEST_CASE("native descriptor validation enforces the initial safety envelope", "[descriptor][reader][native]") {
+    SECTION("native types name a nominal descriptor type") {
+        descriptor::ModuleDescriptor source  = rich_descriptor();
+        source.native_types.front().identity = "checks.reader.Missing";
+        source.descriptor_fingerprint.clear();
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.native.types[0].identity",
+                    "native type does not name a nominal descriptor type");
+    }
+
+    SECTION("evaluation functions are noexcept") {
+        descriptor::ModuleDescriptor source                 = rich_descriptor();
+        source.native_declarations.front().exception_policy = descriptor::NativeExceptionPolicy::Translated;
+        source.descriptor_fingerprint.clear();
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.native.declarations[0].exception",
+                    "evaluation native functions must be noexcept");
+    }
+
+    SECTION("mutation identifies one borrowed argument") {
+        descriptor::ModuleDescriptor source                                       = rich_descriptor();
+        source.native_declarations.front().parameters.front().value.mutable_value = false;
+        source.descriptor_fingerprint.clear();
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.native.declarations[0].effects",
+                    "mutation requires exactly one explicitly mutable borrowed argument");
+    }
+
+    SECTION("borrowed results name their lifetime source") {
+        descriptor::ModuleDescriptor source = rich_descriptor();
+        auto                        &result = source.native_declarations.front().result;
+        result.ownership                    = descriptor::NativeOwnership::Borrowed;
+        source.descriptor_fingerprint.clear();
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.native.declarations[0].result.dependent_on",
+                    "a borrowed native result must name its lifetime parameter");
+    }
+
+    SECTION("lifecycle ABI and query symbol agree") {
+        descriptor::ModuleDescriptor source = rich_descriptor();
+        source.build.lifecycle.query_symbol = "wrong_query";
+        source.descriptor_fingerprint.clear();
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.build.lifecycle.query_symbol",
+                    "query symbol does not match native module ABI version 1");
+    }
 }

--- a/language/tests/descriptor/module_descriptor_reader_tests.cpp
+++ b/language/tests/descriptor/module_descriptor_reader_tests.cpp
@@ -187,14 +187,15 @@ TEST_CASE("module descriptor reader round-trips the complete version-one model",
 }
 
 TEST_CASE("module descriptor reader accepts compatible unknown members", "[descriptor][reader]") {
-    std::string json = descriptor::to_json(minimal_descriptor());
+    const descriptor::ModuleDescriptor expected = rich_descriptor();
+    std::string                        json     = descriptor::to_json(expected);
     replace_once(json, "  \"format\":", "  \"future_top_level\": {\"value\": true},\n  \"format\":");
     replace_once(json, "    \"identity\": \"checks.reader\",",
                  "    \"identity\": \"checks.reader\",\n    \"future_module_member\": [1, 2, 3],");
 
     const descriptor::ReadResult result = descriptor::read_json(json);
     REQUIRE(result);
-    CHECK(result.value == minimal_descriptor());
+    CHECK(result.value == expected);
 }
 
 TEST_CASE("module descriptor reader rejects a stale canonical fingerprint", "[descriptor][reader][fingerprint]") {
@@ -360,6 +361,42 @@ TEST_CASE("native descriptor validation enforces the initial safety envelope", "
         source.descriptor_fingerprint.clear();
         check_error(descriptor::read_json(descriptor::to_json(source)), "$.native.declarations[0].result.dependent_on",
                     "a borrowed native result must name its lifetime parameter");
+    }
+
+    SECTION("borrowed results depend on borrowed parameters") {
+        descriptor::ModuleDescriptor source = rich_descriptor();
+        auto                        &result = source.native_declarations.front().result;
+        result.ownership                    = descriptor::NativeOwnership::Borrowed;
+        result.dependent_on                 = "value";
+        source.descriptor_fingerprint.clear();
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.native.declarations[0].result.dependent_on",
+                    "a dependent lifetime must name a borrowed parameter");
+    }
+
+    SECTION("mutable parameters require mutation metadata") {
+        descriptor::ModuleDescriptor source = rich_descriptor();
+        auto                        &update = source.native_declarations.front();
+        update.effects.clear();
+        update.parameters[1].value = {descriptor::NativeOwnership::Borrowed, {}, true};
+        source.descriptor_fingerprint.clear();
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.native.declarations[0].effects",
+                    "mutation requires exactly one explicitly mutable borrowed argument");
+    }
+
+    SECTION("native signatures reject temporal and container types") {
+        descriptor::ModuleDescriptor source                             = rich_descriptor();
+        source.native_declarations.front().signature.parameters[1].type = 2U;
+        source.descriptor_fingerprint.clear();
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.native.declarations[0].signature.parameters[1].type",
+                    "native signature type is outside the initial scalar and declared-native envelope");
+    }
+
+    SECTION("native signatures reject undeclared nominal types") {
+        descriptor::ModuleDescriptor source = rich_descriptor();
+        source.native_types.clear();
+        source.descriptor_fingerprint.clear();
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.native.declarations[0].signature.parameters[0].type",
+                    "native signature type is outside the initial scalar and declared-native envelope");
     }
 
     SECTION("lifecycle ABI and query symbol agree") {

--- a/language/tests/descriptor/module_descriptor_tests.cpp
+++ b/language/tests/descriptor/module_descriptor_tests.cpp
@@ -44,6 +44,8 @@ TEST_CASE("module descriptors normalize public and provider inventories", "[desc
     REQUIRE(result.format_version == descriptor::module_descriptor_format_version);
     CHECK(result.module_identity == "acme.prices");
     CHECK(result.provider_identity == "acme.prices");
+    CHECK(result.descriptor_fingerprint.starts_with("sha256:"));
+    CHECK(result.descriptor_fingerprint.size() == 71U);
     CHECK(result.provider_requirements == std::vector<std::string>{"alpha", "zeta"});
     REQUIRE(result.interface.size() == 4U);
     CHECK(result.interface[0].identity == "acme.prices.Quote");
@@ -161,7 +163,8 @@ TEST_CASE("module descriptor JSON is canonical and reviewable", "[descriptor]") 
   "format_version": 1,
   "module": {
     "identity": "acme.\"prices\"",
-    "language_version": "test\nversion"
+    "language_version": "test\nversion",
+    "descriptor_fingerprint": ""
   },
   "interface": [
     {
@@ -188,6 +191,10 @@ TEST_CASE("module descriptor JSON is canonical and reviewable", "[descriptor]") 
     "constant_expressions": [],
     "constraints": []
   },
+  "native": {
+    "types": [],
+    "declarations": []
+  },
   "build": {
     "public_headers": [
       "prices.h"
@@ -198,9 +205,14 @@ TEST_CASE("module descriptor JSON is canonical and reviewable", "[descriptor]") 
     "imported_targets": [
       "hgraph::core"
     ],
+    "runtime_images": [],
     "registration": {
       "kind": "cpp",
       "symbol": "acme::prices::register_operators"
+    },
+    "lifecycle": {
+      "abi_version": 0,
+      "query_symbol": ""
     }
   }
 }
@@ -219,6 +231,21 @@ TEST_CASE("module descriptor literals preserve values outside JSON's numeric mod
     CHECK(json.find("\"value\": \"9223372036854775807\"") != std::string::npos);
     CHECK(json.find("\"value\": \"inf\"") != std::string::npos);
     CHECK(json.find("\"value\": \"-inf\"") != std::string::npos);
+}
+
+TEST_CASE("module descriptor fingerprints cover canonical contents", "[descriptor][fingerprint]") {
+    descriptor::ModuleDescriptor module;
+    module.module_identity   = "checks.fingerprint";
+    module.provider_identity = "checks.fingerprint";
+
+    descriptor::seal(module);
+    const std::string original = module.descriptor_fingerprint;
+    CHECK(original == descriptor::fingerprint(module));
+    descriptor::seal(module);
+    CHECK(module.descriptor_fingerprint == original);
+
+    module.build.public_headers.push_back("changed.h");
+    CHECK(descriptor::fingerprint(module) != original);
 }
 
 TEST_CASE("module descriptors preserve structured compile-time expressions", "[descriptor][schema]") {

--- a/language/tests/driver/native_module_tests.cpp
+++ b/language/tests/driver/native_module_tests.cpp
@@ -137,6 +137,21 @@ TEST_CASE("aliased native module wrappers preserve the activation owner") {
     CHECK(state.deinit_calls == 2);
 }
 
+TEST_CASE("native module ABI validation binds identity and descriptor fingerprint") {
+    FakeModuleState      state;
+    hgl_native_module_v1 abi = module_abi(state);
+    std::string          error;
+    abi.descriptor_fingerprint = "sha256:actual";
+
+    CHECK(hgl::driver::validate_native_module_abi(&abi, "example.module", "sha256:actual", error));
+
+    CHECK_FALSE(hgl::driver::validate_native_module_abi(&abi, "example.module", "sha256:expected", error));
+    CHECK(error == "native artifact descriptor fingerprint does not match its descriptor");
+
+    CHECK_FALSE(hgl::driver::validate_native_module_abi(&abi, "other.module", "sha256:actual", error));
+    CHECK(error == "native artifact identity does not match descriptor module 'other.module'");
+}
+
 TEST_CASE("generated C++ is passed through clang-format") {
     hgl::codegen::EmittedModule module;
     module.header = "#pragma once\nnamespace example{using value=int;}\n";


### PR DESCRIPTION
## Summary

- add canonical native type and exact-function metadata for phase, effects, ownership, dependent lifetimes, exceptions, and thread safety
- validate the initial native safety envelope and lifecycle metadata without loading provider code
- seal generated descriptors with a canonical SHA-256 fingerprint and require the scripted image to present that exact fingerprint before activation
- update the native-interface roadmap and user/developer documentation

## Validation

- complete HGL suite: 37/37 passed
- fresh native acceptance build: 1716/1716 passed
- stable-ABI wheel built with Python 3.12; Python 3.14 non-WIP suite: 3241 passed, 10 skipped