### PR TITLE
Delta capture builds through the layout's canonical delta binding (TS data ABI 16)

### DIFF
--- a/docs/source/developer_guide/data_structures/plans_and_ops/ops_catalogue.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/ops_catalogue.rst
@@ -139,7 +139,7 @@ constant when the ops struct layout changes.
      - 7
      - ``include/hgraph/types/value/value_ops.h``
    * - ``TS_DATA_OPS_ABI_VERSION``
-     - 15
+     - 16
      - ``include/hgraph/types/time_series/ts_type_ref.h``
    * - ``NODE_OPS_ABI_VERSION``
      - 5

--- a/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
+++ b/docs/source/developer_guide/data_structures/plans_and_ops/time_series.rst
@@ -96,7 +96,16 @@ The implementation uses the following names consistently:
     The common layout prefix for every TSData kind. It records only the
     offsets/bindings required at the "this is a time-series payload"
     layer: current value, delta value, and local tracking. It does not
-    describe every possible collection shape.
+    describe every possible collection shape. ``delta_binding`` is the
+    storage's delta *surface* -- every structured family projects it over
+    its own storage -- and ``canonical_delta_binding`` (ABI 16) is the
+    portable delta value that surface materialises to, resolved in the
+    type's realization scope when the layout is built. ``capture_delta``,
+    ``capture_current_delta`` and the ``empty_delta`` hooks build through
+    the canonical binding: its bundle fields answer the element, key and
+    child-delta bindings (``BundleBuilder::field_binding``,
+    ``compact_element_binding`` / ``compact_map_bindings``), so a per-tick
+    delta capture reads no registry and interns nothing.
 
 ``FixedTSBDataLayout`` / ``FixedTSLDataLayout``
     Specialised layouts for fixed structured TSData. ``TSB`` keeps
@@ -136,7 +145,12 @@ The implementation uses the following names consistently:
     ``Output`` roles. Data and Output select mutable role-specific ops; an
     owned Input selects the corresponding physical plan under a read-only
     role, while peered positions select target-link storage and ops.
-    ``TS_DATA_OPS_ABI_VERSION`` is 15. ABI 15 (RFC 0035) drops the
+    ``TS_DATA_OPS_ABI_VERSION`` is 16. ABI 16 adds
+    ``TSDataLayout::canonical_delta_binding`` -- the portable delta type a
+    captured or empty delta is built as, resolved when the layout is built
+    so per-tick delta capture never consults the realization snapshot
+    (see :doc:`../../python_bridge`, "Per-tick application is
+    registry-free"). ABI 15 (RFC 0035) drops the
     Python-authoring table pointer: a strategy records only its family and
     the bridge maps it to the table. ABI 14 (RFC 0035) recorded that
     family (``python_family``) beside the pointer. ABI 13 (RFC 0035) makes the Python
@@ -486,7 +500,7 @@ TargetLink projection into producer-owned storage. The ownership table reports
 TargetLink trie/observer storage at the owning endpoint and traverses only
 owned children. This projection is private lifecycle infrastructure; it adds no
 storage-layout cost, and its ops-table ABI contribution is tracked by
-``TS_DATA_OPS_ABI_VERSION``, currently 15.
+``TS_DATA_OPS_ABI_VERSION``, currently 16.
 
 Fixed to-REF alternatives are the exception to the general legacy-alternative
 rule. Their allocation is owned through the canonical Data-role record. At the

--- a/docs/source/developer_guide/python_bridge.rst
+++ b/docs/source/developer_guide/python_bridge.rst
@@ -648,6 +648,21 @@ exists for consumers that need a delta *object* — record/replay ingest,
 current-state transfer — and remains builder-based; it is not the per-tick
 apply path.
 
+**Delta capture is registry-free too** (2026-09-06). ``capture_delta`` is
+per tick for every operator that queues deltas (``throttle``, ``batch``,
+``gate``, ``lag``, the feedback and service nodes), and until this change
+every ``capture_delta_*`` / ``empty_delta_*`` in ``ts_delta.cpp`` resolved
+its bindings through the realization snapshot and re-interned its result
+types through the builders' ``build()`` on every call (about twelve lock
+acquisitions per cycle on a throttled ``TSS``). Each layout now records the
+portable delta type it was built for (``TSDataLayout::canonical_delta_binding``,
+ABI 16), and capture builds through it: the canonical bundle's field
+bindings give the set / map types, ``compact_element_binding`` and
+``compact_map_bindings`` read the element and key bindings off the compact
+plans, an empty collection delta default-constructs its surfaces, and the
+builders publish through ``build_storage()`` into the field bindings. The
+``throttle_tss`` family of the lock matrix guards it.
+
 **Enforcement**: every type-system mutex is a ``TypeSystemMutex``
 (``types/utils/counted_mutex.h``), counted in ``type_system_lock_count()``
 and surfaced as ``RuntimeRegistrySnapshot.type_system_lock_acquisitions``.

--- a/docs/source/developer_guide/writing_nodes.rst
+++ b/docs/source/developer_guide/writing_nodes.rst
@@ -215,10 +215,11 @@ state already holds a queue or buffer keeps the bindings in the same struct
 every remaining call inside a ``start`` hook; the 2026-08-15 audit found
 nine ``eval`` bodies (the tuple / frozenset / dict arithmetic, the
 throttle's set netting, ``window`` and ``batch``) still paying it per tick,
-and ``test_registry_snapshot.py``'s lock matrix now guards each of them (the
-TSS throttle's guard is a strict expected failure until the type layer's
-``capture_delta`` builds through the input layout's bindings instead of
-resolving them per call in ``ts_delta.cpp``).
+and ``test_registry_snapshot.py``'s lock matrix now guards each of them. The
+type layer's own ``capture_delta`` had the same flaw one level down
+(``ts_delta.cpp`` resolved its bindings per call); it now builds through the
+layout's canonical delta binding (:doc:`python_bridge`, "Delta capture is
+registry-free"), guarded by the throttle families of the matrix.
 
 **Why.** The 0.8.15 regression was exactly a per-tick resolution (see
 :doc:`python_bridge`, "Per-tick application is registry-free"): a lock and a

--- a/include/hgraph/types/time_series/ts_data/ops.h
+++ b/include/hgraph/types/time_series/ts_data/ops.h
@@ -225,6 +225,14 @@ namespace hgraph
     namespace ts_data_detail
     {
         [[nodiscard]] HGRAPH_EXPORT const TSDataInspectionOps &empty_inspection_ops() noexcept;
+
+        /** The portable delta type for ``schema`` in the current realization
+            scope (the active snapshot's realization, else the plan factory's
+            canonical one): what ``TSDataLayout::canonical_delta_binding``
+            records when a layout is built. Build-time only (it may lock). */
+        [[nodiscard]] HGRAPH_EXPORT ValueTypeRef canonical_delta_binding_for(const TSValueTypeMetaData &schema);
+        /** The same resolution for a value schema (an atomic delta is its value). */
+        [[nodiscard]] HGRAPH_EXPORT ValueTypeRef canonical_value_binding_for(const ValueTypeMetaData *schema);
     }
 
     /**

--- a/include/hgraph/types/time_series/ts_data/types.h
+++ b/include/hgraph/types/time_series/ts_data/types.h
@@ -334,6 +334,14 @@ namespace hgraph
     {
         ValueTypeRef value_binding{nullptr};
         ValueTypeRef delta_binding{nullptr};
+        /** The portable (canonical) delta type a captured or empty delta is
+            built as: the delta schema's realization in the type's own
+            realization scope. ``delta_binding`` is the storage's delta
+            surface, which every structured family projects over its
+            storage; this is the owning value that surface materialises to.
+            Resolved when the layout is built, so per-tick delta capture
+            reads it instead of the realization snapshot (ABI 16). */
+        ValueTypeRef canonical_delta_binding{nullptr};
         std::size_t             value_offset{0};
         std::size_t             tracking_offset{0};
     };
@@ -416,8 +424,8 @@ namespace hgraph
         ValueTypeRef element_delta_binding{nullptr};
     };
 
-    static_assert(sizeof(TSSDataLayout) == sizeof(void *) * 5);
-    static_assert(sizeof(TSDDataLayout) == sizeof(void *) * 10);
+    static_assert(sizeof(TSSDataLayout) == sizeof(void *) * 6);
+    static_assert(sizeof(TSDDataLayout) == sizeof(void *) * 11);
 
     struct SlotTSDataMutationResult
     {

--- a/include/hgraph/types/time_series/ts_type_ref.h
+++ b/include/hgraph/types/time_series/ts_type_ref.h
@@ -15,7 +15,7 @@ namespace hgraph
     struct TSDataOps;
     struct TSParentLink;
 
-    inline constexpr std::uint16_t TS_DATA_OPS_ABI_VERSION = 15;
+    inline constexpr std::uint16_t TS_DATA_OPS_ABI_VERSION = 16;
 
     class HGRAPH_CLASS_EXPORT TSRoleTypeRef
     {

--- a/include/hgraph/types/value/compact_container_ops.h
+++ b/include/hgraph/types/value/compact_container_ops.h
@@ -1074,6 +1074,13 @@ namespace hgraph
     // ``Value`` over a container schema.
     // -----------------------------------------------------------------
 
+    /** The element binding a compact list / set / cyclic-buffer / queue type
+        was interned with, read from its plan (no registry, no storage). */
+    [[nodiscard]] HGRAPH_EXPORT ValueTypeRef compact_element_binding(const ValueTypeRef &container_binding);
+    /** The (key, value) bindings a compact map type was interned with. */
+    [[nodiscard]] HGRAPH_EXPORT std::pair<ValueTypeRef, ValueTypeRef>
+    compact_map_bindings(const ValueTypeRef &map_binding);
+
     [[nodiscard]] HGRAPH_EXPORT ValueTypeRef compact_list_type(const ValueTypeRef &element_binding);
 
     /** Meta-preserving form: a variadic-TUPLE schema keeps its identity (and

--- a/include/hgraph/types/value/value.h
+++ b/include/hgraph/types/value/value.h
@@ -65,6 +65,17 @@ namespace hgraph
             storage_ = storage_type::empty(*type.record());
         }
 
+        /** A typed-null ``Value`` of ``binding``: the binding is retained, no
+            payload is constructed. The lock-free twin of ``Value(schema)``
+            for a caller that already holds the realized binding. */
+        [[nodiscard]] static Value typed_null(const ValueTypeRef &binding)
+        {
+            if (!binding) { throw std::invalid_argument("Value::typed_null: binding is unbound"); }
+            Value result;
+            result.storage_ = storage_type::empty(*binding.record());
+            return result;
+        }
+
         /**
          * Construct a default-valued ``Value`` for the given binding (the
          * binding's plan default-constructs the payload).

--- a/include/hgraph/types/value/value_builder.h
+++ b/include/hgraph/types/value/value_builder.h
@@ -1033,6 +1033,18 @@ namespace hgraph
         BundleBuilder &set(std::string_view name, Value &&field) { return set(index_of(name), std::move(field)); }
 
         [[nodiscard]] std::size_t size() const noexcept { return field_count(); }
+        /** The binding field ``index`` / ``name`` is built as (the assembly
+            binding's component): what a value assigned to that field must be
+            convertible to, and what a caller builds it as to avoid a copy.
+            Answered from the composite plan, never the registry. */
+        [[nodiscard]] ValueTypeRef field_binding(std::size_t index) const
+        {
+            const auto *ops = checked_value_ops<IndexedValueOps>(binding_, "BundleBuilder");
+            const auto field = ops->element_binding(ops->context, value_.view().data(), index);
+            if (!field) { throw std::logic_error("BundleBuilder: field binding is unresolved"); }
+            return field;
+        }
+        [[nodiscard]] ValueTypeRef field_binding(std::string_view name) const { return field_binding(index_of(name)); }
 
         /** Bundle field validity (core_concepts.rst): set() marks the field
             live; Tuple composites are dense (no validity component). */
@@ -1124,13 +1136,6 @@ namespace hgraph
             return st.components()[index];
         }
 
-        [[nodiscard]] ValueTypeRef field_binding(std::size_t index) const
-        {
-            const auto *ops = checked_value_ops<IndexedValueOps>(binding_, "BundleBuilder");
-            const auto field = ops->element_binding(ops->context, value_.view().data(), index);
-            if (!field) { throw std::logic_error("BundleBuilder: field binding is unresolved"); }
-            return field;
-        }
 
         [[nodiscard]] std::size_t index_of(std::string_view name) const
         {

--- a/python/tests/test_registry_snapshot.py
+++ b/python/tests/test_registry_snapshot.py
@@ -7,10 +7,14 @@ from hgraph import (
     MIN_ST,
     MIN_TD,
     TS,
+    TSB,
     TSD,
+    TSL,
     TSS,
+    Size,
     batch,
     collect,
+    combine,
     convert,
     eq_,
     eval_node,
@@ -30,6 +34,7 @@ from hgraph import (
     service_adaptor_impl,
     throttle,
     to_json,
+    ts_schema,
     window,
 )
 from hgraph import OUT
@@ -365,6 +370,41 @@ def _throttle_tss_graph(cycles: int):
     return _g
 
 
+@generator
+def _tsl_pulse(cycles: int) -> TSL[TS[int], Size[2]]:
+    for i in range(cycles):
+        yield MIN_TD, {0: i, 1: i + 1}
+
+
+_ThrottleBundle = ts_schema(a=TS[int], b=TS[int])
+
+
+def _throttle_tsd_graph(cycles: int):
+    @graph
+    def _g():
+        null_sink(throttle(_churn_tsd_pulse(cycles), timedelta(microseconds=2)))
+
+    return _g
+
+
+def _throttle_tsl_graph(cycles: int):
+    @graph
+    def _g():
+        null_sink(throttle(_tsl_pulse(cycles), timedelta(microseconds=2)))
+
+    return _g
+
+
+def _throttle_tsb_graph(cycles: int):
+    @graph
+    def _g():
+        source = _int_pulse(cycles)
+        bundle = combine[TSB[_ThrottleBundle]](a=source, b=source + 1)
+        null_sink(throttle(bundle, timedelta(microseconds=2)))
+
+    return _g
+
+
 def _window_tick_graph(cycles: int):
     @graph
     def _g():
@@ -405,17 +445,13 @@ _LOCK_MATRIX = [
     pytest.param(_add_tuples_graph, id="add_tuples"),
     pytest.param(_set_ops_graph, id="frozenset_ops"),
     pytest.param(_map_ops_graph, id="dict_ops"),
-    # The throttle's own release is start-resolved, but every queued tick
-    # still goes through the type layer's capture_delta_tss, which resolves
-    # its bindings and re-interns per call (ts_delta.cpp); strict xfail until
-    # delta capture reads the input layout's bindings.
-    pytest.param(
-        _throttle_tss_graph,
-        id="throttle_tss",
-        marks=pytest.mark.xfail(
-            strict=True, reason="capture_delta_tss resolves bindings per tick (ts_delta.cpp)"
-        ),
-    ),
+    # Delta capture (ts_delta.cpp) builds through the layout's canonical delta
+    # binding: throttle queues a captured delta on every input tick, so one
+    # graph per keyed / structured input shape guards it.
+    pytest.param(_throttle_tss_graph, id="throttle_tss"),
+    pytest.param(_throttle_tsd_graph, id="throttle_tsd"),
+    pytest.param(_throttle_tsl_graph, id="throttle_tsl"),
+    pytest.param(_throttle_tsb_graph, id="throttle_tsb"),
     pytest.param(_window_tick_graph, id="window_tick"),
     pytest.param(_window_time_graph, id="window_time"),
     pytest.param(_batch_graph, id="batch"),

--- a/src/hgraph/runtime/mapped_key_source.h
+++ b/src/hgraph/runtime/mapped_key_source.h
@@ -69,10 +69,13 @@ namespace hgraph::runtime_detail
             auto context = std::make_unique<Context>();
             context->schema = &schema;
             context->layout = TSDataLayout{
-                .value_binding   = value_binding,
-                .delta_binding   = delta_binding,
-                .value_offset    = 0,
-                .tracking_offset = 0,
+                .value_binding           = value_binding,
+                .delta_binding           = delta_binding,
+                // The key is an owning scalar value: its delta IS its
+                // portable type (ABI 16 canonical delta binding).
+                .canonical_delta_binding = delta_binding,
+                .value_offset            = 0,
+                .tracking_offset         = 0,
             };
             context->ops = TSDataOps{
                 .context                   = context.get(),

--- a/src/hgraph/types/metadata/ts_data_atomic_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_atomic_ops.cpp
@@ -33,10 +33,11 @@ namespace hgraph::ts_data_plan_factory_detail
               python_value_offset(python_offset)
         {
             layout = TSDataLayout{
-                .value_binding   = value_binding,
-                .delta_binding   = delta_binding,
-                .value_offset    = value_offset,
-                .tracking_offset = tracking_offset,
+                .value_binding            = value_binding,
+                .delta_binding            = delta_binding,
+                .canonical_delta_binding  = ts_data_detail::canonical_value_binding_for(delta_binding.schema()),
+                .value_offset             = value_offset,
+                .tracking_offset          = tracking_offset,
             };
 
             ops = TSDataOps{

--- a/src/hgraph/types/metadata/ts_data_dynamic_list_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_dynamic_list_ops.cpp
@@ -496,6 +496,7 @@ namespace hgraph::ts_data_plan_factory_detail
                 removed_set_binding   = intern_value_type(*removed_schema, *plan, removed_set_ops);
                 modified_map_binding  = intern_value_type(*modified_schema, *plan, delta_map_ops);
                 list_layout.delta_binding = intern_value_type(*delta_schema, *plan, delta_bundle_ops);
+                list_layout.canonical_delta_binding = ts_data_detail::canonical_delta_binding_for(*schema);
             }
 
             [[nodiscard]] static const detail::TSDataOwnershipOps &ownership_ops() noexcept

--- a/src/hgraph/types/metadata/ts_data_fixed_structured_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_fixed_structured_ops.cpp
@@ -177,6 +177,7 @@ namespace hgraph::ts_data_plan_factory_detail
                 projected_value_surface ? intern_value_type(*value_schema, *plan, value_indexed_ops)
                                         : value_owning_binding;
 
+            active_layout().canonical_delta_binding = ts_data_detail::canonical_delta_binding_for(*schema);
             if (schema->kind == TSTypeKind::TSB)
             {
                 active_layout().delta_binding = intern_value_type(*delta_schema, *plan, delta_bundle_ops);

--- a/src/hgraph/types/metadata/ts_data_slot_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_slot_ops.cpp
@@ -1024,6 +1024,7 @@ namespace hgraph::ts_data_plan_factory_detail
                 added_set_binding   = intern_value_type(*delta_schema->fields[0].type, *plan, added_set_ops);
                 removed_set_binding = intern_value_type(*delta_schema->fields[1].type, *plan, removed_set_ops);
                 set_layout.delta_binding = intern_value_type(*delta_schema, *plan, delta_bundle_ops);
+                set_layout.canonical_delta_binding = ts_data_detail::canonical_delta_binding_for(*schema);
             }
 
             template <SlotSetSurface Surface>
@@ -1920,6 +1921,7 @@ namespace hgraph::ts_data_plan_factory_detail
                 added_set_binding = intern_value_type(*TypeRegistry::instance().set(schema_.key_type()),
                                                               plan_, added_set_ops);
                 dict_layout.delta_binding = intern_value_type(*delta_schema, plan_, dict_delta_bundle_ops);
+                dict_layout.canonical_delta_binding = ts_data_detail::canonical_delta_binding_for(schema_);
 
                 key_set_value_binding = intern_value_type(*TypeRegistry::instance().set(schema_.key_type()),
                                                                   plan_, key_set_value_ops);
@@ -1939,6 +1941,9 @@ namespace hgraph::ts_data_plan_factory_detail
                 key_set_ts_ops.mutable_tracking_impl  = &tsd_key_set_mutable_tracking;  // subscriptions only
                 key_set_ts_ops.has_current_value_impl = &tsd_key_set_has_current_value;
                 const auto *key_set_schema = TypeRegistry::instance().tss(schema_.key_type());
+                // The key-set projection captures as a TSS: its layout records
+                // the key set's own canonical delta, not the dictionary's.
+                set_layout.canonical_delta_binding = ts_data_detail::canonical_delta_binding_for(*key_set_schema);
                 const auto role_label = ts_labels::tsd_key_set_label(role);
                 key_set_ts_type = TSRoleTypeRef{intern_ts_type(
                     *key_set_schema, role, plan_, key_set_ts_ops, role_label)};

--- a/src/hgraph/types/metadata/ts_data_window_ops.cpp
+++ b/src/hgraph/types/metadata/ts_data_window_ops.cpp
@@ -786,6 +786,7 @@ namespace hgraph::ts_data_plan_factory_detail
                 layout->value_offset    = value_offset;
                 layout->tracking_offset = tracking_offset;
                 layout->delta_binding   = element_binding;
+                layout->canonical_delta_binding = ts_data_detail::canonical_delta_binding_for(schema_);
 
                 configure_ts_ops();
                 configure_value_ops();

--- a/src/hgraph/types/time_series/ts_data/ops.cpp
+++ b/src/hgraph/types/time_series/ts_data/ops.cpp
@@ -1,5 +1,8 @@
 #include <hgraph/types/time_series/ts_data.h>
 
+#include <hgraph/types/metadata/type_realization.h>
+#include <hgraph/types/metadata/value_plan_factory.h>
+
 #include <hgraph/types/value/value.h>
 
 #include <stdexcept>
@@ -525,3 +528,18 @@ namespace hgraph
         ops.reserve_impl         = set_defaults.reserve_impl;
     }
 }  // namespace hgraph
+
+namespace hgraph::ts_data_detail
+{
+    ValueTypeRef canonical_value_binding_for(const ValueTypeMetaData *schema)
+    {
+        if (schema == nullptr) { return {}; }
+        const auto *snapshot = active_type_realization();
+        return snapshot != nullptr ? snapshot->type_for(schema) : ValuePlanFactory::instance().type_for(schema);
+    }
+
+    ValueTypeRef canonical_delta_binding_for(const TSValueTypeMetaData &schema)
+    {
+        return canonical_value_binding_for(schema.delta_value_schema);
+    }
+}  // namespace hgraph::ts_data_detail

--- a/src/hgraph/types/time_series/ts_data/proxy.cpp
+++ b/src/hgraph/types/time_series/ts_data/proxy.cpp
@@ -116,6 +116,9 @@ namespace hgraph
             const TSValueTypeMetaData      *schema{nullptr};
             const MemoryUtils::StoragePlan *plan{nullptr};
             TSDDataLayout                   layout{};
+            /** The key-set projection's own layout: the key set captures and
+                empties as a TSS, so its canonical delta is the key set's. */
+            TSSDataLayout                   key_set_layout{};
             TSDDataOps                      dict_ops{};
             TSSDataOps                      key_set_ts_ops{};
             SetValueOps                     key_set_value_ops{};
@@ -215,7 +218,7 @@ namespace hgraph
                     .allows_mutation           = false,
                     .current_state_ops =
                         &ts_current_state_detail::current_state_ops_for(TSTypeKind::TSS),
-                    .layout_impl               = &ts_layout,
+                    .layout_impl               = &key_set_ts_layout,
                     .tracking_impl             = &key_set_tracking,
                     .mutable_tracking_impl     = &mutable_key_set_tracking,
                     .has_current_value_impl    = &key_set_has_current_value,
@@ -255,6 +258,7 @@ namespace hgraph
                 TSDataOps &dict_base = dict_ops;
                 dict_base.kind = TSTypeKind::TSD;
                 dict_base.context = this;
+                dict_base.layout_impl = &ts_layout;
                 dict_base.tracking_impl = &tracking;
                 dict_base.mutable_tracking_impl = &mutable_tracking;
                 dict_base.has_current_value_impl = &has_current_value;
@@ -311,8 +315,14 @@ namespace hgraph
                                                                  modified_map_ops);
                 added_set_binding = intern_value_type(*set_schema, *plan, added_set_value_ops);
                 layout.delta_binding = intern_value_type(*schema->delta_value_schema, *plan, delta_bundle_ops);
+                layout.canonical_delta_binding = ts_data_detail::canonical_delta_binding_for(*schema);
 
                 key_set_value_binding = intern_value_type(*set_schema, *plan, key_set_value_ops);
+                key_set_layout.key_binding             = layout.key_binding;
+                key_set_layout.value_binding           = key_set_value_binding;
+                key_set_layout.value_offset            = layout.value_offset;
+                key_set_layout.tracking_offset         = layout.tracking_offset;
+                key_set_layout.canonical_delta_binding = ts_data_detail::canonical_delta_binding_for(*key_set_ts_schema);
                 const auto label = ts_labels::tsd_key_set_label(role);
                 key_set_type = TSRoleTypeRef{intern_ts_type(
                     *key_set_ts_schema, role, *plan, key_set_ts_ops, label)};
@@ -577,6 +587,11 @@ namespace hgraph
             [[nodiscard]] static const TSDataLayout *ts_layout(const void *context) noexcept
             {
                 return &ctx(context)->layout;
+            }
+
+            [[nodiscard]] static const TSDataLayout *key_set_ts_layout(const void *context) noexcept
+            {
+                return &ctx(context)->key_set_layout;
             }
 
             [[nodiscard]] static const TSDataTracking *tracking(const void *, const void *memory) noexcept

--- a/src/hgraph/types/time_series/ts_delta.cpp
+++ b/src/hgraph/types/time_series/ts_delta.cpp
@@ -1,14 +1,12 @@
 #include <hgraph/types/time_series/ts_delta.h>
 
-#include <hgraph/types/metadata/ts_data_plan_factory.h>
-#include <hgraph/types/metadata/type_realization.h>
 #include <hgraph/types/metadata/type_registry.h>
 #include <hgraph/types/metadata/ts_value_type_meta_data.h>
-#include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/metadata/value_type_meta_data.h>
 #include <hgraph/types/time_series/ts_input.h>
 #include <hgraph/types/time_series/ts_data/impl/current_state_ops.h>
 #include <hgraph/types/time_series/ts_output.h>
+#include <hgraph/types/value/compact_container_ops.h>
 #include <hgraph/types/value/value.h>
 #include <hgraph/types/value/value_builder.h>
 #include <hgraph/types/value/value_view.h>
@@ -31,15 +29,6 @@ namespace hgraph
 {
     namespace
     {
-        [[nodiscard]] ValueTypeRef binding_for(const ValueTypeMetaData *meta, const char *fn)
-        {
-            const auto *snapshot = active_type_realization();
-            const auto binding = snapshot != nullptr ? snapshot->type_for(meta)
-                                                     : ValuePlanFactory::instance().type_for(meta);
-            if (!binding) { throw std::logic_error(fmt::format("{}: unresolved value binding", fn)); }
-            return binding;
-        }
-
         using MaterializedOwner =
             MemoryUtils::ErasedOwner<MemoryUtils::InlineStoragePolicy<>, TypeRecord>;
 
@@ -130,36 +119,133 @@ namespace hgraph
             const void                      *data_{nullptr};
         };
 
-        [[nodiscard]] TSRoleTypeRef ts_type_for(const TSValueTypeMetaData *schema, const char *fn)
-        {
-            const auto type = TSDataPlanFactory::instance().data_type_for(schema);
-            if (!type) { throw std::logic_error(fmt::format("{}: unresolved TSData type", fn)); }
-            return type.as_role();
-        }
-
         [[nodiscard]] const TSValueTypeMetaData &require_schema(const TSValueTypeMetaData *schema, const char *fn)
         {
             if (schema == nullptr) { throw std::logic_error(fmt::format("{}: view has no TSData schema", fn)); }
             return *schema;
         }
 
-        void initialize_tsb_delta_defaults(TSRoleTypeRef type, BundleBuilder &builder)
+        /**
+         * The portable delta type a layout records (``TSDataLayout::
+         * canonical_delta_binding``, ABI 16): what a captured or empty delta
+         * is built as. Read from the view's bound data, or from a type's own
+         * layout; never resolved through the realization snapshot per tick
+         * (the 2026-07-02 lock-free ruling).
+         */
+        [[nodiscard]] ValueTypeRef require_canonical_delta(ValueTypeRef binding, const TSValueTypeMetaData *schema,
+                                                           const char *fn)
         {
-            const auto *schema = type.schema();
-            if (schema == nullptr || schema->kind != TSTypeKind::TSB)
+            if (!binding) { throw std::logic_error(fmt::format("{}: layout records no canonical delta binding", fn)); }
+            if (schema != nullptr && binding.schema() != schema->delta_value_schema)
+            {
+                throw std::logic_error(fmt::format(
+                    "{}: the layout's canonical delta binding ({}) is not the delta schema of {} ({})", fn,
+                    binding.schema() != nullptr ? binding.schema()->name() : "<null>", schema->name(),
+                    schema->delta_value_schema != nullptr ? schema->delta_value_schema->name() : "<null>"));
+            }
+            return binding;
+        }
+
+        [[nodiscard]] ValueTypeRef canonical_delta_binding(const TSInputView &in, const char *fn)
+        {
+            const auto &data = in.data_view();
+            if (!data.valid()) { throw std::logic_error(fmt::format("{}: input has no bound data", fn)); }
+            return require_canonical_delta(data.layout().canonical_delta_binding, in.schema(), fn);
+        }
+
+        [[nodiscard]] ValueTypeRef canonical_delta_binding(const TSRoleTypeRef &type, const char *fn)
+        {
+            if (!type) { throw std::logic_error(fmt::format("{}: unresolved TSData type", fn)); }
+            const auto &ops    = type.ops_ref();
+            const auto *layout = ops.layout_impl(ops.context);
+            if (layout == nullptr) { throw std::logic_error(fmt::format("{}: type has no layout", fn)); }
+            return require_canonical_delta(layout->canonical_delta_binding, type.schema(), fn);
+        }
+
+        [[nodiscard]] Value empty_delta_value(const TSValueTypeMetaData &schema, ValueTypeRef binding);
+
+        /** A TSB delta pre-fills every collection child with its EMPTY delta
+            (an applied empty delta validates a fresh set, so replaying a
+            bundle delta validates its collections); scalar children stay
+            absent. The child delta types are the bundle's field bindings. */
+        void initialize_tsb_delta_defaults(const TSValueTypeMetaData &schema, BundleBuilder &builder)
+        {
+            if (schema.kind != TSTypeKind::TSB)
             {
                 throw std::logic_error("empty_delta_tsb: binding is not a TSB schema");
             }
-            for (std::size_t index = 0; index < schema->field_count(); ++index)
+            for (std::size_t index = 0; index < schema.field_count(); ++index)
             {
-                const TSValueTypeMetaData *child_schema = schema->fields()[index].type;
+                const TSValueTypeMetaData *child_schema = schema.fields()[index].type;
                 if (child_schema == nullptr) { throw std::logic_error("empty_delta_tsb: TSB field schema is null"); }
                 if (!child_schema->is_collection()) { continue; }
+                builder.set(index, empty_delta_value(*child_schema, builder.field_binding(index)));
+            }
+        }
 
-                const auto child_type = ts_type_for(child_schema, "empty_delta_tsb");
-                const auto &child_ops = child_type.ops_ref();
-                Value empty = child_ops.empty_delta_impl(child_type);
-                builder.set(index, std::move(empty));
+        /** Assign an EMPTY compact set / map to bundle field ``index``: built
+            through the builders (a default-constructed compact storage has no
+            element binding), copied into the field, nothing interned. */
+        void set_empty_surface(BundleBuilder &bundle, std::size_t index)
+        {
+            const auto field = bundle.field_binding(index);
+            switch (field.ops_ref().kind)
+            {
+                case ValueOpsKind::Set:
+                {
+                    SetBuilder builder{compact_element_binding(field)};
+                    SetStorage storage = builder.build_storage();
+                    bundle.set(index, ValueView{field, &storage});
+                    return;
+                }
+                case ValueOpsKind::Map:
+                {
+                    const auto [key, value] = compact_map_bindings(field);
+                    MapBuilder builder{key, value};
+                    MapStorage storage = builder.build_storage();
+                    bundle.set(index, ValueView{field, &storage});
+                    return;
+                }
+                default: throw std::logic_error("empty_delta: a delta surface is neither a set nor a map");
+            }
+        }
+
+        /** The empty delta of ``schema`` built as ``binding`` (its canonical
+            delta type): a keyed collection's surfaces are empty sets / maps,
+            a fixed TSL is an empty modified map, a TSB pre-fills its
+            collection children, and an atomic delta is a typed null. */
+        Value empty_delta_value(const TSValueTypeMetaData &schema, ValueTypeRef binding)
+        {
+            if (!binding) { throw std::logic_error("empty_delta: canonical delta binding is unresolved"); }
+            switch (schema.kind)
+            {
+                case TSTypeKind::TSS:
+                case TSTypeKind::TSD:
+                {
+                    BundleBuilder bundle{binding};
+                    for (std::size_t index = 0; index < bundle.size(); ++index) { set_empty_surface(bundle, index); }
+                    return bundle.build();
+                }
+                case TSTypeKind::TSL:
+                {
+                    if (schema.fixed_size() != 0)
+                    {
+                        const auto [key, value] = compact_map_bindings(binding);
+                        MapBuilder builder{key, value};
+                        MapStorage storage = builder.build_storage();
+                        return Value{binding, &storage};
+                    }
+                    BundleBuilder bundle{binding};
+                    for (std::size_t index = 0; index < bundle.size(); ++index) { set_empty_surface(bundle, index); }
+                    return bundle.build();
+                }
+                case TSTypeKind::TSB:
+                {
+                    BundleBuilder builder{binding};
+                    initialize_tsb_delta_defaults(schema, builder);
+                    return builder.build();
+                }
+                default: return Value::typed_null(binding);
             }
         }
 
@@ -501,9 +587,10 @@ namespace hgraph
 
         [[nodiscard]] Value capture_current_set(const TSInputView &input)
         {
-            const auto &schema = require_schema(input.schema(), "capture_current_delta");
-            const ValueTypeRef element = binding_for(
-                schema.value_schema->element_type, "capture_current_delta");
+            BundleBuilder bundle{canonical_delta_binding(input, "capture_current_delta")};
+            const auto added_type   = bundle.field_binding(tss_delta_added);
+            const auto removed_type = bundle.field_binding(tss_delta_removed);
+            const auto element      = compact_element_binding(added_type);
             SetBuilder added{element};
             const auto set = input.as_set();
             for (const auto &value : set.values())
@@ -512,21 +599,24 @@ namespace hgraph
                 static_cast<void>(added.insert_copy(borrowed.data()));
             }
             SetBuilder removed{element};
-            BundleBuilder bundle{binding_for(schema.delta_value_schema, "capture_current_delta")};
-            bundle.set("added", added.build());
-            bundle.set("removed", removed.build());
+            SetStorage added_storage   = added.build_storage();
+            SetStorage removed_storage = removed.build_storage();
+            bundle.set(tss_delta_added, ValueView{added_type, &added_storage});
+            bundle.set(tss_delta_removed, ValueView{removed_type, &removed_storage});
             return bundle.build();
         }
 
         [[nodiscard]] Value capture_current_dict(const TSInputView &input)
         {
-            const auto &schema = require_schema(input.schema(), "capture_current_delta");
-            const ValueTypeRef key_binding = binding_for(
-                schema.key_type(), "capture_current_delta");
-            const auto *element_schema = schema.element_ts();
-            const ValueTypeRef delta_binding = binding_for(
-                element_schema->delta_value_schema, "capture_current_delta");
-
+            BundleBuilder bundle{canonical_delta_binding(input, "capture_current_delta")};
+            const auto removed_type              = bundle.field_binding(tsd_delta_removed);
+            const auto modified_type             = bundle.field_binding(tsd_delta_modified);
+            const auto key_binding               = compact_element_binding(removed_type);
+            const auto [map_key, delta_binding]  = compact_map_bindings(modified_type);
+            if (map_key != key_binding)
+            {
+                throw std::logic_error("capture_current_delta: TSD delta key bindings disagree");
+            }
             SetBuilder removed{key_binding};
             MapBuilder modified{key_binding, delta_binding};
             const auto dict = input.as_dict();
@@ -535,26 +625,22 @@ namespace hgraph
                 Value child_delta = capture_current_delta(child);
                 modified.set_item(key, child_delta.view());
             }
-
-            Value removed_delta = removed.build();
-            Value modified_delta = modified.build();
-            const std::array field_bindings{
-                removed_delta.binding(), modified_delta.binding()};
-            const auto bundle_binding = ValuePlanFactory::instance().realized_composite_type_for(
-                schema.delta_value_schema, field_bindings);
-            BundleBuilder bundle{bundle_binding};
-            bundle.set("removed", std::move(removed_delta));
-            bundle.set("modified", std::move(modified_delta));
+            SetStorage removed_storage  = removed.build_storage();
+            MapStorage modified_storage = modified.build_storage();
+            bundle.set(tsd_delta_removed, ValueView{removed_type, &removed_storage});
+            bundle.set(tsd_delta_modified, ValueView{modified_type, &modified_storage});
             return bundle.build();
         }
 
         [[nodiscard]] Value capture_current_list(const TSInputView &input)
         {
             const auto &schema = require_schema(input.schema(), "capture_current_delta");
-            const ValueTypeRef key_binding = binding_for(
-                schema.delta_value_schema->key_type, "capture_current_delta");
-            const ValueTypeRef delta_binding = binding_for(
-                schema.delta_value_schema->element_type, "capture_current_delta");
+            if (schema.fixed_size() == 0)
+            {
+                throw std::logic_error("capture_current_delta: dynamic TSL transport is not supported");
+            }
+            const auto map_type                  = canonical_delta_binding(input, "capture_current_delta");
+            const auto [key_binding, delta_binding] = compact_map_bindings(map_type);
             MapBuilder builder{key_binding, delta_binding};
             const auto list = input.as_list();
             for (const auto &[index, child] : list.valid_items())
@@ -563,15 +649,15 @@ namespace hgraph
                 Value child_delta = capture_current_delta(child);
                 builder.set_item(ValueView{key_binding, std::addressof(key)}, child_delta.view());
             }
-            return builder.build();
+            MapStorage storage = builder.build_storage();
+            return Value{map_type, &storage};
         }
 
         [[nodiscard]] Value capture_current_bundle(const TSInputView &input)
         {
             const auto &schema = require_schema(input.schema(), "capture_current_delta");
-            const auto type = ts_type_for(&schema, "capture_current_delta");
-            BundleBuilder builder{binding_for(schema.delta_value_schema, "capture_current_delta")};
-            initialize_tsb_delta_defaults(type, builder);
+            BundleBuilder builder{canonical_delta_binding(input, "capture_current_delta")};
+            initialize_tsb_delta_defaults(schema, builder);
             auto bundle = input.as_bundle();
             for (std::size_t index = 0; index < bundle.size(); ++index)
             {
@@ -1163,98 +1249,31 @@ namespace hgraph
     {
         [[nodiscard]] Value empty_delta_atomic(const TSRoleTypeRef &binding)
         {
-            const auto *schema = binding.schema();
-            if (schema == nullptr || schema->delta_value_schema == nullptr)
-            {
-                throw std::logic_error("empty_delta_atomic: schema is not resolved");
-            }
-            return Value{*schema->delta_value_schema};
+            return Value::typed_null(canonical_delta_binding(binding, "empty_delta_atomic"));
         }
 
         [[nodiscard]] Value empty_delta_tss(const TSRoleTypeRef &binding)
         {
-            const auto *schema = binding.schema();
-            if (schema == nullptr || schema->value_schema == nullptr || schema->delta_value_schema == nullptr)
-            {
-                throw std::logic_error("empty_delta_tss: schema is not resolved");
-            }
-
-            const ValueTypeRef elem_binding =
-                binding_for(schema->value_schema->element_type, "empty_delta_tss");
-            SetBuilder    added{elem_binding};
-            SetBuilder    removed{elem_binding};
-            BundleBuilder bundle{binding_for(schema->delta_value_schema, "empty_delta_tss")};
-            bundle.set("added", added.build());
-            bundle.set("removed", removed.build());
-            return bundle.build();
+            return empty_delta_value(require_schema(binding.schema(), "empty_delta_tss"),
+                                     canonical_delta_binding(binding, "empty_delta_tss"));
         }
 
         [[nodiscard]] Value empty_delta_tsd(const TSRoleTypeRef &binding)
         {
-            const auto *schema = binding.schema();
-            if (schema == nullptr || schema->delta_value_schema == nullptr || schema->element_ts() == nullptr)
-            {
-                throw std::logic_error("empty_delta_tsd: schema is not resolved");
-            }
-
-            const ValueTypeRef key_binding = binding_for(schema->key_type(), "empty_delta_tsd");
-            const ValueTypeRef delta_binding =
-                binding_for(schema->element_ts()->delta_value_schema, "empty_delta_tsd");
-            SetBuilder    removed{key_binding};
-            MapBuilder    modified{key_binding, delta_binding};
-            BundleBuilder bundle{binding_for(schema->delta_value_schema, "empty_delta_tsd")};
-            bundle.set("removed", removed.build());
-            bundle.set("modified", modified.build());
-            return bundle.build();
-        }
-
-        /** The modified-index map inside a TSL delta: the whole delta for a
-            fixed TSL, and the second bundle field for a dynamic one (RFC 0031). */
-        [[nodiscard]] const ValueTypeMetaData *tsl_modified_map_schema(const TSValueTypeMetaData &schema,
-                                                                        const char *what)
-        {
-            const ValueTypeMetaData *delta = schema.delta_value_schema;
-            if (delta == nullptr) { throw std::logic_error(std::string{what} + ": schema is not resolved"); }
-            if (schema.fixed_size() != 0) { return delta; }
-            if (delta->value_kind() != ValueTypeKind::Bundle || delta->field_count != 2)
-            {
-                throw std::logic_error(std::string{what} + ": dynamic TSL delta must be a bundle");
-            }
-            return delta->fields[tsl_delta_modified].type;
+            return empty_delta_value(require_schema(binding.schema(), "empty_delta_tsd"),
+                                     canonical_delta_binding(binding, "empty_delta_tsd"));
         }
 
         [[nodiscard]] Value empty_delta_tsl(const TSRoleTypeRef &binding)
         {
-            const auto *schema = binding.schema();
-            if (schema == nullptr || schema->delta_value_schema == nullptr)
-            {
-                throw std::logic_error("empty_delta_tsl: schema is not resolved");
-            }
-
-            const ValueTypeMetaData *map_meta = tsl_modified_map_schema(*schema, "empty_delta_tsl");
-            const ValueTypeRef key_binding = binding_for(map_meta->key_type, "empty_delta_tsl");
-            const ValueTypeRef val_binding = binding_for(map_meta->element_type, "empty_delta_tsl");
-            MapBuilder               builder{key_binding, val_binding};
-            if (schema->fixed_size() != 0) { return builder.build(); }
-
-            SetBuilder removed{key_binding};
-            BundleBuilder bundle{binding_for(schema->delta_value_schema, "empty_delta_tsl")};
-            bundle.set("removed", removed.build());
-            bundle.set("modified", builder.build());
-            return bundle.build();
+            return empty_delta_value(require_schema(binding.schema(), "empty_delta_tsl"),
+                                     canonical_delta_binding(binding, "empty_delta_tsl"));
         }
 
         [[nodiscard]] Value empty_delta_tsb(const TSRoleTypeRef &binding)
         {
-            const auto *schema = binding.schema();
-            if (schema == nullptr || schema->delta_value_schema == nullptr)
-            {
-                throw std::logic_error("empty_delta_tsb: schema is not resolved");
-            }
-
-            BundleBuilder builder{binding_for(schema->delta_value_schema, "empty_delta_tsb")};
-            initialize_tsb_delta_defaults(binding, builder);
-            return builder.build();
+            return empty_delta_value(require_schema(binding.schema(), "empty_delta_tsb"),
+                                     canonical_delta_binding(binding, "empty_delta_tsb"));
         }
 
         Value capture_delta_ts(const TSInputView &in)
@@ -1297,10 +1316,10 @@ namespace hgraph
 
         Value capture_delta_tss(const TSInputView &in)
         {
-            const TSValueTypeMetaData *schema = in.schema();
-            const ValueTypeMetaData *bundle_meta = schema->delta_value_schema;
-            const ValueTypeMetaData *elem_meta   = schema->value_schema->element_type;  // the Set's element E
-            const ValueTypeRef elem_binding = binding_for(elem_meta, "capture_delta");
+            BundleBuilder bundle{canonical_delta_binding(in, "capture_delta")};
+            const auto added_type   = bundle.field_binding(tss_delta_added);
+            const auto removed_type = bundle.field_binding(tss_delta_removed);
+            const auto elem_binding = compact_element_binding(added_type);
 
             const auto set = in.as_set();
             SetBuilder added{elem_binding};
@@ -1316,19 +1335,21 @@ namespace hgraph
                 (void)removed.insert_copy(borrowed.data());
             }
 
-            BundleBuilder bundle{binding_for(bundle_meta, "capture_delta")};
-            bundle.set("added", added.build());
-            bundle.set("removed", removed.build());
+            SetStorage added_storage   = added.build_storage();
+            SetStorage removed_storage = removed.build_storage();
+            bundle.set(tss_delta_added, ValueView{added_type, &added_storage});
+            bundle.set(tss_delta_removed, ValueView{removed_type, &removed_storage});
             return bundle.build();
         }
 
         Value capture_delta_tsd(const TSInputView &in)
         {
-            const ValueTypeRef key_binding =
-                binding_for(in.schema()->key_type(), "capture_delta");
-            const auto *element_schema = in.schema()->element_ts();
-            const ValueTypeRef delta_binding =
-                binding_for(element_schema->delta_value_schema, "capture_delta");
+            BundleBuilder bundle{canonical_delta_binding(in, "capture_delta")};
+            const auto removed_type             = bundle.field_binding(tsd_delta_removed);
+            const auto modified_type            = bundle.field_binding(tsd_delta_modified);
+            const auto key_binding              = compact_element_binding(removed_type);
+            const auto [map_key, delta_binding] = compact_map_bindings(modified_type);
+            if (map_key != key_binding) { throw std::logic_error("capture_delta_tsd: delta key bindings disagree"); }
             if (delta_binding.schema() != in.schema()->element_ts()->delta_value_schema)
             {
                 throw std::logic_error("capture_delta_tsd resolved the wrong element delta binding");
@@ -1372,59 +1393,71 @@ namespace hgraph
 
             // No strict removals: a capture reports what happened, and
             // "strict" is an expectation an author holds about the target.
-            Value removed_delta = removed.build();
-            Value modified_delta = modified.build();
-            const std::array field_bindings{removed_delta.binding(), modified_delta.binding()};
-            const auto bundle_binding = ValuePlanFactory::instance().realized_composite_type_for(
-                in.schema()->delta_value_schema,
-                field_bindings);
-            BundleBuilder bundle{bundle_binding};
-            bundle.set("removed", std::move(removed_delta));
-            bundle.set("modified", std::move(modified_delta));
+            SetStorage removed_storage  = removed.build_storage();
+            MapStorage modified_storage = modified.build_storage();
+            bundle.set(tsd_delta_removed, ValueView{removed_type, &removed_storage});
+            bundle.set(tsd_delta_modified, ValueView{modified_type, &modified_storage});
             return bundle.build();
         }
 
         Value capture_delta_tsl(const TSInputView &in)
         {
             const TSValueTypeMetaData *schema = in.schema();
-            const ValueTypeMetaData *map_meta = tsl_modified_map_schema(*schema, "capture_delta");
-            const ValueTypeRef key_binding = binding_for(map_meta->key_type, "capture_delta");
-            const ValueTypeRef val_binding = binding_for(map_meta->element_type, "capture_delta");
+            const auto canonical = canonical_delta_binding(in, "capture_delta");
+            const auto list      = in.as_list();
 
-            MapBuilder builder{key_binding, val_binding};
-            const auto list = in.as_list();
-            for (const auto &[index, child] : list.modified_items())
+            // The modified-index map: the whole delta for a fixed TSL, the
+            // second bundle field for a dynamic one (RFC 0031).
+            const auto fill_modified = [&](MapBuilder &builder, ValueTypeRef key_binding) {
+                for (const auto &[index, child] : list.modified_items())
+                {
+                    if (!child.valid()) { continue; }   // empty-reference elements have no value
+                    const std::int64_t key = static_cast<std::int64_t>(index);
+                    // The child's canonical delta is exactly the map's value schema, so a
+                    // whole-value copy of the (owned, rebuilt) child delta is correct for
+                    // both scalar children (delta == value) and container children.
+                    const Value child_delta = capture_delta(child);
+                    builder.set_item_copy(std::addressof(key), child_delta.view().data());
+                }
+                static_cast<void>(key_binding);
+            };
+
+            if (schema->fixed_size() != 0)
             {
-                if (!child.valid()) { continue; }   // empty-reference elements have no value
-                const std::int64_t key = static_cast<std::int64_t>(index);
-                // The child's canonical delta is exactly the map's value schema, so a
-                // whole-value copy of the (owned, rebuilt) child delta is correct for
-                // both scalar children (delta == value) and container children.
-                const Value child_delta = capture_delta(child);
-                builder.set_item_copy(std::addressof(key), child_delta.view().data());
+                const auto [key_binding, val_binding] = compact_map_bindings(canonical);
+                MapBuilder builder{key_binding, val_binding};
+                fill_modified(builder, key_binding);
+                MapStorage storage = builder.build_storage();
+                return Value{canonical, &storage};
             }
-            if (schema->fixed_size() != 0) { return builder.build(); }
+
+            BundleBuilder bundle{canonical};
+            const auto removed_type  = bundle.field_binding(tsl_delta_removed);
+            const auto modified_type = bundle.field_binding(tsl_delta_modified);
+            const auto [key_binding, val_binding] = compact_map_bindings(modified_type);
+            MapBuilder builder{key_binding, val_binding};
+            fill_modified(builder, key_binding);
 
             // RFC 0031: a dynamic TSL also reports the indices truncated away
             // this cycle. They are always a contiguous suffix.
-            SetBuilder removed{key_binding};
+            SetBuilder removed{compact_element_binding(removed_type)};
             for (const std::size_t index : list.removed_indices())
             {
                 const std::int64_t key = static_cast<std::int64_t>(index);
                 static_cast<void>(removed.insert_copy(std::addressof(key)));
             }
-            BundleBuilder bundle{binding_for(schema->delta_value_schema, "capture_delta")};
-            bundle.set("removed", removed.build());
-            bundle.set("modified", builder.build());
+            SetStorage removed_storage  = removed.build_storage();
+            MapStorage modified_storage = builder.build_storage();
+            bundle.set(tsl_delta_removed, ValueView{removed_type, &removed_storage});
+            bundle.set(tsl_delta_modified, ValueView{modified_type, &modified_storage});
             return bundle.build();
         }
 
         Value capture_delta_tsb(const TSInputView &in)
         {
-            const auto type = ts_type_for(&require_schema(in.schema(), "capture_delta"), "capture_delta");
-            const auto *schema = type.schema();
-            BundleBuilder builder{binding_for(schema->delta_value_schema, "capture_delta")};
-            initialize_tsb_delta_defaults(type, builder);
+            const auto &schema = require_schema(in.schema(), "capture_delta");
+            BundleBuilder builder{canonical_delta_binding(in, "capture_delta")};
+            initialize_tsb_delta_defaults(schema, builder);
             auto          bundle = in.as_bundle();
             for (std::size_t index = 0; index < bundle.size(); ++index)
             {

--- a/src/hgraph/types/time_series/ts_input.cpp
+++ b/src/hgraph/types/time_series/ts_input.cpp
@@ -2152,6 +2152,8 @@ namespace hgraph
             }
             context->layout.delta_binding = context->delta_binding;
             context->bundle_layout.delta_binding = context->delta_binding;
+            context->layout.canonical_delta_binding = ts_data_detail::canonical_delta_binding_for(*context->schema);
+            context->bundle_layout.canonical_delta_binding = context->layout.canonical_delta_binding;
 
             context->ts_data_ops = IndexedTSDataOps{};
             TSDataOps &base_ops = context->ts_data_ops;

--- a/src/hgraph/types/time_series/ts_input/target_link_ops.cpp
+++ b/src/hgraph/types/time_series/ts_input/target_link_ops.cpp
@@ -1395,13 +1395,13 @@ namespace hgraph::detail
             // key set's canonical delta), tracked at this link's offset.
             if (const auto regular_key_set = context->dict_layout.key_set_type; regular_key_set)
             {
-                const auto &regular_ops    = regular_key_set.ops_ref();
-                const auto *regular_layout = regular_ops.layout_impl(regular_ops.context);
-                if (regular_layout == nullptr)
+                const auto &key_set_ops    = regular_key_set.ops_ref();
+                const auto *key_set_layout = key_set_ops.layout_impl(key_set_ops.context);
+                if (key_set_layout == nullptr)
                 {
                     throw std::logic_error("TSInput target-link TSD key-set layout is not resolved");
                 }
-                context->key_set_layout = static_cast<const TSSDataLayout &>(*regular_layout);
+                context->key_set_layout = static_cast<const TSSDataLayout &>(*key_set_layout);
                 context->key_set_layout.tracking_offset = storage_offset;
             }
             context->key_set_ops = TSSDataOps{};

--- a/src/hgraph/types/time_series/ts_input/target_link_ops.cpp
+++ b/src/hgraph/types/time_series/ts_input/target_link_ops.cpp
@@ -85,6 +85,10 @@ namespace hgraph::detail
             TSDDataLayout dict_layout{};
             TSDDataOps    dict_ops{};
             TSSDataOps    key_set_ops{};
+            /** The key-set projection's own layout (mirrored from the regular
+                key set): it captures and empties as a TSS, so its canonical
+                delta is the key set's, not the dictionary's. */
+            TSSDataLayout key_set_layout{};
         };
 
         template <typename Context>
@@ -127,6 +131,11 @@ namespace hgraph::detail
         [[nodiscard]] const TSDataLayout *target_link_layout(const void *context) noexcept
         {
             return static_cast<const TSInputTargetLinkContext *>(context)->active_layout;
+        }
+
+        [[nodiscard]] const TSDataLayout *target_link_key_set_layout(const void *context) noexcept
+        {
+            return &static_cast<const TargetLinkDictContext *>(context)->key_set_layout;
         }
 
         [[nodiscard]] const TSDataTracking *target_link_tracking(const void *context, const void *memory) noexcept
@@ -1382,9 +1391,23 @@ namespace hgraph::detail
             context->dict_ops.make_added_ts_kv_range_impl = &target_link_dict_added_items_range;
             context->dict_ops.make_removed_ts_kv_range_impl = &target_link_dict_removed_items_range;
 
+            // The key set's layout is the regular key set's (bindings and the
+            // key set's canonical delta), tracked at this link's offset.
+            if (const auto regular_key_set = context->dict_layout.key_set_type; regular_key_set)
+            {
+                const auto &regular_ops    = regular_key_set.ops_ref();
+                const auto *regular_layout = regular_ops.layout_impl(regular_ops.context);
+                if (regular_layout == nullptr)
+                {
+                    throw std::logic_error("TSInput target-link TSD key-set layout is not resolved");
+                }
+                context->key_set_layout = static_cast<const TSSDataLayout &>(*regular_layout);
+                context->key_set_layout.tracking_offset = storage_offset;
+            }
             context->key_set_ops = TSSDataOps{};
             TSDataOps key_set_base_ops = target_link_base_ops(*context);
             key_set_base_ops.kind = TSTypeKind::TSS;
+            key_set_base_ops.layout_impl = &target_link_key_set_layout;
             key_set_base_ops.tracking_impl = &target_link_key_set_tracking;
             key_set_base_ops.mutable_tracking_impl = &target_link_mutable_key_set_tracking;
             key_set_base_ops.clear_collection_impl = &ts_data_detail::clear_tss_collection;

--- a/src/hgraph/types/value/compact_container_ops.cpp
+++ b/src/hgraph/types/value/compact_container_ops.cpp
@@ -129,6 +129,35 @@ namespace hgraph
         }
     } // namespace container_ops_detail
 
+    ValueTypeRef compact_element_binding(const ValueTypeRef &container_binding)
+    {
+        using namespace container_ops_detail;
+        const auto *ops = container_binding ? container_binding.ops() : nullptr;
+        if (ops == &compact_list_ops() || ops == &compact_list_ops_impl<true>())
+        {
+            return compact_target_state<ListState>(container_binding, "List").element_binding;
+        }
+        if (ops == &compact_set_ops()) { return compact_target_state<SetState>(container_binding, "Set").element_binding; }
+        if (ops == &compact_cyclic_buffer_ops())
+        {
+            return compact_target_state<CyclicBufferState>(container_binding, "CyclicBuffer").element_binding;
+        }
+        if (ops == &compact_queue_ops()) { return compact_target_state<QueueState>(container_binding, "Queue").element_binding; }
+        throw std::logic_error("compact_element_binding: binding is not a compact list, set, cyclic buffer or queue");
+    }
+
+    std::pair<ValueTypeRef, ValueTypeRef> compact_map_bindings(const ValueTypeRef &map_binding)
+    {
+        using namespace container_ops_detail;
+        const auto *ops = map_binding ? map_binding.ops() : nullptr;
+        if (ops != &compact_map_ops() && ops != &compact_map_key_set_ops())
+        {
+            throw std::logic_error("compact_map_bindings: binding is not a compact map");
+        }
+        const auto &state = compact_target_state<MapState>(map_binding, "Map");
+        return {state.key_binding, state.value_binding};
+    }
+
     ValueTypeRef compact_list_type(const ValueTypeRef &element_binding)
     {
         const auto *meta = TypeRegistry::instance().list(element_binding.schema(), /*fixed_size=*/0);

--- a/src/hgraph/types/value/compact_container_ops.cpp
+++ b/src/hgraph/types/value/compact_container_ops.cpp
@@ -133,7 +133,10 @@ namespace hgraph
     {
         using namespace container_ops_detail;
         const auto *ops = container_binding ? container_binding.ops() : nullptr;
-        if (ops == &compact_list_ops() || ops == &compact_list_ops_impl<true>())
+        // Every compact list strategy (plain, variadic tuple, shaped array)
+        // shares the ListState plan context.
+        if (ops == &compact_list_ops() || ops == &compact_list_ops_impl<true>() ||
+            ops == &compact_list_ops_impl<false, true>())
         {
             return compact_target_state<ListState>(container_binding, "List").element_binding;
         }

--- a/tests/cpp/test_ts_delta.cpp
+++ b/tests/cpp/test_ts_delta.cpp
@@ -16,6 +16,7 @@
 #include <hgraph/types/metadata/value_plan_factory.h>
 #include <hgraph/types/static_node.h>
 #include <hgraph/types/time_series/ts_delta.h>
+#include <hgraph/types/utils/counted_mutex.h>
 #include <hgraph/types/value/value_builder.h>
 
 #include <catch2/catch_test_macros.hpp>
@@ -792,4 +793,83 @@ TEST_CASE("ts_delta: capture/apply round-trip a SIGNAL tick delta") {
       [&](const GlobalStateView &gs) { set_replay_deltas(gs, "in", deltas); });
   CHECK_OUTPUT(get_recorded_deltas(rt.view().graph().global_state(), "out"),
                {Value{true}, Value{true}, Value{true}});
+}
+
+// ABI 16: every layout records the portable delta type it was built for, and
+// the empty / captured deltas are built as that type without touching the
+// realization snapshot (python_bridge.rst, "Delta capture is registry-free").
+TEST_CASE("ts_delta: layouts record the canonical delta binding and empty deltas are built as it") {
+  auto &registry = TypeRegistry::instance();
+  auto &factory = TSDataPlanFactory::instance();
+  const auto *integer = registry.register_scalar<Int>("int");
+  const auto *scalar = registry.ts(integer);
+  const std::vector<const TSValueTypeMetaData *> schemas{
+      scalar,
+      registry.tss(integer),
+      registry.tsd(integer, scalar),
+      registry.tsl(scalar, 2),
+      registry.tsl(scalar),
+      registry.tsb("DeltaBindingProbe", {{"value", scalar}, {"keys", registry.tss(integer)}}),
+  };
+  for (const auto *schema : schemas) {
+    CAPTURE(schema->name());
+    const auto type = factory.data_type_for(schema).as_role();
+    REQUIRE(type);
+    const auto &ops = type.ops_ref();
+    const auto *layout = ops.layout_impl(ops.context);
+    REQUIRE(layout != nullptr);
+    REQUIRE(layout->canonical_delta_binding);
+    CHECK(layout->canonical_delta_binding.schema() == schema->delta_value_schema);
+
+    // Warm once (the first call may publish), then the empty delta of a
+    // realized type is a pure build over the layout: no type-system lock.
+    static_cast<void>(ops.empty_delta_impl(type));
+    const auto before = type_system_lock_count();
+    const Value empty = ops.empty_delta_impl(type);
+    CHECK(type_system_lock_count() == before);
+    CHECK(empty.binding() == layout->canonical_delta_binding);
+    if (schema->kind != TSTypeKind::TS) { CHECK(empty.has_value()); }
+  }
+}
+
+// The capture path itself: a probe that counts the type-system locks taken
+// inside capture_delta alone (the recording harness around it is not the
+// per-tick path). After a warm run, replaying three set deltas must capture
+// each one without a lock.
+namespace {
+std::uint64_t g_capture_locks = 0;
+
+template <typename S> struct ProbeCaptureLocks {
+  static constexpr auto name = "ts_delta_probe_capture_locks";
+  static void eval(In<"ts", S> ts) {
+    const auto before = type_system_lock_count();
+    const Value delta = capture_delta(ts.base());
+    static_cast<void>(delta);
+    g_capture_locks += type_system_lock_count() - before;
+  }
+};
+
+template <typename S> struct CaptureLocksGraph {
+  static constexpr auto name = "ts_delta_capture_locks_graph";
+  static void compose(Wiring &w) {
+    auto src = wire<stdlib::replay_impl, S>(w, Str{"in"});
+    wire<ProbeCaptureLocks<S>>(w, src);
+  }
+};
+} // namespace
+
+TEST_CASE("ts_delta: capture_delta acquires no type-system lock per tick") {
+  (void)TypeRegistry::instance().register_scalar<Int>("int");
+  const std::vector<std::optional<Value>> deltas{set_delta<Int>({1, 2}, {}),
+                                                 set_delta<Int>({3}, {1}),
+                                                 set_delta<Int>({}, {2, 3})};
+  const auto run = [&]() {
+    g_capture_locks = 0;
+    auto ex = run_graph<CaptureLocksGraph<TSS<Int>>>(
+        [&](const GlobalStateView &gs) { set_replay_deltas(gs, "in", deltas); });
+    static_cast<void>(ex);
+    return g_capture_locks;
+  };
+  static_cast<void>(run());  // warm: the first capture may publish once
+  CHECK(run() == 0);
 }

--- a/tests/cpp/test_type_erasure_layout.cpp
+++ b/tests/cpp/test_type_erasure_layout.cpp
@@ -80,12 +80,14 @@ TEST_CASE("current type-erasure records retain their baseline layouts")
     static_assert(!HasNoArgumentRemovedValue<TSWDataView>);
     static_assert(HasNoArgumentRemovedValue<TSWInputView>);
     static_assert(sizeof(TSDataView) == sizeof(void *) * 2);
-    // ABI 15 (RFC 0035): the Python-authoring table pointer is gone; a
-    // strategy records only its family (python_family, ABI 14) and the
-    // bridge maps it to the table. ABI 13 made the Python slots
-    // unconditional and opaque, so a table built with Python off has the
-    // layout of one built with Python on.
-    static_assert(TS_DATA_OPS_ABI_VERSION == 15);
+    // ABI 16: TSDataLayout records the portable delta type
+    // (canonical_delta_binding) beside the storage's delta surface, so delta
+    // capture builds without the realization snapshot. ABI 15 (RFC 0035):
+    // the Python-authoring table pointer is gone; a strategy records only its
+    // family (python_family, ABI 14) and the bridge maps it to the table.
+    // ABI 13 made the Python slots unconditional and opaque.
+    static_assert(TS_DATA_OPS_ABI_VERSION == 16);
+    static_assert(std::is_same_v<decltype(TSDataLayout::canonical_delta_binding), ValueTypeRef>);
     static_assert(std::is_same_v<decltype(TSDataOps::python_family), PythonTSDataFamily>);
     static_assert(std::is_same_v<decltype(TSDataOps::to_python_impl), PyNewRef (*)(const void *, const void *)>);
     // ABI 12: keyed and window TSData projections keep binding and memory together.
@@ -126,8 +128,8 @@ TEST_CASE("current type-erasure records retain their baseline layouts")
     static_assert(sizeof(TSOutput) == sizeof(void *) * 5);
     static_assert(sizeof(TSInput) == sizeof(void *) * 7);
     static_assert(sizeof(FixedTSDataFieldLayout) == sizeof(void *) * 3);
-    static_assert(sizeof(FixedTSBDataLayout) == sizeof(void *) * 7);
-    static_assert(sizeof(FixedTSLDataLayout) == sizeof(void *) * 10);
+    static_assert(sizeof(FixedTSBDataLayout) == sizeof(void *) * 8);
+    static_assert(sizeof(FixedTSLDataLayout) == sizeof(void *) * 11);
 
     using RawHandle = MemoryUtils::ErasedOwner<>;
     static_assert(sizeof(RawHandle) == sizeof(void *) * 3);

--- a/tests/install_consumer/main.cpp
+++ b/tests/install_consumer/main.cpp
@@ -334,7 +334,7 @@ int main()
     // ABI 14 (RFC 0035): TSDataOps records its Python-authoring family; ABI 13 made the
     // Python slots unconditional and opaque; ABI 12 made the keyed and window TSData
     // projections return binding and memory together.
-    static_assert(TS_DATA_OPS_ABI_VERSION == 15);
+    static_assert(TS_DATA_OPS_ABI_VERSION == 16);
     static_assert(sizeof(PolymorphicValueType) == 2 * sizeof(void *));
     static_assert(std::is_standard_layout_v<PolymorphicValueType>);
     static_assert(!std::is_polymorphic_v<TableTypeOps>);


### PR DESCRIPTION
Follow-up to #745, which exposed it: the type layer's own delta capture resolved its bindings through the realization snapshot and re-interned its result types on every call, so every operator that queues deltas (`throttle`, `batch`, `gate`, `lag`, the feedback and service nodes) paid a registry lookup per input tick — about twelve type-system lock acquisitions per cycle on a throttled `TSS`. The lock-matrix guard `throttle_tss` was a strict expected failure for exactly this.

**Design (`plans_and_ops/time_series.rst`, "TSDataLayout"; `python_bridge.rst`, "Delta capture is registry-free")**

- Every family's `layout.delta_binding` is a *projection* over its storage, and its owning-type hook resolves through the plan factory per call (the slot families even through the active realization), so it cannot serve as the portable delta type. `TSDataLayout` gains `canonical_delta_binding` (ABI 15 → 16): the delta schema's realization in the type's own realization scope, resolved once when the layout is built by the shared `ts_data_detail::canonical_delta_binding_for`, at all nine layout sites (atomic, window, slot TSS, slot TSD and its key-set projection, fixed TSB/TSL, dynamic TSL, the TSD proxy and its key-set projection, the non-peered input facades).
- `ts_delta.cpp` builds through it: `BundleBuilder{canonical}` with the now-public `BundleBuilder::field_binding`, element / key / value bindings read off the compact plans through the new `compact_element_binding` / `compact_map_bindings`, empty surfaces from the builders' `build_storage()`, results copied into the field bindings. `capture_delta_*`, `capture_current_*` and `empty_delta_*` no longer touch `ValuePlanFactory`, the snapshot or `TSDataPlanFactory`; the TSB pre-fill of collection children (which validates them on replay) is preserved. A canonical binding whose schema is not the input's delta schema throws instead of building a mis-shaped delta.
- `Value::typed_null(binding)` is the lock-free twin of `Value(schema)` for the atomic empty delta.

**Found on the way**: the TSD key-set projections (slot context and proxy) reported the dictionary's layout, so a set capture through `keys_` on a routed TSD built against the dictionary's `{removed, modified}` bundle; each projection now carries its own `TSSDataLayout`.

**Guards**

- C++ (`test_ts_delta.cpp`): every family's layout records a canonical delta binding whose schema is the delta schema; `empty_delta` builds as it and takes no type-system lock; `capture_delta` on a replayed `TSS` takes no type-system lock per tick (counted inside the call, not around the recording harness).
- Python lock matrix: `throttle_tss` is a real guard again, plus `throttle_tsd`, `throttle_tsl`, `throttle_tsb`.

**ABI**: `TS_DATA_OPS_ABI_VERSION` 16; layout size pins updated (`TSSDataLayout` 6 words, `TSDDataLayout` 11, `FixedTSBDataLayout` 8, `FixedTSLDataLayout` 11); ledger and notes in `ops_catalogue.rst` / `plans_and_ops/time_series.rst`.

**Validation (macOS, local gate)**

- C++ core-only suite: all tests passed (257368 assertions in 1706 test cases)
- Python gate (`python/tests` incl. adaptors + all extension suites): 3618 passed, 10 skipped
- Consumer checks (`python_extension_consumer`, `install_consumer`, fabric test package): passed
- `sphinx -W`: clean

Linux (GCC 14, warnings-as-errors) and Windows (MSVC) results follow as comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsqG5G3RzpnPtLCJ62DFga
