### PR TITLE
language: plan temporal return continuations

### DIFF
--- a/language/docs/design/control-flow.md
+++ b/language/docs/design/control-flow.md
@@ -380,8 +380,10 @@ continuation, because that path never reaches the use. This does not permit
 a read before assignment on a path that does reach it.
 
 See [conditional-early-return.hgl](../../stdlib/examples/conditional-early-return.hgl)
-for the design-corpus example. These semantics are agreed; compiler lowering
-remains separate work.
+for the design-corpus example. These semantics are agreed. HGraph IR now
+represents the callable suffix, branch fallthrough, complete-path captures,
+and enclosing-function result explicitly; backend lowering remains separate
+work.
 
 ## Outputless conditionals
 
@@ -578,8 +580,10 @@ generated structure with escaping assignments. Existing connections can be
 forwarded independently by reference and are adapted back to each result
 slot's declared schema at the branch boundary. A value-producing conditional
 without `else` supplies a type-resolved `nothing` source for the absent false
-branch, so it emits no default value and no tick while false. Continuations
-remain staged.
+branch, so it emits no default value and no tick while false. Shared HGraph IR
+continuation planning is implemented, including path-sensitive fallthrough,
+capture analysis, and a distinct enclosing-function return result. The two
+execution backends do not consume that continuation plan yet.
 
 The parser, typed uninitialized `var`, and path-sensitive definite assignment
 support are broader than this first backend slice. The remaining

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -209,6 +209,16 @@ same plan and never inspect a temporal payload while composing the graph. Each
 capture is explicitly tagged as pass-through at the native map boundary, so a
 captured map or list remains whole rather than becoming another multiplexed
 input.
+The same shared analysis derives `ConditionalPlan` records for temporal
+conditionals. A branch distinguishes “contains an explicit return” from “can
+fall through”; those are different facts when only some nested scalar paths
+return. When a caller supplies the remaining callable suffix, the analysis
+attaches that `ConditionalContinuationPlan` only to paths that can reach it,
+then recomputes captures and assignments over each complete child path. A
+terminal plan has one `FunctionReturn` result contract rather than exposing
+the continuation's local assignments as outer escape results. This planning
+boundary is implemented; consuming the continuation in the direct-wiring and
+generated-C++ backends is the next lowering slice.
 `DeclarationRef` provides typed struct, operator, callable, and test handles;
 the module retains those handles in source order while module and import
 declarations remain frontend-only. Each referenced contract or plan owns its

--- a/language/src/hgraph_ir/control_flow.cpp
+++ b/language/src/hgraph_ir/control_flow.cpp
@@ -155,31 +155,32 @@ namespace hgl::hgraph_ir
                         if constexpr (std::is_same_v<T, Reference>) {
                             if (node.kind == ReferenceKind::Binding) { capture(expression, node.binding); }
                         } else if constexpr (std::is_same_v<T, Unary>) {
-                            (void)scan_value(node.operand);
+                            return scan_value(node.operand);
                         } else if constexpr (std::is_same_v<T, Binary>) {
-                            (void)scan_value(node.lhs);
-                            (void)scan_value(node.rhs);
+                            return scan_value(node.lhs) && scan_value(node.rhs);
                         } else if constexpr (std::is_same_v<T, Call>) {
-                            (void)scan_value(node.callee);
-                            for (const Argument &argument : node.arguments) { (void)scan_value(argument.value); }
+                            if (!scan_value(node.callee)) { return false; }
+                            for (const Argument &argument : node.arguments) {
+                                if (!scan_value(argument.value)) { return false; }
+                            }
                         } else if constexpr (std::is_same_v<T, Index>) {
-                            (void)scan_value(node.target);
-                            (void)scan_value(node.index);
+                            return scan_value(node.target) && scan_value(node.index);
                         } else if constexpr (std::is_same_v<T, Field>) {
-                            (void)scan_value(node.target);
+                            return scan_value(node.target);
                         } else if constexpr (std::is_same_v<T, Sequence>) {
                             for (const SequenceElement &element : node.elements) {
-                                (void)scan_value(element.key);
-                                (void)scan_value(element.value);
+                                if (!scan_value(element.key) || !scan_value(element.value)) { return false; }
                             }
                         } else if constexpr (std::is_same_v<T, Tuple>) {
-                            for (ValueId element : node.elements) { (void)scan_value(element); }
+                            for (ValueId element : node.elements) {
+                                if (!scan_value(element)) { return false; }
+                            }
                         } else if constexpr (std::is_same_v<T, Lambda>) {
                             const auto defined = defined_outer_;
                             (void)scan_value(node.body);
                             defined_outer_ = defined;
                         } else if constexpr (std::is_same_v<T, Conditional>) {
-                            (void)scan_value(node.condition);
+                            if (!scan_value(node.condition)) { return false; }
 
                             const auto incoming   = defined_outer_;
                             defined_outer_        = incoming;
@@ -206,10 +207,14 @@ namespace hgl::hgraph_ir
                         } else if constexpr (std::is_same_v<T, BlockValue>) {
                             return scan_block(node.block);
                         } else if constexpr (std::is_same_v<T, HarnessEval>) {
-                            (void)scan_value(node.callee);
-                            for (const Argument &argument : node.arguments) { (void)scan_value(argument.value); }
+                            if (!scan_value(node.callee)) { return false; }
+                            for (const Argument &argument : node.arguments) {
+                                if (!scan_value(argument.value)) { return false; }
+                            }
                         } else if constexpr (std::is_same_v<T, Construct>) {
-                            for (const Argument &argument : node.arguments) { (void)scan_value(argument.value); }
+                            for (const Argument &argument : node.arguments) {
+                                if (!scan_value(argument.value)) { return false; }
+                            }
                         }
                         return true;
                     },
@@ -258,21 +263,21 @@ namespace hgl::hgraph_ir
                                 (void)scan_block(node.block);
                                 defined_outer_ = defined;
                             } else if constexpr (std::is_same_v<T, Activation>) {
-                                (void)scan_value(node.condition);
+                                if (!scan_value(node.condition)) { return false; }
                                 const auto defined = defined_outer_;
                                 (void)scan_block(node.block);
                                 defined_outer_ = defined;
                             } else if constexpr (std::is_same_v<T, Traversal>) {
-                                (void)scan_value(node.iterable);
+                                if (!scan_value(node.iterable)) { return false; }
                                 const auto defined = defined_outer_;
                                 (void)scan_block(node.block);
                                 defined_outer_ = defined;
                             } else if constexpr (std::is_same_v<T, Assignment>) {
                                 const BindingId target = place_root(node.place);
                                 if (node.op != AssignOp::Assign || direct_assignment_target(node.place) != target) {
-                                    (void)scan_value(node.place);
+                                    if (!scan_value(node.place)) { return false; }
                                 }
-                                (void)scan_value(node.value);
+                                if (!scan_value(node.value)) { return false; }
                                 if (target.valid() && !contains(locals_, target)) {
                                     if (!contains(plan_.assigned_outer, target)) { plan_.assigned_outer.push_back(target); }
                                     if (!contains(defined_outer_, target)) { defined_outer_.push_back(target); }
@@ -308,14 +313,14 @@ namespace hgl::hgraph_ir
     }  // namespace
 
     ConditionalContinuationPlan plan_temporal_continuation(const Module &module, BlockId enclosing, std::size_t first_statement,
-                                                           TypeId result) {
+                                                           TypeId result, ValueId conditional) {
         ConditionalContinuationPlan continuation;
         continuation.result = result;
         if (!enclosing.valid() || enclosing.value >= module.blocks.size()) { return continuation; }
         const Block &block = module.blocks[enclosing.value];
         const auto   first = std::min(first_statement, block.statements.size());
         continuation.statements.assign(block.statements.begin() + static_cast<std::ptrdiff_t>(first), block.statements.end());
-        continuation.tail = block.tail;
+        if (block.tail != conditional) { continuation.tail = block.tail; }
         return continuation;
     }
 

--- a/language/src/hgraph_ir/control_flow.cpp
+++ b/language/src/hgraph_ir/control_flow.cpp
@@ -17,12 +17,23 @@ namespace hgl::hgraph_ir
         class BranchAnalyzer
         {
           public:
-            BranchAnalyzer(const Module &module, BlockId block, std::span<const BindingId> additional_locals = {})
+            BranchAnalyzer(const Module &module, BlockId block, std::span<const BindingId> additional_locals = {},
+                           std::optional<ConditionalContinuationPlan> continuation = std::nullopt)
                 : module_{module} {
                 plan_.block = block;
                 for (BindingId binding : additional_locals) { add_local(binding); }
                 collect_locals(block);
-                scan_block(block);
+                if (continuation) { collect_locals(*continuation); }
+
+                plan_.falls_through = scan_block(block);
+                if (plan_.falls_through && continuation) {
+                    plan_.continuation = std::move(continuation);
+                    (void)scan_continuation(*plan_.continuation);
+                    // The continuation is the complete remainder of the
+                    // callable. Reaching its end supplies that callable's
+                    // result (including the implicit result of a void body).
+                    plan_.falls_through = false;
+                }
             }
 
             [[nodiscard]] ConditionalBranchPlan take() && { return std::move(plan_); }
@@ -80,7 +91,17 @@ namespace hgl::hgraph_ir
             void collect_locals(BlockId id) {
                 if (!id.valid()) { return; }
                 const Block &body = block(id);
-                for (StatementId statement_id : body.statements) {
+                collect_locals(body.statements);
+                collect_value_locals(body.tail);
+            }
+
+            void collect_locals(const ConditionalContinuationPlan &continuation) {
+                collect_locals(continuation.statements);
+                collect_value_locals(continuation.tail);
+            }
+
+            void collect_locals(std::span<const StatementId> statements) {
+                for (StatementId statement_id : statements) {
                     const Statement &item = statement(statement_id);
                     std::visit(
                         [&](const auto &node) {
@@ -112,7 +133,6 @@ namespace hgl::hgraph_ir
                         },
                         item.node);
                 }
-                collect_value_locals(body.tail);
             }
 
             void capture(const Value &expression, BindingId binding) {
@@ -126,64 +146,72 @@ namespace hgl::hgraph_ir
                 }
             }
 
-            void scan_value(ValueId id) {
-                if (!id.valid()) { return; }
+            [[nodiscard]] bool scan_value(ValueId id) {
+                if (!id.valid()) { return true; }
                 const Value &expression = value(id);
-                std::visit(
-                    [&](const auto &node) {
+                return std::visit(
+                    [&](const auto &node) -> bool {
                         using T = std::decay_t<decltype(node)>;
                         if constexpr (std::is_same_v<T, Reference>) {
                             if (node.kind == ReferenceKind::Binding) { capture(expression, node.binding); }
                         } else if constexpr (std::is_same_v<T, Unary>) {
-                            scan_value(node.operand);
+                            (void)scan_value(node.operand);
                         } else if constexpr (std::is_same_v<T, Binary>) {
-                            scan_value(node.lhs);
-                            scan_value(node.rhs);
+                            (void)scan_value(node.lhs);
+                            (void)scan_value(node.rhs);
                         } else if constexpr (std::is_same_v<T, Call>) {
-                            scan_value(node.callee);
-                            for (const Argument &argument : node.arguments) { scan_value(argument.value); }
+                            (void)scan_value(node.callee);
+                            for (const Argument &argument : node.arguments) { (void)scan_value(argument.value); }
                         } else if constexpr (std::is_same_v<T, Index>) {
-                            scan_value(node.target);
-                            scan_value(node.index);
+                            (void)scan_value(node.target);
+                            (void)scan_value(node.index);
                         } else if constexpr (std::is_same_v<T, Field>) {
-                            scan_value(node.target);
+                            (void)scan_value(node.target);
                         } else if constexpr (std::is_same_v<T, Sequence>) {
                             for (const SequenceElement &element : node.elements) {
-                                scan_value(element.key);
-                                scan_value(element.value);
+                                (void)scan_value(element.key);
+                                (void)scan_value(element.value);
                             }
                         } else if constexpr (std::is_same_v<T, Tuple>) {
-                            for (ValueId element : node.elements) { scan_value(element); }
+                            for (ValueId element : node.elements) { (void)scan_value(element); }
                         } else if constexpr (std::is_same_v<T, Lambda>) {
                             const auto defined = defined_outer_;
-                            scan_value(node.body);
+                            (void)scan_value(node.body);
                             defined_outer_ = defined;
                         } else if constexpr (std::is_same_v<T, Conditional>) {
-                            scan_value(node.condition);
+                            (void)scan_value(node.condition);
 
-                            const auto incoming = defined_outer_;
-                            defined_outer_      = incoming;
-                            scan_block(node.then_block);
-                            const auto when_true = defined_outer_;
+                            const auto incoming   = defined_outer_;
+                            defined_outer_        = incoming;
+                            const bool then_falls = scan_block(node.then_block);
+                            const auto when_true  = defined_outer_;
+
+                            defined_outer_             = incoming;
+                            const bool otherwise_falls = node.otherwise.valid() ? scan_value(node.otherwise) : true;
+                            const auto when_false      = defined_outer_;
 
                             defined_outer_ = incoming;
-                            if (node.otherwise.valid()) { scan_value(node.otherwise); }
-                            const auto when_false = defined_outer_;
-
-                            defined_outer_ = incoming;
-                            for (BindingId binding : when_true) {
-                                if (contains(when_false, binding) && !contains(defined_outer_, binding)) {
-                                    defined_outer_.push_back(binding);
+                            if (then_falls && otherwise_falls) {
+                                for (BindingId binding : when_true) {
+                                    if (contains(when_false, binding) && !contains(defined_outer_, binding)) {
+                                        defined_outer_.push_back(binding);
+                                    }
                                 }
+                            } else if (then_falls) {
+                                defined_outer_ = when_true;
+                            } else if (otherwise_falls) {
+                                defined_outer_ = when_false;
                             }
+                            return then_falls || otherwise_falls;
                         } else if constexpr (std::is_same_v<T, BlockValue>) {
-                            scan_block(node.block);
+                            return scan_block(node.block);
                         } else if constexpr (std::is_same_v<T, HarnessEval>) {
-                            scan_value(node.callee);
-                            for (const Argument &argument : node.arguments) { scan_value(argument.value); }
+                            (void)scan_value(node.callee);
+                            for (const Argument &argument : node.arguments) { (void)scan_value(argument.value); }
                         } else if constexpr (std::is_same_v<T, Construct>) {
-                            for (const Argument &argument : node.arguments) { scan_value(argument.value); }
+                            for (const Argument &argument : node.arguments) { (void)scan_value(argument.value); }
                         }
+                        return true;
                     },
                     expression.node);
             }
@@ -205,52 +233,65 @@ namespace hgl::hgraph_ir
                 return {};
             }
 
-            void scan_block(BlockId id) {
-                if (!id.valid()) { return; }
+            [[nodiscard]] bool scan_block(BlockId id) {
+                if (!id.valid()) { return true; }
                 const Block &body = block(id);
-                for (StatementId statement_id : body.statements) {
-                    const Statement &item = statement(statement_id);
-                    std::visit(
-                        [&](const auto &node) {
+                if (!scan_statements(body.statements)) { return false; }
+                return scan_value(body.tail);
+            }
+
+            [[nodiscard]] bool scan_continuation(const ConditionalContinuationPlan &continuation) {
+                if (!scan_statements(continuation.statements)) { return false; }
+                return scan_value(continuation.tail);
+            }
+
+            [[nodiscard]] bool scan_statements(std::span<const StatementId> statements) {
+                for (StatementId statement_id : statements) {
+                    const Statement &item          = statement(statement_id);
+                    const bool       falls_through = std::visit(
+                        [&](const auto &node) -> bool {
                             using T = std::decay_t<decltype(node)>;
                             if constexpr (std::is_same_v<T, LocalBinding> || std::is_same_v<T, StateBinding>) {
-                                scan_value(node.init);
+                                return scan_value(node.init);
                             } else if constexpr (std::is_same_v<T, Lifecycle>) {
                                 const auto defined = defined_outer_;
-                                scan_block(node.block);
+                                (void)scan_block(node.block);
                                 defined_outer_ = defined;
                             } else if constexpr (std::is_same_v<T, Activation>) {
-                                scan_value(node.condition);
+                                (void)scan_value(node.condition);
                                 const auto defined = defined_outer_;
-                                scan_block(node.block);
+                                (void)scan_block(node.block);
                                 defined_outer_ = defined;
                             } else if constexpr (std::is_same_v<T, Traversal>) {
-                                scan_value(node.iterable);
+                                (void)scan_value(node.iterable);
                                 const auto defined = defined_outer_;
-                                scan_block(node.block);
+                                (void)scan_block(node.block);
                                 defined_outer_ = defined;
                             } else if constexpr (std::is_same_v<T, Assignment>) {
                                 const BindingId target = place_root(node.place);
                                 if (node.op != AssignOp::Assign || direct_assignment_target(node.place) != target) {
-                                    scan_value(node.place);
+                                    (void)scan_value(node.place);
                                 }
-                                scan_value(node.value);
+                                (void)scan_value(node.value);
                                 if (target.valid() && !contains(locals_, target)) {
                                     if (!contains(plan_.assigned_outer, target)) { plan_.assigned_outer.push_back(target); }
                                     if (!contains(defined_outer_, target)) { defined_outer_.push_back(target); }
                                 }
                             } else if constexpr (std::is_same_v<T, Return>) {
                                 plan_.returns = true;
-                                scan_value(node.value);
+                                (void)scan_value(node.value);
+                                return false;
                             } else if constexpr (std::is_same_v<T, Assert>) {
-                                scan_value(node.condition);
+                                return scan_value(node.condition);
                             } else if constexpr (std::is_same_v<T, Evaluate>) {
-                                scan_value(node.value);
+                                return scan_value(node.value);
                             }
+                            return true;
                         },
                         item.node);
+                    if (!falls_through) { return false; }
                 }
-                scan_value(body.tail);
+                return true;
             }
 
             const Module          &module_;
@@ -266,7 +307,20 @@ namespace hgl::hgraph_ir
         }
     }  // namespace
 
-    ConditionalPlan analyze_temporal_conditional(const Module &module, ValueId value_id) {
+    ConditionalContinuationPlan plan_temporal_continuation(const Module &module, BlockId enclosing, std::size_t first_statement,
+                                                           TypeId result) {
+        ConditionalContinuationPlan continuation;
+        continuation.result = result;
+        if (!enclosing.valid() || enclosing.value >= module.blocks.size()) { return continuation; }
+        const Block &block = module.blocks[enclosing.value];
+        const auto   first = std::min(first_statement, block.statements.size());
+        continuation.statements.assign(block.statements.begin() + static_cast<std::ptrdiff_t>(first), block.statements.end());
+        continuation.tail = block.tail;
+        return continuation;
+    }
+
+    ConditionalPlan analyze_temporal_conditional(const Module &module, ValueId value_id,
+                                                 std::optional<ConditionalContinuationPlan> continuation) {
         ConditionalPlan plan;
         plan.value = value_id;
         if (!value_id.valid() || value_id.value >= module.values.size()) { return plan; }
@@ -275,24 +329,53 @@ namespace hgl::hgraph_ir
         const auto  *branch = std::get_if<Conditional>(&value.node);
         if (branch == nullptr) { return plan; }
 
-        plan.condition = branch->condition;
-        plan.result    = value.type;
-        plan.when_true = BranchAnalyzer{module, branch->then_block}.take();
+        plan.condition                        = branch->condition;
+        plan.result                           = value.type;
+        plan.when_true                        = BranchAnalyzer{module, branch->then_block}.take();
+        bool                   branch_returns = plan.when_true.returns;
+        std::optional<BlockId> otherwise_block;
+        plan.has_otherwise = branch->otherwise.valid();
+        if (branch->otherwise.valid() && branch->otherwise.value < module.values.size()) {
+            const Value &otherwise = module.values[branch->otherwise.value];
+            if (const auto *block = std::get_if<BlockValue>(&otherwise.node)) {
+                otherwise_block = block->block;
+                plan.when_false = BranchAnalyzer{module, *otherwise_block}.take();
+                branch_returns  = branch_returns || plan.when_false->returns;
+            }
+        }
+
+        // Once either temporal branch returns from its enclosing callable,
+        // every path that can fall through must compose the callable suffix
+        // in the selected child graph. Re-analyzing the complete path keeps
+        // captures and assignments sequenced rather than unioning two
+        // independent lexical analyses.
+        if (continuation && branch_returns && (!plan.has_otherwise || otherwise_block)) {
+            plan.result                = continuation->result;
+            plan.when_true             = BranchAnalyzer{module, branch->then_block, {}, continuation}.take();
+            plan.when_false            = BranchAnalyzer{module, otherwise_block.value_or(BlockId{}), {}, continuation}.take();
+            plan.returns_from_callable = !plan.when_true.falls_through && !plan.when_false->falls_through;
+        }
+
         for (const ConditionalCapture &capture : plan.when_true.captures) { append_capture(plan.captures, capture); }
         for (BindingId binding : plan.when_true.assigned_outer) {
             if (!contains(plan.assigned_outer, binding)) { plan.assigned_outer.push_back(binding); }
         }
 
-        plan.has_otherwise = branch->otherwise.valid();
-        if (branch->otherwise.valid() && branch->otherwise.value < module.values.size()) {
-            const Value &otherwise = module.values[branch->otherwise.value];
-            if (const auto *block = std::get_if<BlockValue>(&otherwise.node)) {
-                plan.when_false = BranchAnalyzer{module, block->block}.take();
-                for (const ConditionalCapture &capture : plan.when_false->captures) { append_capture(plan.captures, capture); }
-                for (BindingId binding : plan.when_false->assigned_outer) {
-                    if (!contains(plan.assigned_outer, binding)) { plan.assigned_outer.push_back(binding); }
-                }
+        if (plan.when_false) {
+            for (const ConditionalCapture &capture : plan.when_false->captures) { append_capture(plan.captures, capture); }
+            for (BindingId binding : plan.when_false->assigned_outer) {
+                if (!contains(plan.assigned_outer, binding)) { plan.assigned_outer.push_back(binding); }
             }
+        }
+
+        if (plan.returns_from_callable) {
+            // All child paths terminate the callable, so assignments are
+            // branch-local implementation details rather than outputs that
+            // escape back into an enclosing continuation.
+            plan.assigned_outer.clear();
+            plan.when_true.assigned_outer.clear();
+            plan.when_false->assigned_outer.clear();
+            return plan;
         }
 
         // A branch that does not assign an escaping binding must receive the
@@ -324,6 +407,15 @@ namespace hgl::hgraph_ir
     std::vector<ConditionalResultSlot> plan_temporal_conditional_results(const Module &module, const ConditionalPlan &plan,
                                                                          bool expression_used) {
         std::vector<ConditionalResultSlot> results;
+        if (plan.returns_from_callable && plan.result.valid() && plan.result.value < module.types.size() &&
+            module.types[plan.result.value].kind != ir::hir::TypeKind::Void) {
+            results.push_back(ConditionalResultSlot{
+                .source     = ConditionalResultSource::FunctionReturn,
+                .type       = plan.result,
+                .field_name = "value",
+            });
+            return results;
+        }
         results.reserve(plan.assigned_outer.size() + (expression_used ? 1U : 0U));
 
         const auto unique_name = [&](std::string base) {

--- a/language/src/hgraph_ir/control_flow.h
+++ b/language/src/hgraph_ir/control_flow.h
@@ -3,6 +3,7 @@
 
 #include "hgraph_ir/ir.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -20,12 +21,28 @@ namespace hgl::hgraph_ir
         ir::hir::Phase phase{ir::hir::Phase::Unknown};
     };
 
+    /// The suffix of an enclosing callable that must execute on every path
+    /// that falls through a temporal conditional containing an early return.
+    /// Keeping the suffix in the execution IR lets both backends place it
+    /// inside the appropriate child graph without recovering syntax context.
+    struct ConditionalContinuationPlan
+    {
+        std::vector<StatementId> statements{};
+        ValueId                  tail{};
+        TypeId                   result{};
+    };
+
     struct ConditionalBranchPlan
     {
-        BlockId                         block{};
-        std::vector<ConditionalCapture> captures{};
-        std::vector<BindingId>          assigned_outer{};
-        bool                            returns{false};
+        BlockId                                    block{};
+        std::optional<ConditionalContinuationPlan> continuation{};
+        std::vector<ConditionalCapture>            captures{};
+        std::vector<BindingId>                     assigned_outer{};
+        /// At least one path in this branch contains an explicit return.
+        bool returns{false};
+        /// At least one path reaches the end of this planned branch. A
+        /// callable continuation, when attached, consumes that fallthrough.
+        bool falls_through{true};
     };
 
     /// Backend-independent plan for one graph-phase conditional. Captures are
@@ -40,13 +57,23 @@ namespace hgl::hgraph_ir
         std::optional<ConditionalBranchPlan> when_false{};
         std::vector<ConditionalCapture>      captures{};
         std::vector<BindingId>               assigned_outer{};
+        /// Every selected child supplies the enclosing callable's result.
+        bool returns_from_callable{false};
     };
+
+    /// Copy the suffix beginning at first_statement from an enclosing block.
+    /// Backends pass the enclosing callable's result type; the plan contains
+    /// only stable HGraph-IR IDs and can outlive traversal of the parent block.
+    [[nodiscard]] ConditionalContinuationPlan plan_temporal_continuation(const Module &module, BlockId enclosing,
+                                                                         std::size_t first_statement, TypeId result);
 
     /// Analyze an HGraph-IR Conditional value. The input module is already
     /// structurally valid; a non-conditional value or non-block else arm is
     /// represented as an incomplete plan for the backends to diagnose against
     /// the original source range.
-    [[nodiscard]] ConditionalPlan analyze_temporal_conditional(const Module &module, ValueId value);
+    [[nodiscard]] ConditionalPlan
+    analyze_temporal_conditional(const Module &module, ValueId value,
+                                 std::optional<ConditionalContinuationPlan> continuation = std::nullopt);
 
     /// Whether this branch supplies an escaping result by retaining the
     /// binding that entered the conditional instead of assigning a new one.
@@ -58,6 +85,7 @@ namespace hgl::hgraph_ir
     enum class ConditionalResultSource : std::uint8_t {
         Expression,
         Binding,
+        FunctionReturn,
     };
 
     /// One field in the common output contract shared by both temporal

--- a/language/src/hgraph_ir/control_flow.h
+++ b/language/src/hgraph_ir/control_flow.h
@@ -62,10 +62,13 @@ namespace hgl::hgraph_ir
     };
 
     /// Copy the suffix beginning at first_statement from an enclosing block.
-    /// Backends pass the enclosing callable's result type; the plan contains
-    /// only stable HGraph-IR IDs and can outlive traversal of the parent block.
+    /// Backends pass the enclosing callable's result type and the conditional
+    /// being planned. If that value is the enclosing block's tail, it is not
+    /// copied into its own continuation. The plan contains only stable
+    /// HGraph-IR IDs and can outlive traversal of the parent block.
     [[nodiscard]] ConditionalContinuationPlan plan_temporal_continuation(const Module &module, BlockId enclosing,
-                                                                         std::size_t first_statement, TypeId result);
+                                                                         std::size_t first_statement, TypeId result,
+                                                                         ValueId conditional = {});
 
     /// Analyze an HGraph-IR Conditional value. The input module is already
     /// structurally valid; a non-conditional value or non-block else arm is

--- a/language/tests/hgraph_ir/control_flow_tests.cpp
+++ b/language/tests/hgraph_ir/control_flow_tests.cpp
@@ -230,7 +230,7 @@ fn choose(condition: bool, x: i64, y: i64) -> i64 {
     REQUIRE(site.callable.valid());
     const gir::Callable &callable = lowered.graph->callables.at(site.callable.value);
     const auto           continuation =
-        gir::plan_temporal_continuation(*lowered.graph, site.block, site.statement_index + 1U, callable.result);
+        gir::plan_temporal_continuation(*lowered.graph, site.block, site.statement_index + 1U, callable.result, site.value);
     REQUIRE(continuation.statements.size() == 2U);
 
     const gir::ConditionalPlan plan = gir::analyze_temporal_conditional(*lowered.graph, site.value, continuation);
@@ -256,6 +256,71 @@ fn choose(condition: bool, x: i64, y: i64) -> i64 {
     REQUIRE(results.size() == 1U);
     CHECK(results.front().source == gir::ConditionalResultSource::FunctionReturn);
     CHECK(results.front().type == callable.result);
+}
+
+TEST_CASE("a tail conditional is excluded from its own continuation", "[hgraph-ir][control-flow][continuation]") {
+    Lowered lowered{R"(
+module checks.temporal_tail_return
+
+fn choose(condition: bool, x: i64, y: i64) -> i64 {
+    if condition {
+        return x
+    } else {
+        y
+    }
+}
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE(lowered.graph);
+    REQUIRE(lowered.graph->callables.size() == 1U);
+
+    const gir::Callable &callable = lowered.graph->callables.front();
+    const gir::Block    &block    = lowered.graph->blocks.at(callable.block_body.value);
+    REQUIRE(block.tail.valid());
+    REQUIRE(std::holds_alternative<gir::Conditional>(lowered.graph->values.at(block.tail.value).node));
+
+    const auto continuation =
+        gir::plan_temporal_continuation(*lowered.graph, callable.block_body, block.statements.size(), callable.result, block.tail);
+    CHECK(continuation.statements.empty());
+    CHECK_FALSE(continuation.tail.valid());
+
+    const gir::ConditionalPlan plan = gir::analyze_temporal_conditional(*lowered.graph, block.tail, continuation);
+    CHECK(plan.returns_from_callable);
+    REQUIRE(plan.when_false);
+    CHECK_FALSE(plan.when_true.continuation);
+    REQUIRE(plan.when_false->continuation);
+    CHECK_FALSE(plan.when_false->continuation->tail.valid());
+}
+
+TEST_CASE("a terminating call argument stops branch capture analysis", "[hgraph-ir][control-flow][continuation]") {
+    Lowered lowered{R"(
+module checks.temporal_nested_return
+
+fn passthrough(value: i64) -> i64 { value }
+
+fn choose(condition: bool, x: i64, y: i64, unreachable: i64) -> i64 {
+    if condition {
+        passthrough({
+            return x
+            y
+        })
+        return unreachable
+    } else {
+        return y
+    }
+}
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE(lowered.graph);
+
+    const gir::ConditionalPlan plan = gir::analyze_temporal_conditional(*lowered.graph, conditional_value(*lowered.graph));
+    CHECK(plan.when_true.returns);
+    CHECK_FALSE(plan.when_true.falls_through);
+    REQUIRE(plan.when_true.captures.size() == 1U);
+    CHECK(lowered.graph->bindings.at(plan.when_true.captures.front().binding.value).name == "x");
+    CHECK(std::ranges::none_of(plan.when_true.captures, [&](const gir::ConditionalCapture &capture) {
+        return lowered.graph->bindings.at(capture.binding.value).name == "unreachable";
+    }));
 }
 
 TEST_CASE("temporal conditional analysis does not capture a result assigned earlier in its branch", "[hgraph-ir][control-flow]") {

--- a/language/tests/hgraph_ir/control_flow_tests.cpp
+++ b/language/tests/hgraph_ir/control_flow_tests.cpp
@@ -53,6 +53,31 @@ namespace
         }
         return nullptr;
     }
+
+    struct ConditionalSite
+    {
+        gir::CallableId callable{};
+        gir::BlockId    block{};
+        gir::ValueId    value{};
+        std::size_t     statement_index{};
+    };
+
+    ConditionalSite conditional_site(const gir::Module &module) {
+        for (std::uint32_t callable_index = 0; callable_index < module.callables.size(); ++callable_index) {
+            const gir::Callable &callable = module.callables[callable_index];
+            if (!callable.block_body.valid()) { continue; }
+            const gir::Block &block = module.blocks.at(callable.block_body.value);
+            for (std::size_t index = 0; index < block.statements.size(); ++index) {
+                const gir::Statement &statement = module.statements.at(block.statements[index].value);
+                const auto           *evaluate  = std::get_if<gir::Evaluate>(&statement.node);
+                if (evaluate == nullptr) { continue; }
+                if (std::holds_alternative<gir::Conditional>(module.values.at(evaluate->value.value).node)) {
+                    return ConditionalSite{gir::CallableId{callable_index}, callable.block_body, evaluate->value, index};
+                }
+            }
+        }
+        return {};
+    }
 }  // namespace
 
 TEST_CASE("temporal conditional analysis produces a stable union capture signature", "[hgraph-ir][control-flow]") {
@@ -180,6 +205,57 @@ fn choose(condition: bool, value: i64) -> i64 {
     CHECK(plan.assigned_outer.front() == plan.when_true.assigned_outer.front());
     CHECK(plan.when_true.returns);
     CHECK_FALSE(plan.when_false->returns);
+    CHECK_FALSE(plan.when_true.falls_through);
+    CHECK(plan.when_false->falls_through);
+}
+
+TEST_CASE("temporal conditional analysis assigns the callable suffix to its falling branch",
+          "[hgraph-ir][control-flow][continuation]") {
+    Lowered lowered{R"(
+module checks.temporal_early_return
+
+fn choose(condition: bool, x: i64, y: i64) -> i64 {
+    if condition {
+        return x + 1
+    }
+
+    let r = y - 1
+    return r * 2
+}
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE(lowered.graph);
+
+    const ConditionalSite site = conditional_site(*lowered.graph);
+    REQUIRE(site.callable.valid());
+    const gir::Callable &callable = lowered.graph->callables.at(site.callable.value);
+    const auto           continuation =
+        gir::plan_temporal_continuation(*lowered.graph, site.block, site.statement_index + 1U, callable.result);
+    REQUIRE(continuation.statements.size() == 2U);
+
+    const gir::ConditionalPlan plan = gir::analyze_temporal_conditional(*lowered.graph, site.value, continuation);
+    CHECK(plan.returns_from_callable);
+    CHECK(plan.result == callable.result);
+    REQUIRE(plan.when_false);
+    CHECK(plan.when_true.returns);
+    CHECK_FALSE(plan.when_true.falls_through);
+    CHECK_FALSE(plan.when_true.continuation);
+    CHECK(plan.when_false->returns);
+    CHECK_FALSE(plan.when_false->falls_through);
+    REQUIRE(plan.when_false->continuation);
+    CHECK(plan.when_false->continuation->statements == continuation.statements);
+    CHECK(plan.assigned_outer.empty());
+
+    REQUIRE(plan.when_true.captures.size() == 1U);
+    CHECK(lowered.graph->bindings[plan.when_true.captures.front().binding.value].name == "x");
+    REQUIRE(plan.when_false->captures.size() == 1U);
+    CHECK(lowered.graph->bindings[plan.when_false->captures.front().binding.value].name == "y");
+    REQUIRE(plan.captures.size() == 2U);
+
+    const auto results = gir::plan_temporal_conditional_results(*lowered.graph, plan, false);
+    REQUIRE(results.size() == 1U);
+    CHECK(results.front().source == gir::ConditionalResultSource::FunctionReturn);
+    CHECK(results.front().type == callable.result);
 }
 
 TEST_CASE("temporal conditional analysis does not capture a result assigned earlier in its branch", "[hgraph-ir][control-flow]") {


### PR DESCRIPTION
## Summary

- distinguish branch-local explicit returns from path fallthrough in shared HGraph IR
- retain the enclosing callable suffix as a typed continuation and attach it only to paths that reach it
- derive complete-path captures and a distinct enclosing-function return result contract
- document the implemented planning boundary while keeping backend execution marked as staged

## Validation

- fresh native configure, clean build, and complete C++ suite: 1772/1772 passed
- stable-ABI wheel built with Python 3.12 and complete non-WIP suite run with Python 3.14: 3242 passed, 10 skipped
- HGL suite: 49/49 passed
