### PR TITLE
Std operators: collection arithmetic, throttle, window and batch resolve bindings in start

### DIFF
--- a/.agents/skills/hgraph-compute-sink-node/SKILL.md
+++ b/.agents/skills/hgraph-compute-sink-node/SKILL.md
@@ -117,6 +117,11 @@ Use `start` for work performed once per node lifetime, including:
   never overwrite recordable state restored for replay;
 - initializing sequences, cursors, buffers, or cached plans associated with
   that state;
+- resolving the value bindings a scalar-collection result needs
+  (`ResolvedBindings` via `resolve_list_bindings` / `resolve_set_bindings` /
+  `resolve_map_bindings` in `lib/std/value_util.h`, from the output's value
+  schema) so `eval` publishes through `finish_list` / `finish_set` /
+  `finish_map` without a realization lookup or a re-interning `build()`;
 - acquiring run-scoped resources or establishing subscriptions;
 - scheduling the initial evaluation when declarative `schedule_on_start` is
   insufficient.

--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -680,7 +680,10 @@ weakening reset semantics (the registry's ``reset()`` is test-only but
 frees interned records): **start-resolved plans** — a node resolves every
 binding/converter its shape needs in its ``start`` hook and carries them in
 node ``State`` (``ResolvedBindings`` in ``lib/std/value_util.h``, the JSON
-operators' ``TsJsonPlan``); and **generation-checked thread-local caches**
+operators' ``TsJsonPlan``; since 2026-09-06 the tuple / frozenset / dict
+arithmetic, the throttle's set netting, ``window`` and ``batch`` follow it
+too, and the ``stdlib-active-realization`` ratchet pins the remaining calls
+to ``start`` hooks); and **generation-checked thread-local caches**
 for process-wide helpers (``TypeRegistry::scalar_type<T>()`` behind
 ``Value{T}``, the JSON ``json_meta``/``json_value_binding`` accessors),
 validated against the lock-free ``TypeRegistry::reset_generation()``

--- a/docs/source/developer_guide/testing.rst
+++ b/docs/source/developer_guide/testing.rst
@@ -212,8 +212,10 @@ Each entry names the layer that owns the rule:
   reverse-binding registry is the one schema-to-annotation authority, and
   the ratchet holds it at zero);
 * a second or third ancestry walker beside ``TypeRegistry::value_is_a``;
-* operators recomputing ``value_type_for_active_realization`` instead of
-  reading the binding from their bound views;
+* operators resolving ``value_type_for_active_realization`` anywhere but a
+  ``start`` hook (``writing_nodes.rst``, "Resolve once in ``start``, read per
+  tick"; the remaining count is the start hooks, and the operator-family
+  lock matrix in ``test_registry_snapshot.py`` guards the per-tick path);
 * Python-object hashing in more than one translation unit,
   ``HGRAPH_ENABLE_PYTHON_USER_NODES`` conditionals inside the type layer,
   and ``nanobind`` spelled inside the type layer (RFC 0035: the type layer

--- a/docs/source/developer_guide/writing_nodes.rst
+++ b/docs/source/developer_guide/writing_nodes.rst
@@ -197,3 +197,30 @@ Anything derivable from the resolved schema — a layout, a converter, a column
 projection — is resolved in ``start`` and carried in ``State``, not recomputed
 per tick. This is the lifecycle form of the builder pattern: compose once, read
 many times.
+
+**Value bindings in particular.** Resolving a value binding
+(``value_type_for_active_realization``, ``ValuePlanFactory::type_for``,
+``compact_list_type`` and friends) consults the realization snapshot or interns
+a record under a counted type-system mutex, and so do the builders' plain
+``build()`` calls, which re-intern the result type per call. An operator that
+builds a scalar collection therefore resolves in ``start`` through the
+``ResolvedBindings`` helpers of ``lib/std/value_util.h``
+(``resolve_list_bindings`` / ``resolve_set_bindings`` /
+``resolve_map_bindings`` from the *output's* value schema, which is the shape
+the result must have) and publishes per tick through ``finish_list`` /
+``finish_set`` / ``finish_map`` (``build_storage()`` plus the cached result
+type). Read the state with ``State::ref()``; ``get()`` copies. A node whose
+state already holds a queue or buffer keeps the bindings in the same struct
+(one ``State`` per node). The ``stdlib-active-realization`` ratchet holds
+every remaining call inside a ``start`` hook; the 2026-08-15 audit found
+nine ``eval`` bodies (the tuple / frozenset / dict arithmetic, the
+throttle's set netting, ``window`` and ``batch``) still paying it per tick,
+and ``test_registry_snapshot.py``'s lock matrix now guards each of them (the
+TSS throttle's guard is a strict expected failure until the type layer's
+``capture_delta`` builds through the input layout's bindings instead of
+resolving them per call in ``ts_delta.cpp``).
+
+**Why.** The 0.8.15 regression was exactly a per-tick resolution (see
+:doc:`python_bridge`, "Per-tick application is registry-free"): a lock and a
+hash lookup per value on every cycle, invisible to correctness tests. The
+lock matrix is the guard because the cost is a *count*, not a failure.

--- a/include/hgraph/lib/std/operators/impl/arithmetic_impl.h
+++ b/include/hgraph/lib/std/operators/impl/arithmetic_impl.h
@@ -6,6 +6,7 @@
 #include <hgraph/lib/std/operators/container.h>
 #include <hgraph/lib/std/operators/logical.h>
 #include <hgraph/lib/std/operators/collection.h>
+#include <hgraph/lib/std/value_util.h>  // ResolvedBindings (start-resolved)
 #include <hgraph/types/value/value_builder.h>
 #include <hgraph/types/value_callable.h>
 #include <hgraph/lib/std/operators/impl/higher_order_impl.h>   // add_ / sub_ / mul_ / div_ / DivideByZero
@@ -558,11 +559,19 @@ namespace hgraph::stdlib
             return resolution.find_scalar("T");
         }
 
-        [[nodiscard]] inline ValueTypeRef element_binding_of(const ValueTypeMetaData *meta)
+        /** The output's container value schema: the collection ops build the
+            result the output holds, so its bindings are the output's. */
+        [[nodiscard]] inline const ValueTypeMetaData *container_out_schema(const TSOutputView &out)
         {
-            const auto binding = value_type_for_active_realization(meta);
-            if (binding == nullptr) { throw std::logic_error("container element schema has no binding"); }
-            return binding;
+            const auto *meta = out.schema()->value_schema;
+            if (meta == nullptr) { throw std::logic_error("container operator output has no value schema"); }
+            return meta;
+        }
+
+        [[nodiscard]] inline ResolvedBindings require_resolved(ResolvedBindings bindings)
+        {
+            if (bindings.primary == nullptr) { throw std::logic_error("container element schema has no binding"); }
+            return bindings;
         }
 
         /** Tuple/list concatenation (python's tuple + tuple). */
@@ -576,16 +585,21 @@ namespace hgraph::stdlib
                 return meta != nullptr && meta->value_kind() == ValueTypeKind::List && !meta->is_mutable();
             }
 
-            static void eval(In<"lhs", TS<ScalarVar<"T">>> lhs, In<"rhs", TS<ScalarVar<"T">>> rhs,
-                             Out<TS<ScalarVar<"T">>> out)
+            static void start(State<ResolvedBindings> bindings, Out<TS<ScalarVar<"T">>> out)
             {
-                const auto *meta = lhs.base().value().schema();
-                ListBuilder builder{element_binding_of(meta->element_type), *meta};
+                bindings.set(require_resolved(resolve_list_bindings(container_out_schema(out))));
+            }
+
+            static void eval(In<"lhs", TS<ScalarVar<"T">>> lhs, In<"rhs", TS<ScalarVar<"T">>> rhs,
+                             State<ResolvedBindings> bindings, Out<TS<ScalarVar<"T">>> out)
+            {
+                const auto &resolved = bindings.ref();
+                ListBuilder builder{resolved.primary, *container_out_schema(out)};
                 const auto lhs_values = lhs.base().value().as_list();
                 const auto rhs_values = rhs.base().value().as_list();
                 for (const ValueView &element : lhs_values) { builder.push_back(element); }
                 for (const ValueView &element : rhs_values) { builder.push_back(element); }
-                out.apply(builder.build().view());
+                out.apply(finish_list(builder, resolved).view());
             }
         };
 
@@ -614,15 +628,21 @@ namespace hgraph::stdlib
                 return std::tuple{arg<"cmp">(ValueCallable{})};
             }
 
+            static void start(State<ResolvedBindings> bindings, Out<TS<ScalarVar<"T">>> out)
+            {
+                bindings.set(require_resolved(resolve_list_bindings(container_out_schema(out))));
+            }
+
             static void eval(In<"lhs", TS<ScalarVar<"T">>> lhs,
                              In<"rhs", TS<ScalarVar<"E">>> rhs,
                              Scalar<"cmp", ValueCallable> cmp,
+                             State<ResolvedBindings> bindings,
                              Out<TS<ScalarVar<"T">>> out)
             {
                 const ValueView rhs_value = rhs.base().value();
                 const ValueCallable &predicate = cmp.value();
-                const auto *meta = lhs.base().value().schema();
-                ListBuilder builder{element_binding_of(meta->element_type), *meta};
+                const auto &resolved = bindings.ref();
+                ListBuilder builder{resolved.primary, *container_out_schema(out)};
                 const auto lhs_values = lhs.base().value().as_list();
                 for (const ValueView element : lhs_values)
                 {
@@ -641,7 +661,7 @@ namespace hgraph::stdlib
                     else { matches = element.equals(rhs_value); }
                     if (!matches) { builder.push_back(element); }
                 }
-                out.apply(builder.build().view());
+                out.apply(finish_list(builder, resolved).view());
             }
         };
 
@@ -662,13 +682,18 @@ namespace hgraph::stdlib
                 return meta != nullptr && meta->value_kind() == ValueTypeKind::Set;
             }
 
-            static void eval(In<"lhs", TS<ScalarVar<"T">>> lhs, In<"rhs", TS<ScalarVar<"T">>> rhs,
-                             Out<TS<ScalarVar<"T">>> out)
+            static void start(State<ResolvedBindings> bindings, Out<TS<ScalarVar<"T">>> out)
             {
-                const auto *meta = lhs.base().value().schema();
+                bindings.set(require_resolved(resolve_set_bindings(container_out_schema(out)->element_type)));
+            }
+
+            static void eval(In<"lhs", TS<ScalarVar<"T">>> lhs, In<"rhs", TS<ScalarVar<"T">>> rhs,
+                             State<ResolvedBindings> bindings, Out<TS<ScalarVar<"T">>> out)
+            {
+                const auto &resolved = bindings.ref();
                 auto        lhs_set = lhs.base().value().as_set();
                 auto        rhs_set = rhs.base().value().as_set();
-                SetBuilder  builder{element_binding_of(meta->element_type)};
+                SetBuilder  builder{resolved.primary};
                 for (const ValueView &element : lhs_set.values())
                 {
                     const bool in_rhs = rhs_set.contains(element);
@@ -688,7 +713,7 @@ namespace hgraph::stdlib
                         }
                     }
                 }
-                out.apply(builder.build().view());
+                out.apply(finish_set(builder, resolved).view());
             }
         };
 
@@ -786,18 +811,24 @@ namespace hgraph::stdlib
                 return meta != nullptr && meta->value_kind() == ValueTypeKind::Map;
             }
 
-            static void eval(In<"lhs", TS<ScalarVar<"T">>> lhs, In<"rhs", TS<ScalarVar<"T">>> rhs,
-                             Out<TS<ScalarVar<"T">>> out)
+            static void start(State<ResolvedBindings> bindings, Out<TS<ScalarVar<"T">>> out)
             {
-                const auto *meta = lhs.base().value().schema();
-                const auto  lhs_map = lhs.base().value().as_map();
-                const auto  rhs_map = rhs.base().value().as_map();
-                MapBuilder  builder{element_binding_of(meta->key_type), element_binding_of(meta->element_type)};
+                const auto *meta = container_out_schema(out);
+                bindings.set(require_resolved(resolve_map_bindings(meta->key_type, meta->element_type)));
+            }
+
+            static void eval(In<"lhs", TS<ScalarVar<"T">>> lhs, In<"rhs", TS<ScalarVar<"T">>> rhs,
+                             State<ResolvedBindings> bindings, Out<TS<ScalarVar<"T">>> out)
+            {
+                const auto &resolved = bindings.ref();
+                const auto  lhs_map  = lhs.base().value().as_map();
+                const auto  rhs_map  = rhs.base().value().as_map();
+                MapBuilder  builder  = map_builder_for(resolved);
                 for (const auto [key, item] : lhs_map)
                 {
                     if (!rhs_map.contains(key)) { builder.set_item(key, item); }
                 }
-                out.apply(builder.build().view());
+                out.apply(finish_map(builder, resolved).view());
             }
         };
 
@@ -888,13 +919,19 @@ namespace hgraph::stdlib
                 return meta != nullptr && meta->value_kind() == ValueTypeKind::Map;
             }
 
-            static void eval(In<"lhs", TS<ScalarVar<"T">>> lhs, In<"rhs", TS<ScalarVar<"T">>> rhs,
-                             Out<TS<ScalarVar<"T">>> out)
+            static void start(State<ResolvedBindings> bindings, Out<TS<ScalarVar<"T">>> out)
             {
-                const auto *meta = lhs.base().value().schema();
-                MapBuilder  builder{element_binding_of(meta->key_type), element_binding_of(meta->element_type)};
-                const auto  lhs_map = lhs.base().value().as_map();
-                const auto  rhs_map = rhs.base().value().as_map();
+                const auto *meta = container_out_schema(out);
+                bindings.set(require_resolved(resolve_map_bindings(meta->key_type, meta->element_type)));
+            }
+
+            static void eval(In<"lhs", TS<ScalarVar<"T">>> lhs, In<"rhs", TS<ScalarVar<"T">>> rhs,
+                             State<ResolvedBindings> bindings, Out<TS<ScalarVar<"T">>> out)
+            {
+                const auto &resolved = bindings.ref();
+                MapBuilder  builder  = map_builder_for(resolved);
+                const auto  lhs_map  = lhs.base().value().as_map();
+                const auto  rhs_map  = rhs.base().value().as_map();
                 for (const auto [key, item] : lhs_map)
                 {
                     builder.set_item(key, item);
@@ -903,7 +940,7 @@ namespace hgraph::stdlib
                 {
                     builder.set_item(key, item);
                 }
-                out.apply(builder.build().view());
+                out.apply(finish_map(builder, resolved).view());
             }
         };
 

--- a/include/hgraph/lib/std/operators/impl/stream_impl.h
+++ b/include/hgraph/lib/std/operators/impl/stream_impl.h
@@ -11,6 +11,7 @@
 #include <hgraph/lib/std/operators/impl/tsl_itemwise_impl.h>
 #include <hgraph/types/operator_dispatch.h>
 #include <hgraph/types/metadata/type_realization.h>
+#include <hgraph/lib/std/value_util.h>  // ResolvedBindings (start-resolved)
 #include <hgraph/types/primitive_types.h>
 #include <hgraph/types/static_node.h>
 #include <hgraph/runtime/service_node.h>
@@ -489,6 +490,30 @@ namespace hgraph::stdlib
             std::deque<std::pair<DateTime, Value>> buffer{};
         };
 
+        /** batch: the queued deltas and the output list bindings (element
+            binding + interned list type), resolved once at start. */
+        struct BatchState
+        {
+            std::deque<Value> buffer{};
+            ResolvedBindings  bindings{};
+        };
+
+        /** The window's {buffer, index} result bindings: the value list and
+            the time list (element binding + interned list type each) and
+            the bundle, resolved once at start (lock-free per-tick ruling). */
+        struct WindowResultBindings
+        {
+            ResolvedBindings values{};
+            ResolvedBindings times{};
+            ValueTypeRef     bundle{nullptr};
+        };
+
+        struct WindowState
+        {
+            std::deque<std::pair<DateTime, Value>> buffer{};
+            WindowResultBindings                   bindings{};
+        };
+
         struct LagProxyState
         {
             // Deltas captured per proxy count, replayed (in arrival order,
@@ -511,6 +536,12 @@ namespace hgraph::stdlib
             // arrival order on release so container deltas MERGE (dict ticks
             // within one window emit as one combined delta).
             std::deque<Value> pending{};
+            // A TSS output nets its pending deltas into one {added, removed}
+            // bundle on release: the set element binding and result type
+            // (primary / result) and the delta bundle binding, resolved once
+            // at start (lock-free per-tick ruling).
+            ResolvedBindings set_bindings{};
+            ValueTypeRef     delta_bundle_binding{nullptr};
         };
 
         inline void require_positive(Int value, const char *name)
@@ -531,8 +562,9 @@ namespace hgraph::stdlib
 
         /** Net a queue of canonical set deltas ({added, removed} bundles) into
             one; an empty optional means the queue cancels out (add then
-            remove of the same element) and nothing should be emitted. */
-        inline std::optional<Value> net_set_deltas(std::deque<Value> &pending)
+            remove of the same element) and nothing should be emitted. The
+            bindings are the throttle's start-resolved TSS delta bindings. */
+        inline std::optional<Value> net_set_deltas(std::deque<Value> &pending, const ThrottleState &state)
         {
             std::vector<Value> added;
             std::vector<Value> removed;
@@ -551,16 +583,9 @@ namespace hgraph::stdlib
                 values.emplace_back(value);
             };
 
-            const ValueTypeMetaData *bundle_meta  = nullptr;
-            const ValueTypeMetaData *element_meta = nullptr;
             for (Value &delta : pending)
             {
                 const auto bundle = delta.view().as_bundle();
-                if (bundle_meta == nullptr)
-                {
-                    bundle_meta  = delta.view().schema();
-                    element_meta = bundle.field("added").schema()->element_type;
-                }
                 // Canonical order inside one delta is remove-before-add.
                 const auto gone = bundle.field("removed").as_indexed_view();
                 for (std::size_t i = 0; i < gone.size(); ++i)
@@ -578,32 +603,30 @@ namespace hgraph::stdlib
             }
             if (added.empty() && removed.empty()) { return std::nullopt; }
 
-            SetBuilder added_builder{value_type_for_active_realization(element_meta)};
+            SetBuilder added_builder{state.set_bindings.primary};
             for (const Value &value : added) { static_cast<void>(added_builder.insert(value.view())); }
-            SetBuilder removed_builder{value_type_for_active_realization(element_meta)};
+            SetBuilder removed_builder{state.set_bindings.primary};
             for (const Value &value : removed) { static_cast<void>(removed_builder.insert(value.view())); }
-            BundleBuilder bundle{value_type_for_active_realization(bundle_meta)};
-            bundle.set("added", added_builder.build());
-            bundle.set("removed", removed_builder.build());
+            BundleBuilder bundle{state.delta_bundle_binding};
+            bundle.set("added", finish_set(added_builder, state.set_bindings));
+            bundle.set("removed", finish_set(removed_builder, state.set_bindings));
             return bundle.build();
         }
 
         struct ThrottleReleaseOps
         {
-            bool (*release)(std::deque<Value> &pending, const TSOutputView &out){nullptr};
+            bool (*release)(ThrottleState &state, const TSOutputView &out){nullptr};
         };
 
-        [[nodiscard]] inline bool throttle_release_ordered(std::deque<Value> &pending,
-                                                           const TSOutputView &out)
+        [[nodiscard]] inline bool throttle_release_ordered(ThrottleState &state, const TSOutputView &out)
         {
-            for (Value &delta : pending) { apply_delta(out, delta.view()); }
+            for (Value &delta : state.pending) { apply_delta(out, delta.view()); }
             return true;
         }
 
-        [[nodiscard]] inline bool throttle_release_set(std::deque<Value> &pending,
-                                                       const TSOutputView &out)
+        [[nodiscard]] inline bool throttle_release_set(ThrottleState &state, const TSOutputView &out)
         {
-            auto net = net_set_deltas(pending);
+            auto net = net_set_deltas(state.pending, state);
             if (!net.has_value()) { return false; }
             apply_delta(out, net->view());
             return true;
@@ -646,6 +669,18 @@ namespace hgraph::static_schema_detail
     struct scalar_name<stdlib::stream_impl_detail::ThrottleState>
     {
         static constexpr std::string_view value{"stdlib.throttle_state"};
+    };
+
+    template <>
+    struct scalar_name<stdlib::stream_impl_detail::WindowState>
+    {
+        static constexpr std::string_view value{"stdlib.window_state"};
+    };
+
+    template <>
+    struct scalar_name<stdlib::stream_impl_detail::BatchState>
+    {
+        static constexpr std::string_view value{"stdlib.batch_state"};
     };
 
     template <>
@@ -1370,26 +1405,31 @@ namespace hgraph::stdlib
             return registry.tsb(name, {{"buffer", registry.ts(buffer)}, {"index", registry.ts(index)}});
         }
 
-        /** Emit the {buffer, index} bundle for the queued (time, value) entries. */
-        inline void emit_window_result(const TSOutputView &out,
-                                       const std::deque<std::pair<DateTime, Value>> &entries)
+        [[nodiscard]] inline WindowResultBindings resolve_window_result_bindings(const TSOutputView &out)
         {
             const auto *meta = out.schema()->value_schema;
-            const auto *element_meta = meta->fields[0].type->element_type;
-            const auto *buffer_meta = meta->fields[0].type;
-            ListBuilder values{
-                value_type_for_active_realization(element_meta), *buffer_meta};
-            ListBuilder times{
-                value_type_for_active_realization(scalar_descriptor<DateTime>::value_meta()),
-                *meta->fields[1].type};
-            for (const auto &[time, value] : entries)
+            return WindowResultBindings{
+                .values = resolve_list_bindings(meta->fields[0].type),
+                .times  = resolve_list_bindings(meta->fields[1].type),
+                .bundle = value_type_for_active_realization(meta),
+            };
+        }
+
+        /** Emit the {buffer, index} bundle for the queued (time, value) entries. */
+        inline void emit_window_result(const TSOutputView &out, const WindowState &state)
+        {
+            const auto *meta     = out.schema()->value_schema;
+            const auto &bindings = state.bindings;
+            ListBuilder values{bindings.values.primary, *meta->fields[0].type};
+            ListBuilder times{bindings.times.primary, *meta->fields[1].type};
+            for (const auto &[time, value] : state.buffer)
             {
                 values.push_back(value.view());
                 times.push_back_copy(&time);
             }
-            BundleBuilder bundle{value_type_for_active_realization(meta)};
-            bundle.set("buffer", values.build());
-            bundle.set("index", times.build());
+            BundleBuilder bundle{bindings.bundle};
+            bundle.set("buffer", finish_list(values, bindings.values));
+            bundle.set("index", finish_list(times, bindings.times));
             auto mutation = out.data_view().begin_mutation(out.evaluation_time());
             static_cast<void>(mutation.move_value_from(bundle.build()));
         }
@@ -1410,9 +1450,15 @@ namespace hgraph::stdlib
             bind_output(resolution, stream_impl_detail::window_result_meta(schema->value_schema));
         }
 
+        static void start(State<stream_impl_detail::WindowState> state, Out<TsVar<"__out__">> out)
+        {
+            state.modify().bindings =
+                stream_impl_detail::resolve_window_result_bindings(static_cast<const TSOutputView &>(out));
+        }
+
         static void eval(In<"ts", TS<ScalarVar<"T">>> ts, Scalar<"period", Int> period,
                          Scalar<"min_window_period", Int> min_window_period,
-                         State<stream_impl_detail::TimedDeltaQueueState> state,
+                         State<stream_impl_detail::WindowState> state,
                          DateTime now, Out<TsVar<"__out__">> out)
         {
             auto &current = state.modify();
@@ -1425,7 +1471,7 @@ namespace hgraph::stdlib
                 min_window_period.value() > 0 ? min_window_period.value() : period.value());
             if (current.buffer.size() >= minimum)
             {
-                stream_impl_detail::emit_window_result(static_cast<const TSOutputView &>(out), current.buffer);
+                stream_impl_detail::emit_window_result(static_cast<const TSOutputView &>(out), current);
             }
         }
 
@@ -1448,9 +1494,15 @@ namespace hgraph::stdlib
             bind_output(resolution, stream_impl_detail::window_result_meta(schema->value_schema));
         }
 
+        static void start(State<stream_impl_detail::WindowState> state, Out<TsVar<"__out__">> out)
+        {
+            state.modify().bindings =
+                stream_impl_detail::resolve_window_result_bindings(static_cast<const TSOutputView &>(out));
+        }
+
         static void eval(In<"ts", TS<ScalarVar<"T">>> ts, Scalar<"period", TimeDelta> period,
                          Scalar<"min_window_period", TimeDelta> min_window_period,
-                         State<stream_impl_detail::TimedDeltaQueueState> state,
+                         State<stream_impl_detail::WindowState> state,
                          DateTime now, Out<TsVar<"__out__">> out)
         {
             auto &current = state.modify();
@@ -1463,7 +1515,7 @@ namespace hgraph::stdlib
                 min_window_period.value() > TimeDelta{0} ? min_window_period.value() : period.value();
             if (now - current.buffer.front().first >= minimum)
             {
-                stream_impl_detail::emit_window_result(static_cast<const TSOutputView &>(out), current.buffer);
+                stream_impl_detail::emit_window_result(static_cast<const TSOutputView &>(out), current);
             }
         }
 
@@ -1487,12 +1539,18 @@ namespace hgraph::stdlib
             bind_output(resolution, registry.ts(registry.list(schema->value_schema, 0, true)));
         }
 
+        static void start(State<stream_impl_detail::BatchState> state, Out<TsVar<"__out__">> out)
+        {
+            state.modify().bindings =
+                resolve_list_bindings(static_cast<const TSOutputView &>(out).schema()->value_schema);
+        }
+
         static void eval(In<"condition", TS<Bool>, InputValidity::Unchecked> condition,
                          In<"ts", TsVar<"S">, InputValidity::Unchecked> ts,
                          Scalar<"delay", TimeDelta> delay,
                          Scalar<"buffer_length", Int> buffer_length,
                          NodeScheduler scheduler,
-                         State<stream_impl_detail::DeltaQueueState> state,
+                         State<stream_impl_detail::BatchState> state,
                          Out<TsVar<"__out__">> out)
         {
             auto &current = state.modify();
@@ -1513,12 +1571,10 @@ namespace hgraph::stdlib
                 if ((scheduler.is_scheduled_now() || condition.modified()) && !current.buffer.empty())
                 {
                     const auto &erased = static_cast<const TSOutputView &>(out);
-                    const auto *meta   = erased.schema()->value_schema;
-                    ListBuilder builder{
-                        value_type_for_active_realization(meta->element_type), *meta};
+                    ListBuilder builder{current.bindings.primary, *erased.schema()->value_schema};
                     for (Value &value : current.buffer) { builder.push_back(value.view()); }
                     current.buffer.clear();
-                    Value result   = builder.build();
+                    Value result   = finish_list(builder, current.bindings);
                     auto  mutation = erased.data_view().begin_mutation(erased.evaluation_time());
                     static_cast<void>(mutation.move_value_from(std::move(result)));
                 }
@@ -1542,7 +1598,15 @@ namespace hgraph::stdlib
         {
             auto &current = state.modify();
             const auto &erased = static_cast<const TSOutputView &>(out);
-            current.release_ops = &stream_impl_detail::throttle_release_ops_for(erased.schema()->kind);
+            const auto *schema = erased.schema();
+            current.release_ops = &stream_impl_detail::throttle_release_ops_for(schema->kind);
+            if (schema->kind == TSTypeKind::TSS)
+            {
+                // The netted release builds {added, removed} in the output's
+                // own delta shape; both bindings are wiring-fixed.
+                current.set_bindings = resolve_set_bindings(schema->value_schema->element_type);
+                current.delta_bundle_binding = value_type_for_active_realization(schema->delta_value_schema);
+            }
         }
 
         static void eval(In<"ts", TsVar<"S">, InputValidity::Unchecked> ts,
@@ -1585,7 +1649,7 @@ namespace hgraph::stdlib
             if (scheduler.is_scheduled_now() && !current.pending.empty())
             {
                 const auto &erased = static_cast<const TSOutputView &>(out);
-                const bool emitted = current.release_ops->release(current.pending, erased);
+                const bool emitted = current.release_ops->release(current, erased);
                 current.pending.clear();
                 if (emitted) { scheduler.schedule(now + current.period); }
             }

--- a/python/tests/test_architecture_ratchets.py
+++ b/python/tests/test_architecture_ratchets.py
@@ -142,12 +142,15 @@ RATCHETS: tuple[Ratchet, ...] = (
     # --- Operators read bindings from views (family 5) ---
     Ratchet(
         id="stdlib-active-realization",
-        baseline=34,
+        baseline=28,
         roots=("include/hgraph/lib/std/operators/impl",),
         suffixes=(".h",),
         pattern=r"\bvalue_type_for_active_realization\b",
-        owner="realized bindings travel with bound views; operators do not "
-        "recompute realization",
+        owner="a binding is resolved once in start and carried in State "
+        "(writing_nodes.rst, 'Resolve once in start, read per tick'); no "
+        "eval body resolves a realization. The remaining sites are start "
+        "hooks; they fall further only when the realized type answers its "
+        "element bindings without the snapshot",
     ),
     # --- Exception boundaries are named (AGENTS.md: prefer the scope.h guards) ---
     Ratchet(

--- a/python/tests/test_registry_snapshot.py
+++ b/python/tests/test_registry_snapshot.py
@@ -1,4 +1,5 @@
-from typing import Set, Tuple
+from datetime import timedelta
+from typing import Mapping, Set, Tuple
 
 import pytest
 
@@ -8,6 +9,7 @@ from hgraph import (
     TS,
     TSD,
     TSS,
+    batch,
     collect,
     convert,
     eq_,
@@ -26,7 +28,9 @@ from hgraph import (
     run_graph,
     service_adaptor,
     service_adaptor_impl,
+    throttle,
     to_json,
+    window,
 )
 from hgraph import OUT
 
@@ -299,6 +303,92 @@ def _race_rebind_graph(cycles: int):
     return _g
 
 
+@generator
+def _frozenset_pulse(cycles: int) -> TS[frozenset[int]]:
+    for i in range(cycles):
+        yield MIN_TD, frozenset({i, i + 1})
+
+
+@generator
+def _dict_pulse(cycles: int) -> TS[Mapping[int, int]]:
+    for i in range(cycles):
+        yield MIN_TD, {i: i, i + 1: i}
+
+
+@generator
+def _tss_pulse(cycles: int) -> TSS[int]:
+    for i in range(cycles):
+        yield MIN_TD, {i}
+
+
+@generator
+def _bool_pulse(cycles: int) -> TS[bool]:
+    for i in range(cycles):
+        yield MIN_TD, i % 2 == 0
+
+
+def _add_tuples_graph(cycles: int):
+    @graph
+    def _g():
+        source = _tuple_pulse(cycles)
+        null_sink(source + source)
+
+    return _g
+
+
+def _set_ops_graph(cycles: int):
+    @graph
+    def _g():
+        lhs = _frozenset_pulse(cycles)
+        rhs = _frozenset_pulse(cycles)
+        null_sink((lhs | rhs) - (lhs & rhs))
+
+    return _g
+
+
+def _map_ops_graph(cycles: int):
+    @graph
+    def _g():
+        lhs = _dict_pulse(cycles)
+        rhs = _dict_pulse(cycles)
+        null_sink((lhs | rhs) - rhs)
+
+    return _g
+
+
+def _throttle_tss_graph(cycles: int):
+    # Two ticks per throttle window, so every release nets pending set deltas.
+    @graph
+    def _g():
+        null_sink(throttle(_tss_pulse(cycles), timedelta(microseconds=2)))
+
+    return _g
+
+
+def _window_tick_graph(cycles: int):
+    @graph
+    def _g():
+        null_sink(window(_int_pulse(cycles), 3).buffer)
+
+    return _g
+
+
+def _window_time_graph(cycles: int):
+    @graph
+    def _g():
+        null_sink(window(_int_pulse(cycles), timedelta(microseconds=3)).buffer)
+
+    return _g
+
+
+def _batch_graph(cycles: int):
+    @graph
+    def _g():
+        null_sink(batch(_bool_pulse(cycles), _int_pulse(cycles), timedelta(microseconds=1)))
+
+    return _g
+
+
 _LOCK_MATRIX = [
     pytest.param(_convert_ts_to_set_graph, id="convert_ts_to_set"),
     pytest.param(_collect_tuple_graph, id="collect_tuple"),
@@ -310,6 +400,25 @@ _LOCK_MATRIX = [
     # Steady-state guard: a stable winner must publish nothing.
     pytest.param(_race_graph, id="race_ref"),
     pytest.param(_race_rebind_graph, id="race_ref_rebind"),
+    # The scalar-collection arithmetic and the stream buffers resolve their
+    # result bindings in start (writing_nodes.rst, "Resolve once in start").
+    pytest.param(_add_tuples_graph, id="add_tuples"),
+    pytest.param(_set_ops_graph, id="frozenset_ops"),
+    pytest.param(_map_ops_graph, id="dict_ops"),
+    # The throttle's own release is start-resolved, but every queued tick
+    # still goes through the type layer's capture_delta_tss, which resolves
+    # its bindings and re-interns per call (ts_delta.cpp); strict xfail until
+    # delta capture reads the input layout's bindings.
+    pytest.param(
+        _throttle_tss_graph,
+        id="throttle_tss",
+        marks=pytest.mark.xfail(
+            strict=True, reason="capture_delta_tss resolves bindings per tick (ts_delta.cpp)"
+        ),
+    ),
+    pytest.param(_window_tick_graph, id="window_tick"),
+    pytest.param(_window_time_graph, id="window_time"),
+    pytest.param(_batch_graph, id="batch"),
 ]
 
 


### PR DESCRIPTION
Closes the `stdlib-active-realization` ratchet family from the 2026-09-04 retrospective (invariant 5) down to its floor, and fixes the nine per-tick breaches of the 2026-07-02 lock-free ruling that the 2026-08-15 std-operator audit (#478) missed because these operator families were not in the lock matrix.

**What was wrong**

Of the 34 `value_type_for_active_realization` calls under `lib/std/operators/impl`, 25 were already the sanctioned start-hook resolution (`ResolvedBindings`). Nine ran per tick, each a realization-snapshot lookup plus a re-interning `build()`:

- `arithmetic_impl.h`: `add_lists`, `sub_list_item`, `sub_/and_/or_/xor_sets`, `sub_maps`, `or_maps` — via the `element_binding_of` helper called from `eval`.
- `stream_impl.h`: the throttle's TSS delta netting (`net_set_deltas`), `window_tick` / `window_time` (`emit_window_result`), and `batch`.

**What changes**

- Each of those operators gains a `start` hook that resolves its bindings from the *output's* value schema through `resolve_list_bindings` / `resolve_set_bindings` / `resolve_map_bindings` (`lib/std/value_util.h`) and publishes per tick through `finish_list` / `finish_set` / `finish_map`. `element_binding_of` is gone.
- `window` and `batch` carry their queue and bindings in one `State` each (`WindowState`, `BatchState`); the throttle's `ThrottleState` carries its TSS set / delta-bundle bindings and the release table now takes the state.
- Ratchet `stdlib-active-realization` 34 → 28. The remaining 28 are `start` hooks; the owner text says so and names what would lower it further (the realized type answering its element bindings without the snapshot).
- Lock matrix (`test_registry_snapshot.py::test_operator_family_lock_matrix`) gains seven families: `add_tuples`, `frozenset_ops`, `dict_ops`, `throttle_tss`, `window_tick`, `window_time`, `batch`. All seven fail against the pre-fix module; six pass now.
- `throttle_tss` is a strict `xfail`: every queued tick still goes through the type layer's `capture_delta_tss` (`ts_delta.cpp`), which resolves its bindings and re-interns per call (~12 lock acquisitions per cycle on that graph). That is the next family — delta capture through the input layout's bindings — and the strict marker forces its removal with that fix.

**Docs (same change)**

- `writing_nodes.rst`, "Resolve once in `start`, read per tick": the value-bindings recipe, why, and the ratchet / lock-matrix guards.
- `testing.rst` ratchet bullet, `python_bridge.rst` start-resolved plans, the compute/sink node skill's lifecycle list.

**Validation (macOS, local gate)**

- C++ core-only suite: all tests passed (257326 assertions in 1704 test cases)
- Python gate (`python/tests` incl. adaptors + all extension suites): 3614 passed, 10 skipped, 1 xfailed (the strict throttle_tss guard)
- Consumer checks (`python_extension_consumer`, `install_consumer`, fabric test package): passed
- `sphinx -W`: clean

Linux (GCC 14, warnings-as-errors) and Windows (MSVC) results follow as comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
