### PR TITLE
Compile single temporal conditional results in HGL

### DIFF
--- a/language/docs/README.md
+++ b/language/docs/README.md
@@ -73,5 +73,7 @@ The [standard-library folder](../stdlib/README.md) collects agreed HGL examples
 to drive core-library coverage and expose missing language features. It starts
 with conditional-result examples; the fixed-list and independent dynamic
 collection cases have graduated into the compiler's runnable example corpus. A
-complete component catalogue remains to be developed. Files left in the design
-corpus are not a claim of implemented support.
+single escaping conditional result has also graduated; multiple/mixed results,
+forwarding, and continuations remain in the design corpus. A complete component
+catalogue remains to be developed. Files left in the design corpus are not a
+claim of implemented support.

--- a/language/docs/design/control-flow.md
+++ b/language/docs/design/control-flow.md
@@ -5,11 +5,13 @@ backends lower an explicit two-branch temporal `if` whose result is the tail
 value of each branch through the native switch. They also lower outputless
 temporal conditionals with an optional block `else` through the native sink
 switch, including discarded conditionals inside value-producing graphs.
-Escaping assignments, scalar branch captures, value-producing omitted `else`,
-temporal `else if`, early-return continuations, and mixed/multiple results remain
-staged. A temporal `else if` is rejected rather than silently treated as an
-omitted `else`. This record uses the existing `if`/`else` syntax. It does not
-settle the other control-flow constructs or introduce new keywords.
+One predeclared temporal variable assigned by both explicit branches is also
+remapped from the switch output for later composition. Scalar branch captures,
+value-producing omitted `else`, forwarding existing bindings, temporal
+`else if`, early-return continuations, and mixed/multiple results remain staged.
+A temporal `else if` is rejected rather than silently treated as an omitted
+`else`. This record uses the existing `if`/`else` syntax. It does not settle the
+other control-flow constructs or introduce new keywords.
 
 ## The three conditional contexts
 
@@ -98,8 +100,9 @@ fn use_conditional_result(condition: bool, x: i64, y: i64) -> i64 {
 The compiler accepts the typed declaration without an initializer,
 `var r: i64`. It does not supply a value or connection: a later read is valid
 only after definite-assignment analysis proves that every reaching path has
-assigned it. This complete example remains outside the executable corpus until
-temporal conditional lowering is implemented.
+assigned it. This single-result form is implemented in both compiler backends;
+see the runnable
+[conditional-result.hgl](../../examples/conditional-result.hgl) example.
 
 An escaping variable must be declared before the conditional in an enclosing
 scope. Its branch-assigned binding is needed outside the conditional. A
@@ -547,13 +550,16 @@ introduced by these conditional agreements.
 
 Both language backends now accept the smallest value-producing form: a
 temporal Boolean condition, an explicit block `else`, no scalar captures,
-escaping assignments, or branch `return`, and one compatible tail value from
-each branch. They also accept outputless temporal conditionals, with or without
-an explicit `else`, and lower them through the native `switch_sink_` operator.
-HGraph IR performs capture/effect analysis once; the direct path builds
+or branch `return`, and one compatible tail value from each branch. They also
+accept outputless temporal conditionals, with or without an explicit block
+`else`, and lower them through the native `switch_sink_` operator. A conditional
+statement may instead assign one predeclared temporal variable in both explicit
+branches; the switch result remaps that binding for later statements. HGraph IR
+performs capture/effect/escape analysis once; the direct path builds
 context-backed branch callables, while `emit-cpp` writes ordinary named graph
-structs and native switch calls. Scripted and generated behavior are covered
-by compiler tests and executable examples.
+structs and native switch calls. Scripted and generated behavior are covered by
+compiler tests and executable examples. Multiple or mixed results, forwarding,
+omitted result branches, and continuations remain staged.
 
 The parser, typed uninitialized `var`, and path-sensitive definite assignment
 support are broader than this first backend slice. The remaining

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -1317,8 +1317,12 @@ walk:
   in HGraph IR and lowers an explicit pair of tail-valued block branches to the
   native `switch_`. The direct backend uses context-backed `WiredFn` branches;
   generated C++ uses readable local graph structs with one consistent union
-  signature. Scalar captures, escaping assignments, branch returns, omitted
-  `else`, multiple results, and sinks fail closed for later slices;
+  signature. Outputless conditionals use `switch_sink_`, including when their
+  containing function later returns a value. One enclosing temporal variable
+  assigned in both explicit branches becomes the switch result and is remapped
+  for subsequent composition. Scalar captures, branch returns,
+  value-producing omitted `else`, existing-binding forwarding, and
+  mixed/multiple results fail closed for later slices;
 - a block body runs its statements in order: `let` and `var` bind locals
   (a declared type converts a constant or checks a port's schema), `=` and
   the compound assignments rebind a `var`, `return` ends the activation,

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -932,8 +932,10 @@ assignments supply its output connection, and lowering remaps the binding
 after the switch. Count any used expression result alongside the escaping
 bindings: one result is returned directly; several are returned through a
 compiler-generated bundle. The grammar and semantic passes implement the
-declaration and definite-assignment portions. No default value or runtime state
-cell is implied; switch-result remapping remains backend work.
+declaration and definite-assignment portions. Both backends implement the
+single-result case when both explicit branches assign the same enclosing
+variable. No default value or runtime state cell is implied. Multiple/mixed
+results and existing-binding forwarding remain backend work.
 
 For each escaping result, lowering preserves the resolved declared temporal
 schema as the common branch-output slot. A branch that forwards an incoming

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -378,9 +378,10 @@ Status: partially implemented. A temporal condition with an explicit `else`
 and one tail value per branch runs in both scripted and compiled modes. The
 compiler also supports outputless temporal conditionals with an optional block
 `else`, including discarded conditionals inside a value-producing graph. The
-current slice rejects scalar branch captures, escaping assignments, temporal
-`else if`, an omitted `else` for a value-producing conditional, early branch
-returns, and mixed/multiple results. The existing syntax needs no new keyword.
+compiler additionally remaps one predeclared temporal variable assigned by both
+explicit branches. The current slice rejects scalar branch captures, temporal
+`else if`, an omitted or forwarding branch for a result, early branch returns,
+and mixed/multiple results. The existing syntax needs no new keyword.
 
 `if` has three context-dependent meanings:
 
@@ -416,12 +417,14 @@ fn use_conditional_result(condition: bool, x: i64, y: i64) -> i64 {
 ```
 
 Each branch returns its binding for `r`, and the enclosing `r` is remapped to
-the switch output. The multiplication is composed outside the switch. For
-multiple escaping variables, the branches return a common bundle whose fields
-are remapped to those variables. Branch-local declarations do not escape.
-The typed declaration without an initializer is compiler-supported. It creates
-no default value or connection; both branches must assign `r` before the later
-read.
+the switch output. The multiplication is composed outside the switch. For this
+single-result form, both scripted and compiled modes are implemented; see
+[conditional-result.hgl](../../examples/conditional-result.hgl). For multiple
+escaping variables, the agreed design has branches return a common bundle whose
+fields are remapped to those variables, but that lowering remains staged.
+Branch-local declarations do not escape. The typed declaration without an
+initializer creates no default value or connection; both branches must assign
+`r` before the later read.
 
 If `r` already has a binding before the conditional, a branch that leaves it
 unchanged forwards that incoming binding, including the implicit false branch
@@ -433,7 +436,8 @@ from a previously selected branch. For a bundled multi-result switch, each
 forwarded field uses the escaped variable's declared temporal schema. An
 ordinary `T` result is dereferenced at the branch-output boundary; an explicitly
 declared `ref<T>` result preserves the reference. Both branch output bundles
-have the same field schemas.
+have the same field schemas. This forwarding form is agreed but not yet
+implemented.
 
 Every escaping variable must have a binding on every path reaching its use:
 either a prior binding to forward or an assignment on that path. Otherwise

--- a/language/docs/user-guide/types-and-expressions.md
+++ b/language/docs/user-guide/types-and-expressions.md
@@ -773,7 +773,8 @@ An initializer may be omitted only from a typed mutable declaration such as
 unassigned variable readable. It supports the agreed
 [conditional-result design](../design/control-flow.md#results-used-after-the-conditional),
 where both branches assign `r` before later statements use its remapped switch
-output. Temporal switch remapping remains separate backend work.
+output. This single explicit-two-branch remapping is implemented in scripted
+and compiled modes; multiple results and forwarding remain staged.
 
 Using an escaping variable without a binding on every path
 reaching that use is a compile-time error. An existing incoming binding can

--- a/language/examples/conditional-result.hgl
+++ b/language/examples/conditional-result.hgl
@@ -1,0 +1,15 @@
+// A temporal conditional can assign one predeclared connection and remap it
+// into the enclosing graph before later composition continues.
+
+module examples.conditional_result
+
+export fn adjusted(condition: bool, x: i64, y: i64) -> i64 {
+    var result: i64
+    if condition {
+        result = x + 1
+    } else {
+        result = y - 1
+    }
+
+    return result * 2
+}

--- a/language/examples/conditional-result.hgl
+++ b/language/examples/conditional-result.hgl
@@ -13,3 +13,18 @@ export fn adjusted(condition: bool, x: i64, y: i64) -> i64 {
 
     return result * 2
 }
+
+// A later read observes the binding established earlier in the same branch;
+// it is not an incoming capture from the enclosing graph.
+export fn adjusted_twice(condition: bool, x: i64, y: i64) -> i64 {
+    var result: i64
+    if condition {
+        result = x + 1
+        result = result * 2
+    } else {
+        result = y - 1
+        result = result * 3
+    }
+
+    result
+}

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -1759,6 +1759,10 @@ namespace hgl::codegen
                 emit_planned_statement(statement, nested, *current_body_, body.range);
             }
             if (output_binding.valid()) {
+                if (body.tail.valid()) {
+                    const Value tail = eval_planned_expr(body.tail, nested);
+                    current_body_->line(tail.kind == Value::Kind::Void ? tail.code + ";" : "(void)" + tail.code + ";");
+                }
                 const auto found = nested.planned_bindings.find(output_binding.value);
                 if (found == nested.planned_bindings.end()) {
                     backend(body.range, "a time-series conditional branch did not assign its escaping result");

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -501,11 +501,11 @@ namespace hgl::codegen
             // -- expressions
             [[nodiscard]] Value eval_planned_expr(gir::ValueId id, Frame &frame);
             [[nodiscard]] Value lower_planned_conditional(gir::ValueId id, const gir::Conditional &branch, SourceRange range,
-                                                          Frame &frame);
+                                                          Frame &frame, bool result_used = true);
             void emit_planned_conditional_branch(std::string_view name, const gir::ConditionalBranchPlan &branch,
                                                  const gir::ConditionalPlan                       &plan,
                                                  const std::vector<std::pair<std::string, HType>> &parameters, Frame &outer,
-                                                 bool has_output, SourceRange range);
+                                                 HType result, gir::BindingId output_binding, bool has_output, SourceRange range);
             [[nodiscard]] Value eval_planned_reference(const gir::Reference &reference, SourceRange range, Frame &frame);
             [[nodiscard]] Value eval_planned_call(const gir::Value &expression, const gir::Call &call, Frame &frame);
             [[nodiscard]] Value eval_planned_construct(gir::TypeId type, const std::vector<gir::Argument> &arguments, bool delta,
@@ -1705,7 +1705,8 @@ namespace hgl::codegen
         void Emitter::emit_planned_conditional_branch(std::string_view name, const gir::ConditionalBranchPlan &branch,
                                                       const gir::ConditionalPlan                       &plan,
                                                       const std::vector<std::pair<std::string, HType>> &parameters, Frame &outer,
-                                                      bool has_output, SourceRange range) {
+                                                      HType result, gir::BindingId output_binding, bool has_output,
+                                                      SourceRange range) {
             if (current_body_ == nullptr) { backend(range, "a generated conditional branch has no enclosing function body"); }
 
             const auto saved_counts = local_counts_;
@@ -1731,8 +1732,7 @@ namespace hgl::codegen
             const SourceRange branch_range = branch.block.valid() ? planned_block(branch.block, range).range : range;
             current_body_->line("// " + where(branch_range));
             current_body_->open("struct " + std::string{name});
-            const std::string result_spelling =
-                has_output ? "hgraph::Port<" + schema(planned_type(plan.result, range), range) + ">" : "void";
+            const std::string result_spelling = has_output ? "hgraph::Port<" + schema(result, range) + ">" : "void";
             current_body_->line("static " + result_spelling + " compose(" + join(signature, ", ") + ")");
             current_body_->open("");
             if (!has_output) {
@@ -1744,10 +1744,31 @@ namespace hgl::codegen
                 return;
             }
 
-            const HType       result = planned_type(plan.result, range);
-            const gir::Block &body   = planned_block(branch.block, range);
+            const gir::Block &body = planned_block(branch.block, range);
+            if (output_binding.valid() && !nested.planned_bindings.contains(output_binding.value)) {
+                const gir::Binding &binding = planned_binding(output_binding, body.range);
+                const std::string   base    = cpp_name(binding.name);
+                std::string         local   = base;
+                int                &suffix  = local_counts_[base];
+                while (local_names_.contains(local)) { local = base + "_" + std::to_string(++suffix); }
+                local_names_.insert(local);
+                current_body_->line("hgraph::Port<" + schema(result, binding.range) + "> " + local + ";");
+                nested.planned_bindings.emplace(output_binding.value, make_port(local, result, binding.range));
+            }
             for (gir::StatementId statement : body.statements) {
                 emit_planned_statement(statement, nested, *current_body_, body.range);
+            }
+            if (output_binding.valid()) {
+                const auto found = nested.planned_bindings.find(output_binding.value);
+                if (found == nested.planned_bindings.end()) {
+                    backend(body.range, "a time-series conditional branch did not assign its escaping result");
+                }
+                current_body_->line("return " + as_port(found->second, result, body.range) + ";");
+                current_body_->close();
+                current_body_->close(";");
+                local_counts_ = saved_counts;
+                local_names_  = saved_names;
+                return;
             }
             if (!body.tail.valid()) { backend(body.range, "a value-producing time-series 'if' branch must end with a value"); }
             const gir::Value &tail  = planned_value(body.tail, body.range);
@@ -1760,17 +1781,32 @@ namespace hgl::codegen
             local_names_  = saved_names;
         }
 
-        Value Emitter::lower_planned_conditional(gir::ValueId id, const gir::Conditional &, SourceRange range, Frame &frame) {
-            const gir::ConditionalPlan plan       = gir::analyze_temporal_conditional(graph_, id);
-            const bool                 has_output = has_planned_result(plan.result, range);
+        Value Emitter::lower_planned_conditional(gir::ValueId id, const gir::Conditional &, SourceRange range, Frame &frame,
+                                                 bool result_used) {
+            const gir::ConditionalPlan plan              = gir::analyze_temporal_conditional(graph_, id);
+            const bool                 expression_output = result_used && has_planned_result(plan.result, range);
             if (plan.has_otherwise && !plan.when_false) {
                 backend(range, "temporal 'else if' is not supported in this compiler stage; use a block 'else'");
             }
-            if (has_output && !plan.when_false) {
+            if (plan.assigned_outer.size() > 1U) {
+                backend(range, "multiple assignments escaping a time-series 'if' are not supported in this compiler stage");
+            }
+            if (expression_output && !plan.assigned_outer.empty()) {
+                backend(range,
+                        "combining an expression result with assignments escaping a time-series 'if' is not supported in this "
+                        "compiler stage");
+            }
+            const gir::BindingId output_binding = plan.assigned_outer.empty() ? gir::BindingId{} : plan.assigned_outer.front();
+            if (expression_output && !plan.when_false) {
                 backend(range, "a value-producing time-series 'if' needs an explicit block 'else' in this compiler stage");
             }
-            if (!plan.when_true.assigned_outer.empty() || (plan.when_false && !plan.when_false->assigned_outer.empty())) {
-                backend(range, "assignment escaping a time-series 'if' is not supported in this compiler stage");
+            if (output_binding.valid() &&
+                (!plan.when_false ||
+                 std::ranges::find(plan.when_true.assigned_outer, output_binding) == plan.when_true.assigned_outer.end() ||
+                 std::ranges::find(plan.when_false->assigned_outer, output_binding) == plan.when_false->assigned_outer.end())) {
+                backend(range,
+                        "forwarding an existing assignment through a time-series 'if' branch is not supported in this compiler "
+                        "stage");
             }
             if (plan.when_true.returns || (plan.when_false && plan.when_false->returns)) {
                 backend(range, "return from a time-series 'if' branch is not supported in this compiler stage");
@@ -1810,9 +1846,17 @@ namespace hgl::codegen
             const std::string base        = "hgl_" + callable_cpp_name(frame.fn) + "_if_" + std::to_string(index);
             const std::string then_branch = base + "_then";
             const std::string else_branch = base + "_else";
-            emit_planned_conditional_branch(then_branch, plan.when_true, plan, parameters, frame, has_output, range);
+            const bool        has_output  = expression_output || output_binding.valid();
+            HType             result{};
+            if (output_binding.valid()) {
+                result = planned_type(planned_binding(output_binding, range).type, range);
+            } else if (expression_output) {
+                result = planned_type(plan.result, range);
+            }
+            emit_planned_conditional_branch(then_branch, plan.when_true, plan, parameters, frame, result, output_binding,
+                                            has_output, range);
             emit_planned_conditional_branch(else_branch, plan.when_false.value_or(gir::ConditionalBranchPlan{}), plan, parameters,
-                                            frame, has_output, range);
+                                            frame, result, output_binding, has_output, range);
 
             std::vector<std::string> switch_arguments{
                 condition.code, "hgraph::stdlib::switch_cases({{hgraph::Value{hgraph::Bool{true}}, hgraph::fn<" + then_branch +
@@ -1825,9 +1869,25 @@ namespace hgl::codegen
                 value.range = range;
                 return value;
             }
-            const HType result = planned_type(plan.result, range);
-            Value       value  = wire("hgraph::stdlib::switch_", switch_arguments, range, result);
+            Value value = wire("hgraph::stdlib::switch_", switch_arguments, range, result);
             value.code += ".as<" + schema(result, range) + ">()";
+            if (output_binding.valid()) {
+                const auto outer = frame.planned_bindings.find(output_binding.value);
+                if (outer == frame.planned_bindings.end() || !outer->second.is_port()) {
+                    backend(planned_binding(output_binding, range).range,
+                            "an escaping conditional result has no enclosing temporal binding");
+                }
+                const std::string outer_code                 = outer->second.code;
+                Value             remapped                   = value;
+                remapped.code                                = outer_code;
+                frame.planned_bindings[output_binding.value] = std::move(remapped);
+
+                Value assignment;
+                assignment.kind  = Value::Kind::Void;
+                assignment.code  = outer_code + " = " + value.code;
+                assignment.range = range;
+                return assignment;
+            }
             return value;
         }
 
@@ -2548,9 +2608,13 @@ namespace hgl::codegen
                         fail(Category::Type, statement.range, "'assert' is only valid in a test");
                     } else if constexpr (std::is_same_v<T, gir::Evaluate>) {
                         const gir::Value &expression = planned_value(node.value, statement.range);
-                        if (const auto *branch = std::get_if<gir::Conditional>(&expression.node);
-                            branch != nullptr && expression.phase != hir::Phase::Wiring) {
-                            emit_planned_if(*branch, expression.range, frame, out);
+                        if (const auto *branch = std::get_if<gir::Conditional>(&expression.node)) {
+                            if (expression.phase != hir::Phase::Wiring) {
+                                emit_planned_if(*branch, expression.range, frame, out);
+                            } else {
+                                const Value value = lower_planned_conditional(node.value, *branch, expression.range, frame, false);
+                                out.line(value.code + ";");
+                            }
                             return;
                         }
                         const Value value = eval_planned_expr(node.value, frame);
@@ -2728,9 +2792,13 @@ namespace hgl::codegen
                 if (function_body) {
                     const Value value = eval_planned_expr(block.tail, frame);
                     emit_return(value, frame, out, tail.range);
-                } else if (const auto *branch = std::get_if<gir::Conditional>(&tail.node);
-                           branch != nullptr && tail.phase != hir::Phase::Wiring) {
-                    emit_planned_if(*branch, tail.range, frame, out);
+                } else if (const auto *branch = std::get_if<gir::Conditional>(&tail.node)) {
+                    if (tail.phase != hir::Phase::Wiring) {
+                        emit_planned_if(*branch, tail.range, frame, out);
+                    } else {
+                        const Value value = lower_planned_conditional(block.tail, *branch, tail.range, frame, false);
+                        out.line(value.code + ";");
+                    }
                 } else {
                     const Value value = eval_planned_expr(block.tail, frame);
                     if (value.kind == Value::Kind::Void) {

--- a/language/src/hgraph_ir/control_flow.cpp
+++ b/language/src/hgraph_ir/control_flow.cpp
@@ -116,7 +116,7 @@ namespace hgl::hgraph_ir
             }
 
             void capture(const Value &expression, BindingId binding) {
-                if (!binding.valid() || contains(locals_, binding)) { return; }
+                if (!binding.valid() || contains(locals_, binding) || contains(defined_outer_, binding)) { return; }
                 const auto existing = std::ranges::find_if(
                     plan_.captures, [&](const ConditionalCapture &candidate) { return candidate.binding == binding; });
                 if (existing == plan_.captures.end()) {
@@ -155,11 +155,27 @@ namespace hgl::hgraph_ir
                         } else if constexpr (std::is_same_v<T, Tuple>) {
                             for (ValueId element : node.elements) { scan_value(element); }
                         } else if constexpr (std::is_same_v<T, Lambda>) {
+                            const auto defined = defined_outer_;
                             scan_value(node.body);
+                            defined_outer_ = defined;
                         } else if constexpr (std::is_same_v<T, Conditional>) {
                             scan_value(node.condition);
+
+                            const auto incoming = defined_outer_;
+                            defined_outer_      = incoming;
                             scan_block(node.then_block);
-                            scan_value(node.otherwise);
+                            const auto when_true = defined_outer_;
+
+                            defined_outer_ = incoming;
+                            if (node.otherwise.valid()) { scan_value(node.otherwise); }
+                            const auto when_false = defined_outer_;
+
+                            defined_outer_ = incoming;
+                            for (BindingId binding : when_true) {
+                                if (contains(when_false, binding) && !contains(defined_outer_, binding)) {
+                                    defined_outer_.push_back(binding);
+                                }
+                            }
                         } else if constexpr (std::is_same_v<T, BlockValue>) {
                             scan_block(node.block);
                         } else if constexpr (std::is_same_v<T, HarnessEval>) {
@@ -200,22 +216,29 @@ namespace hgl::hgraph_ir
                             if constexpr (std::is_same_v<T, LocalBinding> || std::is_same_v<T, StateBinding>) {
                                 scan_value(node.init);
                             } else if constexpr (std::is_same_v<T, Lifecycle>) {
+                                const auto defined = defined_outer_;
                                 scan_block(node.block);
+                                defined_outer_ = defined;
                             } else if constexpr (std::is_same_v<T, Activation>) {
                                 scan_value(node.condition);
+                                const auto defined = defined_outer_;
                                 scan_block(node.block);
+                                defined_outer_ = defined;
                             } else if constexpr (std::is_same_v<T, Traversal>) {
                                 scan_value(node.iterable);
+                                const auto defined = defined_outer_;
                                 scan_block(node.block);
+                                defined_outer_ = defined;
                             } else if constexpr (std::is_same_v<T, Assignment>) {
                                 const BindingId target = place_root(node.place);
-                                if (target.valid() && !contains(locals_, target) && !contains(plan_.assigned_outer, target)) {
-                                    plan_.assigned_outer.push_back(target);
-                                }
                                 if (node.op != AssignOp::Assign || direct_assignment_target(node.place) != target) {
                                     scan_value(node.place);
                                 }
                                 scan_value(node.value);
+                                if (target.valid() && !contains(locals_, target)) {
+                                    if (!contains(plan_.assigned_outer, target)) { plan_.assigned_outer.push_back(target); }
+                                    if (!contains(defined_outer_, target)) { defined_outer_.push_back(target); }
+                                }
                             } else if constexpr (std::is_same_v<T, Return>) {
                                 plan_.returns = true;
                                 scan_value(node.value);
@@ -233,6 +256,7 @@ namespace hgl::hgraph_ir
             const Module          &module_;
             ConditionalBranchPlan  plan_{};
             std::vector<BindingId> locals_{};
+            std::vector<BindingId> defined_outer_{};
         };
 
         void append_capture(std::vector<ConditionalCapture> &captures, const ConditionalCapture &capture) {

--- a/language/src/hgraph_ir/control_flow.cpp
+++ b/language/src/hgraph_ir/control_flow.cpp
@@ -255,6 +255,9 @@ namespace hgl::hgraph_ir
         plan.result    = value.type;
         plan.when_true = BranchAnalyzer{module, branch->then_block}.take();
         for (const ConditionalCapture &capture : plan.when_true.captures) { append_capture(plan.captures, capture); }
+        for (BindingId binding : plan.when_true.assigned_outer) {
+            if (!contains(plan.assigned_outer, binding)) { plan.assigned_outer.push_back(binding); }
+        }
 
         plan.has_otherwise = branch->otherwise.valid();
         if (branch->otherwise.valid() && branch->otherwise.value < module.values.size()) {
@@ -262,6 +265,9 @@ namespace hgl::hgraph_ir
             if (const auto *block = std::get_if<BlockValue>(&otherwise.node)) {
                 plan.when_false = BranchAnalyzer{module, block->block}.take();
                 for (const ConditionalCapture &capture : plan.when_false->captures) { append_capture(plan.captures, capture); }
+                for (BindingId binding : plan.when_false->assigned_outer) {
+                    if (!contains(plan.assigned_outer, binding)) { plan.assigned_outer.push_back(binding); }
+                }
             }
         }
         return plan;

--- a/language/src/hgraph_ir/control_flow.h
+++ b/language/src/hgraph_ir/control_flow.h
@@ -37,6 +37,7 @@ namespace hgl::hgraph_ir
         bool                                 has_otherwise{false};
         std::optional<ConditionalBranchPlan> when_false{};
         std::vector<ConditionalCapture>      captures{};
+        std::vector<BindingId>               assigned_outer{};
     };
 
     /// Analyze an HGraph-IR Conditional value. The input module is already

--- a/language/src/wiring/backend.cpp
+++ b/language/src/wiring/backend.cpp
@@ -363,7 +363,8 @@ namespace hgl::wiring
                                                         std::string_view registry_name = {});
 
             [[nodiscard]] Slot eval_value(gir::ValueId id, Frame &frame);
-            [[nodiscard]] Slot eval_temporal_conditional(gir::ValueId id, const Slot &condition, SourceRange range, Frame &frame);
+            [[nodiscard]] Slot eval_temporal_conditional(gir::ValueId id, const Slot &condition, SourceRange range, Frame &frame,
+                                                         bool result_used = true);
             [[nodiscard]] Slot eval_reference(const gir::Reference &reference, SourceRange range, Frame &frame);
             [[nodiscard]] Slot eval_call(const gir::Value &expression, const gir::Call &call, Frame &frame);
             [[nodiscard]] Slot eval_intrinsic(std::string_view name, const std::vector<gir::Argument> &arguments, SourceRange range,
@@ -390,13 +391,14 @@ namespace hgl::wiring
 
             struct ConditionalBranchContext
             {
-                Compiler    *compiler{nullptr};
-                Frame        frame{};
-                gir::BlockId block{};
-                gir::TypeId  result{};
-                bool         has_output{false};
-                SourceRange  range{};
-                std::string  label{};
+                Compiler      *compiler{nullptr};
+                Frame          frame{};
+                gir::BlockId   block{};
+                gir::TypeId    result{};
+                gir::BindingId output_binding{};
+                bool           has_output{false};
+                SourceRange    range{};
+                std::string    label{};
             };
 
             struct TraversalContext
@@ -412,8 +414,9 @@ namespace hgl::wiring
                 std::string                                      label{};
             };
 
-            [[nodiscard]] hgraph::WiredFn conditional_branch(Frame &frame, gir::BlockId block, gir::TypeId result, bool has_output,
-                                                             SourceRange range, std::string label);
+            [[nodiscard]] hgraph::WiredFn conditional_branch(Frame &frame, gir::BlockId block, gir::TypeId result,
+                                                             gir::BindingId output_binding, bool has_output, SourceRange range,
+                                                             std::string label);
             [[nodiscard]] static hgraph::WiringPortRef wire_conditional_branch(const void *context, hgraph::Wiring &w,
                                                                                std::span<const hgraph::WiringPortRef> arguments);
             [[nodiscard]] static const hgraph::WiredFnOps &conditional_branch_ops();
@@ -1330,14 +1333,16 @@ namespace hgl::wiring
             return ops;
         }
 
-        hgraph::WiredFn Compiler::conditional_branch(Frame &frame, gir::BlockId block, gir::TypeId result, bool has_output,
-                                                     SourceRange range, std::string label) {
+        hgraph::WiredFn Compiler::conditional_branch(Frame &frame, gir::BlockId block, gir::TypeId result,
+                                                     gir::BindingId output_binding, bool has_output, SourceRange range,
+                                                     std::string label) {
             auto context      = std::make_unique<ConditionalBranchContext>();
             context->compiler = this;
             context->frame    = frame;
             context->frame.returned.reset();
             context->block                         = block;
             context->result                        = result;
+            context->output_binding                = output_binding;
             context->has_output                    = has_output;
             context->range                         = range;
             context->label                         = std::move(label);
@@ -1364,7 +1369,15 @@ namespace hgl::wiring
 
             Frame frame  = context.frame;
             Slot  result = context.block.valid() ? compiler.exec_block(context.block, frame) : Slot{};
-            if (frame.returned) { result = *frame.returned; }
+            if (frame.returned) {
+                result = *frame.returned;
+            } else if (context.output_binding.valid()) {
+                const auto found = frame.bindings.find(context.output_binding.value);
+                if (found == frame.bindings.end()) {
+                    compiler.backend(context.range, "a time-series conditional branch did not assign its escaping result");
+                }
+                result = found->second;
+            }
 
             if (!context.has_output) { return {}; }
 
@@ -1525,18 +1538,33 @@ namespace hgl::wiring
                                  compile);
         }
 
-        Slot Compiler::eval_temporal_conditional(gir::ValueId id, const Slot &condition, SourceRange range, Frame &frame) {
-            const gir::ConditionalPlan plan       = gir::analyze_temporal_conditional(module_, id);
-            const bool                 has_output = plan.result.valid() && plan.result.value < module_.types.size() &&
-                                                    module_.types[plan.result.value].kind != hir::TypeKind::Void;
+        Slot Compiler::eval_temporal_conditional(gir::ValueId id, const Slot &condition, SourceRange range, Frame &frame,
+                                                 bool result_used) {
+            const gir::ConditionalPlan plan = gir::analyze_temporal_conditional(module_, id);
+            const bool expression_output    = result_used && plan.result.valid() && plan.result.value < module_.types.size() &&
+                                              module_.types[plan.result.value].kind != hir::TypeKind::Void;
             if (plan.has_otherwise && !plan.when_false) {
                 backend(range, "temporal 'else if' is not supported in this compiler stage; use a block 'else'");
             }
-            if (has_output && !plan.when_false) {
+            if (plan.assigned_outer.size() > 1U) {
+                backend(range, "multiple assignments escaping a time-series 'if' are not supported in this compiler stage");
+            }
+            if (expression_output && !plan.assigned_outer.empty()) {
+                backend(range,
+                        "combining an expression result with assignments escaping a time-series 'if' is not supported in this "
+                        "compiler stage");
+            }
+            const gir::BindingId output_binding = plan.assigned_outer.empty() ? gir::BindingId{} : plan.assigned_outer.front();
+            if (expression_output && !plan.when_false) {
                 backend(range, "a value-producing time-series 'if' needs an explicit block 'else' in this compiler stage");
             }
-            if (!plan.when_true.assigned_outer.empty() || (plan.when_false && !plan.when_false->assigned_outer.empty())) {
-                backend(range, "assignment escaping a time-series 'if' is not supported in this compiler stage");
+            if (output_binding.valid() &&
+                (!plan.when_false ||
+                 std::ranges::find(plan.when_true.assigned_outer, output_binding) == plan.when_true.assigned_outer.end() ||
+                 std::ranges::find(plan.when_false->assigned_outer, output_binding) == plan.when_false->assigned_outer.end())) {
+                backend(range,
+                        "forwarding an existing assignment through a time-series 'if' branch is not supported in this compiler "
+                        "stage");
             }
             if (plan.when_true.returns || (plan.when_false && plan.when_false->returns)) {
                 backend(range, "return from a time-series 'if' branch is not supported in this compiler stage");
@@ -1552,14 +1580,21 @@ namespace hgl::wiring
                 backend(value(plan.condition).range, "a temporal conditional needs a time-series condition");
             }
 
+            const bool        has_output  = expression_output || output_binding.valid();
+            const gir::TypeId result_type = output_binding.valid() ? binding(output_binding).type : plan.result;
+
             hgraph::stdlib::SwitchCases cases = hgraph::stdlib::switch_cases(
-                {{hgraph::Value{hgraph::Bool{true}},
-                  conditional_branch(frame, plan.when_true.block, plan.result, has_output, range, "hgl conditional then")},
+                {{hgraph::Value{hgraph::Bool{true}}, conditional_branch(frame, plan.when_true.block, result_type, output_binding,
+                                                                        has_output, range, "hgl conditional then")},
                  {hgraph::Value{hgraph::Bool{false}},
-                  conditional_branch(frame, plan.when_false ? plan.when_false->block : gir::BlockId{}, plan.result, has_output,
-                                     range, "hgl conditional else")}});
-            return wire("switch_", {time_series_arg(condition.port, "key"), scalar_arg(hgraph::Value{std::move(cases)}, "cases")},
-                        range, has_output, has_output ? schema(plan.result) : nullptr);
+                  conditional_branch(frame, plan.when_false ? plan.when_false->block : gir::BlockId{}, result_type, output_binding,
+                                     has_output, range, "hgl conditional else")}});
+            Slot selected =
+                wire("switch_", {time_series_arg(condition.port, "key"), scalar_arg(hgraph::Value{std::move(cases)}, "cases")},
+                     range, has_output, has_output ? schema(result_type) : nullptr);
+            if (!output_binding.valid()) { return selected; }
+            frame.bindings[output_binding.value] = std::move(selected);
+            return make_marker(Slot::Kind::Void, range);
         }
 
         Slot Compiler::eval_value(gir::ValueId id, Frame &frame) {
@@ -1750,6 +1785,15 @@ namespace hgl::wiring
                             throw TestFailure{std::move(message)};
                         }
                     } else if constexpr (std::is_same_v<T, gir::Evaluate>) {
+                        const gir::Value &expression = value(node.value);
+                        if (const auto *branch = std::get_if<gir::Conditional>(&expression.node);
+                            branch != nullptr && expression.phase == hir::Phase::Wiring) {
+                            Slot condition = eval_value(branch->condition, frame);
+                            if (condition.is_port()) {
+                                (void)eval_temporal_conditional(node.value, condition, expression.range, frame, false);
+                                return;
+                            }
+                        }
                         (void)eval_value(node.value, frame);
                     } else if constexpr (std::is_same_v<T, gir::Traversal>) {
                         exec_traversal(node, statement.range, frame);

--- a/language/stdlib/README.md
+++ b/language/stdlib/README.md
@@ -11,10 +11,12 @@ declarations or native-binding syntax.
 
 ## Conditional results
 
-[conditional-results.hgl](examples/conditional-results.hgl) covers one and
-multiple predeclared variables assigned by temporal `if` branches and used by
-later statements. It also covers forwarding an initialized variable by
-reference through a branch that leaves it unchanged. The
+[conditional-result.hgl](../examples/conditional-result.hgl) is the executable
+single-result case: one predeclared variable is assigned in both explicit
+temporal branches, remapped from the native switch output, and used by later
+composition. [conditional-results.hgl](examples/conditional-results.hgl) keeps
+the remaining multiple-result and initialized-binding forwarding cases in the
+design corpus. The
 [conditional control-flow design](../docs/design/control-flow.md) explains
 branch captures, output signatures, bundle remapping, and remaining decisions.
 
@@ -31,15 +33,16 @@ lifetime. It remains a design example awaiting compiler support.
 Outputless temporal conditionals have graduated into the executable
 [conditional-sinks.hgl](../examples/conditional-sinks.hgl) compiler example.
 `debug_print("enabled", value)` is wired through the native sink switch, while
-`debug_print("always", value)` is always wired outside it. The label precedes
-the time-series argument.
+`debug_print("always", value)` is always wired outside it. The example also
+covers a discarded sink conditional inside a value-producing graph. The label
+precedes the time-series argument.
 
 [conditional-unassigned-result.hgl](examples/invalid/conditional-unassigned-result.hgl)
 is intentionally invalid: the escaping variable has no incoming binding and
 is assigned only on the true path before it is used. It records the agreed
 compile-time definite-assignment error. The compiler now implements this
-path-sensitive check, although the temporal conditional itself still awaits
-backend lowering.
+path-sensitive check. The single explicit-two-branch result form now has
+backend lowering; the invalid example continues to guard the broader rule.
 
 ## Explicit switch
 
@@ -132,9 +135,11 @@ agreed contract and has no corpus example; further loop design is paused.
 The smallest temporal graph conditional—an explicit two-branch expression with
 one tail value and temporal captures—is implemented in both backends and the
 backend-parity fixture. Outputless temporal conditionals with an optional
-`else` are also implemented through the native sink switch. The remaining
-corpus examples depend on broader escaping-result and continuation work. Typed
-declarations without initializers and their definite-assignment checks are
-implemented. The files remain design inputs, not runnable tests, and are
-deliberately outside `language/examples/`, whose `.hgl` files are checked by
-CTest.
+block `else` are also implemented through the native sink switch. One escaping
+assignment that is assigned by both explicit branches is implemented in both
+backends and the generated-code fixture. Multiple escaping assignments, mixed
+expression/assignment results, forwarding an existing binding, and
+continuations remain design inputs. Typed declarations without initializers
+and their definite-assignment checks are implemented. Files left here are not
+runnable tests and remain deliberately outside `language/examples/`, whose
+`.hgl` files are checked by CTest.

--- a/language/stdlib/examples/conditional-mixed-results.hgl
+++ b/language/stdlib/examples/conditional-mixed-results.hgl
@@ -1,4 +1,4 @@
-// Agreed design example; temporal conditional lowering is not implemented yet.
+// Agreed design example; mixed temporal result lowering is not implemented yet.
 // The expression result and escaping r share a generated bundle output.
 // See language/docs/design/control-flow.md.
 

--- a/language/stdlib/examples/conditional-results.hgl
+++ b/language/stdlib/examples/conditional-results.hgl
@@ -1,16 +1,5 @@
-// Agreed design examples; not yet supported by the compiler.
+// Remaining agreed design examples; not yet supported by the compiler.
 // See language/docs/design/control-flow.md.
-
-fn use_conditional_result(condition: bool, x: i64, y: i64) -> i64 {
-    var r: i64
-    if condition {
-        r = x + 1
-    } else {
-        r = y - 1
-    }
-
-    return r * 2
-}
 
 fn use_conditional_results(condition: bool, x: i64, y: i64) -> i64 {
     var r: i64

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -281,6 +281,7 @@ add_test(NAME hgraph_language_codegen COMMAND hgl_codegen_tests)
 hgl_add_module(hgl_codegen_fixture STATIC HGL
     codegen/parity.hgl
     codegen/runtime.hgl
+    ../examples/conditional-result.hgl
     ../examples/conditional-sinks.hgl
     ../examples/dynamic-collection-iteration.hgl
     ../examples/fixed-list-iteration.hgl)

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -734,6 +734,39 @@ export fn adjusted(condition: bool, x: i64, y: i64) -> i64 {
     CHECK(contains(emitted->source, "return hgraph::wire<hgraph::stdlib::mul_>"));
 }
 
+TEST_CASE("emit-cpp preserves a discarded branch tail before returning an escaping result",
+          "[codegen][control-flow][conditional]") {
+    Unit unit{R"(
+module planned_temporal_assignment_tail
+use hgraph.std::{null_sink}
+
+export fn adjusted(condition: bool, x: i64, y: i64) -> i64 {
+    var result: i64
+    if condition {
+        result = x + 1
+        null_sink(x)
+    } else {
+        result = y - 1
+        null_sink(y)
+    }
+    result
+}
+)"};
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+
+    const auto emitted = unit.emit();
+    REQUIRE(emitted);
+    CHECK(occurrences(emitted->source, "hgraph::wire<hgraph::stdlib::null_sink>") == 2U);
+    const std::size_t first_sink    = emitted->source.find("hgraph::wire<hgraph::stdlib::null_sink>");
+    const std::size_t first_return  = emitted->source.find("return result;", first_sink);
+    const std::size_t second_sink   = emitted->source.find("hgraph::wire<hgraph::stdlib::null_sink>", first_return);
+    const std::size_t second_return = emitted->source.find("return result;", second_sink);
+    CHECK(first_sink < first_return);
+    CHECK(first_return < second_sink);
+    CHECK(second_sink < second_return);
+}
+
 TEST_CASE("emit-cpp rejects staged temporal conditional result shapes", "[codegen][control-flow][conditional]") {
     SECTION("multiple escaping assignments") {
         Unit unit{R"(

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -707,6 +707,92 @@ export fn observe(first: bool, second: bool, value: f64) {
     CHECK(unit.has(Category::Backend, "temporal 'else if' is not supported"));
 }
 
+TEST_CASE("emit-cpp remaps one temporal conditional assignment", "[codegen][control-flow][conditional]") {
+    Unit unit{R"(
+module planned_temporal_assignment
+
+export fn adjusted(condition: bool, x: i64, y: i64) -> i64 {
+    var result: i64
+    if condition {
+        result = x + 1
+    } else {
+        result = y - 1
+    }
+    return result * 2
+}
+)"};
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+
+    const auto emitted = unit.emit();
+    REQUIRE(emitted);
+    CHECK(contains(emitted->source, "struct hgl_adjusted_if_1_then"));
+    CHECK(contains(emitted->source, "struct hgl_adjusted_if_1_else"));
+    CHECK(occurrences(emitted->source, "hgraph::Port<hgraph::TS<hgraph::Int>> result;") == 3U);
+    CHECK(occurrences(emitted->source, "return result;") == 2U);
+    CHECK(contains(emitted->source, "result = hgraph::wire<hgraph::stdlib::switch_>"));
+    CHECK(contains(emitted->source, "return hgraph::wire<hgraph::stdlib::mul_>"));
+}
+
+TEST_CASE("emit-cpp rejects staged temporal conditional result shapes", "[codegen][control-flow][conditional]") {
+    SECTION("multiple escaping assignments") {
+        Unit unit{R"(
+module planned_multiple_temporal_assignments
+
+export fn adjusted(condition: bool, x: i64, y: i64) -> i64 {
+    var result: i64
+    var offset: i64
+    if condition {
+        result = x + 1
+        offset = x
+    } else {
+        result = y - 1
+        offset = y
+    }
+    return result + offset
+}
+)"};
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Backend, "multiple assignments escaping a time-series 'if'"));
+    }
+
+    SECTION("forwarding an existing binding") {
+        Unit unit{R"(
+module planned_temporal_forwarding
+
+export fn adjusted(condition: bool, x: i64) -> i64 {
+    var result: i64 = x
+    if condition {
+        result = result + 1
+    }
+    return result
+}
+)"};
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Backend, "forwarding an existing assignment through a time-series 'if'"));
+    }
+
+    SECTION("mixed expression and assignment results") {
+        Unit unit{R"(
+module planned_mixed_temporal_results
+
+export fn adjusted(condition: bool, x: i64, y: i64) -> i64 {
+    var offset: i64
+    let result = if condition {
+        offset = x + 1
+        x * 2
+    } else {
+        offset = y - 1
+        y * 3
+    }
+    return result + offset
+}
+)"};
+        CHECK_FALSE(unit.emit());
+        CHECK(unit.has(Category::Backend, "combining an expression result with assignments escaping a time-series 'if'"));
+    }
+}
+
 TEST_CASE("emit-cpp promotes the first constant assignment to a typed composition var", "[codegen][locals][control-flow]") {
     Unit unit{R"(
 module planned_constant_assignment

--- a/language/tests/codegen/generated_tests.cpp
+++ b/language/tests/codegen/generated_tests.cpp
@@ -2,6 +2,7 @@
 // `parity.hgl` compiled by `hgl emit-cpp` through `hgl_add_module`, wired
 // and evaluated with hgraph's own harness. The expectations are the ones the
 // module's `test` blocks assert under `hgl test`.
+#include <conditional-result.h>
 #include <conditional-sinks.h>
 #include <parity.h>
 
@@ -19,8 +20,9 @@
 
 using namespace hgraph;
 using namespace hgraph::testing;
-namespace parity            = hgl::codegen::parity;
-namespace conditional_sinks = examples::conditional_sinks;
+namespace parity             = hgl::codegen::parity;
+namespace conditional_result = examples::conditional_result;
+namespace conditional_sinks  = examples::conditional_sinks;
 
 namespace
 {
@@ -70,6 +72,12 @@ TEST_CASE("generated outputless conditionals compose inside value graphs", "[cod
     session();
     CHECK(eval_node<conditional_sinks::observe_and_forward>(values<Bool>(false, true), values<Float>(1.0, 2.0)) ==
           values<Float>(1.0, 2.0));
+}
+
+TEST_CASE("generated temporal conditionals remap one assigned result", "[codegen][generated][conditional]") {
+    session();
+    CHECK(eval_node<conditional_result::adjusted>(values<Bool>(true, true, false), values<Int>(1, 2, 3), values<Int>(10, 20, 30)) ==
+          values<Int>(4, 6, 58));
 }
 
 TEST_CASE("generated exports are registered by module-qualified name with their defaults", "[codegen][generated]") {

--- a/language/tests/codegen/generated_tests.cpp
+++ b/language/tests/codegen/generated_tests.cpp
@@ -80,6 +80,12 @@ TEST_CASE("generated temporal conditionals remap one assigned result", "[codegen
           values<Int>(4, 6, 58));
 }
 
+TEST_CASE("generated temporal branches reuse results assigned earlier in the branch", "[codegen][generated][conditional]") {
+    session();
+    CHECK(eval_node<conditional_result::adjusted_twice>(values<Bool>(true, false), values<Int>(1, 2), values<Int>(10, 20)) ==
+          values<Int>(4, 57));
+}
+
 TEST_CASE("generated exports are registered by module-qualified name with their defaults", "[codegen][generated]") {
     session();
     CHECK(hgl::wiring::has_operator("hgl.codegen.parity.plus"));

--- a/language/tests/hgraph_ir/control_flow_tests.cpp
+++ b/language/tests/hgraph_ir/control_flow_tests.cpp
@@ -7,6 +7,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <algorithm>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -155,6 +156,33 @@ fn choose(condition: bool, value: i64) -> i64 {
     CHECK(plan.assigned_outer.front() == plan.when_true.assigned_outer.front());
     CHECK(plan.when_true.returns);
     CHECK_FALSE(plan.when_false->returns);
+}
+
+TEST_CASE("temporal conditional analysis does not capture a result assigned earlier in its branch", "[hgraph-ir][control-flow]") {
+    Lowered lowered{R"(
+module checks.temporal_reassignment
+
+fn choose(condition: bool, x: i64, y: i64) -> i64 {
+    var result: i64
+    if condition {
+        result = x + 1
+        result = result * 2
+    } else {
+        result = y - 1
+        result = result * 3
+    }
+    result
+}
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE(lowered.graph);
+
+    const gir::ConditionalPlan plan = gir::analyze_temporal_conditional(*lowered.graph, conditional_value(*lowered.graph));
+    REQUIRE(plan.when_false);
+    REQUIRE(plan.assigned_outer.size() == 1U);
+    CHECK(lowered.graph->bindings[plan.assigned_outer.front().value].name == "result");
+    CHECK(std::ranges::none_of(
+        plan.captures, [&](const gir::ConditionalCapture &capture) { return capture.binding == plan.assigned_outer.front(); }));
 }
 
 TEST_CASE("traversal analysis separates loop locals from escaping control flow", "[hgraph-ir][control-flow][iteration]") {

--- a/language/tests/hgraph_ir/control_flow_tests.cpp
+++ b/language/tests/hgraph_ir/control_flow_tests.cpp
@@ -151,6 +151,8 @@ fn choose(condition: bool, value: i64) -> i64 {
     REQUIRE(plan.when_true.assigned_outer.size() == 1);
     REQUIRE(plan.when_false->assigned_outer.size() == 1);
     CHECK(plan.when_true.assigned_outer.front() == plan.when_false->assigned_outer.front());
+    REQUIRE(plan.assigned_outer.size() == 1);
+    CHECK(plan.assigned_outer.front() == plan.when_true.assigned_outer.front());
     CHECK(plan.when_true.returns);
     CHECK_FALSE(plan.when_false->returns);
 }

--- a/language/tests/wiring/backend_tests.cpp
+++ b/language/tests/wiring/backend_tests.cpp
@@ -386,6 +386,101 @@ test observe_and_forward {
     CHECK(result.passed);
 }
 
+TEST_CASE("a temporal if remaps one assigned result into the enclosing graph", "[wiring][control-flow][conditional]") {
+    Unit             unit{R"(
+module t
+
+fn adjusted(condition: bool, x: i64, y: i64) -> i64 {
+    var result: i64
+    if condition {
+        result = x + 1
+    } else {
+        result = y - 1
+    }
+    return result * 2
+}
+
+test adjusted_ticks {
+    assert eval(adjusted, condition: [true, true, false], x: [1, 2, 3], y: [10, 20, 30]) == [4, 6, 58]
+}
+)"};
+    const TestResult result = only(unit.tests());
+    INFO(unit.diagnostics.render(unit.file));
+    INFO(result.message);
+    CHECK(result.passed);
+}
+
+TEST_CASE("temporal conditional result boundaries fail closed", "[wiring][control-flow][conditional]") {
+    SECTION("multiple escaping assignments") {
+        Unit unit{R"(
+module t
+
+fn adjusted(condition: bool, x: i64, y: i64) -> i64 {
+    var result: i64
+    var offset: i64
+    if condition {
+        result = x + 1
+        offset = x
+    } else {
+        result = y - 1
+        offset = y
+    }
+    return result + offset
+}
+
+test adjusted_ticks {
+    eval(adjusted, condition: [true], x: [1], y: [2])
+}
+)"};
+        CHECK_FALSE(only(unit.tests()).passed);
+        CHECK(unit.has(Category::Backend, "multiple assignments escaping a time-series 'if'"));
+    }
+
+    SECTION("forwarding an existing binding") {
+        Unit unit{R"(
+module t
+
+fn adjusted(condition: bool, x: i64) -> i64 {
+    var result: i64 = x
+    if condition {
+        result = result + 1
+    }
+    return result
+}
+
+test adjusted_ticks {
+    eval(adjusted, condition: [true], x: [1])
+}
+)"};
+        CHECK_FALSE(only(unit.tests()).passed);
+        CHECK(unit.has(Category::Backend, "forwarding an existing assignment through a time-series 'if'"));
+    }
+
+    SECTION("mixed expression and assignment results") {
+        Unit unit{R"(
+module t
+
+fn adjusted(condition: bool, x: i64, y: i64) -> i64 {
+    var offset: i64
+    let result = if condition {
+        offset = x + 1
+        x * 2
+    } else {
+        offset = y - 1
+        y * 3
+    }
+    return result + offset
+}
+
+test adjusted_ticks {
+    eval(adjusted, condition: [true], x: [1], y: [2])
+}
+)"};
+        CHECK_FALSE(only(unit.tests()).passed);
+        CHECK(unit.has(Category::Backend, "combining an expression result with assignments escaping a time-series 'if'"));
+    }
+}
+
 TEST_CASE("a temporal else-if fails instead of dropping its sink", "[wiring][control-flow][conditional]") {
     Unit             unit{R"(
 module t

--- a/language/tests/wiring/backend_tests.cpp
+++ b/language/tests/wiring/backend_tests.cpp
@@ -410,6 +410,32 @@ test adjusted_ticks {
     CHECK(result.passed);
 }
 
+TEST_CASE("a temporal if can reuse a result assigned earlier in each branch", "[wiring][control-flow][conditional]") {
+    Unit             unit{R"(
+module t
+
+fn adjusted(condition: bool, x: i64, y: i64) -> i64 {
+    var result: i64
+    if condition {
+        result = x + 1
+        result = result * 2
+    } else {
+        result = y - 1
+        result = result * 3
+    }
+    result
+}
+
+test adjusted_ticks {
+    assert eval(adjusted, condition: [true, false], x: [1, 2], y: [10, 20]) == [4, 57]
+}
+)"};
+    const TestResult result = only(unit.tests());
+    INFO(unit.diagnostics.render(unit.file));
+    INFO(result.message);
+    CHECK(result.passed);
+}
+
 TEST_CASE("temporal conditional result boundaries fail closed", "[wiring][control-flow][conditional]") {
     SECTION("multiple escaping assignments") {
         Unit unit{R"(


### PR DESCRIPTION
## Summary

- record escaping outer assignments in the HGraph IR conditional plan
- lower one result assigned by both explicit temporal branches through `switch_` in the direct and generated backends
- remap the selected result into the enclosing graph scope so later expressions can consume it
- add a runnable/generated conditional-result example and graduate the supported shape from the design-only corpus
- reject multiple escapes, mixed expression/assignment results, and forwarding shapes until their dedicated lowering is implemented

## Validation

- HGL suite: 45/45 passed
- fresh native acceptance suite: 1716/1716 passed
- stable-ABI wheel built with Python 3.12; Python 3.14 compatibility suite: 3241 passed, 10 skipped

Stacked on #741.
