### PR TITLE
Document HGL migration readiness

### DIFF
--- a/language/docs/design/language-model.md
+++ b/language/docs/design/language-model.md
@@ -395,11 +395,16 @@ installed in the environment do not participate.
 
 ## Compiled module lifetime
 
-Every compiled HGL module exposes compiler-generated initialization and
-deinitialization entry points. Initialization records a keyed installer for all
-type and operator contributions; the installer can be replayed after an hgraph
-registry reset without repeating one-time module initialization. The final
-application explicitly initializes the complete target closure before wiring.
+The target module model gives every compiled HGL module compiler-generated
+initialization and deinitialization entry points. The current implementation
+provides that versioned lifecycle ABI for dynamically loaded scripted modules;
+AOT output currently provides its descriptor and explicit
+`register_operators()` entry point while the linked application owns its
+lifetime. Completing the AOT lifecycle bootstrap remains compiler work.
+Initialization records a keyed installer for all type and operator
+contributions; the installer can be replayed after an hgraph registry reset
+without repeating one-time module initialization. The final application
+explicitly initializes the complete target closure before wiring.
 
 The module manager retains an opaque registration handle. Removing that handle
 deactivates the provider for future resolution, removes its installer intent so

--- a/language/docs/design/modules.md
+++ b/language/docs/design/modules.md
@@ -225,10 +225,15 @@ deterministic teardown is needed for orderly process shutdown and for unit
 tests that install and remove modules within one process. Running scripts in a
 child process does not cover any of those.
 
-Compilation emits a module descriptor and the version-one, C-compatible
-lifecycle ABI specified by `hgl/native_module_abi.h`. Its fixed query function
-returns a module-owned context and `init`, `deinit`, and `is_active` callbacks.
-The lifecycle has three separate responsibilities:
+Scripted native-module compilation emits a module descriptor and the
+version-one, C-compatible lifecycle ABI specified by
+`hgl/native_module_abi.h`. Its fixed query function returns a module-owned
+context and `init`, `deinit`, and `is_active` callbacks. The AOT
+`hgl emit-cpp` / `hgl_add_module()` path currently emits the descriptor and an
+explicit `register_operators()` entry point, but not this dynamic lifecycle
+query ABI; the linked application owns that registration lifetime. Extending
+the same generated lifecycle boundary to AOT packages remains compiler work.
+The scripted lifecycle has three separate responsibilities:
 
 1. `init` attaches one module instance to an application and records its keyed
    registry installer;
@@ -237,10 +242,10 @@ The lifecycle has three separate responsibilities:
 3. `deinit` removes the module's active contributions and installer intent,
    releases owned resources, and permits later unloading when safe.
 
-`init` and `deinit` are compiler-generated for HGL modules, not source-level
-blocks. A native extension may provide reviewed resource hooks through the same
-ABI. Registry installation remains replayable after reset and must not repeat
-unrelated one-time initialization side effects.
+`init` and `deinit` are compiler-generated for scripted HGL modules, not
+source-level blocks. A native extension may provide reviewed resource hooks
+through the same ABI. Registry installation remains replayable after reset and
+must not repeat unrelated one-time initialization side effects.
 
 Initialization is transactional and idempotent. A failed initialization rolls
 back its pending contribution; repeated initialization of the same module

--- a/language/docs/design/modules.md
+++ b/language/docs/design/modules.md
@@ -1,6 +1,6 @@
 # Modules and native extensions
 
-Status: accepted module boundary; descriptor format remains open
+Status: accepted module boundary; canonical versioned JSON descriptor implemented
 
 ## Boundary
 
@@ -41,16 +41,16 @@ and `==` to public hgraph operator contracts. This is a syntax binding into the
 same registry, not a compiler-owned implementation.
 
 The descriptor contains declarations and build metadata, not executable user
-code. The exact serialization format remains open. A checked-in textual
-interface plus a small manifest is preferred for the first implementation
-because it is reviewable and available before native code is loaded.
+code. Its serialization is canonical, versioned JSON with descriptor-local
+type, constant-expression, and constraint arenas. It is reviewable and can be
+validated before native code is loaded; see
+[ADR 0004](decisions/0004-json-module-descriptors.md).
 
-One descriptor question must be resolved before imported operator checking:
-some native candidates have scalar-dependent `requires` predicates. The
-descriptor must either express those constraints declaratively for hgraph's
-shared resolver or identify a controlled resolver helper that evaluates them
-outside the compiler process. `hgl check` must not approximate or silently omit
-such a predicate.
+Scalar-dependent `requires` predicates are serialized as declarative constraint
+records rather than hidden callbacks. Imported operator checking must pass
+those records to hgraph's shared resolver without approximation. Complete
+imported operator-contract conformance remains compiler work; arbitrary resolver
+helpers running outside the compiler process are not an escape hatch.
 
 ## Public declaration surface
 
@@ -225,8 +225,10 @@ deterministic teardown is needed for orderly process shutdown and for unit
 tests that install and remove modules within one process. Running scripts in a
 child process does not cover any of those.
 
-Compilation emits a module descriptor and explicit lifecycle ABI. The exact C
-or C++ ABI remains to be specified, but it has three separate responsibilities:
+Compilation emits a module descriptor and the version-one, C-compatible
+lifecycle ABI specified by `hgl/native_module_abi.h`. Its fixed query function
+returns a module-owned context and `init`, `deinit`, and `is_active` callbacks.
+The lifecycle has three separate responsibilities:
 
 1. `init` attaches one module instance to an application and records its keyed
    registry installer;

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -261,6 +261,9 @@ remain rejected.
 
 ### G. Standard-library migration
 
+Status: ready to begin inventory; no core implementation has been selected or
+migrated yet.
+
 - generate the complete core graph/node inventory and classify each item;
 - select representative composition, stateless scalar-node, stateful-node,
   collection, and native-kernel migrations;
@@ -271,6 +274,31 @@ remain rejected.
 
 Acceptance is behavioral parity, generated-code inspection, installed-SDK
 coverage, and performance evidence against the implementation removed.
+
+## Migration entry checkpoint (2026-09-06)
+
+The compiler has crossed the gate for starting Stage G. This means the complete
+core inventory can be generated and the first pure-composition candidates can
+be selected. It does not mean the compiler is feature-complete or that every
+core implementation is currently expressible.
+
+| Surface | Migration readiness |
+| --- | --- |
+| Modules, functions, operators, visibility, and descriptors | Implemented through syntax, typed HIR, HGraph IR, both backends, canonical JSON descriptors, and generated registration. |
+| Canonical types, rolling windows, structs, generics, and sparse deltas | Ready for examples using explicit supported types and substitutions; constructor inference, typed `const` generic native metadata, optional clearing, and multiple-parent ordering remain out. |
+| Composition control flow | Scalar `if`, direct temporal conditionals with results or sinks, escaping and forwarded bindings, omitted `else`, nested direct early-return continuations, and independent fixed or dynamic collection bodies are implemented in both backends. |
+| Runtime nodes | Activation and validity, scalar recordable state, `out` and `logger`, lifecycle over state and `const` values, and current collection views support representative stateless and scalar-state candidates. |
+| Native interface | Exact canonical-scalar AOT calls and lifecycle descriptors are ready; normalized wrapper generation, owned opaque state, and portable scripted external dependency loading remain out. |
+| References, signals, enums, and explicit switch | The documented reference subset is limited; SIGNAL spelling, enum lowering, and explicit switch lowering are not migration-ready. |
+
+The inventory therefore comes next. Its first candidate set should prefer pure
+composition and may identify representative stateless scalar nodes after their
+actual requirements are recorded. Compiler work after that point is driven by
+a selected migration and one already-defined semantic contract. Wiring-time
+reference access, collection-reference propagation, SIGNAL spelling, enum and
+switch lowering, multiple-parent field order, optional clearing, opaque state,
+and other open contracts remain fail-closed until their design or owning hgraph
+API is agreed.
 
 ## Prototype checkpoint (2026-09-06)
 
@@ -324,10 +352,11 @@ optional Python module.
 On Unix, file-based `hgl test` and `hgl run` also compile a unit containing
 runtime functions or implementations to a content-addressed image and load its
 candidates into the command process before wiring.
-Generated runtime sources and calls, compound constant literals, `if` as a
-value, and runtime constructs outside the supported selector/output forms fail
-closed with a diagnostic that names the construct. The REPL edits lines with
-history and completion on a terminal.
+Generated runtime sources and calls, compound constant literals, runtime-node
+`if` used as a value, temporal conditionals embedded inside another expression,
+and runtime constructs outside the supported selector/output forms fail closed
+with a diagnostic that names the construct. The REPL edits lines with history
+and completion on a terminal.
 
 Development proceeds through executable vertical slices. Parser-only progress
 is not a usable milestone: each language slice must reach hgraph wiring,

--- a/language/docs/developer-guide/README.md
+++ b/language/docs/developer-guide/README.md
@@ -29,19 +29,26 @@ for hgraph, not a second runtime.
 > planning is available.
 > `src/wiring/` executes the composition subset for `test`, `run`, and the
 > REPL, including scalar and atomic struct values, type-only generic
-> specializations, and field-wise temporal struct composition. `src/codegen/`
-> emits every checked-in example as public hgraph C++, including nominal and
-> generic structs, generic operators and windows, sparse deltas, runtime
-> collection traversal, activation, aggregate scalar recordable state, output,
-> logger injection, and lifecycle hooks over state and `const` configuration.
-> The driver compiles and caches/loads that subset for file-based `test`, `run`, and REPL sessions on
-> Unix. REPL replacement stages the new image, swaps removable provider handles
-> at a quiescent boundary, and restores the old revision if activation fails.
-> Imported operator-contract conformance, arbitrary residual `const` predicates, `const`
-> generic native metadata, multiple-parent linearization, explicit optional-field
-> clearing, wiring-time dereference through `ref<T>`, imported native types,
-> multi-registry module transactions, and the remaining runtime and
-> generated-C++ type support remain to be implemented.
+> specializations, field-wise temporal struct composition, and direct temporal
+> conditionals with ordered top-level and nested early-return continuations.
+> `src/codegen/` emits every checked-in example as public hgraph C++, including
+> nominal and generic structs, generic operators and windows, sparse deltas,
+> runtime collection traversal, activation, aggregate scalar recordable state,
+> output, logger injection, and lifecycle hooks over state and `const`
+> configuration. The driver compiles and caches/loads that subset for file-based
+> `test`, `run`, and REPL sessions on Unix. REPL replacement stages the new
+> image, swaps removable provider handles at a quiescent boundary, and restores
+> the old revision if activation fails. Imported operator-contract conformance,
+> arbitrary residual `const` predicates, `const` generic native metadata,
+> multiple-parent linearization, explicit optional-field clearing, wiring-time
+> dereference through `ref<T>`, imported native types, multi-registry module
+> transactions, and the remaining runtime and generated-C++ type support remain
+> to be implemented.
+>
+> This is sufficient to begin the standard-library inventory and select the
+> first pure-composition migrations. It is not a claim that all core graphs and
+> nodes can be migrated: each selected item must stay blocked rather than cause
+> the compiler to invent an unresolved source or native contract.
 
 ## Guide map
 

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -1142,9 +1142,10 @@ provider and directly references its initialization entry point, preventing
 static-library dead stripping. A candidate-universe fingerprint must agree with
 the registrations installed before graph wiring.
 
-Scalar-dependent native candidate constraints need either a declarative form
-interpreted by hgraph's shared resolver or an isolated resolver helper. The
-compiler must not approximate them.
+Scalar-dependent native candidate constraints use the descriptor's declarative
+constraint records. Complete imported operator checking must pass those records
+to hgraph's shared resolver; the compiler must not approximate them or invoke an
+uncontrolled resolver callback.
 
 ## Generated module lifecycle and ownership
 
@@ -1342,8 +1343,11 @@ walk:
   unchanged receives a `REF`-qualified input; generated branches adapt it to
   the result slot's declared schema before returning it. A consumed conditional
   without `else` materializes a type-resolved native `nothing` source as its
-  false result. Scalar captures and branch returns fail closed for later
-  slices;
+  false result. An early return moves the remaining lexical body into ordered
+  continuation segments; top-level and nested direct conditional statements
+  and block tails are supported in both backends. Scalar captures, temporal
+  `else if`, and temporal conditionals embedded inside another expression fail
+  closed for later slices;
 - a block body runs its statements in order: `let` and `var` bind locals
   (a declared type converts a constant or checks a port's schema), `=` and
   the compound assignments rebind a `var`, `return` ends the activation,
@@ -1562,7 +1566,8 @@ implemented scalar, nominal-struct, map, and reference forms, injectables other 
 `out` and `logger`, lifecycle access to temporal inputs or output, optional
 field clearing in a sparse delta, generic constructor inference and typed
 `const` generic struct metadata, tuple and list literals and other compound
-constants, `if` or a block used as a value, zoned and civil temporal literals,
+constants, runtime-node `if` or a block used as a value, temporal conditionals
+embedded inside another expression, zoned and civil temporal literals,
 an `impl fn` of an imported operator, wiring-time access through a reference,
 unresolved collection-reference mappings, and a missing module declaration.
 Each is a diagnostic naming the construct.

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -1718,8 +1718,10 @@ they never reinterpret an ordinary function as a candidate.
 ## Generated module lifecycle
 
 There is no source grammar for top-level `init`, `deinit`, or disposal blocks.
-The module compiler synthesizes lifecycle entry points and a registration handle
-from the module's exports, operator candidates, types, and dependencies.
+The scripted module compiler synthesizes lifecycle entry points and a
+registration handle from the module's exports, operator candidates, types, and
+dependencies. AOT output currently emits an explicit registration function but
+does not yet synthesize the dynamic query ABI or application bootstrap.
 
 Initialization attaches the module once and records a replayable installer for
 the current and later hgraph registry generations. Deinitialization removes the

--- a/language/docs/user-guide/functions.md
+++ b/language/docs/user-guide/functions.md
@@ -383,9 +383,12 @@ explicit branches, or several such variables through a compiler-generated
 structural result. A used expression result can share that structural result
 with escaping assignments. An initialized result may be forwarded by a branch
 that does not assign it. A consumed temporal conditional without `else` uses a
-typed never-ticking false branch. The current slice rejects scalar branch
-captures, temporal `else if`, and early branch returns. The existing syntax
-needs no new keyword.
+typed never-ticking false branch. Early returns work for top-level and nested
+temporal conditionals when the conditional is a direct statement or block tail;
+the compiler represents the remaining body as ordered lexical continuation
+segments. The current slice still rejects scalar branch captures, temporal
+`else if`, and temporal conditionals embedded inside arbitrary expressions. The
+existing syntax needs no new keyword.
 
 `if` has three context-dependent meanings:
 

--- a/language/docs/user-guide/modules-and-tools.md
+++ b/language/docs/user-guide/modules-and-tools.md
@@ -404,9 +404,9 @@ It still reports, by name, and writes nothing for generated runtime sources,
 calls to other HGL runtime functions, non-scalar state, native opaque state,
 injectables other than `out` and `logger`, lifecycle access to temporal inputs
 or output, optional-field clearing in a sparse delta, generic constructor
-inference and typed `const` generic
-struct metadata, compound constant literals, `if` used as a value, and zoned or
-civil literals.
+inference and typed `const` generic struct metadata, compound constant literals,
+runtime-node `if` used as a value, temporal conditionals embedded inside another
+expression, and zoned or civil literals.
 
 ## One execution model
 

--- a/language/docs/user-guide/modules-and-tools.md
+++ b/language/docs/user-guide/modules-and-tools.md
@@ -138,11 +138,11 @@ arbitrary symbols in a library.
 
 ## Compiled module lifecycle
 
-Each compiled module has compiler-generated lifecycle entry points. Module
-initialization attaches the library to the application and records a keyed
-installer containing its type and operator registrations. Registry installation
-may run again after an hgraph registry reset without repeating unrelated module
-initialization effects.
+Each dynamically loaded scripted module has compiler-generated lifecycle entry
+points. Module initialization attaches the library to the application and
+records a keyed installer containing its type and operator registrations.
+Registry installation may run again after an hgraph registry reset without
+repeating unrelated module initialization effects.
 
 The generated application initializes every module in dependency order before
 wiring a graph. Deinitialization proceeds in reverse dependency order and
@@ -164,6 +164,11 @@ callbacks plus identity and fingerprint metadata. Native C++ extensions may
 attach resource hooks behind that opaque module context, but language source
 cannot perform arbitrary module-load side effects. Logical deactivation does
 not imply that the library image is unloaded.
+
+The AOT `hgl emit-cpp` / `hgl_add_module()` path currently emits a descriptor
+and an explicit `register_operators()` function, not the dynamic lifecycle query
+ABI. Its linked application therefore owns registration lifetime until AOT
+lifecycle bootstrap generation is implemented.
 
 ## Native adaptors stay native
 


### PR DESCRIPTION
## Summary

- reconcile the language documentation with canonical JSON descriptors, declarative constraints, the lifecycle ABI, and implemented nested temporal continuations
- record the exact compiler surface ready for the standard-library inventory
- separate implemented migration capabilities from deferred compiler work and unresolved language or hgraph contracts

## Validation

- git diff --check
- verified relative Markdown links in every edited document
- all 50 HGL CTest cases passed
- full native suite: 1773 passed
- ABI3 wheel installed into Python 3.14: 3248 passed, 10 skipped, 1 xfailed
