### PR TITLE
Add the HGL signal input type

### DIFF
--- a/language/README.md
+++ b/language/README.md
@@ -55,7 +55,7 @@ Portable runtime-module loading, multi-registry module transactions,
 typed `const` arguments in native generic Bundle identity, multiple-parent
 field order, explicit optional-field clearing,
 general runtime calls and non-scalar state, wiring-time reference access,
-collection-reference propagation, SIGNAL spelling, timed harness sequences, and TOML
+collection-reference propagation, timed harness sequences, and TOML
 run configuration remain staged work
 ([roadmap](docs/design/roadmap.md)).
 

--- a/language/docs/README.md
+++ b/language/docs/README.md
@@ -49,7 +49,7 @@ out so examples do not imply an implemented compatibility promise.
    what a host needs to run an HGL program.
 10. [Type extensions](design/type-extensions.md) — agreed atomic treatment of
    imported types, `ref<T>`, reference-transparent type compatibility, opaque
-   node access, wiring-time dereferencing, input-only SIGNAL observation,
+   node access, wiring-time dereferencing, input-only `signal` observation,
    enum declaration/member syntax, explicit and automatic numbering,
    member-name stringification through `str(value)`, and duplicate-number
    rejection.

--- a/language/docs/design/control-flow.md
+++ b/language/docs/design/control-flow.md
@@ -429,7 +429,7 @@ is diagnosed explicitly.
 The true branch takes `value` as a temporal input, with `"enabled"` as its
 fixed label. The selector is `enabled`. The false path has no conditional
 work. This switch has no output: no returned time-series connection, bundle,
-dummy value, or SIGNAL output is required. There are no escaping bindings to
+dummy value, or `signal` output is required. There are no escaping bindings to
 remap. Native sink-switch behavior is covered in
 [test_switch.cpp](../../../tests/cpp/test_switch.cpp).
 
@@ -451,7 +451,7 @@ are insufficient to describe the generated switch.
 This requires identifying the external dependencies of each branch, retaining
 their resolved types and wiring-time versus temporal roles, and describing how
 the branch's inputs bind to the enclosing switch. The agreed REF boundaries
-and SIGNAL input restrictions remain part of the relevant input contracts;
+and `signal` input restrictions remain part of the relevant input contracts;
 type compatibility must not erase those access semantics.
 
 First determine the source return targets and the continuations reached by
@@ -470,7 +470,8 @@ The agreed derivation then has both input and output sides:
    escaping variable unchanged.
 2. Separate wiring-time scalar captures from temporal input captures. Scalar
    captures specialize branch composition; they are not live switch input
-   slots. Preserve resolved input types, REF boundaries, and SIGNAL contracts.
+   slots. Preserve resolved input types, reference boundaries, and `signal`
+   contracts.
    Use reference capture for a generated pure forwarding branch; an ordinary
    temporal input is sufficient where processing is assured.
 3. Form the shared temporal input slots from both branches, deduplicating by

--- a/language/docs/design/roadmap.md
+++ b/language/docs/design/roadmap.md
@@ -289,13 +289,13 @@ core implementation is currently expressible.
 | Composition control flow | Scalar `if`, direct temporal conditionals with results or sinks, escaping and forwarded bindings, omitted `else`, nested direct early-return continuations, and independent fixed or dynamic collection bodies are implemented in both backends. |
 | Runtime nodes | Activation and validity, scalar recordable state, `out` and `logger`, lifecycle over state and `const` values, and current collection views support representative stateless and scalar-state candidates. |
 | Native interface | Exact canonical-scalar AOT calls and lifecycle descriptors are ready; normalized wrapper generation, owned opaque state, and portable scripted external dependency loading remain out. |
-| References, signals, enums, and explicit switch | The documented reference subset is limited; SIGNAL spelling, enum lowering, and explicit switch lowering are not migration-ready. |
+| References, signals, enums, and explicit switch | The documented reference subset is limited; lowercase `signal` inputs are implemented, while enum and explicit switch lowering are not migration-ready. |
 
 The inventory therefore comes next. Its first candidate set should prefer pure
 composition and may identify representative stateless scalar nodes after their
 actual requirements are recorded. Compiler work after that point is driven by
 a selected migration and one already-defined semantic contract. Wiring-time
-reference access, collection-reference propagation, SIGNAL spelling, enum and
+reference access, collection-reference propagation, enum and
 switch lowering, multiple-parent field order, optional clearing, opaque state,
 and other open contracts remain fail-closed until their design or owning hgraph
 API is agreed.
@@ -334,7 +334,7 @@ operator contracts are transparent aliases rather than derived marker classes.
 
 The implementation fails closed where the public or language contract is not
 settled: wiring-time dereference through a reference, collection-reference
-propagation, nested reference normalization, SIGNAL spelling, multiple-parent
+propagation, nested reference normalization, multiple-parent
 field order, constructor inference, typed `const`
 generic Bundle metadata, explicit optional-field clearing, consumption of
 temporal deltas, general callable substitution, portable scripted loading,

--- a/language/docs/design/switch.md
+++ b/language/docs/design/switch.md
@@ -94,7 +94,7 @@ REF binding adaptation must use the existing type and wiring rules. Wiring
 must not read the selector's current runtime payload to choose a branch.
 
 In node evaluation, the selector must be readable under the existing validity
-and access rules. SIGNAL has no selectable payload, and an opaque REF does not
+and access rules. `signal` has no selectable payload, and an opaque `ref` does not
 permit reading the referenced value to make a case comparison. This does not
 restrict the separately supported forwarding of REF values by a branch.
 
@@ -129,7 +129,7 @@ cases and the optional default:
    predeclared escaping variables. Branch-local declarations do not escape.
 2. Separate wiring-time captures from temporal inputs. Form shared temporal
    input slots by source identity and remap each branch's captures onto them.
-   Preserve REF forwarding intent and SIGNAL input restrictions. The selector
+   Preserve reference forwarding intent and `signal` input restrictions. The selector
    is the switch key; a branch which also reads it has that lexical dependency.
 3. Derive compatible result signatures, including used expression results and
    escaping assignments. Zero results use the native outputless switch path;

--- a/language/docs/design/type-extensions.md
+++ b/language/docs/design/type-extensions.md
@@ -1,11 +1,13 @@
-# Imported values, reference types, SIGNAL inputs, and enums
+# Imported values, reference types, `signal` inputs, and enums
 
 Status: agreed source semantics, 2026-09-05; explicit `ref<T>` parsing, type
 checking, metadata, descriptors, and generated reference-routing nodes are
-implemented. Wiring-time access through a reference and imported native types
-remain compiler work. The collection-reference mapping noted below and SIGNAL
-spelling still need clarification. This record introduces no native declaration
-syntax.
+implemented. The lowercase `signal` input marker is also implemented through
+parsing, semantic checking, descriptor validation, direct-wiring type
+materialization, generated C++, and scripted runtime behavior tests.
+Wiring-time access through a reference and imported native types remain
+compiler work. The collection-reference mapping noted below still needs
+clarification. This record introduces no native declaration syntax.
 
 ## Enum types
 
@@ -275,9 +277,9 @@ rejects field or index access through `ref<T>` in every phase rather than
 silently reading a value. Simple reference forwarding and normal hgraph
 endpoint adaptation are supported.
 
-## SIGNAL inputs
+## `signal` inputs
 
-SIGNAL is an input-only observation contract. It accepts a time-series input
+`signal` is an input-only observation contract. It accepts a time-series input
 without exposing the input's value or structure. Its only observation
 operations are:
 
@@ -288,18 +290,22 @@ operations are:
 Value access is unavailable, including any value or delta payload that an
 underlying native representation may technically expose. The intended source
 contract does not permit arithmetic, Boolean value tests, field access,
-indexing, or traversal of the connected data through a SIGNAL input.
+indexing, or traversal of the connected data through a `signal` input.
 
-There is no SIGNAL output in the language contract. There is consequently no
+There is no `signal` output in the language contract. There is consequently no
 signal-emission operation or literal to design. Native implementation details
 must not broaden this source contract.
 
-SIGNAL is primarily meaningful inside a node, where those observation
-operations can control evaluation. Graph functions may also accept SIGNAL
+The source spelling is lowercase `signal`. It is a contextual type marker that
+is legal only as the complete type of a non-`const` function or operator
+parameter. It cannot be nested, used as a field or result, declared `const`, or
+given a default value. Uppercase `SIGNAL` remains unknown in HGL. The generated
+C++ schema spelling is `hgraph::SIGNAL`.
+
+`signal` is primarily meaningful inside a node, where those observation
+operations can control evaluation. Graph functions may also accept `signal`
 inputs and pass them to components with compatible inputs. This does not make
 the graph body execute on ticks or expose a runtime value during wiring.
-
-The semantics above are agreed; the HGL type spelling remains to be confirmed.
 
 ## Collection-reference mapping to clarify
 
@@ -321,8 +327,8 @@ decision.
 
 ## Scope of this agreement
 
-This record does not settle SIGNAL spelling, native declaration syntax,
-reference construction or mutation operations, or additional restrictions on
-reference placement. Those remain separate discussion items. Implemented
+This record does not settle native declaration syntax, reference construction
+or mutation operations, or additional restrictions on reference placement.
+Those remain separate discussion items. Implemented
 reference forms are exercised by `examples/reference-routing.hgl`; unresolved
 forms continue to fail closed.

--- a/language/docs/developer-guide/syntax-and-semantics.md
+++ b/language/docs/developer-guide/syntax-and-semantics.md
@@ -248,6 +248,7 @@ type            = scalar_type
                 | map_type
                 | rolling_type
                 | ref_type
+                | signal_type
                 | named_type
                 | "atomic", "<", value_type, ">";
 value_type      = scalar_type
@@ -275,6 +276,7 @@ rolling_type    = "rolling", "<", value_type, ",",
                   const_expression,
                   [ ",", const_expression ], ">";
 ref_type        = "ref", "<", type, ">";
+signal_type     = "signal";
 value_tuple_type = "tuple", "<", value_type,
                    { ",", value_type }, ">";
 value_list_type = "list", "<", value_type, ">";
@@ -301,7 +303,7 @@ temporalized:
 map<str, atomic<tuple<f64, f64>>>
 ```
 
-`value_type` excludes `atomic`, `rolling`, and `ref` and is used for `const`
+`value_type` excludes `atomic`, `rolling`, `ref`, and `signal` and is used for `const`
 parameters, atomic payloads, map keys, set elements, and rolling values. `type` allows
 atomic and reference boundaries recursively inside structural values. `rolling`
 is already a temporal endpoint shape and therefore cannot appear under `atomic`
@@ -314,7 +316,14 @@ where the grammar requires `value_type`: a `const` annotation, an atomic
 payload, a map or set key, or a rolling value. `ref` is a contextual type
 keyword when directly followed by `<`; otherwise normal name resolution
 applies. Reference access and compatibility rules are recorded in
-[Imported values, reference types, and SIGNAL inputs](../design/type-extensions.md).
+[Imported values, reference types, and signal inputs](../design/type-extensions.md).
+
+`signal` is a contextual, payload-erased input marker. It is legal only as the
+complete type of a non-`const` function or operator parameter; results,
+structure fields, nested uses, `const` parameters, and defaults are rejected
+semantically. It accepts any concrete temporal input, materializes as the
+native `hgraph::SIGNAL` schema, and has no scalar value type. The spelling is
+lowercase in HGL; uppercase `SIGNAL` is not an HGL type.
 
 A rolling window is sized by tick count or by duration. The size arguments
 are constant expressions, and their type selects the kind: `i64` sizes
@@ -1106,8 +1115,8 @@ grammar above does not yet implement this extension. Resolve the operand's
 type and phase before lowering: a constant/wiring-time scalar produces a
 scalar string, a readable node value is converted within evaluation, and a
 temporal graph input wires a string-conversion node. Preserve native type
-metadata, including enum member names, and the existing validity, REF, and
-SIGNAL restrictions. Conversion itself does not classify a function as a
+metadata, including enum member names, and the existing validity, reference, and
+`signal` restrictions. Conversion itself does not classify a function as a
 runtime node. See [String conversion](../user-guide/types-and-expressions.md#string-conversion).
 
 This agreement covers the one-value Python-style spelling, not Python's

--- a/language/docs/user-guide/types-and-expressions.md
+++ b/language/docs/user-guide/types-and-expressions.md
@@ -116,8 +116,8 @@ the function's phase nor creates an extra node inside a `when` handler.
 
 This is Python-style call spelling, not a blanket agreement on Python's
 formatting, encoding arguments, implicit conversions, or custom `__str__`
-methods. The enum member-name rule is unchanged. Existing REF opacity and
-SIGNAL payload restrictions also remain: conversion is not an escape from
+methods. The enum member-name rule is unchanged. Existing reference opacity and
+`signal` payload restrictions also remain: conversion is not an escape from
 them. See the [HGL/C++ mappings](../developer-guide/enum-cpp-mappings.md#conversion-in-nodes-and-graphs).
 
 ## Temporal values
@@ -250,20 +250,35 @@ The executable form is in
 compiler rejects `map<K, ref<V>>` until its outer-reference rule is settled,
 and rejects nested `ref<ref<T>>` rather than normalizing it implicitly.
 
-## SIGNAL inputs
+## `signal` inputs
 
-Status: agreed input semantics; HGL spelling and compiler implementation remain
-separate discussion and implementation work. See
-[SIGNAL inputs](../design/type-extensions.md#signal-inputs).
+Status: implemented for function and operator inputs. See
+[`signal` inputs](../design/type-extensions.md#signal-inputs).
 
-SIGNAL accepts a time-series input and exposes only `modified`, `valid`, and
-`last_modified`. It has no accessible value or delta payload, regardless of
-what the native representation may store internally. It cannot be used to
-read fields, index data, perform arithmetic, or test a Boolean payload.
+`signal` accepts any concrete time-series input and exposes only `modified`,
+`valid`, and `last_modified`. It has no accessible value or delta payload,
+regardless of what the native representation may store internally. It cannot
+be used to read fields, index data, perform arithmetic, or test a Boolean
+payload.
 
-SIGNAL is input-only: there is no SIGNAL result or signal-emission syntax.
+```hgl
+fn count_ticks(pulse: signal) -> i64 {
+    state count: i64 = 0
+
+    when modified(pulse) {
+        count += 1
+        return count
+    }
+}
+```
+
+`signal` is input-only: there is no `signal` result or signal-emission syntax.
+It must be the complete type of a non-`const` parameter and cannot have a
+default. The spelling is lowercase; `SIGNAL` is not an HGL type. Generated C++
+maps the marker to the native `hgraph::SIGNAL` schema.
+
 Its observation operations are primarily useful in nodes. Graph functions may
-also accept SIGNAL inputs and pass them to other components; the graph itself
+also accept `signal` inputs and pass them to other components; the graph itself
 still executes only during wiring.
 
 ## List sizes

--- a/language/src/codegen/cpp_emitter.cpp
+++ b/language/src/codegen/cpp_emitter.cpp
@@ -56,6 +56,7 @@ namespace hgl::codegen
                 Rolling,
                 Atomic,
                 Reference,
+                Signal,
                 Generic,
                 Struct,
             };
@@ -1027,6 +1028,12 @@ namespace hgl::codegen
                         result.children.push_back(planned_type(type.children.front(), range, bindings));
                         return result;
                     }
+                case TypeKind::Signal:
+                    {
+                        HType result;
+                        result.kind = HType::Kind::Signal;
+                        return result;
+                    }
                 case TypeKind::Void:
                 case TypeKind::Iterator:
                 case TypeKind::Callable:
@@ -1228,6 +1235,7 @@ namespace hgl::codegen
                 case HType::Kind::Rolling: backend(range, "'rolling' has no value type; it is a time-series window");
                 case HType::Kind::Atomic: return value_type(type.children[0], range);
                 case HType::Kind::Reference: backend(range, "'ref' has no scalar value type");
+                case HType::Kind::Signal: backend(range, "'signal' has no scalar value type");
                 case HType::Kind::Generic: return type.cpp_type;
                 case HType::Kind::Struct: return "typename " + type.cpp_type + "::value_type";
                 case HType::Kind::Unknown: break;
@@ -1255,6 +1263,7 @@ namespace hgl::codegen
                     return "hgraph::TSW<" + value_type(type.children[0], range) + ", " + type.size + ", " + type.min_size + ">";
                 case HType::Kind::Struct: return "typename " + type.cpp_type + "::time_series";
                 case HType::Kind::Reference: return "hgraph::REF<" + schema(type.children[0], range) + ">";
+                case HType::Kind::Signal: return "hgraph::SIGNAL";
                 case HType::Kind::Generic: return "hgraph::TS<" + value_type(type, range) + ">";
                 case HType::Kind::Unknown: break;
             }
@@ -3694,9 +3703,9 @@ namespace hgl::codegen
                 if (binding.kind != expected) { backend(binding.range, "hgraph IR runtime parameter has the wrong binding kind"); }
                 const HType type = planned_type(parameter.type, planned.range);
                 if (type.kind != HType::Kind::Scalar && type.kind != HType::Kind::Map && type.kind != HType::Kind::Set &&
-                    type.kind != HType::Kind::List && type.kind != HType::Kind::Reference) {
+                    type.kind != HType::Kind::List && type.kind != HType::Kind::Reference && type.kind != HType::Kind::Signal) {
                     backend(graph_type(parameter.type, planned.range).range,
-                            "the runtime-node slice supports scalar, collection, and ref parameters");
+                            "the runtime-node slice supports scalar, collection, ref, and signal parameters");
                 }
                 if (!parameter.is_const) { ++temporal_count; }
             }

--- a/language/src/descriptor/module_descriptor.cpp
+++ b/language/src/descriptor/module_descriptor.cpp
@@ -41,6 +41,7 @@ namespace hgl::descriptor
                 case TypeKind::Rolling: return TypeCategory::Rolling;
                 case TypeKind::Atomic: return TypeCategory::Atomic;
                 case TypeKind::Reference: return TypeCategory::Reference;
+                case TypeKind::Signal: return TypeCategory::Signal;
                 case TypeKind::Iterator: return TypeCategory::Iterator;
                 case TypeKind::Callable: return TypeCategory::Callable;
                 case TypeKind::Capability: return TypeCategory::Capability;

--- a/language/src/descriptor/module_descriptor.h
+++ b/language/src/descriptor/module_descriptor.h
@@ -39,6 +39,7 @@ namespace hgl::descriptor
         Rolling,
         Atomic,
         Reference,
+        Signal,
         Iterator,
         Callable,
         Capability,

--- a/language/src/descriptor/module_descriptor_json.cpp
+++ b/language/src/descriptor/module_descriptor_json.cpp
@@ -113,6 +113,7 @@ namespace hgl::descriptor
                 case TypeCategory::Rolling: return "rolling";
                 case TypeCategory::Atomic: return "atomic";
                 case TypeCategory::Reference: return "ref";
+                case TypeCategory::Signal: return "signal";
                 case TypeCategory::Iterator: return "iterator";
                 case TypeCategory::Callable: return "callable";
                 case TypeCategory::Capability: return "capability";

--- a/language/src/descriptor/module_descriptor_reader.cpp
+++ b/language/src/descriptor/module_descriptor_reader.cpp
@@ -553,6 +553,7 @@ namespace hgl::descriptor
                                      {"rolling", TypeCategory::Rolling},
                                      {"atomic", TypeCategory::Atomic},
                                      {"ref", TypeCategory::Reference},
+                                     {"signal", TypeCategory::Signal},
                                      {"iterator", TypeCategory::Iterator},
                                      {"callable", TypeCategory::Callable},
                                      {"capability", TypeCategory::Capability},
@@ -1016,14 +1017,15 @@ namespace hgl::descriptor
                         return error_;
                     }
                     for (std::size_t parent = 0; parent < declaration.parents.size(); ++parent) {
-                        if (!type_ref(declaration.parents[parent], index_path(member_path(path, "parents"), parent))) {
+                        if (!non_signal_type_ref(declaration.parents[parent],
+                                                 index_path(member_path(path, "parents"), parent))) {
                             return error_;
                         }
                     }
                     for (std::size_t field = 0; field < declaration.fields.size(); ++field) {
                         const StructField &member     = declaration.fields[field];
                         const std::string  field_path = index_path(member_path(path, "fields"), field);
-                        if (!type_ref(member.type, member_path(field_path, "type")) ||
+                        if (!non_signal_type_ref(member.type, member_path(field_path, "type")) ||
                             !constant_ref(member.default_value, member_path(field_path, "default"), true)) {
                             return error_;
                         }
@@ -1078,6 +1080,17 @@ namespace hgl::descriptor
                 return arena_ref(id, descriptor_.types.size(), "type", path, optional);
             }
 
+            [[nodiscard]] bool signal_type(SchemaId id) const noexcept {
+                return id != no_schema_id && id < descriptor_.types.size() &&
+                       descriptor_.types[id].category == TypeCategory::Signal;
+            }
+
+            bool non_signal_type_ref(SchemaId id, std::string_view path, bool optional = false) {
+                if (!type_ref(id, path, optional)) { return false; }
+                return !signal_type(id) ||
+                       fail(std::string{path}, "'signal' is only valid as a complete non-const parameter type");
+            }
+
             bool constant_ref(SchemaId id, std::string_view path, bool optional = false) {
                 return arena_ref(id, descriptor_.constant_expressions.size(), "constant-expression", path, optional);
             }
@@ -1089,7 +1102,7 @@ namespace hgl::descriptor
             bool generic_parameters(const std::vector<GenericParameter> &parameters, std::string_view path) {
                 for (std::size_t index = 0; index < parameters.size(); ++index) {
                     const GenericParameter &parameter = parameters[index];
-                    if (!type_ref(parameter.type, member_path(index_path(path, index), "type"), !parameter.is_const)) {
+                    if (!non_signal_type_ref(parameter.type, member_path(index_path(path, index), "type"), !parameter.is_const)) {
                         return false;
                     }
                 }
@@ -1101,12 +1114,19 @@ namespace hgl::descriptor
                 for (std::size_t index = 0; index < value.parameters.size(); ++index) {
                     const Parameter  &parameter      = value.parameters[index];
                     const std::string parameter_path = index_path(member_path(path, "parameters"), index);
-                    if (!type_ref(parameter.type, member_path(parameter_path, "type")) ||
+                    const std::string type_path      = member_path(parameter_path, "type");
+                    if (!type_ref(parameter.type, type_path) ||
                         !constant_ref(parameter.default_value, member_path(parameter_path, "default"), true)) {
                         return false;
                     }
+                    if (signal_type(parameter.type) && parameter.is_const) {
+                        return fail(type_path, "'signal' is only valid as a complete non-const parameter type");
+                    }
+                    if (signal_type(parameter.type) && parameter.default_value != no_schema_id) {
+                        return fail(member_path(parameter_path, "default"), "a 'signal' input cannot have a default value");
+                    }
                 }
-                return type_ref(value.result, member_path(path, "result"), true) &&
+                return non_signal_type_ref(value.result, member_path(path, "result"), true) &&
                        constraint_ref(value.requirements, member_path(path, "requires"), true);
             }
 
@@ -1301,6 +1321,7 @@ namespace hgl::descriptor
                     case TypeCategory::Void:
                     case TypeCategory::Scalar:
                     case TypeCategory::Symbol:
+                    case TypeCategory::Signal:
                     case TypeCategory::Capability:
                     case TypeCategory::Deferred: required_children = 0U; break;
                     case TypeCategory::Tuple:
@@ -1312,13 +1333,15 @@ namespace hgl::descriptor
                                                                    " child" + (*required_children == 1U ? "" : "ren"));
                 }
                 for (std::size_t index = 0; index < record.children.size(); ++index) {
-                    if (!type_ref(record.children[index], index_path(member_path(path, "children"), index))) { return false; }
+                    if (!non_signal_type_ref(record.children[index], index_path(member_path(path, "children"), index))) {
+                        return false;
+                    }
                 }
                 for (std::size_t index = 0; index < record.arguments.size(); ++index) {
                     const TypeArgument &argument      = record.arguments[index];
                     const std::string   argument_path = member_path(index_path(member_path(path, "arguments"), index), "reference");
                     if (argument.category == TypeArgumentCategory::Type) {
-                        if (!type_ref(argument.reference, argument_path)) { return false; }
+                        if (!non_signal_type_ref(argument.reference, argument_path)) { return false; }
                     } else if (!constant_ref(argument.reference, argument_path)) {
                         return false;
                     }
@@ -1373,7 +1396,7 @@ namespace hgl::descriptor
                     case ConstantExpressionCategory::Sequence:
                     case ConstantExpressionCategory::Tuple: break;
                     case ConstantExpressionCategory::Construct:
-                        if (!type_ref(record.constructed_type, member_path(path, "type"))) { return false; }
+                        if (!non_signal_type_ref(record.constructed_type, member_path(path, "type"))) { return false; }
                         break;
                 }
                 for (std::size_t index = 0; index < record.elements.size(); ++index) {
@@ -1401,7 +1424,7 @@ namespace hgl::descriptor
                     case ConstraintCategory::Symbol:
                         return !record.identity.empty() ||
                                fail(member_path(path, "identity"), "constraint symbol is missing its identity");
-                    case ConstraintCategory::Type: return type_ref(record.type, member_path(path, "type"));
+                    case ConstraintCategory::Type: return non_signal_type_ref(record.type, member_path(path, "type"));
                     case ConstraintCategory::Value: return constant_ref(record.value, member_path(path, "value"));
                     case ConstraintCategory::Set: return constraint_refs(record.elements, member_path(path, "elements"));
                     case ConstraintCategory::Call:
@@ -1412,7 +1435,7 @@ namespace hgl::descriptor
                         return (!record.identity.empty() ||
                                 fail(member_path(path, "identity"), "operator requirement is missing its identity")) &&
                                constraint_refs(record.arguments, member_path(path, "arguments")) &&
-                               type_ref(record.result, member_path(path, "result"), true);
+                               non_signal_type_ref(record.result, member_path(path, "result"), true);
                     case ConstraintCategory::Relation:
                     case ConstraintCategory::Logic:
                         return (!record.operator_spelling.empty() ||

--- a/language/src/hgraph_ir/printer.cpp
+++ b/language/src/hgraph_ir/printer.cpp
@@ -25,6 +25,7 @@ namespace hgl::hgraph_ir
                 case hir::TypeKind::Rolling: return "rolling";
                 case hir::TypeKind::Atomic: return "atomic";
                 case hir::TypeKind::Reference: return "ref";
+                case hir::TypeKind::Signal: return "signal";
                 case hir::TypeKind::Iterator: return "iterator";
                 case hir::TypeKind::Callable: return "callable";
                 case hir::TypeKind::Capability: return "capability";

--- a/language/src/ir/canonical_types.cpp
+++ b/language/src/ir/canonical_types.cpp
@@ -234,6 +234,26 @@ namespace hgl::ir::detail
         if (!expected.valid() || !actual.valid()) { return false; }
         const Type &to   = module_.type(expected);
         const Type &from = module_.type(actual);
+        if (to.kind == TypeKind::Signal) {
+            switch (from.kind) {
+                case TypeKind::Scalar:
+                case TypeKind::Symbol:
+                case TypeKind::List:
+                case TypeKind::Set:
+                case TypeKind::Map:
+                case TypeKind::Rolling:
+                case TypeKind::Atomic:
+                case TypeKind::Reference:
+                case TypeKind::Signal: return true;
+                case TypeKind::Void:
+                case TypeKind::Tuple:
+                case TypeKind::Iterator:
+                case TypeKind::Callable:
+                case TypeKind::Capability:
+                case TypeKind::HarnessSequence:
+                case TypeKind::Deferred: return false;
+            }
+        }
         if (to.kind == TypeKind::Scalar && from.kind == TypeKind::Scalar && to.scalar == ScalarType::F64 &&
             from.scalar == ScalarType::I64) {
             return true;
@@ -310,6 +330,7 @@ namespace hgl::ir::detail
             case TypeKind::Rolling: return "rolling";
             case TypeKind::Atomic: return "atomic";
             case TypeKind::Reference: return "ref";
+            case TypeKind::Signal: return "signal";
             case TypeKind::Iterator: return "iterator";
             case TypeKind::Callable: return "fn";
             case TypeKind::Capability: return "capability";

--- a/language/src/ir/hir.h
+++ b/language/src/ir/hir.h
@@ -109,6 +109,7 @@ namespace hgl::ir::hir
         Rolling,
         Atomic,
         Reference,
+        Signal,
         Iterator,
         Callable,
         Capability,

--- a/language/src/ir/hir_printer.cpp
+++ b/language/src/ir/hir_printer.cpp
@@ -68,6 +68,7 @@ namespace hgl::ir
                 case TypeKind::Rolling: return "rolling";
                 case TypeKind::Atomic: return "atomic";
                 case TypeKind::Reference: return "ref";
+                case TypeKind::Signal: return "signal";
                 case TypeKind::Iterator: return "iterator";
                 case TypeKind::Callable: return "callable";
                 case TypeKind::Capability: return "capability";

--- a/language/src/ir/lower.cpp
+++ b/language/src/ir/lower.cpp
@@ -86,6 +86,7 @@ namespace hgl::ir
                 case TypeKind::Rolling: return hir::TypeKind::Rolling;
                 case TypeKind::Atomic: return hir::TypeKind::Atomic;
                 case TypeKind::Reference: return hir::TypeKind::Reference;
+                case TypeKind::Signal: return hir::TypeKind::Signal;
             }
             std::unreachable();
         }

--- a/language/src/ir/type_check.cpp
+++ b/language/src/ir/type_check.cpp
@@ -125,7 +125,11 @@ namespace hgl::ir
             [[nodiscard]] bool   same(TypeId lhs, TypeId rhs) const noexcept { return canonical_types_.same(lhs, rhs); }
             [[nodiscard]] bool   numeric(TypeId id) const noexcept { return canonical_types_.numeric(id); }
             [[nodiscard]] bool   boolean(TypeId id) const noexcept { return canonical_types_.boolean(id); }
-            [[nodiscard]] bool   reference(TypeId id) const noexcept {
+            [[nodiscard]] bool   signal_marker(TypeId id) const noexcept {
+                id = canonical(id);
+                return id.valid() && type(id).kind == TypeKind::Signal;
+            }
+            [[nodiscard]] bool reference(TypeId id) const noexcept {
                 id = canonical(id);
                 return id.valid() && type(id).kind == TypeKind::Reference;
             }
@@ -619,7 +623,14 @@ namespace hgl::ir
                 expression.operation = Operation{.kind     = OperationKind::NominalOperator,
                                                  .identity = std::string{unary_identity(node.op)},
                                                  .deferred = operand.phase != Phase::Constant};
-                const auto required  = active_required_operation(unary_identity(node.op), {operand.type});
+                if (signal_marker(operand.type)) {
+                    type_error(operand.range, "'signal' has no payload and cannot be used with operators");
+                    expression.type = node.op == UnaryOp::Not ? scalar(ScalarType::Bool) : operand.type;
+                    if (expression.phase == Phase::Wiring) { expression.effects |= Effect::WireGraph; }
+                    expression.value_kind = value_kind_for_phase(expression.phase);
+                    return;
+                }
+                const auto required = active_required_operation(unary_identity(node.op), {operand.type});
                 if (required) {
                     expression.type               = required->result.valid() ? required->result : operand.type;
                     expression.operation.target   = required->op;
@@ -855,7 +866,18 @@ namespace hgl::ir
                 expression.operation = Operation{.kind     = OperationKind::NominalOperator,
                                                  .identity = std::string{binary_identity(node.op)},
                                                  .deferred = expression.phase != Phase::Constant};
-                const auto required  = active_required_operation(binary_identity(node.op), {lhs.type, rhs.type});
+                if (signal_marker(lhs.type) || signal_marker(rhs.type)) {
+                    type_error(expression.range, "'signal' has no payload and cannot be used with operators");
+                    expression.type = node.op == BinaryOp::Less || node.op == BinaryOp::LessEqual || node.op == BinaryOp::Greater ||
+                                              node.op == BinaryOp::GreaterEqual || node.op == BinaryOp::Equal ||
+                                              node.op == BinaryOp::NotEqual || node.op == BinaryOp::And || node.op == BinaryOp::Or
+                                          ? scalar(ScalarType::Bool)
+                                          : lhs.type;
+                    if (expression.phase == Phase::Wiring) { expression.effects |= Effect::WireGraph; }
+                    expression.value_kind = value_kind_for_phase(expression.phase);
+                    return;
+                }
+                const auto required = active_required_operation(binary_identity(node.op), {lhs.type, rhs.type});
                 if (required) {
                     expression.operation.target   = required->op;
                     expression.operation.identity = required->identity;

--- a/language/src/semantics/resolve.cpp
+++ b/language/src/semantics/resolve.cpp
@@ -333,7 +333,13 @@ namespace hgl::semantics
             void resolve_signature(ast::DeclId fn, const ast::Signature &signature, Context &context) {
                 for (std::size_t i = 0; i < signature.parameters.size(); ++i) {
                     const ast::Parameter &parameter = signature.parameters[i];
-                    if (parameter.type != ast::no_node) { resolve_type(parameter.type, context); }
+                    if (parameter.type != ast::no_node) {
+                        resolve_type(parameter.type, context, !parameter.is_const);
+                        if (module_.type(parameter.type).kind == ast::TypeKind::Signal && parameter.default_value != ast::no_node) {
+                            report(Category::Type, module_.expr(parameter.default_value).range,
+                                   "a 'signal' input cannot have a default value");
+                        }
+                    }
                     if (parameter.default_value != ast::no_node) { resolve_expr(parameter.default_value, context); }
                 }
                 if (signature.result != ast::no_node) { resolve_type(signature.result, context); }
@@ -690,8 +696,12 @@ namespace hgl::semantics
                 }
             }
 
-            void resolve_type(ast::TypeId id, Context &context) {
+            void resolve_type(ast::TypeId id, Context &context, bool allow_signal = false) {
                 const ast::Type &type = module_.type(id);
+                if (type.kind == ast::TypeKind::Signal && !allow_signal) {
+                    report(Category::Type, type.range,
+                           "'signal' is an input-only type marker and is only valid as a non-const parameter type");
+                }
                 if (type.value_position && (type.kind == ast::TypeKind::Atomic || type.kind == ast::TypeKind::Rolling ||
                                             type.kind == ast::TypeKind::Reference)) {
                     const std::string_view spelling = type.kind == ast::TypeKind::Atomic    ? "atomic"

--- a/language/src/syntax/ast.h
+++ b/language/src/syntax/ast.h
@@ -68,6 +68,7 @@ namespace hgl::syntax::ast
         Rolling,  ///< `children[0]`, `size` max, `min_size` (no_node = omitted)
         Atomic,   ///< `children[0]`
         Reference,  ///< `ref<children[0]>`
+        Signal,     ///< `signal`: input-only, payload-erased time-series observation
     };
 
     /// One argument of an applied nominal type. A bare identifier is kept

--- a/language/src/syntax/ast_printer.cpp
+++ b/language/src/syntax/ast_printer.cpp
@@ -55,6 +55,7 @@ namespace hgl::syntax
                 case ast::TypeKind::Rolling: return "rolling";
                 case ast::TypeKind::Atomic: return "atomic";
                 case ast::TypeKind::Reference: return "ref";
+                case ast::TypeKind::Signal: return "signal";
             }
             return "?";
         }

--- a/language/src/syntax/ast_projection.cpp
+++ b/language/src/syntax/ast_projection.cpp
@@ -302,6 +302,7 @@ namespace hgl::syntax
                         type.kind = ast::TypeKind::Reference;
                         type.children.push_back(project_type(only_child(id, SyntaxKind::Type), value_position));
                         break;
+                    case SyntaxKind::SignalType: type.kind = ast::TypeKind::Signal; break;
                     default: malformed("expected a type production");
                 }
                 return module_.add(std::move(type));
@@ -890,6 +891,7 @@ namespace hgl::syntax
                         case SyntaxKind::RollingType:
                         case SyntaxKind::AtomicType:
                         case SyntaxKind::RefType:
+                        case SyntaxKind::SignalType:
                             {
                                 const ast::TypeId type = project_type(value, true);
                                 return module_.add(ast::Constraint{module_.type(type).range, ast::ConstraintType{type}});

--- a/language/src/syntax/syntax_tree.cpp
+++ b/language/src/syntax/syntax_tree.cpp
@@ -27,6 +27,7 @@ namespace hgl::syntax
             KindName{SyntaxKind::RollingType, "rolling_type"},
             KindName{SyntaxKind::AtomicType, "atomic_type"},
             KindName{SyntaxKind::RefType, "ref_type"},
+            KindName{SyntaxKind::SignalType, "signal_type"},
             KindName{SyntaxKind::Type, "type"},
             KindName{SyntaxKind::SizeExpression, "size_expression"},
             KindName{SyntaxKind::ContinuedOperator, "continued_operator"},

--- a/language/src/syntax/syntax_tree.h
+++ b/language/src/syntax/syntax_tree.h
@@ -35,6 +35,7 @@ namespace hgl::syntax
         RollingType,
         AtomicType,
         RefType,
+        SignalType,
         Type,
         SizeExpression,
         ContinuedOperator,

--- a/language/src/syntax/token_grammar.cpp
+++ b/language/src/syntax/token_grammar.cpp
@@ -27,6 +27,7 @@ namespace hgl::syntax
             Map,
             Rolling,
             Ref,
+            Signal,
             Unbounded,
             Delta,
             AppliedConstructor,
@@ -44,6 +45,7 @@ namespace hgl::syntax
                                                 contextual<ContextToken::Tuple> / contextual<ContextToken::List> /
                                                 contextual<ContextToken::Set> / contextual<ContextToken::Map> /
                                                 contextual<ContextToken::Rolling> / contextual<ContextToken::Ref> /
+                                                contextual<ContextToken::Signal> /
                                                 contextual<ContextToken::Unbounded> /
                                                 contextual<ContextToken::Delta> / contextual<ContextToken::AppliedConstructor>;
         inline constexpr auto reserved_name =
@@ -171,17 +173,21 @@ namespace hgl::syntax
                                              dsl::recurse<type> + dsl::p<newlines> + token<TokenKind::Greater>;
         };
 
+        struct signal_type
+        { static constexpr auto rule = contextual<ContextToken::Signal>; };
+
         struct type
         {
             static constexpr auto rule = scalar_type | dsl::p<tuple_type> | dsl::p<list_type> | dsl::p<set_type> |
                                          dsl::p<map_type> | dsl::p<rolling_type> | dsl::p<atomic_type> | dsl::p<ref_type> |
-                                         dsl::p<named_type>;
+                                         dsl::p<signal_type> | dsl::p<named_type>;
         };
 
         struct generic_argument
         {
             static constexpr auto rule = scalar_type | dsl::p<tuple_type> | dsl::p<list_type> | dsl::p<set_type> |
                                          dsl::p<map_type> | dsl::p<rolling_type> | dsl::p<atomic_type> | dsl::p<ref_type> |
+                                         dsl::p<signal_type> |
                                          dsl::peek(ordinary_name + (token<TokenKind::Less> / token<TokenKind::ColonColon>)) >>
                                              dsl::p<named_type> |
                                          dsl::peek(expression_start) >> dsl::recurse<size_expression>;
@@ -538,7 +544,8 @@ namespace hgl::syntax
                                                 token<TokenKind::KwNull> / token<TokenKind::Minus>;
             static constexpr auto rule =
                 dsl::p<constraint_set> | scalar_type | dsl::p<tuple_type> | dsl::p<list_type> | dsl::p<set_type> |
-                dsl::p<map_type> | dsl::p<rolling_type> | dsl::p<atomic_type> | dsl::p<ref_type> | dsl::p<constraint_call> |
+                dsl::p<map_type> | dsl::p<rolling_type> | dsl::p<atomic_type> | dsl::p<ref_type> | dsl::p<signal_type> |
+                dsl::p<constraint_call> |
                 dsl::peek(ordinary_name + (token<TokenKind::Less> / token<TokenKind::ColonColon>)) >> dsl::p<named_type> |
                 dsl::peek(value_start) >> dsl::recurse<size_expression> | dsl::p<name>;
         };
@@ -718,6 +725,7 @@ namespace hgl::syntax
                 if (token.text == "map") { return static_cast<std::uint8_t>(grammar::ContextToken::Map); }
                 if (token.text == "rolling") { return static_cast<std::uint8_t>(grammar::ContextToken::Rolling); }
                 if (token.text == "ref") { return static_cast<std::uint8_t>(grammar::ContextToken::Ref); }
+                if (token.text == "signal") { return static_cast<std::uint8_t>(grammar::ContextToken::Signal); }
                 if (token.text == "unbounded") { return static_cast<std::uint8_t>(grammar::ContextToken::Unbounded); }
             }
             return static_cast<std::uint8_t>(token.kind);

--- a/language/src/wiring/backend.cpp
+++ b/language/src/wiring/backend.cpp
@@ -344,7 +344,7 @@ namespace hgl::wiring
             [[nodiscard]] Slot          fold_unary(hir::UnaryOp op, const Slot &operand, SourceRange range);
             [[nodiscard]] Slot          fold_binary(hir::BinaryOp op, const Slot &lhs, const Slot &rhs, SourceRange range);
             [[nodiscard]] Slot compare_sequences(const Slot &lhs, const Slot &rhs, bool negate, SourceRange range, Frame &frame);
-            void               resolve_sequence(Slot &slot, const hgraph::ValueTypeMetaData *element, Frame &frame);
+            void resolve_sequence(Slot &slot, const hgraph::ValueTypeMetaData *element, Frame &frame, bool erase_payload = false);
             [[nodiscard]] Slot constant_of(const Slot &slot, const hgraph::ValueTypeMetaData *meta, Frame &frame,
                                            std::string_view role);
 
@@ -802,7 +802,7 @@ namespace hgl::wiring
             backend(expression.range, "constant expression was not folded before hgraph IR lowering");
         }
 
-        void Compiler::resolve_sequence(Slot &slot, const hgraph::ValueTypeMetaData *element, Frame &frame) {
+        void Compiler::resolve_sequence(Slot &slot, const hgraph::ValueTypeMetaData *element, Frame &frame, bool erase_payload) {
             if (slot.resolved) { return; }
             const gir::Value &literal = value(slot.expression);
             const auto       *source  = std::get_if<gir::Sequence>(&literal.node);
@@ -820,7 +820,10 @@ namespace hgl::wiring
                 if (!item.is_const()) {
                     fail(Category::Type, value(entry.value).range, "a harness sequence element is a constant");
                 }
-                slot.elements.emplace_back(convert(item.value, element, item.range, "the sequence element"));
+                // SIGNAL's bool value schema is a native storage detail, not a
+                // payload type. Every present source value denotes one tick.
+                slot.elements.emplace_back(erase_payload ? hgraph::Value{hgraph::Bool{true}}
+                                                         : convert(item.value, element, item.range, "the sequence element"));
             }
             slot.element_meta = element;
             slot.resolved     = true;
@@ -2088,7 +2091,8 @@ namespace hgl::wiring
                         if (sequence.kind != Slot::Kind::Sequence) {
                             fail(Category::Type, sequence.range, "eval drives '" + parameter.name + "' with a harness sequence");
                         }
-                        resolve_sequence(sequence, parameter_schema->value_schema, caller);
+                        resolve_sequence(sequence, parameter_schema->value_schema, caller,
+                                         parameter_schema->kind == hgraph::TSTypeKind::SIGNAL);
                         inputs.push_back(std::move(sequence.elements));
                     } else {
                         Slot item = eval_const_expr(parameter.default_value, callee);

--- a/language/src/wiring/backend.cpp
+++ b/language/src/wiring/backend.cpp
@@ -2077,7 +2077,7 @@ namespace hgl::wiring
                         continue;
                     }
                     const auto *parameter_schema = schema(parameter.type);
-                    if (parameter_schema->kind != hgraph::TSTypeKind::TS) {
+                    if (parameter_schema->kind != hgraph::TSTypeKind::TS && parameter_schema->kind != hgraph::TSTypeKind::SIGNAL) {
                         backend(binding(parameter.binding).range, "eval drives ts parameters in the first pass; '" +
                                                                       parameter.name + "' is " +
                                                                       std::string{parameter_schema->name()});

--- a/language/src/wiring/operator_types.cpp
+++ b/language/src/wiring/operator_types.cpp
@@ -192,6 +192,7 @@ namespace hgl::wiring
                         if (!type.children.empty()) { result = value(type.children.front()); }
                         break;
                     case hir::TypeKind::Reference: break;
+                    case hir::TypeKind::Signal: break;
                     case hir::TypeKind::Symbol:
                     case hir::TypeKind::Rolling:
                     case hir::TypeKind::Void:
@@ -272,6 +273,7 @@ namespace hgl::wiring
                             if (const auto *target = schema(type.children.front())) { result = registry_.ref(target); }
                         }
                         break;
+                    case hir::TypeKind::Signal: result = registry_.signal(); break;
                     case hir::TypeKind::Symbol:
                     case hir::TypeKind::Tuple:
                     case hir::TypeKind::Void:

--- a/language/src/wiring/type_bridge.cpp
+++ b/language/src/wiring/type_bridge.cpp
@@ -297,6 +297,9 @@ namespace hgl::wiring
             case hir::TypeKind::Reference:
                 report(type.range, "'ref' has no value type; it is an opaque time-series reference");
                 return nullptr;
+            case hir::TypeKind::Signal:
+                report(type.range, "'signal' has no value type; it is an input-only observation marker");
+                return nullptr;
             case hir::TypeKind::Rolling:
                 report(type.range, "'rolling' has no value type; it is a time-series window");
                 return nullptr;
@@ -424,6 +427,7 @@ namespace hgl::wiring
                     }
                 }
                 return nullptr;
+            case hir::TypeKind::Signal: return registry_.signal();
             case hir::TypeKind::Void:
             case hir::TypeKind::Iterator:
             case hir::TypeKind::Callable:

--- a/language/tests/CMakeLists.txt
+++ b/language/tests/CMakeLists.txt
@@ -375,7 +375,7 @@ if(UNIX)
         COMMAND $<TARGET_FILE:hgl> test ${CMAKE_CURRENT_SOURCE_DIR}/codegen/runtime.hgl
     )
     set_tests_properties(hgraph_language_test_runtime PROPERTIES
-        PASS_REGULAR_EXPRESSION "3 tests, 0 failed"
+        PASS_REGULAR_EXPRESSION "4 tests, 0 failed"
     )
 
     add_test(

--- a/language/tests/codegen/generated_runtime_tests.cpp
+++ b/language/tests/codegen/generated_runtime_tests.cpp
@@ -83,6 +83,13 @@ TEST_CASE("generated runtime metadata reads the input selector", "[codegen][runt
                  values<DateTime>(MIN_ST, none, MIN_ST + 2 * MIN_TD));
 }
 
+TEST_CASE("generated signal inputs observe ticks without exposing payloads", "[codegen][runtime][signal]")
+{
+    session();
+    CHECK_OUTPUT(eval_node<runtime::operators::count_ticks>(values<Float>(1.0, 2.0, 3.0)), values<Int>(1, 2, 3));
+    CHECK_OUTPUT(eval_node<runtime::operators::count_float_ticks>(values<Float>(1.0, 2.0, 3.0)), values<Int>(1, 2, 3));
+}
+
 TEST_CASE("generated runtime handlers share recordable state and run in source order", "[codegen][runtime]")
 {
     session();

--- a/language/tests/codegen/runtime.hgl
+++ b/language/tests/codegen/runtime.hgl
@@ -47,6 +47,17 @@ export fn updated_at(value: f64) -> datetime {
     }
 }
 
+export fn count_ticks(pulse: signal) -> i64 {
+    state count: i64 = 0
+
+    when modified(pulse) {
+        count += 1
+        return count
+    }
+}
+
+export fn count_float_ticks(value: f64) -> i64 => count_ticks(value)
+
 export fn combined_total(a: f64, b: f64) -> f64 {
     state total: f64 = 0.0
     inject out
@@ -134,4 +145,8 @@ test scripted_operator_impl {
 
 test scripted_private_runtime_node {
     assert eval(private_total_graph, value: [1.0, 2.0, 3.0]) == [1.0, 3.0, 6.0]
+}
+
+test scripted_signal_input {
+    assert eval(count_ticks, pulse: [true, false, true]) == [1, 2, 3]
 }

--- a/language/tests/codegen/runtime.hgl
+++ b/language/tests/codegen/runtime.hgl
@@ -149,4 +149,5 @@ test scripted_private_runtime_node {
 
 test scripted_signal_input {
     assert eval(count_ticks, pulse: [true, false, true]) == [1, 2, 3]
+    assert eval(count_ticks, pulse: [1.0, 2.0, 3.0]) == [1, 2, 3]
 }

--- a/language/tests/descriptor/module_descriptor_reader_tests.cpp
+++ b/language/tests/descriptor/module_descriptor_reader_tests.cpp
@@ -34,6 +34,7 @@ namespace
             descriptor::TypeRecord{.category = descriptor::TypeCategory::Rolling, .children = {1U}, .size = 0U},
             descriptor::TypeRecord{.category = descriptor::TypeCategory::Reference, .children = {0U}},
             descriptor::TypeRecord{.category = descriptor::TypeCategory::Symbol, .nominal_identity = "checks.reader.State"},
+            descriptor::TypeRecord{.category = descriptor::TypeCategory::Signal},
         };
 
         descriptor::ConstantExpressionRecord integer;
@@ -381,6 +382,60 @@ TEST_CASE("module descriptor reader rejects malformed schema records", "[descrip
         source.types.front().children = {1U};
         check_error(descriptor::read_json(descriptor::to_json(source)), "$.schema.types[0].children",
                     "type requires exactly 0 children");
+    }
+
+    SECTION("signal cannot be nested") {
+        source.types.push_back(descriptor::TypeRecord{.category = descriptor::TypeCategory::Signal});
+        source.types.front().category = descriptor::TypeCategory::List;
+        source.types.front().scalar_name.clear();
+        source.types.front().children = {1U};
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.schema.types[0].children[0]",
+                    "'signal' is only valid as a complete non-const parameter type");
+    }
+}
+
+TEST_CASE("module descriptors restrict signal to non-const inputs", "[descriptor][reader][signal]") {
+    descriptor::ModuleDescriptor source = minimal_descriptor();
+    source.types = {
+        descriptor::TypeRecord{.category = descriptor::TypeCategory::Scalar, .scalar_name = "i64"},
+        descriptor::TypeRecord{.category = descriptor::TypeCategory::Signal},
+    };
+
+    descriptor::InterfaceDeclaration observe;
+    observe.identity             = "checks.reader.observe";
+    observe.execution            = descriptor::ExecutionKind::RuntimeNode;
+    observe.signature.parameters = {{"pulse", "checks.reader.observe::pulse", false, 1U, descriptor::no_schema_id}};
+    observe.signature.result     = 0U;
+    source.interface             = {observe};
+
+    SECTION("a non-const signal parameter is valid") { REQUIRE(descriptor::read_json(descriptor::to_json(source))); }
+
+    SECTION("signal cannot be const") {
+        source.interface.front().signature.parameters.front().is_const = true;
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.interface[0].signature.parameters[0].type",
+                    "'signal' is only valid as a complete non-const parameter type");
+    }
+
+    SECTION("signal cannot have a default") {
+        source.constant_expressions.push_back(
+            descriptor::ConstantExpressionRecord{.literal = hgl::ir::hir::Constant{true}});
+        source.interface.front().signature.parameters.front().default_value = 0U;
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.interface[0].signature.parameters[0].default",
+                    "a 'signal' input cannot have a default value");
+    }
+
+    SECTION("signal cannot be a result") {
+        source.interface.front().signature.result = 1U;
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.interface[0].signature.result",
+                    "'signal' is only valid as a complete non-const parameter type");
+    }
+
+    SECTION("signal cannot be a struct field") {
+        source.interface.front().category = descriptor::DeclarationCategory::Structure;
+        source.interface.front().signature = {};
+        source.interface.front().fields = {{"pulse", 1U, descriptor::no_schema_id, "checks.reader.observe", false}};
+        check_error(descriptor::read_json(descriptor::to_json(source)), "$.interface[0].fields[0].type",
+                    "'signal' is only valid as a complete non-const parameter type");
     }
 }
 

--- a/language/tests/ir/lower_tests.cpp
+++ b/language/tests/ir/lower_tests.cpp
@@ -1269,6 +1269,35 @@ fn invalid(value: ref<bool>) -> bool {
             "node evaluation cannot test a value through ref<T>");
 }
 
+TEST_CASE("typed HIR keeps signal payloads inaccessible to operators", "[ir][typed][signal]") {
+    const auto rejects = [](std::string source) {
+        Lowered lowered{std::move(source)};
+        require_clean(lowered);
+        CHECK_FALSE(complete(lowered));
+        INFO(lowered.diagnostics.render(lowered.file));
+        CHECK(lowered.diagnostics.render(lowered.file).find("'signal' has no payload and cannot be used with operators") !=
+              std::string::npos);
+    };
+
+    rejects(R"(
+module checks.signal_equality
+fn invalid(pulse: signal) -> bool {
+    when modified(pulse) {
+        return pulse == true
+    }
+}
+)");
+
+    rejects(R"(
+module checks.signal_unary
+fn invalid(pulse: signal) -> bool {
+    when modified(pulse) {
+        return !pulse
+    }
+}
+)");
+}
+
 TEST_CASE("typed HIR validates an explicit lambda against collection context", "[ir][typed][lambdas]") {
     Lowered lowered{R"(
 module checks.lambda_context

--- a/language/tests/semantics/resolve_tests.cpp
+++ b/language/tests/semantics/resolve_tests.cpp
@@ -197,6 +197,39 @@ fn invalid(value: ref<ref<i64>>) => value
     CHECK(nested.has(Category::Type, "nested 'ref' boundaries are not supported"));
 }
 
+TEST_CASE("signal is a lowercase input-only type marker", "[semantics][signal]") {
+    const Resolved valid = resolve_clean(R"(
+module checks.signals
+
+fn observe(pulse: signal) -> bool {
+    when modified(pulse) {
+        return valid(pulse)
+    }
+}
+)");
+    CHECK_FALSE(valid.diagnostics.has_errors());
+    const ast::FunctionDecl &observe = valid.function("observe");
+    REQUIRE(observe.signature.parameters.size() == 1U);
+    CHECK(valid.module.type(observe.signature.parameters.front().type).kind == ast::TypeKind::Signal);
+
+    const auto rejects = [](std::string source) {
+        const Resolved resolved{std::move(source)};
+        CHECK(
+            resolved.has(Category::Type, "'signal' is an input-only type marker and is only valid as a non-const parameter type"));
+    };
+
+    rejects("module checks.signal_result\nfn invalid(value: f64) -> signal => value\n");
+    rejects("module checks.signal_const\nfn invalid(const value: signal) => value\n");
+    rejects("module checks.signal_field\nstruct Invalid { value: signal }\n");
+    rejects("module checks.signal_nested\nfn invalid(value: list<signal>) => value\n");
+
+    const Resolved defaulted{"module checks.signal_default\nfn invalid(value: signal = true) => value\n"};
+    CHECK(defaulted.has(Category::Type, "a 'signal' input cannot have a default value"));
+
+    const Resolved uppercase{"module checks.signal_case\nfn invalid(value: SIGNAL) => value\n"};
+    CHECK(uppercase.has(Category::Type, "unknown type 'SIGNAL'"));
+}
+
 TEST_CASE("names resolve through the scope chain", "[semantics]") {
     const Resolved resolved = resolve_clean(R"(
 module t

--- a/language/tests/syntax/parser_tests.cpp
+++ b/language/tests/syntax/parser_tests.cpp
@@ -312,6 +312,7 @@ TEST_CASE("scalar and named types", "[parser]") {
     REQUIRE(type_dump("str") == "Type scalar str\n");
     REQUIRE(type_dump("datetime") == "Type scalar datetime\n");
     REQUIRE(type_dump("duration") == "Type scalar duration\n");
+    REQUIRE(type_dump("signal") == "Type signal\n");
     REQUIRE(type_dump("T") == "Type named T\n");
     REQUIRE(type_dump("Quote") == "Type named Quote\n");
     REQUIRE(type_dump("market::Box<f64, N>") == "Type named market::Box\n"

--- a/language/tests/wiring/type_bridge_tests.cpp
+++ b/language/tests/wiring/type_bridge_tests.cpp
@@ -183,6 +183,21 @@ fn consume(value: atomic<Vector<f64, 2>>) -> atomic<Vector<f64, 2>> => value
     CHECK(unit.diagnostics.render(unit.file).find("typed constant Bundle metadata") != std::string::npos);
 }
 
+TEST_CASE("signal materializes the payload-erased hgraph input schema", "[wiring][hgraph-ir][types][signal]") {
+    Unit unit{R"(
+module checks.signal_type
+fn observe(pulse: signal) -> bool => valid(pulse)
+)"};
+    INFO(unit.diagnostics.render(unit.file));
+    REQUIRE_FALSE(unit.diagnostics.has_errors());
+
+    hgl::wiring::TypeBridge bridge{unit.graph, unit.diagnostics};
+    const auto              pulse = unit.parameter("observe", "pulse");
+    CHECK(bridge.schema(pulse) == hgraph::TypeRegistry::instance().signal());
+    CHECK(bridge.value(pulse) == nullptr);
+    CHECK(unit.diagnostics.render(unit.file).find("input-only observation marker") != std::string::npos);
+}
+
 TEST_CASE("hgraph IR type caches follow registry resets", "[wiring][hgraph-ir][types]") {
     Unit unit{R"(
 module checks.type_reset


### PR DESCRIPTION
## Summary

- add lowercase contextual `signal` syntax through the HGL syntax tree, semantic model, HIR, and module descriptors
- enforce `signal` as an input-only, non-const temporal marker with no default or scalar payload
- map compatible concrete time-series inputs to native `hgraph::SIGNAL` in direct and generated backends
- document the user-facing contract and cover parser, semantic, descriptor, code-generation, and scripted runtime behavior

This is the root of the new post-merge HGL stack and is independently based on `main`.

## Validation

- `cmake --preset cpp --fresh`
- `cmake --preset cpp -DHGRAPH_BUILD_LANGUAGE=ON`
- `cmake --build --preset cpp --target clean`
- `cmake --build --preset cpp --parallel`
- `ctest --preset cpp --parallel 2` — 1775/1775 passed
- stable-ABI wheel built with Python 3.12 and installed into a fresh Python 3.14 environment
- `python -m pytest python/tests -q -m "not wip"` — 3252 passed, 10 skipped
