### PR TITLE
feat(language): author native package descriptors

### DIFF
--- a/.github/workflows/language.yml
+++ b/.github/workflows/language.yml
@@ -110,6 +110,7 @@ jobs:
         run: >-
           cmake --build build-language --parallel ${{ matrix.parallel }} --target
           hgl hgl_syntax_tests hgl_semantics_tests hgl_ir_tests hgl_graph_ir_tests hgl_descriptor_tests hgl_descriptor_reader_tests
+          hgl_native_package_tests
           hgl_wiring_tests hgl_wiring_type_tests
           hgl_operator_type_tests hgl_native_module_tests hgl_native_module_abi_c hgl_codegen_tests hgl_codegen_fixture
           hgl_generated_tests

--- a/language/CHANGELOG.md
+++ b/language/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add an installed `hgl::native_package` C++ authoring API for exact scalar and
+  package-declared nominal native signatures. It produces deterministic sealed
+  descriptors and applies the same safety validator used by `hgl check`.
 - Describe native types and declarations with phase, effect, ownership,
   borrowed-lifetime, exception, and thread-safety metadata. Seal descriptors
   with a canonical SHA-256 fingerprint and require the generated native module

--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -201,7 +201,10 @@ add_library(hgl_native_package SHARED
     src/native/native_package.cpp
 )
 add_library(hgl::native_package ALIAS hgl_native_package)
-set_target_properties(hgl_native_package PROPERTIES EXPORT_NAME native_package)
+set_target_properties(hgl_native_package PROPERTIES
+    EXPORT_NAME native_package
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN YES)
 target_compile_features(hgl_native_package PUBLIC cxx_std_23)
 target_compile_definitions(hgl_native_package PRIVATE HGL_NATIVE_PACKAGE_BUILD=1)
 target_include_directories(hgl_native_package PUBLIC

--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -7,6 +7,11 @@ project(hgraph_language LANGUAGES C CXX)
 include(CTest)
 include(GNUInstallDirs)
 
+# Compiler libraries also back the installed shared native-package facade.
+# Keep standalone language builds position-independent just like repository
+# builds, whose top-level project already enables this setting.
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 set(_hgraph_language_warnings_as_errors OFF)
 if(DEFINED HGRAPH_WARNINGS_AS_ERRORS)
     set(_hgraph_language_warnings_as_errors "${HGRAPH_WARNINGS_AS_ERRORS}")
@@ -168,11 +173,12 @@ hgl_apply_warnings(hgl_graph_ir)
 add_library(hgl_descriptor STATIC
     src/descriptor/module_descriptor.cpp
     src/descriptor/module_descriptor_json.cpp
+    src/descriptor/sha256.cpp
 )
 add_library(hgl::descriptor ALIAS hgl_descriptor)
 target_compile_features(hgl_descriptor PUBLIC cxx_std_23)
 target_include_directories(hgl_descriptor PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
-target_link_libraries(hgl_descriptor PUBLIC hgl::graph_ir PRIVATE hgraph::core)
+target_link_libraries(hgl_descriptor PUBLIC hgl::graph_ir)
 hgl_apply_warnings(hgl_descriptor)
 
 # Descriptor consumption is a separate boundary: the model/writer remains
@@ -185,6 +191,25 @@ target_compile_features(hgl_descriptor_reader PUBLIC cxx_std_23)
 target_include_directories(hgl_descriptor_reader PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_link_libraries(hgl_descriptor_reader PUBLIC hgl::descriptor PRIVATE hgl::native_interface simdjson::simdjson)
 hgl_apply_warnings(hgl_descriptor_reader)
+
+# Installed native-package authoring facade. Its public model is deliberately
+# narrower than the compiler descriptor arena; the implementation translates
+# it to the canonical descriptor and reuses the ordinary validator. A shared
+# library keeps compiler-internal static targets out of the installed link
+# interface.
+add_library(hgl_native_package SHARED
+    src/native/native_package.cpp
+)
+add_library(hgl::native_package ALIAS hgl_native_package)
+set_target_properties(hgl_native_package PROPERTIES EXPORT_NAME native_package)
+target_compile_features(hgl_native_package PUBLIC cxx_std_23)
+target_compile_definitions(hgl_native_package PRIVATE HGL_NATIVE_PACKAGE_BUILD=1)
+target_include_directories(hgl_native_package PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+target_link_libraries(hgl_native_package PRIVATE hgl::descriptor_reader)
+hgl_apply_warnings(hgl_native_package)
 
 # Canonical hgraph metadata materialization for execution backends. Keeping
 # this bridge separate prevents hgraph runtime types from entering hgraph IR.
@@ -358,9 +383,12 @@ install(TARGETS hgl
     COMPONENT Runtime
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
-install(TARGETS hgl_native_interface
+install(TARGETS hgl_native_interface hgl_native_package
     EXPORT HglLanguageTargets
     COMPONENT Development
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 install(EXPORT HglLanguageTargets
     FILE HglLanguageTargets.cmake

--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -41,6 +41,14 @@ if(NOT TARGET hgraph::core)
     find_package(hgraph CONFIG REQUIRED)
 endif()
 
+# The public native-package facade is shared and consumes the descriptor
+# reader, which links simdjson privately. Repository builds may create the
+# fetched static simdjson target before entering this subdirectory, so the
+# directory-wide PIC default above cannot affect it retroactively.
+if(TARGET simdjson)
+    set_property(TARGET simdjson PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif()
+
 # The line editor behind `hgl repl` (developer guide, "Scripted, REPL, and
 # AOT drivers"): isocline, MIT, one C translation unit. Fetched and compiled
 # here rather than added as a subproject so its own CMake (tests, install)

--- a/language/README.md
+++ b/language/README.md
@@ -20,9 +20,9 @@ diagnostics (`--dump-tokens`, `--dump-ast`, `--dump-hir`, and
 `--dump-hgraph-ir` show its successive views). It also validates one generated
 `.hgl-module.json` descriptor without loading native code; dependency closure
 remains staged. The hgraph-IR dump now owns callable and test bodies as well
-as their interfaces. Direct test, REPL, and run evaluation consumes that IR;
-only C++ generation still has its temporary resolved-AST adapter. That frontend now
-models nominal and generic structs, abstract-only inheritance, defaults and
+as their interfaces. Direct test, REPL, run evaluation, and C++ generation all
+consume that IR. The frontend models nominal and generic structs,
+abstract-only inheritance, defaults and
 optional fields, `requires` constraints, and sparse `delta<S>` construction.
 `hgl test`, `hgl run`, and `hgl repl` additionally execute supported generated
 runtime nodes through a content-addressed native image on Unix; the REPL
@@ -39,6 +39,9 @@ concise `map` functions, collection traversal and predicates, logger injection,
 scalar recordable state, prior and keyed output access, and lifecycle blocks.
 Explicit `ref<T>` contracts and guarded fixed-list reference routing also reach
 native schema materialization, descriptors, generated C++, and behavior tests.
+The installed `hgl::native_package` C++ API emits deterministic, validated
+descriptors for constrained native scalar and nominal-type declarations without
+exposing compiler IR.
 Source operators become transparent aliases of `hgraph::Operator` contracts,
 not generated subclasses. `hgl_add_module()`
 builds such modules — together with hand-written C++ — into a library and,

--- a/language/docs/design/decisions/0003-native-descriptor-boundary.md
+++ b/language/docs/design/decisions/0003-native-descriptor-boundary.md
@@ -1,6 +1,7 @@
 # ADR 0003: Native code is exposed by descriptors, not inline source
 
-Status: accepted; JSON representation and lifecycle ABI selected, authoring API pending
+Status: accepted; JSON representation, lifecycle ABI, and explicit C++
+descriptor-authoring API implemented
 
 ## Context
 

--- a/language/docs/design/decisions/0004-json-module-descriptors.md
+++ b/language/docs/design/decisions/0004-json-module-descriptors.md
@@ -80,7 +80,8 @@ install or aggregate it deliberately.
   and dangling references. The native section records type associations, exact
   symbols, phase/effect/ownership/lifetime policy, exception and thread-safety
   policy; build metadata records runtime images and the separate lifecycle ABI.
-  Locked dependency closure and native package authoring remain Stage F work.
+  The installed native-package authoring API produces and validates this same
+  representation. Locked dependency closure remains Stage F work.
 
 ## Alternatives
 

--- a/language/docs/design/native-interface.md
+++ b/language/docs/design/native-interface.md
@@ -1,8 +1,8 @@
 # Native interface
 
 Status: accepted boundary; descriptor validation, native declaration metadata,
-canonical fingerprints, and the lifecycle ABI implemented; authoring and call
-lowering remain
+canonical fingerprints, the lifecycle ABI, and explicit descriptor authoring
+implemented; normalized-wrapper generation and call lowering remain
 
 ## Purpose
 
@@ -64,8 +64,8 @@ lifetimes, exception policy, thread-safety policy, opaque or atomic native type
 associations, runtime images, and lifecycle ABI metadata. The reader enforces
 the initial non-blocking/noexcept evaluation envelope, explicit mutable state,
 borrow rules, and lifecycle consistency. Transitive dependency closure and the
-native-package authoring API remain to be added. No HGL declaration syntax is
-implied by this list.
+import/lowering path remain to be added. No HGL declaration syntax is implied
+by this list.
 
 ## Native declaration categories
 
@@ -167,10 +167,54 @@ question if existing nominal type syntax is insufficient.
 
 ## Producing descriptors
 
-The first producer should be an explicit C++ registration API or build-time
-tool owned by the native package. It emits both the reviewable descriptor and
-any wrapper required to normalize C++ overloads, templates, exceptions, or
-ownership into the declared HGL contract.
+The installed `hgl::native_package` C++ API is the first producer. A small
+build-time executable owned by the native package fills an
+`hgl::native::Package` and calls `write_descriptor`. The authoring model can
+name only canonical scalars and nominal native types declared by that same
+package. It sorts set-like inventories and declarations, creates the shared
+descriptor schema records, seals the result, and runs the same validator used
+by `hgl check` before writing anything.
+
+For example, this describes a non-throwing scalar operation:
+
+```cpp
+#include <hgl/native_package.h>
+
+int main()
+{
+    using namespace hgl::native;
+    Package package{
+        .module_identity = "acme.stats",
+        .language_version = "0.1",
+        .declarations = {
+            Declaration{
+                .identity = "acme.stats::update",
+                .cpp_symbol = "acme::stats::update",
+                .parameters = {
+                    Parameter{.name = "previous",
+                              .type = ValueType::canonical(ScalarType::F64)},
+                    Parameter{.name = "value",
+                              .type = ValueType::canonical(ScalarType::F64)},
+                },
+                .result_type = ValueType::canonical(ScalarType::F64),
+                .phases = {Phase::Evaluation},
+            },
+        },
+        .build = Build{
+            .public_headers = {"acme/stats.h"},
+            .cmake_packages = {"acme_stats"},
+            .imported_targets = {"acme::stats"},
+        },
+    };
+    write_descriptor(package, "acme-stats.hgl-module.json");
+}
+```
+
+The named `cpp_symbol` must already be an exact directly callable public C++
+symbol. If an overload, template, throwing function, or ownership-heavy API
+needs normalization, the package supplies a small reviewed wrapper and names
+that wrapper. Automatic wrapper emission is a remaining Stage F slice; the
+authoring API does not parse headers or accept arbitrary C++ declarations.
 
 An optional Clang-based binding generator may later derive the same artifact
 from annotated public headers. Clang is then a descriptor-generation tool, not

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -238,8 +238,10 @@ HGraph IR; unsupported language-depth items remain explicit roadmap work.
   the operator registry;
 - [x] choose and version the public C-compatible lifecycle ABI and use it for
   scripted native module activation, replacement, and logical removal;
-- provide a native-package authoring API which emits descriptors and normalized
-  wrappers;
+- [x] provide an installed native-package authoring API which emits, seals, and
+  validates descriptors;
+- generate normalized wrappers for C++ overloads, templates, exceptions, and
+  ownership boundaries;
 - [x] add phase, effect, ownership, dependent-lifetime, exception,
   thread-safety, build, lifecycle, and canonical fingerprint metadata;
 - support a canonical scalar evaluation function and owned opaque node state;

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -1066,9 +1066,15 @@ semantics require a format-version increment. The scripted native table embeds
 the same fingerprint, and the loader compares both module identity and the
 exact fingerprint before initialization.
 
-Locked transitive dependency closure and the public native-package authoring
-API are the following Stage F slices. Validating one file does not yet prove
-that its declared provider requirements are present or mutually compatible.
+The installed `hgl::native_package` facade translates its deliberately narrow
+public C++ value model into this descriptor arena. It allocates canonical
+scalar and nominal schema records, normalizes inventories and declaration
+order, seals the descriptor, and invokes the ordinary descriptor validator.
+Compiler-internal HIR and HGraph-IR types remain hidden behind the shared
+library boundary. Locked transitive dependency closure, normalized-wrapper
+generation, and imported native-call lowering remain Stage F work. Validating
+one file does not yet prove that its declared provider requirements are present
+or mutually compatible.
 
 A descriptor separates its importable interface from its provider inventory.
 The interface contains automatically public nominal operators, explicitly

--- a/language/docs/user-guide/modules-and-tools.md
+++ b/language/docs/user-guide/modules-and-tools.md
@@ -326,8 +326,22 @@ also verifies the descriptor's canonical SHA-256 fingerprint and lifecycle ABI
 metadata without loading native code.
 
 Descriptor validation does not yet locate or lock transitive provider
-requirements. The native-package authoring API and lowering imported native
-declarations into HGL calls are the next implementation slices.
+requirements. Lowering imported native declarations into HGL calls is a next
+implementation slice.
+
+Native libraries create descriptors with the installed C++ target
+`hgl::native_package` and `<hgl/native_package.h>`. Its public model is narrower
+than the descriptor format: a signature can contain only canonical scalars or
+a nominal native type declared by that package. `descriptor_json(package)`
+returns canonical sealed JSON; `write_descriptor(package, path)` additionally
+writes it for installation. Both reject the same unsafe phase, effect,
+ownership, borrow, and lifecycle combinations as `hgl check`.
+
+The package names either an exact public C++ function or its own reviewed
+normalizing wrapper in each declaration's `cpp_symbol`. The authoring API does
+not parse C++ headers and does not make arbitrary overloads or templates part
+of HGL. See [Native interface](../design/native-interface.md#producing-descriptors)
+for the complete example and current wrapper boundary.
 
 A package is a CMake project. `hgl_add_module()`, installed with `hgl` in
 `lib/cmake/hgl/HglLanguage.cmake`, runs `emit-cpp` at build time and compiles

--- a/language/include/hgl/native_package.h
+++ b/language/include/hgl/native_package.h
@@ -1,0 +1,190 @@
+#ifndef HGL_NATIVE_PACKAGE_H
+#define HGL_NATIVE_PACKAGE_H
+
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#if defined(_WIN32)
+    #if defined(HGL_NATIVE_PACKAGE_BUILD)
+        #define HGL_NATIVE_PACKAGE_API __declspec(dllexport)
+    #else
+        #define HGL_NATIVE_PACKAGE_API __declspec(dllimport)
+    #endif
+#else
+    #define HGL_NATIVE_PACKAGE_API
+#endif
+
+namespace hgl::native
+{
+    /// Canonical scalar values admitted by the first native-call ABI.
+    enum class ScalarType : std::uint8_t {
+        Bool,
+        I64,
+        F64,
+        Str,
+        Date,
+        Time,
+        DateTime,
+        Duration,
+        CivilDateTime,
+        ZonedDateTime,
+        ZonedTime,
+        TimeZone,
+    };
+
+    enum class ValueTypeCategory : std::uint8_t {
+        Scalar,
+        Native,
+    };
+
+    /// One exact value type in a native signature. Native identities must be
+    /// declared by the same Package; temporal and container types are not
+    /// representable in this API.
+    struct ValueType
+    {
+        ValueTypeCategory category{ValueTypeCategory::Scalar};
+        ScalarType        scalar{ScalarType::Bool};
+        std::string       native_identity{};
+
+        [[nodiscard]] static ValueType canonical(ScalarType type) { return ValueType{.scalar = type}; }
+
+        [[nodiscard]] static ValueType native(std::string identity) {
+            return ValueType{.category = ValueTypeCategory::Native, .native_identity = std::move(identity)};
+        }
+
+        friend bool operator==(const ValueType &, const ValueType &) = default;
+    };
+
+    enum class TypeCategory : std::uint8_t {
+        OpaqueState,
+        AtomicValue,
+    };
+
+    /// A nominal native type exposed by one package. OpaqueState is private
+    /// node state; AtomicValue additionally requires public hgraph value and
+    /// storage metadata supplied by the package.
+    struct Type
+    {
+        TypeCategory category{TypeCategory::OpaqueState};
+        std::string  identity{};
+        std::string  cpp_type{};
+        std::string  public_header{};
+    };
+
+    enum class DeclarationCategory : std::uint8_t {
+        Function,
+        Constructor,
+        Lifecycle,
+    };
+
+    enum class Phase : std::uint8_t {
+        Wiring,
+        Start,
+        Evaluation,
+        Stop,
+    };
+
+    enum class Effect : std::uint8_t {
+        Mutation,
+        InputOutput,
+        Blocking,
+        Allocation,
+    };
+
+    enum class Ownership : std::uint8_t {
+        Value,
+        Owned,
+        Shared,
+        Borrowed,
+    };
+
+    enum class ExceptionPolicy : std::uint8_t {
+        NoThrow,
+        Translated,
+    };
+
+    enum class ThreadSafety : std::uint8_t {
+        NodeLocal,
+        ThreadSafe,
+        Serialized,
+    };
+
+    struct ValuePolicy
+    {
+        Ownership   ownership{Ownership::Value};
+        std::string dependent_on{};
+        bool        mutable_value{false};
+    };
+
+    struct Parameter
+    {
+        std::string name{};
+        ValueType   type{};
+        bool        is_const{false};
+        ValuePolicy policy{};
+    };
+
+    /// One complete, nongeneric native declaration. cpp_symbol names either a
+    /// directly callable public C++ symbol or a package-owned wrapper which
+    /// has already normalized overload, template, exception, and ownership
+    /// details into this exact contract.
+    struct Declaration
+    {
+        DeclarationCategory      category{DeclarationCategory::Function};
+        std::string              identity{};
+        std::string              cpp_symbol{};
+        std::vector<Parameter>   parameters{};
+        std::optional<ValueType> result_type{};
+        ValuePolicy              result_policy{};
+        std::vector<Phase>       phases{};
+        std::vector<Effect>      effects{};
+        ExceptionPolicy          exception_policy{ExceptionPolicy::NoThrow};
+        ThreadSafety             thread_safety{ThreadSafety::NodeLocal};
+    };
+
+    struct Lifecycle
+    {
+        std::uint32_t abi_version{};
+        std::string   query_symbol{};
+    };
+
+    struct Build
+    {
+        std::vector<std::string> public_headers{};
+        std::vector<std::string> cmake_packages{};
+        std::vector<std::string> imported_targets{};
+        std::vector<std::string> runtime_images{};
+        std::string              registration_symbol{};
+        std::optional<Lifecycle> lifecycle{};
+    };
+
+    /// The deliberately small native-package authoring model. It cannot name
+    /// arbitrary HGL schema shapes, generic declarations, raw pointers, or
+    /// callbacks. descriptor_json() normalizes set-like inventories, seals the
+    /// descriptor, and applies the compiler's ordinary descriptor validator.
+    struct Package
+    {
+        std::string              module_identity{};
+        std::string              language_version{};
+        std::string              provider_identity{};
+        std::vector<std::string> provider_requirements{};
+        std::vector<Type>        types{};
+        std::vector<Declaration> declarations{};
+        Build                    build{};
+    };
+
+    /// Produce canonical, fingerprinted module-descriptor JSON. Throws
+    /// std::invalid_argument when the package violates the native safety
+    /// envelope.
+    [[nodiscard]] HGL_NATIVE_PACKAGE_API std::string descriptor_json(const Package &package);
+
+    /// Write descriptor_json(package) to path. Throws std::system_error for an
+    /// I/O failure and std::invalid_argument for an invalid package.
+    HGL_NATIVE_PACKAGE_API void write_descriptor(const Package &package, const std::filesystem::path &path);
+}  // namespace hgl::native
+
+#endif  // HGL_NATIVE_PACKAGE_H

--- a/language/include/hgl/native_package.h
+++ b/language/include/hgl/native_package.h
@@ -14,6 +14,8 @@
     #else
         #define HGL_NATIVE_PACKAGE_API __declspec(dllimport)
     #endif
+#elif defined(__GNUC__) || defined(__clang__)
+    #define HGL_NATIVE_PACKAGE_API __attribute__((visibility("default")))
 #else
     #define HGL_NATIVE_PACKAGE_API
 #endif

--- a/language/src/descriptor/module_descriptor_json.cpp
+++ b/language/src/descriptor/module_descriptor_json.cpp
@@ -1,8 +1,7 @@
 #include "descriptor/module_descriptor.h"
+#include "descriptor/sha256.h"
 
 #include "syntax/temporal.h"
-
-#include <hgraph/util/sha256.h>
 
 #include <array>
 #include <cmath>
@@ -689,9 +688,8 @@ namespace hgl::descriptor
     std::string fingerprint(const ModuleDescriptor &descriptor) {
         ModuleDescriptor canonical = descriptor;
         canonical.descriptor_fingerprint.clear();
-        const std::string                bytes  = to_json(canonical);
-        const hgraph::util::Sha256Digest digest = hgraph::util::sha256(std::as_bytes(std::span{bytes.data(), bytes.size()}));
-        const std::array<char, 64>       hex    = hgraph::util::sha256_hex(digest);
+        const std::string          bytes = to_json(canonical);
+        const std::array<char, 64> hex   = detail::sha256_hex(std::as_bytes(std::span{bytes.data(), bytes.size()}));
         return "sha256:" + std::string{hex.data(), hex.size()};
     }
 

--- a/language/src/descriptor/module_descriptor_reader.cpp
+++ b/language/src/descriptor/module_descriptor_reader.cpp
@@ -69,6 +69,32 @@ namespace hgl::descriptor
             return false;
         }
 
+        [[nodiscard]] constexpr bool cpp_identifier_start(char value) noexcept {
+            return (value >= 'a' && value <= 'z') || (value >= 'A' && value <= 'Z') || value == '_';
+        }
+
+        [[nodiscard]] constexpr bool cpp_identifier_continue(char value) noexcept {
+            return cpp_identifier_start(value) || (value >= '0' && value <= '9');
+        }
+
+        /// Native symbols become tokens in generated C++, so descriptors may
+        /// name one exact qualified identifier but may not carry expressions,
+        /// calls, templates, operators, whitespace, or preprocessor text.
+        [[nodiscard]] bool exact_cpp_symbol(std::string_view value) noexcept {
+            if (value.starts_with("::")) { value.remove_prefix(2U); }
+            if (value.empty()) { return false; }
+            while (true) {
+                if (!cpp_identifier_start(value.front())) { return false; }
+                std::size_t length = 1U;
+                while (length < value.size() && cpp_identifier_continue(value[length])) { ++length; }
+                value.remove_prefix(length);
+                if (value.empty()) { return true; }
+                if (!value.starts_with("::")) { return false; }
+                value.remove_prefix(2U);
+                if (value.empty()) { return false; }
+            }
+        }
+
         [[nodiscard]] std::optional<ReadError> find_duplicate_member(Element value, std::string_view path) {
             if (value.is_object()) {
                 simdjson::dom::object object_value;
@@ -1186,8 +1212,8 @@ namespace hgl::descriptor
                     !native_signature(declaration.signature, member_path(path, "signature"))) {
                     return false;
                 }
-                if (declaration.cpp_symbol.empty()) {
-                    return fail(member_path(path, "cpp_symbol"), "C++ symbol must not be empty");
+                if (!exact_cpp_symbol(declaration.cpp_symbol)) {
+                    return fail(member_path(path, "cpp_symbol"), "C++ symbol must be one exact qualified identifier");
                 }
                 if (declaration.phases.empty()) {
                     return fail(member_path(path, "phases"), "native declaration needs at least one permitted phase");

--- a/language/src/descriptor/module_descriptor_reader.cpp
+++ b/language/src/descriptor/module_descriptor_reader.cpp
@@ -1255,6 +1255,10 @@ namespace hgl::descriptor
                     declaration.result.ownership != NativeOwnership::Owned) {
                     return fail(member_path(path, "result.ownership"), "a native constructor must return owned state");
                 }
+                if (declaration.category == NativeDeclarationCategory::Constructor &&
+                    declaration.signature.result == no_schema_id) {
+                    return fail(member_path(path, "signature.result"), "a native constructor must declare its result type");
+                }
                 return true;
             }
 

--- a/language/src/descriptor/sha256.cpp
+++ b/language/src/descriptor/sha256.cpp
@@ -1,0 +1,153 @@
+#include "descriptor/sha256.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+
+namespace hgl::descriptor::detail
+{
+    namespace
+    {
+        constexpr std::array<std::uint32_t, 64> round_constants{
+            0x428a2f98u, 0x71374491u, 0xb5c0fbcfu, 0xe9b5dba5u, 0x3956c25bu, 0x59f111f1u, 0x923f82a4u, 0xab1c5ed5u,
+            0xd807aa98u, 0x12835b01u, 0x243185beu, 0x550c7dc3u, 0x72be5d74u, 0x80deb1feu, 0x9bdc06a7u, 0xc19bf174u,
+            0xe49b69c1u, 0xefbe4786u, 0x0fc19dc6u, 0x240ca1ccu, 0x2de92c6fu, 0x4a7484aau, 0x5cb0a9dcu, 0x76f988dau,
+            0x983e5152u, 0xa831c66du, 0xb00327c8u, 0xbf597fc7u, 0xc6e00bf3u, 0xd5a79147u, 0x06ca6351u, 0x14292967u,
+            0x27b70a85u, 0x2e1b2138u, 0x4d2c6dfcu, 0x53380d13u, 0x650a7354u, 0x766a0abbu, 0x81c2c92eu, 0x92722c85u,
+            0xa2bfe8a1u, 0xa81a664bu, 0xc24b8b70u, 0xc76c51a3u, 0xd192e819u, 0xd6990624u, 0xf40e3585u, 0x106aa070u,
+            0x19a4c116u, 0x1e376c08u, 0x2748774cu, 0x34b0bcb5u, 0x391c0cb3u, 0x4ed8aa4au, 0x5b9cca4fu, 0x682e6ff3u,
+            0x748f82eeu, 0x78a5636fu, 0x84c87814u, 0x8cc70208u, 0x90befffau, 0xa4506cebu, 0xbef9a3f7u, 0xc67178f2u,
+        };
+
+        [[nodiscard]] constexpr std::uint32_t rotate_right(std::uint32_t value, unsigned bits) noexcept {
+            return (value >> bits) | (value << (32U - bits));
+        }
+
+        class Sha256
+        {
+          public:
+            Sha256() noexcept
+                : state_{0x6a09e667u, 0xbb67ae85u, 0x3c6ef372u, 0xa54ff53au, 0x510e527fu, 0x9b05688cu, 0x1f83d9abu, 0x5be0cd19u} {}
+
+            void update(std::span<const std::byte> data) noexcept {
+                const auto *bytes     = reinterpret_cast<const std::uint8_t *>(data.data());
+                std::size_t remaining = data.size();
+                total_bytes_ += remaining;
+
+                if (buffered_ != 0U) {
+                    const std::size_t take = std::min(remaining, buffer_.size() - buffered_);
+                    std::memcpy(buffer_.data() + buffered_, bytes, take);
+                    buffered_ += take;
+                    bytes += take;
+                    remaining -= take;
+                    if (buffered_ == buffer_.size()) {
+                        process_block(buffer_.data());
+                        buffered_ = 0U;
+                    }
+                }
+                while (remaining >= buffer_.size()) {
+                    process_block(bytes);
+                    bytes += buffer_.size();
+                    remaining -= buffer_.size();
+                }
+                if (remaining != 0U) {
+                    std::memcpy(buffer_.data(), bytes, remaining);
+                    buffered_ = remaining;
+                }
+            }
+
+            [[nodiscard]] std::array<std::byte, 32> finish() noexcept {
+                const std::uint64_t bit_length = total_bytes_ * 8U;
+                const std::uint8_t  pad_one    = 0x80U;
+                update(std::span{reinterpret_cast<const std::byte *>(&pad_one), 1U});
+                const std::uint8_t zero = 0U;
+                while (buffered_ != 56U) { update(std::span{reinterpret_cast<const std::byte *>(&zero), 1U}); }
+                std::array<std::uint8_t, 8> length_be{};
+                for (std::size_t index = 0; index < length_be.size(); ++index) {
+                    length_be[index] = static_cast<std::uint8_t>(bit_length >> (56U - 8U * index));
+                }
+                update(std::as_bytes(std::span{length_be}));
+
+                std::array<std::byte, 32> digest{};
+                for (std::size_t index = 0; index < state_.size(); ++index) {
+                    digest[index * 4U]      = static_cast<std::byte>(state_[index] >> 24U);
+                    digest[index * 4U + 1U] = static_cast<std::byte>(state_[index] >> 16U);
+                    digest[index * 4U + 2U] = static_cast<std::byte>(state_[index] >> 8U);
+                    digest[index * 4U + 3U] = static_cast<std::byte>(state_[index]);
+                }
+                return digest;
+            }
+
+          private:
+            void process_block(const std::uint8_t *block) noexcept {
+                std::array<std::uint32_t, 64> words{};
+                for (std::size_t index = 0; index < 16U; ++index) {
+                    words[index] = (static_cast<std::uint32_t>(block[index * 4U]) << 24U) |
+                                   (static_cast<std::uint32_t>(block[index * 4U + 1U]) << 16U) |
+                                   (static_cast<std::uint32_t>(block[index * 4U + 2U]) << 8U) |
+                                   static_cast<std::uint32_t>(block[index * 4U + 3U]);
+                }
+                for (std::size_t index = 16U; index < words.size(); ++index) {
+                    const std::uint32_t s0 =
+                        rotate_right(words[index - 15U], 7U) ^ rotate_right(words[index - 15U], 18U) ^ (words[index - 15U] >> 3U);
+                    const std::uint32_t s1 =
+                        rotate_right(words[index - 2U], 17U) ^ rotate_right(words[index - 2U], 19U) ^ (words[index - 2U] >> 10U);
+                    words[index] = words[index - 16U] + s0 + words[index - 7U] + s1;
+                }
+
+                std::uint32_t a = state_[0];
+                std::uint32_t b = state_[1];
+                std::uint32_t c = state_[2];
+                std::uint32_t d = state_[3];
+                std::uint32_t e = state_[4];
+                std::uint32_t f = state_[5];
+                std::uint32_t g = state_[6];
+                std::uint32_t h = state_[7];
+                for (std::size_t index = 0; index < words.size(); ++index) {
+                    const std::uint32_t s1       = rotate_right(e, 6U) ^ rotate_right(e, 11U) ^ rotate_right(e, 25U);
+                    const std::uint32_t choice   = (e & f) ^ (~e & g);
+                    const std::uint32_t temp1    = h + s1 + choice + round_constants[index] + words[index];
+                    const std::uint32_t s0       = rotate_right(a, 2U) ^ rotate_right(a, 13U) ^ rotate_right(a, 22U);
+                    const std::uint32_t majority = (a & b) ^ (a & c) ^ (b & c);
+                    const std::uint32_t temp2    = s0 + majority;
+                    h                            = g;
+                    g                            = f;
+                    f                            = e;
+                    e                            = d + temp1;
+                    d                            = c;
+                    c                            = b;
+                    b                            = a;
+                    a                            = temp1 + temp2;
+                }
+                state_[0] += a;
+                state_[1] += b;
+                state_[2] += c;
+                state_[3] += d;
+                state_[4] += e;
+                state_[5] += f;
+                state_[6] += g;
+                state_[7] += h;
+            }
+
+            std::array<std::uint32_t, 8> state_{};
+            std::array<std::uint8_t, 64> buffer_{};
+            std::uint64_t                total_bytes_{0U};
+            std::size_t                  buffered_{0U};
+        };
+    }  // namespace
+
+    std::array<char, 64> sha256_hex(std::span<const std::byte> bytes) noexcept {
+        Sha256 hasher;
+        hasher.update(bytes);
+        const std::array<std::byte, 32> digest     = hasher.finish();
+        constexpr char                  alphabet[] = "0123456789abcdef";
+        std::array<char, 64>            result{};
+        for (std::size_t index = 0; index < digest.size(); ++index) {
+            const auto value        = static_cast<std::uint8_t>(digest[index]);
+            result[index * 2U]      = alphabet[value >> 4U];
+            result[index * 2U + 1U] = alphabet[value & 0x0fU];
+        }
+        return result;
+    }
+}  // namespace hgl::descriptor::detail

--- a/language/src/descriptor/sha256.h
+++ b/language/src/descriptor/sha256.h
@@ -1,0 +1,15 @@
+#ifndef HGL_DESCRIPTOR_SHA256_H
+#define HGL_DESCRIPTOR_SHA256_H
+
+#include <array>
+#include <cstddef>
+#include <span>
+
+namespace hgl::descriptor::detail
+{
+    /// Return the lowercase SHA-256 digest of bytes. This small private helper
+    /// keeps descriptor tooling independent of the hgraph runtime libraries.
+    [[nodiscard]] std::array<char, 64> sha256_hex(std::span<const std::byte> bytes) noexcept;
+}  // namespace hgl::descriptor::detail
+
+#endif  // HGL_DESCRIPTOR_SHA256_H

--- a/language/src/native/native_package.cpp
+++ b/language/src/native/native_package.cpp
@@ -1,0 +1,265 @@
+#include <hgl/native_package.h>
+
+#include "descriptor/module_descriptor.h"
+#include "descriptor/module_descriptor_reader.h"
+
+#include <algorithm>
+#include <fstream>
+#include <ios>
+#include <map>
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+
+namespace hgl::native
+{
+    namespace
+    {
+        using Descriptor = descriptor::ModuleDescriptor;
+
+        template <typename T, typename Projection> void normalize(std::vector<T> &values, Projection projection) {
+            std::ranges::sort(values, {}, projection);
+        }
+
+        void normalize(std::vector<std::string> &values) {
+            std::ranges::sort(values);
+            values.erase(std::ranges::unique(values).begin(), values.end());
+        }
+
+        [[nodiscard]] std::string_view scalar_name(ScalarType type) {
+            switch (type) {
+                case ScalarType::Bool: return "bool";
+                case ScalarType::I64: return "i64";
+                case ScalarType::F64: return "f64";
+                case ScalarType::Str: return "str";
+                case ScalarType::Date: return "date";
+                case ScalarType::Time: return "time";
+                case ScalarType::DateTime: return "datetime";
+                case ScalarType::Duration: return "duration";
+                case ScalarType::CivilDateTime: return "civil_datetime";
+                case ScalarType::ZonedDateTime: return "zoned_datetime";
+                case ScalarType::ZonedTime: return "zoned_time";
+                case ScalarType::TimeZone: return "timezone";
+            }
+            throw std::invalid_argument{"unknown native scalar type"};
+        }
+
+        [[nodiscard]] descriptor::NativeTypeCategory type_category(TypeCategory category) {
+            switch (category) {
+                case TypeCategory::OpaqueState: return descriptor::NativeTypeCategory::OpaqueState;
+                case TypeCategory::AtomicValue: return descriptor::NativeTypeCategory::AtomicValue;
+            }
+            throw std::invalid_argument{"unknown native type category"};
+        }
+
+        [[nodiscard]] descriptor::NativeDeclarationCategory declaration_category(DeclarationCategory category) {
+            switch (category) {
+                case DeclarationCategory::Function: return descriptor::NativeDeclarationCategory::Function;
+                case DeclarationCategory::Constructor: return descriptor::NativeDeclarationCategory::Constructor;
+                case DeclarationCategory::Lifecycle: return descriptor::NativeDeclarationCategory::Lifecycle;
+            }
+            throw std::invalid_argument{"unknown native declaration category"};
+        }
+
+        [[nodiscard]] descriptor::NativePhase phase(Phase value) {
+            switch (value) {
+                case Phase::Wiring: return descriptor::NativePhase::Wiring;
+                case Phase::Start: return descriptor::NativePhase::Start;
+                case Phase::Evaluation: return descriptor::NativePhase::Evaluation;
+                case Phase::Stop: return descriptor::NativePhase::Stop;
+            }
+            throw std::invalid_argument{"unknown native phase"};
+        }
+
+        [[nodiscard]] descriptor::NativeEffect effect(Effect value) {
+            switch (value) {
+                case Effect::Mutation: return descriptor::NativeEffect::Mutation;
+                case Effect::InputOutput: return descriptor::NativeEffect::InputOutput;
+                case Effect::Blocking: return descriptor::NativeEffect::Blocking;
+                case Effect::Allocation: return descriptor::NativeEffect::Allocation;
+            }
+            throw std::invalid_argument{"unknown native effect"};
+        }
+
+        [[nodiscard]] descriptor::NativeOwnership ownership(Ownership value) {
+            switch (value) {
+                case Ownership::Value: return descriptor::NativeOwnership::Value;
+                case Ownership::Owned: return descriptor::NativeOwnership::Owned;
+                case Ownership::Shared: return descriptor::NativeOwnership::Shared;
+                case Ownership::Borrowed: return descriptor::NativeOwnership::Borrowed;
+            }
+            throw std::invalid_argument{"unknown native ownership policy"};
+        }
+
+        [[nodiscard]] descriptor::NativeExceptionPolicy exception_policy(ExceptionPolicy value) {
+            switch (value) {
+                case ExceptionPolicy::NoThrow: return descriptor::NativeExceptionPolicy::NoThrow;
+                case ExceptionPolicy::Translated: return descriptor::NativeExceptionPolicy::Translated;
+            }
+            throw std::invalid_argument{"unknown native exception policy"};
+        }
+
+        [[nodiscard]] descriptor::NativeThreadSafety thread_safety(ThreadSafety value) {
+            switch (value) {
+                case ThreadSafety::NodeLocal: return descriptor::NativeThreadSafety::NodeLocal;
+                case ThreadSafety::ThreadSafe: return descriptor::NativeThreadSafety::ThreadSafe;
+                case ThreadSafety::Serialized: return descriptor::NativeThreadSafety::Serialized;
+            }
+            throw std::invalid_argument{"unknown native thread-safety policy"};
+        }
+
+        [[nodiscard]] descriptor::NativeValuePolicy value_policy(const ValuePolicy &value) {
+            return descriptor::NativeValuePolicy{
+                .ownership     = ownership(value.ownership),
+                .dependent_on  = value.dependent_on,
+                .mutable_value = value.mutable_value,
+            };
+        }
+
+        struct Schema
+        {
+            std::map<ScalarType, descriptor::SchemaId>               scalar{};
+            std::map<std::string, descriptor::SchemaId, std::less<>> native{};
+
+            [[nodiscard]] descriptor::SchemaId at(const ValueType &type) const {
+                switch (type.category) {
+                    case ValueTypeCategory::Scalar: return scalar.at(type.scalar);
+                    case ValueTypeCategory::Native:
+                        {
+                            const auto found = native.find(type.native_identity);
+                            if (found == native.end()) {
+                                throw std::invalid_argument{"native signature names undeclared type '" + type.native_identity +
+                                                            "'"};
+                            }
+                            return found->second;
+                        }
+                }
+                throw std::invalid_argument{"unknown native value type category"};
+            }
+        };
+
+        [[nodiscard]] Schema make_schema(const Package &package, Descriptor &out) {
+            Schema                  result;
+            std::vector<ScalarType> scalars;
+            for (const Declaration &declaration : package.declarations) {
+                for (const Parameter &parameter : declaration.parameters) {
+                    if (parameter.type.category == ValueTypeCategory::Scalar) { scalars.push_back(parameter.type.scalar); }
+                }
+                if (declaration.result_type && declaration.result_type->category == ValueTypeCategory::Scalar) {
+                    scalars.push_back(declaration.result_type->scalar);
+                }
+            }
+            std::ranges::sort(scalars);
+            scalars.erase(std::ranges::unique(scalars).begin(), scalars.end());
+            for (ScalarType scalar : scalars) {
+                const auto id = static_cast<descriptor::SchemaId>(out.types.size());
+                result.scalar.emplace(scalar, id);
+                out.types.push_back(descriptor::TypeRecord{
+                    .category    = descriptor::TypeCategory::Scalar,
+                    .scalar_name = std::string{scalar_name(scalar)},
+                });
+            }
+
+            std::vector<std::string> identities;
+            identities.reserve(package.types.size());
+            for (const Type &type : package.types) { identities.push_back(type.identity); }
+            normalize(identities);
+            for (const std::string &identity : identities) {
+                if (result.native.contains(identity)) { continue; }
+                const auto id = static_cast<descriptor::SchemaId>(out.types.size());
+                result.native.emplace(identity, id);
+                out.types.push_back(descriptor::TypeRecord{
+                    .category         = descriptor::TypeCategory::Symbol,
+                    .nominal_identity = identity,
+                });
+            }
+            return result;
+        }
+
+        [[nodiscard]] Descriptor describe(const Package &package) {
+            Descriptor out;
+            out.module_identity           = package.module_identity;
+            out.language_version          = package.language_version;
+            out.provider_identity         = package.provider_identity.empty() ? package.module_identity : package.provider_identity;
+            out.provider_requirements     = package.provider_requirements;
+            out.build.public_headers      = package.build.public_headers;
+            out.build.cmake_packages      = package.build.cmake_packages;
+            out.build.imported_targets    = package.build.imported_targets;
+            out.build.runtime_images      = package.build.runtime_images;
+            out.build.registration_symbol = package.build.registration_symbol;
+            if (package.build.lifecycle) {
+                out.build.lifecycle = descriptor::LifecycleMetadata{
+                    .abi_version  = package.build.lifecycle->abi_version,
+                    .query_symbol = package.build.lifecycle->query_symbol,
+                };
+            }
+            for (const Type &type : package.types) { out.build.public_headers.push_back(type.public_header); }
+            normalize(out.provider_requirements);
+            normalize(out.build.public_headers);
+            normalize(out.build.cmake_packages);
+            normalize(out.build.imported_targets);
+            normalize(out.build.runtime_images);
+
+            const Schema schema = make_schema(package, out);
+
+            std::vector<Type> types = package.types;
+            normalize(types, &Type::identity);
+            for (const Type &type : types) {
+                out.native_types.push_back(descriptor::NativeTypeDeclaration{
+                    .category      = type_category(type.category),
+                    .identity      = type.identity,
+                    .cpp_type      = type.cpp_type,
+                    .public_header = type.public_header,
+                });
+            }
+
+            std::vector<Declaration> declarations = package.declarations;
+            normalize(declarations, &Declaration::identity);
+            for (const Declaration &declaration : declarations) {
+                descriptor::NativeDeclaration native;
+                native.category         = declaration_category(declaration.category);
+                native.identity         = declaration.identity;
+                native.cpp_symbol       = declaration.cpp_symbol;
+                native.result           = value_policy(declaration.result_policy);
+                native.exception_policy = exception_policy(declaration.exception_policy);
+                native.thread_safety    = thread_safety(declaration.thread_safety);
+                for (const Parameter &parameter : declaration.parameters) {
+                    native.signature.parameters.push_back(descriptor::Parameter{
+                        .name             = parameter.name,
+                        .binding_identity = declaration.identity + "::" + parameter.name,
+                        .is_const         = parameter.is_const,
+                        .type             = schema.at(parameter.type),
+                    });
+                    native.parameters.push_back(descriptor::NativeParameterPolicy{
+                        .name  = parameter.name,
+                        .value = value_policy(parameter.policy),
+                    });
+                }
+                if (declaration.result_type) { native.signature.result = schema.at(*declaration.result_type); }
+                for (Phase allowed : declaration.phases) { native.phases.push_back(phase(allowed)); }
+                for (Effect observable : declaration.effects) { native.effects.push_back(effect(observable)); }
+                std::ranges::sort(native.phases);
+                std::ranges::sort(native.effects);
+                out.native_declarations.push_back(std::move(native));
+            }
+            descriptor::seal(out);
+            return out;
+        }
+    }  // namespace
+
+    std::string descriptor_json(const Package &package) {
+        Descriptor out = describe(package);
+        if (const std::optional<descriptor::ReadError> invalid = descriptor::validate(out)) {
+            throw std::invalid_argument{invalid->path + ": " + invalid->message};
+        }
+        return descriptor::to_json(out);
+    }
+
+    void write_descriptor(const Package &package, const std::filesystem::path &path) {
+        const std::string json = descriptor_json(package);
+        std::ofstream     out{path, std::ios::binary | std::ios::trunc};
+        if (!out) { throw std::ios_base::failure{"open native descriptor '" + path.string() + "'"}; }
+        out.write(json.data(), static_cast<std::streamsize>(json.size()));
+        if (!out) { throw std::ios_base::failure{"write native descriptor '" + path.string() + "'"}; }
+    }
+}  // namespace hgl::native

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -150,6 +150,34 @@ hgl_apply_warnings(hgl_descriptor_reader_tests)
 
 add_test(NAME hgraph_language_descriptor_reader COMMAND hgl_descriptor_reader_tests)
 
+# Public native-package authoring is a separate, installed-facing API. Keep
+# its contract tests distinct from internal descriptor model/reader tests.
+add_executable(hgl_native_package_tests native/native_package_tests.cpp)
+target_compile_features(hgl_native_package_tests PRIVATE cxx_std_23)
+target_link_libraries(hgl_native_package_tests PRIVATE
+    hgl::native_package
+    hgl::descriptor_reader
+    Catch2::Catch2WithMain
+)
+hgl_apply_warnings(hgl_native_package_tests)
+
+add_test(NAME hgraph_language_native_package COMMAND hgl_native_package_tests)
+
+# Install the public authoring target, compile a consumer without source-tree
+# include paths or internal compiler libraries, emit a descriptor, and pass it
+# through the installed-facing command contract.
+add_test(
+    NAME hgraph_language_native_package_install_consumer
+    COMMAND ${CMAKE_COMMAND}
+        -DBUILD=${CMAKE_BINARY_DIR}
+        -DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/cmake/native_package
+        -DOUT=${CMAKE_CURRENT_BINARY_DIR}/native-package-consumer
+        "-DGENERATOR=${CMAKE_GENERATOR}"
+        -DHGL=$<TARGET_FILE:hgl>
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/native_package_test.cmake
+)
+set_tests_properties(hgraph_language_native_package_install_consumer PROPERTIES RUN_SERIAL TRUE)
+
 # The direct-wiring backend against the live registry: folding, eval, the
 # failure detail, run_program (developer guide, "First pass").
 add_executable(hgl_wiring_tests wiring/backend_tests.cpp)

--- a/language/tests/cmake/native_package/CMakeLists.txt
+++ b/language/tests/cmake/native_package/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.25)
+
+project(hgl_native_package_consumer LANGUAGES CXX)
+
+if(NOT HGL_LANGUAGE_TARGETS)
+    message(FATAL_ERROR "HGL_LANGUAGE_TARGETS is required")
+endif()
+
+include("${HGL_LANGUAGE_TARGETS}")
+
+add_executable(hgl_native_package_consumer main.cpp)
+target_compile_features(hgl_native_package_consumer PRIVATE cxx_std_23)
+target_link_libraries(hgl_native_package_consumer PRIVATE hgl::native_package)
+set_target_properties(hgl_native_package_consumer PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "$<1:${CMAKE_CURRENT_BINARY_DIR}/bin>")

--- a/language/tests/cmake/native_package/main.cpp
+++ b/language/tests/cmake/native_package/main.cpp
@@ -1,0 +1,29 @@
+#include <hgl/native_package.h>
+
+#include <filesystem>
+#include <iostream>
+
+int main(int argc, char **argv) {
+    if (argc != 2) {
+        std::cerr << "usage: hgl_native_package_consumer <descriptor>\n";
+        return 2;
+    }
+
+    using namespace hgl::native;
+    Package package{
+        .module_identity  = "consumer.native",
+        .language_version = "installed-test",
+        .declarations =
+            {
+                Declaration{
+                    .identity    = "consumer.native::scale",
+                    .cpp_symbol  = "consumer::scale",
+                    .parameters  = {Parameter{.name = "value", .type = ValueType::canonical(ScalarType::F64)}},
+                    .result_type = ValueType::canonical(ScalarType::F64),
+                    .phases      = {Phase::Evaluation},
+                },
+            },
+        .build = Build{.public_headers = {"consumer/native.h"}},
+    };
+    write_descriptor(package, std::filesystem::path{argv[1]});
+}

--- a/language/tests/cmake/native_package_test.cmake
+++ b/language/tests/cmake/native_package_test.cmake
@@ -1,0 +1,62 @@
+if(NOT BUILD OR NOT SOURCE OR NOT OUT OR NOT GENERATOR OR NOT HGL)
+    message(FATAL_ERROR "BUILD, SOURCE, OUT, GENERATOR and HGL are required")
+endif()
+
+file(REMOVE_RECURSE "${OUT}")
+
+execute_process(
+    COMMAND "${CMAKE_COMMAND}" --install "${BUILD}" --prefix "${OUT}/sdk" --component Development
+    RESULT_VARIABLE _install_result
+    OUTPUT_VARIABLE _install_out
+    ERROR_VARIABLE _install_err)
+if(NOT _install_result EQUAL 0)
+    message(FATAL_ERROR "native-package SDK install failed:\n${_install_out}\n${_install_err}")
+endif()
+
+file(GLOB_RECURSE _targets "${OUT}/sdk/*/cmake/hgl/HglLanguageTargets.cmake")
+list(LENGTH _targets _target_count)
+if(NOT _target_count EQUAL 1)
+    message(FATAL_ERROR "expected one installed HglLanguageTargets.cmake, found: ${_targets}")
+endif()
+list(GET _targets 0 _target_file)
+
+execute_process(
+    COMMAND "${CMAKE_COMMAND}" -S "${SOURCE}" -B "${OUT}/build" -G "${GENERATOR}"
+        "-DHGL_LANGUAGE_TARGETS=${_target_file}"
+    RESULT_VARIABLE _configure_result
+    OUTPUT_VARIABLE _configure_out
+    ERROR_VARIABLE _configure_err)
+if(NOT _configure_result EQUAL 0)
+    message(FATAL_ERROR "native-package consumer configure failed:\n${_configure_out}\n${_configure_err}")
+endif()
+
+execute_process(
+    COMMAND "${CMAKE_COMMAND}" --build "${OUT}/build" --config Release
+    RESULT_VARIABLE _build_result
+    OUTPUT_VARIABLE _build_out
+    ERROR_VARIABLE _build_err)
+if(NOT _build_result EQUAL 0)
+    message(FATAL_ERROR "native-package consumer build failed:\n${_build_out}\n${_build_err}")
+endif()
+
+set(_descriptor "${OUT}/consumer.hgl-module.json")
+if(WIN32)
+    set(ENV{PATH} "${OUT}/sdk/bin;$ENV{PATH}")
+endif()
+execute_process(
+    COMMAND "${OUT}/build/bin/hgl_native_package_consumer${CMAKE_EXECUTABLE_SUFFIX}" "${_descriptor}"
+    RESULT_VARIABLE _run_result
+    OUTPUT_VARIABLE _run_out
+    ERROR_VARIABLE _run_err)
+if(NOT _run_result EQUAL 0)
+    message(FATAL_ERROR "native-package consumer failed:\n${_run_out}\n${_run_err}")
+endif()
+
+execute_process(
+    COMMAND "${HGL}" check "${_descriptor}"
+    RESULT_VARIABLE _check_result
+    OUTPUT_VARIABLE _check_out
+    ERROR_VARIABLE _check_err)
+if(NOT _check_result EQUAL 0)
+    message(FATAL_ERROR "installed consumer descriptor failed validation:\n${_check_out}\n${_check_err}")
+endif()

--- a/language/tests/descriptor/module_descriptor_reader_tests.cpp
+++ b/language/tests/descriptor/module_descriptor_reader_tests.cpp
@@ -410,6 +410,14 @@ TEST_CASE("native descriptor validation enforces the initial safety envelope", "
                     "native signature type is outside the initial scalar and declared-native envelope");
     }
 
+    SECTION("constructors declare their owned result type") {
+        descriptor::ModuleDescriptor source = rich_descriptor();
+        source.native_declarations.back().signature.result = descriptor::no_schema_id;
+        source.descriptor_fingerprint.clear();
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.native.declarations[1].signature.result",
+                    "a native constructor must declare its result type");
+    }
+
     SECTION("lifecycle ABI and query symbol agree") {
         descriptor::ModuleDescriptor source = rich_descriptor();
         source.build.lifecycle.query_symbol = "wrong_query";

--- a/language/tests/descriptor/module_descriptor_reader_tests.cpp
+++ b/language/tests/descriptor/module_descriptor_reader_tests.cpp
@@ -346,6 +346,17 @@ TEST_CASE("native descriptor validation enforces the initial safety envelope", "
                     "evaluation native functions must be noexcept");
     }
 
+    SECTION("native symbols are exact qualified identifiers") {
+        descriptor::ModuleDescriptor source           = rich_descriptor();
+        source.native_declarations.front().cpp_symbol = "checks::reader::update(); injected";
+        source.descriptor_fingerprint.clear();
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.native.declarations[0].cpp_symbol",
+                    "C++ symbol must be one exact qualified identifier");
+
+        source.native_declarations.front().cpp_symbol = "::checks::reader::update";
+        CHECK(descriptor::validate(source) == std::nullopt);
+    }
+
     SECTION("mutation identifies one borrowed argument") {
         descriptor::ModuleDescriptor source                                       = rich_descriptor();
         source.native_declarations.front().parameters.front().value.mutable_value = false;

--- a/language/tests/descriptor/module_descriptor_tests.cpp
+++ b/language/tests/descriptor/module_descriptor_tests.cpp
@@ -1,9 +1,12 @@
 #include "descriptor/module_descriptor.h"
+#include "descriptor/sha256.h"
 
 #include <catch2/catch_test_macros.hpp>
 
 #include <limits>
+#include <span>
 #include <string>
+#include <string_view>
 
 namespace descriptor = hgl::descriptor;
 namespace gir        = hgl::hgraph_ir;
@@ -246,6 +249,19 @@ TEST_CASE("module descriptor fingerprints cover canonical contents", "[descripto
 
     module.build.public_headers.push_back("changed.h");
     CHECK(descriptor::fingerprint(module) != original);
+}
+
+TEST_CASE("descriptor SHA-256 uses the standard digest", "[descriptor][fingerprint]") {
+    const auto digest = [](std::string_view input) {
+        const auto bytes = std::as_bytes(std::span{input.data(), input.size()});
+        const auto value = descriptor::detail::sha256_hex(bytes);
+        return std::string{value.data(), value.size()};
+    };
+
+    CHECK(digest("") == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    CHECK(digest("abc") == "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+    CHECK(digest("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq") ==
+          "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1");
 }
 
 TEST_CASE("module descriptors preserve structured compile-time expressions", "[descriptor][schema]") {

--- a/language/tests/native/native_package_tests.cpp
+++ b/language/tests/native/native_package_tests.cpp
@@ -1,0 +1,130 @@
+#include <hgl/native_package.h>
+
+#include "descriptor/module_descriptor_reader.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include <algorithm>
+#include <stdexcept>
+#include <string>
+
+namespace
+{
+    hgl::native::Package package() {
+        using namespace hgl::native;
+
+        const ValueType f64   = ValueType::canonical(ScalarType::F64);
+        const ValueType state = ValueType::native("acme.stats::state");
+        return Package{
+            .module_identity   = "acme.stats",
+            .language_version  = "0.1-test",
+            .provider_identity = "acme.stats.native",
+            .types =
+                {
+                    Type{
+                        .category      = TypeCategory::OpaqueState,
+                        .identity      = "acme.stats::state",
+                        .cpp_type      = "acme::stats::State",
+                        .public_header = "acme/stats.h",
+                    },
+                },
+            .declarations =
+                {
+                    Declaration{
+                        .category         = DeclarationCategory::Constructor,
+                        .identity         = "acme.stats::make_state",
+                        .cpp_symbol       = "acme::stats::make_state",
+                        .result_type      = state,
+                        .result_policy    = ValuePolicy{.ownership = Ownership::Owned},
+                        .phases           = {Phase::Start},
+                        .effects          = {Effect::Allocation},
+                        .exception_policy = ExceptionPolicy::Translated,
+                    },
+                    Declaration{
+                        .identity   = "acme.stats::update",
+                        .cpp_symbol = "acme::stats::update",
+                        .parameters =
+                            {
+                                Parameter{
+                                    .name = "state",
+                                    .type = state,
+                                    .policy =
+                                        ValuePolicy{
+                                            .ownership     = Ownership::Borrowed,
+                                            .mutable_value = true,
+                                        },
+                                },
+                                Parameter{.name = "value", .type = f64},
+                            },
+                        .result_type = f64,
+                        .phases      = {Phase::Evaluation},
+                        .effects     = {Effect::Mutation},
+                    },
+                    Declaration{
+                        .category   = DeclarationCategory::Lifecycle,
+                        .identity   = "acme.stats::close",
+                        .cpp_symbol = "acme::stats::close",
+                        .parameters =
+                            {
+                                Parameter{
+                                    .name = "state",
+                                    .type = state,
+                                    .policy =
+                                        ValuePolicy{
+                                            .ownership     = Ownership::Borrowed,
+                                            .mutable_value = true,
+                                        },
+                                },
+                            },
+                        .phases  = {Phase::Stop},
+                        .effects = {Effect::Mutation},
+                    },
+                },
+            .build =
+                Build{
+                    .cmake_packages   = {"acme_stats"},
+                    .imported_targets = {"acme::stats"},
+                },
+        };
+    }
+}  // namespace
+
+TEST_CASE("native package API emits a sealed descriptor") {
+    const std::string json   = hgl::native::descriptor_json(package());
+    const auto        parsed = hgl::descriptor::read_json(json);
+
+    REQUIRE(parsed);
+    CHECK(parsed.value->module_identity == "acme.stats");
+    CHECK(parsed.value->provider_identity == "acme.stats.native");
+    CHECK(parsed.value->native_types.size() == 1U);
+    CHECK(parsed.value->native_declarations.size() == 3U);
+    CHECK(parsed.value->build.public_headers == std::vector<std::string>{"acme/stats.h"});
+    CHECK(parsed.value->descriptor_fingerprint.starts_with("sha256:"));
+}
+
+TEST_CASE("native package descriptor order is canonical") {
+    hgl::native::Package reordered = package();
+    std::ranges::reverse(reordered.declarations);
+    reordered.build.public_headers = {"acme/stats.h", "acme/stats.h"};
+    reordered.build.cmake_packages = {"z_package", "acme_stats"};
+
+    hgl::native::Package canonical = package();
+    canonical.build.cmake_packages = {"acme_stats", "z_package"};
+    CHECK(hgl::native::descriptor_json(reordered) == hgl::native::descriptor_json(canonical));
+}
+
+TEST_CASE("native package API applies the descriptor safety envelope") {
+    hgl::native::Package invalid = package();
+    invalid.declarations[1].effects.push_back(hgl::native::Effect::Blocking);
+
+    CHECK_THROWS_WITH(hgl::native::descriptor_json(invalid),
+                      "$.native.declarations[2].effects: evaluation native functions must be non-blocking");
+}
+
+TEST_CASE("native package API rejects undeclared nominal signature types") {
+    hgl::native::Package invalid               = package();
+    invalid.declarations[1].parameters[1].type = hgl::native::ValueType::native("acme.stats::missing");
+
+    CHECK_THROWS_WITH(hgl::native::descriptor_json(invalid), "native signature names undeclared type 'acme.stats::missing'");
+}

--- a/language/tests/native/native_package_tests.cpp
+++ b/language/tests/native/native_package_tests.cpp
@@ -128,3 +128,12 @@ TEST_CASE("native package API rejects undeclared nominal signature types") {
 
     CHECK_THROWS_WITH(hgl::native::descriptor_json(invalid), "native signature names undeclared type 'acme.stats::missing'");
 }
+
+TEST_CASE("native package API rejects C++ source in place of an exact symbol") {
+    hgl::native::Package invalid            = package();
+    invalid.declarations.front().identity   = "acme.stats::a_make_state";
+    invalid.declarations.front().cpp_symbol = "acme::stats::make_state(); injected";
+
+    CHECK_THROWS_WITH(hgl::native::descriptor_json(invalid),
+                      "$.native.declarations[0].cpp_symbol: C++ symbol must be one exact qualified identifier");
+}

--- a/language/tests/native/native_package_tests.cpp
+++ b/language/tests/native/native_package_tests.cpp
@@ -137,3 +137,11 @@ TEST_CASE("native package API rejects C++ source in place of an exact symbol") {
     CHECK_THROWS_WITH(hgl::native::descriptor_json(invalid),
                       "$.native.declarations[0].cpp_symbol: C++ symbol must be one exact qualified identifier");
 }
+
+TEST_CASE("native package API rejects a constructor without a result type") {
+    hgl::native::Package invalid = package();
+    invalid.declarations.front().result_type.reset();
+
+    CHECK_THROWS_WITH(hgl::native::descriptor_json(invalid),
+                      "$.native.declarations[1].signature.result: a native constructor must declare its result type");
+}


### PR DESCRIPTION
## Summary

- add an installed hgl::native_package C++ API for constrained native package declarations
- normalize, seal, and validate generated module descriptors through the compiler descriptor boundary
- keep descriptor authoring independent of the hgraph runtime with a private SHA-256 implementation
- verify the exported CMake target using an installed-SDK consumer
- document the implemented authoring boundary and the remaining wrapper and call-lowering work

## Validation

- cmake --preset cpp --fresh -DHGRAPH_BUILD_LANGUAGE=ON
- cmake --build --preset cpp --target clean
- cmake --build --preset cpp --parallel 8
- ctest --preset cpp --parallel 2 --output-on-failure (1755 passed)
- stable-ABI wheel built with Python 3.12 and installed into a fresh Python 3.14 environment
- python -m pytest python/tests -q -m "not wip" (3241 passed, 10 skipped)
- full HGL CTest suite (39 passed)
- standalone language build with warnings as errors and focused native-package tests
- installed hgl::native_package consumer configure, build, descriptor emission, and hgl check