### PR TITLE
Type layer: TS input and target-link conversions move to the bridge (RFC 0035, PR 5 of 5)

### DIFF
--- a/docs/source/developer_guide/data_structures/plans_and_ops/ops_catalogue.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/ops_catalogue.rst
@@ -139,7 +139,7 @@ constant when the ops struct layout changes.
      - 7
      - ``include/hgraph/types/value/value_ops.h``
    * - ``TS_DATA_OPS_ABI_VERSION``
-     - 14
+     - 15
      - ``include/hgraph/types/time_series/ts_type_ref.h``
    * - ``NODE_OPS_ABI_VERSION``
      - 5
@@ -394,7 +394,7 @@ context is the interned per-shape layout/context object; generic policy
        ``is_target_link`` · ``is_input_binding``
    * - sub-tables
      - ``ownership_ops`` (nullable) · ``inspection_ops`` ·
-       ``current_state_ops`` · ``python_ops``
+       ``current_state_ops``
    * - layout / tracking
      - ``layout`` · ``tracking`` · ``mutable_tracking``
    * - validity
@@ -413,8 +413,9 @@ context is the interned per-shape layout/context object; generic policy
    * - children
      - ``indexed_child_count`` · ``indexed_child_binding`` ·
        ``indexed_child_memory`` · ``mutable_indexed_child_memory``
-   * - python (opt-in build)
-     - ``from_python`` · ``to_python`` · ``delta_to_python``
+   * - python (opaque references, RFC 0035)
+     - ``python_family`` · ``from_python`` · ``to_python`` ·
+       ``delta_to_python``
 
 ``direct_native_value`` is the **typed fast-path gate**: set only by
 pure-native atomic storages (never for python-cached or python-only
@@ -442,7 +443,7 @@ Derived tables and sub-tables:
       TSDataOps ..> TSDataOwnershipOps : ownership_ops (nullable)
       TSDataOps ..> TSDataInspectionOps : inspection_ops
       TSDataOps ..> TSCurrentStateOps : current_state_ops (per kind)
-      TSDataOps ..> PythonTSDataOps : python_ops (per kind)
+      TSDataOps ..> PythonTSDataOps : python_family (the bridge maps it)
       class TSSDataOps {
         slot surface: size · occupied · added/removed
         insert/remove key · touch · ranges
@@ -475,14 +476,18 @@ links, bounds-checked child access, side-effectful subscription, and
 the explicit ``require_live`` API throws
 (``tests/cpp/test_sentinel_ops.cpp`` pins the contract).
 
-The four sub-tables each answer one concern:
+The three sub-tables and the Python-authoring family each answer one
+concern:
 
 - ``TSCurrentStateOps`` — record/replay reconciliation: eight per-kind
   singleton tables selected once at factory time
   (``src/hgraph/types/time_series/ts_delta.cpp``).
-- ``python_bridge::PythonTSDataOps`` — delta conversion and node-result
-  application per kind, plus a target-link alias table that
-  canonicalises through the bound target.
+- ``PythonTSDataOps`` (a type-layer struct the bridge instantiates) —
+  delta conversion and node-result application per family; a strategy
+  records its ``python_family`` and the bridge's
+  ``python_ts_data_ops_for`` maps it to the table (``none`` answers the
+  throwing default). The target-link table canonicalises through the
+  bound target's own family.
 - ``detail::TSDataOwnershipOps`` — owned-child enumeration used by the
   parent-attachment / stop / invalidate tree walkers.
 - ``TSDataInspectionOps`` — cold-path field metadata consumed when

--- a/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
@@ -136,9 +136,10 @@ The implementation uses the following names consistently:
     ``Output`` roles. Data and Output select mutable role-specific ops; an
     owned Input selects the corresponding physical plan under a read-only
     role, while peered positions select target-link storage and ops.
-    ``TS_DATA_OPS_ABI_VERSION`` is 14. ABI 14 (RFC 0035) records the
-    Python-authoring family a strategy uses (``python_family``) beside the
-    table pointer. ABI 13 (RFC 0035) makes the Python
+    ``TS_DATA_OPS_ABI_VERSION`` is 15. ABI 15 (RFC 0035) drops the
+    Python-authoring table pointer: a strategy records only its family and
+    the bridge maps it to the table. ABI 14 (RFC 0035) recorded that
+    family (``python_family``) beside the pointer. ABI 13 (RFC 0035) makes the Python
     slots unconditional -- typed on the opaque ``PyRef`` / ``PyNewRef`` and
     present in a Python-disabled build too, with ``PythonTSDataOps`` now a
     type-layer struct whose default is the throwing table -- so a table
@@ -485,7 +486,7 @@ TargetLink projection into producer-owned storage. The ownership table reports
 TargetLink trie/observer storage at the owning endpoint and traverses only
 owned children. This projection is private lifecycle infrastructure; it adds no
 storage-layout cost, and its ops-table ABI contribution is tracked by
-``TS_DATA_OPS_ABI_VERSION``, currently 14.
+``TS_DATA_OPS_ABI_VERSION``, currently 15.
 
 Fixed to-REF alternatives are the exception to the general legacy-alternative
 rule. Their allocation is owned through the canonical Data-role record. At the

--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -546,10 +546,10 @@ Value and reference crossings
   ``ValueCallable`` / ``WiredFn`` hook pairs the module installs) are in
   ``include/hgraph/python/scalar_conversions.h``. The
   ``type-layer-python-conditionals`` and ``type-layer-nanobind`` ratchets
-  measure what is left: the conversion bodies still beside their storage
-  (``*_slot<&fn>`` adapted) move to ``src/hgraph/python/impl/`` family by
-  family per the RFC's implementation plan. The compact and mutable
-  container conversions were the first to move
+  hold both counts at zero: every conversion body lives in
+  ``src/hgraph/python/impl/`` with its family, and the ``*_slot<&fn>``
+  adapters are what a bridge unit installs into the provider table. The
+  compact and mutable container conversions were the first to move
   (``src/hgraph/python/impl/container_conversions.cpp`` fills the
   ``Compact`` and ``Mutable`` sections; the bodies read only the public
   storage API and rebuild through the value builders, so no detail header
@@ -576,8 +576,9 @@ Value and reference crossings
   ``window_replace`` / ``window_push`` seams, which construct each element
   and hand the bridge the payload. A factory records its Python-authoring
   family on ``TSDataOps::python_family`` and the bridge maps it to the
-  table (``python_ts_data_ops_for``); a family still naming its table by
-  symbol keeps the pointer until it moves. The structured families --
+  table (``python_ts_data_ops_for``; ``none`` answers the throwing
+  default, and the table pointer is gone from ``TSDataOps`` since ABI 15).
+  The structured families --
   fixed TSB / TSL, dynamic TSL, slot-backed TSS / TSD and the TSD proxy --
   are in ``ts_data_structured_conversions.cpp``: children are reached
   through their own erased ``TSDataOps``, and the seams answer each
@@ -586,7 +587,18 @@ Value and reference crossings
   insert / remove key, child memory for write, record child modified);
   a per-surface value-ops slot (live / added / removed / modified) is a
   distinct provider entry selected at table construction, so the bridge
-  never branches on the surface per call.
+  never branches on the surface per call. The TS input facades are the
+  last family (``ts_input_conversions.cpp``): a non-peered TSB / TSL
+  input binding's endpoint-shape slots (``TSInputEndpointOps::to_python``
+  / ``delta_to_python``), its value and delta projections and the bound
+  target of a target link convert through the seams of
+  ``src/hgraph/types/time_series/detail/ts_input_seams.h``; the facade's
+  own ``TSDataOps`` slots stay in the type layer as Python-free dispatch
+  to the endpoint table, and a target link's authoring table
+  (``target_link_python_ts_data_ops``) canonicalises through the bound
+  target's family. With every body moved, ``include/hgraph/config.h`` no
+  longer forces the flag on for the IDE: the type layer compiles the same
+  headers in every preset.
 - **One set of Python-object value primitives** (2026-09-05):
   ``python_bridge::object_hash`` / ``object_equals`` / ``object_compare`` /
   ``object_str`` -- the contract in ``include/hgraph/python/object_semantics.h``,

--- a/docs/source/developer_guide/testing.rst
+++ b/docs/source/developer_guide/testing.rst
@@ -218,8 +218,8 @@ Each entry names the layer that owns the rule:
   ``HGRAPH_ENABLE_PYTHON_USER_NODES`` conditionals inside the type layer,
   and ``nanobind`` spelled inside the type layer (RFC 0035: the type layer
   names Python only through the opaque references of ``python_object.h``
-  and the ``PythonOps`` provider; both counts fall to zero family by
-  family);
+  and the ``PythonOps`` provider; both counts fell to zero family by
+  family and the ratchets hold them there);
 * ``thread_local`` in the runtime;
 * a bare ``catch (...)`` outside ``util/scope.h`` and the three documented
   translation boundaries -- an exception boundary without a name (see

--- a/docs/source/rfc/rfc_0035_python_free_type_layer.rst
+++ b/docs/source/rfc/rfc_0035_python_free_type_layer.rst
@@ -503,10 +503,24 @@ Performance and memory
 * Build time: one hash lookup per scalar type on its first conversion
   (once per process per ``T``); factories install forwarders.
 * Memory: ``PythonOps`` is one static table in the bridge unit.
-* Evidence: the ``tests/benchmarks`` operator and wiring scenarios and the
-  perf guard recorded for the 0.8.15 regression
-  (``perf-regression-0815``) run before and after PR 4, which moves the
-  hot TS data conversions.
+* Evidence (2026-09-06, PR 5): ``benchmarks/orchestrate.py --mode current``
+  on the twelve Python-boundary and TS-conversion scenarios (``tick_py``,
+  ``type_cs_py``, ``tsd_dense_py``, ``tsd_churn_py``, ``tsd_dense_std``,
+  ``python_generator_boundary``, ``python_sink_boundary``,
+  ``type_tsb_partial_fields_std``, ``tss_add_remove_std``,
+  ``tsd_dense_source_std``, ``reduce_tsd_python_combiner``,
+  ``service_reference_py``), Release wheels built from ``main`` at
+  52767e4e0 (PR 1 only, every body still beside its storage) and from the
+  PR 5 head, five fresh-process samples each, run back to back on an idle
+  Apple M4 Max. Every cell is equal within one sample's median absolute
+  deviation: ``tick_py`` 0.021 s / 0.021 s, ``tsd_dense_py`` 0.082 s /
+  0.080 s, ``tsd_churn_py`` 0.031 s / 0.031 s, ``python_sink_boundary``
+  0.013 s / 0.012 s, ``reduce_tsd_python_combiner`` 0.072 s / 0.069 s,
+  ``tsd_dense_std`` 0.093 s / 0.086 s; a three-sample confirmation pair
+  agrees. The extra forwarder hop is below the run-to-run noise of a
+  Python node tick. (A first three-sample run taken immediately after the
+  wheel build read 7--12 % slower on the Python-node scenarios and was
+  not reproducible; measure on an idle machine.)
 
 Installed-extension and ABI consequences
 ----------------------------------------

--- a/docs/source/rfc/rfc_0035_python_free_type_layer.rst
+++ b/docs/source/rfc/rfc_0035_python_free_type_layer.rst
@@ -1,7 +1,7 @@
 RFC 0035: A Python-Free Type Layer
 ==================================
 
-:Status: Proposed
+:Status: Accepted
 :Author: Howard Henson
 :Created: 2026-09-06
 :Target: ``include/hgraph/types/python_object.h`` (new),
@@ -488,8 +488,8 @@ Compatibility and migration
   PR. Extensions that used them switch to the free functions (one-line
   edits; listed in the release note).
 * **``config.h``.** The ``__JETBRAINS_IDE__`` override becomes unnecessary
-  for the type layer and is removed when the ratchet reaches zero; it
-  remains needed for nothing else.
+  for the type layer and is removed when the ratchet reaches zero (PR 5);
+  it remains needed for nothing else.
 * **Serialisation.** None affected.
 
 Performance and memory
@@ -623,7 +623,21 @@ Five PRs, each green on the full gate, each lowering the ratchet:
 Implementation status
 ---------------------
 
-Proposed. PR 4b (``hardening/python-ops-ts-structured``) moves the fixed
+Accepted (2026-09-06). PR 5 (``hardening/python-ops-ts-input``) moves
+the last family: the non-peered TSB / TSL input bindings' endpoint-shape
+slots, their value and delta projections and the bound target of a target
+link convert in ``src/hgraph/python/impl/ts_input_conversions.cpp``
+through the seams of ``src/hgraph/types/time_series/detail/ts_input_seams.h``;
+the facades' own ``TSDataOps`` slots stay Python-free dispatch to the
+endpoint-shape table. The target link's authoring table moves to the bridge
+(``target_link_python_ts_data_ops``, family ``target_link``, canonicalising
+through the bound target's family), which lets ``TSDataOps`` drop the
+authoring-table pointer (``TS_DATA_OPS_ABI_VERSION`` 14 → 15; ``none``
+answers the throwing default on the bridge). ``type-layer-python-conditionals``
+14 → 0 and ``type-layer-nanobind`` 35 → 0, both held at zero; the
+``config.h`` IDE override is removed.
+
+PR 4b (``hardening/python-ops-ts-structured``) moves the fixed
 TSB / TSL, dynamic TSL, slot-backed TSS / TSD and TSD-proxy conversions to
 ``src/hgraph/python/impl/ts_data_structured_conversions.cpp``. The seams
 of ``ts_data_seams.h`` answer each strategy's shape and mutation protocol

--- a/include/hgraph/config.h
+++ b/include/hgraph/config.h
@@ -2,15 +2,11 @@
 #define HGRAPH_CPP_ROOT_CONFIG_H
 
 /*
- * CLion's code model can grey out Python bridge code when the active
- * configure profile has HGRAPH_ENABLE_PYTHON_USER_NODES=0. Keep real
- * compiler builds controlled by CMake, but let JetBrains code insight
- * parse the bridge surface.
+ * Python user nodes are a CMake option; the type layer compiles the same
+ * headers either way (RFC 0035), so only the bridge units under
+ * src/hgraph/python and include/hgraph/python read this flag.
  */
-#if defined(__JETBRAINS_IDE__)
-#undef HGRAPH_ENABLE_PYTHON_USER_NODES
-#define HGRAPH_ENABLE_PYTHON_USER_NODES 1
-#elif !defined(HGRAPH_ENABLE_PYTHON_USER_NODES)
+#if !defined(HGRAPH_ENABLE_PYTHON_USER_NODES)
 #define HGRAPH_ENABLE_PYTHON_USER_NODES 0
 #endif
 

--- a/include/hgraph/python/ts_data_conversion.h
+++ b/include/hgraph/python/ts_data_conversion.h
@@ -24,8 +24,8 @@ namespace hgraph
         /** The table is ``hgraph::PythonTSDataOps`` (``ts_data/ops.h``); the
             bridge defines the per-family instances and the canonical throwing
             default is the type layer's ``ts_data_detail::missing_python_ts_data_ops``. */
-        /** The authoring table for a family a factory recorded on its ops
-            (RFC 0035); ``none`` answers the ops' own pointer. */
+        /** The authoring table for the family a factory recorded on its ops
+            (RFC 0035); ``none`` answers the throwing default. */
         [[nodiscard]] HGRAPH_EXPORT const PythonTSDataOps &python_ts_data_ops_for(const TSDataOps &ops) noexcept;
 
         /** Strategy tables installed by the corresponding TSData factories. */
@@ -36,6 +36,7 @@ namespace hgraph
         [[nodiscard]] HGRAPH_EXPORT const PythonTSDataOps &list_python_ts_data_ops() noexcept;
         [[nodiscard]] HGRAPH_EXPORT const PythonTSDataOps &bundle_python_ts_data_ops() noexcept;
         [[nodiscard]] HGRAPH_EXPORT const PythonTSDataOps &window_python_ts_data_ops() noexcept;
+        [[nodiscard]] HGRAPH_EXPORT const PythonTSDataOps &target_link_python_ts_data_ops() noexcept;
 
         /** Convert a Python-authored value into an owned canonical/authored delta. */
         [[nodiscard]] HGRAPH_EXPORT Value delta_from_python(

--- a/include/hgraph/types/python_ops.h
+++ b/include/hgraph/types/python_ops.h
@@ -185,6 +185,21 @@ namespace hgraph
             ToPythonFn      proxy_map_added_to_python{nullptr};
             ToPythonFn      proxy_map_removed_to_python{nullptr};
             ToPythonFn      proxy_map_modified_to_python{nullptr};
+            // non-peered TSB / TSL input bindings (the endpoint-shape slots of
+            // ts_input/detail.h) and their value / delta projections; the
+            // bridge reaches the binding through
+            // src/hgraph/types/time_series/detail/ts_input_seams.h
+            ToPythonFn      input_bundle_to_python{nullptr};
+            DeltaToPythonFn input_bundle_delta_to_python{nullptr};
+            ToPythonFn      input_list_to_python{nullptr};
+            DeltaToPythonFn input_list_delta_to_python{nullptr};
+            ToPythonFn      input_value_projection_to_python{nullptr};
+            ToPythonFn      input_delta_bundle_to_python{nullptr};
+            ToPythonFn      input_delta_map_to_python{nullptr};
+            ToPythonFn      input_delta_key_set_to_python{nullptr};
+            // a target link: the bound target output's value / delta
+            ToPythonFn      target_link_to_python{nullptr};
+            DeltaToPythonFn target_link_delta_to_python{nullptr};
         } ts_data;
 
         /** The retained-object cache of a ``NativeWithPythonCache`` output:

--- a/include/hgraph/types/time_series/ts_data/ops.h
+++ b/include/hgraph/types/time_series/ts_data/ops.h
@@ -43,10 +43,12 @@ namespace hgraph
      * collection-specific semantics (for example TSS set-vs-frozenset and
      * strict TSD removals) that are not replacement assignment.
      *
-     * Concrete TSData factories select this passive table once. Python
-     * bridge callers dispatch through it and must not reconstruct a TS
-     * shape by switching on ``TSTypeKind``. The default is the canonical
-     * throwing table, never null, so callers dispatch without null branching.
+     * A concrete TSData factory records which table it uses as its
+     * ``python_family``; the bridge maps the family to the table
+     * (``python_ts_data_ops_for``) and dispatches through it, never
+     * reconstructing a TS shape by switching on ``TSTypeKind``. A strategy
+     * that recorded no family answers the canonical throwing table, so
+     * callers dispatch without null branching.
      */
     /** Which of the bridge's Python-authoring tables a TSData strategy uses
         (RFC 0035): recorded by the factory, mapped to the table by the bridge.
@@ -324,11 +326,8 @@ namespace hgraph
             void *memory,
             std::size_t index) = &ts_data_detail::missing_mutable_indexed_element_memory;
         bool indexed_child_growth{false};
-        // Python authoring is a separately selected erased policy. It must
-        // remain non-null so callers dispatch without kind/null branching.
-        const PythonTSDataOps *python_ops{&ts_data_detail::missing_python_ts_data_ops()};
-        /** The bridge's authoring table for this family; ``none`` defers to
-            ``python_ops`` (the families still naming a table by symbol). */
+        /** The bridge's Python-authoring table for this strategy (RFC 0035);
+            ``none`` answers the throwing default. */
         PythonTSDataFamily python_family{PythonTSDataFamily::none};
         // Required for every representation that can reach a Python-authored
         // node. Structural strategies recurse through each child's TSDataOps;

--- a/include/hgraph/types/time_series/ts_type_ref.h
+++ b/include/hgraph/types/time_series/ts_type_ref.h
@@ -15,7 +15,7 @@ namespace hgraph
     struct TSDataOps;
     struct TSParentLink;
 
-    inline constexpr std::uint16_t TS_DATA_OPS_ABI_VERSION = 14;
+    inline constexpr std::uint16_t TS_DATA_OPS_ABI_VERSION = 15;
 
     class HGRAPH_CLASS_EXPORT TSRoleTypeRef
     {

--- a/python/tests/test_architecture_ratchets.py
+++ b/python/tests/test_architecture_ratchets.py
@@ -178,24 +178,24 @@ RATCHETS: tuple[Ratchet, ...] = (
     ),
     Ratchet(
         id="type-layer-python-conditionals",
-        baseline=14,
+        baseline=0,
         roots=("src/hgraph/types", "include/hgraph/types"),
         suffixes=(".cpp", ".h"),
         pattern=r"HGRAPH_ENABLE_PYTHON_USER_NODES",
         owner="the type layer sees Python only through registered ops tables "
         "(python_bridge.rst, 'No kind-switches in conversion'); RFC 0035 "
-        "takes this to zero family by family",
+        "took this to zero family by family and the ratchet holds it there",
     ),
     Ratchet(
         id="type-layer-nanobind",
-        baseline=35,
+        baseline=0,
         roots=("src/hgraph/types", "include/hgraph/types"),
         suffixes=(".cpp", ".h"),
         pattern=r"nanobind|\bnb::",
         owner="the type layer names Python only through the opaque PyRef / "
         "PyNewRef of python_object.h and the PythonOps provider of "
-        "python_ops.h (RFC 0035); conversion bodies that still spell "
-        "nanobind move to src/hgraph/python/impl/ with their family",
+        "python_ops.h (RFC 0035); a conversion body that spells nanobind "
+        "belongs in src/hgraph/python/impl/ with its family",
     ),
     # --- One lifecycle path per Python node kind (family 7) ---
     Ratchet(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -105,6 +105,7 @@ if(HGRAPH_BUILD_PYTHON_BINDINGS OR HGRAPH_ENABLE_PYTHON_USER_NODES)
         hgraph/python/impl/retained_value.cpp
         hgraph/python/impl/ts_data_family_conversions.cpp
         hgraph/python/impl/ts_data_structured_conversions.cpp
+        hgraph/python/impl/ts_input_conversions.cpp
         hgraph/python/impl/ts_data_conversion.cpp
     )
 endif()

--- a/src/hgraph/python/impl/python_ops.cpp
+++ b/src/hgraph/python/impl/python_ops.cpp
@@ -169,6 +169,7 @@ namespace hgraph::python_bridge
                 fill_realized_conversions(ops.realized);
                 fill_ts_data_conversions(ops.ts_data);
                 fill_structured_ts_data_conversions(ops.ts_data);
+                fill_ts_input_conversions(ops.ts_data);
                 fill_retained_conversions(ops.retained);
                 return ops;
             }();

--- a/src/hgraph/python/impl/python_ops_families.h
+++ b/src/hgraph/python/impl/python_ops_families.h
@@ -16,6 +16,7 @@ namespace hgraph::python_bridge
     void fill_realized_conversions(PythonOps::Realized &section) noexcept;
     void fill_ts_data_conversions(PythonOps::TSData &section) noexcept;
     void fill_structured_ts_data_conversions(PythonOps::TSData &section) noexcept;
+    void fill_ts_input_conversions(PythonOps::TSData &section) noexcept;
     void fill_retained_conversions(PythonOps::Retained &section) noexcept;
 }  // namespace hgraph::python_bridge
 

--- a/src/hgraph/python/impl/ts_data_conversion.cpp
+++ b/src/hgraph/python/impl/ts_data_conversion.cpp
@@ -1,5 +1,7 @@
 #include <hgraph/python/ts_data_conversion.h>
 
+#include "../../types/time_series/detail/ts_input_seams.h"
+
 #include <hgraph/python/bridge_state.h>
 #include <hgraph/python/conversion.h>
 #include <hgraph/types/metadata/ts_data_plan_factory.h>
@@ -822,8 +824,8 @@ namespace hgraph::python_bridge
     const PythonTSDataOps &python_ts_data_ops_for(const TSDataOps &ops) noexcept
     {
         // A table lookup by the family the factory recorded, on the bridge;
-        // a family still naming its table by symbol answers through the
-        // pointer, which is never null (the type layer's throwing default).
+        // a strategy that recorded none answers the type layer's throwing
+        // default, so callers dispatch without null branching.
         switch (ops.python_family)
         {
             case PythonTSDataFamily::atomic: return atomic_python_ts_data_ops();
@@ -833,10 +835,10 @@ namespace hgraph::python_bridge
             case PythonTSDataFamily::list: return list_python_ts_data_ops();
             case PythonTSDataFamily::bundle: return bundle_python_ts_data_ops();
             case PythonTSDataFamily::window: return window_python_ts_data_ops();
-            case PythonTSDataFamily::target_link:
+            case PythonTSDataFamily::target_link: return target_link_python_ts_data_ops();
             case PythonTSDataFamily::none: break;
         }
-        return *ops.python_ops;
+        return ts_data_detail::missing_python_ts_data_ops();
     }
 
     const PythonTSDataOps &atomic_python_ts_data_ops() noexcept
@@ -905,6 +907,46 @@ namespace hgraph::python_bridge
             .requires_authored_delta_impl = &ts_requires_authored_slot<&never_requires_authored>,
             .delta_from_python_impl = &ts_delta_from_python_slot<&window_delta_from_python>,
             .apply_result_impl = &ts_apply_result_slot<&apply_delta_result>,
+        };
+        return ops;
+    }
+
+    // -- target links: authoring lands on the bound target through the
+    //    target's own family; the link's canonical data type selects it.
+    namespace
+    {
+        [[nodiscard]] TSRoleTypeRef target_link_canonical_data_type(TSRoleTypeRef type)
+        {
+            if (type.schema() == nullptr)
+            {
+                throw std::logic_error("target-link Python conversion requires a resolved schema");
+            }
+            return TSDataPlanFactory::instance().data_type_for(type.schema()).as_role();
+        }
+
+        [[nodiscard]] bool target_link_requires_authored_delta(TSRoleTypeRef type, nb::handle source)
+        {
+            return requires_authored(target_link_canonical_data_type(type), source);
+        }
+
+        [[nodiscard]] Value target_link_delta_from_python(TSRoleTypeRef type, nb::handle source, bool authored)
+        {
+            return build_delta(target_link_canonical_data_type(type), source, authored);
+        }
+
+        void target_link_apply_python_result(const TSOutputView &output, nb::handle result)
+        {
+            const auto &ops = output.data_view().ops();
+            apply_python_result(ts_input_seams::target_link_delta_target(ops.context, output), result);
+        }
+    }  // namespace
+
+    const PythonTSDataOps &target_link_python_ts_data_ops() noexcept
+    {
+        static const PythonTSDataOps ops{
+            .requires_authored_delta_impl = &ts_requires_authored_slot<&target_link_requires_authored_delta>,
+            .delta_from_python_impl       = &ts_delta_from_python_slot<&target_link_delta_from_python>,
+            .apply_result_impl            = &ts_apply_result_slot<&target_link_apply_python_result>,
         };
         return ops;
     }

--- a/src/hgraph/python/impl/ts_input_conversions.cpp
+++ b/src/hgraph/python/impl/ts_input_conversions.cpp
@@ -1,0 +1,156 @@
+#include "python_ops_families.h"
+
+#include "../../types/time_series/detail/ts_input_seams.h"
+
+#include <hgraph/python/bridge_state.h>
+#include <hgraph/python/conversion.h>
+#include <hgraph/types/metadata/ts_value_type_meta_data.h>
+#include <hgraph/types/time_series/ts_data/ops.h>
+#include <hgraph/types/value/value.h>
+
+#include <nanobind/nanobind.h>
+
+#include <cstddef>
+#include <utility>
+
+/**
+ * TS input facades <-> Python (RFC 0035, PR 5): the non-peered TSB / TSL
+ * input bindings' endpoint-shape slots and value / delta projections, and
+ * the bound target of a target link. Children are reached through their own
+ * erased TSDataOps; the binding's shape comes through ``ts_input_seams.h``.
+ * Each body keeps the semantics it had beside its facade.
+ */
+namespace hgraph::python_bridge
+{
+    namespace
+    {
+        namespace seams = ts_input_seams;
+
+        [[nodiscard]] nb::object child_value_to_python(TSRoleTypeRef type, const void *memory)
+        {
+            if (!type || memory == nullptr) { return nb::none(); }
+            const auto &ops = *type.ops();
+            if (!ops.has_current_value_impl(ops.context, memory)) { return nb::none(); }
+            return take(ops.to_python_impl(ops.context, memory));
+        }
+
+        [[nodiscard]] nb::object child_delta_to_python(TSRoleTypeRef type, const void *memory, DateTime evaluation_time)
+        {
+            if (!type || memory == nullptr) { return nb::none(); }
+            const auto &ops      = *type.ops();
+            const auto *tracking = ops.tracking_impl(ops.context, memory);
+            if (tracking == nullptr || tracking->last_modified_time != evaluation_time) { return nb::none(); }
+            return take(ops.delta_to_python_impl(ops.context, memory, evaluation_time));
+        }
+
+        // -- endpoint shapes -----------------------------------------------------------
+        [[nodiscard]] nb::object input_bundle_to_python(const void *context, const void *memory)
+        {
+            const auto &schema = seams::input_schema(context);
+            nb::dict    result;
+            for (std::size_t index = 0, count = seams::input_child_count(context); index < count; ++index)
+            {
+                const auto &field = schema.fields()[index];
+                if (field.name == nullptr) { continue; }
+                result[nb::str{field.name}] = child_value_to_python(seams::input_child_type(context, memory, index),
+                                                                    seams::input_child_memory(context, memory, index));
+            }
+            return materialize_tsb_python_value(&schema, std::move(result));
+        }
+
+        [[nodiscard]] nb::object input_list_to_python(const void *context, const void *memory)
+        {
+            nb::list result;
+            for (std::size_t index = 0, count = seams::input_child_count(context); index < count; ++index)
+            {
+                result.append(child_value_to_python(seams::input_child_type(context, memory, index),
+                                                    seams::input_child_memory(context, memory, index)));
+            }
+            return nb::tuple(result);
+        }
+
+        [[nodiscard]] nb::object input_bundle_delta_to_python(const void *context, const void *memory,
+                                                              DateTime evaluation_time)
+        {
+            const auto &schema = seams::input_schema(context);
+            nb::dict    result;
+            for (std::size_t index = 0, count = seams::input_child_count(context); index < count; ++index)
+            {
+                const auto &field = schema.fields()[index];
+                if (field.name == nullptr) { continue; }
+                auto child_delta = child_delta_to_python(seams::input_child_type(context, memory, index),
+                                                         seams::input_child_memory(context, memory, index),
+                                                         evaluation_time);
+                if (!child_delta.is_none()) { result[nb::str{field.name}] = child_delta; }
+            }
+            return result;
+        }
+
+        [[nodiscard]] nb::object input_list_delta_to_python(const void *context, const void *memory,
+                                                            DateTime evaluation_time)
+        {
+            nb::dict result;
+            for (std::size_t index = 0, count = seams::input_child_count(context); index < count; ++index)
+            {
+                auto child_delta = child_delta_to_python(seams::input_child_type(context, memory, index),
+                                                         seams::input_child_memory(context, memory, index),
+                                                         evaluation_time);
+                if (!child_delta.is_none()) { result[nb::int_{index}] = child_delta; }
+            }
+            return result;
+        }
+
+        // -- value / delta projections -------------------------------------------------
+        // Projection storage is materialised exclusively through its erased
+        // owning-type and copy hooks; converting the snapshot keeps ValueOps
+        // complete without teaching the caller which endpoint produced it.
+        [[nodiscard]] nb::object input_value_projection_to_python(const void *context, const void *memory)
+        {
+            return to_python(Value{ValueView{seams::input_value_binding(context), memory}});
+        }
+
+        [[nodiscard]] nb::object input_delta_projection_to_python(const void *context, const void *memory)
+        {
+            return to_python(Value{ValueView{seams::input_delta_binding(context), memory}});
+        }
+
+        [[nodiscard]] nb::object input_delta_key_set_to_python(const void *context, const void *memory)
+        {
+            nb::set result;
+            for (std::size_t index = 0, count = seams::input_child_count(context); index < count; ++index)
+            {
+                if (seams::input_child_modified(context, memory, index))
+                {
+                    result.add(nb::int_{seams::input_list_ordinal_key(context, index)});
+                }
+            }
+            return result;
+        }
+
+        // -- target links ----------------------------------------------------------------
+        [[nodiscard]] nb::object target_link_to_python(const void *context, const void *memory)
+        {
+            return value_to_python(seams::target_link_target_view(context, memory));
+        }
+
+        [[nodiscard]] nb::object target_link_delta_to_python(const void *context, const void *memory,
+                                                             DateTime evaluation_time)
+        {
+            return delta_value_to_python(seams::target_link_target_view(context, memory), evaluation_time);
+        }
+    }  // namespace
+
+    void fill_ts_input_conversions(PythonOps::TSData &section) noexcept
+    {
+        section.input_bundle_to_python           = &to_python_slot<&input_bundle_to_python>;
+        section.input_bundle_delta_to_python     = &ts_delta_to_python_slot<&input_bundle_delta_to_python>;
+        section.input_list_to_python             = &to_python_slot<&input_list_to_python>;
+        section.input_list_delta_to_python       = &ts_delta_to_python_slot<&input_list_delta_to_python>;
+        section.input_value_projection_to_python = &to_python_slot<&input_value_projection_to_python>;
+        section.input_delta_bundle_to_python     = &to_python_slot<&input_delta_projection_to_python>;
+        section.input_delta_map_to_python        = &to_python_slot<&input_delta_projection_to_python>;
+        section.input_delta_key_set_to_python    = &to_python_slot<&input_delta_key_set_to_python>;
+        section.target_link_to_python            = &to_python_slot<&target_link_to_python>;
+        section.target_link_delta_to_python      = &ts_delta_to_python_slot<&target_link_delta_to_python>;
+    }
+}  // namespace hgraph::python_bridge

--- a/src/hgraph/types/time_series/detail/ts_input_seams.h
+++ b/src/hgraph/types/time_series/detail/ts_input_seams.h
@@ -1,0 +1,56 @@
+#ifndef HGRAPH_TYPES_TIME_SERIES_DETAIL_TS_INPUT_SEAMS_H
+#define HGRAPH_TYPES_TIME_SERIES_DETAIL_TS_INPUT_SEAMS_H
+
+#include <hgraph/types/time_series/ts_data/base_view.h>
+#include <hgraph/types/time_series/ts_input/detail.h>
+#include <hgraph/types/time_series/ts_type_ref.h>
+#include <hgraph/types/value/value_type_ref.h>
+
+#include <cstddef>
+#include <cstdint>
+
+/**
+ * Private seams of the TS input facades (RFC 0035, PR 5): what the bridge's
+ * ``ts_input_conversions.cpp`` needs from a non-peered TSB / TSL input
+ * binding and from a target link, with no Python in it. The binding context
+ * and the link storage stay private to ``ts_input.cpp`` and
+ * ``ts_input/target_link_ops.cpp``; the bridge converts what the seams
+ * answer. Private to ``hgraph_runtime``.
+ */
+namespace hgraph
+{
+    class TSOutputView;
+    struct TSValueTypeMetaData;
+}  // namespace hgraph
+
+namespace hgraph::ts_input_seams
+{
+    // -- non-peered TSB / TSL input bindings (ts_input.cpp) ---------------------
+    // ``context`` is the binding context the facade's ops carry. Children are
+    // reached through their own erased TSDataOps (``input_child_type``); a
+    // bound target-link child answers the target output's storage type and
+    // memory, an owned child its local storage.
+    [[nodiscard]] const TSValueTypeMetaData &input_schema(const void *context) noexcept;
+    /** The endpoint-shape table (its ``to_python`` / ``delta_to_python`` slots). */
+    [[nodiscard]] const detail::TSInputEndpointOps &input_endpoint_ops(const void *context) noexcept;
+    /** The value-projection binding (what the ``to_python`` value slot converts). */
+    [[nodiscard]] ValueTypeRef input_value_binding(const void *context) noexcept;
+    /** The delta-projection binding (the TSB delta bundle / TSL delta map). */
+    [[nodiscard]] ValueTypeRef input_delta_binding(const void *context) noexcept;
+    [[nodiscard]] std::size_t input_child_count(const void *context) noexcept;
+    [[nodiscard]] TSRoleTypeRef input_child_type(const void *context, const void *memory, std::size_t index) noexcept;
+    [[nodiscard]] const void *input_child_memory(const void *context, const void *memory, std::size_t index) noexcept;
+    /** True when child ``index`` was modified at the parent's last modified time. */
+    [[nodiscard]] bool input_child_modified(const void *context, const void *memory, std::size_t index);
+    /** The TSL delta's ordinal key for child ``index``. */
+    [[nodiscard]] std::int64_t input_list_ordinal_key(const void *context, std::size_t index) noexcept;
+
+    // -- target links (ts_input/target_link_ops.cpp) ----------------------------
+    /** The bound target output's data view, or an empty view when unbound. */
+    [[nodiscard]] TSDataView target_link_target_view(const void *context, const void *memory);
+    /** The target output a delta applied through the link lands on (the
+        write-through of ``apply_delta``); throws when the link is unbound. */
+    [[nodiscard]] TSOutputView target_link_delta_target(const void *context, const TSOutputView &output);
+}  // namespace hgraph::ts_input_seams
+
+#endif  // HGRAPH_TYPES_TIME_SERIES_DETAIL_TS_INPUT_SEAMS_H

--- a/src/hgraph/types/time_series/ts_input.cpp
+++ b/src/hgraph/types/time_series/ts_input.cpp
@@ -20,10 +20,8 @@
 #include <hgraph/types/value/value_builder.h>
 #include <hgraph/util/scope.h>
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-#include <hgraph/python/bridge_state.h>
-#include <hgraph/python/conversion.h>
-#endif
+#include "detail/ts_input_seams.h"
+#include <hgraph/types/python_ops.h>
 
 #include <algorithm>
 #include <array>
@@ -335,16 +333,11 @@ namespace hgraph
             return TimeSeriesReference::non_peered(schema, std::move(items));
         }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-        [[nodiscard]] nb::object input_tsb_to_python(const void *context, const void *memory);
-        [[nodiscard]] nb::object input_tsl_to_python(const void *context, const void *memory);
-        [[nodiscard]] nb::object input_tsb_delta_to_python(const void *context,
-                                                           const void *memory,
-                                                           DateTime evaluation_time);
-        [[nodiscard]] nb::object input_tsl_delta_to_python(const void *context,
-                                                           const void *memory,
-                                                           DateTime evaluation_time);
-#endif
+        /** The endpoint-shape and projection Python slots are provider
+            forwarders (RFC 0035): the bridge's ``ts_input_conversions.cpp``
+            converts through the seams of ``detail/ts_input_seams.h``. */
+        template <auto Member>
+        constexpr auto python_forwarder = &python_ops_detail::forwarder<Member>::call;
 
         const detail::TSInputEndpointOps endpoint_ts_ops{
             .name = "TS",
@@ -387,10 +380,8 @@ namespace hgraph
             .child_schema = &tsl_endpoint_child_schema,
             .target_child = &tsl_target_child_at,
             .reference = &input_tsl_reference,
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-            .to_python = &python_bridge::to_python_slot<&input_tsl_to_python>,
-            .delta_to_python = &python_bridge::ts_delta_to_python_slot<&input_tsl_delta_to_python>,
-#endif
+            .to_python = python_forwarder<&PythonOps::TSData::input_list_to_python>,
+            .delta_to_python = python_forwarder<&PythonOps::TSData::input_list_delta_to_python>,
         };
 
         const detail::TSInputEndpointOps endpoint_tsw_ops{
@@ -414,10 +405,8 @@ namespace hgraph
             .child_schema = &tsb_endpoint_child_schema,
             .target_child = &tsb_target_child_at,
             .reference = &input_tsb_reference,
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-            .to_python = &python_bridge::to_python_slot<&input_tsb_to_python>,
-            .delta_to_python = &python_bridge::ts_delta_to_python_slot<&input_tsb_delta_to_python>,
-#endif
+            .to_python = python_forwarder<&PythonOps::TSData::input_bundle_to_python>,
+            .delta_to_python = python_forwarder<&PythonOps::TSData::input_bundle_delta_to_python>,
         };
 
         const detail::TSInputEndpointOps endpoint_ref_ops{
@@ -1850,92 +1839,10 @@ namespace hgraph
             *static_cast<SetStorage *>(dst) = build_input_delta_key_set_storage(context, binding, memory);
         }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-        [[nodiscard]] nb::object input_delta_bundle_value_to_python(const void *context, const void *memory)
-        {
-            const auto *state = static_cast<const InputBindingContext *>(context);
-            return python_bridge::to_python(Value{ValueView{state->delta_binding, memory}});
-        }
-
-        [[nodiscard]] nb::object input_delta_map_value_to_python(const void *context, const void *memory)
-        {
-            const auto *state = static_cast<const InputBindingContext *>(context);
-            return python_bridge::to_python(Value{ValueView{state->delta_binding, memory}});
-        }
-
-        [[nodiscard]] nb::object input_value_projection_to_python(const void *context,
-                                                                   const void *memory)
-        {
-            const auto *state = static_cast<const InputBindingContext *>(context);
-            // Projection storage is materialised exclusively through its
-            // erased owning-type and copy hooks. This keeps ValueOps complete
-            // without teaching the caller which structural endpoint produced it.
-            return python_bridge::to_python(Value{ValueView{state->value_binding, memory}});
-        }
-
-        [[nodiscard]] nb::object input_delta_key_set_to_python(const void *context, const void *memory)
-        {
-            const auto *state = static_cast<const InputBindingContext *>(context);
-            const auto &delta = state->delta.list();
-            nb::set result;
-            for (std::size_t index = 0; index < state->children.size(); ++index)
-            {
-                if (input_child_modified_for_parent_time(context, memory, index))
-                {
-                    result.add(nb::int_{delta.ordinal_keys[index]});
-                }
-            }
-            return result;
-        }
-
-        [[nodiscard]] nb::object child_value_to_python(TSRoleTypeRef type, const void *memory)
-        {
-            if (!type || memory == nullptr) { return nb::none(); }
-            const auto &ops = *type.ops();
-            if (!ops.has_current_value_impl(ops.context, memory)) { return nb::none(); }
-            return python_bridge::take(ops.to_python_impl(ops.context, memory));
-        }
-
-        [[nodiscard]] nb::object child_delta_to_python(TSRoleTypeRef type,
-                                                       const void          *memory,
-                                                       DateTime        evaluation_time)
-        {
-            if (!type || memory == nullptr) { return nb::none(); }
-            const auto &ops = *type.ops();
-            const auto *tracking = ops.tracking_impl(ops.context, memory);
-            if (tracking == nullptr || tracking->last_modified_time != evaluation_time) { return nb::none(); }
-            return python_bridge::take(ops.delta_to_python_impl(ops.context, memory, evaluation_time));
-        }
-
-        [[nodiscard]] nb::object input_tsb_to_python(const void *context, const void *memory)
-        {
-            const auto *state = static_cast<const InputBindingContext *>(context);
-            nb::dict result;
-            for (std::size_t index = 0; index < state->children.size(); ++index)
-            {
-                const auto &field = state->schema->fields()[index];
-                if (field.name == nullptr) { continue; }
-                result[nb::str{field.name}] =
-                    child_value_to_python(input_value_storage_type(context, memory, index),
-                                          input_element_memory(context, memory, index));
-            }
-            return python_bridge::materialize_tsb_python_value(
-                state->schema, std::move(result));
-        }
-
-        [[nodiscard]] nb::object input_tsl_to_python(const void *context, const void *memory)
-        {
-            const auto *state = static_cast<const InputBindingContext *>(context);
-            nb::list result;
-            for (std::size_t index = 0; index < state->children.size(); ++index)
-            {
-                result.append(child_value_to_python(input_value_storage_type(context, memory, index),
-                                                    input_element_memory(context, memory, index)));
-            }
-            return nb::tuple(result);
-        }
-
-        [[nodiscard]] nb::object input_to_python(const void *context, const void *memory)
+        /** The facade's own Python slots dispatch to the endpoint-shape table
+            (TSB or TSL); the slots there are provider forwarders, so this is
+            Python-free (opaque references, RFC 0035). */
+        [[nodiscard]] PyNewRef input_to_python(const void *context, const void *memory)
         {
             const auto *state = static_cast<const InputBindingContext *>(context);
             const auto &endpoint_ops = *state->endpoint_ops;
@@ -1943,46 +1850,12 @@ namespace hgraph
             {
                 throw std::logic_error("TSInput non-peered to_python is not available for this endpoint shape");
             }
-            return python_bridge::take(endpoint_ops.to_python(context, memory));
+            return endpoint_ops.to_python(context, memory);
         }
 
-        [[nodiscard]] nb::object input_tsb_delta_to_python(const void *context,
-                                                           const void *memory,
-                                                           DateTime evaluation_time)
-        {
-            const auto *state = static_cast<const InputBindingContext *>(context);
-            nb::dict result;
-            for (std::size_t index = 0; index < state->children.size(); ++index)
-            {
-                const auto &field = state->schema->fields()[index];
-                if (field.name == nullptr) { continue; }
-                auto child_delta = child_delta_to_python(input_value_storage_type(context, memory, index),
-                                                         input_element_memory(context, memory, index),
-                                                         evaluation_time);
-                if (!child_delta.is_none()) { result[nb::str{field.name}] = child_delta; }
-            }
-            return result;
-        }
-
-        [[nodiscard]] nb::object input_tsl_delta_to_python(const void *context,
-                                                           const void *memory,
-                                                           DateTime evaluation_time)
-        {
-            const auto *state = static_cast<const InputBindingContext *>(context);
-            nb::dict result;
-            for (std::size_t index = 0; index < state->children.size(); ++index)
-            {
-                auto child_delta = child_delta_to_python(input_value_storage_type(context, memory, index),
-                                                         input_element_memory(context, memory, index),
-                                                         evaluation_time);
-                if (!child_delta.is_none()) { result[nb::int_{index}] = child_delta; }
-            }
-            return result;
-        }
-
-        [[nodiscard]] nb::object input_delta_to_python(const void *context,
-                                                       const void *memory,
-                                                       DateTime evaluation_time)
+        [[nodiscard]] PyNewRef input_delta_to_python(const void *context,
+                                                     const void *memory,
+                                                     DateTime evaluation_time)
         {
             const auto *state = static_cast<const InputBindingContext *>(context);
             const auto &endpoint_ops = *state->endpoint_ops;
@@ -1990,9 +1863,8 @@ namespace hgraph
             {
                 throw std::logic_error("TSInput non-peered delta_to_python is not available for this endpoint shape");
             }
-            return python_bridge::take(endpoint_ops.delta_to_python(context, memory, evaluation_time));
+            return endpoint_ops.delta_to_python(context, memory, evaluation_time);
         }
-#endif
 
         [[nodiscard]] const TSDataOps &target_link_ops_for(const TSEndpointSchema         &endpoint_schema,
                                                            const MemoryUtils::StoragePlan &root_plan,
@@ -2179,10 +2051,8 @@ namespace hgraph
                 {ValueOpsKind::Indexed, context.get(), false, &input_value_hash, &input_value_equals,
                  &input_value_compare,
                  &input_value_to_string
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
                  ,
-                 &python_bridge::to_python_slot<&input_value_projection_to_python>
-#endif
+                  python_forwarder<&PythonOps::TSData::input_value_projection_to_python>
                 },
                 &input_indexed_size,
                 &input_value_element_at,
@@ -2211,10 +2081,8 @@ namespace hgraph
                 delta.ops = IndexedValueOps{
                     {ValueOpsKind::Indexed, context.get(), false, &input_delta_bundle_hash, &input_delta_bundle_equals,
                      &input_delta_bundle_compare, &input_delta_bundle_to_string
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
                      ,
-                     &python_bridge::to_python_slot<&input_delta_bundle_value_to_python>
-#endif
+                      python_forwarder<&PythonOps::TSData::input_delta_bundle_to_python>
                     },
                     &input_indexed_size,
                     &input_delta_bundle_element_at,
@@ -2240,10 +2108,8 @@ namespace hgraph
                 delta.map_ops = MapValueOps{
                     {{ValueOpsKind::Map, context.get(), false, &input_delta_map_hash, &input_delta_map_equals,
                       &input_delta_map_compare, &input_delta_map_to_string
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
                       ,
-                      &python_bridge::to_python_slot<&input_delta_map_value_to_python>
-#endif
+                       python_forwarder<&PythonOps::TSData::input_delta_map_to_python>
                      },
                      &input_delta_map_size,
                      &input_delta_map_key_at_index,
@@ -2266,10 +2132,8 @@ namespace hgraph
                 delta.key_set_ops = SetValueOps{
                     {{ValueOpsKind::Set, context.get(), false, &input_delta_key_set_hash, &input_delta_key_set_equals,
                       &input_delta_key_set_compare, &input_delta_key_set_to_string
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
                       ,
-                      &python_bridge::to_python_slot<&input_delta_key_set_to_python>
-#endif
+                       python_forwarder<&PythonOps::TSData::input_delta_key_set_to_python>
                      },
                      &input_delta_map_size,
                      &input_delta_map_key_at_index,
@@ -2316,10 +2180,8 @@ namespace hgraph
                 .indexed_child_binding_impl = &input_value_storage_type,
                 .indexed_child_memory_impl = &input_element_memory,
                 .mutable_indexed_child_memory_impl = &input_mutable_element_memory,
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-                .to_python_impl = &python_bridge::to_python_slot<&input_to_python>,
-                .delta_to_python_impl = &python_bridge::ts_delta_to_python_slot<&input_delta_to_python>,
-#endif
+                .to_python_impl = &input_to_python,
+                .delta_to_python_impl = &input_delta_to_python,
             };
             context->ts_data_ops.size_impl = &input_indexed_size;
             context->ts_data_ops.element_binding_impl = &input_value_storage_type;
@@ -3196,3 +3058,51 @@ namespace hgraph
     }
 
 }  // namespace hgraph
+
+namespace hgraph::ts_input_seams
+{
+    const TSValueTypeMetaData &input_schema(const void *context) noexcept
+    {
+        return *static_cast<const InputBindingContext *>(context)->schema;
+    }
+
+    const detail::TSInputEndpointOps &input_endpoint_ops(const void *context) noexcept
+    {
+        return *static_cast<const InputBindingContext *>(context)->endpoint_ops;
+    }
+
+    ValueTypeRef input_value_binding(const void *context) noexcept
+    {
+        return static_cast<const InputBindingContext *>(context)->value_binding;
+    }
+
+    ValueTypeRef input_delta_binding(const void *context) noexcept
+    {
+        return static_cast<const InputBindingContext *>(context)->delta_binding;
+    }
+
+    std::size_t input_child_count(const void *context) noexcept
+    {
+        return static_cast<const InputBindingContext *>(context)->children.size();
+    }
+
+    TSRoleTypeRef input_child_type(const void *context, const void *memory, std::size_t index) noexcept
+    {
+        return input_value_storage_type(context, memory, index);
+    }
+
+    const void *input_child_memory(const void *context, const void *memory, std::size_t index) noexcept
+    {
+        return input_element_memory(context, memory, index);
+    }
+
+    bool input_child_modified(const void *context, const void *memory, std::size_t index)
+    {
+        return input_child_modified_for_parent_time(context, memory, index);
+    }
+
+    std::int64_t input_list_ordinal_key(const void *context, std::size_t index) noexcept
+    {
+        return static_cast<const InputBindingContext *>(context)->delta.list().ordinal_keys[index];
+    }
+}  // namespace hgraph::ts_input_seams

--- a/src/hgraph/types/time_series/ts_input/target_link_ops.cpp
+++ b/src/hgraph/types/time_series/ts_input/target_link_ops.cpp
@@ -7,11 +7,8 @@
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/value/value.h>
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-#include <hgraph/python/ts_data_conversion.h>
-#include <hgraph/python/conversion.h>
-#include <hgraph/types/metadata/ts_data_plan_factory.h>
-#endif
+#include "../detail/ts_input_seams.h"
+#include <hgraph/types/python_ops.h>
 
 #include <array>
 #include <memory>
@@ -1133,23 +1130,6 @@ namespace hgraph::detail
             throw std::logic_error("TSInput target-link window mutation is not supported");
         }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-        [[nodiscard]] nb::object target_link_to_python(const void *context, const void *memory)
-        {
-            const auto *link = target_link_storage_at(*static_cast<const TSInputTargetLinkContext *>(context), memory);
-            const auto  target = link != nullptr ? link->target_view() : TSDataView{};
-            return python_bridge::value_to_python(target);
-        }
-
-        [[nodiscard]] nb::object target_link_delta_to_python(const void *context,
-                                                             const void *memory,
-                                                             DateTime evaluation_time)
-        {
-            const auto *link = target_link_storage_at(*static_cast<const TSInputTargetLinkContext *>(context), memory);
-            const auto  target = link != nullptr ? link->target_view() : TSDataView{};
-            return python_bridge::delta_value_to_python(target, evaluation_time);
-        }
-#endif
 
         /**
          * Write-through: a value written to a bound link lands on the TARGET
@@ -1214,62 +1194,6 @@ namespace hgraph::detail
             ::hgraph::apply_delta(target_link_delta_target(out_ops.context, out), delta);
         }
 
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-        [[nodiscard]] TSRoleTypeRef target_link_canonical_data_type(
-            TSRoleTypeRef type)
-        {
-            if (type.schema() == nullptr)
-            {
-                throw std::logic_error(
-                    "target-link Python conversion requires a resolved schema");
-            }
-            return TSDataPlanFactory::instance()
-                .data_type_for(type.schema())
-                .as_role();
-        }
-
-        [[nodiscard]] const PythonTSDataOps &
-        target_link_python_ops_for(TSRoleTypeRef type)
-        {
-            return python_bridge::python_ts_data_ops_for(type.ops_ref());
-        }
-
-        [[nodiscard]] bool target_link_requires_authored_delta(
-            TSRoleTypeRef type, nanobind::handle source)
-        {
-            const auto canonical = target_link_canonical_data_type(type);
-            return target_link_python_ops_for(canonical)
-                .requires_authored_delta_impl(canonical, python_bridge::borrow(source));
-        }
-
-        [[nodiscard]] Value target_link_delta_from_python(
-            TSRoleTypeRef type, nanobind::handle source, bool authored)
-        {
-            const auto canonical = target_link_canonical_data_type(type);
-            return target_link_python_ops_for(canonical)
-                .delta_from_python_impl(canonical, python_bridge::borrow(source), authored);
-        }
-
-        void target_link_apply_python_result(const TSOutputView &output,
-                                             nanobind::handle result)
-        {
-            const auto &ops = output.data_view().ops();
-            python_bridge::apply_python_result(
-                target_link_delta_target(ops.context, output), result);
-        }
-
-        [[nodiscard]] const PythonTSDataOps &
-        target_link_python_ts_data_ops() noexcept
-        {
-            static const PythonTSDataOps ops{
-                .requires_authored_delta_impl =
-                    &python_bridge::ts_requires_authored_slot<&target_link_requires_authored_delta>,
-                .delta_from_python_impl = &python_bridge::ts_delta_from_python_slot<&target_link_delta_from_python>,
-                .apply_result_impl      = &python_bridge::ts_apply_result_slot<&target_link_apply_python_result>,
-            };
-            return ops;
-        }
-#endif
 
         /**
          * Child-modification notifications for children reached THROUGH a
@@ -1335,11 +1259,12 @@ namespace hgraph::detail
                 .capture_delta_impl        = capture_delta,
                 .delta_has_effect_impl     = &target_link_delta_has_effect_op,
                 .apply_delta_impl          = &target_link_apply_delta_op,
-#if HGRAPH_ENABLE_PYTHON_USER_NODES
-                .python_ops               = &target_link_python_ts_data_ops(),
-                .to_python_impl            = &python_bridge::to_python_slot<&target_link_to_python>,
-                .delta_to_python_impl      = &python_bridge::ts_delta_to_python_slot<&target_link_delta_to_python>,
-#endif
+                // The bound target's value / delta convert on the bridge
+                // (RFC 0035); authoring goes through the target's own family.
+                .python_family             = PythonTSDataFamily::target_link,
+                .to_python_impl            = &python_ops_detail::forwarder<&PythonOps::TSData::target_link_to_python>::call,
+                .delta_to_python_impl =
+                    &python_ops_detail::forwarder<&PythonOps::TSData::target_link_delta_to_python>::call,
             };
         }
 
@@ -1664,3 +1589,16 @@ namespace hgraph::detail
         return table[index];
     }
 }  // namespace hgraph::detail
+
+namespace hgraph::ts_input_seams
+{
+    TSDataView target_link_target_view(const void *context, const void *memory)
+    {
+        return detail::target_link_target_view(context, memory);
+    }
+
+    TSOutputView target_link_delta_target(const void *context, const TSOutputView &output)
+    {
+        return detail::target_link_delta_target(context, output);
+    }
+}  // namespace hgraph::ts_input_seams

--- a/tests/cpp/test_python_ops.cpp
+++ b/tests/cpp/test_python_ops.cpp
@@ -3,7 +3,10 @@
 // interpreter: the "objects" are sentinel pointers, which is all the type
 // layer ever sees of them.
 #include <hgraph/types/python_ops.h>
+#include <hgraph/types/time_series/endpoint_schema.h>
 #include <hgraph/types/time_series/ts_data/ops.h>
+#include <hgraph/types/time_series/ts_input.h>
+#include <hgraph/types/time_series/ts_input/detail.h>
 #include <hgraph/types/value/any_ops.h>
 #include <hgraph/types/value/compact_container_ops.h>
 #include <hgraph/types/metadata/type_registry.h>
@@ -54,6 +57,15 @@ namespace
 
     hgraph::PyNewRef fake_any_to_python(const void *, const void *) { return hgraph::PyNewRef{sentinel(0x2000)}; }
     hgraph::PyNewRef fake_set_to_python(const void *, const void *) { return hgraph::PyNewRef{sentinel(0x3000)}; }
+    hgraph::PyNewRef fake_input_bundle_to_python(const void *, const void *)
+    {
+        return hgraph::PyNewRef{sentinel(0x4000)};
+    }
+    hgraph::PyNewRef fake_input_bundle_delta_to_python(const void *, const void *, hgraph::DateTime)
+    {
+        return hgraph::PyNewRef{sentinel(0x4001)};
+    }
+    hgraph::PyNewRef fake_target_link_to_python(const void *, const void *) { return hgraph::PyNewRef{sentinel(0x5000)}; }
 
     const hgraph::PythonOps &fake_provider()
     {
@@ -62,6 +74,9 @@ namespace
             table.scalars.conversion_for = &conversion_for;
             table.any.to_python          = &fake_any_to_python;
             table.compact.set_to_python  = &fake_set_to_python;
+            table.ts_data.input_bundle_to_python       = &fake_input_bundle_to_python;
+            table.ts_data.input_bundle_delta_to_python = &fake_input_bundle_delta_to_python;
+            table.ts_data.target_link_to_python        = &fake_target_link_to_python;
             return table;
         }();
         return ops;
@@ -112,13 +127,14 @@ TEST_CASE("family forwarders read the table when called, so registration order i
                       Catch::Matchers::ContainsSubstring("no Python conversion is registered for Any"));
 }
 
-TEST_CASE("a TSData table without a Python-authoring family holds the throwing table, never null",
+TEST_CASE("a TSData table records no Python-authoring family by default and its slots throw the missing-op error",
           "[python_ops][rfc0035]")
 {
     const hgraph::TSDataOps ops{};
-    REQUIRE(ops.python_ops != nullptr);
-    CHECK(ops.python_ops == &hgraph::ts_data_detail::missing_python_ts_data_ops());
-    CHECK_THROWS_WITH(ops.python_ops->requires_authored_delta_impl(hgraph::TSRoleTypeRef{}, hgraph::PyRef{}),
+    CHECK(ops.python_family == hgraph::PythonTSDataFamily::none);
+    // The canonical throwing table the bridge answers for ``none``.
+    const auto &missing = hgraph::ts_data_detail::missing_python_ts_data_ops();
+    CHECK_THROWS_WITH(missing.requires_authored_delta_impl(hgraph::TSRoleTypeRef{}, hgraph::PyRef{}),
                       Catch::Matchers::ContainsSubstring("requires authored delta"));
     CHECK_THROWS_WITH(ops.to_python_impl(ops.context, nullptr), Catch::Matchers::ContainsSubstring("to Python"));
 }
@@ -161,4 +177,45 @@ TEST_CASE("a realized composite's slots are provider forwarders over its private
     CHECK(state->schema == tuple_meta);
     CHECK(state->child_bindings.size() == 2);
     CHECK(state->offsets.size() == 2);
+}
+
+TEST_CASE("TS input facades dispatch their Python slots through the endpoint table to provider forwarders",
+          "[python_ops][rfc0035]")
+{
+    using namespace hgraph;
+    ProviderReset reset;
+    auto       &registry   = TypeRegistry::instance();
+    const auto *integer    = registry.register_scalar<std::int32_t>("int32");
+    const auto *scalar     = registry.ts(integer);
+    const auto *fixed_list = registry.tsl(scalar, 2);
+    const auto *bundle     = registry.tsb("PythonOpsInputBundle", {{"value", scalar}, {"items", fixed_list}});
+
+    // A non-peered bundle's own slots are Python-free dispatch to the TSB
+    // endpoint table, whose slots are the provider's input_bundle entries.
+    const auto list_endpoint   = TSEndpointSchema::non_peered_list(fixed_list, TSEndpointSchema::peered(scalar));
+    const auto bundle_endpoint = TSEndpointSchema::non_peered(bundle, {TSEndpointSchema::peered(scalar), list_endpoint});
+    TSInput    root{TSInputBuilderFactory::checked_builder_for(*bundle, bundle_endpoint)};
+    const auto  root_view = root.view();
+    const auto &root_data = root_view.data_view();
+    const auto &root_ops  = root_data.ops();
+    REQUIRE(root_ops.is_input_binding);
+    CHECK(root_ops.python_family == PythonTSDataFamily::none);
+    set_python_ops(nullptr);
+    CHECK_THROWS_WITH(root_ops.to_python_impl(root_ops.context, root_data.data()),
+                      Catch::Matchers::ContainsSubstring("no Python conversion is registered for TSData"));
+    set_python_ops(&fake_provider());
+    CHECK(root_ops.to_python_impl(root_ops.context, root_data.data()).ptr == sentinel(0x4000));
+    CHECK(root_ops.delta_to_python_impl(root_ops.context, root_data.data(), MIN_ST).ptr == sentinel(0x4001));
+
+    // Its peered child is a target link: the slots convert the bound target
+    // on the bridge, and authoring goes through the recorded family.
+    const auto  leaf     = detail::input_child_projection(root_data, 0).target_link;
+    REQUIRE(leaf.valid());
+    const auto &leaf_ops = leaf.ops();
+    REQUIRE(leaf_ops.is_target_link);
+    CHECK(leaf_ops.python_family == PythonTSDataFamily::target_link);
+    CHECK(leaf_ops.to_python_impl(leaf_ops.context, leaf.data()).ptr == sentinel(0x5000));
+    set_python_ops(nullptr);
+    CHECK_THROWS_WITH(leaf_ops.to_python_impl(leaf_ops.context, leaf.data()),
+                      Catch::Matchers::ContainsSubstring("no Python conversion is registered for TSData"));
 }

--- a/tests/cpp/test_type_erasure_layout.cpp
+++ b/tests/cpp/test_type_erasure_layout.cpp
@@ -80,14 +80,14 @@ TEST_CASE("current type-erasure records retain their baseline layouts")
     static_assert(!HasNoArgumentRemovedValue<TSWDataView>);
     static_assert(HasNoArgumentRemovedValue<TSWInputView>);
     static_assert(sizeof(TSDataView) == sizeof(void *) * 2);
-    // ABI 14 (RFC 0035): TSDataOps records its Python-authoring family
-    // (python_family) beside the table pointer. ABI 13 made the Python slots
+    // ABI 15 (RFC 0035): the Python-authoring table pointer is gone; a
+    // strategy records only its family (python_family, ABI 14) and the
+    // bridge maps it to the table. ABI 13 made the Python slots
     // unconditional and opaque, so a table built with Python off has the
-    // layout of one built with Python on, and the pointer is never null.
-    static_assert(TS_DATA_OPS_ABI_VERSION == 14);
+    // layout of one built with Python on.
+    static_assert(TS_DATA_OPS_ABI_VERSION == 15);
     static_assert(std::is_same_v<decltype(TSDataOps::python_family), PythonTSDataFamily>);
     static_assert(std::is_same_v<decltype(TSDataOps::to_python_impl), PyNewRef (*)(const void *, const void *)>);
-    static_assert(std::is_same_v<decltype(TSDataOps::python_ops), const PythonTSDataOps *>);
     // ABI 12: keyed and window TSData projections keep binding and memory together.
     using KeyAtSlotFn = ValueView (*)(const void *, const void *, std::size_t);
     using WindowElementFn = ValueView (*)(const void *, const void *, std::size_t);

--- a/tests/install_consumer/main.cpp
+++ b/tests/install_consumer/main.cpp
@@ -334,7 +334,7 @@ int main()
     // ABI 14 (RFC 0035): TSDataOps records its Python-authoring family; ABI 13 made the
     // Python slots unconditional and opaque; ABI 12 made the keyed and window TSData
     // projections return binding and memory together.
-    static_assert(TS_DATA_OPS_ABI_VERSION == 14);
+    static_assert(TS_DATA_OPS_ABI_VERSION == 15);
     static_assert(sizeof(PolymorphicValueType) == 2 * sizeof(void *));
     static_assert(std::is_standard_layout_v<PolymorphicValueType>);
     static_assert(!std::is_polymorphic_v<TableTypeOps>);


### PR DESCRIPTION
Implements RFC 0035, PR 5 of 5 (`docs/source/rfc/rfc_0035_python_free_type_layer.rst`, "Implementation plan"): the last two families move to the bridge, both type-layer ratchets reach zero, and the RFC moves to **Accepted**.

Stacked on #737 (PR 4b). Merge order: #730 → #732 → #734 → #737 → this.

**What moves**

- `src/hgraph/python/impl/ts_input_conversions.cpp` (new) holds the non-peered TSB / TSL input bindings' endpoint-shape conversions (`TSInputEndpointOps::to_python` / `delta_to_python`), their value and delta projections (value projection, delta bundle, delta map, delta key set) and the bound target of a target link. It reads the bindings through `src/hgraph/types/time_series/detail/ts_input_seams.h` (schema, endpoint table, bindings, child type / memory / modified-for-parent-time, ordinal keys; target view and delta target for links).
- The facades' own `TSDataOps` slots stay in the type layer as Python-free dispatch to the endpoint-shape table (opaque `PyNewRef`), so `input_to_python` / `input_delta_to_python` need no provider entry.
- The target link's authoring table moves to the bridge (`python_bridge::target_link_python_ts_data_ops`, family `PythonTSDataFamily::target_link`), canonicalising through the bound target's family as before.

**ABI**

- `TS_DATA_OPS_ABI_VERSION` 14 → 15: `TSDataOps::python_ops` (the authoring-table pointer) is gone; a strategy records only `python_family` and the bridge's `python_ts_data_ops_for` maps it (`none` answers `ts_data_detail::missing_python_ts_data_ops()`). Pins in `tests/cpp/test_type_erasure_layout.cpp` and `tests/install_consumer/main.cpp`; ledger in `ops_catalogue.rst`, note in `plans_and_ops/time_series.rst`.

**Ratchets and cleanup**

- `type-layer-python-conditionals` 14 → 0 and `type-layer-nanobind` 35 → 0, both held at zero (`python/tests/test_architecture_ratchets.py`).
- `include/hgraph/config.h` loses the `__JETBRAINS_IDE__` override: the type layer compiles the same headers in every preset, so nothing is greyed out for the IDE any more.
- `tests/cpp/test_python_ops.cpp` gains a Python-free test: a non-peered bundle input's slots throw the *no Python conversion is registered for TSData* error with no provider and reach the provider's `input_bundle_*` entries with one; its peered child is a target link recording the `target_link` family whose slot reaches `target_link_to_python`.

**Docs**

- RFC 0035: Status → Accepted, implementation status for PR 5.
- `python_bridge.rst` ("The type layer converts through the registered PythonOps table"), `testing.rst` (ratchet bullet), `ops_catalogue.rst`, `plans_and_ops/time_series.rst`.

**Validation (macOS, local gate)**

- C++ core-only suite: all tests passed (257326 assertions in 1704 test cases)
- Python gate (`python/tests` incl. adaptors + all extension suites): 3608 passed, 10 skipped
- `sphinx -W`: clean
- Consumer checks (`python_extension_consumer`, `install_consumer`, fabric test package): passed

Linux (GCC 14, warnings-as-errors) and Windows (MSVC) results follow as comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
