### PR TITLE
Type layer: structured TS conversions move to the bridge (RFC 0035, PR 4b)

### DIFF
--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -585,8 +585,10 @@ Value and reference crossings
   ``Range<ValueView>`` / ``KeyValueRange``) and mutation protocol (touch,
   insert / remove key, child memory for write, record child modified);
   a per-surface value-ops slot (live / added / removed / modified) is a
-  distinct provider entry selected at table construction, so the bridge
-  never branches on the surface per call.
+  distinct provider entry selected at table construction, the proxy seams
+  take the surface as a template argument, and the fixed TSB and TSL
+  strategies select separate bundle / list entries, so the bridge never
+  branches on the surface or the kind per call.
 - **One set of Python-object value primitives** (2026-09-05):
   ``python_bridge::object_hash`` / ``object_equals`` / ``object_compare`` /
   ``object_str`` -- the contract in ``include/hgraph/python/object_semantics.h``,

--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -577,7 +577,16 @@ Value and reference crossings
   and hand the bridge the payload. A factory records its Python-authoring
   family on ``TSDataOps::python_family`` and the bridge maps it to the
   table (``python_ts_data_ops_for``); a family still naming its table by
-  symbol keeps the pointer until it moves.
+  symbol keeps the pointer until it moves. The structured families --
+  fixed TSB / TSL, dynamic TSL, slot-backed TSS / TSD and the TSD proxy --
+  are in ``ts_data_structured_conversions.cpp``: children are reached
+  through their own erased ``TSDataOps``, and the seams answer each
+  strategy's shape (element types, ordinal keys, slot surfaces as
+  ``Range<ValueView>`` / ``KeyValueRange``) and mutation protocol (touch,
+  insert / remove key, child memory for write, record child modified);
+  a per-surface value-ops slot (live / added / removed / modified) is a
+  distinct provider entry selected at table construction, so the bridge
+  never branches on the surface per call.
 - **One set of Python-object value primitives** (2026-09-05):
   ``python_bridge::object_hash`` / ``object_equals`` / ``object_compare`` /
   ``object_str`` -- the contract in ``include/hgraph/python/object_semantics.h``,

--- a/docs/source/rfc/rfc_0035_python_free_type_layer.rst
+++ b/docs/source/rfc/rfc_0035_python_free_type_layer.rst
@@ -623,7 +623,17 @@ Five PRs, each green on the full gate, each lowering the ratchet:
 Implementation status
 ---------------------
 
-Proposed. PR 4a (``hardening/python-ops-ts-atomic-window``) moves the
+Proposed. PR 4b (``hardening/python-ops-ts-structured``) moves the fixed
+TSB / TSL, dynamic TSL, slot-backed TSS / TSD and TSD-proxy conversions to
+``src/hgraph/python/impl/ts_data_structured_conversions.cpp``. The seams
+of ``ts_data_seams.h`` answer each strategy's shape and mutation protocol
+(the slot and fixed contexts grant the seams access through one friend
+struct each); per-surface value-ops slots are distinct provider entries
+selected at table construction. ``type-layer-python-conditionals`` 60 → 14,
+``type-layer-nanobind`` 273 → 35: the TS input and target-link facades
+are all that remain, for PR 5.
+
+PR 4a (``hardening/python-ops-ts-atomic-window``) moves the
 atomic (TS / SIGNAL / REF, in its three value-storage variants) and TSW
 window conversions to ``src/hgraph/python/impl/ts_data_family_conversions.cpp``
 behind ``PythonOps::TSData`` and ``PythonOps::Retained``, through the seams

--- a/docs/source/rfc/rfc_0035_python_free_type_layer.rst
+++ b/docs/source/rfc/rfc_0035_python_free_type_layer.rst
@@ -629,7 +629,9 @@ TSB / TSL, dynamic TSL, slot-backed TSS / TSD and TSD-proxy conversions to
 of ``ts_data_seams.h`` answer each strategy's shape and mutation protocol
 (the slot and fixed contexts grant the seams access through one friend
 struct each); per-surface value-ops slots are distinct provider entries
-selected at table construction. ``type-layer-python-conditionals`` 60 → 14,
+selected at table construction, the proxy seams are instantiated per
+surface, and the fixed TSB and TSL strategies select separate entries, so
+no conversion switches on a surface or a kind. ``type-layer-python-conditionals`` 60 → 14,
 ``type-layer-nanobind`` 273 → 35: the TS input and target-link facades
 are all that remain, for PR 5.
 

--- a/include/hgraph/types/python_ops.h
+++ b/include/hgraph/types/python_ops.h
@@ -140,6 +140,51 @@ namespace hgraph
             DeltaToPythonFn window_delta_to_python{nullptr};
             /** The window's value surface (a value-ops slot over the storage). */
             ToPythonFn      window_value_to_python{nullptr};
+            // fixed structured TSB / TSL, and its value projections
+            FromPythonFn    fixed_from_python{nullptr};
+            ToPythonFn      fixed_to_python{nullptr};
+            DeltaToPythonFn fixed_delta_to_python{nullptr};
+            ToPythonFn      fixed_value_to_python{nullptr};
+            ToPythonFn      fixed_delta_bundle_to_python{nullptr};
+            ToPythonFn      fixed_delta_map_to_python{nullptr};
+            ToPythonFn      fixed_delta_key_set_to_python{nullptr};
+            // dynamic TSL, and its value projections
+            FromPythonFn    dynamic_from_python{nullptr};
+            ToPythonFn      dynamic_to_python{nullptr};
+            DeltaToPythonFn dynamic_delta_to_python{nullptr};
+            ToPythonFn      dynamic_value_projection_to_python{nullptr};
+            ToPythonFn      dynamic_delta_projection_to_python{nullptr};
+            ToPythonFn      dynamic_delta_key_set_projection_to_python{nullptr};
+            ToPythonFn      dynamic_removed_set_projection_to_python{nullptr};
+            ToPythonFn      dynamic_delta_bundle_to_python{nullptr};
+            // slot-backed TSS / TSD, and their set / map surfaces
+            FromPythonFn    tss_from_python{nullptr};
+            ToPythonFn      tss_to_python{nullptr};
+            DeltaToPythonFn tss_delta_to_python{nullptr};
+            ToPythonFn      tss_delta_bundle_to_python{nullptr};
+            ToPythonFn      tss_set_live_to_python{nullptr};
+            ToPythonFn      tss_set_added_to_python{nullptr};
+            ToPythonFn      tss_set_removed_to_python{nullptr};
+            FromPythonFn    tsd_from_python{nullptr};
+            ToPythonFn      tsd_to_python{nullptr};
+            DeltaToPythonFn tsd_delta_to_python{nullptr};
+            ToPythonFn      tsd_map_key_set_to_python{nullptr};
+            ToPythonFn      tsd_dict_delta_to_python{nullptr};
+            ToPythonFn      tsd_map_live_to_python{nullptr};
+            ToPythonFn      tsd_map_modified_to_python{nullptr};
+            // the TSD proxy (input-side projection) and its surfaces
+            ToPythonFn      proxy_dict_to_python{nullptr};
+            DeltaToPythonFn proxy_dict_delta_to_python{nullptr};
+            ToPythonFn      proxy_key_set_to_python{nullptr};
+            DeltaToPythonFn proxy_key_set_delta_to_python{nullptr};
+            ToPythonFn      proxy_delta_projection_to_python{nullptr};
+            ToPythonFn      proxy_set_live_to_python{nullptr};
+            ToPythonFn      proxy_set_added_to_python{nullptr};
+            ToPythonFn      proxy_set_removed_to_python{nullptr};
+            ToPythonFn      proxy_map_live_to_python{nullptr};
+            ToPythonFn      proxy_map_added_to_python{nullptr};
+            ToPythonFn      proxy_map_removed_to_python{nullptr};
+            ToPythonFn      proxy_map_modified_to_python{nullptr};
         } ts_data;
 
         /** The retained-object cache of a ``NativeWithPythonCache`` output:

--- a/include/hgraph/types/python_ops.h
+++ b/include/hgraph/types/python_ops.h
@@ -140,10 +140,14 @@ namespace hgraph
             DeltaToPythonFn window_delta_to_python{nullptr};
             /** The window's value surface (a value-ops slot over the storage). */
             ToPythonFn      window_value_to_python{nullptr};
-            // fixed structured TSB / TSL, and its value projections
-            FromPythonFn    fixed_from_python{nullptr};
-            ToPythonFn      fixed_to_python{nullptr};
-            DeltaToPythonFn fixed_delta_to_python{nullptr};
+            // fixed structured TSB and TSL (the factory selects the shape's
+            // entries once), and their value projections
+            FromPythonFn    fixed_bundle_from_python{nullptr};
+            ToPythonFn      fixed_bundle_to_python{nullptr};
+            DeltaToPythonFn fixed_bundle_delta_to_python{nullptr};
+            FromPythonFn    fixed_list_from_python{nullptr};
+            ToPythonFn      fixed_list_to_python{nullptr};
+            DeltaToPythonFn fixed_list_delta_to_python{nullptr};
             ToPythonFn      fixed_value_to_python{nullptr};
             ToPythonFn      fixed_delta_bundle_to_python{nullptr};
             ToPythonFn      fixed_delta_map_to_python{nullptr};

--- a/python/tests/test_architecture_ratchets.py
+++ b/python/tests/test_architecture_ratchets.py
@@ -178,7 +178,7 @@ RATCHETS: tuple[Ratchet, ...] = (
     ),
     Ratchet(
         id="type-layer-python-conditionals",
-        baseline=60,
+        baseline=14,
         roots=("src/hgraph/types", "include/hgraph/types"),
         suffixes=(".cpp", ".h"),
         pattern=r"HGRAPH_ENABLE_PYTHON_USER_NODES",
@@ -188,7 +188,7 @@ RATCHETS: tuple[Ratchet, ...] = (
     ),
     Ratchet(
         id="type-layer-nanobind",
-        baseline=273,
+        baseline=35,
         roots=("src/hgraph/types", "include/hgraph/types"),
         suffixes=(".cpp", ".h"),
         pattern=r"nanobind|\bnb::",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -104,6 +104,7 @@ if(HGRAPH_BUILD_PYTHON_BINDINGS OR HGRAPH_ENABLE_PYTHON_USER_NODES)
         hgraph/python/impl/realized_conversions.cpp
         hgraph/python/impl/retained_value.cpp
         hgraph/python/impl/ts_data_family_conversions.cpp
+        hgraph/python/impl/ts_data_structured_conversions.cpp
         hgraph/python/impl/ts_data_conversion.cpp
     )
 endif()

--- a/src/hgraph/python/impl/python_ops.cpp
+++ b/src/hgraph/python/impl/python_ops.cpp
@@ -168,6 +168,7 @@ namespace hgraph::python_bridge
                 fill_mutable_container_conversions(ops.mutable_containers);
                 fill_realized_conversions(ops.realized);
                 fill_ts_data_conversions(ops.ts_data);
+                fill_structured_ts_data_conversions(ops.ts_data);
                 fill_retained_conversions(ops.retained);
                 return ops;
             }();

--- a/src/hgraph/python/impl/python_ops_families.h
+++ b/src/hgraph/python/impl/python_ops_families.h
@@ -15,6 +15,7 @@ namespace hgraph::python_bridge
     void fill_mutable_container_conversions(PythonOps::Mutable &section) noexcept;
     void fill_realized_conversions(PythonOps::Realized &section) noexcept;
     void fill_ts_data_conversions(PythonOps::TSData &section) noexcept;
+    void fill_structured_ts_data_conversions(PythonOps::TSData &section) noexcept;
     void fill_retained_conversions(PythonOps::Retained &section) noexcept;
 }  // namespace hgraph::python_bridge
 

--- a/src/hgraph/python/impl/ts_data_structured_conversions.cpp
+++ b/src/hgraph/python/impl/ts_data_structured_conversions.cpp
@@ -163,58 +163,76 @@ namespace hgraph::python_bridge
             return result;
         }
 
-        [[nodiscard]] nb::object fixed_to_python(const void *context, const void *memory)
+        // Python TimeSeries.value is a TSData operation. Recurse through each
+        // child's TSDataOps so nested TSL/TSD/TSB representations retain
+        // their own public Python semantics. The TSB and TSL bodies are
+        // distinct provider entries the factory selects once (no kind switch).
+        [[nodiscard]] nb::object fixed_child_value_to_python(const void *context, const void *memory, std::size_t index)
+        {
+            const auto &ops   = seams::fixed_element_type(context, index).ops_ref();
+            const auto *child = seams::fixed_child_data(context, memory, index);
+            return ops.has_current_value_impl(ops.context, child) ? take(ops.to_python_impl(ops.context, child))
+                                                                  : nb::none();
+        }
+
+        [[nodiscard]] nb::object fixed_bundle_to_python(const void *context, const void *memory)
         {
             const auto &schema = seams::fixed_schema(context);
-            const auto  count  = seams::fixed_element_count(context);
-            // Python TimeSeries.value is a TSData operation. Recurse through
-            // each child's TSDataOps so nested TSL/TSD/TSB representations
-            // retain their own public Python semantics.
-            if (schema.kind == TSTypeKind::TSB)
+            nb::dict    result;
+            for (std::size_t index = 0, count = seams::fixed_element_count(context); index < count; ++index)
             {
-                nb::dict result;
-                for (std::size_t index = 0; index < count; ++index)
-                {
-                    const char *name = schema.fields()[index].name;
-                    if (name == nullptr || *name == '\0') { continue; }
-                    const auto &ops   = seams::fixed_element_type(context, index).ops_ref();
-                    const auto *child = seams::fixed_child_data(context, memory, index);
-                    result[nb::str{name}] = ops.has_current_value_impl(ops.context, child)
-                                                ? take(ops.to_python_impl(ops.context, child))
-                                                : nb::none();
-                }
-                return materialize_tsb_python_value(&schema, std::move(result));
+                const char *name = schema.fields()[index].name;
+                if (name == nullptr || *name == '\0') { continue; }
+                result[nb::str{name}] = fixed_child_value_to_python(context, memory, index);
             }
+            return materialize_tsb_python_value(&schema, std::move(result));
+        }
 
+        [[nodiscard]] nb::object fixed_list_to_python(const void *context, const void *memory)
+        {
             nb::list result;
-            for (std::size_t index = 0; index < count; ++index)
+            for (std::size_t index = 0, count = seams::fixed_element_count(context); index < count; ++index)
             {
-                const auto &ops   = seams::fixed_element_type(context, index).ops_ref();
-                const auto *child = seams::fixed_child_data(context, memory, index);
-                result.append(ops.has_current_value_impl(ops.context, child) ? take(ops.to_python_impl(ops.context, child))
-                                                                             : nb::none());
+                result.append(fixed_child_value_to_python(context, memory, index));
             }
             return nb::tuple(result);
         }
 
-        [[nodiscard]] nb::object fixed_delta_to_python(const void *context, const void *memory, DateTime evaluation_time)
+        /** The child's delta for this cycle, or None when it did not tick. */
+        [[nodiscard]] nb::object fixed_child_delta_to_python(const void *context, const void *memory, std::size_t index,
+                                                             DateTime evaluation_time)
+        {
+            if (!seams::fixed_child_modified_for_parent_time(context, memory, index)) { return nb::none(); }
+            const auto &ops   = seams::fixed_element_type(context, index).ops_ref();
+            const auto *child = seams::fixed_child_data(context, memory, index);
+            return take(ops.delta_to_python_impl(ops.context, child, evaluation_time));
+        }
+
+        [[nodiscard]] nb::object fixed_bundle_delta_to_python(const void *context, const void *memory,
+                                                              DateTime evaluation_time)
         {
             if (seams::fixed_tracking(context, memory).last_modified_time != evaluation_time) { return nb::none(); }
             const auto &schema = seams::fixed_schema(context);
             nb::dict    result;
-            for (std::size_t index = 0; index < seams::fixed_element_count(context); ++index)
+            for (std::size_t index = 0, count = seams::fixed_element_count(context); index < count; ++index)
             {
-                if (!seams::fixed_child_modified_for_parent_time(context, memory, index)) { continue; }
-                const auto &ops   = seams::fixed_element_type(context, index).ops_ref();
-                const auto *child = seams::fixed_child_data(context, memory, index);
-                nb::object  value = take(ops.delta_to_python_impl(ops.context, child, evaluation_time));
-                if (value.is_none()) { continue; }
-                if (schema.kind == TSTypeKind::TSB)
-                {
-                    const char *name = schema.fields()[index].name;
-                    if (name != nullptr && *name != '\0') { result[nb::str{name}] = std::move(value); }
-                }
-                else { result[nb::int_{index}] = std::move(value); }
+                const char *name = schema.fields()[index].name;
+                if (name == nullptr || *name == '\0') { continue; }
+                nb::object value = fixed_child_delta_to_python(context, memory, index, evaluation_time);
+                if (!value.is_none()) { result[nb::str{name}] = std::move(value); }
+            }
+            return result;
+        }
+
+        [[nodiscard]] nb::object fixed_list_delta_to_python(const void *context, const void *memory,
+                                                            DateTime evaluation_time)
+        {
+            if (seams::fixed_tracking(context, memory).last_modified_time != evaluation_time) { return nb::none(); }
+            nb::dict result;
+            for (std::size_t index = 0, count = seams::fixed_element_count(context); index < count; ++index)
+            {
+                nb::object value = fixed_child_delta_to_python(context, memory, index, evaluation_time);
+                if (!value.is_none()) { result[nb::int_{index}] = std::move(value); }
             }
             return result;
         }
@@ -314,17 +332,24 @@ namespace hgraph::python_bridge
             return touched;
         }
 
-        [[nodiscard]] bool fixed_from_python(const void *context, void *memory, nb::handle source, DateTime modified_time)
+        [[nodiscard]] bool fixed_bundle_from_python(const void *context, void *memory, nb::handle source,
+                                                    DateTime modified_time)
         {
             require_source(memory, source, modified_time, "fixed TSData from_python");
             const bool first_for_parent = seams::fixed_tracking(context, memory).last_modified_time != modified_time;
-            bool       touched          = false;
-            if (seams::fixed_schema(context).kind == TSTypeKind::TSB)
-            {
-                touched = fixed_from_python_bundle(context, memory, source, modified_time);
-            }
-            else if (python_has_items(source)) { touched = fixed_from_python_list_mapping(context, memory, source, modified_time); }
-            else { touched = fixed_from_python_sequence(context, memory, source, modified_time, "fixed TSL from_python"); }
+            const bool touched          = fixed_from_python_bundle(context, memory, source, modified_time);
+            return first_for_parent && touched;
+        }
+
+        [[nodiscard]] bool fixed_list_from_python(const void *context, void *memory, nb::handle source,
+                                                  DateTime modified_time)
+        {
+            require_source(memory, source, modified_time, "fixed TSData from_python");
+            const bool first_for_parent = seams::fixed_tracking(context, memory).last_modified_time != modified_time;
+            const bool touched = python_has_items(source)
+                                     ? fixed_from_python_list_mapping(context, memory, source, modified_time)
+                                     : fixed_from_python_sequence(context, memory, source, modified_time,
+                                                                  "fixed TSL from_python");
             return first_for_parent && touched;
         }
 
@@ -717,7 +742,7 @@ namespace hgraph::python_bridge
             nb::list items;
             for (std::size_t slot = 0; slot < seams::proxy_slot_capacity(memory); ++slot)
             {
-                if (!seams::proxy_slot_in_set_surface(context, memory, slot, Surface)) { continue; }
+                if (!seams::proxy_slot_in_set_surface<Surface>(context, memory, slot)) { continue; }
                 auto key = seams::proxy_key_at_slot(memory, slot);
                 items.append(to_python(key.binding(), key.data()));
             }
@@ -728,7 +753,7 @@ namespace hgraph::python_bridge
         {
             const auto &layout = seams::proxy_layout(context);
             nb::set     result;
-            for (const auto key : seams::proxy_keys(context, memory, seams::SetSurface::live))
+            for (const auto key : seams::proxy_keys<seams::SetSurface::live>(context, memory))
             {
                 result.add(to_python(layout.key_binding, key.data()));
             }
@@ -788,15 +813,15 @@ namespace hgraph::python_bridge
         template <seams::ProxyMapSurface Surface>
         [[nodiscard]] nb::object proxy_map_to_python(const void *context, const void *memory)
         {
-            nb::dict result;
+            const auto value_type = seams::proxy_map_value_binding<Surface>(context, memory);
+            nb::dict   result;
             for (std::size_t slot = 0; slot < seams::proxy_slot_capacity(memory); ++slot)
             {
-                if (!seams::proxy_slot_in_map_surface(context, memory, slot, Surface) || !seams::proxy_has_child(memory, slot))
+                if (!seams::proxy_slot_in_map_surface<Surface>(context, memory, slot) || !seams::proxy_has_child(memory, slot))
                 {
                     continue;
                 }
-                const auto  value_type   = seams::proxy_map_value_binding(context, memory, Surface);
-                const auto *value_memory = seams::proxy_map_value_at_slot(context, memory, slot, Surface);
+                const auto *value_memory = seams::proxy_map_value_at_slot<Surface>(context, memory, slot);
                 auto        key          = seams::proxy_key_at_slot(memory, slot);
                 const auto  py_key       = to_python(key.binding(), key.data());
                 result[py_key] = value_memory != nullptr ? to_python(value_type, value_memory) : nb::none();
@@ -807,9 +832,12 @@ namespace hgraph::python_bridge
 
     void fill_structured_ts_data_conversions(PythonOps::TSData &section) noexcept
     {
-        section.fixed_from_python                          = &ts_from_python_slot<&fixed_from_python>;
-        section.fixed_to_python                            = &to_python_slot<&fixed_to_python>;
-        section.fixed_delta_to_python                      = &ts_delta_to_python_slot<&fixed_delta_to_python>;
+        section.fixed_bundle_from_python                   = &ts_from_python_slot<&fixed_bundle_from_python>;
+        section.fixed_bundle_to_python                     = &to_python_slot<&fixed_bundle_to_python>;
+        section.fixed_bundle_delta_to_python               = &ts_delta_to_python_slot<&fixed_bundle_delta_to_python>;
+        section.fixed_list_from_python                     = &ts_from_python_slot<&fixed_list_from_python>;
+        section.fixed_list_to_python                       = &to_python_slot<&fixed_list_to_python>;
+        section.fixed_list_delta_to_python                 = &ts_delta_to_python_slot<&fixed_list_delta_to_python>;
         section.fixed_value_to_python                      = &to_python_slot<&fixed_value_to_python>;
         section.fixed_delta_bundle_to_python               = &to_python_slot<&fixed_delta_bundle_to_python>;
         section.fixed_delta_map_to_python                  = &to_python_slot<&fixed_delta_map_to_python>;

--- a/src/hgraph/python/impl/ts_data_structured_conversions.cpp
+++ b/src/hgraph/python/impl/ts_data_structured_conversions.cpp
@@ -1,0 +1,852 @@
+#include "python_ops_families.h"
+
+#include "../../types/metadata/detail/ts_data_seams.h"
+
+#include <hgraph/python/bridge_state.h>
+#include <hgraph/python/conversion.h>
+#include <hgraph/types/metadata/ts_value_type_meta_data.h>
+#include <hgraph/types/time_series/ts_data/ops.h>
+#include <hgraph/types/value/value.h>
+#include <hgraph/util/scope.h>
+
+#include <fmt/format.h>
+#include <nanobind/nanobind.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+/**
+ * TSData <-> Python for the structured strategies (RFC 0035, PR 4b): fixed
+ * TSB / TSL, dynamic TSL, slot-backed TSS / TSD and the TSD proxy. Children
+ * are reached through their own erased TSDataOps; the strategies' private
+ * shapes and mutation protocols come through ``ts_data_seams.h``. Each body
+ * keeps the semantics it had beside its storage.
+ */
+namespace hgraph::python_bridge
+{
+    namespace
+    {
+        namespace seams = ts_data_seams;
+
+        constexpr std::size_t no_child = std::numeric_limits<std::size_t>::max();
+
+        // -- shared Python-shape helpers ----------------------------------------------
+        [[nodiscard]] bool is_python_sequence(nb::handle source)
+        {
+            nb::object object = nb::borrow<nb::object>(source);
+            return nb::isinstance<nb::list>(object) || nb::isinstance<nb::tuple>(object);
+        }
+
+        [[nodiscard]] bool python_has_items(nb::handle source)
+        {
+            nb::object object = nb::borrow<nb::object>(source);
+            return nb::isinstance<nb::dict>(object) || nb::hasattr(object, "items");
+        }
+
+        template <typename Visitor>
+        void for_each_python_mapping_item(nb::handle source, const char *what, Visitor visitor)
+        {
+            if (!python_has_items(source)) { throw std::invalid_argument(std::string{what} + " expects a Python mapping"); }
+            nb::object   object = nb::borrow<nb::object>(source);
+            nb::object   items  = object.attr("items")();
+            nb::iterator it     = nb::iter(items);
+            while (it != nb::iterator::sentinel())
+            {
+                nb::tuple pair = nb::cast<nb::tuple>(*it);
+                if (pair.size() != 2) { throw std::invalid_argument(std::string{what} + " items() must yield key/value pairs"); }
+                visitor(nb::borrow<nb::object>(pair[0]), nb::borrow<nb::object>(pair[1]));
+                ++it;
+            }
+        }
+
+        template <typename Visitor>
+        void for_each_python_iterable(nb::handle source, const char *what, Visitor visitor)
+        {
+            if (source.is_none()) { return; }
+            nb::object   object = nb::borrow<nb::object>(source);
+            nb::iterator it     = nb::iter(object);
+            while (it != nb::iterator::sentinel())
+            {
+                nb::handle item = *it;
+                if (item.is_none()) { throw std::invalid_argument(std::string{what} + " does not allow None elements"); }
+                visitor(item);
+                ++it;
+            }
+        }
+
+        [[nodiscard]] bool python_named_field(nb::handle source, const char *name, nb::object &out)
+        {
+            nb::object object = nb::borrow<nb::object>(source);
+            if (nb::isinstance<nb::dict>(object))
+            {
+                nb::dict map = nb::cast<nb::dict>(object);
+                nb::str  key{name};
+                if (!map.contains(key)) { return false; }
+                out = map[key];
+                return true;
+            }
+            if (nb::hasattr(object, name))
+            {
+                out = nb::getattr(object, name);
+                return true;
+            }
+            return false;
+        }
+
+        [[nodiscard]] Value value_from_python(const ValueTypeRef &binding, nb::handle source, const char *what)
+        {
+            if (source.is_none()) { throw std::invalid_argument(std::string{what} + " requires a non-None value"); }
+            Value value{binding};
+            from_python(binding, const_cast<void *>(value.view().data()), source);
+            return value;
+        }
+
+        /** A child strategy's Python import, then the tracking record and parent bookkeeping the
+            structured parent owes for it. */
+        [[nodiscard]] bool import_child(const TSDataOps &ops, void *child, nb::handle source, DateTime modified_time,
+                                        const char *what)
+        {
+            if (!ops.from_python_impl(ops.context, child, borrow(source), modified_time)) { return false; }
+            auto *tracking = ops.mutable_tracking_impl(ops.context, child);
+            if (tracking == nullptr) { throw std::logic_error(std::string{what} + " child has no tracking record"); }
+            if (!tracking->record_modified(modified_time))
+            {
+                throw std::logic_error(std::string{what} + " child reported a duplicate Python update modification");
+            }
+            return true;
+        }
+
+        void require_source(const void *memory, nb::handle source, DateTime modified_time, const char *what)
+        {
+            if (memory == nullptr) { throw std::logic_error(std::string{what} + " requires live storage"); }
+            if (source.is_none()) { throw std::invalid_argument(std::string{what} + " requires a non-None source"); }
+            if (modified_time == MIN_DT)
+            {
+                throw std::invalid_argument(std::string{what} + " requires a concrete evaluation time");
+            }
+        }
+
+        // -- fixed TSB / TSL ---------------------------------------------------------------
+        [[nodiscard]] nb::object fixed_value_to_python(const void *context, const void *memory)
+        {
+            // This is a VALUE projection, not the TSData Python surface.
+            // Materialise through the erased owning-type/copy contract so a
+            // projected child never needs ad-hoc recursive shape knowledge.
+            return to_python(Value{ValueView{seams::fixed_layout(context).value_binding, memory}});
+        }
+
+        [[nodiscard]] nb::object fixed_delta_bundle_to_python(const void *context, const void *memory)
+        {
+            return to_python(Value{ValueView{seams::fixed_layout(context).delta_binding, memory}});
+        }
+
+        [[nodiscard]] nb::object fixed_delta_map_to_python(const void *context, const void *memory)
+        {
+            return to_python(Value{ValueView{seams::fixed_layout(context).delta_binding, memory}});
+        }
+
+        [[nodiscard]] nb::object fixed_delta_key_set_to_python(const void *context, const void *memory)
+        {
+            nb::set result;
+            for (std::size_t index = 0; index < seams::fixed_element_count(context); ++index)
+            {
+                if (!seams::fixed_child_modified_for_parent_time(context, memory, index)) { continue; }
+                result.add(nb::int_{seams::fixed_ordinal_key(context, index)});
+            }
+            return result;
+        }
+
+        [[nodiscard]] nb::object fixed_to_python(const void *context, const void *memory)
+        {
+            const auto &schema = seams::fixed_schema(context);
+            const auto  count  = seams::fixed_element_count(context);
+            // Python TimeSeries.value is a TSData operation. Recurse through
+            // each child's TSDataOps so nested TSL/TSD/TSB representations
+            // retain their own public Python semantics.
+            if (schema.kind == TSTypeKind::TSB)
+            {
+                nb::dict result;
+                for (std::size_t index = 0; index < count; ++index)
+                {
+                    const char *name = schema.fields()[index].name;
+                    if (name == nullptr || *name == '\0') { continue; }
+                    const auto &ops   = seams::fixed_element_type(context, index).ops_ref();
+                    const auto *child = seams::fixed_child_data(context, memory, index);
+                    result[nb::str{name}] = ops.has_current_value_impl(ops.context, child)
+                                                ? take(ops.to_python_impl(ops.context, child))
+                                                : nb::none();
+                }
+                return materialize_tsb_python_value(&schema, std::move(result));
+            }
+
+            nb::list result;
+            for (std::size_t index = 0; index < count; ++index)
+            {
+                const auto &ops   = seams::fixed_element_type(context, index).ops_ref();
+                const auto *child = seams::fixed_child_data(context, memory, index);
+                result.append(ops.has_current_value_impl(ops.context, child) ? take(ops.to_python_impl(ops.context, child))
+                                                                             : nb::none());
+            }
+            return nb::tuple(result);
+        }
+
+        [[nodiscard]] nb::object fixed_delta_to_python(const void *context, const void *memory, DateTime evaluation_time)
+        {
+            if (seams::fixed_tracking(context, memory).last_modified_time != evaluation_time) { return nb::none(); }
+            const auto &schema = seams::fixed_schema(context);
+            nb::dict    result;
+            for (std::size_t index = 0; index < seams::fixed_element_count(context); ++index)
+            {
+                if (!seams::fixed_child_modified_for_parent_time(context, memory, index)) { continue; }
+                const auto &ops   = seams::fixed_element_type(context, index).ops_ref();
+                const auto *child = seams::fixed_child_data(context, memory, index);
+                nb::object  value = take(ops.delta_to_python_impl(ops.context, child, evaluation_time));
+                if (value.is_none()) { continue; }
+                if (schema.kind == TSTypeKind::TSB)
+                {
+                    const char *name = schema.fields()[index].name;
+                    if (name != nullptr && *name != '\0') { result[nb::str{name}] = std::move(value); }
+                }
+                else { result[nb::int_{index}] = std::move(value); }
+            }
+            return result;
+        }
+
+        [[nodiscard]] std::size_t fixed_field_index_by_name(const void *context, std::string_view name) noexcept
+        {
+            const auto &schema = seams::fixed_schema(context);
+            for (std::size_t index = 0; index < seams::fixed_element_count(context); ++index)
+            {
+                const char *field_name = schema.fields()[index].name;
+                if (field_name != nullptr && name == field_name) { return index; }
+            }
+            return no_child;
+        }
+
+        [[nodiscard]] bool fixed_child_update_from_python(const void *context, void *memory, std::size_t index,
+                                                          nb::handle source, DateTime modified_time)
+        {
+            if (source.is_none()) { return false; }
+            const auto &ops = seams::fixed_element_type(context, index).ops_ref();
+            return import_child(ops, seams::fixed_mutable_child_data(context, memory, index), source, modified_time,
+                                "fixed TSData");
+        }
+
+        [[nodiscard]] bool fixed_from_python_sequence(const void *context, void *memory, nb::handle source,
+                                                      DateTime modified_time, const char *what)
+        {
+            if (!is_python_sequence(source)) { throw std::invalid_argument(std::string{what} + " expects a Python list or tuple"); }
+
+            nb::object   object   = nb::borrow<nb::object>(source);
+            nb::sequence sequence = nb::cast<nb::sequence>(object);
+            const auto   count    = static_cast<std::size_t>(nb::len(sequence));
+            if (count != seams::fixed_element_count(context))
+            {
+                throw std::invalid_argument(
+                    fmt::format("{} expects {} elements, got {}", what, seams::fixed_element_count(context), count));
+            }
+
+            bool touched = false;
+            for (std::size_t index = 0; index < count; ++index)
+            {
+                nb::object child_source = sequence[index];
+                touched |= fixed_child_update_from_python(context, memory, index, child_source, modified_time);
+            }
+            return touched;
+        }
+
+        [[nodiscard]] bool fixed_from_python_bundle(const void *context, void *memory, nb::handle source,
+                                                    DateTime modified_time)
+        {
+            nb::object object = nb::borrow<nb::object>(source);
+            if (python_has_items(source))
+            {
+                bool touched = false;
+                for_each_python_mapping_item(source, "TSB from_python", [&](nb::handle key, nb::handle value) {
+                    const auto field = nb::cast<std::string>(key);
+                    const auto index = fixed_field_index_by_name(context, field);
+                    if (index == no_child) { throw std::invalid_argument(fmt::format("TSB from_python unknown field '{}'", field)); }
+                    touched |= fixed_child_update_from_python(context, memory, index, value, modified_time);
+                });
+                return touched;
+            }
+
+            if (is_python_sequence(source))
+            {
+                return fixed_from_python_sequence(context, memory, source, modified_time, "TSB from_python");
+            }
+
+            const auto &schema    = seams::fixed_schema(context);
+            bool        saw_field = false;
+            bool        touched   = false;
+            for (std::size_t index = 0; index < seams::fixed_element_count(context); ++index)
+            {
+                const char *name = schema.fields()[index].name;
+                if (name == nullptr || *name == '\0')
+                {
+                    throw std::invalid_argument("TSB from_python has an unnamed field and cannot load attributes");
+                }
+                if (!nb::hasattr(object, name)) { continue; }
+                saw_field               = true;
+                nb::object child_source = nb::getattr(object, name);
+                touched |= fixed_child_update_from_python(context, memory, index, child_source, modified_time);
+            }
+            if (!saw_field) { throw std::invalid_argument("TSB from_python expects a mapping, sequence, or field attributes"); }
+            return touched;
+        }
+
+        [[nodiscard]] bool fixed_from_python_list_mapping(const void *context, void *memory, nb::handle source,
+                                                          DateTime modified_time)
+        {
+            bool touched = false;
+            for_each_python_mapping_item(source, "fixed TSL from_python", [&](nb::handle key, nb::handle value) {
+                const auto index = nb::cast<std::size_t>(key);
+                if (index >= seams::fixed_element_count(context)) { throw std::out_of_range("fixed TSL from_python index out of range"); }
+                touched |= fixed_child_update_from_python(context, memory, index, value, modified_time);
+            });
+            return touched;
+        }
+
+        [[nodiscard]] bool fixed_from_python(const void *context, void *memory, nb::handle source, DateTime modified_time)
+        {
+            require_source(memory, source, modified_time, "fixed TSData from_python");
+            const bool first_for_parent = seams::fixed_tracking(context, memory).last_modified_time != modified_time;
+            bool       touched          = false;
+            if (seams::fixed_schema(context).kind == TSTypeKind::TSB)
+            {
+                touched = fixed_from_python_bundle(context, memory, source, modified_time);
+            }
+            else if (python_has_items(source)) { touched = fixed_from_python_list_mapping(context, memory, source, modified_time); }
+            else { touched = fixed_from_python_sequence(context, memory, source, modified_time, "fixed TSL from_python"); }
+            return first_for_parent && touched;
+        }
+
+        // -- dynamic TSL ---------------------------------------------------------------------
+        /** Either REMOVE sentinel. Truncation is total, so hgraph's strict /
+            lenient distinction has nothing to express for a list. */
+        [[nodiscard]] bool is_removal_sentinel(nb::handle item) noexcept
+        {
+            const auto &strict = removed_sentinel_slot();
+            if (strict.is_valid() && item.is(strict)) { return true; }
+            const auto &lenient = remove_if_exists_sentinel_slot();
+            return lenient.is_valid() && item.is(lenient);
+        }
+
+        [[nodiscard]] nb::object dynamic_value_projection_to_python(const void *context, const void *memory)
+        {
+            return to_python(Value{ValueView{seams::dynamic_layout(context).value_binding, memory}});
+        }
+
+        [[nodiscard]] nb::object dynamic_delta_projection_to_python(const void *context, const void *memory)
+        {
+            return to_python(Value{ValueView{seams::dynamic_layout(context).delta_binding, memory}});
+        }
+
+        [[nodiscard]] nb::object dynamic_delta_key_set_projection_to_python(const void *context, const void *memory)
+        {
+            return to_python(Value{ValueView{seams::dynamic_delta_key_set_binding(context), memory}});
+        }
+
+        [[nodiscard]] nb::object dynamic_removed_set_projection_to_python(const void *context, const void *memory)
+        {
+            return to_python(Value{ValueView{seams::dynamic_removed_set_binding(context), memory}});
+        }
+
+        [[nodiscard]] nb::object dynamic_delta_bundle_to_python(const void *context, const void *memory)
+        {
+            nb::dict result;
+            result[nb::str{"removed"}]  = to_python(seams::dynamic_removed_set_binding(context), memory);
+            result[nb::str{"modified"}] = to_python(seams::dynamic_modified_map_binding(context), memory);
+            return result;
+        }
+
+        /** Dynamic TSL Python export is a TSData strategy. It deliberately
+            recurses through child TSDataOps; the public facade must never
+            infer this representation from TSTypeKind. */
+        [[nodiscard]] nb::object dynamic_to_python(const void *context, const void *memory)
+        {
+            const auto &ops = seams::dynamic_element_type(context).ops_ref();
+            nb::list    result;
+            for (std::size_t index = 0; index < seams::dynamic_size(memory); ++index)
+            {
+                const auto *child = seams::dynamic_child_memory(memory, index);
+                result.append(ops.has_current_value_impl(ops.context, child) ? take(ops.to_python_impl(ops.context, child))
+                                                                             : nb::none());
+            }
+            return nb::tuple(result);
+        }
+
+        [[nodiscard]] nb::object dynamic_delta_to_python(const void *context, const void *memory, DateTime evaluation_time)
+        {
+            if (seams::dynamic_tracking(memory).last_modified_time != evaluation_time) { return nb::none(); }
+            const auto &ops = seams::dynamic_element_type(context).ops_ref();
+            nb::dict    modified;
+            for (std::size_t ordinal = 0; ordinal < seams::dynamic_modified_index_count(memory); ++ordinal)
+            {
+                const auto  index = seams::dynamic_modified_index_at(memory, ordinal);
+                const auto *child = seams::dynamic_child_memory(memory, index);
+                nb::object  value = take(ops.delta_to_python_impl(ops.context, child, evaluation_time));
+                if (!value.is_none()) { modified[nb::int_{index}] = std::move(value); }
+            }
+            // RFC 0031: the canonical {removed, modified} shape, which
+            // hgraph's _simplify_delta rewrites into the friendly
+            // {index: delta, removed_index: REMOVE} form.
+            nb::dict result;
+            result[nb::str{"removed"}]  = to_python(seams::dynamic_removed_set_binding(context), memory);
+            result[nb::str{"modified"}] = std::move(modified);
+            return result;
+        }
+
+        /** Import current/replacement values through the child strategies.
+            A sequence IS the list: it covers consecutive indices and
+            resizes, so a shorter sequence truncates (RFC 0031). A mapping
+            is a sparse replacement/update in which a ``REMOVE`` sentinel
+            truncates to the lowest removed index. */
+        [[nodiscard]] bool dynamic_from_python(const void *context, void *memory, nb::handle source, DateTime modified_time)
+        {
+            require_source(memory, source, modified_time, "dynamic TSL from_python");
+            const auto &ops              = seams::dynamic_element_type(context).ops_ref();
+            const bool  first_for_parent = seams::dynamic_tracking(memory).last_modified_time != modified_time;
+            bool        touched          = false;
+
+            const auto update = [&](std::size_t index, nb::handle item) {
+                seams::dynamic_ensure_size(context, memory, index + 1, modified_time);
+                void *child = seams::dynamic_mutable_child_memory(memory, index);
+                if (!ops.from_python_impl(ops.context, child, borrow(item), modified_time)) { return; }
+                auto *tracking = ops.mutable_tracking_impl(ops.context, child);
+                if (tracking == nullptr || !tracking->record_modified(modified_time))
+                {
+                    throw std::logic_error("dynamic TSL child reported an invalid modification");
+                }
+                seams::dynamic_record_child_modified(memory, index, modified_time);
+                touched = true;
+            };
+
+            if (nb::isinstance<nb::dict>(source))
+            {
+                // Removal is resolved FIRST so a same-cycle re-grow through
+                // `modified` behaves exactly as apply_delta does.
+                auto truncate_to = static_cast<std::size_t>(-1);
+                for (auto [key, item] : nb::cast<nb::dict>(source))
+                {
+                    if (item.is_none() || !is_removal_sentinel(item)) { continue; }
+                    const auto index = nb::cast<std::int64_t>(key);
+                    if (index < 0) { throw std::out_of_range("dynamic TSL from_python index must be non-negative"); }
+                    truncate_to = std::min(truncate_to, static_cast<std::size_t>(index));
+                }
+                if (truncate_to < seams::dynamic_size(memory))
+                {
+                    seams::dynamic_resize(context, memory, truncate_to, modified_time);
+                    touched = true;
+                }
+                for (auto [key, item] : nb::cast<nb::dict>(source))
+                {
+                    if (item.is_none() || is_removal_sentinel(item)) { continue; }
+                    const auto index = nb::cast<std::int64_t>(key);
+                    if (index < 0) { throw std::out_of_range("dynamic TSL from_python index must be non-negative"); }
+                    update(static_cast<std::size_t>(index), item);
+                }
+                return first_for_parent && touched;
+            }
+
+            if (nb::isinstance<nb::str>(source) || !nb::isinstance<nb::sequence>(source))
+            {
+                throw std::invalid_argument("dynamic TSL from_python expects a mapping or sequence");
+            }
+            const auto source_size = static_cast<std::size_t>(nb::len(source));
+            if (source_size != seams::dynamic_size(memory))
+            {
+                seams::dynamic_resize(context, memory, source_size, modified_time);
+                touched = true;
+            }
+            std::size_t index = 0;
+            for (nb::handle item : source)
+            {
+                if (!item.is_none()) { update(index, item); }
+                ++index;
+            }
+            return first_for_parent && touched;
+        }
+
+        // -- slot-backed TSS -----------------------------------------------------------------
+        [[nodiscard]] nb::object tss_to_python(const void *context, const void *memory)
+        {
+            return to_python(seams::tss_layout(context).value_binding, memory);
+        }
+
+        [[nodiscard]] nb::object tss_delta_to_python(const void *context, const void *memory, DateTime evaluation_time)
+        {
+            if (seams::tss_tracking(memory).last_modified_time != evaluation_time) { return nb::none(); }
+            return to_python(seams::tss_layout(context).delta_binding, memory);
+        }
+
+        [[nodiscard]] bool tss_from_python(const void *context, void *memory, nb::handle source, DateTime modified_time)
+        {
+            require_source(memory, source, modified_time, "TSS from_python");
+            const auto key_binding = seams::tss_layout(context).key_binding;
+
+            nb::object added;
+            nb::object removed;
+            const bool has_added   = python_named_field(source, "added", added);
+            const bool has_removed = python_named_field(source, "removed", removed);
+            if (has_added || has_removed)
+            {
+                const bool first_for_parent = seams::tss_tracking(memory).last_modified_time != modified_time;
+                if (has_added && !added.is_none())
+                {
+                    for_each_python_iterable(added, "TSS added update", [&](nb::handle item) {
+                        Value key = value_from_python(key_binding, item, "TSS added update");
+                        seams::tss_insert_key(memory, key.view(), modified_time);
+                    });
+                }
+                if (has_removed && !removed.is_none())
+                {
+                    for_each_python_iterable(removed, "TSS removed update", [&](nb::handle item) {
+                        Value key = value_from_python(key_binding, item, "TSS removed update");
+                        seams::tss_remove_key(memory, key.view(), modified_time);
+                    });
+                }
+                return first_for_parent;
+            }
+
+            nb::object object = nb::borrow<nb::object>(source);
+            if (!nb::isinstance<nb::set>(object) && !nb::isinstance<nb::frozenset>(object) &&
+                !nb::isinstance<nb::list>(object) && !nb::isinstance<nb::tuple>(object))
+            {
+                throw std::invalid_argument("TSS from_python expects a Python set, frozenset, list, or tuple");
+            }
+
+            std::vector<Value> replacement;
+            if (nb::hasattr(object, "__len__")) { replacement.reserve(static_cast<std::size_t>(nb::len(object))); }
+            for_each_python_iterable(source, "TSS value", [&](nb::handle item) {
+                replacement.push_back(value_from_python(key_binding, item, "TSS value"));
+            });
+
+            const bool newly_touched = seams::tss_touch(memory, modified_time);
+            for (const auto &key : replacement) { seams::tss_insert_key(memory, key.view(), modified_time); }
+
+            const auto        &key_ops = key_binding.ops_ref();
+            std::vector<Value> removals;
+            for (const auto key : seams::tss_keys(context, memory, seams::SetSurface::live))
+            {
+                const bool keep = std::any_of(replacement.begin(), replacement.end(), [&](const Value &candidate) {
+                    return key_ops.equals(key.data(), candidate.view().data());
+                });
+                if (!keep) { removals.emplace_back(key); }
+            }
+            for (const auto &key : removals) { seams::tss_remove_key(memory, key.view(), modified_time); }
+            return newly_touched;
+        }
+
+        template <seams::SetSurface Surface>
+        [[nodiscard]] nb::object tss_set_to_python(const void *context, const void *memory)
+        {
+            const auto &ops = seams::tss_layout(context).key_binding.ops_ref();
+            nb::set     result;
+            for (const auto key : seams::tss_keys(context, memory, Surface)) { result.add(to_python(ops, key.data())); }
+            return result;
+        }
+
+        [[nodiscard]] nb::object tss_delta_bundle_to_python(const void *context, const void *memory)
+        {
+            nb::dict result;
+            result[nb::str{"added"}]   = to_python(seams::tss_added_set_binding(context), memory);
+            result[nb::str{"removed"}] = to_python(seams::tss_removed_set_binding(context), memory);
+            return result;
+        }
+
+        // -- slot-backed TSD -----------------------------------------------------------------
+        [[nodiscard]] nb::object tsd_to_python(const void *context, const void *memory)
+        {
+            const auto &layout    = seams::tsd_layout(context);
+            const auto &key_ops   = layout.key_binding.ops_ref();
+            const auto &child_ops = layout.element_type.ops_ref();
+            nb::dict    result;
+            for (std::size_t slot = 0; slot < seams::tsd_slot_capacity(memory); ++slot)
+            {
+                if (!seams::tsd_slot_in_surface(memory, slot, seams::MapSurface::live)) { continue; }
+                const auto *child = seams::tsd_child_at_slot(memory, slot);
+                if (!child_ops.has_current_value_impl(child_ops.context, child)) { continue; }
+                result[to_python(key_ops, seams::tsd_key_at_slot(memory, slot))] =
+                    take(child_ops.to_python_impl(child_ops.context, child));
+            }
+            return result;
+        }
+
+        [[nodiscard]] nb::object tsd_delta_to_python(const void *context, const void *memory, DateTime evaluation_time)
+        {
+            if (seams::tsd_tracking(memory).last_modified_time != evaluation_time) { return nb::none(); }
+            const auto &layout    = seams::tsd_layout(context);
+            const auto &key_ops   = layout.key_binding.ops_ref();
+            const auto &child_ops = layout.element_type.ops_ref();
+            nb::dict    modified;
+            for (std::size_t slot = 0; slot < seams::tsd_slot_capacity(memory); ++slot)
+            {
+                if (!seams::tsd_slot_in_surface(memory, slot, seams::MapSurface::modified)) { continue; }
+                const auto *child = seams::tsd_child_at_slot(memory, slot);
+                nb::object  delta = take(child_ops.delta_to_python_impl(child_ops.context, child, evaluation_time));
+                if (!delta.is_none()) { modified[to_python(key_ops, seams::tsd_key_at_slot(memory, slot))] = std::move(delta); }
+            }
+            nb::dict result;
+            result[nb::str{"removed"}]  = to_python(seams::tsd_removed_set_binding(context), memory);
+            result[nb::str{"modified"}] = std::move(modified);
+            return result;
+        }
+
+        [[nodiscard]] bool tsd_from_python(const void *context, void *memory, nb::handle source, DateTime modified_time)
+        {
+            require_source(memory, source, modified_time, "TSD from_python");
+            if (!python_has_items(source)) { throw std::invalid_argument("TSD from_python expects a Python mapping"); }
+            const auto &layout    = seams::tsd_layout(context);
+            const auto &child_ops = layout.element_type.ops_ref();
+
+            nb::object removed;
+            nb::object modified;
+            const bool has_removed  = python_named_field(source, "removed", removed);
+            const bool has_modified = python_named_field(source, "modified", modified);
+            if (has_removed || has_modified)
+            {
+                const bool first_for_parent = seams::tsd_tracking(memory).last_modified_time != modified_time;
+                if (has_removed && !removed.is_none())
+                {
+                    for_each_python_iterable(removed, "TSD removed update", [&](nb::handle item) {
+                        Value key = value_from_python(layout.key_binding, item, "TSD removed update");
+                        seams::tsd_remove_key(memory, key.view(), modified_time);
+                    });
+                }
+
+                if (has_modified && !modified.is_none())
+                {
+                    for_each_python_mapping_item(modified, "TSD modified update",
+                                                 [&](nb::handle key_source, nb::handle value_source) {
+                        if (value_source.is_none()) { return; }
+
+                        Value      key    = value_from_python(layout.key_binding, key_source, "TSD modified update key");
+                        const auto result = seams::tsd_insert_key(memory, key.view(), modified_time);
+
+                        auto rollback_insert = make_scope_exit<true>([&] {
+                            if (result.changed) { seams::tsd_remove_key(memory, key.view(), modified_time); }
+                        });
+
+                        void *child_memory = seams::tsd_child_memory_for_write(memory, result.slot);
+                        if (!import_child(child_ops, child_memory, value_source, modified_time, "TSD")) { return; }
+                        seams::tsd_record_child_modified(memory, result.slot, modified_time);
+                        rollback_insert.release();
+                    });
+                }
+                return first_for_parent;
+            }
+
+            std::vector<std::pair<Value, nb::object>> entries;
+            for_each_python_mapping_item(source, "TSD value", [&](nb::handle key_source, nb::handle value_source) {
+                if (value_source.is_none()) { throw std::invalid_argument("TSD from_python does not allow None child values"); }
+                entries.emplace_back(value_from_python(layout.key_binding, key_source, "TSD value key"),
+                                     nb::borrow<nb::object>(value_source));
+            });
+
+            const bool newly_touched = seams::tsd_touch(memory, modified_time);
+            for (const auto &[key, value_source] : entries)
+            {
+                const auto result       = seams::tsd_insert_key(memory, key.view(), modified_time);
+                void      *child_memory = seams::tsd_child_memory_for_write(memory, result.slot);
+                if (import_child(child_ops, child_memory, value_source, modified_time, "TSD"))
+                {
+                    seams::tsd_record_child_modified(memory, result.slot, modified_time);
+                }
+            }
+
+            const auto        &key_ops = layout.key_binding.ops_ref();
+            std::vector<Value> removals;
+            for (const auto key : seams::tsd_keys(context, memory, seams::SetSurface::live))
+            {
+                const bool keep = std::any_of(entries.begin(), entries.end(), [&](const auto &entry) {
+                    return key_ops.equals(key.data(), entry.first.view().data());
+                });
+                if (!keep) { removals.emplace_back(key); }
+            }
+            for (const auto &key : removals) { seams::tsd_remove_key(memory, key.view(), modified_time); }
+            return newly_touched;
+        }
+
+        template <seams::MapSurface Surface>
+        [[nodiscard]] nb::object tsd_map_to_python(const void *context, const void *memory)
+        {
+            const auto &key_ops       = seams::tsd_layout(context).key_binding.ops_ref();
+            const auto  value_binding = seams::tsd_map_value_binding(context, memory, Surface);
+            const auto &value_ops     = value_binding.ops_ref();
+            nb::dict    result;
+            for (const auto [key, value] : seams::tsd_map_items(context, memory, Surface))
+            {
+                result[to_python(key_ops, key.data())] = value.valid() ? to_python(value_ops, value.data()) : nb::none();
+            }
+            return result;
+        }
+
+        [[nodiscard]] nb::object tsd_map_key_set_to_python(const void *context, const void *memory)
+        {
+            const auto &ops = seams::tsd_layout(context).key_binding.ops_ref();
+            nb::set     result;
+            for (const auto key : seams::tsd_keys(context, memory, seams::SetSurface::live)) { result.add(to_python(ops, key.data())); }
+            return result;
+        }
+
+        [[nodiscard]] nb::object tsd_dict_delta_to_python(const void *context, const void *memory)
+        {
+            nb::dict result;
+            result[nb::str{"removed"}]  = to_python(seams::tsd_removed_set_binding(context), memory);
+            result[nb::str{"modified"}] = to_python(seams::tsd_modified_map_binding(context), memory);
+            return result;
+        }
+
+        // -- the TSD proxy ---------------------------------------------------------------------
+        [[nodiscard]] nb::object proxy_delta_projection_to_python(const void *context, const void *memory)
+        {
+            return to_python(Value{ValueView{seams::proxy_layout(context).delta_binding, memory}});
+        }
+
+        template <seams::SetSurface Surface>
+        [[nodiscard]] nb::object proxy_set_to_python(const void *context, const void *memory)
+        {
+            nb::list items;
+            for (std::size_t slot = 0; slot < seams::proxy_slot_capacity(memory); ++slot)
+            {
+                if (!seams::proxy_slot_in_set_surface(context, memory, slot, Surface)) { continue; }
+                auto key = seams::proxy_key_at_slot(memory, slot);
+                items.append(to_python(key.binding(), key.data()));
+            }
+            return nb::steal(PyFrozenSet_New(items.ptr()));
+        }
+
+        [[nodiscard]] nb::object proxy_key_set_to_python(const void *context, const void *memory)
+        {
+            const auto &layout = seams::proxy_layout(context);
+            nb::set     result;
+            for (const auto key : seams::proxy_keys(context, memory, seams::SetSurface::live))
+            {
+                result.add(to_python(layout.key_binding, key.data()));
+            }
+            return result;
+        }
+
+        [[nodiscard]] nb::object proxy_key_set_delta_to_python(const void *context, const void *memory,
+                                                               DateTime evaluation_time)
+        {
+            if (seams::proxy_key_set_tracking(memory).last_modified_time != evaluation_time) { return nb::none(); }
+            nb::dict result;
+            result[nb::str{"added"}]   = proxy_set_to_python<seams::SetSurface::added>(context, memory);
+            result[nb::str{"removed"}] = proxy_set_to_python<seams::SetSurface::removed>(context, memory);
+            return result;
+        }
+
+        /** TSDProxy is a concrete TSData representation. Python export
+            therefore lives here and follows each child through its own
+            erased TSDataOps instead of leaking proxy layout to a facade. */
+        [[nodiscard]] nb::object proxy_dict_to_python(const void *context, const void *memory)
+        {
+            const auto &child_ops = seams::proxy_layout(context).element_type.ops_ref();
+            nb::dict    result;
+            for (std::size_t slot = 0; slot < seams::proxy_slot_capacity(memory); ++slot)
+            {
+                if (!seams::proxy_slot_live(memory, slot) || !seams::proxy_has_child(memory, slot)) { continue; }
+                const auto  key   = seams::proxy_key_at_slot(memory, slot);
+                const auto *child = seams::proxy_child_at_slot(memory, slot);
+                if (!child_ops.has_current_value_impl(child_ops.context, child)) { continue; }
+                result[to_python(key.binding(), key.data())] = take(child_ops.to_python_impl(child_ops.context, child));
+            }
+            return result;
+        }
+
+        [[nodiscard]] nb::object proxy_dict_delta_to_python(const void *context, const void *memory, DateTime evaluation_time)
+        {
+            if (seams::proxy_tracking(memory).last_modified_time != evaluation_time) { return nb::none(); }
+            const auto &child_ops = seams::proxy_layout(context).element_type.ops_ref();
+            nb::dict    modified;
+            for (std::size_t slot = 0; slot < seams::proxy_slot_capacity(memory); ++slot)
+            {
+                if (!seams::proxy_slot_modified(context, memory, slot) || !seams::proxy_has_child(memory, slot)) { continue; }
+                const auto  key   = seams::proxy_key_at_slot(memory, slot);
+                const auto *child = seams::proxy_child_at_slot(memory, slot);
+                nb::object  delta = take(child_ops.delta_to_python_impl(child_ops.context, child, evaluation_time));
+                if (!delta.is_none()) { modified[to_python(key.binding(), key.data())] = std::move(delta); }
+            }
+            nb::dict result;
+            result[nb::str{"removed"}]  = proxy_set_to_python<seams::SetSurface::removed>(context, memory);
+            result[nb::str{"modified"}] = std::move(modified);
+            return result;
+        }
+
+        /** Surface read-back for python (type-erasure rule: conversion
+            binds to the ops). Children are read through their TS views -
+            link-endpoint children resolve to their targets. */
+        template <seams::ProxyMapSurface Surface>
+        [[nodiscard]] nb::object proxy_map_to_python(const void *context, const void *memory)
+        {
+            nb::dict result;
+            for (std::size_t slot = 0; slot < seams::proxy_slot_capacity(memory); ++slot)
+            {
+                if (!seams::proxy_slot_in_map_surface(context, memory, slot, Surface) || !seams::proxy_has_child(memory, slot))
+                {
+                    continue;
+                }
+                const auto  value_type   = seams::proxy_map_value_binding(context, memory, Surface);
+                const auto *value_memory = seams::proxy_map_value_at_slot(context, memory, slot, Surface);
+                auto        key          = seams::proxy_key_at_slot(memory, slot);
+                const auto  py_key       = to_python(key.binding(), key.data());
+                result[py_key] = value_memory != nullptr ? to_python(value_type, value_memory) : nb::none();
+            }
+            return result;
+        }
+    }  // namespace
+
+    void fill_structured_ts_data_conversions(PythonOps::TSData &section) noexcept
+    {
+        section.fixed_from_python                          = &ts_from_python_slot<&fixed_from_python>;
+        section.fixed_to_python                            = &to_python_slot<&fixed_to_python>;
+        section.fixed_delta_to_python                      = &ts_delta_to_python_slot<&fixed_delta_to_python>;
+        section.fixed_value_to_python                      = &to_python_slot<&fixed_value_to_python>;
+        section.fixed_delta_bundle_to_python               = &to_python_slot<&fixed_delta_bundle_to_python>;
+        section.fixed_delta_map_to_python                  = &to_python_slot<&fixed_delta_map_to_python>;
+        section.fixed_delta_key_set_to_python              = &to_python_slot<&fixed_delta_key_set_to_python>;
+        section.dynamic_from_python                        = &ts_from_python_slot<&dynamic_from_python>;
+        section.dynamic_to_python                          = &to_python_slot<&dynamic_to_python>;
+        section.dynamic_delta_to_python                    = &ts_delta_to_python_slot<&dynamic_delta_to_python>;
+        section.dynamic_value_projection_to_python         = &to_python_slot<&dynamic_value_projection_to_python>;
+        section.dynamic_delta_projection_to_python         = &to_python_slot<&dynamic_delta_projection_to_python>;
+        section.dynamic_delta_key_set_projection_to_python = &to_python_slot<&dynamic_delta_key_set_projection_to_python>;
+        section.dynamic_removed_set_projection_to_python   = &to_python_slot<&dynamic_removed_set_projection_to_python>;
+        section.dynamic_delta_bundle_to_python             = &to_python_slot<&dynamic_delta_bundle_to_python>;
+        section.tss_from_python                            = &ts_from_python_slot<&tss_from_python>;
+        section.tss_to_python                              = &to_python_slot<&tss_to_python>;
+        section.tss_delta_to_python                        = &ts_delta_to_python_slot<&tss_delta_to_python>;
+        section.tss_delta_bundle_to_python                 = &to_python_slot<&tss_delta_bundle_to_python>;
+        section.tss_set_live_to_python                     = &to_python_slot<&tss_set_to_python<seams::SetSurface::live>>;
+        section.tss_set_added_to_python                    = &to_python_slot<&tss_set_to_python<seams::SetSurface::added>>;
+        section.tss_set_removed_to_python                  = &to_python_slot<&tss_set_to_python<seams::SetSurface::removed>>;
+        section.tsd_from_python                            = &ts_from_python_slot<&tsd_from_python>;
+        section.tsd_to_python                              = &to_python_slot<&tsd_to_python>;
+        section.tsd_delta_to_python                        = &ts_delta_to_python_slot<&tsd_delta_to_python>;
+        section.tsd_map_key_set_to_python                  = &to_python_slot<&tsd_map_key_set_to_python>;
+        section.tsd_dict_delta_to_python                   = &to_python_slot<&tsd_dict_delta_to_python>;
+        section.tsd_map_live_to_python                     = &to_python_slot<&tsd_map_to_python<seams::MapSurface::live>>;
+        section.tsd_map_modified_to_python                 = &to_python_slot<&tsd_map_to_python<seams::MapSurface::modified>>;
+        section.proxy_dict_to_python                       = &to_python_slot<&proxy_dict_to_python>;
+        section.proxy_dict_delta_to_python                 = &ts_delta_to_python_slot<&proxy_dict_delta_to_python>;
+        section.proxy_key_set_to_python                    = &to_python_slot<&proxy_key_set_to_python>;
+        section.proxy_key_set_delta_to_python              = &ts_delta_to_python_slot<&proxy_key_set_delta_to_python>;
+        section.proxy_delta_projection_to_python           = &to_python_slot<&proxy_delta_projection_to_python>;
+        section.proxy_set_live_to_python                   = &to_python_slot<&proxy_set_to_python<seams::SetSurface::live>>;
+        section.proxy_set_added_to_python                  = &to_python_slot<&proxy_set_to_python<seams::SetSurface::added>>;
+        section.proxy_set_removed_to_python                = &to_python_slot<&proxy_set_to_python<seams::SetSurface::removed>>;
+        section.proxy_map_live_to_python                   = &to_python_slot<&proxy_map_to_python<seams::ProxyMapSurface::live>>;
+        section.proxy_map_added_to_python                  = &to_python_slot<&proxy_map_to_python<seams::ProxyMapSurface::added>>;
+        section.proxy_map_removed_to_python                = &to_python_slot<&proxy_map_to_python<seams::ProxyMapSurface::removed>>;
+        section.proxy_map_modified_to_python               = &to_python_slot<&proxy_map_to_python<seams::ProxyMapSurface::modified>>;
+    }
+}  // namespace hgraph::python_bridge

--- a/src/hgraph/types/metadata/detail/ts_data_seams.h
+++ b/src/hgraph/types/metadata/detail/ts_data_seams.h
@@ -139,21 +139,27 @@ namespace hgraph::ts_data_seams
     [[nodiscard]] const TSDDataLayout &proxy_layout(const void *context) noexcept;
     [[nodiscard]] const TSDataTracking &proxy_tracking(const void *memory) noexcept;
     [[nodiscard]] const TSDataTracking &proxy_key_set_tracking(const void *memory) noexcept;
-    [[nodiscard]] std::size_t proxy_slot_capacity(const void *memory) noexcept;
-    [[nodiscard]] bool proxy_slot_live(const void *memory, std::size_t slot) noexcept;
+    /** Both read the bound source and throw when the proxy is unbound. */
+    [[nodiscard]] std::size_t proxy_slot_capacity(const void *memory);
+    [[nodiscard]] bool proxy_slot_live(const void *memory, std::size_t slot);
     [[nodiscard]] bool proxy_slot_modified(const void *context, const void *memory, std::size_t slot);
     [[nodiscard]] bool proxy_has_child(const void *memory, std::size_t slot) noexcept;
     [[nodiscard]] const void *proxy_child_at_slot(const void *memory, std::size_t slot);
     [[nodiscard]] ValueView proxy_key_at_slot(const void *memory, std::size_t slot);
-    [[nodiscard]] Range<ValueView> proxy_keys(const void *context, const void *memory, SetSurface surface);
-    [[nodiscard]] bool proxy_slot_in_set_surface(const void *context, const void *memory, std::size_t slot,
-                                                 SetSurface surface);
-    [[nodiscard]] bool proxy_slot_in_map_surface(const void *context, const void *memory, std::size_t slot,
-                                                 ProxyMapSurface surface);
-    [[nodiscard]] ValueTypeRef proxy_map_value_binding(const void *context, const void *memory,
-                                                       ProxyMapSurface surface) noexcept;
-    [[nodiscard]] const void *proxy_map_value_at_slot(const void *context, const void *memory, std::size_t slot,
-                                                      ProxyMapSurface surface);
+    // The surface is a template argument, as it is on the proxy's own
+    // surface templates: a conversion body instantiated per surface calls
+    // the already-selected operation, with no switch inside its slot loop.
+    // The instantiations live in proxy.cpp (one per surface value).
+    template <SetSurface Surface>
+    [[nodiscard]] Range<ValueView> proxy_keys(const void *context, const void *memory);
+    template <SetSurface Surface>
+    [[nodiscard]] bool proxy_slot_in_set_surface(const void *context, const void *memory, std::size_t slot);
+    template <ProxyMapSurface Surface>
+    [[nodiscard]] bool proxy_slot_in_map_surface(const void *context, const void *memory, std::size_t slot);
+    template <ProxyMapSurface Surface>
+    [[nodiscard]] ValueTypeRef proxy_map_value_binding(const void *context, const void *memory) noexcept;
+    template <ProxyMapSurface Surface>
+    [[nodiscard]] const void *proxy_map_value_at_slot(const void *context, const void *memory, std::size_t slot);
 }  // namespace hgraph::ts_data_seams
 
 #endif  // HGRAPH_TYPES_METADATA_DETAIL_TS_DATA_SEAMS_H

--- a/src/hgraph/types/metadata/detail/ts_data_seams.h
+++ b/src/hgraph/types/metadata/detail/ts_data_seams.h
@@ -3,9 +3,12 @@
 
 #include <hgraph/types/python_object.h>
 #include <hgraph/types/time_series/ts_data/types.h>
+#include <hgraph/types/value/value_range.h>
+#include <hgraph/types/value/value_view.h>
 #include <hgraph/util/date_time.h>
 
 #include <cstddef>
+#include <cstdint>
 
 /**
  * Private seams of the TSData families (RFC 0035, PR 4): what the bridge's
@@ -48,6 +51,109 @@ namespace hgraph::ts_data_seams
                         FillElementFn fill, void *fill_context);
     /** Push one element at ``modified_time``. */
     void window_push(const void *context, void *memory, DateTime modified_time, FillElementFn fill, void *fill_context);
+
+    // -- fixed structured TSB / TSL -------------------------------------------------
+    // Children are reached through their own erased TSDataOps
+    // (``fixed_element_type(...).ops_ref()``); the seams answer the shape.
+    [[nodiscard]] const TSValueTypeMetaData &fixed_schema(const void *context) noexcept;
+    [[nodiscard]] const TSDataLayout &fixed_layout(const void *context) noexcept;
+    [[nodiscard]] std::size_t fixed_element_count(const void *context) noexcept;
+    [[nodiscard]] TSRoleTypeRef fixed_element_type(const void *context, std::size_t index) noexcept;
+    [[nodiscard]] std::int64_t fixed_ordinal_key(const void *context, std::size_t index) noexcept;
+    [[nodiscard]] const TSDataTracking &fixed_tracking(const void *context, const void *memory) noexcept;
+    [[nodiscard]] const void *fixed_child_data(const void *context, const void *memory, std::size_t index) noexcept;
+    [[nodiscard]] void *fixed_mutable_child_data(const void *context, void *memory, std::size_t index) noexcept;
+    [[nodiscard]] bool fixed_child_modified_for_parent_time(const void *context, const void *memory,
+                                                            std::size_t index) noexcept;
+
+    // -- dynamic TSL -------------------------------------------------------------------
+    [[nodiscard]] const FixedTSLDataLayout &dynamic_layout(const void *context) noexcept;
+    [[nodiscard]] TSRoleTypeRef dynamic_element_type(const void *context) noexcept;
+    [[nodiscard]] ValueTypeRef dynamic_delta_key_set_binding(const void *context) noexcept;
+    [[nodiscard]] ValueTypeRef dynamic_removed_set_binding(const void *context) noexcept;
+    [[nodiscard]] ValueTypeRef dynamic_modified_map_binding(const void *context) noexcept;
+    [[nodiscard]] const TSDataTracking &dynamic_tracking(const void *memory) noexcept;
+    [[nodiscard]] std::size_t dynamic_size(const void *memory) noexcept;
+    [[nodiscard]] const void *dynamic_child_memory(const void *memory, std::size_t index);
+    [[nodiscard]] void *dynamic_mutable_child_memory(void *memory, std::size_t index);
+    [[nodiscard]] std::size_t dynamic_modified_index_count(const void *memory) noexcept;
+    [[nodiscard]] std::size_t dynamic_modified_index_at(const void *memory, std::size_t ordinal);
+    void dynamic_ensure_size(const void *context, void *memory, std::size_t size, DateTime modified_time);
+    void dynamic_resize(const void *context, void *memory, std::size_t size, DateTime modified_time);
+    void dynamic_record_child_modified(void *memory, std::size_t index, DateTime modified_time);
+
+    // -- slot-backed TSS / TSD ---------------------------------------------------------
+    enum class SetSurface : std::uint8_t
+    {
+        live,
+        added,
+        removed,
+    };
+    enum class MapSurface : std::uint8_t
+    {
+        live,
+        modified,
+    };
+    struct SlotInsert
+    {
+        std::size_t slot{0};
+        bool        changed{false};
+    };
+
+    [[nodiscard]] const TSSDataLayout &tss_layout(const void *context) noexcept;
+    [[nodiscard]] ValueTypeRef tss_added_set_binding(const void *context) noexcept;
+    [[nodiscard]] ValueTypeRef tss_removed_set_binding(const void *context) noexcept;
+    [[nodiscard]] const TSDataTracking &tss_tracking(const void *memory) noexcept;
+    [[nodiscard]] Range<ValueView> tss_keys(const void *context, const void *memory, SetSurface surface);
+    [[nodiscard]] bool tss_touch(void *memory, DateTime modified_time);
+    void tss_insert_key(void *memory, const ValueView &key, DateTime modified_time);
+    void tss_remove_key(void *memory, const ValueView &key, DateTime modified_time);
+
+    [[nodiscard]] const TSDDataLayout &tsd_layout(const void *context) noexcept;
+    [[nodiscard]] ValueTypeRef tsd_removed_set_binding(const void *context) noexcept;
+    [[nodiscard]] ValueTypeRef tsd_modified_map_binding(const void *context) noexcept;
+    [[nodiscard]] const TSDataTracking &tsd_tracking(const void *memory) noexcept;
+    [[nodiscard]] std::size_t tsd_slot_capacity(const void *memory) noexcept;
+    [[nodiscard]] bool tsd_slot_in_surface(const void *memory, std::size_t slot, MapSurface surface) noexcept;
+    [[nodiscard]] const void *tsd_key_at_slot(const void *memory, std::size_t slot);
+    [[nodiscard]] const void *tsd_child_at_slot(const void *memory, std::size_t slot);
+    [[nodiscard]] Range<ValueView> tsd_keys(const void *context, const void *memory, SetSurface surface);
+    /** The map surfaces the value ops project: (key, value-or-invalid) pairs. */
+    [[nodiscard]] ValueTypeRef tsd_map_value_binding(const void *context, const void *memory, MapSurface surface) noexcept;
+    [[nodiscard]] KeyValueRange<ValueView, ValueView> tsd_map_items(const void *context, const void *memory,
+                                                                     MapSurface surface);
+    [[nodiscard]] bool tsd_touch(void *memory, DateTime modified_time);
+    [[nodiscard]] SlotInsert tsd_insert_key(void *memory, const ValueView &key, DateTime modified_time);
+    void tsd_remove_key(void *memory, const ValueView &key, DateTime modified_time);
+    [[nodiscard]] void *tsd_child_memory_for_write(void *memory, std::size_t slot);
+    void tsd_record_child_modified(void *memory, std::size_t slot, DateTime modified_time);
+
+    // -- TSD proxy (an input-side projection over a bound TSD) ---------------------
+    enum class ProxyMapSurface : std::uint8_t
+    {
+        live,
+        added,
+        removed,
+        modified,
+    };
+    [[nodiscard]] const TSDDataLayout &proxy_layout(const void *context) noexcept;
+    [[nodiscard]] const TSDataTracking &proxy_tracking(const void *memory) noexcept;
+    [[nodiscard]] const TSDataTracking &proxy_key_set_tracking(const void *memory) noexcept;
+    [[nodiscard]] std::size_t proxy_slot_capacity(const void *memory) noexcept;
+    [[nodiscard]] bool proxy_slot_live(const void *memory, std::size_t slot) noexcept;
+    [[nodiscard]] bool proxy_slot_modified(const void *context, const void *memory, std::size_t slot);
+    [[nodiscard]] bool proxy_has_child(const void *memory, std::size_t slot) noexcept;
+    [[nodiscard]] const void *proxy_child_at_slot(const void *memory, std::size_t slot);
+    [[nodiscard]] ValueView proxy_key_at_slot(const void *memory, std::size_t slot);
+    [[nodiscard]] Range<ValueView> proxy_keys(const void *context, const void *memory, SetSurface surface);
+    [[nodiscard]] bool proxy_slot_in_set_surface(const void *context, const void *memory, std::size_t slot,
+                                                 SetSurface surface);
+    [[nodiscard]] bool proxy_slot_in_map_surface(const void *context, const void *memory, std::size_t slot,
+                                                 ProxyMapSurface surface);
+    [[nodiscard]] ValueTypeRef proxy_map_value_binding(const void *context, const void *memory,
+                                                       ProxyMapSurface surface) noexcept;
+    [[nodiscard]] const void *proxy_map_value_at_slot(const void *context, const void *memory, std::size_t slot,
+                                                      ProxyMapSurface surface);
 }  // namespace hgraph::ts_data_seams
 
 #endif  // HGRAPH_TYPES_METADATA_DETAIL_TS_DATA_SEAMS_H

--- a/src/hgraph/types/metadata/ts_data_dynamic_list_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_dynamic_list_ops.cpp
@@ -9,11 +9,9 @@
 #include <hgraph/types/value/value.h>
 #include <hgraph/types/value/value_builder.h>
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-#include <hgraph/python/bridge_state.h>
-#include <hgraph/python/conversion.h>
-#include <hgraph/python/ts_data_conversion.h>
-#endif
+#include <hgraph/types/python_ops.h>
+
+#include "detail/ts_data_seams.h"
 
 #include "../time_series/ts_data/ownership.h"
 
@@ -45,17 +43,6 @@ namespace hgraph::ts_data_plan_factory_detail
             return seed;
         }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-        /** Either REMOVE sentinel. Truncation is total, so hgraph's strict /
-            lenient distinction has nothing to express for a list. */
-        [[nodiscard]] bool is_removal_sentinel(nb::handle item) noexcept
-        {
-            const auto &strict = python_bridge::removed_sentinel_slot();
-            if (strict.is_valid() && item.is(strict)) { return true; }
-            const auto &lenient = python_bridge::remove_if_exists_sentinel_slot();
-            return lenient.is_valid() && item.is(lenient);
-        }
-#endif
 
         using TSDataErasedOwner =
             MemoryUtils::ErasedOwner<MemoryUtils::HeapOnlyStoragePolicy, TypeRecord>;
@@ -578,12 +565,10 @@ namespace hgraph::ts_data_plan_factory_detail
                     .indexed_child_memory_impl = &dynamic_indexed_element_memory,
                     .mutable_indexed_child_memory_impl = &dynamic_mutable_indexed_element_memory,
                     .indexed_child_growth      = true,
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-                    .python_ops               = &python_bridge::list_python_ts_data_ops(),
-                    .from_python_impl          = &python_bridge::ts_from_python_slot<&dynamic_from_python>,
-                    .to_python_impl            = &python_bridge::to_python_slot<&dynamic_to_python>,
-                    .delta_to_python_impl      = &python_bridge::ts_delta_to_python_slot<&dynamic_delta_to_python>,
-#endif
+                    .python_family             = PythonTSDataFamily::list,
+                    .from_python_impl          = &python_ops_detail::forwarder<&PythonOps::TSData::dynamic_from_python>::call,
+                    .to_python_impl            = &python_ops_detail::forwarder<&PythonOps::TSData::dynamic_to_python>::call,
+                    .delta_to_python_impl      = &python_ops_detail::forwarder<&PythonOps::TSData::dynamic_delta_to_python>::call,
                 };
                 ops.size_impl                   = &dynamic_indexed_size;
                 ops.modified_index_count_impl   = &dynamic_modified_index_count;
@@ -602,10 +587,8 @@ namespace hgraph::ts_data_plan_factory_detail
                     {ValueOpsKind::Indexed, this, false, &dynamic_value_hash, &dynamic_value_equals,
                      &dynamic_value_compare,
                      &dynamic_value_to_string
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
                      ,
-                     &python_bridge::to_python_slot<&dynamic_value_projection_to_python>
-#endif
+                     &python_ops_detail::forwarder<&PythonOps::TSData::dynamic_value_projection_to_python>::call
                     },
                     &dynamic_value_size,
                     &dynamic_value_element_at,
@@ -622,10 +605,8 @@ namespace hgraph::ts_data_plan_factory_detail
                     {{ValueOpsKind::Map, this, false, &dynamic_delta_map_hash, &dynamic_delta_map_equals,
                       &dynamic_delta_map_compare,
                       &dynamic_delta_map_to_string
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
                       ,
-                      &python_bridge::to_python_slot<&dynamic_delta_projection_to_python>
-#endif
+                      &python_ops_detail::forwarder<&PythonOps::TSData::dynamic_delta_projection_to_python>::call
                      },
                      &dynamic_delta_map_size,
                      &dynamic_delta_map_key_at_index,
@@ -648,10 +629,8 @@ namespace hgraph::ts_data_plan_factory_detail
                 delta_key_set_ops = SetValueOps{
                     {{ValueOpsKind::Set, this, false, &dynamic_delta_key_set_hash, &dynamic_delta_key_set_equals,
                       &dynamic_delta_key_set_compare, &dynamic_delta_key_set_to_string
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
                       ,
-                      &python_bridge::to_python_slot<&dynamic_delta_key_set_projection_to_python>
-#endif
+                      &python_ops_detail::forwarder<&PythonOps::TSData::dynamic_delta_key_set_projection_to_python>::call
                      },
                      &dynamic_delta_map_size,
                      &dynamic_delta_map_key_at_index,
@@ -667,10 +646,8 @@ namespace hgraph::ts_data_plan_factory_detail
                 removed_set_ops = SetValueOps{
                     {{ValueOpsKind::Set, this, false, &dynamic_removed_set_hash, &dynamic_removed_set_equals,
                       &dynamic_removed_set_compare, &dynamic_removed_set_to_string
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
                       ,
-                      &python_bridge::to_python_slot<&dynamic_removed_set_projection_to_python>
-#endif
+                      &python_ops_detail::forwarder<&PythonOps::TSData::dynamic_removed_set_projection_to_python>::call
                      },
                      &dynamic_removed_set_size,
                      &dynamic_removed_set_key_at_index,
@@ -690,10 +667,8 @@ namespace hgraph::ts_data_plan_factory_detail
                     {ValueOpsKind::Indexed, this, false, &dynamic_delta_bundle_hash,
                      &dynamic_delta_bundle_equals, &dynamic_delta_bundle_compare,
                      &dynamic_delta_bundle_to_string
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
                      ,
-                     &python_bridge::to_python_slot<&dynamic_delta_bundle_to_python>
-#endif
+                     &python_ops_detail::forwarder<&PythonOps::TSData::dynamic_delta_bundle_to_python>::call
                     },
                     &dynamic_delta_bundle_size,
                     &dynamic_delta_bundle_element_at,
@@ -711,184 +686,6 @@ namespace hgraph::ts_data_plan_factory_detail
                 return static_cast<const DynamicTSLContext *>(context);
             }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-            [[nodiscard]] static nb::object dynamic_value_projection_to_python(
-                const void *context, const void *memory)
-            {
-                const auto *state = ctx(context);
-                return python_bridge::to_python(Value{ValueView{state->list_layout.value_binding, memory}});
-            }
-
-            [[nodiscard]] static nb::object dynamic_delta_projection_to_python(
-                const void *context, const void *memory)
-            {
-                const auto *state = ctx(context);
-                return python_bridge::to_python(Value{ValueView{state->list_layout.delta_binding, memory}});
-            }
-
-            [[nodiscard]] static nb::object dynamic_delta_key_set_projection_to_python(
-                const void *context, const void *memory)
-            {
-                const auto *state = ctx(context);
-                return python_bridge::to_python(Value{ValueView{state->delta_key_set_binding, memory}});
-            }
-
-            /** Dynamic TSL Python export is a TSData strategy. It deliberately
-                recurses through child TSDataOps; the public facade must never
-                infer this representation from TSTypeKind. */
-            [[nodiscard]] static nb::object dynamic_to_python(const void *context,
-                                                               const void *memory)
-            {
-                const auto *state = ctx(context);
-                const auto &store = storage(memory);
-                const auto &ops = child_ops(state->element_type);
-                nb::list result;
-                for (std::size_t index = 0; index < store.size(); ++index)
-                {
-                    const auto *child = store.child_memory(index);
-                    result.append(ops.has_current_value_impl(ops.context, child)
-                                      ? python_bridge::take(ops.to_python_impl(ops.context, child))
-                                      : nb::none());
-                }
-                return nb::tuple(result);
-            }
-
-            [[nodiscard]] static nb::object dynamic_delta_to_python(
-                const void *context, const void *memory, DateTime evaluation_time)
-            {
-                const auto *state = ctx(context);
-                const auto &store = storage(memory);
-                if (store.tracking().last_modified_time != evaluation_time)
-                {
-                    return nb::none();
-                }
-                const auto &ops = child_ops(state->element_type);
-                nb::dict modified;
-                for (std::size_t ordinal = 0; ordinal < store.modified_index_count(); ++ordinal)
-                {
-                    const auto index = store.modified_index_at(ordinal);
-                    const auto *child = store.child_memory(index);
-                    nb::object value = python_bridge::take(ops.delta_to_python_impl(
-                        ops.context, child, evaluation_time));
-                    if (!value.is_none()) { modified[nb::int_{index}] = std::move(value); }
-                }
-                // RFC 0031: the canonical {removed, modified} shape, which
-                // hgraph's _simplify_delta rewrites into the friendly
-                // {index: delta, removed_index: REMOVE} form.
-                nb::dict result;
-                result[nb::str{"removed"}] = python_bridge::to_python(state->removed_set_binding, memory);
-                result[nb::str{"modified"}] = std::move(modified);
-                return result;
-            }
-
-            /** Import current/replacement values through the child strategies.
-                A sequence IS the list: it covers consecutive indices and
-                resizes, so a shorter sequence truncates (RFC 0031). A mapping
-                is a sparse replacement/update in which a ``REMOVE`` sentinel
-                truncates to the lowest removed index. */
-            [[nodiscard]] static bool dynamic_from_python(
-                const void *context, void *memory, nb::handle source,
-                DateTime modified_time)
-            {
-                if (memory == nullptr)
-                {
-                    throw std::logic_error(
-                        "dynamic TSL from_python requires live storage");
-                }
-                if (source.is_none())
-                {
-                    throw std::invalid_argument(
-                        "dynamic TSL from_python requires a non-None source");
-                }
-                if (modified_time == MIN_DT)
-                {
-                    throw std::invalid_argument(
-                        "dynamic TSL from_python requires a concrete evaluation time");
-                }
-
-                const auto *state = ctx(context);
-                auto &target = storage(memory);
-                const auto &ops = child_ops(state->element_type);
-                const bool first_for_parent =
-                    target.tracking().last_modified_time != modified_time;
-                bool touched = false;
-
-                const auto update = [&](std::size_t index, nb::handle item) {
-                    target.ensure_size(index + 1, state->element_type, modified_time);
-                    void *child = target.child_memory(index);
-                    if (!ops.from_python_impl(ops.context, child, python_bridge::borrow(item),
-                                              modified_time))
-                    {
-                        return;
-                    }
-                    auto *tracking =
-                        ops.mutable_tracking_impl(ops.context, child);
-                    if (tracking == nullptr ||
-                        !tracking->record_modified(modified_time))
-                    {
-                        throw std::logic_error(
-                            "dynamic TSL child reported an invalid modification");
-                    }
-                    target.record_child_modified(index, modified_time);
-                    touched = true;
-                };
-
-                if (nb::isinstance<nb::dict>(source))
-                {
-                    // Removal is resolved FIRST so a same-cycle re-grow through
-                    // `modified` behaves exactly as apply_delta does.
-                    auto truncate_to = static_cast<std::size_t>(-1);
-                    for (auto [key, item] : nb::cast<nb::dict>(source))
-                    {
-                        if (item.is_none() || !is_removal_sentinel(item)) { continue; }
-                        const auto index = nb::cast<std::int64_t>(key);
-                        if (index < 0)
-                        {
-                            throw std::out_of_range(
-                                "dynamic TSL from_python index must be non-negative");
-                        }
-                        truncate_to = std::min(truncate_to, static_cast<std::size_t>(index));
-                    }
-                    if (truncate_to < target.size())
-                    {
-                        target.resize(truncate_to, state->element_type, modified_time);
-                        touched = true;
-                    }
-                    for (auto [key, item] : nb::cast<nb::dict>(source))
-                    {
-                        if (item.is_none() || is_removal_sentinel(item)) { continue; }
-                        const auto index = nb::cast<std::int64_t>(key);
-                        if (index < 0)
-                        {
-                            throw std::out_of_range(
-                                "dynamic TSL from_python index must be non-negative");
-                        }
-                        update(static_cast<std::size_t>(index), item);
-                    }
-                    return first_for_parent && touched;
-                }
-
-                if (nb::isinstance<nb::str>(source) ||
-                    !nb::isinstance<nb::sequence>(source))
-                {
-                    throw std::invalid_argument(
-                        "dynamic TSL from_python expects a mapping or sequence");
-                }
-                const auto source_size = static_cast<std::size_t>(nb::len(source));
-                if (source_size != target.size())
-                {
-                    target.resize(source_size, state->element_type, modified_time);
-                    touched = true;
-                }
-                std::size_t index = 0;
-                for (nb::handle item : source)
-                {
-                    if (!item.is_none()) { update(index, item); }
-                    ++index;
-                }
-                return first_for_parent && touched;
-            }
-#endif
 
             [[nodiscard]] static const TSDataLayout *dynamic_layout(const void *context) noexcept
             {
@@ -1772,14 +1569,6 @@ namespace hgraph::ts_data_plan_factory_detail
                 *static_cast<SetStorage *>(dst) = build_dynamic_removed_set_storage(context, binding, memory);
             }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-            [[nodiscard]] static nb::object dynamic_removed_set_projection_to_python(
-                const void *context, const void *memory)
-            {
-                const auto *state = ctx(context);
-                return python_bridge::to_python(Value{ValueView{state->removed_set_binding, memory}});
-            }
-#endif
 
             // --- delta bundle {removed, modified} (RFC 0031) ---
 
@@ -1895,17 +1684,6 @@ namespace hgraph::ts_data_plan_factory_detail
                 rollback.release();
             }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-            [[nodiscard]] static nb::object dynamic_delta_bundle_to_python(const void *context,
-                                                                            const void *memory)
-            {
-                const auto *state = ctx(context);
-                nb::dict result;
-                result[nb::str{"removed"}] = python_bridge::to_python(state->removed_set_binding, memory);
-                result[nb::str{"modified"}] = python_bridge::to_python(state->modified_map_binding, memory);
-                return result;
-            }
-#endif
 
             [[nodiscard]] static bool dynamic_copy_value_from(const void *context,
                                                               void *memory,
@@ -2149,3 +1927,78 @@ namespace hgraph::ts_data_plan_factory_detail
     }
 
 }  // namespace hgraph::ts_data_plan_factory_detail
+
+// -- RFC 0035 seams: dynamic TSL for ts_data_structured_conversions.cpp ------
+namespace hgraph::ts_data_seams
+{
+    namespace
+    {
+        using ts_data_plan_factory_detail::DynamicTSLContext;
+
+        [[nodiscard]] const DynamicTSLContext &dynamic(const void *context) noexcept
+        {
+            return *static_cast<const DynamicTSLContext *>(context);
+        }
+    }  // namespace
+
+    const FixedTSLDataLayout &dynamic_layout(const void *context) noexcept { return dynamic(context).list_layout; }
+
+    TSRoleTypeRef dynamic_element_type(const void *context) noexcept { return dynamic(context).element_type; }
+
+    ValueTypeRef dynamic_delta_key_set_binding(const void *context) noexcept
+    {
+        return dynamic(context).delta_key_set_binding;
+    }
+
+    ValueTypeRef dynamic_removed_set_binding(const void *context) noexcept
+    {
+        return dynamic(context).removed_set_binding;
+    }
+
+    ValueTypeRef dynamic_modified_map_binding(const void *context) noexcept
+    {
+        return dynamic(context).modified_map_binding;
+    }
+
+    const TSDataTracking &dynamic_tracking(const void *memory) noexcept
+    {
+        return ts_data_plan_factory_detail::storage(memory).tracking();
+    }
+
+    std::size_t dynamic_size(const void *memory) noexcept { return ts_data_plan_factory_detail::storage(memory).size(); }
+
+    const void *dynamic_child_memory(const void *memory, std::size_t index)
+    {
+        return ts_data_plan_factory_detail::storage(memory).child_memory(index);
+    }
+
+    void *dynamic_mutable_child_memory(void *memory, std::size_t index)
+    {
+        return ts_data_plan_factory_detail::storage(memory).child_memory(index);
+    }
+
+    std::size_t dynamic_modified_index_count(const void *memory) noexcept
+    {
+        return ts_data_plan_factory_detail::storage(memory).modified_index_count();
+    }
+
+    std::size_t dynamic_modified_index_at(const void *memory, std::size_t ordinal)
+    {
+        return ts_data_plan_factory_detail::storage(memory).modified_index_at(ordinal);
+    }
+
+    void dynamic_ensure_size(const void *context, void *memory, std::size_t size, DateTime modified_time)
+    {
+        ts_data_plan_factory_detail::storage(memory).ensure_size(size, dynamic(context).element_type, modified_time);
+    }
+
+    void dynamic_resize(const void *context, void *memory, std::size_t size, DateTime modified_time)
+    {
+        ts_data_plan_factory_detail::storage(memory).resize(size, dynamic(context).element_type, modified_time);
+    }
+
+    void dynamic_record_child_modified(void *memory, std::size_t index, DateTime modified_time)
+    {
+        ts_data_plan_factory_detail::storage(memory).record_child_modified(index, modified_time);
+    }
+}  // namespace hgraph::ts_data_seams

--- a/src/hgraph/types/metadata/ts_data_fixed_structured_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_fixed_structured_ops.cpp
@@ -315,6 +315,7 @@ namespace hgraph::ts_data_plan_factory_detail
         {
             ops = IndexedTSDataOps{};
             TSDataOps &base_ops = ops;
+            const bool bundle = schema->kind == TSTypeKind::TSB;
             base_ops = TSDataOps{
                 .context                   = this,
                 .kind                      = schema->kind,
@@ -349,10 +350,15 @@ namespace hgraph::ts_data_plan_factory_detail
                 .indexed_child_binding_impl = &fixed_indexed_element_binding,
                 .indexed_child_memory_impl = &fixed_indexed_element_memory,
                 .mutable_indexed_child_memory_impl = &fixed_mutable_indexed_element_memory,
-                .python_family = schema->kind == TSTypeKind::TSB ? PythonTSDataFamily::bundle : PythonTSDataFamily::list,
-                .from_python_impl          = &python_ops_detail::forwarder<&PythonOps::TSData::fixed_from_python>::call,
-                .to_python_impl            = &python_ops_detail::forwarder<&PythonOps::TSData::fixed_to_python>::call,
-                .delta_to_python_impl      = &python_ops_detail::forwarder<&PythonOps::TSData::fixed_delta_to_python>::call,
+                .python_family = bundle ? PythonTSDataFamily::bundle : PythonTSDataFamily::list,
+                .from_python_impl =
+                    bundle ? &python_ops_detail::forwarder<&PythonOps::TSData::fixed_bundle_from_python>::call
+                           : &python_ops_detail::forwarder<&PythonOps::TSData::fixed_list_from_python>::call,
+                .to_python_impl = bundle ? &python_ops_detail::forwarder<&PythonOps::TSData::fixed_bundle_to_python>::call
+                                         : &python_ops_detail::forwarder<&PythonOps::TSData::fixed_list_to_python>::call,
+                .delta_to_python_impl =
+                    bundle ? &python_ops_detail::forwarder<&PythonOps::TSData::fixed_bundle_delta_to_python>::call
+                           : &python_ops_detail::forwarder<&PythonOps::TSData::fixed_list_delta_to_python>::call,
             };
             ops.size_impl                   = &fixed_indexed_size;
             ops.element_binding_impl        = &fixed_indexed_element_binding;

--- a/src/hgraph/types/metadata/ts_data_fixed_structured_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_fixed_structured_ops.cpp
@@ -9,11 +9,14 @@
 #include <hgraph/types/value/value_builder.h>
 #include <hgraph/util/scope.h>
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-#include <hgraph/python/bridge_state.h>
-#include <hgraph/python/conversion.h>
-#include <hgraph/python/ts_data_conversion.h>
-#endif
+#include <hgraph/types/python_ops.h>
+
+#include "detail/ts_data_seams.h"
+
+namespace hgraph::ts_data_seams
+{
+    struct FixedSeamAccess;
+}
 
 #include "../time_series/ts_data/ownership.h"
 
@@ -45,6 +48,8 @@ namespace hgraph::ts_data_plan_factory_detail
 
     struct FixedTSDataContext
     {
+        friend struct ts_data_seams::FixedSeamAccess;  // the RFC 0035 seams' one route in
+
         const TSValueTypeMetaData      *schema{nullptr};
         const MemoryUtils::StoragePlan *plan{nullptr};
         TypeRole                        role{TypeRole::Data};
@@ -344,14 +349,10 @@ namespace hgraph::ts_data_plan_factory_detail
                 .indexed_child_binding_impl = &fixed_indexed_element_binding,
                 .indexed_child_memory_impl = &fixed_indexed_element_memory,
                 .mutable_indexed_child_memory_impl = &fixed_mutable_indexed_element_memory,
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-                .python_ops = schema->kind == TSTypeKind::TSB
-                                  ? &python_bridge::bundle_python_ts_data_ops()
-                                  : &python_bridge::list_python_ts_data_ops(),
-                .from_python_impl          = &python_bridge::ts_from_python_slot<&fixed_from_python>,
-                .to_python_impl            = &python_bridge::to_python_slot<&fixed_to_python>,
-                .delta_to_python_impl      = &python_bridge::ts_delta_to_python_slot<&fixed_delta_to_python>,
-#endif
+                .python_family = schema->kind == TSTypeKind::TSB ? PythonTSDataFamily::bundle : PythonTSDataFamily::list,
+                .from_python_impl          = &python_ops_detail::forwarder<&PythonOps::TSData::fixed_from_python>::call,
+                .to_python_impl            = &python_ops_detail::forwarder<&PythonOps::TSData::fixed_to_python>::call,
+                .delta_to_python_impl      = &python_ops_detail::forwarder<&PythonOps::TSData::fixed_delta_to_python>::call,
             };
             ops.size_impl                   = &fixed_indexed_size;
             ops.element_binding_impl        = &fixed_indexed_element_binding;
@@ -364,10 +365,8 @@ namespace hgraph::ts_data_plan_factory_detail
             value_indexed_ops = IndexedValueOps{
                 {ValueOpsKind::Indexed, this, false, &fixed_value_hash, &fixed_value_equals, &fixed_value_compare,
                  &fixed_value_to_string
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
                  ,
-                 &python_bridge::to_python_slot<&fixed_value_to_python>
-#endif
+                 &python_ops_detail::forwarder<&PythonOps::TSData::fixed_value_to_python>::call
                 },
                 &fixed_indexed_size,
                 &fixed_value_element_at,
@@ -384,10 +383,8 @@ namespace hgraph::ts_data_plan_factory_detail
                 {ValueOpsKind::Indexed, this, false, &fixed_delta_bundle_hash, &fixed_delta_bundle_equals,
                  &fixed_delta_bundle_compare,
                  &fixed_delta_bundle_to_string
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
                  ,
-                 &python_bridge::to_python_slot<&fixed_delta_bundle_to_python>
-#endif
+                 &python_ops_detail::forwarder<&PythonOps::TSData::fixed_delta_bundle_to_python>::call
                 },
                 &fixed_indexed_size,
                 &fixed_delta_bundle_element_at,
@@ -403,10 +400,8 @@ namespace hgraph::ts_data_plan_factory_detail
                 {{ValueOpsKind::Map, this, false, &fixed_delta_map_hash, &fixed_delta_map_equals,
                   &fixed_delta_map_compare,
                   &fixed_delta_map_to_string
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
                   ,
-                  &python_bridge::to_python_slot<&fixed_delta_map_to_python>
-#endif
+                  &python_ops_detail::forwarder<&PythonOps::TSData::fixed_delta_map_to_python>::call
                  },
                  &fixed_delta_map_size,
                  &fixed_delta_map_key_at_index,
@@ -430,10 +425,8 @@ namespace hgraph::ts_data_plan_factory_detail
                 {{ValueOpsKind::Set, this, false, &fixed_delta_key_set_hash, &fixed_delta_key_set_equals,
                   &fixed_delta_key_set_compare,
                   &fixed_delta_key_set_to_string
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
                   ,
-                  &python_bridge::to_python_slot<&fixed_delta_key_set_to_python>
-#endif
+                  &python_ops_detail::forwarder<&PythonOps::TSData::fixed_delta_key_set_to_python>::call
                  },
                  &fixed_delta_map_size,
                  &fixed_delta_map_key_at_index,
@@ -887,16 +880,6 @@ namespace hgraph::ts_data_plan_factory_detail
             }
         }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-        [[nodiscard]] static nb::object fixed_value_to_python(const void *context, const void *memory)
-        {
-            const auto *state = ctx(context);
-            // This is a VALUE projection, not the TSData Python surface.
-            // Materialise through the erased owning-type/copy contract so a
-            // projected child never needs ad-hoc recursive shape knowledge.
-            return python_bridge::to_python(Value{ValueView{state->layout_ptr()->value_binding, memory}});
-        }
-#endif
 
         [[nodiscard]] static std::size_t fixed_delta_bundle_hash(const void *context, const void *memory)
         {
@@ -957,13 +940,6 @@ namespace hgraph::ts_data_plan_factory_detail
             return indexed_to_string(ctx(context), memory, true);
         }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-        [[nodiscard]] static nb::object fixed_delta_bundle_to_python(const void *context, const void *memory)
-        {
-            const auto *state = ctx(context);
-            return python_bridge::to_python(Value{ValueView{state->layout_ptr()->delta_binding, memory}});
-        }
-#endif
 
         static void fixed_delta_bundle_copy_construct_view(const void *context,
                                                            const ValueTypeRef &binding,
@@ -1257,13 +1233,6 @@ namespace hgraph::ts_data_plan_factory_detail
             return fmt::to_string(out);
         }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-        [[nodiscard]] static nb::object fixed_delta_map_to_python(const void *context, const void *memory)
-        {
-            const auto *state = ctx(context);
-            return python_bridge::to_python(Value{ValueView{state->layout_ptr()->delta_binding, memory}});
-        }
-#endif
 
         static void fixed_delta_map_copy_construct_view(const void *context,
                                                         const ValueTypeRef &binding,
@@ -1403,19 +1372,6 @@ namespace hgraph::ts_data_plan_factory_detail
             return fmt::to_string(out);
         }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-        [[nodiscard]] static nb::object fixed_delta_key_set_to_python(const void *context, const void *memory)
-        {
-            const auto *state = ctx(context);
-            nb::set     result;
-            for (std::size_t index = 0; index < state->element_count(); ++index)
-            {
-                if (!child_modified_for_parent_time(state, memory, index)) { continue; }
-                result.add(nb::int_{state->ordinal_keys[index]});
-            }
-            return result;
-        }
-#endif
 
         static void fixed_delta_key_set_copy_construct_view(const void *context,
                                                             const ValueTypeRef &binding,
@@ -1583,270 +1539,6 @@ namespace hgraph::ts_data_plan_factory_detail
             return mutation.invalidate();
         }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-        [[nodiscard]] static nb::object fixed_to_python(const void *context, const void *memory)
-        {
-            const auto *state = ctx(context);
-            // Python TimeSeries.value is a TSData operation. Recurse through
-            // each child's TSDataOps so nested TSL/TSD/TSB representations
-            // retain their own public Python semantics.
-            if (state->schema->kind == TSTypeKind::TSB)
-            {
-                nb::dict result;
-                for (std::size_t index = 0; index < state->element_count(); ++index)
-                {
-                    const char *name = state->schema->fields()[index].name;
-                    if (name == nullptr || *name == '\0') { continue; }
-                    const auto &ops = child_ops(state->element_type(index));
-                    const auto *child = child_data(state, memory, index);
-                    result[nb::str{name}] = ops.has_current_value_impl(ops.context, child)
-                                                ? python_bridge::take(ops.to_python_impl(ops.context, child))
-                                                : nb::none();
-                }
-                return python_bridge::materialize_tsb_python_value(
-                    state->schema, std::move(result));
-            }
-
-            nb::list result;
-            for (std::size_t index = 0; index < state->element_count(); ++index)
-            {
-                const auto &ops = child_ops(state->element_type(index));
-                const auto *child = child_data(state, memory, index);
-                result.append(ops.has_current_value_impl(ops.context, child)
-                                  ? python_bridge::take(ops.to_python_impl(ops.context, child))
-                                  : nb::none());
-            }
-            return nb::tuple(result);
-        }
-
-        [[nodiscard]] static nb::object fixed_delta_to_python(const void *context,
-                                                              const void *memory,
-                                                              DateTime evaluation_time)
-        {
-            const auto *state = ctx(context);
-            if (fixed_tracking(state, memory)->last_modified_time != evaluation_time) { return nb::none(); }
-            nb::dict result;
-            for (std::size_t index = 0; index < state->element_count(); ++index)
-            {
-                if (!child_modified_for_parent_time(state, memory, index)) { continue; }
-                const auto &ops = child_ops(state->element_type(index));
-                const auto *child = child_data(state, memory, index);
-                nb::object value = python_bridge::take(ops.delta_to_python_impl(
-                    ops.context, child, evaluation_time));
-                if (value.is_none()) { continue; }
-                if (state->schema->kind == TSTypeKind::TSB)
-                {
-                    const char *name = state->schema->fields()[index].name;
-                    if (name != nullptr && *name != '\0')
-                    {
-                        result[nb::str{name}] = std::move(value);
-                    }
-                }
-                else
-                {
-                    result[nb::int_{index}] = std::move(value);
-                }
-            }
-            return result;
-        }
-
-        [[nodiscard]] static bool is_python_sequence(nb::handle source)
-        {
-            nb::object object = nb::borrow<nb::object>(source);
-            return nb::isinstance<nb::list>(object) || nb::isinstance<nb::tuple>(object);
-        }
-
-        [[nodiscard]] static bool is_python_mapping(nb::handle source)
-        {
-            nb::object object = nb::borrow<nb::object>(source);
-            return nb::isinstance<nb::dict>(object) || nb::hasattr(object, "items");
-        }
-
-        template <typename Visitor>
-        static void for_each_python_mapping_item(nb::handle source, const char *what, Visitor visitor)
-        {
-            if (!is_python_mapping(source))
-            {
-                throw std::invalid_argument(std::string{what} + " expects a Python mapping");
-            }
-
-            nb::object   object = nb::borrow<nb::object>(source);
-            nb::object   items  = object.attr("items")();
-            nb::iterator it     = nb::iter(items);
-            while (it != nb::iterator::sentinel())
-            {
-                nb::tuple pair = nb::cast<nb::tuple>(*it);
-                if (pair.size() != 2)
-                {
-                    throw std::invalid_argument(std::string{what} + " items() must yield key/value pairs");
-                }
-                visitor(nb::borrow<nb::object>(pair[0]), nb::borrow<nb::object>(pair[1]));
-                ++it;
-            }
-        }
-
-        [[nodiscard]] static std::size_t field_index_by_name(const FixedTSDataContext *state,
-                                                              std::string_view          name) noexcept
-        {
-            for (std::size_t index = 0; index < state->element_count(); ++index)
-            {
-                const char *field_name = state->schema->fields()[index].name;
-                if (field_name != nullptr && name == field_name) { return index; }
-            }
-            return TS_DATA_NO_CHILD_ID;
-        }
-
-        [[nodiscard]] static bool fixed_child_update_from_python(const FixedTSDataContext *state,
-                                                                 void                     *memory,
-                                                                 std::size_t               index,
-                                                                 nb::handle                source,
-                                                                 DateTime             modified_time)
-        {
-            if (source.is_none()) { return false; }
-
-            const auto child = state->element_type(index);
-            const auto &ops  = child_ops(child);
-            void       *data  = child_data(state, memory, index);
-            if (!ops.from_python_impl(ops.context, data, python_bridge::borrow(source), modified_time)) { return false; }
-
-            auto *tracking = ops.mutable_tracking_impl(ops.context, data);
-            if (tracking == nullptr) { throw std::logic_error("fixed TSData child has no tracking record"); }
-            if (!tracking->record_modified(modified_time))
-            {
-                throw std::logic_error("fixed TSData child reported a duplicate Python update modification");
-            }
-            return true;
-        }
-
-        [[nodiscard]] static bool fixed_from_python_sequence(const FixedTSDataContext *state,
-                                                             void                     *memory,
-                                                             nb::handle                source,
-                                                             DateTime             modified_time,
-                                                             const char                *what)
-        {
-            if (!is_python_sequence(source))
-            {
-                throw std::invalid_argument(std::string{what} + " expects a Python list or tuple");
-            }
-
-            nb::object   object   = nb::borrow<nb::object>(source);
-            nb::sequence sequence = nb::cast<nb::sequence>(object);
-            const auto   count    = static_cast<std::size_t>(nb::len(sequence));
-            if (count != state->element_count())
-            {
-                throw std::invalid_argument(
-                    fmt::format("{} expects {} elements, got {}", what, state->element_count(), count));
-            }
-
-            bool touched = false;
-            for (std::size_t index = 0; index < count; ++index)
-            {
-                nb::object child_source = sequence[index];
-                touched |= fixed_child_update_from_python(state, memory, index, child_source, modified_time);
-            }
-            return touched;
-        }
-
-        [[nodiscard]] static bool fixed_from_python_bundle(const FixedTSDataContext *state,
-                                                           void                     *memory,
-                                                           nb::handle                source,
-                                                           DateTime             modified_time)
-        {
-            nb::object object = nb::borrow<nb::object>(source);
-            if (is_python_mapping(source))
-            {
-                bool touched = false;
-                for_each_python_mapping_item(source, "TSB from_python", [&](nb::handle key, nb::handle value) {
-                    const auto field = nb::cast<std::string>(key);
-                    const auto index = field_index_by_name(state, field);
-                    if (index == TS_DATA_NO_CHILD_ID)
-                    {
-                        throw std::invalid_argument(fmt::format("TSB from_python unknown field '{}'", field));
-                    }
-                    touched |= fixed_child_update_from_python(state, memory, index, value, modified_time);
-                });
-                return touched;
-            }
-
-            if (is_python_sequence(source))
-            {
-                return fixed_from_python_sequence(state, memory, source, modified_time, "TSB from_python");
-            }
-
-            bool saw_field = false;
-            bool touched   = false;
-            for (std::size_t index = 0; index < state->element_count(); ++index)
-            {
-                const char *name = state->schema->fields()[index].name;
-                if (name == nullptr || *name == '\0')
-                {
-                    throw std::invalid_argument("TSB from_python has an unnamed field and cannot load attributes");
-                }
-                if (!nb::hasattr(object, name)) { continue; }
-                saw_field = true;
-                nb::object child_source = nb::getattr(object, name);
-                touched |= fixed_child_update_from_python(state, memory, index, child_source, modified_time);
-            }
-            if (!saw_field)
-            {
-                throw std::invalid_argument("TSB from_python expects a mapping, sequence, or field attributes");
-            }
-            return touched;
-        }
-
-        [[nodiscard]] static bool fixed_from_python_list_mapping(const FixedTSDataContext *state,
-                                                                 void                     *memory,
-                                                                 nb::handle                source,
-                                                                 DateTime             modified_time)
-        {
-            bool touched = false;
-            for_each_python_mapping_item(source, "fixed TSL from_python", [&](nb::handle key, nb::handle value) {
-                const auto index = nb::cast<std::size_t>(key);
-                if (index >= state->element_count())
-                {
-                    throw std::out_of_range("fixed TSL from_python index out of range");
-                }
-                touched |= fixed_child_update_from_python(state, memory, index, value, modified_time);
-            });
-            return touched;
-        }
-
-        [[nodiscard]] static bool fixed_from_python(const void *context,
-                                                    void       *memory,
-                                                    nb::handle  source,
-                                                    DateTime modified_time)
-        {
-            if (memory == nullptr)
-            {
-                throw std::logic_error("fixed TSData from_python requires live memory");
-            }
-            if (source.is_none())
-            {
-                throw std::invalid_argument("fixed TSData from_python requires a non-None source");
-            }
-            if (modified_time == MIN_DT)
-            {
-                throw std::invalid_argument("fixed TSData from_python requires a concrete evaluation time");
-            }
-
-            const auto *state = ctx(context);
-            const bool  first_for_parent = fixed_tracking(state, memory)->last_modified_time != modified_time;
-            bool        touched = false;
-            if (state->schema->kind == TSTypeKind::TSB)
-            {
-                touched = fixed_from_python_bundle(state, memory, source, modified_time);
-            }
-            else if (is_python_mapping(source))
-            {
-                touched = fixed_from_python_list_mapping(state, memory, source, modified_time);
-            }
-            else
-            {
-                touched = fixed_from_python_sequence(state, memory, source, modified_time, "fixed TSL from_python");
-            }
-            return first_for_parent && touched;
-        }
-#endif
     };
 
     struct FixedTSDataContextKey
@@ -1934,3 +1626,84 @@ namespace hgraph::ts_data_plan_factory_detail
         fixed_ts_data_contexts().clear();
     }
 } // namespace hgraph::ts_data_plan_factory_detail
+
+// -- RFC 0035 seams: fixed TSB / TSL for ts_data_structured_conversions.cpp ---
+namespace hgraph::ts_data_seams
+{
+    using ts_data_plan_factory_detail::FixedTSDataContext;
+
+    /** Friend of the context: the seams reach its private shape through here. */
+    struct FixedSeamAccess
+    {
+        [[nodiscard]] static const FixedTSDataContext &fixed(const void *context) noexcept
+        {
+            return *static_cast<const FixedTSDataContext *>(context);
+        }
+        [[nodiscard]] static std::size_t element_count(const void *context) noexcept
+        {
+            return fixed(context).element_count();
+        }
+        [[nodiscard]] static TSRoleTypeRef element_type(const void *context, std::size_t index) noexcept
+        {
+            return fixed(context).element_type(index);
+        }
+        [[nodiscard]] static const TSDataTracking *tracking(const void *context, const void *memory) noexcept
+        {
+            return FixedTSDataContext::fixed_tracking(context, memory);
+        }
+        [[nodiscard]] static const void *child_data(const void *context, const void *memory, std::size_t index) noexcept
+        {
+            return FixedTSDataContext::child_data(&fixed(context), memory, index);
+        }
+        [[nodiscard]] static void *child_data(const void *context, void *memory, std::size_t index) noexcept
+        {
+            return FixedTSDataContext::child_data(&fixed(context), memory, index);
+        }
+        [[nodiscard]] static bool child_modified(const void *context, const void *memory, std::size_t index) noexcept
+        {
+            return FixedTSDataContext::child_modified_for_parent_time(&fixed(context), memory, index);
+        }
+    };
+
+    const TSValueTypeMetaData &fixed_schema(const void *context) noexcept
+    {
+        return *FixedSeamAccess::fixed(context).schema;
+    }
+
+    const TSDataLayout &fixed_layout(const void *context) noexcept
+    {
+        return *FixedSeamAccess::fixed(context).layout_ptr();
+    }
+
+    std::size_t fixed_element_count(const void *context) noexcept { return FixedSeamAccess::element_count(context); }
+
+    TSRoleTypeRef fixed_element_type(const void *context, std::size_t index) noexcept
+    {
+        return FixedSeamAccess::element_type(context, index);
+    }
+
+    std::int64_t fixed_ordinal_key(const void *context, std::size_t index) noexcept
+    {
+        return FixedSeamAccess::fixed(context).ordinal_keys[index];
+    }
+
+    const TSDataTracking &fixed_tracking(const void *context, const void *memory) noexcept
+    {
+        return *FixedSeamAccess::tracking(context, memory);
+    }
+
+    const void *fixed_child_data(const void *context, const void *memory, std::size_t index) noexcept
+    {
+        return FixedSeamAccess::child_data(context, memory, index);
+    }
+
+    void *fixed_mutable_child_data(const void *context, void *memory, std::size_t index) noexcept
+    {
+        return FixedSeamAccess::child_data(context, memory, index);
+    }
+
+    bool fixed_child_modified_for_parent_time(const void *context, const void *memory, std::size_t index) noexcept
+    {
+        return FixedSeamAccess::child_modified(context, memory, index);
+    }
+}  // namespace hgraph::ts_data_seams

--- a/src/hgraph/types/metadata/ts_data_slot_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_slot_ops.cpp
@@ -16,10 +16,14 @@
 #include <hgraph/types/value/value_builder.h>
 #include <hgraph/util/scope.h>
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-#include <hgraph/python/ts_data_conversion.h>
-#include <hgraph/python/conversion.h>
-#endif
+#include <hgraph/types/python_ops.h>
+
+#include "detail/ts_data_seams.h"
+
+namespace hgraph::ts_data_seams
+{
+    struct SlotSeamAccess;
+}
 
 #include <sul/dynamic_bitset.hpp>
 
@@ -825,80 +829,6 @@ namespace hgraph::ts_data_plan_factory_detail
             return *MemoryUtils::cast<Storage>(memory);
         }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-        [[nodiscard]] Value value_from_python(const ValueTypeRef &binding, nb::handle source, const char *what)
-        {
-            if (source.is_none()) { throw std::invalid_argument(std::string{what} + " requires a non-None value"); }
-            Value value{binding};
-            python_bridge::from_python(binding.ops_ref(), binding, const_cast<void *>(value.view().data()), source);
-            return value;
-        }
-
-        template <typename Visitor>
-        void for_each_python_iterable(nb::handle source, const char *what, Visitor visitor)
-        {
-            if (source.is_none()) { return; }
-            nb::object object = nb::borrow<nb::object>(source);
-            nb::iterator it = nb::iter(object);
-            while (it != nb::iterator::sentinel())
-            {
-                nb::handle item = *it;
-                if (item.is_none())
-                {
-                    throw std::invalid_argument(std::string{what} + " does not allow None elements");
-                }
-                visitor(item);
-                ++it;
-            }
-        }
-
-        [[nodiscard]] bool python_has_items(nb::handle source)
-        {
-            nb::object object = nb::borrow<nb::object>(source);
-            return nb::isinstance<nb::dict>(object) || nb::hasattr(object, "items");
-        }
-
-        template <typename Visitor>
-        void for_each_python_mapping_item(nb::handle source, const char *what, Visitor visitor)
-        {
-            if (!python_has_items(source))
-            {
-                throw std::invalid_argument(std::string{what} + " expects a Python mapping");
-            }
-            nb::object   object = nb::borrow<nb::object>(source);
-            nb::object   items  = object.attr("items")();
-            nb::iterator it     = nb::iter(items);
-            while (it != nb::iterator::sentinel())
-            {
-                nb::tuple pair = nb::cast<nb::tuple>(*it);
-                if (pair.size() != 2)
-                {
-                    throw std::invalid_argument(std::string{what} + " items() must yield key/value pairs");
-                }
-                visitor(nb::borrow<nb::object>(pair[0]), nb::borrow<nb::object>(pair[1]));
-                ++it;
-            }
-        }
-
-        [[nodiscard]] bool python_named_field(nb::handle source, const char *name, nb::object &out)
-        {
-            nb::object object = nb::borrow<nb::object>(source);
-            if (nb::isinstance<nb::dict>(object))
-            {
-                nb::dict map = nb::cast<nb::dict>(object);
-                nb::str  key{name};
-                if (!map.contains(key)) { return false; }
-                out = map[key];
-                return true;
-            }
-            if (nb::hasattr(object, name))
-            {
-                out = nb::getattr(object, name);
-                return true;
-            }
-            return false;
-        }
-#endif
 
         enum class SlotSetSurface
         {
@@ -953,11 +883,16 @@ namespace hgraph::ts_data_plan_factory_detail
             ValueTypeRef added_set_binding{nullptr};
             ValueTypeRef removed_set_binding{nullptr};
             TSRoleTypeRef root_type{};
+            /** True for a TSD context: its set surfaces run over the dict
+                storage (``schema`` above is the key set's TSS schema, so the
+                seams cannot dispatch on it). */
+            bool dict_storage{false};
         };
 
         template <typename Storage>
         struct TSSContextBase : SlotContextCommon
         {
+            friend struct ts_data_seams::SlotSeamAccess;  // the RFC 0035 seams' one route in
             void initialise_tss_common(const TSValueTypeMetaData &schema_,
                                        const MemoryUtils::StoragePlan &plan_,
                                        const ValueTypeRef &key_binding,
@@ -1021,12 +956,10 @@ namespace hgraph::ts_data_plan_factory_detail
                     .delta_has_effect_impl     = &ts_data_detail::delta_has_effect_tss,
                     .apply_delta_impl          = &ts_data_detail::apply_delta_tss,
                     .clear_collection_impl     = &ts_data_detail::clear_tss_collection,
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-                    .python_ops               = &python_bridge::set_python_ts_data_ops(),
-                    .from_python_impl          = &python_bridge::ts_from_python_slot<&tss_from_python>,
-                    .to_python_impl            = &python_bridge::to_python_slot<&tss_to_python>,
-                    .delta_to_python_impl      = &python_bridge::ts_delta_to_python_slot<&tss_delta_to_python>,
-#endif
+                    .python_family             = PythonTSDataFamily::set,
+                    .from_python_impl          = &python_ops_detail::forwarder<&PythonOps::TSData::tss_from_python>::call,
+                    .to_python_impl            = &python_ops_detail::forwarder<&PythonOps::TSData::tss_to_python>::call,
+                    .delta_to_python_impl      = &python_ops_detail::forwarder<&PythonOps::TSData::tss_delta_to_python>::call,
                 };
                 set_ops.size_impl                      = &tss_size;
                 set_ops.slot_capacity_impl             = &tss_slot_capacity;
@@ -1066,10 +999,8 @@ namespace hgraph::ts_data_plan_factory_detail
                     {ValueOpsKind::Indexed, this, false, &delta_bundle_hash, &delta_bundle_equals,
                      &delta_bundle_compare,
                      &delta_bundle_to_string
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
                      ,
-                     &python_bridge::to_python_slot<&delta_bundle_to_python>
-#endif
+                     &python_ops_detail::forwarder<&PythonOps::TSData::tss_delta_bundle_to_python>::call
                     },
                     &delta_bundle_size,
                     &delta_bundle_element_at,
@@ -1101,10 +1032,10 @@ namespace hgraph::ts_data_plan_factory_detail
                 SetValueOps ops{
                     {{ValueOpsKind::Set, this, false, &set_hash<Surface>, &set_equals<Surface>, &set_compare<Surface>,
                       &set_to_string<Surface>
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
                       ,
-                      &python_bridge::to_python_slot<&set_to_python<Surface>>
-#endif
+                      Surface == SlotSetSurface::Live    ? &python_ops_detail::forwarder<&PythonOps::TSData::tss_set_live_to_python>::call
+                      : Surface == SlotSetSurface::Added ? &python_ops_detail::forwarder<&PythonOps::TSData::tss_set_added_to_python>::call
+                                                         : &python_ops_detail::forwarder<&PythonOps::TSData::tss_set_removed_to_python>::call
                      },
                      &set_size<Surface>,
                      &set_element_at<Surface>,
@@ -1340,99 +1271,6 @@ namespace hgraph::ts_data_plan_factory_detail
                 return newly_touched;
             }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-            [[nodiscard]] static nb::object tss_to_python(const void *context, const void *memory)
-            {
-                const auto *state = ctx(context);
-                return python_bridge::to_python(state->set_layout.value_binding, memory);
-            }
-
-            [[nodiscard]] static nb::object tss_delta_to_python(const void *context,
-                                                                const void *memory,
-                                                                DateTime evaluation_time)
-            {
-                const auto *state = ctx(context);
-                if (storage<Storage>(memory).tracking().last_modified_time != evaluation_time) { return nb::none(); }
-                return python_bridge::to_python(state->set_layout.delta_binding, memory);
-            }
-
-            [[nodiscard]] static bool tss_from_python(const void *context,
-                                                      void       *memory,
-                                                      nb::handle  source,
-                                                      DateTime modified_time)
-            {
-                if (memory == nullptr) { throw std::logic_error("TSS from_python requires live storage"); }
-                if (source.is_none()) { throw std::invalid_argument("TSS from_python requires a non-None source"); }
-                if (modified_time == MIN_DT)
-                {
-                    throw std::invalid_argument("TSS from_python requires a concrete evaluation time");
-                }
-
-                auto       &target = storage<Storage>(memory);
-                const auto *state  = ctx(context);
-
-                nb::object added;
-                nb::object removed;
-                const bool has_added = python_named_field(source, "added", added);
-                const bool has_removed = python_named_field(source, "removed", removed);
-                if (has_added || has_removed)
-                {
-                    const bool first_for_parent = target.tracking().last_modified_time != modified_time;
-                    if (has_added && !added.is_none())
-                    {
-                        for_each_python_iterable(added, "TSS added update", [&](nb::handle item) {
-                            Value key = value_from_python(state->set_layout.key_binding, item, "TSS added update");
-                            static_cast<void>(target.insert_key(key.view(), modified_time));
-                        });
-                    }
-                    if (has_removed && !removed.is_none())
-                    {
-                        for_each_python_iterable(removed, "TSS removed update", [&](nb::handle item) {
-                            Value key = value_from_python(state->set_layout.key_binding, item, "TSS removed update");
-                            static_cast<void>(target.remove_key(key.view(), modified_time));
-                        });
-                    }
-                    return first_for_parent;
-                }
-
-                nb::object object = nb::borrow<nb::object>(source);
-                if (!nb::isinstance<nb::set>(object) && !nb::isinstance<nb::frozenset>(object) &&
-                    !nb::isinstance<nb::list>(object) && !nb::isinstance<nb::tuple>(object))
-                {
-                    throw std::invalid_argument("TSS from_python expects a Python set, frozenset, list, or tuple");
-                }
-
-                std::vector<Value> replacement;
-                if (nb::hasattr(object, "__len__"))
-                {
-                    replacement.reserve(static_cast<std::size_t>(nb::len(object)));
-                }
-                for_each_python_iterable(source, "TSS value", [&](nb::handle item) {
-                    replacement.push_back(value_from_python(state->set_layout.key_binding, item, "TSS value"));
-                });
-
-                const bool newly_touched = target.touch(modified_time);
-                for (const auto &key : replacement)
-                {
-                    static_cast<void>(target.insert_key(key.view(), modified_time));
-                }
-
-                const auto &key_ops = state->set_layout.key_binding.ops_ref();
-                std::vector<Value> removals;
-                for (const auto key : set_make_range<SlotSetSurface::Live>(context, memory))
-                {
-                    const bool keep = std::any_of(replacement.begin(), replacement.end(), [&](const Value &candidate) {
-                        return key_ops.equals(key.data(), candidate.view().data());
-                    });
-                    if (!keep) { removals.emplace_back(key); }
-                }
-                for (const auto &key : removals)
-                {
-                    static_cast<void>(target.remove_key(key.view(), modified_time));
-                }
-                return newly_touched;
-            }
-#endif
 
             [[nodiscard]] static std::size_t tss_size(const void *, const void *memory) noexcept
             {
@@ -1718,20 +1556,6 @@ namespace hgraph::ts_data_plan_factory_detail
                 return fmt::to_string(out);
             }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-            template <SlotSetSurface Surface>
-            [[nodiscard]] static nb::object set_to_python(const void *context, const void *memory)
-            {
-                const auto *state = ctx(context);
-                const auto &ops   = state->set_layout.key_binding.ops_ref();
-                nb::set     result;
-                for (const auto key : set_make_range<Surface>(context, memory))
-                {
-                    result.add(python_bridge::to_python(ops, key.data()));
-                }
-                return result;
-            }
-#endif
 
             [[nodiscard]] static std::size_t delta_bundle_size(const void *, const void *) noexcept { return 2; }
 
@@ -1806,16 +1630,6 @@ namespace hgraph::ts_data_plan_factory_detail
                                    state->removed_set_binding.ops_ref().to_string(memory));
             }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-            [[nodiscard]] static nb::object delta_bundle_to_python(const void *context, const void *memory)
-            {
-                const auto *state = ctx(context);
-                nb::dict    result;
-                result[nb::str{"added"}] = python_bridge::to_python(state->added_set_binding, memory);
-                result[nb::str{"removed"}] = python_bridge::to_python(state->removed_set_binding, memory);
-                return result;
-            }
-#endif
         };
 
         struct TSSContext final : TSSContextBase<TSSSlotStorage>
@@ -1834,6 +1648,7 @@ namespace hgraph::ts_data_plan_factory_detail
 
         struct TSDContext final : TSSContextBase<TSDSlotStorage>
         {
+            friend struct ts_data_seams::SlotSeamAccess;
             const TSValueTypeMetaData *dict_schema{nullptr};
             TypeRole                  role{TypeRole::Invalid};
             TSDDataOps              dict_ops{};
@@ -1855,7 +1670,8 @@ namespace hgraph::ts_data_plan_factory_detail
                        bool embedded,
                        bool composite)
             {
-                dict_schema = &schema;
+                dict_schema  = &schema;
+                dict_storage = true;
                 role = role_;
                 element_type = intern_tsd_value_projection_type(element_type, role);
                 const auto *key_set_schema = TypeRegistry::instance().tss(schema.key_type());
@@ -1978,12 +1794,10 @@ namespace hgraph::ts_data_plan_factory_detail
                 base_ops.delta_has_effect_impl = &ts_data_detail::delta_has_effect_tsd;
                 base_ops.apply_delta_impl = &ts_data_detail::apply_delta_tsd;
                 base_ops.clear_collection_impl = &ts_data_detail::clear_tsd_collection;
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-                base_ops.python_ops = &python_bridge::dict_python_ts_data_ops();
-                base_ops.from_python_impl = &python_bridge::ts_from_python_slot<&tsd_from_python>;
-                base_ops.to_python_impl = &python_bridge::to_python_slot<&tsd_to_python>;
-                base_ops.delta_to_python_impl = &python_bridge::ts_delta_to_python_slot<&tsd_delta_to_python>;
-#endif
+                base_ops.python_family        = PythonTSDataFamily::dict;
+                base_ops.from_python_impl     = &python_ops_detail::forwarder<&PythonOps::TSData::tsd_from_python>::call;
+                base_ops.to_python_impl       = &python_ops_detail::forwarder<&PythonOps::TSData::tsd_to_python>::call;
+                base_ops.delta_to_python_impl = &python_ops_detail::forwarder<&PythonOps::TSData::tsd_delta_to_python>::call;
 
                 dict_ops.structural_delta_current_impl = &tsd_structural_delta_current;
                 dict_ops.child_at_slot_impl = &tsd_child_at_slot;
@@ -2014,10 +1828,8 @@ namespace hgraph::ts_data_plan_factory_detail
                 key_set_value_ops = SetValueOps{
                     {{ValueOpsKind::Set, this, false, &map_key_set_hash, &map_key_set_equals, &map_key_set_compare,
                       &map_key_set_to_string
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
                       ,
-                      &python_bridge::to_python_slot<&map_key_set_to_python>
-#endif
+                      &python_ops_detail::forwarder<&PythonOps::TSData::tsd_map_key_set_to_python>::call
                      },
                      &map_live_size,
                      &map_key_at_index,
@@ -2042,10 +1854,8 @@ namespace hgraph::ts_data_plan_factory_detail
                 dict_delta_bundle_ops = IndexedValueOps{
                     {ValueOpsKind::Indexed, this, false, &dict_delta_hash, &dict_delta_equals, &dict_delta_compare,
                      &dict_delta_to_string
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
                      ,
-                     &python_bridge::to_python_slot<&dict_delta_to_python>
-#endif
+                     &python_ops_detail::forwarder<&PythonOps::TSData::tsd_dict_delta_to_python>::call
                     },
                     &dict_delta_size,
                     &dict_delta_element_at,
@@ -2142,10 +1952,9 @@ namespace hgraph::ts_data_plan_factory_detail
                     {{ValueOpsKind::Map, this, false, &map_hash<Surface>, &map_equals<Surface>,
                       &map_compare<Surface>,
                       &map_to_string<Surface>
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
                       ,
-                      &python_bridge::to_python_slot<&map_to_python<Surface>>
-#endif
+                      Surface == SlotMapSurface::Live ? &python_ops_detail::forwarder<&PythonOps::TSData::tsd_map_live_to_python>::call
+                                                      : &python_ops_detail::forwarder<&PythonOps::TSData::tsd_map_modified_to_python>::call
                      },
                      &map_size<Surface>,
                      &map_key_at_index<Surface>,
@@ -2335,175 +2144,6 @@ namespace hgraph::ts_data_plan_factory_detail
                     "TSD copy_value_from must be performed through TSDDataMutationView so child notifications use TSParentLink");
             }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-            [[nodiscard]] static nb::object tsd_to_python(const void *context, const void *memory)
-            {
-                const auto *state = ctxd(context);
-                const auto &store = storage<TSDSlotStorage>(memory);
-                const auto &key_ops = state->dict_layout.key_binding.ops_ref();
-                const auto &child_ops = state->dict_layout.element_type.ops_ref();
-                nb::dict result;
-                for (std::size_t slot = 0; slot < store.slot_capacity(); ++slot)
-                {
-                    if (!map_slot_in_surface<SlotMapSurface::Live>(store, slot)) { continue; }
-                    const auto *child = store.child_at_slot(slot);
-                    if (!child_ops.has_current_value_impl(child_ops.context, child)) { continue; }
-                    result[python_bridge::to_python(key_ops, store.key_at_slot(slot))] =
-                        python_bridge::take(child_ops.to_python_impl(child_ops.context, child));
-                }
-                return result;
-            }
-
-            [[nodiscard]] static nb::object tsd_delta_to_python(const void *context,
-                                                                const void *memory,
-                                                                DateTime evaluation_time)
-            {
-                const auto *state = ctxd(context);
-                if (storage<TSDSlotStorage>(memory).tracking().last_modified_time != evaluation_time)
-                {
-                    return nb::none();
-                }
-                const auto &store = storage<TSDSlotStorage>(memory);
-                const auto &key_ops = state->dict_layout.key_binding.ops_ref();
-                const auto &child_ops = state->dict_layout.element_type.ops_ref();
-                nb::dict modified;
-                for (std::size_t slot = 0; slot < store.slot_capacity(); ++slot)
-                {
-                    if (!map_slot_in_surface<SlotMapSurface::Modified>(store, slot)) { continue; }
-                    const auto *child = store.child_at_slot(slot);
-                    nb::object delta = python_bridge::take(child_ops.delta_to_python_impl(
-                        child_ops.context, child, evaluation_time));
-                    if (!delta.is_none())
-                    {
-                        modified[python_bridge::to_python(key_ops, store.key_at_slot(slot))] = std::move(delta);
-                    }
-                }
-                nb::dict result;
-                result[nb::str{"removed"}] = python_bridge::to_python(state->removed_set_binding, memory);
-                result[nb::str{"modified"}] = std::move(modified);
-                return result;
-            }
-
-            [[nodiscard]] static bool tsd_from_python(const void *context,
-                                                      void       *memory,
-                                                      nb::handle  source,
-                                                      DateTime modified_time)
-            {
-                if (memory == nullptr) { throw std::logic_error("TSD from_python requires live storage"); }
-                if (source.is_none()) { throw std::invalid_argument("TSD from_python requires a non-None source"); }
-                if (modified_time == MIN_DT)
-                {
-                    throw std::invalid_argument("TSD from_python requires a concrete evaluation time");
-                }
-                if (!python_has_items(source))
-                {
-                    throw std::invalid_argument("TSD from_python expects a Python mapping");
-                }
-
-                auto       &target = storage<TSDSlotStorage>(memory);
-                const auto *state  = ctxd(context);
-
-                nb::object removed;
-                nb::object modified;
-                const bool has_removed = python_named_field(source, "removed", removed);
-                const bool has_modified = python_named_field(source, "modified", modified);
-                if (has_removed || has_modified)
-                {
-                    const bool first_for_parent = target.tracking().last_modified_time != modified_time;
-                    if (has_removed && !removed.is_none())
-                    {
-                        for_each_python_iterable(removed, "TSD removed update", [&](nb::handle item) {
-                            Value key = value_from_python(state->dict_layout.key_binding, item, "TSD removed update");
-                            static_cast<void>(target.remove_key(key.view(), modified_time));
-                        });
-                    }
-
-                    if (has_modified && !modified.is_none())
-                    {
-                        for_each_python_mapping_item(modified, "TSD modified update", [&](nb::handle key_source,
-                                                                                          nb::handle value_source) {
-                            if (value_source.is_none()) { return; }
-
-                            Value key = value_from_python(state->dict_layout.key_binding, key_source,
-                                                          "TSD modified update key");
-                            const auto result = target.insert_key(key.view(), modified_time);
-
-                            auto rollback_insert = make_scope_exit<true>([&] {
-                                if (result.changed) { static_cast<void>(target.remove_key(key.view(), modified_time)); }
-                            });
-
-                            const auto &child_ops    = state->dict_layout.element_type.ops_ref();
-                            void       *child_memory = target.child_memory_for_write(result.slot);
-                            if (!child_ops.from_python_impl(child_ops.context, child_memory, python_bridge::borrow(value_source),
-                                                            modified_time))
-                            {
-                                return;
-                            }
-
-                            auto *child_tracking = child_ops.mutable_tracking_impl(child_ops.context, child_memory);
-                            if (child_tracking == nullptr)
-                            {
-                                throw std::logic_error("TSD child has no tracking record");
-                            }
-                            if (!child_tracking->record_modified(modified_time))
-                            {
-                                throw std::logic_error("TSD child reported a duplicate Python update modification");
-                            }
-                            target.record_child_modified(result.slot, modified_time);
-                            rollback_insert.release();
-                        });
-                    }
-                    return first_for_parent;
-                }
-
-                std::vector<std::pair<Value, nb::object>> entries;
-                for_each_python_mapping_item(source, "TSD value", [&](nb::handle key_source, nb::handle value_source) {
-                    if (value_source.is_none())
-                    {
-                        throw std::invalid_argument("TSD from_python does not allow None child values");
-                    }
-                    entries.emplace_back(
-                        value_from_python(state->dict_layout.key_binding, key_source, "TSD value key"),
-                        nb::borrow<nb::object>(value_source));
-                });
-
-                const bool newly_touched = target.touch(modified_time);
-                for (const auto &[key, value_source] : entries)
-                {
-                    const auto result = target.insert_key(key.view(), modified_time);
-                    const auto &child_ops = state->dict_layout.element_type.ops_ref();
-                    void       *child_memory = target.child_memory_for_write(result.slot);
-                    if (child_ops.from_python_impl(child_ops.context, child_memory, python_bridge::borrow(value_source), modified_time))
-                    {
-                        auto *child_tracking = child_ops.mutable_tracking_impl(child_ops.context, child_memory);
-                        if (child_tracking == nullptr)
-                        {
-                            throw std::logic_error("TSD child has no tracking record");
-                        }
-                        if (!child_tracking->record_modified(modified_time))
-                        {
-                            throw std::logic_error("TSD child reported a duplicate Python value modification");
-                        }
-                        target.record_child_modified(result.slot, modified_time);
-                    }
-                }
-
-                const auto &key_ops = state->dict_layout.key_binding.ops_ref();
-                std::vector<Value> removals;
-                for (const auto key : set_make_range<SlotSetSurface::Live>(context, memory))
-                {
-                    const bool keep = std::any_of(entries.begin(), entries.end(), [&](const auto &entry) {
-                        return key_ops.equals(key.data(), entry.first.view().data());
-                    });
-                    if (!keep) { removals.emplace_back(key); }
-                }
-                for (const auto &key : removals)
-                {
-                    static_cast<void>(target.remove_key(key.view(), modified_time));
-                }
-                return newly_touched;
-            }
-#endif
 
             [[nodiscard]] static const void *tsd_child_at_slot(const void *, const void *memory, std::size_t slot)
             {
@@ -2984,23 +2624,6 @@ namespace hgraph::ts_data_plan_factory_detail
                 return fmt::to_string(out);
             }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-            template <SlotMapSurface Surface>
-            [[nodiscard]] static nb::object map_to_python(const void *context, const void *memory)
-            {
-                const auto *state = ctxd(context);
-                const auto &key_ops = state->dict_layout.key_binding.ops_ref();
-                const auto value_binding = map_value_binding<Surface>(context, memory);
-                const auto &value_ops = value_binding.ops_ref();
-                nb::dict result;
-                for (const auto [key, value] : map_kv_range<Surface>(context, memory))
-                {
-                    result[python_bridge::to_python(key_ops, key.data())] =
-                        value.has_value() ? python_bridge::to_python(value_ops, value.data()) : nb::none();
-                }
-                return result;
-            }
-#endif
 
             [[nodiscard]] static std::size_t map_key_set_hash(const void *context, const void *memory)
             {
@@ -3024,12 +2647,6 @@ namespace hgraph::ts_data_plan_factory_detail
                 return set_to_string<SlotSetSurface::Live>(context, memory);
             }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-            [[nodiscard]] static nb::object map_key_set_to_python(const void *context, const void *memory)
-            {
-                return set_to_python<SlotSetSurface::Live>(context, memory);
-            }
-#endif
 
             [[nodiscard]] static std::size_t dict_delta_size(const void *, const void *) noexcept { return 2; }
 
@@ -3105,16 +2722,6 @@ namespace hgraph::ts_data_plan_factory_detail
                                    state->modified_map_binding.ops_ref().to_string(memory));
             }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-            [[nodiscard]] static nb::object dict_delta_to_python(const void *context, const void *memory)
-            {
-                const auto *state = ctxd(context);
-                nb::dict result;
-                result[nb::str{"removed"}] = python_bridge::to_python(state->removed_set_binding, memory);
-                result[nb::str{"modified"}] = python_bridge::to_python(state->modified_map_binding, memory);
-                return result;
-            }
-#endif
         };
 
         using SlotContextOwner =
@@ -3495,3 +3102,159 @@ namespace hgraph::ts_data_plan_factory_detail
         }
     }
 } // namespace hgraph::ts_data_plan_factory_detail
+
+// -- RFC 0035 seams: slot-backed TSS / TSD for ts_data_structured_conversions.cpp
+namespace hgraph::ts_data_seams
+{
+    using namespace ts_data_plan_factory_detail;
+
+    /** Friend of the slot contexts: the seams reach their private surfaces through here. */
+    struct SlotSeamAccess
+    {
+        using SetBase = TSSContextBase<TSSSlotStorage>;
+        using DictCtx = TSDContext;
+
+        [[nodiscard]] static const SlotContextCommon &common(const void *context) noexcept
+        {
+            return *static_cast<const SlotContextCommon *>(context);
+        }
+        [[nodiscard]] static const TSDContext &dict(const void *context) noexcept
+        {
+            return *static_cast<const TSDContext *>(context);
+        }
+        template <typename Base>
+        [[nodiscard]] static Range<ValueView> keys(const void *context, const void *memory, SetSurface surface)
+        {
+            switch (surface)
+            {
+                case SetSurface::added: return Base::template set_make_range<SlotSetSurface::Added>(context, memory);
+                case SetSurface::removed: return Base::template set_make_range<SlotSetSurface::Removed>(context, memory);
+                case SetSurface::live: break;
+            }
+            return Base::template set_make_range<SlotSetSurface::Live>(context, memory);
+        }
+        [[nodiscard]] static bool slot_in_surface(const void *memory, std::size_t slot, MapSurface surface) noexcept
+        {
+            const auto &store = storage<TSDSlotStorage>(memory);
+            return surface == MapSurface::modified ? DictCtx::map_slot_in_surface<SlotMapSurface::Modified>(store, slot)
+                                                   : DictCtx::map_slot_in_surface<SlotMapSurface::Live>(store, slot);
+        }
+        [[nodiscard]] static ValueTypeRef map_value_binding(const void *context, const void *memory,
+                                                            MapSurface surface) noexcept
+        {
+            return surface == MapSurface::modified ? DictCtx::map_value_binding<SlotMapSurface::Modified>(context, memory)
+                                                   : DictCtx::map_value_binding<SlotMapSurface::Live>(context, memory);
+        }
+        [[nodiscard]] static KeyValueRange<ValueView, ValueView> map_items(const void *context, const void *memory,
+                                                                          MapSurface surface)
+        {
+            return surface == MapSurface::modified ? DictCtx::map_kv_range<SlotMapSurface::Modified>(context, memory)
+                                                   : DictCtx::map_kv_range<SlotMapSurface::Live>(context, memory);
+        }
+    };
+
+    const TSSDataLayout &tss_layout(const void *context) noexcept { return SlotSeamAccess::common(context).set_layout; }
+
+    ValueTypeRef tss_added_set_binding(const void *context) noexcept
+    {
+        return SlotSeamAccess::common(context).added_set_binding;
+    }
+
+    ValueTypeRef tss_removed_set_binding(const void *context) noexcept
+    {
+        return SlotSeamAccess::common(context).removed_set_binding;
+    }
+
+    const TSDataTracking &tss_tracking(const void *memory) noexcept { return storage<TSSSlotStorage>(memory).tracking(); }
+
+    Range<ValueView> tss_keys(const void *context, const void *memory, SetSurface surface)
+    {
+        // The set surfaces (live / added / removed) exist on a TSS and on a
+        // TSD's key set alike, over their own storages: dispatch on the
+        // context's kind, as the per-storage instantiation used to.
+        return SlotSeamAccess::common(context).dict_storage
+                   ? SlotSeamAccess::keys<SlotSeamAccess::DictCtx>(context, memory, surface)
+                   : SlotSeamAccess::keys<SlotSeamAccess::SetBase>(context, memory, surface);
+    }
+
+    bool tss_touch(void *memory, DateTime modified_time) { return storage<TSSSlotStorage>(memory).touch(modified_time); }
+
+    void tss_insert_key(void *memory, const ValueView &key, DateTime modified_time)
+    {
+        static_cast<void>(storage<TSSSlotStorage>(memory).insert_key(key, modified_time));
+    }
+
+    void tss_remove_key(void *memory, const ValueView &key, DateTime modified_time)
+    {
+        static_cast<void>(storage<TSSSlotStorage>(memory).remove_key(key, modified_time));
+    }
+
+    const TSDDataLayout &tsd_layout(const void *context) noexcept { return SlotSeamAccess::dict(context).dict_layout; }
+
+    ValueTypeRef tsd_removed_set_binding(const void *context) noexcept
+    {
+        return SlotSeamAccess::dict(context).removed_set_binding;
+    }
+
+    ValueTypeRef tsd_modified_map_binding(const void *context) noexcept
+    {
+        return SlotSeamAccess::dict(context).modified_map_binding;
+    }
+
+    const TSDataTracking &tsd_tracking(const void *memory) noexcept { return storage<TSDSlotStorage>(memory).tracking(); }
+
+    std::size_t tsd_slot_capacity(const void *memory) noexcept { return storage<TSDSlotStorage>(memory).slot_capacity(); }
+
+    bool tsd_slot_in_surface(const void *memory, std::size_t slot, MapSurface surface) noexcept
+    {
+        return SlotSeamAccess::slot_in_surface(memory, slot, surface);
+    }
+
+    const void *tsd_key_at_slot(const void *memory, std::size_t slot)
+    {
+        return storage<TSDSlotStorage>(memory).key_at_slot(slot);
+    }
+
+    const void *tsd_child_at_slot(const void *memory, std::size_t slot)
+    {
+        return storage<TSDSlotStorage>(memory).child_at_slot(slot);
+    }
+
+    Range<ValueView> tsd_keys(const void *context, const void *memory, SetSurface surface)
+    {
+        return SlotSeamAccess::keys<SlotSeamAccess::DictCtx>(context, memory, surface);
+    }
+
+    ValueTypeRef tsd_map_value_binding(const void *context, const void *memory, MapSurface surface) noexcept
+    {
+        return SlotSeamAccess::map_value_binding(context, memory, surface);
+    }
+
+    KeyValueRange<ValueView, ValueView> tsd_map_items(const void *context, const void *memory, MapSurface surface)
+    {
+        return SlotSeamAccess::map_items(context, memory, surface);
+    }
+
+    bool tsd_touch(void *memory, DateTime modified_time) { return storage<TSDSlotStorage>(memory).touch(modified_time); }
+
+    SlotInsert tsd_insert_key(void *memory, const ValueView &key, DateTime modified_time)
+    {
+        const auto result = storage<TSDSlotStorage>(memory).insert_key(key, modified_time);
+        return SlotInsert{.slot = result.slot, .changed = result.changed};
+    }
+
+    void tsd_remove_key(void *memory, const ValueView &key, DateTime modified_time)
+    {
+        static_cast<void>(storage<TSDSlotStorage>(memory).remove_key(key, modified_time));
+    }
+
+    void *tsd_child_memory_for_write(void *memory, std::size_t slot)
+    {
+        return storage<TSDSlotStorage>(memory).child_memory_for_write(slot);
+    }
+
+    void tsd_record_child_modified(void *memory, std::size_t slot, DateTime modified_time)
+    {
+        storage<TSDSlotStorage>(memory).record_child_modified(slot, modified_time);
+    }
+}  // namespace hgraph::ts_data_seams

--- a/src/hgraph/types/time_series/ts_data/proxy.cpp
+++ b/src/hgraph/types/time_series/ts_data/proxy.cpp
@@ -2010,33 +2010,21 @@ namespace hgraph
                 return *static_cast<const TSDProxyContext *>(context);
             }
 
-            template <typename Fn>
-            auto with_set_surface(SetSurface surface, Fn fn)
+            template <SetSurface Surface>
+            constexpr TSDProxySetSurface set_surface_of()
             {
-                switch (surface)
-                {
-                    case SetSurface::added: return fn(std::integral_constant<TSDProxySetSurface, TSDProxySetSurface::Added>{});
-                    case SetSurface::removed:
-                        return fn(std::integral_constant<TSDProxySetSurface, TSDProxySetSurface::Removed>{});
-                    case SetSurface::live: break;
-                }
-                return fn(std::integral_constant<TSDProxySetSurface, TSDProxySetSurface::Live>{});
+                if constexpr (Surface == SetSurface::added) { return TSDProxySetSurface::Added; }
+                else if constexpr (Surface == SetSurface::removed) { return TSDProxySetSurface::Removed; }
+                else { return TSDProxySetSurface::Live; }
             }
 
-            template <typename Fn>
-            auto with_map_surface(ProxyMapSurface surface, Fn fn)
+            template <ProxyMapSurface Surface>
+            constexpr TSDProxyMapSurface map_surface_of()
             {
-                switch (surface)
-                {
-                    case ProxyMapSurface::added:
-                        return fn(std::integral_constant<TSDProxyMapSurface, TSDProxyMapSurface::Added>{});
-                    case ProxyMapSurface::removed:
-                        return fn(std::integral_constant<TSDProxyMapSurface, TSDProxyMapSurface::Removed>{});
-                    case ProxyMapSurface::modified:
-                        return fn(std::integral_constant<TSDProxyMapSurface, TSDProxyMapSurface::Modified>{});
-                    case ProxyMapSurface::live: break;
-                }
-                return fn(std::integral_constant<TSDProxyMapSurface, TSDProxyMapSurface::Live>{});
+                if constexpr (Surface == ProxyMapSurface::added) { return TSDProxyMapSurface::Added; }
+                else if constexpr (Surface == ProxyMapSurface::removed) { return TSDProxyMapSurface::Removed; }
+                else if constexpr (Surface == ProxyMapSurface::modified) { return TSDProxyMapSurface::Modified; }
+                else { return TSDProxyMapSurface::Live; }
             }
         }  // namespace
 
@@ -2049,12 +2037,12 @@ namespace hgraph
             return proxy_storage(memory).key_set_tracking();
         }
 
-        std::size_t proxy_slot_capacity(const void *memory) noexcept
+        std::size_t proxy_slot_capacity(const void *memory)
         {
             return TSDProxyContext::source_dict(memory).slot_capacity();
         }
 
-        bool proxy_slot_live(const void *memory, std::size_t slot) noexcept
+        bool proxy_slot_live(const void *memory, std::size_t slot)
         {
             return TSDProxyContext::source_dict(memory).slot_live(slot);
         }
@@ -2076,40 +2064,54 @@ namespace hgraph
             return TSDProxyContext::source_dict(memory).key_at_slot(slot);
         }
 
-        Range<ValueView> proxy_keys(const void *context, const void *memory, SetSurface surface)
+        template <SetSurface Surface>
+        Range<ValueView> proxy_keys(const void *context, const void *memory)
         {
-            return with_set_surface(surface, [&](auto tag) {
-                return TSDProxyContext::set_range<decltype(tag)::value>(context, memory);
-            });
+            return TSDProxyContext::set_range<set_surface_of<Surface>()>(context, memory);
         }
 
-        bool proxy_slot_in_set_surface(const void *context, const void *memory, std::size_t slot, SetSurface surface)
+        template <SetSurface Surface>
+        bool proxy_slot_in_set_surface(const void *context, const void *memory, std::size_t slot)
         {
-            return with_set_surface(surface, [&](auto tag) {
-                return TSDProxyContext::slot_in_set_surface<decltype(tag)::value>(context, memory, slot);
-            });
+            return TSDProxyContext::slot_in_set_surface<set_surface_of<Surface>()>(context, memory, slot);
         }
 
-        bool proxy_slot_in_map_surface(const void *context, const void *memory, std::size_t slot, ProxyMapSurface surface)
+        template <ProxyMapSurface Surface>
+        bool proxy_slot_in_map_surface(const void *context, const void *memory, std::size_t slot)
         {
-            return with_map_surface(surface, [&](auto tag) {
-                return TSDProxyContext::map_slot_in_surface<decltype(tag)::value>(context, memory, slot);
-            });
+            return TSDProxyContext::map_slot_in_surface<map_surface_of<Surface>()>(context, memory, slot);
         }
 
-        ValueTypeRef proxy_map_value_binding(const void *context, const void *memory, ProxyMapSurface surface) noexcept
+        template <ProxyMapSurface Surface>
+        ValueTypeRef proxy_map_value_binding(const void *context, const void *memory) noexcept
         {
-            return with_map_surface(surface, [&](auto tag) {
-                return TSDProxyContext::map_value_binding<decltype(tag)::value>(context, memory);
-            });
+            return TSDProxyContext::map_value_binding<map_surface_of<Surface>()>(context, memory);
         }
 
-        const void *proxy_map_value_at_slot(const void *context, const void *memory, std::size_t slot,
-                                            ProxyMapSurface surface)
+        template <ProxyMapSurface Surface>
+        const void *proxy_map_value_at_slot(const void *context, const void *memory, std::size_t slot)
         {
-            return with_map_surface(surface, [&](auto tag) {
-                return TSDProxyContext::map_value_at_slot<decltype(tag)::value>(context, memory, slot);
-            });
+            return TSDProxyContext::map_value_at_slot<map_surface_of<Surface>()>(context, memory, slot);
         }
+
+        // One instantiation per surface: the bridge calls the selected one.
+        template Range<ValueView> proxy_keys<SetSurface::live>(const void *, const void *);
+        template Range<ValueView> proxy_keys<SetSurface::added>(const void *, const void *);
+        template Range<ValueView> proxy_keys<SetSurface::removed>(const void *, const void *);
+        template bool proxy_slot_in_set_surface<SetSurface::live>(const void *, const void *, std::size_t);
+        template bool proxy_slot_in_set_surface<SetSurface::added>(const void *, const void *, std::size_t);
+        template bool proxy_slot_in_set_surface<SetSurface::removed>(const void *, const void *, std::size_t);
+        template bool proxy_slot_in_map_surface<ProxyMapSurface::live>(const void *, const void *, std::size_t);
+        template bool proxy_slot_in_map_surface<ProxyMapSurface::added>(const void *, const void *, std::size_t);
+        template bool proxy_slot_in_map_surface<ProxyMapSurface::removed>(const void *, const void *, std::size_t);
+        template bool proxy_slot_in_map_surface<ProxyMapSurface::modified>(const void *, const void *, std::size_t);
+        template ValueTypeRef proxy_map_value_binding<ProxyMapSurface::live>(const void *, const void *) noexcept;
+        template ValueTypeRef proxy_map_value_binding<ProxyMapSurface::added>(const void *, const void *) noexcept;
+        template ValueTypeRef proxy_map_value_binding<ProxyMapSurface::removed>(const void *, const void *) noexcept;
+        template ValueTypeRef proxy_map_value_binding<ProxyMapSurface::modified>(const void *, const void *) noexcept;
+        template const void *proxy_map_value_at_slot<ProxyMapSurface::live>(const void *, const void *, std::size_t);
+        template const void *proxy_map_value_at_slot<ProxyMapSurface::added>(const void *, const void *, std::size_t);
+        template const void *proxy_map_value_at_slot<ProxyMapSurface::removed>(const void *, const void *, std::size_t);
+        template const void *proxy_map_value_at_slot<ProxyMapSurface::modified>(const void *, const void *, std::size_t);
     }  // namespace ts_data_seams
 }  // namespace hgraph

--- a/src/hgraph/types/time_series/ts_data/proxy.cpp
+++ b/src/hgraph/types/time_series/ts_data/proxy.cpp
@@ -3,10 +3,9 @@
 
 #include "ownership.h"
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-#include <nanobind/nanobind.h>
-#include <hgraph/python/conversion.h>
-#endif
+#include <hgraph/types/python_ops.h>
+
+#include "../../metadata/detail/ts_data_seams.h"
 
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/metadata/ts_data_plan_factory_detail.h>
@@ -192,10 +191,8 @@ namespace hgraph
                 delta_bundle_ops      = IndexedValueOps{
                     {ValueOpsKind::Indexed, this, false, &delta_hash, &delta_equals, &delta_compare,
                      &delta_to_string
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
                      ,
-                     &python_bridge::to_python_slot<&delta_projection_to_python>
-#endif
+                     &python_ops_detail::forwarder<&PythonOps::TSData::proxy_delta_projection_to_python>::call
                     },
                     &delta_size,
                     &delta_element_at,
@@ -232,10 +229,8 @@ namespace hgraph
                     .capture_delta_impl        = &ts_data_detail::capture_delta_tss,
                     .delta_has_effect_impl     = &ts_data_detail::delta_has_effect_tss,
                     .apply_delta_impl          = &ts_data_detail::apply_delta_tss,
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-                    .to_python_impl            = &python_bridge::to_python_slot<&key_set_to_python>,
-                    .delta_to_python_impl      = &python_bridge::ts_delta_to_python_slot<&key_set_delta_to_python>,
-#endif
+                    .to_python_impl            = &python_ops_detail::forwarder<&PythonOps::TSData::proxy_key_set_to_python>::call,
+                    .delta_to_python_impl      = &python_ops_detail::forwarder<&PythonOps::TSData::proxy_key_set_delta_to_python>::call,
                 };
                 key_set_ts_ops.size_impl                      = &set_size<TSDProxySetSurface::Live>;
                 key_set_ts_ops.slot_capacity_impl             = &slot_capacity;
@@ -271,10 +266,8 @@ namespace hgraph
                 dict_base.capture_delta_impl = &ts_data_detail::capture_delta_tsd;
                 dict_base.delta_has_effect_impl = &ts_data_detail::delta_has_effect_tsd;
                 dict_base.apply_delta_impl = &ts_data_detail::apply_delta_tsd;
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-                dict_base.to_python_impl = &python_bridge::to_python_slot<&dict_to_python>;
-                dict_base.delta_to_python_impl = &python_bridge::ts_delta_to_python_slot<&dict_delta_to_python>;
-#endif
+                dict_base.to_python_impl       = &python_ops_detail::forwarder<&PythonOps::TSData::proxy_dict_to_python>::call;
+                dict_base.delta_to_python_impl = &python_ops_detail::forwarder<&PythonOps::TSData::proxy_dict_delta_to_python>::call;
                 dict_ops.structural_delta_current_impl = &structural_delta_current;
                 dict_ops.child_at_slot_impl = &tsd_child_at_slot;
                 dict_ops.slot_modified_impl = &slot_modified;
@@ -332,11 +325,11 @@ namespace hgraph
                 SetValueOps ops{
                     {{ValueOpsKind::Set, this, false, &set_hash<Surface>, &set_equals<Surface>,
                       &set_compare<Surface>, &set_to_string<Surface>
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
                       ,
-                      &python_bridge::to_python_slot<&set_surface_to_python<Surface>>,
+                      Surface == TSDProxySetSurface::Live    ? &python_ops_detail::forwarder<&PythonOps::TSData::proxy_set_live_to_python>::call
+                      : Surface == TSDProxySetSurface::Added ? &python_ops_detail::forwarder<&PythonOps::TSData::proxy_set_added_to_python>::call
+                                                             : &python_ops_detail::forwarder<&PythonOps::TSData::proxy_set_removed_to_python>::call,
                       nullptr
-#endif
                      },
                      &set_size<Surface>,
                      &set_element_at<Surface>,
@@ -357,11 +350,12 @@ namespace hgraph
                 MapValueOps ops{
                     {{ValueOpsKind::Map, this, false, &map_hash<Surface>, &map_equals<Surface>,
                       &map_compare<Surface>, &map_to_string<Surface>
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
                       ,
-                      &python_bridge::to_python_slot<&map_surface_to_python<Surface>>,
+                      Surface == TSDProxyMapSurface::Live      ? &python_ops_detail::forwarder<&PythonOps::TSData::proxy_map_live_to_python>::call
+                      : Surface == TSDProxyMapSurface::Added   ? &python_ops_detail::forwarder<&PythonOps::TSData::proxy_map_added_to_python>::call
+                      : Surface == TSDProxyMapSurface::Removed ? &python_ops_detail::forwarder<&PythonOps::TSData::proxy_map_removed_to_python>::call
+                                                               : &python_ops_detail::forwarder<&PythonOps::TSData::proxy_map_modified_to_python>::call,
                       nullptr
-#endif
                      },
                      &map_size<Surface>,
                      &map_key_at_index<Surface>,
@@ -399,96 +393,6 @@ namespace hgraph
                 return binding;
             }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-            [[nodiscard]] static nb::object delta_projection_to_python(
-                const void *context, const void *memory)
-            {
-                const auto *state = ctx(context);
-                return python_bridge::to_python(Value{ValueView{state->layout.delta_binding, memory}});
-            }
-
-            [[nodiscard]] static nb::object key_set_to_python(
-                const void *context, const void *memory)
-            {
-                const auto *state = ctx(context);
-                nb::set result;
-                for (const auto key : set_range<TSDProxySetSurface::Live>(context, memory))
-                {
-                    result.add(python_bridge::to_python(state->layout.key_binding, key.data()));
-                }
-                return result;
-            }
-
-            [[nodiscard]] static nb::object key_set_delta_to_python(
-                const void *context, const void *memory, DateTime evaluation_time)
-            {
-                const auto &proxy = proxy_storage(memory);
-                if (proxy.key_set_tracking().last_modified_time != evaluation_time)
-                {
-                    return nb::none();
-                }
-                nb::dict result;
-                result[nb::str{"added"}] =
-                    set_surface_to_python<TSDProxySetSurface::Added>(context, memory);
-                result[nb::str{"removed"}] =
-                    set_surface_to_python<TSDProxySetSurface::Removed>(context, memory);
-                return result;
-            }
-
-            /** TSDProxy is a concrete TSData representation. Python export
-                therefore lives here and follows each child through its own
-                erased TSDataOps instead of leaking proxy layout to a facade. */
-            [[nodiscard]] static nb::object dict_to_python(
-                const void *context, const void *memory)
-            {
-                const auto *state = ctx(context);
-                const auto &proxy = proxy_storage(memory);
-                const auto dict = source_dict(memory);
-                const auto &child_ops = state->element_type.ops_ref();
-                nb::dict result;
-                for (std::size_t slot = 0; slot < dict.slot_capacity(); ++slot)
-                {
-                    if (!dict.slot_live(slot) || !proxy.has_child(slot)) { continue; }
-                    const auto key = dict.key_at_slot(slot);
-                    const auto *child = proxy.child_at_slot(slot);
-                    if (!child_ops.has_current_value_impl(child_ops.context, child)) { continue; }
-                    result[python_bridge::to_python(key.binding(), key.data())] =
-                        python_bridge::take(child_ops.to_python_impl(child_ops.context, child));
-                }
-                return result;
-            }
-
-            [[nodiscard]] static nb::object dict_delta_to_python(
-                const void *context, const void *memory, DateTime evaluation_time)
-            {
-                const auto *state = ctx(context);
-                const auto &proxy = proxy_storage(memory);
-                if (proxy.tracking().last_modified_time != evaluation_time)
-                {
-                    return nb::none();
-                }
-                const auto dict = source_dict(memory);
-                const auto &child_ops = state->element_type.ops_ref();
-                nb::dict modified;
-                for (std::size_t slot = 0; slot < dict.slot_capacity(); ++slot)
-                {
-                    if (!slot_modified(context, memory, slot) || !proxy.has_child(slot)) { continue; }
-                    const auto key = dict.key_at_slot(slot);
-                    const auto *child = proxy.child_at_slot(slot);
-                    nb::object delta = python_bridge::take(child_ops.delta_to_python_impl(
-                        child_ops.context, child, evaluation_time));
-                    if (!delta.is_none())
-                    {
-                        modified[python_bridge::to_python(key.binding(), key.data())] = std::move(delta);
-                    }
-                }
-                nb::dict result;
-                result[nb::str{"removed"}] =
-                    set_surface_to_python<TSDProxySetSurface::Removed>(context, memory);
-                result[nb::str{"modified"}] = std::move(modified);
-                return result;
-            }
-#endif
 
             static void delta_copy_construct_view(const void *context,
                                                   const ValueTypeRef &binding,
@@ -1058,45 +962,6 @@ namespace hgraph
                 return slot != TS_DATA_NO_CHILD_ID && map_slot_in_surface<Surface>(context, memory, slot);
             }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-            /** Surface read-back for python (type-erasure rule: conversion
-                binds to the ops). Children are read through their TS views -
-                link-endpoint children resolve to their targets. */
-            template <TSDProxyMapSurface Surface>
-            [[nodiscard]] static nanobind::object map_surface_to_python(const void *context, const void *memory)
-            {
-                namespace nb = nanobind;
-                const auto &proxy = proxy_storage(memory);
-                auto        dict  = source_dict(memory);
-                nb::dict    result;
-                for (std::size_t slot = 0; slot < dict.slot_capacity(); ++slot)
-                {
-                    if (!map_slot_in_surface<Surface>(context, memory, slot) || !proxy.has_child(slot)) { continue; }
-                    const auto value_type = map_value_binding<Surface>(context, memory);
-                    const auto *value_memory = map_value_at_slot<Surface>(context, memory, slot);
-                    auto key = dict.key_at_slot(slot);
-                    const auto py_key = python_bridge::to_python(key.binding(), key.data());
-                    result[py_key] = value_memory != nullptr ? python_bridge::to_python(value_type, value_memory)
-                                                              : nb::none();
-                }
-                return result;
-            }
-
-            template <TSDProxySetSurface Surface>
-            [[nodiscard]] static nanobind::object set_surface_to_python(const void *context, const void *memory)
-            {
-                namespace nb = nanobind;
-                auto     dict = source_dict(memory);
-                nb::list items;
-                for (std::size_t slot = 0; slot < dict.slot_capacity(); ++slot)
-                {
-                    if (!slot_in_set_surface<Surface>(context, memory, slot)) { continue; }
-                    auto key = dict.key_at_slot(slot);
-                    items.append(python_bridge::to_python(key.binding(), key.data()));
-                }
-                return nb::steal(PyFrozenSet_New(items.ptr()));
-            }
-#endif
 
             template <TSDProxyMapSurface Surface>
             [[nodiscard]] static const void *map_value_at_slot(const void *context,
@@ -2134,4 +1999,117 @@ namespace hgraph
         storage.bind(proxy.storage_type(), layout.element_type, source, value_ops,
                      builder_context, modified_time, child_refresh);
     }
+
+    // -- RFC 0035 seams: the TSD proxy for ts_data_structured_conversions.cpp -
+    namespace ts_data_seams
+    {
+        namespace
+        {
+            [[nodiscard]] const TSDProxyContext &proxy(const void *context) noexcept
+            {
+                return *static_cast<const TSDProxyContext *>(context);
+            }
+
+            template <typename Fn>
+            auto with_set_surface(SetSurface surface, Fn fn)
+            {
+                switch (surface)
+                {
+                    case SetSurface::added: return fn(std::integral_constant<TSDProxySetSurface, TSDProxySetSurface::Added>{});
+                    case SetSurface::removed:
+                        return fn(std::integral_constant<TSDProxySetSurface, TSDProxySetSurface::Removed>{});
+                    case SetSurface::live: break;
+                }
+                return fn(std::integral_constant<TSDProxySetSurface, TSDProxySetSurface::Live>{});
+            }
+
+            template <typename Fn>
+            auto with_map_surface(ProxyMapSurface surface, Fn fn)
+            {
+                switch (surface)
+                {
+                    case ProxyMapSurface::added:
+                        return fn(std::integral_constant<TSDProxyMapSurface, TSDProxyMapSurface::Added>{});
+                    case ProxyMapSurface::removed:
+                        return fn(std::integral_constant<TSDProxyMapSurface, TSDProxyMapSurface::Removed>{});
+                    case ProxyMapSurface::modified:
+                        return fn(std::integral_constant<TSDProxyMapSurface, TSDProxyMapSurface::Modified>{});
+                    case ProxyMapSurface::live: break;
+                }
+                return fn(std::integral_constant<TSDProxyMapSurface, TSDProxyMapSurface::Live>{});
+            }
+        }  // namespace
+
+        const TSDDataLayout &proxy_layout(const void *context) noexcept { return proxy(context).layout; }
+
+        const TSDataTracking &proxy_tracking(const void *memory) noexcept { return proxy_storage(memory).tracking(); }
+
+        const TSDataTracking &proxy_key_set_tracking(const void *memory) noexcept
+        {
+            return proxy_storage(memory).key_set_tracking();
+        }
+
+        std::size_t proxy_slot_capacity(const void *memory) noexcept
+        {
+            return TSDProxyContext::source_dict(memory).slot_capacity();
+        }
+
+        bool proxy_slot_live(const void *memory, std::size_t slot) noexcept
+        {
+            return TSDProxyContext::source_dict(memory).slot_live(slot);
+        }
+
+        bool proxy_slot_modified(const void *context, const void *memory, std::size_t slot)
+        {
+            return TSDProxyContext::slot_modified(context, memory, slot);
+        }
+
+        bool proxy_has_child(const void *memory, std::size_t slot) noexcept { return proxy_storage(memory).has_child(slot); }
+
+        const void *proxy_child_at_slot(const void *memory, std::size_t slot)
+        {
+            return proxy_storage(memory).child_at_slot(slot);
+        }
+
+        ValueView proxy_key_at_slot(const void *memory, std::size_t slot)
+        {
+            return TSDProxyContext::source_dict(memory).key_at_slot(slot);
+        }
+
+        Range<ValueView> proxy_keys(const void *context, const void *memory, SetSurface surface)
+        {
+            return with_set_surface(surface, [&](auto tag) {
+                return TSDProxyContext::set_range<decltype(tag)::value>(context, memory);
+            });
+        }
+
+        bool proxy_slot_in_set_surface(const void *context, const void *memory, std::size_t slot, SetSurface surface)
+        {
+            return with_set_surface(surface, [&](auto tag) {
+                return TSDProxyContext::slot_in_set_surface<decltype(tag)::value>(context, memory, slot);
+            });
+        }
+
+        bool proxy_slot_in_map_surface(const void *context, const void *memory, std::size_t slot, ProxyMapSurface surface)
+        {
+            return with_map_surface(surface, [&](auto tag) {
+                return TSDProxyContext::map_slot_in_surface<decltype(tag)::value>(context, memory, slot);
+            });
+        }
+
+        ValueTypeRef proxy_map_value_binding(const void *context, const void *memory, ProxyMapSurface surface) noexcept
+        {
+            return with_map_surface(surface, [&](auto tag) {
+                return TSDProxyContext::map_value_binding<decltype(tag)::value>(context, memory);
+            });
+        }
+
+        const void *proxy_map_value_at_slot(const void *context, const void *memory, std::size_t slot,
+                                            ProxyMapSurface surface)
+        {
+            return with_map_surface(surface, [&](auto tag) {
+                return TSDProxyContext::map_value_at_slot<decltype(tag)::value>(context, memory, slot);
+            });
+        }
+    }  // namespace ts_data_seams
 }  // namespace hgraph


### PR DESCRIPTION
Second half of the TS data families for RFC 0035 (#720). Stacked on #734 (PR 4a); retarget as the stack merges.

**What moves.** The fixed TSB / TSL, dynamic TSL, slot-backed TSS / TSD and TSD-proxy conversions leave `ts_data_fixed_structured_ops.cpp`, `ts_data_dynamic_list_ops.cpp`, `ts_data_slot_ops.cpp` and `ts_data/proxy.cpp` for `src/hgraph/python/impl/ts_data_structured_conversions.cpp`, behind new `PythonOps::TSData` entries. The per-surface value-ops slots (a set's live / added / removed, a map's live / modified, the proxy's four map surfaces) are distinct entries a factory selects at table construction, so the bridge never branches on the surface per call. Children are reached through their own erased `TSDataOps`.

**What stays, and how the bridge reaches it.** `ts_data_seams.h` answers each strategy's shape (schema, element types, ordinal keys, layouts, slot surfaces as `Range<ValueView>` / `KeyValueRange`) and mutation protocol (touch, insert / remove key, child memory for write, record child modified, ensure size / resize). The fixed and slot contexts grant the seams access through one friend struct each.

**One bug found on the way.** A TSD context's set surfaces run over the dict storage while the common slot base's `schema` is the key set's TSS schema; a first cut dispatched the shared set-surface seam on that schema, read TSD memory as a TSS storage and crashed every TSD delta export. The context now records `dict_storage` explicitly. A per-family delta-path probe caught it before the gate; the gate's silent death (no pytest summary) was the tell.

**Ratchets**: `type-layer-python-conditionals` 60 → 14; `type-layer-nanobind` 273 → 35. The TS input and target-link facades are all that remain (PR 5).

**Gate** (macOS): core-only tree builds and the header check passes; native `_hgraph` rebuilt; `uv sync` reinstall of every native member; core + adaptor + extension suites 3591 passed, 10 skipped, plus the ratchet and registry-snapshot tests; core C++ suite 1703 cases; the three consumer checks; `sphinx -W`. Linux GCC 14 and Windows MSVC validations to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga