### PR TITLE
Lower nested temporal continuation paths

### DIFF
--- a/language/docs/design/control-flow.md
+++ b/language/docs/design/control-flow.md
@@ -11,8 +11,10 @@ are returned through one compiler-generated structural TSB and remapped by
 field; a used expression result can share the same result structure. A branch
 can also forward an existing binding through a reference-qualified generated
 input. A consumed temporal conditional without `else` receives a typed
-never-ticking false branch in both backends. Scalar branch captures, temporal
-`else if`, and early-return continuations remain staged.
+never-ticking false branch in both backends. Early-return continuations work
+for top-level and nested direct temporal conditional statements and block
+tails. Scalar branch captures, temporal `else if`, and temporal conditionals
+embedded in other expression forms remain staged.
 A temporal `else if` is rejected rather than silently treated as an omitted
 `else`. This record uses the existing `if`/`else` syntax. It does not settle the
 other control-flow constructs or introduce new keywords.
@@ -385,8 +387,10 @@ example. HGraph IR represents the ordered callable-suffix path, branch
 fallthrough, complete-path captures, and enclosing-function result explicitly.
 The path retains a separate segment for every enclosing lexical block so
 intermediate tail expressions keep their source order. Both compiler backends
-consume a single-segment plan for a top-level temporal conditional; execution
-of the multi-segment nested plan remains staged.
+consume that plan for top-level and nested direct temporal conditional
+statements, including paths nested inside an already-attached continuation.
+Temporal conditionals embedded in other expression forms remain outside this
+slice.
 
 ## Outputless conditionals
 
@@ -586,9 +590,10 @@ without `else` supplies a type-resolved `nothing` source for the absent false
 branch, so it emits no default value and no tick while false. Shared HGraph IR
 continuation planning is implemented, including path-sensitive fallthrough,
 capture analysis, a distinct enclosing-function return result, and ordered
-lexical suffix segments for nested paths. Both execution backends consume a
-single-segment plan for a top-level temporal conditional. Nested multi-segment
-execution remains staged.
+lexical suffix segments for nested paths. Both execution backends consume the
+multi-segment plan for nested direct temporal conditional statements and block
+tails. Temporal `else if` and a temporal conditional embedded in another
+expression remain staged.
 
 The parser, typed uninitialized `var`, and path-sensitive definite assignment
 support are broader than this first backend slice. The early-return and

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -299,8 +299,8 @@ unassigned branch, independently for each generated result field.
 A consumed temporal conditional without `else` is type-resolved from its true
 branch and lowers its false path to a native never-ticking `nothing` source.
 Nested early-return paths are represented in shared HGraph IR as ordered
-lexical continuation segments; both execution backends still consume only the
-single-segment top-level form.
+lexical continuation segments and both execution backends consume them for
+direct temporal conditional statements and block tails.
 Generated headers and sources are mandatory `clang-format` output and public
 operator contracts are transparent aliases rather than derived marker classes.
 

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -221,9 +221,10 @@ wiring backend executes an attached suffix in its selected child context; the
 C++ emitter writes the same suffix into the generated branch's `compose`
 function. The planner represents nested temporal continuations as an ordered
 sequence of lexical suffix segments, preserving intermediate tail expressions
-and then the suffixes of each enclosing block. The initial execution
-implementation consumes one segment for a top-level temporal early return;
-recursively executing the multi-segment path remains staged.
+and then the suffixes of each enclosing block. Both execution backends walk
+that sequence recursively for nested direct temporal conditional statements
+and block tails, including another split encountered in an attached segment.
+Temporal conditionals embedded in other expression forms remain staged.
 `DeclarationRef` provides typed struct, operator, callable, and test handles;
 the module retains those handles in source order while module and import
 declarations remain frontend-only. Each referenced contract or plan owns its

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -1023,10 +1023,10 @@ path's continuation before deriving branch captures and result signatures.
 The continuation's computations share that branch's lifetime. Definite
 assignment considers only paths reaching a use, excluding paths that return
 before it. See [Early returns](../design/control-flow.md#early-returns-and-continuations).
-Shared HGraph IR plans this behavior and both backends implement it for a
-top-level temporal conditional. Nested paths are represented as ordered
-lexical continuation segments; execution of those multi-segment plans remains
-staged.
+Shared HGraph IR plans this behavior as ordered lexical continuation segments.
+Both backends execute those paths for top-level and nested direct temporal
+conditional statements and block tails. A temporal conditional embedded in
+another expression form remains staged.
 
 An outputless temporal conditional uses the native sink-switch path without a
 synthetic output. Sinks inside the branch are wired through the switch; sinks

--- a/language/examples/conditional-early-return.hgl
+++ b/language/examples/conditional-early-return.hgl
@@ -23,6 +23,14 @@ export fn choose_tail(condition: bool, x: i64, y: i64) -> i64 {
     r * 2
 }
 
+export fn choose_returning_tail(condition: bool, x: i64, y: i64) -> i64 {
+    if condition {
+        return x + 1
+    } else {
+        y - 1
+    }
+}
+
 export fn choose_assigned(condition: bool, x: i64, y: i64) -> i64 {
     var result: i64
     if condition {
@@ -89,6 +97,10 @@ test choose_ticks {
 
 test choose_tail_ticks {
     assert eval(choose_tail, condition: [true, false], x: [1, 2], y: [10, 20]) == [2, 38]
+}
+
+test choose_returning_tail_ticks {
+    assert eval(choose_returning_tail, condition: [true, false], x: [1, 2], y: [10, 20]) == [2, 19]
 }
 
 test choose_assigned_ticks {

--- a/language/examples/conditional-early-return.hgl
+++ b/language/examples/conditional-early-return.hgl
@@ -41,6 +41,48 @@ export fn observe(enabled: bool, value: f64) {
     null_sink(value)
 }
 
+export fn choose_nested(outer: bool, inner: bool, x: i64, y: i64, z: i64) -> i64 {
+    if outer {
+        if inner {
+            return x + 1
+        }
+        let r = y - 1
+        return r * 2
+    }
+    return z * 3
+}
+
+export fn choose_deep(
+    outer: bool,
+    middle: bool,
+    inner: bool,
+    x: i64,
+    y: i64,
+    z: i64,
+    fallback: i64,
+) -> i64 {
+    if outer {
+        return x
+    }
+    if middle {
+        if inner {
+            return y
+        }
+        return z
+    }
+    return fallback
+}
+
+export fn observe_nested(outer: bool, inner: bool, value: f64) {
+    if outer {
+        if inner {
+            return
+        }
+        null_sink(value)
+    }
+    null_sink(value)
+}
+
 test choose_ticks {
     assert eval(choose, condition: [true, true, false], x: [1, 2, 3], y: [10, 20, 30]) == [2, 3, 58]
 }
@@ -55,4 +97,32 @@ test choose_assigned_ticks {
 
 test observe_ticks {
     eval(observe, enabled: [true, false], value: [1.0, 2.0])
+}
+
+test choose_nested_ticks {
+    assert eval(
+        choose_nested,
+        outer: [true, true, false],
+        inner: [true, false, false],
+        x: [1, 2, 3],
+        y: [10, 20, 30],
+        z: [100, 200, 300],
+    ) == [2, 38, 900]
+}
+
+test choose_deep_ticks {
+    assert eval(
+        choose_deep,
+        outer: [true, false, false, false],
+        middle: [false, false, true, true],
+        inner: [false, false, true, false],
+        x: [1, 2, 3, 4],
+        y: [10, 20, 30, 40],
+        z: [100, 200, 300, 400],
+        fallback: [1000, 2000, 3000, 4000],
+    ) == [1, 2000, 30, 400]
+}
+
+test observe_nested_ticks {
+    eval(observe_nested, outer: [true, true, false], inner: [true, false, false], value: [1.0, 2.0, 3.0])
 }

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -516,6 +516,9 @@ namespace hgl::codegen
                                                  const std::vector<std::pair<std::string, HType>> &parameters, Frame &outer,
                                                  const std::vector<gir::ConditionalResultSlot> &results,
                                                  std::string_view result_schema, SourceRange range);
+            void emit_planned_callable_path(const gir::ConditionalContinuationSegment      &segment,
+                                            std::optional<gir::ConditionalContinuationPlan> following, Frame &frame, Writer &out,
+                                            SourceRange fallback);
             [[nodiscard]] Value eval_planned_reference(const gir::Reference &reference, SourceRange range, Frame &frame);
             [[nodiscard]] Value eval_planned_call(const gir::Value &expression, const gir::Call &call, Frame &frame);
             [[nodiscard]] Value eval_planned_construct(gir::TypeId type, const std::vector<gir::Argument> &arguments, bool delta,
@@ -1766,6 +1769,21 @@ namespace hgl::codegen
                 nested.planned_bindings.emplace(binding_id.value, make_port(local, type, binding.range));
             }
 
+            if (plan.returns_from_callable) {
+                gir::ConditionalContinuationSegment body;
+                if (branch.block.valid()) {
+                    const gir::Block &block = planned_block(branch.block, range);
+                    body.statements         = block.statements;
+                    body.tail               = block.tail;
+                }
+                emit_planned_callable_path(body, branch.continuation, nested, *current_body_, range);
+                current_body_->close();
+                current_body_->close(";");
+                local_counts_ = saved_counts;
+                local_names_  = saved_names;
+                return;
+            }
+
             if (!has_output) {
                 if (branch.block.valid()) { emit_planned_block(branch.block, nested, *current_body_, false, range); }
                 if (branch.continuation) {
@@ -1775,33 +1793,6 @@ namespace hgl::codegen
                         }
                         if (segment.tail.valid()) {
                             const Value value = eval_planned_expr(segment.tail, nested);
-                            current_body_->line(value.kind == Value::Kind::Void ? value.code + ";" : "(void)" + value.code + ";");
-                        }
-                    }
-                }
-                current_body_->close();
-                current_body_->close(";");
-                local_counts_ = saved_counts;
-                local_names_  = saved_names;
-                return;
-            }
-
-            const bool function_return =
-                results.size() == 1U && results.front().source == gir::ConditionalResultSource::FunctionReturn;
-            if (function_return) {
-                if (branch.block.valid()) { emit_planned_block(branch.block, nested, *current_body_, false, range); }
-                if (branch.continuation) {
-                    for (std::size_t index = 0; index < branch.continuation->segments.size(); ++index) {
-                        const gir::ConditionalContinuationSegment &segment = branch.continuation->segments[index];
-                        for (gir::StatementId statement : segment.statements) {
-                            emit_planned_statement(statement, nested, *current_body_, range);
-                        }
-                        if (!segment.tail.valid()) { continue; }
-                        const gir::Value &tail  = planned_value(segment.tail, range);
-                        const Value       value = eval_planned_expr(segment.tail, nested);
-                        if (index + 1U == branch.continuation->segments.size()) {
-                            emit_return(value, nested, *current_body_, tail.range);
-                        } else {
                             current_body_->line(value.kind == Value::Kind::Void ? value.code + ";" : "(void)" + value.code + ";");
                         }
                     }
@@ -1880,6 +1871,75 @@ namespace hgl::codegen
 
             local_counts_ = saved_counts;
             local_names_  = saved_names;
+        }
+
+        void Emitter::emit_planned_callable_path(const gir::ConditionalContinuationSegment      &segment,
+                                                 std::optional<gir::ConditionalContinuationPlan> following, Frame &frame,
+                                                 Writer &out, SourceRange fallback) {
+            const auto continuation = [&](std::size_t first_statement, gir::ValueId conditional) {
+                gir::ConditionalContinuationPlan result =
+                    following.value_or(gir::ConditionalContinuationPlan{.result = callable(frame.fn).result});
+                return gir::prepend_temporal_continuation(segment, first_statement, std::move(result), conditional);
+            };
+
+            for (std::size_t index = 0; index < segment.statements.size(); ++index) {
+                const gir::StatementId statement_id = segment.statements[index];
+                const gir::Statement  &statement    = planned_statement(statement_id, fallback);
+                if (const auto *evaluate = std::get_if<gir::Evaluate>(&statement.node)) {
+                    const gir::Value &expression = planned_value(evaluate->value, statement.range);
+                    if (const auto *branch = std::get_if<gir::Conditional>(&expression.node);
+                        branch != nullptr && expression.phase == hir::Phase::Wiring) {
+                        bool        terminal = false;
+                        const Value selected = lower_planned_conditional(evaluate->value, *branch, expression.range, frame, false,
+                                                                         continuation(index + 1U, evaluate->value), &terminal);
+                        if (terminal) {
+                            emit_return(selected, frame, out, expression.range);
+                            return;
+                        }
+                        out.line(selected.code + ";");
+                        continue;
+                    }
+                }
+
+                emit_planned_statement(statement_id, frame, out, fallback);
+                if (std::holds_alternative<gir::Return>(statement.node)) { return; }
+                if (const auto *evaluate = std::get_if<gir::Evaluate>(&statement.node);
+                    evaluate != nullptr && planned_expression_terminates(evaluate->value, statement.range)) {
+                    return;
+                }
+            }
+
+            Value result;
+            if (segment.tail.valid()) {
+                const gir::Value &tail = planned_value(segment.tail, fallback);
+                if (const auto *branch = std::get_if<gir::Conditional>(&tail.node);
+                    branch != nullptr && tail.phase == hir::Phase::Wiring) {
+                    bool terminal = false;
+                    result        = lower_planned_conditional(segment.tail, *branch, tail.range, frame,
+                                                              !following || following->segments.empty(),
+                                                              continuation(segment.statements.size(), segment.tail), &terminal);
+                    if (terminal) {
+                        emit_return(result, frame, out, tail.range);
+                        return;
+                    }
+                } else {
+                    result = eval_planned_expr(segment.tail, frame);
+                }
+            }
+
+            if (!following) { return; }
+            if (following->segments.empty()) {
+                emit_return(result, frame, out, segment.tail.valid() ? planned_value(segment.tail, fallback).range : fallback);
+                return;
+            }
+
+            if (segment.tail.valid()) {
+                out.line(result.kind == Value::Kind::Void ? result.code + ";" : "(void)" + result.code + ";");
+            }
+            gir::ConditionalContinuationPlan    remaining = std::move(*following);
+            gir::ConditionalContinuationSegment next      = std::move(remaining.segments.front());
+            remaining.segments.erase(remaining.segments.begin());
+            emit_planned_callable_path(next, std::move(remaining), frame, out, fallback);
         }
 
         Value Emitter::lower_planned_conditional(gir::ValueId id, const gir::Conditional &, SourceRange range, Frame &frame,

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -3013,7 +3013,16 @@ namespace hgl::codegen
             if (block.tail.valid()) {
                 const gir::Value &tail = planned_value(block.tail, block.range);
                 if (function_body) {
-                    const Value value = eval_planned_expr(block.tail, frame);
+                    Value value;
+                    if (const auto *branch = std::get_if<gir::Conditional>(&tail.node);
+                        branch != nullptr && tail.phase == hir::Phase::Wiring) {
+                        gir::ConditionalContinuationPlan continuation = gir::plan_temporal_continuation(
+                            graph_, id, block.statements.size(), callable(frame.fn).result, block.tail);
+                        value = lower_planned_conditional(block.tail, *branch, tail.range, frame, true,
+                                                          std::move(continuation));
+                    } else {
+                        value = eval_planned_expr(block.tail, frame);
+                    }
                     emit_return(value, frame, out, tail.range);
                 } else if (const auto *branch = std::get_if<gir::Conditional>(&tail.node)) {
                     if (tail.phase != hir::Phase::Wiring) {

--- a/language/src/hgraph_ir/control_flow.cpp
+++ b/language/src/hgraph_ir/control_flow.cpp
@@ -1,7 +1,6 @@
 #include "hgraph_ir/control_flow.h"
 
 #include <algorithm>
-#include <iterator>
 #include <span>
 #include <type_traits>
 #include <utility>
@@ -336,9 +335,20 @@ namespace hgl::hgraph_ir
         ConditionalContinuationPlan prefix =
             plan_temporal_continuation(module, enclosing, first_statement, following.result, conditional);
         if (prefix.segments.empty()) { return following; }
-        prefix.segments.insert(prefix.segments.end(), std::make_move_iterator(following.segments.begin()),
-                               std::make_move_iterator(following.segments.end()));
-        return prefix;
+        return prepend_temporal_continuation(prefix.segments.front(), 0U, std::move(following), conditional);
+    }
+
+    ConditionalContinuationPlan prepend_temporal_continuation(const ConditionalContinuationSegment &enclosing,
+                                                              std::size_t first_statement, ConditionalContinuationPlan following,
+                                                              ValueId conditional) {
+        const auto                     first = std::min(first_statement, enclosing.statements.size());
+        ConditionalContinuationSegment segment;
+        segment.statements.assign(enclosing.statements.begin() + static_cast<std::ptrdiff_t>(first), enclosing.statements.end());
+        if (enclosing.tail != conditional) { segment.tail = enclosing.tail; }
+        if (!segment.statements.empty() || segment.tail.valid()) {
+            following.segments.insert(following.segments.begin(), std::move(segment));
+        }
+        return following;
     }
 
     ConditionalPlan analyze_temporal_conditional(const Module &module, ValueId value_id,

--- a/language/src/hgraph_ir/control_flow.h
+++ b/language/src/hgraph_ir/control_flow.h
@@ -90,6 +90,15 @@ namespace hgl::hgraph_ir
                                                                             ConditionalContinuationPlan following,
                                                                             ValueId                     conditional = {});
 
+    /// Prepend a suffix of an already materialized segment. Execution
+    /// backends use this while walking a continuation so another nested
+    /// temporal conditional can split the path without reconstructing syntax
+    /// or flattening its remaining enclosing segments.
+    [[nodiscard]] ConditionalContinuationPlan prepend_temporal_continuation(const ConditionalContinuationSegment &enclosing,
+                                                                            std::size_t                           first_statement,
+                                                                            ConditionalContinuationPlan           following,
+                                                                            ValueId                               conditional = {});
+
     /// Analyze an HGraph-IR Conditional value. The input module is already
     /// structurally valid; a non-conditional value or non-block else arm is
     /// represented as an incomplete plan for the backends to diagnose against

--- a/language/src/wiring/backend.cpp
+++ b/language/src/wiring/backend.cpp
@@ -381,7 +381,11 @@ namespace hgl::wiring
                                              Frame &frame);
             [[nodiscard]] Slot wire_function(gir::CallableId id, Frame &frame, SourceRange range);
             [[nodiscard]] Slot invoke(gir::CallableId id, Frame &frame);
-            [[nodiscard]] Slot exec_block(gir::BlockId id, Frame &frame);
+            [[nodiscard]] Slot exec_block(gir::BlockId id, Frame &frame,
+                                          std::optional<gir::ConditionalContinuationPlan> following     = std::nullopt,
+                                          bool                                            callable_path = false);
+            [[nodiscard]] Slot exec_path(const gir::ConditionalContinuationSegment &segment, Frame &frame,
+                                         std::optional<gir::ConditionalContinuationPlan> following, bool callable_path);
             void               exec_statement(gir::StatementId id, Frame &frame);
             void               exec_traversal(const gir::Traversal &traversal, SourceRange range, Frame &frame);
             [[nodiscard]] std::vector<std::optional<gir::ValueId>>
@@ -403,6 +407,7 @@ namespace hgl::wiring
                 const hgraph::TSValueTypeMetaData               *result_schema{nullptr};
                 SourceRange                                      range{};
                 std::string                                      label{};
+                bool                                             returns_from_callable{false};
             };
 
             struct TraversalContext
@@ -1354,8 +1359,9 @@ namespace hgl::wiring
             context->compiler = this;
             context->frame    = frame;
             context->frame.returned.reset();
-            context->block        = branch.block;
-            context->continuation = branch.continuation;
+            context->block                 = branch.block;
+            context->continuation          = branch.continuation;
+            context->returns_from_callable = plan.returns_from_callable;
             context->parameters.reserve(plan.captures.size());
             context->parameter_names.reserve(plan.captures.size());
             context->parameter_schemas.reserve(plan.captures.size());
@@ -1411,17 +1417,18 @@ namespace hgl::wiring
                 argument.schema                                 = expected;
                 frame.bindings[context.parameters[index].value] = make_port(std::move(argument), context.range);
             }
-            Slot expression_result = context.block.valid() ? compiler.exec_block(context.block, frame) : Slot{};
+            Slot expression_result = context.block.valid() ? compiler.exec_block(context.block, frame, context.continuation,
+                                                                                 context.returns_from_callable)
+                                                           : Slot{};
             if (!frame.returned && context.continuation) {
-                for (const gir::ConditionalContinuationSegment &segment : context.continuation->segments) {
-                    for (gir::StatementId statement : segment.statements) {
-                        compiler.exec_statement(statement, frame);
-                        if (frame.returned) { break; }
-                    }
-                    if (frame.returned) { break; }
-                    if (segment.tail.valid()) { expression_result = compiler.eval_value(segment.tail, frame); }
+                if (context.continuation->segments.empty()) {
+                    frame.returned = expression_result;
+                } else {
+                    gir::ConditionalContinuationPlan          remaining = *context.continuation;
+                    const gir::ConditionalContinuationSegment first     = remaining.segments.front();
+                    remaining.segments.erase(remaining.segments.begin());
+                    expression_result = compiler.exec_path(first, frame, std::move(remaining), true);
                 }
-                if (!frame.returned) { frame.returned = expression_result; }
             }
             if (frame.returned) { expression_result = *frame.returned; }
             if (context.result_schema == nullptr) { return {}; }
@@ -1792,15 +1799,28 @@ namespace hgl::wiring
                 expression.node);
         }
 
-        Slot Compiler::exec_block(gir::BlockId id, Frame &frame) {
+        Slot Compiler::exec_block(gir::BlockId id, Frame &frame, std::optional<gir::ConditionalContinuationPlan> following,
+                                  bool callable_path) {
             if (!id.valid() || id.value >= module_.blocks.size()) { backend({}, "invalid hgraph IR block ID"); }
-            const gir::Block &block         = module_.blocks[id.value];
-            const bool        callable_root = frame.callable.valid() && frame.callable.value < module_.callables.size() &&
-                                              module_.callables[frame.callable.value].block_body == id;
-            for (std::size_t index = 0; index < block.statements.size(); ++index) {
+            const gir::Block &block = module_.blocks[id.value];
+            callable_path           = callable_path || (frame.callable.valid() && frame.callable.value < module_.callables.size() &&
+                                                        module_.callables[frame.callable.value].block_body == id);
+            return exec_path(gir::ConditionalContinuationSegment{.statements = block.statements, .tail = block.tail}, frame,
+                             std::move(following), callable_path);
+        }
+
+        Slot Compiler::exec_path(const gir::ConditionalContinuationSegment &segment, Frame &frame,
+                                 std::optional<gir::ConditionalContinuationPlan> following, bool callable_path) {
+            const auto callable_result = [&] {
+                if (!frame.callable.valid() || frame.callable.value >= module_.callables.size()) {
+                    backend({}, "a callable continuation has no enclosing callable");
+                }
+                return module_.callables[frame.callable.value].result;
+            };
+            for (std::size_t index = 0; index < segment.statements.size(); ++index) {
                 if (frame.returned) { break; }
-                const gir::StatementId statement_id = block.statements[index];
-                if (callable_root) {
+                const gir::StatementId statement_id = segment.statements[index];
+                if (callable_path) {
                     const gir::Statement &statement = module_.statements.at(statement_id.value);
                     if (const auto *evaluate = std::get_if<gir::Evaluate>(&statement.node)) {
                         const gir::Value &expression = value(evaluate->value);
@@ -1808,8 +1828,10 @@ namespace hgl::wiring
                             branch != nullptr && expression.phase == hir::Phase::Wiring) {
                             Slot condition = eval_value(branch->condition, frame);
                             if (condition.is_port()) {
-                                const gir::ConditionalContinuationPlan continuation = gir::plan_temporal_continuation(
-                                    module_, id, index + 1U, module_.callables[frame.callable.value].result, evaluate->value);
+                                gir::ConditionalContinuationPlan continuation =
+                                    following.value_or(gir::ConditionalContinuationPlan{.result = callable_result()});
+                                continuation  = gir::prepend_temporal_continuation(segment, index + 1U, std::move(continuation),
+                                                                                   evaluate->value);
                                 bool terminal = false;
                                 Slot selected = eval_temporal_conditional(evaluate->value, condition, expression.range, frame,
                                                                           false, continuation, &terminal);
@@ -1824,7 +1846,40 @@ namespace hgl::wiring
                 }
                 exec_statement(statement_id, frame);
             }
-            return !frame.returned && block.tail.valid() ? eval_value(block.tail, frame) : Slot{};
+            Slot result;
+            if (!frame.returned && segment.tail.valid()) {
+                const gir::Value &tail = value(segment.tail);
+                if (callable_path) {
+                    if (const auto *branch = std::get_if<gir::Conditional>(&tail.node);
+                        branch != nullptr && tail.phase == hir::Phase::Wiring) {
+                        Slot condition = eval_value(branch->condition, frame);
+                        if (condition.is_port()) {
+                            gir::ConditionalContinuationPlan continuation =
+                                following.value_or(gir::ConditionalContinuationPlan{.result = callable_result()});
+                            bool terminal = false;
+                            result        = eval_temporal_conditional(segment.tail, condition, tail.range, frame, true,
+                                                                      std::move(continuation), &terminal);
+                            if (terminal) { frame.returned = result; }
+                        } else {
+                            result = eval_value(segment.tail, frame);
+                        }
+                    } else {
+                        result = eval_value(segment.tail, frame);
+                    }
+                } else {
+                    result = eval_value(segment.tail, frame);
+                }
+            }
+            if (frame.returned || !following) { return frame.returned ? *frame.returned : result; }
+            if (following->segments.empty()) {
+                frame.returned = result;
+                return result;
+            }
+
+            gir::ConditionalContinuationPlan    remaining = std::move(*following);
+            gir::ConditionalContinuationSegment next      = std::move(remaining.segments.front());
+            remaining.segments.erase(remaining.segments.begin());
+            return exec_path(next, frame, std::move(remaining), true);
         }
 
         void Compiler::exec_statement(gir::StatementId id, Frame &frame) {

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -738,6 +738,33 @@ export fn choose(condition: bool, x: i64, y: i64) -> i64 {
     CHECK(contains(emitted->source, "result = hgraph::wire<hgraph::stdlib::sub_>"));
 }
 
+TEST_CASE("emit-cpp nests temporal continuation helpers inside their selected paths",
+          "[codegen][control-flow][conditional][continuation]") {
+    Unit unit{R"(
+module planned_nested_temporal_return
+
+export fn choose(outer: bool, inner: bool, x: i64, y: i64, z: i64) -> i64 {
+    if outer {
+        if !inner {
+            return x + 1
+        }
+        return y + 2
+    }
+    return z + 3
+}
+)"};
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+
+    const auto emitted = unit.emit();
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE(emitted);
+    CHECK(contains(emitted->source, "struct hgl_choose_if_1_then"));
+    CHECK(contains(emitted->source, "struct hgl_choose_if_2_then"));
+    CHECK(occurrences(emitted->source, "hgraph::stdlib::switch_cases(") == 2U);
+    CHECK(occurrences(emitted->source, "hgraph::wire<hgraph::stdlib::not_>") == 1U);
+}
+
 TEST_CASE("emit-cpp rejects temporal else-if before dropping a branch", "[codegen][control-flow][conditional]") {
     Unit unit{R"(
 module planned_temporal_else_if

--- a/language/tests/codegen/emitter_tests.cpp
+++ b/language/tests/codegen/emitter_tests.cpp
@@ -765,6 +765,30 @@ export fn choose(outer: bool, inner: bool, x: i64, y: i64, z: i64) -> i64 {
     CHECK(occurrences(emitted->source, "hgraph::wire<hgraph::stdlib::not_>") == 1U);
 }
 
+TEST_CASE("emit-cpp plans a returning temporal conditional at the callable block tail",
+          "[codegen][control-flow][conditional][continuation]") {
+    Unit unit{R"(
+module planned_temporal_returning_tail
+
+export fn choose(condition: bool, x: i64, y: i64) -> i64 {
+    if condition {
+        return x + 1
+    } else {
+        y - 1
+    }
+}
+)"};
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+
+    const auto emitted = unit.emit();
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE(emitted);
+    CHECK(contains(emitted->source, "struct hgl_choose_if_1_then"));
+    CHECK(contains(emitted->source, "struct hgl_choose_if_1_else"));
+    CHECK(contains(emitted->source, "hgraph::stdlib::switch_cases("));
+}
+
 TEST_CASE("emit-cpp rejects temporal else-if before dropping a branch", "[codegen][control-flow][conditional]") {
     Unit unit{R"(
 module planned_temporal_else_if

--- a/language/tests/codegen/generated_tests.cpp
+++ b/language/tests/codegen/generated_tests.cpp
@@ -69,6 +69,8 @@ TEST_CASE("generated temporal early returns place the continuation in the fallin
           values<Int>(2, 3, 58));
     CHECK(eval_node<conditional_early::choose_tail>(values<Bool>(true, false), values<Int>(1, 2), values<Int>(10, 20)) ==
           values<Int>(2, 38));
+    CHECK(eval_node<conditional_early::choose_returning_tail>(values<Bool>(true, false), values<Int>(1, 2),
+                                                              values<Int>(10, 20)) == values<Int>(2, 19));
     CHECK(eval_node<conditional_early::choose_assigned>(values<Bool>(true, false), values<Int>(1, 2), values<Int>(10, 20)) ==
           values<Int>(2, 38));
 }

--- a/language/tests/codegen/generated_tests.cpp
+++ b/language/tests/codegen/generated_tests.cpp
@@ -73,6 +73,18 @@ TEST_CASE("generated temporal early returns place the continuation in the fallin
           values<Int>(2, 38));
 }
 
+TEST_CASE("generated nested temporal early returns retain every enclosing continuation",
+          "[codegen][generated][conditional][continuation]") {
+    session();
+    CHECK(eval_node<conditional_early::choose_nested>(values<Bool>(true, true, false), values<Bool>(true, false, false),
+                                                      values<Int>(1, 2, 3), values<Int>(10, 20, 30),
+                                                      values<Int>(100, 200, 300)) == values<Int>(2, 38, 900));
+    CHECK(eval_node<conditional_early::choose_deep>(values<Bool>(true, false, false, false), values<Bool>(false, false, true, true),
+                                                    values<Bool>(false, false, true, false), values<Int>(1, 2, 3, 4),
+                                                    values<Int>(10, 20, 30, 40), values<Int>(100, 200, 300, 400),
+                                                    values<Int>(1000, 2000, 3000, 4000)) == values<Int>(1, 2000, 30, 400));
+}
+
 TEST_CASE("generated outputless temporal early returns retain the falling continuation",
           "[codegen][generated][conditional][continuation]") {
     session();
@@ -80,6 +92,7 @@ TEST_CASE("generated outputless temporal early returns retain the falling contin
     auto   enabled = wire<stdlib::const_, TS<Bool>>(w, Bool{true});
     auto   value   = wire<stdlib::const_, TS<Float>>(w, Float{2.0});
     conditional_early::observe::compose(w, enabled, value);
+    conditional_early::observe_nested::compose(w, enabled, enabled, value);
     CHECK_NOTHROW(std::move(w).finish());
 }
 

--- a/language/tests/wiring/backend_tests.cpp
+++ b/language/tests/wiring/backend_tests.cpp
@@ -448,6 +448,68 @@ test choose_ticks {
     CHECK(result.passed);
 }
 
+TEST_CASE("nested temporal early returns retain every enclosing continuation",
+          "[wiring][control-flow][conditional][continuation]") {
+    Unit                          unit{R"(
+module t
+
+fn choose(outer: bool, inner: bool, x: i64, y: i64, z: i64) -> i64 {
+    if outer {
+        if inner {
+            return x + 1
+        }
+        let r = y - 1
+        return r * 2
+    }
+    return z * 3
+}
+
+fn choose_deep(outer: bool, middle: bool, inner: bool, x: i64, y: i64, z: i64, fallback: i64) -> i64 {
+    if outer {
+        return x
+    }
+    if middle {
+        if inner {
+            return y
+        }
+        return z
+    }
+    return fallback
+}
+
+test choose_ticks {
+    assert eval(
+        choose,
+        outer: [true, true, false],
+        inner: [true, false, false],
+        x: [1, 2, 3],
+        y: [10, 20, 30],
+        z: [100, 200, 300],
+    ) == [2, 38, 900]
+}
+
+test choose_deep_ticks {
+    assert eval(
+        choose_deep,
+        outer: [true, false, false, false],
+        middle: [false, false, true, true],
+        inner: [false, false, true, false],
+        x: [1, 2, 3, 4],
+        y: [10, 20, 30, 40],
+        z: [100, 200, 300, 400],
+        fallback: [1000, 2000, 3000, 4000],
+    ) == [1, 2000, 30, 400]
+}
+)"};
+    const std::vector<TestResult> results = unit.tests();
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE(results.size() == 2U);
+    for (const TestResult &result : results) {
+        INFO(result.message);
+        CHECK(result.passed);
+    }
+}
+
 TEST_CASE("an outputless temporal if wires a sink switch", "[wiring][control-flow][conditional]") {
     Unit             unit{R"(
 module t


### PR DESCRIPTION
## Summary

- execute ordered temporal continuation paths recursively in direct wiring and generated C++
- retain enclosing suffixes when another temporal conditional splits an attached continuation
- support value and outputless nested early returns without evaluating nested selectors twice
- extend the executable example and backend parity coverage through three nesting levels
- update implementation status without claiming embedded expression forms or else-if

## Validation

- fresh complete native suite: 1773/1773 passed
- Python 3.12 ABI3 wheel installed and tested with Python 3.14: 3248 passed, 10 skipped, 1 xfailed
- all 50 HGL CTest entries passed
- generated nested source compiled and was inspected after mandatory clang-format

Stacked on #751.