### PR TITLE
Compile dynamic collection graph iteration in HGL

### DIFF
--- a/language/README.md
+++ b/language/README.md
@@ -39,6 +39,8 @@ concise `map` functions, collection traversal and predicates, logger injection,
 scalar recordable state, prior and keyed output access, and lifecycle blocks.
 Explicit `ref<T>` contracts and guarded fixed-list reference routing also reach
 native schema materialization, descriptors, generated C++, and behavior tests.
+Graph composition expands fixed temporal lists and lowers independent
+`values`/`items` bodies over maps and unbounded lists to native child graphs.
 The installed `hgl::native_package` C++ API emits deterministic, validated
 descriptors for constrained native scalar and nominal-type declarations without
 exposing compiler IR.

--- a/language/docs/README.md
+++ b/language/docs/README.md
@@ -65,7 +65,7 @@ constraints.
 
 The [standard-library folder](../stdlib/README.md) collects agreed HGL examples
 to drive core-library coverage and expose missing language features. It starts
-with conditional-result, fixed-list, and independent dynamic-map iteration
-examples; a complete component catalogue remains to be developed. These design
-examples are separate from the compiler's runnable example corpus and are not
-a claim of implemented support.
+with conditional-result examples; the fixed-list and independent dynamic
+collection cases have graduated into the compiler's runnable example corpus. A
+complete component catalogue remains to be developed. Files left in the design
+corpus are not a claim of implemented support.

--- a/language/docs/design/architecture.md
+++ b/language/docs/design/architecture.md
@@ -83,12 +83,12 @@ backend phases:
 | Compute or sink | Evaluation | Read admitted runtime inputs, update declared state, produce the contracted tick or side effect | Add topology, resolve overloads, acquire arbitrary external resources |
 | Imported adaptor or service | Native C++ | Own callbacks, threads, queues, protocols, and resources through hgraph lifecycle contracts | Expose unrestricted native execution to language source |
 
-The current provisional implementation classifies an ordinary body as
-composition. A `state` or `inject` declaration, a `start`, `when`, or `stop`
-block, or any collection iteration classifies the complete function as runtime
-evaluation. The target model instead lets iteration follow the phase selected
-by the containing body; iterator-only runtime functions therefore need a
-still-unresolved disambiguation rule before that classifier migration.
+The current implementation classifies an ordinary body as composition. A
+`state` or `inject` declaration or a `start`, `when`, or `stop` block classifies
+the complete function as runtime evaluation. Collection iteration follows that
+containing phase and does not classify the function by itself. Consequently an
+iterator-only body is a composition function today; a source spelling for an
+otherwise runtime-only iterator body remains unresolved.
 Composition bodies flatten through hgraph wiring, while runtime bodies lower
 to typed static C++ hooks whose instance data uses hgraph selectors and plans.
 

--- a/language/docs/design/iteration.md
+++ b/language/docs/design/iteration.md
@@ -192,7 +192,8 @@ time-series connection.
 For maps and unbounded lists, both backends lower independent `values` and
 `items` bodies to hgraph's outputless native `map_` path. The child signature
 uses the native `key` or `ndx` convention for `items`; temporal captures are
-explicit broadcast inputs. The shared HGraph-IR `TraversalPlan` rejects
+explicit pass-through broadcast inputs, including captured maps and lists. The
+shared HGraph-IR `TraversalPlan` rejects
 assignments to enclosing bindings and returns before either backend lowers the
 loop.
 

--- a/language/docs/design/iteration.md
+++ b/language/docs/design/iteration.md
@@ -2,8 +2,9 @@
 
 Status: phase-dependent iteration and the independent-body boundary for
 dynamic graph loops agreed, 2026-09-05. The compiler implements fixed temporal
-list graph traversal. Dynamic graph mapping and map/reduce lowering of
-loop-carried accumulators remain future extensions.
+list traversal and independent dynamic map/unbounded-list traversal in graph
+composition. Map/reduce lowering of loop-carried accumulators remains a future
+extension.
 
 ## Iteration follows the containing phase
 
@@ -78,12 +79,17 @@ fn observe(book: map<str, f64>, offset: f64) {
 ```
 
 The generated child accepts the current member's time-series connection and
-the shared `offset` connection. Lexical capture analysis separates wiring-time
-scalars from temporal inputs, preserving their types and REF access boundaries,
-as with generated conditional branches. Here the body is outputless, so the
-lowering uses a sink map. The source is recorded in
-[dynamic-map-iteration.hgl](../../stdlib/examples/dynamic-map-iteration.hgl)
-as a design example, not a runnable compiler test.
+the shared `offset` connection. Lexical capture analysis preserves temporal
+input types and REF access boundaries, as with generated conditional branches.
+Here the body is outputless, so the lowering uses a sink map. The runnable
+[dynamic-collection-iteration.hgl](../../examples/dynamic-collection-iteration.hgl)
+example covers both `values` and `items` over maps and unbounded lists.
+
+The current compiler accepts temporal captures such as `offset`. Capturing a
+`const` configuration value in a dynamic child is still unsupported: the
+native mapping contract accepts time-series boundary inputs, while the scalar
+capture ABI and identity rules have not yet been agreed. Such a capture is
+diagnosed rather than silently promoted to a time series.
 
 Map keys determine child identity. Dynamic lists use index identity, not the
 identity of a stored value. Updating an existing member does not recreate its
@@ -177,14 +183,19 @@ policies is introduced here.
 
 ## Implementation status
 
-The classifier and typed HIR now keep `for`, `keys`, `values`, and `items`
+The classifier and typed HIR keep `for`, `keys`, `values`, and `items`
 phase-neutral. In a composition function, both direct wiring and generated C++
 implement `values(fixed_list)` and `items(fixed_list)` by statically expanding
 the body in index order. `items` supplies an `i64` wiring-time index and a child
 time-series connection.
 
-The first implemented graph subset rejects iterator predicates, dynamic lists,
-maps, bundles, sets, assignments to enclosing bindings, and returns from the
-body. Dynamic independent-body mapping remains the next iteration slice;
-loop-result construction, reductions, graph-phase predicates, and loop exits
-remain design questions and fail closed.
+For maps and unbounded lists, both backends lower independent `values` and
+`items` bodies to hgraph's outputless native `map_` path. The child signature
+uses the native `key` or `ndx` convention for `items`; temporal captures are
+explicit broadcast inputs. The shared HGraph-IR `TraversalPlan` rejects
+assignments to enclosing bindings and returns before either backend lowers the
+loop.
+
+Graph-phase `keys`, iterator predicates, scalar captures, bundles, sets,
+loop-result construction, reductions, and loop exits remain design or
+implementation boundaries and fail closed.

--- a/language/docs/design/language-model.md
+++ b/language/docs/design/language-model.md
@@ -515,7 +515,8 @@ any of these constructs makes the complete body a runtime function:
 Under the agreed [iteration model](iteration.md), `for`, `keys`, `values`, and
 `items` follow the containing phase and do not themselves force runtime
 classification. The classifier and typed HIR implement this rule; backend
-support currently reaches fixed temporal-list `values` and `items` traversal.
+support reaches fixed temporal-list traversal and independent `values` and
+`items` bodies over dynamic maps and unbounded lists.
 
 Mixing wiring-only and runtime-only constructs is an error. Classification is
 based on the resolved source body, not on the implementation kind selected for
@@ -674,9 +675,11 @@ wiring-time iterable visits scalar values, and iteration over a fixed temporal
 structure visits child connections. The calls do not themselves make a
 function a runtime node. Dynamic graph loops initially admit independent bodies
 lowered through per-key or per-index mapping. The compiler currently expands
-`values` and `items` over fixed temporal lists at wiring time; dynamic mapping
-is still pending. Loop-carried reductions are deferred, with unordered map
-reduction and linear list reduction documented as future options. See
+`values` and `items` over fixed temporal lists at wiring time and lowers
+independent bodies over maps and unbounded lists through native sink mapping.
+Temporal captures are explicit child inputs; scalar captures remain pending.
+Loop-carried reductions are deferred, with unordered map reduction and linear
+list reduction documented as future options. See
 [Iteration](iteration.md) for the agreement and implementation boundary.
 
 `values` is the common value-only spelling for TSB, TSD, TSL, and TSS; there is

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -177,6 +177,8 @@ planning is implemented.
   compatibility through HIR, hgraph IR, and native type materialization.
 - [x] classify traversal by its containing phase and directly expand
   independent `values` and `items` bodies over fixed temporal lists.
+- [x] lower independent `values` and `items` bodies over maps and unbounded
+  lists to native sink child graphs with explicit temporal captures.
 
 Acceptance: direct-wiring behavior and diagnostics remain equivalent, and the
 wiring target no longer includes syntax AST headers.
@@ -222,6 +224,8 @@ wiring target no longer includes syntax AST headers.
 - [x] remove the compatibility path by which a backend walks `ResolvedModule`.
 - [x] emit explicit reference contracts and guarded fixed-list reference
   routing with selector-aware activation and validity analysis.
+- [x] emit readable native `map_sink_` helpers for independent dynamic map and
+  unbounded-list graph traversal, matching direct-wiring behavior.
 
 Acceptance: both backends consume the same hgraph IR, existing generated tests
 and installed consumers pass, and architecture tests reject backend-to-syntax
@@ -284,7 +288,8 @@ nominal/generic structs and sparse deltas, generic operators, fixed and duration
 windows, concise `map` functions, borrowed runtime collection iteration, and
 guarded selection and forwarding of fixed-list reference elements.
 Both backends also expand graph-phase `values` and `items` over fixed temporal
-lists without reading temporal payloads.
+lists and lower independent dynamic map/unbounded-list bodies through native
+per-key/per-index child graphs without reading temporal payloads.
 Generated headers and sources are mandatory `clang-format` output and public
 operator contracts are transparent aliases rather than derived marker classes.
 

--- a/language/docs/developer-guide/README.md
+++ b/language/docs/developer-guide/README.md
@@ -135,8 +135,9 @@ surface.
 - Name resolution selects one nominal operator identity before hgraph performs
   candidate normalization, ranking, and diagnostics.
 - A body without runtime-only constructs is classified as composition;
-  `state`, `inject`, `start`, `when`, `stop`, or runtime collection iteration
-  classifies the complete `fn` as a runtime node.
+  `state`, `inject`, `start`, `when`, or `stop` classifies the complete `fn` as
+  a runtime node. Collection iteration follows the containing phase and does
+  not classify the function by itself.
 - Runtime `when` predicates are decomposed into activation, validity admission,
   and residual per-evaluation logic where possible.
 - State declarations aggregate into one recordable state value; grouped

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -205,7 +205,10 @@ through hgraph's structural child projection. Independent `values` and `items`
 bodies over maps and unbounded lists become an outputless native map: the child
 signature contains the element, the native `key`/`ndx` input when requested,
 and explicit temporal captures as broadcast inputs. Both backends consume the
-same plan and never inspect a temporal payload while composing the graph.
+same plan and never inspect a temporal payload while composing the graph. Each
+capture is explicitly tagged as pass-through at the native map boundary, so a
+captured map or list remains whole rather than becoming another multiplexed
+input.
 `DeclarationRef` provides typed struct, operator, callable, and test handles;
 the module retains those handles in source order while module and import
 declarations remain frontend-only. Each referenced contract or plan owns its

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -200,10 +200,12 @@ expression evaluation have distinct variants. Tail expressions are removed
 from the executable statement list so they cannot be evaluated twice.
 `hgraph_ir/control_flow` derives one `TraversalPlan` for a loop body, treating
 its iterator bindings as locals while reporting captured and externally
-assigned bindings and returns. The first graph traversal slice accepts only
-independent `values` and `items` bodies over fixed temporal lists. Both backends
-unroll those bodies in index order and use hgraph's structural child projection;
-they never inspect a temporal payload while composing the graph.
+assigned bindings and returns. Fixed temporal lists are unrolled in index order
+through hgraph's structural child projection. Independent `values` and `items`
+bodies over maps and unbounded lists become an outputless native map: the child
+signature contains the element, the native `key`/`ndx` input when requested,
+and explicit temporal captures as broadcast inputs. Both backends consume the
+same plan and never inspect a temporal payload while composing the graph.
 `DeclarationRef` provides typed struct, operator, callable, and test handles;
 the module retains those handles in source order while module and import
 declarations remain frontend-only. Each referenced contract or plan owns its
@@ -1360,8 +1362,9 @@ Status: implemented for the composition and runtime forms exercised by every
 checked-in example as of 2026-09-06. This includes nominal and generic structs,
 generic operator implementations, fixed and duration windows, sparse struct
 deltas, concise `map` functions, scalar and collection runtime inputs, borrowed
-collection traversal, explicit reference schemas, guarded fixed-list reference
-routing, `out`, `logger`, state, and lifecycle hooks. File-based
+collection traversal, fixed-list and independent dynamic graph traversal,
+explicit reference schemas, guarded fixed-list reference routing, `out`,
+`logger`, state, and lifecycle hooks. File-based
 `test` and `run` compile/load supported runtime modules on Unix; portable native
 loading and the remaining language-depth items are still staged. Declaration
 and module planning now come from hgraph IR, as do callable/operator interfaces,

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -1260,11 +1260,13 @@ evaluation. In graph composition, a supported wiring-time iterable provides
 scalar values and a fixed temporal structure provides child connections. The
 current compiler implements `values` and `items` over a fixed TSL by statically
 unrolling the body and projecting children through hgraph's public
-`tsl_element` contract. Both direct wiring and generated C++ reject predicates,
-dynamic structures, assignments to enclosing variables, and loop returns in
-this first graph subset. Independent dynamic graph-loop bodies will lower
-through per-key or per-index mapping. Unordered map reduction and ordered,
-linear list reduction are deferred options, not initial lowering support. See
+`tsl_element` contract. Independent `values` and `items` bodies over a TSD or
+unbounded TSL lower through hgraph's per-key/per-index sink mapping in both
+backends; temporal captures become explicit broadcast child inputs. The
+current subset rejects predicates, graph-phase `keys`, scalar captures,
+assignments to enclosing variables, and loop returns. Unordered map reduction
+and ordered, linear list reduction are deferred options, not initial lowering
+support. See
 [Iteration](../design/iteration.md) for the target design and current boundary.
 
 Traversal and built-in delta-predicate support is:

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -317,8 +317,8 @@ tested as admission-only.
 Tests for the provisional source rule must prove:
 
 - a body without node-only syntax becomes `CompositionFn`;
-- `state`, `inject`, `start`, `when`, `stop`, or runtime collection iteration
-  classifies the complete body as `RuntimeFn`;
+- `state`, `inject`, `start`, `when`, or `stop` classifies the complete body as
+  `RuntimeFn`, while collection iteration inherits the containing phase;
 - ambiguous or mixed forms fail with a `function-kind` diagnostic;
 - declarations and lifecycle blocks obey their function-level ordering and
   cardinality rules;
@@ -513,6 +513,8 @@ example. `generated_structural_tests.cpp`, `generated_generic_tests.cpp`, and
 `generated_example_tests.cpp` exercise nominal hierarchy and generic metadata,
 sparse structural deltas, fixed and duration window schemas, generic operator
 resolution, collection predicates and iteration, and keyed collection output.
+`generated_iteration_tests.cpp` additionally checks fixed expansion and native
+per-key/per-index child-map ownership for independent dynamic graph loops.
 `tests/codegen/runtime.hgl` and
 `generated_runtime_tests.cpp` exercise the compiled node path: modified-or and
 valid-and predicates, passive sampling, ordered state mutation and final-write

--- a/language/docs/user-guide/README.md
+++ b/language/docs/user-guide/README.md
@@ -74,8 +74,8 @@ The current design classifies a function from the constructs used in its body:
 
 The agreed [iteration model](../design/iteration.md) makes `for`, `keys`,
 `values`, and `items` follow the containing phase; they do not alone force a
-runtime function. Graph-phase iteration and the classification update remain
-separate compiler work.
+runtime function. Both compiler backends expand fixed temporal lists and map
+independent dynamic map/list bodies through native child graphs.
 
 Runtime functions use ordinary `return` to produce an output tick. They may
 request direct output access alongside other runtime capabilities:

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -362,8 +362,9 @@ Loop-carried reductions are initially unsupported: unordered map reduction
 and the linear reduction option for ordered lists are documented future
 extensions. In a node, traversal visits the current child views or scalar
 elements. The classifier is phase-neutral and both compiler backends implement
-fixed temporal-list `values` and `items` traversal in graph functions. Dynamic
-graph mapping, graph iterator predicates, escaping assignments, and loop
+fixed temporal-list traversal plus independent `values` and `items` bodies over
+dynamic maps and unbounded lists. Dynamic bodies may capture temporal inputs;
+`const` captures, graph iterator predicates, escaping assignments, and loop
 returns remain unsupported.
 
 This can deliberately fuse work that would otherwise become several

--- a/language/docs/user-guide/types-and-expressions.md
+++ b/language/docs/user-guide/types-and-expressions.md
@@ -779,12 +779,30 @@ Status: `for`, `keys`, `values`, and `items` follow the containing phase rather
 than themselves forcing a runtime node. The compiler implements graph-phase
 `values` and `items` over fixed temporal lists by expanding the body once per
 child connection; `items` also supplies its wiring-time `i64` index. Scalar
-wiring-time iterables, bundles, and independent dynamic map/list bodies remain
-future compiler work. Loop-carried reductions are initially unsupported;
-future map reductions are unordered, while lists may require the linear
-reduction option to preserve index order. See
+wiring-time iterables and bundles remain future compiler work. Independent
+`values` and `items` bodies over maps and unbounded lists run as one native
+child graph per key or index, with temporal captures broadcast to every child.
+Graph-phase predicates, graph-phase `keys`, and `const` captures remain
+unsupported.
+Loop-carried reductions are initially unsupported; future map reductions are
+unordered, while lists may require the linear reduction option to preserve
+index order. See
 [Iteration](../design/iteration.md) for examples, restrictions, and the
 deferred reduction option.
+
+```hgl
+fn observe(book: map<str, f64>, offset: f64) {
+    for value in values(book) {
+        debug_print("adjusted", value + offset)
+    }
+}
+```
+
+This composes one child graph for each live key. `offset` is a shared temporal
+input to every child. Removing a key removes its child; adding a key constructs
+a new one. The equivalent loop over `list<f64>` is keyed by the current index.
+Use `items(book)` or `items(samples)` when the body also needs that key or
+index.
 
 `key_set(value)` exposes the keys of a temporal map as `set<K>`. It works in
 both function phases: a composition function receives the live set-valued

--- a/language/examples/dynamic-collection-iteration.hgl
+++ b/language/examples/dynamic-collection-iteration.hgl
@@ -29,3 +29,11 @@ export fn observe_list_items(samples: list<f64>, offset: f64) {
         null_sink(value + index + offset)
     }
 }
+
+// Collection captures are passed to each child whole; they do not become a
+// second collection over which the child graph is multiplexed.
+export fn observe_list_capture(samples: list<f64>, peers: list<f64>) {
+    for value in values(samples) {
+        null_sink(valid(peers))
+    }
+}

--- a/language/examples/dynamic-collection-iteration.hgl
+++ b/language/examples/dynamic-collection-iteration.hgl
@@ -1,0 +1,31 @@
+// Graph-phase iteration over a dynamic collection constructs one independent
+// sink child graph for every live map key or unbounded-list index.
+
+module examples.dynamic_collection_iteration
+
+use hgraph.std::{null_sink}
+
+export fn observe_values(book: map<str, f64>, offset: f64) {
+    for value in values(book) {
+        null_sink(value + offset)
+    }
+}
+
+export fn observe_items(book: map<str, f64>, offset: f64) {
+    for key, value in items(book) {
+        // `key` identifies this child and is available to graph expressions.
+        null_sink(value + offset)
+    }
+}
+
+export fn observe_list_values(samples: list<f64>, offset: f64) {
+    for value in values(samples) {
+        null_sink(value + offset)
+    }
+}
+
+export fn observe_list_items(samples: list<f64>, offset: f64) {
+    for index, value in items(samples) {
+        null_sink(value + index + offset)
+    }
+}

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -2661,7 +2661,7 @@ namespace hgl::codegen
             std::vector<std::string> arguments{"hgraph::fn<" + helper + ">()", iterator.code};
             for (const auto &[capture, outer] : captures) {
                 static_cast<void>(capture);
-                arguments.push_back(outer.code);
+                arguments.push_back("hgraph::stdlib::pass_through(" + outer.code + ")");
             }
             out.line("hgraph::wire<hgraph::stdlib::map_sink_>(w, " + join(arguments, ", ") + ");");
         }

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -612,6 +612,7 @@ namespace hgl::codegen
             std::size_t                          anonymous_function_index_{0};
             Writer                              *current_body_{nullptr};
             std::size_t                          conditional_index_{0};
+            std::size_t                          traversal_index_{0};
         };
 
         std::string_view Emitter::local_identity(std::string_view identity) noexcept {
@@ -2266,11 +2267,11 @@ namespace hgl::codegen
                 if (!frame.runtime) {
                     if (call.arguments.size() != 1U) { backend(range, "graph-phase iterator predicates are not defined yet"); }
                     const Value source = eval_planned_expr(call.arguments.front().value, frame);
-                    if (!source.is_port() || source.type.kind != HType::Kind::List || source.type.size.empty()) {
-                        backend(range, "the first graph-iteration slice requires a fixed temporal list");
+                    if (!source.is_port() || (source.type.kind != HType::Kind::List && source.type.kind != HType::Kind::Map)) {
+                        backend(range, "graph-phase iteration currently supports temporal maps and lists");
                     }
                     if (name == "keys") {
-                        backend(range, "a fixed temporal list supports values(...) and items(...), not keys(...)");
+                        backend(range, "graph-phase keys(...) traversal is not defined yet; use values(...) or items(...)");
                     }
 
                     Value result;
@@ -2279,8 +2280,13 @@ namespace hgl::codegen
                     result.type  = source.type;
                     result.name  = name;
                     result.range = range;
-                    if (name == "items") { result.iterator_types.push_back(scalar_type(hir::ScalarType::I64)); }
-                    result.iterator_types.push_back(source.type.children.front());
+                    if (source.type.kind == HType::Kind::Map) {
+                        if (name == "items") { result.iterator_types.push_back(source.type.children[0]); }
+                        result.iterator_types.push_back(source.type.children[1]);
+                    } else {
+                        if (name == "items") { result.iterator_types.push_back(scalar_type(hir::ScalarType::I64)); }
+                        result.iterator_types.push_back(source.type.children.front());
+                    }
                     return result;
                 }
                 if (call.arguments.empty() || call.arguments.size() > 2U) {
@@ -2542,39 +2548,122 @@ namespace hgl::codegen
 
             const gir::Value &iterable_expression = planned_value(traversal.iterable, range);
             const Value       iterator            = eval_planned_expr(traversal.iterable, frame);
-            if (!iterator.is_iterator() || iterator.type.kind != HType::Kind::List || iterator.type.size.empty()) {
+            if (!iterator.is_iterator()) {
                 fail(Category::Type, iterable_expression.range,
-                     "a graph 'for' loop currently needs values(...) or items(...) over a fixed temporal list");
+                     "a graph 'for' loop needs values(...) or items(...) over a temporal map or list");
             }
             if (traversal.bindings.empty() || traversal.bindings.size() > 2U ||
                 traversal.bindings.size() != iterator.iterator_types.size()) {
-                backend(range, "hgraph IR traversal bindings do not match the fixed-list iterator");
+                backend(range, "hgraph IR traversal bindings do not match its iterator");
             }
 
-            const std::int64_t count = std::stoll(iterator.type.size);
-            for (std::int64_t index = 0; index < count; ++index) {
-                Frame iteration = frame;
-                out.open("");
+            if (iterator.type.kind == HType::Kind::List && !iterator.type.size.empty()) {
+                const std::int64_t count = std::stoll(iterator.type.size);
+                for (std::int64_t index = 0; index < count; ++index) {
+                    Frame iteration = frame;
+                    out.open("");
 
-                Value position =
-                    make_const("hgraph::Int{" + std::to_string(index) + "}", scalar_type(hir::ScalarType::I64), range, index);
-                Value selected = make_port("hgraph::tsl_element(" + iterator.code + ", " + std::to_string(index) + ")",
-                                           iterator.type.children.front(), range);
+                    Value position =
+                        make_const("hgraph::Int{" + std::to_string(index) + "}", scalar_type(hir::ScalarType::I64), range, index);
+                    Value selected = make_port("hgraph::tsl_element(" + iterator.code + ", " + std::to_string(index) + ")",
+                                               iterator.type.children.front(), range);
 
-                std::vector<Value> loop_values;
-                if (iterator.name == "items") { loop_values.push_back(std::move(position)); }
-                loop_values.push_back(std::move(selected));
-                for (std::size_t binding_index = 0; binding_index < traversal.bindings.size(); ++binding_index) {
-                    const gir::Binding &binding = planned_binding(traversal.bindings[binding_index], range);
-                    if (binding.kind != gir::BindingKind::LoopValue ||
-                        !same_type(planned_type(binding.type, binding.range), loop_values[binding_index].type)) {
-                        backend(binding.range, "hgraph IR fixed-list traversal has an invalid loop binding");
+                    std::vector<Value> loop_values;
+                    if (iterator.name == "items") { loop_values.push_back(std::move(position)); }
+                    loop_values.push_back(std::move(selected));
+                    for (std::size_t binding_index = 0; binding_index < traversal.bindings.size(); ++binding_index) {
+                        const gir::Binding &binding = planned_binding(traversal.bindings[binding_index], range);
+                        if (binding.kind != gir::BindingKind::LoopValue ||
+                            !same_type(planned_type(binding.type, binding.range), loop_values[binding_index].type)) {
+                            backend(binding.range, "hgraph IR fixed-list traversal has an invalid loop binding");
+                        }
+                        iteration.planned_bindings[traversal.bindings[binding_index].value] = loop_values[binding_index];
                     }
-                    iteration.planned_bindings[traversal.bindings[binding_index].value] = loop_values[binding_index];
+                    emit_planned_block(traversal.block, iteration, out, false, range);
+                    out.close();
                 }
-                emit_planned_block(traversal.block, iteration, out, false, range);
-                out.close();
+                return;
             }
+
+            const bool map          = iterator.type.kind == HType::Kind::Map;
+            const bool dynamic_list = iterator.type.kind == HType::Kind::List && iterator.type.size.empty();
+            if (!map && !dynamic_list) {
+                backend(iterable_expression.range, "dynamic graph traversal currently supports temporal maps and unbounded lists");
+            }
+
+            std::vector<std::pair<gir::ConditionalCapture, Value>> captures;
+            captures.reserve(plan.captures.size());
+            for (const gir::ConditionalCapture &capture : plan.captures) {
+                const gir::Binding &binding = planned_binding(capture.binding, range);
+                if (capture.phase != hir::Phase::Wiring) {
+                    backend(binding.range, "capturing scalar configuration in a dynamic graph 'for' body is not supported yet");
+                }
+                const auto outer = frame.planned_bindings.find(capture.binding.value);
+                if (outer == frame.planned_bindings.end() || !outer->second.is_port()) {
+                    backend(binding.range, "a dynamic graph traversal capture is not bound to a time-series port");
+                }
+                captures.emplace_back(capture, outer->second);
+            }
+
+            const auto saved_counts = local_counts_;
+            const auto saved_names  = local_names_;
+            local_counts_.clear();
+            local_names_.clear();
+            local_names_.insert("w");
+
+            std::unordered_map<std::string, int> parameter_counts;
+            const auto                           unique_parameter = [&](std::string_view raw) {
+                const std::string base = cpp_name(raw);
+                std::string       name = base;
+                int              &next = parameter_counts[base];
+                while (local_names_.contains(name)) { name = base + "_" + std::to_string(++next); }
+                local_names_.insert(name);
+                return name;
+            };
+
+            Frame nested;
+            nested.fn = frame.fn;
+            std::vector<std::string> signature{"[[maybe_unused]] hgraph::Wiring &w"};
+            for (std::size_t index = 0; index < traversal.bindings.size(); ++index) {
+                const gir::Binding &binding = planned_binding(traversal.bindings[index], range);
+                const HType         type    = planned_type(binding.type, binding.range);
+                if (binding.kind != gir::BindingKind::LoopValue || !same_type(type, iterator.iterator_types[index])) {
+                    backend(binding.range, "hgraph IR dynamic traversal has an invalid loop binding");
+                }
+                const std::string name = unique_parameter(binding.name);
+                const std::string port =
+                    iterator.name == "items" && index == 0U
+                        ? "hgraph::NamedPort<" + quote(map ? "key" : "ndx") + ", " + schema(type, binding.range) + ">"
+                        : "hgraph::Port<" + schema(type, binding.range) + ">";
+                signature.push_back("[[maybe_unused]] " + port + " " + name);
+                nested.planned_bindings.emplace(traversal.bindings[index].value, make_port(name, type, binding.range));
+            }
+            for (const auto &[capture, outer] : captures) {
+                const gir::Binding &binding = planned_binding(capture.binding, range);
+                const HType         type    = planned_type(capture.type, binding.range);
+                const std::string   name    = unique_parameter(binding.name);
+                signature.push_back("[[maybe_unused]] hgraph::Port<" + schema(type, binding.range) + "> " + name);
+                nested.planned_bindings.emplace(capture.binding.value, make_port(name, type, binding.range));
+            }
+
+            const std::string helper = "hgl_" + callable_cpp_name(frame.fn) + "_for_" + std::to_string(++traversal_index_);
+            out.line("// " + where(planned_block(traversal.block, range).range));
+            out.open("struct " + helper);
+            out.line("static void compose(" + join(signature, ", ") + ")");
+            out.open("");
+            emit_planned_block(traversal.block, nested, out, false, range);
+            out.close();
+            out.close(";");
+
+            local_counts_ = saved_counts;
+            local_names_  = saved_names;
+
+            std::vector<std::string> arguments{"hgraph::fn<" + helper + ">()", iterator.code};
+            for (const auto &[capture, outer] : captures) {
+                static_cast<void>(capture);
+                arguments.push_back(outer.code);
+            }
+            out.line("hgraph::wire<hgraph::stdlib::map_sink_>(w, " + join(arguments, ", ") + ");");
         }
 
         void Emitter::emit_planned_if(const gir::Conditional &branch, SourceRange range, Frame &frame, Writer &out) {

--- a/language/src/wiring/backend.cpp
+++ b/language/src/wiring/backend.cpp
@@ -1802,7 +1802,7 @@ namespace hgl::wiring
                 if (found == frame.bindings.end() || !found->second.is_port()) {
                     backend(binding(capture.binding).range, "a dynamic graph traversal capture is not bound to a time-series port");
                 }
-                arguments.push_back(time_series_arg(found->second.port));
+                arguments.push_back(time_series_arg(found->second.port.with_arg_tag(hgraph::WiringPortRef::ArgTag::PassThrough)));
             }
             (void)wire("map_", std::move(arguments), range, false);
         }

--- a/language/src/wiring/backend.cpp
+++ b/language/src/wiring/backend.cpp
@@ -398,21 +398,44 @@ namespace hgl::wiring
                 std::string  label{};
             };
 
+            struct TraversalContext
+            {
+                Compiler                                        *compiler{nullptr};
+                gir::CallableId                                  callable{};
+                gir::BlockId                                     block{};
+                std::vector<gir::BindingId>                      bindings{};
+                std::vector<const hgraph::TSValueTypeMetaData *> schemas{};
+                std::vector<std::string_view>                    parameter_names{};
+                bool                                             in_test{false};
+                SourceRange                                      range{};
+                std::string                                      label{};
+            };
+
             [[nodiscard]] hgraph::WiredFn              conditional_branch(Frame &frame, gir::BlockId block, gir::TypeId result,
                                                                           SourceRange range, std::string label);
             [[nodiscard]] static hgraph::WiringPortRef wire_conditional_branch(const void *context, hgraph::Wiring &w,
                                                                                std::span<const hgraph::WiringPortRef> arguments);
             [[nodiscard]] static const hgraph::WiredFnOps &conditional_branch_ops();
+            [[nodiscard]] hgraph::WiredFn traversal_function(const gir::Traversal &traversal, const gir::TraversalPlan &plan,
+                                                             const Slot &iterator, Frame &frame, SourceRange range);
+            [[nodiscard]] static hgraph::WiringPortRef wire_traversal(const void *context, hgraph::Wiring &w,
+                                                                      std::span<const hgraph::WiringPortRef> arguments);
+            [[nodiscard]] static hgraph::CompiledSubGraph
+            compile_traversal(const void *context, hgraph::Wiring *parent,
+                              std::span<const hgraph::TSValueTypeMetaData *const> input_schemas);
+            [[nodiscard]] static const hgraph::WiredFnOps &traversal_ops();
 
-            const syntax::SourceFile                              &file_;
-            const gir::Module                                     &module_;
-            syntax::DiagnosticSink                                &diagnostics_;
-            TypeBridge                                             bridge_;
-            hgraph::TypeRegistry                                  &registry_;
-            const hgraph::stdlib::RegisteredStandardTypes         &types_{standard_types()};
-            hgraph::Wiring                                        *wiring_{nullptr};
-            std::string                                            comparison_detail_{};
+            const syntax::SourceFile                      &file_;
+            const gir::Module                             &module_;
+            syntax::DiagnosticSink                        &diagnostics_;
+            TypeBridge                                     bridge_;
+            hgraph::TypeRegistry                          &registry_;
+            const hgraph::stdlib::RegisteredStandardTypes &types_{standard_types()};
+            hgraph::Wiring                                *wiring_{nullptr};
+            std::string                                    comparison_detail_{};
+            // WiredFn is a non-owning view; retain its callback contexts for this compilation.
             std::vector<std::unique_ptr<ConditionalBranchContext>> conditional_branches_{};
+            std::vector<std::unique_ptr<TraversalContext>>         traversals_{};
         };
 
         Slot Compiler::constant(const hir::Constant &source, SourceRange range) {
@@ -1233,12 +1256,17 @@ namespace hgl::wiring
                     fail(Category::Type, source.range, "a graph collection iterator needs a time-series value");
                 }
                 const gir::TypeId source_type = value(arguments.front().value).type;
-                if (!source_type.valid() || source_type.value >= module_.types.size() ||
-                    module_.types[source_type.value].kind != hir::TypeKind::List || source.port.schema == nullptr ||
-                    source.port.schema->kind != hgraph::TSTypeKind::TSL || source.port.schema->fixed_size() == 0U) {
-                    backend(range, "the first graph-iteration slice requires a fixed temporal list");
+                if (!source_type.valid() || source_type.value >= module_.types.size() || source.port.schema == nullptr) {
+                    backend(range, "a graph collection iterator has no concrete collection type");
                 }
-                if (name == "keys") { backend(range, "a fixed temporal list supports values(...) and items(...), not keys(...)"); }
+                const hir::TypeKind kind = module_.types[source_type.value].kind;
+                if ((kind != hir::TypeKind::List || source.port.schema->kind != hgraph::TSTypeKind::TSL) &&
+                    (kind != hir::TypeKind::Map || source.port.schema->kind != hgraph::TSTypeKind::TSD)) {
+                    backend(range, "graph-phase iteration currently supports temporal maps and lists");
+                }
+                if (name == "keys") {
+                    backend(range, "graph-phase keys(...) traversal is not defined yet; use values(...) or items(...)");
+                }
                 source.kind = Slot::Kind::Iterator;
                 source.type = source_type;
                 source.name = name;
@@ -1348,6 +1376,149 @@ namespace hgl::wiring
                 compiler.backend(context.range, "a time-series conditional branch must produce a value");
             }
             return result.port;
+        }
+
+        const hgraph::WiredFnOps &Compiler::traversal_ops() {
+            static constexpr hgraph::WiredFnOps ops{
+                &Compiler::wire_traversal,
+                &Compiler::compile_traversal,
+                nullptr,
+                [](const void *context) {
+                    const auto &traversal = *static_cast<const TraversalContext *>(context);
+                    return std::span<const std::string_view>{traversal.parameter_names};
+                },
+                [](const void *context, std::size_t index) -> const hgraph::TSValueTypeMetaData * {
+                    const auto &traversal = *static_cast<const TraversalContext *>(context);
+                    return index < traversal.schemas.size() ? traversal.schemas[index] : nullptr;
+                },
+                nullptr,
+                [](const void *) -> const hgraph::TSValueTypeMetaData * { return nullptr; },
+                nullptr,
+                nullptr,
+                [](const void *context) -> std::string_view { return static_cast<const TraversalContext *>(context)->label; },
+            };
+            return ops;
+        }
+
+        hgraph::WiredFn Compiler::traversal_function(const gir::Traversal &traversal, const gir::TraversalPlan &plan,
+                                                     const Slot &iterator, Frame &frame, SourceRange range) {
+            const bool items = iterator.name == "items";
+            if (traversal.bindings.size() != (items ? 2U : 1U)) {
+                backend(range, "hgraph IR traversal bindings do not match its iterator");
+            }
+
+            const hgraph::TSValueTypeMetaData *element = iterator.port.schema->element_ts();
+            if (element == nullptr) { backend(range, "a dynamic graph iterator has no element schema"); }
+            std::vector<const hgraph::TSValueTypeMetaData *> expected;
+            if (items) {
+                expected.push_back(iterator.port.schema->kind == hgraph::TSTypeKind::TSD
+                                       ? registry_.ts(iterator.port.schema->key_type())
+                                       : types_.ts_int);
+            }
+            expected.push_back(element);
+
+            auto context              = std::make_unique<TraversalContext>();
+            context->compiler         = this;
+            context->callable         = frame.callable;
+            context->block            = traversal.block;
+            context->in_test          = frame.in_test;
+            context->range            = range;
+            const syntax::Location at = file_.location(range.begin);
+            context->label            = file_.path() + ":" + std::to_string(at.line) + ": graph for";
+            context->bindings.reserve(traversal.bindings.size() + plan.captures.size());
+            context->schemas.reserve(traversal.bindings.size() + plan.captures.size());
+            context->parameter_names.reserve(traversal.bindings.size() + plan.captures.size());
+
+            for (std::size_t index = 0; index < traversal.bindings.size(); ++index) {
+                const gir::Binding &loop = binding(traversal.bindings[index]);
+                if (loop.kind != gir::BindingKind::LoopValue) {
+                    backend(loop.range, "hgraph IR traversal value has the wrong binding kind");
+                }
+                const hgraph::TSValueTypeMetaData *actual = schema(loop.type);
+                if (!hgraph::graph_wiring_detail::input_accepts_output_schema(actual, expected[index])) {
+                    backend(loop.range, "hgraph IR traversal binding does not match the collection element");
+                }
+                context->bindings.push_back(traversal.bindings[index]);
+                context->schemas.push_back(actual);
+                if (items && index == 0U) {
+                    context->parameter_names.push_back(iterator.port.schema->kind == hgraph::TSTypeKind::TSD ? "key" : "ndx");
+                } else {
+                    context->parameter_names.push_back(loop.name);
+                }
+            }
+
+            for (const gir::ConditionalCapture &capture : plan.captures) {
+                const gir::Binding &captured = binding(capture.binding);
+                if (capture.phase != hir::Phase::Wiring) {
+                    backend(captured.range, "capturing scalar configuration in a dynamic graph 'for' body is not supported yet");
+                }
+                const auto outer = frame.bindings.find(capture.binding.value);
+                if (outer == frame.bindings.end() || !outer->second.is_port()) {
+                    backend(captured.range, "a dynamic graph traversal capture is not bound to a time-series port");
+                }
+                context->bindings.push_back(capture.binding);
+                context->schemas.push_back(schema(capture.type));
+                context->parameter_names.push_back(captured.name);
+            }
+
+            const TraversalContext *stored = context.get();
+            traversals_.push_back(std::move(context));
+            return hgraph::WiredFn{
+                .ops        = &traversal_ops(),
+                .context    = stored,
+                .identity   = &typeid(TraversalContext),
+                .arity      = stored->schemas.size(),
+                .has_output = false,
+            };
+        }
+
+        hgraph::WiringPortRef Compiler::wire_traversal(const void *opaque, hgraph::Wiring &child,
+                                                       std::span<const hgraph::WiringPortRef> arguments) {
+            const auto &context = *static_cast<const TraversalContext *>(opaque);
+            if (arguments.size() != context.bindings.size()) {
+                throw std::invalid_argument("an HGL dynamic traversal received the wrong number of child arguments");
+            }
+
+            Compiler       &compiler = *context.compiler;
+            hgraph::Wiring *previous = compiler.wiring_;
+            compiler.wiring_         = &child;
+            auto restore_wiring      = hgraph::make_scope_exit([&]() noexcept { compiler.wiring_ = previous; });
+
+            Frame frame;
+            frame.callable = context.callable;
+            frame.in_test  = context.in_test;
+            for (std::size_t index = 0; index < context.bindings.size(); ++index) {
+                frame.bindings.emplace(context.bindings[index].value, make_port(arguments[index], context.range));
+            }
+            (void)compiler.exec_block(context.block, frame);
+            return {};
+        }
+
+        hgraph::CompiledSubGraph Compiler::compile_traversal(const void *opaque, hgraph::Wiring *parent,
+                                                             std::span<const hgraph::TSValueTypeMetaData *const> input_schemas) {
+            const auto &context = *static_cast<const TraversalContext *>(opaque);
+            if (input_schemas.size() != context.schemas.size()) {
+                throw std::invalid_argument("an HGL dynamic traversal received the wrong number of child schemas");
+            }
+            hgraph::Wiring child = parent != nullptr ? parent->child_wiring() : hgraph::Wiring{hgraph::WiringKind::SubGraph};
+            std::vector<const hgraph::TSValueTypeMetaData *> schemas{input_schemas.begin(), input_schemas.end()};
+            std::vector<hgraph::WiringPortRef>               arguments;
+            arguments.reserve(input_schemas.size());
+            for (std::size_t index = 0; index < input_schemas.size(); ++index) {
+                if (!hgraph::graph_wiring_detail::input_accepts_output_schema(context.schemas[index], input_schemas[index])) {
+                    throw std::invalid_argument("an HGL dynamic traversal child schema does not match its binding");
+                }
+                arguments.push_back(hgraph::WiringPortRef::boundary_source(index, {}, input_schemas[index]));
+            }
+            auto compile = [&] {
+                (void)wire_traversal(opaque, child, arguments);
+                return std::move(child).finish_subgraph(std::nullopt, std::move(schemas));
+            };
+            if (!child.has_wiring_observers()) { return compile(); }
+            return child.observe(hgraph::WiringScopeEvent{.kind      = hgraph::WiringScopeKind::NestedGraph,
+                                                          .label     = context.label,
+                                                          .signature = context.label},
+                                 compile);
         }
 
         Slot Compiler::eval_temporal_conditional(gir::ValueId id, const Slot &condition, SourceRange range, Frame &frame) {
@@ -1585,26 +1756,55 @@ namespace hgl::wiring
             if (plan.returns) { backend(range, "return from a graph 'for' body is not defined yet"); }
 
             Slot iterator = eval_value(traversal.iterable, frame);
-            if (iterator.kind != Slot::Kind::Iterator || iterator.port.schema == nullptr ||
-                iterator.port.schema->kind != hgraph::TSTypeKind::TSL || iterator.port.schema->fixed_size() == 0U) {
+            if (iterator.kind != Slot::Kind::Iterator || iterator.port.schema == nullptr) {
                 fail(Category::Type, value(traversal.iterable).range,
-                     "a graph 'for' loop currently needs values(...) or items(...) over a fixed temporal list");
+                     "a graph 'for' loop needs values(...) or items(...) over a temporal map or list");
             }
             const bool items = iterator.name == "items";
             if (traversal.bindings.size() != (items ? 2U : 1U)) {
-                backend(range, "hgraph IR traversal bindings do not match the fixed-list iterator");
+                backend(range, "hgraph IR traversal bindings do not match its iterator");
             }
 
-            for (std::size_t index = 0; index < iterator.port.schema->fixed_size(); ++index) {
-                Frame iteration = frame;
-                Slot  position  = make_const(hgraph::Value{static_cast<hgraph::Int>(index)}, range);
-                Slot  selected  = make_port(hgraph::subgraph_wiring_detail::tsl_element_ref(
-                                                iterator.port, index, schema(binding(traversal.bindings.back()).type)),
-                                            range);
-                if (items) { iteration.bindings[traversal.bindings.front().value] = std::move(position); }
-                iteration.bindings[traversal.bindings.back().value] = std::move(selected);
-                (void)exec_block(traversal.block, iteration);
+            if (!iterator.type.valid() || iterator.type.value >= module_.types.size()) {
+                backend(value(traversal.iterable).range, "a graph iterator has no canonical collection type");
             }
+            const gir::Type &collection_type = module_.types[iterator.type.value];
+            const bool       fixed_list      = collection_type.kind == hir::TypeKind::List && collection_type.size.valid();
+            if (fixed_list) {
+                if (iterator.port.schema->kind != hgraph::TSTypeKind::TSL || iterator.port.schema->fixed_size() == 0U) {
+                    backend(value(traversal.iterable).range, "a fixed-list graph iterator has no fixed temporal schema");
+                }
+                for (std::size_t index = 0; index < iterator.port.schema->fixed_size(); ++index) {
+                    Frame iteration = frame;
+                    Slot  position  = make_const(hgraph::Value{static_cast<hgraph::Int>(index)}, range);
+                    Slot  selected  = make_port(hgraph::subgraph_wiring_detail::tsl_element_ref(
+                                                    iterator.port, index, schema(binding(traversal.bindings.back()).type)),
+                                                range);
+                    if (items) { iteration.bindings[traversal.bindings.front().value] = std::move(position); }
+                    iteration.bindings[traversal.bindings.back().value] = std::move(selected);
+                    (void)exec_block(traversal.block, iteration);
+                }
+                return;
+            }
+
+            if (iterator.port.schema->kind != hgraph::TSTypeKind::TSD && iterator.port.schema->kind != hgraph::TSTypeKind::TSL) {
+                backend(value(traversal.iterable).range,
+                        "dynamic graph traversal currently supports temporal maps and unbounded lists");
+            }
+
+            const hgraph::WiredFn          function = traversal_function(traversal, plan, iterator, frame, range);
+            std::vector<hgraph::WiringArg> arguments;
+            arguments.reserve(2U + plan.captures.size());
+            arguments.push_back(scalar_arg(hgraph::Value{function}));
+            arguments.push_back(time_series_arg(iterator.port));
+            for (const gir::ConditionalCapture &capture : plan.captures) {
+                const auto found = frame.bindings.find(capture.binding.value);
+                if (found == frame.bindings.end() || !found->second.is_port()) {
+                    backend(binding(capture.binding).range, "a dynamic graph traversal capture is not bound to a time-series port");
+                }
+                arguments.push_back(time_series_arg(found->second.port));
+            }
+            (void)wire("map_", std::move(arguments), range, false);
         }
 
         Slot Compiler::eval_harness(const gir::HarnessEval &eval, SourceRange range, Frame &caller) {

--- a/language/stdlib/README.md
+++ b/language/stdlib/README.md
@@ -49,10 +49,12 @@ the executable compiler example
 backends wire one body per child connection under the agreed
 [phase-dependent iteration model](../docs/design/iteration.md).
 
-[dynamic-map-iteration.hgl](examples/dynamic-map-iteration.hgl) covers an
-independent dynamic graph-loop body: one sink child graph per map key, with a
-shared temporal capture. The initial dynamic-loop design excludes assignments
-to enclosing variables and loop-carried reductions.
+Independent dynamic map and unbounded-list traversal has also graduated into
+the executable
+[dynamic-collection-iteration.hgl](../examples/dynamic-collection-iteration.hgl)
+example. Both backends lower one sink child graph per key or index and pass
+shared temporal captures explicitly. Assignments to enclosing variables and
+loop-carried reductions remain excluded.
 
 The [deferred map/reduce option](../docs/design/iteration.md#deferred-option-map-plus-reduce)
 records future unordered map reductions and the linear reduction option for
@@ -64,8 +66,8 @@ unsupported, not added here as a supported loop contract.
 
 The smallest temporal graph conditional—an explicit two-branch expression with
 one tail value and temporal captures—is implemented in both backends and the
-backend-parity fixture. These corpus examples still depend on the broader
-escaping-result, continuation, sink, and graph-phase iteration work. Typed
+backend-parity fixture. The remaining corpus examples depend on broader
+escaping-result, continuation, and sink work. Typed
 declarations without initializers and their definite-assignment checks are
 implemented. The files remain design inputs, not runnable tests, and are
 deliberately outside `language/examples/`, whose `.hgl` files are checked by

--- a/language/stdlib/examples/dynamic-map-iteration.hgl
+++ b/language/stdlib/examples/dynamic-map-iteration.hgl
@@ -1,9 +1,0 @@
-// Agreed design example; dynamic graph-phase iteration is not implemented yet.
-// Independent bodies lower to one sink child graph per key, with shared captures.
-// Loop-carried reductions are deferred; see language/docs/design/iteration.md.
-
-fn observe(book: map<str, f64>, offset: f64) {
-    for value in values(book) {
-        debug_print("adjusted", value + offset)
-    }
-}

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -281,6 +281,7 @@ add_test(NAME hgraph_language_codegen COMMAND hgl_codegen_tests)
 hgl_add_module(hgl_codegen_fixture STATIC HGL
     codegen/parity.hgl
     codegen/runtime.hgl
+    ../examples/dynamic-collection-iteration.hgl
     ../examples/fixed-list-iteration.hgl)
 hgl_apply_warnings(hgl_codegen_fixture)
 hgl_add_module(hgl_structural_fixture STATIC HGL ../examples/structural-types.hgl)

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -1175,16 +1175,26 @@ export fn observe_items(samples: list<f64, 3>) {
     CHECK(occurrences(emitted->source, "hgraph::wire<hgraph::stdlib::null_sink>") == 6U);
     CHECK(occurrences(emitted->source, "hgraph::wire<hgraph::stdlib::add_>") == 3U);
 
-    SECTION("dynamic graph traversal remains fail closed") {
-        Unit dynamic{R"(
+    SECTION("dynamic graph traversal lowers to independent sink child graphs") {
+        Unit       dynamic{R"(
 module checks.dynamic_iteration
 use hgraph.std::{null_sink}
-export fn observe(samples: list<f64>) {
-    for sample in values(samples) { null_sink(sample) }
+export fn observe(book: map<str, f64>, samples: list<f64>, offset: f64) {
+    for value in values(book) { null_sink(value + offset) }
+    for key, value in items(book) {
+        null_sink(value + offset)
+    }
+    for value in values(samples) { null_sink(value + offset) }
+    for index, value in items(samples) { null_sink(value + index + offset) }
 }
 )"};
-        CHECK_FALSE(dynamic.emit());
-        CHECK(dynamic.has(Category::Backend, "first graph-iteration slice requires a fixed temporal list"));
+        const auto generated = dynamic.emit();
+        REQUIRE(generated);
+        CHECK(occurrences(generated->source, "hgraph::wire<hgraph::stdlib::map_sink_>") == 4U);
+        CHECK(contains(generated->source, "hgraph::NamedPort<\"key\", hgraph::TS<hgraph::Str>> key"));
+        CHECK(contains(generated->source, "hgraph::NamedPort<\"ndx\", hgraph::TS<hgraph::Int>> index"));
+        CHECK(occurrences(generated->source, "[[maybe_unused]] hgraph::Port<hgraph::TS<hgraph::Float>> offset") == 4U);
+        CHECK_FALSE(contains(generated->source, "struct map_sink_"));
     }
 
     SECTION("graph iterator predicates remain a design boundary") {
@@ -1197,6 +1207,19 @@ export fn observe(samples: list<f64, 3>) {
 )"};
         CHECK_FALSE(predicate.emit());
         CHECK(predicate.has(Category::Backend, "graph-phase iterator predicates are not defined yet"));
+    }
+
+    SECTION("scalar captures remain a deliberate boundary") {
+        Unit scalar_capture{R"(
+module checks.scalar_capture
+use hgraph.std::{null_sink}
+export fn observe(samples: list<f64>, const offset: f64) {
+    for sample in values(samples) { null_sink(sample + offset) }
+}
+)"};
+        CHECK_FALSE(scalar_capture.emit());
+        CHECK(scalar_capture.has(Category::Backend,
+                                 "capturing scalar configuration in a dynamic graph 'for' body is not supported yet"));
     }
 
     SECTION("assignments cannot escape the traversal body") {

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -1179,12 +1179,15 @@ export fn observe_items(samples: list<f64, 3>) {
         Unit       dynamic{R"(
 module checks.dynamic_iteration
 use hgraph.std::{null_sink}
-export fn observe(book: map<str, f64>, samples: list<f64>, offset: f64) {
+export fn observe(book: map<str, f64>, samples: list<f64>, peers: list<f64>, offset: f64) {
     for value in values(book) { null_sink(value + offset) }
     for key, value in items(book) {
         null_sink(value + offset)
     }
-    for value in values(samples) { null_sink(value + offset) }
+    for value in values(samples) {
+        null_sink(value + offset)
+        null_sink(valid(peers))
+    }
     for index, value in items(samples) { null_sink(value + index + offset) }
 }
 )"};
@@ -1194,6 +1197,8 @@ export fn observe(book: map<str, f64>, samples: list<f64>, offset: f64) {
         CHECK(contains(generated->source, "hgraph::NamedPort<\"key\", hgraph::TS<hgraph::Str>> key"));
         CHECK(contains(generated->source, "hgraph::NamedPort<\"ndx\", hgraph::TS<hgraph::Int>> index"));
         CHECK(occurrences(generated->source, "[[maybe_unused]] hgraph::Port<hgraph::TS<hgraph::Float>> offset") == 4U);
+        CHECK(contains(generated->source, "[[maybe_unused]] hgraph::Port<hgraph::TSL<hgraph::TS<hgraph::Float>>> peers"));
+        CHECK(contains(generated->source, "hgraph::stdlib::pass_through(peers)"));
         CHECK_FALSE(contains(generated->source, "struct map_sink_"));
     }
 

--- a/language/tests/codegen/generated_iteration_tests.cpp
+++ b/language/tests/codegen/generated_iteration_tests.cpp
@@ -61,6 +61,15 @@ namespace
         return std::move(w).finish();
     }
 
+    GraphBuilder compose_dynamic_list_capture() {
+        hgl::wiring::ensure_session();
+        Wiring w;
+        auto   samples = wire<stdlib::const_, TSL<TS<Float>>>(w, stdlib::make_list<Float>({Float{1.0}, Float{2.0}}));
+        auto   peers   = wire<stdlib::const_, TSL<TS<Float>>>(w, stdlib::make_list<Float>({Float{3.0}, Float{4.0}}));
+        dynamic_iteration::observe_list_capture::compose(w, samples, peers);
+        return std::move(w).finish();
+    }
+
     std::size_t map_nodes(const GraphBuilder &graph) {
         return std::ranges::count_if(graph.nodes(), [](const NodeBuilder &node) {
             const NodeTypeMetaData *type = node.type().schema();
@@ -84,4 +93,5 @@ TEST_CASE("generated dynamic graph iteration wires one child-map owner", "[codeg
         CHECK(map_nodes(compose_dynamic_map_observer(with_items)) == 1U);
         CHECK(map_nodes(compose_dynamic_list_observer(with_items)) == 1U);
     }
+    CHECK(map_nodes(compose_dynamic_list_capture()) == 1U);
 }

--- a/language/tests/codegen/generated_iteration_tests.cpp
+++ b/language/tests/codegen/generated_iteration_tests.cpp
@@ -1,17 +1,21 @@
+#include <dynamic-collection-iteration.h>
 #include <fixed-list-iteration.h>
 
 #include "wiring/backend.h"
 
 #include <hgraph/lib/std/operators/collection.h>
 #include <hgraph/lib/std/operators/conversion.h>
+#include <hgraph/lib/std/value_util.h>
 #include <hgraph/types/graph_wiring.h>
 
 #include <catch2/catch_test_macros.hpp>
 
 #include <algorithm>
+#include <string_view>
 
 using namespace hgraph;
-namespace fixed_iteration = examples::fixed_list_iteration;
+namespace fixed_iteration   = examples::fixed_list_iteration;
+namespace dynamic_iteration = examples::dynamic_collection_iteration;
 
 namespace
 {
@@ -29,6 +33,41 @@ namespace
         }
         return std::move(w).finish();
     }
+
+    GraphBuilder compose_dynamic_map_observer(bool with_items) {
+        hgl::wiring::ensure_session();
+        Wiring w;
+        auto   book = wire<stdlib::const_, TSD<Str, TS<Float>>>(
+            w, stdlib::make_map<Str, Float>({{Str{"A"}, Float{1.0}}, {Str{"B"}, Float{2.0}}}));
+        auto offset = wire<stdlib::const_, TS<Float>>(w, Float{10.0});
+        if (with_items) {
+            dynamic_iteration::observe_items::compose(w, book, offset);
+        } else {
+            dynamic_iteration::observe_values::compose(w, book, offset);
+        }
+        return std::move(w).finish();
+    }
+
+    GraphBuilder compose_dynamic_list_observer(bool with_items) {
+        hgl::wiring::ensure_session();
+        Wiring w;
+        auto   samples = wire<stdlib::const_, TSL<TS<Float>>>(w, stdlib::make_list<Float>({Float{1.0}, Float{2.0}}));
+        auto   offset  = wire<stdlib::const_, TS<Float>>(w, Float{10.0});
+        if (with_items) {
+            dynamic_iteration::observe_list_items::compose(w, samples, offset);
+        } else {
+            dynamic_iteration::observe_list_values::compose(w, samples, offset);
+        }
+        return std::move(w).finish();
+    }
+
+    std::size_t map_nodes(const GraphBuilder &graph) {
+        return std::ranges::count_if(graph.nodes(), [](const NodeBuilder &node) {
+            const NodeTypeMetaData *type = node.type().schema();
+            return type != nullptr && type->node_kind == NodeKind::Nested && type->display_name != nullptr &&
+                   std::string_view{type->display_name} == "map_";
+        });
+    }
 }  // namespace
 
 TEST_CASE("generated fixed-list graph iteration wires one sink per child", "[codegen][generated][iteration]") {
@@ -37,5 +76,12 @@ TEST_CASE("generated fixed-list graph iteration wires one sink per child", "[cod
         const auto         sinks = std::ranges::count_if(
             graph.nodes(), [](const NodeBuilder &node) { return node.type().schema()->node_kind == NodeKind::Sink; });
         CHECK(sinks == 3);
+    }
+}
+
+TEST_CASE("generated dynamic graph iteration wires one child-map owner", "[codegen][generated][iteration]") {
+    for (const bool with_items : {false, true}) {
+        CHECK(map_nodes(compose_dynamic_map_observer(with_items)) == 1U);
+        CHECK(map_nodes(compose_dynamic_list_observer(with_items)) == 1U);
     }
 }

--- a/language/tests/hgraph_ir/control_flow_tests.cpp
+++ b/language/tests/hgraph_ir/control_flow_tests.cpp
@@ -134,3 +134,27 @@ fn examine(samples: list<f64, 3>) -> f64 {
     CHECK(plan.captures.empty());
     CHECK(plan.returns);
 }
+
+TEST_CASE("traversal analysis preserves temporal and scalar capture phases", "[hgraph-ir][control-flow][iteration]") {
+    Lowered lowered{R"(
+module checks.traversal_capture
+
+fn examine(book: map<str, f64>, offset: f64, const scale: f64) {
+    for value in values(book) {
+        value + offset * scale
+    }
+}
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE(lowered.graph);
+    REQUIRE(traversal(*lowered.graph) != nullptr);
+
+    const gir::TraversalPlan plan = gir::analyze_traversal(*lowered.graph, *traversal(*lowered.graph));
+    REQUIRE(plan.captures.size() == 2U);
+    CHECK(lowered.graph->bindings[plan.captures[0].binding.value].name == "offset");
+    CHECK(plan.captures[0].phase == hir::Phase::Wiring);
+    CHECK(lowered.graph->bindings[plan.captures[1].binding.value].name == "scale");
+    CHECK(plan.captures[1].phase == hir::Phase::Constant);
+    CHECK(plan.assigned_outer.empty());
+    CHECK_FALSE(plan.returns);
+}

--- a/language/tests/wiring/backend_tests.cpp
+++ b/language/tests/wiring/backend_tests.cpp
@@ -420,6 +420,7 @@ use hgraph.std::{hgl_dynamic_iteration_book, hgl_dynamic_iteration_list, null_si
 fn discard(trigger: f64, offset: f64) {
     let book: map<str, f64> = hgl_dynamic_iteration_book(trigger)
     let samples: list<f64> = hgl_dynamic_iteration_list(trigger)
+    let peers: list<f64> = hgl_dynamic_iteration_list(trigger)
     for value in values(book) {
         null_sink(value + offset)
     }
@@ -427,7 +428,7 @@ fn discard(trigger: f64, offset: f64) {
         null_sink(value + offset)
     }
     for value in values(samples) {
-        null_sink(value + offset)
+        null_sink(valid(peers))
     }
     for index, value in items(samples) {
         null_sink(value + index + offset)

--- a/language/tests/wiring/backend_tests.cpp
+++ b/language/tests/wiring/backend_tests.cpp
@@ -7,7 +7,9 @@
 #include "wiring/operator_types.h"
 
 #include <hgraph/lib/std/operators/collection.h>
+#include <hgraph/lib/std/operators/conversion.h>
 #include <hgraph/lib/std/operators/logical.h>
+#include <hgraph/lib/std/value_util.h>
 #include <hgraph/types/operator_dispatch.h>
 
 #include <catch2/catch_test_macros.hpp>
@@ -53,6 +55,39 @@ namespace
         static auto compose(hgraph::Wiring &w, hgraph::Port<hgraph::TS<hgraph::Float>> a,
                             hgraph::Port<hgraph::TS<hgraph::Float>> b) {
             return hgraph::stdlib::to_tsl(w, a, b);
+        }
+    };
+
+    struct dynamic_iteration_book_operator
+        : hgraph::Operator<"hgl_dynamic_iteration_book", hgraph::In<"trigger", hgraph::TS<hgraph::Float>>,
+                           hgraph::Out<hgraph::TSD<hgraph::Str, hgraph::TS<hgraph::Float>>>>
+    {};
+
+    struct dynamic_iteration_book_graph
+    {
+        static constexpr auto name = "hgl_dynamic_iteration_book_graph";
+
+        static auto compose(hgraph::Wiring &w, hgraph::Port<hgraph::TS<hgraph::Float>> trigger) {
+            static_cast<void>(trigger);
+            return hgraph::wire<hgraph::stdlib::const_, hgraph::TSD<hgraph::Str, hgraph::TS<hgraph::Float>>>(
+                w, hgraph::stdlib::make_map<hgraph::Str, hgraph::Float>(
+                       {{hgraph::Str{"A"}, hgraph::Float{1.0}}, {hgraph::Str{"B"}, hgraph::Float{2.0}}}));
+        }
+    };
+
+    struct dynamic_iteration_list_operator
+        : hgraph::Operator<"hgl_dynamic_iteration_list", hgraph::In<"trigger", hgraph::TS<hgraph::Float>>,
+                           hgraph::Out<hgraph::TSL<hgraph::TS<hgraph::Float>>>>
+    {};
+
+    struct dynamic_iteration_list_graph
+    {
+        static constexpr auto name = "hgl_dynamic_iteration_list_graph";
+
+        static auto compose(hgraph::Wiring &w, hgraph::Port<hgraph::TS<hgraph::Float>> trigger) {
+            static_cast<void>(trigger);
+            return hgraph::wire<hgraph::stdlib::const_, hgraph::TSL<hgraph::TS<hgraph::Float>>>(
+                w, hgraph::stdlib::make_list<hgraph::Float>({hgraph::Float{1.0}, hgraph::Float{2.0}}));
         }
     };
 
@@ -365,6 +400,42 @@ fn discard(a: f64, b: f64) {
 
 test fixed_iteration {
     eval(discard, a: [1.0], b: [2.0])
+}
+)"};
+    const TestResult result = only(unit.tests());
+    INFO(unit.diagnostics.render(unit.file));
+    INFO(result.message);
+    CHECK(result.passed);
+}
+
+TEST_CASE("dynamic collection graph iteration compiles independent child graphs", "[wiring][iteration]") {
+    ensure_session();
+    hgraph::register_graph_overload<dynamic_iteration_book_operator, dynamic_iteration_book_graph>();
+    hgraph::register_graph_overload<dynamic_iteration_list_operator, dynamic_iteration_list_graph>();
+    Unit             unit{R"(
+module t
+
+use hgraph.std::{hgl_dynamic_iteration_book, hgl_dynamic_iteration_list, null_sink}
+
+fn discard(trigger: f64, offset: f64) {
+    let book: map<str, f64> = hgl_dynamic_iteration_book(trigger)
+    let samples: list<f64> = hgl_dynamic_iteration_list(trigger)
+    for value in values(book) {
+        null_sink(value + offset)
+    }
+    for key, value in items(book) {
+        null_sink(value + offset)
+    }
+    for value in values(samples) {
+        null_sink(value + offset)
+    }
+    for index, value in items(samples) {
+        null_sink(value + index + offset)
+    }
+}
+
+test dynamic_iteration {
+    eval(discard, trigger: [1.0], offset: [10.0])
 }
 )"};
     const TestResult result = only(unit.tests());


### PR DESCRIPTION
## Summary
- lower independent graph-phase values/items traversal over TSD and unbounded TSL through native sink child graphs
- broadcast temporal captures explicitly and expose native key/ndx child inputs for items
- emit readable local C++ composition helpers and keep predicates, scalar captures, escaping assignment, and returns fail-closed
- graduate dynamic collection traversal into the runnable example corpus and update user/developer/design documentation

## Validation
- cmake --preset cpp --fresh -DHGRAPH_BUILD_LANGUAGE=ON
- cmake --build --preset cpp --target clean
- cmake --build --preset cpp --parallel
- ctest --preset cpp --parallel 2 (1759/1759)
- stable-ABI wheel built with Python 3.12 and installed/tested with Python 3.14 (3241 passed, 10 skipped)
- focused HGL suite after final example cleanup (43/43)