### PR TITLE
Compile exact native scalar calls from HGL

### DIFF
--- a/language/CMakeLists.txt
+++ b/language/CMakeLists.txt
@@ -192,6 +192,7 @@ hgl_apply_warnings(hgl_descriptor)
 # Descriptor consumption is a separate boundary: the model/writer remains
 # independent of JSON parsing while check/import tooling opts into simdjson.
 add_library(hgl_descriptor_reader STATIC
+    src/descriptor/import_catalog.cpp
     src/descriptor/module_descriptor_reader.cpp
 )
 add_library(hgl::descriptor_reader ALIAS hgl_descriptor_reader)

--- a/language/cmake/HglLanguage.cmake
+++ b/language/cmake/HglLanguage.cmake
@@ -163,6 +163,21 @@ function(hgl_add_module target)
     set(_generated_descriptors)
     set(_generated_python)
     set(_generated_stems)
+    set(_module_descriptor_options)
+    set(_module_descriptor_dependencies)
+    foreach(_dependency IN LISTS _hgl_LINK_LIBRARIES)
+        if(NOT TARGET "${_dependency}")
+            continue()
+        endif()
+        get_target_property(_dependency_descriptors "${_dependency}" HGL_MODULE_DESCRIPTORS)
+        if(NOT _dependency_descriptors OR _dependency_descriptors STREQUAL "_dependency_descriptors-NOTFOUND")
+            continue()
+        endif()
+        foreach(_dependency_descriptor IN LISTS _dependency_descriptors)
+            list(APPEND _module_descriptor_options --module-descriptor "${_dependency_descriptor}")
+            list(APPEND _module_descriptor_dependencies "${_dependency_descriptor}")
+        endforeach()
+    endforeach()
     foreach(_hgl_file IN LISTS _hgl_HGL)
         get_filename_component(_hgl_abs "${_hgl_file}" ABSOLUTE)
         get_filename_component(_stem "${_hgl_abs}" NAME_WE)
@@ -186,7 +201,8 @@ function(hgl_add_module target)
         add_custom_command(
             OUTPUT ${_outputs}
             COMMAND "${_hgl_compiler}" emit-cpp "${_hgl_abs}" ${_emit_placement} ${_python_options}
-            DEPENDS "${_hgl_abs}" ${_hgl_compiler_dependency}
+                    ${_module_descriptor_options}
+            DEPENDS "${_hgl_abs}" ${_hgl_compiler_dependency} ${_module_descriptor_dependencies}
             COMMENT "hgl emit-cpp ${_stem}.hgl"
             VERBATIM
         )

--- a/language/docs/design/compiler-architecture.md
+++ b/language/docs/design/compiler-architecture.md
@@ -182,6 +182,8 @@ It distinguishes:
 - canonical types, compile-time expressions, normalized requirements, and
   effective nominal struct contracts;
 - wiring-time constants, exact calls, and nominal operator calls;
+- descriptor-selected exact native calls with owned scalar signatures, phases,
+  public headers, and build inventory;
 - runtime node state layout and initialization;
 - injected capabilities;
 - start, ordered activation, evaluation, and stop operations;

--- a/language/docs/design/native-interface.md
+++ b/language/docs/design/native-interface.md
@@ -1,8 +1,10 @@
 # Native interface
 
 Status: accepted boundary; descriptor validation, native declaration metadata,
-canonical fingerprints, the lifecycle ABI, and explicit descriptor authoring
-implemented; normalized-wrapper generation and call lowering remain
+canonical fingerprints, the lifecycle ABI, explicit descriptor authoring, and
+exact canonical-scalar evaluation calls in AOT modules implemented;
+normalized-wrapper generation, opaque state, and external scripted dependency
+loading remain
 
 ## Purpose
 
@@ -63,9 +65,13 @@ symbols, permitted phases, effects, parameter/result ownership and dependent
 lifetimes, exception policy, thread-safety policy, opaque or atomic native type
 associations, runtime images, and lifecycle ABI metadata. The reader enforces
 the initial non-blocking/noexcept evaluation envelope, explicit mutable state,
-borrow rules, and lifecycle consistency. Transitive dependency closure and the
-import/lowering path remain to be added. No HGL declaration syntax is implied
-by this list.
+borrow rules, and lifecycle consistency. The compiler can build an explicit
+module catalog from one or more descriptors, resolve a selective or aliased
+`use`, carry an exact canonical-scalar function through HIR and HGraph IR, and
+emit its reviewed `cpp_symbol` as a direct call. The AOT CMake helper obtains
+descriptors from directly linked targets. Locked transitive dependency closure
+and external-package resolution for the scripted loader remain to be added. No
+new HGL declaration syntax is implied by this list.
 
 ## Native declaration categories
 
@@ -83,15 +89,19 @@ hgraph operator implementation explicitly.
 ### Exact native value functions
 
 An exact native value function is callable only in phases allowed by its
-descriptor. The first implementation targets scalar computations inside an HGL
-runtime node and construction or cleanup of that node's private native state.
+descriptor. The implemented first slice targets exact canonical-scalar
+computations inside an HGL runtime node. Construction or cleanup of private
+native state is the next stateful slice.
 
 The generated C++ calls the declared symbol or its package-provided wrapper
 directly. The direct-wiring backend does not emulate it: a runtime-bearing
 program follows the existing generated, compiled, and loaded image path.
 
 Calls from wiring-time constant evaluation, automatic temporal lifting, and
-general compile-time execution are outside the first interface.
+general compile-time execution are outside the first interface. Although the
+phase metadata can describe wiring, start, evaluation, and stop, the compiler
+accepts a call only in a phase named by the descriptor and the implemented
+canonical-scalar slice is exercised in evaluation.
 
 ### Opaque native state
 
@@ -216,6 +226,24 @@ needs normalization, the package supplies a small reviewed wrapper and names
 that wrapper. Automatic wrapper emission is a remaining Stage F slice; the
 authoring API does not parse headers or accept arbitrary C++ declarations.
 
+For AOT compilation, place the descriptor path on the native dependency
+target's `HGL_MODULE_DESCRIPTORS` property and link that target from the HGL
+module. `hgl_add_module()` passes those descriptors to every HGL compilation
+and links the target that supplies the public header and symbol:
+
+```cmake
+set_property(TARGET acme_stats PROPERTY
+    HGL_MODULE_DESCRIPTORS "${acme_stats_descriptor}")
+
+hgl_add_module(my_hgl_nodes STATIC
+    HGL smooth.hgl
+    LINK_LIBRARIES acme_stats)
+```
+
+This bootstrap follows direct CMake target edges only. It does not yet compute
+the locked transitive descriptor closure or teach `hgl test`, `hgl run`, and
+the REPL how to resolve arbitrary external CMake packages and runtime images.
+
 An optional Clang-based binding generator may later derive the same artifact
 from annotated public headers. Clang is then a descriptor-generation tool, not
 part of HGL parsing or the definition of which arbitrary C++ constructs the
@@ -263,13 +291,15 @@ but deliberately keeps loaded images resident for process lifetime.
 The first native package proves:
 
 - descriptor-only `hgl check` without loading its library;
-- one canonical scalar value function used inside a runtime node;
+- one canonical scalar value function used inside a runtime node in an AOT
+  module;
 - one owned opaque state value constructed at startup, mutated during
   evaluation, and destroyed after stop;
 - rejection of the same calls in an unpermitted phase;
 - rejection of a borrowed value that escapes;
 - generated C++ that is a direct, readable call through public headers;
-- scripted and ahead-of-time execution with identical ticks;
+- scripted and ahead-of-time execution with identical ticks once external
+  dependency resolution is implemented;
 - descriptor/provider fingerprint mismatch before graph wiring;
 - failed activation rollback and provider removal without stale registrations;
 - an installed-SDK consumer build, not only an in-tree test.

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -240,11 +240,13 @@ HGraph IR; unsupported language-depth items remain explicit roadmap work.
   scripted native module activation, replacement, and logical removal;
 - [x] provide an installed native-package authoring API which emits, seals, and
   validates descriptors;
+- [x] resolve exact canonical-scalar native evaluation functions from explicit
+  descriptors and emit direct readable calls in AOT modules;
 - generate normalized wrappers for C++ overloads, templates, exceptions, and
   ownership boundaries;
 - [x] add phase, effect, ownership, dependent-lifetime, exception,
   thread-safety, build, lifecycle, and canonical fingerprint metadata;
-- support a canonical scalar evaluation function and owned opaque node state;
+- support owned opaque node state;
 - prove descriptor-only checking and identical scripted/AOT behavior.
 
 Acceptance is defined in [Native interface](native-interface.md#acceptance).
@@ -287,8 +289,10 @@ settled: wiring-time dereference through a reference, collection-reference
 propagation, nested reference normalization, SIGNAL spelling, multiple-parent
 field order, constructor inference, typed `const`
 generic Bundle metadata, explicit optional-field clearing, consumption of
-temporal deltas, general callable substitution, portable scripted loading, and
-runtime calls. Slice numbering
+temporal deltas, general callable substitution, portable scripted loading,
+external native-package resolution, and calls to other HGL runtime functions.
+Exact canonical-scalar native evaluation calls are supported in AOT modules;
+opaque state and scripted external dependency loading remain. Slice numbering
 below still describes the intended end-to-end acceptance rather than a claim
 that all earlier deliverables are complete.
 

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -1071,10 +1071,15 @@ public C++ value model into this descriptor arena. It allocates canonical
 scalar and nominal schema records, normalizes inventories and declaration
 order, seals the descriptor, and invokes the ordinary descriptor validator.
 Compiler-internal HIR and HGraph-IR types remain hidden behind the shared
-library boundary. Locked transitive dependency closure, normalized-wrapper
-generation, and imported native-call lowering remain Stage F work. Validating
-one file does not yet prove that its declared provider requirements are present
-or mutually compatible.
+library boundary. A data-only module catalog adapts validated descriptors into
+importable declarations. Resolution binds selective imports and module aliases
+to exact native-function symbols; type checking enforces exact
+canonical-scalar arguments, `const` roles, and permitted phases; and HGraph IR
+owns the selected C++ symbol and build inventory. The emitter renders that
+selection as a direct public-header call. Locked transitive dependency closure,
+normalized-wrapper generation, opaque state, and external-package resolution
+for scripted builds remain Stage F work. Validating one file does not yet prove
+that its declared provider requirements are present or mutually compatible.
 
 A descriptor separates its importable interface from its provider inventory.
 The interface contains automatically public nominal operators, explicitly
@@ -1464,6 +1469,14 @@ expression is read from the syntax tree.
   `modified`, `added`, or `removed` views. A concise iterator predicate is
   inlined as a readable loop guard. Keyed `out[key] = value` uses the typed TSD
   output selector and accumulates child writes in the cycle's delta.
+- **Exact native scalar calls.** Explicit module descriptors form a data-only
+  import catalog. A selected native evaluation function retains its exact
+  signature, permitted phases, public headers, C++ symbol, dependency inventory,
+  and descriptor fingerprint through HIR and HGraph IR. Its generated body is a
+  direct call such as `acme::stats::blend(value.value(), hgraph::Int{3})`; the
+  compiler neither derives an operator class nor implicitly lifts the scalar
+  function into a node. Argument order/names, exact scalar types, and `const`
+  roles are rechecked at the IR and emission boundaries.
 - **Registration.** `hgraph::OperatorProviderHandle register_operators()`
   registers each export and
   each `impl fn` with
@@ -1485,14 +1498,18 @@ expression is read from the syntax tree.
   trailing underscore on this surface without changing the registry name;
   mapping collisions and invalid native-module identifiers are diagnostics.
 
-The header includes the standard operator umbrella, the analytics header
-when the module imports from `hgraph.analytics`, and the wiring/dispatch
-headers; the source includes the header plus the scope-guard utility used by
-registration rollback. Every emitted function is preceded by a `// file:line`
-comment; output is deterministic (basenames, no timestamps).
+The header includes the sorted public headers required by selected native
+functions, the standard operator umbrella, the analytics header when the
+module imports from `hgraph.analytics`, and the wiring/dispatch headers; the
+source includes the header plus the scope-guard utility used by registration
+rollback. The emitted module descriptor unions the selected native CMake
+packages, imported targets, and runtime images with its own build boundary.
+Every emitted function is preceded by a `// file:line` comment; output is
+deterministic (basenames, no timestamps).
 
 The first pass still fails closed, before writing either file, on: generated
-runtime sources, runtime calls, non-scalar state, output kinds other than the
+runtime sources, calls to other HGL runtime functions, non-scalar state, opaque
+native state, output kinds other than the
 implemented scalar, nominal-struct, map, and reference forms, injectables other than
 `out` and `logger`, lifecycle access to temporal inputs or output, optional
 field clearing in a sparse delta, generic constructor inference and typed
@@ -1515,6 +1532,13 @@ a configuration child directory, and an installed compiler executable is a
 file dependency of every generated output. The repository's codegen tests
 build every file under `language/examples`, plus the parity and runtime
 fixtures, through exactly this function under the repository warning policy.
+For each directly linked CMake target carrying `HGL_MODULE_DESCRIPTORS`, the
+helper adds repeatable `--module-descriptor` arguments and descriptor file
+dependencies to every relevant custom command. The generated target already
+links that dependency, so its public include paths and exact native symbol are
+available to the generated call. Transitive target inspection is deliberately
+not inferred here; the application/package resolver must eventually provide a
+locked descriptor closure rather than rely on arbitrary CMake graph traversal.
 
 ## Source mapping and generated artifacts
 

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -517,8 +517,11 @@ resolution, collection predicates and iteration, and keyed collection output.
 `generated_runtime_tests.cpp` exercise the compiled node path: modified-or and
 valid-and predicates, passive sampling, ordered state mutation and final-write
 behavior, selector metadata, prior-output access, lifecycle configuration, and
-ordinary no-`when` policy. The command itself is checked on both a composition
-and a runtime fixture.
+ordinary no-`when` policy. `generated_native_tests.cpp` executes a generated
+runtime node whose body calls an exact scalar function from a native descriptor;
+the fixture also proves that `hgl_add_module()` obtains that descriptor from a
+directly linked target and compiles the required public header and symbol. The
+command itself is checked on both a composition and a runtime fixture.
 The CMake package test configures the installed-helper path without an `hgl`
 target, proves that touching the compiler regenerates outputs, checks keyword
 module namespace escaping, and asserts multi-config-safe native-module output.

--- a/language/docs/user-guide/modules-and-tools.md
+++ b/language/docs/user-guide/modules-and-tools.md
@@ -186,14 +186,17 @@ Language source cannot declare an adaptor or embed C++.
 The intended command surface is:
 
 ```text
-hgl check path/to/program.hgl [--dump-tokens] [--dump-ast] [--dump-hir]
-hgl test path/to/program.hgl [test-name]...
+hgl check path/to/program.hgl [--module-descriptor <file>]...
+        [--dump-tokens] [--dump-ast] [--dump-hir]
+hgl test path/to/program.hgl [--module-descriptor <file>]... [test-name]...
 hgl run path/to/program.hgl [--entry name] [--mode sim|realtime]
         [--start <datetime>] [--end <datetime|duration>]
         [--set name=<constant expression>]... [--config run.toml]
+        [--module-descriptor <file>]...
 hgl emit-cpp path/to/program.hgl [--out-dir <dir> | --include-dir <dir> --src-dir <dir>]
         [--python <file.py> --python-native <module>] [--print]
-hgl repl
+        [--module-descriptor <file>]...
+hgl repl [--module-descriptor <file>]...
 ```
 
 | Command | Behavior |
@@ -213,10 +216,9 @@ The current `hgl` implements `--help`, `--version`, `check`, `test`, `run`
 supported scalar runtime-node subset through a native cache on Unix; the REPL
 uses the same route when its session contains runtime declarations. `test`
 accepts test names after the file to run a selection.
-`check --dump-hir` is a compiler-development view with stable IDs and source
-ranges. Its leading `HIR resolved` state is intentional: complete type, phase,
-and effect checking is the next compiler stage, so the dump is not yet a
-promise that every expression is typed.
+`check --dump-hir` and `check --dump-hgraph-ir` are compiler-development views
+with stable IDs and source ranges. They are diagnostic views, not persisted
+formats.
 The first-pass limits are listed in
 [Testing and running](testing-and-running.md#first-pass-limits); the
 constructs `emit-cpp` does not yet lower are listed under
@@ -326,8 +328,11 @@ also verifies the descriptor's canonical SHA-256 fingerprint and lifecycle ABI
 metadata without loading native code.
 
 Descriptor validation does not yet locate or lock transitive provider
-requirements. Lowering imported native declarations into HGL calls is a next
-implementation slice.
+requirements. For source compilation, each repeatable `--module-descriptor`
+option adds one explicitly named module to the import catalog. The compiler can
+currently lower an exact, canonical-scalar native function used during runtime
+evaluation; unsupported ownership, effects, nominal native types, or phases
+are diagnosed at the import or call boundary rather than silently approximated.
 
 Native libraries create descriptors with the installed C++ target
 `hgl::native_package` and `<hgl/native_package.h>`. Its public model is narrower
@@ -359,8 +364,12 @@ hgl_add_module(prices
 ```
 
 The library `prices` publishes its generated headers and exposes its descriptor
-paths through the CMake target property `HGL_MODULE_DESCRIPTORS`;
-`PYTHON_MODULE` adds a
+paths through the CMake target property `HGL_MODULE_DESCRIPTORS`. When a target
+listed directly in `LINK_LIBRARIES` has the same property, `hgl_add_module()`
+passes those descriptors to `hgl emit-cpp`, makes them build dependencies, and
+links the target that supplies the native header and exact symbol. This initial
+bootstrap follows direct target edges; it does not yet calculate a transitive
+locked package closure. `PYTHON_MODULE` adds a
 stable-ABI extension module whose import registers every operator the HGL
 modules export, and a Python package directory with one generated wrapper
 module per source so that
@@ -384,13 +393,18 @@ functions, runtime functions and sinks, source operators and implementations,
 nominal and generic structs, fixed and duration rolling windows, sparse struct
 deltas, concise functions passed to `map`, collection inputs and iteration,
 scalar recordable state, ordered `when` handlers, `inject out`, keyed TSD output
-writes, `inject logger`, and lifecycle blocks over state and `const`
-configuration. The generated package tests compile every example as C++.
+writes, `inject logger`, lifecycle blocks over state and `const` configuration,
+and exact canonical-scalar calls imported from native descriptors during
+runtime evaluation. Native calls remain direct and readable in generated C++;
+the compiler does not synthesize an operator subclass or implicit node. The
+generated package tests compile every example and execute a native-call fixture
+as C++.
 
 It still reports, by name, and writes nothing for generated runtime sources,
-runtime function calls, non-scalar state, injectables other than `out` and
-`logger`, lifecycle access to temporal inputs or output, optional-field clearing
-in a sparse delta, generic constructor inference and typed `const` generic
+calls to other HGL runtime functions, non-scalar state, native opaque state,
+injectables other than `out` and `logger`, lifecycle access to temporal inputs
+or output, optional-field clearing in a sparse delta, generic constructor
+inference and typed `const` generic
 struct metadata, compound constant literals, `if` used as a value, and zoned or
 civil literals.
 
@@ -419,6 +433,14 @@ from the running `hgl` process, so it registers into that process's registry
 rather than linking a second static runtime. The compiler's parity suite holds
 the shared composition subset to the same ticks and executes the runtime
 subset through both the scripted and ahead-of-time compiled paths.
+
+An imported native function may add public headers, CMake packages, linked
+targets, and runtime images that do not belong to the compiler process. AOT
+modules receive that build context from `hgl_add_module()` today. Scripted
+commands validate and lower explicitly supplied descriptors but do not yet
+resolve arbitrary external package build metadata. Native calls that require
+that context are therefore AOT-only for now; descriptor-only `check` remains
+available to scripted workflows.
 
 The native path caches complete images by a SHA-256 key over the emitted code,
 the resolved compiler binary and its version/target and effective options,

--- a/language/src/README.md
+++ b/language/src/README.md
@@ -8,10 +8,10 @@ them.
 | Directory | Owns now | Target input and output |
 | --- | --- | --- |
 | `syntax/` | source buffers, diagnostics, temporal literals, lexer, parser, arena AST | source text to source-accurate syntax |
-| `semantics/` | name binding, nominal hierarchy, generic argument roles, function classification | syntax plus descriptors to resolved names and shapes |
+| `semantics/` | name binding, nominal hierarchy, generic argument roles, function classification, and a frontend-independent imported-module catalog | syntax plus an explicit package catalog to resolved names and shapes |
 | `ir/` | source-ranged HIR, canonical types, substitutions, constraint solving, phase/effect completion | resolved frontend state to typed HIR |
 | `hgraph_ir/` | canonical execution-facing types, compile-time expressions, constraints, typed source-order declaration handles, struct contracts, operator and callable interfaces | typed HIR to executable composition and runtime-node plans |
-| `descriptor/` | versioned module/interface schema, deterministic HGraph-IR snapshot, and canonical JSON serialization | hgraph IR to reviewable package metadata |
+| `descriptor/` | versioned module/interface schema, deterministic HGraph-IR snapshot, canonical JSON serialization/validation, and catalog adaptation | hgraph IR to reviewable package metadata; validated package metadata to catalog values |
 | `wiring/` | direct walk over hgraph IR | hgraph IR to public erased wiring calls |
 | `codegen/` | hgraph-IR declaration, interface, dependency, composition-body, and runtime-body emission | hgraph IR to formatted C++ and build artifacts |
 | `driver/` | commands, native build/cache/load, REPL orchestration | assemble inputs and invoke passes |

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -105,6 +105,7 @@ namespace hgl::codegen
                 Runtime,   ///< an evaluation-time scalar, optionally backed by a selector
                 Iterator,  ///< an evaluation-local borrowed collection range
                 Function,
+                NativeFunction,
                 Struct,
                 Operator,       ///< an imported kernel operator: `name` is the C++ marker
                 LocalOperator,  ///< a module `operator`: `name` is the C++ marker
@@ -121,13 +122,14 @@ namespace hgl::codegen
             std::string selector{};
             /// Const: the value type. Port: the temporal type, Unknown when the
             /// registry decides it (an operator result).
-            HType              type{};
-            gir::CallableId    callable{};
-            std::string        name{};
-            SourceRange        range{};
-            bool               structured_delta{false};
-            std::vector<HType> iterator_types{};
-            gir::ValueId       planned_iterator_predicate{};
+            HType                 type{};
+            gir::CallableId       callable{};
+            gir::NativeFunctionId native_function{};
+            std::string           name{};
+            SourceRange           range{};
+            bool                  structured_delta{false};
+            std::vector<HType>    iterator_types{};
+            gir::ValueId          planned_iterator_predicate{};
             /// Known numeric value of a constant expression. Const parameters
             /// deliberately leave this empty: they are values at composition
             /// time, not compile-time literals. The emitter uses this only for
@@ -317,6 +319,39 @@ namespace hgl::codegen
             });
         }
 
+        bool is_public_header_name(std::string_view name) {
+            if (name.empty() || name.front() == '/' || name.contains("..")) { return false; }
+            return std::ranges::all_of(name, [](char c) {
+                return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '-' ||
+                       c == '.' || c == '/' || c == '+';
+            });
+        }
+
+        [[nodiscard]] constexpr bool cpp_identifier_start(char value) noexcept {
+            return (value >= 'a' && value <= 'z') || (value >= 'A' && value <= 'Z') || value == '_';
+        }
+
+        [[nodiscard]] constexpr bool cpp_identifier_continue(char value) noexcept {
+            return cpp_identifier_start(value) || (value >= '0' && value <= '9');
+        }
+
+        /// HGraph IR can be constructed independently of a descriptor reader;
+        /// recheck the executable token boundary before inserting it into C++.
+        [[nodiscard]] bool exact_cpp_symbol(std::string_view value) noexcept {
+            if (value.starts_with("::")) { value.remove_prefix(2U); }
+            if (value.empty()) { return false; }
+            while (true) {
+                if (!cpp_identifier_start(value.front())) { return false; }
+                std::size_t length = 1U;
+                while (length < value.size() && cpp_identifier_continue(value[length])) { ++length; }
+                value.remove_prefix(length);
+                if (value.empty()) { return true; }
+                if (!value.starts_with("::")) { return false; }
+                value.remove_prefix(2U);
+                if (value.empty()) { return false; }
+            }
+        }
+
         /// The normal Python spelling of an HGL export. Keywords and the
         /// wrapper's public metadata name get a trailing underscore; a
         /// collision after this mapping is diagnosed when the module emits.
@@ -427,6 +462,7 @@ namespace hgl::codegen
             void                                       bind_hgraph_declarations();
             [[nodiscard]] const gir::Binding          &planned_binding(gir::BindingId id, SourceRange fallback);
             [[nodiscard]] const gir::Callable         &callable(gir::CallableId id, SourceRange fallback = {});
+            [[nodiscard]] const gir::NativeFunction   &native_function(gir::NativeFunctionId id, SourceRange fallback = {});
             [[nodiscard]] const gir::OperatorContract &operator_decl(gir::OperatorId id, SourceRange fallback = {});
             [[nodiscard]] const gir::StructContract   &struct_contract(gir::StructId id, SourceRange fallback = {});
             [[nodiscard]] static std::string_view      local_identity(std::string_view identity) noexcept;
@@ -490,6 +526,8 @@ namespace hgl::codegen
             [[nodiscard]] std::string argument_code(const Value &value);
             [[nodiscard]] std::string as_port(const Value &value, const HType &temporal, SourceRange range);
             [[nodiscard]] std::string as_const(const Value &value, const HType &target, SourceRange range, const std::string &what);
+            [[nodiscard]] Value       call_planned_native(gir::NativeFunctionId id, const std::vector<gir::Argument> &arguments,
+                                                          SourceRange range, Frame &frame);
             // -- statements
             void emit_planned_block(gir::BlockId id, Frame &frame, Writer &out, bool function_body, SourceRange fallback);
             void emit_planned_statement(gir::StatementId id, Frame &frame, Writer &out, SourceRange fallback);
@@ -613,6 +651,13 @@ namespace hgl::codegen
                 backend(fallback, "hgraph IR contains an invalid callable ID");
             }
             return graph_.callables[id.value];
+        }
+
+        const gir::NativeFunction &Emitter::native_function(gir::NativeFunctionId id, SourceRange fallback) {
+            if (!id.valid() || id.value >= graph_.native_functions.size()) {
+                backend(fallback, "hgraph IR contains an invalid native function ID");
+            }
+            return graph_.native_functions[id.value];
         }
 
         const gir::OperatorContract &Emitter::operator_decl(gir::OperatorId id, SourceRange fallback) {
@@ -1337,6 +1382,7 @@ namespace hgl::codegen
                 case Value::Kind::Runtime: backend(value.range, "an evaluation-time value cannot be passed while wiring");
                 case Value::Kind::Iterator: backend(value.range, "a runtime iterator is only valid as the source of a 'for' loop");
                 case Value::Kind::Function:
+                case Value::Kind::NativeFunction:
                 case Value::Kind::Struct:
                 case Value::Kind::Operator:
                 case Value::Kind::LocalOperator:
@@ -1608,6 +1654,15 @@ namespace hgl::codegen
                         result.kind     = Value::Kind::Function;
                         result.callable = reference.callable;
                         result.range    = range;
+                        return result;
+                    }
+                case gir::ReferenceKind::NativeFunction:
+                    {
+                        (void)native_function(reference.native_function, range);
+                        Value result;
+                        result.kind            = Value::Kind::NativeFunction;
+                        result.native_function = reference.native_function;
+                        result.range           = range;
                         return result;
                     }
                 case gir::ReferenceKind::Operator:
@@ -1907,6 +1962,71 @@ namespace hgl::codegen
             Value value = wire(callable_cpp_name(id), args, range, result);
             if (!has_planned_result(target.result, target.range)) { value.kind = Value::Kind::Void; }
             return value;
+        }
+
+        Value Emitter::call_planned_native(gir::NativeFunctionId id, const std::vector<gir::Argument> &arguments, SourceRange range,
+                                           Frame &frame) {
+            const gir::NativeFunction &target = native_function(id, range);
+            if (!exact_cpp_symbol(target.cpp_symbol)) {
+                backend(range, "native function '" + target.identity + "' has an invalid exact C++ symbol");
+            }
+            std::vector<std::optional<gir::ValueId>> bound(target.parameters.size());
+            std::size_t                              next = 0U;
+            for (const gir::Argument &argument : arguments) {
+                if (argument.name.empty()) {
+                    while (next < bound.size() && bound[next]) { ++next; }
+                    if (next >= bound.size()) {
+                        fail(Category::Type, argument.range,
+                             "native function '" + target.identity + "' takes " + std::to_string(target.parameters.size()) +
+                                 " arguments");
+                    }
+                    bound[next++] = argument.value;
+                    continue;
+                }
+                const auto found = std::ranges::find(target.parameters, argument.name, &gir::NativeParameter::name);
+                if (found == target.parameters.end()) {
+                    fail(Category::Name, argument.range,
+                         "native function '" + target.identity + "' has no parameter named '" + argument.name + "'");
+                }
+                const std::size_t index = static_cast<std::size_t>(found - target.parameters.begin());
+                if (bound[index]) { fail(Category::Name, argument.range, "'" + argument.name + "' is given twice"); }
+                bound[index] = argument.value;
+            }
+
+            std::vector<std::string> args;
+            args.reserve(target.parameters.size());
+            for (std::size_t index = 0; index < target.parameters.size(); ++index) {
+                const gir::NativeParameter &parameter = target.parameters[index];
+                if (!bound[index]) {
+                    fail(Category::Type, range,
+                         "native function '" + target.identity + "' needs an argument for '" + parameter.name + "'");
+                }
+                const Value argument = eval_planned_expr(*bound[index], frame);
+                const HType expected = planned_type(parameter.type, range);
+                if (!same_type(argument.type, expected)) {
+                    fail(Category::Type, argument.range, "native parameter '" + parameter.name + "' requires an exact scalar type");
+                }
+                if (parameter.is_const || !frame.runtime) {
+                    args.push_back(as_const(argument, expected, argument.range, "native parameter '" + parameter.name + "'"));
+                } else {
+                    if (!argument.is_const() && !argument.is_runtime()) {
+                        fail(Category::Type, argument.range,
+                             "native parameter '" + parameter.name + "' requires an evaluation-time scalar value");
+                    }
+                    args.push_back(argument.code);
+                }
+            }
+
+            const std::string code = target.cpp_symbol + "(" + join(args, ", ") + ")";
+            if (graph_type(target.result, range).kind == hir::TypeKind::Void) {
+                Value result;
+                result.kind  = Value::Kind::Void;
+                result.code  = code;
+                result.range = range;
+                return result;
+            }
+            const HType result_type = planned_type(target.result, range);
+            return frame.runtime ? make_runtime(code, result_type, range) : make_const(code, result_type, range);
         }
 
         Value Emitter::lower_planned_map_call(const Value &callee, const gir::Call &call, SourceRange range, Frame &frame) {
@@ -2212,7 +2332,8 @@ namespace hgl::codegen
 
         Value Emitter::eval_planned_call(const gir::Value &expression, const gir::Call &call, Frame &frame) {
             const Value callee = eval_planned_expr(call.callee, frame);
-            if (frame.runtime && callee.kind != Value::Kind::Intrinsic && callee.kind != Value::Kind::Struct) {
+            if (frame.runtime && callee.kind != Value::Kind::Intrinsic && callee.kind != Value::Kind::Struct &&
+                callee.kind != Value::Kind::NativeFunction) {
                 backend(expression.range, "calls in a runtime function are not supported by emit-cpp yet");
             }
             switch (callee.kind) {
@@ -2249,6 +2370,15 @@ namespace hgl::codegen
                         backend(expression.range, "hgraph IR exact function call disagrees with its callee reference");
                     }
                     return call_planned_function(expression.operation.callable, call.arguments, expression.range, frame);
+                case Value::Kind::NativeFunction:
+                    if (expression.operation.kind != gir::OperationKind::ExactFunction ||
+                        !expression.operation.native_function.valid()) {
+                        backend(expression.range, "hgraph IR exact native call has no resolved native function");
+                    }
+                    if (callee.native_function != expression.operation.native_function) {
+                        backend(expression.range, "hgraph IR exact native call disagrees with its callee reference");
+                    }
+                    return call_planned_native(expression.operation.native_function, call.arguments, expression.range, frame);
                 case Value::Kind::Intrinsic: return eval_planned_intrinsic(callee, call, expression.range, frame);
                 case Value::Kind::Const:
                 case Value::Kind::Port:
@@ -3593,10 +3723,13 @@ namespace hgl::codegen
             const gir::Value &value = planned_value(id, fallback);
             if (!calls.values.insert(id.value).second) { return; }
             if (value.operation.kind == gir::OperationKind::ExactFunction) {
-                if (!value.operation.callable.valid() || value.operation.callable.value >= graph_.callables.size()) {
+                if (value.operation.native_function.valid()) {
+                    (void)native_function(value.operation.native_function, value.range);
+                } else if (!value.operation.callable.valid() || value.operation.callable.value >= graph_.callables.size()) {
                     backend(value.range, "hgraph IR contains an invalid callable dependency ID");
+                } else {
+                    calls.calls.insert(value.operation.callable.value);
                 }
-                calls.calls.insert(value.operation.callable.value);
             }
             std::visit(
                 [&](const auto &node) {
@@ -3776,6 +3909,21 @@ namespace hgl::codegen
                 if (callable(id).visibility == gir::CallableVisibility::Implementation) { impls.push_back(id); }
             }
             const std::vector<gir::CallableId> internal = ordered_internal_functions();
+            std::set<std::string>              native_headers;
+            std::set<std::string>              cmake_packages{"hgraph"};
+            std::set<std::string>              imported_targets{"hgraph::core"};
+            std::set<std::string>              runtime_images;
+            for (const gir::NativeFunction &native : graph_.native_functions) {
+                for (const std::string &header : native.public_headers) {
+                    if (!is_public_header_name(header)) {
+                        backend({}, "native function '" + native.identity + "' names an unsafe public header '" + header + "'");
+                    }
+                    native_headers.insert(header);
+                }
+                cmake_packages.insert(native.cmake_packages.begin(), native.cmake_packages.end());
+                imported_targets.insert(native.imported_targets.begin(), native.imported_targets.end());
+                runtime_images.insert(native.runtime_images.begin(), native.runtime_images.end());
+            }
 
             // Bodies first: they discover which kernels (analytics) the
             // header must include. Anonymous graph bodies are collected while
@@ -3866,6 +4014,8 @@ namespace hgl::codegen
             header.line(banner);
             header.line("#pragma once");
             header.line();
+            for (const std::string &native_header : native_headers) { header.line("#include <" + native_header + ">"); }
+            if (!native_headers.empty()) { header.line(); }
             header.line("#include <hgraph/lib/std/operators/operators.h>");
             if (uses_analytics_) { header.line("#include <hgraph/analytics/operators.h>"); }
             header.line("#include <hgraph/types/graph_wiring.h>");
@@ -3952,11 +4102,14 @@ namespace hgl::codegen
                 result.python = std::move(py);
             }
             descriptor::DescribeOptions descriptor_options;
-            descriptor_options.language_version           = options_.tool_version;
-            descriptor_options.provider_identity          = result.module_name;
-            descriptor_options.public_headers             = {options_.header_name};
-            descriptor_options.cmake_packages             = {"hgraph"};
-            descriptor_options.imported_targets           = {"hgraph::core"};
+            descriptor_options.language_version  = options_.tool_version;
+            descriptor_options.provider_identity = result.module_name;
+            descriptor_options.public_headers    = {options_.header_name};
+            descriptor_options.public_headers.insert(descriptor_options.public_headers.end(), native_headers.begin(),
+                                                     native_headers.end());
+            descriptor_options.cmake_packages.assign(cmake_packages.begin(), cmake_packages.end());
+            descriptor_options.imported_targets.assign(imported_targets.begin(), imported_targets.end());
+            descriptor_options.runtime_images.assign(runtime_images.begin(), runtime_images.end());
             descriptor_options.registration_symbol        = namespace_ + "::register_operators";
             const descriptor::ModuleDescriptor descriptor = descriptor::describe_module(graph_, std::move(descriptor_options));
             result.descriptor_fingerprint                 = descriptor.descriptor_fingerprint;

--- a/language/src/descriptor/import_catalog.cpp
+++ b/language/src/descriptor/import_catalog.cpp
@@ -1,0 +1,117 @@
+#include "descriptor/import_catalog.h"
+
+#include <algorithm>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace hgl::descriptor
+{
+    namespace
+    {
+        [[nodiscard]] std::optional<semantics::ImportedScalarType> scalar_type(const ModuleDescriptor &descriptor,
+                                                                               SchemaId                id) noexcept {
+            if (id == no_schema_id || id >= descriptor.types.size()) { return std::nullopt; }
+            const TypeRecord &type = descriptor.types[id];
+            if (type.category != TypeCategory::Scalar) { return std::nullopt; }
+            using semantics::ImportedScalarType;
+            if (type.scalar_name == "bool") { return ImportedScalarType::Bool; }
+            if (type.scalar_name == "i64") { return ImportedScalarType::I64; }
+            if (type.scalar_name == "f64") { return ImportedScalarType::F64; }
+            if (type.scalar_name == "str") { return ImportedScalarType::Str; }
+            if (type.scalar_name == "date") { return ImportedScalarType::Date; }
+            if (type.scalar_name == "time") { return ImportedScalarType::Time; }
+            if (type.scalar_name == "datetime") { return ImportedScalarType::DateTime; }
+            if (type.scalar_name == "duration") { return ImportedScalarType::Duration; }
+            if (type.scalar_name == "civil_datetime") { return ImportedScalarType::CivilDateTime; }
+            if (type.scalar_name == "zoned_datetime") { return ImportedScalarType::ZonedDateTime; }
+            if (type.scalar_name == "zoned_time") { return ImportedScalarType::ZonedTime; }
+            if (type.scalar_name == "timezone") { return ImportedScalarType::TimeZone; }
+            return std::nullopt;
+        }
+
+        [[nodiscard]] std::string short_name(std::string_view module, std::string_view identity) {
+            const std::string prefix = std::string{module} + "::";
+            if (!identity.starts_with(prefix)) { return {}; }
+            identity.remove_prefix(prefix.size());
+            if (identity.empty() || identity.find("::") != std::string_view::npos) { return {}; }
+            return std::string{identity};
+        }
+
+        [[nodiscard]] semantics::NativeCallPhase phase(NativePhase value) noexcept {
+            using semantics::NativeCallPhase;
+            switch (value) {
+                case NativePhase::Wiring: return NativeCallPhase::Wiring;
+                case NativePhase::Start: return NativeCallPhase::Start;
+                case NativePhase::Evaluation: return NativeCallPhase::Evaluation;
+                case NativePhase::Stop: return NativeCallPhase::Stop;
+            }
+            std::unreachable();
+        }
+    }  // namespace
+
+    std::optional<ReadError> add_to_catalog(const ModuleDescriptor &descriptor, semantics::ModuleCatalog &catalog) {
+        if (const std::optional<ReadError> invalid = validate(descriptor)) { return invalid; }
+
+        semantics::ImportableModule module;
+        module.identity               = descriptor.module_identity;
+        module.descriptor_fingerprint = descriptor.descriptor_fingerprint;
+        for (std::size_t declaration_index = 0; declaration_index < descriptor.native_declarations.size(); ++declaration_index) {
+            const NativeDeclaration &declaration = descriptor.native_declarations[declaration_index];
+            if (declaration.category != NativeDeclarationCategory::Function) { continue; }
+
+            semantics::ImportedFunction function;
+            function.module_identity        = descriptor.module_identity;
+            function.name                   = short_name(descriptor.module_identity, declaration.identity);
+            function.identity               = declaration.identity;
+            function.cpp_symbol             = declaration.cpp_symbol;
+            function.public_headers         = descriptor.build.public_headers;
+            function.cmake_packages         = descriptor.build.cmake_packages;
+            function.imported_targets       = descriptor.build.imported_targets;
+            function.runtime_images         = descriptor.build.runtime_images;
+            function.descriptor_fingerprint = descriptor.descriptor_fingerprint;
+            if (function.name.empty()) {
+                return ReadError{"$.native.declarations[" + std::to_string(declaration_index) + "].identity",
+                                 "native function identity must be '" + descriptor.module_identity + "::<name>'"};
+            }
+            if (!declaration.effects.empty()) {
+                function.support_error = "native scalar calls with declared effects are not supported yet";
+            }
+            if (declaration.phases.size() != 1U || declaration.phases.front() != NativePhase::Evaluation) {
+                function.support_error = "native scalar calls currently require the evaluation phase only";
+            }
+            if (declaration.thread_safety == NativeThreadSafety::Serialized) {
+                function.support_error = "serialized native scalar calls are not supported yet";
+            }
+            if (declaration.result.ownership != NativeOwnership::Value || declaration.result.mutable_value ||
+                !declaration.result.dependent_on.empty()) {
+                function.support_error = "native scalar call results must use value ownership";
+            }
+            for (std::size_t index = 0; index < declaration.signature.parameters.size(); ++index) {
+                const Parameter &parameter = declaration.signature.parameters[index];
+                const auto       type      = scalar_type(descriptor, parameter.type);
+                if (!type) {
+                    function.support_error = "native exact calls currently require canonical scalar parameter types";
+                    continue;
+                }
+                const NativeValuePolicy &policy = declaration.parameters[index].value;
+                if (policy.ownership != NativeOwnership::Value || policy.mutable_value || !policy.dependent_on.empty()) {
+                    function.support_error = "native scalar call parameters must use value ownership";
+                }
+                function.parameters.push_back(semantics::ImportedParameter{parameter.name, *type, parameter.is_const});
+            }
+            if (declaration.signature.result != no_schema_id) {
+                function.result = scalar_type(descriptor, declaration.signature.result);
+                if (!function.result) { function.support_error = "native exact calls currently require a canonical scalar result"; }
+            }
+            for (NativePhase allowed : declaration.phases) { function.phases.push_back(phase(allowed)); }
+            module.functions.push_back(std::move(function));
+        }
+
+        if (const std::optional<semantics::CatalogError> error = catalog.add(std::move(module))) {
+            return ReadError{error->path, error->message};
+        }
+        return std::nullopt;
+    }
+}  // namespace hgl::descriptor

--- a/language/src/descriptor/import_catalog.h
+++ b/language/src/descriptor/import_catalog.h
@@ -1,0 +1,17 @@
+#ifndef HGL_DESCRIPTOR_IMPORT_CATALOG_H
+#define HGL_DESCRIPTOR_IMPORT_CATALOG_H
+
+#include "descriptor/module_descriptor.h"
+#include "descriptor/module_descriptor_reader.h"
+#include "semantics/module_catalog.h"
+
+#include <optional>
+
+namespace hgl::descriptor
+{
+    /// Copy one already validated descriptor into the data-only semantic
+    /// module catalog. Descriptor-local schema IDs never cross this boundary.
+    [[nodiscard]] std::optional<ReadError> add_to_catalog(const ModuleDescriptor &descriptor, semantics::ModuleCatalog &catalog);
+}  // namespace hgl::descriptor
+
+#endif  // HGL_DESCRIPTOR_IMPORT_CATALOG_H

--- a/language/src/driver/driver.cpp
+++ b/language/src/driver/driver.cpp
@@ -1,6 +1,7 @@
 #include "driver/driver.h"
 
 #include "codegen/cpp_emitter.h"
+#include "descriptor/import_catalog.h"
 #include "descriptor/module_descriptor_reader.h"
 #include "driver/cpp_formatter.h"
 #include "driver/line_reader.h"
@@ -45,14 +46,16 @@ namespace hgl::driver
         void print_help() {
             std::cout << "hgl - experimental hgraph language toolchain\n\n"
                          "Usage:\n"
-                         "  hgl check <file> [--dump-tokens] [--dump-ast] [--dump-hir] [--dump-hgraph-ir]\n"
-                         "  hgl test <file> [test-name]...\n"
+                         "  hgl check <file> [--module-descriptor <file>]...\n"
+                         "            [--dump-tokens] [--dump-ast] [--dump-hir] [--dump-hgraph-ir]\n"
+                         "  hgl test <file> [test-name]... [--module-descriptor <file>]...\n"
                          "  hgl run <file> [--entry <name>] [--mode sim|realtime]\n"
                          "          [--start <datetime>] [--end <datetime|duration>]\n"
-                         "          [--set <name>=<constant expression>]...\n"
+                         "          [--set <name>=<constant expression>]... [--module-descriptor <file>]...\n"
                          "  hgl emit-cpp <file> [--out-dir <dir> | --include-dir <dir> --src-dir <dir>]\n"
                          "               [--python <file.py> --python-native <module>] [--print]\n"
-                         "  hgl repl\n"
+                         "               [--module-descriptor <file>]...\n"
+                         "  hgl repl [--module-descriptor <file>]...\n"
                          "  hgl --help\n"
                          "  hgl --version\n\n"
                          "Commands:\n"
@@ -88,6 +91,35 @@ namespace hgl::driver
             return std::string{std::istreambuf_iterator<char>{in}, std::istreambuf_iterator<char>{}};
         }
 
+        std::optional<int> collect_module_descriptors(std::span<const std::string_view> arguments,
+                                                      std::vector<std::string_view> &remaining, semantics::ModuleCatalog &catalog) {
+            for (std::size_t index = 0; index < arguments.size(); ++index) {
+                if (arguments[index] != "--module-descriptor") {
+                    remaining.push_back(arguments[index]);
+                    continue;
+                }
+                if (++index >= arguments.size()) { return usage_error("--module-descriptor needs a file"); }
+                const std::string                path{arguments[index]};
+                const std::optional<std::string> json = read_file(path);
+                if (!json) {
+                    std::cerr << "hgl: cannot read module descriptor '" << path << "'\n";
+                    return exit_usage;
+                }
+                const descriptor::ReadResult parsed = descriptor::read_json(*json);
+                if (!parsed || !parsed.value) {
+                    const descriptor::ReadError error =
+                        parsed.error.value_or(descriptor::ReadError{"$", "descriptor reader returned no result"});
+                    std::cerr << path << ':' << error.path << ": descriptor: " << error.message << '\n';
+                    return exit_diagnostics;
+                }
+                if (const std::optional<descriptor::ReadError> error = descriptor::add_to_catalog(*parsed.value, catalog)) {
+                    std::cerr << path << ':' << error->path << ": descriptor: " << error->message << '\n';
+                    return exit_diagnostics;
+                }
+            }
+            return std::nullopt;
+        }
+
         void dump_tokens(const syntax::SourceFile &file, const syntax::LexResult &lexed) {
             for (const syntax::Token &token : lexed.tokens) {
                 const syntax::Location at = file.location(token.range.begin);
@@ -116,10 +148,10 @@ namespace hgl::driver
             Unit(std::string path, std::string text) : file{std::move(path), std::move(text)} {}
         };
 
-        void frontend(Unit &unit) {
+        void frontend(Unit &unit, const semantics::ModuleCatalog &catalog) {
             unit.module = syntax::parse(unit.file, unit.diagnostics);
             if (unit.diagnostics.has_errors()) { return; }
-            unit.resolved = semantics::resolve(unit.file, unit.module, wiring::has_operator, unit.diagnostics);
+            unit.resolved = semantics::resolve(unit.file, unit.module, catalog, wiring::has_operator, unit.diagnostics);
             if (unit.diagnostics.has_errors()) { return; }
             unit.hir = ir::lower_to_hir(unit.module, unit.resolved, unit.diagnostics);
             if (unit.diagnostics.has_errors()) { return; }
@@ -129,22 +161,23 @@ namespace hgl::driver
             unit.ok = !unit.diagnostics.has_errors();
         }
 
-        std::optional<Unit> load(const std::string &path) {
+        std::optional<Unit> load(const std::string &path, const semantics::ModuleCatalog &catalog) {
             std::optional<std::string> text = read_file(path);
             if (!text) {
                 std::cerr << "hgl: cannot read '" << path << "'\n";
                 return std::nullopt;
             }
             Unit unit{path, std::move(*text)};
-            frontend(unit);
+            frontend(unit, catalog);
             return unit;
         }
 
         bool needs_native_module(const Unit &unit) {
-            return unit.hgraph && std::any_of(unit.hgraph->callables.begin(), unit.hgraph->callables.end(), [](const auto &item) {
-                       return item.kind == hgraph_ir::CallableKind::RuntimeNode ||
-                              item.visibility == hgraph_ir::CallableVisibility::Implementation;
-                   });
+            return unit.hgraph && (!unit.hgraph->native_functions.empty() ||
+                                   std::any_of(unit.hgraph->callables.begin(), unit.hgraph->callables.end(), [](const auto &item) {
+                                       return item.kind == hgraph_ir::CallableKind::RuntimeNode ||
+                                              item.visibility == hgraph_ir::CallableVisibility::Implementation;
+                                   }));
         }
 
         std::optional<codegen::EmittedModule> emit_native_module(Unit &unit, std::string_view language_version) {
@@ -186,7 +219,7 @@ namespace hgl::driver
             return true;
         }
 
-        int check(std::span<const std::string_view> arguments) {
+        int check(std::span<const std::string_view> arguments, const semantics::ModuleCatalog &catalog) {
             std::optional<std::string> path;
             bool                       want_tokens    = false;
             bool                       want_ast       = false;
@@ -240,7 +273,7 @@ namespace hgl::driver
                 dump_tokens(unit.file, syntax::lex(unit.file, lex_diagnostics));
                 // The parser lexes again so token diagnostics are reported once.
             }
-            frontend(unit);
+            frontend(unit, catalog);
             if (want_ast) { std::cout << syntax::print_ast(unit.module); }
             if (want_hir && !unit.hir.path.empty()) { std::cout << ir::print_hir(unit.hir); }
             if (want_hgraph_ir && unit.hgraph) { std::cout << hgraph_ir::print(*unit.hgraph); }
@@ -264,7 +297,8 @@ namespace hgl::driver
             out << results.size() << (results.size() == 1 ? " test" : " tests") << ", " << failed << " failed\n";
         }
 
-        int test(std::span<const std::string_view> arguments, std::string_view language_version) {
+        int test(std::span<const std::string_view> arguments, std::string_view language_version,
+                 const semantics::ModuleCatalog &catalog) {
             std::optional<std::string> path;
             wiring::TestOptions        options;
             for (const std::string_view argument : arguments) {
@@ -276,7 +310,7 @@ namespace hgl::driver
                 }
             }
             if (!path) { return usage_error("test needs a file"); }
-            std::optional<Unit> unit = load(*path);
+            std::optional<Unit> unit = load(*path, catalog);
             if (!unit) { return exit_usage; }
             if (!unit->ok) {
                 std::cerr << unit->diagnostics.render(unit->file);
@@ -311,7 +345,8 @@ namespace hgl::driver
             return parsed.value;
         }
 
-        int run_command(std::span<const std::string_view> arguments, std::string_view language_version) {
+        int run_command(std::span<const std::string_view> arguments, std::string_view language_version,
+                        const semantics::ModuleCatalog &catalog) {
             std::optional<std::string>                       path;
             wiring::RunOptions                               options;
             std::vector<std::pair<std::string, std::string>> raw_settings;
@@ -367,11 +402,11 @@ namespace hgl::driver
                 }
             }
             if (!path) { return usage_error("run needs a file"); }
-            std::optional<Unit> unit = load(*path);
+            std::optional<Unit> unit = load(*path, catalog);
             if (!unit) { return exit_usage; }
             for (const auto &[name, text] : raw_settings) {
                 Unit setting{"--set " + name, "module hgl.cli\ntest __set { " + text + " }\n"};
-                frontend(setting);
+                frontend(setting, catalog);
                 std::optional<hgraph::Value> value;
                 if (setting.ok) {
                     const hgraph_ir::Block &body = setting.hgraph->blocks[setting.hgraph->tests.front().body.value];
@@ -411,7 +446,8 @@ namespace hgl::driver
             return static_cast<bool>(out);
         }
 
-        int emit_cpp(std::span<const std::string_view> arguments, std::string_view tool_version) {
+        int emit_cpp(std::span<const std::string_view> arguments, std::string_view tool_version,
+                     const semantics::ModuleCatalog &catalog) {
             std::optional<std::string> path;
             std::optional<std::string> out_dir;
             std::optional<std::string> include_dir;
@@ -460,7 +496,7 @@ namespace hgl::driver
             if (python_path && python_native.empty()) { return usage_error("--python needs --python-native <module>"); }
             if (!python_path && !python_native.empty()) { return usage_error("--python-native needs --python <file>"); }
 
-            std::optional<Unit> unit = load(*path);
+            std::optional<Unit> unit = load(*path, catalog);
             if (!unit) { return exit_usage; }
             if (!unit->ok) {
                 std::cerr << unit->diagnostics.render(unit->file);
@@ -581,7 +617,8 @@ namespace hgl::driver
         class Repl
         {
           public:
-            explicit Repl(std::string_view language_version) : language_version_(language_version) {}
+            Repl(std::string_view language_version, const semantics::ModuleCatalog &catalog)
+                : language_version_(language_version), catalog_(catalog) {}
 
             int loop() {
                 std::cout << "hgl repl " << hgraph::release_version_string << " (hgraph api " << hgraph::version_string
@@ -684,7 +721,7 @@ namespace hgl::driver
 
             void declare(const std::string &input) {
                 Unit unit{"<repl>", session_text() + input};
-                frontend(unit);
+                frontend(unit, catalog_);
                 if (!unit.ok) {
                     std::cout << unit.diagnostics.render(unit.file);
                     return;
@@ -704,7 +741,7 @@ namespace hgl::driver
 
             void evaluate(const std::string &input) {
                 Unit unit{"<repl>", session_text() + "test __repl {\n" + bindings_text() + "    " + input + "}\n"};
-                frontend(unit);
+                frontend(unit, catalog_);
                 if (!unit.ok) {
                     std::cout << unit.diagnostics.render(unit.file);
                     return;
@@ -744,17 +781,19 @@ namespace hgl::driver
                 return true;
             }
 
-            std::vector<std::string>    declarations_;
-            std::vector<std::string>    bindings_;
-            std::string                 language_version_;
-            std::optional<NativeModule> native_module_{};
-            LineReader                  reader_{};
+            std::vector<std::string>        declarations_;
+            std::vector<std::string>        bindings_;
+            std::string                     language_version_;
+            const semantics::ModuleCatalog &catalog_;
+            std::optional<NativeModule>     native_module_{};
+            LineReader                      reader_{};
         };
 
-        int repl(std::span<const std::string_view> arguments, std::string_view language_version) {
+        int repl(std::span<const std::string_view> arguments, std::string_view language_version,
+                 const semantics::ModuleCatalog &catalog) {
             if (!arguments.empty()) { return usage_error("repl takes no arguments"); }
             wiring::ensure_session();
-            Repl session{language_version};
+            Repl session{language_version, catalog};
             return session.loop();
         }
     }  // namespace
@@ -776,11 +815,15 @@ namespace hgl::driver
             print_version(tool_version);
             return exit_ok;
         }
-        if (command == "check") { return check(rest); }
-        if (command == "test") { return test(rest, tool_version); }
-        if (command == "run") { return run_command(rest, tool_version); }
-        if (command == "repl") { return repl(rest, tool_version); }
-        if (command == "emit-cpp") { return emit_cpp(rest, tool_version); }
+        semantics::ModuleCatalog      catalog;
+        std::vector<std::string_view> command_arguments;
+        if (const std::optional<int> error = collect_module_descriptors(rest, command_arguments, catalog)) { return *error; }
+        const std::span<const std::string_view> filtered{command_arguments};
+        if (command == "check") { return check(filtered, catalog); }
+        if (command == "test") { return test(filtered, tool_version, catalog); }
+        if (command == "run") { return run_command(filtered, tool_version, catalog); }
+        if (command == "repl") { return repl(filtered, tool_version, catalog); }
+        if (command == "emit-cpp") { return emit_cpp(filtered, tool_version, catalog); }
         if (command == "build") {
             return usage_error("'build' is not a command; build a package from emit-cpp output with the "
                                "hgl_add_module() CMake function (user guide, \"Building a package\")");

--- a/language/src/hgraph_ir/complete.cpp
+++ b/language/src/hgraph_ir/complete.cpp
@@ -51,6 +51,24 @@ namespace hgl::hgraph_ir
             void validate_operations() {
                 for (const Value &value : module_.values) {
                     const Operation &operation = value.operation;
+                    if (operation.kind == OperationKind::ExactFunction) {
+                        const bool source_call = operation.callable.valid();
+                        const bool native_call = operation.native_function.valid();
+                        if (source_call == native_call) {
+                            diagnostics_.report(syntax::Category::Build, value.range,
+                                                "exact function '" + operation_name(operation) +
+                                                    "' must name exactly one source or native callable");
+                        } else if (source_call && operation.callable.value >= module_.callables.size()) {
+                            diagnostics_.report(syntax::Category::Build, value.range,
+                                                "exact function '" + operation_name(operation) +
+                                                    "' refers to an invalid source callable");
+                        } else if (native_call && operation.native_function.value >= module_.native_functions.size()) {
+                            diagnostics_.report(syntax::Category::Build, value.range,
+                                                "exact function '" + operation_name(operation) +
+                                                    "' refers to an invalid native callable");
+                        }
+                        continue;
+                    }
                     if (operation.kind != OperationKind::NominalOperator) { continue; }
 
                     // Constant-folded language operators do not execute and

--- a/language/src/hgraph_ir/ir.h
+++ b/language/src/hgraph_ir/ir.h
@@ -20,17 +20,18 @@ namespace hgl::hgraph_ir
         friend constexpr bool        operator==(Id, Id) noexcept = default;
     };
 
-    using TypeId       = Id<struct TypeTag>;
-    using StructId     = Id<struct StructTag>;
-    using OperatorId   = Id<struct OperatorTag>;
-    using CallableId   = Id<struct CallableTag>;
-    using TestId       = Id<struct TestTag>;
-    using ConstExprId  = Id<struct ConstExprTag>;
-    using ConstraintId = Id<struct ConstraintTag>;
-    using BindingId    = Id<struct BindingTag>;
-    using ValueId      = Id<struct ValueTag>;
-    using StatementId  = Id<struct StatementTag>;
-    using BlockId      = Id<struct BlockTag>;
+    using TypeId           = Id<struct TypeTag>;
+    using StructId         = Id<struct StructTag>;
+    using OperatorId       = Id<struct OperatorTag>;
+    using NativeFunctionId = Id<struct NativeFunctionTag>;
+    using CallableId       = Id<struct CallableTag>;
+    using TestId           = Id<struct TestTag>;
+    using ConstExprId      = Id<struct ConstExprTag>;
+    using ConstraintId     = Id<struct ConstraintTag>;
+    using BindingId        = Id<struct BindingTag>;
+    using ValueId          = Id<struct ValueTag>;
+    using StatementId      = Id<struct StatementTag>;
+    using BlockId          = Id<struct BlockTag>;
 
     enum class ConstExprKind : std::uint8_t {
         Literal,
@@ -219,6 +220,30 @@ namespace hgl::hgraph_ir
         syntax::SourceRange           range{};
     };
 
+    struct NativeParameter
+    {
+        std::string name{};
+        TypeId      type{};
+        bool        is_const{false};
+    };
+
+    /// Descriptor-provided exact native callable, independent of descriptor
+    /// arena storage and dynamic module handles.
+    struct NativeFunction
+    {
+        std::string                       module_identity{};
+        std::string                       identity{};
+        std::string                       cpp_symbol{};
+        std::vector<NativeParameter>      parameters{};
+        TypeId                            result{};
+        std::vector<ir::hir::NativePhase> phases{};
+        std::vector<std::string>          public_headers{};
+        std::vector<std::string>          cmake_packages{};
+        std::vector<std::string>          imported_targets{};
+        std::vector<std::string>          runtime_images{};
+        std::string                       descriptor_fingerprint{};
+    };
+
     struct Capability
     {
         std::string name{};
@@ -253,6 +278,7 @@ namespace hgl::hgraph_ir
     enum class ReferenceKind : std::uint8_t {
         Binding,
         Callable,
+        NativeFunction,
         Operator,
         Struct,
         Intrinsic,
@@ -260,11 +286,12 @@ namespace hgl::hgraph_ir
 
     struct Reference
     {
-        ReferenceKind kind{ReferenceKind::Binding};
-        BindingId     binding{};
-        CallableId    callable{};
-        std::string   identity{};
-        std::string   registry_name{};
+        ReferenceKind    kind{ReferenceKind::Binding};
+        BindingId        binding{};
+        CallableId       callable{};
+        NativeFunctionId native_function{};
+        std::string      identity{};
+        std::string      registry_name{};
     };
 
     enum class OperationKind : std::uint8_t {
@@ -295,6 +322,7 @@ namespace hgl::hgraph_ir
     {
         OperationKind             kind{OperationKind::None};
         CallableId                callable{};
+        NativeFunctionId          native_function{};
         CallableId                candidate{};
         BindingId                 capability{};
         std::string               identity{};
@@ -532,6 +560,7 @@ namespace hgl::hgraph_ir
         std::vector<Constraint>       constraints{};
         std::vector<StructContract>   structures{};
         std::vector<OperatorContract> operators{};
+        std::vector<NativeFunction>   native_functions{};
         std::vector<Callable>         callables{};
         std::vector<Binding>          bindings{};
         std::vector<Value>            values{};

--- a/language/src/hgraph_ir/lower.cpp
+++ b/language/src/hgraph_ir/lower.cpp
@@ -33,6 +33,7 @@ namespace hgl::hgraph_ir
                 lower_constraints();
                 lower_structures();
                 lower_operators();
+                lower_native_functions();
                 lower_callables();
                 lower_tests();
                 collect_provider_requirements();
@@ -586,6 +587,35 @@ namespace hgl::hgraph_ir
                 return found == callables_.end() ? CallableId{} : found->second;
             }
 
+            [[nodiscard]] NativeFunctionId native_function(hir::SymbolId source_id) const noexcept {
+                if (!source_id.valid()) { return {}; }
+                const auto found = native_functions_.find(source_id.value);
+                return found == native_functions_.end() ? NativeFunctionId{} : found->second;
+            }
+
+            void lower_native_functions() {
+                for (const hir::NativeFunction &source : source_.native_functions) {
+                    const NativeFunctionId id{static_cast<std::uint32_t>(result_.native_functions.size())};
+                    native_functions_.emplace(source.symbol.value, id);
+                    NativeFunction target;
+                    target.module_identity        = source.module_identity;
+                    target.identity               = source.identity;
+                    target.cpp_symbol             = source.cpp_symbol;
+                    target.result                 = lower_type(source.result);
+                    target.phases                 = source.phases;
+                    target.public_headers         = source.public_headers;
+                    target.cmake_packages         = source.cmake_packages;
+                    target.imported_targets       = source.imported_targets;
+                    target.runtime_images         = source.runtime_images;
+                    target.descriptor_fingerprint = source.descriptor_fingerprint;
+                    for (const hir::NativeParameter &parameter : source.parameters) {
+                        target.parameters.push_back(
+                            NativeParameter{parameter.name, lower_type(parameter.type), parameter.is_const});
+                    }
+                    result_.native_functions.push_back(std::move(target));
+                }
+            }
+
             [[nodiscard]] Reference lower_reference(hir::SymbolId source_id) const {
                 Reference target;
                 if (!source_id.valid()) { return target; }
@@ -601,6 +631,10 @@ namespace hgl::hgraph_ir
                     case hir::SymbolKind::Function:
                         target.kind     = ReferenceKind::Callable;
                         target.callable = callable(source_id);
+                        break;
+                    case hir::SymbolKind::ImportedFunction:
+                        target.kind            = ReferenceKind::NativeFunction;
+                        target.native_function = native_function(source_id);
                         break;
                     case hir::SymbolKind::Operator:
                     case hir::SymbolKind::ImportedOperator: target.kind = ReferenceKind::Operator; break;
@@ -637,6 +671,7 @@ namespace hgl::hgraph_ir
                 Operation target;
                 target.kind            = lower_operation_kind(source.kind);
                 target.callable        = callable(source.target);
+                target.native_function = native_function(source.target);
                 target.candidate       = callable(source.candidate);
                 target.capability      = binding(source.target);
                 target.identity        = source.identity;
@@ -913,18 +948,19 @@ namespace hgl::hgraph_ir
                 }
             }
 
-            const hir::Module                                &source_;
-            syntax::DiagnosticSink                           &diagnostics_;
-            Module                                            result_{};
-            std::unordered_map<std::uint32_t, TypeId>         types_{};
-            std::unordered_map<std::uint32_t, ConstExprId>    const_exprs_{};
-            std::unordered_map<std::uint32_t, ConstraintId>   constraints_{};
-            std::unordered_map<std::uint32_t, BindingId>      bindings_{};
-            std::unordered_map<std::uint32_t, CallableId>     callables_{};
-            std::unordered_map<std::uint32_t, ValueId>        values_{};
-            std::unordered_map<std::uint32_t, StatementId>    statements_{};
-            std::unordered_map<std::uint32_t, BlockId>        blocks_{};
-            std::unordered_map<std::uint32_t, DeclarationRef> declarations_{};
+            const hir::Module                                  &source_;
+            syntax::DiagnosticSink                             &diagnostics_;
+            Module                                              result_{};
+            std::unordered_map<std::uint32_t, TypeId>           types_{};
+            std::unordered_map<std::uint32_t, ConstExprId>      const_exprs_{};
+            std::unordered_map<std::uint32_t, ConstraintId>     constraints_{};
+            std::unordered_map<std::uint32_t, BindingId>        bindings_{};
+            std::unordered_map<std::uint32_t, CallableId>       callables_{};
+            std::unordered_map<std::uint32_t, NativeFunctionId> native_functions_{};
+            std::unordered_map<std::uint32_t, ValueId>          values_{};
+            std::unordered_map<std::uint32_t, StatementId>      statements_{};
+            std::unordered_map<std::uint32_t, BlockId>          blocks_{};
+            std::unordered_map<std::uint32_t, DeclarationRef>   declarations_{};
         };
     }  // namespace
 

--- a/language/src/hgraph_ir/printer.cpp
+++ b/language/src/hgraph_ir/printer.cpp
@@ -119,6 +119,14 @@ namespace hgl::hgraph_ir
             }
         }
 
+        void print_native_function_id(std::ostream &out, NativeFunctionId id) {
+            if (id.valid()) {
+                out << 'z' << id.value;
+            } else {
+                out << '_';
+            }
+        }
+
         void print_declaration_ref(std::ostream &out, const DeclarationRef &declaration) {
             std::visit(
                 [&](auto id) {
@@ -240,6 +248,10 @@ namespace hgl::hgraph_ir
             if (operation.callable.valid()) {
                 out << " callable=";
                 print_callable_id(out, operation.callable);
+            }
+            if (operation.native_function.valid()) {
+                out << " native=";
+                print_native_function_id(out, operation.native_function);
             }
             if (operation.candidate.valid()) {
                 out << " candidate=";
@@ -587,6 +599,27 @@ namespace hgl::hgraph_ir
             out << '\n';
         }
 
+        out << "native-functions\n";
+        static constexpr std::string_view native_phase_names[]{"wiring", "start", "evaluation", "stop"};
+        for (std::size_t native_id = 0; native_id < module.native_functions.size(); ++native_id) {
+            const NativeFunction &native = module.native_functions[native_id];
+            out << "  z" << native_id << ' ' << native.identity << " cpp=" << native.cpp_symbol << " (";
+            for (std::size_t index = 0; index < native.parameters.size(); ++index) {
+                if (index != 0U) { out << ", "; }
+                if (native.parameters[index].is_const) { out << "const "; }
+                out << native.parameters[index].name << ':';
+                print_type_id(out, native.parameters[index].type);
+            }
+            out << ") -> ";
+            print_type_id(out, native.result);
+            out << " phases=[";
+            for (std::size_t index = 0; index < native.phases.size(); ++index) {
+                if (index != 0U) { out << ", "; }
+                out << native_phase_names[static_cast<std::size_t>(native.phases[index])];
+            }
+            out << "]\n";
+        }
+
         out << "callables\n";
         for (const Callable &callable : module.callables) {
             static constexpr std::string_view visibility[]{"internal", "export", "impl"};
@@ -649,12 +682,15 @@ namespace hgl::hgraph_ir
                         out << "literal ";
                         print_constant(out, node.value);
                     } else if constexpr (std::is_same_v<T, Reference>) {
-                        static constexpr std::string_view names[]{"binding", "callable", "operator", "struct", "intrinsic"};
+                        static constexpr std::string_view names[]{"binding",  "callable", "native-function",
+                                                                  "operator", "struct",   "intrinsic"};
                         out << "reference " << names[static_cast<std::size_t>(node.kind)] << ' ';
                         if (node.binding.valid()) {
                             print_binding_id(out, node.binding);
                         } else if (node.callable.valid()) {
                             print_callable_id(out, node.callable);
+                        } else if (node.native_function.valid()) {
+                            print_native_function_id(out, node.native_function);
                         } else {
                             out << node.identity;
                         }

--- a/language/src/ir/hir.h
+++ b/language/src/ir/hir.h
@@ -79,6 +79,7 @@ namespace hgl::ir::hir
         InjectedCapability,
         LoopValue,
         LambdaParameter,
+        ImportedFunction,
         ImportedOperator,
         Intrinsic,
     };
@@ -490,6 +491,38 @@ namespace hgl::ir::hir
         std::vector<Parameter> parameters{};
         TypeId                 result{};
     };
+
+    enum class NativePhase : std::uint8_t {
+        Wiring,
+        Start,
+        Evaluation,
+        Stop,
+    };
+
+    struct NativeParameter
+    {
+        std::string name{};
+        TypeId      type{};
+        bool        is_const{false};
+    };
+
+    /// An exact, descriptor-provided native callable. This is copied into HIR
+    /// so later passes never depend on descriptor storage or a loaded module.
+    struct NativeFunction
+    {
+        SymbolId                     symbol{};
+        std::string                  module_identity{};
+        std::string                  identity{};
+        std::string                  cpp_symbol{};
+        std::vector<NativeParameter> parameters{};
+        TypeId                       result{};
+        std::vector<NativePhase>     phases{};
+        std::vector<std::string>     public_headers{};
+        std::vector<std::string>     cmake_packages{};
+        std::vector<std::string>     imported_targets{};
+        std::vector<std::string>     runtime_images{};
+        std::string                  descriptor_fingerprint{};
+    };
     struct StructField
     {
         std::string         name{};
@@ -560,16 +593,17 @@ namespace hgl::ir::hir
 
     struct Module
     {
-        std::string                path{};
-        Completion                 completion{Completion::Resolved};
-        std::vector<Symbol>        symbols{};
-        std::vector<Type>          types{};
-        std::vector<Expr>          exprs{};
-        std::vector<Stmt>          stmts{};
-        std::vector<Block>         blocks{};
-        std::vector<Constraint>    constraints{};
-        std::vector<Declaration>   declarations{};
-        std::vector<DeclarationId> source_order{};
+        std::string                 path{};
+        Completion                  completion{Completion::Resolved};
+        std::vector<Symbol>         symbols{};
+        std::vector<Type>           types{};
+        std::vector<Expr>           exprs{};
+        std::vector<Stmt>           stmts{};
+        std::vector<Block>          blocks{};
+        std::vector<Constraint>     constraints{};
+        std::vector<NativeFunction> native_functions{};
+        std::vector<Declaration>    declarations{};
+        std::vector<DeclarationId>  source_order{};
 
         [[nodiscard]] const Symbol      &symbol(SymbolId id) const noexcept { return symbols[id.value]; }
         [[nodiscard]] const Type        &type(TypeId id) const noexcept { return types[id.value]; }

--- a/language/src/ir/hir_printer.cpp
+++ b/language/src/ir/hir_printer.cpp
@@ -48,6 +48,7 @@ namespace hgl::ir
                 case SymbolKind::InjectedCapability: return "inject";
                 case SymbolKind::LoopValue: return "loop-value";
                 case SymbolKind::LambdaParameter: return "lambda-parameter";
+                case SymbolKind::ImportedFunction: return "imported-function";
                 case SymbolKind::ImportedOperator: return "imported-operator";
                 case SymbolKind::Intrinsic: return "intrinsic";
             }
@@ -232,6 +233,7 @@ namespace hgl::ir
                 out_ << "HIR " << completion_name(module_.completion) << " module " << module_.path << '\n';
                 print_symbols();
                 print_types();
+                print_native_functions();
                 print_expressions();
                 print_statements();
                 print_blocks();
@@ -285,6 +287,27 @@ namespace hgl::ir
                     if (type.canonical.valid()) { out_ << " canonical=" << ref('t', type.canonical); }
                     range(out_, type.range);
                     out_ << '\n';
+                }
+            }
+
+            void print_native_functions() {
+                out_ << "native-functions\n";
+                static constexpr std::string_view phase_names[]{"wiring", "start", "evaluation", "stop"};
+                for (const hir::NativeFunction &function : module_.native_functions) {
+                    out_ << "  " << ref('s', function.symbol) << ' ' << function.identity << " cpp=" << function.cpp_symbol
+                         << " parameters=[";
+                    for (std::size_t index = 0; index < function.parameters.size(); ++index) {
+                        if (index != 0U) { out_ << ", "; }
+                        const hir::NativeParameter &parameter = function.parameters[index];
+                        if (parameter.is_const) { out_ << "const "; }
+                        out_ << parameter.name << ':' << ref('t', parameter.type);
+                    }
+                    out_ << "] result=" << ref('t', function.result) << " phases=[";
+                    for (std::size_t index = 0; index < function.phases.size(); ++index) {
+                        if (index != 0U) { out_ << ", "; }
+                        out_ << phase_names[static_cast<std::size_t>(function.phases[index])];
+                    }
+                    out_ << "]\n";
                 }
             }
 

--- a/language/src/ir/lower.cpp
+++ b/language/src/ir/lower.cpp
@@ -44,6 +44,36 @@ namespace hgl::ir
             std::unreachable();
         }
 
+        [[nodiscard]] constexpr hir::ScalarType lower_scalar_type(semantics::ImportedScalarType type) noexcept {
+            using semantics::ImportedScalarType;
+            switch (type) {
+                case ImportedScalarType::Bool: return hir::ScalarType::Bool;
+                case ImportedScalarType::I64: return hir::ScalarType::I64;
+                case ImportedScalarType::F64: return hir::ScalarType::F64;
+                case ImportedScalarType::Str: return hir::ScalarType::Str;
+                case ImportedScalarType::Date: return hir::ScalarType::Date;
+                case ImportedScalarType::Time: return hir::ScalarType::Time;
+                case ImportedScalarType::DateTime: return hir::ScalarType::DateTime;
+                case ImportedScalarType::Duration: return hir::ScalarType::Duration;
+                case ImportedScalarType::CivilDateTime: return hir::ScalarType::CivilDateTime;
+                case ImportedScalarType::ZonedDateTime: return hir::ScalarType::ZonedDateTime;
+                case ImportedScalarType::ZonedTime: return hir::ScalarType::ZonedTime;
+                case ImportedScalarType::TimeZone: return hir::ScalarType::TimeZone;
+            }
+            std::unreachable();
+        }
+
+        [[nodiscard]] constexpr hir::NativePhase lower_native_phase(semantics::NativeCallPhase phase) noexcept {
+            using semantics::NativeCallPhase;
+            switch (phase) {
+                case NativeCallPhase::Wiring: return hir::NativePhase::Wiring;
+                case NativeCallPhase::Start: return hir::NativePhase::Start;
+                case NativeCallPhase::Evaluation: return hir::NativePhase::Evaluation;
+                case NativeCallPhase::Stop: return hir::NativePhase::Stop;
+            }
+            std::unreachable();
+        }
+
         [[nodiscard]] constexpr hir::TypeKind lower_type_kind(ast::TypeKind kind) noexcept {
             using ast::TypeKind;
             switch (kind) {
@@ -512,6 +542,41 @@ namespace hgl::ir
                 return symbol;
             }
 
+            [[nodiscard]] hir::SymbolId imported_function(const semantics::Binding &binding, syntax::SourceRange range,
+                                                          std::string_view spelling) {
+                if (binding.index >= resolved_.imported_functions.size()) {
+                    diagnostics_.report(syntax::Category::Name, range,
+                                        "imported function '" + std::string{spelling} + "' has no catalog record");
+                    return {};
+                }
+                if (const auto found = imported_function_symbols_.find(binding.index); found != imported_function_symbols_.end()) {
+                    return found->second;
+                }
+
+                const semantics::ImportedFunction &source = resolved_.imported_functions[binding.index];
+                const hir::SymbolId                symbol =
+                    external_symbol(hir::SymbolKind::ImportedFunction, spelling, source.cpp_symbol, source.identity, range);
+                hir::NativeFunction target;
+                target.symbol                 = symbol;
+                target.module_identity        = source.module_identity;
+                target.identity               = source.identity;
+                target.cpp_symbol             = source.cpp_symbol;
+                target.result                 = source.result ? literal_type(lower_scalar_type(*source.result)) : void_type();
+                target.public_headers         = source.public_headers;
+                target.cmake_packages         = source.cmake_packages;
+                target.imported_targets       = source.imported_targets;
+                target.runtime_images         = source.runtime_images;
+                target.descriptor_fingerprint = source.descriptor_fingerprint;
+                for (const semantics::ImportedParameter &parameter : source.parameters) {
+                    target.parameters.push_back(
+                        hir::NativeParameter{parameter.name, literal_type(lower_scalar_type(parameter.type)), parameter.is_const});
+                }
+                for (semantics::NativeCallPhase phase : source.phases) { target.phases.push_back(lower_native_phase(phase)); }
+                result_.native_functions.push_back(std::move(target));
+                imported_function_symbols_.emplace(binding.index, symbol);
+                return symbol;
+            }
+
             [[nodiscard]] hir::SymbolId symbol_for(const semantics::Binding &binding, syntax::SourceRange range,
                                                    std::string_view spelling) {
                 using semantics::BindingKind;
@@ -543,6 +608,7 @@ namespace hgl::ir
                     case BindingKind::Test:
                         if (binding.decl < declaration_symbols_.size()) { return declaration_symbols_[binding.decl]; }
                         break;
+                    case BindingKind::ImportedFunction: return imported_function(binding, range, spelling);
                     case BindingKind::Operator:
                         return external_symbol(hir::SymbolKind::ImportedOperator, spelling, binding.registry_name,
                                                binding.operator_identity, range);
@@ -687,6 +753,16 @@ namespace hgl::ir
                 return result;
             }
 
+            [[nodiscard]] hir::TypeId void_type() {
+                if (void_type_.valid()) { return void_type_; }
+                void_type_ = hir::TypeId{static_cast<std::uint32_t>(result_.types.size())};
+                hir::Type type;
+                type.kind           = hir::TypeKind::Void;
+                type.value_position = true;
+                result_.types.push_back(type);
+                return void_type_;
+            }
+
             [[nodiscard]] static hir::ScalarType temporal_type(syntax::TemporalKind kind) noexcept {
                 using syntax::TemporalKind;
                 switch (kind) {
@@ -816,6 +892,7 @@ namespace hgl::ir
                             target.value_kind = hir::ValueKind::Signal;
                             break;
                         case hir::SymbolKind::Function: target.value_kind = hir::ValueKind::Function; break;
+                        case hir::SymbolKind::ImportedFunction: target.value_kind = hir::ValueKind::Function; break;
                         case hir::SymbolKind::Operator:
                         case hir::SymbolKind::ImportedOperator: target.value_kind = hir::ValueKind::Operator; break;
                         case hir::SymbolKind::Struct:
@@ -1021,22 +1098,24 @@ namespace hgl::ir
                 result_.declarations[index] = std::move(target);
             }
 
-            const ast::Module                             &module_;
-            const semantics::ResolvedModule               &resolved_;
-            syntax::DiagnosticSink                        &diagnostics_;
-            hir::Module                                    result_{};
-            std::vector<hir::SymbolId>                     declaration_symbols_{};
-            std::vector<std::vector<hir::SymbolId>>        generic_symbols_{};
-            std::vector<std::vector<hir::SymbolId>>        parameter_symbols_{};
-            std::vector<std::vector<hir::SymbolId>>        statement_symbols_{};
-            std::vector<std::vector<hir::SymbolId>>        lambda_symbols_{};
-            std::vector<ast::DeclId>                       type_owners_{};
-            std::vector<ast::DeclId>                       expr_owners_{};
-            std::vector<ast::DeclId>                       stmt_owners_{};
-            std::vector<ast::DeclId>                       block_owners_{};
-            std::unordered_map<std::string, hir::SymbolId> global_symbols_{};
-            std::unordered_map<std::string, hir::SymbolId> external_symbols_{};
-            std::unordered_map<std::uint8_t, hir::TypeId>  literal_types_{};
+            const ast::Module                               &module_;
+            const semantics::ResolvedModule                 &resolved_;
+            syntax::DiagnosticSink                          &diagnostics_;
+            hir::Module                                      result_{};
+            std::vector<hir::SymbolId>                       declaration_symbols_{};
+            std::vector<std::vector<hir::SymbolId>>          generic_symbols_{};
+            std::vector<std::vector<hir::SymbolId>>          parameter_symbols_{};
+            std::vector<std::vector<hir::SymbolId>>          statement_symbols_{};
+            std::vector<std::vector<hir::SymbolId>>          lambda_symbols_{};
+            std::vector<ast::DeclId>                         type_owners_{};
+            std::vector<ast::DeclId>                         expr_owners_{};
+            std::vector<ast::DeclId>                         stmt_owners_{};
+            std::vector<ast::DeclId>                         block_owners_{};
+            std::unordered_map<std::string, hir::SymbolId>   global_symbols_{};
+            std::unordered_map<std::string, hir::SymbolId>   external_symbols_{};
+            std::unordered_map<std::uint32_t, hir::SymbolId> imported_function_symbols_{};
+            std::unordered_map<std::uint8_t, hir::TypeId>    literal_types_{};
+            hir::TypeId                                      void_type_{};
         };
     }  // namespace
 

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -129,7 +129,7 @@ namespace hgl::ir
                 id = canonical(id);
                 return id.valid() && type(id).kind == TypeKind::Reference;
             }
-            [[nodiscard]] bool   assignable(TypeId expected, TypeId actual) const noexcept {
+            [[nodiscard]] bool assignable(TypeId expected, TypeId actual) const noexcept {
                 return canonical_types_.assignable(expected, actual);
             }
 
@@ -174,6 +174,11 @@ namespace hgl::ir
             [[nodiscard]] FunctionDecl *function(DeclarationId id) noexcept {
                 if (!id.valid() || id.value >= module_.declarations.size()) { return nullptr; }
                 return std::get_if<FunctionDecl>(&module_.declarations[id.value].node);
+            }
+
+            [[nodiscard]] const NativeFunction *native_function(SymbolId symbol) const noexcept {
+                const auto found = std::ranges::find(module_.native_functions, symbol, &NativeFunction::symbol);
+                return found == module_.native_functions.end() ? nullptr : &*found;
             }
 
             void check_implementation_conformance(const Declaration &declaration, const FunctionDecl &implementation,
@@ -254,6 +259,15 @@ namespace hgl::ir
             [[nodiscard]] TypeId callable_type(SymbolId symbol) {
                 if (!symbol.valid()) { return make_type(TypeKind::Callable); }
                 const Symbol &target = module_.symbol(symbol);
+                if (target.kind == SymbolKind::ImportedFunction) {
+                    const NativeFunction *native = native_function(symbol);
+                    if (native == nullptr) { return make_type(TypeKind::Callable); }
+                    std::vector<TypeId> children;
+                    children.reserve(native->parameters.size() + 1U);
+                    for (const NativeParameter &parameter : native->parameters) { children.push_back(parameter.type); }
+                    children.push_back(native->result);
+                    return make_type(TypeKind::Callable, std::move(children));
+                }
                 if (!target.owner.valid()) { return make_type(TypeKind::Callable); }
                 const DeclarationNode &node = module_.declaration(target.owner).node;
                 if (const auto *fn = std::get_if<FunctionDecl>(&node)) { return callable_type(fn->signature); }
@@ -305,6 +319,7 @@ namespace hgl::ir
                 if (!id.valid()) { return; }
                 const ConstraintId previous_requirements = active_requirements_;
                 const ConstraintId previous_inherited    = inherited_requirements_;
+                const NativePhase  previous_native_phase = active_native_phase_;
                 active_requirements_                     = {};
                 inherited_requirements_                  = {};
                 inherited_substitution_.reset();
@@ -329,6 +344,8 @@ namespace hgl::ir
                             validate_owned_type_applications(id);
                             check_signature_defaults(node.signature);
                         } else if constexpr (std::is_same_v<T, FunctionDecl>) {
+                            active_native_phase_ =
+                                node.kind == FunctionKind::Runtime ? NativePhase::Evaluation : NativePhase::Wiring;
                             active_requirements_ = node.requirements;
                             if (node.visibility == Visibility::Implementation && node.operator_contract.valid()) {
                                 if (const OperatorDecl *contract = operator_decl(node.operator_contract)) {
@@ -353,6 +370,7 @@ namespace hgl::ir
                             }
                             collect_capabilities(node, id);
                         } else if constexpr (std::is_same_v<T, TestDecl>) {
+                            active_native_phase_ = NativePhase::Wiring;
                             validate_owned_type_applications(id);
                             check_block(node.block, void_type_);
                         }
@@ -360,6 +378,7 @@ namespace hgl::ir
                     declaration.node);
                 active_requirements_    = previous_requirements;
                 inherited_requirements_ = previous_inherited;
+                active_native_phase_    = previous_native_phase;
                 inherited_substitution_.reset();
             }
 
@@ -563,6 +582,7 @@ namespace hgl::ir
                         expression.effects    = Effect::UseCapability;
                         break;
                     case SymbolKind::Function:
+                    case SymbolKind::ImportedFunction:
                         expression.type       = callable_type(reference.symbol);
                         expression.phase      = Phase::Constant;
                         expression.value_kind = ValueKind::Function;
@@ -590,7 +610,7 @@ namespace hgl::ir
             }
 
             void check_unary(Expr &expression, const Unary &node) {
-                Expr &operand        = check_expr(node.operand);
+                Expr &operand = check_expr(node.operand);
                 if (runtime_owner(expression.owner) && reference(operand.type)) {
                     type_error(operand.range, "node evaluation cannot read through ref<T>");
                 }
@@ -932,6 +952,39 @@ namespace hgl::ir
                 return bound;
             }
 
+            [[nodiscard]] std::vector<ExprId> bind_native_arguments(const NativeFunction        &function,
+                                                                    const std::vector<Argument> &arguments,
+                                                                    syntax::SourceRange          range) {
+                std::vector<ExprId> bound(function.parameters.size());
+                std::size_t         next = 0U;
+                for (const Argument &argument : arguments) {
+                    if (argument.name.empty()) {
+                        while (next < bound.size() && bound[next].valid()) { ++next; }
+                        if (next >= bound.size()) {
+                            type_error(argument.range, "too many positional arguments");
+                        } else {
+                            bound[next++] = argument.value;
+                        }
+                        continue;
+                    }
+                    const auto found = std::ranges::find(function.parameters, argument.name, &NativeParameter::name);
+                    if (found == function.parameters.end()) {
+                        diagnostics_.report(syntax::Category::Name, argument.range, "unknown parameter '" + argument.name + "'");
+                        continue;
+                    }
+                    const std::size_t index = static_cast<std::size_t>(found - function.parameters.begin());
+                    if (bound[index].valid()) {
+                        type_error(argument.range, "parameter '" + argument.name + "' is supplied twice");
+                    } else {
+                        bound[index] = argument.value;
+                    }
+                }
+                for (std::size_t index = 0; index < bound.size(); ++index) {
+                    if (!bound[index].valid()) { type_error(range, "missing argument '" + function.parameters[index].name + "'"); }
+                }
+                return bound;
+            }
+
             void require_complete_bindings(const std::vector<GenericParameter> &generics,
                                            const detail::GenericSubstitution &bindings, syntax::SourceRange range,
                                            std::string_view callable) {
@@ -993,6 +1046,44 @@ namespace hgl::ir
                                                   .target        = target,
                                                   .identity      = module_.path + "." + module_.symbol(target).name,
                                                   .substitutions = bindings.materialize(fn.generics)};
+            }
+
+            void check_native_call(Expr &expression, const Call &call, SymbolId target, const NativeFunction &function,
+                                   TypeId expected) {
+                const std::vector<ExprId> bound = bind_native_arguments(function, call.arguments, expression.range);
+                const bool phase_allowed        = std::ranges::find(function.phases, active_native_phase_) != function.phases.end();
+                if (!phase_allowed) {
+                    static constexpr std::string_view names[]{"wiring", "start", "evaluation", "stop"};
+                    diagnostics_.report(syntax::Category::Phase, expression.range,
+                                        "native function '" + function.identity + "' is not available during " +
+                                            std::string{names[static_cast<std::size_t>(active_native_phase_)]});
+                }
+
+                expression.effects = Effect::None;
+                for (std::size_t index = 0; index < bound.size(); ++index) {
+                    if (!bound[index].valid()) { continue; }
+                    Expr &argument = check_expr(bound[index], function.parameters[index].type);
+                    expression.effects |= argument.effects;
+                    if (!same(function.parameters[index].type, argument.type)) {
+                        type_error(argument.range, "native argument has type " + type_name(argument.type) + ", expected exactly " +
+                                                       type_name(function.parameters[index].type));
+                    }
+                    if (function.parameters[index].is_const && argument.phase != Phase::Constant) {
+                        diagnostics_.report(syntax::Category::Phase, argument.range,
+                                            "a const native parameter requires a compile-time value");
+                    }
+                    if (active_native_phase_ == NativePhase::Wiring && argument.phase != Phase::Constant) {
+                        diagnostics_.report(syntax::Category::Phase, argument.range,
+                                            "a wiring-phase native scalar call requires compile-time arguments");
+                    }
+                }
+
+                expression.type       = canonical(function.result);
+                expression.phase      = active_native_phase_ == NativePhase::Wiring ? Phase::Constant : Phase::Runtime;
+                expression.value_kind = expression.type == void_type_ ? ValueKind::Void : value_kind_for_phase(expression.phase);
+                expression.operation =
+                    Operation{.kind = OperationKind::ExactFunction, .target = target, .identity = function.identity};
+                contextualize(expression, expected);
             }
 
             [[nodiscard]] const OperatorDecl *operator_decl(SymbolId symbol) const noexcept {
@@ -1180,6 +1271,11 @@ namespace hgl::ir
                         if (fn) { check_exact_call(expression, call, reference->symbol, *fn, expected); }
                         return;
                     }
+                    if (symbol.kind == SymbolKind::ImportedFunction) {
+                        const NativeFunction *native = native_function(reference->symbol);
+                        if (native != nullptr) { check_native_call(expression, call, reference->symbol, *native, expected); }
+                        return;
+                    }
                     if (symbol.kind == SymbolKind::Operator) {
                         const OperatorDecl *op = operator_decl(reference->symbol);
                         if (op) { check_local_operator_call(expression, call, reference->symbol, *op, expected); }
@@ -1213,8 +1309,8 @@ namespace hgl::ir
             }
 
             void check_index(Expr &expression, const Index &node) {
-                Expr  &target  = check_expr(node.target);
-                Expr  &index   = check_expr(node.index);
+                Expr &target = check_expr(node.target);
+                Expr &index  = check_expr(node.index);
                 if (runtime_owner(expression.owner) && reference(target.type)) {
                     type_error(target.range, "node evaluation cannot index through ref<T>");
                     return;
@@ -1737,7 +1833,10 @@ namespace hgl::ir
                                 statement.effects                = Effect::None;
                             }
                         } else if constexpr (std::is_same_v<T, StateDecl>) {
-                            Expr &init = check_expr(node.init, node.type);
+                            const NativePhase previous_phase = active_native_phase_;
+                            active_native_phase_             = NativePhase::Start;
+                            Expr &init                       = check_expr(node.init, node.type);
+                            active_native_phase_             = previous_phase;
                             if (!node.type.valid()) { node.type = init.type; }
                             require_assignable(node.type, init, "state initializer");
                             module_.symbols[node.symbol.value].type = node.type;
@@ -1755,8 +1854,11 @@ namespace hgl::ir
                                 symbol_phase_[symbol_id.value] = Phase::Runtime;
                             }
                         } else if constexpr (std::is_same_v<T, LifecycleBlock>) {
+                            const NativePhase previous_phase = active_native_phase_;
+                            active_native_phase_             = node.is_stop ? NativePhase::Stop : NativePhase::Start;
                             check_block(node.block, expected_return);
-                            statement.effects = module_.block(node.block).effects;
+                            active_native_phase_ = previous_phase;
+                            statement.effects    = module_.block(node.block).effects;
                         } else if constexpr (std::is_same_v<T, WhenStmt>) {
                             Expr &condition = check_expr(node.condition, scalar(ScalarType::Bool));
                             require_assignable(scalar(ScalarType::Bool), condition, "when condition");
@@ -1868,6 +1970,7 @@ namespace hgl::ir
             std::unordered_map<std::uint32_t, bool>    checked_blocks_{};
             std::unordered_set<std::uint64_t>          checked_type_applications_{};
             TypeId                                     void_type_{};
+            NativePhase                                active_native_phase_{NativePhase::Wiring};
             ConstraintId                               active_requirements_{};
             ConstraintId                               inherited_requirements_{};
             std::optional<detail::GenericSubstitution> inherited_substitution_{};

--- a/language/src/semantics/module_catalog.h
+++ b/language/src/semantics/module_catalog.h
@@ -1,0 +1,126 @@
+#ifndef HGL_SEMANTICS_MODULE_CATALOG_H
+#define HGL_SEMANTICS_MODULE_CATALOG_H
+
+#include <algorithm>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace hgl::semantics
+{
+    /// Canonical scalar spellings at the package-catalog boundary. Keep this
+    /// data model independent of both the syntax AST and compiler IR so a
+    /// validated descriptor can be inspected without pulling in a frontend.
+    enum class ImportedScalarType : std::uint8_t {
+        Bool,
+        I64,
+        F64,
+        Str,
+        Date,
+        Time,
+        DateTime,
+        Duration,
+        CivilDateTime,
+        ZonedDateTime,
+        ZonedTime,
+        TimeZone,
+    };
+
+    /// Native call phases copied out of a validated module descriptor. This
+    /// catalog is a data-only name-resolution input; it owns no descriptor
+    /// arena references and never loads package code.
+    enum class NativeCallPhase : std::uint8_t {
+        Wiring,
+        Start,
+        Evaluation,
+        Stop,
+    };
+
+    struct ImportedParameter
+    {
+        std::string        name{};
+        ImportedScalarType type{ImportedScalarType::Bool};
+        bool               is_const{false};
+    };
+
+    /// One exact native function exported by an importable module. The first
+    /// executable slice admits effect-free canonical scalar signatures only.
+    /// Other descriptor declarations remain visible through support_error so
+    /// name resolution fails with the actual unsupported boundary rather than
+    /// pretending that the declaration does not exist.
+    struct ImportedFunction
+    {
+        std::string                       module_identity{};
+        std::string                       name{};
+        std::string                       identity{};
+        std::string                       cpp_symbol{};
+        std::vector<ImportedParameter>    parameters{};
+        std::optional<ImportedScalarType> result{};
+        std::vector<NativeCallPhase>      phases{};
+        std::vector<std::string>          public_headers{};
+        std::vector<std::string>          cmake_packages{};
+        std::vector<std::string>          imported_targets{};
+        std::vector<std::string>          runtime_images{};
+        std::string                       descriptor_fingerprint{};
+        std::string                       support_error{};
+    };
+
+    struct ImportableModule
+    {
+        std::string                   identity{};
+        std::string                   descriptor_fingerprint{};
+        std::vector<ImportedFunction> functions{};
+    };
+
+    struct CatalogError
+    {
+        std::string path{};
+        std::string message{};
+    };
+
+    /// The locked, explicitly supplied module surface for one compilation.
+    /// Discovery and transitive-closure policy belong to the driver/package
+    /// target; the semantic resolver receives only this deterministic value.
+    class ModuleCatalog
+    {
+      public:
+        [[nodiscard]] std::optional<CatalogError> add(ImportableModule module) {
+            if (module.identity.empty()) { return CatalogError{"$.module.identity", "module identity must not be empty"}; }
+            if (find(module.identity) != nullptr) {
+                return CatalogError{"$.module.identity", "module '" + module.identity + "' is supplied more than once"};
+            }
+            std::ranges::sort(module.functions, {}, &ImportedFunction::name);
+            for (std::size_t index = 1; index < module.functions.size(); ++index) {
+                if (module.functions[index - 1U].name == module.functions[index].name) {
+                    return CatalogError{"$.native.declarations", "module '" + module.identity + "' exports native function '" +
+                                                                     module.functions[index].name + "' more than once"};
+                }
+            }
+            modules_.push_back(std::move(module));
+            std::ranges::sort(modules_, {}, &ImportableModule::identity);
+            return std::nullopt;
+        }
+
+        [[nodiscard]] const ImportableModule *find(std::string_view identity) const noexcept {
+            const auto found = std::ranges::lower_bound(modules_, identity, {}, &ImportableModule::identity);
+            return found != modules_.end() && found->identity == identity ? &*found : nullptr;
+        }
+
+        [[nodiscard]] const ImportedFunction *find_function(std::string_view module, std::string_view name) const noexcept {
+            const ImportableModule *owner = find(module);
+            if (owner == nullptr) { return nullptr; }
+            const auto found = std::ranges::lower_bound(owner->functions, name, {}, &ImportedFunction::name);
+            return found != owner->functions.end() && found->name == name ? &*found : nullptr;
+        }
+
+        [[nodiscard]] const std::vector<ImportableModule> &modules() const noexcept { return modules_; }
+
+      private:
+        std::vector<ImportableModule> modules_{};
+    };
+}  // namespace hgl::semantics
+
+#endif  // HGL_SEMANTICS_MODULE_CATALOG_H

--- a/language/src/semantics/resolve.cpp
+++ b/language/src/semantics/resolve.cpp
@@ -39,8 +39,9 @@ namespace hgl::semantics
         class Resolver
         {
           public:
-            Resolver(const ast::Module &module, const OperatorLookup &has_operator, syntax::DiagnosticSink &diagnostics)
-                : module_{module}, has_operator_{has_operator}, diagnostics_{diagnostics} {
+            Resolver(const ast::Module &module, const ModuleCatalog &catalog, const OperatorLookup &has_operator,
+                     syntax::DiagnosticSink &diagnostics)
+                : module_{module}, catalog_{catalog}, has_operator_{has_operator}, diagnostics_{diagnostics} {
                 result_.bindings.resize(module.exprs.size());
                 result_.type_bindings.resize(module.types.size());
                 result_.constraint_bindings.resize(module.constraints.size());
@@ -182,11 +183,10 @@ namespace hgl::semantics
             }
 
             void resolve_use(const ast::UseDecl &use, SourceRange range) {
-                const std::string path = join_path(use.path);
-                if (path != kernel_std && path != kernel_analytics) {
-                    report(Category::Module, range,
-                           "module '" + path + "' is not available: the first pass links the kernel modules " +
-                               std::string{kernel_std} + " and " + std::string{kernel_analytics} + " only");
+                const std::string path   = join_path(use.path);
+                const bool        kernel = path == kernel_std || path == kernel_analytics;
+                if (!kernel && catalog_.find(path) == nullptr) {
+                    report(Category::Module, range, "module '" + path + "' is not available in the supplied package target");
                     return;
                 }
                 if (!use.alias.empty()) {
@@ -201,6 +201,16 @@ namespace hgl::semantics
                     return;
                 }
                 for (const ast::Name &name : use.names) {
+                    if (!kernel) {
+                        const ImportedFunction *function = catalog_.find_function(path, name.text);
+                        if (function == nullptr) {
+                            report(Category::Module, name.range, path + " does not export '" + std::string{name.text} + "'");
+                            continue;
+                        }
+                        const std::optional<Binding> binding = imported_function(*function, name.range);
+                        if (binding) { declare(name, *binding, "in the module"); }
+                        continue;
+                    }
                     const std::optional<std::string> registry_name = kernel_registry_name(path, name.text);
                     if (!registry_name) {
                         report(Category::Module, name.range, path + " does not export '" + std::string{name.text} + "'");
@@ -221,6 +231,26 @@ namespace hgl::semantics
                     binding.operator_identity = path + "." + std::string{name.text};
                     declare(name, binding, "in the module");
                 }
+            }
+
+            [[nodiscard]] std::optional<Binding> imported_function(const ImportedFunction &function, SourceRange range) {
+                if (!function.support_error.empty()) {
+                    report(Category::Module, range,
+                           "native function '" + function.identity + "' is unavailable: " + function.support_error);
+                    return std::nullopt;
+                }
+                const auto  found = std::ranges::find(result_.imported_functions, function.identity, &ImportedFunction::identity);
+                std::size_t index = 0U;
+                if (found == result_.imported_functions.end()) {
+                    index = result_.imported_functions.size();
+                    result_.imported_functions.push_back(function);
+                } else {
+                    index = static_cast<std::size_t>(found - result_.imported_functions.begin());
+                }
+                Binding binding;
+                binding.kind  = BindingKind::ImportedFunction;
+                binding.index = static_cast<std::uint32_t>(index);
+                return binding;
             }
 
             /// The interim kernel table (developer guide, "Interim kernel table").
@@ -566,6 +596,17 @@ namespace hgl::semantics
             void resolve_qualified(ast::ExprId id, const ast::QualifiedRef &ref) {
                 for (const ModuleAlias &alias : result_.aliases) {
                     if (alias.alias != ref.qualifier.text) { continue; }
+                    if (alias.module != kernel_std && alias.module != kernel_analytics) {
+                        const ImportedFunction *function = catalog_.find_function(alias.module, ref.name.text);
+                        if (function == nullptr) {
+                            report(Category::Module, ref.name.range,
+                                   alias.module + " does not export '" + std::string{ref.name.text} + "'");
+                            return;
+                        }
+                        const std::optional<Binding> binding = imported_function(*function, ref.name.range);
+                        if (binding) { result_.bindings[id] = *binding; }
+                        return;
+                    }
                     const std::optional<std::string> registry_name = kernel_registry_name(alias.module, ref.name.text);
                     if (!registry_name) {
                         report(Category::Module, ref.name.range,
@@ -1013,6 +1054,7 @@ namespace hgl::semantics
             }
 
             const ast::Module        &module_;
+            const ModuleCatalog      &catalog_;
             const OperatorLookup     &has_operator_;
             syntax::DiagnosticSink   &diagnostics_;
             ResolvedModule            result_{};
@@ -1028,8 +1070,13 @@ namespace hgl::semantics
         return false;
     }
 
-    ResolvedModule resolve(const syntax::SourceFile &, const ast::Module &module, const OperatorLookup &has_operator,
+    ResolvedModule resolve(const syntax::SourceFile &, const ast::Module &module, const ModuleCatalog &catalog,
+                           const OperatorLookup &has_operator, syntax::DiagnosticSink &diagnostics) {
+        return Resolver{module, catalog, has_operator, diagnostics}.run();
+    }
+
+    ResolvedModule resolve(const syntax::SourceFile &file, const ast::Module &module, const OperatorLookup &has_operator,
                            syntax::DiagnosticSink &diagnostics) {
-        return Resolver{module, has_operator, diagnostics}.run();
+        return resolve(file, module, ModuleCatalog{}, has_operator, diagnostics);
     }
 }  // namespace hgl::semantics

--- a/language/src/semantics/resolve.h
+++ b/language/src/semantics/resolve.h
@@ -1,6 +1,7 @@
 #ifndef HGL_SEMANTICS_RESOLVE_H
 #define HGL_SEMANTICS_RESOLVE_H
 
+#include "semantics/module_catalog.h"
 #include "syntax/ast.h"
 #include "syntax/diagnostic.h"
 #include "syntax/source.h"
@@ -22,15 +23,16 @@ namespace hgl::semantics
 
     enum class BindingKind : std::uint8_t {
         Unbound,
-        Local,          ///< `let`/`var`/state/inject/for binding: `stmt` + binder `index`
-        Parameter,      ///< `decl` is the function, `index` the parameter
-        Generic,        ///< `decl` is the function, `index` the generic parameter
-        Struct,         ///< `decl` is the nominal struct declaration
-        Function,       ///< `decl` is the `fn`
-        Operator,       ///< an imported kernel operator: `registry_name`
-        LocalOperator,  ///< `decl` is the `operator` declaration
-        Test,           ///< `decl` is the `test` (not a value)
-        Intrinsic,      ///< a prelude intrinsic: `registry_name` holds its name
+        Local,             ///< `let`/`var`/state/inject/for binding: `stmt` + binder `index`
+        Parameter,         ///< `decl` is the function, `index` the parameter
+        Generic,           ///< `decl` is the function, `index` the generic parameter
+        Struct,            ///< `decl` is the nominal struct declaration
+        Function,          ///< `decl` is the `fn`
+        ImportedFunction,  ///< `index` names ResolvedModule::imported_functions
+        Operator,          ///< an imported kernel operator: `registry_name`
+        LocalOperator,     ///< `decl` is the `operator` declaration
+        Test,              ///< `decl` is the `test` (not a value)
+        Intrinsic,         ///< a prelude intrinsic: `registry_name` holds its name
     };
 
     struct Binding
@@ -91,6 +93,7 @@ namespace hgl::semantics
         std::vector<Binding>          implementation_bindings;  ///< selected operator, indexed by DeclId
         std::vector<FunctionKind>     kinds;                    ///< indexed by DeclId
         std::vector<ImportedOperator> imports;
+        std::vector<ImportedFunction> imported_functions;
         std::vector<ModuleAlias>      aliases;
         std::vector<ast::DeclId>      functions;
         std::vector<ast::DeclId>      structs;
@@ -115,6 +118,11 @@ namespace hgl::semantics
     /// does not depend on hgraph (tests pass a table).
     using OperatorLookup = std::function<bool(std::string_view)>;
 
+    [[nodiscard]] ResolvedModule resolve(const syntax::SourceFile &file, const ast::Module &module, const ModuleCatalog &catalog,
+                                         const OperatorLookup &has_operator, syntax::DiagnosticSink &diagnostics);
+
+    /// Compatibility entry point for a compilation with no external module
+    /// descriptors. Kernel operator imports continue to use OperatorLookup.
     [[nodiscard]] ResolvedModule resolve(const syntax::SourceFile &file, const ast::Module &module,
                                          const OperatorLookup &has_operator, syntax::DiagnosticSink &diagnostics);
 }  // namespace hgl::semantics

--- a/language/src/wiring/backend.cpp
+++ b/language/src/wiring/backend.cpp
@@ -107,6 +107,7 @@ namespace hgl::wiring
                 Port,
                 Struct,
                 Function,
+                NativeFunction,
                 Operator,
                 Intrinsic,
                 Sequence,
@@ -845,8 +846,8 @@ namespace hgl::wiring
             if (slot.kind == Slot::Kind::Null) { backend(slot.range, "null needs an optional field context"); }
             if (slot.kind == Slot::Kind::Delta) { backend(slot.range, "a structured delta is not an ordinary operator value"); }
             if (slot.kind == Slot::Kind::Sequence) { backend(slot.range, "a harness sequence is only valid in eval"); }
-            if (slot.kind == Slot::Kind::Function || slot.kind == Slot::Kind::Operator || slot.kind == Slot::Kind::Intrinsic ||
-                slot.kind == Slot::Kind::Struct) {
+            if (slot.kind == Slot::Kind::Function || slot.kind == Slot::Kind::NativeFunction || slot.kind == Slot::Kind::Operator ||
+                slot.kind == Slot::Kind::Intrinsic || slot.kind == Slot::Kind::Struct) {
                 backend(slot.range, "passing a callable to an operator is not supported by the first pass");
             }
             backend(slot.range, "this expression produces no value");
@@ -909,6 +910,13 @@ namespace hgl::wiring
                     result.kind     = Slot::Kind::Function;
                     result.callable = reference.callable;
                     result.name     = reference.identity;
+                    return result;
+                case gir::ReferenceKind::NativeFunction:
+                    if (!reference.native_function.valid() || reference.native_function.value >= module_.native_functions.size()) {
+                        backend(range, "hgraph IR contains an invalid native function reference");
+                    }
+                    result.kind = Slot::Kind::NativeFunction;
+                    result.name = module_.native_functions[reference.native_function.value].identity;
                     return result;
                 case gir::ReferenceKind::Operator:
                     result.kind = Slot::Kind::Operator;
@@ -1226,6 +1234,10 @@ namespace hgl::wiring
             Slot callee = eval_value(call.callee, frame);
             switch (callee.kind) {
                 case Slot::Kind::Function: return call_function(callee.callable, call.arguments, expression.range, frame);
+                case Slot::Kind::NativeFunction:
+                    backend(expression.range,
+                            "native scalar function '" + callee.name +
+                                "' requires generated C++ execution; direct HGraph IR interpretation does not load C++ symbols");
                 case Slot::Kind::Operator:
                     {
                         std::string name =
@@ -1662,6 +1674,7 @@ namespace hgl::wiring
                 case Slot::Kind::Port: return std::string{slot.port.schema->name()};
                 case Slot::Kind::Struct: return "struct " + local_name(slot.name);
                 case Slot::Kind::Function: return "fn " + local_name(callable(slot.callable).identity);
+                case Slot::Kind::NativeFunction: return "native fn " + slot.name;
                 case Slot::Kind::Operator: return "operator " + slot.name;
                 case Slot::Kind::Intrinsic: return "intrinsic " + slot.name;
                 case Slot::Kind::Sequence: return slot.resolved ? describe_sequence(slot.elements) : slice(slot.range);

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -150,6 +150,34 @@ hgl_apply_warnings(hgl_descriptor_reader_tests)
 
 add_test(NAME hgraph_language_descriptor_reader COMMAND hgl_descriptor_reader_tests)
 
+add_executable(hgl_native_scalar_descriptor_fixture driver/native_scalar_descriptor_fixture.cpp)
+target_compile_features(hgl_native_scalar_descriptor_fixture PRIVATE cxx_std_23)
+target_link_libraries(hgl_native_scalar_descriptor_fixture PRIVATE hgl::native_package)
+hgl_apply_warnings(hgl_native_scalar_descriptor_fixture)
+
+set(_hgl_native_scalar_descriptor "${CMAKE_CURRENT_BINARY_DIR}/native-scalar-import.hgl-module.json")
+add_custom_command(
+    OUTPUT "${_hgl_native_scalar_descriptor}"
+    COMMAND hgl_native_scalar_descriptor_fixture "${_hgl_native_scalar_descriptor}"
+    DEPENDS hgl_native_scalar_descriptor_fixture
+    COMMENT "Author native scalar import descriptor"
+    VERBATIM
+)
+add_test(
+    NAME hgraph_language_prepare_native_scalar_descriptor
+    COMMAND hgl_native_scalar_descriptor_fixture "${_hgl_native_scalar_descriptor}"
+)
+set_tests_properties(hgraph_language_prepare_native_scalar_descriptor PROPERTIES FIXTURES_SETUP hgl_native_scalar_descriptor)
+add_test(
+    NAME hgraph_language_check_native_scalar_import
+    COMMAND $<TARGET_FILE:hgl> check "${CMAKE_CURRENT_SOURCE_DIR}/driver/native-scalar-import.hgl"
+            --module-descriptor "${_hgl_native_scalar_descriptor}" --dump-hgraph-ir
+)
+set_tests_properties(hgraph_language_check_native_scalar_import PROPERTIES
+    FIXTURES_REQUIRED hgl_native_scalar_descriptor
+    PASS_REGULAR_EXPRESSION "checks.native_dependency::blend"
+)
+
 # Public native-package authoring is a separate, installed-facing API. Keep
 # its contract tests distinct from internal descriptor model/reader tests.
 add_executable(hgl_native_package_tests native/native_package_tests.cpp)
@@ -262,10 +290,20 @@ hgl_add_module(hgl_stateful_fixture STATIC HGL ../examples/stateful-node.hgl)
 hgl_apply_warnings(hgl_stateful_fixture)
 hgl_add_module(hgl_reference_fixture STATIC HGL ../examples/reference-routing.hgl)
 hgl_apply_warnings(hgl_reference_fixture)
+add_library(hgl_native_scalar_dependency INTERFACE)
+add_library(checks::native_dependency ALIAS hgl_native_scalar_dependency)
+target_include_directories(hgl_native_scalar_dependency INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/driver/include")
+set_property(TARGET hgl_native_scalar_dependency PROPERTY HGL_MODULE_DESCRIPTORS "${_hgl_native_scalar_descriptor}")
+hgl_add_module(hgl_native_scalar_import_fixture STATIC
+    HGL driver/native-scalar-import.hgl
+    LINK_LIBRARIES hgl_native_scalar_dependency
+)
+hgl_apply_warnings(hgl_native_scalar_import_fixture)
 
 set(_hgl_generated_test_sources
     codegen/generated_tests.cpp
     codegen/generated_runtime_tests.cpp
+    codegen/generated_native_tests.cpp
     codegen/generated_reference_tests.cpp
     codegen/generated_structural_tests.cpp
     codegen/generated_generic_tests.cpp
@@ -277,6 +315,7 @@ set(_hgl_generated_test_libraries
     hgl_collection_fixture
     hgl_stateful_fixture
     hgl_reference_fixture
+    hgl_native_scalar_import_fixture
 )
 if(TARGET hgraph::analytics)
     # These two examples intentionally exercise an imported extension. Keep
@@ -399,9 +438,11 @@ add_test(
         -DSOURCE=${CMAKE_CURRENT_SOURCE_DIR}/cmake/package
         -DOUT=${CMAKE_CURRENT_BINARY_DIR}/cmake-package
         -DPYTHON=${Python_EXECUTABLE}
+        -DNATIVE_DESCRIPTOR=${_hgl_native_scalar_descriptor}
         "-DGENERATOR=${CMAKE_GENERATOR}"
         -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/package_test.cmake
 )
+set_tests_properties(hgraph_language_cmake_package PROPERTIES FIXTURES_REQUIRED hgl_native_scalar_descriptor)
 
 # The guide's test example passes end to end through the driver
 # (user guide, "Testing and running").

--- a/language/tests/cmake/package/CMakeLists.txt
+++ b/language/tests/cmake/package/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.25)
 
 project(hgl_package_helper_test LANGUAGES CXX)
 
-if(NOT HGL_LANGUAGE_CMAKE OR NOT HGL_EXECUTABLE)
-    message(FATAL_ERROR "HGL_LANGUAGE_CMAKE and HGL_EXECUTABLE are required")
+if(NOT HGL_LANGUAGE_CMAKE OR NOT HGL_EXECUTABLE OR NOT NATIVE_DESCRIPTOR)
+    message(FATAL_ERROR "HGL_LANGUAGE_CMAKE, HGL_EXECUTABLE and NATIVE_DESCRIPTOR are required")
 endif()
 
 # Minimal imported SDK surface needed to configure hgl_add_module. Nothing is
@@ -20,9 +20,13 @@ endfunction()
 
 include("${HGL_LANGUAGE_CMAKE}")
 
+add_library(hgl_test_native INTERFACE)
+set_property(TARGET hgl_test_native PROPERTY HGL_MODULE_DESCRIPTORS "${NATIVE_DESCRIPTOR}")
+
 set(_package_dir "${CMAKE_CURRENT_BINARY_DIR}/python/_fixture")
 hgl_add_module(hgl_fixture STATIC
     HGL unit.hgl
+    LINK_LIBRARIES hgl_test_native
     PYTHON_MODULE _fixture
     PYTHON_PACKAGE_DIR "${_package_dir}")
 

--- a/language/tests/cmake/package_test.cmake
+++ b/language/tests/cmake/package_test.cmake
@@ -1,5 +1,5 @@
-if(NOT HGL OR NOT HELPER OR NOT TEMPLATE OR NOT SOURCE OR NOT OUT OR NOT PYTHON OR NOT GENERATOR)
-    message(FATAL_ERROR "HGL, HELPER, TEMPLATE, SOURCE, OUT, PYTHON and GENERATOR are required")
+if(NOT HGL OR NOT HELPER OR NOT TEMPLATE OR NOT SOURCE OR NOT OUT OR NOT PYTHON OR NOT NATIVE_DESCRIPTOR OR NOT GENERATOR)
+    message(FATAL_ERROR "HGL, HELPER, TEMPLATE, SOURCE, OUT, PYTHON, NATIVE_DESCRIPTOR and GENERATOR are required")
 endif()
 
 file(REMOVE_RECURSE "${OUT}")
@@ -13,6 +13,7 @@ execute_process(
     COMMAND "${CMAKE_COMMAND}" -S "${SOURCE}" -B "${OUT}/build" -G "${GENERATOR}"
         "-DHGL_LANGUAGE_CMAKE=${OUT}/sdk/lib/cmake/hgl/HglLanguage.cmake"
         "-DHGL_EXECUTABLE=${_installed_hgl}"
+        "-DNATIVE_DESCRIPTOR=${NATIVE_DESCRIPTOR}"
     RESULT_VARIABLE _configure_result
     OUTPUT_VARIABLE _configure_out
     ERROR_VARIABLE _configure_err)
@@ -37,6 +38,11 @@ if(NOT _descriptor_text MATCHES "\"format\"[ 	]*:[ 	]*\"hgl.module\"" OR
    NOT _descriptor_text MATCHES "\"identity\"[ 	]*:[ 	]*\"pkg.new\"" OR
    NOT _descriptor_text MATCHES "\"schema\"[ 	]*:")
     message(FATAL_ERROR "generated package descriptor has the wrong envelope:\n${_descriptor_text}")
+endif()
+set(_generated_header "${OUT}/build/hgl/hgl_fixture/include/unit.h")
+file(READ "${_generated_header}" _generated_header_text)
+if(NOT _generated_header_text MATCHES "checks::native_dependency::blend")
+    message(FATAL_ERROR "installed helper did not pass the linked target descriptor:\n${_generated_header_text}")
 endif()
 execute_process(
     COMMAND "${PYTHON}" -m json.tool "${_descriptor}"

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -65,6 +65,33 @@ namespace
             }
         }
 
+        Unit(std::string text, const ModuleCatalog &catalog, std::string path = "unit.hgl")
+            : file{std::move(path), std::move(text)}, module{parse(file, diagnostics)} {
+            resolved = resolve(file, module, catalog, kernel_has, diagnostics);
+            if (diagnostics.has_errors()) { return; }
+            hir                                       = hgl::ir::lower_to_hir(module, resolved, diagnostics);
+            const hgl::ir::OperatorResolver operators = [](const hgl::ir::hir::Module &, const hgl::ir::OperatorQuery &query) {
+                hgl::ir::OperatorSelection selected;
+                selected.result = query.expected_result;
+                if (!selected.result.valid() && !query.arguments.empty()) { selected.result = query.arguments.front().type; }
+                selected.deferred = true;
+                return selected;
+            };
+            hgl::ir::hir::Module        typed = hir;
+            hgl::syntax::DiagnosticSink graph_diagnostics;
+            if (hgl::ir::complete_hir(typed, operators, graph_diagnostics)) {
+                hgl::hgraph_ir::Module lowered = hgl::hgraph_ir::lower(typed, graph_diagnostics);
+                if (!graph_diagnostics.has_errors()) {
+                    graph = std::move(lowered);
+                    return;
+                }
+            }
+            for (const Diagnostic &diagnostic : graph_diagnostics.diagnostics()) {
+                Diagnostic &copy = diagnostics.report(diagnostic.category, diagnostic.range, diagnostic.message);
+                copy.notes       = diagnostic.notes;
+            }
+        }
+
         [[nodiscard]] std::optional<EmittedModule> emit(EmitOptions options = {}) {
             INFO(diagnostics.render(file));
             if (diagnostics.has_errors()) { return std::nullopt; }
@@ -90,6 +117,29 @@ namespace
     }
 
     bool contains(const std::string &text, std::string_view fragment) { return text.find(fragment) != std::string::npos; }
+
+    ModuleCatalog native_catalog(std::string header = "acme/stats.h") {
+        ModuleCatalog    catalog;
+        ImportableModule module;
+        module.identity = "acme.stats";
+        module.functions.push_back(ImportedFunction{
+            .module_identity        = module.identity,
+            .name                   = "blend",
+            .identity               = "acme.stats::blend",
+            .cpp_symbol             = "acme::stats::blend",
+            .parameters             = {{"value", hgl::semantics::ImportedScalarType::F64, false},
+                                       {"window", hgl::semantics::ImportedScalarType::I64, true}},
+            .result                 = hgl::semantics::ImportedScalarType::F64,
+            .phases                 = {NativeCallPhase::Evaluation},
+            .public_headers         = {std::move(header)},
+            .cmake_packages         = {"acme_stats"},
+            .imported_targets       = {"acme::stats"},
+            .runtime_images         = {"libacme_stats.so"},
+            .descriptor_fingerprint = "sha256:test",
+        });
+        REQUIRE_FALSE(catalog.add(std::move(module)));
+        return catalog;
+    }
 }  // namespace
 
 TEST_CASE("emit-cpp names the pair after the module and exports its functions", "[codegen]") {
@@ -192,6 +242,58 @@ fn hidden(value: f64) -> f64 => value
     CHECK(contains(emitted->source, "return amount;"));
     CHECK_FALSE(contains(emitted->header, "hgraph::TS<hgraph::Float>"));
     CHECK(contains(emitted->source, "register_graph_overload<operators::exposed, exposed>()"));
+}
+
+TEST_CASE("emit-cpp writes readable direct native scalar calls and dependency closure", "[codegen][native]") {
+    const ModuleCatalog catalog = native_catalog();
+    Unit                unit{R"(
+module checks.native
+use acme.stats as stats
+
+export fn smooth(value: f64) -> f64 {
+    when modified(value) && valid(value) { return stats::blend(value, 3) }
+}
+)",
+                             catalog, "native.hgl"};
+    const auto          emitted = unit.emit();
+    REQUIRE(emitted);
+    CHECK(contains(emitted->header, "#include <acme/stats.h>"));
+    CHECK(contains(emitted->header, "hgl_output.set(acme::stats::blend(value.value()"));
+    CHECK_FALSE(contains(emitted->header, "struct blend"));
+    CHECK(contains(emitted->descriptor, "\"acme/stats.h\""));
+    CHECK(contains(emitted->descriptor, "\"acme_stats\""));
+    CHECK(contains(emitted->descriptor, "\"acme::stats\""));
+    CHECK(contains(emitted->descriptor, "\"libacme_stats.so\""));
+}
+
+TEST_CASE("emit-cpp rejects unsafe native header metadata even in constructed IR", "[codegen][native]") {
+    const ModuleCatalog catalog = native_catalog("acme/stats.h>\n#include <evil.h");
+    Unit                unit{R"(
+module checks.native_header
+use acme.stats::{blend}
+fn smooth(value: f64) -> f64 {
+    when modified(value) && valid(value) { return blend(value, 3) }
+}
+)",
+                             catalog};
+    CHECK_FALSE(unit.emit());
+    CHECK(unit.has(Category::Backend, "names an unsafe public header"));
+}
+
+TEST_CASE("emit-cpp rejects unsafe native symbols even in constructed IR", "[codegen][native]") {
+    const ModuleCatalog catalog = native_catalog();
+    Unit                unit{R"(
+module checks.native_symbol
+use acme.stats::{blend}
+fn smooth(value: f64) -> f64 {
+    when modified(value) && valid(value) { return blend(value, 3) }
+}
+)",
+                             catalog};
+    REQUIRE(unit.graph.native_functions.size() == 1U);
+    unit.graph.native_functions.front().cpp_symbol = "acme::stats::blend(); injected";
+    CHECK_FALSE(unit.emit());
+    CHECK(unit.has(Category::Backend, "has an invalid exact C++ symbol"));
 }
 
 TEST_CASE("emit-cpp validates hgraph IR declaration order", "[codegen][hgraph-ir]") {

--- a/language/tests/codegen/generated_native_tests.cpp
+++ b/language/tests/codegen/generated_native_tests.cpp
@@ -1,0 +1,13 @@
+#include <native-scalar-import.h>
+
+#include <hgraph/lib/testing/check_output.h>
+#include <hgraph/lib/testing/eval_node.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace hgraph;
+using namespace hgraph::testing;
+
+TEST_CASE("generated runtime nodes call exact native scalar functions", "[codegen][runtime][native]") {
+    CHECK_OUTPUT(eval_node<checks::native_consumer::smooth>(values<Float>(1.0, 2.5)), values<Float>(4.0, 5.5));
+}

--- a/language/tests/descriptor/module_descriptor_reader_tests.cpp
+++ b/language/tests/descriptor/module_descriptor_reader_tests.cpp
@@ -1,3 +1,4 @@
+#include "descriptor/import_catalog.h"
 #include "descriptor/module_descriptor_reader.h"
 
 #include <catch2/catch_test_macros.hpp>
@@ -162,6 +163,29 @@ namespace
         return result;
     }
 
+    descriptor::ModuleDescriptor scalar_native_descriptor() {
+        descriptor::ModuleDescriptor result = minimal_descriptor();
+        result.types                        = {
+            descriptor::TypeRecord{.category = descriptor::TypeCategory::Scalar, .scalar_name = "f64"},
+            descriptor::TypeRecord{.category = descriptor::TypeCategory::Scalar, .scalar_name = "i64"},
+        };
+        descriptor::NativeDeclaration blend;
+        blend.identity                = "checks.reader::blend";
+        blend.cpp_symbol              = "checks::reader::blend";
+        blend.signature.parameters    = {{"value", "checks.reader::blend::value", false, 0U, descriptor::no_schema_id},
+                                         {"window", "checks.reader::blend::window", true, 1U, descriptor::no_schema_id}};
+        blend.signature.result        = 0U;
+        blend.phases                  = {descriptor::NativePhase::Evaluation};
+        blend.parameters              = {{"value", {}}, {"window", {}}};
+        result.native_declarations    = {std::move(blend)};
+        result.build.public_headers   = {"checks/reader.h"};
+        result.build.cmake_packages   = {"checks"};
+        result.build.imported_targets = {"checks::reader"};
+        result.build.runtime_images   = {"libchecks_reader.so"};
+        descriptor::seal(result);
+        return result;
+    }
+
     void replace_once(std::string &text, std::string_view from, std::string_view to) {
         const std::size_t offset = text.find(from);
         REQUIRE(offset != std::string::npos);
@@ -184,6 +208,68 @@ TEST_CASE("module descriptor reader round-trips the complete version-one model",
     REQUIRE(result.value);
     CHECK(*result.value == expected);
     CHECK_FALSE(result.error);
+}
+
+TEST_CASE("validated native scalar functions form a deterministic import catalog", "[descriptor][catalog]") {
+    hgl::semantics::ModuleCatalog catalog;
+    const auto                    error = descriptor::add_to_catalog(scalar_native_descriptor(), catalog);
+    REQUIRE_FALSE(error);
+
+    const hgl::semantics::ImportedFunction *function = catalog.find_function("checks.reader", "blend");
+    REQUIRE(function != nullptr);
+    CHECK(function->identity == "checks.reader::blend");
+    CHECK(function->cpp_symbol == "checks::reader::blend");
+    REQUIRE(function->parameters.size() == 2U);
+    CHECK(function->parameters[0].type == hgl::semantics::ImportedScalarType::F64);
+    CHECK(function->parameters[1].is_const);
+    CHECK(function->result == hgl::semantics::ImportedScalarType::F64);
+    CHECK(function->phases == std::vector{hgl::semantics::NativeCallPhase::Evaluation});
+    CHECK(function->public_headers == std::vector<std::string>{"checks/reader.h"});
+    CHECK(function->cmake_packages == std::vector<std::string>{"checks"});
+    CHECK(function->imported_targets == std::vector<std::string>{"checks::reader"});
+    CHECK(function->runtime_images == std::vector<std::string>{"libchecks_reader.so"});
+}
+
+TEST_CASE("catalog import rejects native identities outside their module namespace", "[descriptor][catalog]") {
+    descriptor::ModuleDescriptor source         = scalar_native_descriptor();
+    source.native_declarations.front().identity = "checks.reader.blend";
+    source.descriptor_fingerprint.clear();
+    descriptor::seal(source);
+
+    hgl::semantics::ModuleCatalog catalog;
+    const auto                    error = descriptor::add_to_catalog(source, catalog);
+    REQUIRE(error);
+    CHECK(error->path == "$.native.declarations[0].identity");
+    CHECK(error->message == "native function identity must be 'checks.reader::<name>'");
+    CHECK(catalog.modules().empty());
+}
+
+TEST_CASE("catalog preserves unsupported native declarations for precise import diagnostics", "[descriptor][catalog]") {
+    SECTION("effects") {
+        descriptor::ModuleDescriptor source        = scalar_native_descriptor();
+        source.native_declarations.front().effects = {descriptor::NativeEffect::Allocation};
+        source.descriptor_fingerprint.clear();
+        descriptor::seal(source);
+
+        hgl::semantics::ModuleCatalog catalog;
+        REQUIRE_FALSE(descriptor::add_to_catalog(source, catalog));
+        const hgl::semantics::ImportedFunction *function = catalog.find_function("checks.reader", "blend");
+        REQUIRE(function != nullptr);
+        CHECK(function->support_error == "native scalar calls with declared effects are not supported yet");
+    }
+
+    SECTION("phase") {
+        descriptor::ModuleDescriptor source       = scalar_native_descriptor();
+        source.native_declarations.front().phases = {descriptor::NativePhase::Wiring};
+        source.descriptor_fingerprint.clear();
+        descriptor::seal(source);
+
+        hgl::semantics::ModuleCatalog catalog;
+        REQUIRE_FALSE(descriptor::add_to_catalog(source, catalog));
+        const hgl::semantics::ImportedFunction *function = catalog.find_function("checks.reader", "blend");
+        REQUIRE(function != nullptr);
+        CHECK(function->support_error == "native scalar calls currently require the evaluation phase only");
+    }
 }
 
 TEST_CASE("module descriptor reader accepts compatible unknown members", "[descriptor][reader]") {

--- a/language/tests/driver/include/checks/native_dependency.h
+++ b/language/tests/driver/include/checks/native_dependency.h
@@ -1,0 +1,13 @@
+#ifndef HGL_TESTS_CHECKS_NATIVE_DEPENDENCY_H
+#define HGL_TESTS_CHECKS_NATIVE_DEPENDENCY_H
+
+#include <hgraph/types/primitive_types.h>
+
+namespace checks::native_dependency
+{
+    inline hgraph::Float blend(hgraph::Float value, hgraph::Int window) noexcept {
+        return value + static_cast<hgraph::Float>(window);
+    }
+}  // namespace checks::native_dependency
+
+#endif  // HGL_TESTS_CHECKS_NATIVE_DEPENDENCY_H

--- a/language/tests/driver/native-scalar-import.hgl
+++ b/language/tests/driver/native-scalar-import.hgl
@@ -1,8 +1,8 @@
-module pkg.new
+module checks.native_consumer
 
 use checks.native_dependency as native
 
-export fn class(value: f64) -> f64 {
+export fn smooth(value: f64) -> f64 {
     when modified(value) && valid(value) {
         return native::blend(value, 3)
     }

--- a/language/tests/driver/native_scalar_descriptor_fixture.cpp
+++ b/language/tests/driver/native_scalar_descriptor_fixture.cpp
@@ -1,0 +1,45 @@
+#include <hgl/native_package.h>
+
+#include <exception>
+#include <iostream>
+#include <string>
+
+int main(int argc, char **argv) {
+    if (argc != 2) {
+        std::cerr << "usage: native_scalar_descriptor_fixture <output>\n";
+        return 2;
+    }
+    try {
+        using namespace hgl::native;
+        Package package{
+            .module_identity   = "checks.native_dependency",
+            .language_version  = "0.1-test",
+            .provider_identity = "checks.native_dependency",
+            .declarations =
+                {
+                    Declaration{
+                        .identity   = "checks.native_dependency::blend",
+                        .cpp_symbol = "checks::native_dependency::blend",
+                        .parameters =
+                            {
+                                Parameter{.name = "value", .type = ValueType::canonical(ScalarType::F64)},
+                                Parameter{.name = "window", .type = ValueType::canonical(ScalarType::I64), .is_const = true},
+                            },
+                        .result_type = ValueType::canonical(ScalarType::F64),
+                        .phases      = {Phase::Evaluation},
+                    },
+                },
+            .build =
+                Build{
+                    .public_headers   = {"checks/native_dependency.h"},
+                    .cmake_packages   = {"checks_native_dependency"},
+                    .imported_targets = {"checks::native_dependency"},
+                },
+        };
+        write_descriptor(package, argv[1]);
+        return 0;
+    } catch (const std::exception &error) {
+        std::cerr << error.what() << '\n';
+        return 1;
+    }
+}

--- a/language/tests/hgraph_ir/lower_tests.cpp
+++ b/language/tests/hgraph_ir/lower_tests.cpp
@@ -48,6 +48,23 @@ namespace
             if (!hgl::ir::complete_hir(language, operators, diagnostics)) { return; }
             graph = hgl::hgraph_ir::lower(language, diagnostics);
         }
+
+        Lowered(std::string text, const hgl::semantics::ModuleCatalog &catalog, std::string path = "test.hgl")
+            : file{std::move(path), std::move(text)} {
+            hgl::syntax::ast::Module ast = hgl::syntax::parse(file, diagnostics);
+            if (diagnostics.has_errors()) { return; }
+            hgl::semantics::ResolvedModule resolved = hgl::semantics::resolve(file, ast, catalog, has_operator, diagnostics);
+            if (diagnostics.has_errors()) { return; }
+            hir::Module                     language  = hgl::ir::lower_to_hir(ast, resolved, diagnostics);
+            const hgl::ir::OperatorResolver operators = [](const hir::Module &, const hgl::ir::OperatorQuery &query) {
+                hgl::ir::OperatorSelection selected;
+                selected.result   = query.expected_result;
+                selected.deferred = true;
+                return selected;
+            };
+            if (!hgl::ir::complete_hir(language, operators, diagnostics)) { return; }
+            graph = hgl::hgraph_ir::lower(language, diagnostics);
+        }
     };
 
     const hgl::hgraph_ir::Callable *callable(const hgl::hgraph_ir::Module &module, std::string_view identity) {
@@ -62,6 +79,28 @@ namespace
             if (candidate.identity == identity) { return &candidate; }
         }
         return nullptr;
+    }
+
+    hgl::semantics::ModuleCatalog native_catalog() {
+        hgl::semantics::ModuleCatalog    catalog;
+        hgl::semantics::ImportableModule module;
+        module.identity = "acme.stats";
+        module.functions.push_back(hgl::semantics::ImportedFunction{
+            .module_identity        = module.identity,
+            .name                   = "blend",
+            .identity               = "acme.stats::blend",
+            .cpp_symbol             = "acme::stats::blend",
+            .parameters             = {{"value", hgl::semantics::ImportedScalarType::F64, false},
+                                       {"window", hgl::semantics::ImportedScalarType::I64, true}},
+            .result                 = hgl::semantics::ImportedScalarType::F64,
+            .phases                 = {hgl::semantics::NativeCallPhase::Evaluation},
+            .public_headers         = {"acme/stats.h"},
+            .cmake_packages         = {"acme"},
+            .imported_targets       = {"acme::stats"},
+            .descriptor_fingerprint = "sha256:test",
+        });
+        REQUIRE_FALSE(catalog.add(std::move(module)));
+        return catalog;
     }
 }  // namespace
 
@@ -221,6 +260,40 @@ fn adjusted(value: f64) -> f64 => double(value) - 1.0
     });
     REQUIRE(add != lowered.graph->values.end());
     CHECK(add->operation.deferred);
+}
+
+TEST_CASE("hgraph IR owns descriptor-native exact calls and build metadata", "[hgraph-ir][native]") {
+    const hgl::semantics::ModuleCatalog catalog = native_catalog();
+    Lowered                             lowered{R"(
+module checks.native
+use acme.stats::{blend}
+fn smooth(value: f64) -> f64 {
+    when modified(value) { return blend(value, 3) }
+}
+)",
+                                                catalog};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE_FALSE(lowered.diagnostics.has_errors());
+    REQUIRE(lowered.graph);
+    REQUIRE(lowered.graph->native_functions.size() == 1U);
+    const hgl::hgraph_ir::NativeFunction &native = lowered.graph->native_functions.front();
+    CHECK(native.identity == "acme.stats::blend");
+    CHECK(native.cpp_symbol == "acme::stats::blend");
+    CHECK(native.public_headers == std::vector<std::string>{"acme/stats.h"});
+
+    const auto call = std::ranges::find_if(
+        lowered.graph->values, [](const hgl::hgraph_ir::Value &value) { return value.operation.identity == "acme.stats::blend"; });
+    REQUIRE(call != lowered.graph->values.end());
+    CHECK(call->operation.kind == hgl::hgraph_ir::OperationKind::ExactFunction);
+    CHECK_FALSE(call->operation.callable.valid());
+    CHECK(call->operation.native_function == hgl::hgraph_ir::NativeFunctionId{0U});
+    const auto *syntax_call = std::get_if<hgl::hgraph_ir::Call>(&call->node);
+    REQUIRE(syntax_call != nullptr);
+    const auto *reference = std::get_if<hgl::hgraph_ir::Reference>(&lowered.graph->values[syntax_call->callee.value].node);
+    REQUIRE(reference != nullptr);
+    CHECK(reference->kind == hgl::hgraph_ir::ReferenceKind::NativeFunction);
+    CHECK(reference->native_function == hgl::hgraph_ir::NativeFunctionId{0U});
+    CHECK(hgl::hgraph_ir::print(*lowered.graph).find("native-functions\n  z0 acme.stats::blend") != std::string::npos);
 }
 
 TEST_CASE("hgraph IR inventories concrete keyed operator providers deterministically", "[hgraph-ir][providers]") {

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -40,6 +40,13 @@ namespace
             if (!diagnostics.has_errors()) { hir = hgl::ir::lower_to_hir(ast, resolved, diagnostics); }
         }
 
+        Lowered(std::string text, const hgl::semantics::ModuleCatalog &catalog, std::string path = "test.hgl")
+            : file{std::move(path), std::move(text)}, ast{hgl::syntax::parse(file, diagnostics)} {
+            if (diagnostics.has_errors()) { return; }
+            resolved = hgl::semantics::resolve(file, ast, catalog, has_operator, diagnostics);
+            if (!diagnostics.has_errors()) { hir = hgl::ir::lower_to_hir(ast, resolved, diagnostics); }
+        }
+
         [[nodiscard]] std::optional<hir::SymbolId> referenced_symbol(std::string_view spelling) const {
             for (ast::ExprId expression = 0; expression < ast.exprs.size(); ++expression) {
                 const ast::Expr &source  = ast.expr(expression);
@@ -73,6 +80,30 @@ namespace
             return result;
         };
         return hgl::ir::complete_hir(lowered.hir, resolver, lowered.diagnostics);
+    }
+
+    hgl::semantics::ModuleCatalog native_catalog(std::vector<hgl::semantics::NativeCallPhase> phases = {
+                                                     hgl::semantics::NativeCallPhase::Evaluation}) {
+        hgl::semantics::ModuleCatalog    catalog;
+        hgl::semantics::ImportableModule module;
+        module.identity = "acme.stats";
+        module.functions.push_back(hgl::semantics::ImportedFunction{
+            .module_identity        = module.identity,
+            .name                   = "blend",
+            .identity               = "acme.stats::blend",
+            .cpp_symbol             = "acme::stats::blend",
+            .parameters             = {{"value", hgl::semantics::ImportedScalarType::F64, false},
+                                       {"window", hgl::semantics::ImportedScalarType::I64, true}},
+            .result                 = hgl::semantics::ImportedScalarType::F64,
+            .phases                 = std::move(phases),
+            .public_headers         = {"acme/stats.h"},
+            .cmake_packages         = {"acme"},
+            .imported_targets       = {"acme::stats"},
+            .runtime_images         = {"libacme_stats.so"},
+            .descriptor_fingerprint = "sha256:test",
+        });
+        REQUIRE_FALSE(catalog.add(std::move(module)));
+        return catalog;
     }
 }  // namespace
 
@@ -150,6 +181,73 @@ fn escaped(const value: str = "a\nb\r\t\"\\") -> str => value
 
     const std::string printed = hgl::ir::print_hir(lowered.hir);
     CHECK(printed.find(R"(literal "a\nb\r\t\"\\")") != std::string::npos);
+}
+
+TEST_CASE("native scalar imports lower to owned HIR and complete exact calls", "[ir][native]") {
+    const hgl::semantics::ModuleCatalog catalog = native_catalog();
+    Lowered                             lowered{R"(
+module checks.native
+use acme.stats as stats
+
+fn smooth(value: f64) -> f64 {
+    when modified(value) {
+        return stats::blend(value, 3)
+    }
+}
+)",
+                                                catalog};
+    require_clean(lowered);
+    REQUIRE(lowered.hir.native_functions.size() == 1U);
+    const hir::NativeFunction &native = lowered.hir.native_functions.front();
+    CHECK(native.identity == "acme.stats::blend");
+    CHECK(native.cpp_symbol == "acme::stats::blend");
+    CHECK(native.public_headers == std::vector<std::string>{"acme/stats.h"});
+    REQUIRE(native.parameters.size() == 2U);
+    CHECK(native.parameters[1].is_const);
+
+    REQUIRE(complete(lowered));
+    INFO(lowered.diagnostics.render(lowered.file));
+    bool found = false;
+    for (const hir::Expr &expression : lowered.hir.exprs) {
+        if (expression.operation.identity != "acme.stats::blend") { continue; }
+        found = true;
+        CHECK(expression.operation.kind == hir::OperationKind::ExactFunction);
+        CHECK(expression.operation.target == native.symbol);
+        CHECK(expression.phase == hir::Phase::Runtime);
+    }
+    CHECK(found);
+}
+
+TEST_CASE("native calls enforce exact scalar and descriptor phase contracts", "[ir][native]") {
+    SECTION("no implicit scalar conversion") {
+        const hgl::semantics::ModuleCatalog catalog = native_catalog();
+        Lowered                             lowered{R"(
+module checks.native_type
+use acme.stats::{blend}
+fn smooth(value: i64) -> f64 {
+    when modified(value) { return blend(value, 3) }
+}
+)",
+                                                    catalog};
+        require_clean(lowered);
+        CHECK_FALSE(complete(lowered));
+        CHECK(lowered.diagnostics.render(lowered.file).find("expected exactly f64") != std::string::npos);
+    }
+
+    SECTION("phase is declared") {
+        const hgl::semantics::ModuleCatalog catalog = native_catalog({hgl::semantics::NativeCallPhase::Start});
+        Lowered                             lowered{R"(
+module checks.native_phase
+use acme.stats::{blend}
+fn smooth(value: f64) -> f64 {
+    when modified(value) { return blend(value, 3) }
+}
+)",
+                                                    catalog};
+        require_clean(lowered);
+        CHECK_FALSE(complete(lowered));
+        CHECK(lowered.diagnostics.render(lowered.file).find("not available during evaluation") != std::string::npos);
+    }
 }
 
 TEST_CASE("every guide example completes typed HIR", "[ir][examples][typed]") {
@@ -1182,6 +1280,7 @@ types
   t0 scalar f64 owner=d1 signal [42..45)
   t1 scalar f64 owner=d1 signal [50..53)
   t2 scalar f64 value [0..0)
+native-functions
 expressions
   e0 type=t0 phase=wiring value=signal ref s2 [57..62)
   e1 type=t2 phase=constant value=constant literal 1 [65..68)

--- a/language/tests/semantics/resolve_tests.cpp
+++ b/language/tests/semantics/resolve_tests.cpp
@@ -35,6 +35,10 @@ namespace
             : file{"test.hgl", std::move(text)}, module{parse(file, diagnostics)},
               result{resolve(file, module, table_lookup, diagnostics)} {}
 
+        Resolved(std::string text, const ModuleCatalog &catalog)
+            : file{"test.hgl", std::move(text)}, module{parse(file, diagnostics)},
+              result{resolve(file, module, catalog, table_lookup, diagnostics)} {}
+
         [[nodiscard]] std::vector<std::string> messages() const {
             std::vector<std::string> out;
             for (const Diagnostic &diagnostic : diagnostics.diagnostics()) { out.push_back(diagnostic.message); }
@@ -91,6 +95,22 @@ namespace
         REQUIRE_FALSE(resolved.diagnostics.has_errors());
         return resolved;
     }
+
+    ModuleCatalog scalar_catalog(std::string support_error = {}) {
+        ModuleCatalog    catalog;
+        ImportableModule module;
+        module.identity = "checks.reader";
+        module.functions.push_back(ImportedFunction{.module_identity = module.identity,
+                                                    .name            = "blend",
+                                                    .identity        = "checks.reader::blend",
+                                                    .cpp_symbol      = "checks::reader::blend",
+                                                    .parameters      = {{"value", hgl::semantics::ImportedScalarType::F64, false}},
+                                                    .result          = hgl::semantics::ImportedScalarType::F64,
+                                                    .phases          = {NativeCallPhase::Evaluation},
+                                                    .support_error   = std::move(support_error)});
+        REQUIRE_FALSE(catalog.add(std::move(module)));
+        return catalog;
+    }
 }  // namespace
 
 TEST_CASE("kernel imports bind to registry names", "[semantics]") {
@@ -116,11 +136,37 @@ fn f(x: f64) -> f64 => std::add(x, 1.0)
     CHECK(resolved.result.aliases[0].module == "hgraph.std");
 }
 
-TEST_CASE("only the kernel modules link in the first pass", "[semantics]") {
+TEST_CASE("external imports require an explicitly supplied module catalog", "[semantics]") {
     const Resolved resolved{"module t\n\nuse market.pricing::{value}\nuse "
                             "hgraph.std::{nothing_like_this}\n"};
     CHECK(resolved.has(Category::Module, "module 'market.pricing' is not available"));
     CHECK(resolved.has(Category::Module, "hgraph.std does not export 'nothing_like_this'"));
+}
+
+TEST_CASE("supplied native modules support selective and qualified imports", "[semantics][native]") {
+    const ModuleCatalog catalog = scalar_catalog();
+    const Resolved      resolved{R"(
+module checks.uses_native
+use checks.reader::{blend}
+use checks.reader as reader
+
+fn one(value: f64) -> f64 => blend(value)
+fn two(value: f64) -> f64 => reader::blend(value)
+)",
+                                 catalog};
+    INFO(resolved.diagnostics.render(resolved.file));
+    REQUIRE_FALSE(resolved.diagnostics.has_errors());
+    REQUIRE(resolved.result.imported_functions.size() == 1U);
+    CHECK(resolved.result.imported_functions.front().identity == "checks.reader::blend");
+    CHECK(resolved.result.imported_functions.front().cpp_symbol == "checks::reader::blend");
+    CHECK(resolved.binding_of("blend")->kind == BindingKind::ImportedFunction);
+}
+
+TEST_CASE("unsupported native declarations remain visible at the import site", "[semantics][native]") {
+    const ModuleCatalog catalog = scalar_catalog("native scalar calls with declared effects are not supported yet");
+    const Resolved      resolved{"module checks.unsupported\nuse checks.reader::{blend}\n", catalog};
+    CHECK(resolved.has(Category::Module,
+                       "native function 'checks.reader::blend' is unavailable: native scalar calls with declared effects"));
 }
 
 TEST_CASE("reference types are temporal shapes with value-position restrictions", "[semantics][ref]") {


### PR DESCRIPTION
## Summary

- load explicitly supplied native module descriptors into a frontend-independent import catalog
- resolve and type-check exact canonical-scalar native functions, then preserve their identity through HIR and hgraph IR
- emit direct, clang-formatted C++ calls with declared headers and build requirements
- pass module descriptors through the CLI and direct CMake target dependencies
- document the supported AOT boundary and remaining scripted/transitive work

## Validation

- `cmake --build build-language-review --parallel 8`
- `ctest --test-dir build-language-review -R '^hgraph_language_' --output-on-failure --parallel 4` (41/41)
- `cmake --preset cpp --fresh`
- `cmake --build --preset cpp --target clean`
- `cmake --build --preset cpp --parallel 8`
- `ctest --preset cpp --parallel 2 --output-on-failure` (1716/1716)
- stable-ABI wheel built with Python 3.12, installed into a fresh Python 3.14 environment
- `python -m pytest python/tests -q -m "not wip"` (3241 passed, 10 skipped)