### PR TITLE
Type layer: atomic and window TS conversions move to the bridge (RFC 0035, PR 4a)

### DIFF
--- a/docs/source/developer_guide/data_structures/plans_and_ops/ops_catalogue.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/ops_catalogue.rst
@@ -139,7 +139,7 @@ constant when the ops struct layout changes.
      - 7
      - ``include/hgraph/types/value/value_ops.h``
    * - ``TS_DATA_OPS_ABI_VERSION``
-     - 13
+     - 14
      - ``include/hgraph/types/time_series/ts_type_ref.h``
    * - ``NODE_OPS_ABI_VERSION``
      - 5

--- a/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
@@ -136,7 +136,9 @@ The implementation uses the following names consistently:
     ``Output`` roles. Data and Output select mutable role-specific ops; an
     owned Input selects the corresponding physical plan under a read-only
     role, while peered positions select target-link storage and ops.
-    ``TS_DATA_OPS_ABI_VERSION`` is 13. ABI 13 (RFC 0035) makes the Python
+    ``TS_DATA_OPS_ABI_VERSION`` is 14. ABI 14 (RFC 0035) records the
+    Python-authoring family a strategy uses (``python_family``) beside the
+    table pointer. ABI 13 (RFC 0035) makes the Python
     slots unconditional -- typed on the opaque ``PyRef`` / ``PyNewRef`` and
     present in a Python-disabled build too, with ``PythonTSDataOps`` now a
     type-layer struct whose default is the throwing table -- so a table
@@ -483,7 +485,7 @@ TargetLink projection into producer-owned storage. The ownership table reports
 TargetLink trie/observer storage at the owning endpoint and traverses only
 owned children. This projection is private lifecycle infrastructure; it adds no
 storage-layout cost, and its ops-table ABI contribution is tracked by
-``TS_DATA_OPS_ABI_VERSION``, currently 13.
+``TS_DATA_OPS_ABI_VERSION``, currently 14.
 
 Fixed to-REF alternatives are the exception to the general legacy-alternative
 rule. Their allocation is owned through the canonical Data-role record. At the

--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -565,7 +565,19 @@ Value and reference crossings
   closed Bundle holds is the provider's ``polymorphic_source_type``
   forwarder over that view. The type realization asks the storage
   provider's ``bundle_binding_for`` for a Python-owned Bundle binding
-  instead of naming the bridge.
+  instead of naming the bridge. The TS data families follow the same
+  shape through ``src/hgraph/types/metadata/detail/ts_data_seams.h``
+  (``ts_data_family_conversions.cpp`` fills the ``TSData`` and
+  ``Retained`` sections): the atomic strategy's three value-storage
+  variants are three provider entries a factory selects once, the
+  retained-object cache of a ``NativeWithPythonCache`` output is dropped
+  on a native write through ``PythonOps::Retained::invalidate`` (the type
+  layer only locates the holder), and a window rebuilds through the
+  ``window_replace`` / ``window_push`` seams, which construct each element
+  and hand the bridge the payload. A factory records its Python-authoring
+  family on ``TSDataOps::python_family`` and the bridge maps it to the
+  table (``python_ts_data_ops_for``); a family still naming its table by
+  symbol keeps the pointer until it moves.
 - **One set of Python-object value primitives** (2026-09-05):
   ``python_bridge::object_hash`` / ``object_equals`` / ``object_compare`` /
   ``object_str`` -- the contract in ``include/hgraph/python/object_semantics.h``,

--- a/docs/source/rfc/rfc_0035_python_free_type_layer.rst
+++ b/docs/source/rfc/rfc_0035_python_free_type_layer.rst
@@ -612,9 +612,10 @@ Five PRs, each green on the full gate, each lowering the ratchet:
    data families in PR 4.)
 3. **Plan factory and realisation** (98 → 72): composite, array, owned and
    shared entries, closed bundle, pooled polymorphic.
-4. **TS data families** (72 → 14): atomic, slot, fixed structured, dynamic
-   list, window, the TSD proxy surfaces; the authoring tables through the
-   provider; the retained invalidation entry; benchmark evidence.
+4. **TS data families** (72 → 14), in two steps: 4a atomic and window
+   (72 → 60); 4b slot, fixed structured, dynamic list and the TSD proxy
+   surfaces; the authoring tables through the recorded family; the
+   retained invalidation entry; benchmark evidence.
 5. **TS input and target links** (14 → 0): shape facades and target links;
    ``type-layer-nanobind`` ratchet introduced at 0; the ``config.h``
    override removed; this RFC ``Accepted``.
@@ -622,7 +623,19 @@ Five PRs, each green on the full gate, each lowering the ratchet:
 Implementation status
 ---------------------
 
-Proposed. PR 3 (``hardening/python-ops-realized``) moves the composite,
+Proposed. PR 4a (``hardening/python-ops-ts-atomic-window``) moves the
+atomic (TS / SIGNAL / REF, in its three value-storage variants) and TSW
+window conversions to ``src/hgraph/python/impl/ts_data_family_conversions.cpp``
+behind ``PythonOps::TSData`` and ``PythonOps::Retained``, through the seams
+of ``src/hgraph/types/metadata/detail/ts_data_seams.h``; the retained cache
+invalidation on a native write is the provider's ``retained.invalidate``
+over a holder the type layer only locates; ``TSDataOps::python_family``
+records the authoring table the bridge maps to. ``type-layer-python-conditionals``
+72 → 60, ``type-layer-nanobind`` 318 → 273. The slot (TSS / TSD), fixed
+structured (TSB / TSL) and dynamic list families and the TSD proxy
+surfaces follow in PR 4b.
+
+PR 3 (``hardening/python-ops-realized``) moves the composite,
 array, owned-entry, shared-entry, closed-Bundle and pooled-Bundle
 conversions to ``src/hgraph/python/impl/realized_conversions.cpp`` behind
 ``PythonOps::Realized``. The families' private contexts and their

--- a/include/hgraph/python/ts_data_conversion.h
+++ b/include/hgraph/python/ts_data_conversion.h
@@ -24,6 +24,10 @@ namespace hgraph
         /** The table is ``hgraph::PythonTSDataOps`` (``ts_data/ops.h``); the
             bridge defines the per-family instances and the canonical throwing
             default is the type layer's ``ts_data_detail::missing_python_ts_data_ops``. */
+        /** The authoring table for a family a factory recorded on its ops
+            (RFC 0035); ``none`` answers the ops' own pointer. */
+        [[nodiscard]] HGRAPH_EXPORT const PythonTSDataOps &python_ts_data_ops_for(const TSDataOps &ops) noexcept;
+
         /** Strategy tables installed by the corresponding TSData factories. */
         [[nodiscard]] HGRAPH_EXPORT const PythonTSDataOps &atomic_python_ts_data_ops() noexcept;
         [[nodiscard]] HGRAPH_EXPORT const PythonTSDataOps &ref_python_ts_data_ops() noexcept;

--- a/include/hgraph/types/python_ops.h
+++ b/include/hgraph/types/python_ops.h
@@ -7,6 +7,8 @@
 #include <atomic>
 #include <typeinfo>
 
+#include <hgraph/util/date_time.h>
+
 /**
  * The provider table through which the type layer reaches every Python
  * conversion (RFC 0035, "PythonOps -- the provider table").
@@ -113,6 +115,42 @@ namespace hgraph
             ValueTypeRef (*polymorphic_source_type)(const void *context, PyRef source){nullptr};
         } realized;
 
+        /** The TSData families' Python slots. ``context`` is the strategy's
+            private context; the bridge reaches it through the seams of
+            ``src/hgraph/types/metadata/detail/ts_data_seams.h``. The atomic
+            entries come in the three value-storage variants a factory selects
+            at construction (RFC 0035: no runtime branch on the variant). */
+        struct TSData
+        {
+            static constexpr const char *name = "TSData";
+            using FromPythonFn    = bool (*)(const void *context, void *memory, PyRef source, DateTime modified_time);
+            using ToPythonFn      = PyNewRef (*)(const void *context, const void *memory);
+            using DeltaToPythonFn = PyNewRef (*)(const void *context, const void *memory, DateTime evaluation_time);
+            FromPythonFn    atomic_native_from_python{nullptr};
+            ToPythonFn      atomic_native_to_python{nullptr};
+            DeltaToPythonFn atomic_native_delta_to_python{nullptr};
+            FromPythonFn    atomic_python_only_from_python{nullptr};
+            ToPythonFn      atomic_python_only_to_python{nullptr};
+            DeltaToPythonFn atomic_python_only_delta_to_python{nullptr};
+            FromPythonFn    atomic_cached_from_python{nullptr};
+            ToPythonFn      atomic_cached_to_python{nullptr};
+            DeltaToPythonFn atomic_cached_delta_to_python{nullptr};
+            FromPythonFn    window_from_python{nullptr};
+            ToPythonFn      window_to_python{nullptr};
+            DeltaToPythonFn window_delta_to_python{nullptr};
+            /** The window's value surface (a value-ops slot over the storage). */
+            ToPythonFn      window_value_to_python{nullptr};
+        } ts_data;
+
+        /** The retained-object cache of a ``NativeWithPythonCache`` output:
+            a native write drops it through here (the interpreter releases the
+            reference; the type layer only locates the holder). */
+        struct Retained
+        {
+            static constexpr const char *name = "retained value";
+            void (*invalidate)(void *holder) noexcept{nullptr};
+        } retained;
+
         /** ``Any`` and the nominal JSON ``Any``: ``memory`` is the boxed ``Value``. */
         struct Any
         {
@@ -173,6 +211,23 @@ namespace hgraph
         [[nodiscard]] inline const PythonOps::Realized &section_of<PythonOps::Realized>(const PythonOps &ops) noexcept
         {
             return ops.realized;
+        }
+        template <>
+        [[nodiscard]] inline const PythonOps::TSData &section_of<PythonOps::TSData>(const PythonOps &ops) noexcept
+        {
+            return ops.ts_data;
+        }
+
+        /** Drop a retained-object cache on a native write. A missing provider
+            means no output was ever given a cache, so this is a no-op rather
+            than an error, and it may run on the noexcept write path. */
+        inline void invalidate_retained(void *holder) noexcept
+        {
+            if (holder == nullptr) { return; }
+            if (const auto *ops = python_ops(); ops != nullptr && ops->retained.invalidate != nullptr)
+            {
+                ops->retained.invalidate(holder);
+            }
         }
 
         template <auto Member>

--- a/include/hgraph/types/time_series/ts_data/ops.h
+++ b/include/hgraph/types/time_series/ts_data/ops.h
@@ -8,6 +8,8 @@
 #include <hgraph/types/utils/slot_observer.h>
 #include <hgraph/types/value/value_range.h>
 #include <hgraph/types/python_object.h>
+
+#include <cstdint>
 #include <hgraph/types/value/value_view.h>
 #include <cstddef>
 #include <stdexcept>
@@ -46,6 +48,22 @@ namespace hgraph
      * shape by switching on ``TSTypeKind``. The default is the canonical
      * throwing table, never null, so callers dispatch without null branching.
      */
+    /** Which of the bridge's Python-authoring tables a TSData strategy uses
+        (RFC 0035): recorded by the factory, mapped to the table by the bridge.
+        ``none`` keeps the canonical throwing table. */
+    enum class PythonTSDataFamily : std::uint8_t
+    {
+        none = 0,
+        atomic,
+        ref,
+        set,
+        dict,
+        list,
+        bundle,
+        window,
+        target_link,
+    };
+
     struct PythonTSDataOps
     {
         /** True when this authored value (including nested children) needs
@@ -309,6 +327,9 @@ namespace hgraph
         // Python authoring is a separately selected erased policy. It must
         // remain non-null so callers dispatch without kind/null branching.
         const PythonTSDataOps *python_ops{&ts_data_detail::missing_python_ts_data_ops()};
+        /** The bridge's authoring table for this family; ``none`` defers to
+            ``python_ops`` (the families still naming a table by symbol). */
+        PythonTSDataFamily python_family{PythonTSDataFamily::none};
         // Required for every representation that can reach a Python-authored
         // node. Structural strategies recurse through each child's TSDataOps;
         // Python facades must never reconstruct shapes by switching on kind.

--- a/include/hgraph/types/time_series/ts_type_ref.h
+++ b/include/hgraph/types/time_series/ts_type_ref.h
@@ -15,7 +15,7 @@ namespace hgraph
     struct TSDataOps;
     struct TSParentLink;
 
-    inline constexpr std::uint16_t TS_DATA_OPS_ABI_VERSION = 13;
+    inline constexpr std::uint16_t TS_DATA_OPS_ABI_VERSION = 14;
 
     class HGRAPH_CLASS_EXPORT TSRoleTypeRef
     {

--- a/python/tests/test_architecture_ratchets.py
+++ b/python/tests/test_architecture_ratchets.py
@@ -178,7 +178,7 @@ RATCHETS: tuple[Ratchet, ...] = (
     ),
     Ratchet(
         id="type-layer-python-conditionals",
-        baseline=72,
+        baseline=60,
         roots=("src/hgraph/types", "include/hgraph/types"),
         suffixes=(".cpp", ".h"),
         pattern=r"HGRAPH_ENABLE_PYTHON_USER_NODES",
@@ -188,7 +188,7 @@ RATCHETS: tuple[Ratchet, ...] = (
     ),
     Ratchet(
         id="type-layer-nanobind",
-        baseline=318,
+        baseline=273,
         roots=("src/hgraph/types", "include/hgraph/types"),
         suffixes=(".cpp", ".h"),
         pattern=r"nanobind|\bnb::",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,6 +103,7 @@ if(HGRAPH_BUILD_PYTHON_BINDINGS OR HGRAPH_ENABLE_PYTHON_USER_NODES)
         hgraph/python/impl/python_ops.cpp
         hgraph/python/impl/realized_conversions.cpp
         hgraph/python/impl/retained_value.cpp
+        hgraph/python/impl/ts_data_family_conversions.cpp
         hgraph/python/impl/ts_data_conversion.cpp
     )
 endif()

--- a/src/hgraph/python/impl/python_ops.cpp
+++ b/src/hgraph/python/impl/python_ops.cpp
@@ -167,6 +167,8 @@ namespace hgraph::python_bridge
                 fill_compact_container_conversions(ops.compact);
                 fill_mutable_container_conversions(ops.mutable_containers);
                 fill_realized_conversions(ops.realized);
+                fill_ts_data_conversions(ops.ts_data);
+                fill_retained_conversions(ops.retained);
                 return ops;
             }();
             return table;

--- a/src/hgraph/python/impl/python_ops_families.h
+++ b/src/hgraph/python/impl/python_ops_families.h
@@ -14,6 +14,8 @@ namespace hgraph::python_bridge
     void fill_compact_container_conversions(PythonOps::Compact &section) noexcept;
     void fill_mutable_container_conversions(PythonOps::Mutable &section) noexcept;
     void fill_realized_conversions(PythonOps::Realized &section) noexcept;
+    void fill_ts_data_conversions(PythonOps::TSData &section) noexcept;
+    void fill_retained_conversions(PythonOps::Retained &section) noexcept;
 }  // namespace hgraph::python_bridge
 
 #endif  // HGRAPH_PYTHON_IMPL_PYTHON_OPS_FAMILIES_H

--- a/src/hgraph/python/impl/ts_data_conversion.cpp
+++ b/src/hgraph/python/impl/ts_data_conversion.cpp
@@ -77,9 +77,7 @@ namespace hgraph::python_bridge
 
         [[nodiscard]] const PythonTSDataOps &python_ops_for(TSRoleTypeRef type)
         {
-            // TSDataOps binds either a concrete strategy or the canonical
-            // throwing table. A null check here would weaken that invariant.
-            return *type.ops_ref().python_ops;
+            return python_ts_data_ops_for(type.ops_ref());
         }
 
         [[nodiscard]] bool requires_authored(TSRoleTypeRef type,
@@ -820,6 +818,26 @@ namespace hgraph::python_bridge
             ops.apply_delta_impl(output, delta.view());
         }
     }  // namespace
+
+    const PythonTSDataOps &python_ts_data_ops_for(const TSDataOps &ops) noexcept
+    {
+        // A table lookup by the family the factory recorded, on the bridge;
+        // a family still naming its table by symbol answers through the
+        // pointer, which is never null (the type layer's throwing default).
+        switch (ops.python_family)
+        {
+            case PythonTSDataFamily::atomic: return atomic_python_ts_data_ops();
+            case PythonTSDataFamily::ref: return ref_python_ts_data_ops();
+            case PythonTSDataFamily::set: return set_python_ts_data_ops();
+            case PythonTSDataFamily::dict: return dict_python_ts_data_ops();
+            case PythonTSDataFamily::list: return list_python_ts_data_ops();
+            case PythonTSDataFamily::bundle: return bundle_python_ts_data_ops();
+            case PythonTSDataFamily::window: return window_python_ts_data_ops();
+            case PythonTSDataFamily::target_link:
+            case PythonTSDataFamily::none: break;
+        }
+        return *ops.python_ops;
+    }
 
     const PythonTSDataOps &atomic_python_ts_data_ops() noexcept
     {

--- a/src/hgraph/python/impl/ts_data_family_conversions.cpp
+++ b/src/hgraph/python/impl/ts_data_family_conversions.cpp
@@ -1,0 +1,223 @@
+#include "python_ops_families.h"
+
+#include "../../types/metadata/detail/ts_data_seams.h"
+
+#include <hgraph/python/bridge_state.h>
+#include <hgraph/python/conversion.h>
+#include <hgraph/python/retained_value.h>
+#include <hgraph/types/value/value.h>
+
+#include <nanobind/nanobind.h>
+
+#include <cstddef>
+#include <stdexcept>
+
+/**
+ * TSData <-> Python for the atomic and window strategies (RFC 0035, PR 4a).
+ * The bodies read the strategies through ``ts_data_seams.h``: bindings and
+ * memory from the layouts, the retained-object holder of a cached output,
+ * and the window's replace / push seams, which construct each element and
+ * hand this unit the payload to convert into.
+ */
+namespace hgraph::python_bridge
+{
+    namespace
+    {
+        // -- atomic TS / SIGNAL / REF, per value-storage variant ------------------
+        [[nodiscard]] PythonValueHolder *retained(const void *context, const void *memory) noexcept
+        {
+            return static_cast<PythonValueHolder *>(
+                ts_data_seams::atomic_retained_holder(context, const_cast<void *>(memory)));
+        }
+
+        void require_atomic_source(const void *memory, nb::handle source, DateTime modified_time)
+        {
+            if (memory == nullptr) { throw std::logic_error("TSData atomic from_python requires live TSData memory"); }
+            if (source.is_none()) { throw std::invalid_argument("TSData atomic from_python requires a non-None source"); }
+            if (modified_time == MIN_DT)
+            {
+                throw std::invalid_argument("TSData atomic from_python requires a concrete evaluation time");
+            }
+        }
+
+        [[nodiscard]] bool atomic_native_from_python(const void *context, void *memory, nb::handle source,
+                                                     DateTime modified_time)
+        {
+            require_atomic_source(memory, source, modified_time);
+            const auto &layout         = ts_data_seams::atomic_layout(context);
+            const bool  first_for_time = ts_data_seams::atomic_tracking(context, memory).last_modified_time != modified_time;
+            from_python(layout.value_binding, ts_data_seams::atomic_mutable_value_memory(context, memory), source);
+            return first_for_time;
+        }
+
+        [[nodiscard]] bool atomic_cached_from_python(const void *context, void *memory, nb::handle source,
+                                                     DateTime modified_time)
+        {
+            require_atomic_source(memory, source, modified_time);
+            const auto &layout         = ts_data_seams::atomic_layout(context);
+            const bool  first_for_time = ts_data_seams::atomic_tracking(context, memory).last_modified_time != modified_time;
+            nb::object  retained_value = prepare_python_storage_value(layout.value_binding.schema(), source);
+            from_python(layout.value_binding, ts_data_seams::atomic_mutable_value_memory(context, memory), source);
+            retained(context, memory)->set(retained_value);
+            return first_for_time;
+        }
+
+        [[nodiscard]] nb::object atomic_native_to_python(const void *context, const void *memory)
+        {
+            const auto &layout = ts_data_seams::atomic_layout(context);
+            // Scalar Python representation is already owned by the selected
+            // ValueOps strategy (notably compact Set -> frozenset). Atomic
+            // TSData forwards that erased result without re-normalizing it.
+            return to_python(layout.value_binding, ts_data_seams::atomic_value_memory(context, memory));
+        }
+
+        [[nodiscard]] nb::object atomic_cached_to_python(const void *context, const void *memory)
+        {
+            if (const auto *cached = retained(context, memory); cached != nullptr && cached->has_value())
+            {
+                return cached->get();
+            }
+            nb::object converted = atomic_native_to_python(context, memory);
+            if (auto *cached = retained(context, memory); cached != nullptr) { cached->set(converted); }
+            return converted;
+        }
+
+        [[nodiscard]] nb::object atomic_native_delta_to_python(const void *context, const void *memory,
+                                                               DateTime evaluation_time)
+        {
+            if (ts_data_seams::atomic_tracking(context, memory).last_modified_time != evaluation_time) { return nb::none(); }
+            const auto &layout = ts_data_seams::atomic_layout(context);
+            return to_python(layout.delta_binding, ts_data_seams::atomic_delta_memory(context, memory));
+        }
+
+        [[nodiscard]] nb::object atomic_python_only_delta_to_python(const void *context, const void *memory,
+                                                                    DateTime evaluation_time)
+        {
+            if (ts_data_seams::atomic_tracking(context, memory).last_modified_time != evaluation_time) { return nb::none(); }
+            return atomic_native_to_python(context, memory);
+        }
+
+        [[nodiscard]] nb::object atomic_cached_delta_to_python(const void *context, const void *memory,
+                                                               DateTime evaluation_time)
+        {
+            if (ts_data_seams::atomic_tracking(context, memory).last_modified_time != evaluation_time) { return nb::none(); }
+            return atomic_cached_to_python(context, memory);
+        }
+
+        void invalidate_retained_holder(void *holder) noexcept { static_cast<PythonValueHolder *>(holder)->clear(); }
+
+        // -- TSW windows --------------------------------------------------------------
+        [[nodiscard]] bool is_python_sequence(nb::handle source)
+        {
+            nb::object object = nb::borrow<nb::object>(source);
+            return nb::isinstance<nb::list>(object) || nb::isinstance<nb::tuple>(object);
+        }
+
+        struct SequenceFill
+        {
+            nb::object sequence;
+        };
+
+        void fill_element_from_sequence(void *fill_context, std::size_t index, ValueTypeRef element_binding, void *payload)
+        {
+            const auto &fill = *static_cast<const SequenceFill *>(fill_context);
+            nb::object  item = fill.sequence[index];
+            if (item.is_none()) { throw std::invalid_argument("TSW value does not allow None elements"); }
+            from_python(element_binding, payload, item);
+        }
+
+        void fill_element_from_handle(void *fill_context, std::size_t, ValueTypeRef element_binding, void *payload)
+        {
+            from_python(element_binding, payload, *static_cast<const nb::handle *>(fill_context));
+        }
+
+        [[nodiscard]] nb::object window_to_python(const void *context, const void *memory)
+        {
+            return to_python(ts_data_seams::window_layout(context).value_binding,
+                             ts_data_seams::window_value_memory(context, memory));
+        }
+
+        [[nodiscard]] nb::object window_delta_to_python(const void *context, const void *memory, DateTime evaluation_time)
+        {
+            if (ts_data_seams::window_tracking(context, memory).last_modified_time != evaluation_time) { return nb::none(); }
+            const auto *delta = ts_data_seams::window_delta_memory(context, memory);
+            if (delta == nullptr) { return nb::none(); }
+            return to_python(ts_data_seams::window_layout(context).delta_binding, delta);
+        }
+
+        [[nodiscard]] bool window_from_python(const void *context, void *memory, nb::handle source, DateTime modified_time)
+        {
+            if (memory == nullptr) { throw std::logic_error("TSW from_python requires live storage"); }
+            if (source.is_none()) { throw std::invalid_argument("TSW from_python requires a non-None source"); }
+            if (modified_time == MIN_DT) { throw std::invalid_argument("TSW from_python requires a concrete evaluation time"); }
+
+            const bool newly_modified = ts_data_seams::window_tracking(context, memory).last_modified_time != modified_time;
+            if (is_python_sequence(source))
+            {
+                SequenceFill fill{nb::borrow<nb::object>(source)};
+                ts_data_seams::window_replace(context, memory, modified_time, static_cast<std::size_t>(nb::len(fill.sequence)),
+                                              &fill_element_from_sequence, &fill);
+                return newly_modified;
+            }
+
+            if (!newly_modified) { throw std::logic_error("TSW from_python allows only one window tick per evaluation time"); }
+            ts_data_seams::window_push(context, memory, modified_time, &fill_element_from_handle, &source);
+            return true;
+        }
+
+        [[nodiscard]] const void *window_buffer_element_at(const void *owner, std::size_t index)
+        {
+            const auto *pair = static_cast<const std::pair<const void *, const void *> *>(owner);
+            return ts_data_seams::window_storage_element_at(pair->first, pair->second, index);
+        }
+
+        [[nodiscard]] nb::object window_value_to_python(const void *context, const void *memory)
+        {
+            if (memory == nullptr) { throw std::runtime_error("TSW value to_python requires live storage"); }
+            const auto  binding = ts_data_seams::window_layout(context).element_binding;
+            const auto &ops     = binding.ops_ref();
+            const auto  size    = ts_data_seams::window_storage_size(context, memory);
+            if (can_to_python_buffer(ops, binding))
+            {
+                const std::pair<const void *, const void *> owner{context, memory};
+                return to_python_buffer(ops, binding,
+                                        ValueArraySource{
+                                            .owner      = &owner,
+                                            .size       = size,
+                                            .element_at = &window_buffer_element_at,
+                                        });
+            }
+
+            nb::list result;
+            for (std::size_t index = 0; index < size; ++index)
+            {
+                result.append(to_python(ops, ts_data_seams::window_storage_element_at(context, memory, index)));
+            }
+            return result;
+        }
+    }  // namespace
+
+    void fill_ts_data_conversions(PythonOps::TSData &section) noexcept
+    {
+        section.atomic_native_from_python            = &ts_from_python_slot<&atomic_native_from_python>;
+        section.atomic_native_to_python              = &to_python_slot<&atomic_native_to_python>;
+        section.atomic_native_delta_to_python        = &ts_delta_to_python_slot<&atomic_native_delta_to_python>;
+        // A Python-only output's binding IS the retained object: its value
+        // slot converts straight through, like the native variant does.
+        section.atomic_python_only_from_python       = &ts_from_python_slot<&atomic_native_from_python>;
+        section.atomic_python_only_to_python         = &to_python_slot<&atomic_native_to_python>;
+        section.atomic_python_only_delta_to_python   = &ts_delta_to_python_slot<&atomic_python_only_delta_to_python>;
+        section.atomic_cached_from_python            = &ts_from_python_slot<&atomic_cached_from_python>;
+        section.atomic_cached_to_python              = &to_python_slot<&atomic_cached_to_python>;
+        section.atomic_cached_delta_to_python        = &ts_delta_to_python_slot<&atomic_cached_delta_to_python>;
+        section.window_from_python                   = &ts_from_python_slot<&window_from_python>;
+        section.window_to_python                     = &to_python_slot<&window_to_python>;
+        section.window_delta_to_python               = &ts_delta_to_python_slot<&window_delta_to_python>;
+        section.window_value_to_python               = &to_python_slot<&window_value_to_python>;
+    }
+
+    void fill_retained_conversions(PythonOps::Retained &section) noexcept
+    {
+        section.invalidate = &invalidate_retained_holder;
+    }
+}  // namespace hgraph::python_bridge

--- a/src/hgraph/types/metadata/detail/ts_data_seams.h
+++ b/src/hgraph/types/metadata/detail/ts_data_seams.h
@@ -1,0 +1,53 @@
+#ifndef HGRAPH_TYPES_METADATA_DETAIL_TS_DATA_SEAMS_H
+#define HGRAPH_TYPES_METADATA_DETAIL_TS_DATA_SEAMS_H
+
+#include <hgraph/types/python_object.h>
+#include <hgraph/types/time_series/ts_data/types.h>
+#include <hgraph/util/date_time.h>
+
+#include <cstddef>
+
+/**
+ * Private seams of the TSData families (RFC 0035, PR 4): what the bridge's
+ * ``ts_data_family_conversions.cpp`` needs from the atomic and window
+ * strategies, with no Python in it. Memory arithmetic and the storages'
+ * mutation protocol stay here; the bridge converts into the payloads the
+ * seams hand it. Private to ``hgraph_runtime``.
+ */
+namespace hgraph::ts_data_seams
+{
+    // -- atomic TS / SIGNAL / REF -----------------------------------------------
+    // ``context`` is the strategy's layout (its first member), so the public
+    // ``TSDataLayout`` answers bindings and offsets; the retained-object holder
+    // is the one private field.
+    [[nodiscard]] const TSDataLayout &atomic_layout(const void *context) noexcept;
+    [[nodiscard]] const TSDataTracking &atomic_tracking(const void *context, const void *memory) noexcept;
+    [[nodiscard]] const void *atomic_value_memory(const void *context, const void *memory) noexcept;
+    [[nodiscard]] void *atomic_mutable_value_memory(const void *context, void *memory) noexcept;
+    [[nodiscard]] const void *atomic_delta_memory(const void *context, const void *memory) noexcept;
+    /** The retained-object holder of a ``NativeWithPythonCache`` output, or null. */
+    [[nodiscard]] void *atomic_retained_holder(const void *context, void *memory) noexcept;
+
+    // -- TSW windows --------------------------------------------------------------
+    [[nodiscard]] const TSWDataLayout &window_layout(const void *context) noexcept;
+    [[nodiscard]] const TSDataTracking &window_tracking(const void *context, const void *memory) noexcept;
+    [[nodiscard]] const void *window_value_memory(const void *context, const void *memory) noexcept;
+    /** The delta element memory for the current cycle, or null when none. */
+    [[nodiscard]] const void *window_delta_memory(const void *context, const void *memory) noexcept;
+    /** Over the window STORAGE (the value memory), the shape the value ops see. */
+    [[nodiscard]] std::size_t window_storage_size(const void *context, const void *storage) noexcept;
+    [[nodiscard]] const void *window_storage_element_at(const void *context, const void *storage,
+                                                        std::size_t index) noexcept;
+
+    /** Convert element ``index`` into ``payload``, constructed as ``element_binding``. */
+    using FillElementFn = void (*)(void *fill_context, std::size_t index, ValueTypeRef element_binding, void *payload);
+
+    /** Replace the window's contents with ``count`` elements (a size window
+        rejects more than its period), each pushed at ``modified_time``. */
+    void window_replace(const void *context, void *memory, DateTime modified_time, std::size_t count,
+                        FillElementFn fill, void *fill_context);
+    /** Push one element at ``modified_time``. */
+    void window_push(const void *context, void *memory, DateTime modified_time, FillElementFn fill, void *fill_context);
+}  // namespace hgraph::ts_data_seams
+
+#endif  // HGRAPH_TYPES_METADATA_DETAIL_TS_DATA_SEAMS_H

--- a/src/hgraph/types/metadata/ts_data_atomic_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_atomic_ops.cpp
@@ -4,13 +4,10 @@
 #include <hgraph/types/utils/intern_table.h>
 #include <hgraph/types/value/value.h>
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-#include <hgraph/python/bridge_state.h>
-#include <hgraph/python/conversion.h>
-#include <hgraph/python/retained_value.h>
-#include <hgraph/python/ts_data_conversion.h>
 #include <hgraph/types/metadata/value_plan_factory.h>
-#endif
+#include <hgraph/types/python_ops.h>
+
+#include "detail/ts_data_seams.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -76,32 +73,24 @@ namespace hgraph::ts_data_plan_factory_detail
                                                                         : &ts_data_detail::capture_delta_ts,
                 .delta_has_effect_impl     = &ts_data_detail::delta_has_effect_atomic,
                 .apply_delta_impl          = &ts_data_detail::apply_delta_atomic,
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-                .python_ops = kind == TSTypeKind::REF
-                                  ? &python_bridge::ref_python_ts_data_ops()
-                                  : &python_bridge::atomic_python_ts_data_ops(),
+                // Python conversion resolves through the registered provider
+                // (RFC 0035); the storage variant selects the entry here, once.
+                .python_family = kind == TSTypeKind::REF ? PythonTSDataFamily::ref : PythonTSDataFamily::atomic,
                 .from_python_impl =
-                    value_storage == ValueStorageVariant::PythonOnly
-                        ? &python_bridge::ts_from_python_slot<&atomic_from_python<ValueStorageVariant::PythonOnly>>
-                    : value_storage ==
-                              ValueStorageVariant::NativeWithPythonCache
-                        ? &python_bridge::ts_from_python_slot<&atomic_from_python<ValueStorageVariant::NativeWithPythonCache>>
-                        : &python_bridge::ts_from_python_slot<&atomic_from_python<ValueStorageVariant::Native>>,
+                    value_storage == ValueStorageVariant::PythonOnly ? &python_ops_detail::forwarder<&PythonOps::TSData::atomic_python_only_from_python>::call
+                    : value_storage == ValueStorageVariant::NativeWithPythonCache
+                        ? &python_ops_detail::forwarder<&PythonOps::TSData::atomic_cached_from_python>::call
+                        : &python_ops_detail::forwarder<&PythonOps::TSData::atomic_native_from_python>::call,
                 .to_python_impl =
-                    value_storage == ValueStorageVariant::PythonOnly
-                        ? &python_bridge::to_python_slot<&atomic_to_python<ValueStorageVariant::PythonOnly>>
-                    : value_storage ==
-                              ValueStorageVariant::NativeWithPythonCache
-                        ? &python_bridge::to_python_slot<&atomic_to_python<ValueStorageVariant::NativeWithPythonCache>>
-                        : &python_bridge::to_python_slot<&atomic_to_python<ValueStorageVariant::Native>>,
+                    value_storage == ValueStorageVariant::PythonOnly ? &python_ops_detail::forwarder<&PythonOps::TSData::atomic_python_only_to_python>::call
+                    : value_storage == ValueStorageVariant::NativeWithPythonCache
+                        ? &python_ops_detail::forwarder<&PythonOps::TSData::atomic_cached_to_python>::call
+                        : &python_ops_detail::forwarder<&PythonOps::TSData::atomic_native_to_python>::call,
                 .delta_to_python_impl =
-                    value_storage == ValueStorageVariant::PythonOnly
-                        ? &python_bridge::ts_delta_to_python_slot<&atomic_delta_to_python<ValueStorageVariant::PythonOnly>>
-                    : value_storage ==
-                              ValueStorageVariant::NativeWithPythonCache
-                        ? &python_bridge::ts_delta_to_python_slot<&atomic_delta_to_python<ValueStorageVariant::NativeWithPythonCache>>
-                        : &python_bridge::ts_delta_to_python_slot<&atomic_delta_to_python<ValueStorageVariant::Native>>,
-#endif
+                    value_storage == ValueStorageVariant::PythonOnly ? &python_ops_detail::forwarder<&PythonOps::TSData::atomic_python_only_delta_to_python>::call
+                    : value_storage == ValueStorageVariant::NativeWithPythonCache
+                        ? &python_ops_detail::forwarder<&PythonOps::TSData::atomic_cached_delta_to_python>::call
+                        : &python_ops_detail::forwarder<&PythonOps::TSData::atomic_native_delta_to_python>::call,
             };
         }
 
@@ -178,6 +167,24 @@ namespace hgraph::ts_data_plan_factory_detail
             return atomic_value_memory(context, memory);
         }
 
+        /** The retained-object holder of a NativeWithPythonCache output, or
+            null: offset arithmetic only; the bridge owns the holder's type. */
+        [[nodiscard]] static void *retained_holder(const void *context, void *memory) noexcept
+        {
+            const auto &self = entry(context);
+            if (self.python_value_offset == ValueStorageSelection::no_offset) { return nullptr; }
+            return advance(memory, self.python_value_offset);
+        }
+
+        /** A native write drops the cached Python object (RFC 0035: the
+            provider releases the reference; nothing here names Python). */
+        static void invalidate_python_value(const void *context, void *memory) noexcept
+        {
+            const auto &self = entry(context);
+            if (self.storage != ValueStorageVariant::NativeWithPythonCache) { return; }
+            python_ops_detail::invalidate_retained(retained_holder(context, memory));
+        }
+
         [[nodiscard]] static void *atomic_mutable_delta_memory(const void *context, void *memory) noexcept
         {
             return atomic_mutable_value_memory(context, memory);
@@ -236,12 +243,10 @@ namespace hgraph::ts_data_plan_factory_detail
             const auto *tracking       = atomic_tracking(context, memory);
             const bool  first_for_time = tracking->last_modified_time != modified_time;
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
             if constexpr (InvalidatePythonCache)
             {
                 invalidate_python_value(context, memory);
             }
-#endif
             layout->value_binding.ops_ref().copy_assign_from(
                 layout->value_binding,
                 atomic_mutable_value_memory(context, memory),
@@ -281,12 +286,10 @@ namespace hgraph::ts_data_plan_factory_detail
             const auto *tracking       = atomic_tracking(context, memory);
             const bool  first_for_time = tracking->last_modified_time != modified_time;
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
             if constexpr (InvalidatePythonCache)
             {
                 invalidate_python_value(context, memory);
             }
-#endif
             layout->value_binding.ops_ref().move_assign_from(
                 layout->value_binding,
                 atomic_mutable_value_memory(context, memory),
@@ -295,144 +298,6 @@ namespace hgraph::ts_data_plan_factory_detail
             return first_for_time;
         }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-        [[nodiscard]] static python_bridge::PythonValueHolder *
-        python_value(const void *context, void *memory) noexcept
-        {
-            const auto &self = entry(context);
-            if (self.python_value_offset == ValueStorageSelection::no_offset)
-            {
-                return nullptr;
-            }
-            return MemoryUtils::cast<python_bridge::PythonValueHolder>(
-                advance(memory, self.python_value_offset));
-        }
-
-        [[nodiscard]] static const python_bridge::PythonValueHolder *
-        python_value(const void *context, const void *memory) noexcept
-        {
-            return python_value(context, const_cast<void *>(memory));
-        }
-
-        static void invalidate_python_value(const void *context,
-                                            void *memory) noexcept
-        {
-            const auto &self = entry(context);
-            if (self.storage != ValueStorageVariant::NativeWithPythonCache)
-            {
-                return;
-            }
-            if (auto *cached = python_value(context, memory);
-                cached != nullptr)
-            {
-                cached->clear();
-            }
-        }
-
-        template <ValueStorageVariant Storage>
-        [[nodiscard]] static bool atomic_from_python(
-            const void *context, void *memory, nb::handle source,
-            DateTime modified_time)
-        {
-            if (memory == nullptr)
-            {
-                throw std::logic_error("TSData atomic from_python requires live TSData memory");
-            }
-            if (source.is_none())
-            {
-                throw std::invalid_argument("TSData atomic from_python requires a non-None source");
-            }
-            if (modified_time == MIN_DT)
-            {
-                throw std::invalid_argument("TSData atomic from_python requires a concrete evaluation time");
-            }
-
-            const auto *layout = atomic_layout(context);
-            const auto *tracking = atomic_tracking(context, memory);
-            const bool  first_for_time = tracking->last_modified_time != modified_time;
-            if constexpr (Storage == ValueStorageVariant::PythonOnly)
-            {
-                python_bridge::from_python(layout->value_binding.ops_ref(), 
-                    layout->value_binding,
-                    atomic_mutable_value_memory(context, memory), source);
-                return first_for_time;
-            }
-            if constexpr (Storage ==
-                          ValueStorageVariant::NativeWithPythonCache)
-            {
-                nb::object retained =
-                    python_bridge::prepare_python_storage_value(
-                        layout->value_binding.schema(), source);
-                python_bridge::from_python(layout->value_binding.ops_ref(), 
-                    layout->value_binding,
-                    atomic_mutable_value_memory(context, memory), source);
-                python_value(context, memory)->set(retained);
-            }
-            else
-            {
-                python_bridge::from_python(layout->value_binding.ops_ref(), 
-                    layout->value_binding,
-                    atomic_mutable_value_memory(context, memory), source);
-            }
-            return first_for_time;
-        }
-
-        template <ValueStorageVariant Storage>
-        [[nodiscard]] static nb::object atomic_to_python(
-            const void *context, const void *memory)
-        {
-            const auto *layout = atomic_layout(context);
-            nb::object converted;
-            if constexpr (Storage !=
-                          ValueStorageVariant::NativeWithPythonCache)
-            {
-                converted = python_bridge::to_python(layout->value_binding, 
-                    atomic_value_memory(context, memory));
-            }
-            else
-            {
-                if (const auto *retained = python_value(context, memory);
-                    retained != nullptr && retained->has_value())
-                {
-                    converted = retained->get();
-                }
-                else
-                {
-                    converted = python_bridge::to_python(layout->value_binding, 
-                        atomic_value_memory(context, memory));
-                    if (auto *cached =
-                            python_value(context, const_cast<void *>(memory));
-                        cached != nullptr)
-                    {
-                        cached->set(converted);
-                    }
-                }
-            }
-            // Scalar Python representation is already owned by the selected
-            // ValueOps strategy (notably compact Set -> frozenset). Atomic
-            // TSData forwards that erased result without re-normalizing it.
-            return converted;
-        }
-
-        template <ValueStorageVariant Storage>
-        [[nodiscard]] static nb::object atomic_delta_to_python(
-            const void *context, const void *memory,
-            DateTime evaluation_time)
-        {
-            if (atomic_tracking(context, memory)->last_modified_time != evaluation_time) { return nb::none(); }
-            if constexpr (Storage == ValueStorageVariant::Native)
-            {
-                const auto *layout = atomic_layout(context);
-                nb::object converted = python_bridge::to_python(layout->delta_binding, 
-                    atomic_delta_memory(context, memory));
-                return converted;
-            }
-            else
-            {
-                return atomic_to_python<Storage>(context, memory);
-            }
-        }
-#endif
     };
 
     static_assert(std::is_standard_layout_v<AtomicTSDataOpsEntry>);
@@ -502,3 +367,39 @@ namespace hgraph::ts_data_plan_factory_detail
         atomic_ts_data_ops_cache().clear();
     }
 } // namespace hgraph::ts_data_plan_factory_detail
+
+// -- RFC 0035 seams: the atomic strategy for ts_data_family_conversions.cpp ----
+namespace hgraph::ts_data_seams
+{
+    using ts_data_plan_factory_detail::AtomicTSDataOpsEntry;
+
+    const TSDataLayout &atomic_layout(const void *context) noexcept
+    {
+        return *AtomicTSDataOpsEntry::atomic_layout(context);
+    }
+
+    const TSDataTracking &atomic_tracking(const void *context, const void *memory) noexcept
+    {
+        return *AtomicTSDataOpsEntry::atomic_tracking(context, memory);
+    }
+
+    const void *atomic_value_memory(const void *context, const void *memory) noexcept
+    {
+        return AtomicTSDataOpsEntry::atomic_value_memory(context, memory);
+    }
+
+    void *atomic_mutable_value_memory(const void *context, void *memory) noexcept
+    {
+        return AtomicTSDataOpsEntry::atomic_mutable_value_memory(context, memory);
+    }
+
+    const void *atomic_delta_memory(const void *context, const void *memory) noexcept
+    {
+        return AtomicTSDataOpsEntry::atomic_delta_memory(context, memory);
+    }
+
+    void *atomic_retained_holder(const void *context, void *memory) noexcept
+    {
+        return AtomicTSDataOpsEntry::retained_holder(context, memory);
+    }
+}  // namespace hgraph::ts_data_seams

--- a/src/hgraph/types/metadata/ts_data_window_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_window_ops.cpp
@@ -8,10 +8,9 @@
 #include <hgraph/types/value/value_builder.h>
 #include <hgraph/util/scope.h>
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-#include <hgraph/python/ts_data_conversion.h>
-#include <hgraph/python/conversion.h>
-#endif
+#include <hgraph/types/python_ops.h>
+
+#include "detail/ts_data_seams.h"
 
 #include <fmt/format.h>
 
@@ -495,6 +494,7 @@ namespace hgraph::ts_data_plan_factory_detail
         class SizeTSWindowStorage final : public TSWindowStorageCore
         {
           public:
+            using TSWindowStorageCore::clear;  // the RFC 0035 replace seam rebuilds through it
             SizeTSWindowStorage(const ValueTypeRef &time_binding,
                                 const ValueTypeRef &element_binding,
                                 std::size_t period)
@@ -543,33 +543,6 @@ namespace hgraph::ts_data_plan_factory_detail
                 }
             }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-            void copy_from_python(nb::handle source, DateTime modified_time)
-            {
-                nb::object object = nb::borrow<nb::object>(source);
-                if (!nb::isinstance<nb::list>(object) && !nb::isinstance<nb::tuple>(object))
-                {
-                    throw std::invalid_argument("TSW value expects a Python list or tuple");
-                }
-                if (static_cast<std::size_t>(nb::len(object)) > period_)
-                {
-                    throw std::length_error("TSW fixed window source exceeds the configured period");
-                }
-
-                clear();
-                nb::iterator it = nb::iter(object);
-                while (it != nb::iterator::sentinel())
-                {
-                    if ((*it).is_none()) { throw std::invalid_argument("TSW value does not allow None elements"); }
-                    Value element{element_binding()};
-                    python_bridge::from_python(element_binding().ops_ref(), element_binding(),
-                                                                const_cast<void *>(element.view().data()),
-                                                                *it);
-                    push(element.view(), modified_time);
-                    ++it;
-                }
-            }
-#endif
 
           private:
             std::size_t period_{0};
@@ -578,6 +551,7 @@ namespace hgraph::ts_data_plan_factory_detail
         class TimeTSWindowStorage final : public TSWindowStorageCore
         {
           public:
+            using TSWindowStorageCore::clear;  // the RFC 0035 replace seam rebuilds through it
             TimeTSWindowStorage(const ValueTypeRef &time_binding,
                                 const ValueTypeRef &element_binding,
                                 TimeDelta time_range)
@@ -620,29 +594,6 @@ namespace hgraph::ts_data_plan_factory_detail
                 }
             }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-            void copy_from_python(nb::handle source, DateTime modified_time)
-            {
-                nb::object object = nb::borrow<nb::object>(source);
-                if (!nb::isinstance<nb::list>(object) && !nb::isinstance<nb::tuple>(object))
-                {
-                    throw std::invalid_argument("TSW value expects a Python list or tuple");
-                }
-
-                clear();
-                nb::iterator it = nb::iter(object);
-                while (it != nb::iterator::sentinel())
-                {
-                    if ((*it).is_none()) { throw std::invalid_argument("TSW value does not allow None elements"); }
-                    Value element{element_binding()};
-                    python_bridge::from_python(element_binding().ops_ref(), element_binding(),
-                                                                const_cast<void *>(element.view().data()),
-                                                                *it);
-                    push(element.view(), modified_time);
-                    ++it;
-                }
-            }
-#endif
 
           private:
             TimeDelta time_range_{};
@@ -801,6 +752,8 @@ namespace hgraph::ts_data_plan_factory_detail
             TSWDataLayout                  *layout{nullptr};
             TSWDataOps                      ops{};
             IndexedValueOps                 value_ops{};
+            /** Which storage this context drives (the seams dispatch on it). */
+            bool                            time_window{false};
 
             void bind_value_surface()
             {
@@ -823,9 +776,10 @@ namespace hgraph::ts_data_plan_factory_detail
                                    std::size_t value_offset,
                                    std::size_t tracking_offset)
             {
-                schema     = &schema_;
-                value_plan = &value_plan_;
-                layout     = &layout_;
+                schema      = &schema_;
+                value_plan  = &value_plan_;
+                layout      = &layout_;
+                time_window = std::is_same_v<Storage, TimeTSWindowStorage>;
 
                 layout->element_binding = element_binding;
                 layout->time_binding    = time_binding;
@@ -837,7 +791,7 @@ namespace hgraph::ts_data_plan_factory_detail
                 configure_value_ops();
             }
 
-          protected:
+          public:  // the RFC 0035 seams below reach these; nothing else outside the TU can
             void configure_ts_ops()
             {
                 ops = TSWDataOps{};
@@ -863,12 +817,10 @@ namespace hgraph::ts_data_plan_factory_detail
                     .capture_delta_impl        = &ts_data_detail::capture_delta_tsw,
                     .delta_has_effect_impl     = &ts_data_detail::delta_has_effect_atomic,
                     .apply_delta_impl          = &ts_data_detail::apply_delta_tsw,
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-                    .python_ops               = &python_bridge::window_python_ts_data_ops(),
-                    .from_python_impl          = &python_bridge::ts_from_python_slot<&window_from_python>,
-                    .to_python_impl            = &python_bridge::to_python_slot<&window_to_python>,
-                    .delta_to_python_impl      = &python_bridge::ts_delta_to_python_slot<&window_delta_to_python>,
-#endif
+                    .python_family             = PythonTSDataFamily::window,
+                    .from_python_impl          = &python_ops_detail::forwarder<&PythonOps::TSData::window_from_python>::call,
+                    .to_python_impl            = &python_ops_detail::forwarder<&PythonOps::TSData::window_to_python>::call,
+                    .delta_to_python_impl      = &python_ops_detail::forwarder<&PythonOps::TSData::window_delta_to_python>::call,
                 };
                 ops.size_impl        = &window_size;
                 ops.element_at_impl  = &window_element_at;
@@ -904,11 +856,8 @@ namespace hgraph::ts_data_plan_factory_detail
                 value_ops = IndexedValueOps{
                     {ValueOpsKind::Indexed, this, false, &window_value_hash, &window_value_equals,
                      &window_value_compare,
-                     &window_value_to_string
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-                     ,
-                     &python_bridge::to_python_slot<&window_value_to_python>
-#endif
+                     &window_value_to_string,
+                     &python_ops_detail::forwarder<&PythonOps::TSData::window_value_to_python>::call
                     },
                     &window_value_size,
                     &window_value_element_at,
@@ -1080,64 +1029,6 @@ namespace hgraph::ts_data_plan_factory_detail
                 return newly_modified;
             }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-            [[nodiscard]] static bool is_python_sequence(nb::handle source)
-            {
-                nb::object object = nb::borrow<nb::object>(source);
-                return nb::isinstance<nb::list>(object) || nb::isinstance<nb::tuple>(object);
-            }
-
-            [[nodiscard]] static nb::object window_to_python(const void *context, const void *memory)
-            {
-                return python_bridge::to_python(ctx(context)->layout->value_binding, window_value_memory(context, memory));
-            }
-
-            [[nodiscard]] static nb::object window_delta_to_python(const void *context,
-                                                                   const void *memory,
-                                                                   DateTime evaluation_time)
-            {
-                if (window_tracking(context, memory)->last_modified_time != evaluation_time) { return nb::none(); }
-                const auto *delta = window_delta_memory(context, memory);
-                if (delta == nullptr) { return nb::none(); }
-                return python_bridge::to_python(ctx(context)->layout->delta_binding, delta);
-            }
-
-            [[nodiscard]] static bool window_from_python(const void *context,
-                                                         void       *memory,
-                                                         nb::handle  source,
-                                                         DateTime modified_time)
-            {
-                if (memory == nullptr) { throw std::logic_error("TSW from_python requires live storage"); }
-                if (source.is_none()) { throw std::invalid_argument("TSW from_python requires a non-None source"); }
-                if (modified_time == MIN_DT)
-                {
-                    throw std::invalid_argument("TSW from_python requires a concrete evaluation time");
-                }
-
-                const bool newly_modified =
-                    window_tracking(context, memory)->last_modified_time != modified_time;
-                if (is_python_sequence(source))
-                {
-                    storage<Storage>(window_mutable_value_memory(context, memory))
-                        .copy_from_python(source, modified_time);
-                    return newly_modified;
-                }
-
-                if (!newly_modified)
-                {
-                    throw std::logic_error("TSW from_python allows only one window tick per evaluation time");
-                }
-
-                const auto *state = ctx(context);
-                Value       element{state->layout->element_binding};
-                python_bridge::from_python(state->layout->element_binding.ops_ref(), 
-                    state->layout->element_binding,
-                    const_cast<void *>(element.view().data()),
-                    source);
-                storage<Storage>(window_mutable_value_memory(context, memory)).push(element.view(), modified_time);
-                return true;
-            }
-#endif
 
             [[nodiscard]] static std::size_t window_value_size(const void *context, const void *memory) noexcept
             {
@@ -1342,37 +1233,6 @@ namespace hgraph::ts_data_plan_factory_detail
                 return fmt::to_string(out);
             }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-            [[nodiscard]] static nb::object window_value_to_python(const void *context, const void *memory)
-            {
-                if (memory == nullptr) { throw std::runtime_error("TSW value to_python requires live storage"); }
-                const auto *state = ctx(context);
-                const auto &ops   = state->layout->element_binding.ops_ref();
-                const auto binding = state->layout->element_binding;
-                const auto &window = storage<Storage>(memory);
-                if (python_bridge::can_to_python_buffer(ops, binding))
-                {
-                    return python_bridge::to_python_buffer(ops, binding,
-                                                ValueArraySource{
-                                                    .owner      = memory,
-                                                    .size       = window.size(),
-                                                    .element_at = &window_buffer_element_at,
-                                                });
-                }
-
-                nb::list result;
-                for (std::size_t index = 0; index < window.size(); ++index)
-                {
-                    result.append(python_bridge::to_python(ops, window.element_at(index)));
-                }
-                return result;
-            }
-
-            [[nodiscard]] static const void *window_buffer_element_at(const void *owner, std::size_t index)
-            {
-                return storage<Storage>(owner).element_at(index);
-            }
-#endif
         };
 
         struct SizeTSWContext final : TSWContextBase<SizeTSWindowStorage>
@@ -1469,7 +1329,7 @@ namespace hgraph::ts_data_plan_factory_detail
 
             [[nodiscard]] static bool time_all_valid(const void *context, const void *memory)
             {
-                const auto &window = storage<TimeTSWindowStorage>(window_value_memory(context, memory));
+                const auto &window = ts_data_plan_factory_detail::storage<TimeTSWindowStorage>(window_value_memory(context, memory));
                 if (window.empty()) { return false; }
 
                 const auto &layout = layout_for(context);
@@ -1708,3 +1568,106 @@ namespace hgraph::ts_data_plan_factory_detail
         }
     }
 } // namespace hgraph::ts_data_plan_factory_detail
+
+// -- RFC 0035 seams: the window strategies for ts_data_family_conversions.cpp -
+namespace hgraph::ts_data_seams
+{
+    namespace
+    {
+        using namespace ts_data_plan_factory_detail;
+        using SizeBase = TSWContextBase<SizeTSWindowStorage>;
+        using TimeBase = TSWContextBase<TimeTSWindowStorage>;
+
+        [[nodiscard]] const TSWContextCommon &common(const void *context) noexcept
+        {
+            return *static_cast<const TSWContextCommon *>(context);
+        }
+
+        template <typename Storage>
+        void replace_window(Storage &window, DateTime modified_time, std::size_t count, FillElementFn fill,
+                            void *fill_context)
+        {
+            if constexpr (std::is_same_v<Storage, SizeTSWindowStorage>)
+            {
+                if (count > window.capacity())
+                {
+                    throw std::length_error("TSW fixed window source exceeds the configured period");
+                }
+            }
+            window.clear();
+            for (std::size_t index = 0; index < count; ++index)
+            {
+                Value element{window.element_binding()};
+                fill(fill_context, index, window.element_binding(), const_cast<void *>(element.view().data()));
+                window.push(element.view(), modified_time);
+            }
+        }
+
+        template <typename Storage>
+        void push_window(Storage &window, DateTime modified_time, FillElementFn fill, void *fill_context)
+        {
+            Value element{window.element_binding()};
+            fill(fill_context, 0, window.element_binding(), const_cast<void *>(element.view().data()));
+            window.push(element.view(), modified_time);
+        }
+    }  // namespace
+
+    const TSWDataLayout &window_layout(const void *context) noexcept { return *common(context).layout; }
+
+    const TSDataTracking &window_tracking(const void *context, const void *memory) noexcept
+    {
+        return *SizeBase::window_tracking(context, memory);
+    }
+
+    const void *window_value_memory(const void *context, const void *memory) noexcept
+    {
+        return SizeBase::window_value_memory(context, memory);
+    }
+
+    const void *window_delta_memory(const void *context, const void *memory) noexcept
+    {
+        return common(context).time_window ? TimeBase::window_delta_memory(context, memory)
+                                           : SizeBase::window_delta_memory(context, memory);
+    }
+
+    std::size_t window_storage_size(const void *context, const void *storage) noexcept
+    {
+        return common(context).time_window ? ts_data_plan_factory_detail::storage<TimeTSWindowStorage>(storage).size()
+                                           : ts_data_plan_factory_detail::storage<SizeTSWindowStorage>(storage).size();
+    }
+
+    const void *window_storage_element_at(const void *context, const void *storage, std::size_t index) noexcept
+    {
+        return common(context).time_window ? ts_data_plan_factory_detail::storage<TimeTSWindowStorage>(storage).element_at(index)
+                                           : ts_data_plan_factory_detail::storage<SizeTSWindowStorage>(storage).element_at(index);
+    }
+
+    void window_replace(const void *context, void *memory, DateTime modified_time, std::size_t count,
+                        FillElementFn fill, void *fill_context)
+    {
+        if (common(context).time_window)
+        {
+            replace_window(ts_data_plan_factory_detail::storage<TimeTSWindowStorage>(TimeBase::window_mutable_value_memory(context, memory)),
+                           modified_time, count, fill, fill_context);
+        }
+        else
+        {
+            replace_window(ts_data_plan_factory_detail::storage<SizeTSWindowStorage>(SizeBase::window_mutable_value_memory(context, memory)),
+                           modified_time, count, fill, fill_context);
+        }
+    }
+
+    void window_push(const void *context, void *memory, DateTime modified_time, FillElementFn fill, void *fill_context)
+    {
+        if (common(context).time_window)
+        {
+            push_window(ts_data_plan_factory_detail::storage<TimeTSWindowStorage>(TimeBase::window_mutable_value_memory(context, memory)),
+                        modified_time, fill, fill_context);
+        }
+        else
+        {
+            push_window(ts_data_plan_factory_detail::storage<SizeTSWindowStorage>(SizeBase::window_mutable_value_memory(context, memory)),
+                        modified_time, fill, fill_context);
+        }
+    }
+}  // namespace hgraph::ts_data_seams

--- a/src/hgraph/types/metadata/ts_data_window_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_window_ops.cpp
@@ -1614,14 +1614,18 @@ namespace hgraph::ts_data_seams
 
     const TSWDataLayout &window_layout(const void *context) noexcept { return *common(context).layout; }
 
+    // The layout lives on the common base, so these read it there: casting a
+    // duration-window context to the size-window instantiation (or the other
+    // way round) would be a cast between unrelated types.
     const TSDataTracking &window_tracking(const void *context, const void *memory) noexcept
     {
-        return *SizeBase::window_tracking(context, memory);
+        return *MemoryUtils::cast<TSDataTracking>(static_cast<const std::byte *>(memory) +
+                                                  common(context).layout->tracking_offset);
     }
 
     const void *window_value_memory(const void *context, const void *memory) noexcept
     {
-        return SizeBase::window_value_memory(context, memory);
+        return static_cast<const std::byte *>(memory) + common(context).layout->value_offset;
     }
 
     const void *window_delta_memory(const void *context, const void *memory) noexcept

--- a/src/hgraph/types/time_series/ts_input/target_link_ops.cpp
+++ b/src/hgraph/types/time_series/ts_input/target_link_ops.cpp
@@ -1231,7 +1231,7 @@ namespace hgraph::detail
         [[nodiscard]] const PythonTSDataOps &
         target_link_python_ops_for(TSRoleTypeRef type)
         {
-            return *type.ops_ref().python_ops;
+            return python_bridge::python_ts_data_ops_for(type.ops_ref());
         }
 
         [[nodiscard]] bool target_link_requires_authored_delta(

--- a/tests/cpp/test_type_erasure_layout.cpp
+++ b/tests/cpp/test_type_erasure_layout.cpp
@@ -80,10 +80,12 @@ TEST_CASE("current type-erasure records retain their baseline layouts")
     static_assert(!HasNoArgumentRemovedValue<TSWDataView>);
     static_assert(HasNoArgumentRemovedValue<TSWInputView>);
     static_assert(sizeof(TSDataView) == sizeof(void *) * 2);
-    // ABI 13 (RFC 0035): the Python slots are unconditional and opaque, so a
-    // table built with Python off has the layout of one built with Python on,
-    // and the authoring table pointer is never null.
-    static_assert(TS_DATA_OPS_ABI_VERSION == 13);
+    // ABI 14 (RFC 0035): TSDataOps records its Python-authoring family
+    // (python_family) beside the table pointer. ABI 13 made the Python slots
+    // unconditional and opaque, so a table built with Python off has the
+    // layout of one built with Python on, and the pointer is never null.
+    static_assert(TS_DATA_OPS_ABI_VERSION == 14);
+    static_assert(std::is_same_v<decltype(TSDataOps::python_family), PythonTSDataFamily>);
     static_assert(std::is_same_v<decltype(TSDataOps::to_python_impl), PyNewRef (*)(const void *, const void *)>);
     static_assert(std::is_same_v<decltype(TSDataOps::python_ops), const PythonTSDataOps *>);
     // ABI 12: keyed and window TSData projections keep binding and memory together.

--- a/tests/install_consumer/main.cpp
+++ b/tests/install_consumer/main.cpp
@@ -331,9 +331,10 @@ int main()
     static_assert(std::is_trivially_copyable_v<ChildGraphInspectionOps>);
     static_assert(GRAPH_OPS_ABI_VERSION == 8);
     static_assert(EXECUTOR_OPS_ABI_VERSION == 5);
-    // ABI 13 (RFC 0035): the Python slots are unconditional and opaque; ABI 12 made the
-    // keyed and window TSData projections return binding and memory together.
-    static_assert(TS_DATA_OPS_ABI_VERSION == 13);
+    // ABI 14 (RFC 0035): TSDataOps records its Python-authoring family; ABI 13 made the
+    // Python slots unconditional and opaque; ABI 12 made the keyed and window TSData
+    // projections return binding and memory together.
+    static_assert(TS_DATA_OPS_ABI_VERSION == 14);
     static_assert(sizeof(PolymorphicValueType) == 2 * sizeof(void *));
     static_assert(std::is_standard_layout_v<PolymorphicValueType>);
     static_assert(!std::is_polymorphic_v<TableTypeOps>);


### PR DESCRIPTION
Fourth implementation step of RFC 0035 (#720), first half of the TS data families. Stacked on #732 (PR 3); retarget as the stack merges.

**What moves.** The atomic (TS / SIGNAL / REF) strategy's conversions in their three value-storage variants and the TSW window conversions leave `ts_data_atomic_ops.cpp` and `ts_data_window_ops.cpp` for `src/hgraph/python/impl/ts_data_family_conversions.cpp` behind the new `PythonOps::TSData` section. A factory selects the variant's three entries once at construction, so the per-tick path keeps no runtime branch on the storage variant.

**What stays, and how the bridge reaches it.** `src/hgraph/types/metadata/detail/ts_data_seams.h` (private to `hgraph_runtime`) publishes the atomic layout / memory accessors and the retained-object holder locator, and for windows the layout, tracking, delta and storage-shape accessors plus `window_replace` / `window_push`, which construct each element and hand the bridge the payload to convert into (a size window still rejects more elements than its period). A native write on a `NativeWithPythonCache` output drops the cache through `PythonOps::Retained::invalidate`: the type layer only locates the holder, and a missing provider is a no-op on that `noexcept` path.

**Family tables.** `TSDataOps::python_family` records which Python-authoring table a strategy uses; the bridge maps it (`python_ts_data_ops_for`). A family still naming its table by symbol keeps the `python_ops` pointer until it moves in PR 4b / PR 5, after which the pointer goes with an ABI bump.

**Ratchets**: `type-layer-python-conditionals` 72 → 60; `type-layer-nanobind` 318 → 273.

**Gate** (macOS): core-only tree builds; native `_hgraph` rebuilt; `uv sync` reinstall of every native member; core + adaptor + extension suites 3591 passed, 10 skipped, plus the ratchet and registry-snapshot tests; core C++ suite 1703 cases; the three consumer checks; `sphinx -W`. Linux GCC 14 and Windows MSVC validations to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga