### PR TITLE
Compile fixed-list graph iteration in HGL

### DIFF
--- a/language/docs/design/iteration.md
+++ b/language/docs/design/iteration.md
@@ -1,9 +1,9 @@
 # Iteration in graph composition and node evaluation
 
 Status: phase-dependent iteration and the independent-body boundary for
-dynamic graph loops agreed, 2026-09-05; compiler implementation is separate.
-Map/reduce lowering of loop-carried accumulators is a documented future
-extension, explicitly unsupported in the initial graph-loop implementation.
+dynamic graph loops agreed, 2026-09-05. The compiler implements fixed temporal
+list graph traversal. Dynamic graph mapping and map/reduce lowering of
+loop-carried accumulators remain future extensions.
 
 ## Iteration follows the containing phase
 
@@ -30,7 +30,7 @@ every imported atomic type; native operations remain a separate topic.
 ```hgl
 fn observe(samples: list<f64, 3>) {
     for sample in values(samples) {
-        debug_print("sample", sample)
+        null_sink(sample)
     }
 }
 ```
@@ -41,9 +41,11 @@ current payload. No sample value needs to exist during wiring. Source value
 ticks subsequently reach those sinks through their fixed connections; they do
 not cause the graph function to iterate again.
 
-The source is recorded in
-[fixed-list-iteration.hgl](../../stdlib/examples/fixed-list-iteration.hgl)
-as a design example, outside the executable compiler example corpus.
+The compiler expands this loop at wiring time and projects each child through
+the public native `tsl_element` contract. Both compiler backends therefore
+compose three copies of the body without reading a runtime payload. The
+executable source is
+[fixed-list-iteration.hgl](../../examples/fixed-list-iteration.hgl).
 
 ## Node-time traversal
 
@@ -175,10 +177,14 @@ policies is introduced here.
 
 ## Implementation status
 
-Earlier language documentation treated collection iterators as inherently
-runtime-only and as function-classification triggers. The agreed target now
-makes iteration phase-dependent, with an initial independent-body subset for
-dynamic graph loops and deferred map/reduce accumulation. This documentation
-change does not implement graph iteration, its unsupported-pattern diagnostics,
-or the compiler's classifier change. The graph examples are design inputs,
-not passing compiler tests.
+The classifier and typed HIR now keep `for`, `keys`, `values`, and `items`
+phase-neutral. In a composition function, both direct wiring and generated C++
+implement `values(fixed_list)` and `items(fixed_list)` by statically expanding
+the body in index order. `items` supplies an `i64` wiring-time index and a child
+time-series connection.
+
+The first implemented graph subset rejects iterator predicates, dynamic lists,
+maps, bundles, sets, assignments to enclosing bindings, and returns from the
+body. Dynamic independent-body mapping remains the next iteration slice;
+loop-result construction, reductions, graph-phase predicates, and loop exits
+remain design questions and fail closed.

--- a/language/docs/design/language-model.md
+++ b/language/docs/design/language-model.md
@@ -514,8 +514,8 @@ any of these constructs makes the complete body a runtime function:
 
 Under the agreed [iteration model](iteration.md), `for`, `keys`, `values`, and
 `items` follow the containing phase and do not themselves force runtime
-classification. This updates the earlier iterator-only classification rule;
-compiler implementation is separate.
+classification. The classifier and typed HIR implement this rule; backend
+support currently reaches fixed temporal-list `values` and `items` traversal.
 
 Mixing wiring-only and runtime-only constructs is an error. Classification is
 based on the resolved source body, not on the implementation kind selected for
@@ -673,10 +673,11 @@ evaluation-local iterators. In graph composition, iteration over a supported
 wiring-time iterable visits scalar values, and iteration over a fixed temporal
 structure visits child connections. The calls do not themselves make a
 function a runtime node. Dynamic graph loops initially admit independent bodies
-lowered through per-key or per-index mapping. Loop-carried reductions are
-deferred, with unordered map reduction and linear list reduction documented as
-future options. See [Iteration](iteration.md) for the agreement and separate
-compiler implementation status.
+lowered through per-key or per-index mapping. The compiler currently expands
+`values` and `items` over fixed temporal lists at wiring time; dynamic mapping
+is still pending. Loop-carried reductions are deferred, with unordered map
+reduction and linear list reduction documented as future options. See
+[Iteration](iteration.md) for the agreement and implementation boundary.
 
 `values` is the common value-only spelling for TSB, TSD, TSL, and TSS; there is
 no `elements` alias. `items` yields `(field, value)` for TSB, `(key, value)` for

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -175,6 +175,8 @@ planning is implemented.
   expansion, harness evaluation, entry execution, and driver-prepared settings.
 - [x] preserve explicit reference schemas and reference-transparent
   compatibility through HIR, hgraph IR, and native type materialization.
+- [x] classify traversal by its containing phase and directly expand
+  independent `values` and `items` bodies over fixed temporal lists.
 
 Acceptance: direct-wiring behavior and diagnostics remain equivalent, and the
 wiring target no longer includes syntax AST headers.
@@ -281,6 +283,8 @@ logger injection, lifecycle hooks over state and `const` configuration,
 nominal/generic structs and sparse deltas, generic operators, fixed and duration
 windows, concise `map` functions, borrowed runtime collection iteration, and
 guarded selection and forwarding of fixed-list reference elements.
+Both backends also expand graph-phase `values` and `items` over fixed temporal
+lists without reading temporal payloads.
 Generated headers and sources are mandatory `clang-format` output and public
 operator contracts are transparent aliases rather than derived marker classes.
 

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -198,6 +198,12 @@ flow is explicit: state and local declarations, injectables, lifecycle blocks,
 ordered activations, collection traversal, assignment, return, assertion, and
 expression evaluation have distinct variants. Tail expressions are removed
 from the executable statement list so they cannot be evaluated twice.
+`hgraph_ir/control_flow` derives one `TraversalPlan` for a loop body, treating
+its iterator bindings as locals while reporting captured and externally
+assigned bindings and returns. The first graph traversal slice accepts only
+independent `values` and `items` bodies over fixed temporal lists. Both backends
+unroll those bodies in index order and use hgraph's structural child projection;
+they never inspect a temporal payload while composing the graph.
 `DeclarationRef` provides typed struct, operator, callable, and test handles;
 the module retains those handles in source order while module and import
 declarations remain frontend-only. Each referenced contract or plan owns its

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -1257,13 +1257,15 @@ containing function to be a `RuntimeFn`. This section describes their runtime
 interpretation: the iterator must be consumed directly by `for`; it is neither
 a canonical value nor a temporal port and cannot escape the current
 evaluation. In graph composition, a supported wiring-time iterable provides
-scalar values and a fixed temporal structure provides child connections.
-Independent dynamic graph-loop bodies lower through per-key or per-index
-mapping. The initial dynamic subset rejects assignments to enclosing variables
-and loop-carried reductions; it must not silently change the function's phase.
-Unordered map reduction and ordered, linear list reduction are deferred
-options, not initial lowering support. See [Iteration](../design/iteration.md)
-for the target design and its separate compiler implementation work.
+scalar values and a fixed temporal structure provides child connections. The
+current compiler implements `values` and `items` over a fixed TSL by statically
+unrolling the body and projecting children through hgraph's public
+`tsl_element` contract. Both direct wiring and generated C++ reject predicates,
+dynamic structures, assignments to enclosing variables, and loop returns in
+this first graph subset. Independent dynamic graph-loop bodies will lower
+through per-key or per-index mapping. Unordered map reduction and ordered,
+linear list reduction are deferred options, not initial lowering support. See
+[Iteration](../design/iteration.md) for the target design and current boundary.
 
 Traversal and built-in delta-predicate support is:
 

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -361,8 +361,10 @@ bodies over dynamic maps or lists lower through per-key or per-index mapping.
 Loop-carried reductions are initially unsupported: unordered map reduction
 and the linear reduction option for ordered lists are documented future
 extensions. In a node, traversal visits the current child views or scalar
-elements. This is the target design; graph iteration and the classifier change
-are separate compiler work.
+elements. The classifier is phase-neutral and both compiler backends implement
+fixed temporal-list `values` and `items` traversal in graph functions. Dynamic
+graph mapping, graph iterator predicates, escaping assignments, and loop
+returns remain unsupported.
 
 This can deliberately fuse work that would otherwise become several
 primitive nodes and intermediate endpoints. Graph composition still flattens;

--- a/language/docs/user-guide/types-and-expressions.md
+++ b/language/docs/user-guide/types-and-expressions.md
@@ -775,15 +775,14 @@ tick or delta.
 
 ## Collection views and iteration
 
-Status: phase-dependent iteration is agreed design; graph iteration and its
-classification changes are separate compiler work. `for`, `keys`, `values`,
-and `items` follow the containing phase rather than themselves forcing a
-runtime node. A graph loop over a supported wiring-time iterable receives
-scalar values; over a fixed temporal structure it receives child connections.
-For dynamic maps and lists, independent bodies lower through native mapping,
-with one child graph per key or index. Loop-carried reductions are initially
-unsupported; future map reductions are unordered, while lists may require the
-linear reduction option to preserve index order. See
+Status: `for`, `keys`, `values`, and `items` follow the containing phase rather
+than themselves forcing a runtime node. The compiler implements graph-phase
+`values` and `items` over fixed temporal lists by expanding the body once per
+child connection; `items` also supplies its wiring-time `i64` index. Scalar
+wiring-time iterables, bundles, and independent dynamic map/list bodies remain
+future compiler work. Loop-carried reductions are initially unsupported;
+future map reductions are unordered, while lists may require the linear
+reduction option to preserve index order. See
 [Iteration](../design/iteration.md) for examples, restrictions, and the
 deferred reduction option.
 

--- a/language/examples/fixed-list-iteration.hgl
+++ b/language/examples/fixed-list-iteration.hgl
@@ -1,0 +1,18 @@
+// Graph-phase iteration over a fixed temporal structure visits its child
+// connections while the graph is composed. It does not inspect payloads.
+
+module examples.fixed_list_iteration
+
+use hgraph.std::{null_sink}
+
+export fn observe(samples: list<f64, 3>) {
+    for sample in values(samples) {
+        null_sink(sample)
+    }
+}
+
+export fn observe_items(samples: list<f64, 3>) {
+    for index, sample in items(samples) {
+        null_sink(sample + index)
+    }
+}

--- a/language/src/README.md
+++ b/language/src/README.md
@@ -10,7 +10,7 @@ them.
 | `syntax/` | source buffers, diagnostics, temporal literals, lexer, parser, arena AST | source text to source-accurate syntax |
 | `semantics/` | name binding, nominal hierarchy, generic argument roles, function classification, and a frontend-independent imported-module catalog | syntax plus an explicit package catalog to resolved names and shapes |
 | `ir/` | source-ranged HIR, canonical types, substitutions, constraint solving, phase/effect completion | resolved frontend state to typed HIR |
-| `hgraph_ir/` | canonical execution-facing types, compile-time expressions, constraints, typed source-order declaration handles, struct contracts, operator and callable interfaces | typed HIR to executable composition and runtime-node plans |
+| `hgraph_ir/` | canonical execution-facing types, compile-time expressions, constraints, typed source-order declaration handles, struct contracts, operator and callable interfaces, and reusable control-flow analysis | typed HIR to executable composition and runtime-node plans |
 | `descriptor/` | versioned module/interface schema, deterministic HGraph-IR snapshot, canonical JSON serialization/validation, and catalog adaptation | hgraph IR to reviewable package metadata; validated package metadata to catalog values |
 | `wiring/` | direct walk over hgraph IR | hgraph IR to public erased wiring calls |
 | `codegen/` | hgraph-IR declaration, interface, dependency, composition-body, and runtime-body emission | hgraph IR to formatted C++ and build artifacts |
@@ -32,6 +32,9 @@ composition and runtime block bodies additionally consume graph-IR statements,
 blocks, lifecycle plans, capabilities, and lexical bindings. New language
 semantics belong in HIR construction, not in either backend. The executable
 backend architecture test rejects restored AST or resolver dependencies.
+Fixed temporal-list graph traversal is represented once in hgraph IR;
+`control_flow` identifies captures, escaping assignments, and returns before
+the direct and C++ backends expand the independent body.
 
 Every new pass documents:
 

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -103,7 +103,7 @@ namespace hgl::codegen
                 Const,
                 Port,
                 Runtime,   ///< an evaluation-time scalar, optionally backed by a selector
-                Iterator,  ///< an evaluation-local borrowed collection range
+                Iterator,  ///< a phase-specific collection traversal plan
                 Function,
                 NativeFunction,
                 Struct,
@@ -531,6 +531,7 @@ namespace hgl::codegen
             // -- statements
             void emit_planned_block(gir::BlockId id, Frame &frame, Writer &out, bool function_body, SourceRange fallback);
             void emit_planned_statement(gir::StatementId id, Frame &frame, Writer &out, SourceRange fallback);
+            void emit_planned_traversal(const gir::Traversal &traversal, SourceRange range, Frame &frame, Writer &out);
             void emit_planned_if(const gir::Conditional &branch, SourceRange range, Frame &frame, Writer &out);
             void emit_return(const Value &value, Frame &frame, Writer &out, SourceRange range);
             void emit_runtime_stmt(gir::StatementId id, Frame &frame, Writer &out, SourceRange fallback);
@@ -2263,7 +2264,24 @@ namespace hgl::codegen
             }
             if (name == "keys" || name == "values" || name == "items") {
                 if (!frame.runtime) {
-                    backend(range, "'" + name + "' is a runtime traversal; it is not available in a composition body");
+                    if (call.arguments.size() != 1U) { backend(range, "graph-phase iterator predicates are not defined yet"); }
+                    const Value source = eval_planned_expr(call.arguments.front().value, frame);
+                    if (!source.is_port() || source.type.kind != HType::Kind::List || source.type.size.empty()) {
+                        backend(range, "the first graph-iteration slice requires a fixed temporal list");
+                    }
+                    if (name == "keys") {
+                        backend(range, "a fixed temporal list supports values(...) and items(...), not keys(...)");
+                    }
+
+                    Value result;
+                    result.kind  = Value::Kind::Iterator;
+                    result.code  = source.code;
+                    result.type  = source.type;
+                    result.name  = name;
+                    result.range = range;
+                    if (name == "items") { result.iterator_types.push_back(scalar_type(hir::ScalarType::I64)); }
+                    result.iterator_types.push_back(source.type.children.front());
+                    return result;
                 }
                 if (call.arguments.empty() || call.arguments.size() > 2U) {
                     fail(Category::Type, range, "'" + name + "' takes a collection and an optional predicate");
@@ -2508,11 +2526,55 @@ namespace hgl::codegen
                         } else {
                             out.line("(void)" + value.code + ";");
                         }
+                    } else if constexpr (std::is_same_v<T, gir::Traversal>) {
+                        emit_planned_traversal(node, statement.range, frame, out);
                     } else {
                         backend(statement.range, "runtime statements are not evaluated by the first pass");
                     }
                 },
                 statement.node);
+        }
+
+        void Emitter::emit_planned_traversal(const gir::Traversal &traversal, SourceRange range, Frame &frame, Writer &out) {
+            const gir::TraversalPlan plan = gir::analyze_traversal(graph_, traversal);
+            if (!plan.assigned_outer.empty()) { backend(range, "assignment escaping a graph 'for' body is not defined yet"); }
+            if (plan.returns) { backend(range, "return from a graph 'for' body is not defined yet"); }
+
+            const gir::Value &iterable_expression = planned_value(traversal.iterable, range);
+            const Value       iterator            = eval_planned_expr(traversal.iterable, frame);
+            if (!iterator.is_iterator() || iterator.type.kind != HType::Kind::List || iterator.type.size.empty()) {
+                fail(Category::Type, iterable_expression.range,
+                     "a graph 'for' loop currently needs values(...) or items(...) over a fixed temporal list");
+            }
+            if (traversal.bindings.empty() || traversal.bindings.size() > 2U ||
+                traversal.bindings.size() != iterator.iterator_types.size()) {
+                backend(range, "hgraph IR traversal bindings do not match the fixed-list iterator");
+            }
+
+            const std::int64_t count = std::stoll(iterator.type.size);
+            for (std::int64_t index = 0; index < count; ++index) {
+                Frame iteration = frame;
+                out.open("");
+
+                Value position =
+                    make_const("hgraph::Int{" + std::to_string(index) + "}", scalar_type(hir::ScalarType::I64), range, index);
+                Value selected = make_port("hgraph::tsl_element(" + iterator.code + ", " + std::to_string(index) + ")",
+                                           iterator.type.children.front(), range);
+
+                std::vector<Value> loop_values;
+                if (iterator.name == "items") { loop_values.push_back(std::move(position)); }
+                loop_values.push_back(std::move(selected));
+                for (std::size_t binding_index = 0; binding_index < traversal.bindings.size(); ++binding_index) {
+                    const gir::Binding &binding = planned_binding(traversal.bindings[binding_index], range);
+                    if (binding.kind != gir::BindingKind::LoopValue ||
+                        !same_type(planned_type(binding.type, binding.range), loop_values[binding_index].type)) {
+                        backend(binding.range, "hgraph IR fixed-list traversal has an invalid loop binding");
+                    }
+                    iteration.planned_bindings[traversal.bindings[binding_index].value] = loop_values[binding_index];
+                }
+                emit_planned_block(traversal.block, iteration, out, false, range);
+                out.close();
+            }
         }
 
         void Emitter::emit_planned_if(const gir::Conditional &branch, SourceRange range, Frame &frame, Writer &out) {
@@ -4019,6 +4081,7 @@ namespace hgl::codegen
             header.line("#include <hgraph/lib/std/operators/operators.h>");
             if (uses_analytics_) { header.line("#include <hgraph/analytics/operators.h>"); }
             header.line("#include <hgraph/types/graph_wiring.h>");
+            header.line("#include <hgraph/types/subgraph_wiring.h>");
             header.line("#include <hgraph/types/operator_dispatch.h>");
             header.line("#include <hgraph/types/static_node.h>");
             header.line("#include <hgraph/types/static_schema.h>");

--- a/language/src/hgraph_ir/control_flow.cpp
+++ b/language/src/hgraph_ir/control_flow.cpp
@@ -1,6 +1,7 @@
 #include "hgraph_ir/control_flow.h"
 
 #include <algorithm>
+#include <span>
 #include <type_traits>
 #include <utility>
 #include <variant>
@@ -16,8 +17,10 @@ namespace hgl::hgraph_ir
         class BranchAnalyzer
         {
           public:
-            BranchAnalyzer(const Module &module, BlockId block) : module_{module} {
+            BranchAnalyzer(const Module &module, BlockId block, std::span<const BindingId> additional_locals = {})
+                : module_{module} {
                 plan_.block = block;
+                for (BindingId binding : additional_locals) { add_local(binding); }
                 collect_locals(block);
                 scan_block(block);
             }
@@ -261,5 +264,15 @@ namespace hgl::hgraph_ir
             }
         }
         return plan;
+    }
+
+    TraversalPlan analyze_traversal(const Module &module, const Traversal &traversal) {
+        ConditionalBranchPlan nested = BranchAnalyzer{module, traversal.block, traversal.bindings}.take();
+        return TraversalPlan{
+            .block          = nested.block,
+            .captures       = std::move(nested.captures),
+            .assigned_outer = std::move(nested.assigned_outer),
+            .returns        = nested.returns,
+        };
     }
 }  // namespace hgl::hgraph_ir

--- a/language/src/hgraph_ir/control_flow.h
+++ b/language/src/hgraph_ir/control_flow.h
@@ -43,6 +43,19 @@ namespace hgl::hgraph_ir
     /// represented as an incomplete plan for the backends to diagnose against
     /// the original source range.
     [[nodiscard]] ConditionalPlan analyze_temporal_conditional(const Module &module, ValueId value);
+
+    /// Captures and control-flow effects for one traversal body. Loop bindings
+    /// are treated as body locals; assigned_outer therefore names only values
+    /// whose meaning would cross iterations.
+    struct TraversalPlan
+    {
+        BlockId                         block{};
+        std::vector<ConditionalCapture> captures{};
+        std::vector<BindingId>          assigned_outer{};
+        bool                            returns{false};
+    };
+
+    [[nodiscard]] TraversalPlan analyze_traversal(const Module &module, const Traversal &traversal);
 }  // namespace hgl::hgraph_ir
 
 #endif  // HGL_HGRAPH_IR_CONTROL_FLOW_H

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -1783,7 +1783,7 @@ namespace hgl::ir
                 }
                 finish_call_semantics(expression, args);
                 if (expression.type.valid() && type(expression.type).kind == TypeKind::Iterator) {
-                    expression.phase      = Phase::Runtime;
+                    expression.phase      = runtime_owner(expression.owner) ? Phase::Runtime : Phase::Wiring;
                     expression.value_kind = ValueKind::Iterator;
                     expression.effects |= Effect::IterateCollection;
                 }
@@ -1865,15 +1865,16 @@ namespace hgl::ir
                             check_block(node.block, expected_return);
                             statement.effects = condition.effects | module_.block(node.block).effects;
                         } else if constexpr (std::is_same_v<T, ForStmt>) {
-                            Expr       &iterable = check_expr(node.iterable);
-                            const Type *iterator = iterable.type.valid() ? &type(canonical(iterable.type)) : nullptr;
+                            Expr       &iterable   = check_expr(node.iterable);
+                            const Type *iterator   = iterable.type.valid() ? &type(canonical(iterable.type)) : nullptr;
+                            const Phase loop_phase = runtime_owner(statement.owner) ? Phase::Runtime : Phase::Wiring;
                             if (iterator == nullptr || iterator->kind != TypeKind::Iterator ||
                                 iterator->children.size() != node.bindings.size()) {
                                 type_error(iterable.range, "for bindings do not match the iterator item shape");
                             } else {
                                 for (std::size_t index = 0; index < node.bindings.size(); ++index) {
                                     module_.symbols[node.bindings[index].value].type = iterator->children[index];
-                                    symbol_phase_[node.bindings[index].value]        = Phase::Runtime;
+                                    symbol_phase_[node.bindings[index].value]        = loop_phase;
                                 }
                             }
                             check_block(node.block, expected_return);

--- a/language/src/semantics/resolve.cpp
+++ b/language/src/semantics/resolve.cpp
@@ -365,9 +365,14 @@ namespace hgl::semantics
                     [&](const auto &node) -> bool {
                         using T = std::decay_t<decltype(node)>;
                         if constexpr (std::is_same_v<T, ast::StateDecl> || std::is_same_v<T, ast::InjectDecl> ||
-                                      std::is_same_v<T, ast::LifecycleBlock> || std::is_same_v<T, ast::WhenStmt> ||
-                                      std::is_same_v<T, ast::ForStmt>) {
+                                      std::is_same_v<T, ast::LifecycleBlock> || std::is_same_v<T, ast::WhenStmt>) {
                             return true;
+                        } else if constexpr (std::is_same_v<T, ast::ForStmt>) {
+                            // Iteration follows the phase established by its
+                            // containing function. A node-only construct in
+                            // the body still classifies the whole function as
+                            // runtime, but `for` itself is phase-neutral.
+                            return block_has_runtime_form(node.block);
                         } else if constexpr (std::is_same_v<T, ast::ExprStmt>) {
                             return expr_has_runtime_form(node.expr);
                         } else if constexpr (std::is_same_v<T, ast::LocalDecl>) {

--- a/language/src/wiring/backend.cpp
+++ b/language/src/wiring/backend.cpp
@@ -18,6 +18,7 @@
 #include <hgraph/types/record_replay.h>
 #include <hgraph/types/static_node.h>
 #include <hgraph/types/static_schema.h>
+#include <hgraph/types/subgraph_wiring.h>
 #include <hgraph/types/temporal.h>
 #include <hgraph/types/value/value.h>
 #include <hgraph/types/value/value_builder.h>
@@ -110,6 +111,7 @@ namespace hgl::wiring
                 NativeFunction,
                 Operator,
                 Intrinsic,
+                Iterator,
                 Sequence,
             };
 
@@ -379,6 +381,7 @@ namespace hgl::wiring
             [[nodiscard]] Slot invoke(gir::CallableId id, Frame &frame);
             [[nodiscard]] Slot exec_block(gir::BlockId id, Frame &frame);
             void               exec_statement(gir::StatementId id, Frame &frame);
+            void               exec_traversal(const gir::Traversal &traversal, SourceRange range, Frame &frame);
             [[nodiscard]] std::vector<std::optional<gir::ValueId>>
             bind_arguments(const gir::Callable &target, const std::vector<gir::Argument> &arguments, SourceRange range);
             [[nodiscard]] Slot        bind_parameter(const gir::Parameter &parameter, const Slot &argument, Frame &frame,
@@ -847,7 +850,7 @@ namespace hgl::wiring
             if (slot.kind == Slot::Kind::Delta) { backend(slot.range, "a structured delta is not an ordinary operator value"); }
             if (slot.kind == Slot::Kind::Sequence) { backend(slot.range, "a harness sequence is only valid in eval"); }
             if (slot.kind == Slot::Kind::Function || slot.kind == Slot::Kind::NativeFunction || slot.kind == Slot::Kind::Operator ||
-                slot.kind == Slot::Kind::Intrinsic || slot.kind == Slot::Kind::Struct) {
+                slot.kind == Slot::Kind::Intrinsic || slot.kind == Slot::Kind::Struct || slot.kind == Slot::Kind::Iterator) {
                 backend(slot.range, "passing a callable to an operator is not supported by the first pass");
             }
             backend(slot.range, "this expression produces no value");
@@ -1223,6 +1226,24 @@ namespace hgl::wiring
                 }
                 return wire(name == "key_set" ? "keys_" : "last_modified_time", {time_series_arg(item.port)}, range);
             }
+            if (name == "keys" || name == "values" || name == "items") {
+                if (arguments.size() != 1U) { backend(range, "graph-phase iterator predicates are not defined yet"); }
+                Slot source = eval_value(arguments.front().value, frame);
+                if (!source.is_port()) {
+                    fail(Category::Type, source.range, "a graph collection iterator needs a time-series value");
+                }
+                const gir::TypeId source_type = value(arguments.front().value).type;
+                if (!source_type.valid() || source_type.value >= module_.types.size() ||
+                    module_.types[source_type.value].kind != hir::TypeKind::List || source.port.schema == nullptr ||
+                    source.port.schema->kind != hgraph::TSTypeKind::TSL || source.port.schema->fixed_size() == 0U) {
+                    backend(range, "the first graph-iteration slice requires a fixed temporal list");
+                }
+                if (name == "keys") { backend(range, "a fixed temporal list supports values(...) and items(...), not keys(...)"); }
+                source.kind = Slot::Kind::Iterator;
+                source.type = source_type;
+                source.name = name;
+                return source;
+            }
             backend(range, "'" + std::string{name} +
                                "' is a runtime traversal; it is not available in a composition body of the first pass");
         }
@@ -1549,11 +1570,41 @@ namespace hgl::wiring
                         }
                     } else if constexpr (std::is_same_v<T, gir::Evaluate>) {
                         (void)eval_value(node.value, frame);
+                    } else if constexpr (std::is_same_v<T, gir::Traversal>) {
+                        exec_traversal(node, statement.range, frame);
                     } else {
                         backend(statement.range, "runtime statements are not evaluated by the first pass");
                     }
                 },
                 statement.node);
+        }
+
+        void Compiler::exec_traversal(const gir::Traversal &traversal, SourceRange range, Frame &frame) {
+            const gir::TraversalPlan plan = gir::analyze_traversal(module_, traversal);
+            if (!plan.assigned_outer.empty()) { backend(range, "assignment escaping a graph 'for' body is not defined yet"); }
+            if (plan.returns) { backend(range, "return from a graph 'for' body is not defined yet"); }
+
+            Slot iterator = eval_value(traversal.iterable, frame);
+            if (iterator.kind != Slot::Kind::Iterator || iterator.port.schema == nullptr ||
+                iterator.port.schema->kind != hgraph::TSTypeKind::TSL || iterator.port.schema->fixed_size() == 0U) {
+                fail(Category::Type, value(traversal.iterable).range,
+                     "a graph 'for' loop currently needs values(...) or items(...) over a fixed temporal list");
+            }
+            const bool items = iterator.name == "items";
+            if (traversal.bindings.size() != (items ? 2U : 1U)) {
+                backend(range, "hgraph IR traversal bindings do not match the fixed-list iterator");
+            }
+
+            for (std::size_t index = 0; index < iterator.port.schema->fixed_size(); ++index) {
+                Frame iteration = frame;
+                Slot  position  = make_const(hgraph::Value{static_cast<hgraph::Int>(index)}, range);
+                Slot  selected  = make_port(hgraph::subgraph_wiring_detail::tsl_element_ref(
+                                                iterator.port, index, schema(binding(traversal.bindings.back()).type)),
+                                            range);
+                if (items) { iteration.bindings[traversal.bindings.front().value] = std::move(position); }
+                iteration.bindings[traversal.bindings.back().value] = std::move(selected);
+                (void)exec_block(traversal.block, iteration);
+            }
         }
 
         Slot Compiler::eval_harness(const gir::HarnessEval &eval, SourceRange range, Frame &caller) {
@@ -1677,6 +1728,7 @@ namespace hgl::wiring
                 case Slot::Kind::NativeFunction: return "native fn " + slot.name;
                 case Slot::Kind::Operator: return "operator " + slot.name;
                 case Slot::Kind::Intrinsic: return "intrinsic " + slot.name;
+                case Slot::Kind::Iterator: return "iterator " + slot.name;
                 case Slot::Kind::Sequence: return slot.resolved ? describe_sequence(slot.elements) : slice(slot.range);
                 case Slot::Kind::Void: return {};
             }

--- a/language/stdlib/README.md
+++ b/language/stdlib/README.md
@@ -43,8 +43,10 @@ backend lowering.
 
 ## Iteration
 
-[fixed-list-iteration.hgl](examples/fixed-list-iteration.hgl) uses a graph-phase
-`for` to wire one sink per fixed-list child connection. It records the agreed
+Fixed temporal-list traversal has graduated from this design-only corpus into
+the executable compiler example
+[fixed-list-iteration.hgl](../examples/fixed-list-iteration.hgl). Both compiler
+backends wire one body per child connection under the agreed
 [phase-dependent iteration model](../docs/design/iteration.md).
 
 [dynamic-map-iteration.hgl](examples/dynamic-map-iteration.hgl) covers an

--- a/language/stdlib/examples/fixed-list-iteration.hgl
+++ b/language/stdlib/examples/fixed-list-iteration.hgl
@@ -1,9 +1,0 @@
-// Agreed design example; graph-phase iteration is not implemented yet.
-// Wiring visits three child connections and composes one sink for each.
-// See language/docs/design/iteration.md.
-
-fn observe(samples: list<f64, 3>) {
-    for sample in values(samples) {
-        debug_print("sample", sample)
-    }
-}

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -278,7 +278,10 @@ add_test(NAME hgraph_language_codegen COMMAND hgl_codegen_tests)
 # emitted and compiled through the same `hgl_add_module()` a package uses,
 # under the repository's warnings. hgraph's harness evaluates graph parity
 # beside `hgl test` and the native-only runtime-node behavior.
-hgl_add_module(hgl_codegen_fixture STATIC HGL codegen/parity.hgl codegen/runtime.hgl)
+hgl_add_module(hgl_codegen_fixture STATIC HGL
+    codegen/parity.hgl
+    codegen/runtime.hgl
+    ../examples/fixed-list-iteration.hgl)
 hgl_apply_warnings(hgl_codegen_fixture)
 hgl_add_module(hgl_structural_fixture STATIC HGL ../examples/structural-types.hgl)
 hgl_apply_warnings(hgl_structural_fixture)
@@ -304,6 +307,7 @@ set(_hgl_generated_test_sources
     codegen/generated_tests.cpp
     codegen/generated_runtime_tests.cpp
     codegen/generated_native_tests.cpp
+    codegen/generated_iteration_tests.cpp
     codegen/generated_reference_tests.cpp
     codegen/generated_structural_tests.cpp
     codegen/generated_generic_tests.cpp

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -25,7 +25,7 @@ namespace
     // as the resolver tests do (developer guide, "Frontend components").
     bool kernel_has(std::string_view name) {
         static constexpr std::string_view names[] = {
-            "if_then_else", "add_", "mul_", "mean", "map_", "rolling_mean", "hgraph.analytics.rolling_mean", "const"};
+            "if_then_else", "add_", "mul_", "mean", "map_", "null_sink", "rolling_mean", "hgraph.analytics.rolling_mean", "const"};
         return std::find(std::begin(names), std::end(names), name) != std::end(names);
     }
 
@@ -117,6 +117,14 @@ namespace
     }
 
     bool contains(const std::string &text, std::string_view fragment) { return text.find(fragment) != std::string::npos; }
+
+    std::size_t occurrences(std::string_view text, std::string_view fragment) {
+        std::size_t result = 0;
+        for (std::size_t offset = 0; (offset = text.find(fragment, offset)) != std::string_view::npos; offset += fragment.size()) {
+            ++result;
+        }
+        return result;
+    }
 
     ModuleCatalog native_catalog(std::string header = "acme/stats.h") {
         ModuleCatalog    catalog;
@@ -1141,6 +1149,67 @@ export fn adjusted(value: f64, const enabled: bool = true) -> f64 {
 
         CHECK_FALSE(unit.emit());
         CHECK(unit.has(Category::Backend, "hgraph IR contains an invalid body statement ID"));
+    }
+}
+
+TEST_CASE("emit-cpp unrolls fixed temporal list graph iteration", "[codegen][iteration]") {
+    Unit       unit{R"(
+module checks.fixed_iteration
+use hgraph.std::{null_sink}
+
+export fn observe(samples: list<f64, 3>) {
+    for sample in values(samples) {
+        null_sink(sample)
+    }
+}
+
+export fn observe_items(samples: list<f64, 3>) {
+    for index, sample in items(samples) {
+        null_sink(sample + index)
+    }
+}
+)"};
+    const auto emitted = unit.emit();
+    REQUIRE(emitted);
+    CHECK(occurrences(emitted->source, "hgraph::tsl_element(samples,") == 6U);
+    CHECK(occurrences(emitted->source, "hgraph::wire<hgraph::stdlib::null_sink>") == 6U);
+    CHECK(occurrences(emitted->source, "hgraph::wire<hgraph::stdlib::add_>") == 3U);
+
+    SECTION("dynamic graph traversal remains fail closed") {
+        Unit dynamic{R"(
+module checks.dynamic_iteration
+use hgraph.std::{null_sink}
+export fn observe(samples: list<f64>) {
+    for sample in values(samples) { null_sink(sample) }
+}
+)"};
+        CHECK_FALSE(dynamic.emit());
+        CHECK(dynamic.has(Category::Backend, "first graph-iteration slice requires a fixed temporal list"));
+    }
+
+    SECTION("graph iterator predicates remain a design boundary") {
+        Unit predicate{R"(
+module checks.predicate_iteration
+use hgraph.std::{null_sink}
+export fn observe(samples: list<f64, 3>) {
+    for sample in values(samples, modified) { null_sink(sample) }
+}
+)"};
+        CHECK_FALSE(predicate.emit());
+        CHECK(predicate.has(Category::Backend, "graph-phase iterator predicates are not defined yet"));
+    }
+
+    SECTION("assignments cannot escape the traversal body") {
+        Unit escaping{R"(
+module checks.escaping_iteration
+use hgraph.std::{null_sink}
+export fn observe(samples: list<f64, 3>) {
+    var selected: f64
+    for sample in values(samples) { selected = sample }
+}
+)"};
+        CHECK_FALSE(escaping.emit());
+        CHECK(escaping.has(Category::Backend, "assignment escaping a graph 'for' body is not defined yet"));
     }
 }
 

--- a/language/tests/codegen/generated_iteration_tests.cpp
+++ b/language/tests/codegen/generated_iteration_tests.cpp
@@ -1,0 +1,41 @@
+#include <fixed-list-iteration.h>
+
+#include "wiring/backend.h"
+
+#include <hgraph/lib/std/operators/collection.h>
+#include <hgraph/lib/std/operators/conversion.h>
+#include <hgraph/types/graph_wiring.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+
+using namespace hgraph;
+namespace fixed_iteration = examples::fixed_list_iteration;
+
+namespace
+{
+    GraphBuilder compose_observer(bool with_items) {
+        hgl::wiring::ensure_session();
+        Wiring                  w;
+        auto                    first  = wire<stdlib::const_, TS<Float>>(w, Float{1.0});
+        auto                    second = wire<stdlib::const_, TS<Float>>(w, Float{2.0});
+        auto                    third  = wire<stdlib::const_, TS<Float>>(w, Float{3.0});
+        Port<TSL<TS<Float>, 3>> samples{stdlib::to_tsl<TSL<TS<Float>, 3>>(w, first, second, third).erased()};
+        if (with_items) {
+            fixed_iteration::observe_items::compose(w, samples);
+        } else {
+            fixed_iteration::observe::compose(w, samples);
+        }
+        return std::move(w).finish();
+    }
+}  // namespace
+
+TEST_CASE("generated fixed-list graph iteration wires one sink per child", "[codegen][generated][iteration]") {
+    for (const bool with_items : {false, true}) {
+        const GraphBuilder graph = compose_observer(with_items);
+        const auto         sinks = std::ranges::count_if(
+            graph.nodes(), [](const NodeBuilder &node) { return node.type().schema()->node_kind == NodeKind::Sink; });
+        CHECK(sinks == 3);
+    }
+}

--- a/language/tests/hgraph_ir/control_flow_tests.cpp
+++ b/language/tests/hgraph_ir/control_flow_tests.cpp
@@ -45,6 +45,13 @@ namespace
         }
         return {};
     }
+
+    const gir::Traversal *traversal(const gir::Module &module) {
+        for (const gir::Statement &statement : module.statements) {
+            if (const auto *result = std::get_if<gir::Traversal>(&statement.node)) { return result; }
+        }
+        return nullptr;
+    }
 }  // namespace
 
 TEST_CASE("temporal conditional analysis produces a stable union capture signature", "[hgraph-ir][control-flow]") {
@@ -101,4 +108,29 @@ fn choose(condition: bool, value: i64) -> i64 {
     CHECK(plan.when_true.assigned_outer.front() == plan.when_false->assigned_outer.front());
     CHECK(plan.when_true.returns);
     CHECK_FALSE(plan.when_false->returns);
+}
+
+TEST_CASE("traversal analysis separates loop locals from escaping control flow", "[hgraph-ir][control-flow][iteration]") {
+    Lowered lowered{R"(
+module checks.traversal_escape
+
+fn examine(samples: list<f64, 3>) -> f64 {
+    var result: f64 = 0.0
+    for sample in values(samples) {
+        let local = sample
+        result = local
+        return local
+    }
+    return result
+}
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE(lowered.graph);
+    REQUIRE(traversal(*lowered.graph) != nullptr);
+
+    const gir::TraversalPlan plan = gir::analyze_traversal(*lowered.graph, *traversal(*lowered.graph));
+    REQUIRE(plan.assigned_outer.size() == 1U);
+    CHECK(lowered.graph->bindings[plan.assigned_outer.front().value].name == "result");
+    CHECK(plan.captures.empty());
+    CHECK(plan.returns);
 }

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -1259,6 +1259,37 @@ fn wrong(values: map<str, f64>) -> map<str, f64> =>
     CHECK(lowered.hir.completion == hir::Completion::Resolved);
 }
 
+TEST_CASE("typed HIR keeps graph iteration in the wiring phase", "[ir][typed][iteration]") {
+    Lowered lowered{R"(
+module checks.graph_iteration
+use hgraph.std::{null_sink}
+
+fn observe(samples: list<f64, 3>) {
+    for sample in values(samples) {
+        null_sink(sample)
+    }
+}
+)"};
+    require_clean(lowered);
+    REQUIRE(complete(lowered));
+
+    const auto statement = std::ranges::find_if(
+        lowered.hir.stmts, [](const hir::Stmt &candidate) { return std::holds_alternative<hir::ForStmt>(candidate.node); });
+    REQUIRE(statement != lowered.hir.stmts.end());
+    const auto &loop = std::get<hir::ForStmt>(statement->node);
+    REQUIRE(loop.bindings.size() == 1U);
+    CHECK(lowered.hir.expr(loop.iterable).phase == hir::Phase::Wiring);
+
+    bool found_loop_value = false;
+    for (const hir::Expr &expression : lowered.hir.exprs) {
+        const auto *reference = std::get_if<hir::SymbolRef>(&expression.node);
+        if (reference == nullptr || reference->symbol != loop.bindings.front()) { continue; }
+        found_loop_value = true;
+        CHECK(expression.phase == hir::Phase::Wiring);
+    }
+    CHECK(found_loop_value);
+}
+
 TEST_CASE("typed HIR rejects an invalid result without claiming completion", "[ir][typed][diagnostics]") {
     Lowered lowered{"module checks.bad\nfn wrong(value: f64) -> str => value\n"};
     require_clean(lowered);

--- a/language/tests/semantics/resolve_tests.cpp
+++ b/language/tests/semantics/resolve_tests.cpp
@@ -275,11 +275,16 @@ fn lifecycle(x: f64) -> f64 {
     start { }
     out = x
 }
+
+fn iterate(samples: list<f64, 2>) {
+    for value in values(samples) { value }
+}
 )");
     CHECK(resolved.kind_of("compose") == FunctionKind::Composition);
     CHECK(resolved.kind_of("runtime") == FunctionKind::Runtime);
     CHECK(resolved.kind_of("lifecycle") == FunctionKind::Runtime);
-    CHECK(resolved.result.functions.size() == 3);
+    CHECK(resolved.kind_of("iterate") == FunctionKind::Composition);
+    CHECK(resolved.result.functions.size() == 4);
 }
 
 TEST_CASE("implementations bind to an operator in scope", "[semantics]") {

--- a/language/tests/wiring/backend_tests.cpp
+++ b/language/tests/wiring/backend_tests.cpp
@@ -41,6 +41,21 @@ namespace
         }
     };
 
+    struct fixed_iteration_pair_operator
+        : hgraph::Operator<"hgl_fixed_iteration_pair", hgraph::In<"a", hgraph::TS<hgraph::Float>>,
+                           hgraph::In<"b", hgraph::TS<hgraph::Float>>, hgraph::Out<hgraph::TSL<hgraph::TS<hgraph::Float>, 2>>>
+    {};
+
+    struct fixed_iteration_pair_graph
+    {
+        static constexpr auto name = "hgl_fixed_iteration_pair_graph";
+
+        static auto compose(hgraph::Wiring &w, hgraph::Port<hgraph::TS<hgraph::Float>> a,
+                            hgraph::Port<hgraph::TS<hgraph::Float>> b) {
+            return hgraph::stdlib::to_tsl(w, a, b);
+        }
+    };
+
     struct observed_condition_operator
         : hgraph::Operator<"hgl_observed_condition", hgraph::In<"condition", hgraph::TS<hgraph::Bool>>,
                            hgraph::Out<hgraph::TS<hgraph::Bool>>>
@@ -322,6 +337,34 @@ fn discard(value: f64) {
 
 test sink {
     eval(discard, value: [1.0])
+}
+)"};
+    const TestResult result = only(unit.tests());
+    INFO(unit.diagnostics.render(unit.file));
+    INFO(result.message);
+    CHECK(result.passed);
+}
+
+TEST_CASE("fixed temporal list graph iteration wires every child", "[wiring][iteration]") {
+    ensure_session();
+    hgraph::register_graph_overload<fixed_iteration_pair_operator, fixed_iteration_pair_graph>();
+    Unit             unit{R"(
+module t
+
+use hgraph.std::{hgl_fixed_iteration_pair, null_sink}
+
+fn discard(a: f64, b: f64) {
+    let samples: list<f64, 2> = hgl_fixed_iteration_pair(a, b)
+    for sample in values(samples) {
+        null_sink(sample)
+    }
+    for index, sample in items(samples) {
+        null_sink(sample + index)
+    }
+}
+
+test fixed_iteration {
+    eval(discard, a: [1.0], b: [2.0])
 }
 )"};
     const TestResult result = only(unit.tests());


### PR DESCRIPTION
## Summary
- make `for` and collection traversal follow the containing function phase
- lower graph-phase `values` and `items` over fixed temporal lists in both direct wiring and generated C++
- statically expand each child through the public `tsl_element` contract while rejecting unresolved dynamic, predicate, escaping-assignment, and return forms
- promote the fixed-list iteration design fixture into an executable example and update the user, design, and compiler guides

## Validation
- `cmake --build build-language-review --parallel 8`
- `ctest --test-dir build-language-review -R "^hgraph_language_" --parallel 4 --output-on-failure` (42/42)
- `cmake --preset cpp --fresh`
- `cmake --build --preset cpp --target clean`
- `cmake --build --preset cpp --parallel 8`
- `ctest --preset cpp --parallel 2 --output-on-failure` (1716/1716)
- stable-ABI wheel built with Python 3.12, installed into a fresh Python 3.14 environment
- `python -m pytest python/tests -q -m "not wip"` (3241 passed, 10 skipped)