### PR TITLE
docs(language): specify enum values and switch checks

### DIFF
--- a/language/docs/README.md
+++ b/language/docs/README.md
@@ -51,8 +51,8 @@ out so examples do not imply an implemented compatibility promise.
    imported types, `ref<T>`, reference-transparent type compatibility, opaque
    node access, wiring-time dereferencing, input-only SIGNAL observation,
    enum declaration/member syntax, explicit and automatic numbering,
-   member-name stringification through `str(value)`, and duplicate-number
-   rejection.
+   member-name stringification through `str(value)`, checked construction
+   through `Mode(...)`, and duplicate-number rejection.
 11. [Conditional control flow](design/control-flow.md) — wiring-time selection,
    switch-style temporal conditions in graph functions, and node conditionals.
 12. [Explicit switch dispatch](design/switch.md) — node-style C++ dispatch,

--- a/language/docs/design/iteration.md
+++ b/language/docs/design/iteration.md
@@ -30,6 +30,14 @@ runtime payloads available during wiring or make runtime-only borrowed views
 persist across evaluations. It also does not supply an iteration protocol for
 every imported atomic type; native operations remain a separate topic.
 
+The agreed enum-type forms `keys(Mode)`, `values(Mode)`, and `elements(Mode)`
+produce immutable fixed-size scalar lists of known constants. A graph loop
+over such a list visits scalar values during wiring, not temporal child
+connections. The list can also be bound, indexed, and reused; unlike a runtime
+collection iterator, it has no evaluation-local borrowed lifetime. This is
+agreed source behavior awaiting enum/compiler support, not an expansion of
+dynamic graph-loop lowering. See [enum enumeration](type-extensions.md#enumerating-members).
+
 ## Elements for lists and sets
 
 Use `elements(collection)` for element-only traversal of lists and sets. It

--- a/language/docs/design/language-model.md
+++ b/language/docs/design/language-model.md
@@ -564,7 +564,11 @@ they never create unnamed members. Enumeration calls `keys(Mode)`,
 of names, assigned integers, and enum instances. All three use declaration
 order and the declared member count. They are constant data that can be bound,
 indexed, reused, and iterated during wiring, not time-series ports or borrowed
-node iterators. Remaining conversion details and native mapping stay open.
+node iterators. Enum switches reject duplicate resolved cases and can establish
+exhaustiveness by covering every declared member. Partial coverage remains
+permitted with default-or-failure semantics; even exhaustive generated dispatch
+retains no-match failure. These checks apply in both phases and do not replace
+definite assignment. Remaining conversion details and native mapping stay open.
 
 A runtime function may declare persistent state, approved injected
 capabilities, lifecycle behavior, and ordered activation handlers:

--- a/language/docs/design/language-model.md
+++ b/language/docs/design/language-model.md
@@ -559,11 +559,12 @@ types; integer conversion is explicit rather than implicit. Construction from
 an integer or exact member-name string uses the enum type as the callee, such
 as `Mode(10)` or `Mode("first")`. Unknown numbers and names are conversion
 errors at checking, wiring, or evaluation time as appropriate to the operand;
-they never create unnamed members. Enumeration
-exposes member names through `keys`, assigned numbers through `values`, and
-typed enum instances through `elements`. Remaining conversion/enumeration
-details and native mapping stay open. All three enum views iterate in
-declaration order, independent of their assigned numbers.
+they never create unnamed members. Enumeration calls `keys(Mode)`,
+`values(Mode)`, and `elements(Mode)` return immutable fixed-size scalar lists
+of names, assigned integers, and enum instances. All three use declaration
+order and the declared member count. They are constant data that can be bound,
+indexed, reused, and iterated during wiring, not time-series ports or borrowed
+node iterators. Remaining conversion details and native mapping stay open.
 
 A runtime function may declare persistent state, approved injected
 capabilities, lifecycle behavior, and ordered activation handlers:
@@ -699,6 +700,10 @@ endpoint's native `last_modified_time` as `datetime`. The `delta` result shape
 remains open.
 
 ## Collection traversal
+
+Enum-type enumeration is distinct from the collection-value operations below:
+its immutable scalar-list results remain ordinary values in either function
+phase, not borrowed iterators.
 
 The collection surface separates a materialized temporal view from borrowed
 runtime iteration. `key_set(tsd)` is available in both phases: composition

--- a/language/docs/design/language-model.md
+++ b/language/docs/design/language-model.md
@@ -551,7 +551,11 @@ initially. Stringification returns the member name without a type prefix or
 number, using the agreed `str(value)` call spelling. Constant, node-value, and
 temporal graph conversions follow the existing phase distinction; the call
 does not select the function's phase. Enums remain distinct atomic scalar
-types; integer conversion is explicit rather than implicit. Enumeration
+types; integer conversion is explicit rather than implicit. Construction from
+an integer or exact member-name string uses the enum type as the callee, such
+as `Mode(10)` or `Mode("first")`. Unknown numbers and names are conversion
+errors at checking, wiring, or evaluation time as appropriate to the operand;
+they never create unnamed members. Enumeration
 exposes member names through `keys`, assigned numbers through `values`, and
 typed enum instances through `elements`. Remaining conversion/enumeration
 details and native mapping stay open. All three enum views iterate in

--- a/language/docs/design/language-model.md
+++ b/language/docs/design/language-model.md
@@ -546,8 +546,12 @@ separate work. [Enum support](type-extensions.md#enum-types), including named
 member constants for cases, uses the agreed `enum Mode { first, second }`
 declaration and `Mode::first` reference form. An explicit `= constant` assigns
 an integer number; otherwise the first member starts at zero and later
-members increment the preceding number. Duplicate numbers are rejected
-initially. Stringification returns the member name without a type prefix or
+members increment the preceding number. Numbers use the signed `i64` range,
+including negative values; out-of-range explicit numbers and automatic
+successor overflow are compile-time errors without wrapping. An explicit
+assignment may restart numbering after the maximum. Duplicate numbers are
+rejected initially. This source range does not settle the native ABI.
+Stringification returns the member name without a type prefix or
 number, using the agreed `str(value)` call spelling. Constant, node-value, and
 temporal graph conversions follow the existing phase distinction; the call
 does not select the function's phase. Enums remain distinct atomic scalar

--- a/language/docs/design/switch.md
+++ b/language/docs/design/switch.md
@@ -3,6 +3,8 @@
 Status: node-style and graph-style dispatch, selector validation, branch
 capture/result analysis, and `switch selector { case value: ... default: ... }`
 agreed, 2026-09-06. Case values must be expressible as constants in source.
+Duplicate cases after constant resolution and enum exhaustiveness checks are
+also agreed. Partial enum coverage remains permitted with no-match failure.
 Compiler implementation remains separate work.
 
 [Paired HGL and C++ examples](../developer-guide/control-flow-cpp-mappings.md)
@@ -61,6 +63,56 @@ An enum selector retains its enum type: case labels must be members of that
 same enum, not integers or members of another enum with coincident numbers.
 Explicit conversion to an integer is a separate operation; numbering alone
 does not change the selector's type.
+
+## Duplicate cases and enum coverage
+
+Resolve and type-check each case constant before checking for duplicates.
+Reject repeated resolved case values within the same switch, even when their
+source expressions differ. For the numbered `Mode` declaration, `Mode::first`
+and `Mode(10)` both denote the same member and cannot label separate cases.
+A named constant resolving to that member has the same effect. This is a
+source-checking error, not first-match or last-match dispatch. It is distinct
+from rejecting duplicate numbers in an enum declaration.
+
+For an enum selector, covering every declared member establishes exhaustiveness
+over that enum's declared values. No `default` is required. Partial coverage
+is also permitted: an uncovered member selects the supplied default or fails
+if there is none. These checks apply to wiring-time graph choices, temporal
+graph dispatch, and node-local dispatch alike.
+
+Using the three-member `Mode` from [enum types](type-extensions.md#enum-types):
+
+```hgl
+fn choose(mode: Mode, x: i64, y: i64) -> i64 {
+    var r: i64
+    switch mode {
+        case Mode::first:
+            r = x
+        case Mode::second:
+            r = y
+        case Mode::third:
+            r = x + y
+    }
+    return r * 2
+}
+```
+
+Every member has a case and each case assigns `r` before its later use.
+Exhaustive coverage does not by itself prove definite assignment: a case that
+reaches that use must still supply `r`. Conversely, a partial switch's
+no-match failure path does not reach the use and need not assign it.
+
+Generated dispatch retains the no-match failure path even when checking proves
+coverage of all declared enum members. Do not replace it with silent
+continuation or an unchecked unreachable assumption. This does not admit
+unknown enum values at native import boundaries; that remains separate design
+work. A supplied default remains a real branch with the existing capture,
+result, and definite-assignment checks.
+
+[Paired enum-switch HGL/C++ examples](../developer-guide/enum-switch-cpp-mappings.md)
+cover exhaustive and partial dispatch, a supplied default, and intentional
+duplicate/type errors. No new source syntax or compiler implementation is
+introduced by these checks.
 
 ## One construct in both function phases
 
@@ -191,9 +243,10 @@ and lifecycle; [public-wiring tests](../../../tests/cpp/test_switch.cpp) cover
 default selection, no-match failure, outputless branches, and fresh branch
 instances on reselection.
 
-The exact admitted selector types, remaining enum type rules, duplicate-case
-diagnostics after constant resolution, and any exposure of native reload
-policy remain to be discussed. The agreed statement form is illustrated in
-`language/stdlib/`; a switch expression-value surface is not added by these
+The exact admitted selector types, native enum representation/import rules,
+and any exposure of native reload policy remain to be discussed. Duplicate
+resolved case rejection and declared-member exhaustiveness are agreed source
+checks; their compiler implementation remains pending. The statement form is
+illustrated in `language/stdlib/`; a switch expression-value surface is not added by these
 examples. This record does not add parser, IR, backend, or runtime
 implementation, and leaves the deferred `for` work untouched.

--- a/language/docs/design/type-extensions.md
+++ b/language/docs/design/type-extensions.md
@@ -10,7 +10,8 @@ syntax.
 ## Enum types
 
 Status: enum declarations, qualified member references, explicit/automatic
-numbering, member-name stringification, rejection of duplicate numbers,
+numbering within the signed `i64` range with compile-time overflow errors,
+member-name stringification, rejection of duplicate numbers,
 distinct enum identity, explicit integer conversion, checked construction from
 integers or strings through the enum type name, and the `keys`, `values`, and
 `elements` enumeration meanings are agreed, 2026-09-06. Members are
@@ -35,13 +36,43 @@ to `20`.
 The numbering rules are:
 
 - `member = constant` assigns an explicit integer constant value.
+- Assigned numbers must be in the inclusive signed `i64` range,
+  `-9223372036854775808` through `9223372036854775807`. Negative numbers and
+  both endpoints are permitted.
 - An unnumbered first member starts at zero.
 - Every later unnumbered member takes the immediately preceding member's
   resolved number plus one. Explicit assignments therefore reset the next
   automatic number; numbering does not depend on the largest number used.
+- An explicit number outside the range, or an automatic successor past its
+  maximum, is a compile-time error. Numbering never wraps or clamps.
+- An explicit assignment after the maximum may restart numbering at any
+  in-range value, subject to the duplicate-number rule. Do not compute the
+  unused automatic successor before applying that explicit assignment.
 - Duplicate resolved numbers within one enum are rejected initially, whether
   the collision comes from explicit or automatic numbering. Numeric aliases
   are not admitted in this first design.
+
+For example:
+
+```hgl
+enum Direction {
+    reverse = -1,
+    stopped,
+    forward
+}
+```
+
+The assigned numbers are `-1`, `0`, and `1`. The
+[range and overflow examples](../developer-guide/enum-cpp-mappings.md#signed-range-and-overflow)
+also cover both endpoints, a reset after the maximum, and rejected values.
+The frontend must admit the complete signed minimum literal without first
+requiring its positive decimal magnitude to fit in `i64`. Validate the
+resolved signed number and each required automatic increment before native
+emission; do not inherit C++ literal or overflow behavior accidentally.
+
+This fixes the source enum number domain, not the physical native ABI or a
+new backing-type annotation. It does not settle overflow for unrelated runtime
+integer arithmetic or native enum import mapping.
 
 Stringification returns the declared member name without a type prefix or
 numeric value: `Mode::first` becomes `"first"`, `Mode::second` becomes
@@ -151,7 +182,6 @@ dynamic `for` lowering.
 
 The next design discussion needs to settle:
 
-- the integer range and overflow handling for explicit and automatic numbers;
 - treatment of already-typed native enum values not associated with a declared
   member; checked integer/string construction itself rejects unknown values;
 - the exact spelling for conversion from an enum to its assigned integer;

--- a/language/docs/design/type-extensions.md
+++ b/language/docs/design/type-extensions.md
@@ -16,8 +16,10 @@ distinct enum identity, explicit integer conversion, checked construction from
 integers or strings through the enum type name, and the `keys`, `values`, and
 `elements` calls on enum types returning immutable fixed-size scalar lists
 are agreed, 2026-09-06. Members are
-constant switch case values. String conversion uses the agreed Python-style
-`str(value)` spelling. Remaining conversion details and native
+constant switch case values. Duplicate resolved switch cases are rejected;
+covering all declared members establishes exhaustiveness, while partial
+switches remain permitted with the existing no-match failure. String conversion
+uses the agreed Python-style `str(value)` spelling. Remaining conversion details and native
 mapping are still open; compiler support is not implemented.
 
 The agreed declaration form is:
@@ -198,6 +200,19 @@ rules. This agreement covers the one-argument enum-type forms and does not
 introduce a new dynamic `for` lowering or change temporal collection traversal.
 Compiler support for enum enumeration remains separate work.
 
+### Switch checks
+
+An enum selector admits case constants of that same enum. Resolve constants
+before rejecting duplicate cases: `Mode::first` and `Mode(10)` select the
+same member, even though the source expressions differ. Covering all declared
+members establishes exhaustiveness and needs no default. Partial coverage is
+permitted, with a supplied default handling unmatched members and no-match
+failure otherwise. Generated dispatch retains that failure path even for
+exhaustive coverage. These rules apply equally to node and graph forms and
+do not replace definite-assignment checks on successful branches. See
+[switch coverage](switch.md#duplicate-cases-and-enum-coverage) and the
+[paired HGL/C++ examples](../developer-guide/enum-switch-cpp-mappings.md).
+
 ### Remaining enum decisions
 
 The next design discussion needs to settle:
@@ -205,12 +220,13 @@ The next design discussion needs to settle:
 - treatment of already-typed native enum values not associated with a declared
   member; checked integer/string construction itself rejects unknown values;
 - the exact spelling for conversion from an enum to its assigned integer;
-- temporal use and wiring-time use under the existing type mechanism;
 - exposure of native C++ and Python enums without losing their type identity;
-- the native switch-key contract, including duplicate case labels
-  (distinct from duplicate numbers in an enum declaration);
-- whether checking all members can establish exhaustiveness. The existing
-  no-match failure rule still applies when dispatch finds no case or default.
+- the concrete native enum switch-key representation and its integration with
+  the public wiring API.
+
+Checked conversion timing for constant, wiring-time, and temporal operands is
+agreed above; it is not an open phase decision. Native representation and
+import-boundary work must preserve those semantics.
 
 The existing native [enum registration contract](../../../include/hgraph/types/metadata/type_registry.h)
 accepts an ordered member-name/assigned-integer table. Its
@@ -221,9 +237,9 @@ not an agreement that HGL admits unknown enum values or must use that fallback.
 HGL must reject duplicate member numbers before registering the table; native
 registration is not a substitute for that source check.
 
-No implicit integer conversion, flag-enum behaviour, or exhaustiveness
-exemption is introduced by this agreement. Enum declarations and these design
-fixtures remain outside the implemented compiler surface.
+No implicit integer conversion, flag-enum behaviour, or exemption from
+no-match failure is introduced by this agreement. Enum declarations and these
+design fixtures remain outside the implemented compiler surface.
 
 ## Imported types are atomic values
 

--- a/language/docs/design/type-extensions.md
+++ b/language/docs/design/type-extensions.md
@@ -14,9 +14,10 @@ numbering within the signed `i64` range with compile-time overflow errors,
 member-name stringification, rejection of duplicate numbers,
 distinct enum identity, explicit integer conversion, checked construction from
 integers or strings through the enum type name, and the `keys`, `values`, and
-`elements` enumeration meanings are agreed, 2026-09-06. Members are
+`elements` calls on enum types returning immutable fixed-size scalar lists
+are agreed, 2026-09-06. Members are
 constant switch case values. String conversion uses the agreed Python-style
-`str(value)` spelling. Remaining conversion/enumeration details and native
+`str(value)` spelling. Remaining conversion details and native
 mapping are still open; compiler support is not implemented.
 
 The agreed declaration form is:
@@ -157,13 +158,31 @@ separate work.
 
 ### Enumerating members
 
-Enums expose three enumeration operations:
+Call the enumeration operations on the enum type. For the three-member `Mode`:
 
-| Operation | Values exposed | Example members of `Mode` |
+| Call | Scalar result type | Contents |
 | --- | --- | --- |
-| `keys` | Member names as `str` values, as returned by `str` on each member | `"first"`, `"second"`, `"third"` |
-| `values` | Assigned integer values, not ordinal positions | `10`, `11`, `20` |
-| `elements` | Enum instances retaining their enum type | `Mode::first`, `Mode::second`, `Mode::third` |
+| `keys(Mode)` | `list<str, 3>` | `"first"`, `"second"`, `"third"` |
+| `values(Mode)` | `list<i64, 3>` | `10`, `11`, `20` |
+| `elements(Mode)` | `list<Mode, 3>` | `Mode::first`, `Mode::second`, `Mode::third` |
+
+Each result is an immutable, fixed-size scalar list. Its length is the number
+of declared members. Names match `str` on each member; numbers are assigned
+values, not ordinal positions; enum elements preserve the enum's identity.
+The operand is the type, not a current enum time-series value.
+
+```hgl
+const mode_keys: list<str, 3> = keys(Mode)
+const mode_values: list<i64, 3> = values(Mode)
+const mode_elements: list<Mode, 3> = elements(Mode)
+```
+
+These are ordinary constant data, not time-series inputs or evaluation-local
+borrowed iterators. They may be bound, indexed, reused, and iterated during
+graph wiring. Such a loop receives known scalar constants, not child temporal
+connections. The same data remain scalar when used inside a node. The calls
+do not manufacture ticks or classify the containing function as a node.
+The native constant-storage representation remains an implementation choice.
 
 All three views iterate in declaration order, not numeric or alphabetical
 order. Explicit numbering does not reorder members. The views remain aligned:
@@ -173,10 +192,11 @@ makes this distinction explicit.
 
 `elements` is also the agreed element-iteration spelling for lists and sets;
 see [collection iteration](iteration.md#elements-for-lists-and-sets). This does
-not add `elements` for maps or bundles. Exact enum enumeration invocation
-syntax and the returned collection/iterator shape remain to be settled before adding enum
-enumeration calls to HGL fixtures. This agreement does not introduce a new
-dynamic `for` lowering.
+not add `elements` for maps or bundles. Enum-type calls return the constant
+lists above; collection-value calls retain their own phase and borrowed-view
+rules. This agreement covers the one-argument enum-type forms and does not
+introduce a new dynamic `for` lowering or change temporal collection traversal.
+Compiler support for enum enumeration remains separate work.
 
 ### Remaining enum decisions
 
@@ -185,7 +205,6 @@ The next design discussion needs to settle:
 - treatment of already-typed native enum values not associated with a declared
   member; checked integer/string construction itself rejects unknown values;
 - the exact spelling for conversion from an enum to its assigned integer;
-- enum enumeration invocation syntax and result collection/iterator types;
 - temporal use and wiring-time use under the existing type mechanism;
 - exposure of native C++ and Python enums without losing their type identity;
 - the native switch-key contract, including duplicate case labels

--- a/language/docs/design/type-extensions.md
+++ b/language/docs/design/type-extensions.md
@@ -11,8 +11,9 @@ syntax.
 
 Status: enum declarations, qualified member references, explicit/automatic
 numbering, member-name stringification, rejection of duplicate numbers,
-distinct enum identity, explicit integer conversion, and the `keys`, `values`,
-and `elements` enumeration meanings are agreed, 2026-09-06. Members are
+distinct enum identity, explicit integer conversion, checked construction from
+integers or strings through the enum type name, and the `keys`, `values`, and
+`elements` enumeration meanings are agreed, 2026-09-06. Members are
 constant switch case values. String conversion uses the agreed Python-style
 `str(value)` spelling. Remaining conversion/enumeration details and native
 mapping are still open; compiler support is not implemented.
@@ -83,8 +84,45 @@ Obtaining the assigned integer is an explicit conversion, using a type-name
 call in the same style as `str(value)`. For example, converting `Mode::first`
 to an integer produces `10`, while string conversion produces `"first"`.
 The precise integer conversion spelling needs confirmation before adding a
-source example. This does not authorize implicit arithmetic or decide how
-to construct an enum from an integer or string.
+source example. This does not authorize implicit arithmetic.
+
+### Constructing an enum from a number or name
+
+Use the enum type as the callee, with one integer or string argument:
+
+```hgl
+const mode_from_number: Mode = Mode(10)
+const mode_from_name: Mode = Mode("first")
+```
+
+Both results are `Mode::first`. An integer is looked up by assigned number,
+not ordinal position. A string is looked up by exact declared member name,
+with the same spelling returned by `str` on that member. Names are
+case-sensitive; numeric text and qualified display text are not alternate
+names. For example, `Mode(12)`, `Mode("First")`, `Mode("10")`, and
+`Mode("Mode::first")` fail for this declaration.
+
+Unknown numbers or names cause a conversion error; conversion never creates
+an unnamed member or substitutes another member. Failure follows the phase in
+which the operand's value is available:
+
+- An invalid constant is a checking error.
+- An invalid wiring-time scalar is a wiring error.
+- An invalid runtime value is an evaluation error. Inside a node the lookup
+  runs locally; in graph composition a temporal operand wires a checked
+  conversion and the lookup runs when that input is evaluated.
+
+The result retains the target enum type. Conversion does not select the
+containing function's phase, bypass input validity or REF/SIGNAL restrictions,
+or turn failure into a no-tick result. A switch `default` handles an unmatched
+selector, not an error while converting that selector.
+
+This settles integer/string conversion through `Mode(...)`, not a general
+type-constructor API, additional argument forms, or the handling of an
+already-typed native enum value arriving through an import boundary. The
+[paired HGL/C++ conversion examples](../developer-guide/enum-cpp-mappings.md#checked-conversion-into-an-enum)
+include successful lookups and rejected constants. Compiler support remains
+separate work.
 
 ### Enumerating members
 
@@ -104,8 +142,8 @@ makes this distinction explicit.
 
 `elements` is also the agreed element-iteration spelling for lists and sets;
 see [collection iteration](iteration.md#elements-for-lists-and-sets). This does
-not add `elements` for maps or bundles. Exact enum invocation syntax and the
-returned collection/iterator shape remain to be settled before adding enum
+not add `elements` for maps or bundles. Exact enum enumeration invocation
+syntax and the returned collection/iterator shape remain to be settled before adding enum
 enumeration calls to HGL fixtures. This agreement does not introduce a new
 dynamic `for` lowering.
 
@@ -114,9 +152,9 @@ dynamic `for` lowering.
 The next design discussion needs to settle:
 
 - the integer range and overflow handling for explicit and automatic numbers;
-- treatment of values not associated with a declared member;
-- the exact integer conversion spelling and conversion from integers or
-  strings to enum values;
+- treatment of already-typed native enum values not associated with a declared
+  member; checked integer/string construction itself rejects unknown values;
+- the exact spelling for conversion from an enum to its assigned integer;
 - enum enumeration invocation syntax and result collection/iterator types;
 - temporal use and wiring-time use under the existing type mechanism;
 - exposure of native C++ and Python enums without losing their type identity;

--- a/language/docs/developer-guide/README.md
+++ b/language/docs/developer-guide/README.md
@@ -76,6 +76,8 @@ for hgraph, not a second runtime.
    records explicit and automatic duplicate-number errors. It also maps
    `str(value)` in constants, node evaluation, and temporal graph composition,
    and shows declaration-order enumeration with non-monotonic member numbers.
+   Checked `Mode(...)` conversion covers assigned integers, exact member-name
+   strings, and errors for unknown values.
    These remain design fixtures, not implemented HGL enum/conversion support.
 
 The design records provide project boundaries and rationale:

--- a/language/docs/developer-guide/compiler-and-lowering.md
+++ b/language/docs/developer-guide/compiler-and-lowering.md
@@ -954,6 +954,16 @@ behavior remain future source-design work.
 
 ## Metadata and collection-view lowering
 
+The agreed enum-type forms `keys(Mode)`, `values(Mode)`, and `elements(Mode)`
+resolve the enum type and its declaration metadata, producing ordinary
+immutable fixed-size scalar list values. The length is the declared member
+count, ordering is declaration order, and `elements` retains the enum's
+nominal element type. Do not lower these calls to `RuntimeIterator` or
+time-series nodes merely because they share names with collection traversal.
+Their values can be bound, indexed, reused, and consumed during graph wiring.
+This enum lowering remains compiler work; concrete native constant storage
+and imported-enum metadata integration remain separate implementation concerns.
+
 Runtime `last_modified(value)` lowers directly to the endpoint view's public
 `last_modified_time()` operation and produces a canonical `datetime` scalar.
 It does not wire hgraph's similarly named temporal operator from inside an
@@ -964,7 +974,8 @@ composition call dispatches the standard key projection with a TSS output
 shape. A runtime call obtains the current `TSDDataView::key_set()` borrowed
 view. Both paths use public hgraph APIs.
 
-The typed HIR represents `keys`, `values`, and `items` as borrowed
+For runtime collection-value operands, the typed HIR represents `keys`,
+`values`, and `items` as borrowed
 `RuntimeIterator` values carrying:
 
 - the source collection and concrete hgraph shape;

--- a/language/docs/developer-guide/enum-cpp-mappings.md
+++ b/language/docs/developer-guide/enum-cpp-mappings.md
@@ -3,8 +3,9 @@
 Status: worked examples of the agreed [enum value rules](../design/type-extensions.md#enum-types),
 not output from an implemented HGL enum compiler. Source appears before its
 corresponding C++ representation. String conversion uses `str(value)` and
-checked construction uses the enum type name, as in `Mode(value)`. The source
-integer range and complete native type/ABI mapping remain open.
+checked construction uses the enum type name, as in `Mode(value)`. Assigned
+numbers use the signed `i64` range with compile-time overflow errors. The
+complete native type/ABI mapping remains open.
 
 ## Numbered declarations
 
@@ -51,10 +52,102 @@ enum class Sequence : std::int64_t {
 };
 ```
 
-The `std::int64_t` representation here accommodates these example values; it
-does not settle HGL's backing-width, integer overflow, or public ABI rules.
+The `std::int64_t` representation here accommodates the agreed source range;
+it does not require this physical representation in HGL's public native ABI.
 Nor does declaring this C++ enum automatically register it as an hgraph type.
 Actual lowering must preserve enum metadata at native value boundaries.
+
+## Signed range and overflow
+
+Assigned numbers range from `-9223372036854775808` to `9223372036854775807`,
+inclusive. Negative numbers are permitted. These HGL declarations exercise
+negative automatic numbering, both endpoints, and an explicit reset:
+
+```hgl
+enum Direction {
+    reverse = -1,
+    stopped,
+    forward
+}
+
+enum Bounds {
+    minimum = -9223372036854775808,
+    after_minimum,
+    maximum = 9223372036854775807,
+    reset = -1,
+    after_reset
+}
+```
+
+`Direction` receives `-1, 0, 1`. `Bounds::after_minimum` receives
+`-9223372036854775807`, and `Bounds::after_reset` receives `0`. The explicit
+reset after the maximum is valid: only an implicit successor would overflow.
+No member repeats a number within either declaration.
+
+An illustrative C++ representation uses safe expressions for the endpoints:
+
+```cpp
+#include <limits>
+
+enum class Direction : std::int64_t {
+    reverse = -1,
+    stopped = 0,
+    forward = 1
+};
+
+enum class Bounds : std::int64_t {
+    minimum = std::numeric_limits<std::int64_t>::min(),
+    after_minimum = std::numeric_limits<std::int64_t>::min() + 1,
+    maximum = std::numeric_limits<std::int64_t>::max(),
+    reset = -1,
+    after_reset = 0
+};
+
+static_assert(static_cast<std::int64_t>(Direction::stopped) == 0);
+static_assert(static_cast<std::int64_t>(Bounds::minimum) == std::numeric_limits<std::int64_t>::min());
+static_assert(static_cast<std::int64_t>(Bounds::maximum) == std::numeric_limits<std::int64_t>::max());
+static_assert(static_cast<std::int64_t>(Bounds::after_reset) == 0);
+```
+
+The HGL minimum literal is valid as written. A frontend must not reject it
+because the positive magnitude of its negative literal exceeds the signed
+maximum. The C++ mapping avoids copying that magnitude into an unsuitable
+signed literal. Range checks belong to HGL source checking, before native
+emission; C++ diagnostics or an unchecked signed increment are not the source
+contract. These examples define the allowed numbers, not a new backing-type
+annotation, native import rule, or general runtime integer-overflow policy.
+
+Each of the following HGL declarations is independently invalid:
+
+```hgl
+enum AboveRange {
+    value = 9223372036854775808
+}
+```
+
+```hgl
+enum BelowRange {
+    value = -9223372036854775809
+}
+```
+
+```hgl
+enum AutomaticOverflow {
+    maximum = 9223372036854775807,
+    next
+}
+```
+
+The explicit values exceed the permitted endpoints, and the automatic value
+would be `9223372036854775808`. All three are compile-time errors; never wrap,
+clamp, or manufacture another member. No C++ representation is emitted for
+these invalid declarations.
+
+The positive source is [enum-number-range.hgl](../../stdlib/examples/enum-number-range.hgl).
+The invalid fixtures are [enum-number-above-range.hgl](../../stdlib/examples/invalid/enum-number-above-range.hgl),
+[enum-number-below-range.hgl](../../stdlib/examples/invalid/enum-number-below-range.hgl),
+and [enum-number-overflow.hgl](../../stdlib/examples/invalid/enum-number-overflow.hgl).
+They record agreed source checks, not implemented compiler tests.
 
 ## Member-name stringification
 
@@ -357,9 +450,9 @@ They record intended source errors, not currently passing compiler diagnostics.
 
 ## Validation boundary
 
-The first four C++ blocks compile together without hgraph and can be exercised
-for resolved numbers, member strings, checked conversion, and declaration-order
-views. The node and graph blocks additionally require the public hgraph
+The first five C++ blocks compile together without hgraph and can be exercised
+for signed range endpoints, resolved numbers, member strings, checked
+conversion, and declaration-order views. The node and graph blocks additionally require the public hgraph
 headers. Syntax checking those blocks does not prove runtime execution, HGL
 parsing, native enum registration, Python exposure, or temporal enum behaviour.
 All HGL sources here remain design fixtures outside

--- a/language/docs/developer-guide/enum-cpp-mappings.md
+++ b/language/docs/developer-guide/enum-cpp-mappings.md
@@ -2,9 +2,9 @@
 
 Status: worked examples of the agreed [enum value rules](../design/type-extensions.md#enum-types),
 not output from an implemented HGL enum compiler. Source appears before its
-corresponding C++ representation. Conversion uses the agreed `str(value)`
-spelling. The source integer range and complete native type/ABI mapping remain
-open.
+corresponding C++ representation. String conversion uses `str(value)` and
+checked construction uses the enum type name, as in `Mode(value)`. The source
+integer range and complete native type/ABI mapping remain open.
 
 ## Numbered declarations
 
@@ -52,7 +52,7 @@ enum class Sequence : std::int64_t {
 ```
 
 The `std::int64_t` representation here accommodates these example values; it
-does not settle HGL's backing-width, numeric conversion, or public ABI rules.
+does not settle HGL's backing-width, integer overflow, or public ABI rules.
 Nor does declaring this C++ enum automatically register it as an hgraph type.
 Actual lowering must preserve enum metadata at native value boundaries.
 
@@ -104,6 +104,88 @@ already render a registered member by name. Lowering must retain that table
 rather than erase the enum to an ordinary integer and stringify the integer.
 The native unknown-number fallback is not a new HGL source guarantee.
 
+## Checked conversion into an enum
+
+Use the target enum type name with an assigned integer or exact member name.
+For the `Mode` declaration above:
+
+```hgl
+const mode_from_number: Mode = Mode(10)
+const mode_from_name: Mode = Mode("first")
+```
+
+Both constants are `Mode::first`. The C++ mapping must check membership rather
+than perform an unchecked cast to the enum:
+
+```cpp
+constexpr Mode lookup_mode(std::int64_t number)
+{
+    switch (number) {
+    case 10:
+        return Mode::first;
+    case 11:
+        return Mode::second;
+    case 20:
+        return Mode::third;
+    default:
+        throw std::invalid_argument("unknown Mode number");
+    }
+}
+
+constexpr Mode lookup_mode(std::string_view name)
+{
+    if (name == "first") { return Mode::first; }
+    if (name == "second") { return Mode::second; }
+    if (name == "third") { return Mode::third; }
+    throw std::invalid_argument("unknown Mode member name");
+}
+
+constexpr Mode mode_from_number = lookup_mode(std::int64_t{10});
+constexpr Mode mode_from_name = lookup_mode(std::string_view{"first"});
+static_assert(mode_from_number == Mode::first);
+static_assert(mode_from_name == Mode::first);
+```
+
+`lookup_mode` is an illustrative generated helper, not an HGL function name or
+a new native API. The source remains `Mode(...)`. Result values retain enum
+identity; strings match member names exactly, with no case folding, whitespace
+trimming, numeric-string parsing, or qualified-name interpretation. For this
+enum, only the assigned numbers `10`, `11`, and `20` succeed; neither an
+ordinal nor any other number in the interval from `10` to `20` is sufficient.
+
+These two HGL examples are independently invalid constants:
+
+```hgl
+const missing_mode: Mode = Mode(12)
+```
+
+```hgl
+const missing_mode: Mode = Mode("First")
+```
+
+The first has no member with number `12`; the second does not exactly match
+`"first"`. Checking must reject either source rather than emit a runtime cast
+or manufacture an unnamed member. Complete source fixtures are
+[enum-conversion-unknown-number.hgl](../../stdlib/examples/invalid/enum-conversion-unknown-number.hgl)
+and [enum-conversion-unknown-name.hgl](../../stdlib/examples/invalid/enum-conversion-unknown-name.hgl).
+Successful constants are mirrored in [enum-values.hgl](../../stdlib/examples/enum-values.hgl).
+
+Failure timing depends on when the operand is available. A constant is checked
+before runtime; a wiring-time configuration value is checked while wiring.
+Inside node evaluation the checked lookup runs on the admitted current value.
+In a temporal graph, wiring composes the conversion and the runtime lookup
+fails if an evaluated input has no matching member. It must not silently skip
+the tick or reinterpret failure as a switch `default` selection. An input that
+has no valid value is still governed by the existing input-validity rules.
+
+The helper's `std::invalid_argument` illustrates failure; it does not settle
+HGL exception types or error-catching syntax. The compiler must implement its
+own source diagnostic for invalid constants. A public SDK carrier and native
+registration/lowering for enum-typed graph results remain separate work; no
+unimplemented native `Port` or operator API is assumed here. Likewise, this
+checked constructor does not settle import handling for an already-typed
+native enum containing an unknown value.
+
 ## Declaration-order enumeration
 
 All three enum views (`keys`, `values`, and `elements`) iterate in declaration
@@ -151,7 +233,8 @@ These arrays illustrate ordered metadata, not a chosen HGL return container
 or new native enum API. The source enum remains a distinct type in `elements`;
 only `values` exposes integers. Do not sort by number, scan a numeric interval,
 or use unordered-table iteration to implement any of these views. The exact
-enum invocation syntax and returned collection/iterator shape remain open.
+enum enumeration invocation syntax and returned collection/iterator shape
+remain open.
 The source declaration is mirrored in
 [enum-enumeration-order.hgl](../../stdlib/examples/enum-enumeration-order.hgl);
 no speculative enumeration call syntax is included.
@@ -274,10 +357,10 @@ They record intended source errors, not currently passing compiler diagnostics.
 
 ## Validation boundary
 
-The first three C++ blocks compile together without hgraph and can be exercised
-for resolved numbers, member strings, and declaration-order views. The node
-and graph blocks additionally require the public hgraph headers. Syntax checking
-those blocks does not prove runtime execution, HGL parsing, native enum
-registration, Python exposure, or
-temporal enum behaviour. All HGL sources here remain design fixtures outside
+The first four C++ blocks compile together without hgraph and can be exercised
+for resolved numbers, member strings, checked conversion, and declaration-order
+views. The node and graph blocks additionally require the public hgraph
+headers. Syntax checking those blocks does not prove runtime execution, HGL
+parsing, native enum registration, Python exposure, or temporal enum behaviour.
+All HGL sources here remain design fixtures outside
 the executable `language/examples/` corpus.

--- a/language/docs/developer-guide/enum-cpp-mappings.md
+++ b/language/docs/developer-guide/enum-cpp-mappings.md
@@ -5,6 +5,7 @@ not output from an implemented HGL enum compiler. Source appears before its
 corresponding C++ representation. String conversion uses `str(value)` and
 checked construction uses the enum type name, as in `Mode(value)`. Assigned
 numbers use the signed `i64` range with compile-time overflow errors. The
+enum-type enumeration calls return immutable fixed-size scalar lists. The
 complete native type/ABI mapping remains open.
 
 ## Numbered declarations
@@ -281,8 +282,18 @@ native enum containing an unknown value.
 
 ## Declaration-order enumeration
 
-All three enum views (`keys`, `values`, and `elements`) iterate in declaration
-order, independent of assigned numbers or member names. Consider this HGL:
+Call `keys`, `values`, and `elements` on the enum type, not a current enum
+time-series value. For the `Mode` declaration above:
+
+```hgl
+const mode_keys: list<str, 3> = keys(Mode)
+const mode_values: list<i64, 3> = values(Mode)
+const mode_elements: list<Mode, 3> = elements(Mode)
+```
+
+Each result is an immutable fixed-size scalar list with one entry per declared
+member. All three lists preserve declaration order, independent of assigned
+numbers or member names. This HGL also shows indexing and reuse:
 
 ```hgl
 enum EnumerationOrder {
@@ -290,20 +301,33 @@ enum EnumerationOrder {
     low = 5,
     next
 }
+
+const enumeration_keys: list<str, 3> = keys(EnumerationOrder)
+const enumeration_values: list<i64, 3> = values(EnumerationOrder)
+const enumeration_elements: list<EnumerationOrder, 3> = elements(EnumerationOrder)
+
+const first_enumerated_name: str = enumeration_keys[0]
+const first_enumerated_number: i64 = enumeration_values[0]
+const first_enumerated_element: EnumerationOrder = enumeration_elements[0]
+const same_elements: list<EnumerationOrder, 3> = enumeration_elements
 ```
 
 The required sequences are:
 
-| View | First | Second | Third |
+| Call | First | Second | Third |
 | --- | --- | --- | --- |
-| `keys` | `"high"` | `"low"` | `"next"` |
-| `values` | `20` | `5` | `6` |
-| `elements` | `EnumerationOrder::high` | `EnumerationOrder::low` | `EnumerationOrder::next` |
+| `keys(EnumerationOrder)` | `"high"` | `"low"` | `"next"` |
+| `values(EnumerationOrder)` | `20` | `5` | `6` |
+| `elements(EnumerationOrder)` | `EnumerationOrder::high` | `EnumerationOrder::low` | `EnumerationOrder::next` |
 
-An illustrative C++ representation retains the declaration sequence:
+An illustrative C++ representation uses constant arrays for the scalar lists:
 
 ```cpp
 #include <array>
+
+constexpr std::array<std::string_view, 3> mode_keys{"first", "second", "third"};
+constexpr std::array<std::int64_t, 3> mode_values{10, 11, 20};
+constexpr std::array<Mode, 3> mode_elements{Mode::first, Mode::second, Mode::third};
 
 enum class EnumerationOrder : std::int64_t {
     high = 20,
@@ -317,20 +341,37 @@ constexpr std::array<EnumerationOrder, 3> enumeration_elements{
     EnumerationOrder::high, EnumerationOrder::low, EnumerationOrder::next
 };
 
+constexpr std::string_view first_enumerated_name = enumeration_keys[0];
+constexpr std::int64_t first_enumerated_number = enumeration_values[0];
+constexpr EnumerationOrder first_enumerated_element = enumeration_elements[0];
+constexpr auto same_elements = enumeration_elements;
+
+static_assert(mode_keys.size() == 3 && mode_values.size() == 3 && mode_elements.size() == 3);
+static_assert(mode_keys[1] == "second" && mode_values[1] == 11 && mode_elements[1] == Mode::second);
 static_assert(enumeration_keys[1] == "low");
 static_assert(enumeration_values[0] == 20 && enumeration_values[1] == 5);
 static_assert(static_cast<std::int64_t>(enumeration_elements[2]) == 6);
+static_assert(first_enumerated_name == "high" && first_enumerated_number == 20);
+static_assert(first_enumerated_element == EnumerationOrder::high);
+static_assert(same_elements == enumeration_elements);
 ```
 
-These arrays illustrate ordered metadata, not a chosen HGL return container
-or new native enum API. The source enum remains a distinct type in `elements`;
-only `values` exposes integers. Do not sort by number, scan a numeric interval,
-or use unordered-table iteration to implement any of these views. The exact
-enum enumeration invocation syntax and returned collection/iterator shape
-remain open.
-The source declaration is mirrored in
-[enum-enumeration-order.hgl](../../stdlib/examples/enum-enumeration-order.hgl);
-no speculative enumeration call syntax is included.
+The HGL result kind is agreed: an immutable fixed-size scalar list. These
+arrays illustrate its constant contents, indexing, and reuse; they do not
+settle native SDK storage or ABI. In particular, `std::string_view` here is
+an illustrative representation for constant member names, not a new public
+carrier for HGL `str`.
+
+The source enum remains a distinct type in `elements`; only `values` exposes
+integers. Do not sort by number, scan a numeric interval, or use unordered-table
+iteration to implement any of these calls. The results may be bound, indexed,
+reused, and iterated during graph wiring as ordinary scalar data. They are not
+time-series inputs or evaluation-local borrowed iterators, and using them in
+a node does not make the lists temporal. This does not change traversal rules
+for collection-value operands or introduce dynamic graph-loop lowering.
+
+The source is mirrored in [enum-values.hgl](../../stdlib/examples/enum-values.hgl)
+and [enum-enumeration-order.hgl](../../stdlib/examples/enum-enumeration-order.hgl).
 
 ## Conversion in nodes and graphs
 
@@ -452,8 +493,9 @@ They record intended source errors, not currently passing compiler diagnostics.
 
 The first five C++ blocks compile together without hgraph and can be exercised
 for signed range endpoints, resolved numbers, member strings, checked
-conversion, and declaration-order views. The node and graph blocks additionally require the public hgraph
-headers. Syntax checking those blocks does not prove runtime execution, HGL
+conversion, and declaration-order scalar lists including indexing and reuse.
+The node and graph blocks additionally require the public hgraph headers.
+Syntax checking those blocks does not prove runtime execution, HGL
 parsing, native enum registration, Python exposure, or temporal enum behaviour.
 All HGL sources here remain design fixtures outside
 the executable `language/examples/` corpus.

--- a/language/docs/developer-guide/enum-switch-cpp-mappings.md
+++ b/language/docs/developer-guide/enum-switch-cpp-mappings.md
@@ -1,0 +1,298 @@
+# Enum switch source and C++ mappings
+
+Status: worked examples of the agreed [switch checks](../design/switch.md#duplicate-cases-and-enum-coverage),
+not output from an implemented compiler. The HGL source is collected in
+[enum-switch.hgl](../../stdlib/examples/enum-switch.hgl). These are design
+fixtures, not executable compiler examples. Native enum carrier, registration,
+and import-boundary integration remain separate work.
+
+## The selector type
+
+All positive examples use the same HGL declaration:
+
+```hgl
+enum Mode {
+    first = 10,
+    second,
+    third = 20
+}
+```
+
+An illustrative C++ representation preserves the nominal enum and numbers:
+
+```cpp
+#include <cstdint>
+#include <stdexcept>
+
+enum class Mode : std::int64_t {
+    first = 10,
+    second = 11,
+    third = 20
+};
+```
+
+As in the [enum value mappings](enum-cpp-mappings.md), this is not a public
+native ABI or automatic hgraph type registration. HGL case constants must be
+members of this enum; integers or another enum's members are not substitutes.
+
+## Exhaustive graph composition
+
+This HGL has no runtime-only constructs. Its selector is temporal, so its
+body composes a graph:
+
+```hgl
+fn choose(mode: Mode, x: i64, y: i64) -> i64 {
+    var r: i64
+    switch mode {
+        case Mode::first:
+            r = x
+        case Mode::second:
+            r = y
+        case Mode::third:
+            r = x + y
+    }
+    return r * 2
+}
+```
+
+Every member is covered and every successful case supplies `r`. The compiler
+must generate native `switch_` branch wiring, not a C++ payload switch in
+`compose`. The case graphs' computations can be expressed using existing C++
+ports and operators:
+
+```cpp
+#include <hgraph/lib/std/std_operators.h>
+#include <hgraph/types/graph_wiring.h>
+
+using namespace hgraph;
+
+struct EnumFirstBranch
+{
+    static constexpr auto name = "enum_first_branch";
+    static Port<TS<Int>> compose(Wiring &, Port<TS<Int>> x, Port<TS<Int>>)
+    {
+        return x;
+    }
+};
+
+struct EnumSecondBranch
+{
+    static constexpr auto name = "enum_second_branch";
+    static Port<TS<Int>> compose(Wiring &, Port<TS<Int>>, Port<TS<Int>> y)
+    {
+        return y;
+    }
+};
+
+struct EnumThirdBranch
+{
+    static constexpr auto name = "enum_third_branch";
+    static Port<TS<Int>> compose(Wiring &w, Port<TS<Int>> x, Port<TS<Int>> y)
+    {
+        return wire<stdlib::add_>(w, x, y).as<TS<Int>>();
+    }
+};
+```
+
+The complete generated boundary must preserve the following mapping:
+
+| HGL component | Native graph responsibility |
+| --- | --- |
+| Temporal `mode: Mode` | Bind the enum-typed scalar selector to `stdlib::switch_`; never read its payload during composition. |
+| Three member labels | Build `stdlib::switch_cases` entries from resolved enum-typed keys and the three branch callables. |
+| Captured `x`, `y` | Form shared input slots; first/second branches forward a binding and third wires addition, using the existing REF/capture adaptation rules. |
+| Escaping `r` | Return the single branch result directly and remap the switch output to `r`. |
+| `return r * 2` | Wire `stdlib::mul_` with the selected result and scalar `Int{2}` outside the switch. |
+| No source default | Leave the native default absent, retaining native no-match failure even though all declared members are covered. |
+
+The branch snippets show computations, not a replacement for compiler-generated
+boundary signatures and REF adaptation. A complete enum-typed parent signature
+and construction of native enum key values await the native enum mapping;
+this guide does not invent that SDK API or erase `Mode` to `Int` to bypass it.
+Until that mapping exists, the compiler must reject the unsupported lowering.
+The existing [integer-selector mappings](control-flow-cpp-mappings.md#scenario-4-a-temporal-selector-creates-native-switch-branches)
+show the complete native switch call shape without assuming an enum carrier.
+
+Exhaustiveness does not flatten the branches or change their lifetime: only
+the selected child is active, and input updates propagate through its binding
+and computations. A wiring-time scalar selector instead chooses topology
+during composition; it uses the same case-type, duplicate, and coverage checks.
+
+## Exhaustive node-local dispatch
+
+Adding an explicit handler makes this a node-style function. All three inputs
+must be valid for this example, and a tick on any of them may activate it:
+
+```hgl
+fn choose_node(mode: Mode, x: i64, y: i64) -> i64 {
+    when modified(mode, x, y) && valid(mode, x, y) {
+        var r: i64
+        switch mode {
+            case Mode::first:
+                r = x
+            case Mode::second:
+                r = y
+            case Mode::third:
+                r = x + y
+        }
+        return r * 2
+    }
+}
+```
+
+The admitted payload calculation has this C++ mapping:
+
+```cpp
+std::int64_t choose_enum_payload(Mode mode, std::int64_t x, std::int64_t y)
+{
+    std::int64_t r;
+    switch (mode) {
+    case Mode::first:
+        r = x;
+        break;
+    case Mode::second:
+        r = y;
+        break;
+    case Mode::third:
+        r = x + y;
+        break;
+    default:
+        throw std::runtime_error("unmatched enum switch selector");
+    }
+    return r * 2;
+}
+```
+
+The generated node reads admitted inputs, performs this calculation, and
+writes its output only on success. No child graph is created. The C++ default
+implements failure, not an implicit HGL default branch. Do not eliminate it
+because all declared members appear: even this exhaustive dispatch retains
+the no-match failure path. Native exception plumbing is illustrative, not a
+new source exception type or permission to construct unknown HGL enum values.
+
+For `x = 10` and `y = 20`, the three declared members produce `20`, `40`, and
+`60`. Small inputs avoid deciding general integer-overflow behavior. The graph
+and node forms share branch arithmetic, not necessarily activation/validity
+behavior: this handler requires both data inputs to be valid, whereas a graph
+case that forwards only `x` need not observe the unrelated `y` input.
+
+## Partial coverage without a default
+
+Leaving out the third case is permitted source, not an exhaustiveness error:
+
+```hgl
+fn choose_partial_node(mode: Mode, x: i64, y: i64) -> i64 {
+    when modified(mode, x, y) && valid(mode, x, y) {
+        var r: i64
+        switch mode {
+            case Mode::first:
+                r = x
+            case Mode::second:
+                r = y
+        }
+        return r * 2
+    }
+}
+```
+
+The corresponding C++ payload mapping is:
+
+```cpp
+std::int64_t choose_partial_enum_payload(Mode mode, std::int64_t x, std::int64_t y)
+{
+    std::int64_t r;
+    switch (mode) {
+    case Mode::first:
+        r = x;
+        break;
+    case Mode::second:
+        r = y;
+        break;
+    default:
+        throw std::runtime_error("unmatched enum switch selector");
+    }
+    return r * 2;
+}
+```
+
+`Mode::third` now fails before the result is used or an output is written.
+Both successful cases still assign `r`; the failing path never reaches its
+use. In a temporal graph the analogous partial case table leaves the native
+default absent; a wiring-time scalar choice fails while composing instead.
+
+## A supplied default
+
+This source supplies a real fallback branch:
+
+```hgl
+fn choose_default_node(mode: Mode, x: i64, y: i64) -> i64 {
+    when modified(mode, x, y) && valid(mode, x, y) {
+        var r: i64
+        switch mode {
+            case Mode::first:
+                r = x
+            case Mode::second:
+                r = y
+            default:
+                r = x + y
+        }
+        return r * 2
+    }
+}
+```
+
+The C++ payload mapping uses that branch for no-match dispatch:
+
+```cpp
+std::int64_t choose_default_enum_payload(Mode mode, std::int64_t x, std::int64_t y)
+{
+    std::int64_t r;
+    switch (mode) {
+    case Mode::first:
+        r = x;
+        break;
+    case Mode::second:
+        r = y;
+        break;
+    default:
+        r = x + y;
+        break;
+    }
+    return r * 2;
+}
+```
+
+`Mode::third` selects the default and produces `60` for the same inputs. In a
+graph, the default becomes a native switch child with the same capture/result
+analysis as the named cases. A default does not catch errors in a selected
+branch or errors while constructing the selector with `Mode(...)`.
+
+## Source-checking errors
+
+Each of these examples is independently invalid; see the linked complete
+fixtures. No C++ dispatch should be emitted for them.
+
+| Fixture | Required source diagnostic |
+| --- | --- |
+| [Duplicate cases](../../stdlib/examples/invalid/enum-switch-duplicate-case.hgl) | `Mode::first` duplicates `Mode(10)`, or a named constant holding that member, after constant resolution. Reject both forms before backend emission. |
+| [Integer label](../../stdlib/examples/invalid/enum-switch-integer-case.hgl) | `case 10:` is not a `Mode` member; reject the type mismatch before coverage analysis. |
+| [Other enum label](../../stdlib/examples/invalid/enum-switch-other-enum-case.hgl) | `OtherMode::first` is not a `Mode` member, despite the same assigned number. |
+| [Unassigned result](../../stdlib/examples/invalid/enum-switch-unassigned-result.hgl) | All members are covered, but the third branch reaches `return r * 2` without assigning `r`. |
+
+Duplicate detection compares resolved typed constants, not spelling or ordinal
+position. C++ switch diagnostics alone cannot implement these checks for all
+source phases and admitted key types. Full declared-member coverage is a
+separate fact from definite assignment and must not suppress it.
+
+## Validation boundary
+
+The enum declaration and three payload blocks compile and run together without
+hgraph. They can exercise successful dispatch, partial no-match failure,
+default selection, and retained failure for an unknown C++ representation in
+the exhaustive helper. That defensive test does not make unknown values legal
+HGL values or settle native import handling.
+
+The branch-graph block additionally requires hgraph headers and syntax checking;
+it is not a complete enum graph or proof of temporal execution. The source
+fixtures and intended errors require future compiler tests. No compiler,
+runtime, Python bridge, or native enum SDK implementation is added here.

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -1074,8 +1074,19 @@ plus one. Reject duplicate resolved numbers within the enum, including
 collisions introduced by automatic numbering; do not rely on C++ emission or
 native registration to enforce this source rule. Stringification returns the
 declared member name, without a type prefix or numeric value. The source call
-is `str(value)`, including `str(Mode::first)`. Integer range/overflow rules
-remain open.
+is `str(value)`, including `str(Mode::first)`.
+
+Enum numbers use the inclusive signed `i64` range, from
+`-9223372036854775808` to `9223372036854775807`. Negative values and both
+endpoints are permitted. Reject out-of-range explicit values and automatic
+successor overflow at compile time; never wrap or clamp. Apply an explicit
+assignment directly, without first computing an unused successor of the
+previous member. A reset after the maximum is legal if the new value is in
+range and distinct from earlier members. Preserve enough literal information
+to accept the signed minimum without first narrowing its positive decimal
+magnitude to `i64`. These are enum declaration checks, not a general runtime
+integer-overflow policy or a native ABI decision.
+
 An enum is a distinct atomic scalar type, not an integer alias. Preserve that
 identity in equality and switch checking; an assigned number or a member of
 another enum is not an interchangeable case label. Integer conversion is

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -1094,13 +1094,18 @@ explicit and uses a type-name call like string conversion; its exact source
 spelling remains to be confirmed. Enumeration exposes member-name strings
 through `keys`, assigned integers through `values`, and typed enum instances
 through `elements`. All three views iterate in declaration order, never
-numeric or alphabetical order. Enum enumeration invocation syntax and result
-shape remain open; do not infer an enum enumeration grammar or general
-type-constructor surface.
+numeric or alphabetical order. The enum-type calls are `keys(Mode)`,
+`values(Mode)`, and `elements(Mode)`. For an enum with `N` members they return
+immutable scalar `list<str, N>`, `list<i64, N>`, and `list<Mode, N>` values,
+respectively. Resolve the argument as an enum type and preserve its nominal
+identity and declared member count. These are ordinary constant values that
+may be bound, indexed, reused, or iterated during wiring, not temporal ports
+or `RuntimeIterator` values. Their meaning does not become a borrowed runtime
+traversal inside a node. This does not introduce a general type-constructor
+surface or new dynamic-loop lowering.
 [Paired HGL/C++ examples](enum-cpp-mappings.md) cover declarations, numbering,
 string conversion, checked construction through `Mode(...)`, and
-declaration-order expectations; enum enumeration call examples await the open
-syntax decisions. Enum declarations remain a target
+declaration-order scalar-list enumeration. Enum declarations remain a target
 grammar extension, not implemented parser support.
 
 `default:` catches unmatched selector values; an explicitly empty body is
@@ -1351,6 +1356,11 @@ construct another time series. Its result before the endpoint's first
 modification follows hgraph's native endpoint contract.
 
 ## Runtime collection traversal
+
+The traversal rules here apply to collection-value operands. The enum-type
+forms described above return immutable fixed-size scalar lists instead; they
+do not inherit the runtime iterator's non-escape restriction or temporal
+collection phase rules.
 
 `key_set(tsd)` is phase-polymorphic. In a `CompositionFn` it resolves to the
 registered live TSS projection and has temporal source type `set<K>`. In a

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -1064,6 +1064,11 @@ show complete HGL functions before their C++ mappings.
 Every case value must be expressible as a source constant and compatible with
 the selector's admitted key type. Resolve it under the existing constant-value
 rules before evaluation; reject temporal dependencies and node-state reads.
+Reject duplicate resolved case values within one switch, rather than choosing
+the first or last occurrence. Compare typed values, not source spellings:
+if `Mode::first` is assigned `10`, it duplicates `Mode(10)` or a named constant
+resolving to that member. They cannot label separate cases. Source checks
+precede native dispatch emission.
 Case constants are configuration, not additional temporal captures. The
 selector may still be temporal. The agreed [enum source form](../design/type-extensions.md#enum-types)
 uses `enum Mode { first, second }` and qualified member references such as
@@ -1111,9 +1116,14 @@ grammar extension, not implemented parser support.
 `default:` catches unmatched selector values; an explicitly empty body is
 allowed. No match without a default must fail, including for outputless
 switches; do not manufacture an empty branch. Case bodies do not implicitly
-fall through to each other and require no source `break`. Exact selector-type
-coverage, duplicate-case diagnostics, and an expression-value surface remain
-separate design work. No parser or backend support is implemented by this
+fall through to each other and require no source `break`. For an enum selector,
+covering all declared members establishes exhaustiveness without requiring a
+default. Partial coverage is permitted and retains the same no-match rule.
+Even exhaustive dispatch must retain its failure path. Coverage does not replace
+definite-assignment checks on branches reaching a later use. Apply these checks
+in node and graph forms; see [enum switch examples](enum-switch-cpp-mappings.md).
+Exact selector-type admission, native enum mapping, and an expression-value
+surface remain separate design work. No parser or backend support is implemented by this
 design update. Recognition of the new `switch`, `case`, and `default` tokens
 must be added to the parser alongside the statement extension.
 

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -1083,12 +1083,13 @@ explicit and uses a type-name call like string conversion; its exact source
 spelling remains to be confirmed. Enumeration exposes member-name strings
 through `keys`, assigned integers through `values`, and typed enum instances
 through `elements`. All three views iterate in declaration order, never
-numeric or alphabetical order. Enum invocation syntax and result shape remain
-open; do not infer an enum enumeration grammar or general type-constructor
-surface.
+numeric or alphabetical order. Enum enumeration invocation syntax and result
+shape remain open; do not infer an enum enumeration grammar or general
+type-constructor surface.
 [Paired HGL/C++ examples](enum-cpp-mappings.md) cover declarations, numbering,
-string conversion, and declaration-order expectations; enum enumeration call
-examples await the open syntax decisions. Enum declarations remain a target
+string conversion, checked construction through `Mode(...)`, and
+declaration-order expectations; enum enumeration call examples await the open
+syntax decisions. Enum declarations remain a target
 grammar extension, not implemented parser support.
 
 `default:` catches unmatched selector values; an explicitly empty body is
@@ -1170,6 +1171,19 @@ and accepts named arguments only. Required fields must be supplied, ordinary
 defaults fill omitted fields, and a field declared with `= null` may remain
 unset. The literal `null` is accepted only when the expected field is optional;
 it is not an untyped runtime object.
+
+A call whose callee resolves to an enum type is a checked conversion from one
+integer or string operand, such as `Mode(10)` or `Mode("first")`. Resolve the
+callee to the nominal enum identity, then look up an assigned number or exact
+case-sensitive member name. Do not apply struct named-field construction rules
+or erase the result to its backing integer. Unknown numbers and names are
+errors: constants during checking, scalar configuration during wiring, and
+runtime values during evaluation. A temporal graph operand requires a wired
+checked conversion, not a wiring-time payload read. The existing validity,
+REF, and SIGNAL restrictions apply. A conversion error is not a no-match
+switch key and does not activate `default`. This is agreed target behavior,
+not implemented compiler support; see
+[enum conversion](../design/type-extensions.md#constructing-an-enum-from-a-number-or-name).
 
 An explicitly applied constructor such as `Box<f64>(value: 1.5)` must supply
 every generic argument. The `name<...>(...)` syntax is reserved for struct

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -370,6 +370,15 @@ These pending compiler tests must distinguish enum constants from temporal
 collections and evaluation-local borrowed iterators. The HGL design examples
 are not evidence of implemented compiler support.
 
+Pending enum-switch checks must cover same-enum label typing, duplicates after
+constant resolution (including constructor calls and named constants), full
+declared-member coverage without a default, partial coverage with and without
+a default, and preservation of no-match failure even for exhaustive dispatch.
+Test node and graph forms, and keep coverage separate from definite assignment:
+a covered branch that reaches a use without assigning its required result is
+still invalid. See the [design fixtures and C++ mappings](enum-switch-cpp-mappings.md);
+these examples are not implemented compiler acceptance tests.
+
 Local-binding tests distinguish immutable `let`, mutable `var`, and persistent
 `state`, and prove that a runtime `var` is reinitialized for each execution.
 

--- a/language/docs/developer-guide/testing-and-compatibility.md
+++ b/language/docs/developer-guide/testing-and-compatibility.md
@@ -362,6 +362,14 @@ Collection-view semantic tests additionally cover:
 - fixed and unbounded TSL behavior, including native added/removed delta ranges;
 - direct native filtered-range lowering versus generic loop-and-`if` behavior.
 
+Enum enumeration additionally requires coverage for the agreed type-operand
+calls `keys(Mode)`, `values(Mode)`, and `elements(Mode)`: immutable scalar-list
+results with the declared size, string/integer/nominal-enum element types,
+declaration order despite non-monotonic numbers, indexing, and binding/reuse.
+These pending compiler tests must distinguish enum constants from temporal
+collections and evaluation-local borrowed iterators. The HGL design examples
+are not evidence of implemented compiler support.
+
 Local-binding tests distinguish immutable `let`, mutable `var`, and persistent
 `state`, and prove that a runtime `var` is reinitialized for each execution.
 

--- a/language/docs/user-guide/types-and-expressions.md
+++ b/language/docs/user-guide/types-and-expressions.md
@@ -57,18 +57,33 @@ assigned numbers match. Equality and switch matching retain the enum type;
 integer conversion must be explicit, using a type-name call like string
 conversion. The exact integer call spelling remains to be confirmed.
 
+Convert an integer or member-name string into the enum using its type name:
+
+```hgl
+const mode_from_number: Mode = Mode(10)
+const mode_from_name: Mode = Mode("first")
+```
+
+Both produce `Mode::first`. Numbers match assigned values, not declaration
+positions; strings match exact, case-sensitive member names. Unknown numbers
+or names are conversion errors and never create unnamed members. Invalid
+constants fail during checking, wiring-time values during wiring, and runtime
+values during evaluation. Temporal graph arguments wire a checked conversion;
+graph wiring does not read their current payloads. Existing validity and REF
+boundaries still apply. See [checked conversion examples](../developer-guide/enum-cpp-mappings.md#checked-conversion-into-an-enum).
+
 Enums can be enumerated through `keys` (member-name strings), `values`
 (assigned integers), and `elements` (typed enum instances). For `Mode`, the
 three views expose the names `"first"`, `"second"`, `"third"`, the numbers
 `10`, `11`, `20`, and the members `Mode::first`, `Mode::second`, `Mode::third`,
 respectively. All three iterate in declaration order, with corresponding
 members at each position; explicit numbering never sorts or reorders them.
-Enum invocation syntax and result shape remain open. `elements` also provides
-element iteration over lists and sets, as described below.
+Enum enumeration invocation syntax and result shape remain open. `elements`
+also provides element iteration over lists and sets, as described below.
 
-Integer range/overflow, construction from numbers or strings, and native
-C++/Python mapping also remain open. Enums are agreed design, not implemented
-compiler support; see the [paired examples](../developer-guide/enum-cpp-mappings.md)
+Integer range/overflow and native C++/Python mapping remain open. Enums are
+agreed design, not implemented compiler support; see the
+[paired examples](../developer-guide/enum-cpp-mappings.md)
 and [Enum types](../design/type-extensions.md#enum-types).
 
 ## String conversion

--- a/language/docs/user-guide/types-and-expressions.md
+++ b/language/docs/user-guide/types-and-expressions.md
@@ -100,6 +100,14 @@ where their members are known scalar constants. They remain scalar data in
 node evaluation too. `elements` also provides list/set traversal as described
 below; that collection-value operation retains its phase-specific behavior.
 
+Enum switch labels must belong to the selector's enum. Duplicate cases are
+rejected after resolving constants, so `Mode::first` and `Mode(10)` cannot
+label separate cases. Covering every declared member is exhaustive and does
+not require a default. Partial coverage is allowed: unmatched values use the
+default or fail without one. Generated dispatch retains no-match failure even
+for exhaustive coverage. These rules apply in both function phases; see
+[enum switch examples](../developer-guide/enum-switch-cpp-mappings.md).
+
 Native C++/Python mapping remains open. Enums are agreed design, not implemented
 compiler support; see the
 [paired examples](../developer-guide/enum-cpp-mappings.md)

--- a/language/docs/user-guide/types-and-expressions.md
+++ b/language/docs/user-guide/types-and-expressions.md
@@ -50,6 +50,13 @@ resolved number plus one. Here, the numbers are `10`, `11`, and `20`.
 Duplicate numbers in one enum are rejected, including collisions caused by
 automatic numbering.
 
+Assigned numbers use the inclusive signed `i64` range,
+`-9223372036854775808` through `9223372036854775807`. Negative numbers are
+allowed. An out-of-range explicit number or an automatic increment past the
+maximum is a compile-time error, never wrapping. An explicit assignment may
+restart numbering after the maximum, provided it is in range and does not
+duplicate an earlier member. See [range examples](../developer-guide/enum-cpp-mappings.md#signed-range-and-overflow).
+
 Stringification uses `str(Mode::first)` and returns `"first"`, not `"10"` or
 `"Mode::first"`. An enum is a distinct atomic scalar type, not an integer
 alias. Members of different enums are not interchangeable, even when their
@@ -81,8 +88,8 @@ members at each position; explicit numbering never sorts or reorders them.
 Enum enumeration invocation syntax and result shape remain open. `elements`
 also provides element iteration over lists and sets, as described below.
 
-Integer range/overflow and native C++/Python mapping remain open. Enums are
-agreed design, not implemented compiler support; see the
+Native C++/Python mapping remains open. Enums are agreed design, not implemented
+compiler support; see the
 [paired examples](../developer-guide/enum-cpp-mappings.md)
 and [Enum types](../design/type-extensions.md#enum-types).
 

--- a/language/docs/user-guide/types-and-expressions.md
+++ b/language/docs/user-guide/types-and-expressions.md
@@ -79,14 +79,26 @@ values during evaluation. Temporal graph arguments wire a checked conversion;
 graph wiring does not read their current payloads. Existing validity and REF
 boundaries still apply. See [checked conversion examples](../developer-guide/enum-cpp-mappings.md#checked-conversion-into-an-enum).
 
-Enums can be enumerated through `keys` (member-name strings), `values`
-(assigned integers), and `elements` (typed enum instances). For `Mode`, the
+Enums can be enumerated by calling `keys(Mode)` (member-name strings),
+`values(Mode)` (assigned integers), and `elements(Mode)` (typed enum instances)
+on the type. For `Mode`, the
 three views expose the names `"first"`, `"second"`, `"third"`, the numbers
 `10`, `11`, `20`, and the members `Mode::first`, `Mode::second`, `Mode::third`,
 respectively. All three iterate in declaration order, with corresponding
 members at each position; explicit numbering never sorts or reorders them.
-Enum enumeration invocation syntax and result shape remain open. `elements`
-also provides element iteration over lists and sets, as described below.
+Each result is an immutable fixed-size scalar list, not a time series or a
+borrowed runtime iterator:
+
+```hgl
+const mode_keys: list<str, 3> = keys(Mode)
+const mode_values: list<i64, 3> = values(Mode)
+const mode_elements: list<Mode, 3> = elements(Mode)
+```
+
+The lists can be bound, indexed, reused, and iterated during graph wiring,
+where their members are known scalar constants. They remain scalar data in
+node evaluation too. `elements` also provides list/set traversal as described
+below; that collection-value operation retains its phase-specific behavior.
 
 Native C++/Python mapping remains open. Enums are agreed design, not implemented
 compiler support; see the
@@ -889,6 +901,10 @@ the complete output or one of its collection children produces the matching
 tick or delta.
 
 ## Collection views and iteration
+
+This section describes collection-value operands. Enum-type calls such as
+`elements(Mode)` instead produce the immutable fixed-size scalar lists
+described above; they are not subject to borrowed-iterator escape restrictions.
 
 Status: `elements` is the agreed element-iteration spelling for lists and sets,
 awaiting compiler support. Like `for`, `keys`, `values`, and `items`, it follows

--- a/language/stdlib/README.md
+++ b/language/stdlib/README.md
@@ -76,6 +76,14 @@ automatic numbering from zero, and continuation after an explicit number.
 The [paired HGL/C++ mappings](../docs/developer-guide/enum-cpp-mappings.md)
 show the resolved numbers and expected strings.
 
+The same fixture uses `Mode(10)` and `Mode("first")` to produce `Mode::first`.
+Construction checks assigned numbers or exact member names and rejects unknown
+values. The [conversion mappings](../docs/developer-guide/enum-cpp-mappings.md#checked-conversion-into-an-enum)
+show checked C++ lookups and the checking/wiring/evaluation failure boundary.
+[enum-conversion-unknown-number.hgl](examples/invalid/enum-conversion-unknown-number.hgl)
+and [enum-conversion-unknown-name.hgl](examples/invalid/enum-conversion-unknown-name.hgl)
+are intentional constant-conversion errors, not implemented compiler tests.
+
 [enum-duplicate-number.hgl](examples/invalid/enum-duplicate-number.hgl) and
 [enum-implicit-duplicate-number.hgl](examples/invalid/enum-implicit-duplicate-number.hgl)
 record the initial rejection of duplicate numbers, including an automatic

--- a/language/stdlib/README.md
+++ b/language/stdlib/README.md
@@ -67,6 +67,18 @@ intentional error: a temporal parameter cannot be used as a case constant.
 These fixtures await switch parser, checking, and lowering support; they are
 not executable acceptance tests.
 
+[enum-switch.hgl](examples/enum-switch.hgl) covers exhaustive enum dispatch
+in node and graph forms, partial coverage with no default, and a supplied
+default. [Enum-switch HGL/C++ mappings](../docs/developer-guide/enum-switch-cpp-mappings.md)
+show the local payload dispatch and graph branch structure. Invalid fixtures
+cover [duplicate resolved cases](examples/invalid/enum-switch-duplicate-case.hgl),
+an [integer label](examples/invalid/enum-switch-integer-case.hgl), a
+[different enum's label](examples/invalid/enum-switch-other-enum-case.hgl), and
+[an unassigned result despite full coverage](examples/invalid/enum-switch-unassigned-result.hgl).
+Full coverage needs no default, but generated dispatch retains no-match
+failure. Partial coverage is permitted; its unmatched path fails unless a
+default handles it. These are design fixtures, not compiler tests.
+
 ## Enum values
 
 [enum-values.hgl](examples/enum-values.hgl) covers the agreed declaration and

--- a/language/stdlib/README.md
+++ b/language/stdlib/README.md
@@ -100,14 +100,15 @@ number [above the maximum](examples/invalid/enum-number-above-range.hgl),
 These are design fixtures awaiting compiler support. The
 [remaining enum decisions](../docs/design/type-extensions.md#enum-types)
 include unknown imported values and native mapping.
-Enum identity and explicit integer conversion are agreed, as are enumeration
-through `keys` (member-name strings), `values` (assigned integers), and
-`elements` (enum instances). All three iterate in declaration order, regardless
+Enum identity and explicit integer conversion are agreed. Calls on the type
+use `keys(Mode)` (member-name strings), `values(Mode)` (assigned integers), and
+`elements(Mode)` (enum instances). They return immutable fixed-size scalar
+lists, sized by the member count. All three iterate in declaration order, regardless
 of explicit numbers. [enum-enumeration-order.hgl](examples/enum-enumeration-order.hgl)
-uses non-monotonic numbering, with [paired HGL/C++ expectations](../docs/developer-guide/enum-cpp-mappings.md#declaration-order-enumeration).
-Their remaining source and result-shape details are recorded in the design
-document; no speculative enumeration call fixtures are
-added here.
+uses non-monotonic numbering, type-operand calls, indexing, and reuse, with
+[paired HGL/C++ expectations](../docs/developer-guide/enum-cpp-mappings.md#declaration-order-enumeration).
+The results are constant data rather than time series or borrowed iterators.
+These remain design fixtures awaiting compiler support.
 
 ## String conversion
 

--- a/language/stdlib/README.md
+++ b/language/stdlib/README.md
@@ -89,9 +89,17 @@ are intentional constant-conversion errors, not implemented compiler tests.
 record the initial rejection of duplicate numbers, including an automatic
 number that collides with an earlier explicit member.
 
+[enum-number-range.hgl](examples/enum-number-range.hgl) covers negative
+numbering, both signed `i64` endpoints, and an explicit reset after the
+maximum. The [paired HGL/C++ range examples](../docs/developer-guide/enum-cpp-mappings.md#signed-range-and-overflow)
+explain the compile-time, no-wrap rule. Intentional errors cover an explicit
+number [above the maximum](examples/invalid/enum-number-above-range.hgl),
+[below the minimum](examples/invalid/enum-number-below-range.hgl), and
+[automatic successor overflow](examples/invalid/enum-number-overflow.hgl).
+
 These are design fixtures awaiting compiler support. The
 [remaining enum decisions](../docs/design/type-extensions.md#enum-types)
-include integer range/overflow, unknown imported values, and native mapping.
+include unknown imported values and native mapping.
 Enum identity and explicit integer conversion are agreed, as are enumeration
 through `keys` (member-name strings), `values` (assigned integers), and
 `elements` (enum instances). All three iterate in declaration order, regardless

--- a/language/stdlib/examples/enum-enumeration-order.hgl
+++ b/language/stdlib/examples/enum-enumeration-order.hgl
@@ -3,10 +3,19 @@
 // keys: "high", "low", "next".
 // values: 20, 5, 6, in declaration order, not numeric order.
 // elements: EnumerationOrder::high, EnumerationOrder::low, EnumerationOrder::next.
-// Enum enumeration call syntax and return shape remain open.
+// Calls on the enum type return immutable fixed-size scalar lists.
 
 enum EnumerationOrder {
     high = 20,
     low = 5,
     next
 }
+
+const enumeration_keys: list<str, 3> = keys(EnumerationOrder)
+const enumeration_values: list<i64, 3> = values(EnumerationOrder)
+const enumeration_elements: list<EnumerationOrder, 3> = elements(EnumerationOrder)
+
+const first_enumerated_name: str = enumeration_keys[0]
+const first_enumerated_number: i64 = enumeration_values[0]
+const first_enumerated_element: EnumerationOrder = enumeration_elements[0]
+const same_elements: list<EnumerationOrder, 3> = enumeration_elements

--- a/language/stdlib/examples/enum-number-range.hgl
+++ b/language/stdlib/examples/enum-number-range.hgl
@@ -1,0 +1,16 @@
+// Agreed signed-i64 enum numbering examples; compiler support is separate.
+// See language/docs/developer-guide/enum-cpp-mappings.md.
+
+enum Direction {
+    reverse = -1,
+    stopped,
+    forward
+}
+
+enum Bounds {
+    minimum = -9223372036854775808,
+    after_minimum,
+    maximum = 9223372036854775807,
+    reset = -1,
+    after_reset
+}

--- a/language/stdlib/examples/enum-switch.hgl
+++ b/language/stdlib/examples/enum-switch.hgl
@@ -1,0 +1,64 @@
+// Agreed enum-switch design; not yet supported by the compiler.
+// See language/docs/developer-guide/enum-switch-cpp-mappings.md.
+
+enum Mode {
+    first = 10,
+    second,
+    third = 20
+}
+
+fn choose(mode: Mode, x: i64, y: i64) -> i64 {
+    var r: i64
+    switch mode {
+        case Mode::first:
+            r = x
+        case Mode::second:
+            r = y
+        case Mode::third:
+            r = x + y
+    }
+    return r * 2
+}
+
+fn choose_node(mode: Mode, x: i64, y: i64) -> i64 {
+    when modified(mode, x, y) && valid(mode, x, y) {
+        var r: i64
+        switch mode {
+            case Mode::first:
+                r = x
+            case Mode::second:
+                r = y
+            case Mode::third:
+                r = x + y
+        }
+        return r * 2
+    }
+}
+
+fn choose_partial_node(mode: Mode, x: i64, y: i64) -> i64 {
+    when modified(mode, x, y) && valid(mode, x, y) {
+        var r: i64
+        switch mode {
+            case Mode::first:
+                r = x
+            case Mode::second:
+                r = y
+        }
+        return r * 2
+    }
+}
+
+fn choose_default_node(mode: Mode, x: i64, y: i64) -> i64 {
+    when modified(mode, x, y) && valid(mode, x, y) {
+        var r: i64
+        switch mode {
+            case Mode::first:
+                r = x
+            case Mode::second:
+                r = y
+            default:
+                r = x + y
+        }
+        return r * 2
+    }
+}

--- a/language/stdlib/examples/enum-values.hgl
+++ b/language/stdlib/examples/enum-values.hgl
@@ -22,3 +22,7 @@ const first_mode_name: str = str(Mode::first)
 
 const mode_from_number: Mode = Mode(10)
 const mode_from_name: Mode = Mode("first")
+
+const mode_keys: list<str, 3> = keys(Mode)
+const mode_values: list<i64, 3> = values(Mode)
+const mode_elements: list<Mode, 3> = elements(Mode)

--- a/language/stdlib/examples/enum-values.hgl
+++ b/language/stdlib/examples/enum-values.hgl
@@ -3,6 +3,7 @@
 // Mode numbers: 10, 11, 20. Sequence numbers: 0, 1, 10, 11.
 // Stringification uses the member name, without a type prefix or number.
 // String conversion uses the agreed str(value) spelling.
+// Checked enum construction uses the enum type name with a number or name.
 
 enum Mode {
     first = 10,
@@ -18,3 +19,6 @@ enum Sequence {
 }
 
 const first_mode_name: str = str(Mode::first)
+
+const mode_from_number: Mode = Mode(10)
+const mode_from_name: Mode = Mode("first")

--- a/language/stdlib/examples/invalid/enum-conversion-unknown-name.hgl
+++ b/language/stdlib/examples/invalid/enum-conversion-unknown-name.hgl
@@ -1,0 +1,10 @@
+// Intentional design error: member names are exact and case-sensitive.
+// See language/docs/developer-guide/enum-cpp-mappings.md.
+
+enum Mode {
+    first = 10,
+    second,
+    third = 20
+}
+
+const missing_mode: Mode = Mode("First")

--- a/language/stdlib/examples/invalid/enum-conversion-unknown-number.hgl
+++ b/language/stdlib/examples/invalid/enum-conversion-unknown-number.hgl
@@ -1,0 +1,10 @@
+// Intentional design error: 12 is not an assigned Mode number.
+// See language/docs/developer-guide/enum-cpp-mappings.md.
+
+enum Mode {
+    first = 10,
+    second,
+    third = 20
+}
+
+const missing_mode: Mode = Mode(12)

--- a/language/stdlib/examples/invalid/enum-number-above-range.hgl
+++ b/language/stdlib/examples/invalid/enum-number-above-range.hgl
@@ -1,0 +1,6 @@
+// Intentional design error: explicit enum number exceeds signed-i64 maximum.
+// This must fail at compile time, without wrapping to the minimum.
+
+enum AboveRange {
+    value = 9223372036854775808
+}

--- a/language/stdlib/examples/invalid/enum-number-below-range.hgl
+++ b/language/stdlib/examples/invalid/enum-number-below-range.hgl
@@ -1,0 +1,6 @@
+// Intentional design error: explicit enum number is below signed-i64 minimum.
+// This must fail at compile time, without wrapping to the maximum.
+
+enum BelowRange {
+    value = -9223372036854775809
+}

--- a/language/stdlib/examples/invalid/enum-number-overflow.hgl
+++ b/language/stdlib/examples/invalid/enum-number-overflow.hgl
@@ -1,0 +1,7 @@
+// Intentional design error: automatic successor exceeds signed-i64 maximum.
+// An explicit in-range reset would be valid; this implicit member must fail.
+
+enum AutomaticOverflow {
+    maximum = 9223372036854775807,
+    next
+}

--- a/language/stdlib/examples/invalid/enum-switch-duplicate-case.hgl
+++ b/language/stdlib/examples/invalid/enum-switch-duplicate-case.hgl
@@ -1,0 +1,28 @@
+// Intentional source errors: resolve and type-check constants before
+// rejecting duplicate cases. Each function independently repeats Mode::first.
+
+enum Mode {
+    first = 10,
+    second,
+    third = 20
+}
+
+const first_mode: Mode = Mode(10)
+
+fn duplicate_constructor(mode: Mode, x: i64) -> i64 {
+    switch mode {
+        case Mode::first:
+            return x
+        case Mode(10):
+            return x + 1
+    }
+}
+
+fn duplicate_named_constant(mode: Mode, x: i64) -> i64 {
+    switch mode {
+        case Mode::first:
+            return x
+        case first_mode:
+            return x + 1
+    }
+}

--- a/language/stdlib/examples/invalid/enum-switch-integer-case.hgl
+++ b/language/stdlib/examples/invalid/enum-switch-integer-case.hgl
@@ -1,0 +1,12 @@
+// Intentional source error: Mode's assigned integer is not a Mode member.
+
+enum Mode {
+    first = 10
+}
+
+fn integer_case(mode: Mode, x: i64) -> i64 {
+    switch mode {
+        case 10:
+            return x
+    }
+}

--- a/language/stdlib/examples/invalid/enum-switch-other-enum-case.hgl
+++ b/language/stdlib/examples/invalid/enum-switch-other-enum-case.hgl
@@ -1,0 +1,16 @@
+// Intentional source error: coincident numbers do not erase enum identity.
+
+enum Mode {
+    first = 10
+}
+
+enum OtherMode {
+    first = 10
+}
+
+fn other_enum_case(mode: Mode, x: i64) -> i64 {
+    switch mode {
+        case OtherMode::first:
+            return x
+    }
+}

--- a/language/stdlib/examples/invalid/enum-switch-unassigned-result.hgl
+++ b/language/stdlib/examples/invalid/enum-switch-unassigned-result.hgl
@@ -1,0 +1,21 @@
+// Intentional source error: full case coverage is not definite assignment.
+// The third case reaches the return without assigning r.
+
+enum Mode {
+    first = 10,
+    second,
+    third = 20
+}
+
+fn unassigned_enum_result(mode: Mode, x: i64, y: i64) -> i64 {
+    var r: i64
+    switch mode {
+        case Mode::first:
+            r = x
+        case Mode::second:
+            r = y
+        case Mode::third:
+            debug_print("third", x)
+    }
+    return r * 2
+}


### PR DESCRIPTION
## Summary

Focused HGL design follow-up to merged PR #735. No compiler, runtime, or Python implementation changes.

- Checked enum construction uses the type name: `Mode(10)` and `Mode("first")` produce `Mode::first`. Match assigned integers or exact, case-sensitive member names; unknown inputs are conversion errors, not unnamed members.
- Assigned enum numbers use the signed `i64` range, including negative values and both endpoints. Reject out-of-range explicit numbers and automatic successor overflow at compile time, without wrapping or clamping. An explicit in-range reset after the maximum remains valid, subject to duplicate checks.
- Enum enumeration calls take the type: `keys(Mode)`, `values(Mode)`, and `elements(Mode)`. Results are immutable fixed-size scalar lists of member names, assigned integers, and nominally typed enum instances. Size is the declared member count; order is declaration order, even for non-monotonic numbers.
- Enumeration results can be bound, indexed, reused, and iterated during graph wiring as scalar data. They are not time-series inputs or evaluation-local borrowed iterators. Collection-value traversal keeps its existing phase/lifetime rules.
- Enum switches reject duplicate cases after constant resolution, require same-enum labels, and establish exhaustiveness when every declared member is covered. Partial coverage remains permitted; unmatched values use a supplied default or fail. Even exhaustive generated dispatch retains no-match failure. Coverage does not replace definite assignment.
- Add paired HGL/C++ enum-switch examples and negative fixtures for duplicates, wrong label types, and an unassigned result despite full coverage. The graph-authoring guidance keeps temporal dispatch in native child graphs and explicitly separates branch computations from the still-open enum SDK boundary.
- Address the review comment by removing the stale open decision for conversion phases and making clear that only native representation/import integration remains open there.
- Preserve enum identity and existing phase, validity, REF, and SIGNAL rules. Invalid constants fail during checking, scalar configuration during wiring, and dynamic values during evaluation. A switch default does not catch selector conversion errors.
- Update design records, user/developer guides, and standard-library design fixtures. HGL source precedes the C++ mappings, including enumeration, indexing, and reuse. Retain intentionally invalid conversion and numeric-range examples.

## Scope boundary

This records the agreed source contract only. Existing executable compiler examples and runtime files are unchanged; the design fixtures remain outside `language/examples`.

The enum-to-integer call spelling and native enum carrier/import rules remain separate decisions. Enum enumeration invocation and scalar-list result kind are now agreed. The illustrative C++ constant arrays do not settle native SDK storage or ABI; the lookup helpers and exception type are not new SDK APIs or an agreement on HGL catch syntax. Already-typed native enum values containing unknown numbers remain a separate import-boundary question. This does not expand dynamic graph-loop lowering or settle general runtime integer arithmetic.

## Validation

- Latest switch/review checkpoint: 13 documentation/design-fixture files passed scope, whitespace, balanced-fence, private-data, and 115 relative-link/anchor checks. All five positive HGL blocks exactly mirror the corpus and precede their C++ mappings. Negative-fixture intent and the corrected phase/open-decisions boundary were audited; this is not compiler parsing or semantic execution.
- All five new enum-switch C++ blocks syntax-check with Clang C++23 and warnings as errors. The standalone enum and three dispatch helpers compile and run: declared members, partial no-match failure, a supplied default, later result use, negative payloads, and retained exhaustive no-match failure for four unknown C++ representations. These defensive C++ values are not newly admitted HGL values. No complete native enum graph was executed.
- Earlier enumeration checkpoint: 11 documentation/design-fixture files passed scope, whitespace, balanced-fence, private-data, and 118 relative-link/anchor checks. Enum declaration/conversion/enumeration fixtures, range fixtures, and string-conversion examples match the guide; every C++ block has preceding HGL source in its section.
- All seven enum-guide C++ blocks syntax-check together against source headers with Clang C++23 and `-Wall -Wextra -Wpedantic -Werror`.
- The first five standalone C++ blocks compile and run. Checks cover scalar-list sizes, element types, immutable constants, declaration order, indexing, reuse, number/name conversion round trips, and rejected unknown inputs. Existing signed-range assertions remain checked.
- Earlier range checkpoint: a literal-example audit confirmed negative numbering, signed endpoints, explicit reset after the maximum, three intended range/overflow errors, and existing duplicate-number errors. This was not compiler parsing or execution.
- `git diff --check` and `git diff --cached --check` passed before commit.
- HGL fixtures were audited, not parsed or executed. Full native/Python suites and graph execution tests were not run under the documentation-only policy. CI was not checked or monitored.
