### PR TITLE
Compile value-producing temporal if without else in HGL

### DIFF
--- a/language/docs/README.md
+++ b/language/docs/README.md
@@ -76,6 +76,7 @@ collection cases have graduated into the compiler's runnable example corpus. A
 single escaping conditional result and a bundle of several escaping results
 have also graduated, as have a used expression result combined with escaping
 assignments and reference-preserving forwarding of initialized results.
-Continuations remain in the design corpus. A complete component catalogue
-remains to be developed. Files left in the design corpus are not a claim of
-implemented support.
+Value-producing temporal conditionals without `else` have also graduated with
+a typed never-ticking false path. Continuations remain in the design corpus. A
+complete component catalogue remains to be developed. Files left in the design
+corpus are not a claim of implemented support.

--- a/language/docs/design/control-flow.md
+++ b/language/docs/design/control-flow.md
@@ -10,7 +10,8 @@ remapped from the switch output for later composition. Several such variables
 are returned through one compiler-generated structural TSB and remapped by
 field; a used expression result can share the same result structure. A branch
 can also forward an existing binding through a reference-qualified generated
-input. Scalar branch captures, value-producing omitted `else`, temporal
+input. A consumed temporal conditional without `else` receives a typed
+never-ticking false branch in both backends. Scalar branch captures, temporal
 `else if`, and early-return continuations remain staged.
 A temporal `else if` is rejected rather than silently treated as an omitted
 `else`. This record uses the existing `if`/`else` syntax. It does not settle the
@@ -575,10 +576,13 @@ structs and native switch calls. Scripted and generated behavior are covered by
 compiler tests and executable examples. Expression results can share the
 generated structure with escaping assignments. Existing connections can be
 forwarded independently by reference and are adapted back to each result
-slot's declared schema at the branch boundary. Value-producing omitted result
-branches and continuations remain staged.
+slot's declared schema at the branch boundary. A value-producing conditional
+without `else` supplies a type-resolved `nothing` source for the absent false
+branch, so it emits no default value and no tick while false. Continuations
+remain staged.
 
 The parser, typed uninitialized `var`, and path-sensitive definite assignment
 support are broader than this first backend slice. The remaining
 standard-library conditional corpus stays outside the executable example glob
-until continuations and value-producing omitted branches are implemented.
+until continuations are implemented. The omitted-`else` value case has
+graduated to the executable corpus as `conditional-omitted-else.hgl`.

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -296,6 +296,8 @@ structural TSB whose fields are remapped into the enclosing composition. A used
 expression result and escaping assignments can share the same structural
 result. An initialized escaping binding can be forwarded by reference on an
 unassigned branch, independently for each generated result field.
+A consumed temporal conditional without `else` is type-resolved from its true
+branch and lowers its false path to a native never-ticking `nothing` source.
 Generated headers and sources are mandatory `clang-format` output and public
 operator contracts are transparent aliases rather than derived marker classes.
 

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -1324,8 +1324,9 @@ walk:
   structure with escaping assignments. Each selected result is remapped for
   subsequent composition. A branch that leaves an initialized escaping binding
   unchanged receives a `REF`-qualified input; generated branches adapt it to
-  the result slot's declared schema before returning it. Scalar captures,
-  branch returns, and value-producing omitted `else` fail closed for later
+  the result slot's declared schema before returning it. A consumed conditional
+  without `else` materializes a type-resolved native `nothing` source as its
+  false result. Scalar captures and branch returns fail closed for later
   slices;
 - a block body runs its statements in order: `let` and `var` bind locals
   (a declared type converts a constant or checks a port's schema), `=` and

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -1009,11 +1009,12 @@ ordinary current-value conditional. See
 case is implemented in both backends for a two-branch value result and for an
 outputless sink switch with an optional block `else`. A discarded conditional
 is checked without the enclosing function's expected result, so sink operators
-remain outputless inside a value-producing graph. Temporal `else if` is retained
-in the IR but rejected by both backends until nested branch lowering exists;
-it is never rewritten as an omitted false branch. Broader result and
-continuation forms remain implementation limits rather than unresolved choices
-of strategy.
+remain outputless inside a value-producing graph. A consumed temporal
+conditional without `else` instead gets a typed native `nothing` false branch.
+Temporal `else if` is retained in the IR but rejected by both backends until
+nested branch lowering exists; it is never rewritten as an omitted false
+branch. Continuation forms remain implementation limits rather than unresolved
+choices of strategy.
 
 Under the agreed temporal composition design, `return` targets the enclosing
 HGL function, not a compiler-generated branch lambda. Lowering must identify

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -382,9 +382,10 @@ compiler additionally remaps one predeclared temporal variable assigned by both
 explicit branches, or several such variables through a compiler-generated
 structural result. A used expression result can share that structural result
 with escaping assignments. An initialized result may be forwarded by a branch
-that does not assign it. The current slice rejects scalar branch captures,
-temporal `else if`, a value-producing omitted `else`, and early branch returns.
-The existing syntax needs no new keyword.
+that does not assign it. A consumed temporal conditional without `else` uses a
+typed never-ticking false branch. The current slice rejects scalar branch
+captures, temporal `else if`, and early branch returns. The existing syntax
+needs no new keyword.
 
 `if` has three context-dependent meanings:
 
@@ -403,7 +404,9 @@ This differs from calling `if_then_else` on already-wired outputs, whose
 upstream computations remain independently active. A value-producing temporal
 `if` without `else` uses a typed, never-ticking false branch, matching Arrow.
 Lowering computes each branch lambda's input captures and output signature.
-The omitted-`else` rule is agreed but not yet implemented.
+This is implemented in scripted and compiled modes without constructing a
+default scalar value; see
+[conditional-omitted-else.hgl](../../examples/conditional-omitted-else.hgl).
 An escaping variable must be declared before the conditional. For example:
 
 ```hgl

--- a/language/examples/README.md
+++ b/language/examples/README.md
@@ -34,6 +34,9 @@ type-generic struct specializations also have executable unit coverage.
 - [`conditional-forwarding.hgl`](conditional-forwarding.hgl) preserves an
   initialized result through an implicit or explicit unassigned branch and
   exercises independent reference forwarding for structural result fields.
+- [`conditional-omitted-else.hgl`](conditional-omitted-else.hgl) shows that a
+  consumed temporal conditional without `else` produces no tick while false,
+  using a type-resolved `nothing` branch in both compiler backends.
 
 As compiler slices land, each example should advance from parsing and typed IR
 coverage through `hgl test` to generated C++ behavior and backend parity.

--- a/language/examples/conditional-omitted-else.hgl
+++ b/language/examples/conditional-omitted-else.hgl
@@ -1,0 +1,15 @@
+// A consumed temporal conditional without an explicit false branch produces
+// no tick while false. The compiler supplies a typed `nothing` branch rather
+// than inventing a default scalar value.
+
+module examples.conditional_omitted_else
+
+export fn choose(condition: bool, value: i64) -> i64 {
+    if condition {
+        value + 1
+    }
+}
+
+test choose_ticks {
+    assert eval(choose, condition: [false, true, false], value: [1, 2, 3]) == [_, 3, _]
+}

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -1782,10 +1782,15 @@ namespace hgl::codegen
             });
             std::optional<Value> expression_value;
             if (expression_slot != results.end()) {
-                if (body == nullptr || !body->tail.valid()) {
+                if (body == nullptr) {
+                    const HType type = planned_type(expression_slot->type, body_range);
+                    expression_value =
+                        make_port("hgraph::wire<hgraph::stdlib::nothing, " + schema(type, body_range) + ">(w)", type, body_range);
+                } else if (!body->tail.valid()) {
                     backend(body_range, "a value-producing time-series 'if' branch must end with a value");
+                } else {
+                    expression_value = eval_planned_expr(body->tail, nested);
                 }
-                expression_value = eval_planned_expr(body->tail, nested);
             } else if (body != nullptr && body->tail.valid()) {
                 const Value tail = eval_planned_expr(body->tail, nested);
                 current_body_->line(tail.kind == Value::Kind::Void ? tail.code + ";" : "(void)" + tail.code + ";");
@@ -1796,8 +1801,8 @@ namespace hgl::codegen
             for (const gir::ConditionalResultSlot &slot : results) {
                 const HType type = planned_type(slot.type, body_range);
                 if (slot.source == gir::ConditionalResultSource::Expression) {
-                    const gir::Value &tail = planned_value(body->tail, body_range);
-                    outputs.push_back(as_port(*expression_value, type, tail.range));
+                    const SourceRange output_range = body != nullptr ? planned_value(body->tail, body_range).range : body_range;
+                    outputs.push_back(as_port(*expression_value, type, output_range));
                     continue;
                 }
                 const auto found = nested.planned_bindings.find(slot.binding.value);
@@ -1822,16 +1827,10 @@ namespace hgl::codegen
 
         Value Emitter::lower_planned_conditional(gir::ValueId id, const gir::Conditional &, SourceRange range, Frame &frame,
                                                  bool result_used) {
-            const gir::ConditionalPlan plan              = gir::analyze_temporal_conditional(graph_, id);
-            const auto                 results           = gir::plan_temporal_conditional_results(graph_, plan, result_used);
-            const bool                 expression_output = std::ranges::any_of(results, [](const gir::ConditionalResultSlot &slot) {
-                return slot.source == gir::ConditionalResultSource::Expression;
-            });
+            const gir::ConditionalPlan plan    = gir::analyze_temporal_conditional(graph_, id);
+            const auto                 results = gir::plan_temporal_conditional_results(graph_, plan, result_used);
             if (plan.has_otherwise && !plan.when_false) {
                 backend(range, "temporal 'else if' is not supported in this compiler stage; use a block 'else'");
-            }
-            if (expression_output && !plan.when_false) {
-                backend(range, "a value-producing time-series 'if' needs an explicit block 'else' in this compiler stage");
             }
             if (plan.when_true.returns || (plan.when_false && plan.when_false->returns)) {
                 backend(range, "return from a time-series 'if' branch is not supported in this compiler stage");

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -1514,6 +1514,13 @@ namespace hgl::ir
                         type_error(expression.range, "if branches have incompatible result types");
                     }
                     expression.type = expected.valid() ? canonical(expected) : then_type;
+                } else if (condition.phase == Phase::Wiring && then_type != void_type_) {
+                    // A consumed temporal conditional without `else` has the
+                    // true branch's type. Its false branch is materialized as
+                    // a typed never-ticking source by the execution backends.
+                    // Discarded conditionals arrive with an expected void type
+                    // and retain the outputless switch path.
+                    expression.type = expected.valid() ? canonical(expected) : then_type;
                 } else {
                     expression.type = void_type_;
                 }

--- a/language/src/wiring/backend.cpp
+++ b/language/src/wiring/backend.cpp
@@ -1422,6 +1422,11 @@ namespace hgl::wiring
                 return found->second;
             };
             const auto convert_output = [&](Slot result, const hgraph::TSValueTypeMetaData *expected) {
+                if (result.kind == Slot::Kind::Void && !context.block.valid()) {
+                    // The implicit false branch of a value-producing temporal
+                    // conditional has a type but intentionally never ticks.
+                    return compiler.wire("nothing", {}, context.range, true, expected);
+                }
                 if (result.is_const()) {
                     return compiler.wire_constant(make_const(compiler.convert(result.value, expected->value_schema, result.range,
                                                                               "conditional branch result"),
@@ -1594,16 +1599,10 @@ namespace hgl::wiring
 
         Slot Compiler::eval_temporal_conditional(gir::ValueId id, const Slot &condition, SourceRange range, Frame &frame,
                                                  bool result_used) {
-            const gir::ConditionalPlan plan              = gir::analyze_temporal_conditional(module_, id);
-            const auto                 results           = gir::plan_temporal_conditional_results(module_, plan, result_used);
-            const bool                 expression_output = std::ranges::any_of(results, [](const gir::ConditionalResultSlot &slot) {
-                return slot.source == gir::ConditionalResultSource::Expression;
-            });
+            const gir::ConditionalPlan plan    = gir::analyze_temporal_conditional(module_, id);
+            const auto                 results = gir::plan_temporal_conditional_results(module_, plan, result_used);
             if (plan.has_otherwise && !plan.when_false) {
                 backend(range, "temporal 'else if' is not supported in this compiler stage; use a block 'else'");
-            }
-            if (expression_output && !plan.when_false) {
-                backend(range, "a value-producing time-series 'if' needs an explicit block 'else' in this compiler stage");
             }
             if (plan.when_true.returns || (plan.when_false && plan.when_false->returns)) {
                 backend(range, "return from a time-series 'if' branch is not supported in this compiler stage");

--- a/language/stdlib/README.md
+++ b/language/stdlib/README.md
@@ -145,7 +145,9 @@ backends and the generated-code fixture. Several escaping assignments are also
 implemented through a compiler-generated structural TSB. Mixed
 expression/assignment results share that same lowering and are implemented in
 both backends. Existing bindings can be forwarded by reference, independently
-for each structural result field. Continuations remain design inputs. Typed
-declarations without initializers and their definite-assignment checks are
-implemented. Files left here are not runnable tests and remain deliberately
-outside `language/examples/`, whose `.hgl` files are checked by CTest.
+for each structural result field. A value-producing temporal conditional may
+omit `else`; both backends supply a typed never-ticking false result.
+Continuations remain design inputs. Typed declarations without initializers and
+their definite-assignment checks are implemented. Files left here are not
+runnable tests and remain deliberately outside `language/examples/`, whose
+`.hgl` files are checked by CTest.

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -283,6 +283,7 @@ hgl_add_module(hgl_codegen_fixture STATIC HGL
     codegen/runtime.hgl
     ../examples/conditional-forwarding.hgl
     ../examples/conditional-mixed-results.hgl
+    ../examples/conditional-omitted-else.hgl
     ../examples/conditional-result.hgl
     ../examples/conditional-results.hgl
     ../examples/conditional-sinks.hgl

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -894,6 +894,26 @@ export fn adjusted_pair(condition: bool, x: i64, y: i64) -> i64 {
     CHECK(contains(emitted->source, "right.as<hgraph::REF<hgraph::TS<hgraph::Int>>>()"));
 }
 
+TEST_CASE("emit-cpp types an omitted temporal else with a never-ticking source", "[codegen][control-flow][conditional]") {
+    Unit unit{R"(
+module planned_temporal_omitted_else
+
+export fn choose(condition: bool, value: i64) -> i64 {
+    if condition {
+        value + 1
+    }
+}
+)"};
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+
+    const auto emitted = unit.emit();
+    REQUIRE(emitted);
+    CHECK(contains(emitted->source, "struct hgl_choose_if_1_else"));
+    CHECK(contains(emitted->source, "return hgraph::wire<hgraph::stdlib::nothing, hgraph::TS<hgraph::Int>>(w);"));
+    CHECK(contains(emitted->source, "return hgraph::wire<hgraph::stdlib::switch_>"));
+}
+
 TEST_CASE("emit-cpp promotes the first constant assignment to a typed composition var", "[codegen][locals][control-flow]") {
     Unit unit{R"(
 module planned_constant_assignment

--- a/language/tests/codegen/generated_tests.cpp
+++ b/language/tests/codegen/generated_tests.cpp
@@ -4,6 +4,7 @@
 // module's `test` blocks assert under `hgl test`.
 #include <conditional-forwarding.h>
 #include <conditional-mixed-results.h>
+#include <conditional-omitted-else.h>
 #include <conditional-result.h>
 #include <conditional-results.h>
 #include <conditional-sinks.h>
@@ -26,6 +27,7 @@ using namespace hgraph::testing;
 namespace parity              = hgl::codegen::parity;
 namespace conditional_forward = examples::conditional_forwarding;
 namespace conditional_mixed   = examples::conditional_mixed_results;
+namespace conditional_omitted = examples::conditional_omitted_else;
 namespace conditional_result  = examples::conditional_result;
 namespace conditional_results = examples::conditional_results;
 namespace conditional_sinks   = examples::conditional_sinks;
@@ -126,6 +128,12 @@ TEST_CASE("generated temporal conditionals forward structural result fields inde
     session();
     CHECK(eval_node<conditional_forward::adjusted_pair>(values<Bool>(true, false), values<Int>(1, 2), values<Int>(10, 20)) ==
           values<Int>(12, 23));
+}
+
+TEST_CASE("generated value-producing temporal conditionals synthesize an omitted else", "[codegen][generated][conditional]") {
+    session();
+    CHECK(eval_node<conditional_omitted::choose>(values<Bool>(false, true, false), values<Int>(1, 2, 3)) ==
+          values<Int>(none, 3, none));
 }
 
 TEST_CASE("generated exports are registered by module-qualified name with their defaults", "[codegen][generated]") {

--- a/language/tests/hgraph_ir/control_flow_tests.cpp
+++ b/language/tests/hgraph_ir/control_flow_tests.cpp
@@ -108,6 +108,30 @@ fn observe(enabled: bool, value: f64) {
     CHECK(lowered.graph->bindings[plan.captures.front().binding.value].name == "value");
 }
 
+TEST_CASE("value-producing temporal conditional analysis retains an omitted else", "[hgraph-ir][control-flow]") {
+    Lowered lowered{R"(
+module checks.temporal_omitted_else
+
+fn choose(condition: bool, value: i64) -> i64 {
+    if condition {
+        value + 1
+    }
+}
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE(lowered.graph);
+
+    const gir::ConditionalPlan plan = gir::analyze_temporal_conditional(*lowered.graph, conditional_value(*lowered.graph));
+    REQUIRE(plan.result.valid());
+    CHECK(lowered.graph->types[plan.result.value].kind == hir::TypeKind::Scalar);
+    CHECK_FALSE(plan.has_otherwise);
+    CHECK_FALSE(plan.when_false);
+    const auto results = gir::plan_temporal_conditional_results(*lowered.graph, plan, true);
+    REQUIRE(results.size() == 1U);
+    CHECK(results.front().source == gir::ConditionalResultSource::Expression);
+    CHECK(results.front().type == plan.result);
+}
+
 TEST_CASE("temporal conditional analysis distinguishes else-if from an omitted else", "[hgraph-ir][control-flow]") {
     Lowered lowered{R"(
 module checks.temporal_else_if

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -323,6 +323,32 @@ fn wrong() -> str {
     CHECK(lowered.hir.completion == hir::Completion::Resolved);
 }
 
+TEST_CASE("typed HIR gives a consumed temporal if without else its true-branch type", "[ir][typed][control-flow]") {
+    Lowered lowered{R"(
+module checks.temporal_omitted_else
+
+fn choose(condition: bool, value: i64) -> i64 {
+    if condition {
+        value + 1
+    }
+}
+)"};
+    require_clean(lowered);
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE(complete(lowered));
+
+    const hir::FunctionDecl *fn = nullptr;
+    for (const hir::Declaration &declaration : lowered.hir.declarations) {
+        const auto *candidate = std::get_if<hir::FunctionDecl>(&declaration.node);
+        if (candidate && declaration.symbol.valid() && lowered.hir.symbol(declaration.symbol).name == "choose") { fn = candidate; }
+    }
+    REQUIRE(fn != nullptr);
+    const hir::Expr &conditional = lowered.hir.expr(lowered.hir.block(fn->block_body).tail);
+    CHECK(conditional.type == fn->signature.result);
+    CHECK(conditional.phase == hir::Phase::Wiring);
+    CHECK(conditional.value_kind == hir::ValueKind::Signal);
+}
+
 TEST_CASE("typed HIR checks definite assignment across conditional paths", "[ir][typed][locals][control-flow]") {
     SECTION("both reaching branches assign the variable") {
         Lowered lowered{R"(

--- a/language/tests/wiring/backend_tests.cpp
+++ b/language/tests/wiring/backend_tests.cpp
@@ -311,6 +311,26 @@ test choose_ticks {
     CHECK(result.passed);
 }
 
+TEST_CASE("a value-producing temporal if without else uses a typed never-ticking branch", "[wiring][control-flow][conditional]") {
+    Unit             unit{R"(
+module t
+
+fn choose(condition: bool, value: i64) -> i64 {
+    if condition {
+        value + 1
+    }
+}
+
+test choose_ticks {
+    assert eval(choose, condition: [false, true, false], value: [1, 2, 3]) == [_, 3, _]
+}
+)"};
+    const TestResult result = only(unit.tests());
+    INFO(unit.diagnostics.render(unit.file));
+    INFO(result.message);
+    CHECK(result.passed);
+}
+
 TEST_CASE("a temporal if evaluates its condition composition once", "[wiring][control-flow][conditional]") {
     ensure_session();
     hgraph::register_graph_overload<observed_condition_operator, observed_condition_graph>();


### PR DESCRIPTION
## Summary

- type consumed temporal conditionals without `else` from the true branch
- lower the absent false branch to a type-resolved native `nothing` source in both backends
- add readable generated C++ plus direct/generated runtime coverage and an executable example
- update the user, developer, design, roadmap, and corpus status documentation

## Validation

- `ctest --preset cpp --output-on-failure -R '^hgraph_language'` (49/49)\n- `cmake --preset cpp --fresh`\n- `cmake --build --preset cpp --target clean`\n- `cmake --build --preset cpp --parallel`\n- `ctest --preset cpp --parallel 2 --output-on-failure` (1716/1716)\n- ABI3 wheel built with Python 3.12 and installed into a fresh Python 3.14 environment\n- `python -m pytest python/tests -q -m "not wip"` (3241 passed, 10 skipped)