### PR TITLE
docs(language): specify switch and enum syntax with C++ mappings

### DIFF
--- a/language/docs/README.md
+++ b/language/docs/README.md
@@ -49,8 +49,9 @@ out so examples do not imply an implemented compatibility promise.
    what a host needs to run an HGL program.
 10. [Type extensions](design/type-extensions.md) — agreed atomic treatment of
    imported types, `ref<T>`, reference-transparent type compatibility, opaque
-   node access, wiring-time dereferencing, input-only SIGNAL observation, and
-   required enum support whose declaration syntax remains open.
+   node access, wiring-time dereferencing, input-only SIGNAL observation,
+   enum declaration/member syntax, and required numbering and stringification
+   whose detailed rules remain open.
 11. [Conditional control flow](design/control-flow.md) — wiring-time selection,
    switch-style temporal conditions in graph functions, and node conditionals.
 12. [Explicit switch dispatch](design/switch.md) — node-style C++ dispatch,

--- a/language/docs/README.md
+++ b/language/docs/README.md
@@ -50,8 +50,8 @@ out so examples do not imply an implemented compatibility promise.
 10. [Type extensions](design/type-extensions.md) — agreed atomic treatment of
    imported types, `ref<T>`, reference-transparent type compatibility, opaque
    node access, wiring-time dereferencing, input-only SIGNAL observation,
-   enum declaration/member syntax, and required numbering and stringification
-   whose detailed rules remain open.
+   enum declaration/member syntax, explicit and automatic numbering,
+   member-name stringification, and duplicate-number rejection.
 11. [Conditional control flow](design/control-flow.md) — wiring-time selection,
    switch-style temporal conditions in graph functions, and node conditionals.
 12. [Explicit switch dispatch](design/switch.md) — node-style C++ dispatch,

--- a/language/docs/README.md
+++ b/language/docs/README.md
@@ -52,7 +52,10 @@ out so examples do not imply an implemented compatibility promise.
    node access, wiring-time dereferencing, and input-only SIGNAL observation.
 11. [Conditional control flow](design/control-flow.md) — wiring-time selection,
    switch-style temporal conditions in graph functions, and node conditionals.
-12. [Iteration](design/iteration.md) — phase-dependent `for`, wiring-time values
+12. [Explicit switch dispatch](design/switch.md) — node-style C++ dispatch,
+   graph selector checks and branch signatures, default handling, and no-match
+   failure; complete case syntax remains open.
+13. [Iteration](design/iteration.md) — phase-dependent `for`, wiring-time values
    and fixed child connections, independent dynamic graph loops, runtime
    traversal, and deferred map/reduce accumulation.
 

--- a/language/docs/README.md
+++ b/language/docs/README.md
@@ -51,7 +51,8 @@ out so examples do not imply an implemented compatibility promise.
    imported types, `ref<T>`, reference-transparent type compatibility, opaque
    node access, wiring-time dereferencing, input-only SIGNAL observation,
    enum declaration/member syntax, explicit and automatic numbering,
-   member-name stringification, and duplicate-number rejection.
+   member-name stringification through `str(value)`, and duplicate-number
+   rejection.
 11. [Conditional control flow](design/control-flow.md) — wiring-time selection,
    switch-style temporal conditions in graph functions, and node conditionals.
 12. [Explicit switch dispatch](design/switch.md) — node-style C++ dispatch,

--- a/language/docs/README.md
+++ b/language/docs/README.md
@@ -49,12 +49,13 @@ out so examples do not imply an implemented compatibility promise.
    what a host needs to run an HGL program.
 10. [Type extensions](design/type-extensions.md) — agreed atomic treatment of
    imported types, `ref<T>`, reference-transparent type compatibility, opaque
-   node access, wiring-time dereferencing, and input-only SIGNAL observation.
+   node access, wiring-time dereferencing, input-only SIGNAL observation, and
+   required enum support whose declaration syntax remains open.
 11. [Conditional control flow](design/control-flow.md) — wiring-time selection,
    switch-style temporal conditions in graph functions, and node conditionals.
 12. [Explicit switch dispatch](design/switch.md) — node-style C++ dispatch,
    graph selector checks and branch signatures, default handling, and no-match
-   failure; complete case syntax remains open.
+   failure, with agreed source syntax and constant case values.
 13. [Iteration](design/iteration.md) — phase-dependent `for`, wiring-time values
    and fixed child connections, independent dynamic graph loops, runtime
    traversal, and deferred map/reduce accumulation.

--- a/language/docs/design/control-flow.md
+++ b/language/docs/design/control-flow.md
@@ -526,8 +526,13 @@ bindings, definite assignment, early-return continuations, outputless
 conditional wiring, mixed expression/assignment results, and subsequent
 composition. [Iteration](iteration.md) records the subsequent agreement about
 `for` in graph composition and node evaluation.
-No new syntax or lifetime policy for `for`, explicit `switch`, `map`, `reduce`,
-or `mesh` is introduced by these conditional agreements.
+[Explicit switch dispatch](switch.md) records the subsequent agreement about
+node-style C++ dispatch, graph-style branch captures and results, and the
+`default: ...` fallback with no-match failure. Its complete syntax remains open.
+The [worked C++ mappings](../developer-guide/control-flow-cpp-mappings.md)
+illustrate the shared capture/result, early-return, sink, and lifecycle rules.
+No new syntax or lifetime policy for `for`, `map`, `reduce`, or `mesh` is
+introduced by these conditional agreements.
 
 ## Implementation status
 

--- a/language/docs/design/control-flow.md
+++ b/language/docs/design/control-flow.md
@@ -528,8 +528,9 @@ composition. [Iteration](iteration.md) records the subsequent agreement about
 `for` in graph composition and node evaluation.
 [Explicit switch dispatch](switch.md) records the subsequent agreement about
 node-style C++ dispatch, graph-style branch captures and results, and the
-`default: ...` fallback with no-match failure. Its complete syntax remains open.
-The [worked C++ mappings](../developer-guide/control-flow-cpp-mappings.md)
+`default: ...` fallback with no-match failure. The source form is
+`switch selector { case value: ... default: ... }`, with constant case values.
+The [paired HGL/C++ mappings](../developer-guide/control-flow-cpp-mappings.md)
 illustrate the shared capture/result, early-return, sink, and lifecycle rules.
 No new syntax or lifetime policy for `for`, `map`, `reduce`, or `mesh` is
 introduced by these conditional agreements.

--- a/language/docs/design/iteration.md
+++ b/language/docs/design/iteration.md
@@ -4,7 +4,9 @@ Status: phase-dependent iteration and the independent-body boundary for
 dynamic graph loops agreed, 2026-09-05. The compiler implements fixed temporal
 list traversal and independent dynamic map/unbounded-list traversal in graph
 composition. Map/reduce lowering of loop-carried accumulators remains a future
-extension.
+extension and is explicitly unsupported in the initial implementation.
+Graph-phase iterator predicates were also deferred on 2026-09-06; further
+loop design is paused while other language features are discussed.
 
 ## Iteration follows the containing phase
 
@@ -169,11 +171,23 @@ order or change the containing graph into a runtime node. This restriction
 does not prohibit ordinary evaluation-time accumulation inside a node, and
 does not remove the existing native map or reduce APIs.
 
+## Deferred graph-phase predicates
+
+Graph-phase iterator predicates are deferred. Translating a value predicate
+into a per-element switch around the loop body was discussed, but its
+conversion and lifetime semantics need further work before adoption. That
+equivalence is not an agreed lowering and is not part of the initial graph-loop
+subset. No graph-predicate example is added to the standard-library corpus.
+
+The existing node-time predicate and delta-range rules are unchanged. This
+deferral does not undo the separately agreed `if` or independent-body mapping
+contracts. Further loop processing is left for a later iteration.
+
 ## Remaining decisions
 
 Loop result construction, the precise recognition and operator contracts for
-deferred reductions, other cross-iteration dependencies, graph-phase
-predicates, and loop exits remain to be worked through. So does the
+deferred reductions, other cross-iteration dependencies, the deferred
+graph-phase predicates, and loop exits remain to be worked through. So does the
 disambiguation of a function whose only phase-sensitive operation is runtime
 collection traversal: once iteration follows its containing phase, such a body
 contains no existing construct that selects runtime evaluation. Whether this

--- a/language/docs/design/iteration.md
+++ b/language/docs/design/iteration.md
@@ -6,12 +6,14 @@ list traversal and independent dynamic map/unbounded-list traversal in graph
 composition. Map/reduce lowering of loop-carried accumulators remains a future
 extension and is explicitly unsupported in the initial implementation.
 Graph-phase iterator predicates were also deferred on 2026-09-06; further
-loop design is paused while other language features are discussed.
+loop design is paused while other language features are discussed. The
+`elements` spelling for lists and sets was agreed on 2026-09-06 and remains
+compiler work; it does not expand the supported graph-loop subset.
 
 ## Iteration follows the containing phase
 
-The existing `for ... in ... { ... }` syntax and the `keys`, `values`, and
-`items` operations follow the containing function's phase. Their presence
+The existing `for ... in ... { ... }` syntax and the `keys`, `values`, `elements`,
+and `items` operations follow the containing function's phase. Their presence
 alone does not classify a function as a runtime node. Node-only constructs
 such as `when` establish runtime evaluation; a body without node-only
 constructs describes graph composition.
@@ -28,11 +30,35 @@ runtime payloads available during wiring or make runtime-only borrowed views
 persist across evaluations. It also does not supply an iteration protocol for
 every imported atomic type; native operations remain a separate topic.
 
+## Elements for lists and sets
+
+Use `elements(collection)` for element-only traversal of lists and sets. It
+supplies one binding per element; use the existing `items(list)` when an index
+is also needed. Maps and bundles retain `keys`, `values`, and `items`; this
+agreement does not add `elements` to those structures.
+
+Lists preserve index order. Set traversal has no sorting or insertion-order
+guarantee. For temporal lists, graph iteration receives child connections and
+node iteration receives current child views; neither loses endpoint metadata
+or grants access below a REF boundary. Set members are scalar values, not
+independent temporal children. Supported node-time predicates and borrowed
+view lifetimes are unchanged; for example, `elements(symbols, added)` selects
+the set's added members.
+
+This supersedes the earlier rule excluding `elements`. The compiler still
+implements list/set traversal under `values`; retention of that spelling as
+a compatibility alias remains undecided. The worked examples below and
+[elements-iteration.hgl](../../stdlib/examples/elements-iteration.hgl) use the
+agreed target spelling, not implemented compiler support. Dynamic-list loops
+retain their existing independent-body restriction, and graph-phase set
+traversal remains unsupported. No predicate-to-switch or reduction inference
+is introduced.
+
 ## Fixed temporal structure at wiring time
 
 ```hgl
-fn observe(samples: list<f64, 3>) {
-    for sample in values(samples) {
+fn observe_elements(samples: list<f64, 3>) {
+    for sample in elements(samples) {
         null_sink(sample)
     }
 }
@@ -44,11 +70,32 @@ current payload. No sample value needs to exist during wiring. Source value
 ticks subsequently reach those sinks through their fixed connections; they do
 not cause the graph function to iterate again.
 
-The compiler expands this loop at wiring time and projects each child through
-the public native `tsl_element` contract. Both compiler backends therefore
-compose three copies of the body without reading a runtime payload. The
-executable source is
-[fixed-list-iteration.hgl](../../examples/fixed-list-iteration.hgl).
+The expected C++ wiring is:
+
+```cpp
+#include <hgraph/lib/std/std_operators.h>
+#include <hgraph/types/graph_wiring.h>
+#include <hgraph/types/subgraph_wiring.h>
+
+struct ObserveElements
+{
+    static constexpr auto name = "observe_elements";
+
+    static void compose(hgraph::Wiring &w,
+                        hgraph::Port<hgraph::TSL<hgraph::TS<hgraph::Float>, 3>> samples)
+    {
+        for (std::size_t index = 0; index < 3; ++index) {
+            hgraph::wire<hgraph::stdlib::null_sink>(w, hgraph::tsl_element(samples, index));
+        }
+    }
+};
+```
+
+This uses the public native `tsl_element` contract and assumes the standard
+operators are registered before wiring. Both compiler backends already perform
+this expansion for the older `values` spelling in
+[fixed-list-iteration.hgl](../../examples/fixed-list-iteration.hgl). The
+`elements` example is the agreed migration target, not current emitted output.
 
 ## Node-time traversal
 
@@ -63,6 +110,51 @@ In particular, runtime iterators are evaluation-local borrowed views, predicate
 filters are pure, and the supported `modified`, `added`, and `removed` ranges
 follow the collection's native delta semantics. None of those rules grants
 node code access below an explicit REF boundary.
+
+For example, count the current tick's added set members inside a node:
+
+```hgl
+fn count_added_elements(symbols: set<str>) -> i64 {
+    when modified(symbols) && valid(symbols) {
+        var count: i64 = 0
+        for symbol in elements(symbols, added) {
+            count += 1
+        }
+        return count
+    }
+}
+```
+
+An illustrative C++ mapping uses the existing public added-member range:
+
+```cpp
+#include <hgraph/types/static_node.h>
+
+struct CountAddedElements
+{
+    static constexpr auto name = "count_added_elements";
+
+    static void eval(hgraph::In<"symbols", hgraph::TSS<hgraph::Str>> symbols,
+                     hgraph::Out<hgraph::TS<hgraph::Int>> out)
+    {
+        if (symbols.modified() && symbols.valid()) {
+            hgraph::Int count = 0;
+            for (const auto &symbol : symbols.added()) {
+                (void)symbol;
+                ++count;
+            }
+            out.set(count);
+        }
+    }
+};
+```
+
+Adding two members yields `2`; a later removal-only tick yields `0`; no input
+tick produces no output tick. The loop counts scalar members in the native
+delta range, without imposing set order or wiring a child graph per member.
+The count is evaluation-local, not persistent state or a graph reduction.
+These C++ illustrations can be syntax-checked independently of HGL support;
+they are not new native graph execution tests.
 
 ## Dynamic structures: independent bodies first
 

--- a/language/docs/design/language-model.md
+++ b/language/docs/design/language-model.md
@@ -549,7 +549,8 @@ does not select the function's phase. Enums remain distinct atomic scalar
 types; integer conversion is explicit rather than implicit. Enumeration
 exposes member names through `keys`, assigned numbers through `values`, and
 typed enum instances through `elements`. Remaining conversion/enumeration
-details and native mapping stay open.
+details and native mapping stay open. All three enum views iterate in
+declaration order, independent of their assigned numbers.
 
 A runtime function may declare persistent state, approved injected
 capabilities, lifecycle behavior, and ordered activation handlers:
@@ -689,10 +690,11 @@ remains open.
 The collection surface separates a materialized temporal view from borrowed
 runtime iteration. `key_set(tsd)` is available in both phases: composition
 produces the live TSS key projection, while runtime evaluation exposes the
-current borrowed set view. The calls `keys(value)`, `values(value)`, and
-`items(value)` follow the containing phase. In node evaluation they produce
-evaluation-local iterators. In graph composition, iteration over a supported
-wiring-time iterable visits scalar values, and iteration over a fixed temporal
+current borrowed set view. The calls `keys(value)`, `values(value)`,
+`elements(value)`, and `items(value)` follow the containing phase. In node
+evaluation they produce evaluation-local iterators. In graph composition,
+iteration over a supported wiring-time iterable visits scalar values, and
+iteration over a fixed temporal
 structure visits child connections. The calls do not themselves make a
 function a runtime node. Dynamic graph loops initially admit independent bodies
 lowered through per-key or per-index mapping. The compiler currently expands
@@ -703,15 +705,19 @@ Loop-carried reductions are deferred, with unordered map reduction and linear
 list reduction documented as future options. See
 [Iteration](iteration.md) for the agreement and implementation boundary.
 
-`values` is the common value-only spelling for TSB, TSD, TSL, and TSS; there is
-no `elements` alias. `items` yields `(field, value)` for TSB, `(key, value)` for
-TSD, and `(i64, value)` for TSL. `keys` applies only to TSB and TSD.
+`elements` is the agreed spelling for list and set element iteration, replacing
+the earlier no-`elements` design. `values` remains the value-only spelling for
+TSB and TSD. `items` yields `(field, value)` for TSB, `(key, value)` for TSD,
+and `(i64, value)` for TSL. Among these collections, `keys` applies only to TSB
+and TSD. Lists preserve index order; sets do not promise a sorted or insertion
+order. The compiler still uses `values` for lists and sets; `elements` support
+and the compatibility status of that older spelling remain separate work.
 
 Every traversal accepts an optional predicate:
 
 ```hgl
 items(book, modified)
-values(symbols, added)
+elements(symbols, added)
 keys(book, removed)
 items(book, fn(key, value) => last_modified(value) > some_time)
 ```

--- a/language/docs/design/language-model.md
+++ b/language/docs/design/language-model.md
@@ -543,7 +543,9 @@ declaration and `Mode::first` reference form. An explicit `= constant` assigns
 an integer number; otherwise the first member starts at zero and later
 members increment the preceding number. Duplicate numbers are rejected
 initially. Stringification returns the member name without a type prefix or
-number. Conversion-call spelling and the remaining enum type rules stay open.
+number, using the agreed `str(value)` call spelling. Constant, node-value, and
+temporal graph conversions follow the existing phase distinction; the call
+does not select the function's phase. The remaining enum type rules stay open.
 
 A runtime function may declare persistent state, approved injected
 capabilities, lifecycle behavior, and ordered activation handlers:

--- a/language/docs/design/language-model.md
+++ b/language/docs/design/language-model.md
@@ -539,8 +539,11 @@ is `switch selector { case value: ... default: ... }`, with source-expressible
 constant case values and no implicit fallthrough. Implementation remains
 separate work. [Enum support](type-extensions.md#enum-types), including named
 member constants for cases, uses the agreed `enum Mode { first, second }`
-declaration and `Mode::first` reference form. Numbering and stringification
-are required; their detailed syntax/behaviour and enum type rules remain open.
+declaration and `Mode::first` reference form. An explicit `= constant` assigns
+an integer number; otherwise the first member starts at zero and later
+members increment the preceding number. Duplicate numbers are rejected
+initially. Stringification returns the member name without a type prefix or
+number. Conversion-call spelling and the remaining enum type rules stay open.
 
 A runtime function may declare persistent state, approved injected
 capabilities, lifecycle behavior, and ordered activation handlers:

--- a/language/docs/design/language-model.md
+++ b/language/docs/design/language-model.md
@@ -545,7 +545,11 @@ members increment the preceding number. Duplicate numbers are rejected
 initially. Stringification returns the member name without a type prefix or
 number, using the agreed `str(value)` call spelling. Constant, node-value, and
 temporal graph conversions follow the existing phase distinction; the call
-does not select the function's phase. The remaining enum type rules stay open.
+does not select the function's phase. Enums remain distinct atomic scalar
+types; integer conversion is explicit rather than implicit. Enumeration
+exposes member names through `keys`, assigned numbers through `values`, and
+typed enum instances through `elements`. Remaining conversion/enumeration
+details and native mapping stay open.
 
 A runtime function may declare persistent state, approved injected
 capabilities, lifecycle behavior, and ordered activation handlers:

--- a/language/docs/design/language-model.md
+++ b/language/docs/design/language-model.md
@@ -530,6 +530,13 @@ inside node evaluation remains ordinary runtime control flow. See
 [Conditional control flow](control-flow.md) for this agreed strategy and its
 implementation status.
 
+The agreed [explicit switch model](switch.md) follows the same phase split:
+wiring-time selection during composition, native `switch_` with branch capture
+and result analysis for a temporal graph selector, and local C++ dispatch
+inside a node. Selector suitability is checked before lowering. `default: ...`
+handles unmatched values; no match without a default fails. Full case syntax
+and implementation remain separate work.
+
 A runtime function may declare persistent state, approved injected
 capabilities, lifecycle behavior, and ordered activation handlers:
 

--- a/language/docs/design/language-model.md
+++ b/language/docs/design/language-model.md
@@ -538,8 +538,9 @@ handles unmatched values; no match without a default fails. The agreed form
 is `switch selector { case value: ... default: ... }`, with source-expressible
 constant case values and no implicit fallthrough. Implementation remains
 separate work. [Enum support](type-extensions.md#enum-types), including named
-member constants for cases, is required; its source spelling and type rules
-remain to be agreed.
+member constants for cases, uses the agreed `enum Mode { first, second }`
+declaration and `Mode::first` reference form. Numbering and stringification
+are required; their detailed syntax/behaviour and enum type rules remain open.
 
 A runtime function may declare persistent state, approved injected
 capabilities, lifecycle behavior, and ordered activation handlers:

--- a/language/docs/design/language-model.md
+++ b/language/docs/design/language-model.md
@@ -534,8 +534,12 @@ The agreed [explicit switch model](switch.md) follows the same phase split:
 wiring-time selection during composition, native `switch_` with branch capture
 and result analysis for a temporal graph selector, and local C++ dispatch
 inside a node. Selector suitability is checked before lowering. `default: ...`
-handles unmatched values; no match without a default fails. Full case syntax
-and implementation remain separate work.
+handles unmatched values; no match without a default fails. The agreed form
+is `switch selector { case value: ... default: ... }`, with source-expressible
+constant case values and no implicit fallthrough. Implementation remains
+separate work. [Enum support](type-extensions.md#enum-types), including named
+member constants for cases, is required; its source spelling and type rules
+remain to be agreed.
 
 A runtime function may declare persistent state, approved injected
 capabilities, lifecycle behavior, and ordered activation handlers:

--- a/language/docs/design/switch.md
+++ b/language/docs/design/switch.md
@@ -1,0 +1,151 @@
+# Explicit switch dispatch
+
+Status: node-style and graph-style dispatch, selector validation, branch
+capture/result analysis, and `default: ...` agreed, 2026-09-06. Full case syntax
+and compiler implementation remain separate work. No complete switch syntax
+is introduced by this record.
+
+[Worked C++ mappings](../developer-guide/control-flow-cpp-mappings.md) describe
+node and graph scenarios, captures and results, defaults and failures, sinks,
+early returns, and state lifetime without inventing the remaining HGL syntax.
+
+## One construct in both function phases
+
+Explicit `switch` must be supported in both node-style functions and graph
+composition functions. These are the existing function phases, not new
+declaration keywords. A switch does not by itself force a function to become a
+runtime node.
+
+| Context | Dispatch behaviour |
+| --- | --- |
+| Graph composition, wiring-time selector | Select and compose the matching case, or the default, during wiring. |
+| Graph composition, temporal selector | Wire native `switch_` with generated branch callables and boundary signatures. |
+| Node evaluation, including a `when` handler | Dispatch on the current readable selector value inside the node's evaluation. |
+
+Case labels are wiring-time values. One matching branch is selected; there is
+no implicit fallthrough from one case body into the next. Failing to match any
+case is the no-match situation described below, not sequential case execution.
+
+## Validate the selector before lowering
+
+Resolve the selector's type and phase before choosing a lowering. The selector
+must supply a value suitable for comparison with the case labels, rather than
+an arbitrary temporal structure or an untyped condition. It need not be a
+Boolean condition as it is for `if`.
+
+For a temporal graph switch, the selector must bind to the native `switch_`
+scalar-key input, and the case values must be compatible with the selected key
+contract. The native input is `TS<ScalarVar<K>>`; source compatibility and any
+REF binding adaptation must use the existing type and wiring rules. Wiring
+must not read the selector's current runtime payload to choose a branch.
+
+In node evaluation, the selector must be readable under the existing validity
+and access rules. SIGNAL has no selectable payload, and an opaque REF does not
+permit reading the referenced value to make a case comparison. This does not
+restrict the separately supported forwarding of REF values by a branch.
+
+The exact set of admitted scalar key types, including imported native types,
+is not fixed here. A backend's ability to emit a particular C++ statement is
+not by itself evidence that every source type has a valid switch-key contract.
+
+## Node-style lowering to C++
+
+A node-style switch must lower to native C++ dispatch within the generated
+node's evaluation code. It must not require Python execution or create a
+graph-level `switch_` merely to implement local control flow.
+
+The generated C++ may use a C++ `switch` where the admitted selector and case
+types permit that statement. For other admitted types, equivalent native C++
+comparison-based dispatch may be needed. This is a code-generation distinction,
+not an agreement to admit additional selector types or new source syntax.
+
+Branch statements operate on the current evaluation's local values and the
+enclosing node's declared state and output capabilities. Changing the selected
+case does not create or restart a child graph. State and lifecycle continue to
+belong to the enclosing node. An explicit return has the existing node-return
+meaning: produce the requested output and finish the current evaluation.
+
+## Graph-style branch signatures and results
+
+After validating the temporal selector, use the same analysis as
+[temporal `if`/`else`](control-flow.md#branch-signatures), extended across all
+cases and the optional default:
+
+1. Determine return targets, branch continuations, lexical dependencies, and
+   predeclared escaping variables. Branch-local declarations do not escape.
+2. Separate wiring-time captures from temporal inputs. Form shared temporal
+   input slots by source identity and remap each branch's captures onto them.
+   Preserve REF forwarding intent and SIGNAL input restrictions. The selector
+   is the switch key; a branch which also reads it has that lexical dependency.
+3. Derive compatible result signatures, including used expression results and
+   escaping assignments. Zero results use the native outputless switch path;
+   one result is returned directly; multiple results use a generated bundle
+   and remap to the enclosing bindings.
+4. Apply definite assignment and early-return continuation rules to every path
+   reaching a use. The default participates in the same analysis as every
+   other branch; it is not a loosely typed fallback.
+
+The exact common result-schema and per-field REF adaptation requirements from
+[forwarding an existing binding](control-flow.md#forwarding-an-existing-binding)
+also apply. Underlying type compatibility must not hide mismatched native
+bundle fields. If the public native API cannot express a required adaptation,
+the compiler must reject that lowering until the support exists.
+
+Explicit branch arguments still obey the native callable signature rules;
+forming a union of captures does not permit passing arbitrary arguments to a
+branch whose explicit signature rejects them. Reuse the native capture and
+boundary remapping machinery described in the conditional design.
+
+The native switch owns branch activation, binding, and lifetime. Computations
+wired outside the switch remain outside it. Only the selected child executes,
+and selecting a previously stopped branch creates a fresh instance under the
+existing native policy. This differs from local dispatch inside a node.
+
+## Default and no-match failure
+
+The agreed default-case fragment is:
+
+```text
+default: ...
+```
+
+The ellipsis stands for the case body in this design discussion; it is not a
+new language token. A default catches selector values that match none of the
+explicit cases. In graph composition it becomes the native `switch_` default
+branch, with the same captures, result checks, and lifecycle as other branches.
+In node-style code it becomes the native C++ dispatch fallback.
+
+If no case matches and no default was supplied, execution must fail:
+
+- For a wiring-time selector, fail when attempting that composition.
+- For a temporal graph selector, use the native switch no-match failure.
+- Inside a node, fail the current evaluation through the normal error path.
+
+Do not silently continue, keep selecting the previous branch, or synthesize a
+never-ticking result for this situation. This differs from the agreed omitted
+`else` of a value-producing temporal `if`. The rule also applies to outputless
+switches.
+
+A no-match failure path does not reach a later use of an escaping variable;
+definite assignment must check the branches that do reach that use. A supplied
+default which reaches the use must provide the required binding, either by
+assignment or by forwarding an existing incoming binding.
+
+Default is a no-match branch, not an exception handler for failures inside a
+selected case. Nor does this rule make an invalid or unreadable selector into
+a valid unmatched key: existing selector validity and access rules still apply.
+
+## Native references and remaining work
+
+The native [higher-order operator contract](../../../include/hgraph/lib/std/operators/higher_order.h)
+provides the switch key, cases, optional default, and outputless form.
+[Switch execution](../../../src/hgraph/runtime/switch_node.cpp) owns dispatch
+and lifecycle; [public-wiring tests](../../../tests/cpp/test_switch.cpp) cover
+default selection, no-match failure, outputless branches, and fresh branch
+instances on reselection.
+
+The ordinary case-label spelling, full enclosing syntax, exact admitted
+selector types, and any exposure of native reload policy remain to be agreed.
+No switch fixture is added to `language/stdlib/` until a complete example can
+use agreed syntax. This record does not add parser, IR, backend, or runtime
+implementation, and leaves the deferred `for` work untouched.

--- a/language/docs/design/switch.md
+++ b/language/docs/design/switch.md
@@ -1,13 +1,59 @@
 # Explicit switch dispatch
 
 Status: node-style and graph-style dispatch, selector validation, branch
-capture/result analysis, and `default: ...` agreed, 2026-09-06. Full case syntax
-and compiler implementation remain separate work. No complete switch syntax
-is introduced by this record.
+capture/result analysis, and `switch selector { case value: ... default: ... }`
+agreed, 2026-09-06. Case values must be expressible as constants in source.
+Compiler implementation remains separate work.
 
-[Worked C++ mappings](../developer-guide/control-flow-cpp-mappings.md) describe
-node and graph scenarios, captures and results, defaults and failures, sinks,
-early returns, and state lifetime without inventing the remaining HGL syntax.
+[Paired HGL and C++ examples](../developer-guide/control-flow-cpp-mappings.md)
+describe node and graph scenarios, captures and results, defaults and failures,
+sinks, early returns, and state lifetime. The source examples also live in the
+[standard-library design corpus](../../stdlib/examples/switch-scenarios.hgl).
+
+## Source form and constant case values
+
+```hgl
+const first_mode: i64 = 0
+const second_mode: i64 = 1
+
+fn choose(mode: i64, x: i64, y: i64, fallback: i64) -> i64 {
+    var r: i64
+    switch mode {
+        case first_mode:
+            r = x + 1
+        case second_mode:
+            r = y - 1
+        default:
+            r = fallback * 3
+    }
+
+    return r * 2
+}
+```
+
+`switch` introduces the selector and a braced set of cases. `case` introduces
+a constant value followed by `:` and its body; `default:` introduces the
+no-match body. A body ends at the next case/default label or the switch's
+closing brace. Statements retain the existing newline rules. There is no
+source `break` requirement or implicit fallthrough. An explicitly empty
+`default:` body is permitted and differs from omitting the default.
+
+Each case value must be expressible as a constant in HGL source, compatible
+with the selector's admitted key type. Literals and named constants such as
+those above use the existing constant-value rules; constant expressions must
+resolve before evaluation. A temporal input, a state read, or another
+evaluation-dependent expression cannot be a case value, even if its value
+happens not to change during a particular run. See the
+[invalid temporal-label fixture](../../stdlib/examples/invalid/switch-temporal-case.hgl).
+
+The selector is independent of this restriction: it may be wiring-time or
+temporal, according to the function phase. Constant case labels do not make
+a temporal selector a wiring-time choice.
+
+Enum types are a required addition so named enum members can be used as
+constant case values. Their declaration and member-reference syntax, type
+rules, and native mapping remain the next design discussion; see
+[enum requirements](type-extensions.md#enum-types).
 
 ## One construct in both function phases
 
@@ -22,9 +68,10 @@ runtime node.
 | Graph composition, temporal selector | Wire native `switch_` with generated branch callables and boundary signatures. |
 | Node evaluation, including a `when` handler | Dispatch on the current readable selector value inside the node's evaluation. |
 
-Case labels are wiring-time values. One matching branch is selected; there is
-no implicit fallthrough from one case body into the next. Failing to match any
-case is the no-match situation described below, not sequential case execution.
+Case labels are source-expressible constant values. One matching branch is
+selected; there is no implicit fallthrough from one case body into the next.
+Failing to match any case is the no-match situation described below, not
+sequential case execution.
 
 ## Validate the selector before lowering
 
@@ -103,14 +150,7 @@ existing native policy. This differs from local dispatch inside a node.
 
 ## Default and no-match failure
 
-The agreed default-case fragment is:
-
-```text
-default: ...
-```
-
-The ellipsis stands for the case body in this design discussion; it is not a
-new language token. A default catches selector values that match none of the
+The agreed `default:` body catches selector values that match none of the
 explicit cases. In graph composition it becomes the native `switch_` default
 branch, with the same captures, result checks, and lifecycle as other branches.
 In node-style code it becomes the native C++ dispatch fallback.
@@ -144,8 +184,9 @@ and lifecycle; [public-wiring tests](../../../tests/cpp/test_switch.cpp) cover
 default selection, no-match failure, outputless branches, and fresh branch
 instances on reselection.
 
-The ordinary case-label spelling, full enclosing syntax, exact admitted
-selector types, and any exposure of native reload policy remain to be agreed.
-No switch fixture is added to `language/stdlib/` until a complete example can
-use agreed syntax. This record does not add parser, IR, backend, or runtime
+The exact admitted selector types, enum syntax and type rules, duplicate-case
+diagnostics after constant resolution, and any exposure of native reload
+policy remain to be discussed. The agreed statement form is illustrated in
+`language/stdlib/`; a switch expression-value surface is not added by these
+examples. This record does not add parser, IR, backend, or runtime
 implementation, and leaves the deferred `for` work untouched.

--- a/language/docs/design/switch.md
+++ b/language/docs/design/switch.md
@@ -51,9 +51,10 @@ temporal, according to the function phase. Constant case labels do not make
 a temporal selector a wiring-time choice.
 
 Enum declarations and qualified member references are agreed: a member such
-as `Mode::first` can be used in `case Mode::first:`. Numbering and
-stringification are required; their detailed rules and native mapping remain
-the next design discussion. See
+as `Mode::first` can be used in `case Mode::first:`. Explicit/automatic
+numbering, member-name stringification, and initial rejection of duplicate
+enum numbers are also agreed. Conversion-call spelling and the complete
+native mapping remain open. See
 [enum requirements](type-extensions.md#enum-types).
 
 ## One construct in both function phases
@@ -185,7 +186,7 @@ and lifecycle; [public-wiring tests](../../../tests/cpp/test_switch.cpp) cover
 default selection, no-match failure, outputless branches, and fresh branch
 instances on reselection.
 
-The exact admitted selector types, enum numbering and type rules, duplicate-case
+The exact admitted selector types, remaining enum type rules, duplicate-case
 diagnostics after constant resolution, and any exposure of native reload
 policy remain to be discussed. The agreed statement form is illustrated in
 `language/stdlib/`; a switch expression-value surface is not added by these

--- a/language/docs/design/switch.md
+++ b/language/docs/design/switch.md
@@ -57,6 +57,11 @@ enum numbers are also agreed. String conversion uses `str(value)`; the complete
 native enum mapping remains open. See
 [enum requirements](type-extensions.md#enum-types).
 
+An enum selector retains its enum type: case labels must be members of that
+same enum, not integers or members of another enum with coincident numbers.
+Explicit conversion to an integer is a separate operation; numbering alone
+does not change the selector's type.
+
 ## One construct in both function phases
 
 Explicit `switch` must be supported in both node-style functions and graph

--- a/language/docs/design/switch.md
+++ b/language/docs/design/switch.md
@@ -53,8 +53,8 @@ a temporal selector a wiring-time choice.
 Enum declarations and qualified member references are agreed: a member such
 as `Mode::first` can be used in `case Mode::first:`. Explicit/automatic
 numbering, member-name stringification, and initial rejection of duplicate
-enum numbers are also agreed. Conversion-call spelling and the complete
-native mapping remain open. See
+enum numbers are also agreed. String conversion uses `str(value)`; the complete
+native enum mapping remains open. See
 [enum requirements](type-extensions.md#enum-types).
 
 ## One construct in both function phases

--- a/language/docs/design/switch.md
+++ b/language/docs/design/switch.md
@@ -50,9 +50,10 @@ The selector is independent of this restriction: it may be wiring-time or
 temporal, according to the function phase. Constant case labels do not make
 a temporal selector a wiring-time choice.
 
-Enum types are a required addition so named enum members can be used as
-constant case values. Their declaration and member-reference syntax, type
-rules, and native mapping remain the next design discussion; see
+Enum declarations and qualified member references are agreed: a member such
+as `Mode::first` can be used in `case Mode::first:`. Numbering and
+stringification are required; their detailed rules and native mapping remain
+the next design discussion. See
 [enum requirements](type-extensions.md#enum-types).
 
 ## One construct in both function phases
@@ -184,7 +185,7 @@ and lifecycle; [public-wiring tests](../../../tests/cpp/test_switch.cpp) cover
 default selection, no-match failure, outputless branches, and fresh branch
 instances on reselection.
 
-The exact admitted selector types, enum syntax and type rules, duplicate-case
+The exact admitted selector types, enum numbering and type rules, duplicate-case
 diagnostics after constant resolution, and any exposure of native reload
 policy remain to be discussed. The agreed statement form is illustrated in
 `language/stdlib/`; a switch expression-value surface is not added by these

--- a/language/docs/design/type-extensions.md
+++ b/language/docs/design/type-extensions.md
@@ -9,26 +9,48 @@ syntax.
 
 ## Enum types
 
-Status: enum declarations, qualified member references, and use of members as
-constant switch case values are agreed, 2026-09-06. Numbering and
-stringification are also required. Their detailed source rules and the
-type/native mapping remain to be agreed; compiler support is not implemented.
+Status: enum declarations, qualified member references, explicit/automatic
+numbering, member-name stringification, and rejection of duplicate numbers
+are agreed, 2026-09-06. Members are constant switch case values. Conversion-call
+spelling and the remaining type/native mapping are still open; compiler
+support is not implemented.
 
 The agreed declaration form is:
 
 ```hgl
 enum Mode {
-    first,
-    second
+    first = 10,
+    second,
+    third = 20
 }
 ```
 
 A member is referenced as `Mode::first`, including `case Mode::first:` in a
-switch. This example does not choose an automatic-numbering policy.
-Authors must also be able to specify member numbers, and enum values must be
-stringifiable. Number-assignment spelling, automatic numbering, duplicate
-numbers, conversion-call spelling, and the exact string representation remain
-the next decisions; no spelling or default for those is assumed here.
+switch. The declaration resolves `first` to `10`, `second` to `11`, and `third`
+to `20`.
+
+The numbering rules are:
+
+- `member = constant` assigns an explicit integer constant value.
+- An unnumbered first member starts at zero.
+- Every later unnumbered member takes the immediately preceding member's
+  resolved number plus one. Explicit assignments therefore reset the next
+  automatic number; numbering does not depend on the largest number used.
+- Duplicate resolved numbers within one enum are rejected initially, whether
+  the collision comes from explicit or automatic numbering. Numeric aliases
+  are not admitted in this first design.
+
+Stringification returns the declared member name without a type prefix or
+numeric value: `Mode::first` becomes `"first"`, `Mode::second` becomes
+`"second"`, and `Mode::third` becomes `"third"`. Rejecting numeric aliases keeps
+that name unambiguous within an enum. The spelling of the source conversion
+call is not yet chosen; no `str(...)` or other new call syntax is introduced
+by this rule.
+
+[Numbered source examples and C++ mappings](../developer-guide/enum-cpp-mappings.md)
+show explicit values, automatic values starting at zero, stringification,
+and duplicate-number errors. The positive and intentionally invalid HGL
+declarations are also in the [standard-library design corpus](../../stdlib/README.md#enum-values).
 
 Enums should let source give names to the values used by a selector and its
 cases, rather than relying on unexplained integers or strings. Their members
@@ -39,16 +61,15 @@ node dispatch and temporal graph switching still follow the selector's phase.
 
 The next design discussion needs to settle:
 
-- explicit numbering syntax, the integer range, automatic numbering for
-  unnumbered members, and overflow handling;
-- stringification spelling and output, including treatment of aliases and
-  values not associated with a declared member;
+- the integer range and overflow handling for explicit and automatic numbers;
+- string-conversion call spelling and treatment of values not associated
+  with a declared member;
 - type identity, backing values, and whether conversion to or from other
   scalar types is permitted;
 - temporal use and wiring-time use under the existing type mechanism;
 - exposure of native C++ and Python enums without losing their type identity;
-- equality and the native switch-key contract, including duplicate member
-  values and duplicate case labels;
+- equality and the native switch-key contract, including duplicate case labels
+  (distinct from duplicate numbers in an enum declaration);
 - whether checking all members can establish exhaustiveness. The existing
   no-match failure rule still applies when dispatch finds no case or default.
 
@@ -58,10 +79,12 @@ accepts an ordered member-name/assigned-integer table. Its
 currently stringify a known number using its member name, and fall back to
 numeric text for an unknown number. This is native implementation context,
 not an agreement that HGL admits unknown enum values or must use that fallback.
+HGL must reject duplicate member numbers before registering the table; native
+registration is not a substitute for that source check.
 
 No implicit integer conversion, flag-enum behaviour, or exhaustiveness
-exemption is introduced by this agreement. Numbered and stringification
-examples will be added after their source forms and behaviour are agreed.
+exemption is introduced by this agreement. Enum declarations and these design
+fixtures remain outside the implemented compiler surface.
 
 ## Imported types are atomic values
 

--- a/language/docs/design/type-extensions.md
+++ b/language/docs/design/type-extensions.md
@@ -96,12 +96,18 @@ Enums expose three enumeration operations:
 | `values` | Assigned integer values, not ordinal positions | `10`, `11`, `20` |
 | `elements` | Enum instances retaining their enum type | `Mode::first`, `Mode::second`, `Mode::third` |
 
-The table lists corresponding members in source order only to illustrate the
-three views; enumeration ordering is not yet a language guarantee. The
-operation names and element meanings are agreed. Exact invocation syntax,
-the returned collection/iterator shape, and its integration with iteration
-remain to be settled before adding HGL enumeration fixtures. This agreement
-does not introduce a new dynamic `for` lowering.
+All three views iterate in declaration order, not numeric or alphabetical
+order. Explicit numbering does not reorder members. The views remain aligned:
+each position exposes the name, assigned number, or typed instance of the same
+declared member. The [out-of-order numbering example](../developer-guide/enum-cpp-mappings.md#declaration-order-enumeration)
+makes this distinction explicit.
+
+`elements` is also the agreed element-iteration spelling for lists and sets;
+see [collection iteration](iteration.md#elements-for-lists-and-sets). This does
+not add `elements` for maps or bundles. Exact enum invocation syntax and the
+returned collection/iterator shape remain to be settled before adding enum
+enumeration calls to HGL fixtures. This agreement does not introduce a new
+dynamic `for` lowering.
 
 ### Remaining enum decisions
 
@@ -111,8 +117,7 @@ The next design discussion needs to settle:
 - treatment of values not associated with a declared member;
 - the exact integer conversion spelling and conversion from integers or
   strings to enum values;
-- enumeration invocation syntax, ordering, and result collection/iterator
-  types;
+- enum enumeration invocation syntax and result collection/iterator types;
 - temporal use and wiring-time use under the existing type mechanism;
 - exposure of native C++ and Python enums without losing their type identity;
 - the native switch-key contract, including duplicate case labels

--- a/language/docs/design/type-extensions.md
+++ b/language/docs/design/type-extensions.md
@@ -1,4 +1,4 @@
-# Imported values, reference types, and SIGNAL inputs
+# Imported values, reference types, SIGNAL inputs, and enums
 
 Status: agreed source semantics, 2026-09-05; explicit `ref<T>` parsing, type
 checking, metadata, descriptors, and generated reference-routing nodes are
@@ -6,6 +6,35 @@ implemented. Wiring-time access through a reference and imported native types
 remain compiler work. The collection-reference mapping noted below and SIGNAL
 spelling still need clarification. This record introduces no native declaration
 syntax.
+
+## Enum types
+
+Status: enum support and use of enum members as constant switch case values
+are required, agreed 2026-09-06. Declaration syntax, member-reference syntax,
+and the detailed type/native mapping are not yet agreed or implemented.
+
+Enums should let source give names to the values used by a selector and its
+cases, rather than relying on unexplained integers or strings. Their members
+must be usable as source constants under the
+[switch case-value rule](switch.md#source-form-and-constant-case-values).
+Using a named member as a case label does not make the selector wiring-time;
+node dispatch and temporal graph switching still follow the selector's phase.
+
+The next design discussion needs to settle:
+
+- declaration and member-reference spelling;
+- type identity, backing values, and whether conversion to or from other
+  scalar types is permitted;
+- temporal use and wiring-time use under the existing type mechanism;
+- exposure of native C++ and Python enums without losing their type identity;
+- equality and the native switch-key contract, including duplicate member
+  values and duplicate case labels;
+- whether checking all members can establish exhaustiveness. The existing
+  no-match failure rule still applies when dispatch finds no case or default.
+
+No enum syntax, implicit integer representation, flag-enum behaviour, or
+exhaustiveness exemption is introduced by this requirement. Enum examples
+will be added once their source form is agreed.
 
 ## Imported types are atomic values
 

--- a/language/docs/design/type-extensions.md
+++ b/language/docs/design/type-extensions.md
@@ -11,9 +11,9 @@ syntax.
 
 Status: enum declarations, qualified member references, explicit/automatic
 numbering, member-name stringification, and rejection of duplicate numbers
-are agreed, 2026-09-06. Members are constant switch case values. Conversion-call
-spelling and the remaining type/native mapping are still open; compiler
-support is not implemented.
+are agreed, 2026-09-06. Members are constant switch case values. String
+conversion uses the agreed Python-style `str(value)` spelling. The remaining
+type/native mapping is still open; compiler support is not implemented.
 
 The agreed declaration form is:
 
@@ -43,9 +43,19 @@ The numbering rules are:
 Stringification returns the declared member name without a type prefix or
 numeric value: `Mode::first` becomes `"first"`, `Mode::second` becomes
 `"second"`, and `Mode::third` becomes `"third"`. Rejecting numeric aliases keeps
-that name unambiguous within an enum. The spelling of the source conversion
-call is not yet chosen; no `str(...)` or other new call syntax is introduced
-by this rule.
+that name unambiguous within an enum. The source call uses Python-style
+`str(value)`:
+
+```hgl
+const first_mode_name: str = str(Mode::first)
+```
+
+This produces the constant string `"first"`. The spelling follows Python;
+it does not change the agreed enum representation to Python's qualified enum
+display or require Python execution. `str` remains the string type name in
+type positions and is the conversion operation in this expression position.
+See [string conversion](../user-guide/types-and-expressions.md#string-conversion)
+for constant, node, and temporal graph use.
 
 [Numbered source examples and C++ mappings](../developer-guide/enum-cpp-mappings.md)
 show explicit values, automatic values starting at zero, stringification,
@@ -62,8 +72,7 @@ node dispatch and temporal graph switching still follow the selector's phase.
 The next design discussion needs to settle:
 
 - the integer range and overflow handling for explicit and automatic numbers;
-- string-conversion call spelling and treatment of values not associated
-  with a declared member;
+- treatment of values not associated with a declared member;
 - type identity, backing values, and whether conversion to or from other
   scalar types is permitted;
 - temporal use and wiring-time use under the existing type mechanism;

--- a/language/docs/design/type-extensions.md
+++ b/language/docs/design/type-extensions.md
@@ -9,9 +9,26 @@ syntax.
 
 ## Enum types
 
-Status: enum support and use of enum members as constant switch case values
-are required, agreed 2026-09-06. Declaration syntax, member-reference syntax,
-and the detailed type/native mapping are not yet agreed or implemented.
+Status: enum declarations, qualified member references, and use of members as
+constant switch case values are agreed, 2026-09-06. Numbering and
+stringification are also required. Their detailed source rules and the
+type/native mapping remain to be agreed; compiler support is not implemented.
+
+The agreed declaration form is:
+
+```hgl
+enum Mode {
+    first,
+    second
+}
+```
+
+A member is referenced as `Mode::first`, including `case Mode::first:` in a
+switch. This example does not choose an automatic-numbering policy.
+Authors must also be able to specify member numbers, and enum values must be
+stringifiable. Number-assignment spelling, automatic numbering, duplicate
+numbers, conversion-call spelling, and the exact string representation remain
+the next decisions; no spelling or default for those is assumed here.
 
 Enums should let source give names to the values used by a selector and its
 cases, rather than relying on unexplained integers or strings. Their members
@@ -22,7 +39,10 @@ node dispatch and temporal graph switching still follow the selector's phase.
 
 The next design discussion needs to settle:
 
-- declaration and member-reference spelling;
+- explicit numbering syntax, the integer range, automatic numbering for
+  unnumbered members, and overflow handling;
+- stringification spelling and output, including treatment of aliases and
+  values not associated with a declared member;
 - type identity, backing values, and whether conversion to or from other
   scalar types is permitted;
 - temporal use and wiring-time use under the existing type mechanism;
@@ -32,9 +52,16 @@ The next design discussion needs to settle:
 - whether checking all members can establish exhaustiveness. The existing
   no-match failure rule still applies when dispatch finds no case or default.
 
-No enum syntax, implicit integer representation, flag-enum behaviour, or
-exhaustiveness exemption is introduced by this requirement. Enum examples
-will be added once their source form is agreed.
+The existing native [enum registration contract](../../../include/hgraph/types/metadata/type_registry.h)
+accepts an ordered member-name/assigned-integer table. Its
+[enum value operations](../../../src/hgraph/types/metadata/type_registry.cpp)
+currently stringify a known number using its member name, and fall back to
+numeric text for an unknown number. This is native implementation context,
+not an agreement that HGL admits unknown enum values or must use that fallback.
+
+No implicit integer conversion, flag-enum behaviour, or exhaustiveness
+exemption is introduced by this agreement. Numbered and stringification
+examples will be added after their source forms and behaviour are agreed.
 
 ## Imported types are atomic values
 

--- a/language/docs/design/type-extensions.md
+++ b/language/docs/design/type-extensions.md
@@ -10,10 +10,12 @@ syntax.
 ## Enum types
 
 Status: enum declarations, qualified member references, explicit/automatic
-numbering, member-name stringification, and rejection of duplicate numbers
-are agreed, 2026-09-06. Members are constant switch case values. String
-conversion uses the agreed Python-style `str(value)` spelling. The remaining
-type/native mapping is still open; compiler support is not implemented.
+numbering, member-name stringification, rejection of duplicate numbers,
+distinct enum identity, explicit integer conversion, and the `keys`, `values`,
+and `elements` enumeration meanings are agreed, 2026-09-06. Members are
+constant switch case values. String conversion uses the agreed Python-style
+`str(value)` spelling. Remaining conversion/enumeration details and native
+mapping are still open; compiler support is not implemented.
 
 The agreed declaration form is:
 
@@ -69,15 +71,51 @@ must be usable as source constants under the
 Using a named member as a case label does not make the selector wiring-time;
 node dispatch and temporal graph switching still follow the selector's phase.
 
+### Enum identity and explicit conversion
+
+An enum remains a distinct atomic scalar type, not an integer alias. Its
+members retain that enum's identity even when another enum uses the same
+names or assigned numbers. There is no implicit conversion to an integer or
+to another enum. Equality and switch matching therefore require the same
+enum type; an integer case label is not a substitute for an enum member.
+
+Obtaining the assigned integer is an explicit conversion, using a type-name
+call in the same style as `str(value)`. For example, converting `Mode::first`
+to an integer produces `10`, while string conversion produces `"first"`.
+The precise integer conversion spelling needs confirmation before adding a
+source example. This does not authorize implicit arithmetic or decide how
+to construct an enum from an integer or string.
+
+### Enumerating members
+
+Enums expose three enumeration operations:
+
+| Operation | Values exposed | Example members of `Mode` |
+| --- | --- | --- |
+| `keys` | Member names as `str` values, as returned by `str` on each member | `"first"`, `"second"`, `"third"` |
+| `values` | Assigned integer values, not ordinal positions | `10`, `11`, `20` |
+| `elements` | Enum instances retaining their enum type | `Mode::first`, `Mode::second`, `Mode::third` |
+
+The table lists corresponding members in source order only to illustrate the
+three views; enumeration ordering is not yet a language guarantee. The
+operation names and element meanings are agreed. Exact invocation syntax,
+the returned collection/iterator shape, and its integration with iteration
+remain to be settled before adding HGL enumeration fixtures. This agreement
+does not introduce a new dynamic `for` lowering.
+
+### Remaining enum decisions
+
 The next design discussion needs to settle:
 
 - the integer range and overflow handling for explicit and automatic numbers;
 - treatment of values not associated with a declared member;
-- type identity, backing values, and whether conversion to or from other
-  scalar types is permitted;
+- the exact integer conversion spelling and conversion from integers or
+  strings to enum values;
+- enumeration invocation syntax, ordering, and result collection/iterator
+  types;
 - temporal use and wiring-time use under the existing type mechanism;
 - exposure of native C++ and Python enums without losing their type identity;
-- equality and the native switch-key contract, including duplicate case labels
+- the native switch-key contract, including duplicate case labels
   (distinct from duplicate numbers in an enum declaration);
 - whether checking all members can establish exhaustiveness. The existing
   no-match failure rule still applies when dispatch finds no case or default.

--- a/language/docs/developer-guide/README.md
+++ b/language/docs/developer-guide/README.md
@@ -60,6 +60,10 @@ for hgraph, not a second runtime.
 3. [Testing and compatibility](testing-and-compatibility.md) defines syntax,
    type-shape, classification, harness, generated-code, installed-SDK, and
    backend-parity acceptance.
+4. [Control-flow scenarios and C++ mappings](control-flow-cpp-mappings.md)
+   explains the expected node and graph lowerings for the agreed switch and
+   conditional-result scenarios. These are reference mappings, not claims of
+   implemented HGL switch support.
 
 The design records provide project boundaries and rationale:
 

--- a/language/docs/developer-guide/README.md
+++ b/language/docs/developer-guide/README.md
@@ -61,9 +61,9 @@ for hgraph, not a second runtime.
    type-shape, classification, harness, generated-code, installed-SDK, and
    backend-parity acceptance.
 4. [Control-flow scenarios and C++ mappings](control-flow-cpp-mappings.md)
-   explains the expected node and graph lowerings for the agreed switch and
-   conditional-result scenarios. These are reference mappings, not claims of
-   implemented HGL switch support.
+   pairs HGL source with the expected node and graph lowerings for the agreed
+   switch and conditional-result scenarios. These are reference mappings,
+   not claims of implemented HGL switch support.
 
 The design records provide project boundaries and rationale:
 

--- a/language/docs/developer-guide/README.md
+++ b/language/docs/developer-guide/README.md
@@ -66,8 +66,9 @@ for hgraph, not a second runtime.
    not claims of implemented HGL switch support.
 5. [Enum source and C++ mappings](enum-cpp-mappings.md) pairs numbered HGL
    declarations with illustrative C++ values and member-name strings, and
-   records explicit and automatic duplicate-number errors. These remain
-   design fixtures, not implemented HGL enum support.
+   records explicit and automatic duplicate-number errors. It also maps
+   `str(value)` in constants, node evaluation, and temporal graph composition.
+   These remain design fixtures, not implemented HGL enum/conversion support.
 
 The design records provide project boundaries and rationale:
 

--- a/language/docs/developer-guide/README.md
+++ b/language/docs/developer-guide/README.md
@@ -64,6 +64,10 @@ for hgraph, not a second runtime.
    pairs HGL source with the expected node and graph lowerings for the agreed
    switch and conditional-result scenarios. These are reference mappings,
    not claims of implemented HGL switch support.
+5. [Enum source and C++ mappings](enum-cpp-mappings.md) pairs numbered HGL
+   declarations with illustrative C++ values and member-name strings, and
+   records explicit and automatic duplicate-number errors. These remain
+   design fixtures, not implemented HGL enum support.
 
 The design records provide project boundaries and rationale:
 

--- a/language/docs/developer-guide/README.md
+++ b/language/docs/developer-guide/README.md
@@ -67,7 +67,8 @@ for hgraph, not a second runtime.
 5. [Enum source and C++ mappings](enum-cpp-mappings.md) pairs numbered HGL
    declarations with illustrative C++ values and member-name strings, and
    records explicit and automatic duplicate-number errors. It also maps
-   `str(value)` in constants, node evaluation, and temporal graph composition.
+   `str(value)` in constants, node evaluation, and temporal graph composition,
+   and shows declaration-order enumeration with non-monotonic member numbers.
    These remain design fixtures, not implemented HGL enum/conversion support.
 
 The design records provide project boundaries and rationale:
@@ -137,7 +138,8 @@ surface.
 - Source does not expose endpoint `.value`, `.valid`, or `.modified` members.
 - Runtime collection traversal uses `keys`, `values`, and `items` with optional
   built-in, named, or inline predicates; its borrowed iterators cannot escape an
-  evaluation.
+  evaluation. The agreed list/set spelling is now `elements`, awaiting compiler
+  migration from the currently implemented `values` spelling.
 - Selective imports establish the unqualified operator names an `impl fn` may
   bind to; module aliases provide qualified names such as `mm::my_op` without
   binding implementations.

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -960,6 +960,17 @@ The iterator type is compiler-internal. It is valid only as the source of a
 `for` loop and has no scalar schema, time-series schema, state representation,
 or callable ABI.
 
+The agreed source spelling for list/set element traversal is now `elements`,
+superseding the earlier no-`elements` rule. The compiler still recognizes
+`values` for those structures; migration must preserve the existing iteration
+plan, child/membership provenance, predicates, and phase restrictions. Native
+method names need not change to match HGL spelling. For example, the target
+node-time mappings are `elements(tsl)` to `tsl.values()` and
+`elements(tss, added)` to the typed TSS input's `added()` range. See the
+[paired HGL/C++ examples](../design/iteration.md). Whether source `values`
+remains a list/set compatibility alias is unresolved. Map/bundle traversal is
+unchanged, and graph-phase set traversal remains unsupported.
+
 Recognized metadata predicates select the matching public native range
 directly. This includes the delta predicates and other filters such as
 `valid`. For example:

--- a/language/docs/developer-guide/control-flow-cpp-mappings.md
+++ b/language/docs/developer-guide/control-flow-cpp-mappings.md
@@ -7,8 +7,9 @@ the agreed `switch selector { case value: ... default: ... }` form, followed
 by its C++ mapping and behaviour. Case labels are source-expressible constants.
 The same HGL functions are collected in
 [switch-scenarios.hgl](../../stdlib/examples/switch-scenarios.hgl); they are
-design fixtures, not passing compiler tests. Enum declaration/member syntax
-remains open, so these examples use `i64` selectors and integer constants.
+design fixtures, not passing compiler tests. These examples use `i64` selectors
+and integer constants; [enum numbering and stringification](../design/type-extensions.md#enum-types)
+remain a separate design step after the agreed enum declaration/member form.
 
 These are reference fragments, not standalone hgraph applications. The native
 examples share the following preamble and assume standard operators have been
@@ -564,8 +565,9 @@ not a separate HGL default-state policy.
 
 These mappings pair agreed HGL source with the expected native execution and
 wiring shapes. They do not change the parser or backend, or settle graph-loop
-predicates or reductions. Enum syntax, the full native selector-type coverage,
-and any HGL spelling for reload policy remain open.
+predicates or reductions. Enum numbering/stringification details, the full
+native selector-type coverage, and any HGL spelling for reload policy remain
+open.
 
 The standalone payload functions can be compiled and exercised without hgraph.
 The node/graph fragments use the public C++ authoring surface and can be

--- a/language/docs/developer-guide/control-flow-cpp-mappings.md
+++ b/language/docs/developer-guide/control-flow-cpp-mappings.md
@@ -1,0 +1,390 @@
+# Control-flow scenarios and C++ mappings
+
+Status: worked mappings of the agreed [switch contract](../design/switch.md)
+and [conditional result rules](../design/control-flow.md), not output from an
+implemented HGL switch compiler. The ordinary HGL case spelling is still open.
+Scenarios therefore describe cases in prose and tables; the `case` and
+`default` labels inside the C++ blocks below are **C++ syntax**, not a proposal
+for HGL syntax. HGL's agreed default fragment remains `default: ...`.
+
+These are reference fragments, not standalone hgraph applications. The native
+examples share the following preamble and assume standard operators have been
+registered before wiring. They omit module registration, sources, sinks used
+only to collect test results, and the evaluation harness:
+
+```cpp
+#include <hgraph/lib/std/std_operators.h>
+#include <hgraph/types/graph_wiring.h>
+#include <hgraph/types/static_node.h>
+#include <hgraph/types/wired_fn.h>
+
+#include <cstdint>
+#include <stdexcept>
+
+using namespace hgraph;
+```
+
+Generated code must additionally preserve source activation, validity, error
+reporting, and source locations. The examples use small integer values to
+avoid making decisions about unresolved arithmetic-overflow semantics. They
+illustrate integer selectors, not an exhaustive selector-type admission rule.
+
+## Scenario 1: a node computes a result and uses it later
+
+The node has readable inputs `mode`, `x`, `y`, and `fallback`. For this scenario
+all four must be valid, and any input tick may activate the evaluation. The
+selected case assigns an evaluation-local `r`; the function then returns
+`r * 2`:
+
+| Selector | Assignment to `r` | Result when `x = 10`, `y = 20`, `fallback = 7` |
+| --- | --- | --- |
+| `0` | `x + 1` | `22` |
+| `1` | `y - 1` | `38` |
+| Any other valid value, via default | `fallback * 3` | `42` |
+
+The payload calculation has this ordinary C++ mapping:
+
+```cpp
+std::int64_t choose_payload(std::int64_t mode, std::int64_t x,
+                            std::int64_t y, std::int64_t fallback)
+{
+    std::int64_t r;
+    switch (mode) {
+    case 0:
+        r = x + 1;
+        break;
+    case 1:
+        r = y - 1;
+        break;
+    default:
+        r = fallback * 3;
+        break;
+    }
+    return r * 2;
+}
+```
+
+The corresponding native node boundary is:
+
+```cpp
+struct LocalSwitchExample
+{
+    static constexpr auto name = "local_switch_example";
+
+    static void eval(In<"mode", TS<Int>> mode,
+                     In<"x", TS<Int>> x,
+                     In<"y", TS<Int>> y,
+                     In<"fallback", TS<Int>> fallback,
+                     Out<TS<Int>> out)
+    {
+        out.set(choose_payload(mode.value(), x.value(), y.value(),
+                               fallback.value()));
+    }
+};
+```
+
+This all-valid example deliberately reads all arguments. It is not a template
+for a source handler that permits inactive-case inputs to be invalid: that
+handler requires selective validity guards and reads inside the selected
+branch. There is one node evaluation and one output write here. No nested
+graph is created, and changing `mode` does not restart node-owned state.
+
+## Scenario 2: a missing default must fail in node code
+
+Now remove the source default. The generated C++ still needs an error path:
+
+```cpp
+std::int64_t choose_payload_required(std::int64_t mode, std::int64_t x,
+                                     std::int64_t y)
+{
+    std::int64_t r;
+    switch (mode) {
+    case 0:
+        r = x + 1;
+        break;
+    case 1:
+        r = y - 1;
+        break;
+    default:
+        throw std::runtime_error("unmatched switch selector");
+    }
+    return r * 2;
+}
+```
+
+The C++ `default` above implements the mandatory failure for an absent HGL
+default; it does not invent a user-supplied branch. Selector `99` must fail
+before writing an output or reading an unassigned `r`. Exact exception text and
+generated diagnostic plumbing are implementation details. Normal evaluation
+error handling remains responsible for propagation or capture of that failure.
+
+## Scenario 3: a wiring-time selector chooses topology
+
+Use Scenario 1's cases, but make `mode` a wiring-time scalar and the remaining
+inputs temporal. The following C++ branch graphs will also be used by the
+temporal-switch example. Each returns only the case's `r` connection:
+
+```cpp
+struct CaseZeroExample
+{
+    static constexpr auto name = "case_zero_example";
+    static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>> x,
+                                 Port<TS<Int>>, Port<TS<Int>>)
+    {
+        return wire<stdlib::add_>(w, x, Int{1}).as<TS<Int>>();
+    }
+};
+
+struct CaseOneExample
+{
+    static constexpr auto name = "case_one_example";
+    static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>>,
+                                 Port<TS<Int>> y, Port<TS<Int>>)
+    {
+        return wire<stdlib::sub_>(w, y, Int{1}).as<TS<Int>>();
+    }
+};
+
+struct CaseDefaultExample
+{
+    static constexpr auto name = "case_default_example";
+    static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>>,
+                                 Port<TS<Int>>, Port<TS<Int>> fallback)
+    {
+        return wire<stdlib::mul_>(w, fallback, Int{3}).as<TS<Int>>();
+    }
+};
+
+struct WiringTimeSwitchExample
+{
+    static constexpr auto name = "wiring_time_switch_example";
+    static Port<TS<Int>> compose(Wiring &w, Scalar<"mode", Int> mode,
+                                 Port<TS<Int>> x, Port<TS<Int>> y,
+                                 Port<TS<Int>> fallback)
+    {
+        auto r = [&]() -> Port<TS<Int>> {
+            switch (mode.value()) {
+            case 0:
+                return wire<CaseZeroExample>(w, x, y, fallback);
+            case 1:
+                return wire<CaseOneExample>(w, x, y, fallback);
+            default:
+                return wire<CaseDefaultExample>(w, x, y, fallback);
+            }
+        }();
+        return wire<stdlib::mul_>(w, r, Int{2}).as<TS<Int>>();
+    }
+};
+```
+
+The local C++ lambda executes once during composition. With `mode = 0`, only
+the `x + 1` case and the subsequent multiplication are wired. Later value
+ticks do not revisit the scalar switch. If the source had no default, the
+unmatched C++ path would throw during wiring instead of composing
+`CaseDefaultExample`.
+
+## Scenario 4: a temporal selector creates native switch branches
+
+Now `mode` is temporal. Reuse the three case graphs, but compose a native
+switch instead of executing a C++ switch on the current payload:
+
+```cpp
+struct TemporalSwitchExample
+{
+    static constexpr auto name = "temporal_switch_example";
+    static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>> mode,
+                                 Port<TS<Int>> x, Port<TS<Int>> y,
+                                 Port<TS<Int>> fallback)
+    {
+        auto r = wire<stdlib::switch_>(
+            w, mode,
+            stdlib::switch_cases(
+                {{Value{Int{0}}, fn<CaseZeroExample>()},
+                 {Value{Int{1}}, fn<CaseOneExample>()}},
+                fn<CaseDefaultExample>()),
+            x, y, fallback).as<TS<Int>>();
+        return wire<stdlib::mul_>(w, r, Int{2}).as<TS<Int>>();
+    }
+};
+```
+
+`r` is the switch output connection. The final multiplication is wired outside
+the switch. It is not duplicated inside each branch, and `mode` is never read
+as a runtime payload during composition.
+
+The source-level captures are different even though the illustrative C++
+wrappers deliberately accept the same explicit argument list:
+
+| Branch | Temporal captures actually used | Result connection |
+| --- | --- | --- |
+| `0` | `x` | `x + 1` |
+| `1` | `y` | `y - 1` |
+| Default | `fallback` | `fallback * 3` |
+
+The outer temporal slots are `mode`, `x`, `y`, and `fallback`. Literal scalar
+configuration such as `1` and `3` belongs to branch composition, not to the
+outer capture list. The selector itself is not a branch capture here because
+none of the bodies reads it.
+
+These uniform wrappers satisfy native explicit-argument arity. A compiler may
+instead use the existing captured-input boundary remapping to preserve smaller
+branch interfaces. It must not pass the union of arguments to unequal explicit
+signatures and assume the native binder discards the extras. Unused slots must
+not acquire payload reads or extra validity requirements merely because the
+outer switch carries them.
+
+For valid source values, selecting modes `0`, `1`, and `99` yields the numerical
+results in Scenario 1, now through different live child graphs. While mode
+`0` stays selected, ticks of `x` can update the result without a new mode tick.
+Work used only by inactive branches does not become active case work.
+
+Without a source default, omit the default callable from `switch_cases`.
+An unmatched temporal key then fails through native switch execution, as
+covered by `switch_: an unmatched key with no default branch is a runtime
+error` in [test_switch.cpp](../../../tests/cpp/test_switch.cpp). This is not the
+never-ticking false branch of a value-producing temporal `if` without `else`.
+
+## Scenario 5: multiple results and pure forwarding
+
+Consider a predeclared `r` and `adjustment`, both used after the switch. One
+case computes `r` and forwards an existing `adjustment`; another computes both;
+the default forwards their incoming bindings. This uses the same output
+analysis as the agreed [multiple-result conditional](../design/control-flow.md#multiple-escaping-variables).
+
+For two ordinary `i64` result slots, the generated common native shape is:
+
+```cpp
+using OrdinarySwitchResults = UnNamedTSB<
+    Field<"r", TS<Int>>,
+    Field<"adjustment", TS<Int>>>;
+```
+
+This is a schema illustration; field names are internal, not reserved source
+names. Each branch must return this same field-level schema. A pure-forwarding
+input capture may be `REF<TS<Int>>`, but packing it into an ordinary `TS<Int>`
+result slot requires native binding adaptation at the branch-output boundary.
+If the author explicitly declares a reference result, that slot instead stays
+`REF<TS<Int>>`. Do not copy payloads merely to discard the reference intent or
+pretend that REF-transparent compatibility makes unlike native bundle schemas
+identical.
+
+After the switch, the outer bindings refer to the respective bundle-field
+connections; subsequent C++ wiring consumes those projections. They are not a
+simultaneous scalar snapshot. If the public native boundary cannot express a
+required per-field adaptation, reject that HGL lowering until support exists;
+this sketch does not assert that every such product is implemented today.
+
+If a branch reaches later code without supplying one of these bindings and
+there is no incoming binding to forward, reject it for definite assignment.
+An unmatched selector without a default takes the failure path instead and
+does not reach that later use.
+
+## Scenario 6: an early return changes the continuation boundary
+
+Suppose case `0` returns `x + 1` from the enclosing graph function. Case `1`
+assigns `r = y - 1`, and the default assigns `r = fallback * 3`. The statements
+after the switch return `r * 2`.
+
+| Generated C++ branch | Captures | Child output |
+| --- | --- | --- |
+| `0` | `x` | Connection for `x + 1`; no continuation multiplication. |
+| `1` | `y` | Connection for `(y - 1) * 2`, including the continuation. |
+| Default | `fallback` | Connection for `(fallback * 3) * 2`, including the continuation. |
+
+The parent C++ graph returns the native switch output directly. Unlike
+Scenario 4, placing one multiplication after that switch would be wrong: it
+would also multiply case `0`'s early-return result. Nodes and sinks belonging
+to the continuation must therefore be compiled into the non-returning case
+graphs. Any producer wired before the switch remains outside them.
+
+Inside a node, the equivalent C++ uses a direct return from the current
+evaluation path. It does not transform the remaining statements into nested
+graphs. See [early returns](../design/control-flow.md#early-returns-and-continuations).
+
+## Scenario 7: conditional sinks and an unconditional sink
+
+Mode `0` enables a debug sink; the explicit default does nothing. An additional
+debug sink after the switch is always wired:
+
+```cpp
+struct SelectedSinkExample
+{
+    static constexpr auto name = "selected_sink_example";
+    static void compose(Wiring &w, Port<TS<Int>> value)
+    {
+        wire<stdlib::debug_print>(w, Str{"selected"}, value);
+    }
+};
+
+struct EmptySinkExample
+{
+    static constexpr auto name = "empty_sink_example";
+    static void compose(Wiring &, Port<TS<Int>>) {}
+};
+
+struct SinkSwitchExample
+{
+    static constexpr auto name = "sink_switch_example";
+    static void compose(Wiring &w, Port<TS<Int>> mode, Port<TS<Int>> value)
+    {
+        wire<stdlib::switch_sink_>(
+            w, mode,
+            stdlib::switch_cases(
+                {{Value{Int{0}}, fn<SelectedSinkExample>()}},
+                fn<EmptySinkExample>()),
+            value);
+        wire<stdlib::debug_print>(w, Str{"always"}, value);
+    }
+};
+```
+
+The label comes before the time series. The default child is empty because
+the scenario explicitly supplies an empty default, not because a missing
+default is silently filled in. Without that default, an unmatched key must
+fail even though the switch has no output. Logging itself happens in sink
+evaluation, never by printing the current payload in `compose`.
+
+## Scenario 8: state across case changes
+
+Assume each selected case increments its own counter on a valid data tick,
+with a data tick on every row below. In a node, the two counters belong to the
+enclosing node's recordable state and increment only in their selected case.
+In the graph variant, each selected branch owns a counter node and the normal
+switch policy is used, without reload-on-every-selector-tick:
+
+| Selected case | Node-owned selected counter | Graph branch's counter |
+| --- | --- | --- |
+| `0` | `1` | `1` |
+| `0` again | `2` | `2` |
+| `1` | `1` | `1` |
+| `0` again | `3` | `1` |
+
+Local C++ dispatch preserves the enclosing node's two counters. Native
+`switch_` stops the old child and later starts a fresh instance when returning
+to case `0`. It does not suspend and resume that child's counter. The native
+test `switch_: switching back reuses the old slot with a fresh branch graph`
+in [test_switch.cpp](../../../tests/cpp/test_switch.cpp) pins this restart rule.
+The same distinction applies to default-branch state.
+
+The native policy compares selector values, not just the selected callable.
+For example, changing from unmatched key `99` to unmatched key `100` starts a
+fresh default child even though both keys select the same default function.
+Repeating the same unmatched key does not itself request a reload. This follows
+the key comparison in [switch execution](../../../src/hgraph/runtime/switch_node.cpp),
+not a separate HGL default-state policy.
+
+## Scope and validation boundary
+
+These mappings describe the expected native execution and wiring shapes. They
+do not add HGL case syntax, change the parser or backend, or settle graph-loop
+predicates or reductions. The full native selector-type coverage and any HGL
+spelling for reload policy remain open.
+
+The standalone payload functions can be compiled and exercised without hgraph.
+The node/graph fragments use the public C++ authoring surface and can be
+syntax-checked together with the preamble. A syntax check is not a graph
+execution test, an installed-SDK acceptance run, or proof of HGL compiler
+support. Runtime wiring/lifetime references are
+[native switch tests](../../../tests/cpp/test_switch.cpp),
+[static node tests](../../../tests/cpp/test_static_node.cpp), and
+[graph wiring tests](../../../tests/cpp/test_graph_wiring.cpp).

--- a/language/docs/developer-guide/control-flow-cpp-mappings.md
+++ b/language/docs/developer-guide/control-flow-cpp-mappings.md
@@ -2,10 +2,13 @@
 
 Status: worked mappings of the agreed [switch contract](../design/switch.md)
 and [conditional result rules](../design/control-flow.md), not output from an
-implemented HGL switch compiler. The ordinary HGL case spelling is still open.
-Scenarios therefore describe cases in prose and tables; the `case` and
-`default` labels inside the C++ blocks below are **C++ syntax**, not a proposal
-for HGL syntax. HGL's agreed default fragment remains `default: ...`.
+implemented HGL switch compiler. Each scenario starts with HGL source using
+the agreed `switch selector { case value: ... default: ... }` form, followed
+by its C++ mapping and behaviour. Case labels are source-expressible constants.
+The same HGL functions are collected in
+[switch-scenarios.hgl](../../stdlib/examples/switch-scenarios.hgl); they are
+design fixtures, not passing compiler tests. Enum declaration/member syntax
+remains open, so these examples use `i64` selectors and integer constants.
 
 These are reference fragments, not standalone hgraph applications. The native
 examples share the following preamble and assume standard operators have been
@@ -41,6 +44,26 @@ selected case assigns an evaluation-local `r`; the function then returns
 | `0` | `x + 1` | `22` |
 | `1` | `y - 1` | `38` |
 | Any other valid value, via default | `fallback * 3` | `42` |
+
+HGL source:
+
+```hgl
+fn local_switch_example(mode: i64, x: i64, y: i64, fallback: i64) -> i64 {
+    when modified(mode, x, y, fallback) && valid(mode, x, y, fallback) {
+        var r: i64
+        switch mode {
+            case 0:
+                r = x + 1
+            case 1:
+                r = y - 1
+            default:
+                r = fallback * 3
+        }
+
+        return r * 2
+    }
+}
+```
 
 The payload calculation has this ordinary C++ mapping:
 
@@ -91,7 +114,27 @@ graph is created, and changing `mode` does not restart node-owned state.
 
 ## Scenario 2: a missing default must fail in node code
 
-Now remove the source default. The generated C++ still needs an error path:
+Now remove the source default:
+
+```hgl
+fn local_switch_required(mode: i64, x: i64, y: i64) -> i64 {
+    when modified(mode, x, y) && valid(mode, x, y) {
+        var r: i64
+        switch mode {
+            case 0:
+                r = x + 1
+            case 1:
+                r = y - 1
+        }
+
+        return r * 2
+    }
+}
+```
+
+The generated C++ still needs an error path. As in Scenario 1, a native node
+boundary reads the admitted inputs, calls this payload function, and writes
+the result only on success:
 
 ```cpp
 std::int64_t choose_payload_required(std::int64_t mode, std::int64_t x,
@@ -121,7 +164,25 @@ error handling remains responsible for propagation or capture of that failure.
 ## Scenario 3: a wiring-time selector chooses topology
 
 Use Scenario 1's cases, but make `mode` a wiring-time scalar and the remaining
-inputs temporal. The following C++ branch graphs will also be used by the
+inputs temporal:
+
+```hgl
+fn wiring_time_switch_example(const mode: i64, x: i64, y: i64, fallback: i64) -> i64 {
+    var r: i64
+    switch mode {
+        case 0:
+            r = x + 1
+        case 1:
+            r = y - 1
+        default:
+            r = fallback * 3
+    }
+
+    return r * 2
+}
+```
+
+The following C++ branch graphs will also be used by the
 temporal-switch example. Each returns only the case's `r` connection:
 
 ```cpp
@@ -185,8 +246,27 @@ unmatched C++ path would throw during wiring instead of composing
 
 ## Scenario 4: a temporal selector creates native switch branches
 
-Now `mode` is temporal. Reuse the three case graphs, but compose a native
-switch instead of executing a C++ switch on the current payload:
+Now `mode` is temporal. There is no `when` or other runtime-only construct in
+this function, so its body composes a graph:
+
+```hgl
+fn temporal_switch_example(mode: i64, x: i64, y: i64, fallback: i64) -> i64 {
+    var r: i64
+    switch mode {
+        case 0:
+            r = x + 1
+        case 1:
+            r = y - 1
+        default:
+            r = fallback * 3
+    }
+
+    return r * 2
+}
+```
+
+Reuse the three C++ case graphs, but compose a native switch instead of
+executing a C++ switch on the current payload:
 
 ```cpp
 struct TemporalSwitchExample
@@ -251,6 +331,28 @@ case computes `r` and forwards an existing `adjustment`; another computes both;
 the default forwards their incoming bindings. This uses the same output
 analysis as the agreed [multiple-result conditional](../design/control-flow.md#multiple-escaping-variables).
 
+```hgl
+fn multiple_switch_results(mode: i64, x: i64, y: i64) -> i64 {
+    var r: i64 = x
+    var adjustment: i64 = y
+    switch mode {
+        case 0:
+            r = x + 1
+        case 1:
+            r = y - 1
+            adjustment = x + y
+        default:
+    }
+
+    return r * 2 + adjustment
+}
+```
+
+Case `0` forwards the incoming `adjustment` binding; the explicit empty
+default forwards both incoming bindings. Nothing reads or copies their
+payloads merely to pass them through. The final expression consumes the
+remapped results as ordinary `i64` time series.
+
 For two ordinary `i64` result slots, the generated common native shape is:
 
 ```cpp
@@ -285,6 +387,22 @@ Suppose case `0` returns `x + 1` from the enclosing graph function. Case `1`
 assigns `r = y - 1`, and the default assigns `r = fallback * 3`. The statements
 after the switch return `r * 2`.
 
+```hgl
+fn early_return_switch(mode: i64, x: i64, y: i64, fallback: i64) -> i64 {
+    var r: i64
+    switch mode {
+        case 0:
+            return x + 1
+        case 1:
+            r = y - 1
+        default:
+            r = fallback * 3
+    }
+
+    return r * 2
+}
+```
+
 | Generated C++ branch | Captures | Child output |
 | --- | --- | --- |
 | `0` | `x` | Connection for `x + 1`; no continuation multiplication. |
@@ -305,6 +423,20 @@ graphs. See [early returns](../design/control-flow.md#early-returns-and-continua
 
 Mode `0` enables a debug sink; the explicit default does nothing. An additional
 debug sink after the switch is always wired:
+
+```hgl
+fn sink_switch_example(mode: i64, value: i64) {
+    switch mode {
+        case 0:
+            debug_print("selected", value)
+        default:
+    }
+
+    debug_print("always", value)
+}
+```
+
+Its C++ wiring is:
 
 ```cpp
 struct SelectedSinkExample
@@ -346,6 +478,61 @@ evaluation, never by printing the current payload in `compose`.
 
 ## Scenario 8: state across case changes
 
+The node-style source owns both counters in the enclosing node. It increments
+only on a valid `value` tick, not on a selector-only tick:
+
+```hgl
+fn local_switch_counters(mode: i64, value: i64) -> i64 {
+    state zero_count: i64 = 0
+    state one_count: i64 = 0
+
+    when modified(value) && valid(mode, value) {
+        switch mode {
+            case 0:
+                zero_count += 1
+                return zero_count
+            case 1:
+                one_count += 1
+                return one_count
+        }
+    }
+}
+```
+
+The graph-style source instead composes a counter **inside** each branch:
+
+```hgl
+fn branch_tick_count(value: i64) -> i64 {
+    state count: i64 = 0
+
+    when modified(value) && valid(value) {
+        count += 1
+        return count
+    }
+}
+
+fn graph_switch_counters(mode: i64, value: i64) -> i64 {
+    var r: i64
+    switch mode {
+        case 0:
+            r = branch_tick_count(value)
+        case 1:
+            r = branch_tick_count(value)
+    }
+
+    return r
+}
+```
+
+The C++ node mapping stores `zero_count` and `one_count` in the enclosing
+node's `RecordableState`, with replay-aware initialization to zero and local
+dispatch inside `eval`. The graph mapping uses native `switch_` with two case
+entries whose child callable wires `branch_tick_count`'s native counter node.
+Each active child instance owns its counter's `RecordableState`. That call
+must not be hoisted outside the switch merely because its source spelling
+is identical in both branches. Neither source has a default; unmatched keys
+fail when dispatch is attempted.
+
 Assume each selected case increments its own counter on a valid data tick,
 with a data tick on every row below. In a node, the two counters belong to the
 enclosing node's recordable state and increment only in their selected case.
@@ -364,7 +551,7 @@ Local C++ dispatch preserves the enclosing node's two counters. Native
 to case `0`. It does not suspend and resume that child's counter. The native
 test `switch_: switching back reuses the old slot with a fresh branch graph`
 in [test_switch.cpp](../../../tests/cpp/test_switch.cpp) pins this restart rule.
-The same distinction applies to default-branch state.
+The same distinction applies if a default containing a counter is added.
 
 The native policy compares selector values, not just the selected callable.
 For example, changing from unmatched key `99` to unmatched key `100` starts a
@@ -375,10 +562,10 @@ not a separate HGL default-state policy.
 
 ## Scope and validation boundary
 
-These mappings describe the expected native execution and wiring shapes. They
-do not add HGL case syntax, change the parser or backend, or settle graph-loop
-predicates or reductions. The full native selector-type coverage and any HGL
-spelling for reload policy remain open.
+These mappings pair agreed HGL source with the expected native execution and
+wiring shapes. They do not change the parser or backend, or settle graph-loop
+predicates or reductions. Enum syntax, the full native selector-type coverage,
+and any HGL spelling for reload policy remain open.
 
 The standalone payload functions can be compiled and exercised without hgraph.
 The node/graph fragments use the public C++ authoring surface and can be

--- a/language/docs/developer-guide/control-flow-cpp-mappings.md
+++ b/language/docs/developer-guide/control-flow-cpp-mappings.md
@@ -8,8 +8,8 @@ by its C++ mapping and behaviour. Case labels are source-expressible constants.
 The same HGL functions are collected in
 [switch-scenarios.hgl](../../stdlib/examples/switch-scenarios.hgl); they are
 design fixtures, not passing compiler tests. These examples use `i64` selectors
-and integer constants; [enum numbering and stringification](../design/type-extensions.md#enum-types)
-remain a separate design step after the agreed enum declaration/member form.
+and integer constants; the agreed enum value rules have their own
+[HGL source and C++ mappings](enum-cpp-mappings.md).
 
 These are reference fragments, not standalone hgraph applications. The native
 examples share the following preamble and assume standard operators have been
@@ -565,7 +565,7 @@ not a separate HGL default-state policy.
 
 These mappings pair agreed HGL source with the expected native execution and
 wiring shapes. They do not change the parser or backend, or settle graph-loop
-predicates or reductions. Enum numbering/stringification details, the full
+predicates or reductions. The remaining enum type/conversion rules, the full
 native selector-type coverage, and any HGL spelling for reload policy remain
 open.
 

--- a/language/docs/developer-guide/enum-cpp-mappings.md
+++ b/language/docs/developer-guide/enum-cpp-mappings.md
@@ -104,6 +104,58 @@ already render a registered member by name. Lowering must retain that table
 rather than erase the enum to an ordinary integer and stringify the integer.
 The native unknown-number fallback is not a new HGL source guarantee.
 
+## Declaration-order enumeration
+
+All three enum views (`keys`, `values`, and `elements`) iterate in declaration
+order, independent of assigned numbers or member names. Consider this HGL:
+
+```hgl
+enum EnumerationOrder {
+    high = 20,
+    low = 5,
+    next
+}
+```
+
+The required sequences are:
+
+| View | First | Second | Third |
+| --- | --- | --- | --- |
+| `keys` | `"high"` | `"low"` | `"next"` |
+| `values` | `20` | `5` | `6` |
+| `elements` | `EnumerationOrder::high` | `EnumerationOrder::low` | `EnumerationOrder::next` |
+
+An illustrative C++ representation retains the declaration sequence:
+
+```cpp
+#include <array>
+
+enum class EnumerationOrder : std::int64_t {
+    high = 20,
+    low = 5,
+    next = 6
+};
+
+constexpr std::array<std::string_view, 3> enumeration_keys{"high", "low", "next"};
+constexpr std::array<std::int64_t, 3> enumeration_values{20, 5, 6};
+constexpr std::array<EnumerationOrder, 3> enumeration_elements{
+    EnumerationOrder::high, EnumerationOrder::low, EnumerationOrder::next
+};
+
+static_assert(enumeration_keys[1] == "low");
+static_assert(enumeration_values[0] == 20 && enumeration_values[1] == 5);
+static_assert(static_cast<std::int64_t>(enumeration_elements[2]) == 6);
+```
+
+These arrays illustrate ordered metadata, not a chosen HGL return container
+or new native enum API. The source enum remains a distinct type in `elements`;
+only `values` exposes integers. Do not sort by number, scan a numeric interval,
+or use unordered-table iteration to implement any of these views. The exact
+enum invocation syntax and returned collection/iterator shape remain open.
+The source declaration is mirrored in
+[enum-enumeration-order.hgl](../../stdlib/examples/enum-enumeration-order.hgl);
+no speculative enumeration call syntax is included.
+
 ## Conversion in nodes and graphs
 
 The following examples use `i64` so their public C++ signatures do not assume
@@ -222,9 +274,10 @@ They record intended source errors, not currently passing compiler diagnostics.
 
 ## Validation boundary
 
-The first two C++ blocks compile together without hgraph and can be exercised
-for resolved numbers and member strings. The node and graph blocks additionally
-require the public hgraph headers. Syntax checking those blocks does not prove
-runtime execution, HGL parsing, native enum registration, Python exposure, or
+The first three C++ blocks compile together without hgraph and can be exercised
+for resolved numbers, member strings, and declaration-order views. The node
+and graph blocks additionally require the public hgraph headers. Syntax checking
+those blocks does not prove runtime execution, HGL parsing, native enum
+registration, Python exposure, or
 temporal enum behaviour. All HGL sources here remain design fixtures outside
 the executable `language/examples/` corpus.

--- a/language/docs/developer-guide/enum-cpp-mappings.md
+++ b/language/docs/developer-guide/enum-cpp-mappings.md
@@ -1,0 +1,135 @@
+# Enum source and C++ mappings
+
+Status: worked examples of the agreed [enum value rules](../design/type-extensions.md#enum-types),
+not output from an implemented HGL enum compiler. Source appears before its
+corresponding C++ representation. Conversion-call spelling, the source integer
+range, and the complete native type/ABI mapping remain open.
+
+## Numbered declarations
+
+The source is also in [enum-values.hgl](../../stdlib/examples/enum-values.hgl):
+
+```hgl
+enum Mode {
+    first = 10,
+    second,
+    third = 20
+}
+
+enum Sequence {
+    first,
+    second,
+    reset = 10,
+    after_reset
+}
+```
+
+Resolving members in declaration order gives `Mode` the numbers `10, 11, 20`
+and `Sequence` the numbers `0, 1, 10, 11`. Duplicate checking is within each
+enum: the same number occurring in a different enum is not a duplicate member
+of this declaration.
+
+An illustrative C++ representation makes the resolved numbers explicit:
+
+```cpp
+#include <cstdint>
+#include <stdexcept>
+#include <string_view>
+
+enum class Mode : std::int64_t {
+    first = 10,
+    second = 11,
+    third = 20
+};
+
+enum class Sequence : std::int64_t {
+    first = 0,
+    second = 1,
+    reset = 10,
+    after_reset = 11
+};
+```
+
+The `std::int64_t` representation here accommodates these example values; it
+does not settle HGL's backing-width, numeric conversion, or public ABI rules.
+Nor does declaring this C++ enum automatically register it as an hgraph type.
+Actual lowering must preserve enum metadata at native value boundaries.
+
+## Member-name stringification
+
+For the HGL declarations above, the required strings are:
+
+| HGL member | Resolved number | Stringification |
+| --- | --- | --- |
+| `Mode::first` | `10` | `"first"` |
+| `Mode::second` | `11` | `"second"` |
+| `Mode::third` | `20` | `"third"` |
+
+An illustrative C++ helper for those values is:
+
+```cpp
+constexpr std::string_view mode_member_name(Mode value)
+{
+    switch (value) {
+    case Mode::first:
+        return "first";
+    case Mode::second:
+        return "second";
+    case Mode::third:
+        return "third";
+    }
+    throw std::invalid_argument("not a declared Mode member");
+}
+```
+
+`mode_member_name` is a C++ illustration, not a newly agreed HGL function
+name. The HGL conversion-call spelling is still open, so no invented source
+call precedes this helper. The throwing path only makes the C++ illustration
+defensive against a manually constructed unknown C++ value; it neither admits
+such HGL values nor settles their handling at native import boundaries.
+
+The existing native [enum registration contract](../../../include/hgraph/types/metadata/type_registry.h)
+carries the member-name/assigned-number table. Its
+[value operations](../../../src/hgraph/types/metadata/type_registry.cpp)
+already render a registered member by name. Lowering must retain that table
+rather than erase the enum to an ordinary integer and stringify the integer.
+The native unknown-number fallback is not a new HGL source guarantee.
+
+## Duplicate numbers are a source error
+
+This source is intentionally invalid:
+
+```hgl
+enum DuplicateExplicit {
+    first = 10,
+    second = 10
+}
+```
+
+So is this collision introduced by automatic numbering:
+
+```hgl
+enum DuplicateAutomatic {
+    existing = 11,
+    restart = 10,
+    collision
+}
+```
+
+`collision` receives `11` because it follows `restart`, not `12` from the
+largest previous number. That duplicates `existing`, so source checking must
+reject the declaration before native registration or C++ emission. C++ itself
+permits numeric aliases; emitting valid C++ therefore cannot prove this HGL
+rule was checked. No C++ representation is emitted for either invalid source.
+
+The fixtures are [enum-duplicate-number.hgl](../../stdlib/examples/invalid/enum-duplicate-number.hgl)
+and [enum-implicit-duplicate-number.hgl](../../stdlib/examples/invalid/enum-implicit-duplicate-number.hgl).
+They record intended source errors, not currently passing compiler diagnostics.
+
+## Validation boundary
+
+The two C++ blocks compile together without hgraph and can be exercised for
+resolved numbers and member strings. That validates the illustrations only,
+not HGL parsing, native enum registration, Python exposure, or temporal enum
+behaviour. All HGL declarations here remain design fixtures outside the
+executable `language/examples/` corpus.

--- a/language/docs/developer-guide/enum-cpp-mappings.md
+++ b/language/docs/developer-guide/enum-cpp-mappings.md
@@ -2,8 +2,9 @@
 
 Status: worked examples of the agreed [enum value rules](../design/type-extensions.md#enum-types),
 not output from an implemented HGL enum compiler. Source appears before its
-corresponding C++ representation. Conversion-call spelling, the source integer
-range, and the complete native type/ABI mapping remain open.
+corresponding C++ representation. Conversion uses the agreed `str(value)`
+spelling. The source integer range and complete native type/ABI mapping remain
+open.
 
 ## Numbered declarations
 
@@ -65,7 +66,13 @@ For the HGL declarations above, the required strings are:
 | `Mode::second` | `11` | `"second"` |
 | `Mode::third` | `20` | `"third"` |
 
-An illustrative C++ helper for those values is:
+HGL requests the conversion with `str(value)`:
+
+```hgl
+const first_mode_name: str = str(Mode::first)
+```
+
+An illustrative C++ helper and constant for this source are:
 
 ```cpp
 constexpr std::string_view mode_member_name(Mode value)
@@ -80,11 +87,13 @@ constexpr std::string_view mode_member_name(Mode value)
     }
     throw std::invalid_argument("not a declared Mode member");
 }
+
+constexpr std::string_view first_mode_name = mode_member_name(Mode::first);
+static_assert(first_mode_name == "first");
 ```
 
-`mode_member_name` is a C++ illustration, not a newly agreed HGL function
-name. The HGL conversion-call spelling is still open, so no invented source
-call precedes this helper. The throwing path only makes the C++ illustration
+`mode_member_name` is an internal C++ illustration; the source operation is
+`str`. The throwing path only makes the C++ illustration
 defensive against a manually constructed unknown C++ value; it neither admits
 such HGL values nor settles their handling at native import boundaries.
 
@@ -94,6 +103,91 @@ carries the member-name/assigned-number table. Its
 already render a registered member by name. Lowering must retain that table
 rather than erase the enum to an ordinary integer and stringify the integer.
 The native unknown-number fallback is not a new HGL source guarantee.
+
+## Conversion in nodes and graphs
+
+The following examples use `i64` so their public C++ signatures do not assume
+an unresolved enum SDK carrier type. The call still follows the same phase
+rules; stringifying a registered enum must preserve its member metadata.
+
+HGL node source:
+
+```hgl
+fn integer_text_node(value: i64) -> str {
+    when modified(value) && valid(value) {
+        return str(value)
+    }
+}
+```
+
+The native node converts the admitted current value within evaluation:
+
+```cpp
+#include <hgraph/lib/std/std_operators.h>
+#include <hgraph/types/graph_wiring.h>
+#include <hgraph/types/static_node.h>
+#include <hgraph/types/value/value_ops.h>
+
+using namespace hgraph;
+
+struct IntegerTextNode
+{
+    static constexpr auto name = "integer_text_node";
+
+    static void eval(In<"value", TS<Int>> value, Out<TS<Str>> out)
+    {
+        if (value.modified() && value.valid()) {
+            const Int payload = value.value();
+            out.set(ops_for<Int>().to_string(&payload));
+        }
+    }
+};
+```
+
+HGL graph source:
+
+```hgl
+fn integer_text_graph(value: i64) -> str {
+    return str(value)
+}
+```
+
+The native graph wires conversion without reading a runtime payload:
+
+```cpp
+struct IntegerTextGraph
+{
+    static constexpr auto name = "integer_text_graph";
+
+    static Port<TS<Str>> compose(Wiring &w, Port<TS<Int>> value)
+    {
+        return wire<stdlib::str_>(w, value).as<TS<Str>>();
+    }
+};
+```
+
+The graph assumes standard operators have been registered before wiring. For
+valid integer ticks `10, 11`, both forms produce `"10", "11"`; a cycle with no
+input tick contributes no output tick. The `when` guard admits a payload read
+in the node. The graph's activity and validity follow the native conversion
+node. A `str` call does not select the containing function's phase.
+
+These map HGL's `str` spelling to existing C++ value conversion and the native
+[`str_` operator](../../../include/hgraph/lib/std/operators/conversion.h),
+respectively. The integer implementation and graph contract are visible in
+the [conversion implementations](../../../include/hgraph/lib/std/operators/impl/conversion_impl.h)
+and [native operator tests](../../../tests/cpp/test_std_operators.cpp).
+The same approach must retain enum-specific value operations for enum inputs;
+using ordinary integer operations for an enum would incorrectly print its
+number.
+
+The spelling decision alone does not equate every native formatting path:
+for example, native `str_` renders Boolean values differently from the
+Python-style `convert`-to-string overload. These integer and enum examples
+do not settle formatting for every other type or add Python execution to HGL.
+
+The source functions are mirrored in
+[string-conversion.hgl](../../stdlib/examples/string-conversion.hgl).
 
 ## Duplicate numbers are a source error
 
@@ -128,8 +222,9 @@ They record intended source errors, not currently passing compiler diagnostics.
 
 ## Validation boundary
 
-The two C++ blocks compile together without hgraph and can be exercised for
-resolved numbers and member strings. That validates the illustrations only,
-not HGL parsing, native enum registration, Python exposure, or temporal enum
-behaviour. All HGL declarations here remain design fixtures outside the
-executable `language/examples/` corpus.
+The first two C++ blocks compile together without hgraph and can be exercised
+for resolved numbers and member strings. The node and graph blocks additionally
+require the public hgraph headers. Syntax checking those blocks does not prove
+runtime execution, HGL parsing, native enum registration, Python exposure, or
+temporal enum behaviour. All HGL sources here remain design fixtures outside
+the executable `language/examples/` corpus.

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -1045,9 +1045,11 @@ Every case value must be expressible as a source constant and compatible with
 the selector's admitted key type. Resolve it under the existing constant-value
 rules before evaluation; reject temporal dependencies and node-state reads.
 Case constants are configuration, not additional temporal captures. The
-selector may still be temporal. Enum members must also become available as
-case constants once the [enum type design](../design/type-extensions.md#enum-types)
-is agreed; no enum spelling is introduced here.
+selector may still be temporal. The agreed [enum source form](../design/type-extensions.md#enum-types)
+uses `enum Mode { first, second }` and qualified member references such as
+`Mode::first`, including in case labels. Numbering and stringification are
+required; their detailed syntax and behaviour remain open. Enum declarations
+are another target grammar extension, not implemented parser support.
 
 `default:` catches unmatched selector values; an explicitly empty body is
 allowed. No match without a default must fail, including for outputless

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -1047,9 +1047,16 @@ rules before evaluation; reject temporal dependencies and node-state reads.
 Case constants are configuration, not additional temporal captures. The
 selector may still be temporal. The agreed [enum source form](../design/type-extensions.md#enum-types)
 uses `enum Mode { first, second }` and qualified member references such as
-`Mode::first`, including in case labels. Numbering and stringification are
-required; their detailed syntax and behaviour remain open. Enum declarations
-are another target grammar extension, not implemented parser support.
+`Mode::first`, including in case labels. A member may supply `= constant` for
+an explicit integer number. Otherwise the first member starts at zero and
+each later member takes its immediately preceding member's resolved number
+plus one. Reject duplicate resolved numbers within the enum, including
+collisions introduced by automatic numbering; do not rely on C++ emission or
+native registration to enforce this source rule. Stringification returns the
+declared member name, without a type prefix or numeric value. The source
+conversion-call spelling and integer range/overflow rules remain open.
+[Paired HGL/C++ examples](enum-cpp-mappings.md) cover these agreements. Enum
+declarations remain a target grammar extension, not implemented parser support.
 
 `default:` catches unmatched selector values; an explicitly empty body is
 allowed. No match without a default must fail, including for outputless

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -1067,12 +1067,14 @@ another enum is not an interchangeable case label. Integer conversion is
 explicit and uses a type-name call like string conversion; its exact source
 spelling remains to be confirmed. Enumeration exposes member-name strings
 through `keys`, assigned integers through `values`, and typed enum instances
-through `elements`. Invocation syntax, result shape, and order remain open;
-do not infer an enumeration grammar or general type-constructor surface.
+through `elements`. All three views iterate in declaration order, never
+numeric or alphabetical order. Enum invocation syntax and result shape remain
+open; do not infer an enum enumeration grammar or general type-constructor
+surface.
 [Paired HGL/C++ examples](enum-cpp-mappings.md) cover declarations, numbering,
-and string conversion; enumeration source examples await the open syntax
-decisions. Enum declarations remain a target grammar extension, not
-implemented parser support.
+string conversion, and declaration-order expectations; enum enumeration call
+examples await the open syntax decisions. Enum declarations remain a target
+grammar extension, not implemented parser support.
 
 `default:` catches unmatched selector values; an explicitly empty body is
 allowed. No match without a default must fail, including for outputless
@@ -1315,12 +1317,14 @@ registered live TSS projection and has temporal source type `set<K>`. In a
 `RuntimeFn` it produces an evaluation-local borrowed set view over the current
 TSD key set.
 
-In runtime evaluation, `keys`, `values`, and `items` produce evaluation-local
-iterator types. They accept the collection followed by an optional predicate:
+In runtime evaluation, `keys`, `values`, `elements`, and `items` produce
+evaluation-local iterator types. They accept the collection followed by an
+optional predicate. This is the agreed target grammar; `elements` for lists
+and sets is not yet implemented:
 
 ```ebnf
 collection_iterator
-               = ( "keys" | "values" | "items" ), "(", expression,
+               = ( "keys" | "values" | "elements" | "items" ), "(", expression,
                  [ ",", expression ], ")";
 ```
 
@@ -1354,9 +1358,15 @@ Traversal and built-in delta-predicate support is:
 | --- | --- | --- |
 | TSB, including structural tuples | `keys`, `values`, `items` | `modified` for values/items |
 | TSD | `keys`, `values`, `items` | `added`, `modified`, `removed` |
-| `list<T, n>` (fixed TSL) | `values`, `items` | `modified` |
-| `list<T>` (unbounded TSL) | `values`, `items` | `added`, `modified`, `removed` |
-| TSS | `values` | `added`, `removed` |
+| `list<T, n>` (fixed TSL) | `elements`, `items` | `modified` |
+| `list<T>` (unbounded TSL) | `elements`, `items` | `added`, `modified`, `removed` |
+| TSS | `elements` | `added`, `removed` |
+
+The table uses the agreed list/set spelling, superseding the earlier absence
+of `elements`. Current compiler support and executable examples still use
+`values` for lists and sets. Retaining that spelling as a compatibility alias
+has not been decided. Do not infer `elements` support for maps or bundles, or
+new graph-phase support for sets, from this extension.
 
 `items` yields two bindings. TSB yields `str` field names and the corresponding
 field bindings; TSD yields its canonical key type and value-child bindings;
@@ -1365,9 +1375,10 @@ iteration yield scalar values. Other value bindings retain their child endpoint
 identity so metadata calls continue to work inside the predicate and loop body.
 
 A predicate may be a built-in name, a compatible named function, or an inline
-concise `fn`. It is invoked with one argument for `keys` and `values`, or two
-arguments for `items`, and must produce a runtime Boolean scalar. A bare
-metadata predicate is resolved contextually against the iterator entry. For
+concise `fn`. It is invoked with one argument for `keys`, `values`, and
+`elements`, or two arguments for `items`, and must produce a runtime Boolean
+scalar. A bare metadata predicate is resolved contextually against the iterator
+entry. For
 example, `items(tsd, modified)` selects modified entries; it does not mean
 `modified(key, value)`. `added` and `removed` likewise inspect membership-slot
 provenance.
@@ -1386,8 +1397,9 @@ calls with runtime effects, are rejected.
 For a heterogeneous TSB, traversal is statically expanded in schema order. The
 predicate and loop body must type-check for every selected field; the compiler
 must not erase heterogeneous children into a dynamic language value. TSL items
-are traversed in ascending index order. TSB fields use schema order. TSD and TSS
-iteration preserve the native hgraph view order and do not promise sorting.
+and elements are traversed in ascending index order. TSB fields use schema
+order. TSD and TSS iteration preserve the native hgraph view order and do not
+promise sorting.
 
 ## Function classification boundary
 

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -72,6 +72,11 @@ and `state`, and each block keyword carries its own placement rule, so there is
 no ambiguity to resolve by making them contextual; they are withheld from
 parameter and variable names deliberately to keep a runtime body readable.
 
+The agreed `str(value)` extension also uses the reserved `str` token in an
+expression position as a conversion call. It remains a type name in an
+annotation; this does not make it an unrestricted identifier or add a general
+type-constructor call rule. Parser recognition is still implementation work.
+
 `atomic`, `tuple`, `list`, `set`, `map`, and `rolling` are contextual type
 keywords, and `unbounded` is a contextual constant in a list-size position.
 Outside a type position, the same spelling can resolve to a function,
@@ -1053,8 +1058,9 @@ each later member takes its immediately preceding member's resolved number
 plus one. Reject duplicate resolved numbers within the enum, including
 collisions introduced by automatic numbering; do not rely on C++ emission or
 native registration to enforce this source rule. Stringification returns the
-declared member name, without a type prefix or numeric value. The source
-conversion-call spelling and integer range/overflow rules remain open.
+declared member name, without a type prefix or numeric value. The source call
+is `str(value)`, including `str(Mode::first)`. Integer range/overflow rules
+remain open.
 [Paired HGL/C++ examples](enum-cpp-mappings.md) cover these agreements. Enum
 declarations remain a target grammar extension, not implemented parser support.
 
@@ -1066,6 +1072,23 @@ coverage, duplicate-case diagnostics, and an expression-value surface remain
 separate design work. No parser or backend support is implemented by this
 design update. Recognition of the new `switch`, `case`, and `default` tokens
 must be added to the parser alongside the statement extension.
+
+The agreed string-conversion spelling is `str(value)`. The parser must admit
+that reserved type token as a call head in expression position; the expression
+grammar above does not yet implement this extension. Resolve the operand's
+type and phase before lowering: a constant/wiring-time scalar produces a
+scalar string, a readable node value is converted within evaluation, and a
+temporal graph input wires a string-conversion node. Preserve native type
+metadata, including enum member names, and the existing validity, REF, and
+SIGNAL restrictions. Conversion itself does not classify a function as a
+runtime node. See [String conversion](../user-guide/types-and-expressions.md#string-conversion).
+
+This agreement covers the one-value Python-style spelling, not Python's
+additional `str` forms or an unrestricted guarantee of Python formatting.
+The enum result remains its member name. In particular, do not assume native
+`str_` and every native `convert`-to-string overload have identical formatting
+for all scalar types; bind the source contract to the appropriate native
+operation. No compiler or runtime implementation is changed by this record.
 
 Expression precedence is:
 

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -1061,8 +1061,18 @@ native registration to enforce this source rule. Stringification returns the
 declared member name, without a type prefix or numeric value. The source call
 is `str(value)`, including `str(Mode::first)`. Integer range/overflow rules
 remain open.
-[Paired HGL/C++ examples](enum-cpp-mappings.md) cover these agreements. Enum
-declarations remain a target grammar extension, not implemented parser support.
+An enum is a distinct atomic scalar type, not an integer alias. Preserve that
+identity in equality and switch checking; an assigned number or a member of
+another enum is not an interchangeable case label. Integer conversion is
+explicit and uses a type-name call like string conversion; its exact source
+spelling remains to be confirmed. Enumeration exposes member-name strings
+through `keys`, assigned integers through `values`, and typed enum instances
+through `elements`. Invocation syntax, result shape, and order remain open;
+do not infer an enumeration grammar or general type-constructor surface.
+[Paired HGL/C++ examples](enum-cpp-mappings.md) cover declarations, numbering,
+and string conversion; enumeration source examples await the open syntax
+decisions. Enum declarations remain a target grammar extension, not
+implemented parser support.
 
 `default:` catches unmatched selector values; an explicitly empty body is
 allowed. No match without a default must fail, including for outputless

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -1034,12 +1034,29 @@ with the same capture, result-schema, REF adaptation, and continuation analysis
 as temporal `if`, applied to every case and the optional default. A wiring-time
 selector chooses composition directly.
 
-The `default: ...` fragment is agreed: it catches unmatched selector values.
-No match without a default must fail, including for outputless switches; do
-not manufacture an empty branch. Case bodies do not implicitly fall through
-to each other. The full switch grammar and exact selector-type coverage remain
-open, so the productions above are not extended by speculative case syntax.
-No parser or backend support is implemented by this design update.
+The agreed source form is `switch selector { case value: ... default: ... }`.
+This is a target extension to `statement`, not an implemented production in
+the parser described above. Each label ends with `:` and its body continues
+until the next case/default label or closing switch brace. Statements retain
+their existing newline rules. The [worked examples](control-flow-cpp-mappings.md)
+show complete HGL functions before their C++ mappings.
+
+Every case value must be expressible as a source constant and compatible with
+the selector's admitted key type. Resolve it under the existing constant-value
+rules before evaluation; reject temporal dependencies and node-state reads.
+Case constants are configuration, not additional temporal captures. The
+selector may still be temporal. Enum members must also become available as
+case constants once the [enum type design](../design/type-extensions.md#enum-types)
+is agreed; no enum spelling is introduced here.
+
+`default:` catches unmatched selector values; an explicitly empty body is
+allowed. No match without a default must fail, including for outputless
+switches; do not manufacture an empty branch. Case bodies do not implicitly
+fall through to each other and require no source `break`. Exact selector-type
+coverage, duplicate-case diagnostics, and an expression-value surface remain
+separate design work. No parser or backend support is implemented by this
+design update. Recognition of the new `switch`, `case`, and `default` tokens
+must be added to the parser alongside the statement extension.
 
 Expression precedence is:
 

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -1026,6 +1026,21 @@ prior declarations. This uses the existing expression and assignment syntax;
 no source-level bundle declaration or reserved result-field name is needed.
 See [Mixed results](../design/control-flow.md#expression-results-and-escaping-assignments).
 
+The agreed [explicit switch design](../design/switch.md) extends dispatch to
+both function phases without making switch a runtime-classification trigger.
+Validate the selector's phase and key type first. Node-style dispatch must
+lower to native C++ control flow; temporal graph dispatch uses native `switch_`
+with the same capture, result-schema, REF adaptation, and continuation analysis
+as temporal `if`, applied to every case and the optional default. A wiring-time
+selector chooses composition directly.
+
+The `default: ...` fragment is agreed: it catches unmatched selector values.
+No match without a default must fail, including for outputless switches; do
+not manufacture an empty branch. Case bodies do not implicitly fall through
+to each other. The full switch grammar and exact selector-type coverage remain
+open, so the productions above are not extended by speculative case syntax.
+No parser or backend support is implemented by this design update.
+
 Expression precedence is:
 
 | Precedence, high to low | Tokens |
@@ -1268,6 +1283,11 @@ assignments to enclosing variables, and loop returns. Unordered map reduction
 and ordered, linear list reduction are deferred options, not initial lowering
 support. See
 [Iteration](../design/iteration.md) for the target design and current boundary.
+
+Graph-phase iterator predicates are also deferred. Do not treat a predicate
+argument as an agreed rewrite to a per-element switch or infer new graph-loop
+lifetime rules from the runtime predicate grammar below. Node-time predicate
+and delta-range behavior is unchanged.
 
 Traversal and built-in delta-predicate support is:
 

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -348,7 +348,10 @@ Collection-view semantic tests additionally cover:
 - phase-specific `key_set(tsd)` results in composition and runtime functions;
 - `keys`, `values`, and `items` result arity and types for TSB, TSD, TSL, and
   TSS, including `i64` TSL indices;
-- the absence of an `elements` alias;
+- the agreed `elements` traversal for lists and sets, with one yielded binding,
+  list index order, set membership/delta semantics, and unchanged phase/REF
+  restrictions (pending compiler migration; the earlier no-`elements` rule is
+  superseded, and `values` compatibility remains open);
 - built-in `added`, `modified`, and `removed` predicates for every supported
   structure/traversal pair, plus diagnostics for unsupported pairs;
 - built-in, named, and inline predicates, captures, short-circuit validity,

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -480,6 +480,28 @@ precedent, forwarding of existing bindings, definite-assignment and early-return
 examples, outputless conditional wiring, and mixed expression/assignment
 results.
 
+## Explicit switch
+
+Status: node-style and graph-style semantics and the `default: ...` fragment
+are agreed design. Full case syntax and compiler implementation remain open;
+see [Explicit switch dispatch](../design/switch.md).
+
+In a node-style function, switch dispatch uses the current readable selector
+value and lowers to native C++ control flow within that evaluation. It does
+not create switch child graphs or restart the enclosing node's state. In a
+graph function, a wiring-time selector chooses composition; a temporal
+selector must satisfy the native switch-key contract and uses `switch_`.
+
+Graph branches reuse the `if`/`else` rules for input captures, REF forwarding,
+escaping bindings, result signatures and bundle remapping, definite assignment,
+and early returns. The default branch participates in all of those checks.
+One matching branch is selected, without implicit fallthrough between bodies.
+
+`default: ...` handles values matching no explicit case. With no match and no
+default, fail during wiring or evaluation as appropriate to the selector's
+phase. Do not invent a never-ticking result or silently continue. Default is
+not an exception handler and does not permit reading an invalid selector.
+
 ## State
 
 `state` declares mutable data that persists across evaluations:

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -509,8 +509,9 @@ labels. A case body continues until the next label or closing switch brace,
 with no implicit fallthrough and no `break` needed. An explicit empty
 `default:` is allowed. [Enum support](../design/type-extensions.md#enum-types)
 uses the agreed declaration/member form, with case labels such as
-`case Mode::first:`. Enum numbering and stringification are required, with
-their detailed source rules still to be agreed.
+`case Mode::first:`. Explicit/automatic numbering, member-name stringification,
+and rejection of duplicate enum numbers are agreed; the string-conversion
+call spelling and remaining enum type rules are separate design work.
 
 In a node-style function, switch dispatch uses the current readable selector
 value and lowers to native C++ control flow within that evaluation. It does

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -508,8 +508,9 @@ constant-value rules; time-series values and state reads cannot be case
 labels. A case body continues until the next label or closing switch brace,
 with no implicit fallthrough and no `break` needed. An explicit empty
 `default:` is allowed. [Enum support](../design/type-extensions.md#enum-types)
-is also required so named members can be case constants; enum syntax is the
-next design step.
+uses the agreed declaration/member form, with case labels such as
+`case Mode::first:`. Enum numbering and stringification are required, with
+their detailed source rules still to be agreed.
 
 In a node-style function, switch dispatch uses the current readable selector
 value and lowers to native C++ control flow within that evaluation. It does

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -510,8 +510,8 @@ with no implicit fallthrough and no `break` needed. An explicit empty
 `default:` is allowed. [Enum support](../design/type-extensions.md#enum-types)
 uses the agreed declaration/member form, with case labels such as
 `case Mode::first:`. Explicit/automatic numbering, member-name stringification,
-and rejection of duplicate enum numbers are agreed; the string-conversion
-call spelling and remaining enum type rules are separate design work.
+and rejection of duplicate enum numbers are agreed. String conversion uses
+`str(value)`; remaining enum type rules are separate design work.
 
 In a node-style function, switch dispatch uses the current readable selector
 value and lowers to native C++ control flow within that evaluation. It does

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -482,9 +482,34 @@ results.
 
 ## Explicit switch
 
-Status: node-style and graph-style semantics and the `default: ...` fragment
-are agreed design. Full case syntax and compiler implementation remain open;
-see [Explicit switch dispatch](../design/switch.md).
+Status: the following source form and node-style/graph-style semantics are
+agreed design; compiler implementation remains separate work. See
+[Explicit switch dispatch](../design/switch.md).
+
+```hgl
+fn select_result(mode: i64, x: i64, y: i64, fallback: i64) -> i64 {
+    var r: i64
+    switch mode {
+        case 0:
+            r = x + 1
+        case 1:
+            r = y - 1
+        default:
+            r = fallback * 3
+    }
+
+    return r * 2
+}
+```
+
+Case values must be expressible as constants in source and compatible with
+the selector's key type. Literals and named constants follow the existing
+constant-value rules; time-series values and state reads cannot be case
+labels. A case body continues until the next label or closing switch brace,
+with no implicit fallthrough and no `break` needed. An explicit empty
+`default:` is allowed. [Enum support](../design/type-extensions.md#enum-types)
+is also required so named members can be case constants; enum syntax is the
+next design step.
 
 In a node-style function, switch dispatch uses the current readable selector
 value and lowers to native C++ control flow within that evaluation. It does
@@ -501,6 +526,10 @@ One matching branch is selected, without implicit fallthrough between bodies.
 default, fail during wiring or evaluation as appropriate to the selector's
 phase. Do not invent a never-ticking result or silently continue. Default is
 not an exception handler and does not permit reading an invalid selector.
+
+The [paired HGL/C++ scenarios](../developer-guide/control-flow-cpp-mappings.md)
+show node-style `when` handlers, wiring-time selectors, temporal selectors,
+multiple results, early returns, sinks, and state lifetime.
 
 ## State
 

--- a/language/docs/user-guide/language-tour.md
+++ b/language/docs/user-guide/language-tour.md
@@ -191,9 +191,10 @@ true only when every argument is valid. `valid(value)` tests the endpoint
 itself; use `all_valid(value)` when every child of a structural or collection
 endpoint must also be valid.
 
-Runtime collection traversal uses `keys`, `values`, and `items`. An optional
-built-in, named, or inline predicate filters the traversal without changing
-those base names:
+The agreed collection traversal surface uses `keys`, `values`, `elements`,
+and `items`. `elements` is the list/set spelling and awaits compiler support.
+An optional built-in, named, or inline predicate filters the traversal without
+changing those base names:
 
 ```hgl
 for key, value in items(book, modified) {
@@ -208,16 +209,19 @@ for key, value in items(
     consume(key, value)
 }
 
-for symbol in values(symbols, added) {
+for symbol in elements(symbols, added) {
     subscribe(symbol)
 }
 ```
 
 `key_set(book)` is different from `keys(book)`: `key_set` is available in both
 composition and runtime functions and produces the set-shaped key view, while
-`keys`, `values`, and `items` are evaluation-local iterators. Temporal lists use
-`values` for value-only traversal and `items` for `(i64, value)` traversal;
-there is no separate `elements` spelling.
+`keys`, `values`, `elements`, and `items` yield evaluation-local iterators
+inside nodes. Lists and sets use `elements` for element-only traversal; lists
+also use `items` for `(i64, value)` traversal. This replaces the earlier
+no-`elements` design. Current executable examples still use `values` for lists
+and sets; its possible retention as an alias remains open. Graph traversal
+retains the [phase-specific restrictions](../design/iteration.md).
 
 An ordinary body such as `maybe_smooth` runs at wiring time and composes
 operators. Runtime-only declarations and blocks instead implement one generated

--- a/language/docs/user-guide/types-and-expressions.md
+++ b/language/docs/user-guide/types-and-expressions.md
@@ -50,12 +50,60 @@ resolved number plus one. Here, the numbers are `10`, `11`, and `20`.
 Duplicate numbers in one enum are rejected, including collisions caused by
 automatic numbering.
 
-Stringification returns the member name: `Mode::first` becomes `"first"`,
-not `"10"` or `"Mode::first"`. The source conversion-call spelling remains
-open, as do the integer range/overflow rules, detailed type rules, and native
-C++/Python mapping. Enums are agreed design, not implemented compiler support;
-see the [paired examples](../developer-guide/enum-cpp-mappings.md) and
+Stringification uses `str(Mode::first)` and returns `"first"`, not `"10"` or
+`"Mode::first"`. The integer range/overflow rules, detailed type rules, and
+native C++/Python mapping remain open. Enums are agreed design, not implemented
+compiler support; see the [paired examples](../developer-guide/enum-cpp-mappings.md) and
 [Enum types](../design/type-extensions.md#enum-types).
+
+## String conversion
+
+Status: `str(value)` is the agreed source spelling; these examples describe
+the target language contract, not implemented compiler support.
+
+With the enum above:
+
+```hgl
+const first_mode_name: str = str(Mode::first)
+```
+
+The result is the constant string `"first"`. The same call spelling follows
+the existing value/temporal distinction:
+
+| Context | Meaning of `str(value)` |
+| --- | --- |
+| Constant or wiring-time scalar value | Produce a scalar string; a constant result can be evaluated before runtime. |
+| Readable value inside node evaluation | Convert the current value within that evaluation. |
+| Temporal input in graph composition | Wire string conversion, producing a string time series following input ticks. |
+
+For example, the explicit `when` makes this a node:
+
+```hgl
+fn integer_text_node(value: i64) -> str {
+    when modified(value) && valid(value) {
+        return str(value)
+    }
+}
+```
+
+Without runtime-only constructs, the same conversion composes a graph:
+
+```hgl
+fn integer_text_graph(value: i64) -> str {
+    return str(value)
+}
+```
+
+Neither example reads invalid input. Graph composition does not read the
+current payload: it wires the conversion. A call by itself neither changes
+the function's phase nor creates an extra node inside a `when` handler.
+`str` remains the string type in annotations such as `-> str`.
+
+This is Python-style call spelling, not a blanket agreement on Python's
+formatting, encoding arguments, implicit conversions, or custom `__str__`
+methods. The enum member-name rule is unchanged. Existing REF opacity and
+SIGNAL payload restrictions also remain: conversion is not an escape from
+them. See the [HGL/C++ mappings](../developer-guide/enum-cpp-mappings.md#conversion-in-nodes-and-graphs).
 
 ## Temporal values
 

--- a/language/docs/user-guide/types-and-expressions.md
+++ b/language/docs/user-guide/types-and-expressions.md
@@ -51,10 +51,23 @@ Duplicate numbers in one enum are rejected, including collisions caused by
 automatic numbering.
 
 Stringification uses `str(Mode::first)` and returns `"first"`, not `"10"` or
-`"Mode::first"`. The integer range/overflow rules, detailed type rules, and
-native C++/Python mapping remain open. Enums are agreed design, not implemented
-compiler support; see the [paired examples](../developer-guide/enum-cpp-mappings.md) and
-[Enum types](../design/type-extensions.md#enum-types).
+`"Mode::first"`. An enum is a distinct atomic scalar type, not an integer
+alias. Members of different enums are not interchangeable, even when their
+assigned numbers match. Equality and switch matching retain the enum type;
+integer conversion must be explicit, using a type-name call like string
+conversion. The exact integer call spelling remains to be confirmed.
+
+Enums can be enumerated through `keys` (member-name strings), `values`
+(assigned integers), and `elements` (typed enum instances). For `Mode`, the
+three views expose the names `"first"`, `"second"`, `"third"`, the numbers
+`10`, `11`, `20`, and the members `Mode::first`, `Mode::second`, `Mode::third`,
+respectively. These lists illustrate corresponding members, not an agreed
+result container or ordering. Invocation syntax and result shape remain open.
+
+Integer range/overflow, construction from numbers or strings, and native
+C++/Python mapping also remain open. Enums are agreed design, not implemented
+compiler support; see the [paired examples](../developer-guide/enum-cpp-mappings.md)
+and [Enum types](../design/type-extensions.md#enum-types).
 
 ## String conversion
 

--- a/language/docs/user-guide/types-and-expressions.md
+++ b/language/docs/user-guide/types-and-expressions.md
@@ -61,8 +61,10 @@ Enums can be enumerated through `keys` (member-name strings), `values`
 (assigned integers), and `elements` (typed enum instances). For `Mode`, the
 three views expose the names `"first"`, `"second"`, `"third"`, the numbers
 `10`, `11`, `20`, and the members `Mode::first`, `Mode::second`, `Mode::third`,
-respectively. These lists illustrate corresponding members, not an agreed
-result container or ordering. Invocation syntax and result shape remain open.
+respectively. All three iterate in declaration order, with corresponding
+members at each position; explicit numbering never sorts or reorders them.
+Enum invocation syntax and result shape remain open. `elements` also provides
+element iteration over lists and sets, as described below.
 
 Integer range/overflow, construction from numbers or strings, and native
 C++/Python mapping also remain open. Enums are agreed design, not implemented
@@ -862,9 +864,11 @@ tick or delta.
 
 ## Collection views and iteration
 
-Status: `for`, `keys`, `values`, and `items` follow the containing phase rather
-than themselves forcing a runtime node. The compiler implements graph-phase
-`values` and `items` over fixed temporal lists by expanding the body once per
+Status: `elements` is the agreed element-iteration spelling for lists and sets,
+awaiting compiler support. Like `for`, `keys`, `values`, and `items`, it follows
+the containing phase rather than itself forcing a runtime node. The compiler
+currently implements graph-phase `values` and `items` over fixed temporal
+lists by expanding the body once per
 child connection; `items` also supplies its wiring-time `i64` index. Scalar
 wiring-time iterables and bundles remain future compiler work. Independent
 `values` and `items` bodies over maps and unbounded lists run as one native
@@ -896,18 +900,26 @@ both function phases: a composition function receives the live set-valued
 time-series projection, while a runtime function receives the current borrowed
 key-set view.
 
-Runtime functions traverse structural collections with three regular
-operations:
+The agreed collection traversal operations are:
 
 | Operation | Supported structures | Yielded bindings |
 | --- | --- | --- |
 | `keys(value)` | bundle, temporal map | field name or map key |
-| `values(value)` | bundle, temporal map, temporal list, temporal set | child value, or a set member |
+| `values(value)` | bundle, temporal map | child value |
+| `elements(value)` | list, set | list element binding or set member |
 | `items(value)` | bundle, temporal map, temporal list | `(key, value)`, `(field, value)`, or `(index, value)` |
 
-A temporal-list index yielded by `items` is an `i64`. There is no separate
-`elements` operation; `values` is the common value-only spelling for temporal
-bundles, maps, lists, and sets.
+A temporal-list index yielded by `items` is an `i64`. List elements retain
+index order; sets have no sorting or insertion-order guarantee. A temporal
+list element remains a child connection in graph composition and a child view
+in node evaluation, with its metadata and REF boundaries intact. Set members
+are scalar values, not independent time-series children.
+
+This supersedes the earlier design that used `values` for lists and sets and
+excluded `elements`. The current compiler and executable examples still use
+`values` for those structures; whether it remains a compatibility alias is
+not yet decided. The examples below use the agreed target spelling, not
+implemented `elements` support. Graph-phase set traversal remains unsupported.
 
 Each traversal accepts an optional predicate. The built-in `modified`, `added`,
 and `removed` predicates select the corresponding hgraph delta range:
@@ -917,11 +929,11 @@ for key, value in items(book, modified) {
     consume(key, value)
 }
 
-for symbol in values(symbols, added) {
+for symbol in elements(symbols, added) {
     subscribe(symbol)
 }
 
-for symbol in values(symbols, removed) {
+for symbol in elements(symbols, removed) {
     unsubscribe(symbol)
 }
 ```
@@ -932,13 +944,13 @@ The available built-in delta predicates follow the underlying structure:
 | --- | --- | --- |
 | Bundle (TSB) | `keys`, `values`, `items` | `modified` on values and items |
 | Temporal map (TSD) | `keys`, `values`, `items` | `added`, `modified`, `removed` |
-| Fixed temporal list, `list<T, n>` (TSL) | `values`, `items` | `modified` |
-| Unbounded temporal list, `list<T>` (TSL) | `values`, `items` | `added`, `modified`, `removed` |
-| Temporal set (TSS) | `values` | `added`, `removed` |
+| Fixed temporal list, `list<T, n>` (TSL) | `elements`, `items` | `modified` |
+| Unbounded temporal list, `list<T>` (TSL) | `elements`, `items` | `added`, `modified`, `removed` |
+| Temporal set (TSS) | `elements` | `added`, `removed` |
 
 A compatible named function or inline concise function provides a general
-predicate. Its parameters match the traversal result: one parameter for `keys`
-or `values`, and two for `items`.
+predicate. Its parameters match the traversal result: one parameter for
+`keys`, `values`, or `elements`, and two for `items`.
 
 ```hgl
 for key, value in items(

--- a/language/docs/user-guide/types-and-expressions.md
+++ b/language/docs/user-guide/types-and-expressions.md
@@ -37,17 +37,24 @@ The agreed declaration and member-reference forms are:
 
 ```hgl
 enum Mode {
-    first,
-    second
+    first = 10,
+    second,
+    third = 20
 }
 ```
 
 Use `Mode::first` to reference a member, including as a constant `switch` case
-value. Enums must support author-specified member numbers and stringification.
-Numbering syntax and defaults, string conversion spelling and output, type
-identity and conversion rules, and native C++/Python mapping still need
-agreement. This example does not choose an automatic-numbering policy. Enums
-are not implemented by this design update; see
+value. An explicit `= constant` supplies an integer value. Without one, the
+first member starts at zero and later members take the previous member's
+resolved number plus one. Here, the numbers are `10`, `11`, and `20`.
+Duplicate numbers in one enum are rejected, including collisions caused by
+automatic numbering.
+
+Stringification returns the member name: `Mode::first` becomes `"first"`,
+not `"10"` or `"Mode::first"`. The source conversion-call spelling remains
+open, as do the integer range/overflow rules, detailed type rules, and native
+C++/Python mapping. Enums are agreed design, not implemented compiler support;
+see the [paired examples](../developer-guide/enum-cpp-mappings.md) and
 [Enum types](../design/type-extensions.md#enum-types).
 
 ## Temporal values

--- a/language/docs/user-guide/types-and-expressions.md
+++ b/language/docs/user-guide/types-and-expressions.md
@@ -31,6 +31,14 @@ fn scale(value: f64, const factor: f64) -> f64 =>
     value * factor
 ```
 
+## Enum types
+
+Enum support is a required extension, including named enum members usable as
+constant `switch` case values. The declaration and member-reference syntax,
+type identity and conversion rules, and native C++/Python mapping still need
+agreement. Enums are not implemented by this design update; see
+[Enum types](../design/type-extensions.md#enum-types).
+
 ## Temporal values
 
 The temporal scalars are hgraph's RFC 0002 core types. `date` and `time` are

--- a/language/docs/user-guide/types-and-expressions.md
+++ b/language/docs/user-guide/types-and-expressions.md
@@ -877,8 +877,11 @@ consumed by a `for` loop but cannot be returned, stored in state, assigned to
 output, or kept for a later evaluation. Graph-phase iteration instead visits
 wiring-time values or fixed child connections, or describes independently
 mapped child graphs for dynamic collections; it does not read these runtime
-borrowed views. Graph-phase predicate behavior remains a separate design
-decision, and dynamic-loop reductions are deferred.
+borrowed views. Graph-phase iterator predicates and dynamic-loop reductions
+are deferred and are not part of the initial graph-loop subset. In particular,
+no automatic predicate-to-switch conversion has been agreed. The node-time
+predicate rules above are unchanged; see
+[Deferred graph-phase predicates](../design/iteration.md#deferred-graph-phase-predicates).
 
 ## Open scalar edge cases
 

--- a/language/docs/user-guide/types-and-expressions.md
+++ b/language/docs/user-guide/types-and-expressions.md
@@ -33,10 +33,21 @@ fn scale(value: f64, const factor: f64) -> f64 =>
 
 ## Enum types
 
-Enum support is a required extension, including named enum members usable as
-constant `switch` case values. The declaration and member-reference syntax,
-type identity and conversion rules, and native C++/Python mapping still need
-agreement. Enums are not implemented by this design update; see
+The agreed declaration and member-reference forms are:
+
+```hgl
+enum Mode {
+    first,
+    second
+}
+```
+
+Use `Mode::first` to reference a member, including as a constant `switch` case
+value. Enums must support author-specified member numbers and stringification.
+Numbering syntax and defaults, string conversion spelling and output, type
+identity and conversion rules, and native C++/Python mapping still need
+agreement. This example does not choose an automatic-numbering policy. Enums
+are not implemented by this design update; see
 [Enum types](../design/type-extensions.md#enum-types).
 
 ## Temporal values

--- a/language/stdlib/README.md
+++ b/language/stdlib/README.md
@@ -58,11 +58,24 @@ intentional error: a temporal parameter cannot be used as a case constant.
 These fixtures await switch parser, checking, and lowering support; they are
 not executable acceptance tests.
 
-[Enum types](../docs/design/type-extensions.md#enum-types) use the agreed
-`enum Mode { first, second }` declaration and `Mode::first` reference form.
-Numbering and stringification are required. Numbered enum and conversion
-fixtures await agreement on those details rather than assume defaults or
-conversion syntax.
+## Enum values
+
+[enum-values.hgl](examples/enum-values.hgl) covers the agreed declaration and
+`Mode::first` member-reference forms, explicit numbering with `= constant`,
+automatic numbering from zero, and continuation after an explicit number.
+Stringification returns the member name without a type prefix or number.
+The [paired HGL/C++ mappings](../docs/developer-guide/enum-cpp-mappings.md)
+show the resolved numbers and expected strings.
+
+[enum-duplicate-number.hgl](examples/invalid/enum-duplicate-number.hgl) and
+[enum-implicit-duplicate-number.hgl](examples/invalid/enum-implicit-duplicate-number.hgl)
+record the initial rejection of duplicate numbers, including an automatic
+number that collides with an earlier explicit member.
+
+These are design fixtures awaiting compiler support. The
+[remaining enum decisions](../docs/design/type-extensions.md#enum-types)
+include integer range/overflow, type/native mapping, and string-conversion
+call spelling; no conversion call is invented in this corpus.
 
 ## Iteration
 

--- a/language/stdlib/README.md
+++ b/language/stdlib/README.md
@@ -74,7 +74,12 @@ number that collides with an earlier explicit member.
 
 These are design fixtures awaiting compiler support. The
 [remaining enum decisions](../docs/design/type-extensions.md#enum-types)
-include integer range/overflow, unknown imported values, and type/native mapping.
+include integer range/overflow, unknown imported values, and native mapping.
+Enum identity and explicit integer conversion are agreed, as are enumeration
+through `keys` (member-name strings), `values` (assigned integers), and
+`elements` (enum instances). Their remaining source and result-shape details
+are recorded in the design document; no speculative enumeration fixtures are
+added here.
 
 ## String conversion
 

--- a/language/stdlib/README.md
+++ b/language/stdlib/README.md
@@ -46,10 +46,21 @@ backend lowering.
 [Explicit switch dispatch](../docs/design/switch.md) records the agreed
 node-style native C++ path and graph-style selector validation, captures,
 results, and `default: ...` fallback. Unmatched values without a default must
-fail. The full case syntax remains open, so no switch fixture is added yet.
-The [scenario-to-C++ mappings](../docs/developer-guide/control-flow-cpp-mappings.md)
-make the expected native behaviour explicit using descriptions, result tables,
-and C++ reference fragments rather than speculative HGL declarations.
+fail. The agreed form is `switch selector { case value: ... default: ... }`;
+case values must be expressible as source constants.
+
+[switch-scenarios.hgl](examples/switch-scenarios.hgl) contains the node, graph,
+result, early-return, sink, and state-lifetime examples. The
+[paired HGL/C++ mappings](../docs/developer-guide/control-flow-cpp-mappings.md)
+put the same source before its native mapping and expected behaviour.
+[switch-temporal-case.hgl](examples/invalid/switch-temporal-case.hgl) records an
+intentional error: a temporal parameter cannot be used as a case constant.
+These fixtures await switch parser, checking, and lowering support; they are
+not executable acceptance tests.
+
+[Enum types](../docs/design/type-extensions.md#enum-types) are required so
+named members can be case constants. Their declaration/member syntax is not
+yet agreed, so there is no speculative enum declaration in the corpus.
 
 ## Iteration
 

--- a/language/stdlib/README.md
+++ b/language/stdlib/README.md
@@ -63,7 +63,7 @@ not executable acceptance tests.
 [enum-values.hgl](examples/enum-values.hgl) covers the agreed declaration and
 `Mode::first` member-reference forms, explicit numbering with `= constant`,
 automatic numbering from zero, and continuation after an explicit number.
-Stringification returns the member name without a type prefix or number.
+`str(Mode::first)` returns the member name without a type prefix or number.
 The [paired HGL/C++ mappings](../docs/developer-guide/enum-cpp-mappings.md)
 show the resolved numbers and expected strings.
 
@@ -74,8 +74,17 @@ number that collides with an earlier explicit member.
 
 These are design fixtures awaiting compiler support. The
 [remaining enum decisions](../docs/design/type-extensions.md#enum-types)
-include integer range/overflow, type/native mapping, and string-conversion
-call spelling; no conversion call is invented in this corpus.
+include integer range/overflow, unknown imported values, and type/native mapping.
+
+## String conversion
+
+[string-conversion.hgl](examples/string-conversion.hgl) uses the agreed
+Python-style `str(value)` spelling in a node handler and in temporal graph
+composition. The constant enum conversion is in `enum-values.hgl` above.
+The [paired HGL/C++ mappings](../docs/developer-guide/enum-cpp-mappings.md#conversion-in-nodes-and-graphs)
+show conversion within native node evaluation and wiring through native
+`str_`, without making a graph read current payloads. These are design
+fixtures, not passing compiler examples or a blanket Python formatting promise.
 
 ## Iteration
 

--- a/language/stdlib/README.md
+++ b/language/stdlib/README.md
@@ -58,9 +58,11 @@ intentional error: a temporal parameter cannot be used as a case constant.
 These fixtures await switch parser, checking, and lowering support; they are
 not executable acceptance tests.
 
-[Enum types](../docs/design/type-extensions.md#enum-types) are required so
-named members can be case constants. Their declaration/member syntax is not
-yet agreed, so there is no speculative enum declaration in the corpus.
+[Enum types](../docs/design/type-extensions.md#enum-types) use the agreed
+`enum Mode { first, second }` declaration and `Mode::first` reference form.
+Numbering and stringification are required. Numbered enum and conversion
+fixtures await agreement on those details rather than assume defaults or
+conversion syntax.
 
 ## Iteration
 

--- a/language/stdlib/README.md
+++ b/language/stdlib/README.md
@@ -77,8 +77,11 @@ These are design fixtures awaiting compiler support. The
 include integer range/overflow, unknown imported values, and native mapping.
 Enum identity and explicit integer conversion are agreed, as are enumeration
 through `keys` (member-name strings), `values` (assigned integers), and
-`elements` (enum instances). Their remaining source and result-shape details
-are recorded in the design document; no speculative enumeration fixtures are
+`elements` (enum instances). All three iterate in declaration order, regardless
+of explicit numbers. [enum-enumeration-order.hgl](examples/enum-enumeration-order.hgl)
+uses non-monotonic numbering, with [paired HGL/C++ expectations](../docs/developer-guide/enum-cpp-mappings.md#declaration-order-enumeration).
+Their remaining source and result-shape details are recorded in the design
+document; no speculative enumeration call fixtures are
 added here.
 
 ## String conversion
@@ -92,6 +95,14 @@ show conversion within native node evaluation and wiring through native
 fixtures, not passing compiler examples or a blanket Python formatting promise.
 
 ## Iteration
+
+[elements-iteration.hgl](examples/elements-iteration.hgl) records the agreed
+`elements` spelling for list and set traversal, with paired HGL/C++ examples
+in the [iteration design](../docs/design/iteration.md). It covers fixed-list
+graph wiring and a node counting added set members. This supersedes the
+earlier no-`elements` rule but remains outside the executable corpus; the
+compiler examples below still use `values`. Compatibility for that older
+spelling remains undecided. Existing graph-loop restrictions are unchanged.
 
 Fixed temporal-list traversal has graduated from this design-only corpus into
 the executable compiler example

--- a/language/stdlib/README.md
+++ b/language/stdlib/README.md
@@ -41,6 +41,16 @@ compile-time definite-assignment error. The compiler now implements this
 path-sensitive check, although the temporal conditional itself still awaits
 backend lowering.
 
+## Explicit switch
+
+[Explicit switch dispatch](../docs/design/switch.md) records the agreed
+node-style native C++ path and graph-style selector validation, captures,
+results, and `default: ...` fallback. Unmatched values without a default must
+fail. The full case syntax remains open, so no switch fixture is added yet.
+The [scenario-to-C++ mappings](../docs/developer-guide/control-flow-cpp-mappings.md)
+make the expected native behaviour explicit using descriptions, result tables,
+and C++ reference fragments rather than speculative HGL declarations.
+
 ## Iteration
 
 Fixed temporal-list traversal has graduated from this design-only corpus into
@@ -61,6 +71,10 @@ records future unordered map reductions and the linear reduction option for
 lists when index order matters. Neither reduction lowering is initially
 supported by graph `for`; the example in that section is deliberately marked
 unsupported, not added here as a supported loop contract.
+
+[Graph-phase iterator predicates](../docs/design/iteration.md#deferred-graph-phase-predicates)
+are also deferred. The proposed predicate-to-switch conversion is not an
+agreed contract and has no corpus example; further loop design is paused.
 
 ## Compiler status
 

--- a/language/stdlib/examples/elements-iteration.hgl
+++ b/language/stdlib/examples/elements-iteration.hgl
@@ -1,0 +1,18 @@
+// Agreed list/set elements spelling; not yet supported by the compiler.
+// See language/docs/design/iteration.md for paired HGL/C++ mappings.
+
+fn observe_elements(samples: list<f64, 3>) {
+    for sample in elements(samples) {
+        null_sink(sample)
+    }
+}
+
+fn count_added_elements(symbols: set<str>) -> i64 {
+    when modified(symbols) && valid(symbols) {
+        var count: i64 = 0
+        for symbol in elements(symbols, added) {
+            count += 1
+        }
+        return count
+    }
+}

--- a/language/stdlib/examples/enum-enumeration-order.hgl
+++ b/language/stdlib/examples/enum-enumeration-order.hgl
@@ -1,0 +1,12 @@
+// Agreed enum declaration-order example; not yet supported by the compiler.
+// See language/docs/developer-guide/enum-cpp-mappings.md.
+// keys: "high", "low", "next".
+// values: 20, 5, 6, in declaration order, not numeric order.
+// elements: EnumerationOrder::high, EnumerationOrder::low, EnumerationOrder::next.
+// Enum enumeration call syntax and return shape remain open.
+
+enum EnumerationOrder {
+    high = 20,
+    low = 5,
+    next
+}

--- a/language/stdlib/examples/enum-values.hgl
+++ b/language/stdlib/examples/enum-values.hgl
@@ -1,0 +1,18 @@
+// Agreed enum design examples; not yet supported by the compiler.
+// See language/docs/developer-guide/enum-cpp-mappings.md.
+// Mode numbers: 10, 11, 20. Sequence numbers: 0, 1, 10, 11.
+// Stringification uses the member name, without a type prefix or number.
+// Source string-conversion call spelling remains open.
+
+enum Mode {
+    first = 10,
+    second,
+    third = 20
+}
+
+enum Sequence {
+    first,
+    second,
+    reset = 10,
+    after_reset
+}

--- a/language/stdlib/examples/enum-values.hgl
+++ b/language/stdlib/examples/enum-values.hgl
@@ -2,7 +2,7 @@
 // See language/docs/developer-guide/enum-cpp-mappings.md.
 // Mode numbers: 10, 11, 20. Sequence numbers: 0, 1, 10, 11.
 // Stringification uses the member name, without a type prefix or number.
-// Source string-conversion call spelling remains open.
+// String conversion uses the agreed str(value) spelling.
 
 enum Mode {
     first = 10,
@@ -16,3 +16,5 @@ enum Sequence {
     reset = 10,
     after_reset
 }
+
+const first_mode_name: str = str(Mode::first)

--- a/language/stdlib/examples/invalid/enum-duplicate-number.hgl
+++ b/language/stdlib/examples/invalid/enum-duplicate-number.hgl
@@ -1,0 +1,8 @@
+// Intentionally invalid enum design fixture; not implemented compiler checking.
+// Expected: duplicate member number 10 in DuplicateExplicit.
+// Numeric aliases are rejected in the initial HGL enum design.
+
+enum DuplicateExplicit {
+    first = 10,
+    second = 10
+}

--- a/language/stdlib/examples/invalid/enum-implicit-duplicate-number.hgl
+++ b/language/stdlib/examples/invalid/enum-implicit-duplicate-number.hgl
@@ -1,0 +1,9 @@
+// Intentionally invalid enum design fixture; not implemented compiler checking.
+// Expected: collision receives 11, duplicating existing.
+// Automatic numbering follows the previous member, not the largest number.
+
+enum DuplicateAutomatic {
+    existing = 11,
+    restart = 10,
+    collision
+}

--- a/language/stdlib/examples/invalid/switch-temporal-case.hgl
+++ b/language/stdlib/examples/invalid/switch-temporal-case.hgl
@@ -1,0 +1,15 @@
+// Intentionally invalid design fixture; switch checking is not implemented yet.
+// Expected: a case value must be expressible as a constant in source.
+// 'other' is a temporal input, not a constant, even if a particular run never changes it.
+
+fn temporal_case_value(mode: i64, other: i64, value: i64) -> i64 {
+    var r: i64
+    switch mode {
+        case other:
+            r = value + 1
+        default:
+            r = value - 1
+    }
+
+    return r
+}

--- a/language/stdlib/examples/string-conversion.hgl
+++ b/language/stdlib/examples/string-conversion.hgl
@@ -1,0 +1,13 @@
+// Agreed str(value) design examples; not yet supported by the compiler.
+// See language/docs/developer-guide/enum-cpp-mappings.md.
+// Constants (including enums) are covered by enum-values.hgl.
+
+fn integer_text_node(value: i64) -> str {
+    when modified(value) && valid(value) {
+        return str(value)
+    }
+}
+
+fn integer_text_graph(value: i64) -> str {
+    return str(value)
+}

--- a/language/stdlib/examples/switch-scenarios.hgl
+++ b/language/stdlib/examples/switch-scenarios.hgl
@@ -1,0 +1,137 @@
+// Agreed switch design examples; not yet supported by the compiler.
+// Paired source and C++ mappings: language/docs/developer-guide/control-flow-cpp-mappings.md.
+// Case values are source constants. This file is outside the executable example corpus.
+
+fn local_switch_example(mode: i64, x: i64, y: i64, fallback: i64) -> i64 {
+    when modified(mode, x, y, fallback) && valid(mode, x, y, fallback) {
+        var r: i64
+        switch mode {
+            case 0:
+                r = x + 1
+            case 1:
+                r = y - 1
+            default:
+                r = fallback * 3
+        }
+
+        return r * 2
+    }
+}
+
+fn local_switch_required(mode: i64, x: i64, y: i64) -> i64 {
+    when modified(mode, x, y) && valid(mode, x, y) {
+        var r: i64
+        switch mode {
+            case 0:
+                r = x + 1
+            case 1:
+                r = y - 1
+        }
+
+        return r * 2
+    }
+}
+
+fn wiring_time_switch_example(const mode: i64, x: i64, y: i64, fallback: i64) -> i64 {
+    var r: i64
+    switch mode {
+        case 0:
+            r = x + 1
+        case 1:
+            r = y - 1
+        default:
+            r = fallback * 3
+    }
+
+    return r * 2
+}
+
+fn temporal_switch_example(mode: i64, x: i64, y: i64, fallback: i64) -> i64 {
+    var r: i64
+    switch mode {
+        case 0:
+            r = x + 1
+        case 1:
+            r = y - 1
+        default:
+            r = fallback * 3
+    }
+
+    return r * 2
+}
+
+fn multiple_switch_results(mode: i64, x: i64, y: i64) -> i64 {
+    var r: i64 = x
+    var adjustment: i64 = y
+    switch mode {
+        case 0:
+            r = x + 1
+        case 1:
+            r = y - 1
+            adjustment = x + y
+        default:
+    }
+
+    return r * 2 + adjustment
+}
+
+fn early_return_switch(mode: i64, x: i64, y: i64, fallback: i64) -> i64 {
+    var r: i64
+    switch mode {
+        case 0:
+            return x + 1
+        case 1:
+            r = y - 1
+        default:
+            r = fallback * 3
+    }
+
+    return r * 2
+}
+
+fn sink_switch_example(mode: i64, value: i64) {
+    switch mode {
+        case 0:
+            debug_print("selected", value)
+        default:
+    }
+
+    debug_print("always", value)
+}
+
+fn local_switch_counters(mode: i64, value: i64) -> i64 {
+    state zero_count: i64 = 0
+    state one_count: i64 = 0
+
+    when modified(value) && valid(mode, value) {
+        switch mode {
+            case 0:
+                zero_count += 1
+                return zero_count
+            case 1:
+                one_count += 1
+                return one_count
+        }
+    }
+}
+
+fn branch_tick_count(value: i64) -> i64 {
+    state count: i64 = 0
+
+    when modified(value) && valid(value) {
+        count += 1
+        return count
+    }
+}
+
+fn graph_switch_counters(mode: i64, value: i64) -> i64 {
+    var r: i64
+    switch mode {
+        case 0:
+            r = branch_tick_count(value)
+        case 1:
+            r = branch_tick_count(value)
+    }
+
+    return r
+}


### PR DESCRIPTION
## Purpose

Fresh documentation/design checkpoint following merged PR #702, so the next HGL syntax decisions and expected C++ behaviour have a reviewable home.

No compiler, runtime, or Python implementation changes are included. The source form `switch selector { case value: ... default: ... }` is now agreed, with case values expressible as constants in source. Enum declaration/member syntax is agreed: `enum Mode { first, second }` and `Mode::first`. Explicit numbers use `= constant`; unnumbered members start at zero or increment the immediately preceding number. Duplicate numbers within an enum are initially rejected. Stringification returns the member name without a type prefix or number. String conversion uses the agreed Python-style `str(value)` spelling, while retaining enum member-name results. Enums remain distinct atomic scalar types with explicit integer conversion. Enumeration exposes names through `keys`, assigned integers through `values`, and typed enum instances through `elements`. All three enum views iterate in declaration order. `elements` is also the agreed list/set iteration spelling, superseding the earlier no-`elements` design. The exact integer-conversion spelling, enum enumeration invocation/result shape, list/set `values` compatibility, and native mapping remain open.

## Recorded agreements

- Switch source uses `switch selector { case value: ... default: ... }`; case values are source-expressible constants, not temporal inputs or state reads.
- Enum declarations support explicit integer constants and automatic numbering, reject duplicate resolved numbers, and stringify to member names through `str(value)`.
- `str(value)` follows the existing phase distinction: scalar conversion for constant/wiring-time values, conversion within node evaluation for readable values, and wired string conversion for temporal graph inputs. The spelling alone does not promise every Python formatting or conversion form.
- Enum values are not interchangeable with integers or members of other enums; equality and switch matching preserve enum identity. Obtaining an integer is an explicit type-name conversion. Its exact spelling is pending confirmation, so no new conversion syntax is added.
- Enum enumeration meanings are agreed: `keys` returns member-name strings, `values` returns assigned integers (not ordinal positions), and `elements` returns typed enum instances. All three views iterate in declaration order, never numeric or alphabetical order. Enum invocation syntax and returned collection/iterator types remain open; no speculative enum call syntax is included.
- Lists and sets use `elements` for element-only iteration, retaining list index order, unordered set membership, native predicates, REF boundaries, and phase restrictions. Current compiler examples still use `values`; whether that spelling remains an alias is undecided. This is a source design update, not support for additional graph-loop forms.
- Node-style switch dispatch lowers to native C++ within the current evaluation.
- Graph-style switching validates the selector, then uses native `switch_` and the existing `if`/`else` capture, result, REF, definite-assignment, and continuation rules.
- `default: ...` catches unmatched selector values and participates in the same branch checks.
- An unmatched selector without a default fails, including for outputless switches.
- Graph-loop predicate conversion and further loop processing are deferred; the proposed predicate-to-switch rewrite is not recorded as agreed.

## Paired HGL-to-C++ mappings

`language/docs/developer-guide/control-flow-cpp-mappings.md` contains eight worked scenarios. Each now includes the HGL source before the C++ reference mapping, expected results, capture tables, and lifetime descriptions:

1. Node-local selection followed by computation using the selected result.
2. Mandatory no-match failure when the source supplies no default.
3. Wiring-time selection of graph topology.
4. Temporal native switch wiring, including default captures and a downstream result consumer.
5. Multiple results, pure forwarding, and field-level REF adaptation requirements.
6. Early returns and branch-specific continuations.
7. Conditional sinks, explicit empty default, and an unconditional sink.
8. Node-owned state versus restarted graph-branch state, including different unmatched keys selecting the same default callable.

The switch design, developer guide, user guide, and standard-library README link to these mappings. The same ten HGL functions are collected in `language/stdlib/examples/switch-scenarios.hgl`. An intentionally invalid design fixture in `language/stdlib/examples/invalid/switch-temporal-case.hgl` illustrates a temporal input used as a case label. Neither fixture claims implemented compiler support. Enum requirements and open decisions are recorded in `language/docs/design/type-extensions.md`.

## Enum mappings

`language/docs/developer-guide/enum-cpp-mappings.md` places HGL declarations before illustrative C++ enums and a member-name helper. It covers explicit values, automatic numbering from zero and after an explicit value, and both explicit and automatic duplicate-number errors. The positive declaration fixture and two intentionally invalid fixtures live under `language/stdlib/examples/`. C++ representation details are labelled as illustrative, not a settled HGL ABI or implemented compiler feature.

The enum mapping guide now also pairs `str(Mode::first)` with its C++ constant conversion and shows integer node/graph conversion examples without assuming an unresolved enum SDK carrier. `language/stdlib/examples/string-conversion.hgl` mirrors those functions. The parser must recognize reserved `str` as a conversion call head in expression position while retaining its type meaning in annotations; this PR does not implement that parser change.

## Element traversal and enumeration order

`language/docs/design/iteration.md` now pairs `elements` HGL source with C++ fixed-list graph wiring and a node counting added set members. `language/stdlib/examples/elements-iteration.hgl` mirrors both examples. Native method names and runtime semantics are unchanged; graph-phase sets, predicates, and loop reductions remain unsupported.

`language/docs/developer-guide/enum-cpp-mappings.md` adds an enum with assigned numbers `20, 5, 6` and shows all three views retaining declaration order and enum identity. `language/stdlib/examples/enum-enumeration-order.hgl` mirrors the declaration. C++ arrays illustrate ordered metadata, not an agreed HGL return container or enum invocation syntax.

## Progress

- [x] Record node/graph switch behaviour and default/no-match rules.
- [x] Add scenario descriptions and native C++ mappings, now paired with agreed HGL source.
- [x] Record graph-phase predicates as deferred.
- [x] Agree ordinary case spelling, enclosing HGL switch form, and source-constant case values.
- [ ] Agree exact selector-type coverage and any source exposure of reload policy.
- [x] Add HGL switch design fixtures using the agreed form, including an invalid temporal case label.
- [x] Record enum support as required for named case constants.
- [x] Agree enum declaration syntax and qualified member references.
- [x] Agree explicit/automatic numbering, member-name stringification, and initial duplicate-number rejection.
- [x] Add paired HGL/C++ enum examples and duplicate-number design fixtures.
- [x] Agree `str(value)` as the source string-conversion spelling and add constant/node/graph examples.
- [x] Record distinct enum identity, explicit integer conversion, and `keys`/`values`/`elements` meanings.
- [x] Agree declaration-order enumeration for all three enum views, with a non-monotonic numbering example.
- [x] Agree list/set `elements` traversal and add paired HGL/C++ design examples.
- [ ] Confirm integer-conversion spelling and agree enum enumeration invocation/result shape and list/set `values` compatibility.
- [ ] Agree integer range/overflow, unknown imported values, construction from scalar values, and native mapping.
- [ ] Implement switch and enum compiler support separately.

## Validation

- Elements/order follow-up: all 13 documentation/design-fixture files passed scope, fence, whitespace, private-data, and 110 relative-link/anchor checks. HGL snippets match the two new corpus fixtures and precede the corresponding C++ mappings. All seven enum/conversion/iteration C++ blocks syntax-check together against source headers with Clang C++23 and warnings as errors. The standalone enum illustration compiled and ran, checking declaration order across all three views and typed enum elements. The node/graph mappings were syntax-checked, not run as new graph execution tests. `git diff --check` and `git diff --cached --check` passed. Compiler/runtime and executable examples are unchanged.

- Earlier enum identity/enumeration follow-up: all six changed Markdown files passed scope, whitespace, balanced-fence, private-data, and 71 relative-link/anchor checks. Every HGL/C++ fenced block is unchanged from the previous commit. No new code snippets or executable fixtures were added; compiler/runtime files are unchanged. `git diff --check` and `git diff --cached --check` passed.

- String-conversion follow-up: all 12 scoped documentation/design-fixture files passed link, anchor, fence, whitespace, and private-path checks; HGL snippets match the user guide and corpus. All four C++ enum/conversion blocks syntax-check together against source headers with Clang C++23 and warnings as errors. The standalone enum/constant checks compile and run with the documented numbers and names. New node/graph snippets were syntax-checked, not run as graph execution tests.

- Earlier numbered-enum follow-up: all 14 edited documentation/design-fixture files passed scope, link, anchor, fence, whitespace, and private-path checks. HGL declarations match their corpus copies. A small literal-example audit confirmed the documented numbers and both intended duplicate collisions; it is not compiler parsing or execution.
- The two standalone C++ enum blocks compiled together with Clang C++23 and `-Wall -Wextra -Wpedantic -Werror`; static and runtime checks passed for the documented numbers and all three member strings. This exercises standalone illustrations, not native registration or temporal enum execution.
- Existing switch-guide HGL/C++ snippets are unchanged in this enum update.

- `git diff --check` and `git diff --cached --check` passed.
- Documentation audit also passed for the initial checkpoint and all 13 documentation/design-fixture files in the earlier switch-source follow-up: relative links, anchors, fences, whitespace, and private-path checks.
- All eight scenarios contain HGL before any C++ block; the ten source functions match the standard-library design corpus exactly. Positive fixture case labels are integer constants; the negative fixture deliberately uses a temporal parameter. HGL examples were audited as design, not parsed or executed.
- All eight switch-guide C++ documentation blocks syntax-checked together against source headers during that follow-up using Clang C++23 with `-Wall -Wextra -Wpedantic -Werror`.
- The two standalone payload functions compiled and ran successfully, checking the documented numerical results, post-switch computation, and exceptions for unmatched selectors.
- Graph fragments were syntax-checked and reviewed against native contracts/tests; they were not run as new graph execution tests.
- Full native/Python suites were not run under the repository documentation-only policy. Existing HGL executable examples and compiler/runtime files are unchanged; new switch, enum, string-conversion, and `elements` fixtures remain outside the executable corpus. CI was not monitored.