### PR TITLE
Plan nested temporal continuation paths

### DIFF
--- a/language/docs/design/control-flow.md
+++ b/language/docs/design/control-flow.md
@@ -381,10 +381,12 @@ a read before assignment on a path that does reach it.
 
 See the runnable
 [conditional-early-return.hgl](../../examples/conditional-early-return.hgl)
-example. HGraph IR represents the callable suffix, branch fallthrough,
-complete-path captures, and enclosing-function result explicitly. Both
-compiler backends consume that plan for a top-level temporal conditional;
-nested temporal early-return continuations remain staged.
+example. HGraph IR represents the ordered callable-suffix path, branch
+fallthrough, complete-path captures, and enclosing-function result explicitly.
+The path retains a separate segment for every enclosing lexical block so
+intermediate tail expressions keep their source order. Both compiler backends
+consume a single-segment plan for a top-level temporal conditional; execution
+of the multi-segment nested plan remains staged.
 
 ## Outputless conditionals
 
@@ -583,9 +585,10 @@ slot's declared schema at the branch boundary. A value-producing conditional
 without `else` supplies a type-resolved `nothing` source for the absent false
 branch, so it emits no default value and no tick while false. Shared HGraph IR
 continuation planning is implemented, including path-sensitive fallthrough,
-capture analysis, and a distinct enclosing-function return result. Both
-execution backends consume that plan for a top-level temporal conditional.
-Nested temporal early-return continuations remain staged.
+capture analysis, a distinct enclosing-function return result, and ordered
+lexical suffix segments for nested paths. Both execution backends consume a
+single-segment plan for a top-level temporal conditional. Nested multi-segment
+execution remains staged.
 
 The parser, typed uninitialized `var`, and path-sensitive definite assignment
 support are broader than this first backend slice. The early-return and

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -298,6 +298,9 @@ result. An initialized escaping binding can be forwarded by reference on an
 unassigned branch, independently for each generated result field.
 A consumed temporal conditional without `else` is type-resolved from its true
 branch and lowers its false path to a native never-ticking `nothing` source.
+Nested early-return paths are represented in shared HGraph IR as ordered
+lexical continuation segments; both execution backends still consume only the
+single-segment top-level form.
 Generated headers and sources are mandatory `clang-format` output and public
 operator contracts are transparent aliases rather than derived marker classes.
 

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -219,9 +219,11 @@ terminal plan has one `FunctionReturn` result contract rather than exposing
 the continuation's local assignments as outer escape results. The direct
 wiring backend executes an attached suffix in its selected child context; the
 C++ emitter writes the same suffix into the generated branch's `compose`
-function. The initial implementation recognizes top-level temporal early
-returns. Recursively combining nested temporal continuation segments remains
-staged.
+function. The planner represents nested temporal continuations as an ordered
+sequence of lexical suffix segments, preserving intermediate tail expressions
+and then the suffixes of each enclosing block. The initial execution
+implementation consumes one segment for a top-level temporal early return;
+recursively executing the multi-segment path remains staged.
 `DeclarationRef` provides typed struct, operator, callable, and test handles;
 the module retains those handles in source order while module and import
 declarations remain frontend-only. Each referenced contract or plan owns its

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -1023,7 +1023,10 @@ path's continuation before deriving branch captures and result signatures.
 The continuation's computations share that branch's lifetime. Definite
 assignment considers only paths reaching a use, excluding paths that return
 before it. See [Early returns](../design/control-flow.md#early-returns-and-continuations).
-This is a target lowering requirement, not implemented backend behavior.
+Shared HGraph IR plans this behavior and both backends implement it for a
+top-level temporal conditional. Nested paths are represented as ordered
+lexical continuation segments; execution of those multi-segment plans remains
+staged.
 
 An outputless temporal conditional uses the native sink-switch path without a
 synthetic output. Sinks inside the branch are wired through the switch; sinks

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -1769,12 +1769,14 @@ namespace hgl::codegen
             if (!has_output) {
                 if (branch.block.valid()) { emit_planned_block(branch.block, nested, *current_body_, false, range); }
                 if (branch.continuation) {
-                    for (gir::StatementId statement : branch.continuation->statements) {
-                        emit_planned_statement(statement, nested, *current_body_, range);
-                    }
-                    if (branch.continuation->tail.valid()) {
-                        const Value value = eval_planned_expr(branch.continuation->tail, nested);
-                        current_body_->line(value.kind == Value::Kind::Void ? value.code + ";" : "(void)" + value.code + ";");
+                    for (const gir::ConditionalContinuationSegment &segment : branch.continuation->segments) {
+                        for (gir::StatementId statement : segment.statements) {
+                            emit_planned_statement(statement, nested, *current_body_, range);
+                        }
+                        if (segment.tail.valid()) {
+                            const Value value = eval_planned_expr(segment.tail, nested);
+                            current_body_->line(value.kind == Value::Kind::Void ? value.code + ";" : "(void)" + value.code + ";");
+                        }
                     }
                 }
                 current_body_->close();
@@ -1789,13 +1791,19 @@ namespace hgl::codegen
             if (function_return) {
                 if (branch.block.valid()) { emit_planned_block(branch.block, nested, *current_body_, false, range); }
                 if (branch.continuation) {
-                    for (gir::StatementId statement : branch.continuation->statements) {
-                        emit_planned_statement(statement, nested, *current_body_, range);
-                    }
-                    if (branch.continuation->tail.valid()) {
-                        const gir::Value &tail  = planned_value(branch.continuation->tail, range);
-                        const Value       value = eval_planned_expr(branch.continuation->tail, nested);
-                        emit_return(value, nested, *current_body_, tail.range);
+                    for (std::size_t index = 0; index < branch.continuation->segments.size(); ++index) {
+                        const gir::ConditionalContinuationSegment &segment = branch.continuation->segments[index];
+                        for (gir::StatementId statement : segment.statements) {
+                            emit_planned_statement(statement, nested, *current_body_, range);
+                        }
+                        if (!segment.tail.valid()) { continue; }
+                        const gir::Value &tail  = planned_value(segment.tail, range);
+                        const Value       value = eval_planned_expr(segment.tail, nested);
+                        if (index + 1U == branch.continuation->segments.size()) {
+                            emit_return(value, nested, *current_body_, tail.range);
+                        } else {
+                            current_body_->line(value.kind == Value::Kind::Void ? value.code + ";" : "(void)" + value.code + ";");
+                        }
                     }
                 }
                 current_body_->close();

--- a/language/src/hgraph_ir/control_flow.cpp
+++ b/language/src/hgraph_ir/control_flow.cpp
@@ -1,6 +1,7 @@
 #include "hgraph_ir/control_flow.h"
 
 #include <algorithm>
+#include <iterator>
 #include <span>
 #include <type_traits>
 #include <utility>
@@ -96,8 +97,10 @@ namespace hgl::hgraph_ir
             }
 
             void collect_locals(const ConditionalContinuationPlan &continuation) {
-                collect_locals(continuation.statements);
-                collect_value_locals(continuation.tail);
+                for (const ConditionalContinuationSegment &segment : continuation.segments) {
+                    collect_locals(segment.statements);
+                    collect_value_locals(segment.tail);
+                }
             }
 
             void collect_locals(std::span<const StatementId> statements) {
@@ -246,8 +249,10 @@ namespace hgl::hgraph_ir
             }
 
             [[nodiscard]] bool scan_continuation(const ConditionalContinuationPlan &continuation) {
-                if (!scan_statements(continuation.statements)) { return false; }
-                return scan_value(continuation.tail);
+                for (const ConditionalContinuationSegment &segment : continuation.segments) {
+                    if (!scan_statements(segment.statements) || !scan_value(segment.tail)) { return false; }
+                }
+                return true;
             }
 
             [[nodiscard]] bool scan_statements(std::span<const StatementId> statements) {
@@ -317,11 +322,23 @@ namespace hgl::hgraph_ir
         ConditionalContinuationPlan continuation;
         continuation.result = result;
         if (!enclosing.valid() || enclosing.value >= module.blocks.size()) { return continuation; }
-        const Block &block = module.blocks[enclosing.value];
-        const auto   first = std::min(first_statement, block.statements.size());
-        continuation.statements.assign(block.statements.begin() + static_cast<std::ptrdiff_t>(first), block.statements.end());
-        if (block.tail != conditional) { continuation.tail = block.tail; }
+        const Block                   &block = module.blocks[enclosing.value];
+        const auto                     first = std::min(first_statement, block.statements.size());
+        ConditionalContinuationSegment segment;
+        segment.statements.assign(block.statements.begin() + static_cast<std::ptrdiff_t>(first), block.statements.end());
+        if (block.tail != conditional) { segment.tail = block.tail; }
+        if (!segment.statements.empty() || segment.tail.valid()) { continuation.segments.push_back(std::move(segment)); }
         return continuation;
+    }
+
+    ConditionalContinuationPlan prepend_temporal_continuation(const Module &module, BlockId enclosing, std::size_t first_statement,
+                                                              ConditionalContinuationPlan following, ValueId conditional) {
+        ConditionalContinuationPlan prefix =
+            plan_temporal_continuation(module, enclosing, first_statement, following.result, conditional);
+        if (prefix.segments.empty()) { return following; }
+        prefix.segments.insert(prefix.segments.end(), std::make_move_iterator(following.segments.begin()),
+                               std::make_move_iterator(following.segments.end()));
+        return prefix;
     }
 
     ConditionalPlan analyze_temporal_conditional(const Module &module, ValueId value_id,

--- a/language/src/hgraph_ir/control_flow.h
+++ b/language/src/hgraph_ir/control_flow.h
@@ -21,15 +21,26 @@ namespace hgl::hgraph_ir
         ir::hir::Phase phase{ir::hir::Phase::Unknown};
     };
 
-    /// The suffix of an enclosing callable that must execute on every path
-    /// that falls through a temporal conditional containing an early return.
-    /// Keeping the suffix in the execution IR lets both backends place it
-    /// inside the appropriate child graph without recovering syntax context.
-    struct ConditionalContinuationPlan
+    /// One lexical suffix in the path from a nested temporal conditional back
+    /// to the end of its enclosing callable. A nested path can cross several
+    /// blocks, so retaining each suffix separately preserves the order and
+    /// effect of intermediate tail expressions.
+    struct ConditionalContinuationSegment
     {
         std::vector<StatementId> statements{};
         ValueId                  tail{};
-        TypeId                   result{};
+
+        friend bool operator==(const ConditionalContinuationSegment &, const ConditionalContinuationSegment &) = default;
+    };
+
+    /// The ordered callable path that must execute on every branch which falls
+    /// through a temporal conditional containing an early return. Keeping the
+    /// path in execution IR lets both backends place it inside the selected
+    /// child graph without recovering syntax context.
+    struct ConditionalContinuationPlan
+    {
+        std::vector<ConditionalContinuationSegment> segments{};
+        TypeId                                      result{};
     };
 
     struct ConditionalBranchPlan
@@ -69,6 +80,15 @@ namespace hgl::hgraph_ir
     [[nodiscard]] ConditionalContinuationPlan plan_temporal_continuation(const Module &module, BlockId enclosing,
                                                                          std::size_t first_statement, TypeId result,
                                                                          ValueId conditional = {});
+
+    /// Prepend the suffix of a nested enclosing block to an existing callable
+    /// continuation. Empty suffixes are omitted; an empty plan still records
+    /// that falling through supplies the current expression as the callable
+    /// result.
+    [[nodiscard]] ConditionalContinuationPlan prepend_temporal_continuation(const Module &module, BlockId enclosing,
+                                                                            std::size_t                 first_statement,
+                                                                            ConditionalContinuationPlan following,
+                                                                            ValueId                     conditional = {});
 
     /// Analyze an HGraph-IR Conditional value. The input module is already
     /// structurally valid; a non-conditional value or non-block else arm is

--- a/language/src/wiring/backend.cpp
+++ b/language/src/wiring/backend.cpp
@@ -1413,12 +1413,13 @@ namespace hgl::wiring
             }
             Slot expression_result = context.block.valid() ? compiler.exec_block(context.block, frame) : Slot{};
             if (!frame.returned && context.continuation) {
-                for (gir::StatementId statement : context.continuation->statements) {
-                    compiler.exec_statement(statement, frame);
+                for (const gir::ConditionalContinuationSegment &segment : context.continuation->segments) {
+                    for (gir::StatementId statement : segment.statements) {
+                        compiler.exec_statement(statement, frame);
+                        if (frame.returned) { break; }
+                    }
                     if (frame.returned) { break; }
-                }
-                if (!frame.returned && context.continuation->tail.valid()) {
-                    expression_result = compiler.eval_value(context.continuation->tail, frame);
+                    if (segment.tail.valid()) { expression_result = compiler.eval_value(segment.tail, frame); }
                 }
                 if (!frame.returned) { frame.returned = expression_result; }
             }

--- a/language/tests/hgraph_ir/control_flow_tests.cpp
+++ b/language/tests/hgraph_ir/control_flow_tests.cpp
@@ -231,7 +231,8 @@ fn choose(condition: bool, x: i64, y: i64) -> i64 {
     const gir::Callable &callable = lowered.graph->callables.at(site.callable.value);
     const auto           continuation =
         gir::plan_temporal_continuation(*lowered.graph, site.block, site.statement_index + 1U, callable.result, site.value);
-    REQUIRE(continuation.statements.size() == 2U);
+    REQUIRE(continuation.segments.size() == 1U);
+    REQUIRE(continuation.segments.front().statements.size() == 2U);
 
     const gir::ConditionalPlan plan = gir::analyze_temporal_conditional(*lowered.graph, site.value, continuation);
     CHECK(plan.returns_from_callable);
@@ -243,7 +244,7 @@ fn choose(condition: bool, x: i64, y: i64) -> i64 {
     CHECK(plan.when_false->returns);
     CHECK_FALSE(plan.when_false->falls_through);
     REQUIRE(plan.when_false->continuation);
-    CHECK(plan.when_false->continuation->statements == continuation.statements);
+    CHECK(plan.when_false->continuation->segments == continuation.segments);
     CHECK(plan.assigned_outer.empty());
 
     REQUIRE(plan.when_true.captures.size() == 1U);
@@ -314,15 +315,60 @@ fn choose(condition: bool, x: i64, y: i64) -> i64 {
 
     const auto continuation =
         gir::plan_temporal_continuation(*lowered.graph, callable.block_body, block.statements.size(), callable.result, block.tail);
-    CHECK(continuation.statements.empty());
-    CHECK_FALSE(continuation.tail.valid());
+    CHECK(continuation.segments.empty());
 
     const gir::ConditionalPlan plan = gir::analyze_temporal_conditional(*lowered.graph, block.tail, continuation);
     CHECK(plan.returns_from_callable);
     REQUIRE(plan.when_false);
     CHECK_FALSE(plan.when_true.continuation);
     REQUIRE(plan.when_false->continuation);
-    CHECK_FALSE(plan.when_false->continuation->tail.valid());
+    CHECK(plan.when_false->continuation->segments.empty());
+}
+
+TEST_CASE("nested temporal continuation planning preserves every enclosing suffix", "[hgraph-ir][control-flow][continuation]") {
+    Lowered lowered{R"(
+module checks.temporal_nested_continuation
+
+fn choose(outer: bool, inner: bool, x: i64, y: i64, z: i64) -> i64 {
+    if outer {
+        if inner {
+            return x
+        }
+        y + 1
+    }
+    return z
+}
+)"};
+    INFO(lowered.diagnostics.render(lowered.file));
+    REQUIRE(lowered.graph);
+
+    const ConditionalSite outer = conditional_site(*lowered.graph);
+    REQUIRE(outer.callable.valid());
+    const gir::Callable             &callable = lowered.graph->callables.at(outer.callable.value);
+    gir::ConditionalContinuationPlan continuation =
+        gir::plan_temporal_continuation(*lowered.graph, outer.block, outer.statement_index + 1U, callable.result, outer.value);
+    REQUIRE(continuation.segments.size() == 1U);
+    REQUIRE(continuation.segments.front().statements.size() == 1U);
+
+    const auto       &outer_value = std::get<gir::Conditional>(lowered.graph->values.at(outer.value.value).node);
+    const gir::Block &then_block  = lowered.graph->blocks.at(outer_value.then_block.value);
+    REQUIRE_FALSE(then_block.statements.empty());
+    const auto &inner_statement = lowered.graph->statements.at(then_block.statements.front().value);
+    const auto &inner_evaluate  = std::get<gir::Evaluate>(inner_statement.node);
+
+    continuation = gir::prepend_temporal_continuation(*lowered.graph, outer_value.then_block, 1U, std::move(continuation),
+                                                      inner_evaluate.value);
+    REQUIRE(continuation.segments.size() == 2U);
+    CHECK(continuation.segments.front().statements.empty());
+    CHECK(continuation.segments.front().tail == then_block.tail);
+    CHECK(continuation.segments.back().statements.size() == 1U);
+    CHECK(continuation.result == callable.result);
+
+    const gir::ConditionalPlan inner = gir::analyze_temporal_conditional(*lowered.graph, inner_evaluate.value, continuation);
+    CHECK(inner.returns_from_callable);
+    REQUIRE(inner.when_false);
+    REQUIRE(inner.when_false->continuation);
+    CHECK(inner.when_false->continuation->segments.size() == 2U);
 }
 
 TEST_CASE("a terminating call argument stops branch capture analysis", "[hgraph-ir][control-flow][continuation]") {


### PR DESCRIPTION
## Summary

- represent temporal early-return continuations as ordered lexical suffix segments in shared HGraph IR
- preserve intermediate block tails while composing nested paths
- adapt both backends to the segmented representation without changing the supported top-level behavior
- document the planning/execution boundary and add focused planner coverage

## Validation

- Test project /Users/hhenson/.codex/worktrees/67f8b0d4-4ee2-4fc8-934c-9e02cc4778af/hgraph/cmake-build-cpp
      Start 1753: hgraph_language_prepare_native_scalar_descriptor
      Start 1768: hgraph_language_native_cache
 1/50 Test #1753: hgraph_language_prepare_native_scalar_descriptor ............   Passed    0.00 sec
      Start 1771: hgraph_language_repl_smoke
 2/50 Test #1771: hgraph_language_repl_smoke ..................................   Passed    3.56 sec
      Start 1765: hgraph_language_test_runtime
 3/50 Test #1765: hgraph_language_test_runtime ................................   Passed    0.22 sec
      Start 1772: hgraph_language_cmake_package
 4/50 Test #1772: hgraph_language_cmake_package ...............................   Passed    1.41 sec
      Start 1746: hgraph_language_check_descriptor
 5/50 Test #1746: hgraph_language_check_descriptor ............................   Passed    0.14 sec
      Start 1766: hgraph_language_run_runtime
 6/50 Test #1766: hgraph_language_run_runtime .................................   Passed    0.22 sec
      Start 1767: hgraph_language_native_compile_failure
 7/50 Test #1767: hgraph_language_native_compile_failure ......................   Passed    0.20 sec
      Start 1729: hgraph_language_example_conditional-early-return
 8/50 Test #1729: hgraph_language_example_conditional-early-return ............   Passed    0.04 sec
      Start 1732: hgraph_language_example_conditional-omitted-else
 9/50 Test #1732: hgraph_language_example_conditional-omitted-else ............   Passed    0.03 sec
      Start 1730: hgraph_language_example_conditional-forwarding
10/50 Test #1730: hgraph_language_example_conditional-forwarding ..............   Passed    0.03 sec
      Start 1731: hgraph_language_example_conditional-mixed-results
11/50 Test #1731: hgraph_language_example_conditional-mixed-results ...........   Passed    0.03 sec
      Start 1734: hgraph_language_example_conditional-results
12/50 Test #1734: hgraph_language_example_conditional-results .................   Passed    0.03 sec
      Start 1735: hgraph_language_example_conditional-sinks
13/50 Test #1735: hgraph_language_example_conditional-sinks ...................   Passed    0.04 sec
      Start 1733: hgraph_language_example_conditional-result
14/50 Test #1733: hgraph_language_example_conditional-result ..................   Passed    0.03 sec
      Start 1759: hgraph_language_operator_types
15/50 Test #1759: hgraph_language_operator_types ..............................   Passed    0.04 sec
      Start 1737: hgraph_language_example_fixed-list-iteration
16/50 Test #1737: hgraph_language_example_fixed-list-iteration ................   Passed    0.04 sec
      Start 1736: hgraph_language_example_dynamic-collection-iteration
17/50 Test #1736: hgraph_language_example_dynamic-collection-iteration ........   Passed    0.04 sec
      Start 1754: hgraph_language_check_native_scalar_import
18/50 Test #1754: hgraph_language_check_native_scalar_import ..................   Passed    0.03 sec
      Start 1740: hgraph_language_example_reference-routing
19/50 Test #1740: hgraph_language_example_reference-routing ...................   Passed    0.03 sec
      Start 1744: hgraph_language_dump_hir
20/50 Test #1744: hgraph_language_dump_hir ....................................   Passed    0.03 sec
      Start 1745: hgraph_language_dump_hgraph_ir
21/50 Test #1745: hgraph_language_dump_hgraph_ir ..............................   Passed    0.03 sec
      Start 1770: hgraph_language_emit_runtime
22/50 Test #1770: hgraph_language_emit_runtime ................................   Passed    0.05 sec
      Start 1747: hgraph_language_syntax
23/50 Test #1747: hgraph_language_syntax ......................................   Passed    0.05 sec
      Start 1769: hgraph_language_emit_midpoint
24/50 Test #1769: hgraph_language_emit_midpoint ...............................   Passed    0.04 sec
      Start 1764: hgraph_language_test_parity
25/50 Test #1764: hgraph_language_test_parity .................................   Passed    0.04 sec
      Start 1773: hgraph_language_test_midpoint
26/50 Test #1773: hgraph_language_test_midpoint ...............................   Passed    0.04 sec
      Start 1758: hgraph_language_wiring_types
27/50 Test #1758: hgraph_language_wiring_types ................................   Passed    0.02 sec
      Start 1741: hgraph_language_example_runtime-choice
28/50 Test #1741: hgraph_language_example_runtime-choice ......................   Passed    0.04 sec
      Start 1739: hgraph_language_example_operators-and-generics
29/50 Test #1739: hgraph_language_example_operators-and-generics ..............   Passed    0.04 sec
      Start 1738: hgraph_language_example_midpoint
30/50 Test #1738: hgraph_language_example_midpoint ............................   Passed    0.04 sec
      Start 1743: hgraph_language_example_structural-types
31/50 Test #1743: hgraph_language_example_structural-types ....................   Passed    0.04 sec
      Start 1742: hgraph_language_example_stateful-node
32/50 Test #1742: hgraph_language_example_stateful-node .......................   Passed    0.03 sec
      Start 1728: hgraph_language_example_collection-views
33/50 Test #1728: hgraph_language_example_collection-views ....................   Passed    0.03 sec
      Start 1724: hgraph_language_cli_help
34/50 Test #1724: hgraph_language_cli_help ....................................   Passed    0.03 sec
      Start 1725: hgraph_language_cli_version
35/50 Test #1725: hgraph_language_cli_version .................................   Passed    0.03 sec
      Start 1760: hgraph_language_native_module
36/50 Test #1760: hgraph_language_native_module ...............................   Passed    0.02 sec
      Start 1757: hgraph_language_wiring
37/50 Test #1757: hgraph_language_wiring ......................................   Passed    0.05 sec
      Start 1726: hgraph_language_backend_architecture
38/50 Test #1726: hgraph_language_backend_architecture ........................   Passed    0.01 sec
      Start 1763: hgraph_language_generated
39/50 Test #1763: hgraph_language_generated ...................................   Passed    0.04 sec
      Start 1749: hgraph_language_ir
40/50 Test #1749: hgraph_language_ir ..........................................   Passed    0.01 sec
      Start 1727: hgraph_language_backend_architecture_rejects_indirect_ast
41/50 Test #1727: hgraph_language_backend_architecture_rejects_indirect_ast ...   Passed    0.01 sec
      Start 1751: hgraph_language_descriptor
42/50 Test #1751: hgraph_language_descriptor ..................................   Passed    0.00 sec
      Start 1750: hgraph_language_hgraph_ir
43/50 Test #1750: hgraph_language_hgraph_ir ...................................   Passed    0.01 sec
      Start 1752: hgraph_language_descriptor_reader
44/50 Test #1752: hgraph_language_descriptor_reader ...........................   Passed    0.00 sec
      Start 1762: hgraph_language_codegen
45/50 Test #1762: hgraph_language_codegen .....................................   Passed    0.01 sec
      Start 1748: hgraph_language_semantics
46/50 Test #1748: hgraph_language_semantics ...................................   Passed    0.01 sec
      Start 1755: hgraph_language_native_package
47/50 Test #1755: hgraph_language_native_package ..............................   Passed    0.00 sec
      Start 1761: hgraph_language_native_module_abi_c
48/50 Test #1761: hgraph_language_native_module_abi_c .........................   Passed    0.00 sec
49/50 Test #1768: hgraph_language_native_cache ................................   Passed   38.27 sec
      Start 1756: hgraph_language_native_package_install_consumer
50/50 Test #1756: hgraph_language_native_package_install_consumer .............   Passed    0.82 sec

100% tests passed out of 50

Total Test time (real) =  39.12 sec (50/50 passed)
- focused HGraph IR, direct-wiring, and code-generation conditional tests

Stacked on #749.